### PR TITLE
Ticket/2.7.x/8662 elevated priv check fails on 2k3 r2

### DIFF
--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -41,13 +41,13 @@ module Puppet::Util::SUIDManager
 
     require 'sys/admin'
     require 'win32/security'
+    require 'facter'
+
+    majversion = Facter.value(:kernelmajversion)
+    return false unless majversion
 
     # if Vista or later, check for unrestricted process token
-    begin
-      return Win32::Security.elevated_security?
-    rescue Win32::Security::Error => e
-      raise e unless e.to_s =~ /Incorrect function/i
-    end
+    return Win32::Security.elevated_security? unless majversion.to_f < 6.0
 
     group = Sys::Admin.get_group("Administrators", :sid => Win32::Security::SID::BuiltinAdministrators)
     group and group.members.index(Sys::Admin.get_login) != nil

--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -250,19 +250,23 @@ describe Puppet::Util::SUIDManager do
 
     describe "on Microsoft Windows", :if => Puppet.features.microsoft_windows? do
       describe "2003 without UAC" do
+        before :each do
+          Facter.stubs(:value).with(:kernelmajversion).returns("5.2")
+        end
+
         it "should be root if user is a member of the Administrators group" do
-          Win32::Security.stubs(:elevated_security?).raises(Win32::Security::Error, "Incorrect function.")
           Sys::Admin.stubs(:get_login).returns("Administrator")
           Sys::Group.stubs(:members).returns(%w[Administrator])
 
+          Win32::Security.expects(:elevated_security?).never
           Puppet::Util::SUIDManager.should be_root
         end
 
         it "should not be root if the process is running as Guest" do
-          Win32::Security.stubs(:elevated_security?).raises(Win32::Security::Error, "Incorrect function.")
           Sys::Admin.stubs(:get_login).returns("Guest")
           Sys::Group.stubs(:members).returns([])
 
+          Win32::Security.expects(:elevated_security?).never
           Puppet::Util::SUIDManager.should_not be_root
         end
 
@@ -276,6 +280,10 @@ describe Puppet::Util::SUIDManager do
       end
 
       describe "2008 with UAC" do
+        before :each do
+          Facter.stubs(:value).with(:kernelmajversion).returns("6.0")
+        end
+
         it "should be root if user is running with elevated privileges" do
           Win32::Security.stubs(:elevated_security?).returns(true)
           Sys::Admin.expects(:get_login).never


### PR DESCRIPTION
The call to Win32::Security.elevated_privileges? can raise an
exception when running on a pre-Vista computer or if the process fails
to open its process token.

Previously, we were looking at the exception message to determine
which case it was. However, Windows 2003 and 2003 R2 return different
error codes (and therefore messages) for the pre-Vista case. In 2003,
it returns error code 1 (Incorrect function), but in 2003 R2 it
returns 87 (The parameter is incorrect). Since SUIDManager was only
looking for Incorrect function, SUIDManager.root? would always return
false on 2003 R2.

Ideally, we could just check if the GetTokenInformation Win32 API was
available, and only call it on platforms where it makes sense. But
this API is available on all recent version of Windows. What's new in
Vista and up is the TokenElevation value of the
TOKEN_INFORMATION_CLASS enumeration.

This commit changes the suidmanager to only call GetTokenInformation
when the major kernel version, as reported by facter, is 6.0 or
greater, which corresponds to Vista/2008. See:

http://msdn.microsoft.com/en-us/library/ms724833(v=vs.85).aspx
