### PR TITLE
Ticket/2.7.x/11273 init.pp template for module face should be more thorough

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
@@ -1,16 +1,40 @@
-# Class: <%= metadata.name %>
+# == Class: <%= metadata.name %>
 #
-# This module manages <%= metadata.name %>
+# Full description of class <%= metadata.name %> here.
 #
-# Parameters:
+# === Parameters
 #
-# Actions:
+# Document parameters here.
 #
-# Requires:
+# [*sample_parameter*]
+#   Explanation of what this parameter affects and what it defaults to.
+#   e.g. "Specify one or more upstream ntp servers as an array."
 #
-# Sample Usage:
+# === Variables
 #
-# [Remember: No empty lines between comments and class definition]
+# Here you should define a list of variables that this module would require.
+#
+# [*sample_variable*]
+#   Explanation of how this variable affects the funtion of this class and if it
+#   has a default. e.g. "The parameter enc_ntp_servers must be set by the
+#   External Node Classifier as a comma separated list of hostnames." (Note,
+#   global variables should not be used in preference to class parameters  as of
+#   Puppet 2.6.)
+#
+# === Examples
+#
+#  class { <%= metadata.name %>:
+#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ]
+#  }
+#
+# === Authors
+#
+# Author Name <author@domain.com>
+#
+# === Copyright
+#
+# Copyright 2011 Your name here, unless otherwise noted.
+#
 class <%= metadata.name %> {
 
 


### PR DESCRIPTION
This patch introduces a more thorough init.pp template that outlines
  what parameters and variables are, a spot for Author, and Copyright;
  to be used when a new module skeleton is generated using the puppet
  module face.  Content is based on recommended puppet doc format, suggested by
  the official style guide.  Plus a few fix ups in syntax.  In testing this
  template I found errors in our style guide and will be pushing a branch to fix
  that recommendation too.
