### PR TITLE
Distribute Augeas lenses with pluginsync

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -139,11 +139,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
       flags = Augeas::TYPE_CHECK if resource[:type_check] == :true
       flags |= Augeas::NO_MODL_AUTOLOAD if resource[:incl]
       root = resource[:root]
-      if resource[:load_path] == ""
-        load_path = "#{Puppet[:plugindir]}/augeas/lenses"
-      else
-        load_path = "#{resource[:load_path]}:#{Puppet[:plugindir]}/augeas/lenses"
-      end
+      load_path = [resource[:load_path], "#{Puppet[:plugindir]}/augeas/lenses"].reject! { |i| i == "" }.join(':')
       debug("Opening augeas with root #{root}, lens path #{load_path}, flags #{flags}")
       @aug = Augeas::open(root, load_path,flags)
 


### PR DESCRIPTION
In conjunction with https://github.com/puppetlabs/puppet/pull/6 this will add `$plugindir/augeas/lenses` to Augeas' load path so that we can distribute the Augeas lenses that our modules depend on via pluginsync rather than file resources.
