### PR TITLE
(#13204) Workaround duplicate Augeas save events

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -299,6 +299,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             root = resource[:root].sub(/^\/$/, "")
             saved_files.each do |key|
               saved_file = @aug.get(key).sub(/^\/files/, root)
+              next unless File.exists?(saved_file + ".augnew")
               if Puppet[:show_diff]
                 notice "\n" + diff(saved_file, saved_file + ".augnew")
               end

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -329,6 +329,7 @@ describe provider_class do
       it "should call diff when a file is shown to have been changed" do
         file = "/etc/hosts"
         File.stubs(:delete)
+        File.stubs(:exists?).returns(true)
 
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
@@ -346,6 +347,7 @@ describe provider_class do
         file1 = "/etc/hosts"
         file2 = "/etc/resolv.conf"
         File.stubs(:delete)
+        File.stubs(:exists?).returns(true)
 
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file1}/foo bar", "set #{file2}/baz biz"]
@@ -366,6 +368,7 @@ describe provider_class do
           root = "/tmp/foo"
           file = "/etc/hosts"
           File.stubs(:delete)
+          File.stubs(:exists?).returns(true)
 
           @resource[:context] = "/files"
           @resource[:changes] = ["set #{file}/foo bar"]
@@ -398,6 +401,7 @@ describe provider_class do
 
       it "should cleanup the .augnew file" do
         file = "/etc/hosts"
+        File.stubs(:exists?).returns(true)
 
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
@@ -410,6 +414,30 @@ describe provider_class do
         File.expects(:delete).with(file + ".augnew")
 
         @provider.expects(:diff).with("#{file}", "#{file}.augnew").returns("")
+        @provider.should be_need_to_run
+      end
+
+      # Workaround for Augeas bug #264 which reports filenames twice
+      it "should handle duplicate /augeas/events/saved filenames" do
+        file = "/etc/hosts"
+
+        augnew = states("augnew").starts_as("present")
+
+        File.stubs(:exists?).returns(true).when(augnew.is("present"))
+        File.stubs(:exists?).returns(false).when(augnew.is("absent"))
+
+        @resource[:context] = "/files"
+        @resource[:changes] = ["set #{file}/foo bar"]
+
+        @augeas.stubs(:match).with("/augeas/events/saved").returns(["/augeas/events/saved[1]", "/augeas/events/saved[2]"])
+        @augeas.stubs(:get).with("/augeas/events/saved[1]").returns("/files#{file}")
+        @augeas.stubs(:get).with("/augeas/events/saved[2]").returns("/files#{file}")
+        @augeas.expects(:set).with("/augeas/save", "newfile")
+        @augeas.expects(:close)
+
+        File.expects(:delete).with(file + ".augnew").when(augnew.is("present")).then(augnew.is("absent"))
+
+        @provider.expects(:diff).with("#{file}", "#{file}.augnew").returns("").when(augnew.is("present"))
         @provider.should be_need_to_run
       end
 


### PR DESCRIPTION
Bug #264 in Augeas causes duplicate save events to be returned when editing
under /boot in newfile mode.  Because we loop around these events, diffing and
unlinking the files, this causes an ENOENT error when we process the same event
twice.

This commit checks that the file we intend to operate on exists.
