### PR TITLE
(#10837) Retry inventory ActiveRecord transaction failure

### DIFF
--- a/lib/puppet/indirector/facts/inventory_active_record.rb
+++ b/lib/puppet/indirector/facts/inventory_active_record.rb
@@ -2,6 +2,7 @@ require 'puppet/rails'
 require 'puppet/rails/inventory_node'
 require 'puppet/rails/inventory_fact'
 require 'puppet/indirector/active_record'
+require 'puppet/util/retryaction'
 
 class Puppet::Node::Facts::InventoryActiveRecord < Puppet::Indirector::ActiveRecord
   def find(request)
@@ -13,19 +14,21 @@ class Puppet::Node::Facts::InventoryActiveRecord < Puppet::Indirector::ActiveRec
   end
 
   def save(request)
-    facts = request.instance
-    node = Puppet::Rails::InventoryNode.find_by_name(request.key) || Puppet::Rails::InventoryNode.create(:name => request.key, :timestamp => facts.timestamp)
-    node.timestamp = facts.timestamp
+    Puppet::Util::RetryAction.retry_action :retries => 4, :retry_exceptions => {ActiveRecord::StatementInvalid => 'MySQL Error.  Retrying'} do
+      facts = request.instance
+      node = Puppet::Rails::InventoryNode.find_by_name(request.key) || Puppet::Rails::InventoryNode.create(:name => request.key, :timestamp => facts.timestamp)
+      node.timestamp = facts.timestamp
 
-    ActiveRecord::Base.transaction do
-      Puppet::Rails::InventoryFact.delete_all(:node_id => node.id)
-      # We don't want to save internal values as facts, because those are
-      # metadata that belong on the node
-      facts.values.each do |name,value|
-        next if name.to_s =~ /^_/
-        node.facts.build(:name => name, :value => value)
+      ActiveRecord::Base.transaction do
+        Puppet::Rails::InventoryFact.delete_all(:node_id => node.id)
+        # We don't want to save internal values as facts, because those are
+        # metadata that belong on the node
+        facts.values.each do |name,value|
+          next if name.to_s =~ /^_/
+          node.facts.build(:name => name, :value => value)
+        end
+        node.save
       end
-      node.save
     end
   end
 

--- a/lib/puppet/util/retryaction.rb
+++ b/lib/puppet/util/retryaction.rb
@@ -1,0 +1,48 @@
+module Puppet::Util::RetryAction
+  class RetryException < Exception; end
+  class RetryException::NoBlockGiven < RetryException; end
+  class RetryException::NoRetriesGiven < RetryException;end
+  class RetryException::RetriesExceeded < RetryException; end
+
+  def self.retry_action( parameters = { :retry_exceptions => nil, :retries => nil } )
+    # Retry actions for a specified amount of time. This method will allow the final
+    # retry to complete even if that extends beyond the timeout period.
+    unless block_given?
+      raise RetryException::NoBlockGiven
+    end
+
+    raise RetryException::NoRetriesGiven if parameters[:retries].nil?
+    parameters[:retry_exceptions] ||= Hash.new
+
+    start = Time.now
+    failures = 0
+
+    begin
+      yield
+    rescue Exception => e
+      # If we were giving exceptions to catch,
+      # catch the excptions we care about and retry.
+      # All others fail hard
+
+      raise RetryException::RetriesExceeded if parameters[:retries] == 0
+
+      if (not parameters[:retry_exceptions].keys.empty?) and parameters[:retry_exceptions].keys.include?(e.class)
+        Puppet.info("Caught exception #{e.class}:#{e}")
+        Puppet.info(parameters[:retry_exceptions][e.class])
+      elsif (not parameters[:retry_exceptions].keys.empty?)
+        # If the exceptions is not in the list of retry_exceptions re-raise.
+        raise e
+      end
+
+      failures += 1
+      parameters[:retries] -= 1
+
+      # Increase the amount of time that we sleep after every
+      # failed retry attempt.
+      sleep (((2 ** failures) -1) * 0.1)
+
+      retry
+
+    end
+  end
+end

--- a/spec/unit/util/retryaction_spec.rb
+++ b/spec/unit/util/retryaction_spec.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+
+require 'puppet/util/retryaction'
+
+describe Puppet::Util::RetryAction do
+  let (:exceptions) {{ Puppet::Error => 'Puppet Error Exception' }}
+  
+  it 'should retry on any exception if no acceptable exceptions given' do
+    Puppet::Util::RetryAction.expects(:sleep).with( (((2 ** 1) -1) * 0.1) )
+    Puppet::Util::RetryAction.expects(:sleep).with( (((2 ** 2) -1) * 0.1) )
+
+    expect do
+      Puppet::Util::RetryAction.retry_action( :retries => 2 ) do
+        raise ArgumentError, 'Fake Failure'
+      end
+    end.to raise_exception(Puppet::Util::RetryAction::RetryException::RetriesExceeded)
+  end
+
+  it 'should retry on acceptable exceptions' do
+    Puppet::Util::RetryAction.expects(:sleep).with( (((2 ** 1) -1) * 0.1) )
+    Puppet::Util::RetryAction.expects(:sleep).with( (((2 ** 2) -1) * 0.1) )
+
+    expect do
+      Puppet::Util::RetryAction.retry_action( :retries => 2, :retry_exceptions => exceptions) do
+        raise Puppet::Error, 'Fake Failure'
+      end
+    end.to raise_exception(Puppet::Util::RetryAction::RetryException::RetriesExceeded)
+  end
+
+  it 'should not retry on unacceptable exceptions' do
+    Puppet::Util::RetryAction.expects(:sleep).never
+
+    expect do
+      Puppet::Util::RetryAction.retry_action( :retries => 2, :retry_exceptions => exceptions) do
+        raise ArgumentError
+      end
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'should succeed if nothing is raised' do
+    Puppet::Util::RetryAction.expects(:sleep).never
+
+    Puppet::Util::RetryAction.retry_action( :retries => 2) do
+      true
+    end
+  end
+
+  it 'should succeed if an expected exception is raised retried and succeeds' do
+    should_retry = nil
+    Puppet::Util::RetryAction.expects(:sleep).once
+
+    Puppet::Util::RetryAction.retry_action( :retries => 2, :retry_exceptions => exceptions) do
+      if should_retry
+        true
+      else
+        should_retry = true
+        raise Puppet::Error, 'Fake error'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previous to this commit, if the ActiveRecord transaction for saving
facts failed do to MySQL deadlock, for example, the transaction would
fail printing a message to the user.  This primarily occurred during a
PE agent installation if multiple agent's were being creating
simultaneously.

This commit adds the ability to retry if a
ActiveRecord::StatementInvalid exception is thrown.  To accomplish this,
this commit ports Cloud Provisioner's
Puppet::CloudPack::Utils#retry_action method to Puppet core under
Puppet::Util::RetryAction#retry_action.
