### PR TITLE
(#14378) Skip context-based optimisation for complex expressions

### DIFF
--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -690,6 +690,15 @@ describe provider_class do
         aug.match("/files/etc/fstab").should == ["/files/etc/fstab"]
         aug.match("/files/etc/hosts").should == ["/files/etc/hosts"]
       end
+
+      it "should not optimise if the context is a complex path" do
+        @resource[:context] = "/files/*[label()='etc']"
+
+        aug = @provider.open_augeas
+        aug.should_not == nil
+        aug.match("/files/etc/fstab").should == ["/files/etc/fstab"]
+        aug.match("/files/etc/hosts").should == ["/files/etc/hosts"]
+      end
     end
   end
 end


### PR DESCRIPTION
When optimising loaded files based on the context given, the context would be
passed into a path expression itself inside quotes.  If the user had given a
path expression for the context that contained quotes then these would need to
be escaped, which Augeas doesn't support today.

This disables the optimisation when the user supplies a complex context path,
preventing errors caused by improperly quoted paths.
