### PR TITLE
Clear deprecation warnings after each test.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,6 +101,8 @@ RSpec.configure do |config|
     Puppet::Util::Log.close_all
     Puppet::Util::Log.level = @log_level
 
+    Puppet.clear_deprecation_warnings
+
     # uncommenting and manipulating this can be useful when tracking down calls to deprecated code
     #Puppet.log_deprecations_to_file("deprecations.txt", /^Puppet::Util.exec/)
 

--- a/spec/unit/util/logging_spec.rb
+++ b/spec/unit/util/logging_spec.rb
@@ -93,10 +93,6 @@ describe Puppet::Util::Logging do
   end
 
   describe "when sending a deprecation warning" do
-    before do
-      @logger.clear_deprecation_warnings
-    end
-
     it "should log the message with warn" do
       @logger.expects(:warning).with('foo')
       @logger.deprecation_warning 'foo'


### PR DESCRIPTION
this fixes some order dependent test failures
