### PR TITLE
Ticket/2.7.x/8341 prevent duplicate loading of facts

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -15,7 +15,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       end
     end.flatten
     dirs = module_fact_dirs + Puppet[:factpath].split(File::PATH_SEPARATOR)
-    x = dirs.each do |dir|
+    x = dirs.uniq.each do |dir|
       load_facts_in_dir(dir)
     end
   end


### PR DESCRIPTION
If there were duplicate file paths in puppet's modulepath, fact files in
the modulepath would be loaded for every instance of the directory in
the modulepath. The resolution to this was to unique the list of directories
to load facts from.
