### PR TITLE
(#9595) Flush file log destination by default

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -15,7 +15,7 @@ module Puppet
   setdefaults(:main,
     :trace => [false, "Whether to print stack traces on some errors"],
     :autoflush => {
-      :default => false,
+      :default => true,
       :desc    => "Whether log files should always flush to disk.",
       :hook    => proc { |value| Log.autoflush = value }
     },

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -29,8 +29,8 @@ describe Puppet::Util::Log.desttypes[:file] do
     @class = Puppet::Util::Log.desttypes[:file]
   end
 
-  it "should default to autoflush false" do
-    @class.new('/tmp/log').autoflush.should == false
+  it "should default to autoflush true" do
+    @class.new('/tmp/log').autoflush.should == true
   end
 
   describe "when matching" do


### PR DESCRIPTION
Previously, puppet did not call `IO#flush` after writing each log
message to its log file destination. As a result, if the agent
terminated unexpectedly, any data buffered in ruby, but not yet
flushed would be lost.

This commit changes the default value of autoflush to be true, which
will cause ruby to flush its buffer. Since this property is only used
by the file log destination, and the documentation for the property
says, 'Whether log files should always flush to disk.', it seems safe
to change the default value.
