### PR TITLE
#1076: User Type: Show warning if an empty group is specified

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -250,6 +250,7 @@ module Puppet
           raise ArgumentError, "Group names must be provided, not GID numbers."
         end
         raise ArgumentError, "Group names must be provided as an array, not a comma-separated list." if value.include?(",")
+        raise ArgumentError, "Group names must not be empty. If you want to specify \"no groups\" pass an empty array" if value.empty?
       end
     end
 


### PR DESCRIPTION
If one specifies an empty string for the group property of the user type, puppet builds an incorrect usermod command.

Example taken from #1076

```
user { "pinky": 
  gid => "pinky",
  ensure => present,
  groups => ""
}
```

The correct way to remove all group membership is to use `groups => []` so we should guide the user in that direction.

The commit series also tries to clean up the user_spec.
