### PR TITLE
(#11741) Use dns_alt_names instead of certdnsnames in acceptance tests

### DIFF
--- a/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
+++ b/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
@@ -1,12 +1,12 @@
 test_name "generate a helpful error message when hostname doesn't match server certificate"
 
 step "Clear any existing SSL directories"
-on(hosts, "rm -r #{config['puppetpath']}/ssl")
+on(hosts, "rm -rf #{config['puppetpath']}/ssl")
 
 # Start the master with a certname not matching its hostname
-with_master_running_on(master, "--certname foobar_not_my_hostname --certdnsnames one_cert:two_cert:red_cert:blue_cert --autosign true") do
+with_master_running_on(master, "--certname foobar_not_my_hostname --dns_alt_names one_cert,two_cert,red_cert,blue_cert --autosign true") do
   run_agent_on(agents, "--no-daemonize --verbose --onetime --server #{master}", :acceptable_exit_codes => (1..255)) do
-    msg = "Server hostname '#{master}' did not match server certificate; expected one of foobar_not_my_hostname, one_cert, two_cert, red_cert, blue_cert"
+    msg = "Server hostname '#{master}' did not match server certificate; expected one of foobar_not_my_hostname, DNS:blue_cert, DNS:foobar_not_my_hostname, DNS:one_cert, DNS:red_cert, DNS:two_cert"
     assert_match(msg, stdout)
   end
 end

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -5,7 +5,7 @@ agent_hostnames = agents.map {|a| a.to_s}
 step "Remove existing SSL directory for hosts"
 on hosts, "rm -r #{config['puppetpath']}/ssl"
 
-with_master_running_on master, "--allow_duplicate_certs --certdnsnames=\"puppet:$(hostname -s):$(hostname -f)\" --verbose --noop" do
+with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --verbose --noop" do
   step "Generate a certificate request for the agent"
   on agents, "puppet certificate generate `hostname -f` --ca-location remote --server #{master}"
 


### PR DESCRIPTION
The certdnsnames argument is now ignored, and dns_alt_names is the new version. This fixes the helpful_error_message_when_hostname_not_match_server_certificate test.
