### PR TITLE
Ticket/12169 correct redhat spec changelog chronology

### DIFF
--- a/conf/redhat/puppet.spec
+++ b/conf/redhat/puppet.spec
@@ -325,12 +325,6 @@ rm -rf %{buildroot}
 * Wed Jul 06 2011 Michael Stahnke <stahnma@puppetlabs.com> - 2.7.2-0.1.rc1
 - Update to 2.7.2rc1
 
-* Mon Dec 12 2011 Matthaus Litteken <matthaus@puppetlabs.com> - 2.6.13-1
-- Release of 2.6.13
-
-* Fri Oct 21 2011 Michael Stahnke <stahnma@puppetlabs.com> - 2.6.12-1
-- CVE-2011-3872 fixes
-
 * Wed Jun 15 2011 Todd Zullinger <tmz@pobox.com> - 2.6.9-0.1.rc1
 - Update rc versioning to ensure 2.6.9 final is newer to rpm
 - sync changes with Fedora/EPEL


### PR DESCRIPTION
Without this patch, two entries in the %changelog section of the
puppet.spec file in conf/redhat are out of chronological order,
due to merge-ups from 2.6.x. This causes the rpm to not build
cleanly. This patch removes the two entries that are out of order
(placing them in correct date chronology would have resulted
in the version numbers being out of order, hence the removal).

Signed-off-by: Moses Mendoza moses@puppetlabs.com
