### PR TITLE
Provide a helpful error message when name resolution fails

### DIFF
--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -101,6 +101,13 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     end
 
     http_connection.send(method, *args)
+  rescue SocketError => error
+    case error.message
+    when /nodename nor servname provided, or not known/
+      raise Puppet::Error, "Could not resolve hostname '#{http_connection.address}'"
+    else
+      raise
+    end
   rescue OpenSSL::SSL::SSLError => error
     if error.message.include? "certificate verify failed"
       raise Puppet::Error, "#{error.message}.  This is often because the time is out of sync on the server or client"

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -93,6 +93,13 @@ describe Puppet::Indirector::REST do
   describe "when making http requests" do
     include PuppetSpec::Files
 
+    it "should provide a helpful error message when name resolution fails" do
+      connection = Net::HTTP.new('a_hopefully_unresolvable_name', 0)
+      @searcher.stubs(:network).returns connection
+
+      expect { @searcher.http_request(:get, stub('request'), '/') }.to raise_error(/Could not resolve hostname 'a_hopefully_unresolvable_name'/)
+    end
+
     it "should provide a suggestive error message when certificate verify failed" do
       connection = Net::HTTP.new('my_server', 8140)
       @searcher.stubs(:network).returns(connection)


### PR DESCRIPTION
Previously, this would print a message like:

getaddrinfo: nodename nor servname not provided, or not found

Which is opaque to anyone who doesn't already know what it means. This is a
very common case (it happens, for instance, when first starting a default agent
without setting up a DNS entry for 'puppet'). Now, we catch SocketError when
making an HTTP request, and print a more useful error message if this is the
particular failure case.
