### PR TITLE
(#10837 ) Retry inventory ActiveRecord transaction failure

### DIFF
--- a/lib/puppet/util/retryaction.rb
+++ b/lib/puppet/util/retryaction.rb
@@ -1,0 +1,51 @@
+module Puppet::Util::RetryAction
+  class RetryException < Exception; end
+  class RetryException::NoBlockGiven < RetryException; end
+  class RetryException::NoTimeoutGiven < RetryException;end
+  class RetryException::Timeout < RetryException; end
+
+  def self.retry_action( parameters = { :retry_exceptions => nil, :timeout => nil } )
+    # Retry actions for a specified amount of time. This method will allow the final
+    # retry to complete even if that extends beyond the timeout period.
+    unless block_given?
+      raise RetryException::NoBlockGiven
+    end
+
+    raise RetryException::NoTimeoutGiven if parameters[:timeout].nil?
+    parameters[:retry_exceptions] ||= Hash.new
+
+    start = Time.now
+    failures = 0
+
+    begin
+      yield
+    rescue Exception => e
+      # If we were giving exceptions to catch,
+      # catch the excptions we care about and retry.
+      # All others fail hard
+
+      raise RetryException::Timeout if timedout?(start, parameters[:timeout])
+
+      if (not parameters[:retry_exceptions].keys.empty?) and parameters[:retry_exceptions].keys.include?(e.class)
+        Puppet.info("Caught exception #{e.class}:#{e}")
+        Puppet.info(parameters[:retry_exceptions][e.class])
+      elsif (not parameters[:retry_exceptions].keys.empty?)
+        # If the exceptions is not in the list of retry_exceptions re-raise.
+        raise e
+      end
+
+      failures += 1
+      # Increase the amount of time that we sleep after every
+      # failed retry attempt.
+      sleep (((2 ** failures) -1) * 0.1)
+
+      retry
+
+    end
+  end
+
+  def self.timedout?(start, timeout)
+    return true if timeout.nil?
+    (Time.now - start) >= timeout
+  end
+end

--- a/spec/unit/util/retryaction_spec.rb
+++ b/spec/unit/util/retryaction_spec.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+
+require 'puppet/util/retryaction'
+
+describe Puppet::Util::RetryAction do
+  let (:exceptions) {{ Puppet::Error => 'Puppet Error Exception' }}
+  
+  it 'should retry on any exception if no acceptable exceptions given' do
+    expect do
+      Puppet::Util::RetryAction.retry_action( :timeout => 5 ) do
+        raise ArgumentError, 'Fake Failure'
+      end
+    end.to raise_exception(Puppet::Util::RetryAction::RetryException::Timeout)
+  end
+
+  it 'should retry on acceptable exceptions' do
+    expect do
+      Puppet::Util::RetryAction.retry_action( :timeout => 5, :retry_exceptions => exceptions) do
+        raise Puppet::Error, 'Fake Failure'
+      end
+    end.to raise_error(Puppet::Util::RetryAction::RetryException::Timeout)
+  end
+
+  it 'should not retry on unacceptable exceptions' do
+    expect do
+      Puppet::Util::RetryAction.retry_action( :timeout => 5, :retry_exceptions => exceptions) do
+        raise ArgumentError
+      end
+    end.to raise_exception(ArgumentError)
+  end
+end


### PR DESCRIPTION
Previous to this commit, if the ActiveRecord transaction for saving
facts failed do to MySQL deadlock, for example, the transaction would
fail printing a message to the user.  This primarily occurred during a
PE agent installation if multiple agent's were being creating
simultaneously.

This commit adds the ability to retry if a ActiveRecord::StatementInvalid
exception is thrown.  To accomplish this, this commit ports Cloud
Provisioner's Puppet::CloudPack::Utils#retry_action method to Puppet
core under Puppet::Util::RetryAction#retry_action.

Currently spec tests exist for the retry_action method, however properly
testing ActiveRecord inventory indirector is proving difficult since the
proper way to test it is to throw an expected failure once, then succeed
on a subsequent run.
