### PR TITLE
Extend Pacman provider for Archlinux to use Yaourt

### DIFF
--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
   commands :pacman => "/usr/bin/pacman"
   # Yaourt is a common AUR helper which, if installed, we can use to query the AUR
-  commands :yaourt => "/usr/bin/yaourt"
+  commands :yaourt => "/usr/bin/yaourt" if File.exists? '/usr/bin/yaourt'
 
   confine     :operatingsystem => :archlinux
   defaultfor  :operatingsystem => :archlinux


### PR DESCRIPTION
Extend Pacman provider for Archlinux to use the popular AUR helper
Yaourt if it is available. Continues to use Pacman for any command
where it makes sense to do so, and only calls out to Yaourt when
an package isn't found in the standard repositories.
