### PR TITLE
Fix incorrect argument handling for expire in NodeExpirer

### DIFF
--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -16,7 +16,7 @@ class Puppet::Node::Facts
   # We want to expire any cached nodes if the facts are saved.
   module NodeExpirer
     def save(instance, key = nil)
-      Puppet::Node.indirection.expire(instance.name)
+      Puppet::Node.indirection.expire(key, instance)
       super
     end
   end

--- a/spec/integration/node/facts_spec.rb
+++ b/spec/integration/node/facts_spec.rb
@@ -10,9 +10,10 @@ describe Puppet::Node::Facts do
       terminus = Puppet::Node::Facts.indirection.terminus(:yaml)
       terminus.stubs :save
 
-      Puppet::Node.indirection.expects(:expire).with("me")
-
       facts = Puppet::Node::Facts.new("me")
+
+      Puppet::Node.indirection.expects(:expire).with(nil, facts)
+
       Puppet::Node::Facts.indirection.save(facts)
     end
 


### PR DESCRIPTION
Since it takes an optional key it needs to use that key if it exists. This
also resolves an error `undefined method 'name' for #<Hash...` that could
occur when posting facts over REST if the yaml didn't have a proper name
variable. This will still fail, but at a point that gives a much better error
message.
