### PR TITLE
(#8814) Update fqdn_rand for ruby 1.9.2 rand bug.

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -6,7 +6,7 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :type => :rvalue, :doc =>
       $random_number = fqdn_rand(30)
       $random_number_seed = fqdn_rand(30,30)") do |args|
     require 'digest/md5'
-    max = args.shift
+    max = args.shift.to_i
     srand(Digest::MD5.hexdigest([self['::fqdn'],args].join(':')).hex)
     rand(max).to_s
 end


### PR DESCRIPTION
Ruby 1.9.2 does not accept a string for rand function, so rand('1')
fails even though this works in Ruby 1.8.x and the string is implicitly
converted to a number. We added to_i to avoid this bug.
