### PR TITLE
(#7592) Replace all Augeas resource stubs with real resources

### DIFF
--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -5,14 +5,22 @@ require 'puppet/util/package'
 provider_class = Puppet::Type.type(:augeas).provider(:augeas)
 
 describe provider_class do
-  describe "command parsing" do
-    before do
-      @resource = stub("resource")
-      @provider = provider_class.new(@resource)
-    end
+  before(:each) do
+    @resource = Puppet::Type.type(:augeas).new(
+      :name     => "test",
+      :root     => my_fixture_dir,
+      :provider => :augeas
+    )
+    @provider = provider_class.new(@resource)
+  end
 
+  after(:each) do
+    @provider.close_augeas
+  end
+
+  describe "command parsing" do
     it "should break apart a single line into three tokens and clean up the context" do
-      @resource.stubs(:[]).returns("/context")
+      @resource[:context] = "/context"
       tokens = @provider.parse_commands("set Jar/Jar Binks")
       tokens.size.should == 1
       tokens[0].size.should == 3
@@ -22,7 +30,6 @@ describe provider_class do
     end
 
     it "should break apart a multiple line into six tokens" do
-      @resource.stubs(:[]).returns("")
       tokens = @provider.parse_commands("set /Jar/Jar Binks\nrm anakin")
       tokens.size.should == 2
       tokens[0].size.should == 3
@@ -35,7 +42,6 @@ describe provider_class do
     end
 
     it "should strip whitespace and ignore blank lines" do
-      @resource.stubs(:[]).returns("")
       tokens = @provider.parse_commands("  set /Jar/Jar Binks \t\n  \n\n  rm anakin ")
       tokens.size.should == 2
       tokens[0].size.should == 3
@@ -48,7 +54,7 @@ describe provider_class do
     end
 
     it "should handle arrays" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       commands = ["set /Jar/Jar Binks", "rm anakin"]
       tokens = @provider.parse_commands(commands)
       tokens.size.should == 2
@@ -73,7 +79,7 @@ describe provider_class do
     #end
 
     it "should accept spaces in the value and single ticks" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       tokens = @provider.parse_commands("set JarJar 'Binks is my copilot'")
       tokens.size.should == 1
       tokens[0].size.should == 3
@@ -83,7 +89,7 @@ describe provider_class do
     end
 
     it "should accept spaces in the value and double ticks" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       tokens = @provider.parse_commands('set /JarJar "Binks is my copilot"')
       tokens.size.should == 1
       tokens[0].size.should == 3
@@ -93,7 +99,7 @@ describe provider_class do
     end
 
     it "should accept mixed ticks" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       tokens = @provider.parse_commands('set JarJar "Some \'Test\'"')
       tokens.size.should == 1
       tokens[0].size.should == 3
@@ -103,59 +109,59 @@ describe provider_class do
     end
 
     it "should handle predicates with literals" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       tokens = @provider.parse_commands("rm */*[module='pam_console.so']")
       tokens.should == [["rm", "/foo/*/*[module='pam_console.so']"]]
     end
 
     it "should handle whitespace in predicates" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       tokens = @provider.parse_commands("ins 42 before /files/etc/hosts/*/ipaddr[ . = '127.0.0.1' ]")
       tokens.should == [["ins", "42", "before","/files/etc/hosts/*/ipaddr[ . = '127.0.0.1' ]"]]
     end
 
     it "should handle multiple predicates" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       tokens = @provider.parse_commands("clear pam.d/*/*[module = 'system-auth'][type = 'account']")
       tokens.should == [["clear", "/foo/pam.d/*/*[module = 'system-auth'][type = 'account']"]]
     end
 
     it "should handle nested predicates" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       args = ["clear", "/foo/pam.d/*/*[module[ ../type = 'type] = 'system-auth'][type[last()] = 'account']"]
       tokens = @provider.parse_commands(args.join(" "))
       tokens.should == [ args ]
     end
 
     it "should handle escaped doublequotes in doublequoted string" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       tokens = @provider.parse_commands("set /foo \"''\\\"''\"")
       tokens.should == [[ "set", "/foo", "''\\\"''" ]]
     end
 
     it "should allow escaped spaces and brackets in paths" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       args = [ "set", "/white\\ space/\\[section", "value" ]
       tokens = @provider.parse_commands(args.join(" \t "))
       tokens.should == [ args ]
     end
 
     it "should allow single quoted escaped spaces in paths" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       args = [ "set", "'/white\\ space/key'", "value" ]
       tokens = @provider.parse_commands(args.join(" \t "))
       tokens.should == [[ "set", "/white\\ space/key", "value" ]]
     end
 
     it "should allow double quoted escaped spaces in paths" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       args = [ "set", '"/white\\ space/key"', "value" ]
       tokens = @provider.parse_commands(args.join(" \t "))
       tokens.should == [[ "set", "/white\\ space/key", "value" ]]
     end
 
     it "should remove trailing slashes" do
-      @resource.stubs(:[]).returns("/foo/")
+      @resource[:context] = "/foo/"
       tokens = @provider.parse_commands("set foo/ bar")
       tokens.should == [[ "set", "/foo/foo", "bar" ]]
     end
@@ -163,9 +169,9 @@ describe provider_class do
 
   describe "get filters" do
     before do
-      augeas_stub = stub("augeas", :get => "value")
-      @provider = provider_class.new
-      @provider.aug= augeas_stub
+      augeas = stub("augeas", :get => "value")
+      augeas.stubs("close")
+      @provider.aug = augeas
     end
 
     it "should return false for a = nonmatch" do
@@ -191,10 +197,10 @@ describe provider_class do
 
   describe "match filters" do
     before do
-      resource = stub("resource", :[] => "")
-      augeas_stub = stub("augeas", :match => ["set", "of", "values"])
-      @provider = provider_class.new(resource)
-      @provider.aug= augeas_stub
+      augeas = stub("augeas", :match => ["set", "of", "values"])
+      augeas.stubs("close")
+      @provider = provider_class.new(@resource)
+      @provider.aug = augeas
     end
 
     it "should return true for size match" do
@@ -249,114 +255,76 @@ describe provider_class do
   end
 
   describe "need to run" do
+    before(:each) do
+      @augeas = stub("augeas")
+      @augeas.stubs("close")
+      @provider.aug = @augeas
+
+      # These tests pretend to be an earlier version so the provider doesn't
+      # attempt to make the change in the need_to_run? method
+      @provider.stubs(:get_augeas_version).returns("0.3.5")
+    end
+
     it "should handle no filters" do
-      resource = stub("resource")
-      resource.stubs(:[]).returns(false).then.returns("").then.returns("")
-      resource.stubs(:noop?).returns(false)
-      augeas_stub = stub("augeas", :match => ["set", "of", "values"])
-      augeas_stub.stubs("close")
-      provider = provider_class.new(resource)
-      provider.aug= augeas_stub
-      provider.stubs(:get_augeas_version).returns("0.3.5")
-      provider.need_to_run?.should == true
+      @augeas.stubs("match").returns(["set", "of", "values"])
+      @provider.need_to_run?.should == true
     end
 
     it "should return true when a get filter matches" do
-      resource = stub("resource")
-      resource.stubs(:[]).returns(false).then.returns("get path == value").then.returns("")
-      resource.stubs(:noop?).returns(false)
-      provider = provider_class.new(resource)
-      augeas_stub = stub("augeas", :get => "value")
-      augeas_stub.stubs("close")
-      provider.aug= augeas_stub
-      provider.stubs(:get_augeas_version).returns("0.3.5")
-      provider.need_to_run?.should == true
+      @resource[:onlyif] = "get path == value"
+      @augeas.stubs("get").returns("value")
+      @provider.need_to_run?.should == true
     end
 
     it "should return false when a get filter does not match" do
-      resource = stub("resource")
-      resource.stubs(:[]).returns(false).then.returns("get path == another value").then.returns("")
-      provider = provider_class.new(resource)
-      augeas_stub = stub("augeas", :get => "value")
-      augeas_stub.stubs("close")
-      provider.aug= augeas_stub
-      provider.stubs(:get_augeas_version).returns("0.3.5")
-      provider.need_to_run?.should == false
+      @resource[:onlyif] = "get path == another value"
+      @augeas.stubs("get").returns("value")
+      @provider.need_to_run?.should == false
     end
 
     it "should return true when a match filter matches" do
-      resource = stub("resource")
-      resource.stubs(:[]).returns(false).then.returns("match path size == 3").then.returns("")
-      resource.stubs(:noop?).returns(false)
-      provider = provider_class.new(resource)
-      augeas_stub = stub("augeas", :match => ["set", "of", "values"])
-      augeas_stub.stubs("close")
-      provider.aug= augeas_stub
-      provider.stubs(:get_augeas_version).returns("0.3.5")
-      provider.need_to_run?.should == true
+      @resource[:onlyif] = "match path size == 3"
+      @augeas.stubs("match").returns(["set", "of", "values"])
+      @provider.need_to_run?.should == true
     end
 
     it "should return false when a match filter does not match" do
-      resource = stub("resource")
-      resource.stubs(:[]).returns(false).then.returns("match path size == 2").then.returns("")
-      provider = provider_class.new(resource)
-      augeas_stub = stub("augeas", :match => ["set", "of", "values"])
-      augeas_stub.stubs("close")
-      provider.aug= augeas_stub
-      provider.stubs(:get_augeas_version).returns("0.3.5")
-      provider.need_to_run?.should == false
+      @resource[:onlyif] = "match path size == 2"
+      @augeas.stubs("match").returns(["set", "of", "values"])
+      @provider.need_to_run?.should == false
     end
 
-    #This is a copy of the last one, with setting the force to true
+    # Now setting force to true
     it "setting force should not change the above logic" do
-      resource = stub("resource")
-      resource.stubs(:[]).returns(true).then.returns("match path size == 2").then.returns("")
-      provider = provider_class.new(resource)
-      augeas_stub = stub("augeas", :match => ["set", "of", "values"])
-      augeas_stub.stubs("close")
-      provider.aug= augeas_stub
-      provider.stubs(:get_augeas_version).returns("0.3.5")
-      provider.need_to_run?.should == false
+      @resource[:force] = true
+      @resource[:onlyif] = "match path size == 2"
+      @augeas.stubs("match").returns(["set", "of", "values"])
+      @provider.need_to_run?.should == false
     end
 
     #Ticket 5211 testing
     it "should return true when a size != the provided value" do
-      resource = stub("resource")
-      resource.stubs(:[]).returns(false).then.returns("match path size != 17").then.returns("")
-      resource.stubs(:noop?).returns(false)
-      provider = provider_class.new(resource)
-      augeas_stub = stub("augeas", :match => ["set", "of", "values"])
-      augeas_stub.stubs("close")
-      provider.aug= augeas_stub
-      provider.stubs(:get_augeas_version).returns("0.3.5")
-      provider.need_to_run?.should == true
+      @resource[:onlyif] = "match path size != 17"
+      @augeas.stubs("match").returns(["set", "of", "values"])
+      @provider.need_to_run?.should == true
     end
 
     #Ticket 5211 testing
     it "should return false when a size doeas equal the provided value" do
-      resource = stub("resource")
-      resource.stubs(:[]).returns(false).then.returns("match path size != 3").then.returns("")
-      provider = provider_class.new(resource)
-      augeas_stub = stub("augeas", :match => ["set", "of", "values"])
-      augeas_stub.stubs("close")
-      provider.aug= augeas_stub
-      provider.stubs(:get_augeas_version).returns("0.3.5")
-      provider.need_to_run?.should == false
+      @resource[:onlyif] = "match path size != 3"
+      @augeas.stubs("match").returns(["set", "of", "values"])
+      @provider.need_to_run?.should == false
     end
 
     # Ticket 2728 (diff files)
-    describe "and Puppet[:show_diff] is set", :if => Puppet.features.augeas? do
-      before do
+    describe "and Puppet[:show_diff] is set" do
+      before(:each) do
         Puppet[:show_diff] = true
 
-        @resource = Puppet::Type.type(:augeas).new(:name => "test")
-        @provider = provider_class.new(@resource)
-        @augeas_stub = stub("augeas")
-        @provider.aug = @augeas_stub
-
-        @augeas_stub.stubs("get").with("/augeas/version").returns("0.7.2")
-        @augeas_stub.stubs(:set).returns(true)
-        @augeas_stub.stubs(:save).returns(true)
+        @resource[:root] = ""
+        @provider.stubs(:get_augeas_version).returns("0.7.2")
+        @augeas.stubs(:set).returns(true)
+        @augeas.stubs(:save).returns(true)
       end
 
       it "should call diff when a file is shown to have been changed" do
@@ -365,10 +333,10 @@ describe provider_class do
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
 
-        @augeas_stub.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
-        @augeas_stub.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
-        @augeas_stub.expects(:set).with("/augeas/save", "newfile")
-        @augeas_stub.expects(:close).never()
+        @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
+        @augeas.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
+        @augeas.expects(:set).with("/augeas/save", "newfile")
+        @augeas.expects(:close).never()
 
         @provider.expects("diff").with("#{file}", "#{file}.augnew").returns("")
         @provider.should be_need_to_run
@@ -381,11 +349,11 @@ describe provider_class do
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file1}/foo bar", "set #{file2}/baz biz"]
 
