### PR TITLE
10032 fix tests for solaris

### DIFF
--- a/acceptance/tests/ticket_7139_puppet_resource_file_qualified_paths.rm
+++ b/acceptance/tests/ticket_7139_puppet_resource_file_qualified_paths.rm
@@ -5,7 +5,7 @@ create_remote_file(agents, '/tmp/ticket-7139', %w{foo bar contents} )
 
 step "Run puppet file resource on /tmp/ticket-7139"
 agents.each do |host|
-  on(host, "puppet resource file /tmp/ticket-7139") do
+  on host, puppet("resource file /tmp/ticket-7139") do
     assert_match(/file \{ \'\/tmp\/ticket-7139\':/, stdout, "puppet resource file failed on #{host}")
   end
 end


### PR DESCRIPTION
Update test to use the new "puppet" method vs. calling
puppet via "on"; using "puppet" results in correct setting
of RUBYLIB and PATH.
