### PR TITLE
[#13686] Fix Directoryservice bug around non-existant ShadowHashData key

### DIFF
--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -323,9 +323,15 @@ class DirectoryService < Puppet::Provider::NameService
 
         # users_plist['ShadowHashData'][0].string is actually a binary plist
         # that's nested INSIDE the user's plist (which itself is a binary
-        # plist).
-        password_hash_plist = users_plist['ShadowHashData'][0].string
-        converted_hash_plist = convert_binary_to_xml(password_hash_plist)
+        # plist). If we encounter a user plist that DOESN'T have a
+        # ShadowHashData field, create one.
+        if users_plist['ShadowHashData']
+          password_hash_plist = users_plist['ShadowHashData'][0].string
+          converted_hash_plist = convert_binary_to_xml(password_hash_plist)
+        else
+          users_plist['ShadowHashData'] = [StringIO.new]
+          converted_hash_plist = {'SALTED-SHA512' => StringIO.new}
+        end
 
         # converted_hash_plist['SALTED-SHA512'].string expects a Base64 encoded
         # string. The password_hash provided as a resource attribute is a
@@ -348,7 +354,7 @@ class DirectoryService < Puppet::Provider::NameService
   def self.get_password(guid, username)
     # Use Puppet::Util::Package.versioncmp() to catch the scenario where a
     # version '10.10' would be < '10.7' with simple string comparison. This
-    # if-statement only executes if the current version is less-than 10.7 
+    # if-statement only executes if the current version is less-than 10.7
     if (Puppet::Util::Package.versioncmp(get_macosx_version_major, '10.7') == -1)
       password_hash = nil
       password_hash_file = "#{@@password_hash_dir}/#{guid}"

--- a/spec/unit/provider/nameservice/directoryservice_spec.rb
+++ b/spec/unit/provider/nameservice/directoryservice_spec.rb
@@ -155,6 +155,16 @@ describe 'DirectoryService password behavior' do
     Plist::Emit.expects(:save_plist).with(shadow_hash_data, plist_path)
     subject.set_password('jeff', 'uid', sha512_hash)
   end
+
+  it '[#13686] should handle an empty ShadowHashData field in the users plist' do
+    subject.expects(:convert_xml_to_binary).returns(binary_plist)
+    File.expects(:exists?).with(plist_path).once.returns(true)
+    Plist.expects(:parse_xml).returns({'ShadowHashData' => nil})
+    subject.expects(:plutil).with('-convert', 'xml1', '-o', '/dev/stdout', plist_path)
+    subject.expects(:plutil).with('-convert', 'binary1', plist_path)
+    Plist::Emit.expects(:save_plist)
+    subject.set_password('jeff', 'uid', sha512_hash)
+  end
 end
 
 describe '(#4855) directoryservice group resource failure' do


### PR DESCRIPTION
Previously, Puppet wouldn't set a password if the ShadowHashData key was
missing from the User's plist.  This change will handle this situation,
create the key itself, and proceed with setting the password.
