### PR TITLE
(#10081) Creating RC tarballs should be handled by rake.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require 'rspec'
 require "rspec/core/rake_task"
 
 module Puppet
-    PUPPETVERSION = File.read('lib/puppet.rb')[/PUPPETVERSION *= *'(.*)'/,1] or fail "Couldn't find PUPPETVERSION"
+    PUPPETVERSION = `git describe`.strip
 end
 
 Dir['tasks/**/*.rake'].each { |t| load t }


### PR DESCRIPTION
Previously generating tarballs for rc's required a lot of manual
intervention. This fix corrects the versioning scheme so that
everything is handled automatically via the rake task.
