### PR TITLE
(#14454) useradd doesn't work if nss groups use more than just "files" for the data source. 

### DIFF
--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -242,7 +242,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     # reading of the file.
     Etc.endgrent
 
-    groups.join(",")
+    groups.uniq.join(",")
   end
 
   # Convert the Etc struct into a hash.

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -17,10 +17,6 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     value.is_a? Integer
   end
 
-  verify :groups, "Groups must be comma-separated" do |value|
-    value !~ /\s/
-  end
-
   has_features :manages_homedir, :allows_duplicates, :manages_expiry, :system_users
 
   has_features :manages_passwords, :manages_password_age if Puppet.features.libshadow?


### PR DESCRIPTION
The nsslib function, getgrent returns the combined list including
groups that useradd cannot manage, including duplicates, if any.

The duplicate groups were causing the User resource to try to correct the
groups every time. useradd was incorrectly invalidating groupnames with spaces,
which getgrent returns.

This allows useradd to run successfully. If the specified groups exist in the
file data source, the user will be added. If they're in another data source,
useradd will complete without error, but won't alter those memberships.

Bug: 14454
Signed-off-by: Joe Julian me@joejulian.name
