### PR TITLE
(#9443) Allow digits in face names

### DIFF
--- a/lib/puppet/interface/face_collection.rb
+++ b/lib/puppet/interface/face_collection.rb
@@ -119,7 +119,7 @@ module Puppet::Interface::FaceCollection
   end
 
   def self.underscorize(name)
-    unless name.to_s =~ /^[-_a-z]+$/i then
+    unless name.to_s =~ /^[-_a-z][-_a-z0-9]*$/i then
       raise ArgumentError, "#{name.inspect} (#{name.class}) is not a valid face name"
     end
 

--- a/spec/unit/interface/face_collection_spec.rb
+++ b/spec/unit/interface/face_collection_spec.rb
@@ -146,14 +146,16 @@ describe Puppet::Interface::FaceCollection do
   end
 
   describe "::underscorize" do
-    faulty = [1, "#foo", "$bar", "sturm und drang", :"sturm und drang"]
+    faulty = [1, "23foo", "#foo", "$bar", "sturm und drang", :"sturm und drang"]
     valid  = {
-      "Foo"      => :foo,
-      :Foo       => :foo,
-      "foo_bar"  => :foo_bar,
-      :foo_bar   => :foo_bar,
-      "foo-bar"  => :foo_bar,
-      :"foo-bar" => :foo_bar,
+      "Foo"       => :foo,
+      :Foo        => :foo,
+      "foo_bar"   => :foo_bar,
+      :foo_bar    => :foo_bar,
+      "foo-bar"   => :foo_bar,
+      :"foo-bar"  => :foo_bar,
+      "foo_bar23" => :foo_bar23,
+      :foo_bar23  => :foo_bar23,
     }
 
     valid.each do |input, expect|


### PR DESCRIPTION
This patch allows digits to be used in face names. The first character,
however, is not allowed to be a digit. This fixes #9443.
