### PR TITLE
Fix User-Agent for ruby 1.8.5

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -102,8 +102,15 @@ class Puppet::Forge
     end
 
     def user_agent
-      "#{@consumer_version} Puppet/#{Puppet.version} (#{Facter.value(:operatingsystem)} #{Facter.value(:operatingsystemrelease)}) Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE}; #{RUBY_PLATFORM})"
+      "#{@consumer_version} Puppet/#{Puppet.version} (#{Facter.value(:operatingsystem)} #{Facter.value(:operatingsystemrelease)}) #{ruby_version}"
     end
     private :user_agent
+
+    def ruby_version
+      # the patchlevel is not available in ruby 1.8.5
+      patch = defined?(RUBY_PATCHLEVEL) ? "-p#{RUBY_PATCHLEVEL}" : ""
+      "Ruby/#{RUBY_VERSION}#{patch} (#{RUBY_RELEASE_DATE}; #{RUBY_PLATFORM})"
+    end
+    private :ruby_version
   end
 end

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -62,7 +62,7 @@ describe Puppet::Forge::Repository do
         http.expects(:request).with() do |request|
           puppet_version = /Puppet\/\d+\..*/
           os_info = /\(.*\)/
-          ruby_version = /Ruby\/\d+\.\d+\.\d+-p\d+ \(\d{4}-\d{2}-\d{2}; .*\)/
+          ruby_version = /Ruby\/\d+\.\d+\.\d+(-p\d+)? \(\d{4}-\d{2}-\d{2}; .*\)/
 
           request["User-Agent"] =~ /^#{consumer_version} #{puppet_version} #{os_info} #{ruby_version}/
         end


### PR DESCRIPTION
The RUBY_PATCHLEVEL constant is not available on ruby 1.8.5. To fix this
the pathlevel will default to "unknown" if the RUBY_PATCHLEVEL is not
available.
