### PR TITLE
(#12404) Reduce redundant code in lib/puppet/application

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -197,8 +197,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   def setup
     require 'puppet/ssl/certificate_authority'
-    exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
-
+    exit_if_print_configs
+    
     Puppet::Util::Log.newdestination :console
 
     if [:generate, :destroy].include? subcommand

--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -150,18 +150,18 @@ class TypeDoc
   end
 
   def format_providers(type)
-    type.providers.sort { |a,b|
-      a.to_s <=> b.to_s
-    }.each { |prov|
+    sort_providers(type).each { |prov|
       puts "\n- **#{prov}**"
       puts @format.wrap(type.provider(prov).doc, :indent => 4, :scrub => true)
     }
   end
 
+  def sort_providers(type)
+    type.providers.sort { |a,b| a.to_s <=> b.to_s }
+  end
+
   def list_providers(type)
-    list = type.providers.sort { |a,b|
-      a.to_s <=> b.to_s
-    }.join(", ")
+    list = sort_providers(type).join(", ")
     puts @format.wrap(list, :indent => 4)
   end
 

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -1,9 +1,7 @@
 require 'puppet/application'
 require 'puppet/util/network_device'
 
-
 class Puppet::Application::Device < Puppet::Application
-
   should_parse_config
   run_mode :agent
 
@@ -38,15 +36,7 @@ class Puppet::Application::Device < Puppet::Application
     options[:detailed_exitcodes] = true
   end
 
-  option("--logdest DEST", "-l DEST") do |arg|
-    begin
-      Puppet::Util::Log.newdestination(arg)
-      options[:setdest] = true
-    rescue => detail
-      puts detail.backtrace if Puppet[:debug]
-      $stderr.puts detail.to_s
-    end
-  end
+  logdest_option
 
   option("--waitforcert WAITFORCERT", "-w") do |arg|
     options[:waitforcert] = arg.to_i
@@ -171,8 +161,9 @@ Licensed under the Apache 2.0 License
         Puppet.info "starting applying configuration to #{device.name} at #{device.url}"
 
         # override local $vardir and $certname
-        Puppet.settings.set_value(:confdir, ::File.join(Puppet[:devicedir], device.name), :cli)
-        Puppet.settings.set_value(:vardir, ::File.join(Puppet[:devicedir], device.name), :cli)
+        device_dir = ::File.join Puppet[:devicedir], device.name
+        Puppet.settings.set_value(:confdir, device_dir, :cli)
+        Puppet.settings.set_value(:vardir, device_dir, :cli)
         Puppet.settings.set_value(:certname, device.name, :cli)
 
         # this will reload and recompute default settings and create the devices sub vardir, or we hope so :-)
@@ -201,36 +192,11 @@ Licensed under the Apache 2.0 License
     end
   end
 
-  # Handle the logging settings.
-  def setup_logs
-    if options[:debug] or options[:verbose]
-      Puppet::Util::Log.newdestination(:console)
-      if options[:debug]
-        Puppet::Util::Log.level = :debug
-      else
-        Puppet::Util::Log.level = :info
-      end
-    end
-
-    Puppet::Util::Log.newdestination(:syslog) unless options[:setdest]
-  end
-
-  def setup_host
-    @host = Puppet::SSL::Host.new
-    waitforcert = options[:waitforcert] || (Puppet[:onetime] ? 0 : Puppet[:waitforcert])
-    cert = @host.wait_for_cert(waitforcert)
-  end
-
   def setup
-    setup_logs
+    setup_logs :console => :requires_explicit_option
 
     args[:Server] = Puppet[:server]
-    if options[:centrallogs]
-      logdest = args[:Server]
-
-      logdest += ":" + args[:Port] if args.include?(:Port)
-      Puppet::Util::Log.newdestination(logdest)
-    end
+    setup_central_logs if options[:centrallogs]
 
     Puppet.settings.use :main, :agent, :device, :ssl
 

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -1,5 +1,4 @@
 require 'puppet/application'
-
 class Puppet::Application::Doc < Puppet::Application
   should_not_parse_config
   run_mode :master
@@ -263,12 +262,7 @@ HELP
 
     # Handle the logging settings.
     if options[:debug] or options[:verbose]
-      if options[:debug]
-        Puppet::Util::Log.level = :debug
-      else
-        Puppet::Util::Log.level = :info
-      end
-
+      set_log_level
       Puppet::Util::Log.newdestination(:console)
     end
   end

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -170,7 +170,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # Now parse the config
     Puppet.parse_config
 
-      exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
+    exit_if_print_configs
 
     require 'puppet/file_bucket/dipper'
     begin

--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -1,7 +1,6 @@
 require 'puppet/application'
 
 class Puppet::Application::Kick < Puppet::Application
-
   should_not_parse_config
 
   attr_accessor :hosts, :tags, :classes
@@ -287,12 +286,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup
-    if options[:debug]
-      Puppet::Util::Log.level = :debug
-    else
-      Puppet::Util::Log.level = :info
-    end
-
+    set_log_level
+    
     # Now parse the config
     Puppet.parse_config
 

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -1,7 +1,5 @@
 require 'puppet/application'
-
 class Puppet::Application::Master < Puppet::Application
-
   should_parse_config
   run_mode :master
 
@@ -14,16 +12,8 @@ class Puppet::Application::Master < Puppet::Application
   option("--compile host",  "-c host") do |arg|
     options[:node] = arg
   end
-
-  option("--logdest DEST",  "-l DEST") do |arg|
-    begin
-      Puppet::Util::Log.newdestination(arg)
-      options[:setdest] = true
-    rescue => detail
-      puts detail.backtrace if Puppet[:debug]
-      $stderr.puts detail.to_s
-    end
-  end
+  
+  logdest_option
 
   option("--parseonly") do
     puts "--parseonly has been removed. Please use 'puppet parser validate <manifest>'"
@@ -206,12 +196,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     # Handle the logging settings.
     if options[:debug] or options[:verbose]
-      if options[:debug]
-        Puppet::Util::Log.level = :debug
-      else
-        Puppet::Util::Log.level = :info
-      end
-
+      set_log_level
+      
       unless Puppet[:daemonize] or options[:rack]
         Puppet::Util::Log.newdestination(:console)
         options[:setdest] = true
@@ -220,8 +206,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     Puppet::Util::Log.newdestination(:syslog) unless options[:setdest]
 
-    exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
-
+    exit_if_print_configs
+    
     Puppet.settings.use :main, :master, :ssl, :metrics
 
     # Cache our nodes in yaml.  Currently not configurable.

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -1,7 +1,6 @@
 require 'puppet/application'
 
 class Puppet::Application::Resource < Puppet::Application
-
   should_not_parse_config
 
   attr_accessor :host, :extra_params
@@ -152,15 +151,9 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup
-    Puppet::Util::Log.newdestination(:console)
+    setup_logs
 
     Puppet.parse_config
-
-    if options[:debug]
-      Puppet::Util::Log.level = :debug
-    elsif options[:verbose]
-      Puppet::Util::Log.level = :info
-    end
   end
 
   private

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -49,7 +49,7 @@ describe Puppet::Application::Apply do
     end
 
     it "should put the logset options to true" do
-      @apply.options.expects(:[]=).with(:logset,true)
+      @apply.options.expects(:[]=).with(:setdest,true)
 
       @apply.handle_logdest("console")
     end

--- a/spec/unit/application/inspect_spec.rb
+++ b/spec/unit/application/inspect_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Application::Inspect do
   describe "when executing" do
     before :each do
       Puppet[:report] = true
-      @inspect.options[:logset] = true
+      @inspect.options[:setdest] = true
       Puppet::Transaction::Report::Rest.any_instance.stubs(:save)
       @inspect.setup
     end

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -73,6 +73,9 @@ describe Puppet::Application::Resource do
     before :each do
       Puppet::Log.stubs(:newdestination)
       Puppet.stubs(:parse_config)
+      @resource_app.options.stubs(:[]).with(:setdest).returns(false)
+      @resource_app.options.stubs(:[]).with(:debug).returns(nil)
+      @resource_app.options.stubs(:[]).with(:verbose).returns(nil)
     end
 
     it "should set console as the log destination" do


### PR DESCRIPTION
Reduce redundant code by defining Puppet::Application.logdest_option,
which can then be called from applications that need a log destination
instead of copying the 9 lines of code specific to creating a log
destination.

Reduce redundant code by defining Puppet::Application.setup_logs
to ease (and standardize) the log setup across the applications.

Reduce redundant code by moving setup_host into Puppet::Application.

Encapsulate logic for exiting if Puppet.settings.print_config?

Encapsulate logic for sorting type providers in Puppet::Application::Describe.

Modify tests to use standard option :setdest.

Modify tests to mock options :setdest, :debug, and :verbose to
handle standardized checked against each option in consolidated
setup_logs method.
