### PR TITLE
(maint) Add provider confine :exists => nil spec

### DIFF
--- a/spec/unit/provider/confine/exists_spec.rb
+++ b/spec/unit/provider/confine/exists_spec.rb
@@ -12,6 +12,13 @@ describe Puppet::Provider::Confine::Exists do
   it "should be named :exists" do
     Puppet::Provider::Confine::Exists.name.should == :exists
   end
+  
+  it "should not pass if exists is nil" do
+    confine = Puppet::Provider::Confine::Exists.new(nil)
+    confine.label = ":exists => nil"
+    confine.expects(:pass?).with(nil)
+    confine.should_not be_valid
+  end
 
   it "should use the 'pass?' method to test validity" do
     @confine.expects(:pass?).with("/my/file")


### PR DESCRIPTION
Add a test for the provider confine exists when the value is nil.

Related tests are failing when confine :exists => nil, but the confine
:exists => nil case had not explicitly been tested.
