### PR TITLE
(#7917) Puppet apply write classes.txt file

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -202,6 +202,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       # Compile our catalog
       starttime = Time.now
       catalog = Puppet::Resource::Catalog.indirection.find(node.name, :use_node => node)
+      catalog.write_class_file
 
       # Translate it to a RAL catalog
       catalog = catalog.to_ral

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -263,6 +263,12 @@ describe Puppet::Application::Apply do
         expect { @apply.main }.to exit_with 0
       end
 
+      it "should write the classes.txt file" do
+        @catalog.expects(:write_class_file)
+
+        expect { @apply.main }.to exit_with 0
+      end
+
       it "should transform the catalog to ral" do
 
         @catalog.expects(:to_ral).returns(@catalog)


### PR DESCRIPTION
Puppet apply should write classes.txt file to improve support for tools
such as MCollective. Currently puppet apply command does not write
classes.txt file.
