### PR TITLE
Ticket/2.7.x/10109 composite namevars

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -547,7 +547,11 @@ class Puppet::Resource::Catalog < Puppet::SimpleGraph
     ::File.open(Puppet[:resourcefile], "w") do |f|
       to_print = resources.map do |resource|
         next unless resource.managed?
-        "#{resource.type}[#{resource[resource.name_var]}]"
+        if resource.name_var
+          "#{resource.type}[#{resource[resource.name_var]}]"
+        else
+          "#{resource.ref.downcase}"
+        end
       end.compact
       f.puts to_print.join("\n")
     end


### PR DESCRIPTION
The code for creating the resourcefile was directly calling
resource.name_var, which was causing problems with resources that have
composite namevars (since, for these, Type#name_var will return false).
This patch sanitizes the process by first checking whether there is a
single namevar, and simply calling resource.ref if there is not one.

Reviewed-by: Matt Robinson

Patch fixed the bug for the user who reported it (see: http://projects.puppetlabs.com/issues/10109). I was planning on adding a test case with a resource that had a composite namevar to show that this patch resolved the issue in the specs, but found that composite namevars are extremely poorly documented and not really tested at the moment (see: http://projects.puppetlabs.com/issues/11462).
