### PR TITLE
Tickets/2.7.x/6907 pluginsync and providers

### DIFF
--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -99,6 +99,9 @@ module Manager
   def rmtype(name)
     # Then create the class.
 
+    if klass = type(name)
+      klass.clear_providers
+    end
     klass = rmclass(name, :hash => @types)
 
     singleton_class.send(:remove_method, "new#{name}") if respond_to?("new#{name}")

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -866,7 +866,9 @@ class Type
 
     # Put the default provider first, then the rest of the suitable providers.
     provider_instances = {}
-    providers_by_source.collect do |provider|
+    providers_by_source.reject { |provider|
+      ! provider.suitable?
+    }.collect do |provider|
       all_properties = self.properties.find_all do |property|
         provider.supports_parameter?(property)
       end.collect do |property|
@@ -1381,6 +1383,12 @@ class Type
   def self.defaultprovider
     unless @defaultprovider
       suitable = suitableprovider
+      if suitable.empty? and ! provider_hash.empty?
+        # We've got providers but none are suitable.  Pick from this list, but know there aren't
+        # any suitable providers
+        Puppet.warning "Could not find suitable providers for type '#{self.name}'; defaulting to an unsuitable provider"
+        suitable = provider_hash.values
+      end
 
       # Find which providers are a default for this system.
       defaults = suitable.find_all { |provider| provider.default? }
@@ -1429,6 +1437,12 @@ class Type
   # Just list all of the providers.
   def self.providers
     provider_hash.keys
+  end
+
+  # Clear all registered providers. This is generally only
+  # used when cleaning up from testing.
+  def self.clear_providers
+    provider_hash.clear
   end
 
   def self.validprovider?(name)


### PR DESCRIPTION
We were previously failing in two circumstances:
- Prefetching unsuitable providers at the beginning
  of a transaction
- Choosing a default provider when all available
  providers are unsuitable.

The major downside of these failures is that pluginsync
could not reliably be used to download new providers
and use them in the same run.

This commit fixes those two areas, and tests that they
no longer fail.  It unfortunately does not (and, really,
cannot as a unit test) test that pluginsync works with
this kind of provider, but it gets as close as possible.

Signed-off-by: Luke Kanies luke@puppetlabs.com
