### PR TITLE
Don't attempt to load non-ruby plugin files

### DIFF
--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -15,6 +15,7 @@ module Puppet::Configurer::PluginHandler
   def load_plugin(file)
     return unless FileTest.exist?(file)
     return if FileTest.directory?(file)
+    return unless File.extname(file) == '.rb'
 
     begin
       Puppet.info "Loading downloaded plugin #{file}"


### PR DESCRIPTION
Unlike `pluginignore` which doesn't copy files that match the pattern(s), this will allow us to distribute arbitrary files via the pluginsync system (such as Augeas lenses).  Currently without this change, the files are distributed correctly however Puppet then tries to blindly `load` every file rather than just Ruby files.
