### PR TITLE
Update facter dep to reflect epoch 1

### DIFF
--- a/conf/redhat/puppet.spec
+++ b/conf/redhat/puppet.spec
@@ -6,7 +6,7 @@
 
 Name:           puppet
 Version:        2.7.16
-Release:        0.1rc1%{?dist}
+Release:        0.1rc1.2%{?dist}
 #Release:        1%{?dist}
 Summary:        A network tool for managing many disparate systems
 License:        ASL 2.0
@@ -20,7 +20,7 @@ Group:          System Environment/Base
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:  facter >= 1.5, facter < 2.0
+BuildRequires:  facter >= 1.5, facter < 1:2.0
 BuildRequires:  ruby >= 1.8.5
 
 BuildArch:      noarch
@@ -36,7 +36,7 @@ Requires:       ruby-shadow
 %endif
 %endif
 
-Requires:       facter >= 1.5, facter < 2.0
+Requires:       facter >= 1.5, facter < 1:2.0
 Requires:       ruby >= 1.8.5
 %{!?_without_augeas:Requires: ruby-augeas}
 
@@ -289,6 +289,9 @@ fi
 rm -rf %{buildroot}
 
 %changelog
+* Fri Jun 08 2012 Moses Mendoza <moses@puppetlabs.com> - 2.7.16-0.1rc1.2
+- Updated facter 2.0 dep to include epoch 1
+
 * Wed Jun 06 2012 Matthaus Litteken <matthaus@puppetlabs.com> - 2.7.16-0.1rc1
 - Update for 2.7.16rc1, added generated manpages
 


### PR DESCRIPTION
This commit updates the dependency on facter
to include the epoch 1. Without this commit,
now that facter 1.6.9 is epoch 1, rpm sees
facter 1:1.6.9 as > 2.0.0, preventing puppet
2.7.x from installing on systems with facter
1:1.6.9. This commit resolves this issue.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
