### PR TITLE
Fix windows ca specs

### DIFF
--- a/spec/unit/face/certificate_spec.rb
+++ b/spec/unit/face/certificate_spec.rb
@@ -57,6 +57,10 @@ describe Puppet::Face[:certificate, '0.0.1'] do
     let(:host) { Puppet::SSL::Host.new(hostname) }
     let(:csr) { host.certificate_request }
 
+    before :each do
+      Puppet[:autosign] = false
+    end
+
     describe "for the current host" do
       let(:hostname) { Puppet[:certname] }
 
@@ -131,7 +135,7 @@ describe Puppet::Face[:certificate, '0.0.1'] do
     let(:host) { Puppet::SSL::Host.new(hostname) }
     let(:hostname) { "foobar" }
 
-    it "should sign the certificate request if one is waiting" do
+    it "should sign the certificate request if one is waiting", :unless => Puppet.features.microsoft_windows? do
       subject.generate(hostname, options)
 
       subject.sign(hostname, options)
@@ -147,7 +151,7 @@ describe Puppet::Face[:certificate, '0.0.1'] do
       end.to raise_error(ArgumentError, /Could not find certificate request for #{hostname}/)
     end
 
-    describe "when ca_location is local" do
+    describe "when ca_location is local", :unless => Puppet.features.microsoft_windows? do
       describe "when the request has dns alt names" do
         before :each do
           subject.generate(hostname, options.merge(:dns_alt_names => 'some,alt,names'))

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -104,7 +104,7 @@ describe Puppet::Indirector::REST do
       end.to raise_error(/This is often because the time is out of sync on the server or client/)
     end
 
-    it "should provide a helpful error message when hostname was not match with server certificate" do
+    it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet.features.microsoft_windows? do
       Puppet[:confdir] = tmpdir('conf')
       cert = Puppet::SSL::CertificateAuthority.new.generate('not_my_server', :dns_alt_names => 'foo,bar,baz').content
 

--- a/spec/unit/network/handler/ca_spec.rb
+++ b/spec/unit/network/handler/ca_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 require 'puppet/network/handler/ca'
 
-describe Puppet::Network::Handler::CA do
+describe Puppet::Network::Handler::CA, :unless => Puppet.features.microsoft_windows? do
   include PuppetSpec::Files
 
   describe "#getcert" do

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -79,7 +79,7 @@ describe Puppet::SSL::Host do
     Puppet::SSL::Host.localhost.should equal(host)
   end
 
-  it "should create a localhost cert if no cert is available and it is a CA with autosign and it is using DNS alt names" do
+  it "should create a localhost cert if no cert is available and it is a CA with autosign and it is using DNS alt names", :unless => Puppet.features.microsoft_windows? do
     Puppet[:autosign] = true
     Puppet[:confdir] = tmpdir('conf')
     Puppet[:dns_alt_names] = "foo,bar,baz"


### PR DESCRIPTION
These specs were all failing on Windows because they were trying to
perform actions related to signing certificates (either to test that
behavior, or as setup), which is not supported on Windows. So we
disable these tests on Windows.
