### PR TITLE
(#5606) Print Augeas' /augeas//error info to debug on save failure

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -259,6 +259,18 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     @aug.set("/augeas/save", mode)
   end
 
+  def print_put_errors
+    errors = @aug.match("/augeas//error[. = 'put_failed']")
+    debug("Put failed on one or more files, output from /augeas//error:") unless errors.empty?
+    errors.each do |errnode|
+      @aug.match("#{errnode}/*").each do |subnode|
+        sublabel = subnode.split("/")[-1]
+        subvalue = @aug.get(subnode)
+        debug("#{sublabel} = #{subvalue}")
+      end
+    end
+  end
+
   # Determines if augeas acutally needs to run.
   def need_to_run?
     force = resource[:force]
@@ -290,7 +302,10 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           set_augeas_save_mode(SAVE_NEWFILE)
           do_execute_changes
           save_result = @aug.save
-          fail("Save failed with return code #{save_result}") unless save_result
+          unless save_result
+            print_put_errors
+            fail("Save failed with return code #{save_result}, see debug")
+          end
 
           saved_files = @aug.match("/augeas/events/saved")
           if saved_files.size > 0
@@ -339,8 +354,10 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         debug("No saved files, re-executing augeas")
         set_augeas_save_mode(SAVE_OVERWRITE) if get_augeas_version >= "0.3.6"
         do_execute_changes
-        success = @aug.save
-        fail("Save failed with return code #{success}") if success != true
+        unless @aug.save
+          print_put_errors
+          fail("Save failed with return code #{success}, see debug")
+        end
       end
     ensure
       close_augeas

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -606,4 +606,22 @@ describe provider_class do
       @provider.execute_changes.should == :executed
     end
   end
+
+  describe "save failure reporting" do
+    before do
+      @resource = stub("resource")
+      @augeas = stub("augeas")
+      @provider = provider_class.new(@resource)
+      @provider.aug = @augeas
+    end
+
+    it "should find errors and output to debug" do
+      @augeas.expects(:match).with("/augeas//error[. = 'put_failed']").returns(["/augeas/files/foo/error"])
+      @augeas.expects(:match).with("/augeas/files/foo/error/*").returns(["/augeas/files/foo/error/path", "/augeas/files/foo/error/message"])
+      @augeas.expects(:get).with("/augeas/files/foo/error/path").returns("/foo")
+      @augeas.expects(:get).with("/augeas/files/foo/error/message").returns("Failed to...")
+      @provider.expects(:debug).times(3)
+      @provider.print_put_errors
+    end
+  end
 end


### PR DESCRIPTION
When saving fails, the contents of /augeas//error (for put_failed) are printed to the debug log.  Should help users track down the issue without needing to replicate it with augtool.

NOTE: I've cherry-picked the bug fix for #8808 into this branch as it's necessary for this feature to work.  #8808 was originally against 2.7.x, not master.
