### PR TITLE
Bug/2.7.x/util symbolize hash

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -447,15 +447,15 @@ module Util
         newhash[name] = val
       end
     end
+    newhash
   end
 
   def symbolizehash!(hash)
-    hash.each do |name, val|
-      if name.is_a? String
-        hash[name.intern] = val
-        hash.delete(name)
-      end
-    end
+    # this is not the most memory-friendly way to accomplish this, but the
+    #  code re-use and clarity seems worthwhile.
+    newhash = symbolizehash(hash)
+    hash.clear
+    hash.merge!(newhash)
 
     hash
   end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -637,6 +637,26 @@ describe Puppet::Util do
     end
   end
 
+  describe "hash symbolizing functions" do
+    let (:myhash) { { "foo" => "bar", :baz => "bam" } }
+    let (:resulthash) { { :foo => "bar", :baz => "bam" } }
+
+    describe "#symbolizehash" do
+      it "should return a symbolized hash" do
+        newhash = Puppet::Util.symbolizehash(myhash)
+        newhash.should == resulthash
+      end
+    end
+
+    describe "#symbolizehash!" do
+      it "should symbolize the hash in place" do
+        localhash = myhash
+        Puppet::Util.symbolizehash!(localhash)
+        localhash.should == resulthash
+      end
+    end
+  end
+
   context "#replace_file" do
     describe "on POSIX platforms", :if => Puppet.features.posix? do
       subject { Puppet::Util }


### PR DESCRIPTION
The method Puppet::Util.symbolizehash! was modifying a hash
during iteration; this is (sanely, thankfully) not legal
in ruby 1.9.  This has been broken in our code for quite
some time, but we hadn't noticed because nothing was calling
this method.  A recent commit introduced code that calls it,
highlighting the bug, which is fixed by this commit.
