### PR TITLE
2.7.x bug13126

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -331,7 +331,7 @@ module Puppet
       # If the file exists, return false (i.e., don't run the command),
       # else return true
       def check(value)
-        ! FileTest.exists?(value)
+        ! FileTest.exists?(value) and  ! FileTest.symlink?(value)
       end
     end
 

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -541,6 +541,14 @@ describe Puppet::Type.type(:exec) do
           @test[:creates] = @exist
           @test.check_all_attributes.should == false
         end
+
+        it "should not run when the item is a broken symlink" do
+          @badlink = tmpfile('test.link')
+          @badtarget = tmpfile('no.file.here')
+          FileUtils.ln_s(@badtarget, @badlink)
+          @test[:creates] = @badlink
+          @test.check_all_attributes.should == false
+        end
       end
 
       context "with an array with one item" do


### PR DESCRIPTION
Peter Bukowinski reported that Exec's create attribute treats broken symlinks as missing files. This is because FileTest.exists?(value) uses stat (not lstat), and does not find broken symlinks. This patch modifies the :creates attribute of exec to check for symlinks as well as files.
