### PR TITLE
Don't stub the database in Puppet::Rails tests.

### DIFF
--- a/spec/unit/rails/param_value_spec.rb
+++ b/spec/unit/rails/param_value_spec.rb
@@ -2,18 +2,13 @@
 require 'spec_helper'
 require 'puppet/rails'
 
-describe "Puppet::Rails::ParamValue", :if => Puppet.features.rails? do
-  def column(name, type)
-    ActiveRecord::ConnectionAdapters::Column.new(name, nil, type, false)
-  end
-
+describe "Puppet::Rails::ParamValue", :if => can_use_scratch_database? do
   before do
     require 'puppet/rails/param_value'
-
-    name = stub 'param_name', :name => "foo"
+    setup_scratch_database
 
     # Stub this so we don't need access to the DB.
-    Puppet::Rails::ParamValue.stubs(:columns).returns([column("value", "string")])
+    name = stub 'param_name', :name => "foo"
     Puppet::Rails::ParamName.stubs(:find_or_create_by_name).returns(name)
   end
 

--- a/spec/unit/rails/resource_spec.rb
+++ b/spec/unit/rails/resource_spec.rb
@@ -2,16 +2,10 @@
 require 'spec_helper'
 require 'puppet/rails'
 
-describe "Puppet::Rails::Resource", :if => Puppet.features.rails? do
-  def column(name, type)
-    ActiveRecord::ConnectionAdapters::Column.new(name, nil, type, false)
-  end
-
+describe "Puppet::Rails::Resource", :if => can_use_scratch_database? do
   before do
     require 'puppet/rails/resource'
-
-    # Stub this so we don't need access to the DB.
-    Puppet::Rails::Resource.stubs(:columns).returns([column("title", "string"), column("restype", "string"), column("exported", "boolean")])
+    setup_scratch_database
   end
 
   describe "when creating initial resource arguments" do


### PR DESCRIPTION
The tests for the Puppet::Rails::Host and other Rails interface class stubbed
out parts of rails, in a way that confused things later on and ended up
breaking unrelated tests ... but only when they were invoked in a very
particular order.

Thankfully, just using a scratch database is both cheap and easy here, and
makes this all just work.  So, do that instead.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
