### PR TITLE
Maint/2.7.x/type reference revisions

### DIFF
--- a/lib/puppet/provider/group/aix.rb
+++ b/lib/puppet/provider/group/aix.rb
@@ -3,11 +3,11 @@
 #  mkgroup, rmgroup, lsgroup, chgroup
 #
 # Author::    Hector Rivas Gandara <keymon@gmail.com>
-#  
+#
 require 'puppet/provider/aixobject'
 
 Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject do
-  desc "Group management for AIX! Users are managed with mkgroup, rmgroup, lsgroup, chgroup"
+  desc "Group management for AIX."
 
   # This will the the default provider for this platform
   defaultfor :operatingsystem => :aix
@@ -29,7 +29,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
   end
 
   # AIX attributes to properties mapping.
-  # 
+  #
   # Valid attributes to be managed by this provider.
   # It is a list with of hash
   #  :aix_attr      AIX command attribute name
@@ -43,10 +43,10 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
       :from => :users_from_attr},
     {:aix_attr => :attributes, :puppet_prop => :attributes},
   ]
-  
+
   #--------------
   # Command definition
-  
+
   # Return the IA module arguments based on the resource param ia_load_module
   def get_ia_module_args
     if @resource[:ia_load_module]
@@ -55,7 +55,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
       []
     end
   end
-  
+
   def lscmd(value=@resource[:name])
     [self.class.command(:list)] +
       self.get_ia_module_args +
@@ -80,7 +80,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
   def modifycmd(hash = property_hash)
     args = self.hash2args(hash)
     return nil if args.empty?
-    
+
     [self.class.command(:modify)] +
       self.get_ia_module_args +
       args + [@resource[:name]]
@@ -123,7 +123,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
     #self.class.validate(param, value)
     param = :attributes
     cmd = modifycmd({param => filter_attributes(attr_hash)})
-    if cmd 
+    if cmd
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -1,9 +1,7 @@
 require 'puppet/provider/nameservice/objectadd'
 
 Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameService::ObjectAdd do
-  desc "Group management via `groupadd` and its ilk.
-
-  The default for most platforms
+  desc "Group management via `groupadd` and its ilk. The default for most platforms.
 
   "
 

--- a/lib/puppet/provider/group/ldap.rb
+++ b/lib/puppet/provider/group/ldap.rb
@@ -1,18 +1,16 @@
 require 'puppet/provider/ldap'
 
 Puppet::Type.type(:group).provide :ldap, :parent => Puppet::Provider::Ldap do
-  desc "Group management via `ldap`.
+  desc "Group management via LDAP.
 
-  This provider requires that you have valid values for all of the
-  ldap-related settings, including `ldapbase`.  You will also almost
-  definitely need settings for `ldapuser` and `ldappassword`, so that
-  your clients can write to ldap.
+    This provider requires that you have valid values for all of the
+    LDAP-related settings in `puppet.conf`, including `ldapbase`.  You will
+    almost definitely need settings for `ldapuser` and `ldappassword` in order
+    for your clients to write to LDAP.
 
-  Note that this provider will automatically generate a GID for you if you do
-  not specify one, but it is a potentially expensive operation, as it
-  iterates across all existing groups to pick the appropriate next one.
-
-  "
+    Note that this provider will automatically generate a GID for you if you do
+    not specify one, but it is a potentially expensive operation, as it
+    iterates across all existing groups to pick the appropriate next one."
 
   confine :true => Puppet.features.ldap?, :false => (Puppet[:ldapuser] == "")
 

--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -2,7 +2,7 @@ require 'puppet/provider/package'
 require 'puppet/util/package'
 
 Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package do
-  desc "Installation from AIX Software directory"
+  desc "Installation from the AIX software directory."
 
   # The commands we are using on an AIX box are installed standard
   # (except nimclient) nimclient needs the bos.sysmgt.nim.client fileset.

--- a/lib/puppet/provider/package/macports.rb
+++ b/lib/puppet/provider/package/macports.rb
@@ -4,10 +4,10 @@ Puppet::Type.type(:package).provide :macports, :parent => Puppet::Provider::Pack
   desc "Package management using MacPorts on OS X.
 
     Supports MacPorts versions and revisions, but not variants.
