### PR TITLE
Bug/2.7.x/14288 gem provider fails on bad input

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -26,7 +26,9 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     end
 
     begin
-      list = execute(gem_list_command).lines.map {|set| gemsplit(set) }
+      list = execute(gem_list_command).lines.
+        map {|set| gemsplit(set) }.
+        reject {|x| x.nil? }
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not list gems: #{detail}"
     end

--- a/spec/fixtures/unit/provider/package/gem/line-with-1.8.5-warning
+++ b/spec/fixtures/unit/provider/package/gem/line-with-1.8.5-warning
@@ -1,0 +1,14 @@
+/home/jenkins/.rvm/gems/ruby-1.8.5-p231@global/gems/rubygems-bundler-0.9.0/lib/rubygems-bundler/regenerate_binstubs_command.rb:34: warning: parenthesize argument(s) for future version
+
+*** LOCAL GEMS ***
+
+columnize (0.3.2)
+diff-lcs (1.1.3)
+metaclass (0.0.1)
+mocha (0.10.5)
+rake (0.8.7)
+rspec-core (2.9.0)
+rspec-expectations (2.9.1)
+rspec-mocks (2.9.0)
+rubygems-bundler (0.9.0)
+rvm (1.11.3.3)

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -101,7 +101,6 @@ describe provider_class do
     end
   end
 
-
   describe "#instances" do
     before do
       provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
@@ -122,6 +121,23 @@ describe provider_class do
         {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
         {:ensure => ["0.8.7", "0.6.9"], :provider => :gem, :name => 'vagrant'}
       ]
+    end
+
+    it "should not fail when an unmatched line is returned" do
+      provider_class.expects(:execute).with(%w{/my/gem list --local}).
+        returns(File.read(my_fixture('line-with-1.8.5-warning')))
+
+      provider_class.instances.map {|p| p.properties}.
+        should == [{:provider=>:gem, :ensure=>["0.3.2"], :name=>"columnize"},
+                   {:provider=>:gem, :ensure=>["1.1.3"], :name=>"diff-lcs"},
+                   {:provider=>:gem, :ensure=>["0.0.1"], :name=>"metaclass"},
+                   {:provider=>:gem, :ensure=>["0.10.5"], :name=>"mocha"},
+                   {:provider=>:gem, :ensure=>["0.8.7"], :name=>"rake"},
+                   {:provider=>:gem, :ensure=>["2.9.0"], :name=>"rspec-core"},
+                   {:provider=>:gem, :ensure=>["2.9.1"], :name=>"rspec-expectations"},
+                   {:provider=>:gem, :ensure=>["2.9.0"], :name=>"rspec-mocks"},
+                   {:provider=>:gem, :ensure=>["0.9.0"], :name=>"rubygems-bundler"},
+                   {:provider=>:gem, :ensure=>["1.11.3.3"], :name=>"rvm"}]
     end
   end
 end


### PR DESCRIPTION
Previously, when the output of the gem command contained a line that didn't
match it was returned as `nil` - but the rest of the provider didn't handle
that value at all!

That led to any mismatch causing various failures to dereference `nil` as a
hash, and general failure.

This fixes this to behave significantly better by just omitting that entry in
the result, returning only the expected content.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
