### PR TITLE
Clean up deprecation warning

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -1,7 +1,7 @@
 # The container class for implementations.
 class Puppet::Provider
-  include Puppet::Util
   include Puppet::Util::Execution
+  include Puppet::Util
   include Puppet::Util::Errors
   include Puppet::Util::Warnings
   extend Puppet::Util::Warnings

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -420,7 +420,7 @@ module Util
   module_function :execfail
 
   def execute(command, arguments = {})
-    Puppet.deprecation_warning("Puppet::Util::Execution.execute is deprecated; please use Puppet::Util::Execution.execute")
+    Puppet.deprecation_warning("Puppet::Util.execute is deprecated; please use Puppet::Util::Execution.execute")
     Puppet::Util::Execution.execute(command, arguments)
   end
   module_function :execute

--- a/lib/puppet/util/diff.rb
+++ b/lib/puppet/util/diff.rb
@@ -1,6 +1,6 @@
 # Provide a diff between two strings.
 module Puppet::Util::Diff
-  include Puppet::Util
+  include Puppet::Util::Execution
   require 'tempfile'
 
   def diff(old, new)


### PR DESCRIPTION
Puppet::Util.execute deprecation warning message had a typo; also
fixed a few places that were calling the deprecated code path.
