### PR TITLE
Feature/2.7.x/9997

### DIFF
--- a/ext/puppetstoredconfigclean.rb
+++ b/ext/puppetstoredconfigclean.rb
@@ -62,7 +62,7 @@ args = {:adapter => adapter, :log_level => pm_conf[:rails_loglevel]}
 case adapter
   when "sqlite3"
     args[:dbfile] = pm_conf[:dblocation]
-  when "mysql", "postgresql"
+  when "mysql", "mysql2", "postgresql"
     args[:host]     = pm_conf[:dbserver] unless pm_conf[:dbserver].to_s.empty?
     args[:username] = pm_conf[:dbuser] unless pm_conf[:dbuser].to_s.empty?
     args[:password] = pm_conf[:dbpassword] unless pm_conf[:dbpassword].to_s.empty?

--- a/lib/puppet/rails.rb
+++ b/lib/puppet/rails.rb
@@ -47,7 +47,7 @@ module Puppet::Rails
     case adapter
     when "sqlite3"
       args[:database] = Puppet[:dblocation]
-    when "mysql", "postgresql"
+    when "mysql", "mysql2", "postgresql"
       args[:host]     = Puppet[:dbserver] unless Puppet[:dbserver].to_s.empty?
       args[:port]     = Puppet[:dbport] unless Puppet[:dbport].to_s.empty?
       args[:username] = Puppet[:dbuser] unless Puppet[:dbuser].to_s.empty?

--- a/lib/puppet/rails/database/schema.rb
+++ b/lib/puppet/rails/database/schema.rb
@@ -22,7 +22,7 @@ class Puppet::Rails::Schema
         # Thanks, mysql!  MySQL requires a length on indexes in text fields.
         # So, we provide them for mysql and handle everything else specially.
         # Oracle doesn't index on CLOB fields, so we skip it
-        if Puppet[:dbadapter] == "mysql"
+        if ['mysql','mysql2'].include? Puppet[:dbadapter]
           execute "CREATE INDEX typentitle ON resources (restype,title(50));"
         elsif Puppet[:dbadapter] != "oracle_enhanced"
           add_index :resources, [:title, :restype]

--- a/spec/unit/rails_spec.rb
+++ b/spec/unit/rails_spec.rb
@@ -88,169 +88,100 @@ describe Puppet::Rails, "when initializing a sqlite3 connection", :if => Puppet.
   end
 end
 
-describe Puppet::Rails, "when initializing a mysql connection", :if => Puppet.features.rails? do
-  it "should provide the adapter, log_level, and host, port, username, password, database, and reconnect arguments" do
-    Puppet.settings.stubs(:value).with(:dbadapter).returns("mysql")
-    Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
-    Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
-    Puppet.settings.stubs(:value).with(:dbport).returns("")
-    Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
-    Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
-    Puppet.settings.stubs(:value).with(:dbconnections).returns((pool_size = 45).to_s)
-    Puppet.settings.stubs(:value).with(:dbname).returns("testname")
-    Puppet.settings.stubs(:value).with(:dbsocket).returns("")
+['mysql','mysql2','postgresql'].each do |dbadapter|
+  describe Puppet::Rails, "when initializing a #{dbadapter} connection", :if => Puppet.features.rails? do
+    it "should provide the adapter, log_level, and host, port, username, password, database, and reconnect arguments" do
+      Puppet.settings.stubs(:value).with(:dbadapter).returns(dbadapter)
+      Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
+      Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
+      Puppet.settings.stubs(:value).with(:dbport).returns("")
+      Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
+      Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
+      Puppet.settings.stubs(:value).with(:dbconnections).returns((pool_size = 45).to_s)
+      Puppet.settings.stubs(:value).with(:dbname).returns("testname")
+      Puppet.settings.stubs(:value).with(:dbsocket).returns("")
 
-    Puppet::Rails.database_arguments.should == {
-      :adapter => "mysql",
-      :log_level => "testlevel",
-      :host => "testserver",
-      :username => "testuser",
-      :password => "testpassword",
-      :pool => pool_size,
-      :database => "testname",
-      :reconnect => true
-    }
-  end
+      Puppet::Rails.database_arguments.should == {
+        :adapter => dbadapter,
+        :log_level => "testlevel",
+        :host => "testserver",
+        :username => "testuser",
+        :password => "testpassword",
+        :pool => pool_size,
+        :database => "testname",
+        :reconnect => true
+      }
+    end
 
