### PR TITLE
(#11595) Delete unused activerecord catalog find

### DIFF
--- a/lib/puppet/indirector/catalog/active_record.rb
+++ b/lib/puppet/indirector/catalog/active_record.rb
@@ -5,19 +5,9 @@ require 'puppet/resource/catalog'
 class Puppet::Resource::Catalog::ActiveRecord < Puppet::Indirector::ActiveRecord
   use_ar_model Puppet::Rails::Host
 
-  # If we can find the host, then return a catalog with the host's resources
-  # as the vertices.
+  # We don't retrieve catalogs from storeconfigs
   def find(request)
-    return nil unless request.options[:cache_integration_hack]
-    return nil unless host = ar_model.find_by_name(request.key)
-
-    catalog = Puppet::Resource::Catalog.new(host.name)
-
-    host.resources.each do |resource|
-      catalog.add_resource resource.to_transportable
-    end
-
-    catalog
+    nil
   end
 
   # Save the values from a Facts instance as the facts on a Rails Host instance.

--- a/spec/unit/indirector/catalog/active_record_spec.rb
+++ b/spec/unit/indirector/catalog/active_record_spec.rb
@@ -39,56 +39,11 @@ describe "Puppet::Resource::Catalog::ActiveRecord", :if => Puppet.features.rails
   end
 
   describe "when finding an instance" do
-    before do
-      @request = stub 'request', :key => "foo", :options => {:cache_integration_hack => true}
+    it "should return nil" do
+      request = stub 'request', :key => "foo"
+      @terminus.find(request).should be_nil
     end
 
-    # This hack is here because we don't want to look in the db unless we actually want
-    # to look in the db, but our indirection architecture in 0.24.x isn't flexible
-    # enough to tune that via configuration.
-    it "should return nil unless ':cache_integration_hack' is set to true" do
-      @request.options[:cache_integration_hack] = false
-      Puppet::Rails::Host.expects(:find_by_name).never
-      @terminus.find(@request).should be_nil
-    end
-
-    it "should use the Hosts ActiveRecord class to find the host" do
-      Puppet::Rails::Host.expects(:find_by_name).with { |key, args| key == "foo" }
-      @terminus.find(@request)
-    end
-
-    it "should return nil if no host instance can be found" do
-      Puppet::Rails::Host.expects(:find_by_name).returns nil
-
-      @terminus.find(@request).should be_nil
-    end
-
-    it "should return a catalog with the same name as the host if the host can be found" do
-      host = stub 'host', :name => "foo", :resources => []
-      Puppet::Rails::Host.expects(:find_by_name).returns host
-
-      result = @terminus.find(@request)
-      result.should be_instance_of(Puppet::Resource::Catalog)
-      result.name.should == "foo"
-    end
-
-    it "should set each of the host's resources as a transportable resource within the catalog" do
-      host = stub 'host', :name => "foo"
-      Puppet::Rails::Host.expects(:find_by_name).returns host
-
-      res1 = mock 'res1', :to_transportable => "trans_res1"
-      res2 = mock 'res2', :to_transportable => "trans_res2"
-
-      host.expects(:resources).returns [res1, res2]
-
-      catalog = stub 'catalog'
-      Puppet::Resource::Catalog.expects(:new).returns catalog
-
-      catalog.expects(:add_resource).with "trans_res1"
-      catalog.expects(:add_resource).with "trans_res2"
-
-      @terminus.find(@request)
-    end
   end
 
   describe "when saving an instance" do


### PR DESCRIPTION
The find method on lib/puppet/indirector/catalog/active_record.rb was
written in such a way that it could never be used.

First, you had to pass cache_integration_hack as an option to get it to
return anything except nil, and this wasn't used in the code.

Second, if you ever did get past the hack option,
resource.to_transportable was called even though that method was never
defined anywhere.

We noticed this when looking for code that had been orphaned by #11552
to delete TransObjects and TransBuckets.  There was a to_trans method
that was deleted, but never was there a to_transportable.

Paired-with: Patrick Carlisle patrick@puppetlabs.com
