### PR TITLE
Ticket/2.7.x/13640 daemon infinite loop

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -149,6 +149,13 @@ class Puppet::Daemon
     loop do
       now = Time.now.to_i
 
+      # We set a default wakeup of "one hour from now", which will
+      # recheck everything at a minimum every hour.  Just in case something in
+      # the math messes up or something; it should be inexpensive enough to
+      # wake once an hour, then go back to sleep after doing nothing, if
+      # someone only wants listen mode.
+      next_event = now + 60 * 60
+
       # Handle reparsing of configuration files, if desired and required.
       # `reparse` will just check if the action is required, and would be
       # better named `reparse_if_changed` instead.
@@ -158,7 +165,12 @@ class Puppet::Daemon
         # The time to the next reparse might have changed, so recalculate
         # now.  That way we react dynamically to reconfiguration.
         reparse_interval = Puppet[:filetimeout].to_i
-        next_reparse     = now + reparse_interval
+
+        # Set up the next reparse check based on the new reparse_interval.
+        if reparse_interval > 0
+          next_reparse = now + reparse_interval
+          next_event > next_reparse and next_event = next_reparse
+        end
 
         # We should also recalculate the agent run interval, and adjust the
         # next time it is scheduled to run, just in case.  In the event that
@@ -173,21 +185,14 @@ class Puppet::Daemon
       # behaviour.  You should not change that. --daniel 2012-02-21
       if agent and now >= next_agent_run
         agent.run
+
+        # Set up the next agent run time
         next_agent_run = now + agent_run_interval
+        next_event > next_agent_run and next_event = next_agent_run
       end
 
       # Finally, an interruptable able sleep until the next scheduled event.
-      # We also set a default wakeup of "one hour from now", which will
-      # recheck everything at a minimum every hour.  Just in case something in
-      # the math messes up or something; it should be inexpensive enough to
-      # wake once an hour, then go back to sleep after doing nothing, if
-      # someone only wants listen mode.
-      next_event = now + 60 * 60
-      next_event > next_reparse    and next_event = next_reparse
-      next_event > next_agent_run  and next_event = next_agent_run
-
       how_long = next_event - now
-
       how_long > 0 and select([], [], [], how_long)
     end
   end


### PR DESCRIPTION
The new event_loop code in daemon was adjusting the run time based on
next_agent_run even when not running an agent. This caused the interval to
always be 0 and peg CPU usage at 100%. We should only make this adjustment if
there is an agent running.
