### PR TITLE
Update acceptance tests to use confine instead of skip_test loops

### DIFF
--- a/acceptance/tests/resource/cron/should_not_rewrite_with_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_not_rewrite_with_trailing_whitespace.rb
@@ -1,4 +1,5 @@
 test_name "should not rewrite if the job has trailing whitespace"
+confine :except, :platform => 'windows'
 
 tmpuser = "pl#{rand(999999).to_i}"
 tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
@@ -7,11 +8,6 @@ create_user = "user { '#{tmpuser}': ensure => present, managehome => false }"
 delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
 
 agents.each do |host|
-  if host['platform'].include?('windows')
-    skip_test "Test not supported on this platform"
-    next
-  end
-
   step "ensure the user exist via puppet"
   apply_manifest_on host, create_user
 


### PR DESCRIPTION
Now that the test harness supports confine :except, :platform = 'windows' (and the like), update the tests to use that syntax.

This addresses the issue raised in pull request #651, where symbolic_modes.rb should not have been modified. (For whatever reason, that request didn't update when I pushed this update to my branch.)
