### PR TITLE
(#6412) - hash/array access of inexistant value should be false

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -161,7 +161,7 @@ class Puppet::Parser::AST
 
       raise Puppet::ParseError, "#{variable} is not an hash or array when accessing it with #{accesskey}" unless object.is_a?(Hash) or object.is_a?(Array)
 
-      object[array_index_or_key(object, accesskey)]
+      object[array_index_or_key(object, accesskey)] || :undef
     end
 
     # Assign value to this hashkey or array index

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -151,12 +151,28 @@ describe Puppet::Parser::AST::HashOrArrayAccess do
       lambda { access.evaluate(@scope) }.should raise_error
     end
 
+    it "should be able to return :undef for an unknown array index" do
+      @scope.stubs(:lookupvar).with { |name,options| name == 'a'}.returns(["val1", "val2", "val3"])
+
+      access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => 6 )
+
+      access.evaluate(@scope).should == :undef
+    end
+
     it "should be able to return an hash value" do
       @scope.stubs(:lookupvar).with { |name,options| name == 'a'}.returns({ "key1" => "val1", "key2" => "val2", "key3" => "val3" })
 
       access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => "key2" )
 
       access.evaluate(@scope).should == "val2"
+    end
+
+    it "should be able to return :undef for unknown hash keys" do
+      @scope.stubs(:lookupvar).with { |name,options| name == 'a'}.returns({ "key1" => "val1", "key2" => "val2", "key3" => "val3" })
+
+      access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => "key12" )
+
+      access.evaluate(@scope).should == :undef
     end
 
     it "should be able to return an hash value with a numerical key" do


### PR DESCRIPTION
The truethiness test done in P::P::Scope.true? doesn't handle nil
values, because it is not valid as result of a puppet expression.

Unfortunately ruby hash['invalid'] or array[inexistant_index] returns
nil which then was considered as true in an if expression.
This patch makes sure :undef is returned in those cases.
