### PR TITLE
Bug/master/13429 faces as libraries

### DIFF
--- a/ext/nagios/naggen
+++ b/ext/nagios/naggen
@@ -277,7 +277,7 @@ result.each { |opt,arg|
 }
 
 # Read in Puppet settings, so we know how Puppet's configured.
-Puppet.parse_config
+Puppet.initialize_settings
 
 Puppet::Util::Log.newdestination(:console)
 

--- a/ext/puppet-test
+++ b/ext/puppet-test
@@ -542,7 +542,7 @@ rescue GetoptLong::InvalidOption => detail
 end
 
 # Now parse the config
-Puppet.parse_config
+Puppet.initialize_settings
 
 $options[:nodes] << Puppet.settings[:certname] if $options[:nodes].empty?
 

--- a/ext/puppetlisten/puppetlisten.rb
+++ b/ext/puppetlisten/puppetlisten.rb
@@ -11,8 +11,7 @@ require 'socket'
 require 'facter'
 
 # load puppet configuration, needed to find SSL certificates
-Puppet[:config] = "/etc/puppet/puppet.conf"
-Puppet.parse_config
+Puppet.initialize_settings
 
 # set the SSL environment
 ctx = OpenSSL::SSL::SSLContext.new

--- a/ext/puppetlisten/puppetrun.rb
+++ b/ext/puppetlisten/puppetrun.rb
@@ -16,8 +16,7 @@ require 'puppet/sslcertificates/support'
 require 'socket'
 
 # load puppet configuration, needed to find ssl certificates
-Puppet[:config] = "/etc/puppet/puppet.conf"
-Puppet.parse_config
+Puppet.initialize_settings
 
 # establish the certificate
 ctx = OpenSSL::SSL::SSLContext.new

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -113,9 +113,35 @@ module Puppet
   end
 
   # Parse the config file for this process.
-  def self.parse_config
-    Puppet.settings.parse
+  def self.parse_config()
+    Puppet.deprecation_warning("Puppet.parse_config is deprecated; please use Faces API (which will handle settings and state management for you), or (less desirable) call Puppet.initialize_settings")
+    Puppet.initialize_settings
   end
+
+  # Initialize puppet's settings.  This is intended only for use by external tools that are not
+  #  built off of the Faces API or the Puppet::Util::Application class.  It may also be used
+  #  to initialize state so that a Face may be used programatically, rather than as a stand-alone
+  #  command-line tool.
+  #
+  # Note that this API may be subject to change in the future.
+  def self.initialize_settings()
+    do_initialize_settings_for_run_mode(:user)
+  end
+
+  # Initialize puppet's settings for a specified run_mode.  This
+  def self.initialize_settings_for_run_mode(run_mode)
+    Puppet.deprecation_warning("initialize_settings_for_run_mode may be removed in a future release, as may run_mode itself")
+    do_initialize_settings_for_run_mode(run_mode)
+  end
+
+  # private helper method to provide the implementation details of initializing for a run mode,
+  #  but allowing us to control where the deprecation warning is issued
+  def self.do_initialize_settings_for_run_mode(run_mode)
+    Puppet.settings.initialize_global_settings
+    run_mode = Puppet::Util::RunMode[run_mode]
+    Puppet.settings.initialize_app_defaults(Puppet::Util::Settings.app_defaults_for_run_mode(run_mode))
+  end
+  private_class_method :do_initialize_settings_for_run_mode
 
   # Create a new type.  Just proxy to the Type class.  The mirroring query
   # code was deprecated in 2008, but this is still in heavy use.  I suppose

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -266,13 +266,9 @@ class Application
   end
 
   def app_defaults()
-    {
-        :run_mode => self.class.run_mode.name,
-        :confdir  => self.class.run_mode.conf_dir,
-        :vardir   => self.class.run_mode.var_dir,
-        :rundir   => self.class.run_mode.run_dir,
-        :logdir   => self.class.run_mode.log_dir,
-    }
+    Puppet::Util::Settings.app_defaults_for_run_mode(self.class.run_mode).merge(
+        :name => name
+    )
   end
 
   def initialize_app_defaults()
@@ -384,7 +380,7 @@ class Application
 
 
   def handlearg(opt, val)
