### PR TITLE
(#13929) Improve logging for very early failures

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -504,6 +504,7 @@ module Util
   #  code (e.g. webrick), and we have no idea what they might throw.
   rescue Exception => err
     Puppet.log_exception(err, "Could not #{message}: #{err}")
+    Puppet::Util::Log.force_flushqueue()
     exit(code)
   end
   module_function :exit_on_fail

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -170,6 +170,20 @@ class Puppet::Util::Log
     @queued.clear
   end
 
+  # Flush the logging queue.  If there are no destinations available,
+  #  adds in a console logger before flushing the queue.
+  # This is mainly intended to be used as a last-resort attempt
+  #  to ensure that logging messages are not thrown away before
+  #  the program is about to exit--most likely in a horrific
+  #  error scenario.
+  # @return nil
+  def Log.force_flushqueue()
+    if (@destinations.empty? and !(@queued.empty?))
+      newdestination(:console)
+    end
+    flushqueue
+  end
+
   def Log.sendlevel?(level)
     @levels.index(level) >= @loglevel
   end


### PR DESCRIPTION
This adds a "force_flushqueue" method to the Log class.
This can be called prior to a system exit, to force
any queued log messages to be flushed.  If no
logging destinations have been configured it will
attempt to create a console destination for the
queue to be flushed to.
