### PR TITLE
Maint/2.7.x/ssl file spec test failure

### DIFF
--- a/spec/unit/indirector/ssl_file_spec.rb
+++ b/spec/unit/indirector/ssl_file_spec.rb
@@ -19,7 +19,7 @@ describe Puppet::Indirector::SslFile do
 
     @setting = :certdir
     @file_class.store_in @setting
-    @path = make_absolute("/tmp/my_directory")
+    @path = make_absolute("/thisdoesntexist/my_directory")
     Puppet[:noop] = false
     Puppet[@setting] = @path
     Puppet[:trace] = false
@@ -43,7 +43,9 @@ describe Puppet::Indirector::SslFile do
   it "should fail if no store directory or file location has been set" do
     @file_class.store_in nil
     @file_class.store_at nil
-    lambda { @file_class.new }.should raise_error(Puppet::DevError)
+    FileTest.expects(:exists?).with(File.dirname(@path)).at_least(0).returns(true)
+    Dir.stubs(:mkdir).with(@path)
+    lambda { @file_class.new }.should raise_error(Puppet::DevError, /No file or directory setting provided/)
   end
 
   describe "when managing ssl files" do


### PR DESCRIPTION
One of the spec tests required that the parent directory (in this case
/tmp) already existed and that /tmp/my_directory could be created. This
fails on Windows as /tmp likely doesn't exist, and also the test
doesn't actually need to create the directory.

This commit forces the call to exists? with the parent directory to
return true, and stubs the mkdir call so that the directory is not
actually created.

It also makes the raise_error expectation look for the specific error
message, instead of a generic DevError.
