### PR TITLE
Fixed #3323 - Added support for reloading and gracefully restarting

### DIFF
--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -35,6 +35,34 @@ Puppet::Type.type(:service).provide :base do
     nil
   end
 
+  # How to reload the process
+  def reload
+    if @resource[:reload] or reloadcmd
+      ucommand(:reload)
+    elsif
+      self.stop
+      self.start
+    end
+  end
+
+  # There is no default command, which causes other methods to be used
+  def reloadcmd
+  end
+
+  # How to gracefully restart the service
+  def graceful
+    if @resource[:graceful] or gracefulcmd
+      ucommand(:graceful)
+    elsif
+      self.stop
+      self.start
+    end
+  end
+
+  # There is no default command, which causes other methods to be used
+  def gracefulcmd
+  end
+
   # How to restart the process.
   def restart
     if @resource[:restart] or restartcmd

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -126,6 +126,14 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     [initscript, :stop]
   end
 
+  def gracefulcmd
+    (@resource[:hasgraceful] == :true) && [initscript, :graceful]
+  end
+
+  def reloadcmd
+    (@resource[:hasreload] == :true) && [initscript, :reload]
+  end
+
   def restartcmd
     (@resource[:hasrestart] == :true) && [initscript, :restart]
   end

--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -60,6 +60,14 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
     ((@resource.provider.get(:hasstatus) == true) || (@resource[:hasstatus] == :true)) && [command(:service), @resource[:name], "status"]
   end
 
+  def gracefulcmd
+    (@resource[:hasgraceful] == :true) && [command(:service), @resource[:name], "graceful"]
+  end
+
+  def reloadcmd
+    (@resource[:hasreload] == :true) && [command(:service), @resource[:name], "reload"]
+  end
+
   def restartcmd
     (@resource[:hasrestart] == :true) && [command(:service), @resource[:name], "restart"]
   end

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -103,7 +103,7 @@ describe provider_class do
       File.stubs(:stat).with("/service/path/myservice").returns true
     end
 
-    [:start, :stop, :status, :restart].each do |method|
+    [:start, :stop, :status, :restart, :reload, :graceful ].each do |method|
       it "should have a #{method} method" do
         @provider.should respond_to(method)
       end
@@ -157,7 +157,7 @@ describe provider_class do
       end
     end
 
-    describe "when restarting and hasrestart is not :true" do
+    describe "when restarting and hasgraceful, hasreload, and hasrestart is not :true" do
       it "should stop and restart the process" do
         @provider.expects(:texecute).with(:stop, ['/service/path/myservice', :stop ], true).returns("")
         @provider.expects(:texecute).with(:start,['/service/path/myservice', :start], true).returns("")

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -57,7 +57,7 @@ describe provider_class do
     @provider.should respond_to(:disable)
   end
 
-  [:start, :stop, :status, :restart].each do |method|
+  [:start, :stop, :status, :restart, :reload, :graceful ].each do |method|
     it "should have a #{method} method" do
       @provider.should respond_to(method)
     end
@@ -111,7 +111,7 @@ describe provider_class do
     end
   end
 
-  describe "when restarting and hasrestart is not :true" do
+  describe "when restarting and hasreload, hasgraceful and hasrestart is not :true" do
     it "should stop and restart the process with the server script" do
       @provider.expects(:texecute).with(:stop,  ['/sbin/service', 'myservice', 'stop'],  true)
       @provider.expects(:texecute).with(:start, ['/sbin/service', 'myservice', 'start'], true)

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -9,10 +9,18 @@ describe Puppet::Type.type(:service) do
   it "should have a :refreshable feature that requires the :restart method" do
     Puppet::Type.type(:service).provider_feature(:refreshable).methods.should == [:restart]
   end
+
+  it "should have a :reloadable feature that requires the :reload method" do
+    Puppet::Type.type(:service).provider_feature(:reloadable).methods.should == [:reload]
+  end
+
+  it "should have a :graceful feature that requires the :graceful method" do
+    Puppet::Type.type(:service).provider_feature(:graceful).methods.should == [:graceful]
+  end
 end
 
 describe Puppet::Type.type(:service), "when validating attributes" do
-  [:name, :binary, :hasstatus, :path, :pattern, :start, :restart, :stop, :status, :hasrestart, :control].each do |param|
+  [:name, :binary, :hasstatus, :path, :pattern, :start, :restart, :reload, :graceful, :stop, :status, :hasrestart, :hasreload, :hasgraceful, :control].each do |param|
     it "should have a #{param} parameter" do
       Puppet::Type.type(:service).attrtype(param).should == :param
     end
@@ -82,6 +90,22 @@ describe Puppet::Type.type(:service), "when validating attribute values" do
 
   it "should specify :true as the default value of hasstatus" do
     Puppet::Type.type(:service).new(:name => "yay")[:hasstatus].should == :true
+  end
+
+  it "should support :true as a value to :hasgraceful" do
+    Puppet::Type.type(:service).new(:name => "yay", :hasgraceful => :true)
+  end 
+
+  it "should support :false as a value to :hasgraceful" do
+    Puppet::Type.type(:service).new(:name => "yay", :hasgraceful => :false)
+  end 
+
+  it "should support :true as a value to :hasreload" do
+    Puppet::Type.type(:service).new(:name => "yay", :hasreload => :true)
+  end 
+
+  it "should support :false as a value to :hasreload" do
+    Puppet::Type.type(:service).new(:name => "yay", :hasreload => :false)
   end
 
   it "should support :true as a value to :hasrestart" do


### PR DESCRIPTION
services.

Adds new parameters to the service types and methods to the base,
init and redhat providers.  You can now specify:
- hasreload - specifies the init script has a reload option
- hasgraceful - specifices the init script has a graceful option

You can also manually specify the reload and graceful parameters
to indicate specify commands in the init scrip that provide these
capabilities in much the same way you can now with the restart
parameter.
