### PR TITLE
(#13938) Add dedup parameter to zfs provider

### DIFF
--- a/lib/puppet/provider/zfs/solaris.rb
+++ b/lib/puppet/provider/zfs/solaris.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:zfs).provide(:solaris) do
     end
   end
 
-  [:aclinherit, :aclmode, :atime, :canmount, :checksum, :compression, :copies, :devices, :exec, :logbias, :mountpoint, :nbmand, :primarycache, :quota, :readonly, :recordsize, :refquota, :refreservation, :reservation, :secondarycache, :setuid, :shareiscsi, :sharenfs, :sharesmb, :snapdir, :version, :volsize, :vscan, :xattr, :zoned, :vscan].each do |field|
+  [:aclinherit, :aclmode, :atime, :canmount, :checksum, :compression, :copies, :dedup, :devices, :exec, :logbias, :mountpoint, :nbmand, :primarycache, :quota, :readonly, :recordsize, :refquota, :refreservation, :reservation, :secondarycache, :setuid, :shareiscsi, :sharenfs, :sharesmb, :snapdir, :version, :volsize, :vscan, :xattr, :zoned].each do |field|
     define_method(field) do
       zfs(:get, "-H", "-o", "value", field, @resource[:name]).strip
     end

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -40,6 +40,10 @@ parent zfs instances, the zfs resource will autorequire them."
       desc "The copies property. Valid values are `1`, `2`, `3`."
     end
 
+    newproperty(:dedup) do
+      desc "The dedup property. Valid values are `on`, `off`."
+    end
+
     newproperty(:devices) do
       desc "The devices property. Valid values are `on`, `off`."
     end

--- a/spec/unit/provider/zfs/solaris_spec.rb
+++ b/spec/unit/provider/zfs/solaris_spec.rb
@@ -75,7 +75,7 @@ describe provider_class do
 
   end
 
-  [:mountpoint, :recordsize, :aclmode, :aclinherit, :primarycache, :secondarycache, :compression, :copies, :quota, :reservation, :sharenfs, :snapdir].each do |prop|
+  [:aclinherit, :aclmode, :atime, :canmount, :checksum, :compression, :copies, :dedup, :devices, :exec, :logbias, :mountpoint, :nbmand, :primarycache, :quota, :readonly, :recordsize, :refquota, :refreservation, :reservation, :secondarycache, :setuid, :shareiscsi, :sharenfs, :sharesmb, :snapdir, :version, :volsize, :vscan, :xattr, :zoned].each do |prop|
     describe "when getting the #{prop} value" do
       it "should call zfs with :get, #{prop} and this zfs" do
         @provider.expects(:zfs).with(:get, "-H", "-o", "value", prop, @resource[:name]).returns("value\n")


### PR DESCRIPTION
This patch to the zfs type/provider:
- adds "dedup" to the list of properties
- removes a "vscan" property which was listed twice
- updates the spec to list every currently supported property
