### PR TITLE
Don't try to read the body of a file content response twice

### DIFF
--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -3,8 +3,29 @@ test_name "The source attribute"
 step "Ensure the test environment is clean"
 on agents, 'rm -f /tmp/source_file_test.txt'
 
-# TODO: Add tests for puppet:// URIs with master/agent setups.
-# step "when using a puppet:/// URI with a master/agent setup"
+step "when using a puppet:/// URI with a master/agent setup"
+modulepath = nil
+on master, puppet_master('--configprint modulepath') do
+  modulepath = stdout.split(':')[0].chomp
+end
+
+result_file = "/tmp/#{$$}-result-file"
+source_file = File.join(modulepath, 'source_test_module', 'files', 'source_file')
+manifest = "/tmp/#{$$}-source-test.pp"
+
+on master, "mkdir -p #{File.dirname(source_file)}"
+on master, "echo 'the content is present' > #{source_file}"
+on master, %Q[echo "file { '#{result_file}': source => 'puppet:///modules/source_test_module/source_file', ensure => present }" > #{source_file}]
+
+with_master_running_on master, "--autosign true --manifest #{manifest}" do
+  run_agent_on agents, "--test --server #{master}" do
+    on agents, "cat #{result_file}" do
+      assert_match(/the content is present/, stdout, "Result file not created")
+    end
+  end
+end
+
+# TODO: Add tests for puppet:// URIs with multi-master/agent setups.
 # step "when using a puppet://$server/ URI with a master/agent setup"
 
 step "Using a local file path"

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -199,12 +199,12 @@ module Puppet
       end
     end
 
-    def get_from_source(source_or_content)
+    def get_from_source(source_or_content, &block)
       request = Puppet::Indirector::Request.new(:file_content, :find, source_or_content.full_path.sub(/^\//,''))
 
       request.do_request(:fileserver) do |req|
         connection = Puppet::Network::HttpPool.http_instance(req.server, req.port)
-        return yield connection.request_get(indirection2uri(req), add_accept_encoding({"Accept" => "raw"}))
+        connection.request_get(indirection2uri(req), add_accept_encoding({"Accept" => "raw"}), &block)
       end
     end
 

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -334,7 +334,7 @@ describe content do
         @response.stubs(:read_body).multiple_yields(*(["source file content\n"]*10000))
 
         @conn = stub_everything 'connection'
-        @conn.stubs(:request_get).returns(@response)
+        @conn.stubs(:request_get).yields @response
         Puppet::Network::HttpPool.stubs(:http_instance).returns @conn
 
         @content = @resource.newattr(:content)


### PR DESCRIPTION
Previously, get_file_from_source was calling Net::HTTP#request_get to
request file content, and yielding the response to
chunk_file_from_source, which would read the body. However, when called
without a block, request_get will read the body itself before returning
the response. This caused an error when chunk_file_from_source then
tried to read (and inflate if necessary) the body.

Now, get_file_from_source will pass its block along to request_get,
which will yield the unread response, rather than yielding the result of
request_get, which is a read response. This prevents a double read
error, and also allows us to properly inflate the body.

This fixes sourcing remote files.
