### PR TITLE
(Maint) Color console output when the win32console gem is installed

### DIFF
--- a/lib/puppet/util/colors.rb
+++ b/lib/puppet/util/colors.rb
@@ -82,6 +82,7 @@ module Puppet::Util::Colors
   if Puppet::Util::Platform.windows?
     # We're on windows, need win32console for color to work
     begin
+      require 'rubygems'
       require 'win32console'
     rescue LoadError
       def console_has_color?


### PR DESCRIPTION
Originally, we were using a feature to detect whether the platform
supports ANSI color escape sequences. The feature used to invoke
`Puppet.features.rubygems?`, which had the side-effect of loading
rubygems, if it hadn't already been loaded.

However, the ansicolor feature could cause infinite recursive loops when
trying to log that it failed to load the ansicolor feature. So the code
for loading the win32console gem was moved into Puppet::Util::Colors in
commit 91a4a7d.

However, in doing so, rubygems was not being loaded when attempting to
`require 'win32console'`, causing Windows to always raise a LoadError,
even when the win32console gem was installed.

This commit adds an explicit call to require rubygems and now correctly
colors console output when the win32console gem is installed.
