### PR TITLE
(#2744) Display file diffs through the Puppet log system.

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -313,7 +313,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             saved_files.each do |key|
               saved_file = @aug.get(key).to_s.sub(/^\/files/, root)
               if Puppet[:show_diff]
-                print diff(saved_file, saved_file + ".augnew")
+                notice "\n" + diff(saved_file, saved_file + ".augnew")
               end
               if resource.noop?
                 File.delete(saved_file + ".augnew")

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -104,7 +104,7 @@ module Puppet
 
       if ! result and Puppet[:show_diff]
         write_temporarily do |path|
-          print diff(@resource[:path], path)
+          notice "\n" + diff(@resource[:path], path)
         end
       end
       result

--- a/lib/puppet/util/diff.rb
+++ b/lib/puppet/util/diff.rb
@@ -67,7 +67,7 @@ module Puppet::Util::Diff
     tempfile.open
     tempfile.print string
     tempfile.close
-    print diff(path, tempfile.path)
+    notice "\n" + diff(path, tempfile.path)
     tempfile.delete
   end
 end

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -178,7 +178,7 @@ describe content do
         it "should display a diff if the current contents are different from the desired content" do
           @content.should = "some content"
           @content.expects(:diff).returns("my diff").once
-          @content.expects(:print).with("my diff").once
+          @content.expects(:notice).with("\nmy diff").once
 
           @content.safe_insync?("other content")
         end


### PR DESCRIPTION
When Puppet generated a diff between the file on disk, it previously just
printed it directly.  This means that the user can view it, but it is lost in
the rest of the system - monitoring, logs, and reports have no visibility of
this.

Better, then, to send it through our regular logging system, so that the
content is visible in all the places that it might be viewed by the user or
monitored by machines.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
