### PR TITLE
Removing use of deprecated execution methods

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -1,6 +1,5 @@
 # The container class for implementations.
 class Puppet::Provider
-  include Puppet::Util::Execution
   include Puppet::Util
   include Puppet::Util::Errors
   include Puppet::Util::Warnings
@@ -33,6 +32,36 @@ class Puppet::Provider
   # LAK 2007-05-09: Keep the model stuff around for backward compatibility
   attr_reader :model
   attr_accessor :resource
+
+  # Provide access to execution of arbitrary commands in providers. Execution methods are
+  # available on both the instance and the class of a provider because it seems that a lot of
+  # providers switch between these contexts fairly freely.
+  #
+  # @see Puppet::Util::Execution for how to use these methods
+  def execute(*args)
+    Puppet::Util::Execution.execute(*args)
+  end
+
+  def self.execute(*args)
+    Puppet::Util::Execution.execute(*args)
+  end
+
+  def execpipe(*args, &block)
+    Puppet::Util::Execution.execpipe(*args, &block)
+  end
+
+  def self.execpipe(*args)
+    Puppet::Util::Execution.execpipe(*args)
+  end
+
+  def execfail(*args)
+    Puppet::Util::Execution.execfail(*args)
+  end
+
+  def self.execfail(*args)
+    Puppet::Util::Execution.execfail(*args)
+  end
+  #########
 
   def self.command(name)
     name = symbolize(name)

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -3,8 +3,7 @@ require 'puppet/provider/nameservice'
 require 'facter/util/plist'
 require 'fileutils'
 
-class Puppet::Provider::NameService
-class DirectoryService < Puppet::Provider::NameService
+class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameService
   # JJM: Dive into the singleton_class
   class << self
     # JJM: This allows us to pass information when calling
@@ -593,6 +592,5 @@ class DirectoryService < Puppet::Provider::NameService
     end
     @property_value_cache_hash
   end
-end
 end
 

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -394,6 +394,50 @@ describe Puppet::Provider do
     end
   end
 
+  context "execution" do
+    before :each do
+      Puppet.expects(:deprecation_warning).never
+    end
+
+    it "delegates instance execute to Puppet::Util::Execution" do
+      Puppet::Util::Execution.expects(:execute).with("a_command", { :option => "value" })
+
+      provider.new.send(:execute, "a_command", { :option => "value" })
+    end
+
+    it "delegates class execute to Puppet::Util::Execution" do
+      Puppet::Util::Execution.expects(:execute).with("a_command", { :option => "value" })
+
+      provider.send(:execute, "a_command", { :option => "value" })
+    end
+
+    it "delegates instance execpipe to Puppet::Util::Execution" do
+      block = Proc.new { }
+      Puppet::Util::Execution.expects(:execpipe).with("a_command", true, block)
+
+      provider.new.send(:execpipe, "a_command", true, block)
+    end
+
+    it "delegates class execpipe to Puppet::Util::Execution" do
+      block = Proc.new { }
+      Puppet::Util::Execution.expects(:execpipe).with("a_command", true, block)
+
+      provider.send(:execpipe, "a_command", true, block)
+    end
+
+    it "delegates instance execfail to Puppet::Util::Execution" do
+      Puppet::Util::Execution.expects(:execfail).with("a_command", "an exception to raise")
+
+      provider.new.send(:execfail, "a_command", "an exception to raise")
+    end
+
+    it "delegates class execfail to Puppet::Util::Execution" do
+      Puppet::Util::Execution.expects(:execfail).with("a_command", "an exception to raise")
+
+      provider.send(:execfail, "a_command", "an exception to raise")
+    end
+  end
+
   context "mk_resource_methods" do
     before :each do
       type.newproperty(:prop1)


### PR DESCRIPTION
Using the mixins for bringing in the execution methods wasn't
working to bring in the non-deprecated Puppet::Util::Execution methods.
Because of the way that these methods are declared trying to understand
what methods were coming in from where was very hard to trace and so
I decided to go with explicit delegation.

Found this by running `puppet resource user andy` on my machine and seeing it output 2 deprecation warnings.
