### PR TITLE
Do not leak indirector state

### DIFF
--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -90,6 +90,11 @@ describe Puppet::Configurer do
       Puppet::Util::Log.stubs(:close)
     end
 
+    after :all do
+      Puppet::Node::Facts.indirection.reset_terminus_class
+      Puppet::Resource::Catalog.indirection.reset_terminus_class
+    end
+
     it "should prepare for the run" do
       @agent.expects(:prepare)
 


### PR DESCRIPTION
Because the indirector state persists across tests, we need to make
sure that we clean up after ourselves whenever we explicitly set a
non-default configuration.  We now reset the terminus class after all
the tests have run in the context with the modified configuration.

This should also be merged all the way forward to `master`.
