### PR TITLE
Ticket/2.7.x/10064 Add environment to reports

### DIFF
--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -118,6 +118,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       end
 
       @report.configuration_version = catalog.version
+      @report.environment = Puppet[:environment]
 
       inspect_starttime = Time.now
       @report.add_times("config_retrieval", inspect_starttime - retrieval_starttime)

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -116,6 +116,7 @@ class Puppet::Configurer
 
     report = options[:report]
     report.configuration_version = catalog.version
+    report.environment = Puppet[:environment]
 
     benchmark(:notice, "Finished catalog run") do
       catalog.apply(options)

--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -66,6 +66,7 @@ Puppet::Indirector::Face.define(:catalog, '0.0.1') do
 
       report = Puppet::Transaction::Report.new("apply")
       report.configuration_version = catalog.version
+      report.environment = Puppet[:environment]
 
       Puppet::Util::Log.newdestination(report)
 

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -235,7 +235,7 @@ class Puppet::Transaction
   def initialize(catalog, report = nil)
     @catalog = catalog
 
-    @report = report || Puppet::Transaction::Report.new("apply", catalog.version)
+    @report = report || Puppet::Transaction::Report.new("apply", catalog.version, Puppet[:environment])
 
     @event_manager = Puppet::Transaction::EventManager.new(self)
 

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -10,7 +10,7 @@ class Puppet::Transaction::Report
 
   indirects :report, :terminus_class => :processor
 
-  attr_accessor :configuration_version, :host
+  attr_accessor :configuration_version, :host, :environment
   attr_reader :resource_statuses, :logs, :metrics, :time, :kind, :status
 
   # This is necessary since Marshall doesn't know how to
@@ -68,7 +68,7 @@ class Puppet::Transaction::Report
     @status = compute_status(resource_metrics, change_metric)
   end
 
-  def initialize(kind, configuration_version=nil)
+  def initialize(kind, configuration_version=nil, environment=nil)
     @metrics = {}
     @logs = []
     @resource_statuses = {}
@@ -79,6 +79,7 @@ class Puppet::Transaction::Report
     @report_format = 2
     @puppet_version = Puppet.version
     @configuration_version = configuration_version
+    @environment = environment
     @status = 'failed' # assume failed until the report is finalized
   end
 

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -29,13 +29,23 @@ describe Puppet::Transaction::Report do
   end
 
   it "should take a 'configuration_version' as an argument" do
-    Puppet::Transaction::Report.new("inspect", "some configuration version").configuration_version.should == "some configuration version"
+    Puppet::Transaction::Report.new("inspect", "some configuration version", "some environment").configuration_version.should == "some configuration version"
   end
 
   it "should be able to set configuration_version" do
     report = Puppet::Transaction::Report.new("inspect")
     report.configuration_version = "some version"
     report.configuration_version.should == "some version"
+  end
+
+  it "should take 'environment' as an argument" do
+    Puppet::Transaction::Report.new("inspect", "some configuration version", "some environment").environment.should == "some environment"
+  end
+
+  it "should be able to set environment" do
+    report = Puppet::Transaction::Report.new("inspect")
+    report.environment = "some environment"
+    report.environment.should == "some environment"
   end
 
   it "should not include whits" do


### PR DESCRIPTION
Previously the Puppet environment was not included in
the report output. Using the model of how configuration_version
was added to the reports the environment will now also be reported.

Puppet::Transaction::Report now takes three arguments:
- Kind of report
- Configuration version
- Environment

Tests for this have been added and existing tests updated.
