### PR TITLE
Fixed #2043 - up2date provider should split off architecture

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -123,6 +123,9 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
   def self.nevra_to_hash(line)
     line.chomp!
     hash = {}
+    if line == ""
+      return hash
+    end
     NEVRA_FIELDS.zip(line.split) { |f, v| hash[f] = v }
     hash[:provider] = self.name
     hash[:ensure] = "#{hash[:version]}-#{hash[:release]}"


### PR DESCRIPTION
Patch from: James Cammarata

Just came across an issue where I had to install pam.i386 as well as
pam.x86_64 on a RHEL4 machine (via up2date). With the yum provider you
can simply

package { “pam.i386”: }

Because the underlying command is understood by yum yum -y install
pam.i386

With up to date this fails up2date-nox -i pam.i386

You need to up2date —arch=i386 pam

The provider will determine if the name end in an architecture by way of
a long regexp of known architectures. Splitting off via the dots is
unreliable as some package names do have a dot in them.
