### PR TITLE
(#9158) Support old and new versions of STOMP gem.

### DIFF
--- a/lib/puppet/util/queue/stomp.rb
+++ b/lib/puppet/util/queue/stomp.rb
@@ -2,12 +2,14 @@ require 'puppet/util/queue'
 require 'stomp'
 require 'uri'
 
-# Implements the Ruby Stomp client as a queue type within the Puppet::Indirector::Queue::Client
-# registry, for use with the <tt>:queue</tt> indirection terminus type.
+# Implements the Ruby Stomp client as a queue type within the
+# Puppet::Indirector::Queue::Client registry, for use with the <tt>:queue</tt>
+# indirection terminus type.
 #
-# Looks to <tt>Puppet[:queue_source]</tt> for the sole argument to the underlying Stomp::Client constructor;
-# consequently, for this client to work, <tt>Puppet[:queue_source]</tt> must use the Stomp::Client URL-like
-# syntax for identifying the Stomp message broker: <em>login:pass@host.port</em>
+# Looks to <tt>Puppet[:queue_source]</tt> for the sole argument to the
+# underlying Stomp::Client constructor; consequently, for this client to work,
+# <tt>Puppet[:queue_source]</tt> must use the Stomp::Client URL-like syntax
+# for identifying the Stomp message broker: <em>login:pass@host.port</em>
 class Puppet::Util::Queue::Stomp
   attr_accessor :stomp_client
 
@@ -26,10 +28,21 @@ class Puppet::Util::Queue::Stomp
     rescue => detail
       raise ArgumentError, "Could not create Stomp client instance with queue source #{Puppet[:queue_source]}: got internal Stomp client error #{detail}"
     end
+
+    # Identify the supported method for sending messages.
+    @method =
+      case
+      when stomp_client.respond_to?(:publish)
+        :publish
+      when stomp_client.respond_to?(:send)
+        :send
+      else
+        raise ArgumentError, "STOMP client does not respond to either publish or send"
+      end
   end
 
   def publish_message(target, msg)
-    stomp_client.publish(stompify_target(target), msg, :persistent => true)
+    stomp_client.__send__(@method, stompify_target(target), msg, :persistent => true)
   end
 
   def subscribe(target)


### PR DESCRIPTION
The STOMP gem, up to release 1.1.4, used `send` to push messages to the
queue.  From 1.1.5 onward this is replaced by `publish`, and `send` issues a
deprecation warning, but still works.

This commit dynamically adapts to the best available method: if `publish` is
present we use that, otherwise we fall back to `send`, and fail cleanly if we
drift further.

This should behave correctly with all known versions of the STOMP gem, avoid
deprecation warnings, and still end up with the right results.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
