### PR TITLE
Maint/2.7.4/stub upstart spec test in a portable way

### DIFF
--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -23,7 +23,11 @@ describe provider_class do
       resource = Puppet::Type.type(:service).new(:name => "foo", :provider => :upstart, :status => "/bin/foo")
       provider = provider_class.new(resource)
 
-      provider.expects(:ucommand).with { `true`; true }
+      # Because we stub execution, we also need to stub the result of it, or a
+      # previously failing command execution will cause this test to do the
+      # wrong thing.
+      provider.expects(:ucommand)
+      $?.stubs(:exitstatus).returns(0)
       provider.status.should == :running
     end
 


### PR DESCRIPTION
Previously this spec used to execute an external command in order to set the
Ruby `$?` global to a `Process::Status` object with a successful exit.  This
was fine, but not portable to Windows, and not exactly efficient.

Instead, we now stub the exitcode on the $? object, whatever it is, to report
successful exit, and carry on.  That works, stubbing the instance, to make
this both fairly robust and entirely portable.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
