### PR TITLE
Ticket/2.7.x/11958 pip provider better error messages

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -102,7 +102,7 @@ Puppet::Type.type(:package).provide :pip,
       self.class.commands :pip => pathname
       pip *args
     else
-      raise e
+      raise e, 'Could not locate the pip command.'
     end
   end
 end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -175,6 +175,13 @@ describe provider_class do
       expect { @provider.method(:lazy_pip).call("freeze") }.to raise_error(NoMethodError)
     end
 
+    it "should output a useful error message if pip is missing" do
+      @provider.expects(:pip).with('freeze').raises(NoMethodError)
+      @provider.expects(:which).with('pip').returns(nil)
+      expect { @provider.method(:lazy_pip).call("freeze") }.
+        to raise_error(NoMethodError, 'Could not locate the pip command.')
+    end
+
   end
 
 end


### PR DESCRIPTION
(#11958) Improve error msg for missing pip command                                                                                                            

Without this patch the pip package provider does not produce a user
friendly error message when the pip command is not available. The
current error message looks like this:

```
err: /Stage[main]/Dummy/Package[virtualenv]/ensure: change from
absent to present failed: Could not set 'present on ensure:
undefined method `pip' for
#<Puppet::Type::Package::ProviderPip:0xb6cf6cd0> at
/etc/puppet/modules/dummy/manifests/init.pp:5
```

This patch improves the error message by passing a string argument, 'Could not locate
the pip command.', when raising the `NoMethodError`. The new error
message looks like this:

```
err: /Stage[main]/Dummy/Package[virtualenv]/ensure: change from
absent to present failed: Could not set 'present on ensure: Could
not locate the pip command. at
/etc/puppet/modules/dummy/manifests/init.pp:5
```

This patch also includes updated spec tests validating this change. No
other behavior changes are being introduced.
