### PR TITLE
fix to #4946: allow resource arrays on either side of relationship

### DIFF
--- a/lib/puppet/parser/ast/relationship.rb
+++ b/lib/puppet/parser/ast/relationship.rb
@@ -23,8 +23,15 @@ class Puppet::Parser::AST::Relationship < Puppet::Parser::AST::Branch
     real_right = right.safeevaluate(scope)
 
     source, target = sides2edge(real_left, real_right)
-    result = Puppet::Parser::Relationship.new(source, target, type)
-    scope.compiler.add_relationship(result)
+    source_array = (source.is_a? Array) ? source : [source]
+    target_array = (target.is_a? Array) ? target : [target]
+   
+    source_array.each do |single_source|
+      target_array.each do |single_target|
+        result = Puppet::Parser::Relationship.new(single_source, single_target, type)
+        scope.compiler.add_relationship(result)
+      end
+    end
     real_right
   end
 

--- a/spec/unit/parser/ast/relationship_spec.rb
+++ b/spec/unit/parser/ast/relationship_spec.rb
@@ -52,6 +52,58 @@ describe Puppet::Parser::AST::Relationship do
       @compiler.relationships[0].target.should == :right
     end
 
+    describe "an array" do
+      describe "in source" do
+        before (:each) do
+          @source = stub 'left', :safeevaluate => [:left1, :left2]
+          @target = stub 'right', :safeevaluate => :right1
+          @reln = @class.new(@source, @target, '->')
+        end
+        it "should create a relationship for each source to target" do
+          @reln.evaluate(@scope)
+
+          @compiler.relationships[0].source.should == :left1
+          @compiler.relationships[0].target.should == :right1
+          @compiler.relationships[1].source.should == :left2
+          @compiler.relationships[1].target.should == :right1
+        end
+      end
+      describe "in target" do
+        before(:each) do
+          @source = stub 'left', :safeevaluate => :left1
+          @target = stub 'right', :safeevaluate => [:right1, :right2]
+          @reln = @class.new(@source, @target, '->')
+        end
+        it "should create a relationship from source to each target" do
+          @reln.evaluate(@scope)
+
+          @compiler.relationships[0].source.should == :left1
+          @compiler.relationships[0].target.should == :right1
+          @compiler.relationships[1].source.should == :left1
+          @compiler.relationships[1].target.should == :right2
+        end
+      end
+      describe "in both source and target" do
+        before(:each) do
+          @source = stub 'left', :safeevaluate => [:left1, :left2]
+          @target = stub 'right', :safeevaluate => [:right1, :right2]
+          @reln = @class.new(@source, @target, '->')
+        end
+        it "should create a relationship for each source to each target" do
+          @reln.evaluate(@scope)
+
+          @compiler.relationships[0].source.should == :left1
+          @compiler.relationships[0].target.should == :right1
+          @compiler.relationships[1].source.should == :left1
+          @compiler.relationships[1].target.should == :right2
+          @compiler.relationships[2].source.should == :left2
+          @compiler.relationships[2].target.should == :right1
+          @compiler.relationships[3].source.should == :left2
+          @compiler.relationships[3].target.should == :right2
+        end
+      end
+    end
+
     describe "a chained relationship" do
       before do
         @left = stub 'left', :safeevaluate => :left


### PR DESCRIPTION
test to see if the evaluation of either side of the relationship is an array.
when array, iterate through each an add each specific source against each target
added rspec tests to validate
