### PR TITLE
Ticket/2.7.x/9435 log destinations on windows

### DIFF
--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -120,6 +120,10 @@ class Puppet::Util::Log
       klass.match?(dest)
     end
 
+    if type.respond_to?(:suitable?) and not type.suitable?(dest)
+      return
+    end
+
     raise Puppet::DevError, "Unknown destination type #{dest}" unless type
 
     begin

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -1,4 +1,8 @@
 Puppet::Util::Log.newdesttype :syslog do
+  def self.suitable?(obj)
+    Puppet.features.syslog?
+  end
+
   def close
     Syslog.close
   end

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -64,3 +64,48 @@ describe Puppet::Util::Log.desttypes[:file] do
   end
 end
 
+describe Puppet::Util::Log.desttypes[:syslog] do
+  let (:klass) { Puppet::Util::Log.desttypes[:syslog] }
+
+  # these tests can only be run when syslog is present, because
+  # we can't stub the top-level Syslog module
+  describe "when syslog is available", :if => Puppet.features.syslog? do
+    before :each do
+      Syslog.stubs(:opened?).returns(false)
+      Syslog.stubs(:const_get).returns("LOG_KERN").returns(0)
+      Syslog.stubs(:open)
+    end
+
+    it "should open syslog" do
+      Syslog.expects(:open)
+
+      klass.new
+    end
+
+    it "should close syslog" do
+      Syslog.expects(:close)
+
+      dest = klass.new
+      dest.close
+    end
+
+    it "should send messages to syslog" do
+      syslog = mock 'syslog'
+      syslog.expects(:info).with("don't panic")
+      Syslog.stubs(:open).returns(syslog)
+
+      msg = Puppet::Util::Log.new(:level => :info, :message => "don't panic")
+      dest = klass.new
+      dest.handle(msg)
+    end
+  end
+
+  describe "when syslog is unavailable" do
+    it "should not be a suitable log destination" do
+      Puppet.features.stubs(:syslog?).returns(false)
+
+      klass.suitable?(:syslog).should be_false
+    end
+  end
+end
+

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -50,6 +50,12 @@ describe Puppet::Util::Log do
     end
   end
 
+  describe Puppet::Util::Log::DestSyslog do
+    before do
+      @syslog = Puppet::Util::Log::DestSyslog.new
+    end
+  end
+
   describe "instances" do
     before do
       Puppet::Util::Log.stubs(:newmessage)
@@ -165,6 +171,15 @@ describe Puppet::Util::Log do
       report.should be_include("foo")
       report.should be_include(log.source)
       report.should be_include(log.time.to_s)
+    end
+
+    it "should not create unsuitable log destinations" do
+      Puppet.features.stubs(:syslog?).returns(false)
+
+      Puppet::Util::Log::DestSyslog.expects(:suitable?)
+      Puppet::Util::Log::DestSyslog.expects(:new).never
+
+      Puppet::Util::Log.newdestination(:syslog)
     end
 
     describe "when setting the source as a RAL object" do


### PR DESCRIPTION
These two commits fix the file log and syslog log destinations, which were broken on Windows. In the former case, we use Puppet::Util.absolute_path? to determine path absolute-ness. In the latter case, the syslog log destination type is only suitable on platforms where the syslog feature is available.
