### PR TITLE
* Prototype for #7243

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -637,6 +637,15 @@ EOT
         autosigns any key request, and is a very bad idea), false (which
         never autosigns any key request), and the path to a file, which
         uses that configuration file to determine which keys to sign."},
+    :allow_csr_attributes => {
+      :default => false,
+      :type => :boolean,
+      :desc => "Whether to allow CSR attributes.",
+    },
+    :csr_attributes_file => { :default => "$confdir/csrattributes.yaml",
+      :type => :file,
+      :mode => 0644,
+      :desc => "YAML File to hold any attributes that should be added to the CSR."},
     :allow_duplicate_certs => {
       :default    => false,
       :type       => :boolean,


### PR DESCRIPTION
This adds the ability to add arbitrary attributes to Puppet certificate
requests. It is controlled by setting the allow_csr_attributes setting
in the puppet.conf configuration file on the Puppet agent.

```
allow_csr_attributes = true
```

This option defaults to false. If set to true it looks for a YAML file,
csrattributes.yaml, located by default in /etc/puppet but location is
controllable via the csr_attributes_file option in puppet.conf.

Inside this file you can speicfy a list of OIDs and values in the form
of a YAML hash, for example:

```

---
1.3.6.1.4.1.34380.2.1: 'attrval1'
1.3.6.1.4.1.34380.2.2: 'attrval2'
```

When the Puppet CSR is generated these values will be added to the CSR
that is passed to the Puppet master. You can then inspect them using:

```
openssl req -in name.of.csr.file.pem -noout -text
```

This will return the detailed certificate request and you should see in
the attributes section:

```
Attributes:
    testoid1                 :unable to print attribute
    testoid2                 :unable to print attribute
```

This is entirely prototype code and breaks no tests but also I've added no
tests.
