### PR TITLE
Disable SRV lookups of hosts by default when testing

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,11 @@ RSpec.configure do |config|
     # Avoid opening ports to the outside world
     Puppet.settings[:bindaddress] = "127.0.0.1"
 
+    # We don't want to depend upon the reported domain name of the
+    # machine running the tests, nor upon the DNS setup of that
+    # domain.
+    Puppet.settings[:use_srv_records] = false
+
     @logs = []
     Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
 

--- a/spec/unit/indirector/facts/inventory_service_spec.rb
+++ b/spec/unit/indirector/facts/inventory_service_spec.rb
@@ -19,4 +19,3 @@ describe Puppet::Node::Facts::InventoryService do
     }.should_not raise_error
   end
 end
-


### PR DESCRIPTION
The old behavior of leaving SRV lookups turned on by default in tests
was causing problems if the machine running the tests reported itself
as having a domain name that has SRV records setup for Puppet.  This
would cause extra calls to Puppet.warning due to the failed connection
attempts, which could cause a problem if the test was looking
for specific warnings (which
spec/unit/indirector/facts/inventory_service_spec.rb does).
