### PR TITLE
Tickets/2.7.x/12195 puppet outputs ruby warnings on rhel directives

### DIFF
--- a/lib/puppet/util/instrumentation/listeners/process_name.rb
+++ b/lib/puppet/util/instrumentation/listeners/process_name.rb
@@ -85,7 +85,7 @@ Puppet::Util::Instrumentation.new_listener(:process_name) do
     steps ||= 0
     if string.length > 0 && steps > 0
       steps = steps % string.length
-      return string[steps..-1].concat " -- #{string[0..(steps-1)]}"
+      return string[steps..-1].concat( " -- #{string[0..(steps-1)]}" )
     end
     string
   end


### PR DESCRIPTION
Ruby 1.8.7 on RHEL platforms complains about the lack of parenthesis on a
function with an eye to the future. This puts in said parenthesis.
