### PR TITLE
(#14852) Fix incorrect parsing of attributes after CN in the DN

### DIFF
--- a/lib/puppet/network/http/mongrel/rest.rb
+++ b/lib/puppet/network/http/mongrel/rest.rb
@@ -86,7 +86,7 @@ class Puppet::Network::HTTP::MongrelREST < Mongrel::HttpHandler
     # JJM #906 The following dn.match regular expression is forgiving
     # enough to match the two Distinguished Name string contents
     # coming from Apache, Pound or other reverse SSL proxies.
-    if dn = params[Puppet[:ssl_client_header]] and dn_matchdata = dn.match(/^.*?CN\s*=\s*(.*)/)
+    if dn = params[Puppet[:ssl_client_header]] and dn_matchdata = dn.match(/^.*?CN\s*=\s*([^\/]*)/)
       result[:node] = dn_matchdata[1].to_str
       result[:authenticated] = (params[Puppet[:ssl_client_verify_header]] == 'SUCCESS')
     else

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -86,7 +86,7 @@ class Puppet::Network::HTTP::RackREST < Puppet::Network::HTTP::RackHttpHandler
     # if we find SSL info in the headers, use them to get a hostname.
     # try this with :ssl_client_header, which defaults should work for
     # Apache with StdEnvVars.
-    if dn = request.env[Puppet[:ssl_client_header]] and dn_matchdata = dn.match(/^.*?CN\s*=\s*(.*)/)
+    if dn = request.env[Puppet[:ssl_client_header]] and dn_matchdata = dn.match(/^.*?CN\s*=\s*([^\/]*)/)
       result[:node] = dn_matchdata[1].to_str
       result[:authenticated] = (request.env[Puppet[:ssl_client_verify_header]] == 'SUCCESS')
     else

--- a/lib/puppet/network/http/rack/xmlrpc.rb
+++ b/lib/puppet/network/http/rack/xmlrpc.rb
@@ -45,7 +45,7 @@ class Puppet::Network::HTTP::RackXMLRPC < Puppet::Network::HTTP::RackHttpHandler
     # if we find SSL info in the headers, use them to get a hostname.
     # try this with :ssl_client_header, which defaults should work for
     # Apache with StdEnvVars.
-    if dn = request.env[Puppet[:ssl_client_header]] and dn_matchdata = dn.match(/^.*?CN\s*=\s*(.*)/)
+    if dn = request.env[Puppet[:ssl_client_header]] and dn_matchdata = dn.match(/^.*?CN\s*=\s*([^\/]*)/)
       node = dn_matchdata[1].to_str
       authenticated = (request.env[Puppet[:ssl_client_verify_header]] == 'SUCCESS')
     else

--- a/lib/puppet/network/http_server/mongrel.rb
+++ b/lib/puppet/network/http_server/mongrel.rb
@@ -102,7 +102,7 @@ module Puppet::Network
       # JJM #906 The following dn.match regular expression is forgiving
       # enough to match the two Distinguished Name string contents
       # coming from Apache, Pound or other reverse SSL proxies.
-      if dn = params[Puppet[:ssl_client_header]] and dn_matchdata = dn.match(/^.*?CN\s*=\s*(.*)/)
+      if dn = params[Puppet[:ssl_client_header]] and dn_matchdata = dn.match(/^.*?CN\s*=\s*([^\/]*)/)
         client = dn_matchdata[1].to_str
         valid = (params[Puppet[:ssl_client_verify_header]] == 'SUCCESS')
       else

--- a/spec/unit/network/http/mongrel/rest_spec.rb
+++ b/spec/unit/network/http/mongrel/rest_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 
 require 'puppet/network/http'
@@ -222,6 +222,13 @@ describe "Puppet::Network::HTTP::MongrelREST", :if => Puppet.features.mongrel?, 
         Puppet.settings.expects(:value).with(:ssl_client_header).returns "myheader"
         @params["myheader"] = "/CN=host.domain.com"
         @handler.params(@request)[:node].should == "host.domain.com"
+      end
+
+      it "should allow attributes following the CN in the DN (#14852)" do
+        Puppet.settings.stubs(:value).returns "eh"
+        Puppet.settings.expects(:value).with(:ssl_client_header).returns "myheader"
+        @params["myheader"] = "/C=UK/ST=Greater London/O=example/CN=mir.example.net/emailAddress=systems@example.net"
+        @handler.params(@request)[:node].should == "mir.example.net"
       end
 
       it "should use the :ssl_client_header to determine the parameter for checking whether the host certificate is valid" do

--- a/spec/unit/network/http/mongrel_spec.rb
+++ b/spec/unit/network/http/mongrel_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 require 'puppet/network/http'
 

--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 require 'puppet/network/http/rack' if Puppet.features.rack?
 require 'puppet/network/http/rack/rest'
@@ -174,6 +174,13 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
         Puppet.settings.expects(:value).with(:ssl_client_header).returns "myheader"
         req = mk_req('/', "myheader" => "/CN=host.domain.com")
         @handler.params(req)[:node].should == "host.domain.com"
+      end
+
+      it "should allow attributes following the CN in the DN (#14852)" do
+        Puppet.settings.stubs(:value).returns "eh"
+        Puppet.settings.expects(:value).with(:ssl_client_header).returns "myheader"
+        req = mk_req('/', "myheader" => "/C=UK/ST=Greater London/O=example/CN=mir.example.net/emailAddress=systems@example.net")
+        @handler.params(req)[:node].should == "mir.example.net"
       end
 
       it "should use the :ssl_client_header to determine the parameter for checking whether the host certificate is valid" do

--- a/spec/unit/network/http/rack/xmlrpc_spec.rb
+++ b/spec/unit/network/http/rack/xmlrpc_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 require 'puppet/network/handler'
 require 'puppet/network/http/rack' if Puppet.features.rack?
@@ -108,6 +108,14 @@ describe "Puppet::Network::HTTP::RackXMLRPC", :if => Puppet.features.rack? do
         Puppet.settings.expects(:value).with(:ssl_client_header).returns "myheader"
         Puppet::Network::ClientRequest.expects(:new).with { |node,ip,authenticated| node == "host.domain.com" }
         req = mk_req "myheader" => "/CN=host.domain.com"
+        @handler.process(req, @response)
+      end
+
+      it "should allow attributes following the CN in the DN (#14852)" do
+        Puppet.settings.stubs(:value).returns "eh"
+        Puppet.settings.expects(:value).with(:ssl_client_header).returns "myheader"
+        Puppet::Network::ClientRequest.expects(:new).with { |node,ip,authenticated| node == "mir.example.net" }
+        req = mk_req "myheader" => "/C=UK/ST=Greater London/O=example/CN=mir.example.net/emailAddress=systems@example.net"
         @handler.process(req, @response)
       end
 


### PR DESCRIPTION
Without this patch applied Puppet does not correctly parse out the
common name attribute from the distinguished name attribute of the
certificate presented by the agent.

This is a problem because some certificates may have attributes
following the CN field.  For example:

```
subject= /C=UK/ST=Greater London/O=example/CN=mir.example.net/emailAddress=systems@example.net
```

Without this patch Puppet incorrectly parses the CN as
"mir.example.net/emailAddress=systems@example.net" when it should be
"mir.example.net"

This patch fixes the problem by changing the greedy "match anything"
regular expression to the greedy "match anything except the /
character."
