### PR TITLE
Doc/2.7.x/puppet kick howto in manpage

### DIFF
--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -76,16 +76,30 @@ copy things like LDAP settings.
 
 USAGE NOTES
 -----------
-Puppet kick is useless unless puppet agent is listening for incoming
-connections and allowing access to the `run` endpoint. This entails
-starting the agent with `listen = true` in its puppet.conf file, and
-allowing access to the `/run` path in its auth.conf file; see
-`http://docs.puppetlabs.com/guides/rest_auth_conf.html` for more
-details.
+Puppet kick needs the puppet agent on the target machine to be running as a
+daemon, be configured to listen for incoming network connections, and have an
+appropriate security configuration.
 
-Additionally, due to a known bug, you must make sure a
-namespaceauth.conf file exists in puppet agent's $confdir. This file
-will not be consulted, and may be left empty.  
+The specific changes required are:
+
+* Set `listen = true` in the agent's `puppet.conf` file (or `--listen` on the
+  command line)
+* Configure the node's firewall to allow incoming connections on port 8139
+* Insert the following stanza at the top of the node's `auth.conf` file:
+
+        # Allow puppet kick access
+        path    /run
+        method  save
+        auth    any
+        allow   workstation.example.com
+
+This example would allow the machine `workstation.example.com` to trigger a
+Puppet run; adjust the "allow" directive to suit your site. You may also use
+`allow *` to allow anyone to trigger a Puppet run, but that makes it possible
+to interfere with your site by triggering excessive Puppet runs.
+
+See `http://docs.puppetlabs.com/guides/rest_auth_conf.html` for more details
+about security settings.
 
 OPTIONS
 -------


### PR DESCRIPTION
Previously we told users where they had to look to get this to work; now we
tell them exactly which steps to take, hopefully reducing the barrier for entry.

Edits from NF: Tighten up and remove redundancy, bullet-points are good, remove outdated known-issue text (the issue was #6442, which is closed).

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
