### PR TITLE
(#14789) Fix inconsistent normalization and API in autoloader

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -32,13 +32,13 @@ class Puppet::Util::Autoload
     # we can load downloaded plugins if they've already been loaded
     # into memory.
     def mark_loaded(name, file)
-      name = cleanpath(name)
+      name = cleanpath(name).chomp('.rb')
       $LOADED_FEATURES << name + ".rb" unless $LOADED_FEATURES.include?(name)
       loaded[name] = [file, File.mtime(file)]
     end
 
     def changed?(name)
-      name = cleanpath(name)
+      name = cleanpath(name).chomp('.rb')
       return true unless loaded.include?(name)
       file, old_mtime = loaded[name]
       return true unless file == get_file(name)
@@ -198,6 +198,14 @@ class Puppet::Util::Autoload
   # so that already-loaded files don't get reloaded unnecessarily.
   def loadall
     self.class.loadall(@path)
+  end
+
+  def loaded?(name)
+    self.class.loaded?(File.join(@path, name.to_s))
+  end
+
+  def changed?(name)
+    self.class.changed?(File.join(@path, name.to_s))
   end
 
   def files_to_load

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -92,6 +92,16 @@ describe Puppet::Util::Autoload do
       $LOADED_FEATURES.delete("tmp/myfile.rb")
     end
 
+    it "should be seen by loaded? on the instance using the short name" do
+      File.stubs(:exist?).returns true
+      Kernel.stubs(:load)
+      @autoload.load("myfile")
+
+      @autoload.loaded?("myfile.rb").should be
+
+      $LOADED_FEATURES.delete("tmp/myfile.rb")
+    end
+
     it "should register loaded files with the main loaded file list so they are not reloaded by ruby" do
       File.stubs(:exist?).returns true
       Kernel.stubs(:load)
@@ -166,6 +176,24 @@ describe Puppet::Util::Autoload do
     after :each do
       $LOADED_FEATURES.delete("a/file.rb")
       $LOADED_FEATURES.delete("b/file.rb")
+    end
+
+    it "#changed? should return true for a file that was not loaded" do
+      @autoload.class.changed?(@file_a).should be
+    end
+
+    it "changes should be seen by changed? on the instance using the short name" do
+      File.stubs(:mtime).returns(@first_time)
+      File.stubs(:exist?).returns true
+      Kernel.stubs(:load)
+      @autoload.load("myfile")
+      @autoload.loaded?("myfile").should be
+      @autoload.changed?("myfile").should_not be
+
+      File.stubs(:mtime).returns(@second_time)
+      @autoload.changed?("myfile").should be
+
+      $LOADED_FEATURES.delete("tmp/myfile.rb")
     end
 
     describe "in one directory" do


### PR DESCRIPTION
Since I didn't get around to adding a require method to the autoloader, it
still makes sense to have the loaded? method exposed on instances. I also
added the changed? method, which would be useful in similar situations.
Testing these changes revealed inconsistency about how names are normalized,
which is also fixed in this commit.
