### PR TITLE
(#10586) Don't copy owner and group on Windows when sourcing from master

### DIFF
--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -132,6 +132,10 @@ module Puppet
         next if metadata_method == :checksum and metadata.ftype == "directory"
         next if metadata_method == :checksum and metadata.ftype == "link" and metadata.links == :manage
 
+        if Puppet.features.microsoft_windows?
+          next if [:owner, :group].include?(metadata_method) and !local?
+        end
+
         if resource[param_name].nil? or resource[param_name] == :absent
           resource[param_name] = metadata.send(metadata_method)
         end

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -500,8 +500,9 @@ describe Puppet::Type.type(:file) do
     end
 
     it "should not copy values to the child which were set by the source" do
-      file[:source] = File.expand_path(__FILE__)
-      metadata = stub 'metadata', :owner => "root", :group => "root", :mode => 0755, :ftype => "file", :checksum => "{md5}whatever"
+      source = File.expand_path(__FILE__)
+      file[:source] = source
+      metadata = stub 'metadata', :owner => "root", :group => "root", :mode => 0755, :ftype => "file", :checksum => "{md5}whatever", :source => source
       file.parameter(:source).stubs(:metadata).returns metadata
 
       file.parameter(:source).copy_source_values


### PR DESCRIPTION
Previously, puppet on Windows was not able to source files from the
master, because it was attempting to translate the uid/gid from
the Unix master into a Windows account, and obviously failing.

This commit skips the owner and group properties when copying them
from non-local sources, i.e. sources whose URIs have a 'puppet'
scheme.

If the source comes from a local source, then puppet behaves the same
as it did previously, it copies the owner and group if the source
volume supports Windows ACLs, e.g. C:/, samba mapped drives, or uses
default values if the volume does not, e.g. VMware shared drives.
