### PR TITLE
Fix backups_spec, which fails if run by itself

### DIFF
--- a/spec/unit/util/backups_spec.rb
+++ b/spec/unit/util/backups_spec.rb
@@ -13,7 +13,7 @@ describe Puppet::Util::Backups do
 
   describe "when backing up a file" do
     it "should noop if the file does not exist" do
-      FileTest.expects(:exists?).returns false
+      FileTest.expects(:exists?).with(@nosuchfile).returns false
       file = Puppet::Type.type(:file).new(:name => @nosuchfile)
       file.expects(:bucket).never
 


### PR DESCRIPTION
If you run backups_spec without any other tests, it will fail due to
an incomplete expectation on FileTest.exists?.  This commit fixes it.
