### PR TITLE
Fix order dependent terminus tests in 2.7.x

### DIFF
--- a/spec/integration/node_spec.rb
+++ b/spec/integration/node_spec.rb
@@ -10,6 +10,9 @@ require 'puppet/node'
 describe Puppet::Node do
   describe "when delegating indirection calls" do
     before do
+      Puppet::Node.indirection.reset_terminus_class
+      Puppet::Node.indirection.cache_class = nil
+
       @name = "me"
       @node = Puppet::Node.new(@name)
     end

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -12,6 +12,14 @@ describe Puppet::Application::Apply do
     Puppet::Util::Log.stubs(:newdestination)
   end
 
+  after :each do
+    Puppet::Node::Facts.indirection.reset_terminus_class
+    Puppet::Node::Facts.indirection.cache_class = nil
+
+    Puppet::Node.indirection.reset_terminus_class
+    Puppet::Node.indirection.cache_class = nil
+  end
+
   [:debug,:loadclasses,:verbose,:use_nodes,:detailed_exitcodes].each do |option|
     it "should declare handle_#{option} method" do
       @apply.should respond_to("handle_#{option}".to_sym)
@@ -48,7 +56,6 @@ describe Puppet::Application::Apply do
   end
 
   describe "during setup" do
-
     before :each do
       Puppet::Log.stubs(:newdestination)
       Puppet.stubs(:parse_config)
@@ -111,7 +118,6 @@ describe Puppet::Application::Apply do
   end
 
   describe "when executing" do
-
     it "should dispatch to 'apply' if it was called with 'apply'" do
       @apply.options[:catalog] = "foo"
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -130,14 +130,9 @@ end
 describe Puppet::Node, "when indirecting" do
   it "should default to the 'plain' node terminus" do
     Puppet::Node.indirection.reset_terminus_class
+
     Puppet::Node.indirection.terminus_class.should == :plain
-  end
 
-  it "should not have a cache class defined" do
-    Puppet::Node.indirection.cache_class.should be_nil
-  end
-
-  after do
     Puppet::Util::Cacher.expire
   end
 end


### PR DESCRIPTION
Do not leak indirector state from apply tests

Since the indirector state persists across tests, we were seeing order
dependent test failures with tests that assumed the default indirector
settings.

Specifically, if the following tests were run in order, the first
would cause failures in the second two:

```
spec/unit/application/apply_spec.rb
spec/unit/node_spec.rb
spec/integration/node_spec.rb
```

To protect against this state leakage, we now:
- reset the Puppet::Node terminus before each test in
  spec/integration/node_spec.rb to ensure we are testing a clean
  environment.
- reset the Puppet::Node, and Puppet::Node::Facts terminus, and
  cache class after each test in spec/unit/application/apply_spec.rb
  to prevent leakage into other tests.

Since the cache class has the same state leakage problem as the
terminus class, but does not have the same ability to lazily populate
the default when set to nil, we remove the test.  Testing the default
for the cache class would require running the test before all other
tests to ensure there is no state pollution.n
