### PR TITLE
(#14468) get rid of "metaparam compatibility mode"

### DIFF
--- a/lib/puppet/parser/functions/require.rb
+++ b/lib/puppet/parser/functions/require.rb
@@ -32,26 +32,22 @@ fail if used with earlier clients.
   method = Puppet::Parser::Functions.function(:include)
 
   send(method, vals)
-  if resource.metaparam_compatibility_mode?
-    warning "The 'require' function is only compatible with clients at 0.25 and above; including class but not adding dependency"
-  else
-    vals = [vals] unless vals.is_a?(Array)
+  vals = [vals] unless vals.is_a?(Array)
 
-    vals.each do |klass|
-      # lookup the class in the scopes
-      if classobj = find_hostclass(klass)
-        klass = classobj.name
-      else
-        raise Puppet::ParseError, "Could not find class #{klass}"
-      end
-
-      # This is a bit hackish, in some ways, but it's the only way
-      # to configure a dependency that will make it to the client.
-      # The 'obvious' way is just to add an edge in the catalog,
-      # but that is considered a containment edge, not a dependency
-      # edge, so it usually gets lost on the client.
-      ref = Puppet::Resource.new(:class, klass)
-      resource.set_parameter(:require, [resource[:require]].flatten.compact << ref)
+  vals.each do |klass|
+    # lookup the class in the scopes
+    if classobj = find_hostclass(klass)
+      klass = classobj.name
+    else
+      raise Puppet::ParseError, "Could not find class #{klass}"
     end
+
+    # This is a bit hackish, in some ways, but it's the only way
+    # to configure a dependency that will make it to the client.
+    # The 'obvious' way is just to add an edge in the catalog,
+    # but that is considered a containment edge, not a dependency
+    # edge, so it usually gets lost on the client.
+    ref = Puppet::Resource.new(:class, klass)
+    resource.set_parameter(:require, [resource[:require]].flatten.compact << ref)
   end
 end

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -109,7 +109,6 @@ class Puppet::Parser::Resource < Puppet::Resource
     return if finished?
     @finished = true
     add_defaults
-    add_metaparams
     add_scope_tags
     validate
   end
@@ -148,11 +147,6 @@ class Puppet::Parser::Resource < Puppet::Resource
     resource.parameters.each do |name, param|
       override_parameter(param)
     end
-  end
-
-  # Unless we're running >= 0.25, we're in compat mode.
-  def metaparam_compatibility_mode?
-    ! (catalog and ver = (catalog.client_version||'0.0.0').split(".") and (ver[0] > "0" or ver[1].to_i >= 25))
   end
 
   def name
@@ -245,29 +239,6 @@ class Puppet::Parser::Resource < Puppet::Resource
 
         @parameters[name] = param.dup
       end
-    end
-  end
-
-  def add_backward_compatible_relationship_param(name)
-    # Skip metaparams for which we get no value.
-    return unless scope.include?(name.to_s)
-    val = scope[name.to_s]
-
-    # The default case: just set the value
-    set_parameter(name, val) and return unless @parameters[name]
-
-    # For relationship params, though, join the values (a la #446).
-    @parameters[name].value = [@parameters[name].value, val].flatten
-  end
-
-  # Add any metaparams defined in our scope. This actually adds any metaparams
-  # from any parent scope, and there's currently no way to turn that off.
-  def add_metaparams
-    compat_mode = metaparam_compatibility_mode?
-
-    Puppet::Type.eachmetaparam do |name|
-      next unless self.class.relationship_parameter?(name)
-      add_backward_compatible_relationship_param(name) if compat_mode
     end
   end
 

--- a/spec/unit/parser/functions/require_spec.rb
+++ b/spec/unit/parser/functions/require_spec.rb
@@ -17,7 +17,6 @@ describe "the require function" do
     @scope.stubs(:find_hostclass).returns(@klass)
 
     @resource = Puppet::Parser::Resource.new(:file, "/my/file", :scope => @scope, :source => "source")
-    @resource.stubs(:metaparam_compatibility_mode?).returns false
     @scope.stubs(:resource).returns @resource
   end
 
@@ -42,15 +41,6 @@ describe "the require function" do
   it "should verify the 'include' function is loaded" do
     Puppet::Parser::Functions.expects(:function).with(:include).returns(:function_include)
     @scope.stubs(:function_include)
-    @scope.function_require("myclass")
-  end
-
-  it "should include the class but not add a dependency if used on a client not at least version 0.25" do
-    @resource.expects(:metaparam_compatibility_mode?).returns true
-    @scope.expects(:warning)
-    @resource.expects(:set_parameter).never
-    @scope.expects(:function_include)
-
     @scope.function_require("myclass")
   end
 

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -297,51 +297,6 @@ describe Puppet::Parser::Resource do
       @resource[:owner].should == "other"
     end
 
-    it "should be running in metaparam compatibility mode if running a version below 0.25" do
-      catalog = stub 'catalog', :client_version => "0.24.8"
-      @resource.stubs(:catalog).returns catalog
-      @resource.should be_metaparam_compatibility_mode
-    end
-
-    it "should be running in metaparam compatibility mode if running no client version is available" do
-      catalog = stub 'catalog', :client_version => nil
-      @resource.stubs(:catalog).returns catalog
-      @resource.should be_metaparam_compatibility_mode
-    end
-
-    it "should not be running in metaparam compatibility mode if running a version at or above 0.25" do
-      catalog = stub 'catalog', :client_version => "0.25.0"
-      @resource.stubs(:catalog).returns catalog
-      @resource.should_not be_metaparam_compatibility_mode
-    end
-
-    it "should not copy relationship metaparams when not in metaparam compatibility mode" do
-      @scope['require'] = "bar"
-
-      @resource.stubs(:metaparam_compatibility_mode?).returns false
-      @resource.class.publicize_methods(:add_metaparams)  { @resource.add_metaparams }
-
-      @resource["require"].should be_nil
-    end
-
-    it "should copy relationship metaparams when in metaparam compatibility mode" do
-      @scope['require'] = "bar"
-
-      @resource.stubs(:metaparam_compatibility_mode?).returns true
-      @resource.class.publicize_methods(:add_metaparams)  { @resource.add_metaparams }
-
-      @resource["require"].should == "bar"
-    end
-
-    it "should stack relationship metaparams when in metaparam compatibility mode" do
-      @resource.set_parameter("require", "foo")
-      @scope['require'] = "bar"
-
-      @resource.stubs(:metaparam_compatibility_mode?).returns true
-      @resource.class.publicize_methods(:add_metaparams)  { @resource.add_metaparams }
-
-      @resource["require"].should == ["foo", "bar"]
-    end
   end
 
   describe "when being tagged" do


### PR DESCRIPTION
This involves some backward-compatibility hacks targeted at
versions of puppet older than 0.25; These are no longer
needed.
