### PR TITLE
(#11451) Fix improper use of "defined" in the duplicate declaration error

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -105,9 +105,9 @@ class Puppet::Resource::Catalog < Puppet::SimpleGraph
     # isn't sufficient.
     if existing = @resource_table[newref]
       return if existing == resource
-      resource_definition = " at #{resource.file}:#{resource.line}" if resource.file and resource.line
-      existing_definition = " at #{existing.file}:#{existing.line}" if existing.file and existing.line
-      msg = "Cannot alias #{resource.ref} to #{key.inspect}#{resource_definition}; resource #{newref.inspect} already defined#{existing_definition}"
+      resource_declaration = " at #{resource.file}:#{resource.line}" if resource.file and resource.line
+      existing_declaration = " at #{existing.file}:#{existing.line}" if existing.file and existing.line
+      msg = "Cannot alias #{resource.ref} to #{key.inspect}#{resource_declaration}; resource #{newref.inspect} already declared#{existing_declaration}"
       raise ArgumentError, msg
     end
     @resource_table[newref] = resource
@@ -569,17 +569,17 @@ class Puppet::Resource::Catalog < Puppet::SimpleGraph
 
   private
 
-  # Verify that the given resource isn't defined elsewhere.
+  # Verify that the given resource isn't declared elsewhere.
   def fail_on_duplicate_type_and_title(resource)
     # Short-curcuit the common case,
     return unless existing_resource = @resource_table[title_key_for_ref(resource.ref)]
 
     # If we've gotten this far, it's a real conflict
-    msg = "Duplicate definition: #{resource.ref} is already defined"
+    msg = "Duplicate declaration: #{resource.ref} is already declared"
 
     msg << " in file #{existing_resource.file} at line #{existing_resource.line}" if existing_resource.file and existing_resource.line
 
-    msg << "; cannot redefine" if resource.line or resource.file
+    msg << "; cannot redeclare" if resource.line or resource.file
 
     raise DuplicateResourceError.new(msg)
   end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -639,7 +639,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
         @other    = Puppet::Type.type(:multiple).new(:title => "another resource", :color => "red", :designation => "5")
 
         @catalog.add_resource(@resource)
-        expect { @catalog.add_resource(@other) }.to raise_error(ArgumentError, /Cannot alias Multiple\[another resource\] to \["red", "5"\].*resource \["Multiple", "red", "5"\] already defined/)
+        expect { @catalog.add_resource(@other) }.to raise_error(ArgumentError, /Cannot alias Multiple\[another resource\] to \["red", "5"\].*resource \["Multiple", "red", "5"\] already declared/)
       end
 
       it "should conflict when its uniqueness key matches another resource's title" do
@@ -648,7 +648,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
         @other    = Puppet::Type.type(:file).new(:title => "another file", :path => path)
 
         @catalog.add_resource(@resource)
-        expect { @catalog.add_resource(@other) }.to raise_error(ArgumentError, /Cannot alias File\[another file\] to \["#{Regexp.escape(path)}"\].*resource \["File", "#{Regexp.escape(path)}"\] already defined/)
+        expect { @catalog.add_resource(@other) }.to raise_error(ArgumentError, /Cannot alias File\[another file\] to \["#{Regexp.escape(path)}"\].*resource \["File", "#{Regexp.escape(path)}"\] already declared/)
       end
 
       it "should conflict when its uniqueness key matches the uniqueness key derived from another resource's title" do
@@ -656,7 +656,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
         @other    = Puppet::Type.type(:multiple).new(:title => "another resource", :color => "red", :designation => "leader")
 
         @catalog.add_resource(@resource)
-        expect { @catalog.add_resource(@other) }.to raise_error(ArgumentError, /Cannot alias Multiple\[another resource\] to \["red", "leader"\].*resource \["Multiple", "red", "leader"\] already defined/)
+        expect { @catalog.add_resource(@other) }.to raise_error(ArgumentError, /Cannot alias Multiple\[another resource\] to \["red", "leader"\].*resource \["Multiple", "red", "leader"\] already declared/)
       end
     end
   end


### PR DESCRIPTION
Duplicate resource declarations (including classes with the resource-like
class {'name':} syntax) were provoking the following error:

Duplicate definition: Class[Test] is already defined in file /tmp/test.pp at
line 9; cannot redefine at /tmp/test.pp:10 on node example.com

This is incorrect -- the problem is a duplicate declaration, not a duplicate
definition. I believe this is a holdover from our formerly sloppy use of the two
terms.

This commit fixes the error message, and renames several variables and methods
to match our current understanding of the terms "define" and "declare." Tests
are fixed as well.
