### PR TITLE
Fixed #663 - Changed default certificate key length and hash

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -368,9 +368,9 @@ module Puppet
       's' (seconds). The unit defaults to seconds. If this parameter
       is set, ca_days is ignored. Examples are '3600' (one hour)
       and '1825d', which is the same as '5y' (5 years) "],
-    :ca_md => ["md5", "The type of hash used in certificates."],
+    :ca_md => ["sha256", "The type of hash used in certificates."],
     :req_bits => [2048, "The bit length of the certificates."],
-    :keylength => [1024, "The bit length of keys."],
+    :keylength => [2048, "The bit length of keys."],
     :cert_inventory => {
       :default => "$cadir/inventory.txt",
       :mode => 0644,

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -239,7 +239,7 @@ class Puppet::SSL::CertificateAuthority
 
     cert = Puppet::SSL::Certificate.new(hostname)
     cert.content = Puppet::SSL::CertificateFactory.new(cert_type, csr.content, issuer, next_serial).result
-    cert.content.sign(host.key.content, OpenSSL::Digest::SHA1.new)
+    cert.content.sign(host.key.content, OpenSSL::Digest::SHA256.new)
 
     Puppet.notice "Signed certificate request for #{hostname}"
 

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -51,7 +51,7 @@ class Puppet::SSL::CertificateRequest < Puppet::SSL::Base
     csr.version = 0
     csr.subject = OpenSSL::X509::Name.new([["CN", common_name]])
     csr.public_key = key.public_key
-    csr.sign(key, OpenSSL::Digest::MD5.new)
+    csr.sign(key, OpenSSL::Digest::SHA256.new)
 
     raise Puppet::Error, "CSR sign verification failed; you need to clean the certificate request for #{name} on the server" unless csr.verify(key.public_key)
 

--- a/lib/puppet/ssl/certificate_revocation_list.rb
+++ b/lib/puppet/ssl/certificate_revocation_list.rb
@@ -38,7 +38,7 @@ class Puppet::SSL::CertificateRevocationList < Puppet::SSL::Base
     # Keep CRL valid for 5 years
     @content.next_update = Time.now + 5 * 365*24*60*60
 
-    @content.sign(cakey, OpenSSL::Digest::SHA1.new)
+    @content.sign(cakey, OpenSSL::Digest::SHA256.new)
 
     @content
   end
@@ -77,7 +77,7 @@ class Puppet::SSL::CertificateRevocationList < Puppet::SSL::Base
     # Keep CRL valid for 5 years
     @content.next_update = time + 5 * 365*24*60*60
 
-    @content.sign(cakey, OpenSSL::Digest::SHA1.new)
+    @content.sign(cakey, OpenSSL::Digest::SHA256.new)
 
     Puppet::SSL::CertificateRevocationList.indirection.save(self)
   end

--- a/lib/puppet/sslcertificates/ca.rb
+++ b/lib/puppet/sslcertificates/ca.rb
@@ -57,9 +57,6 @@ class Puppet::SSLCertificates::CA
 
     if Puppet[:capass]
       if FileTest.exists?(Puppet[:capass])
-        #puts "Reading #{Puppet[:capass]}"
-        #system "ls -al #{Puppet[:capass]}"
-        #File.read Puppet[:capass]
         @config[:password] = self.getpass
       else
         # Don't create a password if the cert already exists
@@ -350,7 +347,7 @@ class Puppet::SSLCertificates::CA
     end
   end
 
-  def sign_with_key(signable, digest = OpenSSL::Digest::SHA1.new)
+  def sign_with_key(signable, digest = OpenSSL::Digest::SHA256.new)
     cakey = nil
     if @config[:password]
       begin

--- a/lib/puppet/sslcertificates/support.rb
+++ b/lib/puppet/sslcertificates/support.rb
@@ -72,7 +72,7 @@ module Puppet::SSLCertificates::Support
     csr.version = 0
     csr.subject = OpenSSL::X509::Name.new([["CN", Puppet[:certname]]])
     csr.public_key = key.public_key
-    csr.sign(key, OpenSSL::Digest::MD5.new)
+    csr.sign(key, OpenSSL::Digest::SHA256.new)
 
     return csr
   end
@@ -101,8 +101,6 @@ module Puppet::SSLCertificates::Support
     end
     Puppet.settings.write(:hostcert) do |f| f.print cert end
     Puppet.settings.write(:localcacert) do |f| f.print cacert end
-    #File.open(@certfile, "w", 0644) { |f| f.print cert }
-    #File.open(@cacertfile, "w", 0644) { |f| f.print cacert }
     begin
       @cert = OpenSSL::X509::Certificate.new(cert)
       @cacert = OpenSSL::X509::Certificate.new(cacert)

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -380,7 +380,7 @@ describe Puppet::SSL::CertificateAuthority do
 
       it "should sign the resulting certificate using its real key and a digest" do
         digest = mock 'digest'
-        OpenSSL::Digest::SHA1.expects(:new).returns digest
+        OpenSSL::Digest::SHA256.expects(:new).returns digest
 
         key = stub 'key', :content => "real_key"
         @ca.host.stubs(:key).returns key

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -146,7 +146,7 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should sign the csr with the provided key and a digest" do
       digest = mock 'digest'
-      OpenSSL::Digest::MD5.expects(:new).returns(digest)
+      OpenSSL::Digest::SHA256.expects(:new).returns(digest)
       @request.expects(:sign).with(@key, digest)
       @instance.generate(@key)
     end

--- a/spec/unit/ssl/certificate_revocation_list_spec.rb
+++ b/spec/unit/ssl/certificate_revocation_list_spec.rb
@@ -155,7 +155,7 @@ describe Puppet::SSL::CertificateRevocationList do
     end
 
     it "should sign the CRL with the CA's private key and a digest instance" do
-      @crl.content.expects(:sign).with { |key, digest| key == @key and digest.is_a?(OpenSSL::Digest::SHA1) }
+      @crl.content.expects(:sign).with { |key, digest| key == @key and digest.is_a?(OpenSSL::Digest::SHA256) }
       @crl.revoke(1, @key)
     end
 


### PR DESCRIPTION
Updated Puppet to use 2048-bit keys and SHA256 for all hashing related
to key signing.  Tests updated also but no additional tests added.
