### PR TITLE
Bug/2.7.x/3984 better handling of selinux warnings

### DIFF
--- a/lib/puppet/type/file/selcontext.rb
+++ b/lib/puppet/type/file/selcontext.rb
@@ -48,9 +48,13 @@ module Puppet
     def insync?(value)
       if not selinux_support?
         debug("SELinux bindings not found. Ignoring parameter.")
-        return true
+        true
+      elsif not selinux_label_support?(@resource[:path])
+        debug("SELinux not available for this filesystem. Ignoring parameter.")
+        true
+      else
+        super
       end
-      super
     end
 
     def sync


### PR DESCRIPTION
This recovers an old patch that slipped between the cracks in the transition from patchwork to GitHub pull requests.  It is being submitted as a pull request to get it back into our usual system of work.

It is clearly incomplete: it has absolutely no testing, and no validation that the problem would previously have occurred, so those will need to be written before the code can actually be added to the system.

Volumes that don't suport SELinux should be considered in_sync so they don't
generate spurious change notice.

Patch from Darrell Fuhriman
