### PR TITLE
Tickets/2.7.x/8255 use string mode creating file setting resources

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -75,4 +75,3 @@ module Puppet
     end
   end
 end
-

--- a/lib/puppet/util/settings/file_setting.rb
+++ b/lib/puppet/util/settings/file_setting.rb
@@ -91,7 +91,20 @@ class Puppet::Util::Settings::FileSetting < Puppet::Util::Settings::Setting
     resource = Puppet::Resource.new(:file, path)
 
     if Puppet[:manage_internal_file_permissions]
-      resource[:mode] = self.mode if self.mode
+      if self.mode
+        # This ends up mimicking the munge method of the mode
+        # parameter to make sure that we're always passing the string
+        # version of the octal number.  If we were setting the
+        # 'should' value for mode rather than the 'is', then the munge
+        # method would be called for us automatically.  Normally, one
+        # wouldn't need to call the munge method manually, since
+        # 'should' gets set by the provider and it should be able to
+        # provide the data in the appropriate format.
+        mode = self.mode
+        mode = mode.to_i(8) if mode.is_a?(String)
+        mode = mode.to_s(8)
+        resource[:mode] = mode
+      end
 
       # REMIND fails on Windows because chown/chgrp functionality not supported yet
       if Puppet.features.root? and !Puppet.features.microsoft_windows?
@@ -122,4 +135,3 @@ class Puppet::Util::Settings::FileSetting < Puppet::Util::Settings::Setting
     }
   end
 end
-

--- a/spec/unit/util/settings/file_setting_spec.rb
+++ b/spec/unit/util/settings/file_setting_spec.rb
@@ -173,10 +173,16 @@ describe Puppet::Util::Settings::FileSetting do
       @file.to_resource.title.should == path
     end
 
-    it "should set the mode on the file if a mode is provided" do
+    it "should set the mode on the file if a mode is provided as an octal number" do
       @file.mode = 0755
 
-      @file.to_resource[:mode].should == 0755
+      @file.to_resource[:mode].should == '755'
+    end
+
+    it "should set the mode on the file if a mode is provided as a string" do
+      @file.mode = '0755'
+
+      @file.to_resource[:mode].should == '755'
     end
 
     it "should not set the mode on a the file if manage_internal_file_permissions is disabled" do


### PR DESCRIPTION
(#8255) Always use string modes when creating resources from FileSetting settings

Since we're setting the 'is', rather than the 'should' on the
resource, the property's munge method is not automatically called for
us and we need to make sure we're always passing the stringified
version of the mode to the resource.

By doing this, we fix the problem where 'puppet --genmanifest' would
output the (base 10) integer version of the mode in the generated
manifest for settings where the mode was not specified as a string.

It would have been nice to re-use the munge from the mode property
directly, but there doesn't appear to be a good/clean way to do this
(especially without reaching into the internals of other objects).

Another alternative would have been to modify []= to call munge for
us, but this isn't really a change to be made in a point release,
especially not without very careful thought about the implications of
such a change.
