### PR TITLE
(#5224) Unset USER-related env vars during execs

### DIFF
--- a/acceptance/pending/ticket_11860_exec_should_not_override_locale.rb
+++ b/acceptance/pending/ticket_11860_exec_should_not_override_locale.rb
@@ -16,12 +16,6 @@ test_name "#11860: exec resources should not override system locale"
 #
 #######################################################################################
 
-# utility method that adds an extra backslash to the double quotes in a string; this
-# just lets us keep our manifest strings looking normal
-def escape_quotes(str)
-  str.gsub("\"", '\"')
-end
-
 temp_file_name = "/tmp/11860_exec_should_not_override_locale.txt"
 locale_string = "es_ES.UTF-8"
 

--- a/acceptance/pending/ticket_5224_exec_should_unset_user_env_vars.rb
+++ b/acceptance/pending/ticket_5224_exec_should_unset_user_env_vars.rb
@@ -1,0 +1,109 @@
+test_name "#5224: exec resources should unset user-related environment variables"
+
+#######################################################################################
+#                                   NOTE
+#######################################################################################
+#
+# This test depends on the following pull requests:
+#
+#  https://github.com/puppetlabs/puppet-acceptance/pull/123
+#
+# because it needs to be able to set some environment variables for the duration of
+# the puppet commands.  Shouldn't be moved out of 'pending' until after that has been
+# merged.
+#
+#######################################################################################
+
+
+temp_file_name = "/tmp/5224_exec_should_unset_user_env_vars.txt"
+sentinel_string = "Abracadabra"
+
+
+# these should match up with the value of Puppet::Util::POSIX_USER_ENV_VARS,
+# but I don't have access to that from here, so this is unfortunately hard-coded
+# (cprice 2012-01-27)
+POSIX_USER_ENV_VARS = ['HOME', 'USER', 'LOGNAME']
+
+
+
+step "Check value of user-related environment variables"
+
+# in this step we are going to run some "exec" blocks that writes the value of the
+# user-related environment variables to a file.  We need to verify that exec's are
+# unsetting these vars.
+
+
+test_printenv_manifest = <<HERE
+exec {"print %s environment variable":
+      command =>  "/usr/bin/printenv %s > #{temp_file_name}",
+}
+HERE
+
+# loop over the vars that we care about; these should match up with the value of Puppet::Util::POSIX_USER_ENV_VARS,
+# but I don't have access to that from here, so this is unfortunately hard-coded (cprice 2012-01-27)
+POSIX_USER_ENV_VARS.each do |var|
+
+  # apply the manifest.
+  #
+  # note that we are passing in an extra :environment argument, which will cause the
+  # framework to temporarily set this variable before executing the puppet command.
+  # this lets us know what value we should be looking for as the output of the exec.
+
+  apply_manifest_on agents, test_printenv_manifest % [var, var], :environment => {var => sentinel_string}
+
+  # cat the temp file and make sure it contained the correct value.
+  on(agents, "cat #{temp_file_name}").each do |result|
+    assert_equal("", "#{result.stdout.chomp}", "Unexpected result for host '#{result.host}', environment var '#{var}'")
+  end
+end
+
+
+
+
+step "Check value of user-related environment variables when they are provided as part of the exec resource"
+
+# in this step we are going to run some "exec" blocks that write the value of the
+# user-related environment variables to a file.  However, this time, the manifest
+# explicitly overrides these variables in the "environment" section, so we need to
+# be sure that we are respecting these overrides.
+
+test_printenv_with_env_overrides_manifest = <<HERE
+exec {"print %s environment variable":
+      command =>  "/usr/bin/printenv %s > #{temp_file_name}",
+      environment => ["%s=#{sentinel_string}", "FOO=bar"]
+}
+HERE
+
+# loop over the vars that we care about;
+POSIX_USER_ENV_VARS.each do |var|
+
+  # apply the manifest.
+  #
+  # note that we are passing in an extra :environment argument, which will cause the
+  # framework to temporarily set this variable before executing the puppet command.
+  # this lets us know what value we should be looking for as the output of the exec.
+
+  apply_manifest_on agents, test_printenv_with_env_overrides_manifest % [var, var, var],
+                    :environment => {var => sentinel_string}
+
+  # cat the temp file and make sure it contained the correct value.
+  on(agents, "cat #{temp_file_name}").each do |result|
+    assert_equal(sentinel_string, "#{result.stdout.chomp}",
+                 "Unexpected result for host '#{result.host}', environment var '#{var}'")
+  end
+end
+
+
+
+
+
+
+
+
+step "cleanup"
+
+# remove the temp file
+on agents, "rm -f #{temp_file_name}"
+
+
+

--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -44,19 +44,21 @@ class Puppet::Provider::Exec < Puppet::Provider
           end
         end
 
-        withenv environment do
-          Timeout::timeout(resource[:timeout]) do
-            # note that we are passing "false" for the "override_locale" parameter, which ensures that the user's
-            # default/system locale will be respected.  Callers may override this behavior by setting locale-related
-            # environment variables (LANG, LC_ALL, etc.) in their 'environment' configuration.
-            output, status = Puppet::Util::SUIDManager.
-              run_and_capture(command, resource[:user], resource[:group], :override_locale => false)
-          end
-          # The shell returns 127 if the command is missing.
-          if status.exitstatus == 127
-            raise ArgumentError, output
-          end
+
+        Timeout::timeout(resource[:timeout]) do
+          # note that we are passing "false" for the "override_locale" parameter, which ensures that the user's
+          # default/system locale will be respected.  Callers may override this behavior by setting locale-related
+          # environment variables (LANG, LC_ALL, etc.) in their 'environment' configuration.
+          output, status = Puppet::Util::SUIDManager.
+              run_and_capture(command, resource[:user], resource[:group],
+                              :override_locale => false,
+                              :custom_environment => environment)
         end
+        # The shell returns 127 if the command is missing.
+        if status.exitstatus == 127
+          raise ArgumentError, output
+        end
+
       end
     rescue Errno::ENOENT => detail
       self.fail detail.to_s

--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -157,22 +157,26 @@ module Puppet::Util::SUIDManager
   # [new_gid] (optional) a groupid to run the command as
   # [options] (optional, defaults to {}) a hash of option key/value pairs; currently supported:
   #   :override_locale (defaults to true) a flag indicating whether or puppet should temporarily override the
-  #   system locale for the duration of the command.  If true, the locale will be set to 'C' to ensure consistent
-  #   output / formatting from the command, which makes it much easier to parse the output.  If false, the system
-  #   locale will be respected.
+  #     system locale for the duration of the command.  If true, the locale will be set to 'C' to ensure consistent
+  #     output / formatting from the command, which makes it much easier to parse the output.  If false, the system
+  #     locale will be respected.
+  #   :custom_environment (default {}) -- a hash of key/value pairs to set as environment variables for the duration
+  #     of the command
   def run_and_capture(command, new_uid=nil, new_gid=nil, options = {})
 
     # specifying these here rather than in the method signature to allow callers to pass in a partial
     # set of overrides without affecting the default values for options that they don't pass in
     default_options = {
         :override_locale => true,
+        :custom_environment => {},
     }
 
     options = default_options.merge(options)
 
     output = Puppet::Util.execute(command, :failonfail => false, :combine => true,
                                   :uid => new_uid, :gid => new_gid,
-                                  :override_locale => options[:override_locale])
+                                  :override_locale => options[:override_locale],
+                                  :custom_environment => options[:custom_environment])
     [output, $CHILD_STATUS.dup]
   end
   module_function :run_and_capture

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -22,7 +22,13 @@ describe Puppet::Type.type(:exec) do
 
     status = stub "process", :exitstatus => exitstatus
     Puppet::Util::SUIDManager.expects(:run_and_capture).times(tries).
