### PR TITLE
(#11727) Fix support stdin test

### DIFF
--- a/acceptance/tests/ticket_11727_support_stdin_parsing_in_puppet_parser_validate.rb
+++ b/acceptance/tests/ticket_11727_support_stdin_parsing_in_puppet_parser_validate.rb
@@ -1,6 +1,6 @@
 test_name "#11727: support stdin parsing in puppet parser validate"
 
-pp = "#{scratch}/11727.pp"
+pp = "/tmp/11727.pp"
 
 step "validate with a tty parses the default manifest"
 on agents, puppet(%w{parser validate}) do
@@ -9,10 +9,10 @@ on agents, puppet(%w{parser validate}) do
 end
 
 step "create the remote manifest file for redirection"
-create_remote_file agents, pp 'notice("hello")'
+create_remote_file(agents, pp, 'notice("hello")')
 
 step "validate with redirection parses STDIN"
-on agents, puppet(%w{parser validate <}, pp), do
+on agents, puppet(%w{parser validate <}, pp) do
   assert_no_match(/Validating the default manifest/, stdout,
                   "there was message about validating default manifest despite redirect")
 end

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -3,7 +3,9 @@ test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 agent_hostnames = agents.map {|a| a.to_s}
 
 step "Remove existing SSL directory for hosts"
-on hosts, "rm -r #{config['puppetpath']}/ssl"
+hosts.each do |host|
+ on(host, "rm -r #{host['puppetpath']}/ssl")
+end
 
 with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --verbose --noop" do
   step "Generate a certificate request for the agent"


### PR DESCRIPTION
Stdin test had a few typos that required fixing.
ticket_3360 uses the only global config hash -- changed this
to support the per host based configuration data.
