### PR TITLE
(Maint) Don't change /etc/hosts permissions

### DIFF
--- a/acceptance/tests/resource/host/should_query_all.rb
+++ b/acceptance/tests/resource/host/should_query_all.rb
@@ -24,5 +24,5 @@ agents.each do |agent|
   end
 
   step "clean up the system afterwards"
-  on agent, "mv -f #{backup} /etc/hosts"
+  on agent, "cat #{backup} > /etc/hosts && rm -f #{backup}"
 end


### PR DESCRIPTION
Previously, the acceptance test was backing up /etc/hosts, modifying it,
verifying that `puppet resource host` returned all of the host records,
and then moving the backup over /etc/hosts. In doing so, the permissions
on /etc/hosts were overwritten.

Since puppet runs as root on agent nodes, the test was setting the mode
of /etc/hosts to 0600 (based on root's umask).

However, when the node is also a master, the puppet master cannot read
the file, since it runs as `puppet`. This causes problems for any later
test that uses `with_master_running_on`, e.g.
ticket_7117_broke_env_criteria_authconf.rb:

   Could not resolve 192.168.100.114: Permission denied - /etc/hosts

This commit changes the test so that the existing /etc/hosts file is
truncated and the old contents restored, thereby preserving its old
mode.

Ideally, it would be nice to not have to overwrite /etc/hosts at all,
e.g. puppet resource host --param target=/my/tmp/file, but this only
works for a single host resource, not when querying all of them.
