### PR TITLE
(#12914) Allow puppet to be interrupted while waiting for child process

### DIFF
--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -11,7 +11,9 @@ module Puppet::Util::Windows::Process
   module_function :execute
 
   def wait_process(handle)
-    WaitForSingleObject(handle, Windows::Synchronize::INFINITE)
+    while WaitForSingleObject(handle, 0) == Windows::Synchronize::WAIT_TIMEOUT
+      sleep(1)
+    end
 
     exit_status = [0].pack('L')
     unless GetExitCodeProcess(handle, exit_status)


### PR DESCRIPTION
Previously, puppet on Windows could not be interrupted, e.g. Ctrl-C,
while waiting for a child process it executed to exit. For example,
when executing a pre/post run command, msiexec, etc.

This commit changes puppet to poll the state of the child process'
handle, sleeping for 1 second in between.
