### PR TITLE
Show matched processes for services in debug.

### DIFF
--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -26,6 +26,7 @@ Puppet::Type.type(:service).provide :base do
     IO.popen(ps) { |table|
       table.each_line { |line|
         if regex.match(line)
+          self.debug "Process matched: #{line}"
           ary = line.sub(/^\s+/, '').split(/\s+/)
           return ary[1]
         end


### PR DESCRIPTION
I was having a terrible time debugging why nrpe would not restart correctly on Ubuntu 10.04.

It turns out that puppet was sometimes matching the wrong process number, but I had to add a debug line to find this out. 

Here is an example of someone else having this issue, though I did not find this to be a permanent fix:

http://redscreen.wordpress.com/2011/07/22/restarting-nagios-from-puppet-on-debian/

I see this debug message being useful for other situations, such as testing to make sure a process' regex matches correctly. 
