### PR TITLE
Fix #7004 - various indirection with trailing 'e' have a broken plural

### DIFF
--- a/lib/puppet/network/http/api/v1.rb
+++ b/lib/puppet/network/http/api/v1.rb
@@ -74,7 +74,8 @@ module Puppet::Network::HTTP::API::V1
 
     result = (indirection =~ /s$|_search$/) ? :plural : :singular
 
-    indirection.sub!(/s$|_search$|es$/, '')
+    indirection.sub!(/s$|_search$/, '')
+    indirection.sub!(/statuse$/, 'status')
 
     result
   end

--- a/spec/unit/network/http/api/v1_spec.rb
+++ b/spec/unit/network/http/api/v1_spec.rb
@@ -123,6 +123,10 @@ describe Puppet::Network::HTTP::API::V1 do
       @tester.uri2indirection("GET", "/env/statuses/bar", {})[0].should == 'status'
     end
 
+    it "should change indirection name to 'probe' if the http method is a GET and the indirection name is probes" do
+      @tester.uri2indirection("GET", "/env/probes/bar", {})[0].should == 'probe'
+    end
+
     it "should choose 'delete' as the indirection method if the http method is a DELETE and the indirection name is singular" do
       @tester.uri2indirection("DELETE", "/env/foo/bar", {})[1].should == :destroy
     end


### PR DESCRIPTION
This is not a complete fix.
This got broken when the status indirection was added around
d1f1858ea52d3089fd2088994e80d6f49d7e0347.

The problem is that the regex matching is greedy so any indirection
ending in e (and pluralized in 'es') will lose its trailing 'e'.

Since all this was done for the status indirection, my fix is to
treat differently this indirection only, instead of trying to fix
the general case (and breaking it).

Signed-off-by: Brice Figureau brice-puppet@daysofwonder.com
