### PR TITLE
Don't require eventlog gem on non-Windows platforms

### DIFF
--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -82,7 +82,7 @@ describe Puppet::Util::Log do
   end
 
   describe Puppet::Util::Log::DestEventlog, :if => Puppet.features.microsoft_windows? do
-    require 'win32/eventlog'
+    require 'win32/eventlog' if Puppet.features.microsoft_windows?
 
     before :each do
       Win32::EventLog.stubs(:open).returns(mock 'mylog')


### PR DESCRIPTION
Commit `8d2ff89` attempted to require the windows eventlog gem within a
`:if => Puppet.features.microsoft_windows?` describe block, but I forgot
that requires within the block are still evaluated on non-Windows
platform, although the tests themselves won't be run.

This commit just conditionally requires the gem.
