### PR TITLE
(#13888) Fix self.instances for systemd service provider

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -9,9 +9,9 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   def self.instances
     i = []
-    output = `systemctl list-units --full --all --no-pager`
+    output = systemctl('list-units', '--full', '--all',  '--no-pager')
     output.scan(/^(\S+)\s+(loaded|error)\s+(active|inactive)\s+(active|waiting|running|plugged|mounted|dead|exited|listening|elapsed)\s*?(\S.*?)?$/i).each do |m|
-      i << m[0]
+      i << new(:name => m[0])
     end
     return i
   rescue Puppet::ExecutionFailure

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -30,4 +30,13 @@ describe provider_class do
       @provider.should respond_to(method)
     end
   end
+
+
+  it 'should return resources from self.instances' do
+    provider_class.expects(:systemctl).with('list-units', '--full', '--all',  '--no-pager').returns(
+      "my_service loaded active running\nmy_other_service loaded active running"
+    )
+    provider_class.instances.map {|provider| provider.name}.should =~ ["my_service","my_other_service"]
+  end
+
 end


### PR DESCRIPTION
Previously, attempting to run puppet resource service
on Fedora 16 resulted in a stack trace.

This commit resolves the issue so that self.instances should
work for systemd providers. The issue was that the instances
method was returning an Array of strings. This commit updates the
method to correctly return an Array of Provider instances.
