### PR TITLE
Ticket/2.7.x/8612 exec creates parameter

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -311,17 +311,20 @@ module Puppet
     end
 
     newcheck(:creates, :parent => Puppet::Parameter::Path) do
-      desc "A file that this command creates.  If this
+      desc <<-EOT
+        A file that this command creates.  If this
         parameter is provided, then the command will only be run
-        if the specified file does not exist:
+        if the specified file does not exist.
 
-            exec { \"tar xf /my/tar/file.tar\":
-              cwd => \"/var/tmp\",
-              creates => \"/var/tmp/myfile\",
-              path => [\"/usr/bin\", \"/usr/sbin\"]
+            exec { "tar -xf /Volumes/nfs02/important.tar":
+              cwd => "/var/tmp",
+              creates => "/var/tmp/myfile",
+              path => ["/usr/bin", "/usr/sbin"]
             }
 
-        "
+        In this example, if `/var/tmp/myfile` is ever deleted, the exec
+        will bring it back by re-extracting the tarball.
+      EOT
 
       accept_arrays
 


### PR DESCRIPTION
(#8612) Clarify the function of the example for exec's "creates" parameter

It was not clear to all readers that /var/tmp/myfile was being extracted from
the tarball. This commit adds a sentence to make the conditions when the exec
will run more explicit and fixes an error in the tar command.
