### PR TITLE
(#11868) Use `Installer` automation interface to query package state

### DIFF
--- a/lib/puppet/provider/package/msi.rb
+++ b/lib/puppet/provider/package/msi.rb
@@ -4,33 +4,125 @@ Puppet::Type.type(:package).provide(:msi, :parent => Puppet::Provider::Package) 
   desc "Windows package management by installing and removing MSIs.
 
     This provider requires a `source` attribute, and will accept paths to local
-    files or files on mapped drives.
-
-    This provider cannot uninstall arbitrary MSI packages; it can only uninstall
-    packages which were originally installed by Puppet."
+    files, mapped drives, or UNC paths."
 
   confine    :operatingsystem => :windows
   defaultfor :operatingsystem => :windows
 
+  has_feature :installable
+  has_feature :uninstallable
   has_feature :install_options
 
-  # This is just here to make sure we can find it, and fail if we
-  # can't.  Unfortunately, we need to do "special" quoting of the
-  # install options or msiexec.exe won't know what to do with them, if
-  # the value contains a space.
-  commands :msiexec => "msiexec.exe"
+  class MsiPackage
+    extend Enumerable
 
-  def self.instances
-    Dir.entries(installed_listing_dir).reject {|d| d == '.' or d == '..'}.collect do |name|
-      new(:name => File.basename(name, '.yml'), :provider => :msi, :ensure => :installed)
+    # From msi.h
+    INSTALLSTATE_DEFAULT=  5 # product is installed for the current user
+    INSTALLUILEVEL_NONE  = 2 # completely silent installation
+
+    def self.installer
+      require 'win32ole'
+      WIN32OLE.new("WindowsInstaller.Installer")
+    end
+
+    def self.each(&block)
+      inst = installer
+      inst.UILevel = INSTALLUILEVEL_NONE
+
+      inst.Products.each do |guid|
+        # products may be advertised, installed in a different user
+        # context, etc, we only want to know about products currently
+        # installed in our context.
+        next unless inst.ProductState(guid) == INSTALLSTATE_DEFAULT
+
+        package = {
+          :name        => inst.ProductInfo(guid, 'ProductName'),
+          # although packages have a version, the provider isn't versionable,
+          # so we can't return a version
+          # :ensure      => inst.ProductInfo(guid, 'VersionString'),
+          :ensure      => :installed,
+          :provider    => :msi,
+          :productcode => guid,
+          :packagecode => inst.ProductInfo(guid, 'PackageCode')
+        }
+
+        yield package
+      end
     end
   end
 
+  # Get an array of provider instances for currently installed packages
+  def self.instances
+    MsiPackage.enum_for.map { |package| new(package) }
+  end
+
+  # Find first package whose PackageCode, e.g. {B2BE95D2-CD2C-46D6-8D27-35D150E58EC9},
+  # matches the resource name (case-insensitively due to hex) or the ProductName matches
+  # the resource name. The ProductName is not guaranteed to be unique, but the PackageCode
+  # should be if the package is authored correctly.
   def query
-    {:name => resource[:name], :ensure => :installed} if FileTest.exists?(state_file)
+    MsiPackage.enum_for.find do |package|
+      resource[:name].casecmp(package[:packagecode]) == 0 || resource[:name] == package[:name]
+    end
   end
 
   def install
+    fail("The source parameter is required when using the MSI provider.") unless resource[:source]
+
+    # Unfortunately, we can't use the msiexec method defined earlier,
+    # because of the special quoting we need to do around the MSI
+    # properties to use.
+    command = ['msiexec.exe', '/qn', '/norestart', '/i', shell_quote(resource[:source]), install_options].flatten.compact.join(' ')
+    execute(command, :combine => true)
+
+    check_result(exit_status)
+  end
+
+  def uninstall
+    fail("The productcode property is missing.") unless properties[:productcode]
+
+    command = ['msiexec.exe', '/qn', '/norestart', '/x', properties[:productcode]].flatten.compact.join(' ')
+    execute(command, :combine => true)
+
+    check_result(exit_status)
+  end
+
+  def exit_status
+    $CHILD_STATUS.exitstatus
+  end
+
+  # http://msdn.microsoft.com/en-us/library/windows/desktop/aa368542(v=vs.85).aspx
+  ERROR_SUCCESS                  = 0
+  ERROR_SUCCESS_REBOOT_INITIATED = 1641
+  ERROR_SUCCESS_REBOOT_REQUIRED  = 3010
+
+  # (Un)install may "fail" because the package requested a reboot, the system requested a
+  # reboot, or something else entirely. Reboot requests mean the package was installed
+  # successfully, but we warn since we don't have a good reboot strategy.
+  def check_result(hr)
+    operation = resource[:ensure] == :absent ? 'uninstall' : 'install'
+
+    case hr
+    when ERROR_SUCCESS
+      # yeah
+    when 194
+      warning("The package requested a reboot to finish the operation.")
+    when ERROR_SUCCESS_REBOOT_INITIATED
+      warning("The package #{operation}ed successfully and the system is rebooting now.")
+    when ERROR_SUCCESS_REBOOT_REQUIRED
+      warning("The package #{operation}ed successfully, but the system must be rebooted.")
+    else
+      operation = resource[:ensure] == :absent ? 'uninstall' : 'install'
+      raise Puppet::Util::Windows::Error.new("Failed to #{operation}", hr)
+    end
+  end
+
+  def validate_source(value)
+    fail("The source parameter cannot be empty when using the MSI provider.") if value.empty?
+  end
+
+  def install_options
+    # properties is a string delimited by spaces, so each key value must be quoted
     properties_for_command = nil
     if resource[:install_options]
       properties_for_command = resource[:install_options].collect do |k,v|
@@ -41,52 +133,7 @@ Puppet::Type.type(:package).provide(:msi, :parent => Puppet::Provider::Package) 
       end
     end
 
-    # Unfortunately, we can't use the msiexec method defined earlier,
-    # because of the special quoting we need to do around the MSI
-    # properties to use.
-    execute ['msiexec.exe', '/qn', '/norestart', '/i', shell_quote(msi_source), properties_for_command].flatten.compact.join(' ')
-
-    File.open(state_file, 'w') do |f|
-      metadata = {
-        'name'            => resource[:name],
-        'install_options' => resource[:install_options],
-        'source'          => msi_source
-      }
-
-      f.puts(YAML.dump(metadata))
-    end
-  end
-
-  def uninstall
-    msiexec '/qn', '/norestart', '/x', msi_source
-
-    File.delete state_file
-  end
-
-  def validate_source(value)
-    fail("The source parameter cannot be empty when using the MSI provider.") if value.empty?
-  end
-
-  private
-
-  def msi_source
-    resource[:source] ||= YAML.load_file(state_file)['source'] rescue nil
-
-    fail("The source parameter is required when using the MSI provider.") unless resource[:source]
-
-    resource[:source]
-  end
-
-  def self.installed_listing_dir
-    listing_dir = File.join(Puppet[:vardir], 'db', 'package', 'msi')
-
-    FileUtils.mkdir_p listing_dir unless File.directory? listing_dir
-
-    listing_dir
-  end
-
-  def state_file
-    File.join(self.class.installed_listing_dir, "#{resource[:name]}.yml")
+    properties_for_command
   end
 
   def shell_quote(value)

--- a/spec/unit/provider/package/msi_spec.rb
+++ b/spec/unit/provider/package/msi_spec.rb
@@ -1,170 +1,237 @@
 require 'spec_helper'
 
-describe 'Puppet::Provider::Package::Msi' do
-  include PuppetSpec::Files
+describe Puppet::Type.type(:package).provider(:msi) do
+  let (:name)        { 'mysql-5.1.58-win-x64' }
+  let (:source)      { 'E:\mysql-5.1.58-win-x64.msi' }
+  let (:productcode) { '{E437FFB6-5C49-4DAC-ABAE-33FF065FE7CC}' }
+  let (:packagecode) { '{5A6FD560-763A-4BC1-9E03-B18DFFB7C72C}' }
+  let (:resource)    {  Puppet::Type.type(:package).new(:name => name, :provider => :msi, :source => source) }
+  let (:provider)    { resource.provider }
+  let (:execute_options) do {:combine => true} end
 
-  before :each do
-    Puppet::Type.type(:package).stubs(:defaultprovider).returns(Puppet::Type.type(:package).provider(:msi))
-    Puppet[:vardir] = tmpdir('msi')
-    @state_dir = File.join(Puppet[:vardir], 'db', 'package', 'msi')
+  def installer(productcodes)
+    installer = mock
+    installer.expects(:UILevel=).with(2)
+
+    installer.stubs(:ProductState).returns(5)
+    installer.stubs(:Products).returns(productcodes)
+    productcodes.each do |guid|
+      installer.stubs(:ProductInfo).with(guid, 'ProductName').returns("name-#{guid}")
+      installer.stubs(:ProductInfo).with(guid, 'PackageCode').returns("package-#{guid}")
+    end
+
+    MsiPackage.stubs(:installer).returns(installer)
   end
 
-  describe 'when installing' do
-    it 'should create a state file' do
-      resource = Puppet::Type.type(:package).new(
-        :name   => 'mysql-5.1.58-winx64',
-        :source => 'E:\mysql-5.1.58-winx64.msi'
-      )
-      resource.provider.stubs(:execute)
-      resource.provider.install
+  before :each do
+    # make sure we never try to execute msiexec
+    provider.expects(:execute).never
+  end
 
-      File.should be_exists File.join(@state_dir, 'mysql-5.1.58-winx64.yml')
+  describe 'provider features' do
+    it { should be_installable }
+    it { should be_uninstallable }
+    it { should be_install_options }
+  end
+
+  context '::instances' do
+    it 'should return an array of provider instances' do
+      installer([1, 2])
+
+      MsiPackage.map do |pkg|
+        pkg[:name].should        == "name-#{pkg[:productcode]}"
+        pkg[:ensure].should      == :installed
+        pkg[:provider].should    == :msi
+        pkg[:packagecode].should == "package-#{pkg[:productcode]}"
+      end.count.should == 2
+    end
+
+    it 'should return an empty array of none found' do
+      installer([])
+
+      MsiPackage.to_a.size.should == 0
+    end
+  end
+
+  context '#query' do
+    let (:package) do {
+        :name        => name,
+        :ensure      => :installed,
+        :provider    => :msi,
+        :productcode => productcode,
+        :packagecode => packagecode.upcase
+      }
+    end
+
+    before :each do
+      MsiPackage.stubs(:each).yields(package)
+    end
+
+    it 'should match package codes case-insensitively' do
+      resource[:name] = packagecode.downcase
+
+      provider.query.should == package
+    end
+
+    it 'should match product name' do
+      resource[:name] = name
+
+      provider.query.should == package
+    end
+
+    it 'should return nil if none found' do
+      resource[:name] = 'not going to find it'
+
+      provider.query.should be_nil
+    end
+  end
+
+  context '#install' do
+    before :each do
+      provider.stubs(:execute)
+    end
+
+    it 'should require the source parameter' do
+      resource = Puppet::Type.type(:package).new(:name => name, :provider => :msi)
+
+      expect do
+        resource.provider.install
+      end.to raise_error(Puppet::Error, /The source parameter is required when using the MSI provider/)
+    end
+
+    it 'should install using the source and install_options' do
+      resource[:install_options] = { 'INSTALLDIR' => 'C:\mysql-5.1' }
+
+      provider.expects(:execute).with("msiexec.exe /qn /norestart /i #{source} INSTALLDIR=C:\\mysql-5.1", execute_options)
+      provider.expects(:exit_status).returns(0)
+
+      provider.install
+    end
+
+    it 'should warn if the package requests a reboot' do
+      provider.stubs(:exit_status).returns(194)
+
+      provider.expects(:warning).with('The package requested a reboot to finish the operation.')
+
+      provider.install
+    end
+
+    it 'should warn if reboot initiated' do
+      provider.stubs(:exit_status).returns(1641)
+
+      provider.expects(:warning).with('The package installed successfully and the system is rebooting now.')
+
+      provider.install
+    end
+
+    it 'should warn if reboot required' do
+      provider.stubs(:exit_status).returns(3010)
+
+      provider.expects(:warning).with('The package installed successfully, but the system must be rebooted.')
+
+      provider.install
+    end
+
+    it 'should fail otherwise', :if => Puppet.features.microsoft_windows? do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(5)
+
+      expect do
+        provider.install
+      end.to raise_error(Puppet::Util::Windows::Error, /Access is denied/)
+    end
+  end
+
+  context '#uninstall' do
+    before :each do
+      resource[:ensure] = :absent
+      provider.set(:productcode => productcode)
+    end
+
+    it 'should require the productcode' do
+      provider.set(:productcode => nil)
+      expect do
+        provider.uninstall
+      end.to raise_error(Puppet::Error, /The productcode property is missing./)
+    end
+
+    it 'should uninstall using the productcode' do
+      provider.expects(:execute).with("msiexec.exe /qn /norestart /x #{productcode}", execute_options)
+      provider.expects(:exit_status).returns(0)
+
+      provider.uninstall
+    end
+
+    it 'should warn if the package requests a reboot' do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(194)
+
+      provider.expects(:warning).with('The package requested a reboot to finish the operation.')
+
+      provider.uninstall
+    end
+
+    it 'should warn if reboot initiated' do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(1641)
+
+      provider.expects(:warning).with('The package uninstalled successfully and the system is rebooting now.')
+
+      provider.uninstall
+    end
+
+    it 'should warn if reboot required' do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(3010)
+
+      provider.expects(:warning).with('The package uninstalled successfully, but the system must be rebooted.')
+
+      provider.uninstall
+    end
+
+    it 'should fail otherwise', :if => Puppet.features.microsoft_windows? do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(5)
+
+      expect do
+        provider.uninstall
+      end.to raise_error(Puppet::Util::Windows::Error, /Failed to uninstall.*Access is denied/)
+    end
+  end
+
+  context '#validate_source' do
+    it 'should fail if the source parameter is empty' do
+      expect do
+        resource[:source] = ''
+      end.to raise_error(Puppet::Error, /The source parameter cannot be empty when using the MSI provider/)
+    end
+
+    it 'should accept a source' do
+      resource[:source] = source
+    end
+  end
+
+  context '#install_options' do
+    it 'should return nil by default' do
+      provider.install_options.should be_nil
     end
 
     it 'should use the install_options as parameter/value pairs' do
-      resource = Puppet::Type.type(:package).new(
-        :name            => 'mysql-5.1.58-winx64',
-        :source          => 'E:\mysql-5.1.58-winx64.msi',
-        :install_options => { 'INSTALLDIR' => 'C:\mysql-here' }
-      )
+      resource[:install_options] = { 'INSTALLDIR' => 'C:\mysql-here' }
 
-      resource.provider.expects(:execute).with('msiexec.exe /qn /norestart /i E:\mysql-5.1.58-winx64.msi INSTALLDIR=C:\mysql-here')
-      resource.provider.install
+      provider.install_options.should == ['INSTALLDIR=C:\mysql-here']
     end
 
     it 'should only quote the value when an install_options value has a space in it' do
-      resource = Puppet::Type.type(:package).new(
-        :name            => 'mysql-5.1.58-winx64',
-        :source          => 'E:\mysql-5.1.58-winx64.msi',
-        :install_options => { 'INSTALLDIR' => 'C:\mysql here' }
-      )
+      resource[:install_options] = { 'INSTALLDIR' => 'C:\mysql here' }
 
-      resource.provider.expects(:execute).with('msiexec.exe /qn /norestart /i E:\mysql-5.1.58-winx64.msi INSTALLDIR="C:\mysql here"')
-      resource.provider.install
+      provider.install_options.should == ['INSTALLDIR="C:\mysql here"']
     end
 
     it 'should escape embedded quotes in install_options values with spaces' do
-      resource = Puppet::Type.type(:package).new(
-        :name            => 'mysql-5.1.58-winx64',
-        :source          => 'E:\mysql-5.1.58-winx64.msi',
-        :install_options => { 'INSTALLDIR' => 'C:\mysql "here"' }
-      )
+      resource[:install_options] = { 'INSTALLDIR' => 'C:\mysql "here"' }
 
-      resource.provider.expects(:execute).with('msiexec.exe /qn /norestart /i E:\mysql-5.1.58-winx64.msi INSTALLDIR="C:\mysql \"here\""')
-      resource.provider.install
+      provider.install_options.should == ['INSTALLDIR="C:\mysql \"here\""']
     end
-
-    it 'should not create a state file, if the installation fails' do
-      resource = Puppet::Type.type(:package).new(
-        :name   => 'mysql-5.1.58-winx64',
-        :source => 'E:\mysql-5.1.58-winx64.msi'
-      )
-      resource.provider.stubs(:execute).raises(Puppet::ExecutionFailure.new("Execution of 'msiexec.exe' returned 128: Blargle"))
-      expect { resource.provider.install }.to raise_error(Puppet::ExecutionFailure, /msiexec\.exe/)
-
-      File.should_not be_exists File.join(@state_dir, 'mysql-5.1.58-winx64.yml')
-    end
-
-    it 'should fail if the source parameter is not set' do
-      expect do
-        resource = Puppet::Type.type(:package).new(
-          :name => 'mysql-5.1.58-winx64'
-        ).provider.install
-      end.to raise_error(Puppet::Error, /The source parameter is required when using the MSI provider/)
-    end
-
-    it 'should fail if the source parameter is empty' do
-      expect do
-        resource = Puppet::Type.type(:package).new(
-          :name   => 'mysql-5.1.58-winx64',
-          :source => ''
-        )
-      end.to raise_error(Puppet::Error, /The source parameter cannot be empty when using the MSI provider/)
-    end
-  end
-
-  describe 'when uninstalling' do
-    before :each do
-      FileUtils.mkdir_p(@state_dir)
-      File.open(File.join(@state_dir, 'mysql-5.1.58-winx64.yml'), 'w') {|f| f.puts 'Hello'}
-    end
-
-    it 'should remove the state file' do
-      resource = Puppet::Type.type(:package).new(
-        :name   => 'mysql-5.1.58-winx64',
-        :source => 'E:\mysql-5.1.58-winx64.msi'
-      )
-      resource.provider.stubs(:msiexec)
-      resource.provider.uninstall
-
-      File.should_not be_exists File.join(Puppet[:vardir], 'db', 'package', 'msi', 'mysql-5.1.58-winx64.yml')
-    end
-
-    it 'should leave the state file if uninstalling fails' do
-      resource = Puppet::Type.type(:package).new(
-        :name   => 'mysql-5.1.58-winx64',
-        :source => 'E:\mysql-5.1.58-winx64.msi'
-      )
-      resource.provider.stubs(:msiexec).raises(Puppet::ExecutionFailure.new("Execution of 'msiexec.exe' returned 128: Blargle"))
-      expect { resource.provider.uninstall }.to raise_error(Puppet::ExecutionFailure, /msiexec\.exe/)
-
-      File.should be_exists File.join(@state_dir, 'mysql-5.1.58-winx64.yml')
-    end
-
-    it 'should fail if the source parameter is not set' do
-      expect do
-        resource = Puppet::Type.type(:package).new(
-          :name => 'mysql-5.1.58-winx64'
-        ).provider.install
-      end.to raise_error(Puppet::Error, /The source parameter is required when using the MSI provider/)
-    end
-
-    it 'should fail if the source parameter is empty' do
-      expect do
-        resource = Puppet::Type.type(:package).new(
-          :name   => 'mysql-5.1.58-winx64',
-          :source => ''
-        )
-      end.to raise_error(Puppet::Error, /The source parameter cannot be empty when using the MSI provider/)
-    end
-  end
-
-  describe 'when enumerating instances' do
-    it 'should consider the base of the state file name to be the name of the package' do
-      FileUtils.mkdir_p(@state_dir)
-      package_names = ['GoogleChromeStandaloneEnterprise', 'mysql-5.1.58-winx64', 'postgresql-8.3']
-
-      package_names.each do |state_file|
-        File.open(File.join(@state_dir, "#{state_file}.yml"), 'w') {|f| f.puts 'Hello'}
-      end
-
-      installed_package_names = Puppet::Type.type(:package).provider(:msi).instances.collect {|p| p.name}
-
-      installed_package_names.should =~ package_names
-    end
-  end
-
-  it 'should consider the package installed if the state file is present' do
-    FileUtils.mkdir_p(@state_dir)
-    File.open(File.join(@state_dir, 'mysql-5.1.58-winx64.yml'), 'w') {|f| f.puts 'Hello'}
-
-    resource = Puppet::Type.type(:package).new(
-      :name   => 'mysql-5.1.58-winx64',
-      :source => 'E:\mysql-5.1.58-winx64.msi'
-    )
-
-    resource.provider.query.should == {
-      :name   => 'mysql-5.1.58-winx64',
-      :ensure => :installed
-    }
-  end
-
-  it 'should consider the package absent if the state file is missing' do
-    resource = Puppet::Type.type(:package).new(
-      :name   => 'mysql-5.1.58-winx64',
-      :source => 'E:\mysql-5.1.58-winx64.msi'
-    )
-
-    resource.provider.query.should be_nil
   end
 end


### PR DESCRIPTION
Previously, Puppet recorded MSI packages it had installed in a YAML
file. However, if the file was deleted or the system modified, e.g.
Add/Remove Programs, then Puppet did not know the package state had
changed.

Also, if the name of the package did not change across versions, e.g.
VMware Tools, then puppet would report the package as insync even though
the installed version could be different than the one pointed to by the
source parameter.

This commit changes the msi package provider to use the `Installer`
Automation (COM) interface to query the state of the system[1]. It will
now accurately report on installed packages, even those it did not
install, including Puppet itself (#13444). If a package is removed via
Add/Remove Programs, Puppet will re-install it the next time it runs.

When using the msi package resource, the resource title should match the
'ProductName' property in the MSI Property table, which is also the value
displayed in Add/Remove Programs, e.g.

  package { 'Microsoft Visual C++ 2008 Redistributable - x86 9.0.30729.4148':
    ensure => installed,
    ...
  }

In cases where the ProductName does not change across versions, e.g.
VMware Tools, you should use the PackageCode as the name of the resource:

  package { '{0E3AA38E-EAD3-4348-B5C5-051B6852CED6}':
    ensure => installed,
    ...
  }

You can obtain the PackageCode in ruby using:

  require 'win32ole'
  installer = WIN32OLE.new('WindowsInstaller.Installer')
  db = installer.OpenDatabase(path, 0)
  puts db.SummaryInformation.Property(9)

where <path> is the path to the MSI.

The msi provider does not automatically compare PackageCodes when
determining if the resource is insync, because the source MSI could be on
a network share, and we do not want to copy the potentially large file
just to see if changes need to be made.

[1] http://msdn.microsoft.com/en-us/library/windows/desktop/aa369432(v=vs.85).aspx
