### PR TITLE
fix class variable access from toplevel warnings

### DIFF
--- a/lib/puppet/provider/service/bsd.rb
+++ b/lib/puppet/provider/service/bsd.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:service).provide :bsd, :parent => :init do
 
   confine :operatingsystem => [:freebsd, :netbsd, :openbsd]
 
-  @@rcconf_dir = '/etc/rc.conf.d'
+  class_variable_set(:@@rcconf, '/etc/rc.conf')
 
   def self.defpath
     superclass.defpath

--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -5,9 +5,9 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
   confine :operatingsystem => [:freebsd]
   defaultfor :operatingsystem => [:freebsd]
 
-  @@rcconf = '/etc/rc.conf'
-  @@rcconf_local = '/etc/rc.conf.local'
-  @@rcconf_dir = '/etc/rc.conf.d'
+  class_variable_set(:@@rcconf,       '/etc/rc.conf')
+  class_variable_set(:@@rcconf_local, '/etc/rc.conf.local')
+  class_variable_set(:@@rcconf_dir,   '/etc/rc.conf.d')
 
   def self.defpath
     superclass.defpath


### PR DESCRIPTION
Fix class variable access from toplevel warnings:

 *\* [out :: prod-fe-r01] /usr/local/rvm/gems/ruby-1.9.2-p290@puppet/gems/puppet-2.7.10/lib/puppet/provider/service/freebsd.rb:8: warning: class variable access from toplevel
 *\* [out :: prod-fe-r01] /usr/local/rvm/gems/ruby-1.9.2-p290@puppet/gems/puppet-2.7.10/lib/puppet/provider/service/freebsd.rb:9: warning: class variable access from toplevel
 *\* [out :: prod-fe-r01] /usr/local/rvm/gems/ruby-1.9.2-p290@puppet/gems/puppet-2.7.10/lib/puppet/provider/service/freebsd.rb:10: warning: class variable access from toplevel
 *\* [out :: prod-fe-r01] /usr/local/rvm/gems/ruby-1.9.2-p290@puppet/gems/puppet-2.7.10/lib/puppet/provider/service/bsd.rb:12: warning: class variable access from toplevel