-    opt, val = Puppet::Util::CommandLine.clean_opt(opt, val)
+    opt, val = Puppet::Util::Settings.clean_opt(opt, val)
     send(:handle_unknown, opt, val) if respond_to?(:handle_unknown)
   end
 

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -262,9 +262,6 @@ HELP
       end
     end
 
-    # Now parse the config
-    Puppet.parse_config
-
     # Handle the logging settings.
     if options[:debug] or options[:verbose]
       if options[:debug]

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -70,6 +70,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     # REVISIT: These should be configurable versions, through a global
     # '--version' option, but we don't implement that yet... --daniel 2011-03-29
     @type = self.class.name.to_s.sub(/.+:/, '').downcase.to_sym
+
     @face = Puppet::Face[@type, :current]
 
     # Now, walk the command line and identify the action.  We skip over
@@ -118,17 +119,12 @@ class Puppet::Application::FaceBase < Puppet::Application
       if @action = @face.get_default_action() then
         @is_default_action = true
       else
-        # REVISIT: ...and this horror thanks to our log setup, which doesn't
-        # initialize destinations until the setup method, which we will never
-        # reach.  We could also just print here, but that is actually a little
-        # uglier and nastier in the long term, in which we should do log setup
-        # earlier if at all possible. --daniel 2011-05-31
-        Puppet::Util::Log.newdestination(:console)
-
         face   = @face.name
         action = action_name.nil? ? 'default' : "'#{action_name}'"
         msg = "'#{face}' has no #{action} action.  See `puppet help #{face}`."
+
         Puppet.err(msg)
+        Puppet::Util::Log.force_flushqueue()
 
         exit false
       end

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -165,9 +165,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       Puppet::Log.level = :info
     end
 
-    # Now parse the config
-    Puppet.parse_config
-
       exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
     require 'puppet/file_bucket/dipper'

--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -306,9 +306,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       Puppet::Util::Log.level = :info
     end
 
-    # Now parse the config
-    Puppet.parse_config
-
     if Puppet[:node_terminus] == "ldap" and (options[:all] or @classes)
       if options[:all]
         @hosts = Puppet::Node.indirection.search("whatever", :fqdn => options[:fqdn]).collect { |node| node.name }

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -152,8 +152,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def setup
     Puppet::Util::Log.newdestination(:console)
 
-    Puppet.parse_config
-
     if options[:debug]
       Puppet::Util::Log.level = :debug
     elsif options[:verbose]

--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -62,6 +62,7 @@ class Puppet::Interface
           raise Puppet::Error, "Could not find Puppet Face #{name.inspect}"
         end
       end
+
       face
     end
 

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -530,6 +530,9 @@ module Util
   # Now we need to catch *any* other kind of exception, because we may be calling third-party
   #  code (e.g. webrick), and we have no idea what they might throw.
   rescue Exception => err
+    ## NOTE: when debugging spec failures, these two lines can be very useful
+    #puts err.inspect
+    #puts Puppet::Util.pretty_backtrace(err.backtrace)
     Puppet.log_exception(err, "Could not #{message}: #{err}")
     Puppet::Util::Log.force_flushqueue()
     exit(code)

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -1,6 +1,5 @@
 require 'puppet'
 require "puppet/util/plugins"
-require 'puppet/util/command_line/puppet_option_parser'
 
 module Puppet
   module Util
@@ -22,59 +21,7 @@ module Puppet
         File.join('puppet', 'application')
       end
 
-      # This method is called during application bootstrapping.  It is responsible for parsing all of the
-      # command line options and initializing the values in Puppet.settings accordingly.
-      #
-      # It will ignore options that are not defined in the global puppet settings list, because they may
-      # be valid options for the specific application that we are about to launch... however, at this point
-      # in the bootstrapping lifecycle, we don't yet know what that application is.
-      def parse_global_options
-        # Create an option parser
-        option_parser = PuppetOptionParser.new
-        option_parser.ignore_invalid_options = true
 
