### PR TITLE
Bug/2.7.x/4762 ensure that clients on the moon can successfully connect

### DIFF
--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -40,7 +40,7 @@ class Puppet::Network::HTTP::WEBrick
       @listening = true
       @thread = Thread.new {
         @server.start { |sock|
-          raise "Client disconnected before connection could be established" unless IO.select([sock],nil,nil,0.1)
+          raise "Client disconnected before connection could be established" unless IO.select([sock],nil,nil,6.2)
           sock.accept
           @server.run(sock)
         }


### PR DESCRIPTION
https://projects.puppetlabs.com/issues/4762

```
Previously, we only allowed Puppet Clients at a maximum distance of somewhere
between 7,494 and 14,988 kilometers from the master, depending on the variance
in local conditions.

While this gave us good data security against hostile clients connecting from
the dark side of the moon, real world testing shows the moon folks are likely
to just take over a local staging host and attack that way.

So, instead, allow clients sufficient time they should be comfortable able to
connect to a master from the moon.  We still refuse clients further out, like
Mars, since it seems unlikely that Puppet management over that distance should
work.

We advise the manned Mars expedition to deploy a local Puppet Master to manage
infrastructure in their base, and to watch out for the martians.
```
