### PR TITLE
Maint: Escape command in regexp

### DIFF
--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -346,10 +346,10 @@ describe Puppet::Provider do
       parent.commands :sh => command
 
       FileTest.should be_exists parent.command(:sh)
-      parent.command(:sh).should =~ /#{command}$/
+      parent.command(:sh).should =~ /#{Regexp.escape(command)}$/
 
       FileTest.should be_exists child.command(:sh)
-      child.command(:sh).should =~ /#{command}$/
+      child.command(:sh).should =~ /#{Regexp.escape(command)}$/
     end
 
     it "#1197: should find commands added in the same run" do


### PR DESCRIPTION
On 64-bit Windows, the directory for 32-bit applications contains
parentheses: C:/Program Files (x86). The test was using this in a regexp
comparison and failing because the parentheses are metacharcters that
need to be escaped.

This failure was introduced when the `fails_on_windows` exclude filter
was removed (as `Puppet::Util.which` now works on Windows).
