### PR TITLE
Ticket/2.7.x/11198 generated module templates should have a default license

### DIFF
--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -56,7 +56,7 @@ module Puppet::Module::Tool
     end
 
     def license
-      @license || 'UNKNOWN'
+      @license || 'Apache License, Version 2.0'
     end
 
     def license=(license)

--- a/spec/unit/module_tool/metadata_spec.rb
+++ b/spec/unit/module_tool/metadata_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'puppet/module_tool'
+
+describe Puppet::Module::Tool::Metadata do
+  context "when using default values" do
+    it "should set license to 'Apache License, Version 2.0'" do
+      metadata = Puppet::Module::Tool::Metadata.new
+      metadata.license.should == "Apache License, Version 2.0"
+    end
+  end
+end


### PR DESCRIPTION
Before this patch, the module generate action generates Modulefiles
with the license set to UNKNOWN, which is not a valid license.

This patch fixes this issue by setting the default value of the
`Puppet::Module::Tool::Metadata#license` attribute to 'Apache License,
Version 2.0' by default. This patch also adds a new unit test verifying
this this change.
