### PR TITLE
Fixed #10219 - uninitialized class variable Schedule type

### DIFF
--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -230,13 +230,13 @@ module Puppet
 
       newvalues(:hourly, :daily, :weekly, :monthly, :never)
 
-      @@scale = {
+      ScheduleScales = {
         :hourly => 3600,
         :daily => 86400,
         :weekly => 604800,
         :monthly => 2592000
       }
-      @@methods = {
+      ScheduleMethods = {
         :hourly => :hour,
         :daily => :day,
         :monthly => :month,
@@ -253,7 +253,7 @@ module Puppet
         value = self.value
         case @resource[:periodmatch]
         when :number
-          method = @@methods[value]
+          method = ScheduleMethods[value]
           if method.is_a?(Proc)
             return method.call(previous, now)
           else
@@ -261,7 +261,7 @@ module Puppet
             return now.send(method) != previous.send(method)
           end
         when :distance
-          scale = @@scale[value]
+          scale = ScheduleScales[value]
 
           # If the number of seconds between the two times is greater
           # than the unit of time, we match.  We divide the scale


### PR DESCRIPTION
When run with Ruby 1.9.x we receive the error:

uninitialized class variable @@scale in
Puppet::Type::Schedule::ParameterPeriod

This is as a result of the two class variables:

@@scale
@@method

This patch replaces these with the appropriate non-class variables.
