### PR TITLE
Assert that the file listing error message appears on stderr, not stdout

### DIFF
--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -16,7 +16,7 @@ agents.each do |agent|
 
   step "query for all files, which should return nothing"
   on(agent, puppet_resource('file'), :acceptable_exit_codes => [1]) do
-    assert_match(%r{Listing all file instances is not supported.  Please specify a file or directory, e.g. puppet resource file /etc}, stdout)
+    assert_match(%r{Listing all file instances is not supported.  Please specify a file or directory, e.g. puppet resource file /etc}, stderr)
   end
 
   ["/", "/etc"].each do |file|


### PR DESCRIPTION
This acceptance test checks that Puppet returns an error message on
"puppet resource file", but that error message appears on stderr.
Thus, assert_match on stderr, not stdout, so this test will pass.
