### PR TITLE
Support for DragonFly BSD

### DIFF
--- a/lib/puppet/provider/group/pw.rb
+++ b/lib/puppet/provider/group/pw.rb
@@ -1,12 +1,12 @@
 require 'puppet/provider/nameservice/pw'
 
 Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService::PW do
-  desc "Group management via `pw` on FreeBSD."
+  desc "Group management via `pw` on FreeBSD and DragonFly BSD."
 
   commands :pw => "pw"
   has_features :manages_members
 
-  defaultfor :operatingsystem => :freebsd
+  defaultfor :operatingsystem => [:freebsd, :dragonfly]
 
   options :members, :flag => "-M", :method => :mem
 

--- a/lib/puppet/provider/package/pkgin.rb
+++ b/lib/puppet/provider/package/pkgin.rb
@@ -5,6 +5,8 @@ Puppet::Type.type(:package).provide :pkgin, :parent => Puppet::Provider::Package
 
   commands :pkgin => "pkgin"
 
+  defaultfor :operatingsystem => :dragonfly
+
   has_feature :installable, :uninstallable
 
   def self.parse_pkgin_line(package, force_status=nil)

--- a/lib/puppet/provider/service/bsd.rb
+++ b/lib/puppet/provider/service/bsd.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:service).provide :bsd, :parent => :init do
 
   EOT
 
-  confine :operatingsystem => [:freebsd, :netbsd, :openbsd]
+  confine :operatingsystem => [:freebsd, :netbsd, :openbsd, :dragonfly]
 
   def rcconf_dir
     '/etc/rc.conf.d'

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   end
 
   case Facter["operatingsystem"].value
-  when "FreeBSD"
+  when "FreeBSD", "DragonFly"
     @defpath = ["/etc/rc.d", "/usr/local/etc/rc.d"]
   when "HP-UX"
     @defpath = "/sbin/init.d"

--- a/lib/puppet/provider/user/pw.rb
+++ b/lib/puppet/provider/user/pw.rb
@@ -2,12 +2,12 @@ require 'puppet/provider/nameservice/pw'
 require 'open3'
 
 Puppet::Type.type(:user).provide :pw, :parent => Puppet::Provider::NameService::PW do
-  desc "User management via `pw` on FreeBSD."
+  desc "User management via `pw` on FreeBSD and DragonFly BSD."
 
   commands :pw => "pw"
   has_features :manages_homedir, :allows_duplicates, :manages_passwords, :manages_expiry
 
-  defaultfor :operatingsystem => :freebsd
+  defaultfor :operatingsystem => [:freebsd, :dragonfly]
 
   options :home, :flag => "-d", :method => :dir
   options :comment, :method => :gecos

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -217,7 +217,7 @@ module Puppet
       newvalues(:true, :false)
       defaultto do
         case Facter.value(:operatingsystem)
-        when "FreeBSD", "Darwin", "AIX"
+        when "FreeBSD", "Darwin", "AIX", "DragonFly"
           false
         else
           true

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -172,7 +172,7 @@ class Puppet::Util::FileType
 
     # Remove a specific @path's cron tab.
     def remove
-      if %w{Darwin FreeBSD}.include?(Facter.value("operatingsystem"))
+      if %w{Darwin FreeBSD DragonFly}.include?(Facter.value("operatingsystem"))
         %x{/bin/echo yes | #{cmdbase} -r 2>/dev/null}
       else
         %x{#{cmdbase} -r 2>/dev/null}

--- a/spec/integration/provider/service/init_spec.rb
+++ b/spec/integration/provider/service/init_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 provider = Puppet::Type.type(:service).provider(:init)
 
 describe provider do
-  describe "when running on FreeBSD", :if => (Facter.value(:operatingsystem) == "FreeBSD") do
+  describe "when running on FreeBSD", :if => (%w{FreeBSD DragonFly}.include?(Facter.value(:operatingsystem))) do
     it "should set its default path to include /etc/rc.d and /usr/local/etc/rc.d" do
       provider.defpath.should == ["/etc/rc.d", "/usr/local/etc/rc.d"]
     end

--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
   end
 
   def provider_name(os)
-    {"Ubuntu" => :apt, "Debian" => :apt, "Darwin" => :pkgdmg, "RedHat" => :up2date, "Fedora" => :yum, "FreeBSD" => :ports, "OpenBSD" => :openbsd, "Solaris" => :sun}[os]
+    {"Ubuntu" => :apt, "Debian" => :apt, "Darwin" => :pkgdmg, "RedHat" => :up2date, "Fedora" => :yum, "FreeBSD" => :ports, "OpenBSD" => :openbsd, "Solaris" => :sun, "DragonFly" => :pkgin}[os]
   end
 
   it "should have a default provider" do

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -35,6 +35,14 @@ OUTPUT
     @provider.rcvar.should == ['# ntpd', 'ntpd_enable="YES"', '#   (default: "")']
   end
 
+  it "should correctly parse rcvar for DragonFly BSD" do
+    @provider.stubs(:execute).returns <<OUTPUT
+# ntpd
+$ntpd=YES
+OUTPUT
+    @provider.rcvar.should == ['# ntpd', 'ntpd=YES']
+  end
+
   it "should find the right rcvar_value for FreeBSD < 7" do
     @provider.stubs(:rcvar).returns(['# ntpd', 'ntpd_enable=YES'])
 


### PR DESCRIPTION
This patch adds support for DragonFly BSD.

As DragonFly is an offspring of FreeBSD, most of the assumptions for
FreeBSD are valid for DragonFly BSD. The only notable exception is
package management, which is performed using pkgin.

While implementing, a missing function in the FreeBSD service
provider has been noted (and implemented).
