### PR TITLE
(maint) Fix destinations_spec failure on windows

### DIFF
--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -140,23 +140,23 @@ describe Puppet::Util::Log.desttypes[:telly_prototype_console] do
       Puppet.features.stubs(:ansicolor?).returns(true)
     end
     it "should support color output" do
-      Puppet.stubs(:[]).with(:color).returns(true)
+      Puppet[:color] = true
       subject.colorize(:red, 'version').should == "\e[0;31mversion\e[0m"
     end
 
     it "should withhold color output when not appropriate" do
-      Puppet.stubs(:[]).with(:color).returns(false)
+      Puppet[:color] = false
       subject.colorize(:red, 'version').should == "version"
     end
 
     it "should handle multiple overlapping colors in a stack-like way" do
-      Puppet.stubs(:[]).with(:color).returns(true)
+      Puppet[:color] = true
       vstring = subject.colorize(:red, 'version')
       subject.colorize(:green, "(#{vstring})").should == "\e[0;32m(\e[0;31mversion\e[0;32m)\e[0m"
     end
 
     it "should handle resets in a stack-like way" do
-      Puppet.stubs(:[]).with(:color).returns(true)
+      Puppet[:color] = true
       vstring = subject.colorize(:reset, 'version')
       subject.colorize(:green, "(#{vstring})").should == "\e[0;32m(\e[mversion\e[0;32m)\e[0m"
     end


### PR DESCRIPTION
The CI spec tests for Puppet 2.7.x on windows are failing.  This is bad.

 The reason they're failing is because we recently patched Puppet 2.7.x to
 add a new feature, Puppet.features.ansicolor?  If this feature is true
 then Puppet will output with ANSI colors.  If false, bare strings are
 sent.

 The existing destinations_spec test wasn't updated to reflect this new
 feature.  The existing spec test assumes ANSI sequences will always be
 sent if Puppet[:color] = true, but this is no longer the case because we
 only send ANSI sequences if Puppet[:color] = true and
 Puppet.features.ansicolor? is truthy.

 This patch fixes the problem by stubbing Puppet.features.ansicolor? to be
 true, matching up the spec expectation to the behavior of the system.
