### PR TITLE
(#12960) Fix puppet resource <type> if type has no providers

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -905,9 +905,10 @@ class Type
 
   # Return a list of one suitable provider per source, with the default provider first.
   def self.providers_by_source
-    # Put the default provider first, then the rest of the suitable providers.
+    # Put the default provider first (can be nil), then the rest of the suitable providers.
     sources = []
     [defaultprovider, suitableprovider].flatten.uniq.collect do |provider|
+      next if provider.nil?
       next if sources.include?(provider.source)
 
       sources << provider.source

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -611,6 +611,27 @@ describe Puppet::Type, :fails_on_windows => true do
     end
   end
 
+  describe "::instances" do
+    before :each do
+      @fake_type = Puppet::Type.newtype(:foo) do
+        newparam(:name) do
+          isnamevar
+        end
+        newproperty(:prop1) do
+        end
+      end
+      @unsuitable_provider = Puppet::Type.type(:foo).provide(:fake1) do
+        confine :exists => '/no/such/file'
+        mk_resource_methods
+      end
+    end
+
+    it "should not fail if no suitable providers are found" do
+      lambda { @fake_type.instances }.should_not raise_error
+    end
+  end
+
+
   describe "::ensurable?" do
     before :each do
       class TestEnsurableType < Puppet::Type


### PR DESCRIPTION
puppet resource type calls the instances method of the type class. The
instances method then calls providers_by_source which can fail if the
following conditions are true

```
1) there is at least one provider defined for the type
2) all providers are unsuitable
```

If both requirements are met, the method self.defaultprovider will
return nil and we get the following error message (provided by Ben Ford)

```
# puppet resource maillist
puppet/type.rb:902:in `providers_by_source': undefined method `source'
for nil:NilClass (NoMethodError)
```

The fix handles the case where defaultprovider can be nil
