### PR TITLE
(#8808) Fail Augeas resource when unable to save changes

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -290,8 +290,10 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           set_augeas_save_mode(SAVE_NEWFILE)
           do_execute_changes
           save_result = @aug.save
+          fail("Save failed with return code #{save_result}") unless save_result
+
           saved_files = @aug.match("/augeas/events/saved")
-          if save_result and saved_files.size > 0
+          if saved_files.size > 0
             root = resource[:root].sub(/^\/$/, "")
             saved_files.each do |key|
               saved_file = @aug.get(key).to_s.sub(/^\/files/, root)
@@ -305,13 +307,13 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             debug("Files changed, should execute")
             return_value = true
           else
-            debug("Skipping because no files were changed or save failed")
+            debug("Skipping because no files were changed")
             return_value = false
           end
         end
       end
     ensure
-      if not return_value or resource.noop?
+      if not return_value or resource.noop? or not save_result
         close_augeas
       end
     end

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -442,6 +442,20 @@ describe provider_class do
         @provider.expects(:diff).with("#{file}", "#{file}.augnew").returns("")
         @provider.should be_need_to_run
       end
+
+      it "should fail with an error if saving fails" do
+        file = "/etc/hosts"
+
+        @resource[:context] = "/files"
+        @resource[:changes] = ["set #{file}/foo bar"]
+
+        @augeas_stub.stubs(:save).returns(false)
+        @augeas_stub.stubs(:match).with("/augeas/events/saved").returns([])
+        @augeas_stub.expects(:close)
+
+        @provider.expects(:diff).never()
+        lambda { @provider.need_to_run? }.should raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Raise a failure when Augeas changes cannot be saved (due to invalid layout of the tree, permissions etc).

Fixes a regression introduced with #2728 into 2.7.0.
