### PR TITLE
(#8410) Fix child exit status on Windows

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -309,11 +309,11 @@ module Util
       return execution_stub.call(*exec_args)
     elsif Puppet.features.posix?
       child_pid = execute_posix(*exec_args)
+      child_status = Process.waitpid2(child_pid).last.exitstatus
     elsif Puppet.features.microsoft_windows?
       child_pid = execute_windows(*exec_args)
+      child_status = Process.waitpid2(child_pid).last
     end
-
-    child_status = Process.waitpid2(child_pid).last
 
     [stdin, stdout, stderr].each {|io| io.close rescue nil}
 
@@ -324,7 +324,7 @@ module Util
     end
 
     if arguments[:failonfail] and child_status != 0
-      raise ExecutionFailure, "Execution of '#{str}' returned #{child_status.exitstatus}: #{output}"
+      raise ExecutionFailure, "Execution of '#{str}' returned #{child_status}: #{output}"
     end
 
     output


### PR DESCRIPTION
The Process.waitpid2 method in the win32-process gem returns an array,
with the child's exit status as the last element. This is different
than ruby's implementation where the last element is a Process::Status
object, which has an exitstatus method.

As a result, if a child process returned a non-zero exit status on
Windows, then Puppet::Util.execute would raise an error while trying
to call the exitstatus method on a Fixnum (the actual exit status).

This commit ensures we consistently retrieve the exit status
across all platforms.
