### PR TITLE
Document missing --noop option for puppet apply

### DIFF
--- a/man/man8/puppet-apply.8
+++ b/man/man8/puppet-apply.8
@@ -56,6 +56,10 @@ Execute a specific piece of Puppet code
 Print extra information\.
 .
 .TP
+\-\-noop
+Execute in dry-run mode, to see what would be the result of applying the catalog\.
+.
+.TP
 \-\-apply
 Apply a JSON catalog (such as one generated with \'puppet master \-\-compile\')\. You can either specify a JSON file or pipe in JSON from standard input\.
 .


### PR DESCRIPTION
I had to resort to the Interwebs to find that this option exists. `puppet help apply` didn't tell me.
