### PR TITLE
(#3669) Disable SRV record use by default.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -966,7 +966,7 @@ EOT
       :desc => "The server to which the puppet agent should connect"
     },
     :use_srv_records => {
-      :default    => true,
+      :default    => false,
       :type       => :boolean,
       :desc       => "Whether the server will search for SRV records in DNS for the current domain.",
     },


### PR DESCRIPTION
This is a nice feature to have, but it is not widely used.  It also triggers
some odd bugs in some common (embedded device) DNS recursive resolvers, which
simply ignore the question and lead to a long timeout waiting for the response
to come back.

Rather than ship this opt-out, it is safer to ship opt-in, and to allow people
to turn on the facility when they have configured it on their network.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
