### PR TITLE
Bug/2.7.x/6663 increase default key length

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -435,8 +435,8 @@ EOT
       is set, ca_days is ignored. Examples are '3600' (one hour)
       and '1825d', which is the same as '5y' (5 years) "],
     :ca_md => ["md5", "The type of hash used in certificates."],
-    :req_bits => [2048, "The bit length of the certificates."],
-    :keylength => [1024, "The bit length of keys."],
+    :req_bits => [4096, "The bit length of the certificates."],
+    :keylength => [4096, "The bit length of keys."],
     :cert_inventory => {
       :default => "$cadir/inventory.txt",
       :mode => 0644,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,17 @@ RSpec.configure do |config|
     # I suck for letting this float. --daniel 2011-04-21
     Signal.stubs(:trap)
 
+    # Longer keys are secure, but they sure make for some slow testing - both
+    # in terms of generating keys, and in terms of anything the next step down
+    # the line doing validation or whatever.  Most tests don't care how long
+    # or secure it is, just that it exists, so these are better and faster
+    # defaults, in testing only.
+    #
+    # I would make these even shorter, but OpenSSL doesn't support anything
+    # below 512 bits.  Sad, really, because a 0 bit key would be just fine.
+    Puppet[:req_bits]  = 512
+    Puppet[:keylength] = 512
+
     # Set the confdir and vardir to gibberish so that tests
     # have to be correctly mocked.
     Puppet[:confdir] = "/dev/null"

--- a/test/lib/puppettest/certificates.rb
+++ b/test/lib/puppettest/certificates.rb
@@ -17,6 +17,10 @@ module PuppetTest::Certificates
   end
 
   def mkCA
+    # The defaults make tests that consume this very slow.
+    Puppet[:req_bits]  = 512
+    Puppet[:keylength] = 512
+
     ca = nil
     assert_nothing_raised {
       ca = Puppet::SSLCertificates::CA.new
@@ -26,6 +30,10 @@ module PuppetTest::Certificates
   end
 
   def mkStore(ca)
+    # The defaults make tests that consume this very slow.
+    Puppet[:req_bits]  = 512
+    Puppet[:keylength] = 512
+
     store = OpenSSL::X509::Store.new
     store.purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT
     store.flags = OpenSSL::X509::V_FLAG_CRL_CHECK
@@ -35,6 +43,10 @@ module PuppetTest::Certificates
   end
 
   def mkcert(hostname)
+    # The defaults make tests that consume this very slow.
+    Puppet[:req_bits]  = 512
+    Puppet[:keylength] = 512
+
     cert = nil
     assert_nothing_raised {
       cert = Puppet::SSLCertificates::Certificate.new(:name => hostname)
@@ -45,6 +57,10 @@ module PuppetTest::Certificates
   end
 
   def mksignedcert(ca = nil, hostname = nil)
+    # The defaults make tests that consume this very slow.
+    Puppet[:req_bits]  = 512
+    Puppet[:keylength] = 512
+
     ca ||= mkCA()
     hostname ||= "ttltest.example.com"
 

--- a/test/lib/puppettest/servertest.rb
+++ b/test/lib/puppettest/servertest.rb
@@ -31,6 +31,10 @@ module PuppetTest::ServerTest
 
   # create a server, forked into the background
   def mkserver(handlers = nil)
+    # The defaults make for very slow tests.
+    Puppet[:req_bits]  = 512
+    Puppet[:keylength] = 512
+
     Puppet[:name] = "puppetmasterd"
     # our default handlers
     unless handlers


### PR DESCRIPTION
The CA key length was lower than it should be - 1024 bits is no longer secure
enough for real world use.  This raises both client and CA certs to use 4096
bit keys.  Those are slow, but effective for long term security.

People who know enough to decide that the trade-off of speed vs limited window
of security can still totally reduce the size of the key without much trouble,
but we default to being more cautious.

This also pegs the key lengths low in testing, since building a 4K key is
awful slow if you want to do it time and time again over the course of dozens
of tests.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
