### PR TITLE
(#13642) Move search notice message

### DIFF
--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -21,8 +21,6 @@ Puppet::Face.define(:module, '1.0.0') do
     arguments "<search_term>"
 
     when_invoked do |term, options|
-      server = Puppet.settings[:module_repository].sub(/^(?!https?:\/\/)/, 'http://')
-      Puppet.notice "Searching #{server} ..."
       Puppet::Module::Tool::Applications::Searcher.run(term, options)
     end
 

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -26,6 +26,8 @@ module Puppet::Forge
   # ]
   #
   def self.search(term)
+    server = Puppet.settings[:module_repository].sub(/^(?!https?:\/\/)/, 'http://')
+    Puppet.notice "Searching #{server} ..."
     request = Net::HTTP::Get.new("/modules.json?q=#{URI.escape(term)}")
     response = repository.make_http_request(request)
 


### PR DESCRIPTION
Currently the PMT search action assumes the searcher implementation will
connect to the HTTP server defined by
`Puppet.settings[:module_repository]` when searching for modules on the
Forge. The server defined by `Puppet.settings[:module_repository]` is then
used in a message printed on the console: `Searching #{server} …`. This
is a little too close to the implementation and the notice has been
moved closer to where the search is actually taking place.
