### PR TITLE
tickets/2.7.x/10807: Use SMF's svcadm -s option to wait for errors

### DIFF
--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
     when :maintenance
       [command(:adm), :clear, @resource[:name]]
     else
-      [command(:adm), :enable, @resource[:name]]
+      [command(:adm), :enable, "-s", @resource[:name]]
     end
   end
 
@@ -98,7 +98,7 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
   end
 
   def stopcmd
-    [command(:adm), :disable, @resource[:name]]
+    [command(:adm), :disable, "-s", @resource[:name]]
   end
 end
 

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -92,7 +92,7 @@ describe provider_class do
 
     it "should always execute external command 'svcadm enable /system/myservice'" do
       @provider.stubs(:status).returns :running
-      @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, "/system/myservice"], true)
+      @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, "-s", "/system/myservice"], true)
       @provider.start
     end
 
@@ -112,7 +112,7 @@ describe provider_class do
 
     it "should import the manifest if service is missing" do
       @provider.expects(:svccfg).with(:import, "/tmp/myservice.xml")
-      @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, "/system/myservice"], true)
+      @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, "-s", "/system/myservice"], true)
       @provider.expects(:svcs).with('-H', '-o', 'state,nstate', "/system/myservice").returns("online\t-")
       @provider.start
     end
@@ -125,7 +125,7 @@ describe provider_class do
 
   describe "when stopping" do
     it "should execute external command 'svcadm disable /system/myservice'" do
-      @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, "/system/myservice"], true)
+      @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, "-s", "/system/myservice"], true)
       @provider.stop
     end
   end


### PR DESCRIPTION
By default running `svcadm enable example` will start the service in the
background and won't return errors if it fails.  Using the -s option will cause
svcadm to wait and return errors back to the provider if the service cannot
start for some reason.

see http://projects.puppetlabs.com/issues/10807
