### PR TITLE
(#11801) puppet doc uses README.rdoc in toplevel module dir

### DIFF
--- a/lib/puppet/util/rdoc/parser.rb
+++ b/lib/puppet/util/rdoc/parser.rb
@@ -127,11 +127,12 @@ class Parser
 
   # create documentation for the top level +container+
   def scan_top_level(container)
-    # use the module README as documentation for the module
+    # use the module README and/or README.rdoc as documentation for the module
     comment = ""
-    readme = File.join(File.dirname(File.dirname(@input_file_name)), "README")
-    comment = File.open(readme,"r") { |f| f.read } if FileTest.readable?(readme)
-    look_for_directives_in(container, comment) unless comment.empty?
+    Dir.glob(File.join(File.dirname(File.dirname(@input_file_name)), "README{,.rdoc}")) do |readme|
+      comment = File.open(readme,"r") { |f| f.read } if FileTest.readable?(readme)
+      look_for_directives_in(container, comment) unless comment.empty?
+    end
 
     # infer module name from directory
     name = split_module(@input_file_name)


### PR DESCRIPTION
The README in the toplevel module dir gets integrated in the RDoc documentation as created by puppet doc. If it contains RDoc markup, it will be processed and rendered as the rest of the module documentation.
It seems to make sense to rename README to README.rdoc, to clarify the expectation of puppet doc and avoid confusion about the preferred markup .

The patch adds README.rdoc to the files to be scanned for RDoc directives.
