### PR TITLE
Fix for exported resources with async storeconfigs [11415]

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -67,10 +67,6 @@ class Puppet::Resource
 
     params = self.to_hash.inject({}) do |hash, ary|
       param, value = ary
-
-      # Don't duplicate the title as the namevar
-      next hash if param == namevar and value == title
-
       hash[param] = Puppet::Resource.value_to_pson_data(value)
       hash
     end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -748,6 +748,16 @@ type: File
       result = Puppet::Resource.from_pson(PSON.parse(resource.to_pson))
       result[:requires].should == [ "File[/bar]",  "File[/baz]" ]
     end
+
+    it "should include the 'namevar' into params list during pson export" do
+      resource = Puppet::Resource.new("user", "bob")
+      resource[:var1] = "bob"
+      resource[:var2] = "var2"
+      resource.exported = true
+      Puppet::Type.type(:user).stubs(:key_attributes).returns [:var1]
+      Puppet::Resource.from_pson(PSON.parse(resource.to_pson))[:var1].should == 'bob'
+    end
+
   end
 
   describe "when converting from pson", :if => Puppet.features.pson? do


### PR DESCRIPTION
Hey, I have a problem with the following configuration:

```
thin_storeconfigs = true
async_storeconfigs = true
```

For example, when I tried to export nagios_host, puppetmaster lost host_name variable during pson export to stomp queue. Host_name variable is used as "namevar" for nagios_host resource and ignored during pson / json export. The patch removes "namevar" check during the export and fixes the problem.

Signed-off-by: Alexey Lapitsky lex@realisticgroup.com
