### PR TITLE
Apply commit from master that varies ports during tests

### DIFF
--- a/spec/integration/network/server/mongrel_spec.rb
+++ b/spec/integration/network/server/mongrel_spec.rb
@@ -1,24 +1,39 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 require 'puppet/network/server'
-require 'socket'
+require 'net/http'
 
 describe Puppet::Network::Server, :'fails_on_ruby_1.9.2' => true do
   describe "when using mongrel", :if => Puppet.features.mongrel? do
 
+    # This reduces the odds of conflicting port numbers between concurrent runs
+    # of the suite on the same machine dramatically.
+    def port
+      20001 + ($$ % 40000)
+    end
+
     before :each do
       Puppet[:servertype] = 'mongrel'
       Puppet[:server] = '127.0.0.1'
-      @params = { :port => 34346, :handlers => [ :node ] }
+      @params = { :port => port, :handlers => [ :node ] }
       @server = Puppet::Network::Server.new(@params)
     end
 
-    after { Puppet.settings.clear }
+    after :each do
+      @server.unlisten if @server.listening?
+    end
+
+    describe "before listening" do
+      it "should not be reachable at the specified address and port" do
+        lambda { Net::HTTP.get('127.0.0.1', '/', port) }.
+          should raise_error(Errno::ECONNREFUSED)
+      end
+    end
 
     describe "when listening" do
       it "should be reachable on the specified address and port" do
         @server.listen
-        lambda { TCPSocket.new('127.0.0.1', 34346) }.should_not raise_error
+        expect { Net::HTTP.get('127.0.0.1', '/', port) }.should_not raise_error
       end
 
       it "should default to '127.0.0.1' as its bind address" do
@@ -47,12 +62,9 @@ describe Puppet::Network::Server, :'fails_on_ruby_1.9.2' => true do
       it "should not be reachable on the port and address assigned" do
         @server.listen
         @server.unlisten
-        lambda { TCPSocket.new('127.0.0.1', 34346) }.should raise_error(Errno::ECONNREFUSED)
+        expect { Net::HTTP.get('127.0.0.1', '/', port) }.
+          should raise_error Errno::ECONNREFUSED
       end
-    end
-
-    after :each do
-      @server.unlisten if @server.listening?
     end
   end
 end

--- a/spec/integration/network/server/webrick_spec.rb
+++ b/spec/integration/network/server/webrick_spec.rb
@@ -7,17 +7,24 @@ require 'socket'
 describe Puppet::Network::Server, :unless => Puppet.features.microsoft_windows? do
   include PuppetSpec::Files
 
+  # This reduces the odds of conflicting port numbers between concurrent runs
+  # of the suite on the same machine dramatically.
+  def port
+    20000 + ($$ % 40000)
+  end
+
   describe "when using webrick" do
     before :each do
       Puppet[:servertype] = 'webrick'
       Puppet[:server] = '127.0.0.1'
-      @params = { :port => 34343, :handlers => [ :node ], :xmlrpc_handlers => [ :status ] }
+      @params = { :port => port, :handlers => [ :node ] }
 
       # Get a safe temporary file
       dir = tmpdir("webrick_integration_testing")
 
       Puppet.settings[:confdir] = dir
       Puppet.settings[:vardir] = dir
+      Puppet.settings[:logdir] = dir
       Puppet.settings[:group] = Process.gid
 
       Puppet::SSL::Host.ca_location = :local
@@ -34,15 +41,15 @@ describe Puppet::Network::Server, :unless => Puppet.features.microsoft_windows? 
 
     describe "before listening" do
       it "should not be reachable at the specified address and port" do
-        lambda { TCPSocket.new('127.0.0.1', 34343) }.should raise_error
+        lambda { TCPSocket.new('127.0.0.1', port) }.should raise_error
       end
     end
 
     describe "when listening" do
       it "should be reachable on the specified address and port" do
-        @server = Puppet::Network::Server.new(@params.merge(:port => 34343))
+        @server = Puppet::Network::Server.new(@params.merge(:port => port))
         @server.listen
-        lambda { TCPSocket.new('127.0.0.1', 34343) }.should_not raise_error
+        lambda { TCPSocket.new('127.0.0.1', port) }.should_not raise_error
       end
 
       it "should default to '0.0.0.0' as its bind address" do
@@ -53,16 +60,16 @@ describe Puppet::Network::Server, :unless => Puppet.features.microsoft_windows? 
 
       it "should use any specified bind address" do
         Puppet[:bindaddress] = "127.0.0.1"
-        @server = Puppet::Network::Server.new(@params.merge(:port => 34343))
+        @server = Puppet::Network::Server.new(@params.merge(:port => port))
         @server.stubs(:unlisten) # we're breaking listening internally, so we have to keep it from unlistening
         @server.send(:http_server).expects(:listen).with { |args| args[:address] == "127.0.0.1" }
         @server.listen
       end
 
       it "should not allow multiple servers to listen on the same address and port" do
-        @server = Puppet::Network::Server.new(@params.merge(:port => 34343))
+        @server = Puppet::Network::Server.new(@params.merge(:port => port))
         @server.listen
-        @server2 = Puppet::Network::Server.new(@params.merge(:port => 34343))
+        @server2 = Puppet::Network::Server.new(@params.merge(:port => port))
         lambda { @server2.listen }.should raise_error
       end
 
@@ -73,10 +80,10 @@ describe Puppet::Network::Server, :unless => Puppet.features.microsoft_windows? 
 
     describe "after unlistening" do
       it "should not be reachable on the port and address assigned" do
-        @server = Puppet::Network::Server.new(@params.merge(:port => 34343))
+        @server = Puppet::Network::Server.new(@params.merge(:port => port))
         @server.listen
         @server.unlisten
-        lambda { TCPSocket.new('127.0.0.1', 34343) }.should raise_error(Errno::ECONNREFUSED)
+        lambda { TCPSocket.new('127.0.0.1', port) }.should raise_error(Errno::ECONNREFUSED)
       end
     end
   end


### PR DESCRIPTION
This is basically a cherry-pick of

ceee8a185250bb6b5f52e56c7ed9457408b6cb0a

from master, which should provide enough variance in
the ports used for webrick/mongrel spec tests to
reduce or eliminate the transient "address already
in use" failures
