### PR TITLE
Configure rcov and flay tests for metric_fu.

### DIFF
--- a/tasks/rake/metrics.rake
+++ b/tasks/rake/metrics.rake
@@ -3,6 +3,10 @@ begin
   MetricFu::Configuration.run do |config|
     config.flay = { :dirs_to_flay => ['lib'] }
     config.rcov[:rcov_opts] << "-Ispec"
+    config.base_directory = ENV['TMPDIR']
+    config.data_directory = File.join(config.base_directory, '_data')
+    config.scratch_directory = File.join(config.base_directory, 'scratch')
+    config.output_directory = File.join(config.base_directory, 'output')
   end
 rescue LoadError
   # Metric-fu not installed


### PR DESCRIPTION
Currently if you run rake metrics:all on puppet, you get no results
from flay (because it needs to be told the directory to look in),
and incomplete results from rcov (because it needs to be pointed to rspec).
This patch adds the necessary configuration to the rake task.
The metric_fu gem will need to be installed for the metrics:all task to exist.
