### PR TITLE
Minor improvement to backtrace logging

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -373,8 +373,8 @@ module Util
 
   # utility method to get the current call stack and format it to a human-readable string (which some IDEs/editors
   # will recognize as links to the line numbers in the trace)
-  def self.pretty_backtrace()
-    caller(1).collect do |line|
+  def self.pretty_backtrace(backtrace = caller(1))
+    backtrace.collect do |line|
       file_path, line_num = line.split(":")
       file_path = expand_symlinks(File.expand_path(file_path))
 

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -33,7 +33,7 @@ module Puppet::Util::Logging
         err(message)
     end
 
-    err(exception.backtrace) if Puppet[:trace] && exception.backtrace
+    err(Puppet::Util.pretty_backtrace(exception.backtrace)) if Puppet[:trace] && exception.backtrace
   end
 
   class DeprecationWarning < Exception; end


### PR DESCRIPTION
With --trace and log_exception(), backtrace logs were being printed
without line separators between them.  This simply cleans up the
formatting so that each hop in the stack is printed on its own line.
