### PR TITLE
Bug/2.7.x/11057 debug output enhancement

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -46,7 +46,7 @@ class Puppet::Agent
       end
       true
     end
-    Puppet.notice "Shutdown/restart in progress; skipping run" unless block_run
+    Puppet.notice "Shutdown/restart in progress (#{Puppet::Application.run_status.inspect}); skipping run" unless block_run
     result
   end
 


### PR DESCRIPTION
This adds the reason for skipping a run to the message about doing so, which
makes it easier to understand why it happened post-hoc.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
