### PR TITLE
Update acceptance tests to use confine instead of skip_test loops

### DIFF
--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -2,11 +2,8 @@ test_name "#4123: should list all running services on Redhat/CentOS"
 step "Validate services running agreement ralsh vs. OS service count"
 # This will remotely exec:
 # ticket_4123_should_list_all_running_redhat.sh
+confine :to, :platform => /el-/
 
 hosts.each do |host|
-  if host['platform'].include?('el-')
-    run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4123_should_list_all_running_redhat.sh'))
-  else
-    skip_test "Test not supported on this plaform" 
-  end
+  run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4123_should_list_all_running_redhat.sh'))
 end

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -2,11 +2,8 @@ test_name "#4124: should list all disabled services on Redhat/CentOS"
 step "Validate disabled services agreement ralsh vs. OS service count"
 # This will remotely exec:
 # ticket_4124_should_list_all_disabled.sh
+confine :to, :platform => /el-/
 
 hosts.each do |host|
-  unless host['platform'].include?('el-')
-    skip_test "Test not supported on this plaform"
-   else
-    run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4124_should_list_all_disabled.sh'))
-  end
+  run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4124_should_list_all_disabled.sh'))
 end


### PR DESCRIPTION
2.6.x specific tests only. Counterpart to #734 and #736 for the 2.6.x branch.
