### PR TITLE
Update puppet spec for rpm 2.7.x

### DIFF
--- a/conf/redhat/puppet.spec
+++ b/conf/redhat/puppet.spec
@@ -5,7 +5,7 @@
 %global confdir conf/redhat
 
 Name:           puppet
-Version:        2.7.12
+Version:        2.7.13
 #Release:        0.1rc1%{?dist}
 Release:        1%{?dist}
 Summary:        A network tool for managing many disparate systems
@@ -21,13 +21,11 @@ Group:          System Environment/Base
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  facter >= 1.5
-BuildRequires:  ruby >= 1.8.1
+BuildRequires:  ruby >= 1.8.5
 
-%if 0%{?fedora} || 0%{?rhel} >= 5
 BuildArch:      noarch
 Requires:       ruby(abi) >= 1.8
 Requires:       ruby-shadow
-%endif
 
 # Pull in ruby selinux bindings where available
 %if 0%{?fedora} || 0%{?rhel} >= 6
@@ -39,7 +37,7 @@ Requires:       ruby-shadow
 %endif
 
 Requires:       facter >= 1.5
-Requires:       ruby >= 1.8.1
+Requires:       ruby >= 1.8.5
 %{!?_without_augeas:Requires: ruby-augeas}
 
 Requires(pre):  shadow-utils
@@ -285,6 +283,9 @@ fi
 rm -rf %{buildroot}
 
 %changelog
+* Tue Apr 10 2012 Matthaus Litteken <matthaus@puppetlabs.com> - 2.7.13-1
+- Update for 2.7.13
+
 * Mon Mar 12 2012 Michael Stahnke <stahnma@puppetlabs.com> - 2.7.12-1
 - Update for 2.7.12
 


### PR DESCRIPTION
As el4 is now EOL, Ruby 1.8.1 doesn't need to be the minimum Ruby. 1.8.5 is
available in el5, so that is a sane new minimum. This commit also removes a
macro that was needed for building rpms on platforms earlier than el5. It also
updates the changelog and version for the latest release of puppet, 2.7.13.
