### PR TITLE
Fix #7106 - allow to set mode of the last run summary

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -703,11 +703,11 @@ EOT
       "Whether to send reports after every transaction."
     ],
     :lastrunfile =>  { :default => "$statedir/last_run_summary.yaml",
-      :mode => 0660,
+      :mode => 0644,
       :desc => "Where puppet agent stores the last run report summary in yaml format."
     },
     :lastrunreport =>  { :default => "$statedir/last_run_report.yaml",
-      :mode => 0660,
+      :mode => 0644,
       :desc => "Where puppet agent stores the last run report in yaml format."
     },
     :graph => [false, "Whether to create dot graph files for the different

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -47,6 +47,7 @@ describe Puppet::Configurer do
       Puppet::Transaction::Report.indirection.stubs(:save)
 
       Puppet[:lastrunfile] = tmpfile("lastrunfile")
+      Puppet.settings.setting(:lastrunfile).mode = 0666
       Puppet[:report] = true
 
       # We only record integer seconds in the timestamp, and truncate
@@ -55,6 +56,8 @@ describe Puppet::Configurer do
       t1 = Time.now.tv_sec
       @configurer.run :catalog => @catalog, :report => report
       t2 = Time.now.tv_sec
+
+      File.stat(Puppet[:lastrunfile]).mode.to_s(8).should == "100666"
 
       summary = nil
       File.open(Puppet[:lastrunfile], "r") do |fd|


### PR DESCRIPTION
This commit allows to set the last run summary file mode. And also changes the defaults to 0644 instead of 0660.
