### PR TITLE
Ticket/2.7rc/14761 add excludes for sles services to redhat provider

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
 
   def self.instances
     # this exclude list is all from /sbin/service (5.x), but I did not exclude kudzu
-    self.get_services(['/etc/init.d'], ['functions', 'halt', 'killall', 'single', 'linuxconf'])
+    self.get_services(['/etc/init.d'], ['functions', 'halt', 'killall', 'single', 'linuxconf', 'reboot', 'boot'])
   end
 
   def self.defpath

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -24,8 +24,8 @@ describe provider_class, :as_platform => :posix do
   # test self.instances
   describe "when getting all service instances" do
     before :each do
-      @services = ['one', 'two', 'three', 'four', 'kudzu', 'functions', 'halt', 'killall', 'single', 'linuxconf']
-      @not_services = ['functions', 'halt', 'killall', 'single', 'linuxconf']
+      @services = ['one', 'two', 'three', 'four', 'kudzu', 'functions', 'halt', 'killall', 'single', 'linuxconf', 'boot', 'reboot']
+      @not_services = ['functions', 'halt', 'killall', 'single', 'linuxconf', 'reboot', 'boot']
       Dir.stubs(:entries).returns @services
       FileTest.stubs(:directory?).returns(true)
       FileTest.stubs(:executable?).returns(true)


### PR DESCRIPTION
On sles, the reboot init script would be triggered during a `puppet resource
service` call, which would ignore the status argument and proceed to reboot the
system. It would also call the boot init script, which could hang the puppet
call indefinitely. This commit adds both the boot and reboot services to the
redhat provider's exclude list. It also updates the redhat provider spec test
to test for those changes.
