### PR TITLE
Added missing RequestHeader lines to the example apache2.conf

### DIFF
--- a/ext/rack/files/apache2.conf
+++ b/ext/rack/files/apache2.conf
@@ -26,6 +26,10 @@ Listen 8140
         SSLVerifyDepth  1
         SSLOptions +StdEnvVars
 
+        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+
         DocumentRoot /etc/puppet/rack/public/
         RackBaseURI /
         <Directory /etc/puppet/rack/>


### PR DESCRIPTION
Added missing RequestHeader lines to the example apache2.conf:

  RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
  RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
  RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e

Even though these are listed in the documentation, if you copy the apache2.conf file from /usr/share/puppet/ext/rack/files/apache2.conf, you end up with cryptic errors which are difficult to debug.
