### PR TITLE
(#9491) Preserve trailing slashes in FileSettings

### DIFF
--- a/lib/puppet/util/settings/file_setting.rb
+++ b/lib/puppet/util/settings/file_setting.rb
@@ -50,12 +50,10 @@ class Puppet::Util::Settings::FileSetting < Puppet::Util::Settings::Setting
   def munge(value)
     # If it's not a fully qualified path...
     if value.is_a?(String) and value !~ /^\$/ and value != 'false'
-      # Make it one
+      # Preserve trailing slash (stripped by expand_path)
+      isdir = value =~ /\/$/
       value = File.expand_path(value)
-    end
-    if value.to_s =~ /\/$/
-      @type = :directory
-      return value.sub(/\/$/, '')
+      value += '/' if isdir
     end
     value
   end

--- a/spec/unit/util/settings/file_setting_spec.rb
+++ b/spec/unit/util/settings/file_setting_spec.rb
@@ -286,5 +286,14 @@ describe Puppet::Util::Settings::FileSetting do
       @file.to_resource[:links].should == :follow
     end
   end
+
+  describe "when munging a filename" do
+    it "should preserve trailing slashes" do
+      settings = mock 'settings'
+      file = Puppet::Util::Settings::FileSetting.new(:settings => settings, :desc => "eh", :name => :mydir, :section => "mysect")
+      path = @basepath + '/'
+      file.munge(path).should == path
+    end
+  end
 end
 


### PR DESCRIPTION
We use the trailing slash in a FileSetting to determine whether it's a
directory. The change in 97c043f4 caused trailing slashes to be stripped.
This caused errors like:

change from directory to file failed: Could not set 'file on ensure: Is a directory - /var/lib/puppet/facts
