### PR TITLE
(#13659) Convert fact values to string when searching database

### DIFF
--- a/lib/puppet/rails/inventory_node.rb
+++ b/lib/puppet/rails/inventory_node.rb
@@ -10,14 +10,14 @@ class Puppet::Rails::InventoryNode < ::ActiveRecord::Base
 
   scope :has_fact_with_value, lambda { |name,value|
     {
-      :conditions => ["inventory_facts.name = ? AND inventory_facts.value = ?", name, value],
+      :conditions => ["inventory_facts.name = ? AND inventory_facts.value = ?", name, value.to_s],
       :joins => :facts
     }
   }
 
   scope :has_fact_without_value, lambda { |name,value|
     {
-      :conditions => ["inventory_facts.name = ? AND inventory_facts.value != ?", name, value],
+      :conditions => ["inventory_facts.name = ? AND inventory_facts.value != ?", name, value.to_s],
       :joins => :facts
     }
   }


### PR DESCRIPTION
When querying inventory_facts we need to treat the fact value as a string,
since it's stored as text in the database. This causes an error to be raised
on postgres.
