### PR TITLE
Ticket/2.7.x/7485 zypper 0.6 support

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -4,9 +4,14 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
   has_feature :versionable
 
   commands :zypper => "/usr/bin/zypper"
-  commands :rpm    => "rpm"
 
   confine    :operatingsystem => [:suse, :sles, :sled, :opensuse]
+
+  #on zypper versions <1.0, the version option returns 1
+  #some versions of zypper output on stderr
+  def zypper_version
+    zypper "--version", { :failonfail => false, :combine => true}
+  end
 
   # Install a package using 'zypper'.
   def install
@@ -22,7 +27,33 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
       # Add the package version
       wanted = "#{wanted}-#{should}"
     end
-    output = zypper "--quiet", :install, "-l", "-y", wanted
+
+    #This has been tested with following zypper versions
+    #SLE 10.2: 0.6.104
+    #SLE 11.0: 1.0.8
+    #OpenSuse 10.2: 0.6.13
+    #OpenSuse 11.2: 1.2.8
+    #Assume that this will work on newer zypper versions
+
+    #extract version numbers and convert to integers
+    major, minor, patch = zypper_version.scan(/\d+/).map{ |x| x.to_i }
+    self.debug "Detected zypper version #{major}.#{minor}.#{patch}"
+
+    #zypper version < 1.0 does not support --quiet flag
+    quiet = "--quiet"
+    if major < 1
+      quiet = "--terse"
+    end
+
+    license = "--auto-agree-with-licenses"
+    noconfirm = "--no-confirm"
+
+    #zypper 0.6.13 (OpenSuSE 10.2) does not support auto agree with licenses
+    if major < 1 and minor <= 6 and patch <= 13
+      zypper quiet, :install, noconfirm, wanted
+    else
+      zypper quiet, :install, license, noconfirm, wanted
+    end
 
     unless self.query
       raise Puppet::ExecutionFailure.new(

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -24,7 +24,7 @@ describe provider_class do
     @provider.should respond_to(:install)
   end
 
-  it "should have a latest method" do
+  it "should have an uninstall method" do
     @provider = provider_class.new
     @provider.should respond_to(:uninstall)
   end
@@ -39,17 +39,64 @@ describe provider_class do
     @provider.should respond_to(:latest)
   end
 
-  describe "when installing" do
+  describe "when installing with zypper version >= 1.0" do
     it "should use a command-line with versioned package'" do
       @resource.stubs(:should).with(:ensure).returns "1.2.3-4.5.6"
-      @provider.expects(:zypper).with('--quiet', :install, '-l', '-y', 'mypackage-1.2.3-4.5.6')
+      @provider.stubs(:zypper_version).returns "1.2.8"
+
+      @provider.expects(:zypper).with('--quiet', :install,
+        '--auto-agree-with-licenses', '--no-confirm', 'mypackage-1.2.3-4.5.6')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
 
     it "should use a command-line without versioned package" do
       @resource.stubs(:should).with(:ensure).returns :latest
-      @provider.expects(:zypper).with('--quiet', :install, '-l', '-y', 'mypackage')
+      @provider.stubs(:zypper_version).returns "1.2.8"
+      @provider.expects(:zypper).with('--quiet', :install,
+        '--auto-agree-with-licenses', '--no-confirm', 'mypackage')
+      @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
+      @provider.install
+    end
+  end
+
+  describe "when installing with zypper version = 0.6.104" do
+    it "should use a command-line with versioned package'" do
+      @resource.stubs(:should).with(:ensure).returns "1.2.3-4.5.6"
+      @provider.stubs(:zypper_version).returns "0.6.104"
+
+      @provider.expects(:zypper).with('--terse', :install,
+        '--auto-agree-with-licenses', '--no-confirm', 'mypackage-1.2.3-4.5.6')
+      @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
+      @provider.install
+    end
+
+    it "should use a command-line without versioned package" do
+      @resource.stubs(:should).with(:ensure).returns :latest
+      @provider.stubs(:zypper_version).returns "0.6.104"
+      @provider.expects(:zypper).with('--terse', :install,
+        '--auto-agree-with-licenses', '--no-confirm', 'mypackage')
+      @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
+      @provider.install
+    end
+  end
+
+  describe "when installing with zypper version = 0.6.13" do
+    it "should use a command-line with versioned package'" do
+      @resource.stubs(:should).with(:ensure).returns "1.2.3-4.5.6"
+      @provider.stubs(:zypper_version).returns "0.6.13"
+
+      @provider.expects(:zypper).with('--terse', :install,
+        '--no-confirm', 'mypackage-1.2.3-4.5.6')
+      @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
+      @provider.install
+    end
+
+    it "should use a command-line without versioned package" do
+      @resource.stubs(:should).with(:ensure).returns :latest
+      @provider.stubs(:zypper_version).returns "0.6.13"
+      @provider.expects(:zypper).with('--terse', :install,
+        '--no-confirm', 'mypackage')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end


### PR DESCRIPTION
Zypper version 0.6.x which is the default version on SLED 10 does not
support the --quiet flag. It only supports the --terse flag from
rug. Detecting the version number using 'zypper --version' does not
work because, even though this prints the version number, it also exits
with code 1. Puppet correctly interprets this as an execution
error. Executing "zypper --version" through sh allows the return code
to be discarded.
Tested on:
SLE 10.2, 11.0, 11.1
OpenSuSE 10.2, 10.3, 11.1, 11.2, 11.3, 11.4
