### PR TITLE
Ticket/2.7.x/9796

### DIFF
--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -15,9 +15,6 @@ module Puppet
 
       isnamevar
 
-      validate do |value|
-        raise Puppet::Error, "Resourcename must not contain whitespace: #{value}" if value =~ /\s/
-      end
     end
 
     newproperty(:type) do

--- a/spec/unit/provider/ssh_authorized_key/parsed_spec.rb
+++ b/spec/unit/provider/ssh_authorized_key/parsed_spec.rb
@@ -63,6 +63,11 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     genkey(key).should == "from=\"192.168.1.1\",no-pty,no-X11-forwarding ssh-rsa AAAAfsfddsjldjgksdflgkjsfdlgkj root@localhost\n"
   end
 
+  it "should be able to parse name if it includes whitespace" do
+    @provider_class.parse_line('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC7pHZ1XRj3tXbFpPFhMGU1bVwz7jr13zt/wuE+pVIJA8GlmHYuYtIxHPfDHlkixdwLachCpSQUL9NbYkkRFRn9m6PZ7125ohE4E4m96QS6SGSQowTiRn4Lzd9LV38g93EMHjPmEkdSq7MY4uJEd6DUYsLvaDYdIgBiLBIWPA3OrQ== fancy user')[:name].should == 'fancy user'
+    @provider_class.parse_line('from="host1.reductlivelabs.com,host.reductivelabs.com",command="/usr/local/bin/run",ssh-pty ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC7pHZ1XRj3tXbFpPFhMGU1bVwz7jr13zt/wuE+pVIJA8GlmHYuYtIxHPfDHlkixdwLachCpSQUL9NbYkkRFRn9m6PZ7125ohE4E4m96QS6SGSQowTiRn4Lzd9LV38g93EMHjPmEkdSq7MY4uJEd6DUYsLvaDYdIgBiLBIWPA3OrQ== fancy user')[:name].should == 'fancy user'
+  end
+
   it "should be able to parse options containing commas via its parse_options method" do
     options = %w{from="host1.reductlivelabs.com,host.reductivelabs.com" command="/usr/local/bin/run" ssh-pty}
     optionstr = options.join(", ")

--- a/spec/unit/type/ssh_authorized_key_spec.rb
+++ b/spec/unit/type/ssh_authorized_key_spec.rb
@@ -47,9 +47,8 @@ describe ssh_authorized_key, :unless => Puppet.features.microsoft_windows? do
         proc { @class.new(:name => "username@hostname", :ensure => :present, :user => "nobody") }.should_not raise_error
       end
 
-      it "should not support whitespaces" do
-        proc { @class.new(:name => "my test", :ensure => :present, :user => "nobody") }.should raise_error(Puppet::Error,/Resourcename must not contain whitespace/)
-        proc { @class.new(:name => "my\ttest", :ensure => :present, :user => "nobody") }.should raise_error(Puppet::Error,/Resourcename must not contain whitespace/)
+      it "should support whitespace" do
+        proc { @class.new(:name => "my test", :ensure => :present, :user => "nobody") }.should_not raise_error
       end
 
     end


### PR DESCRIPTION
Remove the value validation for the name parameter.

1c7f0c3530 caused a regression: puppet does not support whitespace in
the name anymore, e.g. if you specify

```
ssh_authorized_key { 'fancy user':
  ensure => present,
  type   => rsa,
  key    => 'AAAAB3...iopMxe5aWw==',
}
```

you will get the error "Resourcename must not contain whitespace."

While spaces are in general used as a delimiter OpenSSH does support
these in the comment field and the provider did already handle
whitespace correctly. So the type should not forbid it.
