### PR TITLE
Disable upstart spec windows

### DIFF
--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:service).provider(:upstart)
 
-describe provider_class do
+describe provider_class, :unless => Puppet.features.microsoft_windows? do
   let(:manual) { "\nmanual" }
   let(:start_on_default_runlevels) {  "\nstart on runlevel [2,3,4,5]" }
 


### PR DESCRIPTION
replace_file is disabled on windows, so the upstart spec test fails when the
provider calls out to replace_file. This commit confines the test to
non-windows platforms, where replace_file is defined.
