### PR TITLE
SELinux module headers are always little endian.

### DIFF
--- a/lib/puppet/provider/selmodule/semodule.rb
+++ b/lib/puppet/provider/selmodule/semodule.rb
@@ -83,7 +83,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
     filename = selmod_name_to_filename
     mod = File.new(filename, "r")
 
-    (hdr, ver, numsec) = mod.read(12).unpack('LLL')
+    (hdr, ver, numsec) = mod.read(12).unpack('VVV')
 
     raise Puppet::Error, "Found #{hdr} instead of magic #{magic} in #{filename}" if hdr != magic
 


### PR DESCRIPTION
Fixes bug http://projects.puppetlabs.com/issues/7841.
