### PR TITLE
Maint/2.7.x/provider parameter description

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1477,9 +1477,15 @@ class Type
     return if @paramhash.has_key? :provider
 
     newparam(:provider) do
-      desc "The specific backend for #{self.name.to_s} to use. You will
-        seldom need to specify this --- Puppet will usually discover the
-        appropriate provider for your platform."
+      # We're using a hacky way to get the name of our type, since there doesn't
+      # seem to be a correct way to introspect this at the time this code is run.
+      # We expect that the class in which this code is executed will be something
+      # like Puppet::Type::Ssh_authorized_key::ParameterProvider.
+      desc <<-EOT
+        The specific backend to use for this `#{self.to_s.split('::')[2].downcase}`
+        resource. You will seldom need to specify this --- Puppet will usually
+        discover the appropriate provider for your platform.
+      EOT
 
       # This is so we can refer back to the type to get a list of
       # providers for documentation.

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -159,6 +159,15 @@ describe Puppet::Type, :fails_on_windows => true do
       @type.provider_hash.clear
     end
 
+    it "should have documentation for the 'provider' parameter if there are providers" do
+      @type.provide(:test_provider)
+      @type.paramdoc(:provider).should =~ /`provider_test_type`[\s\r]+resource/
+    end
+
+    it "should not have documentation for the 'provider' parameter if there are no providers" do
+      expect { @type.paramdoc(:provider) }.to raise_error(NoMethodError)
+    end
+
     it "should create a subclass of Puppet::Provider for the provider" do
       provider = @type.provide(:test_provider)
 


### PR DESCRIPTION
The provider parameter had a chunk of code that seemed to be designed to
include the name of the type; however, it has always been broken and was
resulting in bizarre English.

This commit changes the way we introspect the current type -- it's hacky, but
it gives us a correct answer -- and adds two tests to the type spec to ensure
this documentation is being generated correctly.

Paired-with: Matt Robinson matt@puppetlabs.com
