### PR TITLE
Maint/2.7.x/util require puppet

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -197,6 +197,10 @@ module Util
       :posix   => %r!^/!,
     }
 
+    # Due to weird load order issues, I was unable to remove this require.
+    # This is fixed in Telly so it can be removed there.
+    require 'puppet'
+
     # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
     # library uses that to test what platform it's on.  Normally in Puppet we
     # would use Puppet.features.microsoft_windows?, but this method needs to


### PR DESCRIPTION
There is a load order issue here, and removing the `require 'puppet'` line
caused some failures. For now, just put it back. The load issues are resolved
in Telly.
