### PR TITLE
(#7428) Fix option parsing for ruby 1.9 in cert application

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -17,11 +17,11 @@ class Puppet::Application::Cert < Puppet::Application
     @subcommand = (sub == :clean ? :destroy : sub)
   end
 
-  option("--clean", "-c") do
+  option("--clean", "-c") do |arg|
     self.subcommand = "destroy"
   end
 
-  option("--all", "-a") do
+  option("--all", "-a") do |arg|
     @all = true
   end
 
@@ -29,7 +29,7 @@ class Puppet::Application::Cert < Puppet::Application
     @digest = arg
   end
 
-  option("--signed", "-s") do
+  option("--signed", "-s") do |arg|
     @signed = true
   end
 
@@ -39,7 +39,7 @@ class Puppet::Application::Cert < Puppet::Application
 
   require 'puppet/ssl/certificate_authority/interface'
   Puppet::SSL::CertificateAuthority::Interface::INTERFACE_METHODS.reject {|m| m == :destroy }.each do |method|
-    option("--#{method.to_s.gsub('_','-')}", "-#{method.to_s[0,1]}") do
+    option("--#{method.to_s.gsub('_','-')}", "-#{method.to_s[0,1]}") do |arg|
       self.subcommand = method
     end
   end
@@ -48,7 +48,7 @@ class Puppet::Application::Cert < Puppet::Application
     options[:allow_dns_alt_names] = value
   end
 
-  option("--verbose", "-v") do
+  option("--verbose", "-v") do |arg|
     Puppet::Util::Log.level = :info
   end
 

--- a/spec/unit/application/cert_spec.rb
+++ b/spec/unit/application/cert_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/application/cert'
 
-describe Puppet::Application::Cert, :'fails_on_ruby_1.9.2' => true do
+describe Puppet::Application::Cert => true do
   before :each do
     @cert_app = Puppet::Application[:cert]
     Puppet::Util::Log.stubs(:newdestination)


### PR DESCRIPTION
In Ruby 1.9 block arity is strictly enforced. This changes options created
using blocks to all take one argument. The OptionParser library handles this
correctly even if an option doesn't take arguments (giving an argument of true
if the block takes an argument).
