### PR TITLE
(#12881) Fix cron type default name error on windows

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -352,7 +352,10 @@ Puppet::Type.newtype(:cron) do
 
       The user defaults to whomever Puppet is running as."
 
-    defaultto { Etc.getpwuid(Process.uid).name || "root" }
+    defaultto {
+      struct = Etc.getpwuid(Process.uid)
+      struct.respond_to?(:name) && struct.name or 'root'
+    }
   end
 
   newproperty(:target) do

--- a/spec/unit/type/cron_spec.rb
+++ b/spec/unit/type/cron_spec.rb
@@ -468,4 +468,10 @@ describe Puppet::Type.type(:cron), :unless => Puppet.features.microsoft_windows?
     entry = described_class.new(:name => "test_entry", :ensure => :absent)
     entry.value(:command).should == nil
   end
+
+  it "should default to user => root if Etc.getpwuid(Process.uid) returns nil (#12357)" do
+    Etc.expects(:getpwuid).returns(nil)
+    entry = described_class.new(:name => "test_entry", :ensure => :present)
+    entry.value(:user).should eql "root"
+  end
 end


### PR DESCRIPTION
On windows I ran into this error with the cron type:

```
err: Failed to apply catalog: undefined method 'name' for nil:NilClass
```

Without this patch, the problem appears to be that the cron type name
parameter defaults to the following block:

```
defaultto { Etc.getpwuid(Process.uid).name || "root" }
```

On windows `Etc.getpwuid(Process.uid)` returns `nil`.  This patch fixes
the problem by binding the object returned by
`Etc.getpwuid(Process.uid)` to a variable.  We then check if the
variable responds to the `name` method, and only send a message to name
if so.  Otherwise, we return "root"

The included spec test will fail if there is a regression in the desired
behavior.  The expected failure looks like:

```
Failures:

  1) Puppet::Type::Cron should default to user => root if Etc.getpwuid(Process.uid) returns nil (#12357)
     Failure/Error: entry = described_class.new(:name => "test_entry", :ensure => :present)
     NoMethodError:
       undefined method `name' for nil:NilClass
     # ./lib/puppet/type/cron.rb:359:in `default'
     # ./lib/puppet/type.rb:540:in `set_default'
     # ./lib/puppet/type.rb:1834:in `set_parameters'
     # ./lib/puppet/type.rb:1833:in `each'
     # ./lib/puppet/type.rb:1833:in `set_parameters'
     # ./lib/puppet/type.rb:1797:in `initialize'
     # ./spec/unit/type/cron_spec.rb:474:in `new'
     # ./spec/unit/type/cron_spec.rb:474
```
