### PR TITLE
(#1168) Use implicit lower case value of certname

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -226,7 +226,16 @@ module Puppet
     :certname => {:default => fqdn.downcase, :desc => "The name to use when handling certificates.  Defaults
       to the fully qualified domain name.",
       :call_on_define => true, # Call our hook with the default value, so we're always downcased
-      :hook => proc { |value| raise(ArgumentError, "Certificate names must be lower case; see #1168") unless value == value.downcase }},
+      :hook => proc do |value|
+        lowercase_value = value.downcase
+        if value != lowercase_value then
+          Puppet.info "Using the implicit certname value of #{lowercase_value} instead of the explicit #{value} value"
+        end
+        # I have no idea why I need to modify the value in place, but I
+        # do to get the settings system to honor it in the spec test. 
+        value.downcase!
+      end
+    },
     :certdnsnames => {
       :default => '',
       :hook    => proc do |value|

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 
 require 'puppet/defaults'
@@ -17,8 +17,16 @@ describe "Puppet defaults" do
   end
 
   describe "when setting the :certname" do
-    it "should fail if the certname is not downcased" do
-      lambda { Puppet.settings[:certname] = "Host.Domain.Com" }.should raise_error(ArgumentError)
+    it "should implicitly downcase the :certname (#1168)" do
+      Puppet.settings[:certname] = "Host.Domain.Baz"
+      Puppet.settings[:certname].should == "host.domain.baz"
+    end
+    it "should not modify a lower case :certname (#1168)" do
+      Puppet.settings[:certname] = "jeff.foo.yay"
+      Puppet.settings[:certname].should == "jeff.foo.yay"
+    end
+    it "should not fail if the certname is uppercase (#1168)" do
+      lambda { Puppet.settings[:certname] = "Host.Domain.Com" }.should_not raise_error
     end
   end
 


### PR DESCRIPTION
Without this patch we explicitly fail hard when the certname setting is
configured to something that is mixed case or upper case.

This is a problem on Windows where the ComputerName defaults to an upper
case NETBIOS name.  We cannot work around the problem in the MSI
installer effectively because we have virtually no string manipulation
capabilities and embedding JavaScript into an MSI is ill advised for
long term supportability and compatibility with antivirus software.

This patch fixes the problem by always using the implied value of the
certname converted to lower case.  We log an info message for the user
when we're not using the explicit value they've specified.  Info should
only display when using verbose mode to prevent log spam.
