### PR TITLE
Use ExternalFileError when a file name and line are needed

### DIFF
--- a/lib/puppet/parameter.rb
+++ b/lib/puppet/parameter.rb
@@ -153,7 +153,7 @@ class Puppet::Parameter
     if args[0].is_a?(Class)
       type = args.shift
     else
-      type = Puppet::Error
+      type = Puppet::ResourceError
     end
 
     error = type.new(args.join(" "))

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1213,15 +1213,10 @@ if @config.include?(:run_mode)
           end
           result[section][var] = value
         rescue Puppet::Error => detail
-          detail.file = file
-          detail.line = line
-          raise
+          raise ParseError.new(detail.message, file, line, detail)
         end
       else
-        error = Puppet::Error.new("Could not match line #{line}")
-        error.file = file
-        error.line = line
-        raise error
+        raise ParseError.new("Could not match line #{line}", file, line)
       end
     end
 

--- a/lib/puppet/settings/errors.rb
+++ b/lib/puppet/settings/errors.rb
@@ -1,7 +1,11 @@
 # Exceptions for the settings module
+require 'puppet/error'
 
 class Puppet::Settings
   class SettingsError < Puppet::Error ; end
   class ValidationError < SettingsError ; end
   class InterpolationError < SettingsError ; end
+  class ParseError < SettingsError
+    include Puppet::ExternalFileError
+  end
 end

--- a/lib/puppet/util/fileparsing.rb
+++ b/lib/puppet/util/fileparsing.rb
@@ -223,7 +223,7 @@ module Puppet::Util::FileParsing
       if val = parse_line(line)
         val
       else
-        error = Puppet::Error.new("Could not parse line #{line.inspect}")
+        error = Puppet::ResourceError.new("Could not parse line #{line.inspect}")
         error.line = count
         raise error
       end


### PR DESCRIPTION
Several places were trying to set line or file attributes on instances of
Puppet::Error. This changes those to use exception classes that include
ExternalFileError.
