### PR TITLE
Bug/2.7.x/9832 storeconfigs postgresql regression

### DIFF
--- a/spec/unit/parser/collector_spec.rb
+++ b/spec/unit/parser/collector_spec.rb
@@ -340,7 +340,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       host = Puppet::Rails::Host.create!(:name => 'one.local')
       Puppet::Rails::Resource.
         create!(:host     => host,
-                :restype  => 'notify', :title => 'whammo',
+                :restype  => 'Notify', :title => 'whammo',
                 :exported => true)
 
       result = @collector.evaluate
@@ -354,7 +354,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       host = Puppet::Rails::Host.create!(:name => 'one.local')
       Puppet::Rails::Resource.
         create!(:host     => host,
-                :restype  => 'notify', :title => 'whammo',
+                :restype  => 'Notify', :title => 'whammo',
                 :exported => true)
 
       param = Puppet::Parser::Resource::Param.
@@ -369,7 +369,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       host = Puppet::Rails::Host.create!(:name => 'one.local')
       Puppet::Rails::Resource.
         create!(:host     => host,
-                :restype  => 'notify', :title => 'whammo',
+                :restype  => 'Notify', :title => 'whammo',
                 :exported => true)
 
       @compiler.expects(:add_resource).with do |scope, resource|
@@ -387,7 +387,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       host = Puppet::Rails::Host.create!(:name => 'one.local')
       Puppet::Rails::Resource.
         create!(:host     => host,
-                :restype  => 'notify', :title => 'whammo',
+                :restype  => 'Notify', :title => 'whammo',
                 :exported => true)
 
       got = @collector.evaluate
@@ -401,7 +401,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       host = Puppet::Rails::Host.create!(:name => 'one.local')
       Puppet::Rails::Resource.
         create!(:host     => host,
-                :restype  => 'notify', :title => 'whammo',
+                :restype  => 'Notify', :title => 'whammo',
                 :exported => true)
 
       local = Puppet::Parser::Resource.new('notify', 'whammo', :scope => @scope)
@@ -416,12 +416,12 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       # One that we already collected...
       db = Puppet::Rails::Resource.
         create!(:host     => host,
-                :restype  => 'notify', :title => 'whammo',
+                :restype  => 'Notify', :title => 'whammo',
                 :exported => true)
       # ...and one we didn't.
       Puppet::Rails::Resource.
         create!(:host     => host,
-                :restype  => 'notify', :title => 'boingy-boingy',
+                :restype  => 'Notify', :title => 'boingy-boingy',
                 :exported => true)
 
       local = Puppet::Parser::Resource.new('notify', 'whammo',


### PR DESCRIPTION
The previous PostgreSQL fix had issues with some versions of ActiveRecord
causing test failures; this seems to be tied to specific versions of both AR
and SQLite triggering the failure mode.

The root cause was a badly stubbed record in the database, which is corrected
by this change, and the problem resolved.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
