### PR TITLE
#14599 Handle ENOTDIR in file resource

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -724,6 +724,8 @@ Puppet::Type.newtype(:file) do
       ::File.send(method, self[:path])
     rescue Errno::ENOENT => error
       nil
+    rescue Errno::ENOTDIR => error
+      nil
     rescue Errno::EACCES => error
       warning "Could not stat; permission denied"
       nil

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -70,6 +70,31 @@ describe Puppet::Type.type(:file) do
     File.should_not be_exist(path)
   end
 
+  describe "when ensure is absent" do
+    it "should remove the file if present" do
+      FileUtils.touch(path)
+      catalog.add_resource(described_class.new(:path => path, :ensure => :absent, :backup => :false))
+      report = catalog.apply.report
+      report.resource_statuses["File[#{path}]"].should_not be_failed
+      File.should_not be_exist(path)
+    end
+
+    it "should do nothing if file is not present" do
+      catalog.add_resource(described_class.new(:path => path, :ensure => :absent, :backup => :false))
+      report = catalog.apply.report
+      report.resource_statuses["File[#{path}]"].should_not be_failed
+      File.should_not be_exist(path)
+    end
+
+    # issue #14599
+    it "should not fail if parts of path aren't directories" do
+      FileUtils.touch(path)
+      catalog.add_resource(described_class.new(:path => File.join(path,'no_such_file'), :ensure => :absent, :backup => :false))
+      report = catalog.apply.report
+      report.resource_statuses["File[#{File.join(path,'no_such_file')}]"].should_not be_failed
+    end
+  end
+
   describe "when setting permissions" do
     it "should set the owner" do
       FileUtils.touch(path)

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1112,6 +1112,15 @@ describe Puppet::Type.type(:file) do
       File.chmod(0777, dir)
     end
 
+    it "should return nil if parts of path are no directories" do
+      regular_file = tmpfile('ENOTDIR_test')
+      FileUtils.touch(regular_file)
+      impossible_child = File.join(regular_file, 'some_file')
+
+      file[:path] = impossible_child
+      file.stat.should be_nil
+    end
+
     it "should return the stat instance" do
       file.stat.should be_a(File::Stat)
     end


### PR DESCRIPTION
If a file resource is used with a path where a component of path is not
a directory, the stat systemcall can raise the error Errno::ENOTDIR
which was not handled by the file type.

This can lead to the following error (if e.g /tmp/xx is a normal file)

```
err: /Stage[main]//File[/tmp/xx/yy/zz/1]: Could not evaluate: Not a
directory - /tmp/xx/yy/zz/1
```

Catch the error and return nil in the stat method like we do for absent
files or file where we do not have the permission to stat.

Puppet will still raise errors when trying to create such a file of
course like

```
err: /Stage[main]//File[/etc/fstab/foo]/ensure: change from absent to
file failed: Could not set 'file on ensure: Not a directory -
/etc/fstab/foo at line
```

But something like

```
puppet apply -ve 'file { "/etc/fstab/foo": ensure => absent}'
```

will now work without errors because `/etc/fstab/foo` is indeed absent.