-        # Add all global options to it.
-        Puppet.settings.optparse_addargs([]).each do |option|
-          option_parser.on(*option) do |arg|
-            handlearg(option[0], arg)
-
-          end
-        end
-
-        option_parser.parse(args)
-
-      end
-      private :parse_global_options
-
-
-      # Private utility method; this is the callback that the OptionParser will use when it finds
-      # an option that was defined in Puppet.settings.  All that this method does is a little bit
-      # of clanup to get the option into the exact format that Puppet.settings expects it to be in,
-      # and then passes it along to Puppet.settings.
-      #
-      # @param [String] opt the command-line option that was matched
-      # @param [String, TrueClass, FalseClass] the value for the setting (as determined by the OptionParser)
-      def handlearg(opt, val)
-        opt, val = self.class.clean_opt(opt, val)
-        Puppet.settings.handlearg(opt, val)
-      end
-      private :handlearg
-
-      # A utility method (public, is used by application.rb and perhaps elsewhere) that munges a command-line
-      # option string into the format that Puppet.settings expects.  (This mostly has to deal with handling the
-      # "no-" prefix on flag/boolean options).
-      #
-      # @param [String] opt the command line option that we are munging
-      # @param [String, TrueClass, FalseClass] the value for the setting (as determined by the OptionParser)
-      def self.clean_opt(opt, val)
-        # rewrite --[no-]option to --no-option if that's what was given
-        if opt =~ /\[no-\]/ and !val
-          opt = opt.gsub(/\[no-\]/,'no-')
-        end
-        # otherwise remove the [no-] prefix to not confuse everybody
-        opt = opt.gsub(/\[no-\]/, '')
-        [opt, val]
-      end
 
 
 
@@ -104,24 +51,9 @@ module Puppet
       # This is the main entry point for all puppet applications / faces; it is basically where the bootstrapping
       # process / lifecycle of an app begins.
       def execute
-        # The first two phases of the lifecycle of a puppet application are:
-        #  1) To parse the command line options and handle any of them that are registered, defined "global" puppet
-        #     settings (mostly from defaults.rb).)
-        #  2) To parse the puppet config file(s).
-        #
-        # These 2 steps are being handled explicitly here.  If there ever arises a situation where they need to be
-        # triggered from outside of this class, without triggering the rest of the lifecycle--we might want to move them
-        # out into a separate method that we call from here.  However, this seems to be sufficient for now.
-        #  --cprice 2012-03-16
-
-        # Here's step 1.
-        Puppet::Util.exit_on_fail("parse global options")     { parse_global_options }
-
-        # Here's step 2.  NOTE: this is a change in behavior where we are now parsing the config file on every run;
-        # before, there were several apps that specifically registered themselves as not requiring anything from
-        # the config file.  The fact that we're always parsing it now might be a small performance hit, but it was
-        # necessary in order to make sure that we can resolve the libdir before we look for the available applications.
-        Puppet::Util.exit_on_fail("parse configuration file") { Puppet.settings.parse }
+        Puppet::Util.exit_on_fail("intialize global default settings") do
+          Puppet.settings.initialize_global_settings(args)
+        end
 
         # OK, now that we've processed the command line options and the config files, we should be able to say that
         # we definitively know where the libdir is... which means that we can now look for our available

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -65,7 +65,6 @@ describe Puppet::Application::Apply do
   describe "during setup" do
     before :each do
       Puppet::Log.stubs(:newdestination)
-      Puppet.stubs(:parse_config)
       Puppet::FileBucket::Dipper.stubs(:new)
       STDIN.stubs(:read)
       Puppet::Transaction::Report.indirection.stubs(:cache_class=)

--- a/spec/unit/application/doc_spec.rb
+++ b/spec/unit/application/doc_spec.rb
@@ -179,7 +179,6 @@ describe Puppet::Application::Doc do
 
       before :each do
         @doc.options.stubs(:[]).returns(false)
-        Puppet.stubs(:parse_config)
         Puppet::Util::Log.stubs(:newdestination)
       end
 
@@ -213,12 +212,6 @@ describe Puppet::Application::Doc do
 
       it "should operate in master run_mode" do
         @doc.class.run_mode.name.should == :master
-
-        @doc.setup_rdoc
-      end
-
-      it "should parse puppet configuration" do
-        Puppet.expects(:parse_config)
 
         @doc.setup_rdoc
       end

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -160,7 +160,7 @@ describe Puppet::Application::FaceBase do
     }.each do |name, args|
       it "should accept global boolean settings #{name} the action" do
         app.command_line.stubs(:args).returns args
