### PR TITLE
Ticket/3.0rc/14514 use default config when hiera.yaml is missing

### DIFF
--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -15,8 +15,22 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
 
   private
 
+  def self.hiera_config
+    hiera_config = Puppet.settings[:hiera_config]
+    config = {}
+
+    if File.exist?(hiera_config)
+      config = Hiera::Config.load(hiera_config)
+    else
+      Puppet.warning "Config file #{hiera_config} not found, using Hiera defaults"
+    end
+
+    config[:logger] = 'puppet'
+    config
+  end
+
   def self.hiera
-    @hiera || Hiera.new(:config => Puppet.settings[:hiera_config])
+    @hiera ||= Hiera.new(:config => hiera_config)
   end
 
   def hiera


### PR DESCRIPTION
Puppet initializes Hiera using a configuration Hash instead of a
configuration file. Puppet now checks for the existence of the hiera
configuration file and uses an empty configuration and logs a warning
if missing.

We also ensure Hiera uses the Puppet logger by overriding the
configuration hash to set the logger explicitly.

This patch includes updated specs.
