### PR TITLE
Fix a few acceptance tests that were checking stderr

### DIFF
--- a/acceptance/tests/apply/hashes/should_not_reassign.rb
+++ b/acceptance/tests/apply/hashes/should_not_reassign.rb
@@ -6,5 +6,5 @@ $my_hash['one']='1.5'
 
 apply_manifest_on(agents, manifest, :acceptable_exit_codes => [1]) do
     fail_test "didn't find the failure" unless
-        stderr.include? "Assigning to the hash 'my_hash' with an existing key 'one'"
+        stdout.include? "Assigning to the hash 'my_hash' with an existing key 'one'"
 end

--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -10,7 +10,7 @@ on(agents, %Q{ruby -e "require 'socket'; UNIXServer::new('#{target}').close"})
 
 step "query for all files, which should return nothing"
 on(agents, puppet_resource('file'), :acceptable_exit_codes => [1]) do
-  assert_match(%r{Listing all file instances is not supported.  Please specify a file or directory, e.g. puppet resource file /etc}, stderr)
+  assert_match(%r{Listing all file instances is not supported.  Please specify a file or directory, e.g. puppet resource file /etc}, stdout)
 end
 
 ["/", "/etc"].each do |file|


### PR DESCRIPTION
We recently made a change that tried to fix places where we had been
writing output directly to stdout/stderr rather than using the
Puppet::Util::Logging framework.  There were a few acceptance tests
that were not updated properly in accordance with this change; this
should fix "ticket_8740_should_not_enumerate_root_directory.rb" and
"should_not_reassign.rb".
