### PR TITLE
Update acceptance tests to use confine instead of skip_test loops

### DIFF
--- a/acceptance/tests/allow_symlinks_as_config_directories.rb
+++ b/acceptance/tests/allow_symlinks_as_config_directories.rb
@@ -1,11 +1,7 @@
 test_name "Should allow symlinks to directories as configuration directories"
+confine :except, :platform => 'windows'
 
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-    next
-  end
-
   step "Create the test confdir with a link to it"
   confdir = agent.tmpdir('puppet_conf-directory')
   conflink = agent.tmpfile('puppet_conf-symlink')

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -1,4 +1,5 @@
 test_name "should create cron"
+confine :except, :platform => 'windows'
 
 tmpuser = "pl#{rand(999999).to_i}"
 tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
@@ -9,11 +10,6 @@ delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
 package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
 
 agents.each do |host|
-    if host['platform'].include?('windows')
-      skip_test "Test not supported on this platform"
-      next
-    end
-
     step "ensure the user exist via puppet"
     apply_manifest_on host, create_user
     apply_manifest_on host, package_cron

--- a/acceptance/tests/resource/cron/should_match_existing.rb
+++ b/acceptance/tests/resource/cron/should_match_existing.rb
@@ -1,4 +1,5 @@
 test_name "puppet should match existing job"
+confine :except, :platform => 'windows'
 
 tmpuser = "pl#{rand(999999).to_i}"
 tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
@@ -9,11 +10,6 @@ delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
 package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
 
 agents.each do |host|
-    if host['platform'].include?('windows')
-      skip_test "Test not supported on this platform"
-      next
-    end
-
     step "ensure the user exist via puppet"
     apply_manifest_on host, create_user
     apply_manifest_on host, package_cron

--- a/acceptance/tests/resource/cron/should_not_rewrite_with_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_not_rewrite_with_trailing_whitespace.rb
@@ -1,4 +1,5 @@
 test_name "should not rewrite if the job has trailing whitespace"
+confine :except, :platform => 'windows'
 
 tmpuser = "pl#{rand(999999).to_i}"
 tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
@@ -7,11 +8,6 @@ create_user = "user { '#{tmpuser}': ensure => present, managehome => false }"
 delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
 
 agents.each do |host|
