### PR TITLE
Bug/2.7.x/14440-rake-manpages

### DIFF
--- a/tasks/rake/manpages.rake
+++ b/tasks/rake/manpages.rake
@@ -7,6 +7,16 @@ task :gen_manpages do
 
   helpface = Puppet::Face[:help, '0.0.1']
   manface  = Puppet::Face[:man, '0.0.1']
+
+  # TODO: This line is terrible.  The reason we need this here is because we
+  #  handle state initialization differently when we run via command line
+  #  (application.rb) than we do when we try to use Faces as library code.
+  #  This is bad, we need to come up with an official stance on what our
+  #  API is and what the entry points, so that we can make sure that
+  #  state initialization is consistent.  See:
+  # http://projects.puppetlabs.com/issues/14441
+  Puppet::Util::Instrumentation.init()
+
   sbins = Dir.glob(%w{sbin/*})
   bins  = Dir.glob(%w{bin/*})
   non_face_applications = helpface.legacy_applications


### PR DESCRIPTION
Because we have not done a good job of defining
state initialization life cycle when we try to use
puppet as API, we need to add a hack to the rake
manpage task so that it can generate man pages
for some faces that don't get properly initialized
w/o the hack.
