### PR TITLE
Win service eventlog

### DIFF
--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -81,9 +81,7 @@ describe Puppet::Util::Log do
     end
   end
 
-  describe Puppet::Util::Log::DestEventlog, :if => Puppet.features.microsoft_windows? do
-    require 'win32/eventlog' if Puppet.features.microsoft_windows?
-
+  describe Puppet::Util::Log::DestEventlog, :if => Puppet.features.eventlog? do
     before :each do
       Win32::EventLog.stubs(:open).returns(mock 'mylog')
       Win32::EventLog.stubs(:report_event)


### PR DESCRIPTION
Previously, the test would fail when run on a Windows box that didn't
have the eventlog gem installed. Since the Windows agent should be able
to run without the gem installed, and fall back to writing to a log
file, this commit changes the test to only run when the gem is
installed. There is already a test that verifies that we fall back if
the eventlog feature is not available.
