### PR TITLE
11764 fix cron tests x2

### DIFF
--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -16,12 +16,12 @@ agents.each do |host|
     step "apply the resource on the host using puppet resource"
     on(host, puppet_resource("cron", "crontest", "user=#{tmpuser}",
                   "command=/bin/true", "ensure=absent")) do
-      assert_no_match(/crontest\D+ensure:\s+removed/, stdout, "Didn't remove crobtab entry for #{tmpuser} on #{host}")
+      assert_match(/crontest\D+ensure:\s+removed/, stdout, "Didn't remove crobtab entry for #{tmpuser} on #{host}")
     end
 
     step "verify that crontab -l contains what you expected"
     run_cron_on(host, :list, tmpuser) do
-      assert_match(/\/bin\/true/, stdout, "Error: Found entry for #{tmpuser} on #{host}")
+      assert_no_match(/\/bin\/true/, stdout, "Error: Found entry for #{tmpuser} on #{host}")
     end
 
     step "remove the crontab file for that user"


### PR DESCRIPTION
Small logic error is one cron tests -- assert in wrong
step.  Fixed and tested.
Should be merged up to all Puppet branches.