-        @augeas_stub.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved[1]", "/augeas/events/saved[2]"])
-        @augeas_stub.stubs(:get).with("/augeas/events/saved[1]").returns(["/files#{file1}"])
-        @augeas_stub.stubs(:get).with("/augeas/events/saved[2]").returns(["/files#{file2}"])
-        @augeas_stub.expects(:set).with("/augeas/save", "newfile")
-        @augeas_stub.expects(:close).never()
+        @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved[1]", "/augeas/events/saved[2]"])
+        @augeas.stubs(:get).with("/augeas/events/saved[1]").returns(["/files#{file1}"])
+        @augeas.stubs(:get).with("/augeas/events/saved[2]").returns(["/files#{file2}"])
+        @augeas.expects(:set).with("/augeas/save", "newfile")
+        @augeas.expects(:close).never()
 
         @provider.expects(:diff).with("#{file1}", "#{file1}.augnew").returns("")
         @provider.expects(:diff).with("#{file2}", "#{file2}.augnew").returns("")
@@ -401,10 +369,10 @@ describe provider_class do
           @resource[:changes] = ["set #{file}/foo bar"]
           @resource[:root] = root
 
-          @augeas_stub.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
-          @augeas_stub.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
-          @augeas_stub.expects(:set).with("/augeas/save", "newfile")
-          @augeas_stub.expects(:close).never()
+          @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
+          @augeas.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
+          @augeas.expects(:set).with("/augeas/save", "newfile")
+          @augeas.expects(:close).never()
 
           @provider.expects(:diff).with("#{root}#{file}", "#{root}#{file}.augnew").returns("")
           @provider.should be_need_to_run
