### PR TITLE
Ticket/2.7.x/12080 add custom console logging to faces

### DIFF
--- a/lib/puppet/face.rb
+++ b/lib/puppet/face.rb
@@ -10,3 +10,26 @@
 # separate out the interests people will have.  --daniel 2011-04-07
 require 'puppet/interface'
 Puppet::Face = Puppet::Interface
+
+class Puppet::Face
+
+  # We need special logging for Face commands that output to the console.
+  # Errors and warnings should go to stderr, and all other messages should
+  # go to stdout as is. This provides some flexability which allows us to
+  # colorize messages with greater detail by calling the `colorize` method
+  # on specific parts of a message:
+  #
+  #    "This message has a #{Puppet::Face.colorize(:cyan, 'cyan')} part"
+  #
+  # We also gain the ability to log warnings, errors, and notices to the
+  # console using custom formatting and colors that enhance UX.
+  #
+  #    Puppet::Face.err "This will go to stderr with nice formatting"
+  #
+  extend Puppet::Util::Logging
+  @@console = Puppet::Util::Log.desttypes[:console].new
+
+  def self.colorize(color, msg)
+    @@console.colorize(color, msg)
+  end
+end

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -87,32 +87,78 @@ end
 
 Puppet::Util::Log.newdesttype :console do
 
+  RED        = {:console => "[0;31m", :html => "color: #FFA0A0"}
+  GREEN      = {:console => "[0;32m", :html => "color: #00CD00"}
+  YELLOW     = {:console => "[0;33m", :html => "color: #FFFF60"}
+  BLUE       = {:console => "[0;34m", :html => "color: #80A0FF"}
+  PURPLE     = {:console => "[0;35m", :html => "color: #FFA500"}
+  CYAN       = {:console => "[0;36m", :html => "color: #40FFFF"}
+  WHITE      = {:console => "[0;37m", :html => "color: #FFFFFF"}
+  HRED       = {:console => "[1;31m", :html => "color: #FFA0A0"}
+  HGREEN     = {:console => "[1;32m", :html => "color: #00CD00"}
+  HYELLOW    = {:console => "[1;33m", :html => "color: #FFFF60"}
+  HBLUE      = {:console => "[1;34m", :html => "color: #80A0FF"}
+  HPURPLE    = {:console => "[1;35m", :html => "color: #FFA500"}
+  HCYAN      = {:console => "[1;36m", :html => "color: #40FFFF"}
+  HWHITE     = {:console => "[1;37m", :html => "color: #FFFFFF"}
 
