### PR TITLE
(#9167) Do not send email when nothing changes

### DIFF
--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -113,6 +113,13 @@ Puppet::Reports.register_report(:tagmail) do
       return
     end
 
+    metrics = raw_summary['resources'] || {} rescue {}
+
+    if metrics['out_of_sync'] == 0 && metrics['changed'] == 0
+      Puppet.notice "Not sending tagmail report; no changes"
+      return
+    end
+
     taglists = parse(File.read(Puppet[:tagmap]))
 
     # Now find any appropriately tagged messages.

--- a/spec/fixtures/unit/reports/tagmail/tagmail_email.conf
+++ b/spec/fixtures/unit/reports/tagmail/tagmail_email.conf
@@ -1,0 +1,2 @@
+secure: user@domain.com
+

--- a/spec/unit/reports/tagmail_spec.rb
+++ b/spec/unit/reports/tagmail_spec.rb
@@ -88,4 +88,81 @@ describe tagmail do
       results.should be_nil
     end
   end
+
+  describe "the behavior of tagmail.process" do
+    before do
+      Puppet[:tagmap] = my_fixture "tagmail_email.conf"
+    end
+
+    let(:processor) do
+      processor = Puppet::Transaction::Report.new("apply")
+      processor.extend(Puppet::Reports.report(:tagmail))
+      processor
+    end
+
+    context "when any messages match a positive tag" do
+      before do
+        processor << log_entry
+      end
+
+      let(:log_entry) do
+        Puppet::Util::Log.new(
+          :level => :notice, :message => "Secure change", :tags => %w{secure})
+      end
+
+      let(:message) do
+        "#{log_entry.time} Puppet (notice): Secure change"
+      end
+
+      it "should send email if there are changes" do
+        processor.expects(:send).with([[['user@domain.com'], message]])
+        processor.expects(:raw_summary).returns({
+          "resources" => { "changed" => 1, "out_of_sync" => 0 }
+        })
+
+        processor.process
+      end
+
+      it "should send email if there are resources out of sync" do
+        processor.expects(:send).with([[['user@domain.com'], message]])
+        processor.expects(:raw_summary).returns({
+          "resources" => { "changed" => 0, "out_of_sync" => 1 }
+        })
+
+        processor.process
+      end
+
+      it "should not send email if no changes or resources out of sync" do
+        processor.expects(:send).never
+        processor.expects(:raw_summary).returns({
+          "resources" => { "changed" => 0, "out_of_sync" => 0 }
+        })
+
+        processor.process
+      end
+
+      it "should log a message if no changes or resources out of sync" do
+        processor.expects(:send).never
+        processor.expects(:raw_summary).returns({
+          "resources" => { "changed" => 0, "out_of_sync" => 0 }
+        })
+
+        Puppet.expects(:notice).with("Not sending tagmail report; no changes")
+        processor.process
+      end
+
+      it "should send email if raw_summary is not defined" do
+        processor.expects(:send).with([[['user@domain.com'], message]])
+        processor.expects(:raw_summary).returns(nil)
+        processor.process
+      end
+
+      it "should send email if there are no resource metrics" do
+        processor.expects(:send).with([[['user@domain.com'], message]])
+        processor.expects(:raw_summary).returns({'resources' => nil})
+        processor.process
+      end
+    end
+  end
 end
+


### PR DESCRIPTION
Without this patch the tagmail report sends an email even when there are
no changes or resources out of sync. This has the undesired effect of
sending emails after every Puppet run.

When there are no changes or out of sync resources, tagmail logs a
notice stating the fact and skips processing logs and sending emails.

This patch includes new spec tests for the changes in behavior.
