### PR TITLE
(#7296) Make the Debian service provider handle services that don't

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -40,9 +40,23 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
     # See x-man-page://invoke-rc.d
     if [104, 106].include?($CHILD_STATUS.exitstatus)
       return :true
+    elsif [105].include?($CHILD_STATUS.exitstatus)
+      # 105 is unknown, which generally means the the iniscript does not support query
+      # The debian policy states that the initscript should support methods of query
+      # For those that do not, peform the checks manually
+      # http://www.debian.org/doc/debian-policy/ch-opersys.html
+      if get_start_link_count >= 4
+        return :true
+      else
+        return :false
+      end
     else
       return :false
     end
+  end
+
+  def get_start_link_count
+    Dir.glob("/etc/rc*.d/S*#{@resource[:name]}").length
   end
 
   def enable

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -88,6 +88,21 @@ describe provider_class do
       @provider.enabled?.should == :true
     end
 
+    context "when invoke-rc.d exits with 105 status" do
+      it "links count is 4" do
+        @provider.stubs(:system)
+        $CHILD_STATUS.stubs(:exitstatus).returns(105)
+        @provider.stubs(:get_start_link_count).returns(4)
+        @provider.enabled?.should == :true
+      end
+      it "links count is less than 4" do
+        @provider.stubs(:system)
+        $CHILD_STATUS.stubs(:exitstatus).returns(105)
+        @provider.stubs(:get_start_link_count).returns(3)
+        @provider.enabled?.should == :false
+      end
+    end
+
     # pick a range of non-[104.106] numbers, strings and booleans to test with.
     [-100, -1, 0, 1, 100, "foo", "", :true, :false].each do |exitstatus|
       it "should return false when invoke-rc.d exits with #{exitstatus} status" do


### PR DESCRIPTION
conform to the debain policy manual.

This change is to support initscripts that do not support the --query
method of invoke-rc.d used by the Debian provider to determine if
service is enabled.

The fix checks that the link count in /etc/rc?.d is equal to 4, which is
the number of links that should be present when using the Debian service
provider, which is done by `update-rc.d #{service} defaults`.
