### PR TITLE
(#14440) Fix rake manpage generation in master

### DIFF
--- a/tasks/rake/manpages.rake
+++ b/tasks/rake/manpages.rake
@@ -42,7 +42,7 @@ task :gen_manpages do
 #   IO.popen("#{ronn} #{ronn_args} > ./man/man5/puppet.conf.5", 'w') do |fh|
 #     fh.write %x{RUBYLIB=./lib:$RUBYLIB bin/puppetdoc --reference configuration}
 #   end
-  %x{RUBYLIB=./lib:$RUBYLIB bin/puppetdoc --reference configuration > ./man/man5/puppetconf.5.ronn}
+  %x{RUBYLIB=./lib:$RUBYLIB bin/puppet doc --reference configuration > ./man/man5/puppetconf.5.ronn}
   %x{#{ronn} #{ronn_args} ./man/man5/puppetconf.5.ronn}
   FileUtils.mv("./man/man5/puppetconf.5", "./man/man5/puppet.conf.5")
   FileUtils.rm("./man/man5/puppetconf.5.ronn")


### PR DESCRIPTION
This commit does some hacky initialization things
which, in an ideal world, would be handled
by our API rather than spilling out to the calling
code.  However, for now, these initialization calls
are necessary in order to get rake manpage generation
working.
