### PR TITLE
(#8032) Add containment to create_resources

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -27,15 +27,16 @@ Takes two parameters:
   args[1].each do |title, params|
     raise ArgumentError, 'params should not contain title' if(params['title'])
     case type_of_resource
-    when :type
-      res = resource.hash2resource(params.merge(:title => title))
-      catalog.add_resource(res)
-    when :define
+    # JJM The only difference between a type and a define is the call to instantiate_resource
+    # for a defined type.
+    when :type, :define
       p_resource = Puppet::Parser::Resource.new(type_name, title, :scope => self, :source => resource)
       params.merge(:name => title).each do |k,v|
         p_resource.set_parameter(k,v)
       end
-      resource.instantiate_resource(self, p_resource)
+      if type_of_resource == :define then
+        resource.instantiate_resource(self, p_resource)
+      end
       compiler.add_resource(self, p_resource)
     when :class
       klass = find_hostclass(title)


### PR DESCRIPTION
Without this change native resource types declared using the
create_resources() function are not contained within the class scope of
the function call.  As a result, resources were "floating off" in the
graph, disconnected from the rest of the relationship edges.

With this change, the scope is preserved and native resources are
contained by the class the function call is executed from.

Reviewed-by: Dan Bode dan@puppetlabs.com
