### PR TITLE
(#11847) Don't hard code ruby install paths in Windows batch files

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -422,16 +422,12 @@ def install_binfile(from, op_file, target)
 
     if not installed_wrapper
       tmp_file2 = File.join(tmp_dir, '_tmp_wrapper')
-      cwn = File.join(Config::CONFIG['bindir'], op_file)
       cwv = <<-EOS
 @echo off
-if "%OS%"=="Windows_NT" goto WinNT
-#{ruby} -x "#{cwn}" %1 %2 %3 %4 %5 %6 %7 %8 %9
-goto done
-:WinNT
-#{ruby} -x "#{cwn}" %*
-goto done
-:done
+setlocal
+set RUBY_BIN=%~dp0
+set RUBY_BIN=%RUBY_BIN:\\=/%
+"%RUBY_BIN%ruby.exe" -x "%RUBY_BIN%puppet" %*
 EOS
       File.open(tmp_file2, "w") { |cw| cw.puts cwv }
       FileUtils.install(tmp_file2, File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)


### PR DESCRIPTION
Previously, the {filebucket,pi,puppet,puppetdoc,ralsh}.bat files hard
coded the path to the ruby installation, making it impossible to move
the ruby install directory.

This commit changes the script to use the `%~dp0` batch file modifier,
which resolves to the drive letter and path of the directory of the
batch file being executed.

Windows XP and later all support the `%*` modifier, so this commit
removes the Win 9x code paths that are not supported.
