### PR TITLE
(11293) Set/get passwords from OS X 10.7

### DIFF
--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -2,7 +2,7 @@ require 'puppet'
 require 'puppet/provider/nameservice'
 require 'facter/util/plist'
 require 'cgi'
-
+require 'fileutils'
 
 class Puppet::Provider::NameService
 class DirectoryService < Puppet::Provider::NameService
@@ -60,6 +60,8 @@ class DirectoryService < Puppet::Provider::NameService
   }
 
   @@password_hash_dir = "/var/db/shadow/hash"
+  @@users_plist_dir    = '/var/db/dslocal/nodes/Default/users'
+
 
   def self.instances
     # JJM Class method that provides an array of instance objects of this
@@ -193,7 +195,7 @@ class DirectoryService < Puppet::Provider::NameService
     # stored in the user record. It is stored at a path that involves the
     # UUID of the user record for non-Mobile local acccounts.
     # Mobile Accounts are out of scope for this provider for now
-    attribute_hash[:password] = self.get_password(attribute_hash[:guid]) if @resource_type.validproperties.include?(:password) and Puppet.features.root?
+    attribute_hash[:password] = self.get_password(attribute_hash[:guid], attribute_hash[:name]) if @resource_type.validproperties.include?(:password) and Puppet.features.root?
     attribute_hash
   end
 
@@ -268,46 +270,144 @@ class DirectoryService < Puppet::Provider::NameService
   end
 
   def self.set_password(resource_name, guid, password_hash)
-    password_hash_file = "#{@@password_hash_dir}/#{guid}"
-    begin
-      File.open(password_hash_file, 'w') { |f| f.write(password_hash)}
-    rescue Errno::EACCES => detail
-      fail("Could not write to password hash file: #{detail}")
-    end
+    # Use Puppet::Util::Package.versioncmp() to catch the scenario where a
+    # version '10.10' would be < '10.7' with simple string comparison. This
+    # if-statement only executes if the current version is less-than 10.7
+    if (Puppet::Util::Package.versioncmp(get_macosx_version_major, '10.7') == -1)
+      password_hash_file = "#{@@password_hash_dir}/#{guid}"
+      begin
+        File.open(password_hash_file, 'w') { |f| f.write(password_hash)}
+      rescue Errno::EACCES => detail
+        fail("Could not write to password hash file: #{detail}")
+      end
 
-    # NBK: For shadow hashes, the user AuthenticationAuthority must contain a value of
-    # ";ShadowHash;". The LKDC in 10.5 makes this more interesting though as it
-    # will dynamically generate ;Kerberosv5;;username@LKDC:SHA1 attributes if
-    # missing. Thus we make sure we only set ;ShadowHash; if it is missing, and
-    # we can do this with the merge command. This allows people to continue to
-    # use other custom AuthenticationAuthority attributes without stomping on them.
-    #
-    # There is a potential problem here in that we're only doing this when setting
-    # the password, and the attribute could get modified at other times while the
-    # hash doesn't change and so this doesn't get called at all... but
-    # without switching all the other attributes to merge instead of create I can't
-    # see a simple enough solution for this that doesn't modify the user record
-    # every single time. This should be a rather rare edge case. (famous last words)
+      # NBK: For shadow hashes, the user AuthenticationAuthority must contain a value of
+      # ";ShadowHash;". The LKDC in 10.5 makes this more interesting though as it
+      # will dynamically generate ;Kerberosv5;;username@LKDC:SHA1 attributes if
+      # missing. Thus we make sure we only set ;ShadowHash; if it is missing, and
+      # we can do this with the merge command. This allows people to continue to
+      # use other custom AuthenticationAuthority attributes without stomping on them.
+      #
+      # There is a potential problem here in that we're only doing this when setting
+      # the password, and the attribute could get modified at other times while the
+      # hash doesn't change and so this doesn't get called at all... but
+      # without switching all the other attributes to merge instead of create I can't
+      # see a simple enough solution for this that doesn't modify the user record
+      # every single time. This should be a rather rare edge case. (famous last words)
 
