### PR TITLE
Ticket/2.7.x/12349 order module list stderr output

### DIFF
--- a/acceptance/tests/modules/list.rb
+++ b/acceptance/tests/modules/list.rb
@@ -1,7 +1,7 @@
 test_name "puppet module list test output and dependency error checking"
 
 step "Run puppet module list"
-expected_stdout = <<-HEREDOC
+expected_stdout = <<-HEREDOC.strip
 /opt/puppet-git-repos/puppet/acceptance/tests/modules/fake_modulepath
   apache (0.0.3)
   bacula (0.0.2)
@@ -9,18 +9,18 @@ expected_stdout = <<-HEREDOC
   sqlite (0.0.1.1)
   HEREDOC
 
-expected_stderr = <<-HEREDOC
-Missing dependency `create_resources`:
-  `mysql` (0.0.0) requires `bodepd/create_resources` (>= 0.0.1)
-Missing dependency `stdlib`:
-  `bacula` (0.0.2) requires `puppetlabs/stdlib` (>= 2.2.0)
+expected_stderr = <<-HEREDOC.strip
 Version dependency mismatch `mysql` (0.0.0):
   `bacula` (0.0.2) requires `puppetlabs/mysql` (>= 0.0.1)
 Non semantic version dependency `sqlite` (0.0.1.1):
   `bacula` (0.0.2) requires `puppetlabs/sqlite` (>= 0.0.1)
+Missing dependency `stdlib`:
+  `bacula` (0.0.2) requires `puppetlabs/stdlib` (>= 2.2.0)
+Missing dependency `create_resources`:
+  `mysql` (0.0.0) requires `bodepd/create_resources` (>= 0.0.1)
   HEREDOC
 
 on master, "puppet module list --modulepath /opt/puppet-git-repos/puppet/acceptance/tests/modules/fake_modulepath" do
-  assert_match(expected_stdout, stdout, "puppet module list did not output expected stdout")
-  assert_match(expected_stderr, stderr, "puppet module list did not output expected stderr")
+  assert_equal(expected_stdout, stdout.strip, "puppet module list did not output expected stdout")
+  assert_equal(expected_stderr, stderr.strip, "puppet module list did not output expected stderr")
 end

--- a/lib/puppet/face/module/list.rb
+++ b/lib/puppet/face/module/list.rb
@@ -3,7 +3,9 @@ Puppet::Face.define(:module, '1.0.0') do
     summary "List installed modules"
     description <<-HEREDOC
       List puppet modules from a specific environment, specified modulepath or
-      default to listing modules in the default modulepath:
+      default to listing modules in the default modulepath.  The output will
+      include information about unmet module dependencies based on information
+      from module metadata.
       #{Puppet.settings[:modulepath]}
     HEREDOC
     returns "hash of paths to module objects"
@@ -29,6 +31,9 @@ Puppet::Face.define(:module, '1.0.0') do
       List installed modules from a specified environment:
 
       $ puppet module list --env 'test'
+        Missing dependency `stdlib`:
+          `rrd` (0.0.2) requires `puppetlabs/stdlib` (>= 2.2.0)
+
         /tmp/puppet/modules
           rrd (0.0.2)
 
@@ -56,10 +61,10 @@ Puppet::Face.define(:module, '1.0.0') do
 
       dependency_errors = false
 
-      environment.modules.each do |mod|
-        mod.unsatisfied_dependencies.each do |dep_issue|
+      environment.modules.sort_by {|mod| mod.name}.each do |mod|
+        mod.unmet_dependencies.sort_by {|dep| dep[:name]}.each do |dep|
           dependency_errors = true
-          $stderr.puts dep_issue.to_s
+          $stderr.puts dep[:error]
         end
       end
 

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -155,10 +155,10 @@ class Puppet::Module
     result
   end
 
-  def unsatisfied_dependencies
+  def unmet_dependencies
     return [] unless dependencies
 
-    unsatisfied_dependencies = []
+    unmet_dependencies = []
 
     dependencies.each do |dependency|
       forge_name = dependency['name']
@@ -170,14 +170,14 @@ class Puppet::Module
       unless dep_mod = environment.module(dep_name)
         msg =  "Missing dependency `#{dep_name}`:\n"
         msg += "  `#{self.name}` (#{self.version}) requires `#{forge_name}` (#{version_string})\n"
-        unsatisfied_dependencies << msg
+        unmet_dependencies << { :name => forge_name, :error => msg }
         next
       end
 
       if dep_version && !dep_mod.version
         msg =  "Unversioned dependency `#{dep_mod.name}`:\n"
         msg += "  `#{self.name}` (#{self.version}) requires `#{forge_name}` (#{version_string})\n"
-        unsatisfied_dependencies << msg
+        unmet_dependencies << { :name => forge_name, :error => msg }
         next
       end
 
@@ -188,19 +188,19 @@ class Puppet::Module
         rescue ArgumentError
           msg =  "Non semantic version dependency `#{dep_mod.name}` (#{dep_mod.version}):\n"
           msg += "  `#{self.name}` (#{self.version}) requires `#{forge_name}` (#{version_string})\n"
-          unsatisfied_dependencies << msg
+          unmet_dependencies << { :name => forge_name, :error => msg }
           next
         end
 
         if !actual_version_semver.send(equality, required_version_semver)
           msg =  "Version dependency mismatch `#{dep_mod.name}` (#{dep_mod.version}):\n"
           msg += "  `#{self.name}` (#{self.version}) requires `#{forge_name}` (#{version_string})\n"
-          unsatisfied_dependencies << msg
+          unmet_dependencies << { :name => forge_name, :error => msg }
           next
         end
       end
     end
-    unsatisfied_dependencies
+    unmet_dependencies
   end
 
   def validate_puppet_version


### PR DESCRIPTION
The stdout was ordered, but not the stderr, so the acceptance tests that
passed on my system failed when run by CI.

To order the stderr output I changed the format of the method that gets
unmet dependencies to be a hash that contains the dependency module name
in addition to the error message so that I could sort by that name.

There's also some additional documentation updates to the list command
to show example error output for unmet dependencies.

I changed the unsatisfied_dependencies method to unmet_dependencies
since in future changes that's how dependency problems will be
described to the user, and it's shorter.
