### PR TITLE
use EIX_CACHEFILE in portage provider 

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     version_format = "{last}<version>{}"
     search_format = "<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] <homepage> <description>\n"
     eix_cachefile = (eix "--print", "EIX_CACHEFILE").rstrip
-    
+
     begin
       update_eix if !FileUtils.uptodate?(eix_cachefile, %w{/usr/bin/eix /usr/portage/metadata/timestamp})
 
@@ -78,7 +78,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     version_format = "{last}<version>{}"
     search_format = "<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] <homepage> <description>\n"
     eix_cachefile = (eix "--print", "EIX_CACHEFILE").rstrip
-    
+
     search_field = package_name.count('/') > 0 ? "--category-name" : "--name"
     search_value = package_name
 


### PR DESCRIPTION
the portage provider uses eix but does not let me configure it for keeping a central eix cache.

I want to keep the eix cache file in a single location for a vserver setup I'm doing. This commit helps by allowing me to decide where I want to store the cache through default eix mechanisms. I can then configure eix using puppet however i need.
