### PR TITLE
(#8062) yum package ensure=>latest not checking the epoch tag

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -86,7 +86,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     unless upd.nil?
       # FIXME: there could be more than one update for a package
       # because of multiarch
-      return "#{upd[:version]}-#{upd[:release]}"
+      return "#{upd[:epoch]}:#{upd[:version]}-#{upd[:release]}"
     else
       # Yum didn't find updates, pretend the current
       # version is the latest


### PR DESCRIPTION
Please include the epoch tag version in the latest return value.
This should allow 'ensure => latest' to work for rpm packages where the version differs only by the epoch tag.
