### PR TITLE
Ticket/2.6.x/10677 fix 4135 in 2.6 branch

### DIFF
--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -24,8 +24,12 @@ module Puppet::Configurer::PluginHandler
     return if FileTest.directory?(file)
 
     begin
-      Puppet.info "Loading downloaded plugin #{file}"
-      load file
+      if file =~ /.rb$/
+        Puppet.info "Loading downloaded plugin #{file}"
+        load file
+      else
+        Puppet.debug "Skipping downloaded plugin #{file}"
+      end
     rescue Exception => detail
       Puppet.err "Could not load downloaded file #{file}: #{detail}"
     end

--- a/spec/unit/configurer/plugin_handler_spec.rb
+++ b/spec/unit/configurer/plugin_handler_spec.rb
@@ -76,18 +76,25 @@ describe Puppet::Configurer::PluginHandler do
     @pluginhandler.download_plugins
   end
 
-  it "should load plugins when asked to do so" do
+  it "should load ruby plugins when asked to do so" do
     FileTest.stubs(:exist?).returns true
-    @pluginhandler.expects(:load).with("foo")
+    @pluginhandler.expects(:load).with("foo.rb")
+
+    @pluginhandler.load_plugin("foo.rb")
+  end
+
+  it "should skip non-ruby plugins when asked to do so" do
+    FileTest.stubs(:exist?).returns true
+    @pluginhandler.expects(:load).never
 
     @pluginhandler.load_plugin("foo")
   end
 
   it "should not try to load files that don't exist" do
-    FileTest.expects(:exist?).with("foo").returns false
+    FileTest.expects(:exist?).with("foo.rb").returns false
     @pluginhandler.expects(:load).never
 
-    @pluginhandler.load_plugin("foo")
+    @pluginhandler.load_plugin("foo.rb")
   end
 
   it "should not try to load directories" do
@@ -100,17 +107,17 @@ describe Puppet::Configurer::PluginHandler do
 
   it "should warn but not fail if loading a file raises an exception" do
     FileTest.stubs(:exist?).returns true
-    @pluginhandler.expects(:load).with("foo").raises "eh"
+    @pluginhandler.expects(:load).with("foo.rb").raises "eh"
 
     Puppet.expects(:err)
-    @pluginhandler.load_plugin("foo")
+    @pluginhandler.load_plugin("foo.rb")
   end
 
   it "should warn but not fail if loading a file raises a LoadError" do
     FileTest.stubs(:exist?).returns true
-    @pluginhandler.expects(:load).with("foo").raises LoadError.new("eh")
+    @pluginhandler.expects(:load).with("foo.rb").raises LoadError.new("eh")
 
     Puppet.expects(:err)
-    @pluginhandler.load_plugin("foo")
+    @pluginhandler.load_plugin("foo.rb")
   end
 end


### PR DESCRIPTION
Pluginsync allows replication of all files, but we should only load
ruby files available in the pluginsync directory. For example,
currently pluginsync will attempt and fail to load puppet-module
generated readme files. This change restrict puppet agent to only load
ruby files, but preserve the ability to sync other files such as
scripts in other languages, augeus lens, etc.