-  if host['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-    next
-  end
-
   step "ensure the user exist via puppet"
   apply_manifest_on host, create_user
 

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -1,4 +1,5 @@
 test_name "puppet should remove a crontab entry as expected"
+confine :except, :platform => 'windows'
 
 tmpuser = "pl#{rand(999999).to_i}"
 tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
@@ -9,11 +10,6 @@ delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
 package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
 
 agents.each do |host|
-    if host['platform'].include?('windows')
-      skip_test "Test not supported on this platform"
-      next
-    end
-
     step "ensure the user exist via puppet"
     apply_manifest_on host, create_user
     apply_manifest_on host, package_cron

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -1,4 +1,5 @@
 test_name "puppet should remove a crontab entry based on command matching"
+confine :except, :platform => 'windows'
 
 tmpuser = "pl#{rand(999999).to_i}"
 tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
@@ -11,11 +12,6 @@ delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
 package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
 
 agents.each do |host|
-    if host['platform'].include?('windows')
-      skip_test "Test not supported on this platform"
-      next
-    end
-
     step "ensure the user exist via puppet"
     apply_manifest_on host, create_user
     apply_manifest_on host, package_cron

--- a/acceptance/tests/resource/cron/should_update_existing.rb
+++ b/acceptance/tests/resource/cron/should_update_existing.rb
@@ -1,4 +1,5 @@
 test_name "puppet should update existing crontab entry"
+confine :except, :platform => 'windows'
 
 tmpuser = "pl#{rand(999999).to_i}"
 tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
@@ -9,11 +10,6 @@ delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
 package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
 
 agents.each do |host|
-    if host['platform'].include?('windows')
-      skip_test "Test not supported on this platform"
-      next
-    end
-
     step "ensure the user exist via puppet"
     apply_manifest_on host, create_user
     apply_manifest_on host, package_cron

--- a/acceptance/tests/resource/exec/accept_multi-line_commands.rb
+++ b/acceptance/tests/resource/exec/accept_multi-line_commands.rb
@@ -1,11 +1,7 @@
 test_name "Be able to execute multi-line commands (#9996)"
+confine :except, :platform => 'windows'
 
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-    next
-  end
-
   temp_file_name = agent.tmpfile('9996-multi-line-commands')
 
   test_manifest = <<HERE

--- a/acceptance/tests/resource/file/should_create_symlink.rb
+++ b/acceptance/tests/resource/file/should_create_symlink.rb
@@ -1,15 +1,11 @@
 test_name "should create symlink"
+confine :except, :platform => 'windows'
 
 message = 'hello world'
 target  = "/tmp/test-#{Time.new.to_i}"
 source  = "/tmp/test-#{Time.new.to_i}-source"
 
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-    next
-  end
-
   step "clean up the system before we begin"
   on agent, "rm -rf #{target}"
   on agent, "echo '#{message}' > #{source}"

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -1,15 +1,11 @@
 test_name "file resource: symbolic modes"
+confine :except, :platform => 'windows'
 
 def validate(path, mode)
   "ruby -e 'exit (File::Stat.new(#{path.inspect}).mode & 0777 == #{mode})'"
 end
 
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    Log.warn("Pending: this does not currently work on Windows")
-    next
-  end
-
   user = agent['user']
   group = agent['group'] || user
   file = agent.tmpfile('symbolic-mode-file')

--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -1,13 +1,9 @@
 test_name "#8740: should not enumerate root directory"
+confine :except, :platform => 'windows'
 
 target = "/test-socket-#{$$}"
 
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-    next
-  end
-
   step "clean up the system before we begin"
   on(agent, "rm -f #{target}")
 

--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -1,15 +1,11 @@
 test_name "should modify gid of existing group"
+confine :except, :platform => 'windows'
 
 name = "pl#{rand(999999).to_i}"
 gid1  = rand(999999).to_i
 gid2  = rand(999999).to_i
 
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-    next
-  end
-
   step "ensure that the group exists with gid #{gid1}"
   on(agent, puppet_resource('group', name, 'ensure=present', "gid=#{gid1}")) do
     fail_test "missing gid notice" unless stdout =~ /gid +=> +'#{gid1}'/

--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -2,11 +2,8 @@ test_name "#4123: should list all running services on Redhat/CentOS"
 step "Validate services running agreement ralsh vs. OS service count"
 # This will remotely exec:
 # ticket_4123_should_list_all_running_redhat.sh
+confine :to, :platform => /el-/
 
 hosts.each do |host|
-  if host['platform'].include?('el-')
-    run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4123_should_list_all_running_redhat.sh'))
-  else
-    skip_test "Test not supported on this plaform" 
-  end
+  run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4123_should_list_all_running_redhat.sh'))
 end

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -2,11 +2,8 @@ test_name "#4124: should list all disabled services on Redhat/CentOS"
 step "Validate disabled services agreement ralsh vs. OS service count"
 # This will remotely exec:
 # ticket_4124_should_list_all_disabled.sh
+confine :to, :platform => /el-/
 
 hosts.each do |host|
-  unless host['platform'].include?('el-')
-    skip_test "Test not supported on this plaform"
-   else
-    run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4124_should_list_all_disabled.sh'))
-  end
+  run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4124_should_list_all_disabled.sh'))
 end

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -1,12 +1,10 @@
 test_name "verifies that puppet resource creates a user and assigns the correct group"
+confine :except, :platform => 'windows'
 
 user = "pl#{rand(999999).to_i}"
 group = "gp#{rand(999999).to_i}"
 
 agents.each do |host|
-  if host['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-  else
     step "user should not exist"
     on host, "if getent passwd #{user}; then userdel #{user}; fi"
 

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -1,13 +1,11 @@
 test_name "verify that we can modify the gid"
+confine :except, :platform => 'windows'
 
 user = "pl#{rand(99999).to_i}"
 group1 = "#{user}old"
 group2 = "#{user}new"
 
 agents.each do |host|
-  if host['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-  else
     step "ensure that the groups both exist"
     on(host, puppet_resource('group', group1, 'ensure=present'))
     on(host, puppet_resource('group', group2, 'ensure=present'))

--- a/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
+++ b/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
@@ -1,4 +1,5 @@
 test_name "#3961: puppet ca should produce certs spec"
+confine :except, :platform => 'windows'
 
 target  = "working3961.example.org"
 
@@ -9,11 +10,6 @@ expect = ['notice: Signed certificate request for ca',
           'notice: Removing file Puppet::SSL::CertificateRequest working3961.example.org']
 
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-    next
-  end
-
   scratch = agent.tmpdir('puppet-ssl-3961')
   options = { :confdir => scratch, :vardir => scratch }
 


### PR DESCRIPTION
Now that the test harness supports confine :except, :platform = 'windows'
(and the like), update the tests to use that syntax.
