### PR TITLE
Maint/2.7.x/fix range monkey patch mistake

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -160,7 +160,7 @@ class Range
     end
   end unless method_defined? :intersection
 
-  alias_method :&, :intersection unless method_defined? :intersection
+  alias_method :&, :intersection unless method_defined? :&
 end
 
 # Ruby 1.8.5 doesn't have tap


### PR DESCRIPTION
I made a last minute change to the original pull request to not monkey
patch Range to have an intersection method if it was already defined.
However, I also added `unless method_defined? :intersection` to the &
alias after intersection had been defined, so the alias never got
defined.  This commit fixes the :& alias.
