### PR TITLE
Fix broken man page rake task

### DIFF
--- a/lib/puppet/indirector/face.rb
+++ b/lib/puppet/indirector/face.rb
@@ -72,7 +72,7 @@ class Puppet::Indirector::Face < Puppet::Face
 
   action :save do
     summary "API only: create or overwrite an object."
-    arguments "<object>"
+    arguments "<key>"
     description <<-EOT
       API only: create or overwrite an object. As the Faces framework does not
       currently accept data from STDIN, save actions cannot currently be invoked

--- a/tasks/rake/manpages.rake
+++ b/tasks/rake/manpages.rake
@@ -49,9 +49,7 @@ task :gen_manpages do
   # Create face man pages
   faces.each do |face|
     File.open("./man/man8/puppet-#{face}.8.ronn", 'w') do |fh|
-      # For some reason no one understands at the moment, it duplicates termini,
-      # so we have to remove the dupes with a gsub.
-      fh.write manface.man("#{face}", {:render_as => :s}).gsub(/^(\* `[^`]+`)\n\1/, '\1')
+      fh.write manface.man("#{face}")
     end
 
     %x{#{ronn} #{ronn_args} ./man/man8/puppet-#{face}.8.ronn}


### PR DESCRIPTION
The mass static man page generator was broken! Something changed in commit
82e5fa9561e2d4cb1d699a41c14f50953d8f2d97 which broke the way we were passing
render_as to the man action; while that bears further investigation, we were
able to get the task working again by simply removing it, since the value we
were passing to option turned out to be redundant when using the action from
the API.

We also found that I had unwisely called the argument of the save action for
indirector faces "<object>", which Ronn confuses for an HTML tag of the same
name and then barfs on. This commit fixes that, too.
