### PR TITLE
(#14715) Use gtar or Solaris tar properly with 'puppet module install' o...

### DIFF
--- a/spec/unit/module_tool/applications/unpacker_spec.rb
+++ b/spec/unit/module_tool/applications/unpacker_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+require 'puppet/module_tool/applications'
+require 'puppet_spec/modules'
+
+describe Puppet::ModuleTool::Applications::Unpacker, :fails_on_windows => true do
+  include PuppetSpec::Files
+
+  let(:target) { tmpdir("unpacker") }
+
+  context "initialization" do
+    it "should support filename and basic options" do
+      Puppet::ModuleTool::Applications::Unpacker.new("myusername-mytarball-1.0.0.tar.gz", :target_dir => target)
+    end
+
+    it "should raise ArgumentError when filename is invalid" do
+      expect { Puppet::ModuleTool::Applications::Unpacker.new("invalid.tar.gz", :target_dir => target) }.to raise_error(ArgumentError)
+    end
+  end
+
+  context "#run" do
+    let(:cache_base_path) { Pathname.new(tmpdir("unpacker")) }
+    let(:filename) { tmpdir("module") + "/myusername-mytarball-1.0.0.tar.gz" }
+    let(:build_dir) { Pathname.new(tmpdir("build_dir")) }
+    let(:unpacker) do
+      Puppet::ModuleTool::Applications::Unpacker.new(filename, :target_dir => target)
+    end
+
+    before :each do
+      # Mock redhat for most test cases
+      Facter.stubs(:value).with("operatingsystem").returns("Redhat")
+      build_dir.stubs(:mkpath => nil, :rmtree => nil, :children => [])
+      unpacker.stubs(:build_dir).at_least_once.returns(build_dir)
+      FileUtils.stubs(:mv)
+    end
+
+    context "on linux" do
+      it "should attempt to untar file to temporary location using system tar" do
+        Puppet::Util.expects(:execute).with("tar xzf #{filename} -C #{build_dir}").returns(true)
+        unpacker.run
+      end
+    end
+
+    context "on solaris" do
+      before :each do
+        Facter.expects(:value).with("operatingsystem").returns("Solaris")
+        File.stubs(:exists?).with("/usr/sfw/bin/gtar").returns(true)
+      end
+
+      it "should attempt to untar file to temporary location using gnu tar" do
+        Puppet::Util.stubs(:which).with('gtar').returns('/usr/sfw/bin/gtar')
+        Puppet::Util.expects(:execute).with("gtar xzf #{filename} -C #{build_dir}").returns(true)
+        unpacker.run
+      end
+
+      it "should attempt to use solaris tar if gnu tar is missing" do
+        Puppet::Util.stubs(:which).with('gtar').returns(nil)
+        Puppet::Util.stubs(:which).with('tar').returns('/usr/sbin/tar')
+        Puppet::Util.stubs(:which).with('gzip').returns('/usr/sbin/gzip')
+        Puppet::Util.expects(:execute).with("gzip -cd #{filename} | tar xf -").returns(true)
+        unpacker.run
+      end
+
+      it "should throw exception if no tar and/or gzip implementation exists" do
+        Puppet::Util.stubs(:which).with('gtar').returns(nil)
+        Puppet::Util.stubs(:which).with('tar').returns(nil)
+        Puppet::Util.stubs(:which).with('gzip').returns(nil)
+        expect { unpacker.run }.to raise_error RuntimeError, "Unable to find a suitable tar and/or gzip implementation"
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
...n Solaris

Previously we were assuming there was a usable GNU tar in the path for Solaris,
but Solaris provides its own tar implementation which works quite differently.

This patch changes the behaviour of the unpacker code during module
installation to use the 'gtar' implementation found on most Solaris 10 systems,
and later part of core with Solaris 11.

If 'gtar' is not found the behaviour is to fall back to Solaris tar instead,
using a gzip pipe to tar to get around the lack of decompression capabilities
in that implementation.

This also adds some unit tests for puppet/module_tool/applications/unpacker.
