### PR TITLE
(#14387) user agent for module tool

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+require 'puppet/forge'
 
 Puppet::Face.define(:module, '1.0.0') do
   action(:install) do
@@ -119,7 +120,7 @@ Puppet::Face.define(:module, '1.0.0') do
     when_invoked do |name, options|
       Puppet::ModuleTool.set_option_defaults options
       Puppet.notice "Preparing to install into #{options[:target_dir]} ..."
-      Puppet::ModuleTool::Applications::Installer.run(name, options)
+      Puppet::ModuleTool::Applications::Installer.new(name, Puppet::Forge.new("PMT", self.version), options).run
     end
 
     when_rendering :console do |return_value, name, options|

--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -1,4 +1,5 @@
 require 'puppet/util/terminal'
+require 'puppet/forge'
 
 Puppet::Face.define(:module, '1.0.0') do
   action(:search) do
@@ -22,7 +23,7 @@ Puppet::Face.define(:module, '1.0.0') do
 
     when_invoked do |term, options|
       Puppet::ModuleTool.set_option_defaults options
-      Puppet::ModuleTool::Applications::Searcher.run(term, options)
+      Puppet::ModuleTool::Applications::Searcher.new(term, Puppet::Forge.new("PMT", self.version), options).run
     end
 
     when_rendering :console do |results, term, options|

--- a/lib/puppet/face/module/upgrade.rb
+++ b/lib/puppet/face/module/upgrade.rb
@@ -57,7 +57,7 @@ Puppet::Face.define(:module, '1.0.0') do
       name = name.gsub('/', '-')
       Puppet.notice "Preparing to upgrade '#{name}' ..."
       Puppet::ModuleTool.set_option_defaults options
-      Puppet::ModuleTool::Applications::Upgrader.new(name, options).run
+      Puppet::ModuleTool::Applications::Upgrader.new(name, Puppet::Forge.new("PMT", self.version), options).run
     end
 
     when_rendering :console do |return_value|

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -5,7 +5,15 @@ require 'uri'
 require 'puppet/forge/cache'
 require 'puppet/forge/repository'
 
-module Puppet::Forge
+class Puppet::Forge
+  # +consumer_name+ is a name to be used for identifying the consumer of the
+  # forge and +consumer_semver+ is a SemVer object to identify the version of
+  # the consumer
+  def initialize(consumer_name, consumer_semver)
+    @consumer_name = consumer_name
+    @consumer_semver = consumer_semver
+  end
+
   # Return a list of module metadata hashes that match the search query.
   # This return value is used by the module_tool face install search,
   # and displayed to on the console.
@@ -25,7 +33,7 @@ module Puppet::Forge
   #   }
   # ]
   #
-  def self.search(term)
+  def search(term)
     server = Puppet.settings[:module_repository].sub(/^(?!https?:\/\/)/, 'http://')
     Puppet.notice "Searching #{server} ..."
     response = repository.make_http_request("/modules.json?q=#{URI.escape(term)}")
@@ -40,7 +48,7 @@ module Puppet::Forge
     matches
   end
 
-  def self.remote_dependency_info(author, mod_name, version)
+  def remote_dependency_info(author, mod_name, version)
     version_string = version ? "&version=#{version}" : ''
     response = repository.make_http_request("/api/v1/releases.json?module=#{author}/#{mod_name}#{version_string}")
     json = PSON.parse(response.body) rescue {}
@@ -57,7 +65,7 @@ module Puppet::Forge
     end
   end
 
-  def self.get_release_packages_from_repository(install_list)
+  def get_release_packages_from_repository(install_list)
     install_list.map do |release|
       modname, version, file = release
       cache_path = nil
@@ -77,7 +85,7 @@ module Puppet::Forge
   # Locate a module release package on the local filesystem and move it
   # into the `Puppet.settings[:module_working_dir]`. Do not unpack it, just
   # return the location of the package on disk.
-  def self.get_release_package_from_filesystem(filename)
+  def get_release_package_from_filesystem(filename)
     if File.exist?(File.expand_path(filename))
       repository = Repository.new('file:///')
       uri = URI.parse("file://#{URI.escape(File.expand_path(filename))}")
@@ -89,7 +97,17 @@ module Puppet::Forge
     cache_path
   end
 
-  def self.repository
-    @repository ||= Puppet::Forge::Repository.new
+  def retrieve(release)
+    repository.retrieve(release)
   end
+
+  def uri
+    repository.uri
+  end
+
+  def repository
+    version = "#{@consumer_name}/#{[@consumer_semver.major, @consumer_semver.minor, @consumer_semver.tiny].join('.')}#{@consumer_semver.special}"
+    @repository ||= Puppet::Forge::Repository.new(Puppet[:module_repository], version)
+  end
+  private :repository
 end

--- a/lib/puppet/forge/cache.rb
+++ b/lib/puppet/forge/cache.rb
@@ -1,6 +1,6 @@
 require 'uri'
 
-module Puppet::Forge
+class Puppet::Forge
   # = Cache
   #
   # Provides methods for reading files from local cache, filesystem or network.

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -12,12 +12,13 @@ module Puppet::ModuleTool
 
       include Puppet::ModuleTool::Errors
 
-      def initialize(name, options = {})
+      def initialize(name, forge, options = {})
         @action              = :install
         @environment         = Puppet::Node::Environment.new(Puppet.settings[:environment])
         @force               = options[:force]
         @ignore_dependencies = options[:force] || options[:ignore_dependencies]
         @name                = name
+        @forge               = forge
         super(options)
       end
 
@@ -102,7 +103,7 @@ module Puppet::ModuleTool
             ]
           }
         else
