### PR TITLE
Ticket/2.6.x/10289

### DIFF
--- a/spec/unit/indirector/facts/inventory_service_spec.rb
+++ b/spec/unit/indirector/facts/inventory_service_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Node::Facts::InventoryService do
 
     expect {
       subject.save(request)
-    }.not_to raise_error
+    }.should_not raise_error
   end
 end
 


### PR DESCRIPTION
This spec was failing with older rspecs because not_to was not defined.
