### PR TITLE
Simplistic fix for puppet labs Issue #4480

### DIFF
--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -83,7 +83,14 @@ Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
   end
 
   def start
-    enable unless enabled? == :true
+    if enabled? != :true
+        enable
+        # Work around issue #4480
+        # runsvdir takes up to 5 seconds to recognize
+        # the symlink created by this call to enable
+        Puppet.info "Waiting 5 seconds for runsvdir to discover service #{self.service}"
+        sleep 5
+    end
     sv "start", self.service
   end
 


### PR DESCRIPTION
This will eliminate a significant issue for runit users which causes new service installtion to require
two passes from puppet before the dependent resources get a chance to run.

There is more detailed discussion in the issue tracker:  http://projects.puppetlabs.com/issues/4480
