### PR TITLE
(#6541) Use the same filebucket for backup and restore

### DIFF
--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -1,9 +1,18 @@
-test_name "start with a file"
-manifest = "file { '/tmp/6541': content => 'some text' }"
+test_name "#6541: file type truncates target when filebucket cannot retrieve hash"
+
+target="/tmp/6541-$$"
+on agents, host_command('rm -rf #{host["puppetvardir"]}/*bucket')
+
+step "write zero length file"
+manifest = "file { '#{target}': content => '' }"
+apply_manifest_on(agents, manifest)
+
+step "overwrite file, causing zero-length file to be backed up"
+manifest = "file { '#{target}': content => 'some text' }"
 apply_manifest_on(agents, manifest)
 
 test_name "verify invalid hashes should not change the file"
-manifest = "file { '/tmp/6541': content => '{md5}notahash' }"
+manifest = "file { '#{target}': content => '{md5}notahash' }"
 agents.each do |host|
   apply_manifest_on(host, manifest) do
     assert_no_match(/content changed/, stdout, "#{host}: shouldn't have overwrote the file")
@@ -11,17 +20,15 @@ agents.each do |host|
 end
 
 test_name "verify valid but unbucketed hashes should not change the file"
-manifest = "file { '/tmp/6541': content => '{md5}13ad7345d56b566a4408ffdcd877bc78' }"
+manifest = "file { '#{target}': content => '{md5}13ad7345d56b566a4408ffdcd877bc78' }"
 agents.each do |host|
   apply_manifest_on(host, manifest) do
     assert_no_match(/content changed/, stdout, "#{host}: shouldn't have overwrote the file")
   end
 end
 
-on(agents, puppet_filebucket("backup -l /dev/null") )
-
 test_name "verify that an empty file can be retrieved from the filebucket"
-manifest = "file { '/tmp/6541': content => '{md5}d41d8cd98f00b204e9800998ecf8427e' }"
+manifest = "file { '#{target}': content => '{md5}d41d8cd98f00b204e9800998ecf8427e' }"
 agents.each do |host|
   apply_manifest_on(host, manifest) do
     assert_match(/content changed '\{md5\}552e21cd4cd9918678e3c1a0df491bc3' to '\{md5\}d41d8cd98f00b204e9800998ecf8427e'/, stdout, "#{host}: shouldn't have overwrote the file")


### PR DESCRIPTION
The acceptance test for #6541 was using `puppet filebucket backup -l
/dev/null` to cause a 0-length file to be created in the agent's
filebucket, and then attempting to retrieve the file using:

```
file { ...:
  content => '{md5}d41d8cd98f00b204e9800998ecf8427e'
```

However, this was failing because the former was writing to
`${vardir}/bucket`, while the latter was trying to read from
`${vardir}/clientbucket`, and failing to find the 0-length file.

This test reported a false positive earlier, because the test was
reusing the clientbucket from a previous test. Now that the acceptance
tests clean the agent vardir, it uncovered this problem.

This commit changes the test to create a 0-length file, then
overwrites it, causing the old file to be backed up into the
clientbucket.
