### PR TITLE
Ticket/2.7.x/10269 build break

### DIFF
--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -228,6 +228,10 @@ describe Puppet::Type.type(:file) do
               File.symlink(target, link)
             end
 
+            after :each do
+              File.chmod(0750, target)
+            end
+
             describe "that is readable" do
               it "should set the executable bits when creating the destination (#10315)" do
                 pending "bug #10315"
@@ -314,6 +318,10 @@ describe Puppet::Type.type(:file) do
               # link -> target -> real_target
               File.symlink(real_target, target)
               File.symlink(target, link)
+            end
+
+            after :each do
+              File.chmod(0750, real_target)
             end
 
             describe "when following all links" do


### PR DESCRIPTION
Previously, some of the file integration tests were failing to cleanup
non-executable directories when using a world-writable TMPDIR.

The issue is that if the parent directory is world-writable, then
FileUtils.rm_r performs additional steps to ensure it is not
vulnerable to a TOCTTOU attack, such as ensuring the parent directory
is sticky and that the directory-to-be-deleted is readable.

This was not noticed earlier, because on Mac and Windows, TMPDIR
defaults to a user-specific directory, which is not
world-writable. But the Jenkins nodes are using /tmp, so it caused
these failures.

This commit changes the tests to explicitly make the directories
read/write/executable for the current user, so that they can be
cleaned up.
