### PR TITLE
(#14173) Enforce that filebucket paths must be absolute

### DIFF
--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -61,6 +61,18 @@ module Puppet
         can be specified to set the remote server."
 
       defaultto { Puppet[:clientbucketdir] }
+
+      validate do |value|
+        if value.is_a? Array
+          raise ArgumentError, "You can only have one filebucket path"
+        end
+
+        if value.is_a? String and not Puppet::Util.absolute_path?(value)
+          raise ArgumentError, "Filebucket paths must be absolute"
+        end
+
+        true
+      end
     end
 
     # Create a default filebucket.


### PR DESCRIPTION
If you passed the filebucket a relative path, perhaps by accidentally quoting
'false', it would happily accept that and create a directory relative to the
current working directory to store content in.

This enforces that the path must be absolute, as well as failing cleanly if
multiple paths are passed.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