@@ -417,10 +385,10 @@ describe provider_class do
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
 
-        @augeas_stub.stubs(:match).with("/augeas/events/saved").returns([])
-        @augeas_stub.expects(:set).with("/augeas/save", "newfile")
-        @augeas_stub.expects(:get).with("/augeas/events/saved").never()
-        @augeas_stub.expects(:close)
+        @augeas.stubs(:match).with("/augeas/events/saved").returns([])
+        @augeas.expects(:set).with("/augeas/save", "newfile")
+        @augeas.expects(:get).with("/augeas/events/saved").never()
+        @augeas.expects(:close)
 
         @provider.expects(:diff).never()
         @provider.should_not be_need_to_run
@@ -433,10 +401,10 @@ describe provider_class do
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
 
-        @augeas_stub.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
-        @augeas_stub.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
-        @augeas_stub.expects(:set).with("/augeas/save", "newfile")
-        @augeas_stub.expects(:close)
+        @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
+        @augeas.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
+        @augeas.expects(:set).with("/augeas/save", "newfile")
+        @augeas.expects(:close)
 
         File.expects(:delete).with(file + ".augnew")
 
@@ -450,9 +418,9 @@ describe provider_class do
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
 
-        @augeas_stub.stubs(:save).returns(false)
-        @augeas_stub.stubs(:match).with("/augeas/events/saved").returns([])
-        @augeas_stub.expects(:close)
+        @augeas.stubs(:save).returns(false)
+        @augeas.stubs(:match).with("/augeas/events/saved").returns([])
+        @augeas.expects(:close)
 
         @provider.expects(:diff).never()
         lambda { @provider.need_to_run? }.should raise_error