-        app.command_line.send(:parse_global_options)
+        Puppet.settings.initialize_global_settings(args)
         app.preinit
         app.parse_options
         Puppet[:trace].should be_true
@@ -172,7 +172,7 @@ describe Puppet::Application::FaceBase do
     }.each do |name, args|
       it "should accept global settings with arguments #{name} the action" do
         app.command_line.stubs(:args).returns args
-        app.command_line.send(:parse_global_options)
+        Puppet.settings.initialize_global_settings(args)
         app.preinit
         app.parse_options
         Puppet[:syslogfacility].should == "user1"
@@ -181,7 +181,6 @@ describe Puppet::Application::FaceBase do
 
     it "should handle application-level options" do
       app.command_line.stubs(:args).returns %w{--verbose return_true}
-      app.command_line.send(:parse_global_options)
       app.preinit
       app.parse_options
       app.face.name.should == :basetest
@@ -191,7 +190,6 @@ describe Puppet::Application::FaceBase do
   describe "#setup" do
     it "should remove the action name from the arguments" do
       app.command_line.stubs(:args).returns %w{--mandatory --bar foo}
-      app.command_line.send(:parse_global_options)
       app.preinit
       app.parse_options
       app.setup
@@ -199,8 +197,8 @@ describe Puppet::Application::FaceBase do
     end
 
     it "should pass positional arguments" do
-      app.command_line.stubs(:args).returns %w{--mandatory --bar foo bar baz quux}
-      app.command_line.send(:parse_global_options)
+      myargs = %w{--mandatory --bar foo bar baz quux}
+      app.command_line.stubs(:args).returns(myargs)
       app.preinit
       app.parse_options
       app.setup
@@ -361,8 +359,6 @@ EOT
 
     it "should fail early if asked to render an invalid format" do
       app.command_line.stubs(:args).returns %w{--render-as interpretive-dance return_true}
-      app.command_line.send(:parse_global_options)
-
       # We shouldn't get here, thanks to the exception, and our expectation on
       # it, but this helps us fail if that slips up and all. --daniel 2011-04-27
       Puppet::Face[:help, :current].expects(:help).never
@@ -371,9 +367,6 @@ EOT
 
       expect { app.run }.to exit_with 1
 
-      #expect {
-      #  expect { app.run }.to exit_with 1
-      #}.to have_printed(/I don't know how to render 'interpretive-dance'/)
     end
 
     it "should work if asked to render a NetworkHandler format" do

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -37,7 +37,6 @@ describe Puppet::Application::Filebucket do
     before :each do
       Puppet::Log.stubs(:newdestination)
       Puppet.stubs(:settraps)
-      Puppet.stubs(:parse_config)
       Puppet::FileBucket::Dipper.stubs(:new)
       @filebucket.options.stubs(:[]).with(any_parameters)
     end
@@ -65,12 +64,6 @@ describe Puppet::Application::Filebucket do
       @filebucket.options.stubs(:[]).with(:verbose).returns(true)
       @filebucket.setup
       Puppet::Log.level.should == :info
-    end
-
-    it "should Parse puppet config" do
-      Puppet.expects(:parse_config)
-
-      @filebucket.setup
     end
 
     it "should print puppet config if asked to in Puppet config" do
@@ -127,7 +120,6 @@ describe Puppet::Application::Filebucket do
     before :each do
       Puppet::Log.stubs(:newdestination)
       Puppet.stubs(:settraps)
-      Puppet.stubs(:parse_config)
       Puppet::FileBucket::Dipper.stubs(:new)
       @filebucket.options.stubs(:[]).with(any_parameters)
 

--- a/spec/unit/application/kick_spec.rb
+++ b/spec/unit/application/kick_spec.rb
@@ -117,7 +117,6 @@ describe Puppet::Application::Kick, :if => Puppet.features.posix? do
       @kick.hosts = []
       @kick.stubs(:trap)
       @kick.stubs(:puts)
-      Puppet.stubs(:parse_config)
 
       @kick.options.stubs(:[]).with(any_parameters)
     end
