### PR TITLE
Refactor/master/12359 improve backtrace logging

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -49,8 +49,7 @@ class Puppet::Agent
           rescue SystemExit,NoMemoryError
             raise
           rescue Exception => detail
-            puts detail.backtrace if Puppet[:trace]
-            Puppet.err "Could not run #{client_class}: #{detail}"
+            Puppet.log_exception(detail, "Could not run #{client_class}: #{detail}")
           end
         end
       end
@@ -129,8 +128,7 @@ class Puppet::Agent
     rescue SystemExit,NoMemoryError
       raise
     rescue Exception => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Could not create instance of #{client_class}: #{detail}"
+      Puppet.log_exception(detail, "Could not create instance of #{client_class}: #{detail}")
       return
     end
     yield @client

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -403,8 +403,7 @@ class Application
   def exit_on_fail(message, code = 1)
     yield
   rescue ArgumentError, RuntimeError, NotImplementedError => detail
-    puts detail.backtrace if Puppet[:trace]
-    $stderr.puts "Could not #{message}: #{detail}"
+    Puppet.log_exception(detail, "Could not #{message}: #{detail}")
     exit(code)
   end
 

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -68,8 +68,7 @@ class Puppet::Application::Agent < Puppet::Application
       Puppet::Util::Log.newdestination(arg)
       options[:setdest] = true
     rescue => detail
-      puts detail.backtrace if Puppet[:debug]
-      $stderr.puts detail.to_s
+      Puppet.log_exception(detail)
     end
   end
 
@@ -328,8 +327,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       @agent.should_fork = false
       exitstatus = @agent.run
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err detail.to_s
+      Puppet.log_exception(detail)
     end
 
     @daemon.stop(:exit => false)

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -223,8 +223,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         exit(0)
       end
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      $stderr.puts detail.message
+      Puppet.log_exception(detail)
       exit(1)
     end
   end

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -189,8 +189,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       @ca.apply(:revoke, options.merge(:to => hosts)) if subcommand == :destroy
       @ca.apply(subcommand, options.merge(:to => hosts, :digest => @digest))
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      puts detail.to_s
+      Puppet.log_exception(detail)
       exit(24)
     end
   end
@@ -219,8 +218,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     begin
       @ca = Puppet::SSL::CertificateAuthority.new
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      puts detail.to_s
+      Puppet.log_exception(detail)
       exit(23)
     end
   end

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -43,8 +43,7 @@ class Puppet::Application::Device < Puppet::Application
       Puppet::Util::Log.newdestination(arg)
       options[:setdest] = true
     rescue => detail
-      puts detail.backtrace if Puppet[:debug]
-      $stderr.puts detail.to_s
+      Puppet.log_exception(detail)
     end
   end
 
@@ -190,8 +189,7 @@ Licensed under the Apache 2.0 License
         configurer = Puppet::Configurer.new
         report = configurer.run(:network_device => true)
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err detail.to_s
+        Puppet.log_exception(detail)
       ensure
         Puppet.settings.set_value(:vardir, vardir, :cli)
         Puppet.settings.set_value(:confdir, confdir, :cli)

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -182,8 +182,7 @@ HELP
         Puppet::Util::RDoc.rdoc(options[:outputdir], files, options[:charset])
       end
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      $stderr.puts "Could not generate documentation: #{detail}"
+      Puppet.log_exception(detail, "Could not generate documentation: #{detail}")
       exit_code = 1
     end
     exit exit_code
@@ -201,8 +200,7 @@ HELP
         # Add the per-section text, but with no ToC
         text += section.send(options[:format], with_contents)
       rescue => detail
-        puts detail.backtrace
-        $stderr.puts "Could not generate reference #{name}: #{detail}"
+        Puppet.log_exception(detail, "Could not generate reference #{name}: #{detail}")
         exit_code = 1
         next
       end

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -237,8 +237,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     status = true
 
   rescue Exception => detail
-    puts detail.backtrace if Puppet[:trace]
-    Puppet.err detail.to_s
+    Puppet.log_exception(detail)
     Puppet.err "Try 'puppet help #{@face.name} #{@action.name}' for usage"
 
   ensure

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -181,8 +181,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         @client = Puppet::FileBucket::Dipper.new(:Server => Puppet[:server])
       end
     rescue => detail
-      $stderr.puts detail
-      puts detail.backtrace if Puppet[:trace]
+      Puppet.log_exception(detail)
       exit(1)
     end
   end

