### PR TITLE
Bug/2.7.x/9832 storeconfigs regressions

### DIFF
--- a/lib/puppet/indirector/resource/active_record.rb
+++ b/lib/puppet/indirector/resource/active_record.rb
@@ -16,9 +16,8 @@ class Puppet::Resource::ActiveRecord < Puppet::Indirector::ActiveRecord
 
   private
   def request_to_type_name(request)
-    name = request.key.split('/', 2)[0]
-    type = Puppet::Type.type(name) or raise Puppet::Error, "Could not find type #{name}"
-    type.name
+    request.key.split('/', 2)[0] or
+      raise "No key found in the request, failing: #{request.inspect}"
   end
 
   def filter_to_active_record(filter)
@@ -59,13 +58,7 @@ class Puppet::Resource::ActiveRecord < Puppet::Indirector::ActiveRecord
     raise Puppet::DevError, "Cannot collect resources for a nil host" unless host
 
     search = "(exported=? AND restype=?)"
-    # Some versions of ActiveRecord just to_s a symbol, which our type is, but
-    # others preserve the symbol-nature, which causes our storage (string) and
-    # query (symbol) to mismatch.  So, manually stringify. --daniel 2011-09-08
-    #
-    # Also, PostgreSQL is case sensitive; we need to make sure our type name
-    # here matches what we inject. --daniel 2011-09-30
-    arguments = [true, type.to_s.capitalize]
+    arguments = [true, type]
 
     if filter then
       sql, values = filter_to_active_record(filter)

--- a/spec/unit/indirector/resource/active_record_spec.rb
+++ b/spec/unit/indirector/resource/active_record_spec.rb
@@ -48,19 +48,15 @@ describe "Puppet::Resource::ActiveRecord", :if => (Puppet.features.rails? and de
       subject.search(Puppet::Resource.indirection.request(:search, type, args))
     end
 
-    it "should fail if the type is not known to Puppet" do
-      expect { search("banana") }.to raise_error Puppet::Error, /Could not find type/
-    end
-
     it "should return an empty array if no resources match" do
-      search("exec").should == []
+      search("Exec").should == []
     end
 
     # Assert that this is a case-insensitive rule, too.
     %w{and or AND OR And Or anD oR}.each do |op|
       it "should fail if asked to search with #{op.inspect}" do
         filter = [%w{tag == foo}, op, %w{title == bar}]
-        expect { search("notify", 'localhost', filter) }.
+        expect { search("Notify", 'localhost', filter) }.
           to raise_error Puppet::Error, /not supported/
       end
     end
@@ -76,7 +72,7 @@ describe "Puppet::Resource::ActiveRecord", :if => (Puppet.features.rails? and de
       end
 
       it "should return something responding to `to_resource` if a resource matches" do
-        found = search("exec")
+        found = search("Exec")
         found.length.should == 1
         found.map do |item|
           item.should respond_to :to_resource
@@ -95,9 +91,7 @@ describe "Puppet::Resource::ActiveRecord", :if => (Puppet.features.rails? and de
       Puppet::Rails.init
     end
 
-    let :type do
-      Puppet::Type.type('notify').name
-    end
+    let :type do 'Notify' end
 
     def query(type, host, filter = nil)
       subject.send :build_active_record_query, type, host, filter


### PR DESCRIPTION
The previous fixes around PostgreSQL were not complete in addressing the
regression: some StoreConfigs exported and imported resources would not be
found.

This removes the last bits that were causing regressions, and additional
testing shows that the generated SQL is now identical between 2.7.3 and the
current version.

This should resolve all the remaining regressions.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
