### PR TITLE
(#3324) yumrepo doesn't support ssl options

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -357,5 +357,33 @@ module Puppet
       newvalue(:absent) { self.should = :absent }
       newvalue(/.*/) { }
     end
+
+    newproperty(:sslcacert, :parent => Puppet::IniProperty) do
+      desc "Path to the directory containing the databases of the
+        certificate authorities yum should use to verify SSL certificates.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(/.*/) { }
+    end
+
+    newproperty(:sslverify, :parent => Puppet::IniProperty) do
+      desc "Should yum verify SSL certificates/hosts at all.
+        Possible values are 'True' or 'False'.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(%r(True|False)) { }
+    end
+
+    newproperty(:sslclientcert, :parent => Puppet::IniProperty) do
+      desc "Path  to the SSL client certificate yum should use to connect
+        to repos/remote sites.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(/.*/) { }
+    end
+
+    newproperty(:sslclientkey, :parent => Puppet::IniProperty) do
+      desc "Path to the SSL client key yum should use to connect
+        to repos/remote sites.\n#{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(/.*/) { }
+    end
   end
 end

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:yumrepo) do
+
+  describe "When validating attributes" do
+
+    it "should have a 'name' parameter'" do
+      Puppet::Type.type(:yumrepo).new(:name => "puppetlabs")[:name].should == "puppetlabs"
+    end
+
+    [:baseurl, :cost, :descr, :enabled, :enablegroups, :exclude, :failovermethod, :gpgcheck, :gpgkey, :http_caching, 
+       :include, :includepkgs, :keepalive, :metadata_expire, :mirrorlist, :priority, :protect, :proxy, :proxy_username, :proxy_password, :timeout, 
+       :sslcacert, :sslverify, :sslclientcert, :sslclientkey].each do |param|
+      it "should have a '#{param}' parameter" do
+        Puppet::Type.type(:yumrepo).attrtype(param).should == :property
+     end
+    end
+
+  end
+
+  describe "When validating attribute values" do
+    
+    [:cost, :enabled, :enablegroups, :failovermethod, :gpgcheck, :http_caching, :keepalive, :metadata_expire, :priority, :protect, :timeout].each do |param|
+      it "should support :absent as a value to '#{param}' parameter" do
+        Puppet::Type.type(:yumrepo).new(:name => "puppetlabs.repo", param => :absent)
+     end
+    end
+
+    [:cost, :enabled, :enablegroups, :gpgcheck, :keepalive, :metadata_expire, :priority, :protect, :timeout].each do |param|
+      it "should fail if '#{param}' is not a number" do
+        lambda { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", param => "notanumber") }.should raise_error
+     end
+    end
+
+    [:enabled, :enabledgroups, :gpgcheck, :keepalive, :protect].each do |param|
+      it "should fail if '#{param}' does not have one of the following values (0|1)" do
+        lambda { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", param => "2") }.should raise_error
+      end
+    end
+    
+    it "should fail if 'failovermethod' does not have one of the following values (roundrobin|priority)" do
+      lambda { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :failovermethod => "notavalidvalue") }.should raise_error
+    end
+
+    it "should fail if 'http_caching' does not have one of the following values (packages|all|none)" do
+      lambda { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :http_caching => "notavalidvalue") }.should raise_error
+    end
+
+    it "should fail if 'sslverify' does not have one of the following values (True|False)" do
+      lambda { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :sslverify => "notavalidvalue") }.should raise_error
+    end
+
+    it "should succeed if 'sslverify' has one of the following values (True|False)" do
+      Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :sslverify => "True")[:sslverify].should == "True"
+      Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :sslverify => "False")[:sslverify].should == "False"
+    end
+
+  end
+
+end


### PR DESCRIPTION
The yumrepo resource doesn't support attributes for SSL authentication.
This patch adds the following ssl attributes to the yumrepo resource: 
sslcacert, sslverify, sslclientcert and sslclientkey.

There was no RSpec test present for the yumrepo resource.
So I have added a new test case, containing tests for the current attributes and also for the new ssl options.