--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -136,8 +136,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         begin
           audited_resource = ral_resource.to_resource
         rescue StandardError => detail
-          puts detail.backtrace if Puppet[:trace]
-          ral_resource.err "Could not inspect #{ral_resource}; skipping: #{detail}"
+          ral_resource.log_exception(detail, "Could not inspect #{ral_resource}; skipping: #{detail}")
           audited_attributes.each do |name|
             event = ral_resource.event(
                                        :property => name,
@@ -183,8 +182,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       begin
         Puppet::Transaction::Report.indirection.save(@report)
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Could not send report: #{detail}"
+        Puppet.log_exception(detail, "Could not send report: #{detail}")
       end
     end
   end

--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -248,8 +248,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       result = run.status
       puts "status is #{result}"
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      $stderr.puts "Host #{host} failed: #{detail}\n"
+      Puppet.log_exception(detail, "Host #{host} failed: #{detail}\n")
       exit(2)
     end
 

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -20,8 +20,7 @@ class Puppet::Application::Master < Puppet::Application
       Puppet::Util::Log.newdestination(arg)
       options[:setdest] = true
     rescue => detail
-      puts detail.backtrace if Puppet[:debug]
-      $stderr.puts detail.to_s
+      Puppet.log_exception(detail)
     end
   end
 
@@ -177,8 +176,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       begin
         Puppet::Util.chuser
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        $stderr.puts "Could not change user to #{Puppet[:user]}: #{detail}"
+        Puppet.log_exception(detail, "Could not change user to #{Puppet[:user]}: #{detail}")
         exit(39)
       end
     end

--- a/lib/puppet/application/queue.rb
+++ b/lib/puppet/application/queue.rb
@@ -113,8 +113,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       Puppet::Util::Log.newdestination(arg)
       options[:setdest] = true
     rescue => detail
-      puts detail.backtrace if Puppet[:debug]
-      $stderr.puts detail.to_s
+      Puppet.log_exception(detail)
     end
   end
 
@@ -123,8 +122,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       Puppet::Util::Log.newdestination(arg)
       options[:setdest] = true
     rescue => detail
-      puts detail.backtrace if Puppet[:debug]
-      $stderr.puts detail.to_s
+      Puppet.log_exception(detail)
     end
   end
 
@@ -139,8 +137,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         begin
           Puppet::Resource::Catalog.indirection.save(catalog)
         rescue => detail
-          puts detail.backtrace if Puppet[:trace]
-          Puppet.err "Could not save queued catalog for #{catalog.name}: #{detail}"
+          Puppet.log_exception(detail, "Could not save queued catalog for #{catalog.name}: #{detail}")
         end
       end
     end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -51,14 +51,13 @@ class Puppet::Configurer
       Puppet::Util::Storage.load
       @compile_time ||= Puppet::Util::Storage.cache(:configuration)[:compile_time]
   rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Corrupt state file #{Puppet[:statefile]}: #{detail}"
-      begin
-        ::File.unlink(Puppet[:statefile])
-        retry
-      rescue => detail
-        raise Puppet::Error.new("Cannot remove #{Puppet[:statefile]}: #{detail}")
-      end
+    Puppet.log_exception(detail, "Removing corrupt state file #{Puppet[:statefile]}: #{detail}")
+    begin
+      ::File.unlink(Puppet[:statefile])
+      retry
+    rescue => detail
+      raise Puppet::Error.new("Cannot remove #{Puppet[:statefile]}: #{detail}")
+    end
   end
 
   # Just so we can specify that we are "the" instance.
@@ -154,8 +153,7 @@ class Puppet::Configurer
       rescue SystemExit,NoMemoryError
         raise
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Failed to apply catalog: #{detail}"
+        Puppet.log_exception(detail, "Failed to apply catalog: #{detail}")
         return nil
       ensure
         execute_postrun_command or return nil
@@ -175,8 +173,7 @@ class Puppet::Configurer
     save_last_run_summary(report)
     Puppet::Transaction::Report.indirection.save(report) if Puppet[:report]
   rescue => detail
-    puts detail.backtrace if Puppet[:trace]
-    Puppet.err "Could not send report: #{detail}"
+    Puppet.log_exception(detail, "Could not send report: #{detail}")
   end
 
   def save_last_run_summary(report)
@@ -192,8 +189,7 @@ class Puppet::Configurer
     ral.host_config = false
     ral.apply
   rescue => detail
-    puts detail.backtrace if Puppet[:trace]
-    Puppet.err "Could not save last run local report: #{detail}"
+    Puppet.log_exception(detail, "Could not save last run local report: #{detail}")
   end
 
   private
@@ -222,8 +218,7 @@ class Puppet::Configurer
       Puppet::Util::Execution.execute([command])
       true
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Could not run command from #{setting}: #{detail}"
+      Puppet.log_exception(detail, "Could not run command from #{setting}: #{detail}")
       false
     end
   end
@@ -236,8 +231,7 @@ class Puppet::Configurer
     Puppet.notice "Using cached catalog"
     result
   rescue => detail
-    puts detail.backtrace if Puppet[:trace]
-    Puppet.err "Could not retrieve catalog from cache: #{detail}"
+    Puppet.log_exception(detail, "Could not retrieve catalog from cache: #{detail}")
     return nil
   end
 
@@ -250,8 +244,7 @@ class Puppet::Configurer
   rescue SystemExit,NoMemoryError
     raise
   rescue Exception => detail
-    puts detail.backtrace if Puppet[:trace]
-    Puppet.err "Could not retrieve catalog from remote server: #{detail}"
+    Puppet.log_exception(detail, "Could not retrieve catalog from remote server: #{detail}")
     return nil
   end
 end

--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -37,8 +37,7 @@ class Puppet::Configurer::Downloader
         end
       end
     rescue Puppet::Error, Timeout::Error => detail
-      puts detail.backtrace if Puppet[:debug]
-      Puppet.err "Could not retrieve #{name}: #{detail}"
+      Puppet.log_exception(detail, "Could not retrieve #{name}: #{detail}")
     end
 
     files

--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -20,8 +20,9 @@ module Puppet::Configurer::FactHandler
     rescue SystemExit,NoMemoryError
       raise
     rescue Exception => detail
-      puts detail.backtrace if Puppet[:trace]
-      raise Puppet::Error, "Could not retrieve local facts: #{detail}"
+      message = "Could not retrieve local facts: #{detail}"
+      Puppet.log_exception(detail, message)
+      raise Puppet::Error, message
     end
   end
 

--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -75,8 +75,7 @@ Puppet::Indirector::Face.define(:catalog, '0.0.1') do
           catalog.apply(:report => report)
         end
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Failed to apply catalog: #{detail}"
+        Puppet.log_exception(detail, "Failed to apply catalog: #{detail}")
       end
 
       report.finalize_report

--- a/lib/puppet/face/report.rb
+++ b/lib/puppet/face/report.rb
@@ -21,8 +21,7 @@ Puppet::Indirector::Face.define(:report, '0.0.1') do
           Puppet::Face[:report, "0.0.1"].save(report)
           Puppet.notice "Uploaded report for #{report.name}"
         rescue => detail
-          puts detail.backtrace if Puppet[:trace]
-          Puppet.err "Could not send report: #{detail}"
+          Puppet.log_exception(detail, "Could not send report: #{detail}")
         end
   EOT
 
@@ -48,8 +47,7 @@ Puppet::Indirector::Face.define(:report, '0.0.1') do
         Puppet::Face[:report, "0.0.1"].save(report)
         Puppet.notice "Uploaded report for #{report.name}"
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Could not send report: #{detail}"
+        Puppet.log_exception(detail, "Could not send report: #{detail}")
       end
     end
   end

--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -46,8 +46,9 @@ class Puppet::FileBucket::Dipper
 
       return file_bucket_file.checksum_data
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      raise Puppet::Error, "Could not back up #{file}: #{detail}"
+      message = "Could not back up #{file}: #{detail}"
+      Puppet.log_exception(detail, message)
+      raise Puppet::Error, message
     end
   end
 

--- a/lib/puppet/file_serving/configuration.rb
+++ b/lib/puppet/file_serving/configuration.rb
@@ -110,8 +110,7 @@ class Puppet::FileServing::Configuration
       newmounts = @parser.parse
       @mounts = newmounts
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Error parsing fileserver configuration: #{detail}; using old configuration"
+      Puppet.log_exception(detail, "Error parsing fileserver configuration: #{detail}; using old configuration")
     end
 
   ensure

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -89,8 +89,9 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     begin
       return nil unless node = Puppet::Node.indirection.find(name)
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      raise Puppet::Error, "Failed when searching for node #{name}: #{detail}"
+      message = "Failed when searching for node #{name}: #{detail}"
+      Puppet.log_exception(detail, message)
+      raise Puppet::Error, message
     end
 
 

--- a/lib/puppet/indirector/face.rb
+++ b/lib/puppet/indirector/face.rb
@@ -41,8 +41,9 @@ class Puppet::Indirector::Face < Puppet::Face
     begin
       result = indirection.__send__(method, key, options)
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      raise "Could not call '#{method}' on '#{indirection_name}': #{detail}"
+      message = "Could not call '#{method}' on '#{indirection_name}': #{detail}"
+      Puppet.log_exception(detail, message)
+      raise message
     end
 
     return result

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -228,8 +228,7 @@ class Puppet::Indirector::Indirection
     Puppet.debug "Using cached #{self.name} for #{request.key}"
     cached
   rescue => detail
-    puts detail.backtrace if Puppet[:trace]
-    Puppet.err "Cached #{self.name} for #{request.key} failed: #{detail}"
+    Puppet.log_exception(detail, "Cached #{self.name} for #{request.key} failed: #{detail}")
     nil
   end
 

--- a/lib/puppet/indirector/ldap.rb
+++ b/lib/puppet/indirector/ldap.rb
@@ -68,8 +68,9 @@ class Puppet::Indirector::Ldap < Puppet::Indirector::Terminus
         conn.start
         @connection = conn.connection
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        raise Puppet::Error, "Could not connect to LDAP: #{detail}"
+        message = "Could not connect to LDAP: #{detail}"
+        Puppet.log_exception(detail, message)
+        raise Puppet::Error, message
       end
     end
 

--- a/lib/puppet/indirector/queue.rb
+++ b/lib/puppet/indirector/queue.rb
@@ -73,8 +73,7 @@ class Puppet::Indirector::Queue < Puppet::Indirector::Terminus
       begin
         yield(self.intern(msg))
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Error occured with subscription to queue #{queue} for indirection #{indirection_name}: #{detail}"
+        Puppet.log_exception(detail, "Error occured with subscription to queue #{queue} for indirection #{indirection_name}: #{detail}")
       end
     end
   end

--- a/lib/puppet/indirector/report/processor.rb
+++ b/lib/puppet/indirector/report/processor.rb
@@ -36,8 +36,7 @@ class Puppet::Transaction::Report::Processor < Puppet::Indirector::Code
         newrep.extend(mod)
         newrep.process
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Report #{name} failed: #{detail}"
+        Puppet.log_exception(detail, "Report #{name} failed: #{detail}")
       end
     end
   end

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -89,8 +89,7 @@ module Puppet::Network::HTTP::Handler
       status = 403 if status == 400
     end
     if exception.is_a?(Exception)
-      puts exception.backtrace if Puppet[:trace]
-      Puppet.err(exception)
+      Puppet.log_exception(exception)
     end
     set_content_type(response, "text/plain")
     set_response(response, exception.to_s, status)

--- a/lib/puppet/network/http/rack.rb
+++ b/lib/puppet/network/http/rack.rb
@@ -25,9 +25,7 @@ class Puppet::Network::HTTP::Rack
       response['Content-Type'] = 'text/plain'
       response.write 'Internal Server Error: "%s"' % detail.message
       # log what happened
-      Puppet.err "Puppet Server (Rack): Internal Server Error: Unhandled Exception: \"%s\"" % detail.message
-      Puppet.err "Backtrace:"
-      detail.backtrace.each { |line| Puppet.err " > #{line}" }
+      Puppet.log_exception(detail, "Puppet Server (Rack): Internal Server Error: Unhandled Exception: \"%s\"" % detail.message)
     end
     response.finish
   end

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -23,8 +23,9 @@ class Puppet::Parser::Compiler
     # ...and we actually do the compile now we have caching ready.
     new(node).compile.to_resource
   rescue => detail
-    puts detail.backtrace if Puppet[:trace]
-    raise Puppet::Error, "#{detail} on node #{node.name}"
+    message = "#{detail} on node #{node.name}"
+    Puppet.log_exception(detail, message)
+    raise Puppet::Error, message
  end
 
   attr_reader :node, :facts, :collections, :catalog, :node_scope, :resources, :relationships

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -285,7 +285,6 @@ class Puppet::Parser::Resource < Puppet::Resource
 
     # The parameter is already set.  Fail if they're not allowed to override it.
     unless param.source.child_of?(current.source)
-      puts caller if Puppet[:trace]
       msg = "Parameter '#{param.name}' is already set on #{self}"
       msg += " by #{current.source}" if current.source.to_s != ""
       if current.file or current.line
@@ -295,6 +294,7 @@ class Puppet::Parser::Resource < Puppet::Resource
         msg += " at #{fields.join(":")}"
       end
       msg += "; cannot redefine"
+      Puppet.log_exception(ArgumentError.new(), msg)
       raise Puppet::ParseError.new(msg, param.line, param.file)
     end
 

--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -82,9 +82,9 @@ class Puppet::Property < Puppet::Parameter
       rescue Puppet::Error
         raise
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
         error = Puppet::Error.new("Could not set '#{value} on #{self.class.name}: #{detail}", @resource.line, @resource.file)
         error.set_backtrace detail.backtrace
+        Puppet.log_exception(detail, error.message)
         raise error
       end
     elsif block = self.class.value_option(name, :block)
@@ -109,8 +109,9 @@ class Puppet::Property < Puppet::Parameter
     rescue Puppet::Error, Puppet::DevError
       raise
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      raise Puppet::DevError, "Could not convert change '#{name}' to string: #{detail}"
+      message = "Could not convert change '#{name}' to string: #{detail}"
+      Puppet.log_exception(detail, message)
+      raise Puppet::DevError, message
     end
   end
 

--- a/lib/puppet/provider/package/sun.rb
+++ b/lib/puppet/provider/package/sun.rb
@@ -107,8 +107,9 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
       return hash
     rescue Puppet::ExecutionFailure => detail
       return {:ensure => :absent} if detail.message =~ /information for "#{Regexp.escape(@resource[:name])}" was not found/
-      puts detail.backtrace if Puppet[:trace]
-      raise Puppet::Error, "Unable to get information about package #{@resource[:name]} because of: #{detail}"
+      message = "Unable to get information about package #{@resource[:name]} because of: #{detail}"
+      Puppet.log_exception(detail, message)
+      raise Puppet::Error, message
     end
   end
 

--- a/lib/puppet/rails.rb
+++ b/lib/puppet/rails.rb
@@ -33,8 +33,9 @@ module Puppet::Rails
       Puppet.info "Connecting to #{args[:adapter]} database: #{args[:database]}"
       ActiveRecord::Base.establish_connection(args)
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      raise Puppet::Error, "Could not connect to database: #{detail}"
+      message = "Could not connect to database: #{detail}"
+      Puppet.log_exception(detail, message)
+      raise Puppet::Error, message
     end
   end
 
@@ -104,7 +105,8 @@ module Puppet::Rails
     begin
       ActiveRecord::Migrator.migrate(dbdir)
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
+      message = "Could not migrate database: #{detail}"
+      Puppet.log_exception(detail, message)
       raise Puppet::Error, "Could not migrate database: #{detail}"
     end
   end
@@ -118,7 +120,7 @@ module Puppet::Rails
     begin
       ActiveRecord::Base.establish_connection(database_arguments)
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
+      Puppet.log_exception(detail)
       raise Puppet::Error, "Could not connect to database: #{detail}"
     end
 

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -16,8 +16,7 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
     begin
       str << object.desc.gsub(/\n/, " ")
     rescue => detail
-      puts detail.backtrace
-      puts detail
+      Puppet.log_exception(detail)
     end
     str << "\n\n"
 

--- a/lib/puppet/reference/metaparameter.rb
+++ b/lib/puppet/reference/metaparameter.rb
@@ -34,8 +34,7 @@ in your manifest, including defined components.
       str << "\n\n"
     }
   rescue => detail
