### PR TITLE
(#13655) test failures on centos5 on 2.7.x branch

### DIFF
--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -118,10 +118,10 @@ Puppet::Type.newtype(:resources) do
     return true unless self[:unless_system_user]
 
     resource[:audit] = :uid
-    current_values = resource.retrieve_resource
 
     return false if system_users.include?(resource[:name])
 
+    current_values = resource.retrieve_resource
     current_values[resource.property(:uid)] > self[:unless_system_user]
   end
 

--- a/spec/unit/indirector/resource/ral_spec.rb
+++ b/spec/unit/indirector/resource/ral_spec.rb
@@ -20,12 +20,17 @@ describe "Puppet::Resource::Ral" do
 
     it "if there is no instance, it should create one", :'fails_on_ruby_1.9.2' => true do
       wrong_instance = stub "wrong user", :name => "bob"
+      root = mock "Root User"
+      root_resource = mock "Root Resource"
 
       require 'puppet/type/user'
       Puppet::Type::User.expects(:instances).returns([ wrong_instance, wrong_instance ])
+      Puppet::Type::User.expects(:new).with(has_entry(:name => "root")).returns(root)
+      root.expects(:to_resource).returns(root_resource)
+
       result = Puppet::Resource::Ral.new.find(@request)
-      result.should be_is_a(Puppet::Resource)
-      result.title.should == "root"
+
+      result.should == root_resource
     end
   end
 

--- a/spec/unit/type/group_spec.rb
+++ b/spec/unit/type/group_spec.rb
@@ -3,16 +3,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:group) do
   before do
-    ENV["PATH"] += File::PATH_SEPARATOR + "/usr/sbin" unless ENV["PATH"].split(File::PATH_SEPARATOR).include?("/usr/sbin")
     @class = Puppet::Type.type(:group)
-  end
-
-  it "should have a default provider" do
-    @class.defaultprovider.should_not be_nil
-  end
-
-  it "should have a default provider inheriting from Puppet::Provider" do
-    @class.defaultprovider.ancestors.should be_include(Puppet::Provider)
   end
 
   it "should have a system_groups feature" do

--- a/spec/unit/type/resources_spec.rb
+++ b/spec/unit/type/resources_spec.rb
@@ -51,14 +51,13 @@ describe resources do
           @resources.generate.collect { |r| r.ref }.should_not include(@host1.ref)
         end
 
-        it "should not include the skipped users", :'fails_on_ruby_1.9.2' => true do
+        it "should not include the skipped system users", :'fails_on_ruby_1.9.2' => true do
           res = Puppet::Type.type(:resources).new :name => :user, :purge => true
           res.catalog = Puppet::Resource::Catalog.new
 
-          users = [
-            Puppet::Type.type(:user).new(:name => "root")
-          ]
-          Puppet::Type.type(:user).expects(:instances).returns users
+          root = Puppet::Type.type(:user).new(:name => "root")
+          Puppet::Type.type(:user).expects(:instances).returns [ root ]
+
           list = res.generate
 
           names = list.collect { |r| r[:name] }

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -15,10 +15,6 @@ describe Puppet::Type.type(:user) do
     described_class.stubs(:defaultprovider).returns @provider_class
   end
 
-  it "should have a default provider inheriting from Puppet::Provider" do
-    described_class.defaultprovider.ancestors.should be_include(Puppet::Provider)
-  end
-
   it "should be able to create a instance" do
     described_class.new(:name => "foo").should_not be_nil
   end
@@ -52,10 +48,6 @@ describe Puppet::Type.type(:user) do
   end
 
   describe "instances" do
-    it "should have a valid provider" do
-      described_class.new(:name => "foo").provider.class.ancestors.should be_include(Puppet::Provider)
-    end
-
     it "should delegate existence questions to its provider" do
       @provider = @provider_class.new(:name => 'foo', :ensure => :absent)
       instance = described_class.new(:name => "foo", :provider => @provider)


### PR DESCRIPTION
Several tests were failing because the depended on being able to find a
user provider. On CentOS 5 this didn't work because the provider that
should be used (the useradd provider) is not considered suitable when it
gets run as a non-privaleged user because the useradd and related
commands are not executable.

The user_spec.rb and group_spec.rb test didn't need the tests that were
failing because they were testing functionality that is already tested
by the Type base class's own tests.

The ral_spec.rb needed more mocking of the things it was using in order
to abstract it from the system on which it is running.

The resources_spec.rb got a small cleanup and was fixed by reordering
the data loading in Puppet::Type::Resources so that it doesn't load
information about a user until it needs to.

Conflicts:

```
spec/unit/type/resources_spec.rb
```
