### PR TITLE
(Maint) Consistently use the same agent fqdn

### DIFF
--- a/acceptance/tests/ticket_7117_broke_env_criteria_authconf.rb
+++ b/acceptance/tests/ticket_7117_broke_env_criteria_authconf.rb
@@ -23,9 +23,10 @@ with_master_running_on(master, "--dns_alt_names=\"puppet, $(hostname -s), $(host
     # Run test on Agents
     step "Run agent to upload facts"
     on agent, puppet_agent("--test --server #{master}")
+    fqdn = on(agent, facter("fqdn")).stdout
 
     step "Fetch agent facts from Puppet Master"
-    on(agent, "curl -k -H \"Accept: yaml\" https://#{master}:8140/override/facts/\`hostname -f\`") do
+    on(agent, "curl -k -H \"Accept: yaml\" https://#{master}:8140/override/facts/#{fqdn}") do
       assert_match(/--- !ruby\/object:Puppet::Node::Facts/, stdout, "Agent Facts not returned for #{agent}")
     end
   end


### PR DESCRIPTION
Previously, the test would always fail when the rhel6-32-1 box was
reverted to its `git` snapshot, and the test executed. The box, for
better or worse, reports the following:

```
[root@rhel6-32-1 ~]# hostname -f
rhel6-32-1
[root@rhel6-32-1 ~]# facter fqdn
rhel6-32-1.puppetlabs.lan
```

The agent submits its report using the latter, but the test attempts to
retrieve the facts using the former:

```
curl -k -H \"Accept: yaml\" https://rhel6-32-1:8140/override/facts/`hostname -f`"
```

And that always fails:

```
Could not find facts rhel6-32-1
```

This issue does not occur when running the non-Windows acceptance tests,
because those jobs run on centos-55-386-1 and ubuntu-1004-32-1, which
don't have inconsistency in their domain as reported by facter and
`hostname -f`

This commit changes the test to request the facts from the master using
the same fqdn that the agent used in its report.
