### PR TITLE
Ticket/2.7.x/5362

### DIFF
--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -21,9 +21,7 @@ module Puppet
 
           # Define the bucket
           filebucket { 'main':
-            server => puppet,
-            path   => false,
-            # Due to a known issue, path must be set to false for remote filebuckets.
+            server => puppet.puppetlabs.lan
           }
 
           # Specify it as the default target
@@ -45,7 +43,17 @@ module Puppet
 
         Due to a known issue, you currently must set the `path` attribute to
         false if you wish to specify a `server` attribute."
-      defaultto { Puppet[:server] }
+
+      # Setting value to undef so we know whether the value is provide by user.
+      defaultto { :undef }
+      munge do |value|
+        if value == :undef
+          value = Puppet[:server]
+        else
+          resource[:path] = false
+        end
+        value
+      end
     end
 
     newparam(:port) do
@@ -58,9 +66,11 @@ module Puppet
     newparam(:path) do
       desc "The path to the local filebucket.  If this is
         unset, then the bucket is remote.  The parameter *server* must
-        can be specified to set the remote server."
+        be specified to set the remote server."
 
-      defaultto { Puppet[:clientbucketdir] }
+      defaultto {
+        Puppet[:clientbucketdir]
+      }
     end
 
     # Create a default filebucket.

--- a/spec/unit/type/filebucket_spec.rb
+++ b/spec/unit/type/filebucket_spec.rb
@@ -29,6 +29,14 @@ describe Puppet::Type.type(:filebucket) do
     Puppet::Type.type(:filebucket).new(:name => "main")[:server].should == Puppet[:server]
   end
 
+  it "should use the set the server to Puppet[:server] by default path" do
+    Puppet::Type.type(:filebucket).new(:name => "main", :path => '/tmp/bucket')[:server].should == Puppet[:server]
+  end
+
+  it "should set the path to false is server is provided" do
+    Puppet::Type.type(:filebucket).new(:name => "main", :server => 'puppet')[:path].should == false
+  end
+
   it "be local by default" do
     bucket = Puppet::Type.type(:filebucket).new :name => "main"
 


### PR DESCRIPTION
This doesn't resolve the underlying issue, but it sets path=false if the
user provide a server setting for filebucket, so users no longer need
to use this work around:

```
filebucket { 'remote':
  server => 'puppet',
  path => false, #no longer required.
}
```

The documentation on the type have been updated, but there are other
places where this should also be updated.
