### PR TITLE
Use expand_path to normalize paths in autoloader

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -93,7 +93,7 @@ class Puppet::Util::Autoload
     end
 
     def files_in_dir(dir, path)
-      dir = Pathname.new(dir)
+      dir = Pathname.new(File.expand_path(dir))
       Dir.glob(File.join(dir, path, "*.rb")).collect do |file|
         Pathname.new(file).relative_path_from(dir).to_s
       end
@@ -156,7 +156,14 @@ class Puppet::Util::Autoload
     # Normalize a path. This converts ALT_SEPARATOR to SEPARATOR on Windows
     # and eliminates unnecessary parts of a path.
     def cleanpath(path)
-      Pathname.new(path).cleanpath.to_s
+      # There are two cases here because cleanpath does not handle absolute
+      # paths correctly on windows (c:\ and c:/ are treated as distinct) but
+      # we don't want to convert relative paths to absolute
+      if Puppet::Util.absolute_path?(path)
+        File.expand_path(path)
+      else
+        Pathname.new(path).cleanpath.to_s
+      end
     end
   end
 


### PR DESCRIPTION
Just using Pathname#cleanpath didn't properly convert \ to / on windows. Using
both should give correct normalized paths.
