### PR TITLE
Bug/2.7.x/12479 bad undef vs regex match behaviour

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -202,7 +202,7 @@ class Puppet::Parser::AST
     end
 
     def evaluate_match(value, scope, options = {})
-      value = value.is_a?(String) ? value : value.to_s
+      value = value == :undef ? '' : value.to_s
 
       if matched = @value.match(value)
         scope.ephemeral_from(matched, options[:file], options[:line])

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -263,7 +263,7 @@ end
 
 describe Puppet::Parser::AST::Regex do
   before :each do
-    @scope = stub 'scope'
+    @scope = stub 'scope', :ephemeral_from => true
   end
 
   describe "when initializing" do
@@ -321,6 +321,21 @@ describe Puppet::Parser::AST::Regex do
 
       @regex.evaluate_match("value", @scope)
     end
+  end
+
+  it "should match undef to the empty string" do
+    regex = Puppet::Parser::AST::Regex.new(:value => "^$")
+    regex.evaluate_match(:undef, @scope).should be_true
+  end
+
+  it "should not match undef to a non-empty string" do
+    regex = Puppet::Parser::AST::Regex.new(:value => '\w')
+    regex.evaluate_match(:undef, @scope).should be_false
+  end
+
+  it "should match a string against a string" do
+    regex = Puppet::Parser::AST::Regex.new(:value => '\w')
+    regex.evaluate_match('foo', @scope).should be_true
   end
 
   it "should return the regex source with to_s" do


### PR DESCRIPTION
As part of commit 53869e99 we did work to make the behaviour of variables that
were explicitly `undef` at least somewhat saner.

One unintended side-effect of this was that we started matching `undef` as the
literal string `undef`, not as the empty string, and not "not matching".

Either of the later would have been sane things to do; this fixes that by
picking "match undef as empty string".

That is for consistency: we already match the _literal_ empty string as equal
to undef, so it makes sense to treat it the same way for a regular expression.
(Debate on that point is welcome elsewhere, but we should change literal and
regexp matching the same, consistent way if we change it anywhere.)

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
