### PR TITLE
(#13966) Fix default pidfile race condition

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -678,7 +678,7 @@ EOT
       },
       :pidfile => {
           :type => :file,
-          :default  => "$rundir/#{Puppet.run_mode.name}.pid",
+          :default  => "$rundir/${run_mode}.pid",
           :desc     => "The pid file",
       },
       :bindaddress => {


### PR DESCRIPTION
Commit 8b81794 introduced a race condition for the pidfile that
incorrectly defaulted all pidfiles to user.pid because of when in load
time defaults.rb was read.  Run_mode bootstraps as user and then
switches to [master|agent] if necessary. This change modifies the
default pidfile value to interpolate run_mode at time of pidfile use
rather than bootstrapped run_mode.  This commit restores proper
functionality for the pidfile names.
