### PR TITLE
default for log output is on_failure, see #10907

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -185,6 +185,8 @@ module Puppet
         log the output when the command reports an error.  Values are
         **true**, *false*, *on_failure*, and any legal log level."
 
+      defaultto :on_failure
+
       newvalues(:true, :false, :on_failure)
     end
 

--- a/test/ral/type/exec.rb
+++ b/test/ral/type/exec.rb
@@ -377,10 +377,10 @@ class TestExec < Test::Unit::TestCase
         :title     => "logoutputesting",
         :path      => "/usr/bin:/bin",
         :command   => "echo logoutput is false",
-        :logoutput => false
       )
     }
 
+    assert_equal(:on_failure, exec[:logoutput])
     assert_apply(exec)
 
     assert_nothing_raised {
@@ -388,6 +388,15 @@ class TestExec < Test::Unit::TestCase
       exec[:logoutput] = true
     }
 
+    assert_equal(:true, exec[:logoutput])
+    assert_apply(exec)
+
+    assert_nothing_raised {
+      exec[:command] = "echo logoutput is false"
+      exec[:logoutput] = false
+    }
+
+    assert_equal(:false, exec[:logoutput])
     assert_apply(exec)
 
     assert_nothing_raised {
@@ -395,6 +404,7 @@ class TestExec < Test::Unit::TestCase
       exec[:logoutput] = "on_failure"
     }
 
+    assert_equal(:on_failure, exec[:logoutput])
     assert_apply(exec)
   end
 


### PR DESCRIPTION
See redmine at https://projects.puppetlabs.com/issues/10907
