### PR TITLE
(#9328) Retrieve user and group SIDs on windows

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -35,11 +35,11 @@ Puppet::Type.type(:group).provide :windows_adsi do
   end
 
   def gid
-    nil
+    Puppet::Util::ADSI.sid_for_account(resource[:name])
   end
 
   def gid=(value)
-    warning "No support for managing property gid of group #{@resource[:name]} on Windows"
+    fail "gid is read-only"
   end
 
   def self.instances

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -57,11 +57,18 @@ Puppet::Type.type(:user).provide :windows_adsi do
     user['HomeDirectory'] = value
   end
 
-  [:uid, :gid, :shell].each do |prop|
-    define_method(prop) { nil }
+  def uid
+    Puppet::Util::ADSI.sid_for_account(resource[:name])
+  end
 
+  def uid=(value)
+    fail "uid is read-only"
+  end
+
+  [:gid, :shell].each do |prop|
+    define_method(prop) { nil }
     define_method("#{prop}=") do |v|
-      warning "No support for managing property #{prop} of user #{@resource[:name]} on Windows"
+      fail "No support for managing property #{prop} of user #{@resource[:name]} on Windows"
     end
   end
 

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -37,7 +37,10 @@ module Puppet
       desc "The group ID.  Must be specified numerically.  If not
         specified, a number will be picked, which can result in ID
         differences across systems and thus is not recommended.  The
-        GID is picked according to local system standards."
+        GID is picked according to local system standards.
+
+        On Windows, the property will return the group's security
+        identifier (SID)."
 
       def retrieve
         provider.gid

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -93,7 +93,10 @@ module Puppet
         recommended.  This is especially noteworthy if you use Puppet
         to manage the same user on both Darwin and other platforms,
         since Puppet does the ID generation for you on Darwin, but the
-        tools do so on other platforms."
+        tools do so on other platforms.
+
+        On Windows, the property will return the user's security
+        identifier (SID)."
 
       munge do |value|
         case value

--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -48,6 +48,16 @@ module Puppet::Util::ADSI
     def execquery(query)
       connect(wmi_resource_uri).execquery(query)
     end
+
+    def sid_for_account(name)
+      sid = nil
+      execquery( "SELECT Sid from Win32_Account WHERE Name = '#{name}'
+                  AND LocalAccount = true").each { |u|
+                    sid ||= u.Sid
+                  }
+      sid
+    end
+
   end
 
   class User

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -72,8 +72,13 @@ describe Puppet::Type.type(:group).provider(:windows_adsi) do
     provider.delete
   end
 
-  it "should warn when trying to manage the gid property" do
-    provider.expects(:warning).with { |msg| msg =~ /No support for managing property gid/ }
+  it "should report the group's SID as gid" do
+    Puppet::Util::ADSI.expects(:sid_for_account).with('testers').returns('S-1-5-32-547')
+    provider.gid.should == 'S-1-5-32-547'
+  end
+
+  it "should fail when trying to manage the gid property" do
+    provider.expects(:fail).with { |msg| msg =~ /gid is read-only/ }
     provider.send(:gid=, 500)
   end
 end

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -101,9 +101,20 @@ describe Puppet::Type.type(:user).provider(:windows_adsi) do
     provider.flush
   end
 
-  [:uid, :gid, :shell].each do |prop|
-    it "should warn when trying to manage the #{prop} property" do
-      provider.expects(:warning).with { |msg| msg =~ /No support for managing property #{prop}/ }
+  it "should return the user's SID as uid" do
+    Puppet::Util::ADSI.expects(:sid_for_account).with('testuser').returns('S-1-5-21-1362942247-2130103807-3279964888-1111')
+
+    provider.uid.should == 'S-1-5-21-1362942247-2130103807-3279964888-1111'
+  end
+
+  it "should fail when trying to manage the uid property" do
+    provider.expects(:fail).with { |msg| msg =~ /uid is read-only/ }
+    provider.send(:uid=, 500)
+  end
+
+  [:gid, :shell].each do |prop|
+    it "should fail when trying to manage the #{prop} property" do
+      provider.expects(:fail).with { |msg| msg =~ /No support for managing property #{prop}/ }
       provider.send("#{prop}=", 'foo')
     end
   end

--- a/spec/unit/util/adsi_spec.rb
+++ b/spec/unit/util/adsi_spec.rb
@@ -24,6 +24,11 @@ describe Puppet::Util::ADSI do
     Puppet::Util::ADSI.computer_uri.should == "WinNT://testcomputername"
   end
 
+  it "should return a SID for a passed user or group name" do
+    Puppet::Util::ADSI.expects(:execquery).returns([stub('acct_id', :Sid => 'S-1-5-32-547')])
+    Puppet::Util::ADSI.sid_for_account('testers').should == 'S-1-5-32-547'
+  end
+
   describe Puppet::Util::ADSI::User do
     let(:username)  { 'testuser' }
 


### PR DESCRIPTION
This commit implements the ID get-method for Windows 'user' and 'group' providers. Prior to this commit, 'puppet resource {user,group} would not return an id property for each resource. With this change, the Windows user/group security identifier (SID) is provided as the id. 

The uid and gid properties are read only. Setting these values is still not supported for Windows providers.

Spec tests have been updated; a test failure with a previous user/group commit has also been fixed.
