### PR TITLE
(#8413) Properly clean up stale pidfile on Windows 

### DIFF
--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -61,7 +61,7 @@ class Puppet::Util::Pidlock
 
     begin
       Process.kill(0, lock_pid)
-    rescue Errno::ESRCH
+    rescue Errno::ESRCH, Process::Error
       File.unlink(@lockfile)
     end
   end


### PR DESCRIPTION
This code uses 'kill 0' to determine whether a process is running with
the pid found in the pidfile. Typically, that will raise Errno::ESRCH if
no such process is running. However, the win32-process gem on Windows
changes this behavior to raise Process::Error instead. Thus, we need to
also catch Process::Error.