-      with(command, nil, nil, :override_locale => false).returns([output, status])
+      with() { |*args|
+        args[0] == command &&
+        args[1] == nil &&
+        args[2] == nil &&
+        args[3][:override_locale] == false &&
+        args[3].has_key?(:custom_environment)
+      } .returns([output, status])
 
     return exec
   end

--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -218,8 +218,15 @@ describe Puppet::Util::SUIDManager do
       it "should capture the output and return process status" do
         Puppet::Util.
           expects(:execute).
-          with('yay', :combine => true, :failonfail => false, :uid => user[:uid], :gid => user[:gid],
-               :override_locale => true).
+          with() { |*args|
+              args[0] == 'yay' &&
+              args[1][:combine] == true &&
+              args[1][:failonfail] == false &&
+              args[1][:uid] == user[:uid] &&
+              args[1][:gid] == user[:gid] &&
+              args[1][:override_locale] == true &&
+              args[1].has_key?(:custom_environment)
+        } .
           returns('output')
         output = Puppet::Util::SUIDManager.run_and_capture 'yay', user[:uid], user[:gid]
 


### PR DESCRIPTION
This bug report was related to the fact that you may end up with very different values for environment variables such as "HOME", "USER", "LOGNAME" depending on how you start puppet (at boot time, via "service", via /etc/init.d, etc.).  These variations can have an effect on the behavior of programs / services that are launched by puppet, particularly those that are triggered via Exec resources.  Change the behavior such that these environment variables are simply unset by puppet prior to executing commands.
