### PR TITLE
Move rubygems require to executable entry points to Puppet

### DIFF
--- a/bin/puppet
+++ b/bin/puppet
@@ -1,4 +1,10 @@
 #!/usr/bin/env ruby
 
+# Load rubygems so we can require gems
+begin
+  require 'rubygems'
+rescue LoadError
+end
+
 require 'puppet/util/command_line'
 Puppet::Util::CommandLine.new.execute

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,11 @@ $LOAD_PATH.unshift File.join(dir, 'lib')
 # Don't want puppet getting the command line arguments for rake or autotest
 ARGV.clear
 
+begin
+  require 'rubygems'
+rescue LoadError
+end
+
 require 'puppet'
 require 'mocha'
 gem 'rspec', '>=2.0.0'


### PR DESCRIPTION
We were trying to load rubygems in lib/puppet.rb so that we could load other
libraries installed as gems, but this isn't anywhere near the first file
loaded. By moving this into bin/puppet and other executable entry points, we
ensure that rubygems is loaded as early as possible.
