### PR TITLE
Revert "(#11858) Don't load plugins during sync."

### DIFF
--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -16,6 +16,22 @@ module Puppet::Configurer::PluginHandler
       Puppet[:pluginsignore]
     )
 
-    plugin_downloader.evaluate.each { |file| Puppet.info "Downloaded #{file} from master" unless FileTest.directory?(file) }
+    plugin_downloader.evaluate.each { |file| load_plugin(file) }
+  end
+
+  def load_plugin(file)
+    return unless FileTest.exist?(file)
+    return if FileTest.directory?(file)
+
+    begin
+      if file =~ /.rb$/
+        Puppet.info "Loading downloaded plugin #{file}"
+        load file
+      else
+        Puppet.debug "Skipping downloaded plugin #{file}"
+      end
+    rescue Exception => detail
+      Puppet.err "Could not load downloaded file #{file}: #{detail}"
+    end
   end
 end

--- a/spec/unit/configurer/plugin_handler_spec.rb
+++ b/spec/unit/configurer/plugin_handler_spec.rb
@@ -10,6 +10,10 @@ end
 describe Puppet::Configurer::PluginHandler do
   before do
     @pluginhandler = PluginHandlerTester.new
+
+    # PluginHandler#load_plugin has an extra-strong rescue clause
+    # this mock is to make sure that we don't silently ignore errors
+    Puppet.expects(:err).never
   end
 
   it "should have a method for downloading plugins" do
@@ -49,5 +53,70 @@ describe Puppet::Configurer::PluginHandler do
 
     @pluginhandler.expects(:download_plugins?).returns true
     @pluginhandler.download_plugins
+  end
+
+  it "should be able to load plugins" do
+    @pluginhandler.should respond_to(:load_plugin)
+  end
+
+  it "should load each downloaded file" do
+    FileTest.stubs(:exist?).returns true
+    downloader = mock 'downloader'
+
+    Puppet::Configurer::Downloader.expects(:new).returns downloader
+
+    downloader.expects(:evaluate).returns %w{one two}
+
+    @pluginhandler.expects(:download_plugins?).returns true
+
+    @pluginhandler.expects(:load_plugin).with("one")
+    @pluginhandler.expects(:load_plugin).with("two")
+
+    @pluginhandler.download_plugins
+  end
+
+  it "should load ruby plugins when asked to do so" do
+    FileTest.stubs(:exist?).returns true
+    @pluginhandler.expects(:load).with("foo.rb")
+
+    @pluginhandler.load_plugin("foo.rb")
+  end
+
+  it "should skip non-ruby plugins when asked to do so" do
+    FileTest.stubs(:exist?).returns true
+    @pluginhandler.expects(:load).never
+
+    @pluginhandler.load_plugin("foo")
+  end
+
+  it "should not try to load files that don't exist" do
+    FileTest.expects(:exist?).with("foo.rb").returns false
+    @pluginhandler.expects(:load).never
+
+    @pluginhandler.load_plugin("foo.rb")
+  end
+
+  it "should not try to load directories" do
+    FileTest.stubs(:exist?).returns true
+    FileTest.expects(:directory?).with("foo").returns true
+    @pluginhandler.expects(:load).never
+
+    @pluginhandler.load_plugin("foo")
+  end
+
+  it "should warn but not fail if loading a file raises an exception" do
+    FileTest.stubs(:exist?).returns true
+    @pluginhandler.expects(:load).with("foo.rb").raises "eh"
+
+    Puppet.expects(:err)
+    @pluginhandler.load_plugin("foo.rb")
+  end
+
+  it "should warn but not fail if loading a file raises a LoadError" do
+    FileTest.stubs(:exist?).returns true
+    @pluginhandler.expects(:load).with("foo.rb").raises LoadError.new("eh")
+
+    Puppet.expects(:err)
+    @pluginhandler.load_plugin("foo.rb")
   end
 end


### PR DESCRIPTION
This reverts commit ddb1b3fb219727880161d3844f1981ea8b8d98c8. It requires the
autoloader to be extended to reload changed plugins.
