### PR TITLE
(#11764) Fix cron jobs for passing block to method

### DIFF
--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -16,7 +16,7 @@ agents.each do |host|
     step "apply the resource on the host using puppet resource"
     on(host, puppet_resource("cron", "crontest", "user=#{tmpuser}",
                   "command=/bin/true", "ensure=absent")) do
-      assert_match(/crontest\D+ensure:\s+removed/, stdout, "Didn't remove crobtab entry for #{tmpuser} on #{host}")
+      assert_no_match(/crontest\D+ensure:\s+removed/, stdout, "Didn't remove crobtab entry for #{tmpuser} on #{host}")
     end
 
     step "verify that crontab -l contains what you expected"

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -24,7 +24,7 @@ agents.each do |host|
     step "verify that crontab -l contains what you expected"
     run_cron_on(host,:list,tmpuser) do
         count = stdout.scan("/bin/true").length
-        fail_test "found /bin/true the wrong number of times (#{count})" unless count == 1
+        fail_test "found /bin/true the wrong number of times (#{count})" unless count == 0
     end
 
     step "remove the crontab file for that user"


### PR DESCRIPTION
Fixing the run_x_on methods to accept a passed block causes the
cron resrouce tests to fail.  Minor fixes to regex and asserts
fix the issue.

This affect all versions of puppet and should be merged up.
