### PR TITLE
Ticket/3.0rc/14900 data bindings does not support hiera puppet backend

### DIFF
--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -9,8 +9,7 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
   end
 
   def find(request)
-    facts = Puppet::Node::Facts.indirection.find(request.options[:host]).values
-    hiera.lookup(request.key, nil, facts, nil, nil)
+    hiera.lookup(request.key, nil, request.options[:scope], nil, nil)
   end
 
   private

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -317,7 +317,7 @@ class Puppet::Resource
       if resource_type.type == :hostclass
         namespaced_param = "#{resource_type.name}::#{param}"
         external_value = Puppet::DataBinding.indirection.find(
-          namespaced_param, :host => scope.host)
+          namespaced_param, :scope => scope)
       end
 
       if external_value.nil?

--- a/spec/unit/indirector/hiera_spec.rb
+++ b/spec/unit/indirector/hiera_spec.rb
@@ -119,10 +119,6 @@ describe Puppet::Indirector::Hiera do
   end
 
   describe "the behavior of the find method", :if => Puppet.features.hiera? do
-    before do
-      Puppet::Node::Facts.indirection.expects(:find).with('foo').
-        returns(facter_obj)
-    end
 
     let(:data_binder) { @hiera_class.new }
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -322,26 +322,26 @@ describe Puppet::Resource do
 
         it "should query the data_binding terminus using a namespaced key" do
           Puppet::DataBinding.indirection.expects(:find).with(
-            'apache::port', :host => 'foo')
+            'apache::port', :scope => @scope)
           resource.set_default_parameters(@scope)
         end
 
-        it "should query the data_binding terminus using the host attribute from the scope" do
+        it "should query the data_binding terminus using the scope object" do
           Puppet::DataBinding.indirection.expects(:find).with(
-            'apache::port', :host => 'foo')
+            'apache::port', :scope => @scope)
           resource.set_default_parameters(@scope)
         end
 
         it "should use the value from the data_binding terminus" do
           Puppet::DataBinding.indirection.expects(:find).with(
-            'apache::port', :host => 'foo').returns('443')
+            'apache::port', :scope => @scope).returns('443')
           resource.set_default_parameters(@scope).should == [:port]
           resource[:port].should == '443'
         end
 
         it "should use the default value if the data_binding terminus returns nil" do
           Puppet::DataBinding.indirection.expects(:find).with(
-            'apache::port', :host => 'foo').returns(nil)
+            'apache::port', :scope => @scope).returns(nil)
           resource.set_default_parameters(@scope).should == [:port]
           resource[:port].should == '80'
         end


### PR DESCRIPTION
Data binding now supports the hiera-puppet backend. When looking up data
in Hiera we now call the `Hiera#lookup` function with the Puppet scope
object instead of the host's facts (Hash).

We also remove the need to fetch node facts for every lookup; the scope
object already contains this info. The scope object provides access to
Facter Facts via the `Scope#[]` method.

This patch includes updated tests.
