### PR TITLE
(#13584) master swallows errors during startup

### DIFF
--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -135,10 +135,10 @@ class Puppet::Util::Log
       flushqueue
       @destinations[dest]
     rescue => detail
-      Puppet.log_exception(detail)
-
       # If this was our only destination, then add the console back in.
       newdestination(:console) if @destinations.empty? and (dest != :console and dest != "console")
+
+      Puppet.log_exception(detail)
     end
   end
 


### PR DESCRIPTION
Our main "exit_on_fail" method was only catching
and logging a limited subset of all possible errors;
this was preventing some types of errors (e.g.
File Access errors) from being logged, which makes
it much more difficult to troubleshoot failures
on CI and other locations.
