### PR TITLE
(#10296) Switch schedule tests from should to must

### DIFF
--- a/spec/unit/type/schedule_spec.rb
+++ b/spec/unit/type/schedule_spec.rb
@@ -33,24 +33,24 @@ describe Puppet::Type.type(:schedule) do
     include ScheduleTesting
 
     it "should apply to device" do
-      @schedule.should be_appliable_to_device
+      @schedule.must be_appliable_to_device
     end
 
     it "should apply to host" do
-      @schedule.should be_appliable_to_host
+      @schedule.must be_appliable_to_host
     end
 
     it "should default to :distance for period-matching" do
-      @schedule[:periodmatch].should == :distance
+      @schedule[:periodmatch].must == :distance
     end
 
     it "should default to a :repeat of 1" do
-      @schedule[:repeat].should == 1
+      @schedule[:repeat].must == 1
     end
 
     it "should never match when the period is :never" do
       @schedule[:period] = :never
-      @schedule.should_not be_match
+      @schedule.must_not be_match
     end
   end
 
@@ -61,7 +61,7 @@ describe Puppet::Type.type(:schedule) do
       period = period.to_sym
       it "should produce a #{period} schedule with the period set appropriately" do
         schedules = Puppet::Type.type(:schedule).mkdefaultschedules
-        schedules.find { |s| s[:name] == period.to_s and s[:period] == period }.should be_instance_of(Puppet::Type.type(:schedule))
+        schedules.find { |s| s[:name] == period.to_s and s[:period] == period }.must be_instance_of(Puppet::Type.type(:schedule))
       end
     end
 
@@ -69,7 +69,7 @@ describe Puppet::Type.type(:schedule) do
       schedules = Puppet::Type.type(:schedule).mkdefaultschedules
       schedules.find { |s|
         s[:name] == "puppet" and s[:period] == :hourly and s[:repeat] == 2
-      }.should be_instance_of(Puppet::Type.type(:schedule))
+      }.must be_instance_of(Puppet::Type.type(:schedule))
     end
   end
 
@@ -98,7 +98,7 @@ describe Puppet::Type.type(:schedule) do
     it "should throw an error if the upper limit is less than the lower limit" do
       pending "bug #7639"
       @schedule[:range] = "01:02:03 - 01:00:00"
-      @schedule.should_throw Puppet::Error
+      @schedule.must_throw Puppet::Error
     end
 
     it "should not match the current time fails between an array of ranges" do
@@ -128,15 +128,15 @@ describe Puppet::Type.type(:schedule) do
     end
 
     it "should match when the previous time was an hour ago" do
-      @schedule.should be_match(hour("-", 1))
+      @schedule.must be_match(hour("-", 1))
     end
 
     it "should not match when the previous time was now" do
-      @schedule.should_not be_match(Time.now)
+      @schedule.must_not be_match(Time.now)
     end
 
     it "should not match when the previous time was 59 minutes ago" do
-      @schedule.should_not be_match(min("-", 59))
+      @schedule.must_not be_match(min("-", 59))
     end
   end
 
@@ -151,15 +151,15 @@ describe Puppet::Type.type(:schedule) do
     end
 
     it "should match when the previous time was one day ago" do
-      @schedule.should be_match(day("-", 1))
+      @schedule.must be_match(day("-", 1))
     end
 
     it "should not match when the previous time is now" do
-      @schedule.should_not be_match(Time.now)
+      @schedule.must_not be_match(Time.now)
     end
 
     it "should not match when the previous time was 23 hours ago" do
-      @schedule.should_not be_match(hour("-", 23))
+      @schedule.must_not be_match(hour("-", 23))
     end
   end
 
@@ -174,15 +174,15 @@ describe Puppet::Type.type(:schedule) do
     end
 
     it "should match when the previous time was seven days ago" do
-      @schedule.should be_match(day("-", 7))
+      @schedule.must be_match(day("-", 7))
     end
 
     it "should not match when the previous time was now" do
-      @schedule.should be_match(Time.now)
+      @schedule.must_not be_match(Time.now)
     end
 
     it "should not match when the previous time was six days ago" do
-      @schedule.should_not be_match(day("-", 6))
+      @schedule.must_not be_match(day("-", 6))
     end
   end
 
@@ -197,15 +197,15 @@ describe Puppet::Type.type(:schedule) do
     end
 
     it "should match when the previous time was 32 days ago" do
