### PR TITLE
Add comment with URL of upstream pull request for trollop

### DIFF
--- a/lib/puppet/util/command_line/trollop.rb
+++ b/lib/puppet/util/command_line/trollop.rb
@@ -2,6 +2,10 @@
 ## Author::    William Morgan (mailto: wmorgan-trollop@masanjin.net)
 ## Copyright:: Copyright 2007 William Morgan
 ## License::   the same terms as ruby itself
+##
+## 2012-03: small changes made by cprice (chris@puppetlabs.com);
+##           patch submitted for upstream consideration:
+##           https://gitorious.org/trollop/mainline/merge_requests/9
 
 require 'date'
 


### PR DESCRIPTION
Submitted a patch to the upstream trollop library, in hopes
that these changes will get included and we won't have our
own custom fork of the project.  Added this to the comments
for visibility.
