### PR TITLE
Ticket/2.7.x/9459 user group failures

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -23,6 +23,8 @@ Puppet::Type.type(:group).provide :windows_adsi do
 
   def create
     @group = Puppet::Util::ADSI::Group.create(@resource[:name])
+    @group.commit
+
     self.members = @resource[:members]
   end
 
@@ -32,6 +34,11 @@ Puppet::Type.type(:group).provide :windows_adsi do
 
   def delete
     Puppet::Util::ADSI::Group.delete(@resource[:name])
+  end
+
+  # Only flush if we created or modified a group, not deleted
+  def flush
+    @group.commit if @group
   end
 
   def gid

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -23,6 +23,8 @@ Puppet::Type.type(:user).provide :windows_adsi do
 
   def create
     @user = Puppet::Util::ADSI::User.create(@resource[:name])
+    @user.commit
+
     [:comment, :home, :groups].each do |prop|
       send("#{prop}=", @resource[prop]) if @resource[prop]
     end

--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -127,7 +127,7 @@ module Puppet::Util::ADSI
     def groups
       # WIN32OLE objects aren't enumerable, so no map
       groups = []
-      native_user.Groups.each {|g| groups << g.Name}
+      native_user.Groups.each {|g| groups << g.Name} rescue nil
       groups
     end
 
@@ -163,6 +163,8 @@ module Puppet::Util::ADSI
     end
 
     def self.create(name)
+      # Windows error 1379: The specified local group already exists.
+      raise Puppet::Error.new( "Cannot create user if group '#{name}' exists." ) if Puppet::Util::ADSI::Group.exists? name
       new(name, Puppet::Util::ADSI.create(name, 'user'))
     end
 
@@ -253,6 +255,8 @@ module Puppet::Util::ADSI
     end
 
     def self.create(name)
+      # Windows error 2224: The account already exists.
+      raise Puppet::Error.new( "Cannot create group if user '#{name}' exists." ) if Puppet::Util::ADSI::User.exists? name
       new(name, Puppet::Util::ADSI.create(name, 'group'))
     end
 

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -73,11 +73,19 @@ describe Puppet::Type.type(:user).provider(:windows_adsi) do
 
       user.stubs(:groups).returns(['group2', 'group3'])
 
-      user.expects(:set_groups).with('group1,group2', false)
+      create = sequence('create')
+      user.expects(:commit).in_sequence(create)
+      user.expects(:set_groups).with('group1,group2', false).in_sequence(create)
       user.expects(:[]=).with('Description', 'a test user')
       user.expects(:[]=).with('HomeDirectory', 'C:\Users\testuser')
 
       provider.create
+    end
+
+    it 'should not create a user if a group by the same name exists' do
+      Puppet::Util::ADSI::User.expects(:create).with('testuser').raises( Puppet::Error.new("Cannot create user if group 'testuser' exists.") )
+      expect{ provider.create }.to raise_error( Puppet::Error,
+        /Cannot create user if group 'testuser' exists./ )
     end
   end
 

--- a/spec/unit/util/adsi_spec.rb
+++ b/spec/unit/util/adsi_spec.rb
@@ -39,6 +39,7 @@ describe Puppet::Util::ADSI do
       adsi_user = stub('adsi')
 
       connection.expects(:Create).with('user', username).returns(adsi_user)
+      Puppet::Util::ADSI::Group.expects(:exists?).with(username).returns(false)
 
       user = Puppet::Util::ADSI::User.create(username)
 
@@ -184,6 +185,7 @@ describe Puppet::Util::ADSI do
       adsi_group = stub("adsi")
 
       connection.expects(:Create).with('group', groupname).returns(adsi_group)
+      Puppet::Util::ADSI::User.expects(:exists?).with(groupname).returns(false)
 
       group = Puppet::Util::ADSI::Group.create(groupname)
 


### PR DESCRIPTION
This commit corrects several problems with the Windows 'user' and
'group' providers, Puppet::Util::ADSI helper class.

The 'user' provider failed to add the username to the set of groups
specified in the 'groups' property when creating a new user, due to
the provider trying to enumerate a user's group membership before the
underlying ADSI user object was saved. Any group referenced in the
property must exist prior to creating the resource.

The 'group' provider failed to save a newly-created resource, due to a
missing 'flush' method, which in turn calls the
'Puppet::Util::ADSI.commit' (save) method. It also had the same
problem when creating a new group and trying to add members to it,
before the underlying ADSI group object was saved.

Windows does not allow user and groups to share the same name,
and when attempted the ADSI connection would throw a misleading
exception referring to an 'invalid moniker'. The 'user' provider will
now raise an error if it attempts to create a resource when a like-named
group already exists, and vice-versa.

Spec tests were updated to reflect code changes. Added expectation
sequence to ensure newly created users and groups are committed before
making the ADSI connection.
