### PR TITLE
Ticket/2.7.x/9879

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -250,11 +250,16 @@ class Puppet::Resource
     return(resource_type.respond_to? :key_attributes) ? resource_type.key_attributes : [:name]
   end
 
+  # caculate whitespace padding for an array of strings
+  def whitespace_padding(values)
+    values.inject(0) { |max,k| k.to_s.length > max ? k.to_s.length : max }
+  end
+
   # Convert our resource to Puppet code.
   def to_manifest
     # Collect list of attributes to align => and move ensure first
     attr = parameters.keys
-    attr_max = attr.inject(0) { |max,k| k.to_s.length > max ? k.to_s.length : max }
+    attr_pad = whitespace_padding(attr)
 
     attr.sort!
     if attr.first != :ensure  && attr.include?(:ensure)
@@ -265,9 +270,16 @@ class Puppet::Resource
     attributes = attr.collect { |k|
       v = parameters[k]
       if v.is_a? Array
-        "  %-#{attr_max}s => %s,\n" % [ k, "[\'#{v.join("', '")}\']" ]
+        "  %-#{attr_pad}s => %s,\n" % [ k, "[\'#{v.join("', '")}\']" ]
+      elsif v.is_a? Hash
+        # addition 2 space padding for two single quotes
+        hash_pad = whitespace_padding(v.keys) + 2
+        output = v.sort.collect { |key, val|
+          "%-#{hash_pad}s => '%s'" % [ "'#{key}'", val ]
+        }.join(",\n "+' '*(attr_pad+7)) # 7 space for padding the following characters: '  => { '
+        "  %-#{attr_pad}s => %s,\n" % [ k, "{ #{output} }" ]
       else
-        "  %-#{attr_max}s => %s,\n" % [ k, "\'#{v}\'" ]
+        "  %-#{attr_pad}s => %s,\n" % [ k, "\'#{v}\'" ]
       end
     }.join
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -507,6 +507,7 @@ type: File
         :parameters => {
           :noop => true,
           :foo => %w{one two},
+          :bar => { 'one' => 'two', 'three' => 'four' },
           :ensure => 'present',
         }
       )
@@ -516,6 +517,8 @@ type: File
       @resource.to_manifest.should == <<-HEREDOC.gsub(/^\s{8}/, '').gsub(/\n$/, '')
         one::two { '/my/file':
           ensure => 'present',
+          bar    => { 'one'   => 'two',
+                      'three' => 'four' },
           foo    => ['one', 'two'],
           noop   => 'true',
         }


### PR DESCRIPTION
This patch improves readability of puppet resource attribute display for
hash values.

Current output:

```
type { 'title':
  attribute => hashkeyhashvalue,
}
```

New output:

```
type { 'title':
  attribute => { hashkey => 'hashvalue' },
}
```
