### PR TITLE
Ticket/2.7.x/9522

### DIFF
--- a/lib/puppet/util/network_device/config.rb
+++ b/lib/puppet/util/network_device/config.rb
@@ -2,6 +2,7 @@ require 'ostruct'
 require 'puppet/util/loadedfile'
 
 class Puppet::Util::NetworkDevice::Config < Puppet::Util::LoadedFile
+  class ConfigurationError < Puppet::Error; end
 
   def self.main
     @main ||= self.new
@@ -51,7 +52,7 @@ class Puppet::Util::NetworkDevice::Config < Puppet::Util::LoadedFile
           when /^\s*$/  # skip blank lines
             count += 1
             next
-          when /^\[([\w.]+)\]\s*$/ # [device.fqdn]
+          when /^\[([\w.-]+)\]\s*$/ # [device.fqdn]
             name = $1
             name.chomp!
             raise ConfigurationError, "Duplicate device found at line #{count}, already found at #{device.line}" if devices.include?(name)

--- a/spec/unit/util/network_device/config_spec.rb
+++ b/spec/unit/util/network_device/config_spec.rb
@@ -52,10 +52,10 @@ describe Puppet::Util::NetworkDevice::Config do
     end
 
     it "should increment line number even on commented lines" do
-      @fd.stubs(:each).multiple_yields('  # comment','[router.puppetlabs.com]')
+      @fd.stubs(:each).multiple_yields('  # comment','[router-foo.puppetlabs.com]')
 
       @config.read
-      @config.devices.should be_include('router.puppetlabs.com')
+      @config.devices.should be_include('router-foo.puppetlabs.com')
     end
 
     it "should skip blank lines" do
@@ -79,7 +79,7 @@ describe Puppet::Util::NetworkDevice::Config do
     end
 
     it "should create a new device for each found device line" do
-      @fd.stubs(:each).multiple_yields('[router.puppetlabs.com]', '[swith.puppetlabs.com]')
+      @fd.stubs(:each).multiple_yields('[router.puppetlabs.com]', '[test-switch.puppetlabs.com]')
 
       @config.read
       @config.devices.size.should == 2


### PR DESCRIPTION
This patch resolves the following two issue.
- Network device config parsing doens't support - in hostname.
- ConfigurationError isn't declared.
