### PR TITLE
Ruby 1.9.3-p0 support in spec tests.

### DIFF
--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -589,9 +589,9 @@ describe Puppet::SSL::Host do
     end
 
     it "should return a Host instance created with the name of each found instance" do
-      key = stub 'key', :name => "key"
-      cert = stub 'cert', :name => "cert"
-      csr = stub 'csr', :name => "csr"
+      key  = stub 'key',  :name => "key",  :to_ary => nil
+      cert = stub 'cert', :name => "cert", :to_ary => nil
+      csr  = stub 'csr',  :name => "csr",  :to_ary => nil
 
       Puppet::SSL::Key.indirection.expects(:search).returns [key]
       Puppet::SSL::Certificate.indirection.expects(:search).returns [cert]


### PR DESCRIPTION
Ruby 1.9.3-p0 will invoke `to_ary` on every element of an Array when
`Array#flatten` is invoked, which Ruby 1.8.7, and Ruby 1.9.3-p125 will not.

This leads to a failure in this test because our stub objects explode when you
invoke that method, rather than the normal Ruby behaviour.  Just stubbing that
method to return `nil` will do the right thing.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
