### PR TITLE
maint: Fix build break due to recent merge from 2.7.x to master

### DIFF
--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -235,12 +235,13 @@ describe Puppet::Application::Resource do
     end
 
     it "should output a file resource when given a file path" do
-      res = Puppet::Type.type(:file).new(:path => "/etc").to_resource
+      path = File.expand_path('/etc')
+      res = Puppet::Type.type(:file).new(:path => path).to_resource
       Puppet::Resource.indirection.expects(:find).returns(res)
 
-      @resource.command_line.stubs(:args).returns(['file', '/etc'])
+      @resource.command_line.stubs(:args).returns(['file', path])
       @resource.expects(:puts).with do |args|
-        args.should =~ /file \{ '\/etc'/m
+        args.should =~ /file \{ '#{Regexp.escape(path)}'/m
       end
 
       @resource.main

--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -33,6 +33,7 @@ describe Puppet::Util::SUIDManager do
   describe "#asuser" do
     it "should set euid/egid when root" do
       Process.stubs(:uid).returns(0)
+      Puppet.features.stubs(:microsoft_windows?).returns(false)
 
       Process.stubs(:egid).returns(51)
       Process.stubs(:euid).returns(50)
@@ -168,6 +169,8 @@ describe Puppet::Util::SUIDManager do
     describe "with #system" do
       it "should set euid/egid when root" do
         Process.stubs(:uid).returns(0)
+        Puppet.features.stubs(:microsoft_windows?).returns(false)
+
         Process.stubs(:egid).returns(51)
         Process.stubs(:euid).returns(50)
 


### PR DESCRIPTION
The resource_spec was failing because /etc is not considered a
fully-qualified path on Windows. Using File.expand_path fixes that.

The suidmanager_spec was failing because we weren't stubbing the
microsoft_windows feature, so SUIDManager.asuser was a no-op when
running as root, and our expectations weren't being met.
