### PR TITLE
(#11115) Support spec tests under rspec 2.7.x

### DIFF
--- a/spec/unit/network/resolver_spec.rb
+++ b/spec/unit/network/resolver_spec.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 require 'puppet/network/resolver'
 
 describe Puppet::Network::Resolver do


### PR DESCRIPTION
Without this patch, the puppet spec tests do not run under rspec 2.7.x.

This patch fixes this issue by using a proper require expression to
include the `spec_helper` module in `spec/unit/network/resolver_spec.rb`

This patch changes a single line in `spec/unit/network/resolver_spec.rb`
as the other tests already require the `spec_helper` the _right_ way.
