### PR TITLE
Schedule/bug/10321 rangearray

### DIFF
--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -74,7 +74,8 @@ module Puppet
             }
 
         This is mostly useful for restricting certain resources to being
-        applied in maintenance windows or during off-peak hours."
+        applied in maintenance windows or during off-peak hours. Multiple
+        ranges can be applied in array context."
 
       # This is lame; properties all use arrays as values, but parameters don't.
       # That's going to hurt eventually.
@@ -170,7 +171,7 @@ module Puppet
 
           #self.info limits.inspect
           #self.notice now
-          return now.between?(*limits)
+          return true if now.between?(*limits)
         end
 
         # Else, return false, since our current time isn't between


### PR DESCRIPTION
Change the schedule type's range parameter to properly evaluate
all elements of a supplied array for validity instead of only
checking the first member of the array. Add documentation to
clarify that range does accept an array.
