### PR TITLE
#12081 ensure that managehome is respected when deleting users with the pw provider

### DIFF
--- a/lib/puppet/provider/user/pw.rb
+++ b/lib/puppet/provider/user/pw.rb
@@ -54,6 +54,12 @@ Puppet::Type.type(:user).provide :pw, :parent => Puppet::Provider::NameService::
     cmd
   end
 
+  def deletecmd
+    cmd = super
+    cmd << "-r" if @resource.managehome?
+    cmd
+  end
+
   def create
     super
 

--- a/spec/unit/provider/user/pw_spec.rb
+++ b/spec/unit/provider/user/pw_spec.rb
@@ -106,6 +106,25 @@ describe provider_class do
       provider.expects(:execute).with([provider_class.command(:pw), "userdel", "testuser"])
       provider.delete
     end
+
+    # The above test covers this, but given the consequences of
+    # accidently deleting a user's home directory it seems better to
+    # have an explicit test.
+    it "should not use -r when managehome is not set" do
+      provider = resource.provider
+      provider.expects(:exists?).returns true
+      resource[:managehome] = false
+      provider.expects(:execute).with(Not(includes("-r")))
+      provider.delete
+    end
+
+    it "should use -r when managehome is set" do
+      provider = resource.provider
+      provider.expects(:exists?).returns true
+      resource[:managehome] = true
+      provider.expects(:execute).with(includes("-r"))
+      provider.delete
+    end
   end
 
   describe "when modifying users" do


### PR DESCRIPTION
When deleting a user with managehome set the documentation says the
provider should remove the user's home directory. This fixes the
pw provider to do that by adding the -r flag to the command.
