### PR TITLE
(#14296) Improve template function error message.

### DIFF
--- a/lib/puppet/parser/functions/template.rb
+++ b/lib/puppet/parser/functions/template.rb
@@ -17,8 +17,9 @@ Puppet::Parser::Functions::newfunction(:template, :type => :rvalue, :doc =>
       begin
         wrapper.result
       rescue => detail
+        info = detail.backtrace.first.split(':')
         raise Puppet::ParseError,
-          "Failed to parse template #{file}: #{detail}"
+          "Failed to parse template #{file}:\n  Filepath: #{info[0]}\n  Line: #{info[1]}\n  Detail: #{detail}\n"
       end
     end.join("")
 end


### PR DESCRIPTION
The current template function does not provide sufficient detail for
troubleshooting. This patch uses the backtrace to provide the fully
qualified filepath and line number.

Previous error message:
Failed to parse template test/example.erb: undefined method `[]' for
nil:NilClass at /tmp/module/test/manifests/init.pp:2 on node example

New error message:
Failed to parse template test/example.erb:
  Filepath: /tmp/module/test/templates/example.erb
  Line: 10
  Detail: undefined method `[]' for nil:NilClass
 at /tmp/module/test/manifests/init.pp:2 on node example
