### PR TITLE
Bug/2.7.x/11423 better collector error message

### DIFF
--- a/lib/puppet/parser/collector.rb
+++ b/lib/puppet/parser/collector.rb
@@ -111,7 +111,7 @@ class Puppet::Parser::Collector
           unless existing.collector_id == item.collector_id
             # unless this is the one we've already collected
             raise Puppet::ParseError,
-              "Exported resource #{item.ref} cannot override local resource"
+              "Another local or imported resource exists with the type and title #{item.ref}"
           end
         else
           item.exported = false

--- a/spec/unit/parser/collector_spec.rb
+++ b/spec/unit/parser/collector_spec.rb
@@ -416,7 +416,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       @compiler.add_resource(@scope, local)
 
       expect { @collector.evaluate }.
-        to raise_error Puppet::ParseError, /cannot override local resource/
+        to raise_error Puppet::ParseError, /exists with the type and title/
     end
 
     it "should ignore exported resources that match already-collected resources" do


### PR DESCRIPTION
When multiple nodes export a resource with a duplicate type and title, and you
import both, the error message misleadingly tells you that this was a _local_
duplication.

This improves the error message to cover all the bases, which is suboptimal -
it should tell you where the duplicate comes from - but at least doesn't lead
to a wild goose hunt for the _local_ duplicate that doesn't exist.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
