### PR TITLE
(#9416) Make zfs/zpool work for more platforms

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -1,8 +1,17 @@
-Puppet::Type.type(:zfs).provide(:solaris) do
-  desc "Provider for Solaris zfs."
+Puppet::Type.type(:zfs).provide(:zfs) do
+  desc "Provider for zfs."
 
-  commands :zfs => "/usr/sbin/zfs"
-  defaultfor :operatingsystem => :solaris
+  zfspath = case Facter.value(:operatingsystem)
+            when /^(Solaris|SunOS|Darwin)/i
+              '/usr/sbin'
+            else
+              '/sbin'
+            end
+
+  commands :zfs => "#{zfspath}/zfs"
+
+  defaultfor :kernel => :linux
+  defaultfor :operatingsystem => [:solaris, :sunos, :darwin, :freebsd, :netbsd, :"gnu/kfreebsd"]
 
   def add_properties
     properties = []

--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -1,8 +1,18 @@
-Puppet::Type.type(:zpool).provide(:solaris) do
-  desc "Provider for Solaris zpool."
+Puppet::Type.type(:zpool).provide(:zpool) do
+  desc "Provider for zpool."
 
-  commands :zpool => "/usr/sbin/zpool"
-  defaultfor :operatingsystem => :solaris
+  zpoolpath = case Facter.value(:operatingsystem)
+              when /^(Solaris|SunOS|Darwin)/i
+                '/usr/sbin'
+              else
+                '/sbin'
+              end
+
+  commands :zpool => "#{zpoolpath}/zpool"
+
+  defaultfor :kernel => :linux
+  defaultfor :operatingsystem => [:solaris, :sunos, :darwin, :freebsd, :netbsd, :"gnu/kfreebsd"]
+
 
   def process_zpool_data(pool_array)
     if pool_array == []

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:zfs).provider(:solaris)
+provider_class = Puppet::Type.type(:zfs).provider(:zfs)
 
 describe provider_class do
   before do

--- a/spec/unit/provider/zpool/zpool_spec.rb
+++ b/spec/unit/provider/zpool/zpool_spec.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:zpool).provider(:solaris)
+provider_class = Puppet::Type.type(:zpool).provider(:zpool)
 
 describe provider_class do
   before do

--- a/spec/unit/type/zfs_spec.rb
+++ b/spec/unit/type/zfs_spec.rb
@@ -20,12 +20,14 @@ describe zfs do
     end
   end
 
-  it "should autorequire the containing zfss and the zpool" do
-    provider = mock "provider"
-    provider.stubs(:name).returns(:solaris)
-    zfs.stubs(:defaultprovider).returns(provider)
-    Puppet::Type.type(:zpool).stubs(:defaultprovider).returns(provider)
+  it "should autorequire the containing zfs and the zpool" do
+    zfs_provider = mock "provider"
+    zfs_provider.stubs(:name).returns(:zfs)
+    zfs.stubs(:defaultprovider).returns(zfs_provider)
 
+    zpool_provider = mock "provider"
+    zpool_provider.stubs(:name).returns(:zpool)
+    Puppet::Type.type(:zpool).stubs(:defaultprovider).returns(zpool_provider)
 
     foo_pool = Puppet::Type.type(:zpool).new(:name => "foo")
 
@@ -40,5 +42,10 @@ describe zfs do
     req = foo_bar_baz_buz_zfs.autorequire.collect { |edge| edge.source.ref }
 
     [foo_pool.ref, foo_bar_zfs.ref, foo_bar_baz_zfs.ref].each { |ref| req.include?(ref).should == true }
+  end
+
+  it "should select the zfs provider" do
+    provider_class = Puppet::Type::Zfs.provider(Puppet::Type::Zfs.providers[0])
+    zfs.new(:name => 'foo').provider.class.should be(provider_class)
   end
 end

--- a/spec/unit/type/zone_spec.rb
+++ b/spec/unit/type/zone_spec.rb
@@ -61,7 +61,7 @@ describe zone do
 
     # ick
     provider = stub 'zfs::provider'
-    provider.stubs(:name).returns(:solaris)
+    provider.stubs(:name).returns(:zfs)
     Puppet::Type.type(:zfs).stubs(:defaultprovider).returns(provider)
 
     catalog = Puppet::Resource::Catalog.new

--- a/spec/unit/type/zpool_spec.rb
+++ b/spec/unit/type/zpool_spec.rb
@@ -24,6 +24,12 @@ describe zpool do
       zpool.attrclass(parameter).ancestors.should be_include(Puppet::Parameter)
     end
   end
+
+  it "should select the zpool provider" do
+    provider_class = Puppet::Type::Zpool.provider(Puppet::Type::Zpool.providers[0])
+    zpool.new(:name => 'foo').provider.class.should be(provider_class)
+  end
+
 end
 
 vdev_property = Puppet::Property::VDev


### PR DESCRIPTION
ZFS is no longer only available on the Solaris platform. This patch
adapts the zfs and zpool type & provider to support the most common
platforms where ZFS is found nowdays.
