### PR TITLE
(maint) Fix time-dependent certificate factory spec tests

### DIFF
--- a/spec/unit/ssl/certificate_factory_spec.rb
+++ b/spec/unit/ssl/certificate_factory_spec.rb
@@ -52,19 +52,19 @@ describe Puppet::SSL::CertificateFactory do
 
     it "should have 24 hours grace on the start of the cert" do
       cert = subject.build(:server, csr, issuer, serial)
-      cert.not_before.should be_within(1).of(Time.now - 24*60*60)
+      cert.not_before.should be_within(30).of(Time.now - 24*60*60)
     end
 
     it "should set the default TTL of the certificate" do
       ttl  = Puppet::SSL::CertificateFactory.ttl
       cert = subject.build(:server, csr, issuer, serial)
-      cert.not_after.should be_within(1).of(Time.now + ttl)
+      cert.not_after.should be_within(30).of(Time.now + ttl)
     end
 
     it "should respect a custom TTL for the CA" do
       Puppet[:ca_ttl] = 12
       cert = subject.build(:server, csr, issuer, serial)
-      cert.not_after.should be_within(1).of(Time.now + 12)
+      cert.not_after.should be_within(30).of(Time.now + 12)
     end
 
     it "should build extensions for the certificate" do


### PR DESCRIPTION
Some of the certificate factory spec tests were trying to ensure that
the certificate factory's ttl was being applied when signing a
certificate's `not_after` time. However, the tests did not take into
account the amount of time it takes to sign the certificate, which can
be non-negligible.

As a result, the absolute difference between `not_after` and `Time.now +
ttl` was somtimes greater than or equal to 1 second, causing sporadic
test failures.

This commit changes the tests to be less time dependent by ensuring the
difference is within 30 seconds (for both `not_before` and `not_after`)
