### PR TITLE
(#14200) Fix help face

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'puppet/util/plugins'
+require 'puppet/util/constant_inflector'
 require 'puppet/error'
 
 # This class handles all the aspects of a Puppet application/executable
@@ -219,7 +220,7 @@ class Application
     end
 
     def find(name)
-      klass = name.to_s.capitalize
+      klass = Puppet::Util::ConstantInflector.file2constant(name.to_s)
 
       begin
         require ::File.join('puppet', 'application', name.to_s.downcase)

--- a/lib/puppet/application/certificate_request.rb
+++ b/lib/puppet/application/certificate_request.rb
@@ -1,4 +1,4 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::Certificate_request < Puppet::Application::IndirectionBase
+class Puppet::Application::CertificateRequest < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/certificate_revocation_list.rb
+++ b/lib/puppet/application/certificate_revocation_list.rb
@@ -1,4 +1,4 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::Certificate_revocation_list < Puppet::Application::IndirectionBase
+class Puppet::Application::CertificateRevocationList < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -69,7 +69,7 @@ class Puppet::Application::FaceBase < Puppet::Application
 
     # REVISIT: These should be configurable versions, through a global
     # '--version' option, but we don't implement that yet... --daniel 2011-03-29
-    @type = self.class.name.to_s.sub(/.+:/, '').downcase.to_sym
+    @type = Puppet::Util::ConstantInflector.constant2file(self.class.name.to_s.sub(/.+:/, '')).to_sym
     @face = Puppet::Face[@type, :current]
 
     # Now, walk the command line and identify the action.  We skip over

--- a/lib/puppet/application/instrumentation_data.rb
+++ b/lib/puppet/application/instrumentation_data.rb
@@ -1,4 +1,4 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::Instrumentation_data < Puppet::Application::IndirectionBase
+class Puppet::Application::InstrumentationData < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/instrumentation_listener.rb
+++ b/lib/puppet/application/instrumentation_listener.rb
@@ -1,4 +1,4 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::Instrumentation_listener < Puppet::Application::IndirectionBase
+class Puppet::Application::InstrumentationListener < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/instrumentation_probe.rb
+++ b/lib/puppet/application/instrumentation_probe.rb
@@ -1,4 +1,4 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::Instrumentation_probe < Puppet::Application::IndirectionBase
+class Puppet::Application::InstrumentationProbe < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/resource_type.rb
+++ b/lib/puppet/application/resource_type.rb
@@ -1,4 +1,4 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::Resource_type < Puppet::Application::IndirectionBase
+class Puppet::Application::ResourceType < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/secret_agent.rb
+++ b/lib/puppet/application/secret_agent.rb
@@ -1,6 +1,6 @@
 require 'puppet/application/face_base'
 require 'puppet/face'
 
-class Puppet::Application::Secret_agent < Puppet::Application::FaceBase
+class Puppet::Application::SecretAgent < Puppet::Application::FaceBase
   run_mode :agent
 end

--- a/lib/puppet/face/help/global.erb
+++ b/lib/puppet/face/help/global.erb
@@ -1,18 +1,14 @@
 Usage: puppet <subcommand> [options] <action> [options]
 
-Available subcommands, from Puppet Faces:
-<% Puppet::Face.faces.sort.each do |name|
-     face = Puppet::Face[name, :current] -%>
-  <%= face.name.to_s.ljust(16) %>  <%= face.summary %>
-<% end -%>
-
-<% unless legacy_applications.empty? then # great victory when this is true! -%>
-Available applications, soon to be ported to Faces:
-<%   legacy_applications.each do |appname|
-       summary = horribly_extract_summary_from appname -%>
+Available subcommands:
+    <%# NOTE: this is probably not a good long-term solution for this.  We're only iterating over
+        applications to find the list of things we need to show help for... this works for now
+        because faces can't be run without an application stub.  However, when #6753 is resolved,
+        all of the application stubs for faces will go away, and this will need to be updated
+        to reflect that.  --cprice 2012-04-26 %>
+<% all_application_summaries.each do |appname, summary| -%>
   <%= appname.to_s.ljust(16) %>  <%= summary %>
-<%   end
-   end -%>
+<% end -%>
 
 See 'puppet help <subcommand> <action>' for help on a specific subcommand action.
 See 'puppet help <subcommand>' for help on a specific subcommand.

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -133,7 +133,7 @@ module Puppet
           #  (i.e.. so that we can load faces).  Longer-term, use the autoloader.  See comments in
           #  #available_subcommands method above.  --cprice 2012-03-06
           app = Puppet::Application.find(subcommand_name).new(self)
-          Puppet::Plugins.on_application_initialization(:appliation_object => self)
+          Puppet::Plugins.on_application_initialization(:application_object => self)
 
           app.run
         elsif ! execute_external_subcommand then

--- a/lib/puppet/util/constant_inflector.rb
+++ b/lib/puppet/util/constant_inflector.rb
@@ -1,6 +1,8 @@
 # Created on 2008-02-12
 # Copyright Luke Kanies
 
+# NOTE: I think it might be worth considering moving these methods directly into Puppet::Util.
+
 # A common module for converting between constants and
 # file names.
 module Puppet::Util::ConstantInflector
@@ -8,8 +10,10 @@ module Puppet::Util::ConstantInflector
     # LAK:NOTE See http://snurl.com/21zf8  [groups_google_com]
     x = file.split("/").collect { |name| name.capitalize }.join("::").gsub(/_+(.)/) { |term| $1.capitalize }
   end
+  module_function :file2constant
 
   def constant2file(constant)
     constant.to_s.gsub(/([a-z])([A-Z])/) { |term| $1 + "_#{$2}" }.gsub("::", "/").downcase
   end
+  module_function :constant2file
 end

--- a/spec/unit/application/indirection_base_spec.rb
+++ b/spec/unit/application/indirection_base_spec.rb
@@ -8,7 +8,7 @@ require 'puppet/indirector/face'
 class Puppet::Application::TestIndirection < Puppet::Application::IndirectionBase
 end
 
-face = Puppet::Indirector::Face.define(:testindirection, '0.0.1') do
+face = Puppet::Indirector::Face.define(:test_indirection, '0.0.1') do
   summary "fake summary"
   copyright "Puppet Labs", 2011
   license   "Apache 2 license; see COPYING"
@@ -26,10 +26,14 @@ describe Puppet::Application::IndirectionBase do
     # It would be nice not to have to stub this, but whatever... writing an
     # entire indirection stack would cause us more grief. --daniel 2011-03-31
     terminus = stub_everything("test indirection terminus")
-    terminus.stubs(:name).returns(:testindirection)
+    terminus.stubs(:name).returns(:test_indirection)
+
+    # This is necessary because Instrumentation tickles indirection, which
+    #  messes up our expectations.
+    Puppet::Util::Instrumentation.stubs(:init)
 
     Puppet::Indirector::Indirection.expects(:instance).
-      with(:testindirection).returns(terminus)
+      with(:test_indirection).returns(terminus)
 
     subject.command_line.instance_variable_set('@args', %w{--terminus foo save bar})
 
@@ -37,6 +41,8 @@ describe Puppet::Application::IndirectionBase do
     $stderr.stubs(:puts)
     Puppet.stubs(:err)
 
-    expect { subject.run }.to exit_with 0
+    expect {
+      subject.run
+    }.to exit_with 0
   end
 end

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -12,7 +12,9 @@ describe Puppet::Face[:help, '0.0.1'] do
   end
 
   it "should accept a call with no arguments" do
-    expect { subject.help() }.should_not raise_error
+    expect {
+      subject.help()
+    }.should_not raise_error
   end
 
   it "should accept a face name" do
@@ -62,8 +64,16 @@ describe Puppet::Face[:help, '0.0.1'] do
       end
     end
 
-    it "should list all faces" do
-      Puppet::Face.faces.each do |name|
+    it "should list all faces which are runnable from the command line" do
+      help_face = Puppet::Face[:help, :current]
+      # The main purpose of the help face is to provide documentation for
+      #  command line users.  It shouldn't show documentation for faces
+      #  that can't be run from the command line, so, rather than iterating
+      #  over all available faces, we need to iterate over the subcommands
+      #  that are available from the command line.
+      Puppet::Util::CommandLine.available_subcommands.each do |name|
+        next unless help_face.is_face_app?(name)
+        next if help_face.exclude_from_docs?(name)
         face = Puppet::Face[name, :current]
         summary = face.summary
 

--- a/spec/unit/util/constant_inflector_spec.rb
+++ b/spec/unit/util/constant_inflector_spec.rb
@@ -4,63 +4,53 @@ require 'spec_helper'
 require 'puppet/util/constant_inflector'
 
 describe Puppet::Util::ConstantInflector, "when converting file names to constants" do
-  before do
-    @inflector = Object.new
-    @inflector.extend(Puppet::Util::ConstantInflector)
-  end
-
   it "should capitalize terms" do
-    @inflector.file2constant("file").should == "File"
+    subject.file2constant("file").should == "File"
   end
 
   it "should switch all '/' characters to double colons" do
-    @inflector.file2constant("file/other").should == "File::Other"
+    subject.file2constant("file/other").should == "File::Other"
   end
 
   it "should remove underscores and capitalize the proceeding letter" do
-    @inflector.file2constant("file_other").should == "FileOther"
+    subject.file2constant("file_other").should == "FileOther"
   end
 
   it "should correctly replace as many underscores as exist in the file name" do
-    @inflector.file2constant("two_under_scores/with_some_more_underscores").should == "TwoUnderScores::WithSomeMoreUnderscores"
+    subject.file2constant("two_under_scores/with_some_more_underscores").should == "TwoUnderScores::WithSomeMoreUnderscores"
   end
 
   it "should collapse multiple underscores" do
-    @inflector.file2constant("many___scores").should == "ManyScores"
+    subject.file2constant("many___scores").should == "ManyScores"
   end
 
   it "should correctly handle file names deeper than two directories" do
-    @inflector.file2constant("one_two/three_four/five_six").should == "OneTwo::ThreeFour::FiveSix"
+    subject.file2constant("one_two/three_four/five_six").should == "OneTwo::ThreeFour::FiveSix"
   end
 end
 
 describe Puppet::Util::ConstantInflector, "when converting constnats to file names" do
-  before do
-    @inflector = Object.new
-    @inflector.extend(Puppet::Util::ConstantInflector)
-  end
-
   it "should convert them to a string if necessary" do
-    @inflector.constant2file(Puppet::Util::ConstantInflector).should be_instance_of(String)
+    subject.constant2file(Puppet::Util::ConstantInflector).should be_instance_of(String)
   end
 
   it "should accept string inputs" do
-    @inflector.constant2file("Puppet::Util::ConstantInflector").should be_instance_of(String)
+    subject.constant2file("Puppet::Util::ConstantInflector").should be_instance_of(String)
   end
 
   it "should downcase all terms" do
-    @inflector.constant2file("Puppet").should == "puppet"
+    subject.constant2file("Puppet").should == "puppet"
   end
 
   it "should convert '::' to '/'" do
-    @inflector.constant2file("Puppet::Util::Constant").should == "puppet/util/constant"
+    subject.constant2file("Puppet::Util::Constant").should == "puppet/util/constant"
   end
 
   it "should convert mid-word capitalization to an underscore" do
-    @inflector.constant2file("OneTwo::ThreeFour").should == "one_two/three_four"
+    subject.constant2file("OneTwo::ThreeFour").should == "one_two/three_four"
   end
 
   it "should correctly handle constants with more than two parts" do
-    @inflector.constant2file("OneTwoThree::FourFiveSixSeven").should == "one_two_three/four_five_six_seven"
+    subject.constant2file("OneTwoThree::FourFiveSixSeven").should == "one_two_three/four_five_six_seven"
   end
 end


### PR DESCRIPTION
This commit does the following:
1. Fix the help face so that--in the case where there exists both an
   App and a Face by the same name, and the App is not just a stub for the
   Face--help gives preference to the App instead of the Face.  The help
   face (as a command line tool) is mostly going to be used to help
   users navigate the other command line tools, so, e.g.,
   "puppet help resource" should show help for the same tool that you
   will get by running "puppet resource".  This was not the case
   prior to this commit.
2. Get rid of the separation between faces and applications in the
   help screen... making this distinction seems more confusing than
   helpful to the users, and exposes implementation details that
   users should not need to be concerned with.
3. Change all class names for Applications to conform to the
   convention of "foo_bar" file names mapping to "FooBar" class names.
