### PR TITLE
(#11592) Fix `puppet resource` ability to display parameters

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1902,6 +1902,16 @@ class Type
   def to_resource
     resource = self.retrieve_resource
     resource.tag(*self.tags)
+
+    @parameters.each do |name, param|
+      # Avoid adding each instance name twice
+      next if param.class.isnamevar? and param.value == self.title
+
+      # We've already got property values
+      next if param.is_a?(Puppet::Property)
+      resource[name] = param.value
+    end
+
     resource
   end
 

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'puppet/application/resource'
 
 describe Puppet::Application::Resource do
+  include PuppetSpec::Files
   before :each do
     @resource_app = Puppet::Application[:resource]
     Puppet::Util::Log.stubs(:newdestination)
@@ -53,6 +54,18 @@ describe Puppet::Application::Resource do
       @resource_app.handle_param("whatever")
 
       @resource_app.extra_params.should == [ :param1, :whatever ]
+    end
+
+    it "should get a parameter in the printed data if extra_params are passed" do
+      tty  = stub("tty",  :tty? => true )
+      path = tmpfile('testfile')
+      command_line = Puppet::Util::CommandLine.new("puppet", [ 'resource', 'file', path ], tty )
+      @resource_app.stubs(:command_line).returns command_line
+
+      # provider is a parameter that should always be available
+      @resource_app.extra_params = [ :provider ]
+
+      expect { @resource_app.main }.to have_printed /provider\s+=>/
     end
   end
 


### PR DESCRIPTION
The original commit for #11592 removing TransObject and TransBucket
removed the code that manually added parameters when converting from a
Puppet::Type::Resource to a Resource.  No tests in Puppet caught this
problem, but a test of the puppetral MCollective provider caught that
Puppet::Resource could no longer give back paramger information.

This restores the ability to retrieve parameters and adds tests to
Puppet.  Long term the logic for adding parameters really shouldn't live
in a method that converts between resource representations, but for now
I'm fixing the regression to work the same way it used to.

Also removed the explicit call to add tags when converting resources
since it was happening anyway elsewhere in the conversion process.
