### PR TITLE
(#12412) Don't assume root user exists

### DIFF
--- a/acceptance/tests/ticket_4110_puppet_apply_should_not_create_a_user_that_already_exists.rb
+++ b/acceptance/tests/ticket_4110_puppet_apply_should_not_create_a_user_that_already_exists.rb
@@ -1,7 +1,8 @@
 test_name "#4110: puppet apply should not create a user that already exists"
 
 agents.each do |host|
-  apply_manifest_on(host, "user { 'root': ensure => 'present' }") do
-     assert_no_match(/created/, stdout, "we tried to create root on #{host}" )
+  user = host['user']
+  apply_manifest_on(host, "user { '#{user}': ensure => 'present' }") do
+    assert_no_match(/created/, stdout, "we tried to create #{user} on #{host}")
   end
 end


### PR DESCRIPTION
Previously, the test was verifying that puppet didn't create the
`root` user, assuming it already existed on the host. But that's not
the case on Windows.

This commit just changes the test to use `Host['user']`, which always
refers to the user that we ssh'ed to the host as, and therefore,
always exists.
