### PR TITLE
Ticket/2.7.x/9435 log destinations on windows

### DIFF
--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -1,9 +1,11 @@
 Puppet::Util::Log.newdesttype :syslog do
   def close
-    Syslog.close
+    Syslog.close if Puppet.features.syslog?
   end
 
   def initialize
+    return unless Puppet.features.syslog?
+
     Syslog.close if Syslog.opened?
     name = Puppet[:name]
     name = "puppet-#{name}" unless name =~ /puppet/
@@ -22,6 +24,8 @@ Puppet::Util::Log.newdesttype :syslog do
   end
 
   def handle(msg)
+    return unless Puppet.features.syslog?
+
     # XXX Syslog currently has a bug that makes it so you
     # cannot log a message with a '%' in it.  So, we get rid
     # of them.


### PR DESCRIPTION
This set of changes enables the file log destination to work on Windows, e.g. puppet agent --logdest=c:\log.txt, and modifies the syslog log destination to not generate errors when the syslog feature is absent.
