### PR TITLE
(#13737) Swap build_tree and format_tree method names

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -164,9 +164,9 @@ Puppet::Face.define(:module, '1.0.0') do
         Puppet.err(return_value[:error][:multiline])
         exit 1
       else
-        tree = Puppet::Module::Tool.format_tree(return_value[:installed_modules], return_value[:install_dir])
+        tree = Puppet::Module::Tool.build_tree(return_value[:installed_modules], return_value[:install_dir])
         return_value[:install_dir] + "\n" +
-        Puppet::Module::Tool.build_tree(tree)
+        Puppet::Module::Tool.format_tree(tree)
       end
     end
   end

--- a/lib/puppet/face/module/list.rb
+++ b/lib/puppet/face/module/list.rb
@@ -171,17 +171,17 @@ Puppet::Face.define(:module, '1.0.0') do
           # since dependencies may be cyclical.
           modules_by_num_requires = modules.sort_by {|m| m.required_by.size}
           @seen = {}
-          tree = list_format_tree(modules_by_num_requires, [], nil,
+          tree = list_build_tree(modules_by_num_requires, [], nil,
             :label_unmet => true, :path => path, :label_invalid => false)
         else
           tree = []
           modules.sort_by { |mod| mod.forge_name or mod.name  }.each do |mod|
-            tree << list_format_node(mod, path, :label_unmet => false,
+            tree << list_build_node(mod, path, :label_unmet => false,
                       :path => path, :label_invalid => true)
           end
         end
 
-        output << Puppet::Module::Tool.build_tree(tree)
+        output << Puppet::Module::Tool.format_tree(tree)
       end
 
       output
@@ -224,10 +224,10 @@ Puppet::Face.define(:module, '1.0.0') do
   #     │ └── bodepd-create_resources (v0.0.1)
   #     └── puppetlabs-sqlite (v0.0.1)
   #
-  def list_format_tree(list, ancestors=[], parent=nil, params={})
+  def list_build_tree(list, ancestors=[], parent=nil, params={})
     list.map do |mod|
       next if @seen[(mod.forge_name or mod.name)]
-      node = list_format_node(mod, parent, params)
+      node = list_build_node(mod, parent, params)
       @seen[(mod.forge_name or mod.name)] = true
 
       unless ancestors.include?(mod)
@@ -240,7 +240,7 @@ Puppet::Face.define(:module, '1.0.0') do
           str << "(#{colorize(:cyan, mis_mod[:version_constraint])})"
           node[:dependencies] << { :text => str }
         end
-        node[:dependencies] += list_format_tree(mod.dependencies_as_modules,
+        node[:dependencies] += list_build_tree(mod.dependencies_as_modules,
           ancestors + [mod], mod, params)
       end
 
@@ -259,7 +259,7 @@ Puppet::Face.define(:module, '1.0.0') do
   #
   # Returns a Hash
   #
-  def list_format_node(mod, parent, params)
+  def list_build_node(mod, parent, params)
     str = ''
     str << (mod.forge_name ? mod.forge_name.gsub('/', '-') : mod.name)
     str << ' (' + colorize(:cyan, mod.version ? "v#{mod.version}" : '???') + ')'

--- a/lib/puppet/face/module/upgrade.rb
+++ b/lib/puppet/face/module/upgrade.rb
@@ -75,9 +75,9 @@ Puppet::Face.define(:module, '1.0.0') do
         Puppet.err(return_value[:error][:multiline])
         exit 0
       else
-        tree = Puppet::Module::Tool.format_tree(return_value[:affected_modules], return_value[:base_dir])
+        tree = Puppet::Module::Tool.build_tree(return_value[:affected_modules], return_value[:base_dir])
         return_value[:base_dir] + "\n" +
-        Puppet::Module::Tool.build_tree(tree)
+        Puppet::Module::Tool.format_tree(tree)
       end
     end
   end

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -50,7 +50,7 @@ module Puppet
 
       # Builds a formatted tree from a list of node hashes containing +:text+
       # and +:dependencies+ keys.
-      def self.build_tree(nodes, level = 0)
+      def self.format_tree(nodes, level = 0)
         str = ''
         nodes.each_with_index do |node, i|
           last_node = nodes.length - 1 == i
@@ -62,7 +62,7 @@ module Puppet
           str << (deps.empty? ? "─" : "┬")
           str << " #{node[:text]}\n"
 
-          branch = build_tree(deps, level + 1)
+          branch = format_tree(deps, level + 1)
           branch.gsub!(/^#{indent} /, indent + '│') unless last_node
           str << branch
         end
@@ -70,7 +70,7 @@ module Puppet
         return str
       end
 
-      def self.format_tree(mods, dir)
+      def self.build_tree(mods, dir)
         mods.each do |mod|
           version_string = mod[:version][:vstring].sub(/^(?!v)/, 'v')
 
@@ -81,7 +81,7 @@ module Puppet
 
           mod[:text] = "#{mod[:module]} (#{colorize(:cyan, version_string)})"
           mod[:text] += " [#{mod[:path]}]" unless mod[:path] == dir
-          format_tree(mod[:dependencies], dir)
+          build_tree(mod[:dependencies], dir)
         end
       end
     end

--- a/spec/unit/module_tool_spec.rb
+++ b/spec/unit/module_tool_spec.rb
@@ -4,14 +4,14 @@ require 'spec_helper'
 require 'puppet/module_tool'
 
 describe Puppet::Module::Tool, :fails_on_windows => true do
-  describe '.build_tree' do
+  describe '.format_tree' do
     it 'should return an empty tree when given an empty list' do
-      subject.build_tree([]).should == ''
+      subject.format_tree([]).should == ''
     end
 
     it 'should return a shallow when given a list without dependencies' do
       list = [ { :text => 'first' }, { :text => 'second' }, { :text => 'third' } ]
-      subject.build_tree(list).should == <<-TREE
+      subject.format_tree(list).should == <<-TREE
 ├── first
 ├── second
 └── third
@@ -32,7 +32,7 @@ TREE
           ]
         },
       ]
-      subject.build_tree(list).should == <<-TREE
+      subject.format_tree(list).should == <<-TREE
 └─┬ first
   └─┬ second
     └── third
@@ -54,7 +54,7 @@ TREE
         },
         { :text => 'fourth' }
       ]
-      subject.build_tree(list).should == <<-TREE
+      subject.format_tree(list).should == <<-TREE
 ├─┬ first
 │ └─┬ second
 │   └── third
@@ -77,7 +77,7 @@ TREE
           ]
         }
       ]
-      subject.build_tree(list).should == <<-TREE
+      subject.format_tree(list).should == <<-TREE
 └─┬ first
   ├─┬ second
   │ └── third
@@ -101,7 +101,7 @@ TREE
         },
         { :text => 'fifth' }
       ]
-      subject.build_tree(list).should == <<-TREE
+      subject.format_tree(list).should == <<-TREE
 ├─┬ first
 │ ├─┬ second
 │ │ └── third


### PR DESCRIPTION
The `Puppet::Module::Tool.build_tree` and
`Puppet::Module::Tool.format_tree` method names do not match their
behavior. Both methods actually do the inverse,
`Puppet::Module::Tool.build_tree` formats a tree for output and
`Puppet::Module::Tool.format_tree` builds the tree that is passed to
`Puppet::Module::Tool.build_tree`. Even this commit message is
confusing.

This patch swaps the names and updates the related specs.
