### PR TITLE
Maint/2.7.x/strip incorrect rights statements

### DIFF
--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -1,6 +1,3 @@
-#  Created by Luke Kanies on 2006-04-30.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'puppet/util/feature'
 
 # Add the simple features, all in one file.

--- a/lib/puppet/feature/rails.rb
+++ b/lib/puppet/feature/rails.rb
@@ -1,6 +1,3 @@
-#  Created by Luke Kanies on 2006-11-07.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'puppet/util/feature'
 
 Puppet.features.rubygems?

--- a/lib/puppet/feature/rubygems.rb
+++ b/lib/puppet/feature/rubygems.rb
@@ -1,6 +1,3 @@
-#  Created by Luke Kanies on 2006-11-07.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'puppet/util/feature'
 
 Puppet.features.add(:rubygems, :libs => "rubygems")

--- a/lib/puppet/file_serving.rb
+++ b/lib/puppet/file_serving.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-16.
-#  Copyright (c) 2007. All rights reserved.
-
 # Just a stub class.
 class Puppet::FileServing # :nodoc:
 end

--- a/lib/puppet/file_serving/base.rb
+++ b/lib/puppet/file_serving/base.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-22.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving'
 
 # The base class for Content and Metadata; provides common

--- a/lib/puppet/file_serving/configuration.rb
+++ b/lib/puppet/file_serving/configuration.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-16.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet'
 require 'puppet/file_serving'
 require 'puppet/file_serving/mount'

--- a/lib/puppet/file_serving/content.rb
+++ b/lib/puppet/file_serving/content.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-16.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/indirector'
 require 'puppet/file_serving'
 require 'puppet/file_serving/base'

--- a/lib/puppet/file_serving/fileset.rb
+++ b/lib/puppet/file_serving/fileset.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-22.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'find'
 require 'puppet/file_serving'
 require 'puppet/file_serving/metadata'

--- a/lib/puppet/file_serving/indirection_hooks.rb
+++ b/lib/puppet/file_serving/indirection_hooks.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'uri'
 require 'puppet/file_serving'
 

--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-16.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet'
 require 'puppet/indirector'
 require 'puppet/file_serving'

--- a/lib/puppet/file_serving/mount.rb
+++ b/lib/puppet/file_serving/mount.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-16.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/network/authstore'
 require 'puppet/util/logging'
 require 'puppet/util/cacher'

--- a/lib/puppet/file_serving/terminus_helper.rb
+++ b/lib/puppet/file_serving/terminus_helper.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-22.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving'
 require 'puppet/file_serving/fileset'
 

--- a/lib/puppet/indirector/direct_file_server.rb
+++ b/lib/puppet/indirector/direct_file_server.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-24.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving/terminus_helper'
 require 'puppet/indirector/terminus'
 

--- a/lib/puppet/indirector/file_content/file.rb
+++ b/lib/puppet/indirector/file_content/file.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-16.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving/content'
 require 'puppet/indirector/file_content'
 require 'puppet/indirector/direct_file_server'

--- a/lib/puppet/indirector/file_content/file_server.rb
+++ b/lib/puppet/indirector/file_content/file_server.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving/content'
 require 'puppet/indirector/file_content'
 require 'puppet/indirector/file_server'

--- a/lib/puppet/indirector/file_content/rest.rb
+++ b/lib/puppet/indirector/file_content/rest.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving/content'
 require 'puppet/indirector/file_content'
 require 'puppet/indirector/rest'

--- a/lib/puppet/indirector/file_metadata/file.rb
+++ b/lib/puppet/indirector/file_metadata/file.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-16.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving/metadata'
 require 'puppet/indirector/file_metadata'
 require 'puppet/indirector/direct_file_server'

--- a/lib/puppet/indirector/file_metadata/file_server.rb
+++ b/lib/puppet/indirector/file_metadata/file_server.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving/metadata'
 require 'puppet/indirector/file_metadata'
 require 'puppet/indirector/file_server'

