### PR TITLE
(#11717) Fix for adsi user create

### DIFF
--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -27,6 +27,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
     # the account is created, a call to .password is all that is needed it does
     # it's own commit.
     @user.password = @resource[:password]
+    @user.commit
 
     [:comment, :home, :groups].each do |prop|
       send("#{prop}=", @resource[prop]) if @resource[prop]

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -75,6 +75,7 @@ describe Puppet::Type.type(:user).provider(:windows_adsi) do
 
       create = sequence('create')
       user.expects(:password=).in_sequence(create)
+      user.expects(:commit).in_sequence(create)
       user.expects(:set_groups).with('group1,group2', false).in_sequence(create)
       user.expects(:[]=).with('Description', 'a test user')
       user.expects(:[]=).with('HomeDirectory', 'C:\Users\testuser')


### PR DESCRIPTION
Previous to this pull request, the windows provider would call commit on a Puppet::Util::ADSI::User object. This will fail if password requirements are in place and the password fails to meet them.  Calling Puppet::Util::ADSI::User#password= method to set the password works around this while committing as well.
