### PR TITLE
(#14598) Add SSL support for forge interaction

### DIFF
--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -34,7 +34,7 @@ class Puppet::Forge
   # ]
   #
   def search(term)
-    server = Puppet.settings[:module_repository].sub(/^(?!https?:\/\/)/, 'http://')
+    server = Puppet.settings[:module_repository]
     Puppet.notice "Searching #{server} ..."
     response = repository.make_http_request("/modules.json?q=#{URI.escape(term)}")
 

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -1,4 +1,4 @@
-require 'net/http'
+require 'net/https'
 require 'digest/sha1'
 require 'uri'
 
@@ -13,7 +13,7 @@ class Puppet::Forge
     # The agent will report +consumer_version+ in the User-Agent to
     # the repository.
     def initialize(url, consumer_version)
-      @uri = url.is_a?(::URI) ? url : ::URI.parse(url.sub(/^(?!https?:\/\/)/, 'http://'))
+      @uri = url.is_a?(::URI) ? url : ::URI.parse(url)
       @cache = Cache.new(self)
       @consumer_version = consumer_version
     end
@@ -66,10 +66,15 @@ class Puppet::Forge
     # Return a Net::HTTPResponse read from this HTTPRequest +request+.
     def read_response(request)
       begin
-        Net::HTTP::Proxy(
-            http_proxy_host,
-            http_proxy_port
-            ).start(@uri.host, @uri.port) do |http|
+        proxy_class = Net::HTTP::Proxy(http_proxy_host, http_proxy_port)
+        proxy = proxy_class.new(@uri.host, @uri.port)
+
+        if @uri.scheme == 'https'
+          proxy.use_ssl = true
+          proxy.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        end
+
+        proxy.start do |http|
           http.request(request)
         end
       rescue Errno::ECONNREFUSED, SocketError


### PR DESCRIPTION
This patch turn on SSL support when an HTTPS url is provided.
