### PR TITLE
Tickets/2.7.x/9192 launchd fix

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -54,14 +54,19 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     "/System/Library/LaunchDaemons",]
 
   Launchd_Overrides = "/var/db/launchd.db/com.apple.launchd/overrides.plist"
+
+  if Facter.value(:macosx_productversion_major)
+    @product_version = Facter.value(:macosx_productversion_major)
+  else
+    @product_version = sw_vers "-productVersion"
+  end
   
   # Launchd implemented plist overrides in version 10.6.
   # This method checks the major_version of OS X and returns true if 
   # it is 10.6 or greater. This allows us to implement different plist
   # behavior for versions >= 10.6
   def has_macosx_plist_overrides?
-    product_version = sw_vers "-productVersion"
-    return true unless /^10\.[0-5]/.match(product_version)
+    return true unless /^10\.[0-5]/.match(@product_version)
     return false
   end
 


### PR DESCRIPTION
Previously, the has_macosx_plist_overrides? method would run the
sw_vers command every time it was called. This commit will set the
class instance variable @product_version to the value of either
the macosx_productversion_major fact or the value of sw_vers -productVersion.
The has_macosx_plist_overrides? method now only checks the class
instance variable.
