### PR TITLE
(#13679) Skip variable interpolation on dbpassword setting

### DIFF
--- a/lib/puppet/util/settings.rb
+++ b/lib/puppet/util/settings.rb
@@ -687,7 +687,9 @@ if @config.include?(:run_mode)
     end
 
     # Convert it if necessary
-    val = convert(val, environment)
+    unless param == :dbpassword
+      val = convert(val, environment)
+    end
 
     # And cache it
     @cache[environment||"none"][param] = val

--- a/spec/unit/util/settings_spec.rb
+++ b/spec/unit/util/settings_spec.rb
@@ -235,7 +235,7 @@ describe Puppet::Util::Settings do
   describe "when returning values" do
     before do
       @settings = Puppet::Util::Settings.new
-      @settings.setdefaults :section, :config => ["/my/file", "eh"], :one => ["ONE", "a"], :two => ["$one TWO", "b"], :three => ["$one $two THREE", "c"], :four => ["$two $three FOUR", "d"]
+      @settings.setdefaults :section, :config => ["/my/file", "eh"], :one => ["ONE", "a"], :two => ["$one TWO", "b"], :three => ["$one $two THREE", "c"], :four => ["$two $three FOUR", "d"], :dbpassword => ["puppet", "e" ]
       FileTest.stubs(:exist?).returns true
     end
 
@@ -275,6 +275,11 @@ describe Puppet::Util::Settings do
       @settings[:two].should == "ONE TWO"
       @settings[:one] = "one"
       @settings[:two].should == "one TWO"
+    end
+
+    it "should not interpolate dbpassword" do
+      @settings[:dbpassword] = "my$one"
+      @settings[:dbpassword].should == "my$one"
     end
 
     it "should not cache values such that information from one environment is returned for another environment" do


### PR DESCRIPTION
when puppet reads `/etc/puppet/puppet.conf` it does variable interpolation
when receiving a setting. The convert method that is involved here does
not allow for escaping/quoting or any other mechanism to stop variable
interpolation. While most settings do not allow a dollar-sign anyways
the dbpassword may legally include one.

I'm not sure if we need a general escaping mechanism or if we should just skip value interpolation for different settings. I'm afraid that introducing quoting and esacping in `/etc/puppet.conf` would both make the parser and the file itself needlessly complex for a single usecase. In my opinion `dbpassword` is the only setting that may legally include a dollar sign and I cannot come up with a usecase where you do want to have value interpolation on `dbpassword`. So the fix attached in the branch field just skips validation on `dbpassword`.

But I'm happy to hear different opinions.
