### PR TITLE
Bug/2.7.x/12188 pid handling warning cleanup

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -74,8 +74,7 @@ class Puppet::Daemon
   # Remove the pid file for our daemon.
   def remove_pidfile
     Puppet::Util.synchronize_on(Puppet[:name],Sync::EX) do
-      locker = Puppet::Util::Pidlock.new(pidfile)
-      locker.unlock or Puppet.err "Could not remove PID file #{pidfile}" if locker.locked?
+      Puppet::Util::Pidlock.new(pidfile).unlock
     end
   end
 

--- a/lib/puppet/network/server.rb
+++ b/lib/puppet/network/server.rb
@@ -40,8 +40,7 @@ class Puppet::Network::Server
   # Remove the pid file for our daemon.
   def remove_pidfile
     Puppet::Util.synchronize_on(Puppet[:name],Sync::EX) do
-      locker = Puppet::Util::Pidlock.new(pidfile)
-      locker.unlock or Puppet.err "Could not remove PID file #{pidfile}" if locker.locked?
+      Puppet::Util::Pidlock.new(pidfile).unlock
     end
   end
 

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -173,36 +173,20 @@ describe Puppet::Daemon do
     end
 
     it "should do nothing if the pidfile is not present" do
-      pidfile = mock 'pidfile', :locked? => false
+      pidfile = mock 'pidfile', :unlock => false
+
+      Puppet[:pidfile] = "/my/file"
       Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
 
-      Puppet.settings.stubs(:value).with(:name).returns "eh"
-      Puppet.settings.stubs(:value).with(:pidfile).returns "/my/file"
-
-      pidfile.expects(:unlock).never
       @daemon.remove_pidfile
     end
 
     it "should unlock the pidfile using the Pidlock class" do
-      pidfile = mock 'pidfile', :locked? => true
+      pidfile = mock 'pidfile', :unlock => true
+
+      Puppet[:pidfile] = "/my/file"
       Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
-      pidfile.expects(:unlock).returns true
 
-      Puppet.settings.stubs(:value).with(:name).returns "eh"
-      Puppet.settings.stubs(:value).with(:pidfile).returns "/my/file"
-
-      @daemon.remove_pidfile
-    end
-
-    it "should warn if it cannot remove the pidfile" do
-      pidfile = mock 'pidfile', :locked? => true
-      Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
-      pidfile.expects(:unlock).returns false
-
-      Puppet.settings.stubs(:value).with(:name).returns "eh"
-      Puppet.settings.stubs(:value).with(:pidfile).returns "/my/file"
-
-      Puppet.expects :err
       @daemon.remove_pidfile
     end
   end

--- a/spec/unit/network/server_spec.rb
+++ b/spec/unit/network/server_spec.rb
@@ -196,36 +196,18 @@ describe Puppet::Network::Server do
     end
 
     it "should do nothing if the pidfile is not present" do
-      pidfile = mock 'pidfile', :locked? => false
+      pidfile = mock 'pidfile', :unlock => false
       Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
-
-      Puppet.settings.stubs(:value).with(:name).returns "eh"
       Puppet.settings.stubs(:value).with(:pidfile).returns "/my/file"
 
-      pidfile.expects(:unlock).never
       @server.remove_pidfile
     end
 
     it "should unlock the pidfile using the Pidlock class" do
-      pidfile = mock 'pidfile', :locked? => true
+      pidfile = mock 'pidfile', :unlock => true
       Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
-      pidfile.expects(:unlock).returns true
-
-      Puppet.settings.stubs(:value).with(:name).returns "eh"
       Puppet.settings.stubs(:value).with(:pidfile).returns "/my/file"
 
-      @server.remove_pidfile
-    end
-
-    it "should warn if it cannot remove the pidfile" do
-      pidfile = mock 'pidfile', :locked? => true
-      Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
-      pidfile.expects(:unlock).returns false
-
-      Puppet.settings.stubs(:value).with(:name).returns "eh"
-      Puppet.settings.stubs(:value).with(:pidfile).returns "/my/file"
-
-      Puppet.expects :err
       @server.remove_pidfile
     end
   end


### PR DESCRIPTION
Previously everyone who invoked the `unlock` method of our pid file code would
duplicate all the internal logic to issue a warning, but only if we tried and
failed to delete the PID file.

This seems redundant compared to just pushing that down to the code that
actually fails, which this commit does.

Along the way it helps ensure that we don't warn unnecessarily about PID file
deletion, and adds tests to validate that.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
