### PR TITLE
(#5246) Puppetd does not remove it's pidfile when it exits

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -117,6 +117,8 @@ class Puppet::Application::Agent < Puppet::Application
       Puppet.err detail.to_s
     end
 
+    @daemon.stop(:exit => false)
+
     if not report
       exit(1)
     elsif options[:detailed_exitcodes] then

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -519,6 +519,12 @@ describe Puppet::Application::Agent do
         @puppetd.onetime
       end
 
+      it "should stop the daemon" do
+        @daemon.expects(:stop).with(:exit => false)
+
+        @puppetd.onetime
+      end
+
       describe "and --detailed-exitcodes" do
         before :each do
           @puppetd.options.stubs(:[]).with(:detailed_exitcodes).returns(true)


### PR DESCRIPTION
The Puppet::Daemon instance sets up the pid file when it starts
but it's up to the user of that object to arrange for stop to be
called

There are signal handlers setup to call stop but in a onetime run
those are never called

This change arrange for the stop method to be called after a onetime
run is done but do not hand the task of exiting the application over
to that so that the agent application can handle the report status
based exit codes
