### PR TITLE
Maint/2.7.x/no private forges

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -2,10 +2,9 @@
 
 Puppet::Face.define(:module, '1.0.0') do
   action(:install) do
-    summary "Install a module from a repository or release archive."
+    summary "Install a module from the Puppet Forge or a release archive."
     description <<-EOT
-      Installs a module from the Puppet Forge, from a release archive file
-      on-disk, or from a private Forge-like repository.
+      Installs a module from the Puppet Forge or from a release archive file.
 
       The specified module will be installed into the directory
       specified with the `--target-dir` option, which defaults to

--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -2,16 +2,16 @@ require 'puppet/util/terminal'
 
 Puppet::Face.define(:module, '1.0.0') do
   action(:search) do
-    summary "Search a repository for a module."
+    summary "Search the Puppet Forge for a module."
     description <<-EOT
-      Searches a repository for modules whose names, descriptions, or keywords
+      Searches the Puppet Forge for modules whose names, descriptions, or keywords
       match the provided search term.
     EOT
 
     returns "Array of module metadata hashes"
 
     examples <<-EOT
-      Search the default repository for a module:
+      Search the Puppet Forge for a module:
 
       $ puppet module search puppetlabs
       NAME          DESCRIPTION                          AUTHOR             KEYWORDS


### PR DESCRIPTION
The module tool supports a private Forge right now, but only if you have THE
Forge -- the APIs are not public yet, and are still subject to change as we
build out new features. This commit changes the help text so that it doesn't
imply private repos to be an immediately viable thing.
