### PR TITLE
(#13567) Fix create_resources name parameter bug

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -51,14 +51,15 @@ Puppet::Parser::Functions::newfunction(:create_resources, :doc => <<-'ENDHEREDOC
   # iterate through the resources to create
   defaults = args[2] || {}
   args[1].each do |title, params|
-    raise ArgumentError, 'params should not contain title' if(params['title'])
     params = defaults.merge(params)
+    Puppet::Util.symbolizehash!(params)
+    raise ArgumentError, 'params should not contain title' if(params[:title])
     case type_of_resource
     # JJM The only difference between a type and a define is the call to instantiate_resource
     # for a defined type.
     when :type, :define
       p_resource = Puppet::Parser::Resource.new(type_name, title, :scope => self, :source => resource)
-      params.merge(:name => title).each do |k,v|
+      {:name => title}.merge(params).each do |k,v|
         p_resource.set_parameter(k,v)
       end
       if type_of_resource == :define then

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -26,6 +26,20 @@ describe 'function for dynamically creating resources' do
     expect { @scope.function_create_resources(['foo', 'bar', 'blah', 'baz']) }.should raise_error(ArgumentError, 'create_resources(): wrong number of arguments (4; must be 2 or 3)')
   end
 
+  describe 'when the caller does not supply a name parameter' do
+    it 'should set a default resource name equal to the resource title' do
+      Puppet::Parser::Resource.any_instance.expects(:set_parameter).with(:name, 'test').once
+      @scope.function_create_resources(['notify', {'test'=>{}}])
+    end
+  end
+  describe 'when the caller supplies a name parameter' do
+    it 'should set the resource name to the value provided' do
+      Puppet::Parser::Resource.any_instance.expects(:set_parameter).with(:name, 'user_supplied').once
+      Puppet::Parser::Resource.any_instance.expects(:set_parameter).with(:name, 'test').never
+      @scope.function_create_resources(['notify', {'test'=>{'name' => 'user_supplied'}}])
+    end
+  end
+
   describe 'when creating native types' do
     before :each do
       Puppet[:code]='notify{test:}'


### PR DESCRIPTION
Previously, the create_resources function would inconsistently override name parameters provided by the user, setting the name parameter equal to the resource title. This commit modifies create_resources such that when provided, user-supplied name parameters are used correctly and consistently.

See [http://projects.puppetlabs.com/issues/13567](http://projects.puppetlabs.com/issues/13567) for full description.
