### PR TITLE
(#8701) waitforcert param configurable for puppet agent

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -399,7 +399,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   def setup_host
     @host = Puppet::SSL::Host.new
-    waitforcert = options[:waitforcert] || (Puppet[:onetime] ? 0 : 120)
+    waitforcert = options[:waitforcert] || (Puppet[:onetime] ? 0 : Puppet[:waitforcert])
     cert = @host.wait_for_cert(waitforcert) unless options[:fingerprint]
   end
 

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -78,7 +78,7 @@ USAGE
 
 DESCRIPTION
 -----------
-Once the client has a signed certificate for a given remote device, it will 
+Once the client has a signed certificate for a given remote device, it will
 retrieve its configuration and apply it.
 
 USAGE NOTES
@@ -148,7 +148,7 @@ Brice Figureau
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC 
+Copyright (c) 2011 Puppet Labs, LLC
 Licensed under the Apache 2.0 License
       HELP
     end
@@ -217,7 +217,7 @@ Licensed under the Apache 2.0 License
 
   def setup_host
     @host = Puppet::SSL::Host.new
-    waitforcert = options[:waitforcert] || (Puppet[:onetime] ? 0 : 120)
+    waitforcert = options[:waitforcert] || (Puppet[:onetime] ? 0 : Puppet[:waitforcert])
     cert = @host.wait_for_cert(waitforcert)
   end
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -730,7 +730,12 @@ EOT
       Your puppet master needs to support compression (usually by activating some settings in a reverse-proxy
       in front of the puppet master, which rules out webrick).
       It is harmless to activate this settings if your master doesn't support
-      compression, but if it supports it, this setting might reduce performance on high-speed LANs."]
+      compression, but if it supports it, this setting might reduce performance on high-speed LANs."],
+    :waitforcert => [120, # 2 minutes
+      "The time interval, specified in seconds, 'puppet agent' should connect to the server
+      and ask it to sign a certificate request. This is useful for the initial setup of a
+      puppet client. You can turn off waiting for certificates by specifying a time of 0."
+    ]
   )
 
   setdefaults(:inspect,

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -83,6 +83,12 @@ describe Puppet::Application::Agent do
 
       @puppetd.options[:fingerprint].should be_false
     end
+
+    it "should init waitforcert to nil" do
+      @puppetd.preinit
+
+      @puppetd.options[:waitforcert].should be_nil
+    end
   end
 
   describe "when handling options" do
@@ -121,6 +127,12 @@ describe Puppet::Application::Agent do
 
     it "should use a default value for waitforcert when --onetime and --waitforcert are not specified" do
       Puppet::SSL::Host.any_instance.expects(:wait_for_cert).with(120)
+      @puppetd.setup_host
+    end
+
+    it "should use the waitforcert setting when checking for a signed certificate" do
+      Puppet[:waitforcert] = 10
+      Puppet::SSL::Host.any_instance.expects(:wait_for_cert).with(10)
       @puppetd.setup_host
     end
 

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -45,6 +45,12 @@ describe Puppet::Application::Device do
 
       @device.preinit
     end
+
+    it "should init waitforcert to nil" do
+      @device.preinit
+
+      @device.options[:waitforcert].should be_nil
+    end
   end
 
   describe "when handling options" do
@@ -78,6 +84,12 @@ describe Puppet::Application::Device do
 
     it "should use a default value for waitforcert when --onetime and --waitforcert are not specified" do
       Puppet::SSL::Host.any_instance.expects(:wait_for_cert).with(120)
+      @device.setup_host
+    end
+
+    it "should use the waitforcert setting when checking for a signed certificate" do
+      Puppet[:waitforcert] = 10
+      Puppet::SSL::Host.any_instance.expects(:wait_for_cert).with(10)
       @device.setup_host
     end
 


### PR DESCRIPTION
Allow configuring the default value (120 seconds) for the `waitforcert`
parameter through configuration.
