### PR TITLE
Tickets/2.7.x/7274 always output 4 digit modes

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -73,6 +73,13 @@ module Puppet
 
       super
     end
+
+    def should_to_s(should_value)
+      should_value.rjust(4,"0")
+    end
+
+    def is_to_s(currentvalue)
+      currentvalue.rjust(4,"0")
+    end
   end
 end
-

--- a/spec/unit/type/file/mode_spec.rb
+++ b/spec/unit/type/file/mode_spec.rb
@@ -103,4 +103,40 @@ describe Puppet::Type.type(:file).attrclass(:mode) do
       mode.retrieve.should == '644'
     end
   end
+
+  describe '#should_to_s' do
+    describe 'with a 3-digit mode' do
+      it 'returns a 4-digit mode with a leading zero' do
+        mode.should_to_s('755').should == '0755'
+      end
+    end
+
+    describe 'with a 4-digit mode' do
+      it 'returns the 4-digit mode when the first digit is a zero' do
+        mode.should_to_s('0755').should == '0755'
+      end
+
+      it 'returns the 4-digit mode when the first digit is not a zero' do
+        mode.should_to_s('1755').should == '1755'
+      end
+    end
+  end
+
+  describe '#is_to_s' do
+    describe 'with a 3-digit mode' do
+      it 'returns a 4-digit mode with a leading zero' do
+        mode.is_to_s('755').should == '0755'
+      end
+    end
+
+    describe 'with a 4-digit mode' do
+      it 'returns the 4-digit mode when the first digit is a zero' do
+        mode.is_to_s('0755').should == '0755'
+      end
+
+      it 'returns the 4-digit mode when the first digit is not a zero' do
+        mode.is_to_s('1755').should == '1755'
+      end
+    end
+  end
 end


### PR DESCRIPTION
When updating file mode, output 4 digit file mode instead of omitting
the leading 0, i.e. 0755 instead of 755.  This fully represents the
file mode, and lessens the likelihood of someone incorrectly setting
the mode on a file by copy/pasting the incomplete mode specification.

Signed-off-by: Nan Liu nan@puppetlabs.com
Signed-off-by: Jacob Helwig jacob@puppetlabs.com
