### PR TITLE
Ticket/2.7.x/11988 Augeas spec fixes on Ruby 1.9

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -298,7 +298,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           if saved_files.size > 0
             root = resource[:root].sub(/^\/$/, "")
             saved_files.each do |key|
-              saved_file = @aug.get(key).to_s.sub(/^\/files/, root)
+              saved_file = @aug.get(key).sub(/^\/files/, root)
               if Puppet[:show_diff]
                 notice "\n" + diff(saved_file, saved_file + ".augnew")
               end

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -334,7 +334,7 @@ describe provider_class do
         @resource[:changes] = ["set #{file}/foo bar"]
 
         @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
-        @augeas.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
+        @augeas.stubs(:get).with("/augeas/events/saved").returns("/files#{file}")
         @augeas.expects(:set).with("/augeas/save", "newfile")
         @augeas.expects(:close).never()
 
@@ -351,8 +351,8 @@ describe provider_class do
         @resource[:changes] = ["set #{file1}/foo bar", "set #{file2}/baz biz"]
 
         @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved[1]", "/augeas/events/saved[2]"])
-        @augeas.stubs(:get).with("/augeas/events/saved[1]").returns(["/files#{file1}"])
-        @augeas.stubs(:get).with("/augeas/events/saved[2]").returns(["/files#{file2}"])
+        @augeas.stubs(:get).with("/augeas/events/saved[1]").returns("/files#{file1}")
+        @augeas.stubs(:get).with("/augeas/events/saved[2]").returns("/files#{file2}")
         @augeas.expects(:set).with("/augeas/save", "newfile")
         @augeas.expects(:close).never()
 
@@ -372,7 +372,7 @@ describe provider_class do
           @resource[:root] = root
 
           @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
-          @augeas.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
+          @augeas.stubs(:get).with("/augeas/events/saved").returns("/files#{file}")
           @augeas.expects(:set).with("/augeas/save", "newfile")
           @augeas.expects(:close).never()
 
@@ -403,7 +403,7 @@ describe provider_class do
         @resource[:changes] = ["set #{file}/foo bar"]
 
         @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved"])
-        @augeas.stubs(:get).with("/augeas/events/saved").returns(["/files#{file}"])
+        @augeas.stubs(:get).with("/augeas/events/saved").returns("/files#{file}")
         @augeas.expects(:set).with("/augeas/save", "newfile")
         @augeas.expects(:close)
 


### PR DESCRIPTION
Previously, the augeas provider made calls like the following:

 @aug.get(key).to_s

Since the Augeas#get method returns a String not an array, the to_s
call is redundant. (Note the #match method does return an array.)

The augeas tests were stubbing the #get method to return an array in
some places (and a string in others). Prior to 1.9.2, ruby will
automatically convert ["foo"].to_s to "foo", so everything worked as
expected. However, under 1.9.2, ["foo"].to_s becomes "[\"foo\"]".

These failures weren't noticed earlier, because our 1.9.2@allFeatures
jenkins nodes do not have ruby-augeas installed. In other words, tests
that require Puppet.features.augeas? were never running in
Jenkins. The recent change to improve augeas testing, removed the
dependency on this feature being installed, so these tests started
failing.

This commit just removes the redundant call to String#to_s, and
updates the spec tests to match what the Augeas#get method really
returns.
