### PR TITLE
Bug/2.7.x/12188 pid handling warning cleanup

### DIFF
--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -10,6 +10,8 @@ def without_warnings
 end
 
 describe Puppet::Daemon do
+  include PuppetSpec::Files
+
   before do
     @daemon = Puppet::Daemon.new
   end
@@ -141,9 +143,9 @@ describe Puppet::Daemon do
       pidfile = mock 'pidfile'
 
       Puppet.settings.stubs(:value).with(:name).returns "eh"
-      Puppet.settings.expects(:value).with(:pidfile).returns "/my/file"
+      Puppet.settings.expects(:value).with(:pidfile).returns make_absolute("/my/file")
 
-      Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
+      Puppet::Util::Pidlock.expects(:new).with(make_absolute("/my/file")).returns pidfile
 
       pidfile.expects(:lock).returns true
       @daemon.create_pidfile
@@ -153,9 +155,9 @@ describe Puppet::Daemon do
       pidfile = mock 'pidfile'
 
       Puppet.settings.stubs(:value).with(:name).returns "eh"
-      Puppet.settings.stubs(:value).with(:pidfile).returns "/my/file"
+      Puppet.settings.stubs(:value).with(:pidfile).returns make_absolute("/my/file")
 
-      Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
+      Puppet::Util::Pidlock.expects(:new).with(make_absolute("/my/file")).returns pidfile
 
       pidfile.expects(:lock).returns false
 
@@ -175,8 +177,8 @@ describe Puppet::Daemon do
     it "should do nothing if the pidfile is not present" do
       pidfile = mock 'pidfile', :unlock => false
 
-      Puppet[:pidfile] = "/my/file"
-      Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
+      Puppet[:pidfile] = make_absolute("/my/file")
+      Puppet::Util::Pidlock.expects(:new).with(make_absolute("/my/file")).returns pidfile
 
       @daemon.remove_pidfile
     end
@@ -184,8 +186,8 @@ describe Puppet::Daemon do
     it "should unlock the pidfile using the Pidlock class" do
       pidfile = mock 'pidfile', :unlock => true
 
-      Puppet[:pidfile] = "/my/file"
-      Puppet::Util::Pidlock.expects(:new).with("/my/file").returns pidfile
+      Puppet[:pidfile] = make_absolute("/my/file")
+      Puppet::Util::Pidlock.expects(:new).with(make_absolute("/my/file")).returns pidfile
 
       @daemon.remove_pidfile
     end


### PR DESCRIPTION
When I changed the testing for the PID file system I neglected to check that
Win32 would work; this makes sure the path used is absolute for the platform
the specs run on, fixing that problem.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
