### PR TITLE
(#11740) Wait on the handle from the PROCESS_INFORMATION structure

### DIFF
--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -15,11 +15,6 @@ def after(agent, touched)
 end
 
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    Log.warn('Pending due to #11740')
-    next
-  end
-
   touched = before(agent)
   apply_manifest_on(agent, "exec {'test': command=>'#{agent.touch(touched)}'}") do
     fail_test "didn't seem to run the command" unless

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -311,8 +311,7 @@ module Util
       part.include?(' ') ? %Q["#{part.gsub(/"/, '\"')}"] : part
     end.join(" ") if command.is_a?(Array)
 
-    process_info = Process.create( :command_line => command, :startup_info => {:stdin => stdin, :stdout => stdout, :stderr => stderr} )
-    process_info.process_id
+    Puppet::Util::Windows::Process.execute(command, arguments, stdin, stdout, stderr)
   end
   module_function :execute_windows
 
@@ -349,13 +348,13 @@ module Util
       child_pid = execute_posix(*exec_args)
       exit_status = Process.waitpid2(child_pid).last.exitstatus
     elsif Puppet.features.microsoft_windows?
-      child_pid = execute_windows(*exec_args)
-      exit_status = Process.waitpid2(child_pid).last
-      # $CHILD_STATUS is not set when calling win32/process Process.create
-      # and since it's read-only, we can't set it. But we can execute a
-      # a shell that simply returns the desired exit status, which has the
-      # desired effect.
-      %x{#{ENV['COMSPEC']} /c exit #{exit_status}}
+      process_info = execute_windows(*exec_args)
+      begin
+        exit_status = Puppet::Util::Windows::Process.wait_process(process_info.process_handle)
+      ensure
+        Process.CloseHandle(process_info.process_handle)
+        Process.CloseHandle(process_info.thread_handle)
+      end
     end
 
     [stdin, stdout, stderr].each {|io| io.close rescue nil}

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -2,4 +2,5 @@ module Puppet::Util::Windows
   require 'puppet/util/windows/error'
   require 'puppet/util/windows/security'
   require 'puppet/util/windows/user'
+  require 'puppet/util/windows/process'
 end

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -1,0 +1,31 @@
+require 'puppet/util/windows'
+
+module Puppet::Util::Windows::Process
+  extend Windows::Process
+  extend Windows::Handle
+  extend Windows::Synchronize
+
+  def execute(command, arguments, stdin, stdout, stderr)
+    Process.create( :command_line => command, :startup_info => {:stdin => stdin, :stdout => stdout, :stderr => stderr}, :close_handles => false )
+  end
+  module_function :execute
+
+  def wait_process(handle)
+    WaitForSingleObject(handle, Windows::Synchronize::INFINITE)
+
+    exit_status = [0].pack('L')
+    unless GetExitCodeProcess(handle, exit_status)
+      raise Puppet::Util::Windows::Error.new("Failed to get child process exit code")
+    end
+    exit_status = exit_status.unpack('L').first
+
+    # $CHILD_STATUS is not set when calling win32/process Process.create
+    # and since it's read-only, we can't set it. But we can execute a
+    # a shell that simply returns the desired exit status, which has the
+    # desired effect.
+    %x{#{ENV['COMSPEC']} /c exit #{exit_status}}
+
+    exit_status
+  end
+  module_function :wait_process
+end

--- a/spec/unit/util/execution_stub_spec.rb
+++ b/spec/unit/util/execution_stub_spec.rb
@@ -16,8 +16,7 @@ describe Puppet::Util::ExecutionStub do
     Puppet::Util::ExecutionStub.current_value.should == nil
   end
 
-  # fails on windows, see #11740
-  it "should restore normal execution after 'reset' is called", :fails_on_windows => true do
+  it "should restore normal execution after 'reset' is called" do
     # Note: "true" exists at different paths in different OSes
     if Puppet.features.microsoft_windows?
       true_command = [Puppet::Util.which('cmd.exe').tr('/', '\\'), '/c', 'exit 0']


### PR DESCRIPTION
Previously, the `Puppet::Util.execute` method was using `waitpid2` to
wait for the child process to exit and retrieve its exit status. On
Windows, this method (as implemented by the win32-process gem) opens a
handle to the process with the given pid, and then calls
`WaitForSingleObject` and `GetExitCodeProcess` on the process
handle. However, the pid-to-handle lookup will raise an exception if
the child process has exited. As a result there was a race condition
whereby puppet could sometimes fail to retrieve the exit status of
child processes.

The normal way of getting the exit code for a child process on Windows
is to use the child process handle contained in the
`PROCESS_INFORMATION` structure returned by `CreateProcess`. This
works regardless of whether the child process is currently executing
or not.

This commit reworks the `Puppet::Util.execute_windows` method to wait
on the child process handle contained in the process information
structure. This requires that we pass the `:close_handles => false`
option to the win32-process gem so that it doesn't close the handles.

This commit also re-enables tests that were previously being skipped
due to this bug.
