### PR TITLE
Fix for ignoring nonexistent home dirs on Windows

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -182,7 +182,7 @@ module Util
           end
           return dest if FileTest.file? dest and FileTest.executable? dest
         rescue ArgumentError => e
-          raise unless e.to_s =~ /doesn't exist/
+          raise unless e.to_s =~ /doesn't exist|can't find user/
           # ...otherwise, we just skip the non-existent entry, and do nothing.
         end
       end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -577,7 +577,7 @@ describe Puppet::Util do
       # behave consistently.  If they ever implement it correctly (eg: to do
       # the lookup for real) it should just work transparently.
       baduser = 'if_this_user_exists_I_will_eat_my_hat'
-      Puppet::Util::Execution.withenv("PATH" => "~#{baduser}:#{base}") do
+      Puppet::Util::Execution.withenv("PATH" => "~#{baduser}#{File::PATH_SEPARATOR}#{base}") do
         Puppet::Util.which('foo').should == path
       end
     end


### PR DESCRIPTION
Windows raised a different exception when a home directory doesn't exist, so
we catch that too.