--- a/lib/puppet/indirector/file_metadata/rest.rb
+++ b/lib/puppet/indirector/file_metadata/rest.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving/metadata'
 require 'puppet/indirector/file_metadata'
 require 'puppet/indirector/rest'

--- a/lib/puppet/indirector/file_server.rb
+++ b/lib/puppet/indirector/file_server.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2007-10-19.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/file_serving/configuration'
 require 'puppet/file_serving/fileset'
 require 'puppet/file_serving/terminus_helper'

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -1,6 +1,3 @@
-#  Created by Luke A. Kanies on 2007-08-13.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet/node'
 require 'puppet/resource/catalog'
 require 'puppet/util/errors'

--- a/lib/puppet/provider/mount.rb
+++ b/lib/puppet/provider/mount.rb
@@ -1,6 +1,3 @@
-#  Created by Luke Kanies on 2006-11-12.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'puppet'
 
 # A module just to store the mount/unmount methods.  Individual providers

--- a/lib/puppet/provider/naginator.rb
+++ b/lib/puppet/provider/naginator.rb
@@ -1,6 +1,3 @@
-#  Created by Luke Kanies on 2007-11-27.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppet'
 require 'puppet/provider/parsedfile'
 require 'puppet/external/nagios'

--- a/lib/puppet/provider/package.rb
+++ b/lib/puppet/provider/package.rb
@@ -1,6 +1,3 @@
-#  Created by Luke A. Kanies on 2007-06-05.
-#  Copyright (c) 2007. All rights reserved.
-
 class Puppet::Provider::Package < Puppet::Provider
   # Prefetch our package list, yo.
   def self.prefetch(packages)

--- a/lib/puppet/relationship.rb
+++ b/lib/puppet/relationship.rb
@@ -1,7 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke A. Kanies on 2006-11-24.
-#  Copyright (c) 2006. All rights reserved.
 
 # subscriptions are permanent associations determining how different
 # objects react to an event

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -1,6 +1,3 @@
-#  Created by Luke Kanies on 2006-11-07.
-#  Copyright (c) 2006. All rights reserved.
-
 class Puppet::Util::Feature
   attr_reader :path
 

--- a/lib/puppet/util/graph.rb
+++ b/lib/puppet/util/graph.rb
@@ -1,6 +1,3 @@
-#  Created by Luke Kanies on 2006-11-16.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'puppet'
 require 'puppet/simple_graph'
 

--- a/lib/puppet/util/ldap.rb
+++ b/lib/puppet/util/ldap.rb
@@ -1,5 +1,2 @@
-#
-#  Created by Luke Kanies on 2008-3-23.
-#  Copyright (c) 2008. All rights reserved.
 module Puppet::Util::Ldap
 end

--- a/lib/puppet/util/ldap/connection.rb
+++ b/lib/puppet/util/ldap/connection.rb
@@ -1,6 +1,3 @@
-#
-#  Created by Luke Kanies on 2008-3-23.
-#  Copyright (c) 2008. All rights reserved.
 require 'puppet/util/ldap'
 
 class Puppet::Util::Ldap::Connection

--- a/lib/puppet/util/ldap/generator.rb
+++ b/lib/puppet/util/ldap/generator.rb
@@ -1,6 +1,3 @@
-#
-#  Created by Luke Kanies on 2008-3-28.
-#  Copyright (c) 2008. All rights reserved.
 require 'puppet/util/ldap'
 
 class Puppet::Util::Ldap::Generator

--- a/lib/puppet/util/log_paths.rb
+++ b/lib/puppet/util/log_paths.rb
@@ -1,6 +1,3 @@
-#  Created by Luke Kanies on 2007-07-04.
-#  Copyright (c) 2007. All rights reserved.
-
 module Puppet::Util::LogPaths
   # return the full path to us, for logging and rollback
   # some classes (e.g., FileTypeRecords) will have to override this

--- a/spec/integration/file_serving/content_spec.rb
+++ b/spec/integration/file_serving/content_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/file_serving/content'

