### PR TITLE
Feature/2.7.x/11472 add pe version

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -25,9 +25,14 @@ require 'puppet/util/run_mode'
 
 module Puppet
   PUPPETVERSION = '2.7.9'
+  PEVersionFile = '/opt/puppet/pe_version'
 
   def Puppet.version
-    PUPPETVERSION
+    if File.readable? PEVersionFile then
+      "#{PUPPETVERSION} (Puppet Enterprise %s)" % File.new(PEVersionFile).gets.chomp
+    else
+      PUPPETVERSION
+    end
   end
 
   class << self

--- a/spec/unit/version_spec.rb
+++ b/spec/unit/version_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Puppet.version do
+  include PuppetSpec::Files
+
+  let(:test_version) { "1.2.3" }
+  let(:test_pe_version) { "3.4.5" }
+
+  before do
+    # Create a temp file to use for the pe version file
+    # and write the desired version string out to it
+    @pe_file = tmpfile('pe_version')
+    pe_version_file = File.open(@pe_file, "w")
+    pe_version_file.puts(test_pe_version)
+    pe_version_file.close
+    with_verbose_disabled { Puppet.const_set(:PEVersionFile, @pe_file) }
+    with_verbose_disabled { Puppet.const_set(:PUPPETVERSION, test_version) }
+  end
+
+  it "Should return just the version if there is no pe_version file" do
+    File.stubs(:readable?).with(@pe_file).returns(false)
+    Puppet.version.should == test_version
+  end
+
+  it "Should return '$Version (Puppet Enterprise $PEVersion)' if there is a pe_version file" do
+    Puppet.version.should == "#{test_version} (Puppet Enterprise #{test_pe_version})"
+  end
+end


### PR DESCRIPTION
In Puppet Enterprise, the version is contained in a file
/opt/puppet/pe_version. If this file is present, `puppet --version` should
return a version string including that information. `puppet --version` relies
on the version method in the Puppet module. This patch adds a check for the PE
version file, and returns a string containing both the puppet and puppet
enterprise versions if it is present. Otherwise, it defaults to the previous
behavior of returning a string of the puppet version, as defined by the
constant PUPPETVERSION in puppet.rb.

This also includes two spec tests to verify the desired behavior, both with
and without the PE version file being present.
