### PR TITLE
Ticket/2.7.x/7485 zypper 0.6 support

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -10,7 +10,8 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
   #on zypper versions <1.0, the version option returns 1
   #some versions of zypper output on stderr
   def zypper_version
-    zypper "--version", { :failonfail => false, :combine => true}
+    cmd = [self.class.command(:zypper),"--version"]
+    execute(cmd, { :failonfail => false, :combine => true})
   end
 
   # Install a package using 'zypper'.


### PR DESCRIPTION
Replaced code that was erroneously assumed to be equivalent with a
more verbose version that works on all Suse systems.

@daniel-pittman Sorry for not testing more thoroughly on my end. I had originally written the zypper_version function like this pull request and simplified it at the very end. I then incorrectly assumed that if it worked on one puppet then it would work on all. Is this a known puppet issue? It doesn't make sense to me that the current version of the code is not equivalent on all installations of puppet.

@mikeknox I saw the same error you reported on SLED 10.2. This change fixes it and this time I tested it on all Suse versions I have: SLED 10.2, 11.0 and OpenSuse 11.2
