### PR TITLE
(#14424) Expand path of the target directory

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -149,6 +149,7 @@ Puppet::Face.define(:module, '1.0.0') do
     when_invoked do |name, options|
       sep = File::PATH_SEPARATOR
       if options[:target_dir]
+        options[:target_dir] = File.expand_path(options[:target_dir])
         options[:modulepath] = "#{options[:target_dir]}#{sep}#{options[:modulepath]}"
       end
 


### PR DESCRIPTION
This patch expands the path of the target installation directory and
will prevent the following errors:

```
Error: undefined method `each' for nil:NilClass
```
