### PR TITLE
(#8413) Only try to catch Process::Error if it's defined 

### DIFF
--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -59,9 +59,13 @@ class Puppet::Util::Pidlock
   def clear_if_stale
     return if lock_pid.nil?
 
+    errors = [Errno::ESRCH]
+    # Process::Error can only happen, and is only defined, on Windows
+    errors << Process::Error if defined? Process::Error
+
     begin
       Process.kill(0, lock_pid)
-    rescue Errno::ESRCH, Process::Error
+    rescue *errors
       File.unlink(@lockfile)
     end
   end


### PR DESCRIPTION
This error class is only defined when using the win32-process gem on
Windows. So rather than always trying to rescue Process::Error (which of
course causes its own error), we build a list of classes to rescue,
which initially only contains Errno::ESRCH, and add Process::Error if
it exists.
