### PR TITLE
Ticket/2.7.x/dont count audited resources as managed

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -546,7 +546,7 @@ class Puppet::Resource::Catalog < Puppet::SimpleGraph
   def write_resource_file
     ::File.open(Puppet[:resourcefile], "w") do |f|
       to_print = resources.map do |resource|
-        next if resource.type == :component
+        next unless resource.managed?
         "#{resource.type}[#{resource[resource.name_var]}]"
       end.compact
       f.puts to_print.join("\n")

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -152,11 +152,29 @@ describe Puppet::Type, :fails_on_windows => true do
 
   describe "when creating a provider" do
     before :each do
-      @type = Puppet::Type.newtype(:provider_test_type)
+      @type = Puppet::Type.newtype(:provider_test_type) do
+        newparam(:name) { isnamevar }
+        newparam(:foo)
+        newproperty(:bar)
+      end
     end
 
     after :each do
       @type.provider_hash.clear
+    end
+
+    describe "when determining if instances of the type are managed" do
+      it "should not consider audit only resources to be managed" do
+        @type.new(:name => "foo", :audit => 'all').managed?.should be_false
+      end
+
+      it "should not consider resources with only parameters to be managed" do
+        @type.new(:name => "foo", :foo => 'did someone say food?').managed?.should be_false
+      end
+
+      it "should consider resources with any properties set to be managed" do
+        @type.new(:name => "foo", :bar => 'Let us all go there').managed?.should be_true
+      end
     end
 
     it "should create a subclass of Puppet::Provider for the provider" do


### PR DESCRIPTION
In ticket #8667 puppet was made to write out a list of resources in the
catalog. However, it sometimes wrote out resources that weren’t actually
being managed, like audited resources.

Turns out that there was already a method on the resources to ask if
they were managed, it it did what I needed, so I used it.
