### PR TITLE
(#11826) Fix error when no certs were printed to console from ca face

### DIFF
--- a/lib/puppet/face/ca.rb
+++ b/lib/puppet/face/ca.rb
@@ -75,7 +75,7 @@ Puppet::Face.define(:ca, '0.1.0') do
         raise "Unable to fetch the CA"
       end
 
-      length = hosts.map{|x| x.name.length }.max + 1
+      length = hosts.map{|x| x.name.length }.max.to_i + 1
 
       hosts.map do |host|
         name = host.name.ljust(length)

--- a/spec/unit/face/ca_spec.rb
+++ b/spec/unit/face/ca_spec.rb
@@ -312,15 +312,26 @@ describe Puppet::Face[:ca, '0.1.0'], :unless => Puppet.features.microsoft_window
     end
 
     context "with no hosts in CA" do
-      [:pending, :signed, :all].each do |type|
-        it "should return nothing for #{type}" do
-          subject.list(type => true).should == []
+      [
+        {},
+        { :pending => true },
+        { :signed => true },
+        { :all => true },
+      ].each do |type|
+        it "should return nothing for #{type.inspect}" do
+          subject.list(type).should == []
         end
 
         it "should not fail when a matcher is passed" do
           expect {
-            subject.list(type => true, :subject => '.').should == []
+            subject.list(type.merge :subject => '.').should == []
           }.should_not raise_error
+        end
+
+        context "when_rendering :console" do
+          it "should return nothing for #{type.inspect}" do
+            action.when_rendering(:console).call(subject.list(type)).should == ""
+          end
         end
       end
     end


### PR DESCRIPTION
When no hosts needed to be printed from the 'ca' face to console, an error was
hit when trying to add an integer to nil.
