### PR TITLE
Ticket/2.7.x/2744

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -423,9 +423,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
-    # If noop is set, then also enable diffs
-    Puppet[:show_diff] = true if Puppet[:noop]
-
     args[:Server] = Puppet[:server]
     if options[:fqdn]
       args[:FQDN] = options[:fqdn]

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -231,9 +231,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def setup
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
-    # If noop is set, then also enable diffs
-    Puppet[:show_diff] = true if Puppet[:noop]
-
     Puppet::Util::Log.newdestination(:console) unless options[:logset]
     client = nil
     server = nil

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -66,15 +66,6 @@ describe Puppet::Application::Apply do
       @apply.options.stubs(:[]).with(any_parameters)
     end
 
-    it "should set show_diff on --noop" do
-      Puppet[:noop] = true
-      Puppet[:show_diff] = false
-
-      @apply.setup
-
-      Puppet[:show_diff].should == true
-    end
-
     it "should set console as the log destination if logdest option wasn't provided" do
       Puppet::Log.expects(:newdestination).with(:console)
 


### PR DESCRIPTION
As of 845825a, file diffs are now logged, rather than printed to
console. Because log messages may be stored and more broadly readable,
we no longer implicitly set show_diff in noop mode.
