### PR TITLE
Bug/master/enc variables not overridden by node

### DIFF
--- a/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
+++ b/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
@@ -1,0 +1,67 @@
+test_name "ENC still allows a node to override a topscope var"
+
+testdir = master.tmpdir('scoping_deprecation')
+
+create_remote_file(master, "#{testdir}/puppet.conf", <<END)
+[main]
+node_terminus = exec
+external_nodes = "#{testdir}/enc"
+manifest = "#{testdir}/site.pp"
+modulepath = "#{testdir}/modules"
+END
+
+on master, "mkdir -p #{testdir}/modules/a/manifests"
+
+create_remote_file(master, "#{testdir}/enc", <<-PP)
+#!/usr/bin/env sh
+
+cat <<END
+---
+classes:
+  a
+parameters:
+  enc_var: "Set from ENC."
+END
+exit 0
+PP
+
+agent_names = agents.map { |agent| "'#{agent.to_s}'" }.join(', ')
+create_remote_file(master, "#{testdir}/site.pp", <<-PP)
+$top_scope = "set from site.pp"
+node default {
+  $enc_var = "ENC overridden in default node."
+}
+
+node #{agent_names} inherits default {
+  $top_scope = "top_scope overridden in agent node."
+}
+PP
+create_remote_file(master, "#{testdir}/modules/a/manifests/init.pp", <<-PP)
+class a {
+  notify { "from enc": message => $enc_var }
+  notify { "from site.pp": message => $top_scope }
+}
+PP
+
+on master, "chown -R root:puppet #{testdir}"
+on master, "chmod -R g+rwX #{testdir}"
+on master, "chmod -R a+x #{testdir}/enc"
+
+assert_log_on_master_contains = lambda do |string|
+  on master, "grep '#{string}' #{testdir}/log"
+end
+
+assert_log_on_master_does_not_contain = lambda do |string|
+  on master, "grep -v '#{string}' #{testdir}/log"
+end
+
+with_master_running_on(master, "--config #{testdir}/puppet.conf --debug --verbose --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+  agents.each do |agent|
+    run_agent_on(agent, "--no-daemonize --onetime --verbose --server #{master}")
+
+    assert_match("top_scope overridden in agent node.", stdout)
+    assert_match("ENC overridden in default node.", stdout)
+  end
+end
+
+on master, "rm -rf #{testdir}"

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -128,7 +128,7 @@ class Puppet::Parser::Compiler
 
   # Evaluate all of the classes specified by the node.
   def evaluate_node_classes
-    evaluate_classes(@node.classes, topscope)
+    evaluate_classes(@node.classes, @node_scope || topscope)
   end
 
   # Evaluate each specified class in turn.  If there are any classes we can't
@@ -225,6 +225,8 @@ class Puppet::Parser::Compiler
     resource = astnode.ensure_in_catalog(topscope)
 
     resource.evaluate
+
+    @node_scope = topscope.class_scope(astnode)
   end
 
   # Evaluate our collections and return true if anything returned an object.


### PR DESCRIPTION
After the merge of the 2.7.x code that included the new lookup code, the fix to that caused ENC variable lookups to start behaving incorrectly. The problem was the the classes included by the ENC were no longer being interpreted in the correct scope. This fix ensures that the ENC classes are interpreted in either the scope of the best matching node or in the topscope.
