### PR TITLE
Bug/2.7.x/spec tmpfile cleanup

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
     Signal.stubs(:trap)
 
 
-    # TODO: in a saner world, we'd move this logging redirection into our TestHelper class.
+    # TODO: in a more sane world, we'd move this logging redirection into our TestHelper class.
     #  Without doing so, external projects will all have to roll their own solution for
     #  redirecting logging, and for validating expected log messages.  However, because the
     #  current implementation of this involves creating an instance variable "@logs" on
@@ -83,6 +83,9 @@ RSpec.configure do |config|
 
   config.after :each do
     Puppet::Test::TestHelper.after_each_test()
+
+    # TODO: would like to move this into puppetlabs_spec_helper, but there are namespace issues at the moment.
+    PuppetSpec::Files.cleanup
 
     # TODO: this should be abstracted in the future--see comments above the '@logs' block in the
     #  "before" code above.


### PR DESCRIPTION
Recent spec_helper changes accidentally removed the behavior of cleaning up temp files after each test.  This adds it back in.
