### PR TITLE
Tickets/2.7.x/4872 replace false on links

### DIFF
--- a/lib/puppet/type/file/target.rb
+++ b/lib/puppet/type/file/target.rb
@@ -63,7 +63,7 @@ module Puppet
     def insync?(currentvalue)
       if [:nochange, :notlink].include?(self.should) or @resource.recurse?
         return true
-      elsif ! @resource.replace? and File.exists?(@resource[:path])
+      elsif ! @resource.replace? and FileTest.symlink?(@resource[:path])
         return true
       else
         return super(currentvalue)

--- a/test/ral/type/file/target.rb
+++ b/test/ral/type/file/target.rb
@@ -342,5 +342,29 @@ class TestFileTarget < Test::Unit::TestCase
 
     assert_equal(dest, File.readlink(link), "Link did not get changed")
   end
+
+  def test_replace_links_noreplace
+    dest = tempfile
+    otherdest = tempfile
+    link = tempfile
+
+    File.open(otherdest, "w") { |f| f.puts "yay" }
+
+    obj = Puppet::Type.type(:file).new(
+      :path => link,
+      :ensure => dest,
+      :replace => false
+    )
+
+    assert_apply(obj)
+
+    assert_equal(dest, File.readlink(link), "Link did not get created")
+
+    obj[:ensure] = otherdest
+
+    assert_apply(obj)
+
+    assert_equal(dest, File.readlink(link), "Link did change when replace == false")
+  end
 end
 


### PR DESCRIPTION
Fixed the issue when given "replace => false" in the recipe the
destinations were compared instead of the links itself.

It should ignore the links destination when given replace => false.
