### PR TITLE
(#11727) Allocate a PTY when running the acceptance test.

### DIFF
--- a/acceptance/tests/ticket_11727_support_stdin_parsing_in_puppet_parser_validate.rb
+++ b/acceptance/tests/ticket_11727_support_stdin_parsing_in_puppet_parser_validate.rb
@@ -1,18 +1,19 @@
 test_name "#11727: support stdin parsing in puppet parser validate"
 
 pp = "/tmp/11727.pp"
+manifest = 'notice("hello")'
 
 step "validate with a tty parses the default manifest"
-on agents, puppet(%q{parser validate}) do
+on agents, puppet("parser validate"), :pty => true do
   assert_match(/Validating the default manifest/, stdout,
                "no message about validating default manifest")
 end
 
 step "create the remote manifest file for redirection"
-create_remote_file(agents, pp, 'notice("hello")')
+create_remote_file(agents, pp, manifest)
 
-step "validate with redirection parses STDIN"
-on agents, puppet(%q{parser validate <}, pp) do
+step "validate with redirection parses STDIN from redirection"
+on agents, puppet("parser validate < #{pp}"), :pty => true do
   assert_no_match(/Validating the default manifest/, stdout,
                   "there was message about validating default manifest despite redirect")
 end


### PR DESCRIPTION
When submitted this acceptance test didn't actually pass - which, ultimately,
turns out to be that the puppet command was run without a TTY attached by
default in the acceptance test harness.

Once https://github.com/puppetlabs/puppet-acceptance/pull/115 is merged, which
adds the feature to the core of the suite to support PTY allocation through
SSH, this turns that feature on, and the test can finally pass.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
