### PR TITLE
(9547) Minor mods to acceptance tests

### DIFF
--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -4,7 +4,7 @@ step "Validate services running agreement ralsh vs. OS service count"
 # ticket_4123_should_list_all_running_redhat.sh
 
 hosts.each do |host|
-  if host['platform'].include?('centos') or host['platform'].include?('rhel')
+  if host['platform'].include?('el-')
     run_script_on(host,'acceptance-tests/tests/resource/service/ticket_4123_should_list_all_running_redhat.sh')
   else
     skip_test "Test not supported on this plaform" 

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -4,7 +4,7 @@ step "Validate disabled services agreement ralsh vs. OS service count"
 # ticket_4124_should_list_all_disabled.sh
 
 hosts.each do |host|
-  unless host['platform'].include? 'centos' or host['platform'].include? 'rhel'
+  unless host['platform'].include?('el-')
     skip_test "Test not supported on this plaform"
    else
     run_script_on(host,'acceptance-tests/tests/resource/service/ticket_4124_should_list_all_disabled.sh')

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -1,7 +1,7 @@
 test_name "#6857: redact password hashes when applying in noop mode"
 
 hosts_to_test = agents.reject do |agent|
-  if agent['platform'].match /(?:ubuntu|centos|debian|rhel)/
+  if agent['platform'].match /(?:ubuntu|centos|debian|el-)/
     result = on(agent, %q{ruby -e 'require "shadow" or raise'}, :silent => true)
     result.exit_code != 0
   else


### PR DESCRIPTION
Consolidation of all RHEL based systems to now be identified as
"el-" vs. rhel-, centos-, scientific-, etc.  Platform regex
changed to only use "el-".
