### PR TITLE
(#10887) Wait until puppet is stopped before returning

### DIFF
--- a/conf/redhat/client.init
+++ b/conf/redhat/client.init
@@ -50,9 +50,28 @@ start() {
 
 stop() {
     echo -n $"Stopping puppet: "
+    pid=`cat $pidfile 2> /dev/null`
     killproc $pidopts $puppetd
     RETVAL=$?
     echo
+    # wait until really stopped
+    i=0
+    if [ -n "${pid:-}" ]; then
+      while kill -0 "${pid:-}" 2> /dev/null;  do
+          if [ $i = '60' ]; then
+              kill -9 $pid
+              break;
+          else
+              if [ $i = '0' ]; then
+                  echo -n " ... waiting "
+              else
+                  echo -n "."
+              fi
+              i=$(($i+1))
+              sleep 1
+          fi
+      done
+    fi
     [ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}
 }
 


### PR DESCRIPTION
In some cases, the agent init script will return off a stop before the puppet
agent has actually stopped. This patch verifies that the process has stopped by
looping on `kill -0` on the pid number (if it exists) until kill -0 returns 1,
at which point the process will really have stopped. After 60
seconds/iterations, it falls back to a kill -9 on the pid number. This patch
addresses that concern with the redhat agent init script.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