-    puts detail.backtrace
-    puts "incorrect metaparams: #{detail}"
+    Puppet.log_exception(detail, "incorrect metaparams: #{detail}")
     exit(1)
   end
 

--- a/lib/puppet/reports/store.rb
+++ b/lib/puppet/reports/store.rb
@@ -41,8 +41,7 @@ Puppet::Reports.register_report(:store) do
       end
       FileUtils.mv(f.path, file)
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.warning "Could not write report for #{client} at #{file}: #{detail}"
+      Puppet.log_exception(detail, "Could not write report for #{client} at #{file}: #{detail}")
     end
 
     # Only testing cares about the return value

--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -139,9 +139,9 @@ Puppet::Reports.register_report(:tagmail) do
             end
           end
         rescue => detail
-          puts detail.backtrace if Puppet[:debug]
-          raise Puppet::Error,
-            "Could not send report emails through smtp: #{detail}"
+          message = "Could not send report emails through smtp: #{detail}"
+          Puppet.log_exception(detail, message)
+          raise Puppet::Error, message
         end
       elsif Puppet[:sendmail] != ""
         begin
@@ -156,9 +156,9 @@ Puppet::Reports.register_report(:tagmail) do
             end
           end
         rescue => detail
-          puts detail.backtrace if Puppet[:debug]
-          raise Puppet::Error,
-            "Could not send report emails via sendmail: #{detail}"
+          message = "Could not send report emails via sendmail: #{detail}"
+          Puppet.log_exception(detail, message)
+          raise Puppet::Error, message
         end
       else
         raise Puppet::Error, "SMTP server is unset and could not find sendmail"

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -143,11 +143,9 @@ class Puppet::Resource::Catalog < Puppet::SimpleGraph
         Puppet::Util::Log.close(transaction.report) if register_report
       end
     rescue Puppet::Error => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Could not apply complete catalog: #{detail}"
