### PR TITLE
make the debian service provider handle services that dont provide the th

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -40,6 +40,13 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
     # See x-man-page://invoke-rc.d
     if [104, 106].include?($CHILD_STATUS.exitstatus)
       return :true
+    elsif [105].include?($CHILD_STATUS.exitstatus)
+      # 105 is unknown, which generally means the the iniscript does not support query
+      if `/bin/ls -1 /etc/rc*.d/S*#{@resource[:name]} 2>/dev/null| wc -l`.to_i >= 4
+        return :true
+      else
+        return :false
+      end
     else
       return :false
     end


### PR DESCRIPTION
make the debian service provider handle services that dont provide the the query methods as specified in http://www.debian.org/doc/debian-policy/ch-opersys.html
