### PR TITLE
Ticket/2.7.x/10346

### DIFF
--- a/spec/unit/indirector/node/store_configs_spec.rb
+++ b/spec/unit/indirector/node/store_configs_spec.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 require 'puppet/node'
+require 'puppet/indirector/memory'
 require 'puppet/indirector/node/store_configs'
 
 class Puppet::Node::StoreConfigsTesting < Puppet::Indirector::Memory


### PR DESCRIPTION
This spec was failing when run by itself (or with other specs in a
certain order) because it was trying to use Puppet::Indirector::Memory
without requiring it first. So add the necessary require line.
