### PR TITLE
(#3452) Autorequire user for cron

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -358,6 +358,11 @@ Puppet::Type.newtype(:cron) do
     }
   end
 
+  # Autorequire the owner of the crontab entry.
+  autorequire(:user) do
+    self[:user]
+  end
+
   newproperty(:target) do
     desc "Where the cron job should be stored.  For crontab-style
       entries this is the same as the user and defaults that way.


### PR DESCRIPTION
If you specify a “user” on a cron entry, it ought to be automatically
required.
