### PR TITLE
Maint/2.7.x/test failure after activerecord cleanup

### DIFF
--- a/spec/unit/indirector/catalog/active_record_spec.rb
+++ b/spec/unit/indirector/catalog/active_record_spec.rb
@@ -121,10 +121,8 @@ describe "Puppet::Resource::Catalog::ActiveRecord", :if => can_use_scratch_datab
 
     it "should set the last compile time on the host" do
       now = Time.now
-      Time.stubs(:now).returns now
-
       terminus.save(request)
-      Puppet::Rails::Host.find_by_name("foo").last_compile.should == now
+      Puppet::Rails::Host.find_by_name("foo").last_compile.should be_within(1).of(now)
     end
 
     it "should save the Rails host instance" do


### PR DESCRIPTION
This test stubbed time, but didn't catch every possible avenue for creating a
new instance based no the current time of day.  This, combined with the
Ruby 1.9.2 runtime moving to support fractional seconds more broadly, led to
two "equal" times that didn't compare as identical.

We really don't care about the exact time, so much as that we update it
appropriately on the object, so an approximate comparison is more robust than
trying to stub out and freeze time.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
