### PR TITLE
Ticket/2.7.x/8411 change group broken

### DIFF
--- a/lib/puppet/provider/file/posix.rb
+++ b/lib/puppet/provider/file/posix.rb
@@ -103,9 +103,9 @@ Puppet::Type.type(:file).provide :posix do
   def group=(should)
     # Set our method appropriately, depending on links.
     if resource[:links] == :manage
-      method = :lchgrp
+      method = :lchown
     else
-      method = :chgrp
+      method = :chown
     end
 
     begin

--- a/spec/unit/provider/file/posix_spec.rb
+++ b/spec/unit/provider/file/posix_spec.rb
@@ -198,27 +198,27 @@ describe Puppet::Type.type(:file).provider(:posix), :if => Puppet.features.posix
 
   describe "#group=" do
     it "should set the group but not the owner of the file" do
-      File.expects(:lchgrp).with(nil, 15, resource[:path])
+      File.expects(:lchown).with(nil, 15, resource[:path])
 
       provider.group = 15
     end
 
-    it "should chgrp a link if managing links" do
+    it "should change the group for a link if managing links" do
       resource[:links] = :manage
-      File.expects(:lchgrp).with(nil, 20, resource[:path])
+      File.expects(:lchown).with(nil, 20, resource[:path])
 
       provider.group = 20
     end
 
-    it "should chgrp a link target if following links" do
+    it "should change the group for a link target if following links" do
       resource[:links] = :follow
-      File.expects(:chgrp).with(nil, 20, resource[:path])
+      File.expects(:chown).with(nil, 20, resource[:path])
 
       provider.group = 20
     end
 
     it "should pass along any error encountered setting the group" do
-      File.expects(:lchgrp).raises(ArgumentError)
+      File.expects(:lchown).raises(ArgumentError)
 
       expect { provider.group = 25 }.to raise_error(Puppet::Error, /Failed to set group to '25'/)
     end


### PR DESCRIPTION
During the file type refactor, the POSIX file provider was
accidentally changed to invoke the File.chgrp and File.lchgrp
methods. These methods don't actually exist and this was causing
acceptance test failures.

This commit changes the POSIX file provider to invoke the File.chown
and File.lchown methods when changing the group. Updated the spec
tests, and also added integration tests, which simply change the owner
and group to the current values. While not the best test, it will work
in non-root contexts and will ensure this doesn't happen again.