+      Puppet.log_exception(detail, "Could not apply complete catalog: #{detail}")
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Got an uncaught exception of type #{detail.class}: #{detail}"
+      Puppet.log_exception(detail, "Got an uncaught exception of type #{detail.class}: #{detail}")
     ensure
       # Don't try to store state unless we're a host config
       # too recursive.

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -26,8 +26,7 @@ module Puppet
           rescue InterfaceError
             raise
           rescue => detail
-            puts detail.backtrace if Puppet[:trace]
-            Puppet.err "Could not call #{method}: #{detail}"
+            Puppet.log_exception(detail, "Could not call #{method}: #{detail}")
           end
         end
 

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -293,8 +293,7 @@ ERROR_STRING
     rescue SystemExit,NoMemoryError
       raise
     rescue Exception => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Could not request certificate: #{detail}"
+      Puppet.log_exception(detail, "Could not request certificate: #{detail}")
       if time < 1
         puts "Exiting; failed to retrieve certificate and waitforcert is disabled"
         exit(1)
@@ -315,8 +314,7 @@ ERROR_STRING
         break if certificate
         Puppet.notice "Did not receive certificate"
       rescue StandardError => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Could not request certificate: #{detail}"
+        Puppet.log_exception(detail, "Could not request certificate: #{detail}")
       end
     end
   end

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -153,8 +153,7 @@ class Puppet::Transaction
       return false if made.empty?
       made = made.inject({}) {|a,v| a.merge(v.name => v) }
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      resource.err "Failed to generate additional resources using 'eval_generate: #{detail}"
+      resource.log_exception(detail, "Failed to generate additional resources using 'eval_generate: #{detail}")
       return false
     end
     made.values.each do |res|
