### PR TITLE
Ticket/2.7.x/12645 face actions should have the ability to set specific exit codes

### DIFF
--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -243,6 +243,16 @@ class Puppet::Application::FaceBase < Puppet::Application
     puts render(result, arguments) unless result.nil?
     status = true
 
+  # We need an easy way for the action to set a specific exit code, so we
+  # rescue SystemExit here; This allows each action to set the desired exit
+  # code by simply calling Kernel::exit.  eg:
+  #
+  #   exit(2)
+  #
+  # --kelsey 2012-02-14
+  rescue SystemExit => detail
+    status = detail.status
+
   rescue Exception => detail
     puts detail.backtrace if Puppet[:trace]
     Puppet.err detail.to_s

--- a/spec/lib/puppet/face/basetest.rb
+++ b/spec/lib/puppet/face/basetest.rb
@@ -43,4 +43,9 @@ Puppet::Face.define(:basetest, '0.0.1') do
     summary "return the count of arguments given"
     when_invoked do |*args| args.length - 1 end
   end
+
+  action :with_specific_exit_code do
+    summary "just call exit with the desired exit code"
+    when_invoked do |options| exit(5) end
+  end
 end

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -257,6 +257,11 @@ describe Puppet::Application::FaceBase do
       app.action = app.face.get_action :return_raise
       expect { app.main }.not_to exit_with 0
     end
+
+    it "should use the exit code set by the action" do
+      app.action = app.face.get_action :with_specific_exit_code
+      expect { app.main }.to exit_with 5
+    end
   end
 
   describe "#render" do


### PR DESCRIPTION
Before this patch Face actions do not have the ability to set specific
exit codes. The only way to set a non-zero exit code is to raise an
exception, which sets the exit code to 1.

This patch provides the ability for Face actions to set specific exit
codes by simply calling `Kernel::exit`.

Example:

```
exit(2)
```

Calling `Kernel::exit` raises a SystemExit exception which we rescue in
the `Puppet::Application::FaceBase` class -- the base class of all
Faces, which updates the status variable used to set the exit code later
on.

This patch also includes updated specs related to this change.
