### PR TITLE
Add nagios_host parameter "address6"

### DIFF
--- a/lib/puppet/external/nagios/base.rb
+++ b/lib/puppet/external/nagios/base.rb
@@ -320,7 +320,7 @@ class Nagios::Base
 
   # object types
   newtype :host do
-    setparameters :host_name, :alias, :display_name, :address, :parents,
+    setparameters :host_name, :alias, :display_name, :address, :address6, :parents,
       :hostgroups, :check_command, :initial_state, :max_check_attempts,
       :check_interval, :retry_interval, :active_checks_enabled,
       :passive_checks_enabled, :check_period, :obsess_over_host,


### PR DESCRIPTION
The "address6" parameter is used for multi-protocol (ipv4 and ipv6)
 monitoring.
- supported in nagios via community patch in nagios exchange
  (http://exchange.nagios.org/directory/Patches/Nagios/IPv6-address-in-host-definition-patch/details)
- supported in icinga
