### PR TITLE
maint: Fix order dependent test failure

### DIFF
--- a/spec/unit/face/node_spec.rb
+++ b/spec/unit/face/node_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 require 'puppet/face'
 
 describe Puppet::Face[:node, '0.0.1'] do
+  after :all do
+    Puppet::SSL::Host.ca_location = :none
+  end
+
   describe '#cleanup' do
     it "should clean everything" do
       {


### PR DESCRIPTION
The spec tests failed when running spec/unit/face/node_spec.rb
followed by spec/unit/ssl/certificate_request_spec.rb, because the
clean action for the node face was leaving
Puppet::SSL::Host.ca_location set to :local instead of its default
:none state.

This commit resets the ca_location back to :none in the top-level
after :all block.
