### PR TITLE
Maint/2.7.x/add tap

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -130,3 +130,11 @@ class IO
     lines
   end
 end
+
+# Ruby 1.8.5 doesn't have tap
+module Kernel
+  def tap
+    yield(self)
+    self
+  end unless method_defined?(:tap)
+end


### PR DESCRIPTION
The module tool used to rely on facets to get tap in Ruby 1.8.5, but it
lost that behavior when ported over.  This monkey patches Kernel to have
tap in case it doesn't already.
