### PR TITLE
Tickets/master/11263

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -221,6 +221,22 @@ module Puppet
       newvalue(/.*/) { }
     end
 
+    newproperty(:mirrorlist_expire, :parent => Puppet::IniProperty) do
+      desc "Time (in seconds) after which the mirrorlist locally cached
+        will expire.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      # Should really check that it's a valid URL
+      newvalue(%r{[0-9]+}) { }
+    end
+
+    newproperty(:metalink, :parent => Puppet::IniProperty) do
+      desc "Specifies a URL to a metalink file for the repomd.xml.
+        #{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      # Should really check that it's a valid URL
+      newvalue(/.*/) { }
+    end
+
     newproperty(:baseurl, :parent => Puppet::IniProperty) do
       desc "The URL for this repository. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
@@ -249,6 +265,20 @@ module Puppet
       newvalue(:absent) { self.should = :absent }
       # Should really check that it's a valid URL
       newvalue(/.*/) { }
+    end
+
+    newproperty(:gpgcakey, :parent => Puppet::IniProperty) do
+      desc "The URL for the GPG CA key for this repository. #{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      # Should really check that it's a valid URL
+      newvalue(/.*/) { }
+    end
+
+    newproperty(:repo_gpgcheck, :parent => Puppet::IniProperty) do
+      desc "This tells yum whether or not it should perform a GPG
+        signature check on the repodata from this repository. #{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(%r{(0|1)}) { }
     end
 
     newproperty(:include, :parent => Puppet::IniProperty) do
@@ -287,7 +317,7 @@ module Puppet
       desc "The failover methode for this repository; should be either
         `roundrobin` or `priority`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(%r{roundrobin|priority}) { }
+      newvalue(%r{(roundrobin|priority)}) { }
     end
 
     newproperty(:keepalive, :parent => Puppet::IniProperty) do
@@ -297,17 +327,32 @@ module Puppet
       newvalue(%r{(0|1)}) { }
     end
 
-     newproperty(:http_caching, :parent => Puppet::IniProperty) do
-       desc "What to cache from this repository. #{ABSENT_DOC}"
-       newvalue(:absent) { self.should = :absent }
-       newvalue(%r(packages|all|none)) { }
-     end
+    newproperty(:http_caching, :parent => Puppet::IniProperty) do
+      desc "What to cache from this repository. #{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(%r{(packages|all|none)}) { }
+    end
+
+    newproperty(:skip_if_unavailable, :parent => Puppet::IniProperty) do
+      desc "Control whether yum will continue running if this repository
+        cannot be contacted for any reason.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(%r{(0|1)}) { }
+    end
 
     newproperty(:timeout, :parent => Puppet::IniProperty) do
       desc "Number of seconds to wait for a connection before timing
         out. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{[0-9]+}) { }
+    end
+
+    newproperty(:retries, :parent => Puppet::IniProperty) do
+      desc "Set the number of times any attempt to retrieve a file should
+        retry before returning an error. Setting this to `0` makes yum 
+       try forever.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(%r{[0-9]+}) { } 
     end
 
     newproperty(:metadata_expire, :parent => Puppet::IniProperty) do
@@ -337,6 +382,25 @@ module Puppet
       desc "Cost of this repository.\n#{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
       newvalue(%r{\d+}) { }
+    end
+
+    newproperty(:throttle, :parent => Puppet::IniProperty) do
+      desc "Enable bandwidth throttling for downloads. This option
+        can be expressed as a absolute data rate in bytes/sec or a
+        percentage `60%`. An SI prefix (k, M or G) may be appended
+        to the data rate values.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(%r{[.0-9]+[k|M|G|%]?}) { }
+    end
+
+    newproperty(:bandwidth, :parent => Puppet::IniProperty) do
+      desc "Use to specify the maximum available network bandwidth
+        in bytes/second. Used with the `throttle` option. If `throttle`
+        is a percentage and `bandwidth` is `0` then bandwidth throttling
+        will be disabled. If `throttle` is expressed as a data rate then
+        this option is ignored.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(%r{[.0-9]+[k|M|G]?}) { }
     end
 
     newproperty(:proxy, :parent => Puppet::IniProperty) do


### PR DESCRIPTION
Two patches:
1. The metadata_expire option of the yumrepo type has the wrong regex match for it’s available options. We only match seconds but the option can in fact take:

metadata_expire Time (in seconds) after which the metadata will expire. So that if the current metadata downloaded is less than this many seconds old then yum will not update the metadata against the repository. If you find that yum is not downloading information on updates as often as you would like lower the value of this option. You can also change from the default of using seconds to using days, hours or minutes by appending a d, h or m respectively. The default is 6 hours, to compliment yum-updatesd running once an hour. It’s also possible to use the word “never”, meaning that the metadata will never expire. Note that when using a metalink file the metalink must always be newer than the metadata for the repository, due to the validation, so this timeout also applies to the metalink file.
1. Added a number of new yumrepo attributes that were missing from the type.
