### PR TITLE
Fix order-dependent failures in spec/unit/parser/functions/split_spec.rb

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -57,6 +57,7 @@ class Puppet::Node::Environment
 
   def self.clear
     @seen.clear
+    self.current = nil
   end
 
   attr_reader :name


### PR DESCRIPTION
These were happening when this file was run after
spec/unit/resource/type_spec.rb. The issue is that type_spec.rb was creating an
environment called 'env', which made that the 'current' (thread-local)
environment. This caused functions to be loaded onto it, rather than onto the
root environment. However, in split_spec.rb, a scope was created with the
default environment ('production'). This caused functions to be found and thus
not loaded (as they are on the current environment 'env'), but not actually
available to the scope, which has functions from 'production' and root.

This is a degenerate state, as ordinarily scope objects are created during a
compilation, using the environment of the compiler, which is always the current
environment.

This change clears the current environment whenever known environments are
cleared. This solve the problem because we clear environments between tests.
It should be safe because the only place we do it in code is when setting the
value of settings, which doesn't happen during a compilation.
