### PR TITLE
(#12386) Disable puppet kick application on windows

### DIFF
--- a/acceptance/tests/ticket_3172_puppet_kick_with_hostnames_on_the_command_line.rb
+++ b/acceptance/tests/ticket_3172_puppet_kick_with_hostnames_on_the_command_line.rb
@@ -3,7 +3,13 @@ step "verify that we trigger our host"
 
 target = 'working.example.org'
 agents.each do |host|
-  on(host, puppet_kick(target), :acceptable_exit_codes => [3]) {
-    assert_match(/Triggering #{target}/, stdout, "didn't trigger #{target} on #{host}" )
-  }
+  if host['platform'].include?('windows')
+    on(host, puppet_kick(target), :acceptable_exit_codes => [1]) {
+      assert_match(/Puppet kick is not supported/, stderr)
+    }
+  else
+    on(host, puppet_kick(target), :acceptable_exit_codes => [3]) {
+      assert_match(/Triggering #{target}/, stdout, "didn't trigger #{target} on #{host}" )
+    }
+  end
 end

--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -287,6 +287,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup
+    raise Puppet::Error.new("Puppet kick is not supported on Microsoft Windows") if Puppet.features.microsoft_windows?
+
     if options[:debug]
       Puppet::Util::Log.level = :debug
     else

--- a/spec/unit/application/kick_spec.rb
+++ b/spec/unit/application/kick_spec.rb
@@ -126,6 +126,12 @@ describe Puppet::Application::Kick, :if => Puppet.features.posix? do
       @kick.options.stubs(:[]).with(any_parameters)
     end
 
+    it "should abort stating that kick is not supported on Windows" do
+      Puppet.features.stubs(:microsoft_windows?).returns(true)
+
+      expect { @kick.setup }.to raise_error(Puppet::Error, /Puppet kick is not supported on Microsoft Windows/)
+    end
+
     it "should set log level to debug if --debug was passed" do
       @kick.options.stubs(:[]).with(:debug).returns(true)
       @kick.setup


### PR DESCRIPTION
Previously, running puppet kick on Windows would go into an infinite
loop, because the win32-process version of Process.wait returns nil
instead of Errno::ECHILD, if there are no child processes. This was
causing puppet kick to go into an infinite loop.

This commit disables the puppet kick application on Windows, in the
same way that we handle running puppet master on Windows. I also
audited the code base to ensure Process.wait is not being used
elsewhere, and it's not.
