### PR TITLE
(#13439) refactor spec helper for spec compatibility between 2.7 and master

### DIFF
--- a/lib/puppet/util/settings.rb
+++ b/lib/puppet/util/settings.rb
@@ -921,4 +921,24 @@ if @config.include?(:run_mode)
       end
     end
   end
+
+  def initialize_everything_for_tests()
+    # these globals are set by Application
+    $puppet_application_mode = nil
+    $puppet_application_name = nil
+    # Set the confdir and vardir to gibberish so that tests
+    # have to be correctly mocked.
+    self[:confdir] = "/dev/null"
+    self[:vardir] = "/dev/null"
+
+    # Avoid opening ports to the outside world
+    self[:bindaddress] = "127.0.0.1"
+  end
+  private :initialize_everything_for_tests
+
+  def clear_everything_for_tests()
+    self.clear
+  end
+  private :clear_everything_for_tests
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,14 +62,13 @@ RSpec.configure do |config|
       }
     end
 
-    # these globals are set by Application
-    $puppet_application_mode = nil
-    $puppet_application_name = nil
 
     # REVISIT: I think this conceals other bad tests, but I don't have time to
     # fully diagnose those right now.  When you read this, please come tell me
     # I suck for letting this float. --daniel 2011-04-21
     Signal.stubs(:trap)
+
+    Puppet.settings.send(:initialize_everything_for_tests)
 
     # Longer keys are secure, but they sure make for some slow testing - both
     # in terms of generating keys, and in terms of anything the next step down
@@ -82,13 +81,6 @@ RSpec.configure do |config|
     Puppet[:req_bits]  = 512
     Puppet[:keylength] = 512
 
-    # Set the confdir and vardir to gibberish so that tests
-    # have to be correctly mocked.
-    Puppet[:confdir] = "/dev/null"
-    Puppet[:vardir] = "/dev/null"
-
-    # Avoid opening ports to the outside world
-    Puppet.settings[:bindaddress] = "127.0.0.1"
 
     @logs = []
     Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
@@ -97,7 +89,7 @@ RSpec.configure do |config|
   end
 
   config.after :each do
-    Puppet.settings.clear
+    Puppet.settings.send(:clear_everything_for_tests)
     Puppet::Node::Environment.clear
     Puppet::Util::Storage.clear
     Puppet::Util::ExecutionStub.reset


### PR DESCRIPTION
This change is intended to allow specs in external projects (grayskull, puppetlabs-stdlib) to be compatible with both 2.7 and master versions of puppet.  It basically just abstracts the interactions with the Settings objects that was happening in spec_helper into private setup / teardown methods in the Settings class itself.

We'd already started this pattern in master, so this change just exposes it in 2.7 as well.
