### PR TITLE
Bug/2.7.x/6710 fixed 1.9.2 test failures

### DIFF
--- a/lib/puppet/parser/relationship.rb
+++ b/lib/puppet/parser/relationship.rb
@@ -31,14 +31,30 @@ class Puppet::Parser::Relationship
   end
 
   def mk_relationship(source, target, catalog)
-    unless source_resource = catalog.resource(source.to_s)
+    # REVISIT: In Ruby 1.8 we applied `to_s` to source and target, rather than
+    # `join` without an argument.  In 1.9 the behaviour of Array#to_s changed,
+    # and it gives a different representation than just concat the stringified
+    # elements.
+    #
+    # This restores the behaviour, but doesn't address the underlying question
+    # of what would happen when more than one item was passed in that array.
+    # (Hint: this will not end well.)
+    #
+    # See http://projects.puppetlabs.com/issues/12076 for the ticket tracking
+    # the fact that we should dig out the sane version of this behaviour, then
+    # implement it - where we don't risk breaking a stable release series.
+    # --daniel 2012-01-21
+    source = source.is_a?(Array) ? source.join : source.to_s
+    target = target.is_a?(Array) ? target.join : target.to_s
+
+    unless source_resource = catalog.resource(source)
       raise ArgumentError, "Could not find resource '#{source}' for relationship on '#{target}'"
     end
-    unless target_resource = catalog.resource(target.to_s)
+    unless target_resource = catalog.resource(target)
       raise ArgumentError, "Could not find resource '#{target}' for relationship from '#{source}'"
     end
-    Puppet.debug "Adding relationship from #{source.to_s} to #{target.to_s} with '#{param_name}'"
+    Puppet.debug "Adding relationship from #{source} to #{target} with '#{param_name}'"
     source_resource[param_name] ||= []
-    source_resource[param_name] << target.to_s
+    source_resource[param_name] << target
   end
 end


### PR DESCRIPTION
The behaviour of Array#to_s is different between 1.8.7 and 1.9.2, and this
code actually depended on the older behaviour.

Since this is part of a stable series, the smallest set of changes possible to
make things work have been applied - and a ticket filed to do the deep
analysis of data flow required to fix this properly in a release where we have
more stomach for risk.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
