### PR TITLE
Feature/2.7.x/9051 storeconfig backend should be configurable

### DIFF
--- a/spec/unit/parser/collector_spec.rb
+++ b/spec/unit/parser/collector_spec.rb
@@ -287,6 +287,8 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
 
   context "with storeconfigs enabled" do
     before :each do
+      ActiveRecord::Base.remove_connection
+
       dir = Pathname(tmpdir('puppet-var'))
       Puppet[:vardir]       = dir.to_s
       Puppet[:dbadapter]    = 'sqlite3'


### PR DESCRIPTION
```
Debug order-dependent test failures in CI / ActiveRecord.

At this point it looks like the only remaining cause of the ActiveRecord
failures could be that someone is leaking an active database handle in
ActiveRecord from an unrelated test.

The theory is that if the handle is open, SQLite will try to create a lock
file in a directory that no longer exists during the test; this raises the I/O
error we see here.

To verify this, which can currently only be reproduced in the CI system, we
close off any active handle before changing the database location settings.
```
