### PR TITLE
Maint/2.7.x/communication error test

### DIFF
--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -5,10 +5,10 @@ apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '127.0.0.2' }"
 
 step "Search against a non-existent Forge"
 on master, puppet("module search yup"), :acceptable_exit_codes => [1] do
-  assert_equal <<-STDOUT, stdout
+  assert_match <<-STDOUT, stdout
 Searching http://forge.puppetlabs.com ...
 STDOUT
-  assert_equal <<-STDERR, stderr
+  assert_match <<-STDERR, stderr
 Error: Could not connect to http://forge.puppetlabs.com
   There was a network communications problem
     Check your network connection and try again


### PR DESCRIPTION
The assert_equal was failing because the output can have color escape codes.
Use assert_match instead.