@@ -461,20 +429,18 @@ describe provider_class do
   end
 
   describe "augeas execution integration" do
-
     before do
-      @resource = stub("resource")
-      @provider = provider_class.new(@resource)
       @augeas = stub("augeas")
-      @provider.aug= @augeas
-      @provider.stubs(:get_augeas_version).returns("0.3.5")
+      @augeas.stubs("close")
       @augeas.stubs(:match).with("/augeas/events/saved")
+
+      @provider.aug = @augeas
+      @provider.stubs(:get_augeas_version).returns("0.3.5")
     end
 
     it "should handle set commands" do
-      command = "set JarJar Binks"
-      context = "/some/path/"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "set JarJar Binks"
+      @resource[:context] = "/some/path/"
       @augeas.expects(:set).with("/some/path/JarJar", "Binks").returns(true)
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -482,9 +448,7 @@ describe provider_class do
     end
 
     it "should handle rm commands" do
-      command = "rm /Jar/Jar"
-      context = ""
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "rm /Jar/Jar"
       @augeas.expects(:rm).with("/Jar/Jar")
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -492,9 +456,7 @@ describe provider_class do
     end
 
     it "should handle remove commands" do
-      command = "remove /Jar/Jar"
-      context = ""
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "remove /Jar/Jar"
       @augeas.expects(:rm).with("/Jar/Jar")
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -502,20 +464,17 @@ describe provider_class do
     end
 
     it "should handle clear commands" do
