### PR TITLE
Allow storeconfigs collector to accept parser resources

### DIFF
--- a/lib/puppet/parser/collector.rb
+++ b/lib/puppet/parser/collector.rb
@@ -102,9 +102,11 @@ class Puppet::Parser::Collector
 
       # key is '#{type}/#{name}', and host and filter.
       found = Puppet::Resource.indirection.
-        search(@type, :host => @scope.host, :filter => @equery)
+        search(@type, :host => @scope.host, :filter => @equery, :scope => @scope)
 
-      found.map {|x| x.to_resource(@scope) }.each do |item|
+      found_resources = found.map {|x| x.is_a?(Puppet::Parser::Resource) ? x : x.to_resource(@scope)}
+
+      found_resources.each do |item|
         if existing = @scope.findresource(item.type, item.title)
           unless existing.collector_id == item.collector_id
             # unless this is the one we've already collected

--- a/spec/unit/parser/collector_spec.rb
+++ b/spec/unit/parser/collector_spec.rb
@@ -295,6 +295,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       Puppet[:dblocation]   = (dir + 'storeconfigs.sqlite').to_s
       Puppet[:storeconfigs] = true
       Puppet[:environment]  = "production"
+      Puppet[:storeconfigs_backend] = :active_record
       Puppet::Rails.init
     end
 
@@ -336,7 +337,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       one.should_not be_virtual
     end
 
-    it "should convert all found resources into parser resources" do
+    it "should convert all found resources into parser resources if necessary" do
       host = Puppet::Rails::Host.create!(:name => 'one.local')
       Puppet::Rails::Resource.
         create!(:host     => host,
@@ -348,6 +349,19 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       result.first.should be_an_instance_of Puppet::Parser::Resource
       result.first.type.should == 'Notify'
       result.first.title.should == 'whammo'
+    end
+
+    it "should leave parser resources alone" do
+      resource = Puppet::Parser::Resource.new(:file, "/tmp/foo", :scope => @scope)
+      resource2 = Puppet::Parser::Resource.new(:file, "/tmp/bar", :scope => @scope)
+      resource.expects(:to_resource).never
+      resource2.expects(:to_resource).never
+
+      resources = [resource, resource2]
+
+      Puppet::Resource.indirection.stubs(:search).returns resources
+
+      @collector.evaluate.should == resources
     end
 
     it "should override all exported collected resources if collector has an override" do


### PR DESCRIPTION
Previously, the collector would call the storeconfigs backend and assume it was
going to receive an object which responded to a #to_resource method to convert
it into Puppet::Parser::Resource. This required any storeconfigs backend to
provide an intermediate class simply to call #to_resource on, even if it wasn't
necessary. Now, the collector will only call that method if it receives
something that isn't already a Puppet::Parser::Resource. This allows
storeconfigs backends to opt to simply construct the resources themselves,
rather than define an intermediate class.

Additionally, because Puppet::Parser::Resource instances require a scope when
initializing, the collector will now provide the scope to the storeconfigs
backend as an option to search. This provides the backend with the information
necessary to actually create the Puppet::Parser::Resource objects.