@@ -138,12 +137,6 @@ describe Puppet::Application::Kick, :if => Puppet.features.posix? do
       @kick.options.stubs(:[]).with(:verbose).returns(true)
       @kick.setup
       Puppet::Log.level.should == :info
-    end
-
-    it "should Parse puppet config" do
-      Puppet.expects(:parse_config)
-
-      @kick.setup
     end
 
     describe "when using the ldap node terminus" do

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -101,10 +101,8 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
     end
 
     it "should support dns alt names from ARGV" do
-      @master.command_line.stubs(:args).returns(["--dns_alt_names", "foo,bar,baz"])
+      Puppet.settings.initialize_global_settings(["--dns_alt_names", "foo,bar,baz"])
 
-      @master.command_line.send(:parse_global_options)
-      Puppet.settings.parse
       @master.preinit
       @master.parse_options
 

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -68,7 +68,6 @@ describe Puppet::Application::Resource do
   describe "during setup" do
     before :each do
       Puppet::Log.stubs(:newdestination)
-      Puppet.stubs(:parse_config)
     end
 
     it "should set console as the log destination" do
@@ -90,11 +89,6 @@ describe Puppet::Application::Resource do
       Puppet::Log.level.should == :info
     end
 
-    it "should Parse puppet config" do
-      Puppet.expects(:parse_config)
-
-      @resource_app.setup
-    end
   end
 
   describe "when running" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -8,14 +8,12 @@ require 'timeout'
 
 describe Puppet::Application do
 
-  before do
+  before(:each) do
     Puppet::Util::Instrumentation.stubs(:init)
     @app = Class.new(Puppet::Application).new
     @appclass = @app.class
 
     @app.stubs(:name).returns("test_app")
-    # avoid actually trying to parse any settings
-    Puppet.settings.stubs(:parse)
 
   end
 
@@ -165,6 +163,13 @@ describe Puppet::Application do
   end
 
   it "should initialize the Puppet Instrumentation layer early in the life cycle" do
+    # Not proud of this, but the fact that we are stubbing init_app_defaults
+    #  below means that we will get errors if anyone tries to access any
+    #  settings that depend on app_defaults.  In general this whole test
+    #  seems to be testing too many implementation details rather than
+    #  functionality, but, hey.
+    Puppet[:route_file] = "/dev/null"
+
     startup_sequence = sequence('startup')
     @app.expects(:initialize_app_defaults).in_sequence(startup_sequence)
     Puppet::Util::Instrumentation.expects(:init).in_sequence(startup_sequence)

--- a/spec/unit/util/command_line_spec.rb
+++ b/spec/unit/util/command_line_spec.rb
@@ -67,56 +67,6 @@ describe Puppet::Util::CommandLine do
     command_line.args.should            == []
   end
 
-  # A lot of settings management stuff has moved into command_line.rb; we need to do a first pass over
-  #  all of the supplied command-line arguments before we attempt to determine what application or
-  #  face we're going to run, because we need to be able to load apps/faces from the libdir
-  describe "when dealing with settings" do
-    let(:command_line) { Puppet::Util::CommandLine.new( "foo", [], @tty ) }
-
-    it "should get options from Puppet.settings.optparse_addargs" do
-      Puppet.settings.expects(:optparse_addargs).returns([])
-
-      command_line.send(:parse_global_options)
-    end
-
-    it "should add Puppet.settings options to OptionParser" do
-      Puppet.settings.stubs(:optparse_addargs).returns( [["--option","-o", "Funny Option", :NONE]])
-      Puppet.settings.expects(:handlearg).with("--option", true)
-      command_line.stubs(:args).returns(["--option"])
-      command_line.send(:parse_global_options)
-    end
-
-    it "should not die if it sees an unrecognized option, because the app/face may handle it later" do
-      command_line.stubs(:args).returns(["--topuppet", "value"])
-      expect { command_line.send(:parse_global_options) } .to_not raise_error
-    end
-
-    it "should not pass an unrecognized option to Puppet.settings" do
-      command_line.stubs(:args).returns(["--topuppet", "value"])
-      Puppet.settings.expects(:handlearg).with("--topuppet", "value").never
-      expect { command_line.send(:parse_global_options) } .to_not raise_error
-    end
-
-    it "should pass valid puppet settings options to Puppet.settings even if they appear after an unrecognized option" do
-      Puppet.settings.stubs(:optparse_addargs).returns( [["--option","-o", "Funny Option", :NONE]])
-      Puppet.settings.expects(:handlearg).with("--option", true)
-      command_line.stubs(:args).returns(["--invalidoption", "--option"])
-      command_line.send(:parse_global_options)
-    end
-
-
-    it "should transform boolean option to normal form for Puppet.settings" do
-      Puppet.settings.expects(:handlearg).with("--option", true)
-      command_line.send(:handlearg, "--[no-]option", true)
-    end
-
-    it "should transform boolean option to no- form for Puppet.settings" do
-      Puppet.settings.expects(:handlearg).with("--no-option", false)
-      command_line.send(:handlearg, "--[no-]option", false)
-    end
-  end
-
-
   describe "when dealing with puppet commands" do
 
     it "should return the executable name if it is not puppet" do