-      command = "clear Jar/Jar"
-      context = "/foo/"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "clear Jar/Jar"
+      @resource[:context] = "/foo/"
       @augeas.expects(:clear).with("/foo/Jar/Jar").returns(true)
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
       @provider.execute_changes.should == :executed
     end
 
-
     it "should handle ins commands with before" do
-      command = "ins Binks before Jar/Jar"
-      context = "/foo"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "ins Binks before Jar/Jar"
+      @resource[:context] = "/foo"
       @augeas.expects(:insert).with("/foo/Jar/Jar", "Binks", true)
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -523,9 +482,8 @@ describe provider_class do
     end
 
     it "should handle ins commands with after" do
-      command = "ins Binks after /Jar/Jar"
-      context = "/foo"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "ins Binks after /Jar/Jar"
+      @resource[:context] = "/foo"
       @augeas.expects(:insert).with("/Jar/Jar", "Binks", false)
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -533,9 +491,7 @@ describe provider_class do
     end
 
     it "should handle ins with no context" do
-      command = "ins Binks after /Jar/Jar"
-      context = "" # this is the default
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "ins Binks after /Jar/Jar"
       @augeas.expects(:insert).with("/Jar/Jar", "Binks", false)
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -543,9 +499,8 @@ describe provider_class do
     end
 
     it "should handle multiple commands" do
-      command = ["ins Binks after /Jar/Jar", "clear Jar/Jar"]
-      context = "/foo/"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = ["ins Binks after /Jar/Jar", "clear Jar/Jar"]
+      @resource[:context] = "/foo/"
       @augeas.expects(:insert).with("/Jar/Jar", "Binks", false)
       @augeas.expects(:clear).with("/foo/Jar/Jar").returns(true)
       @augeas.expects(:save).returns(true)
@@ -554,9 +509,8 @@ describe provider_class do
     end
 
     it "should handle defvar commands" do
-      command = "defvar myjar Jar/Jar"
-      context = "/foo/"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "defvar myjar Jar/Jar"
+      @resource[:context] = "/foo/"
       @augeas.expects(:defvar).with("myjar", "/foo/Jar/Jar").returns(true)
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -564,9 +518,8 @@ describe provider_class do
     end
 
     it "should pass through augeas variables without context" do
