### PR TITLE
Fixed #14660 - Queries do not use source attribute

### DIFF
--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -92,7 +92,7 @@ describe provider_class do
       #gemlist is used for retrieving both local and remote version numbers, and there are cases
       # (particularly local) where it makes sense for it to return an array.  That doesn't make
       # sense for '#latest', though.
-      provider.class.expects(:gemlist).with({ :justme => 'myresource'}).returns({
+      provider.class.expects(:gemlist).with({ :source => nil, :justme => 'myresource'}).returns({
           :name     => 'myresource',
           :ensure   => ["3.0"],
           :provider => :gem,


### PR DESCRIPTION
The gem provider takes the source attribute into account
when installing a gem but not when querying the current state
of a gem. Hence if a newer version of a gem exists in an outside
source then it is not found by the querying and hence not installed.
Worse, if a lower version of a gem exists in an external gem source
then Puppet will actually downgrade the gem.
