### PR TITLE
(#14348) Hiera is the default data binding terminus

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -229,7 +229,7 @@ module Puppet
       :desc       => "Where to find information about nodes.",
     },
     :data_binding_terminus => {
-      :default => "none",
+      :default => "hiera",
       :desc    => "Where to retrive information about data.",
     },
     :hiera_config => {

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -317,8 +317,8 @@ describe "Puppet defaults" do
       Puppet.settings[:data_binding_terminus].should_not be_nil
     end
 
-    it "should be set to none by default" do
-      Puppet.settings[:data_binding_terminus].should == 'none'
+    it "should be set to hiera by default" do
+      Puppet.settings[:data_binding_terminus].should == 'hiera'
     end
   end
 end

--- a/spec/unit/data_binding_spec.rb
+++ b/spec/unit/data_binding_spec.rb
@@ -3,9 +3,9 @@ require 'puppet/data_binding'
 
 describe Puppet::DataBinding do
   describe "when indirecting" do
-    it "should default to the 'none' data_binding terminus" do
+    it "should default to the 'hiera' data_binding terminus" do
       Puppet::DataBinding.indirection.reset_terminus_class
-      Puppet::DataBinding.indirection.terminus_class.should == :none
+      Puppet::DataBinding.indirection.terminus_class.should == :hiera
     end
   end
 end

--- a/spec/unit/indirector/hiera_spec.rb
+++ b/spec/unit/indirector/hiera_spec.rb
@@ -44,8 +44,8 @@ describe Puppet::Indirector::Hiera do
   end
   let(:facter_obj) { stub(:values => facts) }
 
-  it "should not be the default data_binding terminus" do
-    Puppet.settings[:data_binding_terminus].should_not == 'hiera'
+  it "should be the default data_binding terminus" do
+    Puppet.settings[:data_binding_terminus].should == 'hiera'
   end
 
   it "should raise an error if we don't have the hiera feature" do

--- a/spec/unit/indirector/none_spec.rb
+++ b/spec/unit/indirector/none_spec.rb
@@ -21,8 +21,8 @@ describe Puppet::Indirector::None do
       :model => model)
   end
 
-  it "should be the default data_binding_terminus" do
-    Puppet.settings[:data_binding_terminus].should == 'none'
+  it "should not be the default data_binding_terminus" do
+    Puppet.settings[:data_binding_terminus].should_not == 'none'
   end
 
   describe "the behavior of the find method" do

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -558,6 +558,7 @@ describe Puppet::Parser::Compiler do
   describe "when evaluating found classes" do
 
     before do
+      Puppet.settings[:data_binding_terminus] = "none"
       @class = stub 'class', :name => "my::class"
       @scope.stubs(:find_hostclass).with("myclass", {:assume_fqname => false}).returns(@class)
 


### PR DESCRIPTION
This patch makes Hiera the default data binding terminus. Users have the
option of "turning it off" by setting `data_binding_terminus` in
puppet.conf to "none":

```
# puppet.conf
[main]
  data_binding_terminus = "none"
```

This patch includes updated specs.
