### PR TITLE
#12188 Prevent "Could not remove PID file" error message in --no-daemonize agent run

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -75,7 +75,7 @@ class Puppet::Daemon
   def remove_pidfile
     Puppet::Util.synchronize_on(Puppet[:name],Sync::EX) do
       locker = Puppet::Util::Pidlock.new(pidfile)
-      locker.unlock or Puppet.err "Could not remove PID file #{pidfile}" if locker.locked?
+      locker.unlock or Puppet.err "Could not remove PID file #{pidfile}" if locker.locked? and locker.mine?
     end
   end
 

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -184,7 +184,7 @@ describe Puppet::Daemon do
     end
 
     it "should unlock the pidfile using the Pidlock class" do
-      pidfile = mock 'pidfile', :locked? => true
+      pidfile = mock 'pidfile', :locked? => true, :mine? => true
       Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
       pidfile.expects(:unlock).returns true
 
@@ -195,7 +195,7 @@ describe Puppet::Daemon do
     end
 
     it "should warn if it cannot remove the pidfile" do
-      pidfile = mock 'pidfile', :locked? => true
+      pidfile = mock 'pidfile', :locked? => true, :mine? => true
       Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
       pidfile.expects(:unlock).returns false
 


### PR DESCRIPTION
Fix for #5246 added a daemon.stop to the agent in the --no-daemonize
call path to properly remove the pid file.

But the daemon.remove_pid method didn't check the pidfile owner before
deciding it should remove it, and thus was producing this harmless error.
