### PR TITLE
Add gitignore to default puppet module

### DIFF
--- a/lib/puppet/module_tool/applications/generator.rb
+++ b/lib/puppet/module_tool/applications/generator.rb
@@ -93,6 +93,9 @@ module Puppet::Module::Tool
         def target
           target = @generator.destination + @source.relative_path_from(@generator.skeleton.path)
           components = target.to_s.split(File::SEPARATOR).map do |part|
+            if part[0] == '_'
+              part[0] = '.'
+            end
             part == 'NAME' ? @generator.metadata.name : part
           end
           Pathname.new(components.join(File::SEPARATOR))

--- a/lib/puppet/module_tool/skeleton/templates/generator/_gitignore
+++ b/lib/puppet/module_tool/skeleton/templates/generator/_gitignore
@@ -1,0 +1,15 @@
+## MAC OS
+.DS_Store
+
+## TEXTMATE
+*.tmproj
+tmtags
+
+## EMACS
+*~
+\#*
+.\#*
+
+## VIM
+*.swp
+tags


### PR DESCRIPTION
This patch was merged into the seperate puppet-modlue-tool repo but I've
been asked to submit it here as well.  See:

https://github.com/puppetlabs/puppet-module-tool/pull/17
