### PR TITLE
Fix test 3360 allow duplicate csr with option

### DIFF
--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -3,7 +3,9 @@ test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 agent_hostnames = agents.map {|a| a.to_s}
 
 step "Remove existing SSL directory for hosts"
-on hosts, "rm -r #{config['puppetpath']}/ssl"
+hosts.each do |host|
+ on(host, "rm -r #{host['puppetpath']}/ssl")
+end
 
 with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --verbose --noop" do
   step "Generate a certificate request for the agent"


### PR DESCRIPTION
Test harness formerly used a global config hash to store config data;
this breaks with the intoduction on non-posix hosts (windows).  Now
using a per host config hash.  Updating this test to use the new
style.  This will need to be merged into 2.7rc as well; already
applied to Master.
