### PR TITLE
Ticket/2.7.x/12349 order module list output

### DIFF
--- a/acceptance/tests/modules/list.rb
+++ b/acceptance/tests/modules/list.rb
@@ -3,9 +3,9 @@ test_name "puppet module list test output and dependency error checking"
 step "Run puppet module list"
 expected_stdout = <<-HEREDOC
 /opt/puppet-git-repos/puppet/acceptance/tests/modules/fake_modulepath
-  mysql (0.0.0)
   apache (0.0.3)
   bacula (0.0.2)
+  mysql (0.0.0)
   sqlite (0.0.1.1)
   HEREDOC
 

--- a/lib/puppet/face/module/list.rb
+++ b/lib/puppet/face/module/list.rb
@@ -67,7 +67,7 @@ Puppet::Face.define(:module, '1.0.0') do
 
       modules_by_path.each do |path, modules|
         output << "#{path}\n"
-        modules.each do |mod|
+        modules.sort_by {|mod| mod.name }.each do |mod|
           version_string = mod.version ? "(#{mod.version})" : ''
           output << "  #{mod.name} #{version_string}\n"
         end


### PR DESCRIPTION
This is necessary both for consistency for the user, and so that tests
pass every time.  An acceptance test that passed when I ran it did not
when CI ran it because the output order was different.  This fixes that.