@@ -203,8 +202,7 @@ class Puppet::Transaction
     begin
       made = resource.generate
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      resource.err "Failed to generate additional resources using 'generate': #{detail}"
+      resource.log_exception(detail, "Failed to generate additional resources using 'generate': #{detail}")
     end
     return unless made
     made = [made] unless made.is_a?(Array)
@@ -285,8 +283,7 @@ class Puppet::Transaction
     begin
       provider_class.prefetch(resources)
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Could not prefetch #{type_name} provider '#{provider_class.name}': #{detail}"
+      Puppet.log_exception(detail, "Could not prefetch #{type_name} provider '#{provider_class.name}': #{detail}")
     end
     @prefetched_providers[type_name][provider_class.name] = true
   end

--- a/lib/puppet/transaction/event_manager.rb
+++ b/lib/puppet/transaction/event_manager.rb
@@ -101,7 +101,7 @@ class Puppet::Transaction::EventManager
     resource.err "Failed to call #{callback}: #{detail}"
 
     transaction.resource_status(resource).failed_to_restart = true
-    puts detail.backtrace if Puppet[:trace]
+    resource.log_exception(detail)
     return false
   end
 

--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -117,7 +117,7 @@ class Puppet::Transaction::ResourceHarness
     end
     event
   rescue => detail
