### PR TITLE
Add "trace" for a couple of failing tests

### DIFF
--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -42,7 +42,7 @@ notify { "mytemp is ${::mytemp}": }
 END
     on master, "chmod 644 #{testdir}/different.pp"
 
-    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose")
+    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --trace")
     on agent, "cat #{atmp}/special_testy"
     assert_match(/special_environment/, stdout, "The file from environment 'special' was not found")
     on agent, "rm -rf #{atmp}"

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -99,7 +99,7 @@ on master, %Q[echo "file { '#{posix_result_file}': source => 'puppet:///modules/
   end
 
   manifest = "file { '#{target}': source => 'puppet:///modules/test_module/test_file.txt', ensure => present }"
-  apply_manifest_on agent, manifest
+  apply_manifest_on agent, manifest, :trace => true
 
   on agent, "cat #{target}" do
     assert_match(/Yay, this is the puppetfile./, stdout, "SECOND: File contents not matched on #{agent}")


### PR DESCRIPTION
We have been unable to reproduce these tests locally, so
a trace would be very helpful.