--- a/spec/integration/file_serving/metadata_spec.rb
+++ b/spec/integration/file_serving/metadata_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/file_serving/metadata'

--- a/spec/integration/indirector/direct_file_server_spec.rb
+++ b/spec/integration/indirector/direct_file_server_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-19.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/file_content/file'

--- a/spec/integration/indirector/file_content/file_server_spec.rb
+++ b/spec/integration/indirector/file_content/file_server_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/file_content/file_server'

--- a/spec/integration/indirector/file_metadata/file_server_spec.rb
+++ b/spec/integration/indirector/file_metadata/file_server_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/file_metadata/file_server'

--- a/spec/integration/node/facts_spec.rb
+++ b/spec/integration/node/facts_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-4-8.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 describe Puppet::Node::Facts do

--- a/spec/integration/node_spec.rb
+++ b/spec/integration/node_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-9-23.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/node'

--- a/spec/integration/reports_spec.rb
+++ b/spec/integration/reports_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-12.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/reports'

--- a/spec/integration/resource/catalog_spec.rb
+++ b/spec/integration/resource/catalog_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-4-8.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 describe Puppet::Resource::Catalog do

--- a/spec/integration/ssl/certificate_authority_spec.rb
+++ b/spec/integration/ssl/certificate_authority_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-4-17.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/ssl/certificate_authority'

--- a/spec/integration/ssl/certificate_request_spec.rb
+++ b/spec/integration/ssl/certificate_request_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-4-17.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/ssl/certificate_request'

--- a/spec/integration/ssl/certificate_revocation_list_spec.rb
+++ b/spec/integration/ssl/certificate_revocation_list_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-5-5.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/ssl/certificate_revocation_list'

--- a/spec/integration/ssl/host_spec.rb
+++ b/spec/integration/ssl/host_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-4-17.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/ssl/host'

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-4-8.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 describe Puppet::Transaction::Report do

--- a/spec/shared_behaviours/file_server_terminus.rb
+++ b/spec/shared_behaviours/file_server_terminus.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 shared_examples_for "Puppet::Indirector::FileServerTerminus" do
   # This only works if the shared behaviour is included before
   # the 'before' block in the including context.

--- a/spec/shared_behaviours/file_serving.rb
+++ b/spec/shared_behaviours/file_serving.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 shared_examples_for "Puppet::FileServing::Files" do
   it "should use the rest terminus when the 'puppet' URI scheme is used and a host name is present" do
     uri = "puppet://myhost/fakemod/my/file"

--- a/spec/shared_behaviours/memory_terminus.rb
+++ b/spec/shared_behaviours/memory_terminus.rb
@@ -1,7 +1,3 @@
-#
-#  Created by Luke Kanies on 2008-4-8.
-#  Copyright (c) 2008. All rights reserved.
-
 shared_examples_for "A Memory Terminus" do
   it "should find no instances by default" do
     @searcher.find(@request).should be_nil

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-11-12.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 require 'puppet/agent'
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-11-12.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 require 'puppet/configurer'
 

--- a/spec/unit/file_serving/indirection_hooks_spec.rb
+++ b/spec/unit/file_serving/indirection_hooks_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/file_serving/indirection_hooks'

--- a/spec/unit/file_serving/terminus_helper_spec.rb
+++ b/spec/unit/file_serving/terminus_helper_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-22.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/file_serving/terminus_helper'

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-9-23.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/catalog/compiler'

--- a/spec/unit/indirector/certificate/ca_spec.rb
+++ b/spec/unit/indirector/certificate/ca_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-7.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/certificate/ca'

--- a/spec/unit/indirector/certificate/file_spec.rb
+++ b/spec/unit/indirector/certificate/file_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-7.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/certificate/file'

--- a/spec/unit/indirector/certificate_request/ca_spec.rb
+++ b/spec/unit/indirector/certificate_request/ca_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-7.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/ssl/host'

