### PR TITLE
Ticket/2.7.x/12329 faces rendering takes args and options

### DIFF
--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -37,10 +37,17 @@ class Puppet::Application::FaceBase < Puppet::Application
     @render_as or raise ArgumentError, "I don't know how to render '#{format}'"
   end
 
-  def render(result)
-    # Invoke the rendering hook supplied by the user, if appropriate.
-    if hook = action.when_rendering(render_as.name)
-      result = hook.call(result)
+  def render(result, args_and_options)
+    hook = action.when_rendering(render_as.name)
+
+    if hook
+      # when defining when_rendering on your action you can optionally
+      # include arguments and options
+      if hook.arity > 1
+        result = hook.call(result, *args_and_options)
+      else
+        result = hook.call(result)
+      end
     end
 
     render_as.render(result)
@@ -233,7 +240,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     end
 
     result = @face.send(@action.name, *arguments)
-    puts render(result) unless result.nil?
+    puts render(result, arguments) unless result.nil?
     status = true
 
   rescue Exception => detail

--- a/lib/puppet/interface/action.rb
+++ b/lib/puppet/interface/action.rb
@@ -74,8 +74,12 @@ class Puppet::Interface::Action
       msg += ", not #{proc.class.name}" unless proc.nil?
       raise ArgumentError, msg
     end
-    if proc.arity != 1 then
-      msg = "when_rendering methods take one argument, the result, not "
+
+    if proc.arity != 1 and proc.arity != (@positional_arg_count + 1)
+      msg =  "the when_rendering method for the #{@face.name} face #{name} action "
+      msg += "takes either just one argument, the result of when_invoked, "
+      msg += "or the result plus the #{@positional_arg_count} arguments passed "
+      msg += "to the when_invoked block, not "
       if proc.arity < 0 then
         msg += "a variable number"
       else

--- a/spec/unit/interface/action_builder_spec.rb
+++ b/spec/unit/interface/action_builder_spec.rb
@@ -114,16 +114,18 @@ describe Puppet::Interface::ActionBuilder do
           when_invoked do |options| true end
           when_rendering :json do true end
         end
-      }.to raise_error ArgumentError, /when_rendering methods take one argument, the result, not/
+      }.to raise_error ArgumentError,
+        /the puppet_interface_actionbuilder face foo action takes .* not/
     end
 
-    it "should fail if the block takes more than one argument" do
+    it "should fail if the when_rendering block takes a different number of arguments than when_invoked" do
       expect {
         Puppet::Interface::ActionBuilder.build(face, :foo) do
           when_invoked do |options| true end
           when_rendering :json do |a, b, c| true end
         end
-      }.to raise_error ArgumentError, /when_rendering methods take one argument, the result, not/
+      }.to raise_error ArgumentError,
+        /the puppet_interface_actionbuilder face foo action takes .* not 3/
     end
 
     it "should fail if the block takes a variable number of arguments" do
@@ -132,8 +134,8 @@ describe Puppet::Interface::ActionBuilder do
           when_invoked do |options| true end
           when_rendering :json do |*args| true end
         end
-      }.to raise_error(ArgumentError,
-                       /when_rendering methods take one argument, the result, not/)
+      }.to raise_error ArgumentError,
+        /the puppet_interface_actionbuilder face foo action takes .* not/
     end
 
     it "should stash a rendering block" do


### PR DESCRIPTION
When rendering for face actions was implemented it was assumed that all
the options that an action took would go toward determining the data
that the when_invoked block returned, and the rendering would make
decisions based on that data's structure.  However, there are times when
the data returned may be the same even with different options, and the
option will determine how it's rendered.

For example, the `module list` action has a --tree option that will
display the installed modules in a tree view based on dependencies. The
`module search` action will be able to highlight the word that was
searched for in the results.

This commit allows the when_rendering blocks to optionally add options
and arguments along with the invoked result.  I made the options and
arguments optional since most when_rendering blocks won't need the
them, and having them show up in the block declaration when not used
is confusing.  This also means that all faces previously written don't
need changes and this change is backward compatible.
