### PR TITLE
Tickets/2.7.x/9831 standardize windows provider confines

### DIFF
--- a/lib/puppet/provider/exec/windows.rb
+++ b/lib/puppet/provider/exec/windows.rb
@@ -3,8 +3,8 @@ require 'puppet/provider/exec'
 Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
   include Puppet::Util::Execution
 
-  confine :feature => :microsoft_windows
-  defaultfor :feature => :microsoft_windows
+  confine    :operatingsystem => :windows
+  defaultfor :operatingsystem => :windows
 
   desc "Execute external binaries directly, on Windows systems.
 This does not pass through a shell, or perform any interpolation, but

--- a/lib/puppet/provider/file/windows.rb
+++ b/lib/puppet/provider/file/windows.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:file).provide :windows do
   desc "Uses Microsoft Windows functionality to manage file's users and rights."
 
-  confine :feature => :microsoft_windows
+  confine :operatingsystem => :windows
 
   include Puppet::Util::Warnings
 

--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -4,8 +4,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
   desc "Group management for Windows"
 
   defaultfor :operatingsystem => :windows
-  confine :operatingsystem => :windows
-  confine :feature => :microsoft_windows
+  confine    :operatingsystem => :windows
 
   has_features :manages_members
 

--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:service).provide :windows do
   * Control of service groups (dependencies) is not yet supported."
 
   defaultfor :operatingsystem => :windows
-  confine :operatingsystem => :windows
+  confine    :operatingsystem => :windows
 
   has_feature :refreshable
 

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -4,8 +4,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
   desc "User management for Windows"
 
   defaultfor :operatingsystem => :windows
-  confine :operatingsystem => :windows
-  confine :feature => :microsoft_windows
+  confine    :operatingsystem => :windows
 
   has_features :manages_homedir, :manages_passwords
 


### PR DESCRIPTION
The newly created providers for Windows were using a combination of
`:operatingsystem => :windows` and `:feature => :microsoft_windows`
for their confine and defaultfor calls.  This brings them in line to
all use the `:operatingsystem => :windows` form.

The general reasoning being that `:operatingsystem` is used for things
that are platform specific, where `:feature` is used for things that are
supported across multiple platforms, but require that external (to
Puppet or the base platform) support exist on the host.
