### PR TITLE
(#7801) Modify include function to accept arrays

### DIFF
--- a/lib/puppet/parser/functions/include.rb
+++ b/lib/puppet/parser/functions/include.rb
@@ -1,6 +1,11 @@
 # Include the specified classes
 Puppet::Parser::Functions::newfunction(:include, :doc => "Evaluate one or more classes.") do |vals|
-    vals = [vals] unless vals.is_a?(Array)
+    if vals.is_a?(Array)
+      # Protect against array inside array
+      vals = vals.flatten
+    else
+      vals = [vals]
+    end
 
     # The 'false' disables lazy evaluation.
     klasses = compiler.evaluate_classes(vals, self, false)

--- a/spec/unit/parser/functions/include_spec.rb
+++ b/spec/unit/parser/functions/include_spec.rb
@@ -28,6 +28,18 @@ describe "the 'include' function" do
     @scope.function_include(["foo","bar"])
   end
 
+  it "should include multiple classes passed in an array" do
+    inc = ["foo","bar"]
+    @compiler.expects(:evaluate_classes).with {|klasses,parser,lazy| klasses == inc}.returns(inc)
+    @scope.function_include([["foo","bar"]])
+  end
+
+  it "should flatten nested arrays" do
+    inc = ["foo","bar","baz"]
+    @compiler.expects(:evaluate_classes).with {|klasses,parser,lazy| klasses == inc}.returns(inc)
+    @scope.function_include([["foo","bar"],"baz"])
+  end
+
   it "should not lazily evaluate the included class" do
     @compiler.expects(:evaluate_classes).with {|klasses,parser,lazy| lazy == false}.returns("foo")
     @scope.function_include("foo")


### PR DESCRIPTION
When an array of classes is passed to the :include function, it
currently attempts to wrap the array in another array, and then pass the
entire array through as a single argument, causing an error.  This
commit calls flatten against the array before sending it through,
following the pattern of :realize, and enabling arrays to be passed as
well as comma-separated or individual class values.
