### PR TITLE
Bug/master/14609 cant run under passenger

### DIFF
--- a/ext/rack/files/config.ru
+++ b/ext/rack/files/config.ru
@@ -10,7 +10,22 @@ $0 = "master"
 # ARGV << "--debug"
 
 ARGV << "--rack"
-require 'puppet/application/master'
+
+
+# NOTE: it's unfortunate that we have to use the "CommandLine" class
+#  here to launch the app, but it contains some initialization logic
+#  (such as triggering the parsing of the config file) that is very
+#  important.  We should do something less nasty here when we've
+#  gotten our API and settings initialization logic cleaned up.
+#
+# Also note that the "$0 = master" line up near the top here is
+#  the magic that allows the CommandLine class to know that it's
+#  supposed to be running master.
+#
+# --cprice 2012-05-22
+
+require 'puppet/util/command_line'
 # we're usually running inside a Rack::Builder.new {} block,
 # therefore we need to call run *here*.
-run Puppet::Application[:master].run
+run Puppet::Util::CommandLine.new.execute
+


### PR DESCRIPTION
There is some initialization that happens in CommandLine.rb
(such as parsing the puppet config file) which was being
bypassed when launching puppetmaster as a Rack/Passenger app.

This commit tweaks the rack config to call into CommandLine
directly, which is unfortunate but works for now.
