### PR TITLE
Clean up launchd service provider spec tests

### DIFF
--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -37,22 +37,21 @@ describe Puppet::Type.type(:service).provider(:launchd) do
 
   describe "when checking whether the service is enabled on OS X 10.5" do
     it "should return true in if the job plist says disabled is false" do
-      Facter.stubs(:value).with(:macosx_productversion_major).returns('10.5')
-      Facter.stubs(:value).with(:kernel).returns('Darwin')
-      Facter.stubs(:value).with(:macaddress).returns('')
-      Facter.stubs(:value).with(:arp).returns('')
+      subject.expects(:has_macosx_plist_overrides?).returns(false)
       subject.expects(:plist_from_label).with(joblabel).returns(["foo", {"Disabled" => false}])
       subject.expects(:resource).returns({:name => joblabel})
       subject.enabled?.should == :true
     end
     it "should return true in if the job plist has no disabled key" do
+      subject.expects(:has_macosx_plist_overrides?).returns(false)
       subject.expects(:resource).returns({:name => joblabel})
-      subject.stubs(:plist_from_label).returns(["foo", {}])
+      subject.expects(:plist_from_label).returns(["foo", {}])
       subject.enabled?.should == :true
     end
     it "should return false in if the job plist says disabled is true" do
+      subject.expects(:has_macosx_plist_overrides?).returns(false)
       subject.expects(:resource).returns({:name => joblabel})
-      subject.stubs(:plist_from_label).returns(["foo", {"Disabled" => true}])
+      subject.expects(:plist_from_label).returns(["foo", {"Disabled" => true}])
       subject.enabled?.should == :false
     end
   end
@@ -61,7 +60,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
     it "should return true if the job plist says disabled is true and the global overrides says disabled is false" do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => true}])
-      provider.stubs(:read_plist).returns({joblabel => {"Disabled" => false}})
+      provider.expects(:read_plist).returns({joblabel => {"Disabled" => false}})
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.stubs(:resource).returns({:name => joblabel})
       subject.enabled?.should == :true
@@ -69,7 +68,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
     it "should return false if the job plist says disabled is false and the global overrides says disabled is true" do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => false}])
-      provider.stubs(:read_plist).returns({joblabel => {"Disabled" => true}})
+      provider.expects(:read_plist).returns({joblabel => {"Disabled" => true}})
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.stubs(:resource).returns({:name => joblabel})
       subject.enabled?.should == :false
@@ -77,7 +76,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
     it "should return true if the job plist and the global overrides have no disabled keys" do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {}])
-      provider.stubs(:read_plist).returns({})
+      provider.expects(:read_plist).returns({})
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.stubs(:resource).returns({:name => joblabel})
       subject.enabled?.should == :true
@@ -87,29 +86,29 @@ describe Puppet::Type.type(:service).provider(:launchd) do
   describe "when starting the service" do
     it "should look for the relevant plist once" do
       subject.expects(:plist_from_label).returns([joblabel, {}]).once
-      subject.stubs(:enabled?).returns :true
-      subject.stubs(:execute).with([:launchctl, :load, joblabel])
+      subject.expects(:enabled?).returns :true
+      subject.expects(:execute).with([:launchctl, :load, joblabel])
       subject.stubs(:resource).returns({:name => joblabel})
       subject.start
     end
     it "should execute 'launchctl load' once without writing to the plist if the job is enabled" do  
-      subject.stubs(:plist_from_label).returns([joblabel, {}])
-      subject.stubs(:enabled?).returns :true
+      subject.expects(:plist_from_label).returns([joblabel, {}])
+      subject.expects(:enabled?).returns :true
       subject.expects(:execute).with([:launchctl, :load, joblabel]).once
       subject.stubs(:resource).returns({:name => joblabel})
       subject.start
     end
     it "should execute 'launchctl load' with writing to the plist once if the job is disabled" do
-      subject.stubs(:plist_from_label).returns([joblabel, {}])
-      subject.stubs(:enabled?).returns(:false)
+      subject.expects(:plist_from_label).returns([joblabel, {}])
+      subject.expects(:enabled?).returns(:false)
       subject.stubs(:resource).returns({:name => joblabel})
       subject.expects(:execute).with([:launchctl, :load, "-w", joblabel]).once
       subject.start
     end
     it "should disable the job once if the job is disabled and should be disabled at boot" do
-      subject.stubs(:plist_from_label).returns([joblabel, {"Disabled" => true}])
-      subject.stubs(:enabled?).returns :false
-      subject.stubs(:execute).with([:launchctl, :load, "-w", joblabel])
+      subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => true}])
+      subject.expects(:enabled?).returns :false
+      subject.expects(:execute).with([:launchctl, :load, "-w", joblabel])
       subject.stubs(:resource).returns({:name => joblabel, :enable => :false})
       subject.expects(:disable).once
       subject.start
@@ -119,29 +118,29 @@ describe Puppet::Type.type(:service).provider(:launchd) do
   describe "when stopping the service" do
     it "should look for the relevant plist once" do
       subject.expects(:plist_from_label).returns([joblabel, {}]).once
-      subject.stubs(:enabled?).returns :true
-      subject.stubs(:execute).with([:launchctl, :unload, '-w', joblabel])
+      subject.expects(:enabled?).returns :true
+      subject.expects(:execute).with([:launchctl, :unload, '-w', joblabel])
       subject.stubs(:resource).returns({:name => joblabel})
       subject.stop
     end
     it "should execute 'launchctl unload' once without writing to the plist if the job is disabled" do
