### PR TITLE
Add RSpec exclusion option to "module generate"

### DIFF
--- a/lib/puppet/face/module/generate.rb
+++ b/lib/puppet/face/module/generate.rb
@@ -31,6 +31,15 @@ Puppet::Face.define(:module, '1.0.0') do
 
     arguments "<name>"
 
+    option "--exclude_spec", "-x" do
+      summary "Exclude RSpec test boilerplate."
+      description <<-EOT
+        Exclude the RSpec boilerplate code. This is handy if you are writing your
+        own tests or if you want to generate the boilerplate with the rspec-puppet
+        tool itself.
+      EOT
+    end
+
     when_invoked do |name, options|
       Puppet::ModuleTool.set_option_defaults options
       Puppet::ModuleTool::Applications::Generator.run(name, options)

--- a/lib/puppet/module_tool/applications/generator.rb
+++ b/lib/puppet/module_tool/applications/generator.rb
@@ -33,6 +33,7 @@ module Puppet::ModuleTool
           if path == skeleton
             destination.mkpath
           else
+            next if (path.fnmatch?('*/spec*') && @options[:exclude_spec])
             node = Node.on(path, self)
             if node
               node.install!


### PR DESCRIPTION
This is basically a feature request for the 'generate' method. I prefer to use the boilerplate from rspec-puppet so I've added the following option:

Add option to exclude RSpec tests (-x).

Let me know if this looks OK. If you prefer not to merge it no sweat... :)

Cheers,

Dan Wanek
