### PR TITLE
(#5445) Create /var/lib/puppet in OS X Package

### DIFF
--- a/conf/osx/createpackage.sh
+++ b/conf/osx/createpackage.sh
@@ -51,6 +51,7 @@ function find_puppet_root() {
 function install_puppet() {
   echo "Installing Puppet to ${pkgroot}"
   "${installer}" --destdir="${pkgroot}" --bindir="${BINDIR}" --sbindir="${SBINDIR}" --sitelibdir="${SITELIBDIR}"
+  mkdir -p ${pkgroot}/var/lib/puppet
   chown -R root:admin "${pkgroot}"
 }
 


### PR DESCRIPTION
Previously, the $vardir (/var/lib/puppet) didn't exist on OS X, and our
package creation script didn't create it. This commit adds that
directory to the package BOM so that it's ensured as created.
