### PR TITLE
Fix augeas_spec branch merging mistake

### DIFF
--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -432,7 +432,7 @@ describe provider_class do
     before do
       @augeas = stub("augeas")
       @augeas.stubs("close")
-      @augeas.stubs(:match).with("/augeas/events/saved")
+      @augeas.stubs(:match).with("/augeas/events/saved").returns([])
 
       @provider.aug = @augeas
       @provider.stubs(:get_augeas_version).returns("0.3.5")


### PR DESCRIPTION
spec/unit/provider/augeas/augeas_spec.rb had merge conflicts when I
merged 2.7.x into master.  I resolved them incorrectly at first, then
forgot to add the fixed resolution to the merge commit before pushing,
so all the tests passed on my local machine.  This corrects that merge
resolution so that tests all pass.
