### PR TITLE
Bug/2.7.x/13397 ensure latest multiple gems

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -104,7 +104,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     # This always gets the latest version available.
     hash = self.class.gemlist(:justme => resource[:name])
 
-    hash[:ensure]
+    hash[:ensure][0]
   end
 
   def query

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -141,16 +141,20 @@ module Puppet
               end
             end
 
-            case is
-            when @latest
-              return true
-            when :present
-              # This will only happen on retarded packaging systems
-              # that can't query versions.
-              return true
-            else
-              self.debug "#{@resource.name} #{is.inspect} is installed, latest is #{@latest.inspect}"
+            case
+              when is.is_a?(Array) && is.include?(@latest)
+                return true
+              when is == @latest
+                return true
+              when is == :present
+                # This will only happen on retarded packaging systems
+                # that can't query versions.
+                return true
+              else
+                self.debug "#{@resource.name} #{is.inspect} is installed, latest is #{@latest.inspect}"
             end
+
+
           when :absent
             return true if is == :absent or is == :purged
           when :purged

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -87,6 +87,21 @@ describe provider_class do
     end
   end
 
+  describe "#latest" do
+    it "should return a single value for 'latest'" do
+      #gemlist is used for retrieving both local and remote version numbers, and there are cases
+      # (particularly local) where it makes sense for it to return an array.  That doesn't make
+      # sense for '#latest', though.
+      provider.class.expects(:gemlist).with({ :justme => 'myresource'}).returns({
+          :name     => 'myresource',
+          :ensure   => ["3.0"],
+          :provider => :gem,
+          })
+      provider.latest.should == "3.0"
+    end
+  end
+
+
   describe "#instances" do
     before do
       provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -270,6 +270,16 @@ describe Puppet::Type.type(:package) do
           @provider.expects(:install).never
           @catalog.apply
         end
+
+        describe "when ensure is set to 'latest'" do
+          it "should not install if the value is in the array" do
+            @provider.expects(:latest).returns("3.0")
+            @package[:ensure] = "latest"
+            @package.property(:ensure).insync?(installed_versions).should be_true
+            @provider.expects(:install).never
+            @catalog.apply
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
As of 2.7.12, if you had "ensure=>latest" for any gem package
resource, puppet would not correctly detect that the gem
was already installed and would attempt to install it on
every run.  (This was because the "latest" method on the
gem provider was always returning an array, when it should
always be returning a single value.)
