### PR TITLE
Fix console logging for no-daemonize mode

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -139,7 +139,7 @@ class Puppet::Daemon
     #  our streams and become a "real" daemon process.  This is in hopes of allowing
     #  errors to have the console available as a fallback for logging for as long as
     #  possible.
-    close_streams
+    close_streams if Puppet[:daemonize]
 
     # Finally, loop forever running events - or, at least, until we exit.
     run_event_loop

--- a/lib/puppet/network/server.rb
+++ b/lib/puppet/network/server.rb
@@ -110,7 +110,7 @@ class Puppet::Network::Server
 
   def start
     create_pidfile
-    close_streams
+    close_streams if Puppet[:daemonize]
     listen
   end
 

--- a/spec/unit/network/server_spec.rb
+++ b/spec/unit/network/server_spec.rb
@@ -10,6 +10,7 @@ describe Puppet::Network::Server do
     Puppet.settings.stubs(:value).with(:servertype).returns(:suparserver)
     Puppet.settings.stubs(:value).with(:bindaddress).returns("")
     Puppet.settings.stubs(:value).with(:masterport).returns(8140)
+    Puppet.settings.stubs(:value).with(:daemonize).returns(true)
     Puppet::Network::HTTP.stubs(:server_class_by_type).returns(@mock_http_server_class)
     Puppet.settings.stubs(:value).with(:servertype).returns(:suparserver)
     @server = Puppet::Network::Server.new(:port => 31337)


### PR DESCRIPTION
A recent change to how we handle logging for master accidentally
broke console logging for no-daemonize mode.  This change fixes it.
