### PR TITLE
(#14378) Skip context-based optimisation for complex expressions

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -159,14 +159,15 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
       debug("Augeas version #{get_augeas_version} is installed") if versioncmp(get_augeas_version, "0.3.6") >= 0
 
+      # Optimize loading if the context is given and it's a simple path,
+      # requires the glob function from Augeas 0.8.2 or up
       glob_avail = !aug.match("/augeas/version/pathx/functions/glob").empty?
+      opt_ctx = resource[:context].match("^/files/[^'\"]+$") if resource[:context]
 
       if resource[:incl]
         aug.set("/augeas/load/Xfm/lens", resource[:lens])
         aug.set("/augeas/load/Xfm/incl", resource[:incl])
-      elsif glob_avail and resource[:context] and resource[:context].match("^/files/")
-        # Optimize loading if the context is given, requires the glob function
-        # from Augeas 0.8.2 or up
+      elsif glob_avail and opt_ctx
         ctx_path = resource[:context].sub(/^\/files(.*?)\/?$/, '\1/')
         load_path = "/augeas/load/*['%s' !~ glob(incl) + regexp('/.*')]" % ctx_path
 

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -690,6 +690,15 @@ describe provider_class do
         aug.match("/files/etc/fstab").should == ["/files/etc/fstab"]
         aug.match("/files/etc/hosts").should == ["/files/etc/hosts"]
       end
+
+      it "should not optimise if the context is a complex path" do
+        @resource[:context] = "/files/*[label()='etc']"
+
+        aug = @provider.open_augeas
+        aug.should_not == nil
+        aug.match("/files/etc/fstab").should == ["/files/etc/fstab"]
+        aug.match("/files/etc/hosts").should == ["/files/etc/hosts"]
+      end
     end
   end
 end


### PR DESCRIPTION
When optimising loaded files based on the context given, the context would be
passed into a path expression itself inside quotes.  If the user had given a
path expression for the context that contained quotes then these would need to
be escaped, which Augeas doesn't support today.

This disables the optimisation when the user supplies a complex context path,
preventing errors caused by improperly quoted paths.
