### PR TITLE
Ticket/2.7.x/12466 unset x forwarded for headers in supplied config

### DIFF
--- a/ext/rack/files/apache2.conf
+++ b/ext/rack/files/apache2.conf
@@ -26,6 +26,9 @@ Listen 8140
         SSLVerifyDepth  1
         SSLOptions +StdEnvVars
 
+        # This header needs to be set if using a loadbalancer or proxy
+        RequestHeader unset X-Forwarded-For
+
         RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
         RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
         RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e


### PR DESCRIPTION
Without this patch the handling of
X-Forwarded-For headers is insecure in a
default apache conf supplied with puppet.
This patch ensures X-Forwarded-For headers
are dropped.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
