### PR TITLE
Fix validate args

### DIFF
--- a/lib/puppet/type/file/ctime.rb
+++ b/lib/puppet/type/file/ctime.rb
@@ -10,7 +10,7 @@ module Puppet
       current_value
     end
 
-    validate do
+    validate do |val|
       fail "ctime is read-only"
     end
   end

--- a/lib/puppet/type/file/mtime.rb
+++ b/lib/puppet/type/file/mtime.rb
@@ -10,7 +10,7 @@ module Puppet
       current_value
     end
 
-    validate do
+    validate do |val|
       fail "mtime is read-only"
     end
   end

--- a/lib/puppet/type/file/type.rb
+++ b/lib/puppet/type/file/type.rb
@@ -11,7 +11,7 @@ module Puppet
       current_value
     end
 
-    validate do
+    validate do |val|
       fail "type is read-only"
     end
   end


### PR DESCRIPTION
In Ruby 1.9 define_method respects arity of blocks, so blocks given to
validate must take one arg.
