### PR TITLE
(#10727) Don't rely on Kernel#Pathname

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -261,7 +261,7 @@ Puppet::Type.newtype(:file) do
 
   # Autorequire the nearest ancestor directory found in the catalog.
   autorequire(:file) do
-    path = Pathname(self[:path])
+    path = Pathname.new(self[:path])
     if !path.root?
       # Start at our parent, to avoid autorequiring ourself
       parents = path.parent.enum_for(:ascend)


### PR DESCRIPTION
A recent change to Puppet::Type::File made use of Kernel#Pathname
which is only available in ruby 1.8.5 and later. Since the change
introduced more incompatibility with pre-1.8.5 for no good reason, and
is trivial to fix, I'm fixing it to use Pathname.new instead.