--- a/spec/unit/util/settings_spec.rb
+++ b/spec/unit/util/settings_spec.rb
@@ -535,7 +535,7 @@ describe Puppet::Util::Settings do
     it "should not cache values such that information from one environment is returned for another environment" do
       text = "[env1]\none = oneval\n[env2]\none = twoval\n"
       @settings.stubs(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
 
       @settings.value(:one, "env1").should == "oneval"
       @settings.value(:one, "env2").should == "twoval"
@@ -576,7 +576,7 @@ describe Puppet::Util::Settings do
       text = "[main]\none = fileval\n"
       @settings.stubs(:read_file).returns(text)
       @settings.handlearg("--one", "clival")
-      @settings.parse
+      @settings.send(:parse_config_files)
 
       @settings[:one].should == "clival"
     end
@@ -590,7 +590,7 @@ describe Puppet::Util::Settings do
     it "should return values set in the mode-specific section before values set in the main section" do
       text = "[main]\none = mainval\n[mymode]\none = modeval\n"
       @settings.stubs(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
 
       @settings[:one].should == "modeval"
     end
@@ -599,14 +599,14 @@ describe Puppet::Util::Settings do
       text = "[other]\none = oval\n"
       file = "/some/file"
       @settings.stubs(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:one].should == "ONE"
     end
 
     it "should return values in a specified environment" do
       text = "[env]\none = envval\n"
       @settings.stubs(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings.value(:one, "env").should == "envval"
     end
 
@@ -619,7 +619,7 @@ describe Puppet::Util::Settings do
     it "should interpolate found values using the current environment" do
       text = "[main]\none = mainval\n[myname]\none = nameval\ntwo = $one/two\n"
       @settings.stubs(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
 
       @settings.value(:two, "myname").should == "nameval/two"
     end
@@ -627,7 +627,7 @@ describe Puppet::Util::Settings do
     it "should return values in a specified environment before values in the main or name sections" do
       text = "[env]\none = envval\n[main]\none = mainval\n[myname]\none = nameval\n"
       @settings.stubs(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings.value(:one, "env").should == "envval"
     end
   end
@@ -644,7 +644,7 @@ describe Puppet::Util::Settings do
         FileTest.expects(:exist?).with(MAIN_CONFIG_FILE_DEFAULT_LOCATION).returns(false)
         FileTest.expects(:exist?).with(USER_CONFIG_FILE_DEFAULT_LOCATION).never
 
-        @settings.parse()
+        @settings.send(:parse_config_files)
       end
     end
 
@@ -656,7 +656,7 @@ describe Puppet::Util::Settings do
         FileTest.expects(:exist?).with(MAIN_CONFIG_FILE_DEFAULT_LOCATION).returns(false).in_sequence(seq)
         FileTest.expects(:exist?).with(USER_CONFIG_FILE_DEFAULT_LOCATION).returns(false).in_sequence(seq)
 
-        @settings.parse()
+        @settings.send(:parse_config_files)
       end
     end
   end
@@ -688,7 +688,7 @@ describe Puppet::Util::Settings do
       CONF
       FileTest.expects(:exist?).with(myfile).returns(true)
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:report].should be_true
     end
 
@@ -700,7 +700,7 @@ describe Puppet::Util::Settings do
 
       File.expects(:read).with(myfile).returns "[main]"
 
-      @settings.parse
+      @settings.send(:parse_config_files)
     end
 
     it "should not try to parse non-existent files" do
@@ -708,7 +708,7 @@ describe Puppet::Util::Settings do
 
       File.expects(:read).with("/some/file").never
 
-      @settings.parse
+      @settings.send(:parse_config_files)
     end
 
     it "should return values set in the configuration file" do
@@ -716,7 +716,7 @@ describe Puppet::Util::Settings do
       one = fileval
       "
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:one].should == "fileval"
     end
 
@@ -724,7 +724,7 @@ describe Puppet::Util::Settings do
     it "should not throw an exception on unknown parameters" do
       text = "[main]\nnosuchparam = mval\n"
       @settings.expects(:read_file).returns(text)
-      lambda { @settings.parse }.should_not raise_error
+      lambda { @settings.send(:parse_config_files) }.should_not raise_error
     end
 
     it "should convert booleans in the configuration file into Ruby booleans" do
@@ -733,7 +733,7 @@ describe Puppet::Util::Settings do
       two = false
       "
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:one].should == true
       @settings[:two].should == false
     end
@@ -743,7 +743,7 @@ describe Puppet::Util::Settings do
       one = 65
       "
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:one].should == 65
     end
 
@@ -755,7 +755,7 @@ describe Puppet::Util::Settings do
       myfile = #{otherfile} {owner = service, group = service, mode = 644}
       "
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:myfile].should == otherfile
       @settings.metadata(:myfile).should == {:owner => "suser", :group => "sgroup", :mode => "644"}
     end
