### PR TITLE
Fix disabled error message

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -31,7 +31,7 @@ class Puppet::Agent
       return
     end
     if disabled?
-      Puppet.notice "Skipping run of #{client_class}; administratively disabled; use 'puppet #{client_class} --enable' to re-enable."
+      Puppet.notice "Skipping run of #{client_class}; administratively disabled; use 'puppet agent --enable' to re-enable."
       return
     end
 


### PR DESCRIPTION
When attempting to run a disabled agent the user was given an incorrect command to re-enable the agent. This fixes that.