-          get_remote_constraints
+          get_remote_constraints(@forge)
         end
 
         @graph = resolve_constraints({ @module_name => @version })
@@ -116,7 +117,7 @@ module Puppet::ModuleTool
         # Long term we should just get rid of this caching behavior and cleanup downloaded modules after they install
         # but for now this is a quick fix to disable caching
         Puppet::Forge::Cache.clean
-        download_tarballs(@graph, @graph.last[:path])
+        download_tarballs(@graph, @graph.last[:path], @forge)
       end
 
       #

--- a/lib/puppet/module_tool/applications/searcher.rb
+++ b/lib/puppet/module_tool/applications/searcher.rb
@@ -2,13 +2,14 @@ module Puppet::ModuleTool
   module Applications
     class Searcher < Application
 
-      def initialize(term, options = {})
+      def initialize(term, forge, options = {})
         @term = term
+        @forge = forge
         super(options)
       end
 
       def run
-        Puppet::Forge.search(@term)
+        @forge.search(@term)
       end
     end
   end

--- a/spec/unit/face/module/install_spec.rb
+++ b/spec/unit/face/module/install_spec.rb
@@ -37,7 +37,8 @@ describe "puppet module install" do
       end
 
       it "should not require any options" do
-        Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
+        expects_installer_run_with("puppetlabs-apache", expected_options)
+
         subject.install("puppetlabs-apache")
       end
     end
@@ -45,7 +46,9 @@ describe "puppet module install" do
     it "should accept the --force option" do
       options[:force] = true
       expected_options.merge!(options)
-      Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
+
+      expects_installer_run_with("puppetlabs-apache", expected_options)
+
       subject.install("puppetlabs-apache", options)
     end
 
@@ -54,21 +57,26 @@ describe "puppet module install" do
       expected_options.merge!(options)
       expected_options[:modulepath] = "#{options[:target_dir]}#{sep}#{fakemodpath}"
 
-      Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
+      expects_installer_run_with("puppetlabs-apache", expected_options)
+
       subject.install("puppetlabs-apache", options)
     end
 
     it "should accept the --version option" do
       options[:version] = "0.0.1"
       expected_options.merge!(options)
-      Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
+
+      expects_installer_run_with("puppetlabs-apache", expected_options)
+
       subject.install("puppetlabs-apache", options)
     end
 
     it "should accept the --ignore-dependencies option" do
       options[:ignore_dependencies] = true
       expected_options.merge!(options)
-      Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
+
+      expects_installer_run_with("puppetlabs-apache", expected_options)
+
       subject.install("puppetlabs-apache", options)
     end
 