-    puts detail.backtrace if Puppet[:trace]
+    Puppet.log_exception(detail)
     event.status = "failure"
 
     event.message = "change from #{property.is_to_s(current_value)} to #{property.should_to_s(property.should)} failed: #{detail}"
@@ -142,8 +142,7 @@ class Puppet::Transaction::ResourceHarness
     return status
   rescue => detail
     resource.fail "Could not create resource status: #{detail}" unless status
-    puts detail.backtrace if Puppet[:trace]
-    resource.err "Could not evaluate: #{detail}"
+    resource.log_exception(detail, "Could not evaluate: #{detail}")
     status.failed = true
     return status
   ensure

--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -92,8 +92,9 @@ module Puppet
       begin
         @bucket = Puppet::FileBucket::Dipper.new(args)
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        self.fail("Could not create #{type} filebucket: #{detail}")
+        message = "Could not create #{type} filebucket: #{detail}"
+        self.log_exception(detail, message)
+        self.fail(message)
       end
 
       @bucket.name = self.name

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -81,8 +81,9 @@ class Puppet::Util::Autoload
       rescue SystemExit,NoMemoryError
         raise
       rescue Exception => detail
-        puts detail.backtrace if Puppet[:trace]
-        raise Puppet::Error, "Could not autoload #{name}: #{detail}"
+        message = "Could not autoload #{name}: #{detail}"
+        Puppet.log_exception(detail, message)
+        raise Puppet::Error, message
       end
     end
     false
