### PR TITLE
(#10739) Provide default subjectAltNames while bootstrapping master

### DIFF
--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -151,6 +151,8 @@ class Puppet::SSL::Host
       # ...add our configured dns_alt_names
       if Puppet[:dns_alt_names] and Puppet[:dns_alt_names] != ''
         options[:dns_alt_names] ||= Puppet[:dns_alt_names]
+      elsif Puppet::SSL::CertificateAuthority.ca? and fqdn = Facter.value(:fqdn) and domain = Facter.value(:domain)
+        options[:dns_alt_names] = "puppet, #{fqdn}, puppet.#{domain}"
       end
     end
 

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -82,8 +82,6 @@ describe Puppet::SSL::Host do
 
   context "with dns_alt_names" do
     before :each do
-      Puppet[:dns_alt_names] = 'one, two'
-
       @key = stub('key content')
       key = stub('key', :generate => true, :save => true, :content => @key)
       Puppet::SSL::Key.stubs(:new).returns key
@@ -92,17 +90,68 @@ describe Puppet::SSL::Host do
       Puppet::SSL::CertificateRequest.stubs(:new).returns @cr
     end
 
-    it "should not include subjectAltName if not the local node" do
-      @cr.expects(:generate).with(@key, {})
+    describe "explicitly specified" do
+      before :each do
+        Puppet[:dns_alt_names] = 'one, two'
+      end
 
-      Puppet::SSL::Host.new('not-the-' + Puppet[:certname]).generate
+      it "should not include subjectAltName if not the local node" do
+        @cr.expects(:generate).with(@key, {})
+
+        Puppet::SSL::Host.new('not-the-' + Puppet[:certname]).generate
+      end
+
+      it "should include subjectAltName if I am a CA" do
+        @cr.expects(:generate).
+          with(@key, { :dns_alt_names => Puppet[:dns_alt_names] })
+
+        Puppet::SSL::Host.localhost
+      end
     end
 
-    it "should include subjectAltName if I am a CA" do
-      @cr.expects(:generate).
-        with(@key, { :dns_alt_names => Puppet[:dns_alt_names] })
+    describe "implicitly defaulted" do
+      let(:ca) { stub('ca', :sign => nil) }
 
-      Puppet::SSL::Host.localhost
+      before :each do
+        Puppet[:dns_alt_names] = ''
+
+        Puppet::SSL::CertificateAuthority.stubs(:instance).returns ca
+      end
+
+      it "should not include defaults if we're not the CA" do
+        Puppet::SSL::CertificateAuthority.stubs(:ca?).returns false
+
+        @cr.expects(:generate).with(@key, {})
+
+        Puppet::SSL::Host.localhost
+      end
+
+      it "should not include defaults if not the local node" do
+        Puppet::SSL::CertificateAuthority.stubs(:ca?).returns true
+
+        @cr.expects(:generate).with(@key, {})
+
+        Puppet::SSL::Host.new('not-the-' + Puppet[:certname]).generate
+      end
+
+      it "should not include defaults if we can't resolve our fqdn" do
+        Puppet::SSL::CertificateAuthority.stubs(:ca?).returns true
+        Facter.stubs(:value).with(:fqdn).returns nil
+
+        @cr.expects(:generate).with(@key, {})
+
+        Puppet::SSL::Host.localhost
+      end
+
+      it "should provide defaults if we're bootstrapping the local master" do
+        Puppet::SSL::CertificateAuthority.stubs(:ca?).returns true
+        Facter.stubs(:value).with(:fqdn).returns 'web.foo.com'
+        Facter.stubs(:value).with(:domain).returns 'foo.com'
+
+        @cr.expects(:generate).with(@key, {:dns_alt_names => "puppet, web.foo.com, puppet.foo.com"})
+
+        Puppet::SSL::Host.localhost
+      end
     end
   end
 


### PR DESCRIPTION
Prior to #2848 (CVE-2011-3872), if Puppet[:certdnsnames] was not set,
puppet would add default subjectAltNames to any non-CA cert it signed,
including agent certs. The subjectAltNames were of the form:

  DNS:puppet, DNS:<fqdn>, DNS:puppet.<domain>

The fix for #2848, prevented subjectAltNames from ever being
implicitly added at signing time. But during this change, the default
subjectAltNames behavior was accidentally removed.

This commit restores the 'defaulting' behavior that existed
previously, but only when bootstrapping the initial master.
Additionally, default subjectAltNames are only ever added when
generating the master's certificate signing request, not at signing
time. This is important, because it ensures all subjectAltNames
originate from the CSR and are subject to our internal signing policy.

The code now requires that all of the following be true in order to
add default subjectAltNames to the CSR:
1. We are a CA and master
2. We're signing the master's cert, not self-signing the CA
3. The CSR is for the current host
4. No subjectAltNames have been specified, e.g. Puppet[:dns_alt_names]
5. The master can resolve its fqdn

These should only ever be true when bootstrapping the initial
master. In particular, it should never be true for the CA's
self-signed cert, for remote agents, or for servers that are either
masters or CAs, but not both.

The fqdn requirement existed previously, and so the same behavior has
been restored.

Note if Puppet[:dns_alt_names] are specified when bootstrapping the
master, then we do not merge the default options -- it's either one of
the other, but not both.
