### PR TITLE
Added missing RequestHeader lines to ext/rack/files/apache2.conf

### DIFF
--- a/ext/rack/files/apache2.conf
+++ b/ext/rack/files/apache2.conf
@@ -26,6 +26,10 @@ Listen 8140
         SSLVerifyDepth  1
         SSLOptions +StdEnvVars
 
+        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+
         DocumentRoot /etc/puppet/rack/public/
         RackBaseURI /
         <Directory /etc/puppet/rack/>


### PR DESCRIPTION
The following lines were missing from the example apache2.conf:

```
    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
```

Even though these lines are listed in the documentation, if you copy this file it causes cryptic errors and is quite difficult to debug.
