### PR TITLE
(#12060) Remove factsync

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -73,10 +73,7 @@ class Puppet::Configurer
   # Prepare for catalog retrieval.  Downloads everything necessary, etc.
   def prepare(options)
     dostorage
-
     download_plugins unless options[:skip_plugin_download]
-
-    download_fact_plugins unless options[:skip_plugin_download]
   end
 
   # Get the remote catalog, yo.  Returns nil if no catalog can be found.

--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -6,10 +6,6 @@ require 'puppet/configurer/downloader'
 # just included into the agent, but having it here makes it
 # easier to test.
 module Puppet::Configurer::FactHandler
-  def download_fact_plugins?
-    Puppet[:factsync]
-  end
-
   def find_facts
     # This works because puppet agent configures Facts to use 'facter' for
     # finding facts and the 'rest' terminus for caching them.  Thus, we'll
@@ -42,15 +38,5 @@ module Puppet::Configurer::FactHandler
     text = facts.render(format)
 
     {:facts_format => format, :facts => CGI.escape(text)}
-  end
-
-  # Retrieve facts from the central server.
-  def download_fact_plugins
-    return unless download_fact_plugins?
-
-    # Deprecated prior to 0.25, as of 5/19/2008
-    Puppet.warning "Fact syncing is deprecated as of 0.25 -- use 'pluginsync' instead"
-
-    Puppet::Configurer::Downloader.new("fact", Puppet[:factdest], Puppet[:factsource], Puppet[:factsignore]).evaluate
   end
 end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -764,16 +764,7 @@ EOT
 
       :call_on_define => true, # Call our hook with the default value, so we always get the value added to facter.
       :type => :setting, # Don't consider it a file, because it could be multiple colon-separated files
-      :hook => proc { |value| Facter.search(value) if Facter.respond_to?(:search) }},
-    :factdest => ["$vardir/facts/",
-      "Where Puppet should store facts that it pulls down from the central
-      server."],
-    :factsource => ["puppet://$server/facts/",
-      "From where to retrieve facts.  The standard Puppet `file` type
-      is used for retrieval, so anything that is a valid file source can
-      be used here."],
-    :factsync => [false, "Whether facts should be synced with the central server."],
-    :factsignore => [".svn CVS", "What files to ignore when pulling down facts."]
+      :hook => proc { |value| Facter.search(value) if Facter.respond_to?(:search) }}
   )
 
 

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -122,12 +122,6 @@ describe "Puppet defaults" do
     Puppet.settings[:bindaddress].should == ""
   end
 
-  [:factdest].each do |setting|
-    it "should force the :factdest to be a directory" do
-      Puppet.settings[setting].should =~ /\/$/
-    end
-  end
-
   [:modulepath, :factpath].each do |setting|
     it "should configure '#{setting}' not to be a file setting, so multi-directory settings are acceptable" do
       Puppet.settings.setting(setting).should be_instance_of(Puppet::Util::Settings::Setting)

--- a/spec/unit/configurer/fact_handler_spec.rb
+++ b/spec/unit/configurer/fact_handler_spec.rb
@@ -12,37 +12,6 @@ describe Puppet::Configurer::FactHandler do
     @facthandler = FactHandlerTester.new
   end
 
-  it "should download fact plugins when :factsync is true" do
-    Puppet.settings.expects(:value).with(:factsync).returns true
-    @facthandler.should be_download_fact_plugins
-  end
-
-  it "should not download fact plugins when :factsync is false" do
-    Puppet.settings.expects(:value).with(:factsync).returns false
-    @facthandler.should_not be_download_fact_plugins
-  end
-
-  it "should not download fact plugins when downloading is disabled" do
-    Puppet::Configurer::Downloader.expects(:new).never
-    @facthandler.expects(:download_fact_plugins?).returns false
-    @facthandler.download_fact_plugins
-  end
-
-  it "should use an Agent Downloader, with the name, source, destination, and ignore set correctly, to download fact plugins when downloading is enabled" do
-    downloader = mock 'downloader'
-
-    Puppet.settings.expects(:value).with(:factsource).returns "fsource"
-    Puppet.settings.expects(:value).with(:factdest).returns "fdest"
-    Puppet.settings.expects(:value).with(:factsignore).returns "fignore"
-
-    Puppet::Configurer::Downloader.expects(:new).with("fact", "fdest", "fsource", "fignore").returns downloader
-
-    downloader.expects(:evaluate)
-
-    @facthandler.expects(:download_fact_plugins?).returns true
-    @facthandler.download_fact_plugins
-  end
-
   describe "when finding facts" do
     before :each do
       @facthandler.stubs(:reload_facter)
@@ -90,14 +59,6 @@ describe Puppet::Configurer::FactHandler do
   it "should only load fact plugins once" do
     Puppet::Node::Facts.indirection.expects(:find).once
     @facthandler.find_facts
-  end
-
-  it "should warn about factsync deprecation when factsync is enabled" do
-    Puppet::Configurer::Downloader.stubs(:new).returns mock("downloader", :evaluate => nil)
-
-    @facthandler.expects(:download_fact_plugins?).returns true
-    Puppet.expects(:warning)
-    @facthandler.download_fact_plugins
   end
 
   # I couldn't get marshal to work for this, only yaml, so we hard-code yaml.

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -585,20 +585,12 @@ describe Puppet::Configurer do
   describe "when preparing for a run" do
     before do
       Puppet.settings.stubs(:use).returns(true)
-      @agent.stubs(:download_fact_plugins)
-      @agent.stubs(:download_plugins)
       @facts = {"one" => "two", "three" => "four"}
     end
 
     it "should initialize the metadata store" do
       @agent.class.stubs(:facts).returns(@facts)
       @agent.expects(:dostorage)
-      @agent.prepare({})
-    end
-
-    it "should download fact plugins" do
-      @agent.expects(:download_fact_plugins)
-
       @agent.prepare({})
     end
 


### PR DESCRIPTION
Fact syncing is now done through pluginsync. The separate factsync option has
been deprecated since 0.25 (ticket #2277).
