### PR TITLE
(#9508) Unify `auth no` and `auth any` in the system.

### DIFF
--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -79,17 +79,17 @@ allow *
 
 # allow access to the master CA
 path /certificate/ca
-auth no
+auth any
 method find
 allow *
 
 path /certificate/
-auth no
+auth any
 method find
 allow *
 
 path /certificate_request
-auth no
+auth any
 method find, save
 allow *
 

--- a/lib/puppet/network/rights.rb
+++ b/lib/puppet/network/rights.rb
@@ -190,7 +190,7 @@ class Rights
     def allowed?(name, ip, args = {})
       return :dunno if acl_type == :regex and not @methods.include?(args[:method])
       return :dunno if acl_type == :regex and @environment.size > 0 and not @environment.include?(args[:environment])
-      return :dunno if acl_type == :regex and not @authentication.nil? and args[:authenticated] != @authentication
+      return :dunno if acl_type == :regex and (@authentication and not args[:authenticated])
 
       begin
         # make sure any capture are replaced if needed
@@ -229,10 +229,8 @@ class Rights
       case authentication
       when "yes", "on", "true", true
         authentication = true
-      when "no", "off", "false", false
+      when "no", "off", "false", false, "all" ,"any", :all, :any
         authentication = false
-      when "all","any", :all, :any
-        authentication = nil
       else
         raise ArgumentError, "'#{name}' incorrect authenticated value: #{authentication}"
       end

--- a/spec/unit/network/rights_spec.rb
+++ b/spec/unit/network/rights_spec.rb
@@ -461,19 +461,10 @@ describe Puppet::Network::Rights do
       end
     end
 
-    ["off", "no", "false", false].each do |auth|
-      it "should allow filtering on unauthenticated requests with '#{auth}'" do
+    ["off", "no", "false", false, "all", "any", :all, :any].each do |auth|
+      it "should allow filtering on authenticated or unauthenticated requests with '#{auth}'" do
         @acl.restrict_authenticated(auth)
-
         @acl.authentication.should be_false
-      end
-    end
-
-    ["all", "any", :all, :any].each do |auth|
-      it "should not use request authenticated state filtering with '#{auth}'" do
-        @acl.restrict_authenticated(auth)
-
-        @acl.authentication.should be_nil
       end
     end
 


### PR DESCRIPTION
In `auth.conf`, a setting of `auth no` means that only unauthenticated
requests are allowed.  If you actually have a certificate you can't use the
service.  (Yes, anonymous users have _more_ access than authenticated ones.)

This is about as strange as you can get, so instead we unify those: you now
have the choices `auth yes` and `auth any`; `auth no` is an alias for the
later.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
