### PR TITLE
Update certificate_spec.rb test to include spec_helper

### DIFF
--- a/spec/unit/application/certificate_spec.rb
+++ b/spec/unit/application/certificate_spec.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
 require 'puppet/application/certificate'
 
 describe Puppet::Application::Certificate do


### PR DESCRIPTION
The spec/unit/application/certificate_spec.rb test was missing a require for
spec_helper, which then meant that the stubs method wasn't available to the
test, and the test would fail when run on its own. This adds that require, so
the test now passes.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
