### PR TITLE
(#11929) serve files in binary mode

### DIFF
--- a/lib/puppet/file_serving/content.rb
+++ b/lib/puppet/file_serving/content.rb
@@ -35,7 +35,7 @@ class Puppet::FileServing::Content < Puppet::FileServing::Base
       # This stat can raise an exception, too.
       raise(ArgumentError, "Cannot read the contents of links unless following links") if stat.ftype == "symlink"
 
-      @content = ::File.read(full_path)
+      @content = Puppet::Util.binread(full_path)
     end
     @content
   end

--- a/spec/integration/indirector/direct_file_server_spec.rb
+++ b/spec/integration/indirector/direct_file_server_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Indirector::DirectFileServer, " when interacting with the files
   it "should return an instance capable of returning its content" do
     FileTest.expects(:exists?).with(@filepath).returns(true)
     File.stubs(:lstat).with(@filepath).returns(stub("stat", :ftype => "file"))
-    File.expects(:read).with(@filepath).returns("my content")
+    Puppet::Util.expects(:binread).with(@filepath).returns("my content")
 
     instance = @terminus.find(@terminus.indirection.request(:find, "file://host#{@filepath}"))
 

--- a/spec/integration/indirector/file_content/file_server_spec.rb
+++ b/spec/integration/indirector/file_content/file_server_spec.rb
@@ -24,7 +24,7 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
     modpath = File.join(path, "mod")
     FileUtils.mkdir_p(File.join(modpath, "lib"))
     file = File.join(modpath, "lib", "file.rb")
-    File.open(file, "w") { |f| f.puts "1" }
+    File.open(file, "wb") { |f| f.write "1\r\n" }
 
     Puppet.settings[:modulepath] = "/no/such/file"
 
@@ -36,7 +36,7 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
     result.should_not be_nil
     result.length.should == 2
     result[1].should be_instance_of(Puppet::FileServing::Content)
-    result[1].content.should == "1\n"
+    result[1].content.should == "1\r\n"
   end
 
   it "should find file content in modules" do
@@ -47,7 +47,7 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
     modpath = File.join(path, "mymod")
     FileUtils.mkdir_p(File.join(modpath, "files"))
     file = File.join(modpath, "files", "myfile")
-    File.open(file, "w") { |f| f.puts "1" }
+    File.open(file, "wb") { |f| f.write "1\r\n" }
 
     Puppet.settings[:modulepath] = path
 
@@ -55,7 +55,7 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
 
     result.should_not be_nil
     result.should be_instance_of(Puppet::FileServing::Content)
-    result.content.should == "1\n"
+    result.content.should == "1\r\n"
   end
 
   it "should find file content in files when node name expansions are used" do
@@ -67,7 +67,7 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
     Dir.mkdir(@path)
     subdir = File.join(@path, "mynode")
     Dir.mkdir(subdir)
-    File.open(File.join(subdir, "myfile"), "w") { |f| f.puts "1" }
+    File.open(File.join(subdir, "myfile"), "wb") { |f| f.write "1\r\n" }
 
     # Use a real mount, so the integration is a bit deeper.
     @mount1 = Puppet::FileServing::Configuration::Mount::File.new("one")
@@ -85,6 +85,6 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
 
     result.should_not be_nil
     result.should be_instance_of(Puppet::FileServing::Content)
-    result.content.should == "1\n"
+    result.content.should == "1\r\n"
   end
 end

--- a/spec/unit/file_serving/content_spec.rb
+++ b/spec/unit/file_serving/content_spec.rb
@@ -102,13 +102,13 @@ describe Puppet::FileServing::Content, "when returning the contents" do
 
   it "should return the contents of the path if the file exists" do
     File.expects(:stat).with(@path).returns stub("stat", :ftype => "file")
-    File.expects(:read).with(@path).returns(:mycontent)
+    Puppet::Util.expects(:binread).with(@path).returns(:mycontent)
     @content.content.should == :mycontent
   end
 
   it "should cache the returned contents" do
     File.expects(:stat).with(@path).returns stub("stat", :ftype => "file")
-    File.expects(:read).with(@path).returns(:mycontent)
+    Puppet::Util.expects(:binread).with(@path).returns(:mycontent)
     @content.content
 
     # The second run would throw a failure if the content weren't being cached.


### PR DESCRIPTION
Previously, Windows agents were reading files in text mode when serving
them locally, such as when serving files from a local module, corrupting
them in the process.

This commit reads files in binary mode, which is a noop on Unix.

Serving files from remote puppet masters was fixed in #9983.
