### PR TITLE
Fixed #11888 - Changed providers to use osfamily fact.

### DIFF
--- a/lib/puppet/provider/package/up2date.rb
+++ b/lib/puppet/provider/package/up2date.rb
@@ -4,10 +4,9 @@ Puppet::Type.type(:package).provide :up2date, :parent => :rpm, :source => :rpm d
 
   commands :up2date => "/usr/sbin/up2date-nox"
 
-  defaultfor :operatingsystem => [:redhat, :oel, :ovm],
-    :lsbdistrelease => ["2.1", "3", "4"]
+  defaultfor :osfamily => :redhat, :lsbdistrelease => ["2.1", "3", "4"]
 
-  confine    :operatingsystem => [:redhat, :oel, :ovm]
+  confine    :osfamily => :redhat
 
   # Install a package using 'up2date'.
   def install

--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
 
   commands :chkconfig => "/sbin/chkconfig", :service => "/sbin/service"
 
-  defaultfor :operatingsystem => [:redhat, :fedora, :suse, :centos, :sles, :oel, :ovm]
+  defaultfor :osfamily => [:redhat, :suse]
 
   def self.instances
     # this exclude list is all from /sbin/service (5.x), but I did not exclude kudzu

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   commands :systemctl => "/bin/systemctl"
 
-  #defaultfor :operatingsystem => [:redhat, :fedora, :suse, :centos, :sles, :oel, :ovm]
+  #defaultfor :osfamily => [:redhat, :suse]
 
   def self.instances
     i = []

--- a/spec/unit/provider/package/up2date_spec.rb
+++ b/spec/unit/provider/package/up2date_spec.rb
@@ -1,0 +1,22 @@
+# spec/unit/provider/package/up2date_spec.rb
+require 'spec_helper'
+
+describe 'up2date package provider' do
+
+  # This sets the class itself as the subject rather than
+  # an instance of the class.
+  subject do
+    Puppet::Type.type(:package).provider(:up2date)
+  end
+
+  osfamily = [ 'redhat' ]
+  releases = [ '2.1', '3', '4' ]
+
+  osfamily.product(releases).each do |osfamily, release|
+    it "should be the default provider on #{osfamily} #{release}" do
+      Facter.expects(:value).with(:osfamily).returns(osfamily)
+      Facter.expects(:value).with(:lsbdistrelease).returns(release)
+      subject.default?.should be_true
+    end
+  end
+end

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -23,6 +23,15 @@ describe provider_class do
     FileTest.stubs(:executable?).with('/sbin/service').returns true
   end
 
+  osfamily = [ 'redhat', 'suse' ]
+
+  osfamily.each do |osfamily|
+    it "should be the default provider on #{osfamily}" do
+      Facter.expects(:value).with(:osfamily).returns(osfamily)
+      provider_class.default?.should be_true
+    end
+  end
+
   # test self.instances
   describe "when getting all service instances" do
     before :each do

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -17,6 +17,14 @@ describe provider_class do
     @provider.resource = @resource
   end
 
+  osfamily = [ 'redhat', 'suse' ]
+
+  osfamily.each do |osfamily|
+    it "should be the default provider on #{osfamily}" do
+      pending "This test is pending the change in RedHat-related Linuxes to systemd for service management"
+    end
+  end
+
   [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|
     it "should have a #{method} method" do
       @provider.should respond_to(method)


### PR DESCRIPTION
Previously the up2date, redhat and systemd providers used the
operatingsystem fact to select defaults and constraints. This often
meant that new operating systems using the same providers had to be
manually added to the list of supported operating systems

This commit replaces the use of operatingsystem with osfamily meaning
addition of new operating systems is now centralised in one place in
Facter rather than requiring multiple updates.

Tests supporting this have been added to prevent regressions.
