### PR TITLE
Ticket/2.7.x/9544

### DIFF
--- a/spec/integration/provider/package_spec.rb
+++ b/spec/integration/provider/package_spec.rb
@@ -27,6 +27,13 @@ describe "Package provider", :'fails_on_ruby_1.9.2' => true do
           Puppet[:vardir] = tmpdir('msi_package_var_dir')
         end
 
+        # the instances method requires root priviledges on gentoo
+        # if the eix cache is outdated (to run eix-update) so make
+        # sure we dont actually run eix-update
+        if provider.name == :portage
+          provider.stubs(:update_eix).returns('Database contains 15240 packages in 155 categories')
+        end
+
         provider.instances.each do |package|
           package.should be_instance_of(provider)
           package.properties[:provider].should == provider.name


### PR DESCRIPTION
The portage package provider on gentoo uses the helper program eix to
query packages.  Eix uses a cache and the portage provider calls
eix-update in case the cache is out of date.  The eix-update needs root
priviledges (or the user at least has to be in the portage group) that
may not be the case when running the specs.

Stub the update_eix method to prevent puppet from modifying the current
system when running the specs.
