### PR TITLE
Puppet instrumentation test fixes for ruby 1.9.2

### DIFF
--- a/spec/unit/indirector/instrumentation_probe/local_spec.rb
+++ b/spec/unit/indirector/instrumentation_probe/local_spec.rb
@@ -40,8 +40,8 @@ describe Puppet::Indirector::InstrumentationProbe::Local do
       instance2 = stub 'instance2', :method => "probe2", :klass => "Klass2"
       Puppet::Util::Instrumentation::IndirectionProbe.expects(:new).with("Klass1.probe1").returns(:instance1)
       Puppet::Util::Instrumentation::IndirectionProbe.expects(:new).with("Klass2.probe2").returns(:instance2)
-      Puppet::Util::Instrumentation::Instrumentable.expects(:each_probe).multiple_yields(instance1, instance2)
-      @probe.search(@request).should == [ :instance1, :instance2]
+      Puppet::Util::Instrumentation::Instrumentable.expects(:each_probe).multiple_yields([instance1], [instance2])
+      @probe.search(@request).should == [ :instance1, :instance2 ]
     end
   end
 

--- a/spec/unit/util/instrumentation/listeners/process_name_spec.rb
+++ b/spec/unit/util/instrumentation/listeners/process_name_spec.rb
@@ -70,7 +70,8 @@ describe process_name do
       @process_name.push_activity(thread1,"Parsing file site.pp")
       @process_name.push_activity(thread2,"Parsing file node.pp")
 
-      @process_name.process_name.should == "12344321 Compiling node4.domain.com,Parsing file node.pp | deadbeef Compiling node1.domain.com,Parsing file site.pp"
+      @process_name.process_name.should =~ /12344321 Compiling node4.domain.com,Parsing file node.pp/
+      @process_name.process_name.should =~ /deadbeef Compiling node1.domain.com,Parsing file site.pp/
     end
   end
 


### PR DESCRIPTION
That's the ransom of not developing with ruby 1.9.2. Those tests were passing fine with ruby 1.8.7.
Here is a commit that fixes those tests under 1.9.2.
