### PR TITLE
(#13638) Add SemVer#pre function

### DIFF
--- a/lib/semver.rb
+++ b/lib/semver.rb
@@ -17,18 +17,21 @@ class SemVer < Numeric
     versions.select { |v| v.matched_by?("#{pattern}") }.sort.last
   end
 
+  def self.pre(vstring)
+    vstring =~ /-/ ? vstring : vstring + '-'
+  end
+
   def self.[](range)
-    pre = proc { |vstring| vstring =~ /-/ ? vstring : vstring + '-' }
     range.gsub(/([><=])\s+/, '\1').split(/\b\s+(?!-)/).map do |r|
       case r
       when SemVer::VERSION
-        SemVer.new(pre[r]) .. SemVer.new(r)
+        SemVer.new(pre(r)) .. SemVer.new(r)
       when SemVer::SIMPLE_RANGE
         r += ".0" unless SemVer.valid?(r.gsub(/x/i, '0'))
         SemVer.new(r.gsub(/x/i, '0'))...SemVer.new(r.gsub(/(\d+)\.x/i) { "#{$1.to_i + 1}.0" } + '-')
       when /\s+-\s+/
         a, b = r.split(/\s+-\s+/)
-        SemVer.new(pre[a]) .. SemVer.new(b)
+        SemVer.new(pre(a)) .. SemVer.new(b)
       when /^~/
         ver = r.sub(/~/, '').split('.').map(&:to_i)
         start = (ver + [0] * (3 - ver.length)).join('.')
@@ -37,10 +40,10 @@ class SemVer < Numeric
         ver[-1] = ver.last + 1
 
         finish = (ver + [0] * (3 - ver.length)).join('.')
-        SemVer.new(pre[start]) ... SemVer.new(pre[finish])
+        SemVer.new(pre(start)) ... SemVer.new(pre(finish))
       when /^>=/
         ver = r.sub(/^>=/, '')
-        SemVer.new(pre[ver]) .. SemVer::MAX
+        SemVer.new(pre(ver)) .. SemVer::MAX
       when /^<=/
         ver = r.sub(/^<=/, '')
         SemVer::MIN .. SemVer.new(ver)
@@ -54,7 +57,7 @@ class SemVer < Numeric
         SemVer.new(ver.join('.') + '-') .. SemVer::MAX
       when /^</
         ver = r.sub(/^</, '')
-        SemVer::MIN ... SemVer.new(pre[ver])
+        SemVer::MIN ... SemVer.new(pre(ver))
       else
         (1..1)
       end

--- a/spec/unit/semver_spec.rb
+++ b/spec/unit/semver_spec.rb
@@ -22,6 +22,16 @@ describe SemVer do
     end
   end
 
+  describe '::pre' do
+    it 'should append a dash when no dash appears in the string' do
+      SemVer.pre('1.2.3').should == '1.2.3-'
+    end
+
+    it 'should not append a dash when a dash appears in the string' do
+      SemVer.pre('1.2.3-a').should == '1.2.3-a'
+    end
+  end
+
   describe '::find_matching' do
     before :all do
       @versions = %w[


### PR DESCRIPTION
Before this patch the `SemVer#[]` method uses a `proc` to pre-process
version strings, which seems a bit unnecessary when a method would do.

This patch replaces the `proc` with the `SemVer#pre` method and updates
the related specs.