@@ -769,7 +769,7 @@ describe Puppet::Util::Settings do
       "
       file = "/some/file"
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:myfile].should == otherfile
       @settings.metadata(:myfile).should == {:owner => "suser"}
     end
@@ -782,7 +782,7 @@ describe Puppet::Util::Settings do
       mysetting = setval
       "
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       values.should == ["setval"]
     end
 
@@ -796,7 +796,7 @@ describe Puppet::Util::Settings do
       mysetting = other
       "
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       values.should == ["setval"]
     end
 
@@ -812,7 +812,7 @@ describe Puppet::Util::Settings do
       mysetting = other
       "
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       values.should == ["other"]
     end
 
@@ -825,7 +825,7 @@ describe Puppet::Util::Settings do
       mysetting = $base/setval
       "
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       values.should == ["yay/setval"]
     end
 
@@ -836,7 +836,7 @@ describe Puppet::Util::Settings do
       myarg =
       "
       @settings.stubs(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:myarg].should == ""
     end
 
@@ -875,12 +875,12 @@ describe Puppet::Util::Settings do
     end
 
     it "should return values from the config file in the user's home dir before values set in the main configuration file" do
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:one].should == "user"
     end
 
     it "should return values from the main config file if they aren't overridden in the config file in the user's home dir" do
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:two].should == "main2"
     end
 
@@ -906,16 +906,16 @@ describe Puppet::Util::Settings do
       file.expects(:changed?)
 
       @settings.stubs(:parse)
-      @settings.reparse
+      @settings.reparse_config_files
     end
 
     it "should not create the LoadedFile instance and should not parse if the file does not exist" do
       FileTest.expects(:exist?).with("/test/file").returns false
       Puppet::Util::LoadedFile.expects(:new).never
 
-      @settings.expects(:parse).never
+      @settings.expects(:parse_config_files).never
 
-      @settings.reparse
+      @settings.reparse_config_files
     end
 
     it "should not reparse if the file has not changed" do
@@ -924,9 +924,9 @@ describe Puppet::Util::Settings do
 
       file.expects(:changed?).returns false
 
-      @settings.expects(:parse).never
+      @settings.expects(:parse_config_files).never
 
-      @settings.reparse
+      @settings.reparse_config_files
     end
 
     it "should reparse if the file has changed" do
@@ -935,9 +935,9 @@ describe Puppet::Util::Settings do
 
       file.expects(:changed?).returns true
 
-      @settings.expects(:parse)
+      @settings.expects(:parse_config_files)
 
