### PR TITLE
(#8778) Make '' == undef commutative in the DSL

### DIFF
--- a/lib/puppet/parser/ast.rb
+++ b/lib/puppet/parser/ast.rb
@@ -103,7 +103,7 @@ class Puppet::Parser::AST
     value = Puppet::Parser::Scope.number?(value) || value
 
     # "" == undef for case/selector/if
-    obj == value or (obj == "" and value == :undef)
+    obj == value or (obj == "" and value == :undef) or (obj == :undef and value == "")
   end
 end
 

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 
 describe Puppet::Parser::AST::Leaf do
@@ -95,7 +95,7 @@ describe Puppet::Parser::AST::Undef do
   end
 
   it "should not match undef with an empty string" do
-    @undef.evaluate_match("", @scope).should be_false
+    @undef.evaluate_match("", @scope).should be_true
   end
 end
 

--- a/spec/unit/parser/ast_spec.rb
+++ b/spec/unit/parser/ast_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 
 require 'puppet/parser/ast'
@@ -102,9 +102,9 @@ describe 'AST Generic Child' do
       @evaluateable.evaluate_match(parameter, @scope)
     end
 
-    it "should not match '' if value is undef" do
+    it "should match '' if value is undef" do
       @evaluateable.value = :undef
-      @evaluateable.evaluate_match('', @scope).should be_false
+      @evaluateable.evaluate_match('', @scope).should be_true
     end
   end
 end


### PR DESCRIPTION
Without this patch applied the Puppet DSL treats undef == '' as true
but '' == undef as false.  This is undesirable because the equality
operator should be commutative.

This patch fixes the problem by adding an explicit check for '' == undef
in the AST.  Without this patch applied, Puppet already has an explicit
check for undef == '' but not for '' == undef.

The spec tests are also updated by this patch to reflect the change.
