### PR TITLE
Possible fix for #8435 - remote package installation broken

### DIFF
--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -60,9 +60,9 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
         "You must specify a package source for BSD packages"
     end
 
-    if @resource[:source][-1,1] == ::File::PATH_SEPARATOR
-      e_vars = { :PKG_PATH => @resource[:source] }
-      full_name = [ @resource[:name], get_version || @resource[:ensure], @resource[:flavor] ].join('-').chomp('-')
+    if @resource[:source][-1,1] == ::File::SEPARATOR
+      e_vars = { 'PKG_PATH' => @resource[:source] }
+      full_name = [ @resource[:name], get_version || @resource[:ensure], @resource[:flavor] ].join('-').chomp('-').chomp('-')
     else
       e_vars = {}
       full_name = @resource[:source]
@@ -77,6 +77,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
         regex = /^(.*)-(\d[^-]*)[-]?(\D*)(.*)$/
         fields = [ :name, :version, :flavor ]
         master_version = 0
+        version = -1
 
         process.each do |line|
           if match = regex.match(line.split[0])
@@ -89,6 +90,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
         end
 
         return master_version unless master_version == 0
+        return '' if version == -1
         raise Puppet::Error, "#{version} is not available for this package"
       end
   rescue Puppet::ExecutionFailure


### PR DESCRIPTION
This is the current fix I'm using to be able to use remote package
installations on openbsd. This is just a proposal as it's a quick
and dirty workaround and lacks tests.

I send this to be able to start a discussion, whether it's going into the right direction or not. I don't really understand the reasons for all the changes that have been made in 4a3d5d7c11bea5efba6f and also I don't know the openbsd pkg_add good enough to be sure about the right strategy.

So I would welcome if someone more familiar with openbsd or the changes in 4a3d5d7c11bea5efba6f could have a look into my proposed changes and maybe fix them or propose at least an alternative strategy.

I would certainly be able to work on that patch and also on tests if I'm sure it's going in the right direction. But you won't here anything from me before Mid-September. So until then either somebody needs to jump in and do the rest of the work or we have to live with this bug and that currently the installation from remote repositories on openbsd is broken until I'm back to work on that fix. Thanks!
