### PR TITLE
(#12268) String#each is not available in Ruby 1.9

### DIFF
--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -15,7 +15,7 @@ class Puppet::FileServing::Configuration::Parser < Puppet::Util::LoadedFile
 
     File.open(self.file) { |f|
       mount = nil
-      f.each { |line|
+      f.each_line { |line|
         # Have the count increment at the top, in case we throw exceptions.
         @count += 1
 

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -55,7 +55,7 @@ module Puppet::FileBucketFile
       paths_path = ::File.join(dir_path, 'paths')
       return false unless ::File.exists?(paths_path)
       ::File.open(paths_path) do |f|
-        f.each do |line|
+        f.each_line do |line|
           return true if line.chomp == files_original_path
         end
       end

--- a/lib/puppet/network/authconfig.rb
+++ b/lib/puppet/network/authconfig.rb
@@ -89,7 +89,7 @@ module Puppet
         File.open(@file) { |f|
           right = nil
           count = 1
-          f.each { |line|
+          f.each_line { |line|
             case line
             when /^\s*#/ # skip comments
               count += 1

--- a/lib/puppet/network/handler/fileserver.rb
+++ b/lib/puppet/network/handler/fileserver.rb
@@ -255,7 +255,7 @@ class Puppet::Network::Handler
         File.open(@configuration.file) { |f|
           mount = nil
           count = 1
-          f.each { |line|
+          f.each_line { |line|
             case line
             when /^\s*#/; next # skip comments
             when /^\s*$/; next # skip blank lines

--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
 
     updates = {}
     sources.each do |source|
-      execute(self.srclistcmd(source)).each do |line|
+      execute(self.srclistcmd(source)).each_line do |line|
         if line =~ /^[^#][^:]*:([^:]*):([^:]*)/
           current = {}
           current[:name]    = $1

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
       hash = {}
 
       # now turn each returned line into a package object
-      process.each { |line|
+      process.each_line { |line|
         if hash = parse_line(line)
           packages << new(hash)
         end

--- a/lib/puppet/provider/package/macports.rb
+++ b/lib/puppet/provider/package/macports.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:package).provide :macports, :parent => Puppet::Provider::Pack
 
   def self.instances
     packages = []
-    port("-q", :installed).each do |line|
+    port("-q", :installed).each_line do |line|
       if hash = parse_installed_query_line(line)
         packages << new(hash)
       end

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
         hash = {}
 
         # now turn each returned line into a package object
-        process.each { |line|
+        process.each_line { |line|
           if match = regex.match(line.split[0])
             fields.zip(match.captures) { |field,value|
               hash[field] = value
@@ -78,7 +78,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
       fields = [ :name, :version, :flavor ]
       master_version = 0
 
-      process.each do |line|
+      process.each_line do |line|
         if match = regex.match(line.split[0])
           # now we return the first version, unless ensure is latest
           version = match.captures[1]

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       hash = {}
 
       # now turn each returned line into a package object
-      process.each { |line|
+      process.each_line { |line|
         if hash = parse_line(line)
           packages << new(hash)
         end

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -20,7 +20,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
     correct_wgetopts = false
     [ "/opt/csw/etc/pkgutil.conf", "/etc/opt/csw/pkgutil.conf" ].each do |confpath|
       File.open(confpath) do |conf|
-        conf.each {|line| correct_wgetopts = true if line =~ /^\s*wgetopts\s*=.*(-nv|-q|--no-verbose|--quiet)/ }
+        conf.each_line {|line| correct_wgetopts = true if line =~ /^\s*wgetopts\s*=.*(-nv|-q|--no-verbose|--quiet)/ }
       end
     end
     if ! correct_wgetopts

--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
       end
 
       packages = []
-      search_output.each do |search_result|
+      search_output.each_line do |search_result|
         match = result_format.match(search_result)
 
         if match
@@ -89,7 +89,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
       end
 
       packages = []
-      search_output.each do |search_result|
+      search_output.each_line do |search_result|
         match = result_format.match(search_result)
 
         if match

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -37,7 +37,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
     begin
       execpipe("#{command(:rpm)} -qa #{sig} --nodigest --qf '#{NEVRAFORMAT}\n'") { |process|
         # now turn each returned line into a package object
-        process.each { |line|
+        process.each_line { |line|
           hash = nevra_to_hash(line)
           packages << new(hash)
         }

--- a/lib/puppet/provider/package/sun.rb
+++ b/lib/puppet/provider/package/sun.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
     execpipe(cmd) { |process|
       # we're using the long listing, so each line is a separate
       # piece of information
-      process.each { |line|
+      process.each_line { |line|
         case line
         when /^$/
           hash[:provider] = :sun

--- a/lib/puppet/provider/selmodule/semodule.rb
+++ b/lib/puppet/provider/selmodule/semodule.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
   def exists?
     self.debug "Checking for module #{@resource[:name]}"
     execpipe("#{command(:semodule)} --list") do |out|
-      out.each do |line|
+      out.each_line do |line|
         if line =~ /#{@resource[:name]}\b/
           return :true
         end
@@ -118,7 +118,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
     begin
       execpipe("#{command(:semodule)} --list") do |output|
         lines = output.readlines
-        lines.each do |line|
+        lines.each_line do |line|
           line.chomp!
           bits = line.split
           if bits[0] == @resource[:name]

--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:service).provide :base do
     regex = Regexp.new(@resource[:pattern])
     self.debug "Executing '#{ps}'"
     IO.popen(ps) { |table|
-      table.each { |line|
+      table.each_line { |line|
         if regex.match(line)
           ary = line.sub(/^\s+/, '').split(/\s+/)
           return ary[1]

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
   end
 
   def restart
-      execute([command(:lssrc), "-Ss", @resource[:name]]).each do |line|
+      execute([command(:lssrc), "-Ss", @resource[:name]]).each_line do |line|
         args = line.split(":")
 
         next unless args[0] == @resource[:name]
@@ -62,7 +62,7 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
   end
 
   def status
-      execute([command(:lssrc), "-s", @resource[:name]]).each do |line|
+      execute([command(:lssrc), "-s", @resource[:name]]).each_line do |line|
         args = line.split
 
         # This is the header line

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -20,7 +20,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :init do
   def self.instances
     instances = []
     execpipe("#{command(:initctl)} list") { |process|
-      process.each { |line|
+      process.each_line { |line|
         # needs special handling of services such as network-interface:
         # initctl list:
         # network-interface (lo) start/running

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -148,7 +148,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   # Get the groupname from its id
   def self.groupname_by_id(gid)
     groupname=nil
-    execute(lsgroupscmd("ALL")).each { |entry|
+    execute(lsgroupscmd("ALL")).each_line { |entry|
       attrs = self.parse_attr_list(entry, nil)
       if attrs and attrs.include? :id and gid == attrs[:id].to_i
         groupname = entry.split(" ")[0]
@@ -229,9 +229,9 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     user = @resource[:name]
     f = File.open("/etc/security/passwd", 'r')
     # Skip to the user
-    f.each { |l| break if l  =~ /^#{user}:\s*$/ }
+    f.each_line { |l| break if l  =~ /^#{user}:\s*$/ }
     if ! f.eof?
-      f.each { |l|
+      f.each_line { |l|
         # If there is a new user stanza, stop
         break if l  =~ /^\S*:\s*$/
         # If the password= entry is found, return it

--- a/spec/unit/file_serving/configuration/parser_spec.rb
+++ b/spec/unit/file_serving/configuration/parser_spec.rb
@@ -14,7 +14,8 @@ module FSConfigurationParserTesting
   def mock_file_content(content)
     # We want an array, but we actually want our carriage returns on all of it.
     lines = content.split("\n").collect { |l| l + "\n" }
-    @filehandle.stubs(:each).multiple_yields(*lines)
+    @filehandle.stubs(:each_line).multiple_yields(*lines)
+    @filehandle.expects(:each).never
   end
 end
 
@@ -24,6 +25,7 @@ describe Puppet::FileServing::Configuration::Parser do
     FileTest.stubs(:exists?).with(@path).returns(true)
     FileTest.stubs(:readable?).with(@path).returns(true)
     @filehandle = mock 'filehandle'
+    @filehandle.expects(:each).never
     File.expects(:open).with(@path).yields(@filehandle)
     @parser = Puppet::FileServing::Configuration::Parser.new(@path)
   end
@@ -32,12 +34,12 @@ describe Puppet::FileServing::Configuration::Parser do
     include FSConfigurationParserTesting
 
     it "should allow comments" do
-      @filehandle.expects(:each).yields("# this is a comment\n")
+      @filehandle.expects(:each_line).yields("# this is a comment\n")
       proc { @parser.parse }.should_not raise_error
     end
 
     it "should allow blank lines" do
-      @filehandle.expects(:each).yields("\n")
+      @filehandle.expects(:each_line).yields("\n")
       proc { @parser.parse }.should_not raise_error
     end
 

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -30,7 +30,8 @@ describe provider do
 
     it "should create and return an instance with each parsed line from dpkg-query" do
       pipe = mock 'pipe'
-      pipe.expects(:each).yields @fakeresult
+      pipe.expects(:each).never
+      pipe.expects(:each_line).yields @fakeresult
       provider.expects(:execpipe).yields pipe
 
       asdf = mock 'pkg1'
@@ -41,7 +42,8 @@ describe provider do
 
     it "should warn on and ignore any lines it does not understand" do
       pipe = mock 'pipe'
-      pipe.expects(:each).yields "foobar"
+      pipe.expects(:each).never
+      pipe.expects(:each_line).yields "foobar"
       provider.expects(:execpipe).yields pipe
 
       Puppet.expects(:warning)

--- a/spec/unit/provider/selmodule_spec.rb
+++ b/spec/unit/provider/selmodule_spec.rb
@@ -19,19 +19,19 @@ describe provider_class do
   describe "exists? method" do
     it "should find a module if it is already loaded" do
       @provider.expects(:command).with(:semodule).returns "/usr/sbin/semodule"
-      @provider.expects(:execpipe).with("/usr/sbin/semodule --list").yields ["bar\t1.2.3\n", "foo\t4.4.4\n", "bang\t1.0.0\n"]
+      @provider.expects(:execpipe).with("/usr/sbin/semodule --list").yields "bar\t1.2.3\nfoo\t4.4.4\nbang\t1.0.0\n"
       @provider.exists?.should == :true
     end
 
     it "should return nil if not loaded" do
       @provider.expects(:command).with(:semodule).returns "/usr/sbin/semodule"
-      @provider.expects(:execpipe).with("/usr/sbin/semodule --list").yields ["bar\t1.2.3\n", "bang\t1.0.0\n"]
+      @provider.expects(:execpipe).with("/usr/sbin/semodule --list").yields "bar\t1.2.3\nbang\t1.0.0\n"
       @provider.exists?.should be_nil
     end
 
     it "should return nil if no modules are loaded" do
       @provider.expects(:command).with(:semodule).returns "/usr/sbin/semodule"
-      @provider.expects(:execpipe).with("/usr/sbin/semodule --list").yields []
+      @provider.expects(:execpipe).with("/usr/sbin/semodule --list").yields ""
       @provider.exists?.should be_nil
     end
   end


### PR DESCRIPTION
In earlier versions of Ruby, String#each and String#each_line were identical.
In the 1.9 series the former was dropped; this audits the code for places that
should by using `each_line` instead.

This includes some fixes for tests that had very specific stubs around reading
file content, where the expectation - but not the test - was broken by
changing the method we invoke.

It also fixes a stub over `execpipe` that had a different return type to the
actual method, but which happened to work because `each` was defined on both
Array and String in earlier versions.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
