### PR TITLE
Better warning about metaparameter redefinitions

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -335,7 +335,7 @@ class Puppet::Resource::Type
     return unless Puppet::Type.metaparamclass(param)
 
     if default
-      warnonce "#{param} is a metaparam; this value will inherit to all contained resources"
+      warnonce "#{param} is a metaparam; this value will inherit to all contained resources in the #{self.name} definition"
     else
       raise Puppet::ParseError, "#{param} is a metaparameter; please choose another parameter name in the #{self.name} definition"
     end


### PR DESCRIPTION
A definition such as the following, which redefines metaparameters:

<pre>
define contact_info($alias = undef) {
  ...
}
</pre>

generates the following warning:

<pre>
warning: alias is a metaparam; this value will inherit to all contained resources
</pre>


To find and fix this problem in the manifests we need to know where the parameter is defined or at least the name of the definition, which this commit adds.
