### PR TITLE
Prototype code for #7243 - Additional data in Puppet CSRs

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -354,6 +354,10 @@ module Puppet
         autosigns any key request, and is a very bad idea), false (which
         never autosigns any key request), and the path to a file, which
         uses that configuration file to determine which keys to sign."},
+    :allow_csr_attributes => [false, "Whether to allow CSR attributes."],
+    :csr_attributes_file => { :default => "$confdir/csrattributes.yaml",
+      :mode => 0644,
+      :desc => "YAML File to hold any attributes that should be added to the CSR."},
     :allow_duplicate_certs => [false, "Whether to allow a new certificate
       request to overwrite an existing certificate."],
     :ca_days => ["", "How long a certificate should be valid.

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -126,6 +126,8 @@ describe Puppet::SSL::CertificateRequest do
     it "should set the CN to the :ca_name setting when the CSR is for a CA" do
       subject = mock 'subject'
       Puppet.settings.expects(:value).with(:ca_name).returns "mycertname"
+      Puppet.settings.expects(:value).with(:allow_csr_attributes).returns false
+      Puppet.settings.expects(:value).with(:certdnsnames).returns "othercertname"
       OpenSSL::X509::Name.expects(:new).with { |subject| subject[0][1] == "mycertname" }.returns(subject)
       @request.expects(:subject=).with(subject)
       Puppet::SSL::CertificateRequest.new(Puppet::SSL::CA_NAME).generate(@key)


### PR DESCRIPTION
This adds the ability to add arbitrary attributes to Puppet certificate
requests.  It is controlled by setting the allow_csr_attributes setting
in the puppet.conf configuration file on the Puppet agent.

```
allow_csr_attributes = true
```

This option defaults to false.  If set to true it looks for a YAML file,
csrattributes.yaml, located by default in /etc/puppet but location is
controllable via the csr_attributes_file option in puppet.conf.

Inside this file you can speicfy a list of OIDs and values in the form
of a YAML hash, for example:

```

---
1.3.6.1.4.1.34380.2.1: 'attrval1'
1.3.6.1.4.1.34380.2.2: 'attrval2'
```

When the Puppet CSR is generated these values will be added to the CSR
that is passed to the Puppet master.  You can then inspect them using:

```
openssl req -in name.of.csr.file.pem -noout -text
```

This will return the detailed certificate request and you should see in
the attributes section:

```
    Attributes:
        testoid1                 :unable to print attribute
        testoid2                 :unable to print attribute
```

This is entirely prototype code and I've fixed any tests broken by its
introduction but not added any new tests.

This patch also adds the contents of certdnsnames to the CSR being generated
on the Puppet agent as Extensions.