-      subject.stubs(:plist_from_label).returns([joblabel, {}])
-      subject.stubs(:enabled?).returns :false
+      subject.expects(:plist_from_label).returns([joblabel, {}])
+      subject.expects(:enabled?).returns :false
       subject.expects(:execute).with([:launchctl, :unload, joblabel]).once
       subject.stubs(:resource).returns({:name => joblabel})
       subject.stop
     end
     it "should execute 'launchctl unload' with writing to the plist once if the job is enabled" do
-      subject.stubs(:plist_from_label).returns([joblabel, {}])
-      subject.stubs(:enabled?).returns :true
+      subject.expects(:plist_from_label).returns([joblabel, {}])
+      subject.expects(:enabled?).returns :true
       subject.expects(:execute).with([:launchctl, :unload, '-w', joblabel]).once
       subject.stubs(:resource).returns({:name => joblabel})
       subject.stop
     end
     it "should enable the job once if the job is enabled and should be enabled at boot" do
-      subject.stubs(:plist_from_label).returns([joblabel, {"Disabled" => false}])
-      subject.stubs(:enabled?).returns :true
-      subject.stubs(:execute).with([:launchctl, :unload, "-w", joblabel])
+      subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => false}])
+      subject.expects(:enabled?).returns :true
+      subject.expects(:execute).with([:launchctl, :unload, "-w", joblabel])
       subject.stubs(:resource).returns({:name => joblabel, :enable => :true})
       subject.expects(:enable).once
       subject.stop
@@ -151,15 +150,15 @@ describe Puppet::Type.type(:service).provider(:launchd) do
   describe "when enabling the service" do
     it "should look for the relevant plist once" do   ### Do we need this test?  Differentiating it?
       subject.expects(:plist_from_label).returns([joblabel, {}]).once
-      subject.stubs(:enabled?).returns :false
-      subject.stubs(:execute).with([:launchctl, :unload, joblabel])
+      subject.expects(:enabled?).returns :false
+      subject.expects(:execute).with([:launchctl, :unload, joblabel])
       subject.stubs(:resource).returns({:name => joblabel, :enable => :true})
       subject.stop
     end
     it "should check if the job is enabled once" do
-      subject.stubs(:plist_from_label).returns([joblabel, {}]).once
+      subject.expects(:plist_from_label).returns([joblabel, {}]).once
       subject.expects(:enabled?).once
-      subject.stubs(:execute).with([:launchctl, :unload, joblabel])
+      subject.expects(:execute).with([:launchctl, :unload, joblabel])
       subject.stubs(:resource).returns({:name => joblabel, :enable => :true})
       subject.stop
     end
@@ -168,8 +167,8 @@ describe Puppet::Type.type(:service).provider(:launchd) do
   describe "when disabling the service" do
     it "should look for the relevant plist once" do
       subject.expects(:plist_from_label).returns([joblabel, {}]).once
-      subject.stubs(:enabled?).returns :true
-      subject.stubs(:execute).with([:launchctl, :unload, '-w', joblabel])
+      subject.expects(:enabled?).returns :true
+      subject.expects(:execute).with([:launchctl, :unload, '-w', joblabel])
       subject.stubs(:resource).returns({:name => joblabel, :enable => :false})
       subject.stop
     end
@@ -177,8 +176,8 @@ describe Puppet::Type.type(:service).provider(:launchd) do
 
   describe "when enabling the service on OS X 10.6" do
     it "should write to the global launchd overrides file once" do
-      provider.stubs(:get_macosx_version_major).returns("10.6")
-      provider.stubs(:read_plist).returns({})
+      provider.expects(:get_macosx_version_major).returns("10.6")
+      provider.expects(:read_plist).returns({})
       Plist::Emit.expects(:save_plist).once
       subject.stubs(:resource).returns({:name => joblabel, :enable => :true})
       subject.enable
@@ -200,15 +199,13 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       provider.instance_variable_set(:@macosx_version_major, nil)
     end
     it "should display a deprecation warning" do
-      Facter.stubs(:value).with(:macosx_productversion_major).returns(nil)
-      Facter.stubs(:value).with(:kernel).returns('Darwin')
-      Facter.stubs(:value).with(:macosx_productversion).returns('10.5.8')
+      Facter.expects(:value).with(:macosx_productversion_major).returns(nil)
+      Facter.expects(:value).with(:macosx_productversion).returns('10.5.8')
+      Facter.expects(:loadfacts)
       Puppet::Util::Warnings.expects(:maybe_log)
-      provider.stubs(:read_plist).returns({joblabel => {"Disabled" => false}})
-      subject.stubs(:plist_from_label).returns([joblabel, {"Disabled" => false}])
-      subject.stubs(:enabled?).returns :false
-      subject.stubs(:execute).with([:launchctl, :load, '-w', joblabel]).returns('')
-      File.stubs(:open).returns('')
+      subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => false}])
+      subject.expects(:enabled?).returns :false
+      File.expects(:open).returns('')
       subject.stubs(:resource).returns({:name => joblabel, :enable => :true})
       subject.enable
     end


### PR DESCRIPTION
The launchd service provider spec tests WORKED, but largely used stubs
instead of establishing expectations. As such, they were fairly loose
and tolerant to changes that could break the provider. There were also
redundant stubs that didn't contribute directly to the test at hand.

In both cases, the tests have been improved.  I've tested these in 10.5, 10.6, 10.7, Ubuntu Lucid, and Centos 5
