### PR TITLE
Maint/2.7.x/typo in create resources

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -14,7 +14,7 @@ Puppet::Parser::Functions::newfunction(:create_resources, :doc => <<-'ENDHEREDOC
                       groups => ['developers', 'prosvc', 'release'], }
         }
 
-        create_resource(user, $myusers)
+        create_resources(user, $myusers)
 
     A third, optional parameter may be given, also as a hash:
 


### PR DESCRIPTION
The create_resources function had an example that referred to it as the
create_resource function. This commit fixes the missing plural.