-  RED     = {:console => "[0;31m", :html => "FFA0A0"}
-  GREEN   = {:console => "[0;32m", :html => "00CD00"}
-  YELLOW  = {:console => "[0;33m", :html => "FFFF60"}
-  BLUE    = {:console => "[0;34m", :html => "80A0FF"}
-  PURPLE  = {:console => "[0;35m", :html => "FFA500"}
-  CYAN    = {:console => "[0;36m", :html => "40FFFF"}
-  WHITE   = {:console => "[0;37m", :html => "FFFFFF"}
-  HRED    = {:console => "[1;31m", :html => "FFA0A0"}
-  HGREEN  = {:console => "[1;32m", :html => "00CD00"}
-  HYELLOW = {:console => "[1;33m", :html => "FFFF60"}
-  HBLUE   = {:console => "[1;34m", :html => "80A0FF"}
-  HPURPLE = {:console => "[1;35m", :html => "FFA500"}
-  HCYAN   = {:console => "[1;36m", :html => "40FFFF"}
-  HWHITE  = {:console => "[1;37m", :html => "FFFFFF"}
-  RESET   = {:console => "[0m",    :html => ""      }
+  BG_RED     = {:console => "[0;41m", :html => "background: #FFA0A0"}
+  BG_GREEN   = {:console => "[0;42m", :html => "background: #00CD00"}
+  BG_YELLOW  = {:console => "[0;43m", :html => "background: #FFFF60"}
+  BG_BLUE    = {:console => "[0;44m", :html => "background: #80A0FF"}
+  BG_PURPLE  = {:console => "[0;45m", :html => "background: #FFA500"}
+  BG_CYAN    = {:console => "[0;46m", :html => "background: #40FFFF"}
+  BG_WHITE   = {:console => "[0;47m", :html => "background: #FFFFFF"}
+  BG_HRED    = {:console => "[1;41m", :html => "background: #FFA0A0"}
+  BG_HGREEN  = {:console => "[1;42m", :html => "background: #00CD00"}
+  BG_HYELLOW = {:console => "[1;43m", :html => "background: #FFFF60"}
+  BG_HBLUE   = {:console => "[1;44m", :html => "background: #80A0FF"}
+  BG_HPURPLE = {:console => "[1;45m", :html => "background: #FFA500"}
+  BG_HCYAN   = {:console => "[1;46m", :html => "background: #40FFFF"}
+  BG_HWHITE  = {:console => "[1;47m", :html => "background: #FFFFFF"}
+
+  RESET      = {:console => "[0m", :html => ""}
 
   Colormap = {
-    :debug => WHITE,
-    :info => GREEN,
-    :notice => CYAN,
-    :warning => YELLOW,
-    :err => HPURPLE,
-    :alert => RED,
-    :emerg => HRED,
-    :crit => HRED
+    :debug      => WHITE,
+    :info       => GREEN,
+    :notice     => CYAN,
+    :warning    => YELLOW,
+    :err        => HPURPLE,
+    :alert      => RED,
+    :emerg      => HRED,
+    :crit       => HRED,
+
+    :red        => RED,
+    :green      => GREEN,
+    :yellow     => YELLOW,
+    :blue       => BLUE,
+    :purple     => PURPLE,
+    :cyan       => CYAN,
+    :white      => WHITE,
+    :hred       => HRED,
+    :hgreen     => HGREEN,
+    :hyellow    => HYELLOW,
+    :hblue      => HBLUE,
+    :hpurple    => HPURPLE,
+    :hcyan      => HCYAN,
+    :hwhite     => HWHITE,
+    :bg_red     => BG_RED,
+    :bg_green   => BG_GREEN,
+    :bg_yellow  => BG_YELLOW,
+    :bg_blue    => BG_BLUE,
+    :bg_purple  => BG_PURPLE,
+    :bg_cyan    => BG_CYAN,
+    :bg_white   => BG_WHITE,
+    :bg_hred    => BG_HRED,
+    :bg_hgreen  => BG_HGREEN,
+    :bg_hyellow => BG_HYELLOW,
+    :bg_hblue   => BG_HBLUE,
+    :bg_hpurple => BG_HPURPLE,
+    :bg_hcyan   => BG_HCYAN,
+    :bg_hwhite  => BG_HWHITE,
+
+    :reset      => {:console => "[m", :html => ""}
   }
 
   def colorize(level, str)
@@ -125,21 +171,29 @@ Puppet::Util::Log.newdesttype :console do
   end
 
   def console_color(level, str)
-    Colormap[level][:console] + str + RESET[:console]
+    Colormap[level][:console] + str.gsub(RESET[:console], Colormap[level][:console]) + RESET[:console]
   end
 
   def html_color(level, str)
-    %{<span style="color: %s">%s</span>} % [Colormap[level][:html], str]
+    %{<span style="%s">%s</span>} % [Colormap[level][:html], str]
   end
 
   def initialize
     # Flush output immediately.
+    $stderr.sync = true
     $stdout.sync = true
   end
 
   def handle(msg)
-    if msg.source == "Puppet"
+    case msg.source
+    when "Puppet"
       puts colorize(msg.level, "#{msg.level}: #{msg}")
+    when "Puppet::Interface"
+      if [:err, :warning].include?(msg.level)
+        $stderr.puts colorize(:hred, "#{msg}")
+      else
+        $stdout.puts "#{msg}"
+      end
     else
       puts colorize(msg.level, "#{msg.level}: #{msg.source}: #{msg}")
     end

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -34,7 +34,7 @@ describe Puppet::Util::Log do
     it "should htmlize if Puppet[:color] is :html" do
       Puppet[:color] = :html
 
-      @console.colorize(:alert, "abc").should == "<span style=\"color: FFA0A0\">abc</span>"
+      @console.colorize(:alert, "abc").should == "<span style=\"color: #FFA0A0\">abc</span>"
     end
 
     it "should do nothing if Puppet[:color] is false" do


### PR DESCRIPTION
Without this patch, Face commands do not support custom formatting of
console output.

This patch fixes this issue by enhancing the current console logging
destination with support for custom formatting of messages that
originate from `Puppet::Interface`.

This patch enables the ability to log warnings, errors, and notices to
stderr with better formatting and colors:

```
Puppet::Face.err "This error will go to stderr with nice formatting"
```

This patch enables the ability to color specific sections of a given string:

```
"This is a red #{Puppet::Face.colorize(:red, 'string'}"
```

Related spec tests are included.
