### PR TITLE
(#2279) Handle providers with multiple installed versions - ruby gems

### DIFF
--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -115,7 +115,6 @@ module Puppet
       # Override the parent method, because we've got all kinds of
       # funky definitions of 'in sync'.
       def insync?(is)
-        @latest ||= nil
         @lateststamp ||= (Time.now.to_i - 1000)
         # Iterate across all of the should values, and see how they
         # turn out.
@@ -156,7 +155,9 @@ module Puppet
             return true if is == :absent or is == :purged
           when :purged
             return true if is == :purged
-          when is
+          # this handles version number matches and
+          # supports providers that can have multiple versions installed
+          when *Array(is)
             return true
           end
         }


### PR DESCRIPTION
Ruby gems can have multiple versions installed, and the current
implementation of the gem provider only reads the very latest installed
version when self.instances is called.  This leads to Puppet potentially
reinstalling the gem on every run if the Puppet manifest specifies a gem
that _is_ installed, but is not the latest version installed.

This does require a change to how the package type checks if ensure is
insync? to handle multiple versions for the 'is' ensure value, but the
change is backward compatible with the providers that specify single
versions.
