### PR TITLE
Update redhat init scripts

### DIFF
--- a/conf/redhat/client.init
+++ b/conf/redhat/client.init
@@ -16,14 +16,14 @@ export PATH
 [ -f /etc/sysconfig/puppet ] && . /etc/sysconfig/puppet
 lockfile=${LOCKFILE-/var/lock/subsys/puppet}
 pidfile=${PIDFILE-/var/run/puppet/agent.pid}
-puppetd=${PUPPETD-/usr/sbin/puppetd}
+puppetd=${PUPPETD-/usr/bin/puppet}
 RETVAL=0
 
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-PUPPET_OPTS=""
-[ -n "${PUPPET_SERVER}" ] && PUPPET_OPTS="--server=${PUPPET_SERVER}"
+PUPPET_OPTS="agent "
+[ -n "${PUPPET_SERVER}" ] && PUPPET_OPTS="${PUPPET_OPTS} --server=${PUPPET_SERVER}"
 [ -n "$PUPPET_LOG" ] && PUPPET_OPTS="${PUPPET_OPTS} --logdest=${PUPPET_LOG}"
 [ -n "$PUPPET_PORT" ] && PUPPET_OPTS="${PUPPET_OPTS} --masterport=${PUPPET_PORT}"
 
@@ -40,7 +40,7 @@ fi
 ##[ -n "$INIT_VERSION" ] && PUPPET_OPTS="${PUPPET_OPTS} --fullrun"
 
 start() {
-    echo -n $"Starting puppet: "
+    echo -n $"Starting puppet agent: "
     daemon $daemonopts $puppetd ${PUPPET_OPTS} ${PUPPET_EXTRA_OPTS}
     RETVAL=$?
     echo
@@ -49,7 +49,7 @@ start() {
 }
 
 stop() {
-    echo -n $"Stopping puppet: "
+    echo -n $"Stopping puppet agent: "
     killproc $pidopts $puppetd
     RETVAL=$?
     echo
@@ -57,7 +57,7 @@ stop() {
 }
 
 reload() {
-    echo -n $"Restarting puppet: "
+    echo -n $"Restarting puppet agent: "
     killproc $pidopts $puppetd -HUP
     RETVAL=$?
     echo
@@ -80,7 +80,7 @@ rh_status_q() {
 }
 
 genconfig() {
-    echo -n $"Generate configuration puppet: "
+    echo -n $"Generate puppet agent configuration: "
     $puppetd ${PUPPET_OPTS} ${PUPPET_EXTRA_OPTS} --genconfig
 }
 
@@ -106,7 +106,7 @@ case "$1" in
     ;;
     once)
         shift
-        $puppetd -o ${PUPPET_OPTS} ${PUPPET_EXTRA_OPTS} $@
+        $puppetd ${PUPPET_OPTS} --onetime ${PUPPET_EXTRA_OPTS} $@
         ;;
     genconfig)
         genconfig

--- a/conf/redhat/queue.init
+++ b/conf/redhat/queue.init
@@ -13,11 +13,14 @@ export PATH
 [ -f /etc/sysconfig/puppetqueue ] && . /etc/sysconfig/puppetqueue
 lockfile=${LOCKFILE-/var/lock/subsys/puppetqd}
 pidfile=${PIDFILE-/var/run/puppet/queue.pid}
-puppetqd=${PUPPETQD-/usr/sbin/puppetqd}
+puppetqd=${PUPPETQD-/usr/bin/puppet}
 RETVAL=0
 
 # Source function library.
 . /etc/rc.d/init.d/functions
+
+PUPPET_OPTS="queue "
+[ -n "${PUPPET_SERVER}" ] && PUPPET_OPTS="${PUPPET_OPTS} --server=${PUPPET_SERVER}"
 
 # Determine if we can use the -p option to daemon, killproc, and status.
 # RHEL < 5 can't.
@@ -27,8 +30,8 @@ if status | grep -q -- '-p' 2>/dev/null; then
 fi
 
 start() {
-    echo -n $"Starting puppetqd: "
-    daemon $daemonopts $puppetqd
+    echo -n $"Starting puppet queue: "
+    daemon $daemonopts $puppetqd ${PUPPET_OPTS}
     RETVAL=$?
     echo
         [ $RETVAL = 0 ] && touch ${lockfile}
@@ -36,7 +39,7 @@ start() {
 }
 
 stop() {
-    echo -n $"Stopping puppetqd: "
+    echo -n $"Stopping puppet queue: "
     killproc $pidopts $puppetqd
     RETVAL=$?
     echo
@@ -44,7 +47,7 @@ stop() {
 }
 
 reload() {
-    echo -n $"Restarting puppetqd: "
+    echo -n $"Restarting puppet queue: "
     killproc $pidopts $puppetqd -HUP
     RETVAL=$?
     echo
@@ -67,8 +70,8 @@ rh_status_q() {
 }
 
 genconfig() {
-    echo -n $"Generate configuration puppetqd: "
-    $puppetqd --genconfig
+    echo -n $"Generate puppet queue configuration: "
+    $puppetqd ${PUPPET_OPTS} --genconfig
 }
 
 case "$1" in

--- a/conf/redhat/server.init
+++ b/conf/redhat/server.init
@@ -22,10 +22,10 @@ if [ -f /etc/sysconfig/puppetmaster ]; then
     . /etc/sysconfig/puppetmaster
 fi
 
-PUPPETMASTER_OPTS=""
-[ -n "$PUPPETMASTER_MANIFEST" ] && PUPPETMASTER_OPTS="--manifest=${PUPPETMASTER_MANIFEST}"
+PUPPETMASTER_OPTS="master "
+[ -n "$PUPPETMASTER_MANIFEST" ] && PUPPETMASTER_OPTS="${PUPPETMASTER_OPTS} --manifest=${PUPPETMASTER_MANIFEST}"
 if [ -n "$PUPPETMASTER_PORTS" ] && [ ${#PUPPETMASTER_PORTS[@]} -gt 1 ]; then
-    PUPPETMASTER_OPTS="$PUPPETMASTER_OPTS --servertype=mongrel"
+    PUPPETMASTER_OPTS="${PUPPETMASTER_OPTS} --servertype=mongrel"
 elif [ -n "$PUPPETMASTER_PORTS" ] && [ ${#PUPPETMASTER_PORTS[@]} -eq 1 ]; then
     PUPPETMASTER_OPTS="${PUPPETMASTER_OPTS} --masterport=${PUPPETMASTER_PORTS[0]}"
 fi
@@ -43,7 +43,7 @@ fi
 RETVAL=0
 
 prog=puppetmasterd
-PUPPETMASTER=/usr/sbin/$prog
+PUPPETMASTER=/usr/bin/puppet
 
 start() {
     echo -n $"Starting puppetmaster: "


### PR DESCRIPTION
The redhat init scripts still referenced binaries which have been deprecated
for at least a major release and removed in Telly. This commit updates those
init scripts to use the appropriate puppet calls, updates the daemon call to
reference the correct binary, and corrects some of the passed arguments.
