### PR TITLE
Fix puppet parser validate --ignoreimport [9670]

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -148,7 +148,6 @@ class Puppet::Node::Environment
   private
 
   def perform_initial_import
-    return empty_parse_result if Puppet.settings[:ignoreimport]
     parser = Puppet::Parser::Parser.new(self)
     if code = Puppet.settings.uninterpolated_value(:code, name.to_s) and code != ""
       parser.string = code


### PR DESCRIPTION
Puppet parser validate --ignoreimport currently returns 0 when it should fail
