### PR TITLE
Fix StoreConfig regression for PostgreSQL users.

### DIFF
--- a/lib/puppet/indirector/resource/active_record.rb
+++ b/lib/puppet/indirector/resource/active_record.rb
@@ -62,7 +62,10 @@ class Puppet::Resource::ActiveRecord < Puppet::Indirector::ActiveRecord
     # Some versions of ActiveRecord just to_s a symbol, which our type is, but
     # others preserve the symbol-nature, which causes our storage (string) and
     # query (symbol) to mismatch.  So, manually stringify. --daniel 2011-09-08
-    arguments = [true, type.to_s]
+    #
+    # Also, PostgreSQL is case sensitive; we need to make sure our type name
+    # here matches what we inject. --daniel 2011-09-30
+    arguments = [true, type.to_s.capitalize]
 
     if filter then
       sql, values = filter_to_active_record(filter)

--- a/spec/unit/indirector/resource/active_record_spec.rb
+++ b/spec/unit/indirector/resource/active_record_spec.rb
@@ -70,7 +70,7 @@ describe "Puppet::Resource::ActiveRecord", :if => (Puppet.features.rails? and de
         host = Puppet::Rails::Host.create!(:name => 'one.local')
         Puppet::Rails::Resource.
           create!(:host     => host,
-                  :restype  => 'exec', :title => 'whammo',
+                  :restype  => 'Exec', :title => 'whammo',
                   :exported => true)
 
       end
@@ -80,12 +80,12 @@ describe "Puppet::Resource::ActiveRecord", :if => (Puppet.features.rails? and de
         found.length.should == 1
         found.map do |item|
           item.should respond_to :to_resource
-          item.restype.should == "exec"
+          item.restype.should == "Exec"
         end
       end
 
       it "should not filter resources that have been found before" do
-        search("exec").should == search("exec")
+        search("Exec").should == search("Exec")
       end
     end
   end
@@ -137,7 +137,12 @@ describe "Puppet::Resource::ActiveRecord", :if => (Puppet.features.rails? and de
       got.keys.should =~ [:conditions]
       got[:conditions][0].should be_include "(exported=? AND restype=?)"
       got[:conditions][1].should == true
-      got[:conditions][2].should == type.to_s
+      got[:conditions][2].should == type.to_s.capitalize
+    end
+
+    it "should capitalize the type, since PGSQL is case sensitive" do
+      got = query(type, 'whatever')
+      got[:conditions][2].should == 'Notify'
     end
   end
 


### PR DESCRIPTION
The extraction of StoreConfigs to a terminus caused a regression for
PostgreSQL users, in that we had the wrong case for the title of resources in
the database when matching.

This wasn't caught because MySQL and SQLite do case insensitive matching, and
our stub data was wrongly using a downcased name to test.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
