### PR TITLE
(maint) Manually resolve broken merge of 2.7.x

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -3,10 +3,9 @@ require 'puppet/forge'
 
 Puppet::Face.define(:module, '1.0.0') do
   action(:install) do
-    summary "Install a module from a repository or release archive."
+    summary "Install a module from the Puppet Forge or a release archive."
     description <<-EOT
-      Installs a module from the Puppet Forge, from a release archive file
-      on-disk, or from a private Forge-like repository.
+      Installs a module from the Puppet Forge or from a release archive file.
 
       The specified module will be installed into the directory
       specified with the `--target-dir` option, which defaults to

--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -3,7 +3,7 @@ require 'puppet/forge'
 
 Puppet::Face.define(:module, '1.0.0') do
   action(:search) do
-    summary "Search a repository for a module."
+    summary "Search the Puppet Forge for a module."
     description <<-EOT
       Searches a repository for modules whose names, descriptions, or keywords
       match the provided search term.
@@ -12,7 +12,7 @@ Puppet::Face.define(:module, '1.0.0') do
     returns "Array of module metadata hashes"
 
     examples <<-EOT
-      Search the default repository for a module:
+      Search the Puppet Forge for a module:
 
       $ puppet module search puppetlabs
       NAME          DESCRIPTION                          AUTHOR             KEYWORDS

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -86,6 +86,9 @@ module Puppet
 
     def self.set_option_defaults(options)
       sep = File::PATH_SEPARATOR
+      if options[:target_dir]
+        options[:target_dir] = File.expand_path(options[:target_dir])
+      end
 
       prepend_target_dir = !! options[:target_dir]
 

--- a/spec/unit/face/module/install_spec.rb
+++ b/spec/unit/face/module/install_spec.rb
@@ -138,6 +138,17 @@ describe "puppet module install" do
           Puppet::Face[:module, :current].install("puppetlabs-apache", options)
           Puppet.settings[:modulepath].should == expected_options[:modulepath]
         end
+
+        it "should expand the target directory" do
+          options[:target_dir] = "modules"
+          expanded_path = File.expand_path("modules")
+          expected_options.merge!(options)
+          expected_options[:target_dir] = expanded_path
+          expected_options[:modulepath] = "#{expanded_path}#{sep}#{fakemodpath}"
+
+          expects_installer_run_with("puppetlabs-apache", expected_options)
+          Puppet::Face[:module, :current].install("puppetlabs-apache", options)
+        end
       end
     end
   end


### PR DESCRIPTION
This patch resolves a merge conflict with 2.7.x, mainly around some
changes in the PMT installer face options.
