### PR TITLE
(#13204) Don't ignore missing PATH.augnew files

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -297,9 +297,8 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           saved_files = @aug.match("/augeas/events/saved")
           if saved_files.size > 0
             root = resource[:root].sub(/^\/$/, "")
-            saved_files.each do |key|
-              saved_file = @aug.get(key).sub(/^\/files/, root)
-              next unless File.exists?(saved_file + ".augnew")
+            saved_files.map! {|key| @aug.get(key).sub(/^\/files/, root) }
+            saved_files.uniq.each do |saved_file|
               if Puppet[:show_diff]
                 notice "\n" + diff(saved_file, saved_file + ".augnew")
               end

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -329,7 +329,6 @@ describe provider_class do
       it "should call diff when a file is shown to have been changed" do
         file = "/etc/hosts"
         File.stubs(:delete)
-        File.stubs(:exists?).returns(true)
 
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
@@ -347,7 +346,6 @@ describe provider_class do
         file1 = "/etc/hosts"
         file2 = "/etc/resolv.conf"
         File.stubs(:delete)
-        File.stubs(:exists?).returns(true)
 
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file1}/foo bar", "set #{file2}/baz biz"]
@@ -368,7 +366,6 @@ describe provider_class do
           root = "/tmp/foo"
           file = "/etc/hosts"
           File.stubs(:delete)
-          File.stubs(:exists?).returns(true)
 
           @resource[:context] = "/files"
           @resource[:changes] = ["set #{file}/foo bar"]
@@ -401,7 +398,6 @@ describe provider_class do
 
       it "should cleanup the .augnew file" do
         file = "/etc/hosts"
-        File.stubs(:exists?).returns(true)
 
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
@@ -421,11 +417,6 @@ describe provider_class do
       it "should handle duplicate /augeas/events/saved filenames" do
         file = "/etc/hosts"
 
-        augnew = states("augnew").starts_as("present")
-
-        File.stubs(:exists?).returns(true).when(augnew.is("present"))
-        File.stubs(:exists?).returns(false).when(augnew.is("absent"))
-
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
 
@@ -435,9 +426,9 @@ describe provider_class do
         @augeas.expects(:set).with("/augeas/save", "newfile")
         @augeas.expects(:close)
 
-        File.expects(:delete).with(file + ".augnew").when(augnew.is("present")).then(augnew.is("absent"))
+        File.expects(:delete).with(file + ".augnew").once()
 
-        @provider.expects(:diff).with("#{file}", "#{file}.augnew").returns("").when(augnew.is("present"))
+        @provider.expects(:diff).with("#{file}", "#{file}.augnew").returns("").once()
         @provider.should be_need_to_run
       end
 


### PR DESCRIPTION
This is a followup to pull req #587, where a better solution was discussed that doesn't squash other errors.

Commit log:
The original fix for #13204 may have masked other potential bugs if the
PATH.augnew file was missing.  It simply tested for the file existance and not
only when duplicate save events occurred.

This change de-duplicates the list of save events instead, so if a bug appeared
where PATH.augnew was genuinely missing, the error wouldn't be squashed.
