### PR TITLE
(#8011) Support temp repo URLs in pkgutil provider

### DIFF
--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -39,7 +39,8 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
 
     # The -c pkglist lists installed packages
     pkginsts = []
-    pkglist(hash).each do |pkg|
+    output = pkguti(["-c"])
+    parse_pkglist(output).each do |pkg|
       pkg.delete(:avail)
       pkginsts << new(pkg)
 
@@ -72,19 +73,17 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
     end.reject { |h| h.nil? }
   end
 
+  # Turn our pkgutil -c listing into a hash for a single package.
+  def pkgsingle(resource)
+    # The --single option speeds up the execution, because it queries
+    # the package managament system for one package only.
+    command = ["-c", "--single", resource[:name]]
+    self.class.parse_pkglist(run_pkgutil(resource, command), { :justme => resource[:name] })
+  end
+
   # Turn our pkgutil -c listing into a bunch of hashes.
-  # Supports :justme => packagename, which uses the optimised --single arg
-  def self.pkglist(hash)
-    command = ["-c"]
-
-    if hash[:justme]
-      # The --single option speeds up the execution, because it queries
-      # the package managament system for one package only.
-      command << "--single"
-      command << hash[:justme]
-    end
-
-    output = pkguti(command).split("\n")
+  def self.parse_pkglist(output, hash = {})
+    output = output.split("\n")
 
     if output[-1] == "Not in catalog"
       Puppet.warning "Package not in pkgutil catalog: %s" % hash[:justme]
@@ -146,18 +145,29 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
     end
   end
 
+  def run_pkgutil(resource, *args)
+    # Allow source to be one or more URLs pointing to a repository that all
+    # get passed to pkgutil via one or more -t options
+    if resource[:source]
+      sources = [resource[:source]].flatten
+      pkguti *[sources.map{|src| [ "-t", src ]}, *args].flatten
+    else
+      pkguti *args.flatten
+    end
+  end
+
   def install
-    pkguti "-y", "-i", @resource[:name]
+    run_pkgutil @resource, "-y", "-i", @resource[:name]
   end
 
   # Retrieve the version from the current package file.
   def latest
-    hash = self.class.pkglist(:justme => @resource[:name])
+    hash = pkgsingle(@resource)
     hash[:avail] if hash
   end
 
   def query
-    if hash = self.class.pkglist(:justme => @resource[:name])
+    if hash = pkgsingle(@resource)
       hash
     else
       {:ensure => :absent}
@@ -165,10 +175,10 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
   end
 
   def update
-    pkguti "-y", "-u", @resource[:name]
+    run_pkgutil @resource, "-y", "-u", @resource[:name]
   end
 
   def uninstall
-    pkguti "-y", "-r", @resource[:name]
+    run_pkgutil @resource, "-y", "-r", @resource[:name]
   end
 end

--- a/spec/unit/provider/package/pkgutil_spec.rb
+++ b/spec/unit/provider/package/pkgutil_spec.rb
@@ -38,11 +38,37 @@ describe provider do
       @provider.expects(:pkguti).with('-y', '-i', 'TESTpkg')
       @provider.install
     end
+
+    it "should support a single temp repo URL" do
+      @resource[:ensure] = :latest
+      @resource[:source] = "http://example.net/repo"
+      @provider.expects(:pkguti).with('-t', 'http://example.net/repo', '-y', '-i', 'TESTpkg')
+      @provider.install
+    end
+
+    it "should support multiple temp repo URLs as array" do
+      @resource[:ensure] = :latest
+      @resource[:source] = [ 'http://example.net/repo', 'http://example.net/foo' ]
+      @provider.expects(:pkguti).with('-t', 'http://example.net/repo', '-t', 'http://example.net/foo', '-y', '-i', 'TESTpkg')
+      @provider.install
+    end
   end
 
   describe "when updating" do
     it "should use a command without versioned package" do
       @provider.expects(:pkguti).with('-y', '-u', 'TESTpkg')
+      @provider.update
+    end
+
+    it "should support a single temp repo URL" do
+      @resource[:source] = "http://example.net/repo"
+      @provider.expects(:pkguti).with('-t', 'http://example.net/repo', '-y', '-u', 'TESTpkg')
+      @provider.update
+    end
+
+    it "should support multiple temp repo URLs as array" do
+      @resource[:source] = [ 'http://example.net/repo', 'http://example.net/foo' ]
+      @provider.expects(:pkguti).with('-t', 'http://example.net/repo', '-t', 'http://example.net/foo', '-y', '-u', 'TESTpkg')
       @provider.update
     end
   end
@@ -52,6 +78,18 @@ describe provider do
       @provider.expects(:pkguti).with('-y', '-r', 'TESTpkg')
       @provider.uninstall
     end
+
+    it "should support a single temp repo URL" do
+      @resource[:source] = "http://example.net/repo"
+      @provider.expects(:pkguti).with('-t', 'http://example.net/repo', '-y', '-r', 'TESTpkg')
+      @provider.uninstall
+    end
+
+    it "should support multiple temp repo URLs as array" do
+      @resource[:source] = [ 'http://example.net/repo', 'http://example.net/foo' ]
+      @provider.expects(:pkguti).with('-t', 'http://example.net/repo', '-t', 'http://example.net/foo', '-y', '-r', 'TESTpkg')
+      @provider.uninstall
+    end
   end
 
   describe "when getting latest version" do
@@ -59,7 +97,16 @@ describe provider do
       fake_data = "
 noisy output here
 TESTpkg                   1.4.5,REV=2007.11.18      1.4.5,REV=2007.11.20"
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns fake_data
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns fake_data
+      @provider.latest.should == "1.4.5,REV=2007.11.20"
+    end
+
+    it "should support a temp repo URL" do
+      @resource[:source] = "http://example.net/repo"
+      fake_data = "
+noisy output here
+TESTpkg                   1.4.5,REV=2007.11.18      1.4.5,REV=2007.11.20"
+      provider.expects(:pkguti).with('-t', 'http://example.net/repo', '-c', '--single', 'TESTpkg').returns fake_data
       @provider.latest.should == "1.4.5,REV=2007.11.20"
     end
 
@@ -67,19 +114,19 @@ TESTpkg                   1.4.5,REV=2007.11.18      1.4.5,REV=2007.11.20"
       fake_data = "
 noisy output here
 TESTpkg                   1.4.5,REV=2007.11.18      SAME"
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns fake_data
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns fake_data
       @provider.latest.should == "1.4.5,REV=2007.11.18"
     end
 
     it "should handle a non-existent package" do
       fake_data = "noisy output here
 Not in catalog"
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns fake_data
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns fake_data
       @provider.latest.should == nil
     end
 
     it "should warn on unknown pkgutil noise" do
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns("testingnoise")
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns("testingnoise")
       @provider.latest.should == nil
     end
 
@@ -93,7 +140,7 @@ gpg: Good signature from \"Distribution Manager <dm@blastwave.org>\"
 ==> 2770 packages loaded from /var/opt/csw/pkgutil/catalog.mirror.opencsw.org_opencsw_unstable_i386_5.11
 package                   installed                 catalog
 TESTpkg                   1.4.5,REV=2007.11.18      1.4.5,REV=2007.11.20"
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns fake_data
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns fake_data
       @provider.latest.should == "1.4.5,REV=2007.11.20"
     end
 
@@ -101,7 +148,7 @@ TESTpkg                   1.4.5,REV=2007.11.18      1.4.5,REV=2007.11.20"
       fake_data = "
 noisy output here
 REALpkg                   1.4.5,REV=2007.11.18      1.4.5,REV=2007.11.20"
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns fake_data
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns fake_data
       @provider.query[:name].should == "TESTpkg"
     end
   end
@@ -109,21 +156,28 @@ REALpkg                   1.4.5,REV=2007.11.18      1.4.5,REV=2007.11.20"
   describe "when querying current version" do
     it "should return TESTpkg's version string" do
       fake_data = "TESTpkg  1.4.5,REV=2007.11.18  1.4.5,REV=2007.11.20"
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns fake_data
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns fake_data
       @provider.query[:ensure].should == "1.4.5,REV=2007.11.18"
     end
 
     it "should handle a package that isn't installed" do
       fake_data = "TESTpkg  notinst  1.4.5,REV=2007.11.20"
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns fake_data
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns fake_data
       @provider.query[:ensure].should == :absent
     end
 
     it "should handle a non-existent package" do
       fake_data = "noisy output here
 Not in catalog"
-      provider.expects(:pkguti).with(['-c', '--single', 'TESTpkg']).returns fake_data
+      provider.expects(:pkguti).with('-c', '--single', 'TESTpkg').returns fake_data
       @provider.query[:ensure].should == :absent
+    end
+
+    it "should support a temp repo URL" do
+      @resource[:source] = "http://example.net/repo"
+      fake_data = "TESTpkg  1.4.5,REV=2007.11.18  1.4.5,REV=2007.11.20"
+      provider.expects(:pkguti).with('-t', 'http://example.net/repo', '-c', '--single', 'TESTpkg').returns fake_data
+      @provider.query[:ensure].should == "1.4.5,REV=2007.11.18"
     end
   end
 


### PR DESCRIPTION
One or more URLs to pkgutil repositories can be supplied in the "source"
attribute and are given to pkgutil via the -t option as temporary repos.  A
single URL can be given, or multiple URLs as an array.

Issue: https://projects.puppetlabs.com/issues/8011

We went on a wild goose chase in the redmine thread, I wouldn't pay to much attention to it all!  The problem was that there was an issue with String#map on Ruby 1.9, so I copied code from the Augeas provider that then let it support a newline delimited string of URLs as well as an array.  This was superfluous, so this commit only supports a single URL as a string and an array of multiple URLs.
