### PR TITLE
Resolve #11042 

### DIFF
--- a/lib/puppet/provider/ldap.rb
+++ b/lib/puppet/provider/ldap.rb
@@ -46,7 +46,11 @@ class Puppet::Provider::Ldap < Puppet::Provider
     @property_hash[:ensure] = :present
     self.class.resource_type.validproperties.each do |property|
       if val = resource.should(property)
-        @property_hash[property] = val
+        if property.to_s == 'gid'
+          self.gid = val
+        else
+          @property_hash[property] = val
+        end
       end
     end
   end

--- a/spec/unit/provider/user/ldap_spec.rb
+++ b/spec/unit/provider/user/ldap_spec.rb
@@ -24,14 +24,6 @@ describe provider_class do
     provider_class.should be_manages_passwords
   end
 
-  it "should use the ldap group provider to convert group names to numbers" do
-    provider = provider_class.new(:name => "foo")
-    Puppet::Type.type(:group).provider(:ldap).expects(:name2id).with("bar").returns 10
-
-    provider.gid = 'bar'
-    provider.gid.should == 10
-  end
-
   {:name => "uid",
     :password => "userPassword",
     :comment => "cn",
@@ -53,10 +45,13 @@ describe provider_class do
     end
 
     it "should generate the sn as the last field of the cn" do
+      Puppet::Type.type(:group).provider(:ldap).expects(:name2id).with(["whatever"]).returns [123]
+
       resource = stub 'resource', :should => %w{whatever}
       resource.stubs(:should).with(:comment).returns ["Luke Kanies"]
       resource.stubs(:should).with(:ensure).returns :present
       instance = provider_class.new(:name => "luke", :ensure => :absent)
+
       instance.stubs(:resource).returns resource
 
       @connection.expects(:add).with { |dn, attrs| attrs["sn"] == ["Kanies"] }
@@ -65,8 +60,25 @@ describe provider_class do
       instance.flush
     end
 
+    it "should translate a group name to the numeric id" do
+      Puppet::Type.type(:group).provider(:ldap).expects(:name2id).with("bar").returns 101
+
+      resource = stub 'resource', :should => %w{whatever}
+      resource.stubs(:should).with(:gid).returns 'bar'
+      resource.stubs(:should).with(:ensure).returns :present
+      instance = provider_class.new(:name => "luke", :ensure => :absent)
+      instance.stubs(:resource).returns resource
+
+      @connection.expects(:add).with { |dn, attrs| attrs["gidNumber"] == ["101"] }
+
+      instance.create
+      instance.flush
+    end
+
     describe "with no uid specified" do
       it "should pick the first available UID after the largest existing UID" do
+        Puppet::Type.type(:group).provider(:ldap).expects(:name2id).with(["whatever"]).returns [123]
+
         low = {:name=>["luke"], :shell=>:absent, :uid=>["600"], :home=>["/h"], :gid=>["1000"], :password=>["blah"], :comment=>["l k"]}
         high = {:name=>["testing"], :shell=>:absent, :uid=>["640"], :home=>["/h"], :gid=>["1000"], :password=>["blah"], :comment=>["t u"]}
         provider_class.manager.expects(:search).returns([low, high])
@@ -84,6 +96,8 @@ describe provider_class do
       end
 
       it "should pick 501 of no users exist" do
+        Puppet::Type.type(:group).provider(:ldap).expects(:name2id).with(["whatever"]).returns [123]
+
         provider_class.manager.expects(:search).returns nil
 
         resource = stub 'resource', :should => %w{whatever}


### PR DESCRIPTION
I’ve just pushed https://github.com/nhemingway/puppet/commit/b5b292d09ed283a0e2930ee7cfedf8fa64108a8c. Is this the kind of thing you were looking for?

Incidentally, I now notice that puppet is spamming the log because @should=&lt;groupname&gt;, whereas is=&lt;gid&gt;, and it thinks they don’t match. I’ve investigated a couple of ways of teaching puppet that they do match, but I’m not convinced I’ve got the best place.

The first solution I tried was to convert the gid back to the groupname in Puppet::Type::user using is_to_s and should_to_s.

My second try replaced the call of Puppet::util.gid with one to a new function provider.group2id, but: (a) this would also require adding support functions to the other providers and I’ve no means of testing those (b) I wasn’t sure whether it was a design decision to indirect through posix to ensure that not only does the group exist in ldap, but that the local machine can also see it.
