### PR TITLE
Ticket/2.7.x/12464 puppet apply fact loading

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -182,12 +182,12 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       Puppet[:manifest] = manifest
     end
 
-    # Collect our facts.
-    unless facts = Puppet::Node::Facts.indirection.find(Puppet[:node_name_value])
-      raise "Could not find facts for #{Puppet[:node_name_value]}"
-    end
-
     unless Puppet[:node_name_fact].empty?
+      # Collect our facts.
+      unless facts = Puppet::Node::Facts.indirection.find(Puppet[:node_name_value])
+        raise "Could not find facts for #{Puppet[:node_name_value]}"
+      end
+
       Puppet[:node_name_value] = facts.values[Puppet[:node_name_fact]]
       facts.name = Puppet[:node_name_value]
     end
@@ -198,7 +198,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     end
 
     # Merge in the facts.
-    node.merge(facts.values)
+    node.merge(facts.values) if facts
 
     # Allow users to load the classes that puppet agent creates.
     if options[:loadclasses]

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -210,50 +210,10 @@ describe Puppet::Application::Apply do
         expect { @apply.main }.to exit_with 0
       end
 
-      it "should set the facts name based on the node_name_fact" do
-        @facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
-        Puppet::Node::Facts.indirection.save(@facts)
-
-        node = Puppet::Node.new('other_node_name')
-        Puppet::Node.indirection.save(node)
-
-        Puppet[:node_name_fact] = 'my_name_fact'
-
-        expect { @apply.main }.to exit_with 0
-
-        @facts.name.should == 'other_node_name'
-      end
-
-      it "should set the node_name_value based on the node_name_fact" do
-        facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
-        Puppet::Node::Facts.indirection.save(facts)
-        node = Puppet::Node.new('other_node_name')
-        Puppet::Node.indirection.save(node)
-        Puppet[:node_name_fact] = 'my_name_fact'
-
-        expect { @apply.main }.to exit_with 0
-
-        Puppet[:node_name_value].should == 'other_node_name'
-      end
-
-      it "should raise an error if we can't find the facts" do
-        Puppet::Node::Facts.indirection.expects(:find).returns(nil)
-
-        lambda { @apply.main }.should raise_error
-      end
-
       it "should raise an error if we can't find the node" do
         Puppet::Node.indirection.expects(:find).returns(nil)
 
         lambda { @apply.main }.should raise_error
-      end
-
-      it "should merge in our node the loaded facts" do
-        @facts.values = {'key' => 'value'}
-
-        expect { @apply.main }.to exit_with 0
-
-        @node.parameters['key'].should == 'value'
       end
 
       it "should load custom classes if loadclasses" do
@@ -306,6 +266,40 @@ describe Puppet::Application::Apply do
 
         Puppet::Configurer.any_instance.expects(:save_last_run_summary).with(report)
         expect { @apply.main }.to exit_with 0
+      end
+
+      describe "when using node_name_fact" do
+        before :each do
+          @facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
+          Puppet::Node::Facts.indirection.save(@facts)
+          @node = Puppet::Node.new('other_node_name')
+          Puppet::Node.indirection.save(@node)
+          Puppet[:node_name_fact] = 'my_name_fact'
+        end
+
+        it "should set the facts name based on the node_name_fact" do
+          expect { @apply.main }.to exit_with 0
+          @facts.name.should == 'other_node_name'
+        end
+
+        it "should set the node_name_value based on the node_name_fact" do
+          expect { @apply.main }.to exit_with 0
+          Puppet[:node_name_value].should == 'other_node_name'
+        end
+
+        it "should merge in our node the loaded facts" do
+          @facts.values.merge!('key' => 'value')
+
+          expect { @apply.main }.to exit_with 0
+
+          @node.parameters['key'].should == 'value'
+        end
+
+        it "should raise an error if we can't find the facts" do
+          Puppet::Node::Facts.indirection.expects(:find).returns(nil)
+
+          lambda { @apply.main }.should raise_error
+        end
       end
 
       describe "with detailed_exitcodes" do


### PR DESCRIPTION
In fixing #8341 we reduced the caching of facts, leading to a performance
regression in puppet apply. Puppet apply loaded facts twice, first to look up
the fact for node_name_fact, and then a second time under the new node name
given by node_name_fact. This optimizes the common case where node_name_fact
is not set so that facts are only looked up once.

Reported in #12310.
