### PR TITLE
(#12452) Make Puppet::Util::SELinux#read_mounts work on Ruby 1.9

### DIFF
--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -163,7 +163,7 @@ module Puppet::Util::SELinux
     # Read all entries in /proc/mounts.  The second column is the
     # mountpoint and the third column is the filesystem type.
     # We skip rootfs because it is always mounted at /
-    mounts.collect do |line|
+    mounts.each_line do |line|
       params = line.split(' ')
       next if params[2] == 'rootfs'
       mntpoint[params[1]] = params[2]

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::Util::SELinux do
     end
   end
 
-  describe "filesystem detection", :'fails_on_ruby_1.9.2' => true do
+  describe "filesystem detection" do
     before :each do
       fh = stub 'fh', :close => nil
       File.stubs(:open).with("/proc/mounts").returns fh
@@ -192,7 +192,7 @@ describe Puppet::Util::SELinux do
     end
   end
 
-  describe "set_selinux_context", :'fails_on_ruby_1.9.2' => true do
+  describe "set_selinux_context" do
     before :each do
       fh = stub 'fh', :close => nil
       File.stubs(:open).with("/proc/mounts").returns fh


### PR DESCRIPTION
There's no String#collect in Ruby 1.9. #each_line works in both 1.8 and 1.9,
and I think better captures the intent of what we were trying to do anyway.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
