### PR TITLE
Bug/2.7.x/12564 insufficient stubbing of childstatus

### DIFF
--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -457,11 +457,13 @@ describe Puppet::Util do
 
     it "should execute a string as a string" do
       instance.expects(:open).with('| echo hello 2>&1').returns('hello')
+      $CHILD_STATUS.expects(:==).with(0).returns(true)
       instance.execpipe('echo hello').should == 'hello'
     end
 
     it "should execute an array by pasting together with spaces" do
       instance.expects(:open).with('| echo hello 2>&1').returns('hello')
+      $CHILD_STATUS.expects(:==).with(0).returns(true)
       instance.execpipe(['echo', 'hello']).should == 'hello'
     end
 


### PR DESCRIPTION
On my machine, $CHILDSTATUS is always "success", so I didn't notice the
failure to stub out the first couple of tests correctly.  Now, with them
stubbed, it is no longer possible that a previous test can leave global state
dangling that will break their assumptions.

Signed-off-by: Daniel Pittman daniel@rimspace.net
