### PR TITLE
(#8062) Consider package epoch version when comparing yum package versions

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -56,7 +56,6 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     wanted = @resource[:name]
     operation = :install
 
-    # XXX: We don't actually deal with epochs here.
     case should
     when true, false, Symbol
       # pass
@@ -87,7 +86,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     unless upd.nil?
       # FIXME: there could be more than one update for a package
       # because of multiarch
-      return "#{upd[:version]}-#{upd[:release]}"
+      return "#{upd[:epoch]}:#{upd[:version]}-#{upd[:release]}"
     else
       # Yum didn't find updates, pretend the current
       # version is the latest

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -30,16 +30,19 @@ describe provider do
       @provider.expects(:yum).with('-d', '0', '-e', '0', '-y', :install, 'mypackage')
       @provider.install
     end
+
     it 'should use :install to update' do
       @provider.expects(:install)
       @provider.update
     end
+
     it 'should be able to set version' do
       @resource.stubs(:should).with(:ensure).returns '1.2'
       @provider.expects(:yum).with('-d', '0', '-e', '0', '-y', :install, 'mypackage-1.2')
       @provider.stubs(:query).returns :ensure => '1.2'
       @provider.install
     end
+
     it 'should be able to downgrade' do
       @resource.stubs(:should).with(:ensure).returns '1.0'
       @provider.expects(:yum).with('-d', '0', '-e', '0', '-y', :downgrade, 'mypackage-1.0')
@@ -53,6 +56,7 @@ describe provider do
       @provider.expects(:yum).with('-y', :erase, 'mypackage')
       @provider.purge
     end
+
     it 'should use rpm to uninstall' do
       @provider.expects(:rpm).with('-e', 'mypackage-1-1.i386')
       @provider.uninstall
@@ -62,5 +66,45 @@ describe provider do
   it 'should be versionable' do
     provider.should be_versionable
   end
-end
 
+  describe '#latest' do
+    describe 'when latest_info is nil' do
+      before :each do
+        @provider.stubs(:latest_info).returns(nil)
+      end
+
+      it 'raises if ensure is absent and latest_info is nil' do
+        @provider.stubs(:properties).returns({:ensure => :absent})
+
+        expect { @provider.latest }.to raise_error(
+          Puppet::DevError,
+          'Tried to get latest on a missing package'
+        )
+      end
+
+      it 'returns the ensure value if the package is not already installed' do
+        @provider.stubs(:properties).returns({:ensure => '3.4.5'})
+
+        @provider.latest.should == '3.4.5'
+      end
+    end
+
+    describe 'when latest_info is populated' do
+      before :each do
+        @provider.stubs(:latest_info).returns({
+          :name     => 'mypackage',
+          :epoch    => '1',
+          :version  => '2.3.4',
+          :release  => '5',
+          :arch     => 'i686',
+          :provider => :yum,
+          :ensure   => '2.3.4-5'
+        })
+      end
+
+      it 'includes the epoch in the version string' do
+        @provider.latest.should == '1:2.3.4-5'
+      end
+    end
+  end
+end


### PR DESCRIPTION
By including the epoch version in the version returned as the "latest"
available, we can now properly consider package updates where only the
epoch version has changed.

Signed-off-by: Jude Nagurney jude@pwan.org
Signed-off-by: Jacob Helwig jacob@puppetlabs.com
