### PR TITLE
(#14424) Expand path of the target directory

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -149,6 +149,7 @@ Puppet::Face.define(:module, '1.0.0') do
     when_invoked do |name, options|
       sep = File::PATH_SEPARATOR
       if options[:target_dir]
+        options[:target_dir] = File.expand_path(options[:target_dir])
         options[:modulepath] = "#{options[:target_dir]}#{sep}#{options[:modulepath]}"
       end
 

--- a/spec/unit/face/module/install_spec.rb
+++ b/spec/unit/face/module/install_spec.rb
@@ -90,6 +90,17 @@ describe "puppet module install" do
       end
 
       describe "when target-dir option is passed" do
+        it "should expand the target directory" do
+          options[:target_dir] = "modules"
+          expanded_path = File.expand_path("modules")
+          expected_options.merge!(options)
+          expected_options[:target_dir] = expanded_path
+          expected_options[:modulepath] = "#{expanded_path}#{sep}#{fakemodpath}"
+
+          Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
+          subject.install("puppetlabs-apache", options)
+        end
+
         it "should set target-dir to be first path of modulepath" do
           options[:target_dir] = fakedirpath
           expected_options[:target_dir] = fakedirpath


### PR DESCRIPTION
This patch expands the path of the target installation directory and
will prevent the following errors:

```
Error: undefined method `each' for nil:NilClass
```
