### PR TITLE
Bug/2.7.x/incorrect dynamic scope warnings

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -21,7 +21,7 @@ class Puppet::Parser::Scope
   attr_accessor :source, :resource
   attr_accessor :base, :keyword
   attr_accessor :top, :translated, :compiler
-  attr_accessor :parent, :dynamic
+  attr_accessor :parent
   attr_reader :namespaces
 
   # thin wrapper around an ephemeral
@@ -273,7 +273,7 @@ class Puppet::Parser::Scope
       # We can't use "if table[name]" here because the value might be false
       table[name]
     elsif parent
-      parent.oldlookupvar(name,options.merge(:dynamic => (dynamic || options[:dynamic])))
+      parent.oldlookupvar(name,options)
     else
       :undefined
     end

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -66,7 +66,7 @@ class Puppet::Resource::Type
     static_parent = evaluate_parent_type(resource)
     scope = static_parent || resource.scope
 
-    scope = scope.newscope(:namespace => namespace, :source => self, :resource => resource, :dynamic => !static_parent) unless resource.title == :main
+    scope = scope.newscope(:namespace => namespace, :source => self, :resource => resource) unless resource.title == :main
     scope.compiler.add_class(name) unless definition?
 
     set_resource_parameters(resource, scope)

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -92,14 +92,6 @@ describe Puppet::Parser::Scope do
 
       Puppet::Parser::Scope.new.singleton_class.ancestors.should be_include(mod)
     end
-
-    it "should remember if it is dynamic" do
-      (!!Puppet::Parser::Scope.new(:dynamic => true).dynamic).should == true
-    end
-
-    it "should assume it is not dynamic" do
-      (!Puppet::Parser::Scope.new.dynamic).should == true
-    end
   end
 
   describe "when looking up a variable" do

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -435,7 +435,7 @@ describe Puppet::Resource::Type do
 
     it "should set all of its parameters in a subscope" do
       subscope = stub 'subscope', :compiler => @compiler
-      @scope.expects(:newscope).with(:source => @type, :dynamic => true, :namespace => 'foo', :resource => @resource).returns subscope
+      @scope.expects(:newscope).with(:source => @type, :namespace => 'foo', :resource => @resource).returns subscope
       @type.expects(:set_resource_parameters).with(@resource, subscope)
 
       @type.evaluate_code(@resource)


### PR DESCRIPTION
Until the scope inheritance is completely fixed for the new non-dynamic scoping model, we should give appropriate dynamic scoping deprecation warnings.

This branch will perform two queries; one with the dynamic scoping and a second one that directly references the local scope or top/node scope. If the answers differ then removing dynamic scoping would affect the puppet run and a warning should be given.
