### PR TITLE
fix of self::REGEX and version(in def latest) to support extra pkg repositories (e.g. sfe)

### DIFF
--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     packages
   end
 
-  self::REGEX = %r{^(\S+)\s+(\S+)\s+(\S+)\s+}
+  self::REGEX = %r{^(\S+)\s+(?:\(.+\)\s+)?(\S+)\s+(\S+)\s+}
   self::FIELDS = [:name, :version, :status]
 
   def self.parse_line(line)
@@ -59,7 +59,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
   def latest
     version = nil
     pkg(:list, "-Ha", @resource[:name]).split("\n").each do |line|
-      v = line.split[2]
+      v = line.split[-2]
       case v
       when "known"
         return v


### PR DESCRIPTION
using extra repos like sfe will give one additional field in the pkg
output:
# pkg list -H | grep geoip

library/geoip (see)                           1.4.6-0.151.1   installed

---

this commit fixes this problem
