### PR TITLE
Maint/2.7.x/fix enviornment sort spec failure

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -141,15 +141,18 @@ class Puppet::Node::Environment
     modules.each do |mod|
       next unless mod.forge_name
       deps[mod.forge_name] ||= []
-      mod.dependencies and mod.dependencies.sort_by {|mod_dep| mod_dep['name']}.each do |mod_dep|
+      mod.dependencies and mod.dependencies.each do |mod_dep|
         deps[mod_dep['name']] ||= []
         dep_details = {
-          'name'    => mod.forge_name,
-          'version' => mod.version,
+          'name'                => mod.forge_name,
+          'version'             => mod.version,
           'version_requirement' => mod_dep['version_requirement']
         }
         deps[mod_dep['name']] << dep_details
       end
+    end
+    deps.each do |mod, mod_deps|
+      deps[mod] = mod_deps.sort_by {|d| d['name']}
     end
     deps
   end

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -235,8 +235,17 @@ describe Puppet::Node::Environment do
               :dependencies => [{ 'name' => 'puppetlabs/bar', "version_requirement" => "3.0.0" }]
             }
           )
+          PuppetSpec::Modules.create(
+            'alpha',
+            @first,
+            :metadata => {
+              :author       => 'puppetlabs',
+              :dependencies => [{ 'name' => 'puppetlabs/bar', "version_requirement" => "~3.0.0" }]
+            }
+          )
 
           env.module_requirements.should == {
+            'puppetlabs/alpha' => [],
             'puppetlabs/foo' => [
               {
                 "name"    => "puppetlabs/bar",
@@ -245,6 +254,11 @@ describe Puppet::Node::Environment do
               }
             ],
             'puppetlabs/bar' => [
+              {
+                "name"    => "puppetlabs/alpha",
+                "version" => "9.9.9",
+                "version_requirement" => "~3.0.0"
+              },
               {
                 "name"    => "puppetlabs/baz",
                 "version" => "9.9.9",


### PR DESCRIPTION
The module_requirements method was sorting the requirements, but only as
it went along, not for the entire list of requirements that got put in
the data structure.  This caused intermittent test failures since
sometimes the results would come out in a different order than the
specs asserted.

This moves the sort to happen _after_ the data is all in.
