### PR TITLE
(#14391) Fix inaccurate message from Hiera data lookups

### DIFF
--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -3,7 +3,7 @@ require 'puppet/indirector/terminus'
 class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
   def initialize(*args)
     if ! Puppet.features.hiera?
-      raise "Hiera terminus not supported without hiera gem"
+      raise "Hiera terminus not supported without hiera library"
     end
     super
   end

--- a/spec/unit/indirector/hiera_spec.rb
+++ b/spec/unit/indirector/hiera_spec.rb
@@ -51,7 +51,7 @@ describe Puppet::Indirector::Hiera do
   it "should raise an error if we don't have the hiera feature" do
     Puppet.features.expects(:hiera?).returns(false)
     lambda { @hiera_class.new }.should raise_error RuntimeError,
-      "Hiera terminus not supported without hiera gem"
+      "Hiera terminus not supported without hiera library"
   end
 
   describe "the behavior of the find method", :if => Puppet.features.hiera? do


### PR DESCRIPTION
When the Hiera gem is missing the error message now reads:

"Hiera terminus not supported without hiera library"
