### PR TITLE
(#13643) Make the use of FileUtils.rm_rf secure

### DIFF
--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -61,7 +61,7 @@ module Puppet::Module::Tool
       def create_directory
         FileUtils.mkdir(@pkg_path) rescue nil
         if File.directory?(build_path)
-          FileUtils.rm_rf(build_path)
+          FileUtils.rm_rf(build_path, :secure => true)
         end
         FileUtils.mkdir(build_path)
       end

--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -22,7 +22,7 @@ module Puppet::Module::Tool
         begin
           find_installed_module
           validate_module
-          FileUtils.rm_rf(@installed.first.path)
+          FileUtils.rm_rf(@installed.first.path, :secure => true)
 
           results[:affected_modules] = @installed
           results[:result] = :success

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -41,7 +41,7 @@ module Puppet::Module::Tool
 
       def delete_existing_installation_or_abort!
         return unless @module_dir.exist?
-        FileUtils.rm_rf @module_dir
+        FileUtils.rm_rf(@module_dir, :secure => true)
       end
     end
   end


### PR DESCRIPTION
Use the `:secure` option with the `FileUtils.rm_rf` method to
avoid a TOCTTOU (time-of-check-to-time-of-use) local security
vulnerability.
