### PR TITLE
(#11767) No longer necessary to delete ssl directory in test cases

### DIFF
--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -39,8 +39,6 @@ create_remote_file master, manifest_file, manifest
 
 on master, "chmod 644 #{authfile} #{manifest_file}"
 
-on hosts, "rm -rf /etc/puppet/ssl"
-
 with_master_running_on(master, "--rest_authconfig #{authfile} --manifest #{manifest_file} --daemonize --dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\" --autosign true") do
   run_agent_on(agents, "--no-daemonize --verbose --onetime --node_name_fact kernel --server #{master}") do
     assert_match(success_message, stdout)

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -22,8 +22,6 @@ MANIFEST
 
 on master, "chmod 644 #{authfile} #{manifest_file}"
 
-on hosts, "rm -rf /etc/puppet/ssl"
-
 with_master_running_on(master, "--rest_authconfig #{authfile} --manifest #{manifest_file} --daemonize --dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\" --autosign true") do
   run_agent_on(agents, "--no-daemonize --verbose --onetime --node_name_value specified_node_name --server #{master}") do
     assert_match(success_message, stdout)

--- a/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
+++ b/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
@@ -1,8 +1,5 @@
 test_name "generate a helpful error message when hostname doesn't match server certificate"
 
-step "Clear any existing SSL directories"
-on(hosts, "rm -rf #{config['puppetpath']}/ssl")
-
 # Start the master with a certname not matching its hostname
 with_master_running_on(master, "--certname foobar_not_my_hostname --dns_alt_names one_cert,two_cert,red_cert,blue_cert --autosign true") do
   run_agent_on(agents, "--no-daemonize --verbose --onetime --server #{master}", :acceptable_exit_codes => (1..255)) do

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -2,9 +2,6 @@ test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 
 agent_hostnames = agents.map {|a| a.to_s}
 
-step "Remove existing SSL directory for hosts"
-on hosts, "rm -r #{config['puppetpath']}/ssl"
-
 with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --verbose --noop" do
   step "Generate a certificate request for the agent"
   on agents, "puppet certificate generate `hostname -f` --ca-location remote --server #{master}"

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -9,7 +9,6 @@ test_name "Ticket 5477, Puppet Master does not detect newly created site.pp file
 manifest_file = "/tmp/missing_site-5477-#{$$}.pp"
 
 on master, "rm -f #{manifest_file}"
-on hosts, "rm -rf /etc/puppet/ssl"
 
 with_master_running_on(master, "--manifest #{manifest_file} --dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\" --verbose --filetimeout 1 --autosign true") do
   # Run test on Agents

--- a/acceptance/tests/ticket_7117_broke_env_criteria_authconf.rb
+++ b/acceptance/tests/ticket_7117_broke_env_criteria_authconf.rb
@@ -13,8 +13,6 @@ create_remote_file master, "/tmp/auth.conf-7117", add_2_authconf
 
 on master, "chmod 644 /tmp/auth.conf-7117"
 
-on hosts, "rm -rf /etc/puppet/ssl"
-
 with_master_running_on(master, "--dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\" --rest_authconfig /tmp/auth.conf-7117 --verbose --autosign true") do
   # Run test on Agents
   step "Run agent to upload facts"


### PR DESCRIPTION
Previously, each TestCase that used `with_master_running_on` had to
remember to delete the ssl directories from every host. Otherwise, if
either the master or any of its agents used a certificate from a
previous run, the test would fail.

Also, previously, TestCases were not consistent in how they referenced
the ssl directory: /etc/puppet/ssl, #{host['puppetpath']}/ssl,
on the configuration file being used.

Deletion of the ssl directories now happens within the
`with_master_running_on method` itself, so that individual TestCases
don't need to.
