### PR TITLE
Ticket/3.0rc/14843 add block to self execpipe

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -50,8 +50,8 @@ class Puppet::Provider
     Puppet::Util::Execution.execpipe(*args, &block)
   end
 
-  def self.execpipe(*args)
-    Puppet::Util::Execution.execpipe(*args)
+  def self.execpipe(*args, &block)
+    Puppet::Util::Execution.execpipe(*args, &block)
   end
 
   def execfail(*args)

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:package).provider(:rpm)
+
+describe provider_class do
+  subject { provider_class }
+
+  let (:packages) do
+    <<-RPM_OUTPUT
+    cracklib-dicts 0 2.8.9 3.3 x86_64
+    basesystem 0 8.0 5.1.1.el5.centos noarch
+    chkconfig 0 1.3.30.2 2.el5 x86_64
+    RPM_OUTPUT
+  end
+
+  describe "self.instances" do
+    it "returns an array of packages" do
+      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "--version"], {:custom_environment => {}}).returns("RPM version 5.x")
+      Puppet::Util.stubs(:which).with("rpm").returns("/bin/rpm")
+      subject.stubs(:which).with("rpm").returns("/bin/rpm")
+      Puppet::Util::Execution.expects(:execpipe).with("/bin/rpm -qa --nosignature --nodigest --qf '%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\n'").yields(packages)
+
+      installed_packages = subject.instances
+
+      installed_packages[0].properties.should ==
+        {
+          :provider => :rpm,
+          :name => "cracklib-dicts",
+          :epoch => "0",
+          :version => "2.8.9",
+          :release => "3.3",
+          :arch => "x86_64",
+          :ensure => "2.8.9-3.3"
+        }
+      installed_packages[1].properties.should ==
+        {
+          :provider => :rpm,
+          :name => "basesystem",
+          :epoch => "0",
+          :version => "8.0",
+          :release => "5.1.1.el5.centos",
+          :arch => "noarch",
+          :ensure => "8.0-5.1.1.el5.centos"
+        }
+      installed_packages[2].properties.should ==
+        {
+          :provider => :rpm,
+          :name => "chkconfig",
+          :epoch => "0",
+          :version => "1.3.30.2",
+          :release => "2.el5",
+          :arch => "x86_64",
+          :ensure => "1.3.30.2-2.el5"
+        }
+    end
+  end
+end


### PR DESCRIPTION
Previously the execpipe wrapper in Puppet::Provider only accepted and passed a
block if called from a provider instance, and not the class. This led to
providers failiing with messages of "No block given". This commit brings the
class wrapper in line with the instance wrapper, adding a block to its argument
list and to its Puppet::Util::Execution.execpipe call.
It also adds a single test for the rpm package provider, to verify sanity of
self.instances.
