### PR TITLE
(#8037) Fix incorrect example in Augeas type reference

### DIFF
--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -20,7 +20,8 @@ Puppet::Type.newtype(:augeas) do
   feature :need_to_run?, "If the command should run"
   feature :execute_changes, "Actually make the changes"
 
-  @doc = "Apply the changes (single or array of changes) to the filesystem
+  @doc = <<-EOT
+    Apply the changes (single or array of changes) to the filesystem
     via the augeas tool.
 
     Requires:
@@ -30,24 +31,24 @@ Puppet::Type.newtype(:augeas) do
 
     Sample usage with a string:
 
-        augeas{\"test1\" :
-          context => \"/files/etc/sysconfig/firstboot\",
-          changes => \"set RUN_FIRSTBOOT YES\",
-          onlyif  => \"match other_value size > 0\",
+        augeas{"test1" :
+          context => "/files/etc/sysconfig/firstboot",
+          changes => "set RUN_FIRSTBOOT YES",
+          onlyif  => "match other_value size > 0",
         }
 
     Sample usage with an array and custom lenses:
 
-        augeas{\"jboss_conf\":
-          context => \"/files\",
+        augeas{"jboss_conf":
+          context => "/files",
           changes => [
-            \"set /etc/jbossas/jbossas.conf/JBOSS_IP $ipaddress\",
-            \"set /etc/jbossas/jbossas.conf/JAVA_HOME /usr\"
+            "set etc/jbossas/jbossas.conf/JBOSS_IP $ipaddress",
+            "set etc/jbossas/jbossas.conf/JAVA_HOME /usr",
           ],
-          load_path => \"$/usr/share/jbossas/lenses\",
+          load_path => "$/usr/share/jbossas/lenses",
         }
 
-    "
+  EOT
 
   newparam (:name) do
     desc "The name of this task. Used for uniqueness"


### PR DESCRIPTION
The changes attribute for the Augeas type's second example was
incorrect, as it had leading slashes that took the paths out of the
context of /files. This commit fixes the bad example, and changes the doc
string to a heredoc to eliminate some messy escaping.
