### PR TITLE
(#8714) Process symlinks correctly during SELinux fs-type detection

### DIFF
--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -189,6 +189,16 @@ module Puppet::Util::SELinux
     end
 
     # For a given file:
+    # If the file is a symlink, then we start processing with the
+    #   parent directory. If the symlink points to another mount
+    #   point and we call realpath() on it then we end up
+    #   determining if the destination of the symlink can support
+    #   SELinux when what we really want to know is if the
+    #   filesystem where the symlink lives can support it.
+    if File.symlink?(path)
+       path = parent_directory(path)
+    end
+
     # Check if the filename is in the data structure;
     #   return the fstype if it is.
     # Just in case: return something if you're down to "/" or ""

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -67,8 +67,23 @@ describe Puppet::Util::SELinux do
 
     it "should follow symlinks when determining file systems" do
       self.stubs(:realpath).with('/mnt/symlink/testfile').returns('/mnt/nfs/dest/testfile')
+      File.stubs(:symlink?).with('/mnt/symlink/testfile').returns(false)
 
       selinux_label_support?('/mnt/symlink/testfile').should be_false
+    end
+
+    it "should check filesystem capability for the symlink, not the destination, on a capable filesystem" do
+      self.stubs(:realpath).with('/mnt').returns('/mnt')
+      File.stubs(:symlink?).with('/mnt/symlink').returns(true)
+
+      selinux_label_support?('/mnt/symlink').should be_true
+    end
+
+    it "should check filesystem capability for the symlink, not the destination, on a non-capable filesystem" do
+      self.stubs(:realpath).with('/mnt/symlink').returns('/mnt/nfs/dest')
+      File.stubs(:symlink?).with('/mnt/symlink/testsymlink').returns(true)
+
+      selinux_label_support?('/mnt/symlink/testsymlink').should be_false
     end
 
   end


### PR DESCRIPTION
Symlinks support SELinux file labels independent of the target
file or the capabilities of the target filesystem. This corrects
the filesystem detection used to determine if a file should support
a SELinux label to properly support symlinks which exist on capable
filesystems that have a destination on non-capable filesystems.

This is my second take on this issue to address https://projects.puppetlabs.com/issues/8714 and replaces the incorrect fix proposed in https://github.com/puppetlabs/puppet/pull/563.

Thanks!

Sean
