### PR TITLE
(maint) Fix acceptance tests for Windows

### DIFF
--- a/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
+++ b/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
@@ -1,5 +1,7 @@
 test_name "ENC still allows a node to override a topscope var"
 
+confine :except, :platform => 'windows'
+
 testdir = master.tmpdir('scoping_deprecation')
 
 create_remote_file(master, "#{testdir}/puppet.conf", <<END)

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -200,7 +200,7 @@ begin
     step "verify that the application shows up in help" do
       agents.each do |agent|
         on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do
-          assert_match(/^\s+#{app_name}\s+#{app_desc % mode}$/, result.stdout)
+          assert_match(/^\s+#{app_name}\s+#{app_desc % mode}/, result.stdout)
         end
       end
     end
@@ -208,7 +208,7 @@ begin
     step "verify that we can run the application" do
       agents.each do |agent|
         on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do
-          assert_match(/^#{app_output % mode}$/, result.stdout)
+          assert_match(/^#{app_output % mode}/, result.stdout)
         end
       end
     end

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -223,7 +223,7 @@ begin
   step "verify that the application shows up in help" do
     agents.each do |agent|
       on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do
-        assert_match(/^\s+#{app_name}\s+#{app_desc % "face"}$/, result.stdout)
+        assert_match(/^\s+#{app_name}\s+#{app_desc % "face"}/, result.stdout)
       end
     end
   end
@@ -231,7 +231,7 @@ begin
   step "verify that we can run the application" do
     agents.each do |agent|
       on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do
-        assert_match(/^#{app_output % "face"}$/, result.stdout)
+        assert_match(/^#{app_output % "face"}/, result.stdout)
       end
     end
   end

--- a/acceptance/tests/ticket_3172_puppet_kick_with_hostnames_on_the_command_line.rb
+++ b/acceptance/tests/ticket_3172_puppet_kick_with_hostnames_on_the_command_line.rb
@@ -5,7 +5,7 @@ target = 'working.example.org'
 agents.each do |host|
   if host['platform'].include?('windows')
     on(host, puppet_kick(target), :acceptable_exit_codes => [1]) {
-      assert_match(/Puppet kick is not supported/, stderr)
+      assert_match(/Puppet kick is not supported/, stdout)
     }
   else
     on(host, puppet_kick(target), :acceptable_exit_codes => [3]) {

--- a/acceptance/tests/ticket_4233_resource_with_a_newline.rb
+++ b/acceptance/tests/ticket_4233_resource_with_a_newline.rb
@@ -12,6 +12,6 @@ test_name "#4233: resource with a newline"
 agents.each do |host|
   resource = host.echo('-e "\nHello World\n"')
   apply_manifest_on(host, "exec { '#{resource}': }") do
-    assert_no_match(/err:/, stdout, "error report in output on #{host}")
+    assert_match(/notice:.*Hello World.*success/, stdout)
   end
 end


### PR DESCRIPTION
Change acceptance tests to resolve issues around newlines not being properly matched with Windows and linux.
Mark topscope acceptance test as win32 pending.

Signed-off-by: Jeff Weiss jeff.weiss@puppetlabs.com
