### PR TITLE
(#14964) Don't fail if we can't unlink the Tempfile on Windows

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -419,7 +419,14 @@ module Util
       if File.exists?(stdout.path)
         output = stdout.open.read
 
-        stdout.close(true)
+        begin
+          stdout.close(true)
+        rescue Errno::EACCES => e
+          # try to unlink, though it will fail on Windows if the child process,
+          # e.g. start.exe, executed another process asynchronously, as the
+          # grandchild still has a handle to the tempfile
+          raise e unless Puppet.features.microsoft_windows?
+        end
 
         return output
       else

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -456,6 +456,21 @@ describe Puppet::Util do
         File.should_not be_exist(path)
       end
 
+      it "should handle when unlink fails" do
+        stdout = Tempfile.new('test')
+        stdout.stubs(:close)
+        stdout.expects(:close).with(true).raises(Errno::EACCES, stdout.path)
+        Tempfile.stubs(:new).returns(stdout)
+
+        if Puppet.features.microsoft_windows?
+          Puppet::Util.execute('test command')
+        else
+          expect {
+            Puppet::Util.execute('test command')
+          }.to raise_error(Errno::EACCES, /Permission denied/)
+        end
+      end
+
       it "should raise an error if failonfail is true and the child failed" do
         stub_process_wait(1)
 


### PR DESCRIPTION
Previously, if the exec resource created a process, e.g. start.exe, that
executed another process asynchronously, then the grandchild would inherit
the tempfile handle, preventing puppet from being able to unlink it. This
is not an issue on POSIX systems.

This commit changes the `wait_for_output` method to ignore Errno::EACCES
exceptions caused when closing and unlinking the stdout tempfile. The
behavior on POSIX systems is unchanged.
