### PR TITLE
Fix unit test failure in fileserver due to modules

### DIFF
--- a/test/network/handler/fileserver.rb
+++ b/test/network/handler/fileserver.rb
@@ -1100,14 +1100,20 @@ allow *
     mounts = {}
     Puppet[:modulepath] = moddir
 
-    mods = %w{green red}.collect do |name|
+    %w{green red}.each do |name|
       path = File::join(moddir, name, Puppet::Module::FILES)
       FileUtils::mkdir_p(path)
       if name == "green"
         file = File::join(path, "test.txt")
         File::open(file, "w") { |f| f.print name }
       end
+    end
 
+    # We changed modulepath, so we have to clear the environment cache to
+    # refresh it
+    Puppet::Node::Environment.current.modules = nil
+
+    mods = %w{green red}.map do |name|
       Puppet::Module::find(name)
     end
 


### PR DESCRIPTION
This test is setting modulepath, and then testing that it can find
modules from the modulepath. However, the recent change to module find
causing it to read from the cached list of modules requires the cache be
cleared after changing the modulepath in order for the modules to be
found.

Also, the structure of the test changed a bit because we have to put the
modules on disk, THEN refresh the cache, THEN we can find them, rather
than putting them on disk and immediately finding them.
