### PR TITLE
Fix for puppetlabs issue 4480 (bug in the runit service)

### DIFF
--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -83,7 +83,14 @@ Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
   end
 
   def start
-    enable unless enabled? == :true
+    if enabled? != :true
+        enable
+        # Work around issue #4480
+        # runsvdir takes up to 5 seconds to recognize
+        # the symlink created by this call to enable
+        Puppet.info "Waiting 5 seconds for runsvdir to discover service #{self.service}"
+        sleep 5
+    end
     sv "start", self.service
   end
 


### PR DESCRIPTION
Sleep for 5 seconds after enabling the service,
before calling sv start. This gives runsvdir time to
notice the new service symlink. Without this delay,
the runit service will an error on start which causes
puppet to fail the start command and skip dependent
resources.

Note: this is identical to the code in https://github.com/puppetlabs/puppet/pull/422, just moved to a branch.
