### PR TITLE
Ticket/2.7.x/9458 puppet fails when no subcommand

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -208,6 +208,7 @@ module Util
       :windows => %r!^([A-Z]:#{slash})|(#{slash}#{slash}#{name}#{slash}#{name})|(#{slash}#{slash}\?#{slash}#{name})!i,
       :posix   => %r!^/!,
     }
+    require 'puppet'
     platform ||= Puppet.features.microsoft_windows? ? :windows : :posix
 
     !! (path =~ regexes[platform])


### PR DESCRIPTION
Puppet was getting an undefined method error when running puppet
without a subcommand or with an "unavailable" subcommand. This was due
to the Puppet::Util.which method attempting to access the
Puppet.features.microsoft_windows? feature before the main Puppet
module had been loaded.

The command_line code is very order-dependent when launching available
applications: it has to instanciate the application and set the
run-mode prior to loading the top-level Puppet module. However, the
command_line only invokes the Puppet::Util.which method when
attempting to resolve an external application or when displaying usage
information. In other words, we've already decided that we're not
going to launch an available application and we're either going to
invoke system(..) or we're going to exit, in which case, it's safe to
load the top-level Puppet module without side-effects.
