### PR TITLE
(#10417) Disable show diffs on Windows by default

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -108,7 +108,10 @@ module Puppet
       we know nothing about."
     },
     :diff_args => ["-u", "Which arguments to pass to the diff command when printing differences between files."],
-    :diff => ["diff", "Which diff command to use when printing differences between files."],
+    :diff => {
+      :default => (Puppet.features.microsoft_windows? ? "" : "diff"),
+      :desc    => "Which diff command to use when printing differences between files.",
+    },
     :show_diff => [false, "Whether to log and report a contextual diff when files are being replaced.  This causes
       partial file contents to pass through Puppet's normal logging and reporting system, so this setting should be
       used with caution if you are sending Puppet's reports to an insecure destination.

--- a/lib/puppet/util/diff.rb
+++ b/lib/puppet/util/diff.rb
@@ -4,7 +4,9 @@ module Puppet::Util::Diff
   require 'tempfile'
 
   def diff(old, new)
-    command = [Puppet[:diff]]
+    return '' unless diff_cmd = Puppet[:diff] and diff_cmd != ""
+
+    command = [diff_cmd]
     if args = Puppet[:diff_args] and args != ""
       command << args
     end

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -309,4 +309,14 @@ describe "Puppet defaults" do
       end
     end
   end
+
+  describe "diff" do
+    it "should default to 'diff' on POSIX", :unless => Puppet.features.microsoft_windows? do
+      Puppet.settings[:diff].should == 'diff'
+    end
+
+    it "should default to '' on Windows", :if => Puppet.features.microsoft_windows? do
+      Puppet.settings[:diff].should == ''
+    end
+  end
 end

--- a/spec/unit/util/diff_spec.rb
+++ b/spec/unit/util/diff_spec.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+require 'puppet/util/diff'
+
+describe Puppet::Util::Diff do
+  describe ".diff" do
+    it "should execute the diff command with arguments" do
+      Puppet[:diff] = 'foo'
+      Puppet[:diff_args] = 'bar'
+
+      subject.expects(:execute).with(['foo', 'bar', 'a', 'b'], {:failonfail => false}).returns('baz')
+      subject.diff('a', 'b').should == 'baz'
+    end
+
+    it "should omit diff arguments if none are specified" do
+      Puppet[:diff] = 'foo'
+      Puppet[:diff_args] = ''
+
+      subject.expects(:execute).with(['foo', 'a', 'b'], {:failonfail => false}).returns('baz')
+      subject.diff('a', 'b').should == 'baz'
+    end
+
+    it "should return empty string if the diff command is empty" do
+      Puppet[:diff] = ''
+
+      subject.expects(:execute).never
+      subject.diff('a', 'b').should == ''
+    end
+  end
+end


### PR DESCRIPTION
Previously, anyone running `puppet apply` or `puppet agent` with
either the `--test`, `--noop`, or `--show_diffs` option, would see a
`CreateProcess` exception while trying to execute the `diff`
command. This was made worse by the recent change that causes puppet
to diff its last run summary file.

On Windows, diff is not present, by default. There is fc.exe (file
compare), but it is rather brain-dead, especially if you diff a binary
file.

This commit makes `Puppet::Util::Diff.diff` return '' by default on
Windows. However, if a diff command has been specified in puppet.conf,
then puppet will use it, as before.
