### PR TITLE
Fix order dependent acceptance test on Windows

### DIFF
--- a/acceptance/tests/windows/eventlog.rb
+++ b/acceptance/tests/windows/eventlog.rb
@@ -14,13 +14,16 @@ agents.each do |agent|
   # get remote time
   now = on(agent, "#{get_cmd(agent)} -e \"puts Time.now.utc.strftime('%m/%d/%Y %H:%M:%S')\"").stdout.chomp
 
+  # it should fail to start since parent directories don't exist
+  confdir = "/does/not/exist"
+
   # generate an error, no master on windows boxes
-  on agent, puppet_agent('--server', '127.0.0.1', '--test'), :acceptable_exit_codes => [1]
+  on agent, puppet_agent('--server', '127.0.0.1', '--test', '--confdir', confdir), :acceptable_exit_codes => [1]
 
   # make sure there's a Puppet error message in the log
   # cygwin + ssh + wmic hangs trying to read stdin, so echo '' |
   on agent, "cmd /c echo '' | wmic ntevent where \"LogFile='Application' and SourceName='Puppet' and TimeWritten >= '#{now}'\"  get Message,Type /format:csv" do
     fail_test "Event not found in Application event log" unless
-      stdout =~ /Could not retrieve catalog from remote server.*,Error/m
+      stdout =~ /Cannot create [a-z]:\/does\/not\/exist.*,Error/mi
   end
 end


### PR DESCRIPTION
Previously, the test assumed that the agent already had a signed
certificate and would fail trying to connect to the master to retrieve a
catalog. But this didn't work if the agent didn't have a cert.

This commit changes the test to use a conf directory, whose parents
don't exist. As a result, puppet will immediately fail to start, but
report the error, including the path we specified. This way it's not
dependent on the SSL state, and it doesn't affect the SSL-ness of other
tests.
