### PR TITLE
Last run summary permissions on windows

### DIFF
--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -57,7 +57,9 @@ describe Puppet::Configurer do
       @configurer.run :catalog => @catalog, :report => report
       t2 = Time.now.tv_sec
 
-      File.stat(Puppet[:lastrunfile]).mode.to_s(8).should == "100666"
+      file_mode = Puppet.features.microsoft_windows? ? '100644' : '100666'
+
+      File.stat(Puppet[:lastrunfile]).mode.to_s(8).should == file_mode
 
       summary = nil
       File.open(Puppet[:lastrunfile], "r") do |fd|


### PR DESCRIPTION
Windows file modes do not directly translate to POSIX file modes, so
we can't use the same file mode on Windows to check that setting the
mode worked correctly.