-  it "should provide the adapter, log_level, and host, port, username, password, database, socket, connections, and reconnect arguments" do
-    Puppet.settings.stubs(:value).with(:dbadapter).returns("mysql")
-    Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
-    Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
-    Puppet.settings.stubs(:value).with(:dbport).returns("9999")
-    Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
-    Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
-    Puppet.settings.stubs(:value).with(:dbconnections).returns((pool_size = 12).to_s)
-    Puppet.settings.stubs(:value).with(:dbname).returns("testname")
-    Puppet.settings.stubs(:value).with(:dbsocket).returns("testsocket")
+    it "should provide the adapter, log_level, and host, port, username, password, database, socket, connections, and reconnect arguments" do
+      Puppet.settings.stubs(:value).with(:dbadapter).returns(dbadapter)
+      Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
+      Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
+      Puppet.settings.stubs(:value).with(:dbport).returns("9999")
+      Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
+      Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
+      Puppet.settings.stubs(:value).with(:dbconnections).returns((pool_size = 12).to_s)
+      Puppet.settings.stubs(:value).with(:dbname).returns("testname")
+      Puppet.settings.stubs(:value).with(:dbsocket).returns("testsocket")
 
-    Puppet::Rails.database_arguments.should == {
-      :adapter => "mysql",
-      :log_level => "testlevel",
-      :host => "testserver",
-      :port => "9999",
-      :username => "testuser",
-      :password => "testpassword",
-      :pool => pool_size,
-      :database => "testname",
-      :socket => "testsocket",
-      :reconnect => true
-    }
-  end
+      Puppet::Rails.database_arguments.should == {
+        :adapter => dbadapter,
+        :log_level => "testlevel",
+        :host => "testserver",
+        :port => "9999",
+        :username => "testuser",
+        :password => "testpassword",
+        :pool => pool_size,
+        :database => "testname",
+        :socket => "testsocket",
+        :reconnect => true
+      }
+    end
 
-  it "should provide the adapter, log_level, and host, port, username, password, database, socket, and connections arguments" do
-    Puppet.settings.stubs(:value).with(:dbadapter).returns("mysql")
-    Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
-    Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
-    Puppet.settings.stubs(:value).with(:dbport).returns("9999")
-    Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
-    Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
-    Puppet.settings.stubs(:value).with(:dbconnections).returns((pool_size = 23).to_s)
-    Puppet.settings.stubs(:value).with(:dbname).returns("testname")
-    Puppet.settings.stubs(:value).with(:dbsocket).returns("testsocket")
+    it "should provide the adapter, log_level, and host, port, username, password, database, socket, and connections arguments" do
+      Puppet.settings.stubs(:value).with(:dbadapter).returns(dbadapter)
+      Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
+      Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
+      Puppet.settings.stubs(:value).with(:dbport).returns("9999")
+      Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
+      Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
+      Puppet.settings.stubs(:value).with(:dbconnections).returns((pool_size = 23).to_s)
+      Puppet.settings.stubs(:value).with(:dbname).returns("testname")
+      Puppet.settings.stubs(:value).with(:dbsocket).returns("testsocket")
 
-    Puppet::Rails.database_arguments.should == {
-      :adapter => "mysql",
-      :log_level => "testlevel",
-      :host => "testserver",
-      :port => "9999",
-      :username => "testuser",
-      :password => "testpassword",
-      :pool => pool_size,
-      :database => "testname",
-      :socket => "testsocket",
-      :reconnect => true
-    }
-  end
+      Puppet::Rails.database_arguments.should == {
+        :adapter => dbadapter,
+        :log_level => "testlevel",
+        :host => "testserver",
+        :port => "9999",
+        :username => "testuser",
+        :password => "testpassword",
+        :pool => pool_size,
+        :database => "testname",
+        :socket => "testsocket",
+        :reconnect => true
+      }
+    end
 
-  it "should not provide the pool if dbconnections is 0, '0', or ''" do
-    Puppet.settings.stubs(:value).with(:dbadapter).returns("mysql")
-    Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
-    Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
-    Puppet.settings.stubs(:value).with(:dbport).returns("9999")
-    Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
-    Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
-    Puppet.settings.stubs(:value).with(:dbname).returns("testname")
-    Puppet.settings.stubs(:value).with(:dbsocket).returns("testsocket")
+    it "should not provide the pool if dbconnections is 0, '0', or ''" do
+      Puppet.settings.stubs(:value).with(:dbadapter).returns(dbadapter)
+      Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
+      Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
+      Puppet.settings.stubs(:value).with(:dbport).returns("9999")
+      Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
+      Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
+      Puppet.settings.stubs(:value).with(:dbname).returns("testname")
+      Puppet.settings.stubs(:value).with(:dbsocket).returns("testsocket")
 
-    Puppet.settings.stubs(:value).with(:dbconnections).returns(0)
-    Puppet::Rails.database_arguments.should_not be_include(:pool)
+      Puppet.settings.stubs(:value).with(:dbconnections).returns(0)
+      Puppet::Rails.database_arguments.should_not be_include(:pool)
 
