### PR TITLE
Bug/master/14200 face class names

### DIFF
--- a/lib/puppet/application/certificate_request.rb
+++ b/lib/puppet/application/certificate_request.rb
@@ -1,4 +1,7 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::CertificateRequest < Puppet::Application::IndirectionBase
+# NOTE: this is using an "old" naming convention (underscores instead of camel-case), for backwards
+#  compatibility with 2.7.x.  When the old naming convention is officially and publicly deprecated,
+#  this should be changed to camel-case.
+class Puppet::Application::Certificate_request < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/certificate_revocation_list.rb
+++ b/lib/puppet/application/certificate_revocation_list.rb
@@ -1,4 +1,7 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::CertificateRevocationList < Puppet::Application::IndirectionBase
+# NOTE: this is using an "old" naming convention (underscores instead of camel-case), for backwards
+#  compatibility with 2.7.x.  When the old naming convention is officially and publicly deprecated,
+#  this should be changed to camel-case.
+class Puppet::Application::Certificate_revocation_list < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/instrumentation_data.rb
+++ b/lib/puppet/application/instrumentation_data.rb
@@ -1,4 +1,7 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::InstrumentationData < Puppet::Application::IndirectionBase
+# NOTE: this is using an "old" naming convention (underscores instead of camel-case), for backwards
+#  compatibility with 2.7.x.  When the old naming convention is officially and publicly deprecated,
+#  this should be changed to camel-case.
+class Puppet::Application::Instrumentation_data < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/instrumentation_listener.rb
+++ b/lib/puppet/application/instrumentation_listener.rb
@@ -1,4 +1,7 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::InstrumentationListener < Puppet::Application::IndirectionBase
+# NOTE: this is using an "old" naming convention (underscores instead of camel-case), for backwards
+#  compatibility with 2.7.x.  When the old naming convention is officially and publicly deprecated,
+#  this should be changed to camel-case.
+class Puppet::Application::Instrumentation_listener < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/instrumentation_probe.rb
+++ b/lib/puppet/application/instrumentation_probe.rb
@@ -1,4 +1,7 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::InstrumentationProbe < Puppet::Application::IndirectionBase
+# NOTE: this is using an "old" naming convention (underscores instead of camel-case), for backwards
+#  compatibility with 2.7.x.  When the old naming convention is officially and publicly deprecated,
+#  this should be changed to camel-case.
+class Puppet::Application::Instrumentation_probe < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/resource_type.rb
+++ b/lib/puppet/application/resource_type.rb
@@ -1,4 +1,7 @@
 require 'puppet/application/indirection_base'
 
-class Puppet::Application::ResourceType < Puppet::Application::IndirectionBase
+# NOTE: this is using an "old" naming convention (underscores instead of camel-case), for backwards
+#  compatibility with 2.7.x.  When the old naming convention is officially and publicly deprecated,
+#  this should be changed to camel-case.
+class Puppet::Application::Resource_type < Puppet::Application::IndirectionBase
 end

--- a/lib/puppet/application/secret_agent.rb
+++ b/lib/puppet/application/secret_agent.rb
@@ -1,6 +1,9 @@
 require 'puppet/application/face_base'
 require 'puppet/face'
 
-class Puppet::Application::SecretAgent < Puppet::Application::FaceBase
+# NOTE: this is using an "old" naming convention (underscores instead of camel-case), for backwards
+#  compatibility with 2.7.x.  When the old naming convention is officially and publicly deprecated,
+#  this should be changed to camel-case.
+class Puppet::Application::Secret_agent < Puppet::Application::FaceBase
   run_mode :agent
 end

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -129,11 +129,6 @@ Puppet::Face.define(:help, '0.0.1') do
 
   def horribly_extract_summary_from(appname)
     begin
-      # it sucks that this 'require' is necessary, and it sucks even more that we are
-      #  doing it in two different places in this class (#horribly_extract_summary_from,
-      #  #is_face_app?).  However, we can take some solace in the fact that ruby will
-      #  at least recognize that it's already done a 'require' for any individual app
-      #  and basically treat it as a no-op if we try to 'require' it twice.
       require "puppet/application/#{appname}"
       help = Puppet::Application[appname].help.split("\n")
       # Now we find the line with our summary, extract it, and return it.  This
@@ -165,15 +160,8 @@ Puppet::Face.define(:help, '0.0.1') do
   #private :exclude_from_docs?
 
   def is_face_app?(appname)
-    # it sucks that this 'require' is necessary, and it sucks even more that we are
-    #  doing it in two different places in this class (#horribly_extract_summary_from,
-    #  #is_face_app?).  However, we can take some solace in the fact that ruby will
-    #  at least recognize that it's already done a 'require' for any individual app
-    #  and basically treat it as a no-op if we try to 'require' it twice.
-    require "puppet/application/#{appname}"
-    # Would much rather use "const_get" than "eval" here, but for some reason it is not available.
-    #  See #14205.
-    clazz = eval("Puppet::Application::#{Puppet::Util::ConstantInflector.file2constant(appname)}")
+    clazz = Puppet::Application.find(appname)
+
     clazz.ancestors.include?(Puppet::Application::FaceBase)
   end
   # This should probably be a private method, but for some reason it appears

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -50,7 +50,7 @@ module Puppet::Util::Logging
 
   def log_and_raise(exception, message)
     log_exception(exception, message)
-    raise exception, message + "\n" + exception, exception.backtrace
+    raise exception, message + "\n" + exception.to_s, exception.backtrace
   end
 
   class DeprecationWarning < Exception; end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -38,17 +38,17 @@ describe Puppet::Application do
     end
 
     it "should not find classes outside the namespace" do
-      expect { @klass.find("String") }.to exit_with 1
+      expect { @klass.find("String") }.to raise_error(LoadError)
     end
 
-    it "should exit if it can't find a class" do
-      @klass.expects(:puts).with do |value|
+    it "should error if it can't find a class" do
+      Puppet.expects(:err).with do |value|
         value =~ /Unable to find application 'ThisShallNeverEverEverExist'/ and
           value =~ /puppet\/application\/thisshallneverevereverexist/ and
           value =~ /no such file to load|cannot load such file/
       end
 
-      expect { @klass.find("ThisShallNeverEverEverExist") }.to exit_with 1
+      expect { @klass.find("ThisShallNeverEverEverExist") }.to raise_error(LoadError)
     end
 
     it "#12114: should prevent File namespace collisions" do


### PR DESCRIPTION
```
This is basically just a re-introduction of
ce1e5555a847163e6448d1442a6d626957dac798, which was mostly
some cleanup and fixes for the help face.  However, that commit
also (intentionally) broke backward compatibility for application class names;

In 2.7.x, underscores in file names for puppet applications are expected
to translate to underscores in the class name.  So, e.g., the
application defined in "resource_type.rb" is expected to have a class
name of "Resource_type".

However, that doesn't really match up with "standard" ruby or the
expectations of ruby developers.  They expect for "resource_type.rb"
to translate to "ResourceType".  The original commit introduced that,
but did not provide backward compatibility support for the "_" class
naming.

This commit does everything that the original one did, but includes
some hacks for backward compatibility with the underscore pattern.
```
