### PR TITLE
Ticket/2.7.x/9174

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -244,7 +244,12 @@ def prepare_installation
   if not InstallOptions.configdir.nil?
     configdir = InstallOptions.configdir
   elsif $operatingsystem == "windows"
-    require 'win32/dir'
+    begin
+      require 'win32/dir'
+    rescue LoadError => e
+      puts "Cannot run on Microsoft Windows without the sys-admin, win32-process, win32-dir & win32-service gems: #{e}"
+      exit -1
+    end
     configdir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "etc")
   else
     configdir = "/etc/puppet"


### PR DESCRIPTION
(#9174) Provide a helpful error when missing a gem and installing on Windows

We require the sys-admin, win32-process, win32-dir, and win32-service
gems in order to run on Windows, and the win32-dir gem to install.
Previously, failing to require the win32-dir gem would just raise an
exception and fail. Now we catch it, and turn it into a more helpful
explanation of the requirements.
