### PR TITLE
(#10739) Provide default subjectAltNames while bootstrapping master

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -243,7 +243,7 @@ class Puppet::SSL::CertificateAuthority
   end
 
   # Sign a given certificate request.
-  def sign(hostname, allow_dns_alt_names = false, self_signing_csr = nil)
+  def sign(hostname, allow_dns_alt_names = false, self_signing_csr = nil, default_alt_names = nil)
     # This is a self-signed certificate
     if self_signing_csr
       # # This is a self-signed certificate, which is for the CA.  Since this
@@ -270,7 +270,7 @@ class Puppet::SSL::CertificateAuthority
 
     cert = Puppet::SSL::Certificate.new(hostname)
     cert.content = Puppet::SSL::CertificateFactory.
-      build(cert_type, csr, issuer, next_serial)
+      build(cert_type, csr, issuer, next_serial, default_alt_names)
     cert.content.sign(host.key.content, OpenSSL::Digest::SHA1.new)
 
     Puppet.notice "Signed certificate request for #{hostname}"

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -329,6 +329,13 @@ describe Puppet::SSL::CertificateAuthority do
         @ca.sign(@name, :ca, @request)
       end
 
+      it "should pass nil for the default subject alt names" do
+        Puppet::SSL::CertificateFactory.expects(:build).with do |*args|
+          args[4] == nil
+        end.returns "my real cert"
+        @ca.sign(@name, :ca, @request)
+      end
+
       it "should sign the certificate request even if it contains alt names" do
         @request.stubs(:subject_alt_names).returns %w[DNS:foo DNS:bar DNS:baz]
 
@@ -413,6 +420,13 @@ describe Puppet::SSL::CertificateAuthority do
           args[3] == @serial
         end.returns "my real cert"
         @ca.sign(@name)
+      end
+
+      it "should pass the default subject alt names" do
+        Puppet::SSL::CertificateFactory.expects(:build).with do |*args|
+          args[4] == %w[blarg]
+        end.returns "my real cert"
+        @ca.sign(@name, :server, @request, %w[blarg])
       end
 
       it "should sign the resulting certificate using its real key and a digest" do


### PR DESCRIPTION
Prior to #2848 (CVE-2011-3872), if Puppet[:certdnsnames] was not set,
puppet would add default subjectAltNames to any non-CA cert it
signed. The subjectAltNames were of the form:

  DNS:puppet, DNS:<fqdn>, DNS:puppet.<domain>

The fix for #2848, prevented implicit subjectAltNames from ever being
added. However, this is desirable behavior when bootstrapping the
initial puppet master.

This commit re-enables this behavior but restricts it to the case
where all of the following are true:
1. We are a CA and master
2. We're signing the master's cert, not self-signing the CA
3. The CSR is for the current host

These should only ever be true when bootstrapping the initial
master. In particular, it should never be true for the CA's
self-signed cert, for remote agents, or for servers that are either
masters or CAs, but not both.

This commit also restores the previous behavior of only adding default
subject alt names if the fqdn of the host can be resolved.

Since the CSR for the initial master may contain subjectAltNames,
e.g. by setting Puppet[:dns_alt_names] prior to starting the master
for the first time, then the default subjectAltNames will not be
merged -- it's either one or the other, but not both.
