### PR TITLE
Fixed #9258 - Puppet Rack logging

### DIFF
--- a/lib/puppet/network/http/rack.rb
+++ b/lib/puppet/network/http/rack.rb
@@ -10,6 +10,7 @@ require 'puppet/network/http/rack/xmlrpc'
 class Puppet::Network::HTTP::Rack
 
   def initialize(args)
+    Puppet::Util::Log.reopen
     raise ArgumentError, ":protocols must be specified." if !args[:protocols] or args[:protocols].empty?
     protocols = args[:protocols]
 

--- a/spec/unit/network/http/rack_spec.rb
+++ b/spec/unit/network/http/rack_spec.rb
@@ -6,6 +6,11 @@ require 'puppet/network/http/rack' if Puppet.features.rack?
 describe "Puppet::Network::HTTP::Rack", :if => Puppet.features.rack? do
   describe "while initializing" do
 
+    it "should reopen logs" do
+      Puppet::Util::Log.expects(:reopen)
+      Puppet::Network::HTTP::Rack.new({:protocols => [:rest]})
+    end
+
     it "should require a protocol specification" do
       Proc.new { Puppet::Network::HTTP::Rack.new({}) }.should raise_error(ArgumentError)
     end


### PR DESCRIPTION
Puppet Master as Rack application ignores syslogfacility

Attempting to define a syslogfacility in the config file (under [main]
or [master], makes no difference) or in ARGV in rack/config.ru when
running Puppet as Rack app through Passenger will not apply the setting,
and it will stubbornly log with the default settings to syslog.

This can be traced back to the fact that both daemon.rb and
network/server.rb (during daemonize) call Puppet::Util::Log.reopen, but
when using Rack, network/http/rack.rb will be used, which never does.

This add reopen to rack.rb and a test
