### PR TITLE
Bug/2.7.x/12844 agent enable doesnt remove old lockfile

### DIFF
--- a/test/util/pidlock.rb
+++ b/test/util/pidlock.rb
@@ -91,12 +91,11 @@ class TestPuppetUtilPidlock < Test::Unit::TestCase
     assert l.locked?
     assert l.mine?
 
-    # unlock should fail, and should *not* molest the existing lockfile,
-    # despite it being stale
+    # unlock should fail, but should clear the stale lockfile.
     File.open(l.lockfile, 'w') { |fd| fd.write(childpid) }
     assert File.exists?(l.lockfile)
     assert !l.unlock
-    assert File.exists?(l.lockfile)
+    assert !File.exists?(l.lockfile)
   end
 
   def test_40_not_locked_at_all


### PR DESCRIPTION
The recent changes to support backwards compatibility with 2.7.10
and 2.7.11 introduced a very minor change in behavior with regards
to when a stale lockfile gets cleaned up.  Fixed this test to
recognize the change.
