### PR TITLE
Remove 'ca_md' option from the documentation.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -639,10 +639,6 @@ EOT
       is set, ca_days is ignored. Examples are '3600' (one hour)
       and '1825d', which is the same as '5y' (5 years) ",
 		},
-    :ca_md => {
-			:default		=> "md5",
-			:desc				=> "The type of hash used in certificates.",
-		},
     :req_bits => {
 			:default		=> 4096,
 			:desc				=> "The bit length of the certificates.",

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -107,14 +107,6 @@ Wether the master should function as a certificate authority\.
 .SS "ca_days"
 How long a certificate should be valid\. This parameter is deprecated, use ca_ttl instead
 .
-.SS "ca_md"
-The type of hash used in certificates\.
-.
-.IP "\(bu" 4
-\fIDefault\fR: md5
-.
-.IP "" 0
-.
 .SS "ca_name"
 The name to use the Certificate Authority certificate\.
 .


### PR DESCRIPTION
certificate_authority.rb is hardcoded to use SHA1.

Signed-off-by: Michael Smith michael@hurts.ca
