### PR TITLE
(#8465) Make report URL reporting work over HTTPS.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -480,6 +480,9 @@ module Puppet
         subdirectory."},
     :reporturl => ["http://localhost:3000/reports/upload",
       "The URL used by the http reports processor to send reports"],
+    :reporturl_ssl_verify => [ false, "Whether to verify SSL connections for reporting URL."],
+    :reporturl_ssl_cert => ["/etc/ssl/certs/ca-certificates.crt",
+      "File path to SSL CA certificate for HTTPS connections to report URL."],
     :fileserverconfig => ["$confdir/fileserver.conf", "Where the fileserver configuration is stored."],
     :strict_hostname_checking => [false, "Whether to only search for the complete
       hostname as it is in the certificate when searching for node information


### PR DESCRIPTION
Add in two defaults to the master section for doing HTTPS verification and
for a path to the CA file in question. Modify http reports to do http and
https and emit a warning if said CA file doesn't exist.

Errors if the specified CA file doesn't exist. Defaults to the location used in Debian/Ubuntu.