-    Puppet.settings.stubs(:value).with(:dbconnections).returns('0')
-    Puppet::Rails.database_arguments.should_not be_include(:pool)
+      Puppet.settings.stubs(:value).with(:dbconnections).returns('0')
+      Puppet::Rails.database_arguments.should_not be_include(:pool)
 
-    Puppet.settings.stubs(:value).with(:dbconnections).returns('')
-    Puppet::Rails.database_arguments.should_not be_include(:pool)
-  end
-end
-
-describe Puppet::Rails, "when initializing a postgresql connection", :if => Puppet.features.rails? do
-  it "should provide the adapter, log_level, and host, port, username, password, connections, and database arguments" do
-    Puppet.settings.stubs(:value).with(:dbadapter).returns("postgresql")
-    Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
-    Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
-    Puppet.settings.stubs(:value).with(:dbport).returns("9999")
-    Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
-    Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
-    Puppet.settings.stubs(:value).with(:dbconnections).returns((pool_size = 200).to_s)
-    Puppet.settings.stubs(:value).with(:dbname).returns("testname")
-    Puppet.settings.stubs(:value).with(:dbsocket).returns("")
-
-    Puppet::Rails.database_arguments.should == {
-      :adapter => "postgresql",
-      :log_level => "testlevel",
-      :host => "testserver",
-      :port => "9999",
-      :username => "testuser",
-      :password => "testpassword",
-      :pool => pool_size,
-      :database => "testname",
-      :reconnect => true
-    }
-  end
-
-  it "should provide the adapter, log_level, and host, port, username, password, database, connections, and socket arguments" do
-    Puppet.settings.stubs(:value).with(:dbadapter).returns("postgresql")
-    Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
-    Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
-    Puppet.settings.stubs(:value).with(:dbport).returns("9999")
-    Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
-    Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
-    Puppet.settings.stubs(:value).with(:dbconnections).returns((pool_size = 122).to_s)
-    Puppet.settings.stubs(:value).with(:dbname).returns("testname")
-    Puppet.settings.stubs(:value).with(:dbsocket).returns("testsocket")
-
-    Puppet::Rails.database_arguments.should == {
-      :adapter => "postgresql",
-      :log_level => "testlevel",
-      :host => "testserver",
-      :port => "9999",
-      :username => "testuser",
-      :password => "testpassword",
-      :pool => pool_size,
-      :database => "testname",
-      :socket => "testsocket",
-      :reconnect => true
-    }
-  end
-
-  it "should not provide the pool if dbconnections is 0, '0', or ''" do
-    Puppet.settings.stubs(:value).with(:dbadapter).returns("mysql")
-    Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
-    Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
-    Puppet.settings.stubs(:value).with(:dbport).returns("9999")
-    Puppet.settings.stubs(:value).with(:dbuser).returns("testuser")
-    Puppet.settings.stubs(:value).with(:dbpassword).returns("testpassword")
-    Puppet.settings.stubs(:value).with(:dbname).returns("testname")
-    Puppet.settings.stubs(:value).with(:dbsocket).returns("testsocket")
-
-    Puppet.settings.stubs(:value).with(:dbconnections).returns(0)
-    Puppet::Rails.database_arguments.should_not be_include(:pool)
-
-    Puppet.settings.stubs(:value).with(:dbconnections).returns('0')
-    Puppet::Rails.database_arguments.should_not be_include(:pool)
-
-    Puppet.settings.stubs(:value).with(:dbconnections).returns('')
-    Puppet::Rails.database_arguments.should_not be_include(:pool)
+      Puppet.settings.stubs(:value).with(:dbconnections).returns('')
+      Puppet::Rails.database_arguments.should_not be_include(:pool)
+    end
   end
 end
 
@@ -292,7 +223,7 @@ describe Puppet::Rails, "when initializing an Oracle connection", :if => Puppet.
   end
 
   it "should not provide the pool if dbconnections is 0, '0', or ''" do
-    Puppet.settings.stubs(:value).with(:dbadapter).returns("mysql")
+    Puppet.settings.stubs(:value).with(:dbadapter).returns("oracle_enhanced")
     Puppet.settings.stubs(:value).with(:rails_loglevel).returns("testlevel")
     Puppet.settings.stubs(:value).with(:dbserver).returns("testserver")
     Puppet.settings.stubs(:value).with(:dbport).returns("9999")


### PR DESCRIPTION
Besides the mysql gem there is a mysql2 gem that is a "modern, simple
and very fast Mysql library for Ruby" [1]. It can either be installed as a
seperate gem (v0.2.x) for ActiveRecord < 3.1 or can be used as part of
ActiveRecord 3.1

To use mysql2 the dbadapter setting must be set to "mysql2" and this patch
adds support for this setting.

[1] https://github.com/brianmario/mysql2#readme
