### PR TITLE
(#7986) Modify pkg provider to handle publisher

### DIFF
--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -12,22 +12,17 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
   def self.instances
     packages = []
 
-    cmd = "#{command(:pkg)} list -H"
-    execpipe(cmd) do |process|
-      hash = {}
-
+    pkg(:list, '-H').each_line do |line|
       # now turn each returned line into a package object
-      process.each_line { |line|
-        if hash = parse_line(line)
-          packages << new(hash)
-        end
-      }
+      if hash = parse_line(line.chomp)
+        packages << new(hash)
+      end
     end
 
     packages
   end
 
-  self::REGEX = %r{^(\S+)\s+(\S+)\s+(\S+)\s+}
+  self::REGEX = /^(\S+)(?:\s+\(.*?\))?\s+(\S+)\s+(\S+)\s+\S+$/
   self::FIELDS = [:name, :version, :status]
 
   def self.parse_line(line)
@@ -57,8 +52,8 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
   # TODO deal with multiple publishers
   def latest
     version = nil
-    pkg(:list, "-Ha", @resource[:name]).split("\n").each do |line|
-      v = line.split[2]
+    pkg(:list, "-Ha", @resource[:name]).each_line do |line|
+      v = parse_line(line.chomp)[:status]
       case v
       when "known"
         return v
@@ -95,7 +90,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       return {:ensure => :absent, :name => @resource[:name]}
     end
 
-    hash = self.class.parse_line(output) || {:ensure => :absent, :name => @resource[:name]}
+    hash = self.class.parse_line(output.chomp) || {:ensure => :absent, :name => @resource[:name]}
     hash
   end
 end

--- a/spec/fixtures/unit/provider/package/pkg/dummy
+++ b/spec/fixtures/unit/provider/package/pkg/dummy
@@ -1,0 +1,1 @@
+dummy                                     2.5.5-0.111     installed  ----

--- a/spec/fixtures/unit/provider/package/pkg/incomplete
+++ b/spec/fixtures/unit/provider/package/pkg/incomplete
@@ -1,0 +1,1 @@
+dummy                                     2.5.5-0.111     installed  ---- RANDOM_TRASH  

--- a/spec/fixtures/unit/provider/package/pkg/publisher
+++ b/spec/fixtures/unit/provider/package/pkg/publisher
@@ -1,0 +1,2 @@
+SUNWpcre (solaris)                            8.8-0.111       installed  ----
+service/network/ssh (solaris)                 0.5.11-0.151.0.1 installed  -----

--- a/spec/fixtures/unit/provider/package/pkg/simple
+++ b/spec/fixtures/unit/provider/package/pkg/simple
@@ -1,0 +1,4 @@
+SUNPython                                     2.5.5-0.111     installed  ----
+SUNWbind                                      9.3.6.1-0.111   installed  ----
+SUNWdistro-license-copyright                  0.5.11-0.111    installed  ----
+SUNWfppd                                      0.2008.8.18-0.111 installed  ----

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -26,38 +26,60 @@ describe Puppet::Type.type(:package).provider(:pkg) do
     @provider.update
   end
 
-  it "should parse a line correctly" do
-    result = described_class.parse_line("dummy 1.0@1.0-1.0 installed ----")
-    result.should == {:name => "dummy", :version => "1.0@1.0-1.0",
-      :ensure => :present, :status => "installed",
-      :provider => :pkg}
+  describe "when calling instances" do
+    it "should correctly parse lines with preferred publisher" do
+      described_class.expects(:pkg).with(:list,'-H').returns File.read(my_fixture('simple'))
+      @instances = described_class.instances.map { |p| Hash.new(:name => p.get(:name), :ensure => p.get(:ensure)) }
+      @instances.size.should == 4
+      @instances[0].should eql Hash.new(:name => 'SUNPython', :ensure => :present)
+      @instances[1].should eql Hash.new(:name => 'SUNWbind', :ensure => :present)
+      @instances[2].should eql Hash.new(:name => 'SUNWdistro-license-copyright', :ensure => :present)
+      @instances[3].should eql Hash.new(:name => 'SUNWfppd', :ensure => :present)
+    end
+
+    it "should correctly parse lines with non preferred publisher" do
+      described_class.expects(:pkg).with(:list,'-H').returns File.read(my_fixture('publisher'))
+      @instances = described_class.instances.map { |p| Hash.new(:name => p.get(:name), :ensure => p.get(:ensure)) }
+      @instances.size.should == 2
+      @instances[0].should eql Hash.new(:name => 'SUNWpcre', :ensure => :present)
+      @instances[1].should eql Hash.new(:name => 'service/network/ssh', :ensure => :present)
+    end
+
+    it "should warn about incorrect lines" do
+      fake_output = File.read(my_fixture('incomplete'))
+      error_line = fake_output.lines[0]
+      described_class.expects(:pkg).with(:list,'-H').returns fake_output
+      described_class.expects(:warning).with "Failed to match 'pkg list' line #{error_line.inspect}"
+      described_class.instances
+    end
   end
 
-  it "should fail to parse an incorrect line" do
-    result = described_class.parse_line("foo")
-    result.should be_nil
+  describe "when query a package" do
+    it "should find the package" do
+      @provider.stubs(:pkg).with(:list,'-H','dummy').returns File.read(my_fixture('dummy'))
+      @provider.query.should == {
+        :name     => 'dummy',
+        :ensure   => :present,
+        :version  => '2.5.5-0.111',
+        :status   => "installed",
+        :provider => :pkg,
+      }
+    end
+
+    it "should return :absent when the package is not found" do
+      # I dont know what the acutal error looks like, but according to type/pkg.rb we're just
+      # reacting on the Exception anyways
+      @provider.expects(:pkg).with(:list, "-H", "dummy").raises Puppet::ExecutionFailure, 'Not found'
+      @provider.query.should == {:ensure => :absent, :name => "dummy"}
+    end
+
+    it "should return :absent when the packageline cannot be parsed" do
+      @provider.stubs(:pkg).with(:list,'-H','dummy').returns File.read(my_fixture('incomplete'))
+      @provider.query.should == {
+        :name   => 'dummy',
+        :ensure => :absent
+      }
+    end
   end
 
-  it "should fail to list a missing package" do
-    # I dont know what the acutal error looks like, but according to type/pkg.rb we're just
-    # reacting on the Exception anyways
-    @provider.expects(:pkg).with(:list, "-H", "dummy").raises Puppet::ExecutionFailure, 'Not found'
-    @provider.query.should == {:ensure => :absent, :name => "dummy"}
-  end
-
-  it "should fail to list a package when it can't parse the output line" do
-    @provider.expects(:pkg).with(:list, "-H", "dummy").returns "failed"
-    @provider.query.should == {:ensure => :absent, :name => "dummy"}
-  end
-
-  it "should list package correctly" do
-    @provider.expects(:pkg).with(:list, "-H", "dummy").returns "dummy 1.0@1.0-1.0 installed ----"
-    @provider.query.should == {
-      :name     => "dummy",
-      :version  => "1.0@1.0-1.0",
-      :ensure   => :present,
-      :status   => "installed",
-      :provider => :pkg
-    }
-  end
 end


### PR DESCRIPTION
The pkg provider that is used on solaris does not handle output lines of pkg list correctly if there is a package installed that is not from the preferred publisher.

The patchset changes the regex so lines are correctly parsed, updates the spec tests and contains some general cleanup of the provider
