### PR TITLE
Ticket/2.7.x/7274

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -85,6 +85,14 @@ module Puppet
       end
       :file_changed
     end
+
+    def should_to_s(should_value)
+      should_value.to_s.rjust(4,"0")
+    end
+
+    def is_to_s(currentvalue)
+      currentvalue.to_s.rjust(4,"0")
+    end
   end
 end
 

--- a/spec/unit/type/file/mode_spec.rb
+++ b/spec/unit/type/file/mode_spec.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+
+property = Puppet::Type.type(:file).attrclass(:mode)
+
+describe property do
+  before do
+    @resource = stub 'resource', :line => "foo", :file => "bar"
+    @resource.stubs(:[]).returns "foo"
+    @resource.stubs(:[]).with(:path).returns "/my/file"
+    @mode = property.new :resource => @resource
+  end
+
+  describe "when changing the mode" do
+    before do
+    end
+
+    it "should handle 3 to 3 digit file mode" do
+      @mode.stubs(:mode).returns 644
+      @mode.should = '755'
+      File.expects(:chmod).with('755'.to_i(8), "/my/file")
+
+      @mode.sync
+      # for some reasons it's not logging yet.
+      #@logs.first.message.should =~ /0644/
+    end
+
+    it "should handle 3 to 4 digit file mode" do
+      @mode.stubs(:mode).returns 644
+      @mode.should = '1755'
+      File.expects(:chmod).with('1755'.to_i(8), "/my/file")
+
+      @mode.sync
+    end
+
+    it "should handle 4 to 3 digit file mode" do
+      @mode.stubs(:mode).returns 1755
+      @mode.should = '644'
+      File.expects(:chmod).with('644'.to_i(8), "/my/file")
+
+      @mode.sync
+    end
+
+    it "should handle 4 to 4 digit file mode" do
+      @mode.stubs(:mode).returns 1755
+      @mode.should = '1644'
+      File.expects(:chmod).with('1644'.to_i(8), "/my/file")
+
+      @mode.sync
+    end
+  end
+end


### PR DESCRIPTION
This enhances the file changes to always display 4 digit file mode. So rather than:
changed mode '755' to '644'

It will display:
changed mode '0755' to '0644'

I know I shouldn't request a merge for something that has an incomplete spec tests, however it's an improvement over the missing spec test. Due to how the mode property is implemented, I'm not sure why the log message isn't getting the changes to file.