@@ -112,8 +113,9 @@ class Puppet::Util::Autoload
       rescue SystemExit,NoMemoryError
         raise
       rescue Exception => detail
-        puts detail.backtrace if Puppet[:trace]
-        raise Puppet::Error, "Could not autoload #{file}: #{detail}"
+        message = "Could not autoload #{file}: #{detail}"
+        Puppet.log_exception(detail, message)
+        raise Puppet::Error, message
       end
     end
   end

--- a/lib/puppet/util/backups.rb
+++ b/lib/puppet/util/backups.rb
@@ -74,8 +74,9 @@ module Puppet::Util::Backups
     begin
       File.unlink(newfile)
     rescue => detail
-      puts detail.backtrace if Puppet[:trace]
-      self.fail "Could not remove old backup: #{detail}"
+      message = "Could not remove old backup: #{detail}"
+      self.log_exception(detail, message)
+      self.fail message
     end
   end
 

--- a/lib/puppet/util/docs.rb
+++ b/lib/puppet/util/docs.rb
@@ -110,8 +110,7 @@ module Puppet::Util::Docs
       begin
         return text.gsub(/^#{indent}/,'')
       rescue => detail
-        puts detail.backtrace
-        puts detail
+        Puppet.log_exception(detail)
       end
     else
       return text

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -178,9 +178,7 @@ module Util::Execution
           Kernel.exec(*command)
         end
       rescue => detail
-        puts detail.message
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Could not execute posix command: #{detail}"
+        Puppet.log_exception(detail, "Could not execute posix command: #{detail}")
         exit!(1)
       end
     end

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -44,8 +44,9 @@ class Puppet::Util::FileType
         rescue Puppet::Error => detail
           raise
         rescue => detail
-          puts detail.backtrace if Puppet[:trace]
-          raise Puppet::Error, "#{self.class} could not read #{@path}: #{detail}"
+          message = "#{self.class} could not read #{@path}: #{detail}"
+          Puppet.log_exception(detail, message)
+          raise Puppet::Error, message
         end
       end
 
@@ -59,8 +60,9 @@ class Puppet::Util::FileType
         rescue Puppet::Error => detail
           raise
         rescue => detail
-          puts detail.backtrace if Puppet[:debug]
-          raise Puppet::Error, "#{self.class} could not write #{@path}: #{detail}"
+          message = "#{self.class} could not write #{@path}: #{detail}"
+          Puppet.log_exception(detail, message)
+          raise Puppet::Error, message
         end
       end
     end

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -135,7 +135,7 @@ class Puppet::Util::Log
       flushqueue
       @destinations[dest]
     rescue => detail
-      puts detail.backtrace if Puppet[:debug]
+      Puppet.log_exception(detail)
 
       # If this was our only destination, then add the console back in.
       newdestination(:console) if @destinations.empty? and (dest != :console and dest != "console")

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -189,8 +189,7 @@ Puppet::Util::Log.newdesttype :host do
         # Add the hostname to the source
         @driver.addlog(tmp)
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err detail
+        Puppet.log_exception(detail)
         Puppet::Util::Log.close(self)
       end
     end

--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -34,8 +34,7 @@ class Puppet::Util::Pidlock < Puppet::Util::AnonymousFilelock
         # This one is a real failure though.  No idea what went wrong, but it
         # is most likely "read only file(system)" or wrong permissions or
         # something like that.
-        Puppet.err "Could not remove PID file #{@lockfile}: #{e}"
-        puts e.backtrace if Puppet[:trace]
+        Puppet.log_exception(e, "Could not remove PID file #{@lockfile}: #{e}")
       end
       true
     else

--- a/lib/puppet/util/settings.rb
+++ b/lib/puppet/util/settings.rb
@@ -307,9 +307,8 @@ class Puppet::Util::Settings
     return unless FileTest.exist?(file)
     begin
       data = parse_file(file)
-    rescue => details
-      puts details.backtrace if Puppet[:trace]
-      Puppet.err "Could not parse #{file}: #{details}"
+    rescue => detail
+      Puppet.log_exception(detail, "Could not parse #{file}: #{detail}")
       return
     end
 
@@ -622,8 +621,7 @@ if @config.include?(:run_mode)
       begin
         catalog = to_catalog(*sections).to_ral
       rescue => detail
-        puts detail.backtrace if Puppet[:trace]
-        Puppet.err "Could not create resources for managing Puppet's files and directories in sections #{sections.inspect}: #{detail}"
+        Puppet.log_exception(detail, "Could not create resources for managing Puppet's files and directories in sections #{sections.inspect}: #{detail}")
 
         # We need some way to get rid of any resources created during the catalog creation
         # but not cleaned up.

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -338,9 +338,13 @@ EOT
       # it, but this helps us fail if that slips up and all. --daniel 2011-04-27
       Puppet::Face[:help, :current].expects(:help).never
 
-      expect {
-        expect { app.run }.to exit_with 1
-      }.to have_printed(/I don't know how to render 'interpretive-dance'/)
+      Puppet.expects(:err).with("Could not parse options: I don't know how to render 'interpretive-dance'")
+
+      expect { app.run }.to exit_with 1
+
+      #expect {
+      #  expect { app.run }.to exit_with 1
+      #}.to have_printed(/I don't know how to render 'interpretive-dance'/)
     end
 
     it "should work if asked to render a NetworkHandler format" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -517,19 +517,19 @@ describe Puppet::Application do
     end
 
     it "should warn and exit if no command can be called" do
-      $stderr.expects(:puts)
+      Puppet.expects(:err)
       expect { @app.run }.to exit_with 1
     end
 
     it "should raise an error if dispatch returns no command" do
       @app.stubs(:get_command).returns(nil)
-      $stderr.expects(:puts)
+      Puppet.expects(:err)
       expect { @app.run }.to exit_with 1
     end
 
     it "should raise an error if dispatch returns an invalid command" do
       @app.stubs(:get_command).returns(:this_function_doesnt_exist)
-      $stderr.expects(:puts)
+      Puppet.expects(:err)
       expect { @app.run }.to exit_with 1
     end
   end

--- a/spec/unit/util/logging_spec.rb
+++ b/spec/unit/util/logging_spec.rb
@@ -98,18 +98,24 @@ describe Puppet::Util::Logging do
     end
 
     it "should log the message with warn" do
-      @logger.expects(:warning).with('foo')
+      @logger.expects(:warning).with do |msg|
+        msg =~ /^foo\n/
+      end
       @logger.deprecation_warning 'foo'
     end
 
     it "should only log each offending line once" do
-      @logger.expects(:warning).with('foo').once
+      @logger.expects(:warning).with do |msg|
+        msg =~ /^foo\n/
+      end .once
       5.times { @logger.deprecation_warning 'foo' }
     end
 
     it "should only log the first 100 messages" do
       (1..100).each { |i|
-        @logger.expects(:warning).with(i).once
+        @logger.expects(:warning).with do |msg|
+          msg =~ /^#{i}\n/
+        end .once
         # since the deprecation warning will only log each offending line once, we have to do some tomfoolery
         # here in order to make it think each of these calls is coming from a unique call stack; we're basically
         # mocking the method that it would normally use to find the call stack.


### PR DESCRIPTION
This pull request builds on the following one, which should probably be reviewed independently and merged prior to this one:

https://github.com/puppetlabs/puppet/pull/454

Details:
    There were a ton of places in the code where we were doing this:

```
    rescue => detail
       puts detail.backtrace if Puppet[:trace]

In addition to this not being very DRY, it was making it harder to debug the puppet master from within the acceptance testing framework (because when puppet is run in a daemon mode, stdout is swallowed... the "puts" messages were not showing up in the log files or anywhere else, so it was impossible to see the backtrace when something went wrong on the master).

This commit refactors all(?) occurrences of this pattern to call a new utility method:  Puppet::Util::Logging.log_exception(), which provides one single code path for handling exception logging.  It still only logs the backtrace if Puppet[:trace] == true, but it now logs it through the standard Puppet logging framework rather than via "puts".
```
