### PR TITLE
Call Array#join explicitly in execpipe

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -222,7 +222,8 @@ module Util
       Puppet.debug "Executing '#{command}'"
     end
 
-    output = open("| #{command} 2>&1") do |pipe|
+    command_str = command.respond_to?(:join) ? command.join('') : command
+    output = open("| #{command_str} 2>&1") do |pipe|
       yield pipe
     end
 


### PR DESCRIPTION
In Ruby 1.8 Array#to_s simply returns `self.join` and in 1.9 it works like `self.join(", ")`. We should avoid relying on it.

Previously: https://github.com/puppetlabs/puppet/pull/130
