### PR TITLE
Ticket/9440

### DIFF
--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -14,13 +14,13 @@ tab = case Facter.value(:operatingsystem)
 Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "root", :filetype => tab) do
   commands :crontab => "crontab"
 
-  text_line :comment, :match => %r{^#}, :post_parse => proc { |record|
+  text_line :comment, :match => %r{^\s*#}, :post_parse => proc { |record|
     record[:name] = $1 if record[:line] =~ /Puppet Name: (.+)\s*$/
   }
 
   text_line :blank, :match => %r{^\s*$}
 
-  text_line :environment, :match => %r{^\w+=}
+  text_line :environment, :match => %r{^\s*\w+=}
 
   record_line :freebsd_special, :fields => %w{special command},
     :match => %r{^@(\w+)\s+(.+)$}, :pre_gen => proc { |record|

--- a/test/ral/providers/cron/crontab.rb
+++ b/test/ral/providers/cron/crontab.rb
@@ -378,6 +378,7 @@ class TestCronParsedProvider < Test::Unit::TestCase
     target = @provider.target_object(@me)
 
     [
+      "   FOO=var",
       "* * * * * /some/command",
       "0,30 * * * * /some/command",
       "0-30 * * * * /some/command",


### PR DESCRIPTION
Patch applied from Jeremy Thornhill. This allows whitespace to appear before
cron variables. Previously, whitespace before cron variables would trigger a
parse failure, and the crontab, except for the puppet managed portion, would
get removed. This addresses that issue. It also includes a test for this issue,
added into the tests directory, which seems to be where the crontab tests live.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
