### PR TITLE
(maint) Get provider specs working on windows

### DIFF
--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 def existing_command
-  Facter.value(:operatingsystem) =~ /windows/ ? "cmd" : "echo"
+  Puppet.features.microsoft_windows? ? "cmd" : "echo"
 end
 
 describe Puppet::Provider do


### PR DESCRIPTION
Define helper to provider an existing command for windows because "echo"
is a shell interpreted command, not a proper executable.

As a side note, a helper method was the only way this actually functions
because of the evaluation context of the confine scenarios hash. Let,
before(:each), and instance variable all fail.
