### PR TITLE
Ticket/2.7.x/11641 Properly track blockers when generating additional resources 

### DIFF
--- a/acceptance/tests/resource/tidy/should_remove_old_files.rb
+++ b/acceptance/tests/resource/tidy/should_remove_old_files.rb
@@ -1,0 +1,34 @@
+test_name "Tidying files by date"
+
+step "Create a directory of old and new files"
+
+dir = "/tmp/tidy-test-#{$$}"
+on agents, "mkdir -p #{dir}"
+# YYMMddhhmm, so 03:04 Jan 2 1970
+old = %w[one two three four five]
+new = %w[a b c d e]
+on agents, "touch -t 7001020304 #{dir}/{#{old.join(',')}}"
+on agents, "touch #{dir}/{#{new.join(',')}}"
+
+step "Run a tidy resource to remove the old files"
+
+manifest = <<-MANIFEST
+  tidy { "#{dir}":
+    age     => '1d',
+    recurse => true,
+  }
+MANIFEST
+
+apply_manifest_on agents, manifest
+
+step "Ensure the old files are gone"
+
+old_test = old.map {|name| "-f #{File.join(dir, name)}"}.join(' -o ')
+
+on agents, "[ #{old_test} ]", :acceptable_exit_codes => [1]
+
+step "Ensure the new files are still present"
+
+new_test = new.map {|name| "-f #{File.join(dir, name)}"}.join(' -a ')
+
+on agents, "[ #{new_test} ]"


### PR DESCRIPTION
Previously, we would enqueue any unblocked resources as we added them to the
graph. These were our initial resources, with no dependencies, and served as a
starting place for traversal. However, we would
add_dynamically_generated_resources before traversing, which could add
additional resources and dependencies. We never accounted for these, causing
our measure of blockedness to become incorrect (a resource could have more
dependencies than we counted).

This is similar to the case of eval_generate adding additional resources. In
that case, we clear the blockers list and allow it to be recalculated on
demand. Unfortunately, that approach doesn't work for the case where we add
resources before traversing (as in add_dynamically_generated_resources),
because we wouldn't have a reliable list of resources to begin traversal with.
Now we no longer enqueue resources when adding them, and instead wait until
after we have called add_dynamically_generated_resources (which happens only
once). This allows us to add our root resources with the assurance they won't
change before we start evaluating them.
