### PR TITLE
(#10161) Fix spurious ruby warning

### DIFF
--- a/lib/puppet/provider/package/msi.rb
+++ b/lib/puppet/provider/package/msi.rb
@@ -47,7 +47,7 @@ Puppet::Type.type(:package).provide(:msi, :parent => Puppet::Provider::Package) 
         'source'          => msi_source
       }
 
-      f.puts(YAML.dump metadata)
+      f.puts(YAML.dump(metadata))
     end
   end
 

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -46,7 +46,7 @@ Puppet::Type.newtype(:file) do
     # path name. The aim is to use less storage for all common paths in a hierarchy
     munge do |value|
       # We know the value is absolute, so expanding it will just standardize it.
-      path, name = ::File.split(::File.expand_path value)
+      path, name = ::File.split(::File.expand_path(value))
 
       { :index => Puppet::FileCollection.collection.index(path), :name => name }
     end


### PR DESCRIPTION
Ruby 1.8.6 issues warnings when arguments to nested methods are not
parenthesized, e.g.

  f.puts(YAML.dump metadata)

results in:

  warning: parenthsize arguments(s) for future versions

These warnings were introduced during Windows development, but not
noticed on that platform due to using ruby 1.8.7, which doesn't issue
a warning. This commit just wraps the arguments in parenthesis.
