### PR TITLE
(#3909) Strip trailing dot from default FQDN

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -369,23 +369,13 @@ module Puppet
     }
   )
 
-  hostname = Facter["hostname"].value
-  domain = Facter["domain"].value
-  if domain and domain != ""
-    fqdn = [hostname, domain].join(".")
-  else
-    fqdn = hostname
-  end
-  fqdn.gsub(/\.$/, '')
-
-
     Puppet.define_settings(
     :main,
 
     # We have to downcase the fqdn, because the current ssl stuff (as oppsed to in master) doesn't have good facilities for
     # manipulating naming.
     :certname => {
-      :default => fqdn.downcase, :desc => "The name to use when handling certificates.  Defaults
+      :default => Puppet::Settings.default_certname.downcase, :desc => "The name to use when handling certificates.  Defaults
       to the fully qualified domain name.",
       :call_hook => :on_define_and_write, # Call our hook with the default value, so we're always downcased
       :hook => proc { |value| raise(ArgumentError, "Certificate names must be lower case; see #1168") unless value == value.downcase }},
@@ -972,7 +962,7 @@ EOT
       :desc       => "Whether the server will search for SRV records in DNS for the current domain.",
     },
     :srv_domain => {
-      :default    => "#{domain}",
+      :default    => "#{Puppet::Settings.domain_fact}",
       :desc       => "The domain which will be queried to find the SRV records of servers to use.",
     },
     :ignoreschedules => {

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -37,6 +37,26 @@ class Puppet::Settings
         :logdir   => run_mode.log_dir,
     }
   end
+  
+  def self.default_certname() 
+    hostname = hostname_fact
+    domain = domain_fact
+    if domain and domain != ""
+      fqdn = [hostname, domain].join(".")
+    else
+      fqdn = hostname
+    end
+    fqdn.gsub(/\.$/, '')
+  end 
+
+  def self.hostname_fact()
+    Facter["hostname"].value 
+  end 
+
+  def self.domain_fact()
+    Facter["domain"].value
+  end 
+
 
   def self.default_global_config_dir
     Puppet.features.microsoft_windows? ? File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "etc") : "/etc/puppet"

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1486,6 +1486,34 @@ describe Puppet::Settings do
       Puppet::Settings.clean_opt("--[no-]option", false).should == ["--no-option", false]
     end
   end
-
-
+  
+  describe "default_certname" do
+    describe "using hostname and domainname" do
+      before :each do 
+        Puppet::Settings.stubs(:hostname_fact).returns("testhostname")
+        Puppet::Settings.stubs(:domain_fact).returns("domain.test.")
+        end 
+      it "should use both to generate fqdn" do 
+        Puppet::Settings.default_certname.should =~ /testhostname\.domain\.test/
+      end
+      
+      it "should remove trailing dots from fqdn" do 
+        Puppet::Settings.default_certname.should == 'testhostname.domain.test'
+      end 
+    end
+    
+    describe "using just hostname" do
+      before :each do
+        Puppet::Settings.stubs(:hostname_fact).returns("testhostname") 
+        Puppet::Settings.stubs(:domain_fact).returns("")
+        end 
+      it "should use only hostname to generate fqdn" do 
+        Puppet::Settings.default_certname.should == "testhostname" 
+      end 
+      
+      it "should removing trailing dots from fqdn" do 
+        Puppet::Settings.default_certname.should == "testhostname" 
+      end 
+    end 
+  end 
 end


### PR DESCRIPTION
In Facter pull request 200 the default domian can no longer end
with a trailing '.'. This modifies Puppet's defaults to mirror
that change.
