### PR TITLE
(#12692) Don't hard code CI paths into tests

### DIFF
--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -5,7 +5,7 @@ step "Validate services running agreement ralsh vs. OS service count"
 
 hosts.each do |host|
   if host['platform'].include?('el-')
-    run_script_on(host,'acceptance-tests/tests/resource/service/ticket_4123_should_list_all_running_redhat.sh')
+    run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4123_should_list_all_running_redhat.sh'))
   else
     skip_test "Test not supported on this plaform" 
   end

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -7,6 +7,6 @@ hosts.each do |host|
   unless host['platform'].include?('el-')
     skip_test "Test not supported on this plaform"
    else
-    run_script_on(host,'acceptance-tests/tests/resource/service/ticket_4124_should_list_all_disabled.sh')
+    run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4124_should_list_all_disabled.sh'))
   end
 end


### PR DESCRIPTION
Prior to this commit we hard coded paths in two tests that depended on
our CI system directory structure. This made it hard to use our
acceptance suite without also including the exact same setup. It also
increased the cost of maintaining our CI setup.

This uses a path relative to the test itself (the file that it SCPs
should always be in the same directory as the test itself)

Signed-off-by: Justin Stoller justin@puppetlabs.com

There are no immediate plans to change this directory structure, 
so there no urgency for the pull request, it should be merged up of course,
and you can view the test results here:

https://jenkins.puppetlabs.com/job/Puppet%20FOSS%20CI%20dev%20--%20Test%20Harness%20ticket%207200%20Xml%20formatting/8/
