### PR TITLE
Add ability to log spec test order to a file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,4 +101,15 @@ RSpec.configure do |config|
     # just letting it run all the time.
     GC.enable
   end
+
+  config.after :suite do
+    # Log the spec order to a file, but only if the LOG_SPEC_ORDER environment variable is
+    #  set.  This should be enabled on Jenkins runs, as it can be used with Nick L.'s bisect
+    #  script to help identify and debug order-dependent spec failures.
+    if ENV['LOG_SPEC_ORDER']
+      File.open("./spec_order.txt", "w") do |logfile|
+        config.instance_variable_get(:@files_to_run).each { |f| logfile.puts f }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit tweaks the spec_helper to give it the
ability to log the spec test order to a file.  It
will only log the order if you have set the
environment variable "LOG_SPEC_ORDER", e.g.:

LOG_SPEC_ORDER=true rspec spec

This will be useful when using Nick L.'s bisect
script to identify order-dependent spec failures.
It should probably be enabled on all of our
Jenkins jobs, and would potentially allow us to
start running them with the random order flag
enabled.
