### PR TITLE
(#11961) Apply and catch a timeout when contacting PyPI over XMLRPC

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -50,8 +50,11 @@ Puppet::Type.type(:package).provide :pip,
   def latest
     client = XMLRPC::Client.new2("http://pypi.python.org/pypi")
     client.http_header_extra = {"Content-Type" => "text/xml"}
+    client.timeout = 10
     result = client.call("package_releases", @resource[:name])
     result.first
+  rescue Timeout::Error => detail
+    raise Puppet::Error, "Timeout while contacting pypi.python.org: #{detail}";
   end
 
   # Install a package.  The ensure parameter may specify installed,

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -8,10 +8,10 @@ describe provider_class do
   before do
     @resource = Puppet::Resource.new(:package, "fake_package")
     @provider = provider_class.new(@resource)
-    client = stub_everything('client')
-    client.stubs(:call).with('package_releases', 'real_package').returns(["1.3", "1.2.5", "1.2.4"])
-    client.stubs(:call).with('package_releases', 'fake_package').returns([])
-    XMLRPC::Client.stubs(:new2).returns(client)
+    @client = stub_everything('client')
+    @client.stubs(:call).with('package_releases', 'real_package').returns(["1.3", "1.2.5", "1.2.4"])
+    @client.stubs(:call).with('package_releases', 'fake_package').returns([])
+    XMLRPC::Client.stubs(:new2).returns(@client)
   end
 
   describe "parse" do
@@ -84,6 +84,12 @@ describe provider_class do
     it "should not find a version number for fake_package" do
       @resource[:name] = "fake_package"
       @provider.latest.should == nil
+    end
+
+    it "should handle a timeout gracefully" do
+      @resource[:name] = "fake_package"
+      @client.stubs(:call).raises(Timeout::Error)
+      lambda { @provider.latest }.should raise_error(Puppet::Error)
     end
 
   end


### PR DESCRIPTION
Apply a 10 second timeout to XMLRPC calls to PyPI and catch them, reporting an error gracefully.
