### PR TITLE
(#9459) Fix problems with Windows 'user' and 'group' providers.

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -34,6 +34,11 @@ Puppet::Type.type(:group).provide :windows_adsi do
     Puppet::Util::ADSI::Group.delete(@resource[:name])
   end
 
+  # Only flush if we created or modified a group, not deleted
+  def flush
+    @group.commit if @group
+  end
+
   def gid
     nil
   end

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -23,6 +23,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
 
   def create
     @user = Puppet::Util::ADSI::User.create(@resource[:name])
+    @user.commit if @user #9459: ensure the state is set before enumerating groups
     [:comment, :home, :groups].each do |prop|
       send("#{prop}=", @resource[prop]) if @resource[prop]
     end

--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -127,7 +127,7 @@ module Puppet::Util::ADSI
     def groups
       # WIN32OLE objects aren't enumerable, so no map
       groups = []
-      native_user.Groups.each {|g| groups << g.Name}
+      native_user.Groups.each {|g| groups << g.Name} rescue nil
       groups
     end
 
@@ -163,6 +163,8 @@ module Puppet::Util::ADSI
     end
 
     def self.create(name)
+      # Windows error 1379: The specified local group already exists.
+      raise Puppet::Error.new( "Cannot create user if group '#{name}' exists." ) if Puppet::Util::ADSI::Group.exists? name
       new(name, Puppet::Util::ADSI.create(name, 'user'))
     end
 
@@ -253,6 +255,8 @@ module Puppet::Util::ADSI
     end
 
     def self.create(name)
+      # Windows error 2224: The account already exists.
+      raise Puppet::Error.new( "Cannot create group if user '#{name}' exists." ) if Puppet::Util::ADSI::User.exists? name
       new(name, Puppet::Util::ADSI.create(name, 'group'))
     end
 


### PR DESCRIPTION
This commit corrects several problems with the Windows 'user' and
'group' providers, and Puppet::Util::ADSI helper class.

The 'user' provider failed to add the username to the set of groups
specified in the 'groups' property when creating a new user, due to
the provider trying to enumerate a user's group membership before the
underlying ADSI user object was saved. Any group referenced in the
property must exist prior to creating the resource.

The 'group' provider failed to save a newly-created resource,
due to a missing 'flush' method, which in turn calls the
'Puppet::Util::ADSI.commit' (save) method.

Windows does not allow user and groups to share the same name,
and when attempted the ADSI connection would throw a misleading
exception referring to an 'invalid moniker'. The 'user' provider will
now raise an error if it attempts to create a resource when a like-named
group already exists, and vice-versa.