@@ -80,9 +88,7 @@ describe "puppet module install" do
         it "should set target-dir to be first path from modulepath" do
           expected_options[:target_dir] = fakefirstpath
 
-          Puppet::ModuleTool::Applications::Installer.
-            expects(:run).
-            with("puppetlabs-apache", expected_options)
+          expects_installer_run_with("puppetlabs-apache", expected_options)
 
           Puppet::Face[:module, :current].install("puppetlabs-apache", options)
 
@@ -96,9 +102,7 @@ describe "puppet module install" do
           expected_options[:target_dir] = fakedirpath
           expected_options[:modulepath] = "#{fakedirpath}#{sep}#{fakemodpath}"
 
-          Puppet::ModuleTool::Applications::Installer.
-            expects(:run).
-            with("puppetlabs-apache", expected_options)
+          expects_installer_run_with("puppetlabs-apache", expected_options)
 
           Puppet::Face[:module, :current].install("puppetlabs-apache", options)
 
@@ -117,9 +121,7 @@ describe "puppet module install" do
           expected_options[:target_dir] = fakefirstpath
           expected_options[:modulepath] = fakemodpath
 
-          Puppet::ModuleTool::Applications::Installer.
-            expects(:run).
-            with("puppetlabs-apache", expected_options)
+          expects_installer_run_with("puppetlabs-apache", expected_options)
 
           Puppet::Face[:module, :current].install("puppetlabs-apache", options)
         end
@@ -131,9 +133,7 @@ describe "puppet module install" do
           expected_options[:target_dir] = fakedirpath
           expected_options[:modulepath] = "#{options[:target_dir]}#{sep}#{fakemodpath}"
 
-          Puppet::ModuleTool::Applications::Installer.
-            expects(:run).
-            with("puppetlabs-apache", expected_options)
+          expects_installer_run_with("puppetlabs-apache", expected_options)
 
           Puppet::Face[:module, :current].install("puppetlabs-apache", options)
           Puppet.settings[:modulepath].should == expected_options[:modulepath]
@@ -155,5 +155,14 @@ describe "puppet module install" do
         its(doc.to_sym) { should_not =~ /(FIXME|REVISIT|TODO)/ }
       end
     end
+  end
+
+  def expects_installer_run_with(name, options)
+    installer = mock("Installer")
+    forge = mock("Forge")
+
+    Puppet::Forge.expects(:new).with("PMT", subject.version).returns(forge)
+    Puppet::ModuleTool::Applications::Installer.expects(:new).with("puppetlabs-apache", forge, expected_options).returns(installer)
+    installer.expects(:run)
   end
 end

--- a/spec/unit/face/module/search_spec.rb
+++ b/spec/unit/face/module/search_spec.rb
@@ -140,8 +140,14 @@ describe "puppet module search" do
     end
 
     it "should accept the --module-repository option" do
+      forge = mock("Puppet::Forge")
+      searcher = mock("Searcher")
       options[:module_repository] = "http://forge.example.com"
-      Puppet::ModuleTool::Applications::Searcher.expects(:run).with("puppetlabs-apache", has_entries(options)).once
+
+      Puppet::Forge.expects(:new).with("PMT", subject.version).returns(forge)
+      Puppet::ModuleTool::Applications::Searcher.expects(:new).with("puppetlabs-apache", forge, has_entries(options)).returns(searcher)
+      searcher.expects(:run)
+
       subject.search("puppetlabs-apache", options)
     end
   end

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -4,7 +4,8 @@ require 'puppet/forge/repository'
 require 'puppet/forge/cache'
 
 describe Puppet::Forge::Repository do
-  let(:repository) { Puppet::Forge::Repository.new('http://fake.com') }
+  let(:consumer_version) { "Test/1.0" }
+  let(:repository) { Puppet::Forge::Repository.new('http://fake.com', consumer_version) }
 
   it "retrieve accesses the cache" do
     uri = URI.parse('http://some.url.com')
@@ -40,10 +41,48 @@ describe Puppet::Forge::Repository do
       repository.http_proxy_host.should == "test1.com"
       repository.http_proxy_port.should == 8011
     end
