### PR TITLE
Fix #11990 - Allow puppet doc rdoc to use README.rdoc for module main page

### DIFF
--- a/lib/puppet/util/rdoc/parser.rb
+++ b/lib/puppet/util/rdoc/parser.rb
@@ -129,8 +129,10 @@ class Parser
   def scan_top_level(container)
     # use the module README as documentation for the module
     comment = ""
-    readme = File.join(File.dirname(File.dirname(@input_file_name)), "README")
-    comment = File.open(readme,"r") { |f| f.read } if FileTest.readable?(readme)
+    %w{README README.rdoc}.each do |rfile|
+      readme = File.join(File.dirname(File.dirname(@input_file_name)), rfile)
+      comment = File.open(readme,"r") { |f| f.read } if FileTest.readable?(readme)
+    end
     look_for_directives_in(container, comment) unless comment.empty?
 
     # infer module name from directory

--- a/spec/unit/util/rdoc/parser_spec.rb
+++ b/spec/unit/util/rdoc/parser_spec.rb
@@ -75,11 +75,35 @@ describe RDoc::Parser, :'fails_on_ruby_1.9.2' => true do
     end
 
     it "should read any present README as module documentation" do
-      FileTest.stubs(:readable?).returns(true)
+      FileTest.stubs(:readable?).with("module/README").returns(true)
+      FileTest.stubs(:readable?).with("module/README.rdoc").returns(false)
       File.stubs(:open).returns("readme")
       @parser.stubs(:parse_elements)
 
       @module.expects(:comment=).with("readme")
+
+      @parser.scan_top_level(@topcontainer)
+    end
+
+    it "should read any present README.rdoc as module documentation" do
+      FileTest.stubs(:readable?).with("module/README.rdoc").returns(true)
+      FileTest.stubs(:readable?).with("module/README").returns(false)
+      File.stubs(:open).returns("readme")
+      @parser.stubs(:parse_elements)
+
+      @module.expects(:comment=).with("readme")
+
+      @parser.scan_top_level(@topcontainer)
+    end
+
+    it "should prefer README.rdoc over README as module documentation" do
+      FileTest.stubs(:readable?).with("module/README.rdoc").returns(true)
+      FileTest.stubs(:readable?).with("module/README").returns(true)
+      File.stubs(:open).with("module/README", "r").returns("readme")
+      File.stubs(:open).with("module/README.rdoc", "r").returns("readme.rdoc")
+      @parser.stubs(:parse_elements)
+
+      @module.expects(:comment=).with("readme.rdoc")
 
       @parser.scan_top_level(@topcontainer)
     end


### PR DESCRIPTION
And even prefer README.rdoc over README if both are present.
