### PR TITLE
(New Feature) Added basic integration with Travis CI service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.rspec
 results
 .*.sw[op]

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,2 @@
---format
-s
 --colour
 --backtrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - ree
+branches:
+  only:
+    - master
+script: bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source "http://rubygems.org"
+
+group :development, :test do
+  gem "rack"
+  gem "facter"
+  gem "rspec", "~> 2.8.0"
+  gem "mocha"
+  gem "rcov", :platform => [:mri_18]
+  gem "watchr"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.1.3)
+    facter (1.6.4)
+    metaclass (0.0.1)
+    mocha (0.10.3)
+      metaclass (~> 0.0.1)
+    rack (1.4.0)
+    rcov (1.0.0)
+    rspec (2.8.0)
+      rspec-core (~> 2.8.0)
+      rspec-expectations (~> 2.8.0)
+      rspec-mocks (~> 2.8.0)
+    rspec-core (2.8.0)
+    rspec-expectations (2.8.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.8.0)
+    watchr (0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  facter
+  mocha
+  rack
+  rcov
+  rspec (~> 2.8.0)
+  watchr


### PR DESCRIPTION
Added basic config for Travis CI service, including 4 basic
platforms: Ruby 1.8.7, Ruby 1.9.2, Ruby 1.9.3 and Ruby
Enterprise Edition. Also moved rSpec options from deprcated
spec.opts file to .rspec, so rSpec output in Travis CI
will be mush more prettier.