--- a/spec/unit/indirector/certificate_request/file_spec.rb
+++ b/spec/unit/indirector/certificate_request/file_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-7.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/certificate_request/file'

--- a/spec/unit/indirector/certificate_revocation_list/ca_spec.rb
+++ b/spec/unit/indirector/certificate_revocation_list/ca_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-7.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/certificate_revocation_list/ca'

--- a/spec/unit/indirector/certificate_revocation_list/file_spec.rb
+++ b/spec/unit/indirector/certificate_revocation_list/file_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-7.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/certificate_revocation_list/file'

--- a/spec/unit/indirector/direct_file_server_spec.rb
+++ b/spec/unit/indirector/direct_file_server_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-24.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/direct_file_server'

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-9-23.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/facts/facter'

--- a/spec/unit/indirector/file_content/file_server_spec.rb
+++ b/spec/unit/indirector/file_content/file_server_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/file_content/file_server'

--- a/spec/unit/indirector/file_content/file_spec.rb
+++ b/spec/unit/indirector/file_content/file_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/file_content/file'

--- a/spec/unit/indirector/file_metadata/file_server_spec.rb
+++ b/spec/unit/indirector/file_metadata/file_server_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/file_metadata/file_server'

--- a/spec/unit/indirector/file_metadata/file_spec.rb
+++ b/spec/unit/indirector/file_metadata/file_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/file_metadata/file'

--- a/spec/unit/indirector/file_server_spec.rb
+++ b/spec/unit/indirector/file_server_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-10-19.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/file_server'

--- a/spec/unit/indirector/key/ca_spec.rb
+++ b/spec/unit/indirector/key/ca_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-7.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/key/ca'

--- a/spec/unit/indirector/key/file_spec.rb
+++ b/spec/unit/indirector/key/file_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-7.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/key/file'

--- a/spec/unit/indirector/report/processor_spec.rb
+++ b/spec/unit/indirector/report/processor_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-9-23.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/report/processor'

--- a/spec/unit/indirector/ssl_file_spec.rb
+++ b/spec/unit/indirector/ssl_file_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-10.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/indirector/ssl_file'

--- a/spec/unit/network/client_spec.rb
+++ b/spec/unit/network/client_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-24.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/network/client'

--- a/spec/unit/network/http/mongrel_spec.rb
+++ b/spec/unit/network/http/mongrel_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Rick Bradley on 2007-10-15.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 require 'puppet/network/http'
 

--- a/spec/unit/network/http/webrick_spec.rb
+++ b/spec/unit/network/http/webrick_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Rick Bradley on 2007-10-15.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 require 'puppet/network/handler'
 require 'puppet/network/http'

--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-11-26.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 require 'puppet/network/http_pool'
 

--- a/spec/unit/network/http_spec.rb
+++ b/spec/unit/network/http_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Rick Bradley on 2007-10-03.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/network/http'

--- a/spec/unit/network/server_spec.rb
+++ b/spec/unit/network/server_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Rick Bradley on 2007-10-03.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 require 'puppet/network/server'
 require 'puppet/network/handler'

--- a/spec/unit/provider/group/ldap_spec.rb
+++ b/spec/unit/provider/group/ldap_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-10.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:group).provider(:ldap)

--- a/spec/unit/provider/ldap_spec.rb
+++ b/spec/unit/provider/ldap_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-21.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/provider/ldap'

--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-9-12.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'spec_helper'
 require 'shared_behaviours/all_parsedfile_providers'
 

--- a/spec/unit/provider/user/ldap_spec.rb
+++ b/spec/unit/provider/user/ldap_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-10.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:user).provider(:ldap)

--- a/spec/unit/relationship_spec.rb
+++ b/spec/unit/relationship_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-11-1.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'spec_helper'
 require 'puppet/relationship'
 

--- a/spec/unit/simple_graph_spec.rb
+++ b/spec/unit/simple_graph_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-11-1.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'spec_helper'
 require 'puppet/simple_graph'
 

