### PR TITLE
(#8770) Don't fail to set supplementary groups when changing user to root

### DIFF
--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -134,6 +134,28 @@ describe Puppet::Util::SUIDManager do
         xids[:euid].should == 42
         xids[:uid].should == 0
       end
+
+      it "should set euid before groups if changing to root" do
+        Process.stubs(:euid).returns 50
+
+        when_not_root = sequence 'when_not_root'
+
+        Process.expects(:euid=).in_sequence(when_not_root)
+        Puppet::Util::SUIDManager.expects(:initgroups).in_sequence(when_not_root)
+
+        Puppet::Util::SUIDManager.change_user(0, false)
+      end
+
+      it "should set groups before euid if changing from root" do
+        Process.stubs(:euid).returns 0
+
+        when_root = sequence 'when_root'
+
+        Puppet::Util::SUIDManager.expects(:initgroups).in_sequence(when_root)
+        Process.expects(:euid=).in_sequence(when_root)
+
+        Puppet::Util::SUIDManager.change_user(50, false)
+      end
     end
   end
 


### PR DESCRIPTION
Previously, Puppet::Util::SUIDManager.change_user would always try to set
supplementary groups (Process.initgroups) before changing its EUID.
Process.initgroups requires the calling process to have EUID 0 in order to
succeed.

This worked fine in the case where the process was changing from root to a
normal user, as it would set groups as root and then change EUID to 0.
However, in the case where the process was changing back to root from a normal
user, it would attempt to set groups as the normal user, and fail.

Now, we check Process.euid before changing, and will set groups first if root,
and will set euid first if not root. This ensures we can freely switch back
and forth between root.

This behavior is maintained inside of the change_user, rather than being broken
into eg. raise_privilege and lower_privilege, because it is a relatively minor
behavior difference, and the helper methods on their own would not have been
generically useful.
