### PR TITLE
base setting refactor

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -10,7 +10,7 @@ require 'facter'
 require 'puppet/error'
 require 'puppet/util'
 require 'puppet/util/autoload'
-require 'puppet/util/settings'
+require 'puppet/settings'
 require 'puppet/util/feature'
 require 'puppet/util/suidmanager'
 require 'puppet/util/run_mode'
@@ -37,7 +37,7 @@ module Puppet
   end
 
   # the hash that determines how our system behaves
-  @@settings = Puppet::Util::Settings.new
+  @@settings = Puppet::Settings.new
 
   # The services running in this process.
   @services ||= []
@@ -139,7 +139,7 @@ module Puppet
   def self.do_initialize_settings_for_run_mode(run_mode)
     Puppet.settings.initialize_global_settings
     run_mode = Puppet::Util::RunMode[run_mode]
-    Puppet.settings.initialize_app_defaults(Puppet::Util::Settings.app_defaults_for_run_mode(run_mode))
+    Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(run_mode))
   end
   private_class_method :do_initialize_settings_for_run_mode
 

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -269,7 +269,7 @@ class Application
   end
 
   def app_defaults()
-    Puppet::Util::Settings.app_defaults_for_run_mode(self.class.run_mode).merge(
+    Puppet::Settings.app_defaults_for_run_mode(self.class.run_mode).merge(
         :name => name
     )
   end
@@ -383,7 +383,7 @@ class Application
 
 
   def handlearg(opt, val)
-    opt, val = Puppet::Util::Settings.clean_opt(opt, val)
+    opt, val = Puppet::Settings.clean_opt(opt, val)
     send(:handle_unknown, opt, val) if respond_to?(:handle_unknown)
   end
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -684,7 +684,7 @@ EOT
     define_settings(:application,
       :config_file_name => {
           :type     => :string,
-          :default  => Puppet::Util::Settings.default_config_file_name,
+          :default  => Puppet::Settings.default_config_file_name,
           :desc     => "The name of the puppet config file.",
       },
       :config => {

--- a/lib/puppet/reports/rrdgraph.rb
+++ b/lib/puppet/reports/rrdgraph.rb
@@ -95,7 +95,7 @@ Puppet::Reports.register_report(:rrdgraph) do
 
     unless File.directory?(hostdir) and FileTest.writable?(hostdir)
       # Some hackishness to create the dir with all of the right modes and ownership
-      config = Puppet::Util::Settings.new
+      config = Puppet::Settings.new
       config.define_settings(:reports, :hostdir => {:type => :directory, :default => hostdir, :owner => 'service', :mode => 0755, :group => 'service', :desc => "eh"})
 
       # This creates the dir.

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -3,15 +3,15 @@ require 'sync'
 require 'getoptlong'
 require 'puppet/util/loadedfile'
 require 'puppet/util/command_line/puppet_option_parser'
-require 'puppet/util/settings/errors'
-require 'puppet/util/settings/string_setting'
-require 'puppet/util/settings/file_setting'
-require 'puppet/util/settings/directory_setting'
-require 'puppet/util/settings/path_setting'
-require 'puppet/util/settings/boolean_setting'
+require 'puppet/settings/errors'
+require 'puppet/settings/string_setting'
+require 'puppet/settings/file_setting'
+require 'puppet/settings/directory_setting'
+require 'puppet/settings/path_setting'
+require 'puppet/settings/boolean_setting'
 
 # The class for handling configuration files.
-class Puppet::Util::Settings
+class Puppet::Settings
   include Enumerable
 
   # local reference for convenience
@@ -171,7 +171,7 @@ class Puppet::Util::Settings
     # Add all global options to it.
     self.optparse_addargs([]).each do |option|
       option_parser.on(*option) do |arg|
-        opt, val = Puppet::Util::Settings.clean_opt(option[0], arg)
+        opt, val = Puppet::Settings.clean_opt(option[0], arg)
         handlearg(opt, val)
       end
     end
@@ -316,7 +316,7 @@ class Puppet::Util::Settings
     end
     str = str.intern
 
-    if @config[str].is_a?(Puppet::Util::Settings::BooleanSetting)
+    if @config[str].is_a?(Puppet::Settings::BooleanSetting)
       if value == "" or value.nil?
         value = bool
       end

--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -1,7 +1,7 @@
-require 'puppet/util/settings/errors'
+require 'puppet/settings/errors'
 
 # The base setting type
-class Puppet::Util::Settings::BaseSetting
+class Puppet::Settings::BaseSetting
   attr_accessor :name, :section, :default, :call_on_define, :call_hook
   attr_reader :desc, :short
 

--- a/lib/puppet/settings/boolean_setting.rb
+++ b/lib/puppet/settings/boolean_setting.rb
@@ -1,7 +1,7 @@
-require 'puppet/util/settings/base_setting'
+require 'puppet/settings/base_setting'
 
 # A simple boolean.
-class Puppet::Util::Settings::BooleanSetting < Puppet::Util::Settings::BaseSetting
+class Puppet::Settings::BooleanSetting < Puppet::Settings::BaseSetting
   # get the arguments in getopt format
   def getopt_args
     if short
@@ -24,7 +24,7 @@ class Puppet::Util::Settings::BooleanSetting < Puppet::Util::Settings::BaseSetti
     when true, "true"; return true
     when false, "false"; return false
     else
-      raise Puppet::Util::Settings::ValidationError, "Invalid value '#{value.inspect}' for boolean parameter: #{@name}"
+      raise Puppet::Settings::ValidationError, "Invalid value '#{value.inspect}' for boolean parameter: #{@name}"
     end
   end
 

--- a/lib/puppet/settings/directory_setting.rb
+++ b/lib/puppet/settings/directory_setting.rb
@@ -1,0 +1,7 @@
+require 'puppet/settings/file_setting'
+
+class Puppet::Settings::DirectorySetting < Puppet::Settings::FileSetting
+  def type
+    :directory
+  end
+end

--- a/lib/puppet/settings/errors.rb
+++ b/lib/puppet/settings/errors.rb
@@ -1,6 +1,6 @@
 # Exceptions for the settings module
 
-class Puppet::Util::Settings
+class Puppet::Settings
   class SettingsError < Puppet::Error ; end
   class ValidationError < SettingsError ; end
   class InterpolationError < SettingsError ; end

--- a/lib/puppet/settings/file_setting.rb
+++ b/lib/puppet/settings/file_setting.rb
@@ -1,7 +1,7 @@
-require 'puppet/util/settings/string_setting'
+require 'puppet/settings/string_setting'
 
 # A file.
-class Puppet::Util::Settings::FileSetting < Puppet::Util::Settings::StringSetting
+class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
   AllowedOwners = %w{root service}
   AllowedGroups = %w{root service}
 

--- a/lib/puppet/settings/path_setting.rb
+++ b/lib/puppet/settings/path_setting.rb
@@ -1,6 +1,6 @@
-require 'puppet/util/settings/string_setting'
+require 'puppet/settings/string_setting'
 
-class Puppet::Util::Settings::PathSetting < Puppet::Util::Settings::StringSetting
+class Puppet::Settings::PathSetting < Puppet::Settings::StringSetting
   def munge(value)
     if value.is_a?(String)
       value = value.split(File::PATH_SEPARATOR).map { |d| File.expand_path(d) }.join(File::PATH_SEPARATOR)

--- a/lib/puppet/settings/string_setting.rb
+++ b/lib/puppet/settings/string_setting.rb
@@ -1,7 +1,7 @@
 # The base element type.
-require 'puppet/util/settings/base_setting'
+require 'puppet/settings/base_setting'
 
-class Puppet::Util::Settings::StringSetting < Puppet::Util::Settings::BaseSetting
+class Puppet::Settings::StringSetting < Puppet::Settings::BaseSetting
   def type
     :string
   end

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -28,15 +28,15 @@ module Puppet
 
       def conf_dir
         which_dir(
-            Puppet::Util::Settings.default_global_config_dir,
-            Puppet::Util::Settings.default_user_config_dir
+            Puppet::Settings.default_global_config_dir,
+            Puppet::Settings.default_user_config_dir
         )
       end
 
       def var_dir
         which_dir(
-            Puppet::Util::Settings.default_global_var_dir,
-            Puppet::Util::Settings.default_user_var_dir
+            Puppet::Settings.default_global_var_dir,
+            Puppet::Settings.default_user_var_dir
         )
       end
 

--- a/lib/puppet/util/settings/directory_setting.rb
+++ b/lib/puppet/util/settings/directory_setting.rb
@@ -1,7 +1,0 @@
-require 'puppet/util/settings/file_setting'
-
-class Puppet::Util::Settings::DirectorySetting < Puppet::Util::Settings::FileSetting
-  def type
-    :directory
-  end
-end

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -121,7 +121,7 @@ describe "Puppet defaults" do
 
   [:modulepath, :factpath].each do |setting|
     it "should configure '#{setting}' not to be a file setting, so multi-directory settings are acceptable" do
-      Puppet.settings.setting(setting).should be_instance_of(Puppet::Util::Settings::PathSetting)
+      Puppet.settings.setting(setting).should be_instance_of(Puppet::Settings::PathSetting)
     end
   end
 

--- a/spec/integration/util/settings_spec.rb
+++ b/spec/integration/util/settings_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet_spec/files'
 
-describe Puppet::Util::Settings do
+describe Puppet::Settings do
   include PuppetSpec::Files
 
   def minimal_default_settings
@@ -11,7 +11,7 @@ describe Puppet::Util::Settings do
   end
 
   it "should be able to make needed directories" do
-    settings = Puppet::Util::Settings.new
+    settings = Puppet::Settings.new
     settings.define_settings :main, minimal_default_settings.update(
         :maindir => {
             :default => tmpfile("main"),
@@ -25,7 +25,7 @@ describe Puppet::Util::Settings do
   end
 
   it "should make its directories with the correct modes" do
-    settings = Puppet::Util::Settings.new
+    settings = Puppet::Settings.new
     settings.define_settings :main,  minimal_default_settings.update(
         :maindir => {
             :default => tmpfile("main"),

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -282,7 +282,7 @@ describe Puppet::Application::Agent do
       path = make_absolute('/my/path')
       Puppet[:modulepath] = path
       Puppet[:configprint] = "modulepath"
-      Puppet::Util::Settings.any_instance.expects(:puts).with(path)
+      Puppet::Settings.any_instance.expects(:puts).with(path)
       expect { @puppetd.setup }.to exit_with 0
     end
 

--- a/spec/unit/settings/directory_setting_spec.rb
+++ b/spec/unit/settings/directory_setting_spec.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 
-require 'puppet/util/settings'
-require 'puppet/util/settings/directory_setting'
+require 'puppet/settings'
+require 'puppet/settings/directory_setting'
 
-describe Puppet::Util::Settings::DirectorySetting do
-  DirectorySetting = Puppet::Util::Settings::DirectorySetting
+describe Puppet::Settings::DirectorySetting do
+  DirectorySetting = Puppet::Settings::DirectorySetting
 
   include PuppetSpec::Files
 
@@ -16,7 +16,7 @@ describe Puppet::Util::Settings::DirectorySetting do
   describe "when being converted to a resource" do
     before do
       @settings = mock 'settings'
-      @dir = Puppet::Util::Settings::DirectorySetting.new(
+      @dir = Puppet::Settings::DirectorySetting.new(
           :settings => @settings, :desc => "eh", :name => :mydir, :section => "mysect")
       @settings.stubs(:value).with(:mydir).returns @basepath
     end

--- a/spec/unit/settings/file_setting_spec.rb
+++ b/spec/unit/settings/file_setting_spec.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 
-require 'puppet/util/settings'
-require 'puppet/util/settings/file_setting'
+require 'puppet/settings'
+require 'puppet/settings/file_setting'
 
-describe Puppet::Util::Settings::FileSetting do
-  FileSetting = Puppet::Util::Settings::FileSetting
+describe Puppet::Settings::FileSetting do
+  FileSetting = Puppet::Settings::FileSetting
 
   include PuppetSpec::Files
 
@@ -124,7 +124,7 @@ describe Puppet::Util::Settings::FileSetting do
   describe "when being converted to a resource" do
     before do
       @settings = mock 'settings'
-      @file = Puppet::Util::Settings::FileSetting.new(:settings => @settings, :desc => "eh", :name => :myfile, :section => "mysect")
+      @file = Puppet::Settings::FileSetting.new(:settings => @settings, :desc => "eh", :name => :myfile, :section => "mysect")
       @file.stubs(:create_files?).returns true
       @settings.stubs(:value).with(:myfile).returns @basepath
     end

--- a/spec/unit/settings/path_setting_spec.rb
+++ b/spec/unit/settings/path_setting_spec.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 
-describe Puppet::Util::Settings::PathSetting do
+describe Puppet::Settings::PathSetting do
   subject { described_class.new(:settings => mock('settings'), :desc => "test") }
 
   context "#munge" do

--- a/spec/unit/settings/string_setting_spec.rb
+++ b/spec/unit/settings/string_setting_spec.rb
@@ -1,22 +1,22 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 
-require 'puppet/util/settings'
-require 'puppet/util/settings/string_setting'
+require 'puppet/settings'
+require 'puppet/settings/string_setting'
 
-describe Puppet::Util::Settings::StringSetting do
-  StringSetting = Puppet::Util::Settings::StringSetting
+describe Puppet::Settings::StringSetting do
+  StringSetting = Puppet::Settings::StringSetting
 
   before(:each) do
     @test_setting_name = :test_setting 
     @test_setting_default = "my_crazy_default/$var"
     @application_setting = "application/$var"
     @application_defaults = { } 
-    Puppet::Util::Settings::REQUIRED_APP_SETTINGS.each do |key|
+    Puppet::Settings::REQUIRED_APP_SETTINGS.each do |key|
       @application_defaults[key] = "foo"
     end
     @application_defaults[:run_mode] = :user
-    @settings = Puppet::Util::Settings.new
+    @settings = Puppet::Settings.new
     @application_defaults.each { |k,v| @settings.define_settings :main, k => {:default=>"", :desc => "blah"} }
     @settings.define_settings :main, :var               => {  :default => "interpolate!", 
                                                               :type => :string, 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1,17 +1,17 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 require 'ostruct'
-require 'puppet/util/settings/errors'
+require 'puppet/settings/errors'
 
-describe Puppet::Util::Settings do
+describe Puppet::Settings do
   include PuppetSpec::Files
 
-  MAIN_CONFIG_FILE_DEFAULT_LOCATION = File.join(Puppet::Util::Settings.default_global_config_dir, "puppet.conf")
-  USER_CONFIG_FILE_DEFAULT_LOCATION = File.join(Puppet::Util::Settings.default_user_config_dir, "puppet.conf")
+  MAIN_CONFIG_FILE_DEFAULT_LOCATION = File.join(Puppet::Settings.default_global_config_dir, "puppet.conf")
+  USER_CONFIG_FILE_DEFAULT_LOCATION = File.join(Puppet::Settings.default_user_config_dir, "puppet.conf")
 
   describe "when specifying defaults" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
     end
 
     it "should start with no defined parameters" do
@@ -52,7 +52,7 @@ describe Puppet::Util::Settings do
 
     it "should support specifying the setting type" do
       @settings.define_settings(:section, :myvalue => {:default => "/w", :desc => "b", :type => :string})
-      @settings.setting(:myvalue).should be_instance_of(Puppet::Util::Settings::StringSetting)
+      @settings.setting(:myvalue).should be_instance_of(Puppet::Settings::StringSetting)
     end
 
     it "should fail if an invalid setting type is specified" do
@@ -68,7 +68,7 @@ describe Puppet::Util::Settings do
 
   describe "when initializing application defaults do" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
     end
 
     it "should fail if someone attempts to initialize app defaults more than once" do
@@ -81,7 +81,7 @@ describe Puppet::Util::Settings do
     it "should fail if the app defaults hash is missing any required values" do
       expect {
         @settings.initialize_app_defaults({})
-      }.to raise_error(Puppet::Util::Settings::SettingsError)
+      }.to raise_error(Puppet::Settings::SettingsError)
     end
 
     # ultimately I'd like to stop treating "run_mode" as a normal setting, because it has so many special
@@ -89,7 +89,7 @@ describe Puppet::Util::Settings do
     #  setter method gets properly called during app initialization.
     it "should call the hacky run mode setter method until we do a better job of separating run_mode" do
       app_defaults = {}
-      Puppet::Util::Settings::REQUIRED_APP_SETTINGS.each do |key|
+      Puppet::Settings::REQUIRED_APP_SETTINGS.each do |key|
         app_defaults[key] = "foo"
       end
 
@@ -103,7 +103,7 @@ describe Puppet::Util::Settings do
     let (:good_default) { "yay" }
     let (:bad_default) { "$doesntexist" }
     before(:each) do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
     end
 
     describe "when ignoring dependency interpolation errors" do
@@ -145,7 +145,7 @@ describe Puppet::Util::Settings do
             )
             expect do
               @settings.send(:call_hooks_deferred_to_application_initialization, options)
-            end.to raise_error Puppet::Util::Settings::InterpolationError
+            end.to raise_error Puppet::Settings::InterpolationError
           end
           it "should contain the setting name in error message" do
             hook_values = []
@@ -160,7 +160,7 @@ describe Puppet::Util::Settings do
             )
             expect do
               @settings.send(:call_hooks_deferred_to_application_initialization, options)
-            end.to raise_error Puppet::Util::Settings::InterpolationError, /badhook/
+            end.to raise_error Puppet::Settings::InterpolationError, /badhook/
           end
         end
         describe "if no interpolation error" do
@@ -186,7 +186,7 @@ describe Puppet::Util::Settings do
 
   describe "when setting values" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.define_settings :main, :myval => { :default => "val", :desc => "desc" }
       @settings.define_settings :main, :bool => { :type => :boolean, :default => true, :desc => "desc" }
     end
@@ -303,7 +303,7 @@ describe Puppet::Util::Settings do
     end
 
     describe "call_hook" do
-      Puppet::Util::Settings::StringSetting.available_call_hook_values.each do |val|
+      Puppet::Settings::StringSetting.available_call_hook_values.each do |val|
         describe "when :#{val}" do
           describe "and definition invalid" do
             it "should raise error if no hook defined" do
@@ -377,7 +377,7 @@ describe Puppet::Util::Settings do
 
         it "should call the hook at initialization" do
           app_defaults = {}
-          Puppet::Util::Settings::REQUIRED_APP_SETTINGS.each do |key|
+          Puppet::Settings::REQUIRED_APP_SETTINGS.each do |key|
             app_defaults[key] = "foo"
           end
           app_defaults[:run_mode] = :user
@@ -477,7 +477,7 @@ describe Puppet::Util::Settings do
 
   describe "when returning values" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.define_settings :section,
           :config => { :type => :file, :default => "/my/file", :desc => "eh" },
           :one    => { :default => "ONE", :desc => "a" },
@@ -494,7 +494,7 @@ describe Puppet::Util::Settings do
         @settings.setting(:hooker).call_on_define
       end
 
-      Puppet::Util::Settings::StringSetting.available_call_hook_values.each do |val|
+      Puppet::Settings::StringSetting.available_call_hook_values.each do |val|
         it "should match value for call_hook => :#{val}" do
           hook_values = []
           @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => val, :hook => lambda { |v| hook_values << v  }})
@@ -568,7 +568,7 @@ describe Puppet::Util::Settings do
 
   describe "when choosing which value to return" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.define_settings :section,
         :config => { :type => :file, :default => "/my/file", :desc => "a" },
         :one => { :default => "ONE", :desc => "a" },
@@ -644,7 +644,7 @@ describe Puppet::Util::Settings do
 
   describe "when locating config files" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
     end
 
     describe "when root" do
@@ -672,7 +672,7 @@ describe Puppet::Util::Settings do
 
   describe "when parsing its configuration" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.stubs(:service_user_available?).returns true
       @file = make_absolute("/some/file")
       @userconfig = make_absolute("/test/userconfigfile")
@@ -873,7 +873,7 @@ describe Puppet::Util::Settings do
 
     before do
       Puppet.features.stubs(:root?).returns(false)
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.define_settings(:section,
           { :one => { :default => "ONE", :desc => "a" },
             :two => { :default => "TWO", :desc => "b" }, })
@@ -899,7 +899,7 @@ describe Puppet::Util::Settings do
     before do
       @file = make_absolute("/test/file")
       @userconfig = make_absolute("/test/userconfigfile")
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.define_settings :section,
           :config => { :type => :file, :default => @file, :desc => "a" },
           :one => { :default => "ONE", :desc => "a" },
@@ -1021,12 +1021,12 @@ describe Puppet::Util::Settings do
   end
 
   it "should provide a method for creating a catalog of resources from its configuration" do
-    Puppet::Util::Settings.new.should respond_to(:to_catalog)
+    Puppet::Settings.new.should respond_to(:to_catalog)
   end
 
   describe "when creating a catalog" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.stubs(:service_user_available?).returns true
       @prefix = Puppet.features.posix? ? "" : "C:"
     end
@@ -1124,7 +1124,7 @@ describe Puppet::Util::Settings do
 
       it "should not add users or groups to the catalog if :mkusers is not a valid setting" do
         Puppet.features.stubs(:root?).returns true
-        settings = Puppet::Util::Settings.new
+        settings = Puppet::Settings.new
         settings.define_settings :other, :otherdir => {:type => :directory, :default => "/otherdir", :desc => "a", :owner => "service", :group => "service"}
 
         catalog = settings.to_catalog
@@ -1166,12 +1166,12 @@ describe Puppet::Util::Settings do
   end
 
   it "should be able to be converted to a manifest" do
-    Puppet::Util::Settings.new.should respond_to(:to_manifest)
+    Puppet::Settings.new.should respond_to(:to_manifest)
   end
 
   describe "when being converted to a manifest" do
     it "should produce a string with the code for each resource joined by two carriage returns" do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.define_settings :main,
           :maindir => { :type => :directory, :default => "/maindir", :desc => "a"},
           :seconddir => { :type => :directory, :default => "/seconddir", :desc => "a"}
@@ -1189,7 +1189,7 @@ describe Puppet::Util::Settings do
 
   describe "when using sections of the configuration to manage the local host" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       @settings.stubs(:service_user_available?).returns true
       @settings.define_settings :main, :noop => { :default => false, :desc => "", :type => :boolean }
       @settings.define_settings :main,
@@ -1284,7 +1284,7 @@ describe Puppet::Util::Settings do
 
   describe "when dealing with printing configs" do
     before do
-      @settings = Puppet::Util::Settings.new
+      @settings = Puppet::Settings.new
       #these are the magic default values
       @settings.stubs(:value).with(:configprint).returns("")
       @settings.stubs(:value).with(:genconfig).returns(false)
@@ -1407,11 +1407,11 @@ describe Puppet::Util::Settings do
 
   describe "when determining if the service user is available" do
     it "should return false if there is no user setting" do
-      Puppet::Util::Settings.new.should_not be_service_user_available
+      Puppet::Settings.new.should_not be_service_user_available
     end
 
     it "should return false if the user provider says the user is missing" do
-      settings = Puppet::Util::Settings.new
+      settings = Puppet::Settings.new
       settings.define_settings :main, :user => { :default => "foo", :desc => "doc" }
 
       user = mock 'user'
@@ -1423,7 +1423,7 @@ describe Puppet::Util::Settings do
     end
 
     it "should return true if the user provider says the user is present" do
-      settings = Puppet::Util::Settings.new
+      settings = Puppet::Settings.new
       settings.define_settings :main, :user => { :default => "foo", :desc => "doc" }
 
       user = mock 'user'
@@ -1439,7 +1439,7 @@ describe Puppet::Util::Settings do
 
   describe "#writesub" do
     it "should only pass valid arguments to File.open" do
-      settings = Puppet::Util::Settings.new
+      settings = Puppet::Settings.new
       settings.stubs(:get_config_file_default).with(:privatekeydir).returns(OpenStruct.new(:mode => "750"))
 
       File.expects(:open).with("/path/to/keydir", "w", 750).returns true
@@ -1449,7 +1449,7 @@ describe Puppet::Util::Settings do
 
 
   describe "when dealing with command-line options" do
-    let(:settings) { Puppet::Util::Settings.new }
+    let(:settings) { Puppet::Settings.new }
 
     it "should get options from Puppet.settings.optparse_addargs" do
       settings.expects(:optparse_addargs).returns([])
@@ -1479,11 +1479,11 @@ describe Puppet::Util::Settings do
     end
 
     it "should transform boolean option to normal form" do
-      Puppet::Util::Settings.clean_opt("--[no-]option", true).should == ["--option", true]
+      Puppet::Settings.clean_opt("--[no-]option", true).should == ["--option", true]
     end
 
     it "should transform boolean option to no- form" do
-      Puppet::Util::Settings.clean_opt("--[no-]option", false).should == ["--no-option", false]
+      Puppet::Settings.clean_opt("--[no-]option", false).should == ["--no-option", false]
     end
   end
 


### PR DESCRIPTION
Extract common Setting functionality from StringSetting into BaseSetting. Refactor settings to be cleaner and have a meaningful exception hierarchy. Move settings out of Util.
