### PR TITLE
(#12392): Colorize console output on Windows

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -47,11 +47,10 @@ module Puppet
       exits.  Comma-separate multiple values.  For a list of all values,
       specify 'all'."],
     :color => {
-      :default => (Puppet.features.microsoft_windows? ? "false" : "ansi"),
+      :default => "ansi",
       :type    => :setting,
       :desc    => "Whether to use colors when logging to the console.  Valid values are
-      `ansi` (equivalent to `true`), `html`, and `false`, which produces no color.
-      Defaults to false on Windows, as its console does not support ansi colors.",
+      `ansi` (equivalent to `true`), `html`, and `false`, which produces no color.",
     },
     :mkusers => [false,
       "Whether to create the necessary user and group that puppet agent will

--- a/lib/puppet/feature/ansicolor.rb
+++ b/lib/puppet/feature/ansicolor.rb
@@ -1,0 +1,5 @@
+require 'puppet/util/feature'
+
+Puppet.features.rubygems?
+Puppet.features.add(:ansicolor,
+  Puppet.features.microsoft_windows? ? { :libs => 'win32console' } : {} )

--- a/lib/puppet/util/colors.rb
+++ b/lib/puppet/util/colors.rb
@@ -77,7 +77,11 @@ module Puppet::Util::Colors
   def colorize(color, str)
     case Puppet[:color]
     when true, :ansi, "ansi", "yes"
-      console_color(color, str)
+      if Puppet.features.ansicolor?
+        console_color(color, str)
+      else
+        str
+      end
     when :html, "html"
       html_color(color, str)
     else

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -285,13 +285,8 @@ describe "Puppet defaults" do
   end
 
   describe "when configuring color" do
-    it "should default to ansi", :unless => Puppet.features.microsoft_windows? do
-      Puppet.settings[:color].should == 'ansi'
-    end
-
-    it "should default to false", :if => Puppet.features.microsoft_windows? do
-      Puppet.settings[:color].should == 'false'
-    end
+    subject { Puppet.settings[:color] }
+    it { should == "ansi" }
   end
 
   describe "daemonize" do

--- a/spec/unit/util/colors_spec.rb
+++ b/spec/unit/util/colors_spec.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Util::Colors do
+  include Puppet::Util::Colors
+
+  let (:message) { 'a message' }
+  let (:color) { :black }
+  let (:subject) { self }
+
+  describe ".console_color" do
+    it { should respond_to :console_color }
+
+    it "should generate ANSI escape sequences" do
+      subject.console_color(color, message).should == "\e[0;30m#{message}\e[0m"
+    end
+  end
+
+  describe ".html_color" do
+    it { should respond_to :html_color }
+
+    it "should generate an HTML span element and style attribute" do
+      subject.html_color(color, message).should =~ /<span style=\"color: #FFA0A0\">#{message}<\/span>/
+    end
+  end
+
+  describe ".colorize" do
+    it { should respond_to :colorize }
+
+    context "ansicolor supported" do
+      before :each do
+        Puppet.features.stubs(:ansicolor?).returns(true)
+      end
+
+      it "should colorize console output" do
+        Puppet[:color] = true
+
+        subject.expects(:console_color).with(color, message)
+        subject.colorize(:black, message)
+      end
+
+      it "should not colorize unknown color schemes" do
+        Puppet[:color] = :thisisanunknownscheme
+
+        subject.colorize(:black, message).should == message
+      end
+    end
+
+    context "ansicolor not supported" do
+      before :each do
+        Puppet.features.stubs(:ansicolor?).returns(false)
+      end
+
+      it "should not colorize console output" do
+        Puppet[:color] = true
+
+        subject.expects(:console_color).never
+        subject.colorize(:black, message).should == message
+      end
+
+      it "should colorize html output" do
+        Puppet[:color] = :html
+
+        subject.expects(:html_color).with(color, message)
+        subject.colorize(color, message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, `Puppet[:color]` was false on Windows, because the Windows
console does not support ANSI escape sequences.

The win32console gem converts ANSI color escape sequences into Win32
console API calls to change the foreground color, etc. If the output
stream has been redirected to a file, then the gem does not translate
the sequences, instead preserving them in the stream, as is done on
Unix.

To disable colorized output specify `color=false` or `--color=false` on
the command line.

This commit adds a `Puppet.features.ansicolor?` feature that defines
whether ANSI color escape sequences are supported. On Windows, this is
only true if the win32console gem can be loaded. On other platforms, the
value is always true.

The win32console gem will be packaged into the Windows installer, and
so, `Puppet[:color]` now defaults to true. If the gem can't be loaded,
then puppet will revert to its previous behavior.
