### PR TITLE
Set node_terminus in device application

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -6,6 +6,14 @@ class Puppet::Application::Agent < Puppet::Application
 
   attr_accessor :args, :agent, :daemon, :host
 
+  def app_defaults
+    super.merge({
+      :catalog_terminus => :rest,
+      :node_terminus => :rest,
+      :facts_terminus => :facter,
+    })
+  end
+
   def preinit
     # Do an initial trap, so that cancels don't get a stack trace.
     Signal.trap(:INT) do
@@ -449,14 +457,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     Puppet::Transaction::Report.indirection.terminus_class = :rest
     # we want the last report to be persisted locally
     Puppet::Transaction::Report.indirection.cache_class = :yaml
-
-    # Override the default; puppet agent needs this, usually.
-    # You can still override this on the command-line with, e.g., :compiler.
-    Puppet[:catalog_terminus] = :rest
-    Puppet[:node_terminus] = :rest
-
-    # Override the default.
-    Puppet[:facts_terminus] = :facter
 
     Puppet::Resource::Catalog.indirection.cache_class = :yaml
 

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -8,6 +8,14 @@ class Puppet::Application::Device < Puppet::Application
 
   attr_accessor :args, :agent, :host
 
+  def app_defaults
+    super.merge({
+      :catalog_terminus => :rest,
+      :node_terminus => :rest,
+      :facts_terminus => :network_device,
+    })
+  end
+
   def preinit
     # Do an initial trap, so that cancels don't get a stack trace.
     Signal.trap(:INT) do
@@ -227,12 +235,6 @@ Licensed under the Apache 2.0 License
     Puppet::SSL::Host.ca_location = :remote
 
     Puppet::Transaction::Report.indirection.terminus_class = :rest
-
-    # Override the default; the agent needs this, usually.
-    # You can still override this on the command-line with, e.g., :compiler.
-    Puppet[:catalog_terminus] = :rest
-
-    Puppet[:facts_terminus] = :network_device
 
     Puppet::Resource::Catalog.indirection.cache_class = :yaml
   end

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -327,10 +327,14 @@ describe Puppet::Application::Agent do
       @puppetd.setup
     end
 
-    it "should change the catalog_terminus setting to 'rest'" do
-      Puppet[:catalog_terminus] = :foo
-      @puppetd.setup
+    it "should default catalog_terminus setting to 'rest'" do
+      @puppetd.initialize_app_defaults
       Puppet[:catalog_terminus].should ==  :rest
+    end
+
+    it "should default node_terminus setting to 'rest'" do
+      @puppetd.initialize_app_defaults
+      Puppet[:node_terminus].should ==  :rest
     end
 
     it "should tell the catalog handler to use cache" do
@@ -339,10 +343,8 @@ describe Puppet::Application::Agent do
       @puppetd.setup
     end
 
-    it "should change the facts_terminus setting to 'facter'" do
-      Puppet[:facts_terminus] = :foo
-
-      @puppetd.setup
+    it "should default facts_terminus setting to 'facter'" do
+      @puppetd.initialize_app_defaults
       Puppet[:facts_terminus].should == :facter
     end
 

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -209,10 +209,14 @@ describe Puppet::Application::Device do
       @device.setup
     end
 
-    it "should change the catalog_terminus setting to 'rest'" do
-      Puppet[:catalog_terminus] = :foo
-      @device.setup
+    it "should default the catalog_terminus setting to 'rest'" do
+      @device.initialize_app_defaults
       Puppet[:catalog_terminus].should ==  :rest
+    end
+
+    it "should default the node_terminus setting to 'rest'" do
+      @device.initialize_app_defaults
+      Puppet[:node_terminus].should ==  :rest
     end
 
     it "should tell the catalog handler to use cache" do
@@ -221,10 +225,8 @@ describe Puppet::Application::Device do
       @device.setup
     end
 
-    it "should change the facts_terminus setting to 'network_device'" do
-      Puppet[:facts_terminus] = :foo
-
-      @device.setup
+    it "should default the facts_terminus setting to 'network_device'" do
+      @device.initialize_app_defaults
       Puppet[:facts_terminus].should == :network_device
     end
   end


### PR DESCRIPTION
This was set in the agent application so that an ENC can be properly used, but
not in device. I also refactored these settings slightly to use the new
app_defaults method.
