### PR TITLE
(#11727) Another fix to 11727

### DIFF
--- a/acceptance/tests/ticket_11727_support_stdin_parsing_in_puppet_parser_validate.rb
+++ b/acceptance/tests/ticket_11727_support_stdin_parsing_in_puppet_parser_validate.rb
@@ -3,7 +3,7 @@ test_name "#11727: support stdin parsing in puppet parser validate"
 pp = "/tmp/11727.pp"
 
 step "validate with a tty parses the default manifest"
-on agents, puppet(%w{parser validate}) do
+on agents, puppet(%q{parser validate}) do
   assert_match(/Validating the default manifest/, stdout,
                "no message about validating default manifest")
 end
@@ -12,7 +12,7 @@ step "create the remote manifest file for redirection"
 create_remote_file(agents, pp, 'notice("hello")')
 
 step "validate with redirection parses STDIN"
-on agents, puppet(%w{parser validate <}, pp) do
+on agents, puppet(%q{parser validate <}, pp) do
   assert_no_match(/Validating the default manifest/, stdout,
                   "there was message about validating default manifest despite redirect")
 end


### PR DESCRIPTION
Incorrecty string quoting resulted in remote commands running
together: "puppetparservalidate"
