### PR TITLE
(#12336) Util::'which' may fail if user's path contains a tilde

### DIFF
--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -216,6 +216,13 @@ describe Puppet::Util do
       Puppet::Util.which('doesnotexist').should be_nil
     end
 
+    it "should warn if the user's HOME is not set but their PATH contains a ~" do
+      Puppet::Util.withenv({:HOME => nil, :PATH => "~/bin:/usr/bin:/bin"}) do
+        Puppet::Util::Warnings.expects(:warnonce).once
+        Puppet::Util.which('foo').should_not be_nil
+      end
+    end
+
     it "should reject directories" do
       Puppet::Util.which(base).should be_nil
     end


### PR DESCRIPTION
In certain circumstances (user's HOME environment variable is not set, or has
been unset during ruby execution, plus PATH contains a literal ~ character), Util::w
hich would raise an ArgumentError.  Handle this error by logging a warning (one time only) and ignoring this element of the PATH.
