### PR TITLE
(#14442) dont refer to features that dont exist

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -4,8 +4,8 @@ Puppet::Face.define(:module, '1.0.0') do
   action(:install) do
     summary "Install a module from a repository or release archive."
     description <<-EOT
-      Installs a module from the Puppet Forge, from a release archive file
-      on-disk, or from a private Forge-like repository.
+      Installs a module from the Puppet Forge or from a release archive file
+      on-disk.
 
       The specified module will be installed into the directory
       specified with the `--target-dir` option, which defaults to


### PR DESCRIPTION
We were saying that we supported using private Forge-like repos for installing modules. While that might work _in theory_ we don't publicly provide or support a tool to do this or the API that is necessary to build a tool like this.

This is a minor documentation fix to not mention the 'private Forge-like repo'.
