### PR TITLE
(#14860) Fix puppet cert exit status on failures

### DIFF
--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -28,6 +28,7 @@ module Puppet
           rescue => detail
             puts detail.backtrace if Puppet[:trace]
             Puppet.err "Could not call #{method}: #{detail}"
+            raise
           end
         end
 

--- a/spec/unit/ssl/certificate_authority/interface_spec.rb
+++ b/spec/unit/ssl/certificate_authority/interface_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 
 require 'puppet/ssl/certificate_authority'
@@ -95,14 +95,14 @@ describe Puppet::SSL::CertificateAuthority::Interface do
       lambda { @applier.apply(@ca) }.should raise_error(Puppet::SSL::CertificateAuthority::Interface::InterfaceError)
     end
 
-    it "should log non-Interface failures rather than failing" do
+    it "should log non-Interface failures" do
       @applier = @class.new(:revoke, :to => :all)
 
       @ca.expects(:list).raises ArgumentError
 
       Puppet.expects(:err)
 
-      lambda { @applier.apply(@ca) }.should_not raise_error
+      lambda { @applier.apply(@ca) }.should raise_error
     end
 
     describe "with an empty array specified and the method is not list" do


### PR DESCRIPTION
Without this patch applied the following command errors out but does not
correctly set the exit status:

```
puppet cert generate foo.bar.com --dns_alt_names foo,foo.bar.com
```

The error returned is:

```
err: Could not call generate: CSR 'pe-internal-broker-test'
  contains subject alternative names (DNS:pe-centos6, \
  DNS:pe-centos6.puppetlabs.vm, DNS:pe-internal-broker-test, \
  DNS:stomp), which are disallowed. Use `puppet cert \
  --allow-dns-alt-names sign pe-internal-broker-test` to sign this \
  request.
```

However, the exit status is 0.

This is a problem because we need to easily detect if certificate
generation from the command line failed or succeeded.  The most natural
and expected way to check this is by looking at the exit status.

The root cause of the problem is that
Puppet::SSL::CertificateAuthority::InterFace#apply incorrectly catches
and masks the exception raised by the generate method because it simply
logs an error with Puppet.err and continues along happily.

This patch fixes the problem by re-raising the error produced by
generate, allowing the application controller to catch the error
appropriately and exit with the non-zero exit status.