-      @settings.reparse
+      @settings.reparse_config_files
     end
 
     it "should replace in-memory values with on-file values" do
@@ -956,7 +956,7 @@ describe Puppet::Util::Settings do
       # it goes to parse again when we ask for the value, because the
       # mock always says it should get reparsed.
       @settings.stubs(:read_file).returns(text)
-      @settings.reparse
+      @settings.reparse_config_files
       @settings[:one].should == "disk-replace"
     end
 
@@ -965,7 +965,7 @@ describe Puppet::Util::Settings do
 
       text = "[main]\none = on-disk\n"
       @settings.stubs(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
 
       @settings[:one].should == "clival"
     end
@@ -974,13 +974,13 @@ describe Puppet::Util::Settings do
       # Init the value
       text = "[main]\none = disk-init\n"
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:one].should == "disk-init"
 
       # Now replace the value
       text = "[main]\ntwo = disk-replace\n"
       @settings.expects(:read_file).returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
 
       # The originally-overridden value should be replaced with the default
       @settings[:one].should == "ONE"
@@ -993,13 +993,13 @@ describe Puppet::Util::Settings do
       # Init the value
       text = "[main]\none = initial-value\n"
       @settings.expects(:read_file).with("/test/file").returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
       @settings[:one].should == "initial-value"
 
       # Now replace the value with something bogus
       text = "[main]\nkenny = killed-by-what-follows\n1 is 2, blah blah florp\n"
       @settings.expects(:read_file).with("/test/file").returns(text)
-      @settings.parse
+      @settings.send(:parse_config_files)
 
       # The originally-overridden value should not be replaced with the default
       @settings[:one].should == "initial-value"
@@ -1435,4 +1435,46 @@ describe Puppet::Util::Settings do
       settings.writesub(:privatekeydir, "/path/to/keydir")
     end
   end
+
+
+  describe "when dealing with command-line options" do
+    let(:settings) { Puppet::Util::Settings.new }
+
+    it "should get options from Puppet.settings.optparse_addargs" do
+      settings.expects(:optparse_addargs).returns([])
+
+      settings.send(:parse_global_options, [])
+    end
+
+    it "should add options to OptionParser" do
+      settings.stubs(:optparse_addargs).returns( [["--option","-o", "Funny Option", :NONE]])
+      settings.expects(:handlearg).with("--option", true)
+      settings.send(:parse_global_options, ["--option"])
+    end
+
+    it "should not die if it sees an unrecognized option, because the app/face may handle it later" do
+      expect { settings.send(:parse_global_options, ["--topuppet", "value"]) } .to_not raise_error
+    end
+
+    it "should not pass an unrecognized option to handleargs" do
+      settings.expects(:handlearg).with("--topuppet", "value").never
+      expect { settings.send(:parse_global_options, ["--topuppet", "value"]) } .to_not raise_error
+    end
+
+    it "should pass valid puppet settings options to handlearg even if they appear after an unrecognized option" do
+      settings.stubs(:optparse_addargs).returns( [["--option","-o", "Funny Option", :NONE]])
+      settings.expects(:handlearg).with("--option", true)
+      settings.send(:parse_global_options, ["--invalidoption", "--option"])
+    end
+
+    it "should transform boolean option to normal form" do
+      Puppet::Util::Settings.clean_opt("--[no-]option", true).should == ["--option", true]
+    end
+
+    it "should transform boolean option to no- form" do
+      Puppet::Util::Settings.clean_opt("--[no-]option", false).should == ["--no-option", false]
+    end
+  end
+
+
 end


### PR DESCRIPTION
This pull request is based off of Jeff's previous one, because there were going to be some merge conflicts later otherwise.  There is really only one commit here:

https://github.com/cprice-puppet/puppet/commit/27abe6a84b4519cfa16f5689dda7878820e77fe5

And basically all it does is move some logic for initializing puppet's global settings out of CommandLine and into Settings, so that the methods can be accessed from other places outside of the CommandLine class.  This allows external tools to call Puppet.initialize_settings to get into a state where they can use Faces (and some other classes) as library code without getting errors about settings initialization.  It addresses #13429, along with a pull request that I'm about to submit to the mcollective-plugins project.
