### PR TITLE
(maint) Make 3.0.x work with rspec-puppet

### DIFF
--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -135,6 +135,7 @@ module Puppet::Test
           :confdir    => "/dev/null",
           :vardir     => "/dev/null",
           :rundir     => "/dev/null",
+          :hiera_config => "/dev/null",
       }
     end
     private_class_method :app_defaults_for_tests


### PR DESCRIPTION
Without this patch applied Hiera tries to load a file that does not
exist when running spec tests with rspec-puppet.

The error message without this patch looks like:

```
  1) ntp test platform specific resources for operating system centos should allow package ensure to be overridden
     Failure/Error: subject.should contain_package('ntp').with_ensure('latest')
     Puppet::Error:
       Puppet::Parser::AST::Resource failed with error RuntimeError: Config file /dev/null/hiera.yaml not found at line 3 on node maynard.puppetlab
s.lan
     # /vagrant/src/hiera/lib/hiera/config.rb:17:in `load'
```

This patch fixes the problem by setting the hiera_config setting to /dev/null
explicitly in the TestHelper class.  This is a file that should exist which
will avoid the exception coming out of the hiera library.
