### PR TITLE
Feature/2.7.x/5421

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -261,13 +261,18 @@ Puppet::Type.newtype(:file) do
 
   # Autorequire the nearest ancestor directory found in the catalog.
   autorequire(:file) do
+    req = []
     path = Pathname.new(self[:path])
     if !path.root?
       # Start at our parent, to avoid autorequiring ourself
       parents = path.parent.enum_for(:ascend)
-      found = parents.find { |p| catalog.resource(:file, p.to_s) }
-      found and found.to_s
+      if found = parents.find { |p| catalog.resource(:file, p.to_s) }
+        req << found.to_s
+      end
     end
+    # if the resource is a link, make sure the target is created first
+    req << self[:target] if self[:target]
+    req
   end
 
   # Autorequire the owner and group of the file.

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1253,6 +1253,36 @@ describe Puppet::Type.type(:file) do
   end
 
   describe "when autorequiring" do
+    describe "target" do
+      it "should require file resource when specified with the target property" do
+        file = described_class.new(:path => "/foo", :ensure => :directory)
+        link = described_class.new(:path => "/bar", :ensure => :symlink, :target => "/foo")
+        catalog.add_resource file
+        catalog.add_resource link
+        reqs = link.autorequire
+        reqs.size.must == 1
+        reqs[0].source.must == file
+        reqs[0].target.must == link
+      end
+
+      it "should require file resource when specified with the ensure property" do
+        file = described_class.new(:path => "/foo", :ensure => :directory)
+        link = described_class.new(:path => "/bar", :ensure => "/foo")
+        catalog.add_resource file
+        catalog.add_resource link
+        reqs = link.autorequire
+        reqs.size.must == 1
+        reqs[0].source.must == file
+        reqs[0].target.must == link
+      end
+
+      it "should not require target if target is not managed" do
+        link = described_class.new(:path => '/foo', :ensure => :symlink, :target => '/bar')
+        catalog.add_resource link
+        link.autorequire.size.should == 0
+      end
+    end
+
     describe "directories" do
       it "should autorequire its parent directory" do
         dir = described_class.new(:path => File.dirname(path))


### PR DESCRIPTION
When we manage a local link to a directory and the target directory is
managed by puppet as well, establish an autorequire. So if we have
something like

  file { '/foo': ensure => directory }
  file { '/link_to_foo': ensure => '/foo' }
  file { '/link_to_foo/bar': ensure => file }

we can ensure that puppet does not create dead links and does not try to
create '/link_to_foo/bar' before /foo is created.
