### PR TITLE
Added unless_uid option to User Resource management.

### DIFF
--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:resources) do
        when Array
          value
        when /^\[\d+/
-         values.split(',').collect{|x| x.include?('..') ? Integer(x.split('..')[0])..Integer(x.split('..')[1]) : Integer(x) }
+         value.split(',').collect{|x| x.include?('..') ? Integer(x.split('..')[0])..Integer(x.split('..')[1]) : Integer(x) }
        else
          raise ArgumentError, "Invalid value #{value.inspect}"
        end

--- a/spec/unit/type/resources_spec.rb
+++ b/spec/unit/type/resources_spec.rb
@@ -173,8 +173,36 @@ describe resources do
           user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
           @res.user_check(user).should be_false
         end
-
       end
+
+      describe "with a mixed uid array" do
+        before do
+          @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_uid => [10_000..15_000, 16_666]
+          @res.catalog = Puppet::Resource::Catalog.new
+        end
+
+        it "should not purge ids in the range" do
+          user_hash = {:name => 'special_user', :uid => 15_000}
+          user = Puppet::Type.type(:user).new(user_hash)
+          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
+          @res.user_check(user).should be_false
+        end
+
+        it "should not purge specified ids" do
+          user_hash = {:name => 'special_user', :uid => 16_666}
+          user = Puppet::Type.type(:user).new(user_hash)
+          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
+          @res.user_check(user).should be_false
+        end
+
+        it "should purge unspecified ids" do
+          user_hash = {:name => 'special_user', :uid => 17_000}
+          user = Puppet::Type.type(:user).new(user_hash)
+          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
+          @res.user_check(user).should be_true
+        end
+      end
+      
     end
   end
 


### PR DESCRIPTION
Currently there are only two options for user management: purge => true or purge => false.
Purge true works great if all your apps are deployed via puppet, but when you have a mix of puppet system uids and application uids, you are forced to turn purge off.
This has the undesired side-effect that users that are managed through puppet will never revoked for the servers that have purge disabled.

At our company Devops deploys the servers & frameworks using Puppet so that Devs can take over and deploy applications on their own.
Each of these application runs under its own uid. For this reason we have to run with purge => false, which is something we don't want.

The only option available to alter this behavior is "unless_system_user => true", but this just protects users with a UID < 500 and that is not where I want to have my application UIDs.
In order to fix this properly, I've added an extra option to puppet: unless_uid.

You van specify specific Uids here or even Ranges of UIDS. Uids that match these ranges will not be purged, even though purge => true.

This way Puppet still automatically revokes access to the servers for Devs and Devops that are removed, while allowing Devs to deploy their own application application.

Example:

```
class users::resources {
  resources { 'user':
  purge              => true,
  unless_system_user => true,
  unless_uid => [10_000..20_000];
  }
}
```

Unless_uid accepts Integers, Ranges or Arrays with both.
I also added specs for both the old and the new check_user behavior, as the old behaviour was not specced.