+  end
 
-    def proxy_settings_of(host, port)
-      Puppet.settings.stubs(:[]).with(:http_proxy_host).returns(host)
-      Puppet.settings.stubs(:[]).with(:http_proxy_port).returns(port)
+  describe "making a request" do
+    before :each do
+      proxy_settings_of("proxy", 1234)
     end
+
+    it "returns the result object from the request" do
+      result = "the http response" 
+      performs_an_http_request result do |http|
+        http.expects(:request).with(responds_with(:path, "the_path"))
+      end
+
+      repository.make_http_request("the_path").should == result
+    end
+
+    it "sets the user agent for the request" do
+      performs_an_http_request do |http|
+        http.expects(:request).with() do |request|
+          puppet_version = /Puppet\/\d+\..*/
+          os_info = /\(.*\)/
+          ruby_version = /Ruby\/\d+\.\d+\.\d+-p\d+ \(\d{4}-\d{2}-\d{2}; .*\)/
+
+          request["User-Agent"] =~ /^#{consumer_version} #{puppet_version} #{os_info} #{ruby_version}/
+        end
+      end
+
+      repository.make_http_request("the_path")
+    end
+
+    def performs_an_http_request(result = nil, &block)
+      http = mock("http client")
+      yield http
+
+      proxy = mock("http proxy")
+      proxy.expects(:start).with("fake.com", 80).yields(http).returns(result)
+      Net::HTTP.expects(:Proxy).with("proxy", 1234).returns(proxy)
+    end
+  end
+
+  def proxy_settings_of(host, port)
+    Puppet.settings.stubs(:[]).with(:http_proxy_host).returns(host)
+    Puppet.settings.stubs(:[]).with(:http_proxy_port).returns(port)
   end
 end

--- a/spec/unit/forge_spec.rb
+++ b/spec/unit/forge_spec.rb
@@ -21,6 +21,8 @@ describe Puppet::Forge do
   EOF
   end
 
+  let(:forge) { Puppet::Forge.new("test_agent", SemVer.new("v1.0.0")) }
+
   def repository_responds_with(response)
     Puppet::Forge::Repository.any_instance.stubs(:make_http_request).returns(response)
   end
@@ -29,7 +31,7 @@ describe Puppet::Forge do
     response = stub(:body => response_body, :code => '200')
     repository_responds_with(response)
 
-    Puppet::Forge.search('bacula').should == PSON.load(response_body)
+    forge.search('bacula').should == PSON.load(response_body)
   end
 
   context "when the connection to the forge fails" do
@@ -38,11 +40,11 @@ describe Puppet::Forge do
     end
 
     it "raises an error for search" do
-      expect { Puppet::Forge.search('bacula') }.should raise_error RuntimeError
+      expect { forge.search('bacula') }.should raise_error RuntimeError
     end
 
     it "raises an error for remote_dependency_info" do
-      expect { Puppet::Forge.remote_dependency_info('puppetlabs', 'bacula', '0.0.1') }.should raise_error RuntimeError
+      expect { forge.remote_dependency_info('puppetlabs', 'bacula', '0.0.1') }.should raise_error RuntimeError
     end
   end
 end

--- a/spec/unit/module_tool/applications/upgrader_spec.rb
+++ b/spec/unit/module_tool/applications/upgrader_spec.rb
@@ -6,9 +6,6 @@ require 'semver'
 describe Puppet::ModuleTool::Applications::Upgrader do
   include PuppetSpec::Files
 
-  before do
-  end
-
   it "should update the requested module"
   it "should not update dependencies"
   it "should fail when updating a dependency to an unsupported version"


### PR DESCRIPTION
This pull request changes the puppet module face to send a User-Agent header to the forge to identify itself. The User-Agent will contain the version of the module tool, the version of puppet, the operating system, and the version of ruby that is being used.

This pull request also ensures that Puppet::Forge does not depend on the Puppet::Face code. In order to achieve that the module face now is responsible for creating the correct Puppet::Forge object and handing
that to the various components of the face for execution.

The Puppet::Face now provides an interface for interacting with the repository in ways that various users were doing by asking for the repository directly.
