### PR TITLE
Allow 1/2 syntax in cron files,...

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -164,7 +164,12 @@ Puppet::Type.newtype(:cron) do
       if value =~ /^[0-9]+-[0-9]+\/[0-9]+$/
         return value
       end
-
+      
+      # Allow the 1/2 syntax
+      if value =~ /^[0-9]+\/[0-9]+$/
+        return value
+      end
+      
       if value == "*"
         return :absent
       end


### PR DESCRIPTION
 to allow people to run cron jobs regularly with an offset.

I have a service that I want to run 4 times an hour, but on different times on different hosts (as the service contacts a server that would die if every server connected at the same time. The nice way to do that is a cron job that runs at <random_minute>/15.
