### PR TITLE
puppet apply manual - correct inconsistent example of using config params as options 

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -76,7 +76,7 @@ manifests.
 OPTIONS
 -------
 Note that any configuration parameter that's valid in the configuration
-file is also a valid long argument. For example, 'modulepath' is a
+file is also a valid long argument. For example, 'tags' is a
 valid configuration parameter, so you can specify '--tags <class>,<tag>'
 as an argument.
 


### PR DESCRIPTION
.I noticed that 'modulepath' and '--tags' are used inconsistently.  Trivial suggested fix to use 'tags'.
