### PR TITLE
(#9329) Disable agent daemonizing on Windows

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -112,9 +112,15 @@ module Puppet
     :show_diff => [false, "Whether to print a contextual diff when files are being replaced.  The diff
       is printed on stdout, so this option is meaningless unless you are running Puppet interactively.
       This feature currently requires the `diff/lcs` Ruby library."],
-    :daemonize => { :default => true,
+    :daemonize => {
+      :default => (Puppet.features.microsoft_windows? ? false : true),
       :desc => "Send the process into the background.  This is the default.",
-      :short => "D"
+      :short => "D",
+      :hook => proc do |value|
+        if value and Puppet.features.microsoft_windows?
+          raise "Cannot daemonize on Windows"
+        end
+      end
     },
     :maximum_uid => [4294967290, "The maximum allowed UID.  Some platforms use negative UIDs
       but then ship with tools that do not know how to handle signed ints, so the UIDs show up as

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -282,4 +282,20 @@ describe "Puppet defaults" do
       Puppet.settings[:color].should == 'false'
     end
   end
+
+  describe "daemonize" do
+    it "should default to true", :unless => Puppet.features.microsoft_windows? do
+      Puppet.settings[:daemonize].should == true
+    end
+
+    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+      it "should default to false" do
+        Puppet.settings[:daemonize].should == false
+      end
+
+      it "should raise an error if set to true" do
+        lambda { Puppet.settings[:daemonize] = true }.should raise_error(/Cannot daemonize on Windows/)
+      end
+    end
+  end
 end

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -367,6 +367,7 @@ describe Puppet::Application::Agent do
     end
 
     it "should daemonize if needed" do
+      Puppet.features.stubs(:microsoft_windows?).returns false
       Puppet[:daemonize] = true
 
       @daemon.expects(:daemonize)


### PR DESCRIPTION
Running puppet agent on Windows with the default set of options fails
because the win32-process gem doesn't really support fork (it
re-executes the parent program, but doesn't preserve the parent
context), and then it fails to setsid as this call is not implemented
by the ruby runtime.

But the bigger issue is that Windows services are the preferred way to
run daemon processes. For this release, we will not be providing the
code to run puppet agent as a service, though we have verified that
puppet will run as a service using a third-party service wrapper,
nssm.

This commit changes the daemonize option to default to false on
Windows, so that the typical 'puppet agent' command does the right
thing. And if the daemonize option is set to true on Windows, it will
report an error.
