### PR TITLE
(#11282) PMT creates all five module subdirectories

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/files/README
+++ b/lib/puppet/module_tool/skeleton/templates/generator/files/README
@@ -1,0 +1,7 @@
+Files associated with the module go in this directory.
+
+They can be accessed in the following manner.
+
+file { 'myfile':
+  source => "puppet:///modules/${module_name}/myfile",
+}

--- a/lib/puppet/module_tool/skeleton/templates/generator/lib/README
+++ b/lib/puppet/module_tool/skeleton/templates/generator/lib/README
@@ -1,0 +1,15 @@
+Ruby code to extend Puppet that is associated with this module goes in
+a specific subdirectory of this directory.
+
+lib
+├── facter (custom facts)
+└── puppet
+    ├── parser
+    │   └── functions (custom functions)
+    ├── provider
+        ├── exec
+        ├── package
+        └── etc... (any resource type)
+    └── type
+
+see http://docs.puppetlabs.com/guides/modules.html for more information.

--- a/lib/puppet/module_tool/skeleton/templates/generator/templates/README
+++ b/lib/puppet/module_tool/skeleton/templates/generator/templates/README
@@ -1,0 +1,7 @@
+Templates associated with the module go in this directory.
+
+They can be accessed in the following manner.
+
+file { 'myfile':
+  content => template("${module_name}/myfile.erb"),
+}


### PR DESCRIPTION
puppet module generate will now create files, lib, and templates
directories in addition to the manifests, spec, and tests directories
that were already created in order to be complete.
