### PR TITLE
Re-enable this test to work on windows

### DIFF
--- a/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
+++ b/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
@@ -1,7 +1,5 @@
 test_name "ENC still allows a node to override a topscope var"
 
-confine :except, :platform => 'windows'
-
 testdir = master.tmpdir('scoping_deprecation')
 
 create_remote_file(master, "#{testdir}/puppet.conf", <<END)


### PR DESCRIPTION
The reason the test wasn't working and why it was changed to not execute
was that the test environment was mis-configured (the hostname of the
windows agent was different from what the puppet master knew as that
machine's name).

NOTE: THIS WILL CAUSE ACCEPTANCE TESTS TO FAIL UNTIL THE WINDOWS VM IS FIXED!