-    dscl_vector = self.get_exec_preamble("-merge", resource_name)
-    dscl_vector << "AuthenticationAuthority" << ";ShadowHash;"
-    begin
-      dscl_output = execute(dscl_vector)
-    rescue Puppet::ExecutionFailure => detail
-      fail("Could not set AuthenticationAuthority.")
+      dscl_vector = self.get_exec_preamble("-merge", resource_name)
+      dscl_vector << "AuthenticationAuthority" << ";ShadowHash;"
+      begin
+        dscl_output = execute(dscl_vector)
+      rescue Puppet::ExecutionFailure => detail
+        fail("Could not set AuthenticationAuthority.")
+      end
+    else
+      # 10.7 uses salted SHA512 password hashes which are 128 characters plus
+      # an 8 character salt. Previous versions used a SHA1 hash padded with
+      # zeroes. If someone attempts to use a password hash that worked with
+      # a previous version of OX X, we will fail early and warn them.
+      if password_hash.length != 136
+        fail("OS X 10.7 requires a Salted SHA512 hash password of 136 characters. \
+             Please check your password and try again.")
+      end
+
+      if File.exists?("#{@@users_plist_dir}/#{resource_name}.plist")
+        # If a plist already exists in /var/db/dslocal/nodes/Default/users, then
+        # we will need to extract the binary plist from the 'ShadowHashData'
+        # key, log the new password into the resultant plist's 'SALTED-SHA512'
+        # key, and then save the entire structure back.
+        users_plist = Plist::parse_xml(`plutil -convert xml1 -o /dev/stdout  \
+                                       #{@@users_plist_dir}/#{resource_name}.plist`)
+
+        # users_plist['ShadowHashData'][0].string is actually a binary plist
+        # that's nested INSIDE the user's plist (which itself is a binary
+        # plist).
+        password_hash_plist = users_plist['ShadowHashData'][0].string
+        converted_hash_plist = convert_binary_to_xml(password_hash_plist)
+
+        # converted_hash_plist['SALTED-SHA512'].string expects a Base64 encoded
+        # string. The password_hash provided as a resource attribute is a
+        # hex value. We need to convert the provided hex value to a Base64
+        # encoded string to nest it in the converted hash plist.
+        converted_hash_plist['SALTED-SHA512'].string = \
+          password_hash.unpack('a2'*(password_hash.size/2)).collect { |i| i.hex.chr }.join
+
+        # Finally, we can convert the nested plist back to binary, embed it
+        # into the user's plist, and convert the resultant plist back to
+        # a binary plist.
+        changed_plist = convert_xml_to_binary(converted_hash_plist)
+        users_plist['ShadowHashData'][0].string = changed_plist
+        Plist::Emit.save_plist(users_plist, "#{@@users_plist_dir}/#{resource_name}.plist")
+        %x{plutil -convert binary1 #{@@users_plist_dir}/#{resource_name}.plist}
+      end
     end
   end
 
-  def self.get_password(guid)
-    password_hash = nil
-    password_hash_file = "#{@@password_hash_dir}/#{guid}"
-    if File.exists?(password_hash_file) and File.file?(password_hash_file)
-      fail("Could not read password hash file at #{password_hash_file}") if not File.readable?(password_hash_file)
-      f = File.new(password_hash_file)
-      password_hash = f.read
-      f.close
+  def self.get_password(guid, username)
+    # Use Puppet::Util::Package.versioncmp() to catch the scenario where a
+    # version '10.10' would be < '10.7' with simple string comparison. This
+    # if-statement only executes if the current version is less-than 10.7 
+    if (Puppet::Util::Package.versioncmp(get_macosx_version_major, '10.7') == -1)
+      password_hash = nil
+      password_hash_file = "#{@@password_hash_dir}/#{guid}"
+      if File.exists?(password_hash_file) and File.file?(password_hash_file)
+        fail("Could not read password hash file at #{password_hash_file}") if not File.readable?(password_hash_file)
+        f = File.new(password_hash_file)
+        password_hash = f.read
+        f.close
+      end
+      password_hash
+    else
+      if File.exists?("#{@@users_plist_dir}/#{username}.plist")
+        # If a plist exists in /var/db/dslocal/nodes/Default/users, we will
+        # extract the binary plist from the 'ShadowHashData' key, decode the
+        # salted-SHA512 password hash, and then return it.
+        users_plist = Plist::parse_xml(`plutil -convert xml1 -o /dev/stdout #{@@users_plist_dir}/#{username}.plist`)
+        if users_plist['ShadowHashData']
+          # users_plist['ShadowHashData'][0].string is actually a binary plist
+          # that's nested INSIDE the user's plist (which itself is a binary
+          # plist).
+          password_hash_plist = users_plist['ShadowHashData'][0].string
+          converted_hash_plist = convert_binary_to_xml(password_hash_plist)
+
+          # converted_hash_plist['SALTED-SHA512'].string is a Base64 encoded
+          # string. The password_hash provided as a resource attribute is a
+          # hex value. We need to convert the Base64 encoded string to a
+          # hex value and provide it back to Puppet.
+          password_hash = converted_hash_plist['SALTED-SHA512'].string.unpack("H*")[0]
+          password_hash
+        end
+      end
     end
-    password_hash
+  end
+
+  # This method will accept a hash that has been returned from Plist::parse_xml
+  # and convert it to a binary plist (string value).
+  def self.convert_xml_to_binary(plist_data)
+    Puppet.debug('Converting XML plist to binary')
+    Puppet.debug('Executing: \'plutil -convert binary1 -o - -\'')
+    IO.popen('plutil -convert binary1 -o - -', mode='r+') do |io|
+      io.write plist_data.to_plist
+      io.close_write
+      @converted_plist = io.read
+    end
+    @converted_plist
+  end
+
+  # This method will accept a binary plist (as a string) and convert it to a
+  # hash via Plist::parse_xml.
+  def self.convert_binary_to_xml(plist_data)
+    Puppet.debug('Converting binary plist to XML')
+    Puppet.debug('Executing: \'plutil -convert xml1 -o - -\'')
+    IO.popen('plutil -convert xml1 -o - -', mode='r+') do |io|
+      io.write plist_data
+      io.close_write
+      @converted_plist = io.read
+    end
+    Puppet.debug('Converting XML values to a hash.')
+    @plist_hash = Plist::parse_xml(@converted_plist)
+    @plist_hash
   end
 
   # Unlike most other *nixes, OS X doesn't provide built in functionality

--- a/spec/unit/provider/nameservice/directoryservice_spec.rb
+++ b/spec/unit/provider/nameservice/directoryservice_spec.rb
@@ -95,3 +95,44 @@ describe 'DirectoryService.get_exec_preamble' do
     Puppet::Provider::NameService::DirectoryService.get_exec_preamble('-list').should include("-plist")
   end
 end
+
+describe 'DirectoryService password behavior' do
+  # The below is a binary plist containing a ShadowHashData key which CONTAINS
+  # another binary plist. The nested binary plist contains a 'SALTED-SHA512'
+  # key that contains a base64 encoded salted-SHA512 password hash...
+  let (:binary_plist) { "bplist00\324\001\002\003\004\005\006\a\bXCRAM-MD5RNT]SALTED-SHA512[RECOVERABLEO\020 \231k2\3360\200GI\201\355J\216\202\215y\243\001\206J\300\363\032\031\022\006\2359\024\257\217<\361O\020\020F\353\at\377\277\226\276c\306\254\031\037J(\235O\020D\335\006{\3744g@\377z\204\322\r\332t\021\330\n\003\246K\223\356\034!P\261\305t\035\346\352p\206\003n\247MMA\310\301Z<\366\246\023\0161W3\340\357\000\317T\t\301\311+\204\246L7\276\370\320*\245O\021\002\000k\024\221\270x\353\001\237\346D}\377?\265]\356+\243\v[\350\316a\340h\376<\322\266\327\016\306n\272r\t\212A\253L\216\214\205\016\241 [\360/\335\002#\\A\372\241a\261\346\346\\\251\330\312\365\016\n\341\017\016\225&;\322\\\004*\ru\316\372\a \362?8\031\247\231\030\030\267\315\023\v\343{@\227\301s\372h\212\000a\244&\231\366\nt\277\2036,\027bZ+\223W\212g\333`\264\331N\306\307\362\257(^~ b\262\247&\231\261t\341\231%\244\247\203eOt\365\271\201\273\330\350\363C^A\327F\214!\217hgf\e\320k\260n\315u~\336\371M\t\235k\230S\375\311\303\240\351\037d\273\321y\335=K\016`_\317\230\2612_\023K\036\350\v\232\323Y\310\317_\035\227%\237\v\340\023\016\243\233\025\306:\227\351\370\364x\234\231\266\367\016w\275\333-\351\210}\375x\034\262\272kRuHa\362T/F!\347B\231O`K\304\037'k$$\245h)e\363\365mT\b\317\\2\361\026\351\254\375Jl1~\r\371\267\352\2322I\341\272\376\243^Un\266E7\230[VocUJ\220N\2116D/\025f=\213\314\325\vG}\311\360\377DT\307m\261&\263\340\272\243_\020\271rG^BW\210\030l\344\0324\335\233\300\023\272\225Im\330\n\227*Yv[\006\315\330y'\a\321\373\273A\240\305F{S\246I#/\355\2425\031\031GGF\270y\n\331\004\023G@\331\000\361\343\350\264$\032\355_\210y\000\205\342\375\212q\024\004\026W:\205 \363v?\035\270L-\270=\022\323\2003\v\336\277\t\237\356\374\n\267n\003\367\342\330;\371S\326\016`B6@Njm>\240\021%\336\345\002(P\204Yn\3279l\0228\264\254\304\2528t\372h\217\347sA\314\345\245\337)]\000\b\000\021\000\032\000\035\000+\0007\000Z\000m\000\264\000\000\000\000\000\000\002\001\000\000\000\000\000\000\000\t\000\000\000\000\000\000\000\000\000\000\000\000\000\000\002\270" }
+
+  # The below is a base64 encoded salted-SHA512 password hash.
+  let (:pw_string) { "\335\006{\3744g@\377z\204\322\r\332t\021\330\n\003\246K\223\356\034!P\261\305t\035\346\352p\206\003n\247MMA\310\301Z<\366\246\023\0161W3\340\357\000\317T\t\301\311+\204\246L7\276\370\320*\245" }
+
+  # The below is a salted-SHA512 password hash in hex.
+  let (:sha512_hash) { 'dd067bfc346740ff7a84d20dda7411d80a03a64b93ee1c2150b1c5741de6ea7086036ea74d4d41c8c15a3cf6a6130e315733e0ef00cf5409c1c92b84a64c37bef8d02aa5' }
+
+  it 'should execute convert_binary_to_xml once when getting the password on >= 10.7' do
+    Puppet::Provider::NameService::DirectoryService.stubs(:get_macosx_version_major).returns("10.7")
+    Puppet::Provider::NameService::DirectoryService.expects(:convert_binary_to_xml).returns({'SALTED-SHA512' => StringIO.new(pw_string)})
+    File.stubs(:exists?).returns(true)
+    Plist.stubs(:parse_xml).returns({'ShadowHashData' => [StringIO.new(binary_plist)]})
+    Puppet::Provider::NameService::DirectoryService.get_password('uid', 'jeff')
+  end
+
+  it 'should fail if a salted-SHA512 password hash is not passed in >= 10.7' do
+    Puppet::Provider::NameService::DirectoryService.stubs(:get_macosx_version_major).returns("10.7")
+    File.stubs(:exists?).returns(true)
+    Plist.stubs(:parse_xml).returns({'ShadowHashData' => [StringIO.new(binary_plist)]})
+    expect {
+      Puppet::Provider::NameService::DirectoryService.set_password('jeff', 'uid', 'badpassword')
+    }.should raise_error(RuntimeError, /OS X 10.7 requires a Salted SHA512 hash password of 136 characters./)
+  end
+
+  it 'should convert xml-to-binary and binary-to-xml when setting the pw on >= 10.7' do
+    Puppet::Provider::NameService::DirectoryService.stubs(:get_macosx_version_major).returns("10.7")
+    Puppet::Provider::NameService::DirectoryService.expects(:convert_binary_to_xml).returns({'SALTED-SHA512' => StringIO.new(pw_string)})
+    Puppet::Provider::NameService::DirectoryService.expects(:convert_xml_to_binary).returns(binary_plist)
+    File.stubs(:exists?).returns(true)
+    Plist.stubs(:parse_xml).returns({'ShadowHashData' => [StringIO.new(binary_plist)]})
+    Plist::Emit.stubs(:save_plist)
+    Puppet::Provider::NameService::DirectoryService.set_password('jeff', 'uid', sha512_hash)
+  end
+end
+


### PR DESCRIPTION
OS X version 10.7 implemented a new methodology for storing passwords.  Every user now has a plist file in /var/db/dslocal/nodes/Default/users/<username>.plist.  This binary plist has a key called 'ShadowHashData' whose value is a binary plist.  This nested binary plist in turn has a key called 'SALTED-SHA512' that contains a salted-SHA512 password hash stored in a base64 encoded string.  To get/set the password, we need to access this string.

This series of commits implements the methodology for accessing and setting this salted-SHA512 password hash, and also implements spec tests to ensure that functionality isn't broken with future commits.
