### PR TITLE
(#13649) Restrict module name matching

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -128,7 +128,7 @@ class Puppet::Node::Environment
     modulepath.each do |path|
       Dir.chdir(path) do
         module_names = Dir.glob('*').select do |d|
-          FileTest.directory?(d) && (File.basename(d) =~ /^[-\w]+$/)
+          FileTest.directory?(d) && (File.basename(d) =~ /^[\w]+([-]{1}[\w]+)*$/)
         end
         modules_by_path[path] = module_names.sort.map do |name|
           Puppet::Module.new(name, :environment => self, :path => File.join(path, name))

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -216,6 +216,9 @@ describe Puppet::Node::Environment do
           FileUtils.mkdir_p(File.join(@first, 'foo=bar'))
           FileUtils.mkdir_p(File.join(@first, 'foo bar'))
           FileUtils.mkdir_p(File.join(@first, 'foo.bar'))
+          FileUtils.mkdir_p(File.join(@first, '-foo'))
+          FileUtils.mkdir_p(File.join(@first, 'foo-'))
+          FileUtils.mkdir_p(File.join(@first, 'foo--bar'))
 
           env.modules_by_path[@first].collect{|mod| mod.name}.sort.should == %w{foo foo-bar foo2 foo_bar}
         end


### PR DESCRIPTION
Before this patch the regex used to match valid module names in
`Puppet::Node::Environment#modules_by_path` matches invalid module
names.

This patch replaces the current regex pattern with one more accurate.
This patch also includes updated specs to cover this change in behavior.
