### PR TITLE
(#8272) Add missing tests for Windows service provider methods.

### DIFF
--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:service).provide :windows do
   def stop
     Win32::Service.stop( @resource[:name] )
   rescue Win32::Service::Error => detail
-    raise Puppet::Error.new("Cannot start #{@resource[:name]}, error was: #{detail}" )
+    raise Puppet::Error.new("Cannot stop #{@resource[:name]}, error was: #{detail}" )
   end
 
   def restart


### PR DESCRIPTION
Added missing spec tests for Windows service provider methods:
  :stop, :enable, :disable, and :manual_start
Refactored to match Nick's previous work.

Reviewed By: Nick Lewis [nick@puppetlabs.com]
