### PR TITLE
Bug/2.7.x/7177 ralsh still uses implicit apply

### DIFF
--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -194,7 +194,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         end
         ENV["EDITOR"] ||= "vi"
         system(ENV["EDITOR"], file)
-        system("puppet -v #{file}")
+        system("puppet apply -v #{file}")
       ensure
         #if FileTest.exists? file
         #    File.unlink(file)


### PR DESCRIPTION
The RAL shell, in edit mode, still used implicit 'puppet apply' invocation to
apply the modified manifest.  In 2.7, this now raises a deprecation warning,
and rightly so.

Fix the invocation to use explicit apply instead.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