-      @schedule.should be_match(day("-", 32))
+      @schedule.must be_match(day("-", 32))
     end
 
     it "should not match when the previous time was now" do
-      @schedule.should_not be_match(Time.now)
+      @schedule.must_not be_match(Time.now)
     end
 
     it "should not match when the previous time was 27 days ago" do
-      @schedule.should_not be_match(day("-", 27))
+      @schedule.must_not be_match(day("-", 27))
     end
   end
 
@@ -222,7 +222,7 @@ describe Puppet::Type.type(:schedule) do
       previous = Time.utc(2007, 12, 31, 23, 59, 0)
 
       Time.stubs(:now).returns(current)
-      @schedule.should be_match(previous)
+      @schedule.must be_match(previous)
     end
 
     it "should not match if the times are 59 minutes apart and the current minute is 59" do
@@ -230,7 +230,7 @@ describe Puppet::Type.type(:schedule) do
       previous = Time.utc(2009, 2, 1, 12, 0, 0)
 
       Time.stubs(:now).returns(current)
-      @schedule.should_not be_match(previous)
+      @schedule.must_not be_match(previous)
     end
   end
 
@@ -249,7 +249,7 @@ describe Puppet::Type.type(:schedule) do
       previous = current - 60
 
       Time.stubs(:now).returns(current)
-      @schedule.should be_match(previous)
+      @schedule.must be_match(previous)
     end
 
     it "should not match if the times are 23 hours and 58 minutes apart and the current hour is 23 and the current minute is 59" do
@@ -261,7 +261,7 @@ describe Puppet::Type.type(:schedule) do
       now = previous + (23 * 3600) + (59 * 60)
 
       Time.stubs(:now).returns(now)
-      @schedule.should_not be_match(previous)
+      @schedule.must_not be_match(previous)
     end
   end
 
@@ -278,7 +278,7 @@ describe Puppet::Type.type(:schedule) do
       Time.stubs(:now).returns(now)
       previous = Time.utc(2010, "nov", 6, 23, 59, 59) # Sat
 
-      @schedule.should be_match(previous)
+      @schedule.must be_match(previous)
     end
 
     it "should not match if the previous time is after the most recent Saturday" do
@@ -286,7 +286,7 @@ describe Puppet::Type.type(:schedule) do
       Time.stubs(:now).returns(now)
       previous = Time.utc(2010, "nov", 7, 0, 0, 0) # Sunday
 
-      @schedule.should_not be_match(previous)
+      @schedule.must_not be_match(previous)
     end
   end
 
@@ -303,7 +303,7 @@ describe Puppet::Type.type(:schedule) do
       Time.stubs(:now).returns(now)
       previous = Time.utc(2010, "oct", 31, 23, 59, 59)
 
-      @schedule.should be_match(previous)
+      @schedule.must be_match(previous)
     end
 
     it "should not match when the previous time is after the last day of last month" do
@@ -311,7 +311,7 @@ describe Puppet::Type.type(:schedule) do
       Time.stubs(:now).returns(now)
       previous = Time.utc(2010, "nov", 1, 0, 0, 0)
 
-      @schedule.should_not be_match(previous)
+      @schedule.must_not be_match(previous)
     end
   end
 
@@ -327,17 +327,17 @@ describe Puppet::Type.type(:schedule) do
 
     it "should fail if the periodmatch is 'number'" do
       @schedule[:periodmatch] = :number
-      proc { @schedule[:repeat] = 2 }.should raise_error(Puppet::Error)
+      proc { @schedule[:repeat] = 2 }.must raise_error(Puppet::Error)
     end
 
     it "should match if the previous run was further away than the distance divided by the repeat" do
       previous = Time.now - (3600 * 13)
-      @schedule.should be_match(previous)
+      @schedule.must be_match(previous)
     end
 
     it "should not match if the previous run was closer than the distance divided by the repeat" do
       previous = Time.now - (3600 * 11)
-      @schedule.should_not be_match(previous)
+      @schedule.must_not be_match(previous)
     end
   end
 end


### PR DESCRIPTION
Per Patrick's explanation in #10296, all of the
"should" forms of the rspec tests have been converted
to "must" forms to that the tests will function properly.
As part of this cleanup, one test was found that was "should"
and converted to "must_not" as the original logic seemed
inconsistent with the test.
