### PR TITLE
(#2773) Fix launchd provider bug

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -196,7 +196,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     did_enable_job = false
     cmds = []
     cmds << :launchctl << :load
-    if self.enabled? == :false  # launchctl won't load disabled jobs
+    if self.enabled? == :false  || self.status == :stopped # launchctl won't load disabled jobs
       cmds << "-w"
       did_enable_job = true
     end

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -113,6 +113,14 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       subject.expects(:disable).once
       subject.start
     end
+    it "(#2773) should execute 'launchctl load -w' if the job is enabled but stopped" do
+      subject.expects(:plist_from_label).returns([joblabel, {}])
+      subject.expects(:enabled?).returns(:true)
+      subject.expects(:status).returns(:stopped)
+      subject.expects(:resource).returns({:name => joblabel}).twice
+      subject.expects(:execute).with([:launchctl, :load, '-w', joblabel])
+      subject.start
+    end
   end
 
   describe "when stopping the service" do


### PR DESCRIPTION
There was an issue where a service on OS X would be enabled but also
stopped and the launchd service provider couldn't start it. In this
case, the launchd service provider needed to execute `launchctl load -w
<job_path>` to successfully start the service, but it wasn't programmed
to do so.

To remedy this, the launchd service provider's start method now checks
if the job is disabled OR if the job is currently stopped.

A spec test was added to catch for this unique situation.
