### PR TITLE
Bug/2.7.x/11333 type ensurable doesn't work

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -107,11 +107,9 @@ class Type
   def self.ensurable?
     # If the class has all three of these methods defined, then it's
     # ensurable.
-    ens = [:exists?, :create, :destroy].inject { |set, method|
-      set &&= self.public_method_defined?(method)
+    [:exists?, :create, :destroy].all? { |method|
+      self.public_method_defined?(method)
     }
-
-    ens
   end
 
   def self.apply_to_device


### PR DESCRIPTION
Puppet::Type.ensurable? incorrectly returns true even when
public_method_defined?(:exists?) is false because the check
never actually happens due to a bug. This fix handles this
and simplifies the code.
