### PR TITLE
Feature/2.7.x/4865 notify start of evaluation not just end

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -100,6 +100,7 @@ class Puppet::Transaction
       if resource.is_a?(Puppet::Type::Component)
         Puppet.warning "Somehow left a component in the relationship graph"
       else
+        resource.debug "Starting to evaluate the resource" if Puppet[:evaltrace] and @catalog.host_config?
         seconds = thinmark { eval_resource(resource) }
         resource.info "Evaluated in %0.2f seconds" % seconds if Puppet[:evaltrace] and @catalog.host_config?
       end


### PR DESCRIPTION
The `evaltrace` option allowed individual resource evaluation time to be
tracked, which made it easier to post-hoc identify which resources took long
periods of time to process.

It is also helpful, when doing live debugging, to know where the hang happens;
to support that we now log a debug message about starting the evaluation of
the resource before we go into the process.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
