### PR TITLE
(#11996) Fix test failures due to hash processing order changes.

### DIFF
--- a/spec/unit/parser/ast/asthash_spec.rb
+++ b/spec/unit/parser/ast/asthash_spec.rb
@@ -92,7 +92,6 @@ describe Puppet::Parser::AST::ASTHash do
 
   it "should return a valid string with to_s" do
     hash = Puppet::Parser::AST::ASTHash.new(:value => { "a" => "b", "c" => "d" })
-
-    hash.to_s.should == '{a => b, c => d}'
+    ["{a => b, c => d}", "{c => d, a => b}"].should be_include hash.to_s
   end
 end

--- a/spec/unit/property/keyvalue_spec.rb
+++ b/spec/unit/property/keyvalue_spec.rb
@@ -36,8 +36,11 @@ describe klass do
       @property.should_to_s({:foo => "baz", :bar => "boo"}) == "foo=baz;bar=boo"
     end
 
-    it "should return the passed in array values joined with the delimiter from is_to_s" do
-      @property.is_to_s({"foo" => "baz" , "bar" => "boo"}).should == "foo=baz;bar=boo"
+    it "should return the passed in hash values joined with the delimiter from is_to_s" do
+      s = @property.is_to_s({"foo" => "baz" , "bar" => "boo"})
+
+      # We can't predict the order the hash is processed in...
+      ["foo=baz;bar=boo", "bar=boo;foo=baz"].should be_include s
     end
 
     describe "when calling inclusive?" do

--- a/spec/unit/util/zaml_spec.rb
+++ b/spec/unit/util/zaml_spec.rb
@@ -36,29 +36,31 @@ describe "Pure ruby yaml implementation" do
     end
   }
 
-  def set_of_lines(l)
-    l.split("\n").sort
-  end
-
   it "should handle references to Array in Hash values correctly" do
     list = [1]
     data = { "one" => list, "two" => list }
-    data.to_yaml.should == "--- \n  two: &id001 \n    - 1\n  one: *id001"
+    data.to_yaml.should =~ /  two: [&*]id001/
+    data.to_yaml.should =~ /  one: [&*]id001/
     expect { YAML.load(data.to_yaml).should == data }.should_not raise_error
   end
 
   it "should handle references to Hash in Hash values correctly" do
     hash = { 1 => 1 }
     data = { "one" => hash, "two" => hash }
-    # This could still someday fail because the order change would also change which one got the back ref
-    set_of_lines(data.to_yaml).should == set_of_lines("--- \n  two: &id001 \n    1: 1\n  one: *id001")
+    lines = data.to_yaml.split("\n")
+    lines.should be_any {|x| x =~ /--- / }
+    lines.should be_any {|x| x =~ /  one: [*&]id001/ }
+    lines.should be_any {|x| x =~ /  two: [*&]id001/ }
     expect { YAML.load(data.to_yaml).should == data }.should_not raise_error
   end
 
   it "should handle references to Scalar in Hash" do
     str = "hello"
     data = { "one" => str, "two" => str }
-    set_of_lines(data.to_yaml).should == set_of_lines("--- \n  two: hello\n  one: hello")
+    lines = data.to_yaml.split("\n")
+    lines.should be_any {|x| x =~ /--- / }
+    lines.should be_any {|x| x =~ /  one: hello/ }
+    lines.should be_any {|x| x =~ /  two: hello/ }
     expect { YAML.load(data.to_yaml).should == data }.should_not raise_error
   end
 


### PR DESCRIPTION
As part of fixing CVE-2011-4815, Ruby has made the order that hash tables are
keyed unpredictable - where they were formerly fixed in stone.  This, in turn,
means that all the tests that depended on that order started to fail randomly
on the most recent patch release of Ruby 1.8.7, and will fail in recent Ruby
1.9.\* releases.

This makes those tests insensitive to ordering of the content, at the cost of
being a little less strict in places.  This seems less harmful, overall, than
alternative approaches like sorting the hash in the code, or enumerating all
possible combinations of order and testing on all of them.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
