### PR TITLE
8341 facts load once

### DIFF
--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -15,7 +15,6 @@ module Puppet::Configurer::FactHandler
     # finding facts and the 'rest' terminus for caching them.  Thus, we'll
     # compile them and then "cache" them on the server.
     begin
-      reload_facter
       facts = Puppet::Node::Facts.indirection.find(Puppet[:node_name_value])
       unless Puppet[:node_name_fact].empty?
         Puppet[:node_name_value] = facts.values[Puppet[:node_name_fact]]
@@ -53,25 +52,5 @@ module Puppet::Configurer::FactHandler
     Puppet.warning "Fact syncing is deprecated as of 0.25 -- use 'pluginsync' instead"
 
     Puppet::Configurer::Downloader.new("fact", Puppet[:factdest], Puppet[:factsource], Puppet[:factsignore]).evaluate
-  end
-
-  # Clear out all of the loaded facts and reload them from disk.
-  # NOTE: This is clumsy and shouldn't be required for later (1.5.x) versions
-  # of Facter.
-  def reload_facter
-    Facter.clear
-
-    # Reload everything.
-    if Facter.respond_to? :loadfacts
-      Facter.loadfacts
-    elsif Facter.respond_to? :load
-      Facter.load
-    else
-      Puppet.warning "You should upgrade your version of Facter to at least 1.3.8"
-    end
-
-    # This loads all existing facts and any new ones.  We have to remove and
-    # reload because there's no way to unload specific facts.
-    Puppet::Node::Facts::Facter.load_fact_plugins
   end
 end

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -7,6 +7,22 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     returns the local host's facts, regardless of what you attempt to find."
 
 
+  # Clear out all of the loaded facts. Reload facter but not puppet facts.
+  # NOTE: This is clumsy and shouldn't be required for later (1.5.x) versions
+  # of Facter.
+  def self.reload_facter
+    Facter.clear
+
+    # Reload everything.
+    if Facter.respond_to? :loadfacts
+      Facter.loadfacts
+    elsif Facter.respond_to? :load
+      Facter.load
+    else
+      Puppet.warning "You should upgrade your version of Facter to at least 1.3.8"
+    end
+  end
+
   def self.load_fact_plugins
     # Add any per-module fact directories to the factpath
     module_fact_dirs = Puppet[:modulepath].split(File::PATH_SEPARATOR).collect do |d|
@@ -27,7 +43,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       Dir.glob("*.rb").each do |file|
         fqfile = ::File.join(dir, file)
         begin
-          Puppet.info "Loading facts in #{::File.basename(file.sub(".rb",''))}"
+          Puppet.info "Loading facts in #{fqfile}"
           Timeout::timeout(self.timeout) do
             load file
           end
@@ -57,17 +73,14 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     timeout
   end
 
-  def initialize(*args)
-    super
-    self.class.load_fact_plugins
-  end
-
   def destroy(facts)
     raise Puppet::DevError, "You cannot destroy facts in the code store; it is only used for getting facts from Facter"
   end
 
   # Look a host's facts up in Facter.
   def find(request)
+    self.class.reload_facter
+    self.class.load_fact_plugins
     result = Puppet::Node::Facts.new(request.key, Facter.to_hash)
 
     result.add_local_facts

--- a/spec/unit/configurer/fact_handler_spec.rb
+++ b/spec/unit/configurer/fact_handler_spec.rb
@@ -78,12 +78,6 @@ describe Puppet::Configurer::FactHandler do
       Puppet[:node_name_value].should == 'other_node_name'
     end
 
-    it "should reload Facter before finding facts" do
-      @facthandler.expects(:reload_facter)
-
-      @facthandler.find_facts
-    end
-
     it "should fail if finding facts fails" do
       Puppet[:trace] = false
       Puppet[:certname] = "myhost"
@@ -91,6 +85,11 @@ describe Puppet::Configurer::FactHandler do
 
       lambda { @facthandler.find_facts }.should raise_error(Puppet::Error)
     end
+  end
+
+  it "should only load fact plugins once" do
+    Puppet::Node::Facts.indirection.expects(:find).once
+    @facthandler.find_facts
   end
 
   it "should warn about factsync deprecation when factsync is enabled" do
@@ -144,28 +143,5 @@ describe Puppet::Configurer::FactHandler do
     @facthandler.expects(:find_facts).returns facts
 
     @facthandler.facts_for_uploading
-  end
-
-  describe "when reloading Facter" do
-    before do
-      Facter.stubs(:clear)
-      Facter.stubs(:load)
-      Facter.stubs(:loadfacts)
-    end
-
-    it "should clear Facter" do
-      Facter.expects(:clear)
-      @facthandler.reload_facter
-    end
-
-    it "should load all Facter facts" do
-      Facter.expects(:loadfacts)
-      @facthandler.reload_facter
-    end
-
-    it "should use the Facter terminus load all Puppet Fact plugins" do
-      Puppet::Node::Facts::Facter.expects(:load_fact_plugins)
-      @facthandler.reload_facter
-    end
   end
 end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -21,14 +21,29 @@ describe Puppet::Node::Facts::Facter do
     Puppet::Node::Facts::Facter.name.should == :facter
   end
 
-  it "should load facts on initialization" do
-    Puppet::Node::Facts::Facter.expects(:load_fact_plugins)
-    Puppet::Node::Facts::Facter.new
+  describe "when reloading Facter" do
+    before do
+      @facter_class = Puppet::Node::Facts::Facter
+      Facter.stubs(:clear)
+      Facter.stubs(:load)
+      Facter.stubs(:loadfacts)
+    end
+
+    it "should clear Facter" do
+      Facter.expects(:clear)
+      @facter_class.reload_facter
+    end
+
+    it "should load all Facter facts" do
+      Facter.expects(:loadfacts)
+      @facter_class.reload_facter
+    end
   end
 end
 
 describe Puppet::Node::Facts::Facter do
   before :each do
+    Puppet::Node::Facts::Facter.stubs(:reload_facter)
     @facter = Puppet::Node::Facts::Facter.new
     Facter.stubs(:to_hash).returns({})
     @name = "me"
@@ -36,6 +51,13 @@ describe Puppet::Node::Facts::Facter do
   end
 
   describe Puppet::Node::Facts::Facter, " when finding facts" do
+    it "should reset and load facts" do
+      clear = sequence 'clear'
+      Puppet::Node::Facts::Facter.expects(:reload_facter).in_sequence(clear)
+      Puppet::Node::Facts::Facter.expects(:load_fact_plugins).in_sequence(clear)
+      @facter.find(@request)
+    end
+
     it "should return a Facts instance" do
       @facter.find(@request).should be_instance_of(Puppet::Node::Facts)
     end


### PR DESCRIPTION
Make the facter terminus the only place that loads facts (with the notable
exception of pluginsync which loads any ruby code it syncs).

This should satisfy several requirements:
    \* daemonized puppet agent can get fresh facts on each run
    \* puppet master can load facts
    \* facts are not loaded more than once by the puppet agent fact handler
