### PR TITLE
Fixed #11989 - Changed confine on upstart service provider

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -4,9 +4,8 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   This provider manages `upstart` jobs, which have replaced `initd` services
   on Ubuntu. For `upstart` documentation, see <http://upstart.ubuntu.com/>.
   "
-  # confine to :ubuntu for now because I haven't tested on other platforms
-  confine :operatingsystem => :ubuntu #[:ubuntu, :fedora, :debian]
-  
+  confine :osfamily => [ :debian, :redhat ]
+
   defaultfor :operatingsystem => :ubuntu
 
   commands :start   => "/sbin/start",


### PR DESCRIPTION
Upstart is now valid on a variety of systems including CentOS 6
and Red Hat 6. Changing the confine from operatingsystem to osfamily
and making the confine cover the Debian and RedHat families of
operating systems.
