### PR TITLE
(#13956) Fix failing spec tests

### DIFF
--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 
 require 'puppet/util/log'
@@ -42,6 +42,7 @@ describe Puppet::Util::Log do
   describe Puppet::Util::Log::DestConsole do
     before do
       @console = Puppet::Util::Log::DestConsole.new
+      Puppet.features.stubs(:ansicolor?).returns(true)
     end
 
     it "should colorize if Puppet[:color] is :ansi" do


### PR DESCRIPTION
The tests fail if the win32console gem isn't installed.  This patch fixes the 
problem by stubbing out Puppet.features.ansicolor?
