### PR TITLE
(maint) Remove unnecessary step from puppet module build help

### DIFF
--- a/lib/puppet/face/module/build.rb
+++ b/lib/puppet/face/module/build.rb
@@ -3,9 +3,7 @@ Puppet::Face.define(:module, '1.0.0') do
     summary "Build a module release package."
     description <<-EOT
       Prepares a local module for release on the Puppet Forge by building a
-      ready-to-upload archive file. Before using this action, make sure that
-      the module directory's name is in the standard <username>-<module>
-      format.
+      ready-to-upload archive file.
 
       This action uses the Modulefile in the module directory to set metadata
       used by the Forge. See <http://links.puppetlabs.com/modulefile> for more


### PR DESCRIPTION
Without this patch the `puppet help module build` command says to make
sure the module directory is in the form of <username>-<modulename>.
This is an unnecessary step because it isn't actually necessary anymore.
It's a problem because we want to make things appear to be as simple as
they actually are, not more complex than they need to be.

I just tested this with a module existing at /vagrant/modules/jenkins
(no symlinks) using the command: `puppet module build .`

Everything worked out fine.  Puppet correctly reads the Modulefile and
figures out the author name.

This is a documentation only change.
