### PR TITLE
(#12725) Skip setting close-on-exec flag on Windows

### DIFF
--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -78,7 +78,7 @@ class Puppet::Network::HTTP::WEBrick
 
     # open the log manually to prevent file descriptor leak
     file_io = ::File.open(file, "a+")
-    file_io.sync
+    file_io.sync = true
     if defined?(Fcntl::FD_CLOEXEC)
       file_io.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
     end

--- a/spec/unit/network/http/webrick_spec.rb
+++ b/spec/unit/network/http/webrick_spec.rb
@@ -196,7 +196,7 @@ describe Puppet::Network::HTTP::WEBrick do
     before do
       Puppet.settings.stubs(:value).returns "something"
       Puppet.settings.stubs(:use)
-      @filehandle = stub 'handle', :fcntl => nil, :sync => nil
+      @filehandle = stub 'handle', :fcntl => nil, :sync= => nil
 
       File.stubs(:open).returns @filehandle
     end
@@ -238,7 +238,7 @@ describe Puppet::Network::HTTP::WEBrick do
       end
 
       it "should sync the filehandle" do
-        @filehandle.expects(:sync)
+        @filehandle.expects(:sync=).with(true)
 
         @server.setup_logger
       end


### PR DESCRIPTION
When running `puppet agent --listen` on Windows, it would fail trying to set the close-on-exec flag on Windows. While researching this I also found that webrick's http access log was not sync'ing (on any platform) due to a bad copy & paste.
