### PR TITLE
Makes the apt provider not uninstall conflicting packages automatically during package install.

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     should = @resource[:ensure]
 
     checkforcdrom
-    cmd = %w{-q -y}
+    cmd = %w{-q -y --no-remove}
 
     keep = ""
     if config = @resource[:configfiles]


### PR DESCRIPTION
As puppet installs packages one by one you get into a bad situation if
you try ensure => installed on two conflicting packages. With this patch
that would cause an error on the second package install instead of
silently removing the first.

Tested using this on a debian system:
puppet apply --execute "package { ['sudo','sudo-ldap']: ensure => installed }"

Without this patch that alternates between installing those two packages, and consequently uninstalling the other silently.
