### PR TITLE
Bug/2.7.x/14060 incorrect quoting in shell exec provider

### DIFF
--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -1,3 +1,6 @@
+require 'puppet/provider'
+require 'puppet/util/execution'
+
 class Puppet::Provider::Exec < Puppet::Provider
   include Puppet::Util::Execution
 
@@ -63,9 +66,11 @@ class Puppet::Provider::Exec < Puppet::Provider
   end
 
   def extractexe(command)
-    # easy case: command was quoted
-    if command =~ /^"([^"]+)"/
-      $1
+    if command.is_a? Array
+      command.first
+    elsif match = /^"([^"]+)"|^'([^']+)'/.match(command)
+      # extract whichever of the two sides matched the content.
+      match[1] or match[2]
     else
       command.split(/ /)[0]
     end

--- a/lib/puppet/provider/exec/shell.rb
+++ b/lib/puppet/provider/exec/shell.rb
@@ -16,8 +16,7 @@ Puppet::Type.type(:exec).provide :shell, :parent => :posix do
   EOT
 
   def run(command, check = false)
-    command = %Q{/bin/sh -c "#{command.gsub(/"/,'\"')}"}
-    super(command, check)
+    super(['/bin/sh', '-c', command], check)
   end
 
   def validatecmd(command)

--- a/spec/unit/provider/exec/shell_spec.rb
+++ b/spec/unit/provider/exec/shell_spec.rb
@@ -36,6 +36,13 @@ describe Puppet::Type.type(:exec).provider(:shell), :unless => Puppet.features.m
       status.exitstatus.should == 0
       output.should == "bar\n"
     end
+
+    it "#14060: should interpolate inside the subshell, not outside it" do
+      resource[:environment] = "foo=outer"
+      output, status = provider.run("foo=inner; echo \"foo is $foo\"")
+      status.exitstatus.should == 0
+      output.should == "foo is inner\n"
+    end
   end
 
   describe "#validatecmd" do

--- a/spec/unit/provider/exec_spec.rb
+++ b/spec/unit/provider/exec_spec.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+require 'puppet/provider/exec'
+
+describe Puppet::Provider::Exec do
+  describe "#extractexe" do
+    it "should return the first element of an array" do
+      subject.extractexe(['one', 'two']).should == 'one'
+    end
+
+    {
+      # double-quoted commands
+      %q{"/has whitespace"}            => "/has whitespace",
+      %q{"/no/whitespace"}             => "/no/whitespace",
+      # singe-quoted commands
+      %q{'/has whitespace'}            => "/has whitespace",
+      %q{'/no/whitespace'}             => "/no/whitespace",
+      # combinations
+      %q{"'/has whitespace'"}          => "'/has whitespace'",
+      %q{'"/has whitespace"'}          => '"/has whitespace"',
+      %q{"/has 'special' characters"}  => "/has 'special' characters",
+      %q{'/has "special" characters'}  => '/has "special" characters',
+      # whitespace split commands
+      %q{/has whitespace}              => "/has",
+      %q{/no/whitespace}               => "/no/whitespace",
+    }.each do |base_command, exe|
+      ['', ' and args', ' "and args"', " 'and args'"].each do |args|
+        command = base_command + args
+        it "should extract #{exe.inspect} from #{command.inspect}" do
+          subject.extractexe(command).should == exe
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
(#14060) Fix quoting of commands to interpolate inside the shell.

The `shell` exec provider was supposed to emulate the behaviour of 0.25 exec,
which was to pass the content through the default shell to get it executed.

Unfortunately, it got quoting a bit wrong, and ended up interpolating
variables at the wrong point - it used double quotes where single quotes were
really what was desired.

Thanks to Matthew Byng-Maddick for the fix.
