### PR TITLE
(#11408) Fix fact and plugin sync on Windows

### DIFF
--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -63,14 +63,16 @@ class Puppet::Configurer::Downloader
 
   private
 
+  require 'sys/admin' if Puppet.features.microsoft_windows?
+
   def default_arguments
     {
       :path => path,
       :recurse => true,
       :source => source,
       :tag => name,
-      :owner => Process.uid,
-      :group => Process.gid,
+      :owner => Puppet.features.microsoft_windows? ? Sys::Admin.get_login : Process.uid,
+      :group => Puppet.features.microsoft_windows? ? 'S-1-0-0' : Process.gid,
       :purge => true,
       :force => true,
       :backup => false,


### PR DESCRIPTION
Previously, fact and pluginsync were broken on Windows, because it was
defaulting the owner and group to Process.uid/gid, and then failing to
translate them into Windows SIDs.

This commit changes the default file owner to the current user name,
and the default file group to Nobody, which is the group that Windows
typically applies to newly created files.
