### PR TITLE
Ticket/2.6.x/2128 docstrings

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -488,16 +488,16 @@ module Puppet
   setdefaults(:agent,
     :node_name_value => { :default => "$certname",
       :desc => "The explicit value used for the node name for all requests the agent
-        makes to the master. This setting is mutually exclusive with node_name_fact.
-        Changing this setting also requires changes to the default auth.conf
-        configuration on the Puppet Master.  Please see
+        makes to the master. WARNING: This setting is mutually exclusive with
+        node_name_fact.  Changing this setting also requires changes to the default
+        auth.conf configuration on the Puppet Master.  Please see
         http://links.puppetlabs.com/node_name_value for more information."
     },
     :node_name_fact => { :default => "",
-      :desc => " The fact name used to determine the node name used for all requests the agent
-        makes to the master. This setting is mutually exclusive with node_name_value.
-        Changing this setting also requires changes to the default auth.conf
-        configuration on the Puppet Master.  Please see
+      :desc => "The fact name used to determine the node name used for all requests the agent
+        makes to the master. WARNING: This setting is mutually exclusive with
+        node_name_value.  Changing this setting also requires changes to the default
+        auth.conf configuration on the Puppet Master.  Please see
         http://links.puppetlabs.com/node_name_fact for more information.",
       :hook => proc do |value|
         if !value.empty? and Puppet[:node_name_value] != Puppet[:certname]


### PR DESCRIPTION
This change augments the in-line documentation for the node_name_fact and
node_name_value configuration settings.  These settings will not work
effectively without additional changes elsewhere in the system, e.g. to
auth.conf.

In order to help the end user land softly if they choose to change these
settings, a short link URL we control and can redirect has been added
to each setting.  These currently point to the community Wiki but may be
redirected to docs.puppetlabs.com in the future.
