### PR TITLE
Add autonotify support to types

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -322,6 +322,16 @@ class Puppet::Resource::Catalog < Puppet::SimpleGraph
             end
           end
         end
+        vertex.autonotify(self).each do |edge|
+          unless @relationship_graph.edge?(edge.source, edge.target) # don't let automatic relationships conflict with manual ones.
+            unless @relationship_graph.edge?(edge.target, edge.source)
+              vertex.debug "Autonotifying #{edge.target}"
+              @relationship_graph.add_edge(edge)
+            else
+              vertex.debug "Skipping automatic relationship with #{(edge.source == vertex ? edge.target : edge.source)}"
+            end
+          end
+        end
       end
       @relationship_graph.write_graph(:relationships) if host_config?
 


### PR DESCRIPTION
Blatant copy of existing autorequire code to add graceful automatic notify support to types.  

A potential use case for such a feature is where a resource needs to notify 1 or more services, but only if those services are configured on the node.
