### PR TITLE
(#12051) Send exec onlyif/unless command output to debug log

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -369,6 +369,10 @@ module Puppet
           return false
         end
 
+        output.split(/\n/).each { |line|
+          self.debug(line)
+        }
+
         status.exitstatus != 0
       end
     end
@@ -411,6 +415,10 @@ module Puppet
           err "Check #{value.inspect} exceeded timeout"
           return false
         end
+
+        output.split(/\n/).each { |line|
+          self.debug(line)
+        }
 
         status.exitstatus == 0
       end

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -632,6 +632,13 @@ describe Puppet::Type.type(:exec) do
             @test.check_all_attributes.should == false
           end
         end
+
+        it "should emit output to debug" do
+          Puppet::Util::Log.level = :debug
+          @test[param] = @fail
+          @test.check_all_attributes.should == true
+          @logs.shift.message.should == "test output"
+        end
       end
     end
   end


### PR DESCRIPTION
When an onlyif or unless exec clause is run, the output is now always sent to
the debug log irrespective of the loglevel output, which controls the logging
level of the command itself.

https://projects.puppetlabs.com/issues/12051
