### PR TITLE
(13914) Fix ownership of log files

### DIFF
--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -77,7 +77,11 @@ Puppet::Util::Log.newdesttype :file do
     file = File.open(path, File::WRONLY|File::CREAT|File::APPEND)
 
     # Give ownership to the user and group puppet will run as
-    FileUtils.chown(Puppet[:user], Puppet[:group], path) unless Puppet::Util::Platform.windows?
+    begin
+      FileUtils.chown(Puppet[:user], Puppet[:group], path) unless Puppet::Util::Platform.windows?
+    rescue ArgumentError, Errno::EPERM
+      Puppet.err "Unable to set ownership of log file"
+    end
 
     @file = file
 


### PR DESCRIPTION
The puppet master creates log files while running as the root user,
then switches to running as the puppet user. This commit ensures it
will still have permission to write to the log file after switching users.
