### PR TITLE
(#9326) Support plaintext passwords in Windows 'user' provider

### DIFF
--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
   confine :operatingsystem => :windows
   confine :feature => :microsoft_windows
 
-  has_features :manages_homedir
+  has_features :manages_homedir, :manages_passwords
 
   def user
     @user ||= Puppet::Util::ADSI::User.new(@resource[:name])
@@ -55,6 +55,14 @@ Puppet::Type.type(:user).provide :windows_adsi do
 
   def home=(value)
     user['HomeDirectory'] = value
+  end
+
+  def password
+    user.password_is?( @resource[:password] ) ? @resource[:password] : :absent
+  end
+
+  def password=(value)
+    user.password = value
   end
 
   [:uid, :gid, :shell].each do |prop|

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -79,6 +79,28 @@ describe Puppet::Type.type(:user).provider(:windows_adsi) do
 
       provider.create
     end
+
+    it "should set a user's password" do
+      provider.user.expects(:password=).with('plaintextbad')
+
+      provider.password = "plaintextbad"
+    end
+
+    it "should test a valid user password" do
+      resource[:password] = 'plaintext'
+      provider.user.expects(:password_is?).with('plaintext').returns true
+
+      provider.password.should == 'plaintext'
+
+    end
+
+    it "should test a bad user password" do
+      resource[:password] = 'plaintext'
+      provider.user.expects(:password_is?).with('plaintext').returns false
+
+      provider.password.should == :absent
+    end
+
   end
 
   it 'should be able to test whether a user exists' do


### PR DESCRIPTION
This commit adds password support to the Windows 'user' provider. When setting the password, the resource value is passed unmolested to the underlying ADSI 'SetPassword' method.  During a get, the password is checked using the Windows 'LoginUser' function with the current user name and password. If the call succeeds, the password is returned; if unsuccessful, ':absent' is returned.

The spec test has been updated to reflect these changes.
