### PR TITLE
(#3581) Stop forking around: Add fork helper method

### DIFF
--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -201,7 +201,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       # do, then do the next host.
       if @children.length < options[:parallel] and ! todo.empty?
         host = todo.shift
-        pid = fork do
+        pid = safe_posix_fork do
           run_for_host(host)
         end
         @children[pid] = host

--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -123,7 +123,7 @@ Puppet::Reports.register_report(:tagmail) do
 
   # Send the email reports.
   def send(reports)
-    pid = fork do
+    pid = Puppet::Util.safe_posix_fork do
       if Puppet[:smtpserver] != "none"
         begin
           Net::SMTP.start(Puppet[:smtpserver]) do |smtp|

--- a/spec/unit/application/kick_spec.rb
+++ b/spec/unit/application/kick_spec.rb
@@ -239,14 +239,14 @@ describe Puppet::Application::Kick, :if => Puppet.features.posix? do
         @kick.hosts = ['host1', 'host2', 'host3']
         Process.stubs(:wait).returns(1).then.returns(2).then.returns(3).then.raises(Errno::ECHILD)
 
-        @kick.expects(:fork).times(3).returns(1).then.returns(2).then.returns(3)
+        @kick.expects(:safe_posix_fork).times(3).returns(1).then.returns(2).then.returns(3)
 
         expect { @kick.main }.to raise_error SystemExit
       end
 
       it "should delegate to run_for_host per host" do
         @kick.hosts = ['host1', 'host2']
-        @kick.stubs(:fork).returns(1).yields
+        @kick.stubs(:safe_posix_fork).returns(1).yields
         Process.stubs(:wait).returns(1).then.raises(Errno::ECHILD)
 
         @kick.expects(:run_for_host).times(2)


### PR DESCRIPTION
Without this patch we are forking all over the place. All this forking
around is problematic when it comes to things like ActiveRecord and
database connections. It turns out that forking has a nasty side effect
of aggressively closing database connections and spewing errors all over
the place.

This patch introduces a new `Puppet::Util#safe_posix_fork` method that
does forking the right way (closing file descriptors, and resetting
stdin, stdout, and stderr). Tagmail, Puppet kick, and
`Puppet::Util#execute_posix` have been updated to make use of this new
functionality.

In the future, `Puppet::Util#safe_posix_fork` should be used in-place of
direct calls to `Kernel#fork`.

This patch includes related spec tests.
