### PR TITLE
Ticket/2.7.x/9027 groupadd aix warning

### DIFF
--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -107,8 +107,6 @@ module Puppet
 
     newparam(:ia_load_module, :required_features => :manages_aix_lam) do
       desc "The name of the I&A module to use to manage this user"
-
-      defaultto "compat"
     end
 
     newproperty(:attributes, :parent => Puppet::Property::KeyValue, :required_features => :manages_aix_lam) do


### PR DESCRIPTION
Usage of the groupadd provider was leading to spurious log messages of
this form:

info: /Group[developer]: Provider groupadd does not support features
manages_aix_lam; not managing attribute ia_load_module

This was due to the ia_load_module parameter requiring manages_aix_lam
and additionally having a defaultto value of "compat."

This fix is the same as was done for the useradd provider in commit
49c5152d64bb2d73a2751e9844bb2b92b14b88eb and issue #7137.
