### PR TITLE
Ticket/2.7.x/10237

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -172,11 +172,11 @@ class Puppet::Property < Puppet::Parameter
   def insync?(is)
     self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
 
-    # an empty array is analogous to no should values
-    return true if @should.empty?
-
     # Look for a matching value
     return (is == @should or is == @should.collect { |v| v.to_s }) if match_all?
+
+    # an empty array is analogous to no should values
+    return true if @should.empty?
 
     @should.each { |val| return true if is == val or is == val.to_s }
 

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -355,6 +355,71 @@ describe Puppet::Property do
     end
   end
 
+  describe "when calling safe_insync?" do
+
+    describe "and array_matching is set to :first" do
+
+      before :each do
+        @class.array_matching = :first
+      end
+
+      it "should return in sync if no @should value is set" do
+        @property.should.must be_nil # checking whether my assumption of an empty @should is correct
+        @property.safe_insync?('foo').should == true
+        @property.safe_insync?(['foo','bar']).should == true
+      end
+      it "should return in sync if @should is empty" do
+        @property.should = []
+        @property.safe_insync?('foo').should == true
+        @property.safe_insync?(['foo','bar']).should == true
+      end
+      it "should return in sync if @is matches any @should value" do
+        @property.should = ['alt1','alt2','alt3']
+        @property.safe_insync?('alt1').should == true
+        @property.safe_insync?('alt2').should == true
+        @property.safe_insync?('alt3').should == true
+      end
+      it "should return out of sync if @is matches no @should value" do
+        @property.should = ['alt1','alt2','alt3']
+        @property.safe_insync?('alt4').should == false
+      end
+    end
+
+    describe "and array_matching is set to :all" do
+
+      before :each do
+        @class.array_matching = :all
+      end
+
+      it "should return in sync if no @should value is set" do
+        @property.should.must be_nil # checking whether my assumption of an empty @should is correct
+        @property.safe_insync?('foo').should == true
+        @property.safe_insync?(['foo','bar']).should == true
+      end
+      it "should return in sync if both @is and @should are empty" do
+        @property.should = []
+        @property.safe_insync?([]).should == true
+      end
+      it "should return in sync if @is and @should have the same content" do
+        [ %w{single}, %w{mult1 mult2} ].each do |test_array|
+          @property.should = test_array
+          @property.safe_insync?(test_array).should == true
+        end
+      end
+      it "should return out of sync if @should is an empty array while @is is not" do
+        @property.should = []
+        @property.safe_insync?(['alt1']).should == false
+        @property.safe_insync?(['alt2','alt3']).should == false
+      end
+      it "should return out of sync if @should and @is have different contents" do
+        @property.should = ['alt1','alt2','alt3']
+        @property.safe_insync?(['alt2','alt3']).should == false
+      end
+    end
+
+  end
+
+
   describe "when syncing the 'should' value" do
     it "should set the value" do
       @class.newvalue(:foo)


### PR DESCRIPTION
If we specify array_matching => all for a property and the should value
is an empty array I would expect that puppet removes any possible is
value instead of ignoring the property entirely. Example taken from
issue #10237:

```
k5login {'/root/.k5login':
  principals => []
}
```

With this patch applied we do not ignore the principals property.
Instead we do remove any principal that is mentioned in
`/root/.k5login` (in my opinion the expected behaviour).

This change effects other types that use :array_matching => all
as well and is potentially dangerous if we have a default value
of [] somewhere. But that does not seem to be the case.
