### PR TITLE
#10799 Regexp escaping too much

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -423,11 +423,17 @@ def install_binfile(from, op_file, target)
     if not installed_wrapper
       tmp_file2 = File.join(tmp_dir, '_tmp_wrapper')
       cwn = File.join(Config::CONFIG['bindir'], op_file)
-      regex_safe_ruby = Regexp.escape(ruby.gsub(%r{/}) { "\\" })
-      regex_safe_cwn = Regexp.escape(cwn.gsub(%r{/}) { "\\" })
-
-      cwv = CMD_WRAPPER.gsub('<ruby>', regex_safe_ruby).gsub('<command>', regex_safe_cwn)
-      File.open(tmp_file2, "wb") { |cw| cw.puts cwv }
+      cwv = <<-EOS
+@echo off
+if "%OS%"=="Windows_NT" goto WinNT
+#{ruby} -x "#{cwn}" %1 %2 %3 %4 %5 %6 %7 %8 %9
+goto done
+:WinNT
+#{ruby} -x "#{cwn}" %*
+goto done
+:done
+EOS
+      File.open(tmp_file2, "w") { |cw| cw.puts cwv }
       FileUtils.install(tmp_file2, File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
 
       File.unlink(tmp_file2)
@@ -437,17 +443,6 @@ def install_binfile(from, op_file, target)
   FileUtils.install(tmp_file, File.join(target, op_file), :mode => 0755, :verbose => true)
   File.unlink(tmp_file)
 end
-
-CMD_WRAPPER = <<-EOS
-@echo off
-if "%OS%"=="Windows_NT" goto WinNT
-<ruby> -x "<command>" %1 %2 %3 %4 %5 %6 %7 %8 %9
-goto done
-:WinNT
-<ruby> -x "<command>" %*
-goto done
-:done
-EOS
 
 check_prereqs
 prepare_installation


### PR DESCRIPTION
Previously, we were substituting occurrences of <ruby> and <command>
in the Windows batch wrapper scripts with the corresponding
paths. However, the call to Regexp.gsub was escaping potential
backreferences in the replacement string, e.g. foo\1bar, but in doing
so, was also escaping valid path characters that don't need to be
escaped, e.g. ruby-1.8.7, causing the batch file to refer to
non-existent paths, e.g. ruby-1.8.7.

This commit eliminates the need for gsub and regexp escaping.

It also writes the bat file in 'text' mode so that the resulting file
has '\r\n' line endings.
