### PR TITLE
Tickets/2.7.x/9143 make macauthorization work on lion

### DIFF
--- a/lib/puppet/provider/macauthorization/macauthorization.rb
+++ b/lib/puppet/provider/macauthorization/macauthorization.rb
@@ -14,13 +14,13 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
 
   confine :operatingsystem => :darwin
 
-  # This should be confined based on macosx_productversion once
-  # http://projects.reductivelabs.com/issues/show/1796
-  # is resolved.
+  # This should be confined based on macosx_productversion
+  # but puppet resource doesn't make the facts available and
+  # that interface is heavily used with this provider.
   if FileTest.exists?("/usr/bin/sw_vers")
     product_version = sw_vers "-productVersion"
 
-    confine :true => if /^10.5/.match(product_version) or /^10.6/.match(product_version)
+    confine :true => unless /^10\.[0-4]/.match(product_version)
       true
     end
   end


### PR DESCRIPTION
We've flipped around the confine check so we explicitly exclude the
versions of OS X where this provider won't work, rather than working
from a whitelist.
