### PR TITLE
Pip Package Provider: index-url & extra-index-url

### DIFF
--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -140,6 +140,36 @@ describe provider_class do
       @provider.install
     end
 
+    it "should use the extra-index-url option" do
+      @resource[:ensure] = :installed
+      @extra_index_url = 'http://example.com/pypi/'
+      @resource[:source] = "extra-index-url:#{@extra_index_url}"
+      @provider.expects(:lazy_pip).
+        with("install", '-q', "--extra-index-url='#{@extra_index_url}'",
+             "fake_package")
+      @provider.install
+    end
+
+    it "should use the extra-index-url option with spaces" do
+      @resource[:ensure] = :installed
+      @extra_index_url = ' http://example.com/pypi/ http://example2.com/pypi/ '
+      @resource[:source] = "extra-index-url:#{@extra_index_url}"
+      @provider.expects(:lazy_pip).
+        with("install", '-q',
+             "--extra-index-url='http://example.com/pypi/ http://example2.com/pypi/'",
+             "fake_package")
+      @provider.install
+    end
+
+    it "should use the index-url option" do
+      @resource[:ensure] = :installed
+      @index_url = 'http://example.com/pypi/'
+      @resource[:source] = "index-url: #{@index_url}"
+      @provider.expects(:lazy_pip).
+        with("install", '-q', "--index-url=#{@index_url}", "fake_package")
+      @provider.install
+    end
+
   end
 
   describe "uninstall" do


### PR DESCRIPTION
Modified the pip package provider to take the index-url and extra-index-url in the source parameter. This is useful when you want to point to an index server other than PyPi. i.e.

pip install &lt;local-package&gt; --extra-index-url='http://&lt;your-server&gt;/pypi'