--- a/spec/unit/util/checksums_spec.rb
+++ b/spec/unit/util/checksums_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-9-22.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/util/checksums'

--- a/spec/unit/util/constant_inflector_spec.rb
+++ b/spec/unit/util/constant_inflector_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-02-12.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/util/constant_inflector'

--- a/spec/unit/util/ldap/connection_spec.rb
+++ b/spec/unit/util/ldap/connection_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-19.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/util/ldap/connection'

--- a/spec/unit/util/ldap/generator_spec.rb
+++ b/spec/unit/util/ldap/generator_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-28.
-#  Copyright (c) 2008. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/util/ldap/generator'

--- a/spec/unit/util/ldap/manager_spec.rb
+++ b/spec/unit/util/ldap/manager_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-3-19.
-#  Copyright (c) 2006. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/util/ldap/manager'

--- a/spec/unit/util/nagios_maker_spec.rb
+++ b/spec/unit/util/nagios_maker_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2007-11-18.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/util/nagios_maker'

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env rspec
-#
-#  Created by Luke Kanies on 2008-01-19.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'spec_helper'
 
 require 'puppet/util/tagging'

--- a/test/language/ast/variable.rb
+++ b/test/language/ast/variable.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke A. Kanies on 2007-0419.
-#  Copyright (c) 2006. All rights reserved.
-
 require File.expand_path(File.dirname(__FILE__) + '/../../lib/puppettest')
 
 require 'puppettest'

--- a/test/lib/puppettest/support/resources.rb
+++ b/test/lib/puppettest/support/resources.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke A. Kanies on 2006-11-29.
-#  Copyright (c) 2006. All rights reserved.
-
 module PuppetTest::Support::Resources
   def tree_resource(name)
     Puppet::Type.type(:file).new :title => name, :path => "/tmp/#{name}", :mode => 0755

--- a/test/lib/puppettest/testcase.rb
+++ b/test/lib/puppettest/testcase.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke A. Kanies on 2007-03-05.
-#  Copyright (c) 2007. All rights reserved.
-
 require 'puppettest'
 require 'puppettest/runnable_test'
 require 'test/unit'

--- a/test/ral/manager/attributes.rb
+++ b/test/ral/manager/attributes.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke A. Kanies on 2007-02-05.
-#  Copyright (c) 2007. All rights reserved.
-
 require File.expand_path(File.dirname(__FILE__) + '/../../lib/puppettest')
 
 require 'puppettest'

--- a/test/ral/manager/instances.rb
+++ b/test/ral/manager/instances.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke A. Kanies on 2007-06-10.
-#  Copyright (c) 2007. All rights reserved.
-
 require File.expand_path(File.dirname(__FILE__) + '/../../lib/puppettest')
 
 require 'puppettest'

--- a/test/ral/manager/manager.rb
+++ b/test/ral/manager/manager.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke A. Kanies on 2006-11-29.
-#  Copyright (c) 2006. All rights reserved.
-
 require File.expand_path(File.dirname(__FILE__) + '/../../lib/puppettest')
 
 require 'puppettest'

--- a/test/ral/providers/service/base.rb
+++ b/test/ral/providers/service/base.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke A. Kanies on 2007-01-28.
-#  Copyright (c) 2007. All rights reserved.
-
 require File.expand_path(File.dirname(__FILE__) + '/../../../lib/puppettest')
 
 require 'puppettest'

--- a/test/ral/type/resources.rb
+++ b/test/ral/type/resources.rb
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Created by Luke Kanies on 2006-12-12.
-#  Copyright (c) 2006. All rights reserved.
-
 require File.expand_path(File.dirname(__FILE__) + '/../../lib/puppettest')
 
 require 'puppettest'


### PR DESCRIPTION
For a while Luke, and other authors, injected a created tag, copyright
statement, and "All rights reserved" into every new file they added to the
Puppet project.

This isn't really true, and we have a global license covering the code, so
we have now stripped out all those old tags.