-    Variant preferences may be specified using the MacPorts variants.conf file
-    http://guide.macports.org/chunked/internals.configuration-files.html#internals.configuration-files.variants-conf
+    Variant preferences may be specified using
+    [the MacPorts variants.conf file](http://guide.macports.org/chunked/internals.configuration-files.html#internals.configuration-files.variants-conf).
 
-    When specifying a version in the Puppet DSL, only specify the version, not the revision
+    When specifying a version in the Puppet DSL, only specify the version, not the revision.
     Revisions are only used internally for ensuring the latest version/revision of a port.
   "
 

--- a/lib/puppet/provider/package/nim.rb
+++ b/lib/puppet/provider/package/nim.rb
@@ -2,7 +2,7 @@ require 'puppet/provider/package'
 require 'puppet/util/package'
 
 Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
-  desc "Installation from NIM LPP source"
+  desc "Installation from NIM LPP source."
 
   # The commands we are using on an AIX box are installed standard
   # (except nimclient) nimclient needs the bos.sysmgt.nim.client fileset.

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -15,9 +15,9 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
   desc "Package management based on Apple's Installer.app and
     DiskUtility.app.  This package works by checking the contents of a
     DMG image for Apple pkg or mpkg files. Any number of pkg or mpkg
-    files may exist in the root directory of the DMG file system. Sub
-    directories are not checked for packages.  See `the wiki docs
-    <http://projects.puppetlabs.com/projects/puppet/wiki/Package_Management_With_Dmg_Patterns>`
+    files may exist in the root directory of the DMG file system.
+    Subdirectories are not checked for packages.  See
+    [the wiki docs on this provider](http://projects.puppetlabs.com/projects/puppet/wiki/Package_Management_With_Dmg_Patterns)
     for more detail."
 
   confine :operatingsystem => :darwin

--- a/lib/puppet/provider/package/ports.rb
+++ b/lib/puppet/provider/package/ports.rb
@@ -1,5 +1,5 @@
 Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :freebsd do
-  desc "Support for FreeBSD's ports.  Again, this still mixes packages and ports."
+  desc "Support for FreeBSD's ports.  Note that this, too, mixes packages and ports."
 
   commands :portupgrade => "/usr/local/sbin/portupgrade",
     :portversion => "/usr/local/sbin/portversion",

--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -4,8 +4,8 @@ Puppet::Type.type(:service).provide :base do
   You have to specify enough about your service for this to work; the
   minimum you can specify is a binary for starting the process, and this
   same binary will be searched for in the process table to stop the
-  service.  It is preferable to specify start, stop, and status commands,
-  akin to how you would do so using `init`.
+  service.  As with `init`-style services, it is preferable to specify start,
+  stop, and status commands.
 
   "
 

--- a/lib/puppet/provider/service/bsd.rb
+++ b/lib/puppet/provider/service/bsd.rb
@@ -1,10 +1,11 @@
 # Manage FreeBSD services.
 Puppet::Type.type(:service).provide :bsd, :parent => :init do
-  desc "FreeBSD's (and probably NetBSD?) form of `init`-style service management.
+  desc <<-EOT
+    FreeBSD's (and probably NetBSD's?) form of `init`-style service management.
 
-  Uses `rc.conf.d` for service enabling and disabling.
+    Uses `rc.conf.d` for service enabling and disabling.
 
-"
+  EOT
 
   confine :operatingsystem => [:freebsd, :netbsd, :openbsd]
 

--- a/lib/puppet/provider/service/daemontools.rb
+++ b/lib/puppet/provider/service/daemontools.rb
@@ -2,42 +2,42 @@
 #
 # author Brice Figureau <brice-puppet@daysofwonder.com>
 Puppet::Type.type(:service).provide :daemontools, :parent => :base do
-  desc "Daemontools service management.
+  desc <<-EOT
+    Daemontools service management.
 
-  This provider manages daemons running supervised by D.J.Bernstein daemontools.
-  It tries to detect the service directory, with by order of preference:
+    This provider manages daemons supervised by D.J. Bernstein daemontools.
+    When detecting the service directory it will check, in order of preference:
 
-  * /service
-  * /etc/service
-  * /var/lib/svscan
+    * `/service`
+    * `/etc/service`
+    * `/var/lib/svscan`
 
-  The daemon directory should be placed in a directory that can be
-  by default in:
+    The daemon directory should be in one of the following locations:
 
-  * /var/lib/service
-  * /etc
+    * `/var/lib/service`
+    * `/etc`
 
-  or this can be overriden in the service resource parameters::
+    ...or this can be overriden in the resource's attributes:
 
-      service { \"myservice\":
-        provider => \"daemontools\",
-        path => \"/path/to/daemons\",
-      }
+        service { "myservice":
+          provider => "daemontools",
+          path     => "/path/to/daemons",
+        }
 
-  This provider supports out of the box:
+    This provider supports out of the box:
 
-  * start/stop (mapped to enable/disable)
-  * enable/disable
-  * restart
-  * status
+    * start/stop (mapped to enable/disable)
+    * enable/disable
+    * restart
+    * status
 
-  If a service has `ensure => \"running\"`, it will link /path/to/daemon to
-  /path/to/service, which will automatically enable the service.
+    If a service has `ensure => "running"`, it will link /path/to/daemon to
+    /path/to/service, which will automatically enable the service.
 
-  If a service has `ensure => \"stopped\"`, it will only down the service, not
-  remove the /path/to/service link.
+    If a service has `ensure => "stopped"`, it will only shut down the service, not
+    remove the `/path/to/service` link.
 
-  "
+  EOT
 
   commands :svc  => "/usr/bin/svc", :svstat => "/usr/bin/svstat"
 

--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -1,12 +1,14 @@
 # Manage debian services.  Start/stop is the same as InitSvc, but enable/disable
 # is special.
 Puppet::Type.type(:service).provide :debian, :parent => :init do
-  desc "Debian's form of `init`-style management.
+  desc <<-EOT
+    Debian's form of `init`-style management.
 
-  The only difference is that this supports service enabling and disabling
-  via `update-rc.d` and determines enabled status via `invoke-rc.d`.
+    The only differences from `init` are support for enabling and disabling
+    services via `update-rc.d` and the ability to determine enabled status via
+    `invoke-rc.d`.
 
-  "
+  EOT
 
   commands :update_rc => "/usr/sbin/update-rc.d"
   # note this isn't being used as a command until

--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -1,6 +1,6 @@
 Puppet::Type.type(:service).provide :freebsd, :parent => :init do
 
-  desc "Provider for FreeBSD. Makes use of rcvar argument of init scripts and parses/edits rc files."
+  desc "Provider for FreeBSD. Uses the `rcvar` argument of init scripts and parses/edits rc files."
 
   confine :operatingsystem => [:freebsd]
   defaultfor :operatingsystem => [:freebsd]

--- a/lib/puppet/provider/service/gentoo.rb
+++ b/lib/puppet/provider/service/gentoo.rb
@@ -1,11 +1,12 @@
 # Manage gentoo services.  Start/stop is the same as InitSvc, but enable/disable
 # is special.
 Puppet::Type.type(:service).provide :gentoo, :parent => :init do
-  desc "Gentoo's form of `init`-style service management.
+  desc <<-EOT
+    Gentoo's form of `init`-style service management.
 
-  Uses `rc-update` for service enabling and disabling.
+    Uses `rc-update` for service enabling and disabling.
 
-  "
+  EOT
 
   commands :update => "/sbin/rc-update"
 

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -1,14 +1,7 @@
 # The standard init-based service type.  Many other service types are
 # customizations of this module.
 Puppet::Type.type(:service).provide :init, :parent => :base do
-  desc "Standard init service management.
-
-  This provider assumes that the init script has no `status` command,
-  because so few scripts do, so you need to either provide a status
-  command or specify via `hasstatus` that one already exists in the
-  init script.
-
-"
+  desc "Standard `init`-style service management."
 
   class << self
     attr_accessor :defpath

--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -1,38 +1,41 @@
 require 'facter/util/plist'
 Puppet::Type.type(:service).provide :launchd, :parent => :base do
-  desc "launchd service management framework.
+  desc <<-EOT
+    This provider manages jobs with `launchd`, which is the default service
+    framework for Mac OS X (and may be available for use on other platforms).
 
-  This provider manages jobs with launchd, which is the default service framework for
-  Mac OS X and is potentially available for use on other platforms.
+    For `launchd` documentation, see:
 
-  See:
-  * http://developer.apple.com/macosx/launchd.html
-  * http://launchd.macosforge.org/
+    * <http://developer.apple.com/macosx/launchd.html>
+    * <http://launchd.macosforge.org/>
 
-  This provider reads plists out of the following directories:
-  * /System/Library/LaunchDaemons
-  * /System/Library/LaunchAgents
-  * /Library/LaunchDaemons
-  * /Library/LaunchAgents
+    This provider reads plists out of the following directories:
 
-  ...and builds up a list of services based upon each plist's \"Label\" entry.
+    * `/System/Library/LaunchDaemons`
+    * `/System/Library/LaunchAgents`
+    * `/Library/LaunchDaemons`
+    * `/Library/LaunchAgents`
 
-  This provider supports:
-  * ensure => running/stopped,
-  * enable => true/false
-  * status
-  * restart
+    ...and builds up a list of services based upon each plist's "Label" entry.
 
-  Here is how the Puppet states correspond to launchd states:
-  * stopped --- job unloaded
-  * started --- job loaded
-  * enabled --- 'Disable' removed from job plist file
-  * disabled --- 'Disable' added to job plist file
+    This provider supports:
 
-  Note that this allows you to do something launchctl can't do, which is to
-  be in a state of \"stopped/enabled\ or \"running/disabled\".
+    * ensure => running/stopped,
+    * enable => true/false
+    * status
+    * restart
 
-  "
+    Here is how the Puppet states correspond to `launchd` states:
+
+    * stopped --- job unloaded
+    * started --- job loaded
+    * enabled --- 'Disable' removed from job plist file
+    * disabled --- 'Disable' added to job plist file
+
+    Note that this allows you to do something `launchctl` can't do, which is to
+    be in a state of "stopped/enabled" or "running/disabled".
+
+  EOT
 
   include Puppet::Util::Warnings
 

--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -1,9 +1,8 @@
 # Manage Red Hat services.  Start/stop uses /sbin/service and enable/disable uses chkconfig
 
 Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init do
-  desc "Red Hat's (and probably many others) form of `init`-style service management:
-
-  Uses `chkconfig` for service enabling and disabling.
+  desc "Red Hat's (and probably many others') form of `init`-style service
+    management. Uses `chkconfig` for service enabling and disabling.
 
   "
 

--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -2,36 +2,36 @@
 #
 # author Brice Figureau <brice-puppet@daysofwonder.com>
 Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
-  desc "Runit service management.
+  desc <<-EOT
+    Runit service management.
 
-  This provider manages daemons running supervised by Runit.
-  It tries to detect the service directory, with by order of preference:
+    This provider manages daemons running supervised by Runit.
+    When detecting the service directory it will check, in order of preference:
 
-  * /service
-  * /var/service
-  * /etc/service
+    * `/service`
+    * `/var/service`
+    * `/etc/service`
 
-  The daemon directory should be placed in a directory that can be
-  by default in:
+    The daemon directory should be in one of the following locations:
 
-  * /etc/sv
+    * `/etc/sv`
 
-  or this can be overriden in the service resource parameters::
+    or this can be overriden in the service resource parameters::
 
-      service { \"myservice\":
-        provider => \"runit\",
-        path => \"/path/to/daemons\",
-      }
+        service { "myservice":
+          provider => "runit",
+          path => "/path/to/daemons",
+        }
 
-  This provider supports out of the box:
+    This provider supports out of the box:
 
-  * start/stop
-  * enable/disable
-  * restart
-  * status
+    * start/stop
+    * enable/disable
+    * restart
+    * status
 
 
-"
+  EOT
 
   commands :sv => "/usr/bin/sv"
 

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -1,15 +1,16 @@
 # Solaris 10 SMF-style services.
 Puppet::Type.type(:service).provide :smf, :parent => :base do
-  desc "Support for Sun's new Service Management Framework.
+  desc <<-EOT
+    Support for Sun's new Service Management Framework.
 
-  Starting a service is effectively equivalent to enabling it, so there is
-  only support for starting and stopping services, which also enables and
-  disables them, respectively.
+    Starting a service is effectively equivalent to enabling it, so there is
+    only support for starting and stopping services, which also enables and
+    disables them, respectively.
 
-  By specifying manifest => \"/path/to/service.xml\", the SMF manifest will
-  be imported if it does not exist.
+    By specifying `manifest => "/path/to/service.xml"`, the SMF manifest will
+    be imported if it does not exist.
 
-  "
+  EOT
 
   defaultfor :operatingsystem => :solaris
 

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -3,13 +3,12 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
 
   desc "Support for AIX's System Resource controller.
 
-  Services are started/stopped based on the stopsrc and startsrc
-  commands, and some services can be refreshed with refresh command.
+  Services are started/stopped based on the `stopsrc` and `startsrc`
+  commands, and some services can be refreshed with `refresh` command.
 
-  * Enabling and disableing services is not supported, as it requires
-  modifications to /etc/inittab.
-
-  * Starting and stopping groups of subsystems is not yet supported
+  Enabling and disabling services is not supported, as it requires
+  modifications to `/etc/inittab`. Starting and stopping groups of subsystems
+  is not yet supported.
   "
 
   defaultfor :operatingsystem => :aix

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -1,7 +1,7 @@
 # Manage systemd services using /bin/systemctl
 
 Puppet::Type.type(:service).provide :systemd, :parent => :base do
-  desc "Manage systemd services using /bin/systemctl"
+  desc "Manages `systemd` services using `/bin/systemctl`."
 
   commands :systemctl => "/bin/systemctl"
 

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -1,10 +1,8 @@
 Puppet::Type.type(:service).provide :upstart, :parent => :init do
-  desc "Ubuntu service manager upstart.
+  desc "Ubuntu service management with `upstart`.
 
-  This provider manages upstart jobs which have replaced initd.
-
-  See:
-   * http://upstart.ubuntu.com/
+  This provider manages `upstart` jobs, which have replaced `initd` services
+  on Ubuntu. For `upstart` documentation, see <http://upstart.ubuntu.com/>.
   "
   # confine to :ubuntu for now because I haven't tested on other platforms
   confine :operatingsystem => :ubuntu #[:ubuntu, :fedora, :debian]

--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -4,13 +4,13 @@ require 'win32/service' if Puppet.features.microsoft_windows?
 
 Puppet::Type.type(:service).provide :windows do
 
-  desc "Support for Windows Service Control Manager (SCM).
+  desc <<-EOT
+    Support for Windows Service Control Manager (SCM).
 
-  Services are controlled according to win32-service gem.
-
-  * All SCM operations (start/stop/enable/disable/query) are supported.
-
-  * Control of service groups (dependencies) is not yet supported."
+    Services are controlled according to the capabilities of the `win32-service`
+    gem. All SCM operations (start/stop/enable/disable/query) are supported.
+    Control of service groups (dependencies) is not yet supported.
+  EOT
 
   defaultfor :operatingsystem => :windows
   confine    :operatingsystem => :windows

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -17,7 +17,7 @@ require 'tempfile'
 require 'date'
 
 Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
-  desc "User management for AIX! Users are managed with mkuser, rmuser, chuser, lsuser"
+  desc "User management for AIX."
 
   # This will the the default provider for this platform
   defaultfor :operatingsystem => :aix
@@ -28,7 +28,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   commands :add       => "/usr/bin/mkuser"
   commands :delete    => "/usr/sbin/rmuser"
   commands :modify    => "/usr/bin/chuser"
-  
+
   commands :lsgroup   => "/usr/sbin/lsgroup"
   commands :chpasswd  => "/bin/chpasswd"
 
@@ -52,7 +52,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   end
 
   # AIX attributes to properties mapping.
-  # 
+  #
   # Valid attributes to be managed by this provider.
   # It is a list with of hash
   #  :aix_attr      AIX command attribute name
@@ -73,10 +73,10 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     {:aix_attr => :minage,     :puppet_prop => :password_min_age},
     {:aix_attr => :attributes, :puppet_prop => :attributes},
   ]
-  
+
   #--------------
   # Command definition
-  
+
   # Return the IA module arguments based on the resource param ia_load_module
   def get_ia_module_args
     if @resource[:ia_load_module]
@@ -85,7 +85,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
       []
     end
   end
-  
+
   # List groups and Ids
   def lsgroupscmd(value=@resource[:name])
     [command(:lsgroup)] +
@@ -116,7 +116,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   def modifycmd(hash = property_hash)
     args = self.hash2args(hash)
     return nil if args.empty?
-    
+
     [self.class.command(:modify)] + self.get_ia_module_args +
       args + [@resource[:name]]
   end
@@ -131,9 +131,9 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     super
     # Reset the password if needed
     self.password = @resource[:password] if @resource[:password]
-  end 
+  end
 
-  
+
   def get_arguments(key, value, mapping, objectinfo)
     # In the case of attributes, return a list of key=vlaue
     if key == :attributes
@@ -141,10 +141,10 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
         unless value and value.is_a? Hash
       return value.select { |k,v| true }.map { |pair| pair.join("=") }
     end
-        
+
     super(key, value, mapping, objectinfo)
   end
-  
+
   # Get the groupname from its id
   def self.groupname_by_id(gid)
     groupname=nil
@@ -165,16 +165,16 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
 
   # Check that a group exists and is valid
   def verify_group(value)
-    if value.is_a? Integer or value.is_a? Fixnum  
+    if value.is_a? Integer or value.is_a? Fixnum
       groupname = self.groupname_by_id(value)
       raise ArgumentError, "AIX group must be a valid existing group" unless groupname
-    else 
+    else
       raise ArgumentError, "AIX group must be a valid existing group" unless groupid_by_name(value)
       groupname = value
     end
     groupname
   end
-  
+
   # The user's primary group.  Can be specified numerically or by name.
   def gid_to_attr(value)
     verify_group(value)
@@ -186,7 +186,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   end
 
   # The expiry date for this user. Must be provided in
-  # a zero padded YYYY-MM-DD HH:MM format 
+  # a zero padded YYYY-MM-DD HH:MM format
   def expiry_to_attr(value)
     # For chuser the expires parameter is a 10-character string in the MMDDhhmmyy format
     # that is,"%m%d%H%M%y"
@@ -197,7 +197,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     end
     newdate
   end
-  
+
   def expiry_from_attr(value)
     if value =~ /(..)(..)(..)(..)(..)/
       #d= DateTime.parse("20#{$5}-#{$1}-#{$2} #{$3}:#{$4}")
