### PR TITLE
Feature/2.7.x/9508 auth any rather than auth no

### DIFF
--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -75,21 +75,22 @@ path /file
 allow *
 
 ### Unauthenticated ACL, for clients for which the current master doesn't
-### have a valid certificate
+### have a valid certificate; we allow authenticated users, too, because
+### there isn't a great harm in letting that request through.
 
 # allow access to the master CA
 path /certificate/ca
-auth no
+auth any
 method find
 allow *
 
 path /certificate/
-auth no
+auth any
 method find
 allow *
 
 path /certificate_request
-auth no
+auth any
 method find, save
 allow *
 

--- a/lib/puppet/network/rest_authconfig.rb
+++ b/lib/puppet/network/rest_authconfig.rb
@@ -14,9 +14,11 @@ module Puppet
       { :acl => "/file" },
       { :acl => "/certificate_revocation_list/ca", :method => :find, :authenticated => true },
       { :acl => "/report", :method => :save, :authenticated => true },
-      { :acl => "/certificate/ca", :method => :find, :authenticated => false },
-      { :acl => "/certificate/", :method => :find, :authenticated => false },
-      { :acl => "/certificate_request", :method => [:find, :save], :authenticated => false },
+      # These allow `auth any`, because if you can do them anonymously you
+      # should probably also be able to do them when trusted.
+      { :acl => "/certificate/ca", :method => :find, :authenticated => nil },
+      { :acl => "/certificate/", :method => :find, :authenticated => nil },
+      { :acl => "/certificate_request", :method => [:find, :save], :authenticated => nil },
       { :acl => "/status", :method => [:find], :authenticated => true },
     ]
 


### PR DESCRIPTION
In `auth.conf`, a setting of `auth no` means that only unauthenticated
requests are allowed.  If you actually have a certificate you can't use the
service.  (Yes, anonymous users have _more_ access than authenticated ones.)

This alters the default to `auth any` instead, which allows you to access
these endpoints even where you already have a certificate.

This better supports the distributed model of certificate management anyhow,
now that we have things like the cloud provisioner trying to manage
certificates for other nodes over the network.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
