### PR TITLE
Typo/2.7.x/seperated

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -941,7 +941,7 @@ database from within the Puppet Master process."
 
     :lexical => [false, "Whether to use lexical scoping (vs. dynamic)."],
     :templatedir => ["$vardir/templates",
-      "Where Puppet looks for template files.  Can be a list of colon-seperated
+      "Where Puppet looks for template files.  Can be a list of colon-separated
       directories."
     ]
   )

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1258,7 +1258,7 @@ class Type
             require => File[\"/usr/local/scripts\"]
           }
 
-      Multiple dependencies can be specified by providing a comma-seperated list
+      Multiple dependencies can be specified by providing a comma-separated list
       of resources, enclosed in square brackets:
 
           require => [ File[\"/usr/local\"], File[\"/usr/local/scripts\"] ]

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -124,7 +124,7 @@ module Puppet
       end
 
       validate do |value|
-        raise ArgumentError, "Attributes value pairs must be seperated by an =" unless value.include?("=")
+        raise ArgumentError, "Attributes value pairs must be separated by an =" unless value.include?("=")
       end
     end
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -470,7 +470,7 @@ module Puppet
       end
 
       validate do |value|
-        raise ArgumentError, "Key/value pairs must be seperated by an =" unless value.include?("=")
+        raise ArgumentError, "Key/value pairs must be separated by an =" unless value.include?("=")
       end
     end
 
@@ -504,7 +504,7 @@ module Puppet
       end
 
       validate do |value|
-        raise ArgumentError, "Attributes value pairs must be seperated by an =" unless value.include?("=")
+        raise ArgumentError, "Attributes value pairs must be separated by an =" unless value.include?("=")
       end
     end
 


### PR DESCRIPTION
A surprisingly widespread typo! This commit changes all instances of
"seperated" in description strings to "separated."
