### PR TITLE
Ticket/2.7.x/fix module spec for windows

### DIFF
--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -314,7 +314,7 @@ describe Puppet::Node::Environment do
           FileUtils.mkdir_p(File.join(@first, 'foo2'))
           FileUtils.mkdir_p(File.join(@first, 'foo-bar'))
           FileUtils.mkdir_p(File.join(@first, 'foo_bar'))
-          FileUtils.mkdir_p(File.join(@first, 'foo*bar'))
+          FileUtils.mkdir_p(File.join(@first, 'foo=bar'))
           FileUtils.mkdir_p(File.join(@first, 'foo bar'))
 
           env.modules.collect{|mod| mod.name}.sort.should == %w{foo foo-bar foo2 foo_bar}


### PR DESCRIPTION
Windows has a bigger list of reserved characters that can't be used in
directory names than Linux does, so a spec failed that tried to create
an invalid module dir actually created an invalid Windows dir.

http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#naming_conventions

```
The following reserved characters:
< (less than)
> (greater than)
: (colon)
" (double quote)
/ (forward slash)
\ (backslash)
| (vertical bar or pipe)
? (question mark)
* (asterisk)
```

The main point of the failing spec was to show the restrictions on module
directory names, which is /^[-\w]+$/, so I'm just going to use an '=' in the
spec since Windows doesn't reserve that.
