### PR TITLE
Facter 1.5.7 compatibility in the test condition.

### DIFF
--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -611,7 +611,7 @@ describe provider_class do
     end
 
     # Optimisations added for Augeas 0.8.2 or higher is available, see #7285
-    describe ">= 0.8.2 optimisations", :if => Puppet.features.augeas? && Puppet::Util::Package.versioncmp(Facter.value(:augeasversion), "0.8.2") >= 0 do
+    describe ">= 0.8.2 optimisations", :if => Puppet.features.augeas? && Facter.value(:augeasversion) && Puppet::Util::Package.versioncmp(Facter.value(:augeasversion), "0.8.2") >= 0 do
       it "should only load one file if relevant context given" do
         @resource[:context] = "/files/etc/fstab"
 


### PR DESCRIPTION
The `augeasversion` fact was only introduced in Facter 1.6.1, and this test
depends on it - or blows up trying to process `nil` in `versioncmp`.

If we don't have the fact we might as well skip over the test set; it isn't
much worse than working harder at this, and less false positives than guessing
the other way around.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
