### PR TITLE
Feature/2.7.x/8855 follow http redirects in mac pkg providers

### DIFF
--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
     if %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ cached_source
       cached_source = "/tmp/#{name}"
       begin
-        curl "-o", cached_source, "-C", "-", "-k", "-s", "--url", source
+        curl "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--url", source
         Puppet.debug "Success: curl transfered [#{name}]"
       rescue Puppet::ExecutionFailure
         Puppet.debug "curl did not transfer [#{name}].  Falling back to slower open-uri transfer methods."

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
     if %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ cached_source
       cached_source = "/tmp/#{name}"
       begin
-        curl "-o", cached_source, "-C", "-", "-k", "-s", "--url", source
+        curl "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--url", source
         Puppet.debug "Success: curl transfered [#{name}]"
       rescue Puppet::ExecutionFailure
         Puppet.debug "curl did not transfer [#{name}].  Falling back to slower open-uri transfer methods."


### PR DESCRIPTION
The Mac appdmg and pkgdmg providers previously didn't follow HTTP redirects
when fetching down the content; this extends the system to support them.
