### PR TITLE
(#8714) Remove SELinux symlink dereferencing

### DIFF
--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -171,12 +171,6 @@ module Puppet::Util::SELinux
     mntpoint
   end
 
-  def realpath(path)
-    path, rest = Pathname.new(path), []
-    path, rest = path.dirname, [path.basename] + rest while ! path.exist?
-    File.join( path.realpath, *rest )
-  end
-
   def parent_directory(path)
     Pathname.new(path).dirname.to_s
   end
@@ -194,7 +188,6 @@ module Puppet::Util::SELinux
     # Just in case: return something if you're down to "/" or ""
     # Remove the last slash and everything after it,
     #   and repeat with that as the file for the next loop through.
-    path = realpath(path)
     while not path.empty?
       return mnts[path] if mnts.has_key?(path)
       path = parent_directory(path)

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -64,43 +64,6 @@ describe Puppet::Util::SELinux do
     it "should return false for a noncapable filesystem" do
       selinux_label_support?('/mnt/nfs/testfile').should be_false
     end
-
-    it "should follow symlinks when determining file systems" do
-      self.stubs(:realpath).with('/mnt/symlink/testfile').returns('/mnt/nfs/dest/testfile')
-
-      selinux_label_support?('/mnt/symlink/testfile').should be_false
-    end
-
-  end
-
-  describe "realpath" do
-    it "should handle files that don't exist" do
-
-      # Since I'm stubbing Pathname.new for this test,
-      # I need to also stub the internal calls to Pathname.new,
-      # which happen in Pathname.dirname and Parthname.basename
-      # I want those to return real Pathname objects,
-      # so I'm creating them before the stub is in place.
-      realpaths = Hash.new {|hash, path| hash[path] = Pathname.new(path) }
-      paths = ['symlink', '/mnt']
-      paths.each { |path| realpaths[path] }
-
-      realpaths['/mnt/symlink'] = stubs "Pathname"
-      realpaths['/mnt/symlink'].stubs(:realpath).returns(realpaths['/mnt/nfs/dest'])
-      realpaths['/mnt/symlink'].stubs(:exist?).returns(true)
-
-      realpaths['/mnt/symlink/nonexistant'] = stubs "Pathname"
-      realpaths['/mnt/symlink/nonexistant'].stubs(:realpath).raises(Errno::ENOENT)
-      realpaths['/mnt/symlink/nonexistant'].stubs(:exist?).returns(false)
-      realpaths['/mnt/symlink/nonexistant'].stubs(:dirname).returns(realpaths['/mnt/symlink'])
-      realpaths['/mnt/symlink/nonexistant'].stubs(:basename).returns(realpaths['nonexistant'])
-
-      realpaths.each do |path, value|
-        Pathname.stubs(:new).with(path).returns(value)
-      end
-
-      realpath('/mnt/symlink/nonexistant').should == '/mnt/nfs/dest/nonexistant'
-    end
   end
 
   describe "get_selinux_current_context" do


### PR DESCRIPTION
Symlinks support SELinux file labels independent of the target
file or the capabilities of the target filesystem. This removes
the intentional dereferencing of the symlink we were doing to
determine if the path specified for the file resource was on a
SELinux-capable filesystem or not.
