### PR TITLE
Fixed hash ordering dependency in a test

### DIFF
--- a/spec/integration/indirector/file_content/file_server_spec.rb
+++ b/spec/integration/indirector/file_content/file_server_spec.rb
@@ -38,8 +38,8 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
 
     result.should_not be_nil
     result.length.should == 2
-    result[1].should be_instance_of(Puppet::FileServing::Content)
-    result[1].content.should == "1\n"
+    result.map {|x| x.should be_instance_of(Puppet::FileServing::Content) }
+    result.find {|x| x.relative_path == 'file.rb' }.content.should == "1\n"
   end
 
   it "should find file content in modules" do


### PR DESCRIPTION
Seen as a failure in CI when we started adding more patchlevels of ruby
to test against. Fix is a backport of the fix that appears on the 2.7.x
branch.
