### PR TITLE
(#13439) refactor spec_helper for spec compatibility between 2.7 and master

### DIFF
--- a/lib/puppet/util/settings.rb
+++ b/lib/puppet/util/settings.rb
@@ -106,16 +106,7 @@ class Puppet::Util::Settings
   end
   private :unsafe_clear
 
-  # Private method for internal test use only; allows to do a comprehensive clear of all settings between tests.
-  #
-  # @return nil
-  def clear_everything_for_tests()
-    @sync.synchronize do
-      unsafe_clear(true, true)
-      @app_defaults_initialized = false
-    end
-  end
-  private :clear_everything_for_tests
+
 
   # This is mostly just used for testing.
   def clearused
@@ -1139,4 +1130,57 @@ if @config.include?(:run_mode)
       end
     end
   end
+
+
+
+
+  # Private method for internal test use only; allows to assign reasonable values to the "app defaults"
+  #  settings for the purpose of test runs.
+  #
+  # @return [Hash] a hash containing the default values to use for application settings during testing.
+  def app_defaults_for_tests()
+    {
+        :run_mode   => :user,
+        :name       => :apply,
+        :logdir     => "/dev/null",
+        :confdir    => "/dev/null",
+        :vardir     => "/dev/null",
+        :rundir     => "/dev/null",
+    }
+  end
+  private :app_defaults_for_tests
+
+
+  # Private method for internal test use only; allows to assign reasonable values to the "app defaults"
+  #  settings for the purpose of test runs.
+  #
+  # @return nil
+  def initialize_everything_for_tests()
+    # Initialize "app defaults" settings to a good set of test values
+    app_defaults_for_tests.each do |key, value|
+      Puppet.settings.set_value(key, value, :application_defaults)
+    end
+
+    # Avoid opening ports to the outside world
+    Puppet.settings[:bindaddress] = "127.0.0.1"
+
+    # We don't want to depend upon the reported domain name of the
+    # machine running the tests, nor upon the DNS setup of that
+    # domain.
+    Puppet.settings[:use_srv_records] = false
+  end
+  private :initialize_everything_for_tests
+
+  # Private method for internal test use only; allows to do a comprehensive clear of all settings between tests.
+  #
+  # @return nil
+  def clear_everything_for_tests()
+    @sync.synchronize do
+      unsafe_clear(true, true)
+      @app_defaults_initialized = false
+    end
+  end
+  private :clear_everything_for_tests
+
+
 end

--- a/spec/lib/puppet_spec/settings.rb
+++ b/spec/lib/puppet_spec/settings.rb
@@ -1,8 +1,9 @@
 module PuppetSpec::Settings
 
-  # It would probably be preferable to refactor defaults.rb such that the real definitions of these settings
-  #  were available as a variable, which was then accessible for use during tests.  However, I'm not doing that
-  #  yet because I don't want to introduce any additional moving parts to this already very large changeset.
+  # It would probably be preferable to refactor defaults.rb such that the real definitions of
+  #  these settings were available as a variable, which was then accessible for use during tests.
+  #  However, I'm not doing that yet because I don't want to introduce any additional moving parts
+  #  to this already very large changeset.
   #  Would be nice to clean this up later.  --cprice 2012-03-20
   TEST_APP_DEFAULT_DEFINITIONS = {
     :run_mode     => { :default => :test, :desc => "run mode" },
@@ -11,13 +12,5 @@ module PuppetSpec::Settings
     :confdir      => { :type => :directory, :default => "test", :desc => "confdir" },
     :vardir       => { :type => :directory, :default => "test", :desc => "vardir" },
     :rundir       => { :type => :directory, :default => "test", :desc => "rundir" },
-  }
-  TEST_APP_DEFAULTS = {
-      :run_mode   => :user,
-      :name       => :apply,
-      :logdir     => "/dev/null",
-      :confdir    => "/dev/null",
-      :vardir     => "/dev/null",
-      :rundir     => "/dev/null",
   }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,8 @@ RSpec.configure do |config|
     # I suck for letting this float. --daniel 2011-04-21
     Signal.stubs(:trap)
 
+    Puppet.settings.send(:initialize_everything_for_tests)
+
     # Longer keys are secure, but they sure make for some slow testing - both
     # in terms of generating keys, and in terms of anything the next step down
     # the line doing validation or whatever.  Most tests don't care how long
@@ -80,19 +82,6 @@ RSpec.configure do |config|
     Puppet[:req_bits]  = 512
     Puppet[:keylength] = 512
 
-    # Initialize "app defaults" settings to a good set of test values
-    PuppetSpec::Settings::TEST_APP_DEFAULTS.each do |key, value|
-      Puppet.settings.set_value(key, value, :application_defaults)
-    end
-
-
-    # Avoid opening ports to the outside world
-    Puppet.settings[:bindaddress] = "127.0.0.1"
-
-    # We don't want to depend upon the reported domain name of the
-    # machine running the tests, nor upon the DNS setup of that
-    # domain.
-    Puppet.settings[:use_srv_records] = false
 
     @logs = []
     Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))

--- a/spec/unit/util/settings_spec.rb
+++ b/spec/unit/util/settings_spec.rb
@@ -73,7 +73,7 @@ describe Puppet::Util::Settings do
     it "should fail if someone attempts to initialize app defaults more than once" do
       @settings.expects(:app_defaults_initialized?).returns(true)
       expect {
-        @settings.initialize_app_defaults(PuppetSpec::Settings::TEST_APP_DEFAULTS)
+        @settings.initialize_app_defaults({})
       }.to raise_error(Puppet::DevError)
     end
 
@@ -89,7 +89,7 @@ describe Puppet::Util::Settings do
     it "should call the hacky run mode setter method until we do a better job of separating run_mode" do
       @settings.define_settings(:main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS)
       @settings.expects(:run_mode=).with(:user)
-      @settings.initialize_app_defaults(PuppetSpec::Settings::TEST_APP_DEFAULTS)
+      @settings.initialize_app_defaults(@settings.send(:app_defaults_for_tests))
     end
   end
 


### PR DESCRIPTION
This change is intended to allow specs in external projects (grayskull, puppetlabs-stdlib) to be compatible with both 2.7 and master versions of puppet.  It basically just abstracts the interactions with the Settings objects that was happening in spec_helper into private setup / teardown methods in the Settings class itself.