-      command = ["defvar myjar Jar/Jar","set $myjar/Binks 1"]
-      context = "/foo/"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = ["defvar myjar Jar/Jar","set $myjar/Binks 1"]
+      @resource[:context] = "/foo/"
       @augeas.expects(:defvar).with("myjar", "/foo/Jar/Jar").returns(true)
       # this is the important bit, shouldn't be /foo/$myjar/Binks
       @augeas.expects(:set).with("$myjar/Binks", "1").returns(true)
@@ -576,9 +529,8 @@ describe provider_class do
     end
 
     it "should handle defnode commands" do
-      command = "defnode newjar Jar/Jar[last()+1] Binks"
-      context = "/foo/"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "defnode newjar Jar/Jar[last()+1] Binks"
+      @resource[:context] = "/foo/"
       @augeas.expects(:defnode).with("newjar", "/foo/Jar/Jar[last()+1]", "Binks").returns(true)
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -586,9 +538,8 @@ describe provider_class do
     end
 
     it "should handle mv commands" do
-      command = "mv Jar/Jar Binks"
-      context = "/foo/"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = "mv Jar/Jar Binks"
+      @resource[:context] = "/foo/"
       @augeas.expects(:mv).with("/foo/Jar/Jar", "/foo/Binks").returns(true)
       @augeas.expects(:save).returns(true)
       @augeas.expects(:close)
@@ -596,9 +547,8 @@ describe provider_class do
     end
 
     it "should handle setm commands" do
-      command = ["set test[1]/Jar/Jar Foo","set test[2]/Jar/Jar Bar","setm test Jar/Jar Binks"]
-      context = "/foo/"
-      @resource.expects(:[]).times(2).returns(command).then.returns(context)
+      @resource[:changes] = ["set test[1]/Jar/Jar Foo","set test[2]/Jar/Jar Bar","setm test Jar/Jar Binks"]
+      @resource[:context] = "/foo/"
       @augeas.expects(:set).with("/foo/test[1]/Jar/Jar", "Foo").returns(true)
       @augeas.expects(:set).with("/foo/test[2]/Jar/Jar", "Bar").returns(true)
       @augeas.expects(:setm).with("/foo/test", "Jar/Jar", "Binks").returns(true)
@@ -610,9 +560,8 @@ describe provider_class do
 
   describe "save failure reporting" do
     before do
-      @resource = stub("resource")
       @augeas = stub("augeas")
-      @provider = provider_class.new(@resource)
+      @augeas.stubs("close")
       @provider.aug = @augeas
     end
 
@@ -621,7 +570,7 @@ describe provider_class do
       @augeas.expects(:match).with("/augeas/files/foo/error/*").returns(["/augeas/files/foo/error/path", "/augeas/files/foo/error/message"])
       @augeas.expects(:get).with("/augeas/files/foo/error/path").returns("/foo")
       @augeas.expects(:get).with("/augeas/files/foo/error/message").returns("Failed to...")
-      @provider.expects(:debug).times(3)
+      @provider.expects(:debug).times(4)
       @provider.print_put_errors
     end
   end
@@ -630,19 +579,6 @@ describe provider_class do
   # method.  This relies on Augeas and ruby-augeas on the host to be
   # functioning.
   describe "augeas lib initialisation", :if => Puppet.features.augeas? do
-    before(:each) do
-      @resource = Puppet::Type.type(:augeas).new(
-        :name     => "test",
-        :root     => my_fixture_dir,
-        :provider => :augeas
-      )
-      @provider = provider_class.new(@resource)
-    end
-
-    after(:each) do
-      @provider.close_augeas
-    end
-
     # Expect lenses for fstab and hosts
     it "should have loaded standard files by default" do
       aug = @provider.open_augeas


### PR DESCRIPTION
Cleanup of existing unit tests to use instances of resources rather than stubbed objects, which were very much tied to how the provider worked.

http://projects.puppetlabs.com/issues/7592