@@ -233,7 +233,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     if ! f.eof?
       f.each { |l|
         # If there is a new user stanza, stop
-        break if l  =~ /^\S*:\s*$/ 
+        break if l  =~ /^\S*:\s*$/
         # If the password= entry is found, return it
         if l  =~ /^\s*password\s*=\s*(.*)$/
           password = $1; break;
@@ -242,11 +242,11 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     end
     f.close()
     return password
-  end 
+  end
 
   def password=(value)
     user = @resource[:name]
-    
+
     # Puppet execute does not support strings as input, only files.
     tmpfile = Tempfile.new('puppet_#{user}_pw')
     tmpfile << "#{user}:#{value}\n"
@@ -264,7 +264,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     ensure
       tmpfile.delete()
     end
-  end 
+  end
 
   def filter_attributes(hash)
     # Return only not managed attributtes.
@@ -284,7 +284,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     #self.class.validate(param, value)
     param = :attributes
     cmd = modifycmd({param => filter_attributes(attr_hash)})
-    if cmd 
+    if cmd
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail

--- a/lib/puppet/provider/user/hpux.rb
+++ b/lib/puppet/provider/user/hpux.rb
@@ -1,5 +1,7 @@
 Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
-  desc "User management for hp-ux! Undocumented switch to special usermod because HP-UX regular usermod is TOO STUPID to change stuff while the user is logged in."
+  desc "User management for HP-UX. This provider uses the undocumented `-F`
+    switch to HP-UX's special `usermod` binary to work around the fact that
+    its standard `usermod` cannot make changes while the user is logged in."
 
   defaultfor :operatingsystem => "hp-ux"
   confine :operatingsystem => "hp-ux"

--- a/lib/puppet/provider/user/ldap.rb
+++ b/lib/puppet/provider/user/ldap.rb
@@ -1,16 +1,16 @@
 require 'puppet/provider/ldap'
 
 Puppet::Type.type(:user).provide :ldap, :parent => Puppet::Provider::Ldap do
-  desc "User management via `ldap`.  This provider requires that you
-    have valid values for all of the ldap-related settings,
-    including `ldapbase`.  You will also almost definitely need settings
-    for `ldapuser` and `ldappassword`, so that your clients can write
-    to ldap.
+  desc "User management via LDAP.
+
+    This provider requires that you have valid values for all of the
+    LDAP-related settings in `puppet.conf`, including `ldapbase`.  You will
+    almost definitely need settings for `ldapuser` and `ldappassword` in order
+    for your clients to write to LDAP.
 
     Note that this provider will automatically generate a UID for you if
     you do not specify one, but it is a potentially expensive operation,
-    as it iterates across all existing users to pick the appropriate next
-    one."
+    as it iterates across all existing users to pick the appropriate next one."
 
   confine :feature => :ldap, :false => (Puppet[:ldapuser] == "")
 

--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -2,7 +2,7 @@ require 'puppet/util/user_attr'
 
 Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source => :useradd do
 
-  desc "User management inherits `useradd` and adds logic to manage roles on Solaris using roleadd."
+  desc "User and role management on Solaris, via `useradd` and `roleadd`."
 
   defaultfor :operatingsystem => :solaris
 

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -1,7 +1,9 @@
 require 'puppet/provider/nameservice/objectadd'
 
 Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameService::ObjectAdd do
-  desc "User management via `useradd` and its ilk.  Note that you will need to install the `Shadow Password` Ruby library often known as ruby-libshadow to manage user passwords."
+  desc "User management via `useradd` and its ilk.  Note that you will need to
+    install Ruby's shadow password library (often known as `ruby-libshadow`)
+    if you wish to manage user passwords."
 
   commands :add => "useradd", :delete => "userdel", :modify => "usermod", :password => "chage"
 

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -1,7 +1,7 @@
 require 'puppet/util/adsi'
 
 Puppet::Type.type(:user).provide :windows_adsi do
-  desc "User management for Windows"
+  desc "User management for Windows."
 
   defaultfor :operatingsystem => :windows
   confine    :operatingsystem => :windows

--- a/lib/puppet/reference/type.rb
+++ b/lib/puppet/reference/type.rb
@@ -23,7 +23,7 @@ type = Puppet::Util::Reference.newreference :type, :doc => "All Puppet resource 
       file { "/etc/passwd":
         owner => root,
         group => root,
-        mode => 644
+        mode  => 644
       }
 
   `/etc/passwd` is considered the title of the file object (used for things like

--- a/lib/puppet/type/computer.rb
+++ b/lib/puppet/type/computer.rb
@@ -15,7 +15,7 @@ Puppet::Type.newtype(:computer) do
 
     This type primarily exists to create localhost Computer objects that MCX
     policy can then be attached to.
-    
+
     **Autorequires:** If Puppet is managing the plist file representing a
     Computer object (located at `/var/db/dslocal/nodes/Default/computers/{name}.plist`),
     the Computer resource will autorequire it."

--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -20,17 +20,17 @@ Puppet::Type.newtype(:cron) do
 
         cron { logrotate:
           command => "/usr/sbin/logrotate",
-          user => root,
-          hour => 2,
-          minute => 0
+          user    => root,
+          hour    => 2,
+          minute  => 0
         }
 
     Note that all periodic attributes can be specified as an array of values:
 
         cron { logrotate:
           command => "/usr/sbin/logrotate",
-          user => root,
-          hour => [2, 4]
+          user    => root,
+          hour    => [2, 4]
         }
 
     ...or using ranges or the step syntax `*/2` (although there's no guarantee
@@ -38,9 +38,9 @@ Puppet::Type.newtype(:cron) do
 
         cron { logrotate:
           command => "/usr/sbin/logrotate",
-          user => root,
-          hour => ['2-4'],
-          minute => '*/10'
+          user    => root,
+          hour    => ['2-4'],
+          minute  => '*/10'
         }
   EOT
   ensurable
@@ -338,9 +338,9 @@ Puppet::Type.newtype(:cron) do
       is used for human reference only and is generated automatically
       for cron jobs found on the system.  This generally won't
       matter, as Puppet will do its best to match existing cron jobs
-      against specified jobs (and Puppet adds a comment to cron jobs it adds), but it is at least possible that converting from
-      unmanaged jobs to managed jobs might require manual
-      intervention."
+      against specified jobs (and Puppet adds a comment to cron jobs it adds),
+      but it is at least possible that converting from unmanaged jobs to
+      managed jobs might require manual intervention."
 
     isnamevar
   end

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -24,7 +24,10 @@ module Puppet
       us at Puppet Labs what you are doing, and hopefully we can work with
       you to get a native resource type for the work you are doing.
 
-      **Autorequires:** If Puppet is managing an exec's cwd or the executable file used in an exec's command, the exec resource will autorequire those files. If Puppet is managing the user that an exec should run as, the exec resource will autorequire that user."
+      **Autorequires:** If Puppet is managing an exec's cwd or the executable
+      file used in an exec's command, the exec resource will autorequire those
+      files. If Puppet is managing the user that an exec should run as, the
+      exec resource will autorequire that user."
 
     # Create a new check mechanism.  It's basically just a parameter that
     # provides one extra 'check' method.
@@ -271,25 +274,27 @@ module Puppet
 
 
     newcheck(:refreshonly) do
-      desc "The command should only be run as a
+      desc <<-EOT
+        The command should only be run as a
         refresh mechanism for when a dependent object is changed.  It only
         makes sense to use this option when this command depends on some
         other object; it is useful for triggering an action:
 
             # Pull down the main aliases file
-            file { \"/etc/aliases\":
-              source => \"puppet://server/module/aliases\"
+            file { "/etc/aliases":
+              source => "puppet://server/module/aliases"
             }
 
             # Rebuild the database, but only when the file changes
             exec { newaliases:
-              path => [\"/usr/bin\", \"/usr/sbin\"],
-              subscribe => File[\"/etc/aliases\"],
+              path        => ["/usr/bin", "/usr/sbin"],
+              subscribe   => File["/etc/aliases"],
               refreshonly => true
             }
 
         Note that only `subscribe` and `notify` can trigger actions, not `require`,
-        so it only makes sense to use `refreshonly` with `subscribe` or `notify`."
+        so it only makes sense to use `refreshonly` with `subscribe` or `notify`.
+      EOT
 
       newvalues(:true, :false)
 
@@ -312,9 +317,9 @@ module Puppet
         if the specified file does not exist.
 
             exec { "tar -xf /Volumes/nfs02/important.tar":
-              cwd => "/var/tmp",
+              cwd     => "/var/tmp",
               creates => "/var/tmp/myfile",
-              path => ["/usr/bin", "/usr/sbin"]
+              path    => ["/usr/bin", "/usr/sbin"]
             }
 
         In this example, if `/var/tmp/myfile` is ever deleted, the exec
@@ -331,12 +336,13 @@ module Puppet
     end
 
     newcheck(:unless) do
-      desc "If this parameter is set, then this `exec` will run unless
+      desc <<-EOT
+        If this parameter is set, then this `exec` will run unless
         the command returns 0.  For example:
 
-            exec { \"/bin/echo root >> /usr/lib/cron/cron.allow\":
-              path => \"/usr/bin:/usr/sbin:/bin\",
-              unless => \"grep root /usr/lib/cron/cron.allow 2>/dev/null\"
+            exec { "/bin/echo root >> /usr/lib/cron/cron.allow":
+              path   => "/usr/bin:/usr/sbin:/bin",
+              unless => "grep root /usr/lib/cron/cron.allow 2>/dev/null"
             }
 
         This would add `root` to the cron.allow file (on Solaris) unless
@@ -344,7 +350,7 @@ module Puppet
 
         Note that this command follows the same rules as the main command,
         which is to say that it must be fully qualified if the path is not set.
-        "
+      EOT
 
       validate do |cmds|
         cmds = [cmds] unless cmds.is_a? Array
@@ -368,12 +374,13 @@ module Puppet
     end
 
     newcheck(:onlyif) do
-      desc "If this parameter is set, then this `exec` will only run if
+      desc <<-EOT
+        If this parameter is set, then this `exec` will only run if
         the command returns 0.  For example:
 
-            exec { \"logrotate\":
-              path => \"/usr/bin:/usr/sbin:/bin\",
-              onlyif => \"test `du /var/log/messages | cut -f1` -gt 100000\"
+            exec { "logrotate":
+              path   => "/usr/bin:/usr/sbin:/bin",
+              onlyif => "test `du /var/log/messages | cut -f1` -gt 100000"
             }
 
         This would run `logrotate` only if that test returned true.
@@ -383,10 +390,10 @@ module Puppet
 
         Also note that onlyif can take an array as its value, e.g.:
 
-            onlyif => [\"test -f /tmp/file1\", \"test -f /tmp/file2\"]
+            onlyif => ["test -f /tmp/file1", "test -f /tmp/file2"]
 
-        This will only run the exec if /all/ conditions in the array return true.
-        "
+        This will only run the exec if _all_ conditions in the array return true.
+      EOT
 
       validate do |cmds|
         cmds = [cmds] unless cmds.is_a? Array

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -25,7 +25,9 @@ Puppet::Type.newtype(:file) do
     Puppet Labs and we can hopefully work with you to develop a
     native resource to support what you are doing.
 
-    **Autorequires:** If Puppet is managing the user or group that owns a file, the file resource will autorequire them. If Puppet is managing any parent directories of a file, the file resource will autorequire them."
+    **Autorequires:** If Puppet is managing the user or group that owns a
+    file, the file resource will autorequire them. If Puppet is managing any
+    parent directories of a file, the file resource will autorequire them."
 
   def self.title_patterns
     [ [ /^(.*?)\/*\Z/m, [ [ :path, lambda{|x| x} ] ] ] ]
@@ -221,8 +223,8 @@ Puppet::Type.newtype(:file) do
       `follow` will copy the target file instead of the link, `manage`
       will copy the link itself, and `ignore` will just pass it by.
       When not copying, `manage` and `ignore` behave equivalently
-      (because you cannot really ignore links entirely during local recursion), and `follow` will manage the file to which the
-      link points."
+      (because you cannot really ignore links entirely during local
+      recursion), and `follow` will manage the file to which the link points."
 
     newvalues(:follow, :manage)
 

--- a/lib/puppet/type/file/ensure.rb
+++ b/lib/puppet/type/file/ensure.rb
@@ -1,29 +1,32 @@
 module Puppet
   Puppet::Type.type(:file).ensurable do
     require 'etc'
-    desc "Whether to create files that don't currently exist.
+    desc <<-EOT
+      Whether to create files that don't currently exist.
       Possible values are *absent*, *present*, *file*, and *directory*.
       Specifying `present` will match any form of file existence, and
       if the file is missing will create an empty file. Specifying
-      `absent` will delete the file (and directory if recurse => true).
+      `absent` will delete the file (and directory if `recurse => true`).
 
-      Anything other than those values will create a symlink. In the interest of readability and clarity, you should use `ensure => link` and explicitly specify a
-      target; however, if a `target` attribute isn't provided, the value of the `ensure`
-      attribute will be used as the symlink target:
+      Anything other than those values will create a symlink. In the interest
+      of readability and clarity, you should use `ensure => link` and
+      explicitly specify a target; however, if a `target` attribute isn't
+      provided, the value of the `ensure` attribute will be used as the
+      symlink target. The following two declarations are equivalent:
 
           # (Useful on Solaris)
-          # Less maintainable: 
-          file { \"/etc/inetd.conf\":
-            ensure => \"/etc/inet/inetd.conf\",
+
+          # Less maintainable:
+          file { "/etc/inetd.conf":
+            ensure => "/etc/inet/inetd.conf",
           }
 
           # More maintainable:
-          file { \"/etc/inetd.conf\":
+          file { "/etc/inetd.conf":
             ensure => link,
-            target => \"/etc/inet/inetd.conf\",
+            target => "/etc/inet/inetd.conf",
           }
-      
-      These two declarations are equivalent."
+    EOT
 
     # Most 'ensure' properties have a default, but with files we, um, don't.
     nodefault

--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -15,7 +15,7 @@ module Puppet
       world-readable by setting e.g.:
 
           file { '/some/dir':
-            mode => 644,
+            mode    => 644,
             recurse => true,
           }
 

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -12,7 +12,8 @@ module Puppet
     include Puppet::Util::Diff
 
     attr_accessor :source, :local
-    desc "Copy a file over the current file.  Uses `checksum` to
+    desc <<-EOT
+      Copy a file over the current file.  Uses `checksum` to
       determine when a file should be copied.  Valid values are either
       fully qualified paths to files, or URIs.  Currently supported URI
       types are *puppet* and *file*.
@@ -23,8 +24,8 @@ module Puppet
       sytems.  For instance:
 
           class sendmail {
-            file { \"/etc/mail/sendmail.cf\":
-              source => \"puppet://server/modules/module_name/sendmail.cf\"
+            file { "/etc/mail/sendmail.cf":
+              source => "puppet://server/modules/module_name/sendmail.cf"
             }
           }
 
@@ -42,18 +43,18 @@ module Puppet
       on the local host, whereas `agent` will connect to the
       puppet server that it received the manifest from.
 
-      See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
-      and use file services within Puppet.
+      See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html)
+      for information on how to configure and use file services within Puppet.
 
       If you specify multiple file sources for a file, then the first
       source that exists will be used.  This allows you to specify
       what amount to search paths for files:
 
-          file { \"/path/to/my/file\":
+          file { "/path/to/my/file":
             source => [
-              \"/modules/nfs/files/file.$host\",
-              \"/modules/nfs/files/file.$operatingsystem\",
-              \"/modules/nfs/files/file\"
+              "/modules/nfs/files/file.$host",
+              "/modules/nfs/files/file.$operatingsystem",
+              "/modules/nfs/files/file"
             ]
           }
 
@@ -61,7 +62,7 @@ module Puppet
 
       You cannot currently copy links using this mechanism; set `links`
       to `follow` if any remote sources are links.
-      "
+    EOT
 
     validate do |sources|
       sources = [sources] unless sources.is_a?(Array)

--- a/lib/puppet/type/file/target.rb
+++ b/lib/puppet/type/file/target.rb
@@ -2,7 +2,7 @@ module Puppet
   Puppet::Type.type(:file).newproperty(:target) do
     desc "The target for creating a link.  Currently, symlinks are the
       only type supported.
-      
+
       You can make relative links:
 
           # (Useful on Solaris)
@@ -10,7 +10,7 @@ module Puppet
             ensure => link,
             target => \"inet/inetd.conf\",
           }
-    
+
       You can also make recursive symlinks, which will create a
       directory structure that maps to the target directory,
       with directories corresponding to each directory

--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -42,7 +42,7 @@ module Puppet
         specified then *path* is checked. If it is set, then the
         bucket is local.  Otherwise the puppetmaster server specified
         in the config or at the commandline is used.
-        
+
         Due to a known issue, you currently must set the `path` attribute to
         false if you wish to specify a `server` attribute."
       defaultto { Puppet[:server] }

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -89,10 +89,9 @@ module Puppet
     end
 
     newparam(:name) do
-      desc "The group name.  While naming limitations vary by
-        system, it is advisable to keep the name to the degenerate
-        limitations, which is a maximum of 8 characters beginning with
-        a letter."
+      desc "The group name. While naming limitations vary by operating system,
+        it is advisable to restrict names to the lowest common denominator,
+        which is a maximum of 8 characters beginning with a letter."
       isnamevar
     end
 
@@ -110,7 +109,7 @@ module Puppet
     end
 
     newproperty(:attributes, :parent => Puppet::Property::KeyValue, :required_features => :manages_aix_lam) do
-      desc "Specify group AIX attributes in an array of keyvalue pairs"
+      desc "Specify group AIX attributes in an array of `key=value` pairs."
 
       def membership
         :attribute_membership

--- a/lib/puppet/type/host.rb
+++ b/lib/puppet/type/host.rb
@@ -36,7 +36,7 @@ module Puppet
     end
 
     newproperty(:comment) do
-      desc "A comment that will be attached to the line with a # character"
+      desc "A comment that will be attached to the line with a # character."
     end
 
     newproperty(:target) do

--- a/lib/puppet/type/interface.rb
+++ b/lib/puppet/type/interface.rb
@@ -7,7 +7,7 @@ require 'puppet/util/network_device/ipcalc'
 Puppet::Type.newtype(:interface) do
 
     @doc = "This represents a router or switch interface. It is possible to manage
-    interface mode (access or trunking, native vlan and encapsulation), 
+    interface mode (access or trunking, native vlan and encapsulation) and
     switchport characteristics (speed, duplex)."
 
     apply_to_device
@@ -22,11 +22,11 @@ Puppet::Type.newtype(:interface) do
     end
 
     newparam(:name) do
-      desc "Interface name"
+      desc "The interface's name."
     end
 
     newparam(:device_url) do
-      desc "Url to connect to a router or switch."
+      desc "The URL at which the router or switch can be reached."
     end
 
     newproperty(:description) do
@@ -73,14 +73,17 @@ Puppet::Type.newtype(:interface) do
     newproperty(:ipaddress, :array_matching => :all) do
       include Puppet::Util::NetworkDevice::IPCalc
 
-      desc "IP Address of this interface (it might not be possible to set an interface IP address 
-      it depends on the interface type and device type).
+      desc "IP Address of this interface. Note that it might not be possible to set
+      an interface IP address; it depends on the interface type and device type.
+
       Valid format of ip addresses are:
-       * IPV4, like 127.0.0.1
-       * IPV4/prefixlength like 127.0.1.1/24
-       * IPV6/prefixlength like FE80::21A:2FFF:FE30:ECF0/128
-       * an optional suffix for IPV6 addresses from this list: eui-64, link-local
-      It is also possible to use an array of values. 
+
+      * IPV4, like 127.0.0.1
+      * IPV4/prefixlength like 127.0.1.1/24
+      * IPV6/prefixlength like FE80::21A:2FFF:FE30:ECF0/128
+      * an optional suffix for IPV6 addresses from this list: `eui-64`, `link-local`
+
+      It is also possible to supply an array of values.
       "
 
       validate do |values|

--- a/lib/puppet/type/k5login.rb
+++ b/lib/puppet/type/k5login.rb
@@ -2,31 +2,31 @@
 
 Puppet::Type.newtype(:k5login) do
   @doc = "Manage the `.k5login` file for a user.  Specify the full path to
-    the `.k5login` file as the name and an array of principals as the
-    property principals."
+    the `.k5login` file as the name, and an array of principals as the
+    `principals` attribute."
 
   ensurable
 
   # Principals that should exist in the file
   newproperty(:principals, :array_matching => :all) do
-    desc "The principals present in the `.k5login` file."
+    desc "The principals present in the `.k5login` file. This should be specified as an array."
   end
 
   # The path/name of the k5login file
   newparam(:path) do
     isnamevar
-    desc "The path to the file to manage.  Must be fully qualified."
+    desc "The path to the `.k5login` file to manage.  Must be fully qualified."
 
     validate do |value|
       unless value =~ /^#{File::SEPARATOR}/
-        raise Puppet::Error, "File paths must be fully qualified"
+        raise Puppet::Error, "File paths must be fully qualified."
       end
     end
   end
 
   # To manage the mode of the file
   newproperty(:mode) do
-    desc "Manage the k5login file's mode"
+    desc "The desired permissions mode of the `.k5login` file. Defaults to `644`."
     defaultto { "644" }
   end
 

--- a/lib/puppet/type/macauthorization.rb
+++ b/lib/puppet/type/macauthorization.rb
@@ -1,7 +1,12 @@
 Puppet::Type.newtype(:macauthorization) do
 
-  @doc = "Manage the Mac OS X authorization database.
-    See the [Apple developer site](http://developer.apple.com/documentation/Security/Conceptual/Security_Overview/Security_Services/chapter_4_section_5.html) for more information.
+  @doc = "Manage the Mac OS X authorization database. See the
+    [Apple developer site](http://developer.apple.com/documentation/Security/Conceptual/Security_Overview/Security_Services/chapter_4_section_5.html)
+    for more information.
+
+    Note that authorization store directives with hyphens in their names have
+    been renamed to use underscores, as Puppet does not react well to hyphens
+    in identifiers.
 
     **Autorequires:** If Puppet is managing the `/etc/authorization` file, each
     macauthorization resource will autorequire it."
@@ -31,7 +36,7 @@ Puppet::Type.newtype(:macauthorization) do
 
   newparam(:name) do
     desc "The name of the right or rule to be managed.
-    Corresponds to 'key' in Authorization Services. The key is the name
+    Corresponds to `key` in Authorization Services. The key is the name
     of a rule. A key uses the same naming conventions as a right. The
     Security Server uses a rule's key to match the rule with a right.
     Wildcard keys end with a '.'. The generic rule has an empty key value.
@@ -41,8 +46,8 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:auth_type) do
-    desc "type - can be a 'right' or a 'rule'. 'comment' has not yet been
-    implemented."
+    desc "Type --- this can be a `right` or a `rule`. The `comment` type has
+    not yet been implemented."
 
     newvalue(:right)
     newvalue(:rule)
@@ -50,11 +55,10 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:allow_root, :boolean => true) do
-    desc "Corresponds to 'allow-root' in the authorization store, renamed
-    due to hyphens being problematic. Specifies whether a right should be
-    allowed automatically if the requesting process is running with
-    uid == 0.  AuthorizationServices defaults this attribute to false if
-    not specified"
+    desc "Corresponds to `allow-root` in the authorization store. Specifies
+    whether a right should be allowed automatically if the requesting process
+    is running with `uid == 0`.  AuthorizationServices defaults this attribute
+    to false if not specified."
 
     newvalue(:true)
     newvalue(:false)
@@ -65,8 +69,7 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:authenticate_user, :boolean => true) do
-    desc "Corresponds to 'authenticate-user' in the authorization store,
-    renamed due to hyphens being problematic."
+    desc "Corresponds to `authenticate-user` in the authorization store."
 
     newvalue(:true)
     newvalue(:false)
@@ -77,8 +80,8 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:auth_class) do
-    desc "Corresponds to 'class' in the authorization store, renamed due
-    to 'class' being a reserved word."
+    desc "Corresponds to `class` in the authorization store; renamed due
+    to 'class' being a reserved word in Puppet."
 
     newvalue(:user)
     newvalue(:'evaluate-mechanisms')
@@ -88,20 +91,20 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:comment) do
-    desc "The 'comment' attribute for authorization resources."
+    desc "The `comment` attribute for authorization resources."
   end
 
   newproperty(:group) do
-    desc "The user must authenticate as a member of this group. This
-    attribute can be set to any one group."
+    desc "A group which the user must authenticate as a member of. This
+    must be a single group."
   end
 
   newproperty(:k_of_n) do
-    desc "k-of-n describes how large a subset of rule mechanisms must
-    succeed for successful authentication. If there are 'n' mechanisms,
-    then 'k' (the integer value of this parameter) mechanisms must succeed.
-    The most common setting for this parameter is '1'. If k-of-n is not
-    set, then 'n-of-n' mechanisms must succeed."
+    desc "How large a subset of rule mechanisms must succeed for successful
+    authentication. If there are 'n' mechanisms, then 'k' (the integer value
+    of this parameter) mechanisms must succeed. The most common setting for
+    this parameter is `1`. If `k-of-n` is not set, then every mechanism ---
+    that is, 'n-of-n' --- must succeed."
 
     munge do |value|
       @resource.munge_integer(value)
@@ -109,7 +112,7 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:mechanisms, :array_matching => :all) do
-    desc "an array of suitable mechanisms."
+    desc "An array of suitable mechanisms."
   end
 
   newproperty(:rule, :array_matching => :all) do
@@ -117,9 +120,8 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:session_owner, :boolean => true) do
-    desc "Corresponds to 'session-owner' in the authorization store,
-    renamed due to hyphens being problematic.  Whether the session owner
-    automatically matches this rule or right."
+    desc "Whether the session owner automatically matches this rule or right.
+    Corresponds to `session-owner` in the authorization store."
 
     newvalue(:true)
     newvalue(:false)
@@ -130,11 +132,11 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:shared, :boolean => true) do
-    desc "If this is set to true, then the Security Server marks the
-    credentials used to gain this right as shared. The Security Server
-    may use any shared credentials to authorize this right. For maximum
-    security, set sharing to false so credentials stored by the Security
-    Server for one application may not be used by another application."
+    desc "Whether the Security Server should mark the credentials used to gain
+    this right as shared. The Security Server may use any shared credentials
+    to authorize this right. For maximum security, set sharing to false so
+    credentials stored by the Security Server for one application may not be
+    used by another application."
 
     newvalue(:true)
     newvalue(:false)
@@ -145,11 +147,10 @@ Puppet::Type.newtype(:macauthorization) do
   end
 
   newproperty(:timeout) do
-    desc "The credential used by this rule expires in the specified
-    number of seconds. For maximum security where the user must
-    authenticate every time, set the timeout to 0. For minimum security,
-    remove the timeout attribute so the user authenticates only once per
-    session."
+    desc "The number of seconds in which the credential used by this rule will
+    expire. For maximum security where the user must authenticate every time,
+    set the timeout to 0. For minimum security, remove the timeout attribute
+    so the user authenticates only once per session."
 
     munge do |value|
       @resource.munge_integer(value)

--- a/lib/puppet/type/maillist.rb
+++ b/lib/puppet/type/maillist.rb
@@ -1,7 +1,7 @@
 module Puppet
   newtype(:maillist) do
-    @doc = "Manage email lists.  This resource type currently can only create
-      and remove lists, it cannot reconfigure them."
+    @doc = "Manage email lists.  This resource type can only create
+      and remove lists; it cannot currently reconfigure them."
 
     ensurable do
       defaultvalues

--- a/lib/puppet/type/mcx.rb
+++ b/lib/puppet/type/mcx.rb
@@ -3,7 +3,7 @@ Puppet::Type.newtype(:mcx) do
   @doc = "MCX object management using DirectoryService on OS X.
 
 The default provider of this type merely manages the XML plist as
-reported by the dscl -mcxexport command.  This is similar to the
+reported by the `dscl -mcxexport` command.  This is similar to the
 content property of the file type in Puppet.
 
 The recommended method of using this type is to use Work Group Manager
@@ -53,14 +53,14 @@ MCX settings refer to, the MCX resource will autorequire that user, group, or co
   end
 
   newparam(:ds_name) do
-    desc "The name to attach the MCX Setting to.
-    e.g. 'localhost' when ds_type => computer. This setting is not
-    required, as it may be parsed so long as the resource name is
-    parseable.  e.g. /Groups/admin where 'group' is the dstype."
+    desc "The name to attach the MCX Setting to. (For example, `localhost`
+    when `ds_type => computer`.) This setting is not required, as it can be
+    automatically discovered when the resource name is parseable.  (For
+    example, in `/Groups/admin`, `group` will be used as the dstype.)"
   end
 
   newproperty(:content, :required_features => :manages_content) do
-    desc "The XML Plist.  The value of MCXSettings in DirectoryService.
+    desc "The XML Plist used as the value of MCXSettings in DirectoryService.
     This is the standard output from the system command:
 
         dscl localhost -mcxexport /Local/Default/<ds_type>/ds_name

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -16,10 +16,11 @@ module Puppet
     newproperty(:ensure) do
       desc "Control what to do with this mount. Set this attribute to
         `umounted` to make sure the filesystem is in the filesystem table
-        but not mounted (if the filesystem is currently mounted, it will be unmounted).  Set it to `absent` to unmount (if necessary) and remove
+        but not mounted (if the filesystem is currently mounted, it will be
+        unmounted).  Set it to `absent` to unmount (if necessary) and remove
         the filesystem from the fstab.  Set to `mounted` to add it to the
         fstab and mount it. Set to `present` to add to fstab but not change
-        mount/unmount status"
+        mount/unmount status."
 
       #  IS        -> SHOULD     In Sync  Action
       #  ghost     -> present    NO       create

--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -30,7 +30,7 @@ module Puppet
     end
 
     newparam(:withpath) do
-      desc "Whether to not to show the full object path."
+      desc "Whether to show the full object path. Defaults to false."
       defaultto :false
 
       newvalues(:true, :false)

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -6,11 +6,10 @@
 module Puppet
   newtype(:package) do
     @doc = "Manage packages.  There is a basic dichotomy in package
-      support right now: Some package types (e.g., yum and apt) can
-      retrieve their own package files, while others (e.g., rpm and
-      sun) cannot.  For those package formats that cannot retrieve
-      their own files, you can use the `source` parameter to point to
-      the correct file.
+      support right now:  Some package types (e.g., yum and apt) can
+      retrieve their own package files, while others (e.g., rpm and sun)
+      cannot.  For those package formats that cannot retrieve their own files,
+      you can use the `source` parameter to point to the correct file.
 
       Puppet will automatically guess the packaging format that you are
       using based on the platform you are on, but you can override it
@@ -49,14 +48,14 @@ module Puppet
       passed to the installer command."
 
     ensurable do
-      desc "What state the package should be in.
-        *latest* only makes sense for those packaging formats that can
-        retrieve new packages on their own and will throw an error on
-        those that cannot.  For those packaging systems that allow you
-        to specify package versions, specify them here.  Similarly,
-        *purged* is only useful for packaging systems that support
-        the notion of managing configuration files separately from
-        'normal' system files."
+      desc <<-EOT
+        What state the package should be in. On packaging systems that can
+        retrieve new packages on their own, you can choose which package to
+        retrieve by specifying a version number or `latest` as the ensure
+        value. On packaging systems that manage configuration files separately
+        from "normal" system files, you can uninstall config files by
+        specifying `purged` as the ensure value.
+      EOT
 
       attr_accessor :latest
 
@@ -197,7 +196,7 @@ module Puppet
           # object name.
           package { $ssl:
             ensure => installed,
-            alias => openssl
+            alias  => openssl
           }
 
           . etc. .
@@ -210,8 +209,8 @@ module Puppet
           # Use the alias to specify a dependency, rather than
           # having another selector to figure it out again.
           package { $ssh:
-            ensure => installed,
-            alias => openssh,
+            ensure  => installed,
+            alias   => openssh,
             require => Package[openssl]
           }
 
@@ -222,7 +221,8 @@ module Puppet
     newparam(:source) do
       desc "Where to find the actual package.  This must be a local file
         (or on a network file system) or a URL that your specific
-        packaging type understands; Puppet will not retrieve files for you."
+        packaging type understands; Puppet will not retrieve files for you,
+        although you can manage packages as `file` resources."
 
       validate do |value|
         provider.validate_source(value)
@@ -265,7 +265,7 @@ module Puppet
 
     newparam(:configfiles) do
       desc "Whether configfiles should be kept or replaced.  Most packages
-        types do not support this parameter."
+        types do not support this parameter. Defaults to `keep`."
 
       defaultto :keep
 

--- a/lib/puppet/type/router.rb
+++ b/lib/puppet/type/router.rb
@@ -7,7 +7,10 @@ module Puppet
     @doc = "Manages connected router."
 
     newparam(:url) do
-      desc "An URL to access the router of the form (ssh|telnet)://user:pass:enable@host/."
+      desc <<-EOT
+        An SSH or telnet URL at which to access the router, in the form
+        `ssh://user:pass:enable@host/` or `telnet://user:pass:enable@host/`.
+      EOT
       isnamevar
     end
   end

--- a/lib/puppet/type/selmodule.rb
+++ b/lib/puppet/type/selmodule.rb
@@ -6,8 +6,11 @@ Puppet::Type.newtype(:selmodule) do
   @doc = "Manages loading and unloading of SELinux policy modules
     on the system.  Requires SELinux support.  See man semodule(8)
     for more information on SELinux policy modules.
-    
-    **Autorequires:** If Puppet is managing the file containing this SELinux policy module (which is either explicitly specified in the `selmodulepath` attribute or will be found at {`selmoduledir`}/{`name`}.pp), the selmodule resource will autorequire that file."
+
+    **Autorequires:** If Puppet is managing the file containing this SELinux
+    policy module (which is either explicitly specified in the `selmodulepath`
+    attribute or will be found at {`selmoduledir`}/{`name`}.pp), the selmodule
+    resource will autorequire that file."
 
   ensurable
 
@@ -20,9 +23,10 @@ Puppet::Type.newtype(:selmodule) do
   newparam(:selmoduledir) do
 
     desc "The directory to look for the compiled pp module file in.
-      Currently defaults to `/usr/share/selinux/targeted`.  If selmodulepath
-      is not specified the module will be looked for in this directory in a
-      in a file called NAME.pp, where NAME is the value of the name parameter."
+      Currently defaults to `/usr/share/selinux/targeted`.  If the
+      `selmodulepath` attribute is not specified, Puppet will expect to find
+      the module in `<selmoduledir>/<name>.pp`, where `name` is the value of the
+      `name` parameter."
 
     defaultto "/usr/share/selinux/targeted"
   end
@@ -30,7 +34,7 @@ Puppet::Type.newtype(:selmodule) do
   newparam(:selmodulepath) do
 
     desc "The full path to the compiled .pp policy module.  You only need to use
-      this if the module file is not in the directory pointed at by selmoduledir."
+      this if the module file is not in the `selmoduledir` directory."
 
   end
 

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -20,10 +20,10 @@ module Puppet
 
       Note that if a `service` receives an event from another resource,
       the service will get restarted. The actual command to restart the
-      service depends on the platform. You can provide an explicit command
-      for restarting with the `restart` attribute, or use the init script's
-      restart command with the `hasrestart` attribute; if you do neither,
-      the service's stop and start commands will be used."
+      service depends on the platform. You can provide an explicit command for
+      restarting with the `restart` attribute, or you can set `hasrestart` to
+      true to use the init script's restart command; if you do neither, the
+      service's stop and start commands will be used."
 
     feature :refreshable, "The provider can restart the service.",
       :methods => [:restart]
@@ -143,10 +143,8 @@ module Puppet
         status on those service whose init scripts do not include a status
         command.
 
-        If this is left unspecified and is needed to check the status
-        of a service, then the service name will be used instead.
-
-        The pattern can be a simple string or any legal Ruby pattern."
+        Defaults to the name of the service. The pattern can be a simple string
+        or any legal Ruby pattern."
 
       defaultto { @resource[:binary] || @resource[:name] }
     end
@@ -164,7 +162,7 @@ module Puppet
         return 0 if the service is running and a nonzero value otherwise.
         Ideally, these return codes should conform to
         [the LSB's specification for init script status actions](http://refspecs.freestandards.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html),
-        but puppet only considers the difference between 0 and nonzero
+        but Puppet only considers the difference between 0 and nonzero
         to be relevant.
 
         If left unspecified, the status method will be determined
@@ -184,8 +182,10 @@ module Puppet
     end
 
     newparam :hasrestart do
-      desc "Specify that an init script has a `restart` option.  Otherwise,
-        the init script's `stop` and `start` methods are used."
+      desc "Specify that an init script has a `restart` command.  If this is
+        false and you do not specify a command in the `restart` attribute,
+        the init script's `stop` and `start` commands will be used. Defaults
+        to true; note that this is a change from earlier versions of Puppet."
       newvalues(:true, :false)
     end
 

--- a/lib/puppet/type/sshkey.rb
+++ b/lib/puppet/type/sshkey.rb
@@ -1,7 +1,7 @@
 module Puppet
   newtype(:sshkey) do
     @doc = "Installs and manages ssh host keys.  At this point, this type
-      only knows how to install keys into `/etc/ssh/ssh_known_hosts`.  See 
+      only knows how to install keys into `/etc/ssh/ssh_known_hosts`.  See
       the `ssh_authorized_key` type to manage authorized keys."
 
     ensurable

--- a/lib/puppet/type/stage.rb
+++ b/lib/puppet/type/stage.rb
@@ -1,7 +1,7 @@
 Puppet::Type.newtype(:stage) do
   desc "A resource type for specifying run stages.  The actual stage should
   be specified on resources:
-      
+
       class { foo: stage => pre }
 
   And you must manually control stage order:

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -43,17 +43,18 @@ Puppet::Type.newtype(:tidy) do
   end
 
   newparam(:matches) do
-    desc "One or more (shell type) file glob patterns, which restrict
+    desc <<-EOT
+      One or more (shell type) file glob patterns, which restrict
       the list of files to be tidied to those whose basenames match
       at least one of the patterns specified. Multiple patterns can
       be specified using an array.
 
       Example:
 
-          tidy { \"/tmp\":
-            age => \"1w\",
+          tidy { "/tmp":
+            age     => "1w",
             recurse => 1,
-            matches => [ \"[0-9]pub*.tmp\", \"*.temp\", \"tmpfile?\" ]
+            matches => [ "[0-9]pub*.tmp", "*.temp", "tmpfile?" ]
           }
 
       This removes files from `/tmp` if they are one week old or older,
@@ -68,7 +69,8 @@ Puppet::Type.newtype(:tidy) do
       for recurse if matches is used, as matches only apply to files found
       by recursion (there's no reason to use static patterns match against
       a statically determined path).  Requiering explicit recursion clears
-      up a common source of confusion."
+      up a common source of confusion.
+    EOT
 
     # Make sure we convert to an array.
     munge do |value|
@@ -87,8 +89,8 @@ Puppet::Type.newtype(:tidy) do
 
   newparam(:backup) do
     desc "Whether tidied files should be backed up.  Any values are passed
-      directly to the file resources used for actual file deletion, so use
-      its backup documentation to determine valid values."
+      directly to the file resources used for actual file deletion, so consult
+      the `file` type's backup documentation to determine valid values."
   end
 
   newparam(:age) do
@@ -143,7 +145,7 @@ Puppet::Type.newtype(:tidy) do
       the specified size.  Unqualified values are in kilobytes, but
       *b*, *k*, *m*, *g*, and *t* can be appended to specify *bytes*,
       *kilobytes*, *megabytes*, *gigabytes*, and *terabytes*, respectively.
-      Only the first character is significant, so the full word can also 
+      Only the first character is significant, so the full word can also
       be used."
 
     @@sizeconvertors = {

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -14,7 +14,10 @@ module Puppet
       groups and generally uses POSIX APIs for retrieving information
       about them.  It does not directly modify `/etc/passwd` or anything.
 
-      **Autorequires:** If Puppet is managing the user's primary group (as provided in the `gid` attribute), the user resource will autorequire that group. If Puppet is managing any role accounts corresponding to the user's roles, the user resource will autorequire those role accounts."
+      **Autorequires:** If Puppet is managing the user's primary group (as
+      provided in the `gid` attribute), the user resource will autorequire
+      that group. If Puppet is managing any role accounts corresponding to the
+      user's roles, the user resource will autorequire those role accounts."
 
     feature :allows_duplicates,
       "The provider supports duplicate users with the same UID."
@@ -86,17 +89,16 @@ module Puppet
     end
 
     newproperty(:uid) do
-      desc "The user ID.  Must be specified numerically.  For new users
-        being created, if no user ID is specified then one will be
-        chosen automatically, which will likely result in the same user
-        having different IDs on different systems, which is not
-        recommended.  This is especially noteworthy if you use Puppet
-        to manage the same user on both Darwin and other platforms,
-        since Puppet does the ID generation for you on Darwin, but the
-        tools do so on other platforms.
+      desc "The user ID; must be specified numerically. If no user ID is
+        specified when creating a new user, then one will be chosen
+        automatically. This will likely result in the same user having
+        different UIDs on different systems, which is not recommended. This is
+        especially noteworthy when managing the same user on both Darwin and
+        other platforms, since Puppet does UID generation on Darwin, but
+        the underlying tools do so on other platforms.
 
-        On Windows, the property will return the user's security
-        identifier (SID)."
+        On Windows, this property is read-only and will return the user's
+        security identifier (SID)."
 
       munge do |value|
         case value
@@ -149,7 +151,7 @@ module Puppet
     end
 
     newproperty(:comment) do
-      desc "A description of the user.  Generally is a user's full name."
+      desc "A description of the user.  Generally the user's full name."
     end
 
     newproperty(:shell) do
@@ -158,7 +160,10 @@ module Puppet
     end
 
     newproperty(:password, :required_features => :manages_passwords) do
-      desc "The user's password, in whatever encrypted format the local machine requires. Be sure to enclose any value that includes a dollar sign ($) in single quotes (\')."
+      desc %q{The user's password, in whatever encrypted format the local
+        machine requires. Be sure to enclose any value that includes a dollar
+        sign ($) in single quotes (') to avoid accidental variable
+        interpolation.}
 
       validate do |value|
         raise ArgumentError, "Passwords cannot include ':'" if value.is_a?(String) and value.include?(":")
@@ -182,7 +187,7 @@ module Puppet
     end
 
     newproperty(:password_min_age, :required_features => :manages_password_age) do
-      desc "The minimum amount of time in days a password must be used before it may be changed"
+      desc "The minimum number of days a password must be used before it may be changed."
 
       munge do |value|
         case value
@@ -195,13 +200,13 @@ module Puppet
 
       validate do |value|
         if value.to_s !~ /^-?\d+$/
-          raise ArgumentError, "Password minimum age must be provided as a number"
+          raise ArgumentError, "Password minimum age must be provided as a number."
         end
       end
     end
 
     newproperty(:password_max_age, :required_features => :manages_password_age) do
-      desc "The maximum amount of time in days a password may be used before it must be changed"
+      desc "The maximum number of days a password may be used before it must be changed."
 
       munge do |value|
         case value
@@ -214,35 +219,35 @@ module Puppet
 
       validate do |value|
         if value.to_s !~ /^-?\d+$/
-          raise ArgumentError, "Password maximum age must be provided as a number"
+          raise ArgumentError, "Password maximum age must be provided as a number."
         end
       end
     end
 
     newproperty(:groups, :parent => Puppet::Property::List) do
-      desc "The groups of which the user is a member.  The primary
-        group should not be listed.  Multiple groups should be
-        specified as an array."
+      desc "The groups to which the user belongs.  The primary group should
+        not be listed, and groups should be identified by name rather than by
+        GID.  Multiple groups should be specified as an array."
 
       validate do |value|
         if value =~ /^\d+$/
-          raise ArgumentError, "Group names must be provided, not numbers"
+          raise ArgumentError, "Group names must be provided, not GID numbers."
         end
-        raise ArgumentError, "Group names must be provided as an array, not a comma-separated list" if value.include?(",")
+        raise ArgumentError, "Group names must be provided as an array, not a comma-separated list." if value.include?(",")
       end
     end
 
     newparam(:name) do
-      desc "User name.  While limitations are determined for
-        each operating system, it is generally a good idea to keep to
-        the degenerate 8 characters, beginning with a letter."
+      desc "The user name. While naming limitations vary by operating system,
+        it is advisable to restrict names to the lowest common denominator,
+        which is a maximum of 8 characters beginning with a letter."
       isnamevar
     end
 
     newparam(:membership) do
-      desc "Whether specified groups should be treated as the only groups
-        of which the user is a member or whether they should merely
-        be treated as the minimum membership list."
+      desc "Whether specified groups should be considered the **complete list**
+        (`inclusive`) or the **minimum list** (`minimum`) of groups to which
+        the user belongs. Defaults to `minimum`."
 
       newvalues(:inclusive, :minimum)
 
@@ -250,7 +255,9 @@ module Puppet
     end
 
     newparam(:system, :boolean => true) do
-      desc "Whether the user is a system user with lower UID."
+      desc "Whether the user is a system user, according to the OS's criteria;
+      on most platforms, a UID less than or equal to 500 indicates a system
+      user. Defaults to `false`."
 
       newvalues(:true, :false)
 
@@ -258,7 +265,7 @@ module Puppet
     end
 
     newparam(:allowdupe, :boolean => true) do
-      desc "Whether to allow duplicate UIDs."
+      desc "Whether to allow duplicate UIDs. Defaults to `false`."
 
       newvalues(:true, :false)
 
@@ -266,7 +273,8 @@ module Puppet
     end
 
     newparam(:managehome, :boolean => true) do
-      desc "Whether to manage the home directory when managing the user."
+      desc "Whether to manage the home directory when managing the user.
+        Defaults to `false`."
 
       newvalues(:true, :false)
 
@@ -281,7 +289,7 @@ module Puppet
 
     newproperty(:expiry, :required_features => :manages_expiry) do
       desc "The expiry date for this user. Must be provided in
-           a zero padded YYYY-MM-DD format - e.g 2010-02-19."
+           a zero-padded YYYY-MM-DD format --- e.g. 2010-02-19."
 
       validate do |value|
         if value !~ /^\d{4}-\d{2}-\d{2}$/
@@ -373,9 +381,9 @@ module Puppet
     end
 
     newparam(:role_membership) do
-      desc "Whether specified roles should be treated as the only roles
-        of which the user is a member or whether they should merely
-        be treated as the minimum membership list."
+      desc "Whether specified roles should be considered the **complete list**
+        (`inclusive`) or the **minimum list** (`minimum`) of roles the user
+        has. Defaults to `minimum`."
 
       newvalues(:inclusive, :minimum)
 
@@ -399,9 +407,9 @@ module Puppet
     end
 
     newparam(:auth_membership) do
-      desc "Whether specified auths should be treated as the only auths
-        of which the user is a member or whether they should merely
-        be treated as the minimum membership list."
+      desc "Whether specified auths should be considered the **complete list**
+        (`inclusive`) or the **minimum list** (`minimum`) of auths the user
+        has. Defaults to `minimum`."
 
       newvalues(:inclusive, :minimum)
 
@@ -425,9 +433,9 @@ module Puppet
     end
 
     newparam(:profile_membership) do
-      desc "Whether specified roles should be treated as the only roles
-        of which the user is a member or whether they should merely
-        be treated as the minimum membership list."
+      desc "Whether specified roles should be treated as the **complete list**
+        (`inclusive`) or the **minimum list** (`minimum`) of roles
+        of which the user is a member. Defaults to `minimum`."
 
       newvalues(:inclusive, :minimum)
 
@@ -435,21 +443,21 @@ module Puppet
     end
 
     newproperty(:keys, :parent => Puppet::Property::KeyValue, :required_features => :manages_solaris_rbac) do
-      desc "Specify user attributes in an array of keyvalue pairs"
+      desc "Specify user attributes in an array of key = value pairs."
 
       def membership
         :key_membership
       end
 
       validate do |value|
-        raise ArgumentError, "key value pairs must be seperated by an =" unless value.include?("=")
+        raise ArgumentError, "Key/value pairs must be seperated by an =" unless value.include?("=")
       end
     end
 
     newparam(:key_membership) do
-      desc "Whether specified key value pairs should be treated as the only attributes
-        of the user or whether they should merely
-        be treated as the minimum list."
+      desc "Whether specified key/value pairs should be considered the
+        **complete list** (`inclusive`) or the **minimum list** (`minimum`) of
+        the user's attributes. Defaults to `minimum`."
 
       newvalues(:inclusive, :minimum)
 
@@ -457,15 +465,15 @@ module Puppet
     end
 
     newproperty(:project, :required_features => :manages_solaris_rbac) do
-      desc "The name of the project associated with a user"
+      desc "The name of the project associated with a user."
     end
 
     newparam(:ia_load_module, :required_features => :manages_aix_lam) do
-      desc "The name of the I&A module to use to manage this user"
+      desc "The name of the I&A module to use to manage this user."
     end
 
     newproperty(:attributes, :parent => Puppet::Property::KeyValue, :required_features => :manages_aix_lam) do
-      desc "Specify user AIX attributes in an array of keyvalue pairs"
+      desc "Specify AIX attributes for the user in an array of attribute = value pairs."
 
       def membership
         :attribute_membership
@@ -481,9 +489,9 @@ module Puppet
     end
 
     newparam(:attribute_membership) do
-      desc "Whether specified attribute value pairs should be treated as the only attributes
-        of the user or whether they should merely
-        be treated as the minimum list."
+      desc "Whether specified attribute value pairs should be treated as the
+        **complete list** (`inclusive`) or the **minimum list** (`minimum`) of
+        attribute/value pairs for the user. Defaults to `minimum`."
 
       newvalues(:inclusive, :minimum)
 

--- a/lib/puppet/type/vlan.rb
+++ b/lib/puppet/type/vlan.rb
@@ -3,24 +3,24 @@
 #
 
 Puppet::Type.newtype(:vlan) do
-    @doc = "This represents a router or switch vlan."
+    @doc = "Manages a VLAN on a router or switch."
 
     apply_to_device
 
     ensurable
 
     newparam(:name) do
-      desc "Vlan id. It must be a number"
+      desc "The numeric VLAN ID."
       isnamevar
 
       newvalues(/^\d+/)
     end
 
     newproperty(:description) do
-      desc "Vlan name"
+      desc "The VLAN's name."
     end
 
     newparam(:device_url) do
-      desc "Url to connect to a router or switch."
+      desc "The URL of the router or switch maintaining this VLAN."
     end
 end

--- a/lib/puppet/type/whit.rb
+++ b/lib/puppet/type/whit.rb
@@ -1,5 +1,9 @@
 Puppet::Type.newtype(:whit) do
-  desc "The smallest possible resource type, for when you need a resource and naught else."
+  desc "Whits are internal artifacts of Puppet's current implementation, and
+    Puppet suppresses their appearance in all logs. We make no guarantee of
+    the whit's continued existence, and it should never be used in an actual
+    manifest. Use the `anchor` type from the puppetlabs-stdlib module if you
+    need arbitrary whit-like no-op resources."
 
   newparam :name do
     desc "The name of the whit, because it must have one."
@@ -18,6 +22,6 @@ Puppet::Type.newtype(:whit) do
   def refresh
     # We don't do anything with them, but we need this to
     #   show that we are "refresh aware" and not break the
-    #   chain of propogation.
+    #   chain of propagation.
   end
 end

--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -48,20 +48,20 @@ module Puppet
   end
 
   # Doc string for properties that can be made 'absent'
-  ABSENT_DOC="Set this to 'absent' to remove it from the file completely"
+  ABSENT_DOC="Set this to `absent` to remove it from the file completely."
 
   newtype(:yumrepo) do
     @doc = "The client-side description of a yum repository. Repository
       configurations are found by parsing `/etc/yum.conf` and
-      the files indicated by the `reposdir` option in that file 
-      (see yum.conf(5) for details)
+      the files indicated by the `reposdir` option in that file
+      (see `yum.conf(5)` for details).
 
       Most parameters are identical to the ones documented
-      in yum.conf(5)
+      in the `yum.conf(5)` man page.
 
-      Continuation lines that yum supports for example for the
-      baseurl are not supported. No attempt is made to access
-      files included with the **include** directive"
+      Continuation lines that yum supports (for the `baseurl`, for example)
+      are not supported. This type does not attempt to read or verify the
+      exinstence of files listed in the `include` attribute."
 
     class << self
       attr_accessor :filetype
@@ -200,13 +200,13 @@ module Puppet
 
     newparam(:name) do
       desc "The name of the repository.  This corresponds to the
-        repositoryid parameter in yum.conf(5)."
+        `repositoryid` parameter in `yum.conf(5)`."
       isnamevar
     end
 
     newproperty(:descr, :parent => Puppet::IniProperty) do
-      desc "A human readable description of the repository.
-        This corresponds to the name parameter in yum.conf(5).
+      desc "A human-readable description of the repository.
+        This corresponds to the name parameter in `yum.conf(5)`.
         #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(/.*/) { }
@@ -222,37 +222,39 @@ module Puppet
     end
 
     newproperty(:baseurl, :parent => Puppet::IniProperty) do
-      desc "The URL for this repository.\n#{ABSENT_DOC}"
+      desc "The URL for this repository. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       # Should really check that it's a valid URL
       newvalue(/.*/) { }
     end
 
     newproperty(:enabled, :parent => Puppet::IniProperty) do
-      desc "Whether this repository is enabled or disabled. Possible
-        values are '0', and '1'.\n#{ABSENT_DOC}"
+      desc "Whether this repository is enabled, as represented by a
+        `0` or `1`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{(0|1)}) { }
     end
 
     newproperty(:gpgcheck, :parent => Puppet::IniProperty) do
       desc "Whether to check the GPG signature on packages installed
-        from this repository. Possible values are '0', and '1'.
-        \n#{ABSENT_DOC}"
+        from this repository, as represented by a `0` or `1`.
+        #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{(0|1)}) { }
     end
 
     newproperty(:gpgkey, :parent => Puppet::IniProperty) do
       desc "The URL for the GPG key with which packages from this
-        repository are signed.\n#{ABSENT_DOC}"
+        repository are signed. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       # Should really check that it's a valid URL
       newvalue(/.*/) { }
     end
 
     newproperty(:include, :parent => Puppet::IniProperty) do
-      desc "A URL from which to include the config.\n#{ABSENT_DOC}"
+      desc "The URL of a remote file containing additional yum configuration
+        settings. Puppet does not check for this file's existence or validity.
+        #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       # Should really check that it's a valid URL
       newvalue(/.*/) { }
@@ -269,41 +271,41 @@ module Puppet
     newproperty(:includepkgs, :parent => Puppet::IniProperty) do
       desc "List of shell globs. If this is set, only packages
         matching one of the globs will be considered for
-        update or install.\n#{ABSENT_DOC}"
+        update or install from this repo. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(/.*/) { }
     end
 
     newproperty(:enablegroups, :parent => Puppet::IniProperty) do
-      desc "Determines whether yum will allow the use of
-        package groups for this  repository. Possible
-        values are '0', and '1'.\n#{ABSENT_DOC}"
+      desc "Whether yum will allow the use of package groups for this
+        repository, as represented by a `0` or `1`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{(0|1)}) { }
     end
 
     newproperty(:failovermethod, :parent => Puppet::IniProperty) do
-      desc "Either 'roundrobin' or 'priority'.\n#{ABSENT_DOC}"
+      desc "The failover methode for this repository; should be either
+        `roundrobin` or `priority`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{roundrobin|priority}) { }
     end
 
     newproperty(:keepalive, :parent => Puppet::IniProperty) do
-      desc "Either '1' or '0'. This tells yum whether or not HTTP/1.1
-        keepalive  should  be  used with this repository.\n#{ABSENT_DOC}"
+      desc "Whether HTTP/1.1 keepalive should be used with this repository, as
+        represented by a `0` or `1`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{(0|1)}) { }
     end
 
      newproperty(:http_caching, :parent => Puppet::IniProperty) do
-       desc "Either 'packages' or 'all' or 'none'.\n#{ABSENT_DOC}" 
+       desc "What to cache from this repository. #{ABSENT_DOC}"
        newvalue(:absent) { self.should = :absent }
        newvalue(%r(packages|all|none)) { }
      end
 
     newproperty(:timeout, :parent => Puppet::IniProperty) do
       desc "Number of seconds to wait for a connection before timing
-        out.\n#{ABSENT_DOC}"
+        out. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{[0-9]+}) { }
     end
@@ -317,7 +319,7 @@ module Puppet
 
     newproperty(:protect, :parent => Puppet::IniProperty) do
       desc "Enable or disable protection for this repository. Requires
-        that the protectbase plugin is installed and enabled.
+        that the `protectbase` plugin is installed and enabled.
         #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{(0|1)}) { }
@@ -325,7 +327,7 @@ module Puppet
 
     newproperty(:priority, :parent => Puppet::IniProperty) do
       desc "Priority of this repository from 1-99. Requires that
-        the priorities plugin is installed and enabled.
+        the `priorities` plugin is installed and enabled.
         #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{[1-9][0-9]?}) { }
@@ -338,20 +340,20 @@ module Puppet
     end
 
     newproperty(:proxy, :parent => Puppet::IniProperty) do
-      desc "URL to the proxy server for this repository.\n#{ABSENT_DOC}"
+      desc "URL to the proxy server for this repository. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       # Should really check that it's a valid URL
       newvalue(/.*/) { }
     end
 
     newproperty(:proxy_username, :parent => Puppet::IniProperty) do
-      desc "Username for this proxy.\n#{ABSENT_DOC}"
+      desc "Username for this proxy. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(/.*/) { }
     end
 
     newproperty(:proxy_password, :parent => Puppet::IniProperty) do
-      desc "Password for this proxy.\n#{ABSENT_DOC}"
+      desc "Password for this proxy. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(/.*/) { }
     end

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -2,132 +2,134 @@ module Puppet
   newtype(:zfs) do
     @doc = "Manage zfs. Create destroy and set properties on zfs instances.
 
-**Autorequires:** If Puppet is managing the zpool at the root of this zfs instance, the zfs resource will autorequire it. If Puppet is managing any parent zfs instances, the zfs resource will autorequire them."
+**Autorequires:** If Puppet is managing the zpool at the root of this zfs
+instance, the zfs resource will autorequire it. If Puppet is managing any
+parent zfs instances, the zfs resource will autorequire them."
 
     ensurable
 
     newparam(:name) do
-      desc "The full name for this filesystem. (including the zpool)"
+      desc "The full name for this filesystem (including the zpool)."
     end
 
     newproperty(:aclinherit) do
-      desc "The aclinherit property. Values: discard | noallow | restricted | passthrough | passthrough-x"
+      desc "The aclinherit property. Valid values are `discard`, `noallow`, `restricted`, `passthrough`, `passthrough-x`."
     end
 
     newproperty(:aclmode) do
-      desc "The aclmode property. Values: discard | groupmask | passthrough"
+      desc "The aclmode property. Valid values are `discard`, `groupmask`, `passthrough`."
     end
 
     newproperty(:atime) do
-      desc "The atime property. Values: on | off"
+      desc "The atime property. Valid values are `on`, `off`."
     end
 
     newproperty(:canmount) do
-      desc "The canmount property. Values: on | off | noauto"
+      desc "The canmount property. Valid values are `on`, `off`, `noauto`."
     end
 
     newproperty(:checksum) do
-      desc "The checksum property. Values: on | off | fletcher2 | fletcher4 | sha256"
+      desc "The checksum property. Valid values are `on`, `off`, `fletcher2`, `fletcher4`, `sha256`."
     end
 
     newproperty(:compression) do
-      desc "The compression property. Values: on | off | lzjb | gzip | gzip-[1-9] | zle"
+      desc "The compression property. Valid values are `on`, `off`, `lzjb`, `gzip`, `gzip-[1-9]`, `zle`."
     end
 
     newproperty(:copies) do
-      desc "The copies property. Values: 1 | 2 | 3"
+      desc "The copies property. Valid values are `1`, `2`, `3`."
     end
 
     newproperty(:devices) do
-      desc "The devices property. Values: on | off"
+      desc "The devices property. Valid values are `on`, `off`."
     end
 
     newproperty(:exec) do
-      desc "The exec property. Values: on | off"
+      desc "The exec property. Valid values are `on`, `off`."
     end
 
     newproperty(:logbias) do
-      desc "The logbias property. Values: latency | throughput"
+      desc "The logbias property. Valid values are `latency`, `throughput`."
     end
 
     newproperty(:mountpoint) do
-      desc "The mountpoint property. Values: <path> | legacy | none"
+      desc "The mountpoint property. Valid values are `<path>`, `legacy`, `none`."
     end
 
     newproperty(:nbmand) do
-      desc "The nbmand property. Values: on | off"
+      desc "The nbmand property. Valid values are `on`, `off`."
     end
 
     newproperty(:primarycache) do
-      desc "The primarycache property. Values: all | none | metadata"
+      desc "The primarycache property. Valid values are `all`, `none`, `metadata`."
     end
 
     newproperty(:quota) do
-      desc "The quota property. Values: <size> | none"
+      desc "The quota property. Valid values are `<size>`, `none`."
     end
 
     newproperty(:readonly) do
-      desc "The readonly property. Values: on | off"
+      desc "The readonly property. Valid values are `on`, `off`."
     end
 
     newproperty(:recordsize) do
-      desc "The recordsize property. Values: 512 to 128k, power of 2"
+      desc "The recordsize property. Valid values are powers of two between 512 and 128k."
     end
 
     newproperty(:refquota) do
-      desc "The refquota property. Values: <size> | none"
+      desc "The refquota property. Valid values are `<size>`, `none`."
     end
 
     newproperty(:refreservation) do
-      desc "The refreservation property. Values: <size> | none"
+      desc "The refreservation property. Valid values are `<size>`, `none`."
     end
 
     newproperty(:reservation) do
-      desc "The reservation property. Values: <size> | none"
+      desc "The reservation property. Valid values are `<size>`, `none`."
     end
 
     newproperty(:secondarycache) do
-      desc "The secondarycache property. Values: all | none | metadata"
+      desc "The secondarycache property. Valid values are `all`, `none`, `metadata`."
     end
 
     newproperty(:setuid) do
-      desc "The setuid property. Values: on | off"
+      desc "The setuid property. Valid values are `on`, `off`."
     end
 
     newproperty(:shareiscsi) do
-      desc "The shareiscsi property. Values: on | off | type=<type>"
+      desc "The shareiscsi property. Valid values are `on`, `off`, `type=<type>`."
     end
 
     newproperty(:sharenfs) do
-      desc "The sharenfs property. Values: on | off | share(1M) options"
+      desc "The sharenfs property. Valid values are `on`, `off`, share(1M) options"
     end
 
     newproperty(:sharesmb) do
-      desc "The sharesmb property. Values: on | off | sharemgr(1M) options"
+      desc "The sharesmb property. Valid values are `on`, `off`, sharemgr(1M) options"
     end
 
     newproperty(:snapdir) do
-      desc "The snapdir property. Values: hidden | visible"
+      desc "The snapdir property. Valid values are `hidden`, `visible`."
     end
 
     newproperty(:version) do
-      desc "The version property. Values: 1 | 2 | 3 | 4 | current"
+      desc "The version property. Valid values are `1`, `2`, `3`, `4`, `current`."
     end
 
     newproperty(:volsize) do
-      desc "The volsize property. Values: <size>"
+      desc "The volsize property. Valid values are `<size>`"
     end
 
     newproperty(:vscan) do
-      desc "The vscan property. Values: on | off"
+      desc "The vscan property. Valid values are `on`, `off`."
     end
 
     newproperty(:xattr) do
-      desc "The xattr property. Values: on | off"
+      desc "The xattr property. Valid values are `on`, `off`."
     end
 
     newproperty(:zoned) do
-      desc "The zoned property. Values: on | off"
+      desc "The zoned property. Valid values are `on`, `off`."
     end
 
     autorequire(:zpool) do

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -1,7 +1,9 @@
 Puppet::Type.newtype(:zone) do
-  @doc = "Solaris zones.
+  @doc = "Manages Solaris zones.
 
-**Autorequires:** If Puppet is managing the directory specified as the root of the zone's filesystem (with the `path` attribute), the zone resource will autorequire that directory."
+**Autorequires:** If Puppet is managing the directory specified as the root of
+the zone's filesystem (with the `path` attribute), the zone resource will
+autorequire that directory."
 
   # These properties modify the zone configuration, and they need to provide
   # the text separately from syncing it, so all config statements can be rolled
@@ -72,7 +74,7 @@ Puppet::Type.newtype(:zone) do
   ensurable do
     desc "The running state of the zone.  The valid states directly reflect
       the states that `zoneadm` provides.  The states are linear,
-      in that a zone must be `configured` then `installed`, and
+      in that a zone must be `configured`, then `installed`, and
       only then can be `running`.  Note also that `halt` is currently
       used to stop zones."
 
@@ -198,8 +200,8 @@ Puppet::Type.newtype(:zone) do
   newparam(:clone) do
     desc "Instead of installing the zone, clone it from another zone.
       If the zone root resides on a zfs file system, a snapshot will be
-      used to create the clone, is it redisides on ufs, a copy of the zone
-      will be used. The zone you clone from must not be running."
+      used to create the clone; if it resides on a ufs filesystem, a copy of the
+      zone will be used. The zone from which you clone must not be running."
   end
 
   newproperty(:ip, :parent => ZoneMultiConfigProperty) do
@@ -243,7 +245,7 @@ Puppet::Type.newtype(:zone) do
   end
 
   newproperty(:iptype, :parent => ZoneConfigProperty) do
-    desc "The IP stack type of the zone. Can either be 'shared' or 'exclusive'."
+    desc "The IP stack type of the zone."
 
     defaultto :shared
 
@@ -285,9 +287,9 @@ Puppet::Type.newtype(:zone) do
   end
 
   newproperty(:dataset, :parent => ZoneMultiConfigProperty) do
-    desc "The list of datasets delegated to the non global zone from the
-      global zone.  All datasets must be zfs filesystem names which is
-      different than the mountpoint." 
+    desc "The list of datasets delegated to the non-global zone from the
+      global zone.  All datasets must be zfs filesystem names which are
+      different from the mountpoint."
 
     validate do |value|
       unless value !~ /^\//
@@ -341,10 +343,10 @@ Puppet::Type.newtype(:zone) do
   # Specify the sysidcfg file.  This is pretty hackish, because it's
   # only used to boot the zone the very first time.
   newparam(:sysidcfg) do
-    desc %{The text to go into the sysidcfg file when the zone is first
+    desc %{The text to go into the `sysidcfg` file when the zone is first
       booted.  The best way is to use a template:
 
-          # $templatedir/sysidcfg
+          # $confdir/modules/site/templates/sysidcfg.erb
           system_locale=en_US
           timezone=GMT
           terminal=xterms
@@ -362,20 +364,20 @@ Puppet::Type.newtype(:zone) do
       And then call that:
 
           zone { myzone:
-            ip => "bge0:192.168.0.23",
-            sysidcfg => template(sysidcfg),
-            path => "/opt/zones/myzone",
+            ip           => "bge0:192.168.0.23",
+            sysidcfg     => template("site/sysidcfg.erb"),
+            path         => "/opt/zones/myzone",
             realhostname => "fully.qualified.domain.name"
           }
 
-      The sysidcfg only matters on the first booting of the zone,
+      The `sysidcfg` only matters on the first booting of the zone,
       so Puppet only checks for it at that time.}
   end
 
   newparam(:path) do
     desc "The root of the zone's filesystem.  Must be a fully qualified
-      file name.  If you include '%s' in the path, then it will be
-      replaced with the zone's name.  At this point, you cannot use
+      file name.  If you include `%s` in the path, then it will be
+      replaced with the zone's name.  Currently, you cannot use
       Puppet to move a zone."
 
     validate do |value|
@@ -394,11 +396,11 @@ Puppet::Type.newtype(:zone) do
   end
 
   newparam(:create_args) do
-    desc "Arguments to the zonecfg create command.  This can be used to create branded zones."
+    desc "Arguments to the `zonecfg` create command.  This can be used to create branded zones."
   end
 
   newparam(:install_args) do
-    desc "Arguments to the zoneadm install command.  This can be used to create branded zones."
+    desc "Arguments to the `zoneadm` install command.  This can be used to create branded zones."
   end
 
   newparam(:realhostname) do

--- a/lib/puppet/type/zpool.rb
+++ b/lib/puppet/type/zpool.rb
@@ -37,7 +37,7 @@ module Puppet
     ensurable
 
     newproperty(:disk, :array_matching => :all, :parent => Puppet::Property::VDev) do
-      desc "The disk(s) for this pool. Can be an array or space separated string"
+      desc "The disk(s) for this pool. Can be an array or a space separated string."
     end
 
     newproperty(:mirror, :array_matching => :all, :parent => Puppet::Property::MultiVDev) do
@@ -71,7 +71,7 @@ module Puppet
     end
 
     newproperty(:log, :array_matching => :all, :parent => Puppet::Property::VDev) do
-      desc "Log disks for this pool. (doesn't support mirroring yet)"
+      desc "Log disks for this pool. This type does not currently support mirroring of log disks."
     end
 
     newparam(:pool) do
@@ -80,7 +80,7 @@ module Puppet
     end
 
     newparam(:raid_parity) do
-      desc "Determines parity when using raidz property."
+      desc "Determines parity when using the `raidz` parameter."
     end
 
     validate do

--- a/lib/puppet/util/nagios_maker.rb
+++ b/lib/puppet/util/nagios_maker.rb
@@ -16,7 +16,7 @@ module Puppet::Util::NagiosMaker
     type.ensurable
 
     type.newparam(nagtype.namevar, :namevar => true) do
-      desc "The name parameter for Nagios type #{nagtype.name}"
+      desc "The name of this nagios_#{nagtype.name} resource."
     end
 
     # We deduplicate the parameters because it makes sense to allow Naginator to have dupes.
@@ -33,7 +33,7 @@ module Puppet::Util::NagiosMaker
     end
 
     type.newproperty(:target) do
-      desc 'target'
+      desc 'The target.'
 
       defaultto do
         resource.class.defaultprovider.default_target


### PR DESCRIPTION
This documentation-only commit makes edits for wording, clarity, accuracy, and
formatting to the description strings in 64 type and provider files, with the aim
of improving the type reference (http://docs.puppetlabs.com/references/latest/type.html).
