### PR TITLE
(#14901) duplicate args remove all args

### DIFF
--- a/lib/puppet/util/command_line/puppet_option_parser.rb
+++ b/lib/puppet/util/command_line/puppet_option_parser.rb
@@ -5,9 +5,6 @@ module Puppet
       class PuppetOptionError < Puppet::Error
       end
 
-      class PuppetUnrecognizedOptionError < PuppetOptionError
-      end
-
       # This is a command line option parser.  It is intended to have an API that is very similar to
       #  the ruby stdlib 'OptionParser' API, for ease of integration into our existing code... however,
       #  However, we've removed the OptionParser-based implementation and are only maintaining the
@@ -20,7 +17,7 @@ module Puppet
 
           @create_default_short_options = false
 
-          @wrapped_parser = ::Trollop::Parser.new do
+          @parser = ::Trollop::Parser.new do
             banner usage_msg
             create_default_short_options = false
             handle_help_and_version = false
@@ -36,13 +33,11 @@ module Puppet
         attr_reader :ignore_invalid_options
 
         def ignore_invalid_options=(value)
-          @wrapped_parser.ignore_invalid_options = value
+          @parser.ignore_invalid_options = value
         end
 
-
         def on(*args, &block)
-          # The 2nd element is an optional
-          # "short" representation.
+          # The 2nd element is an optional "short" representation.
           if args.length == 3
             long, desc, type = args
           elsif args.length == 4
@@ -68,22 +63,23 @@ module Puppet
               raise PuppetOptionError.new("Unsupported type: '#{type}'")
           end
 
-          @wrapped_parser.opt long.sub("^--", "").intern, desc, options
+          @parser.opt long.sub("^--", "").intern, desc, options
         end
 
         def parse(*args)
           args = args[0] if args.size == 1 and Array === args[0]
           args_copy = args.dup
           begin
-            @wrapped_parser.parse args_copy
+            @parser.parse args_copy
           rescue ::Trollop::CommandlineError => err
-            raise PuppetUnrecognizedOptionError.new(err) if err.message =~ /^unknown argument/
+            raise PuppetOptionError.new("Error parsing arguments", err)
           end
         end
 
         def pass_only_last_value_on_to(block)
           lambda { |values| block.call(values.is_a?(Array) ? values.last : values) }
         end
+        private :pass_only_last_value_on_to
       end
     end
   end

--- a/spec/unit/util/command_line_utils/puppet_option_parser_spec.rb
+++ b/spec/unit/util/command_line_utils/puppet_option_parser_spec.rb
@@ -98,7 +98,7 @@ describe Puppet::Util::CommandLine::PuppetOptionParser do
       option_parser.on(*option) {}
     end
 
-    expect { option_parser.parse(["-r"]) }.to raise_error(Puppet::Util::CommandLine::PuppetUnrecognizedOptionError)
+    expect { option_parser.parse(["-r"]) }.to raise_error(Puppet::Util::CommandLine::PuppetOptionError)
   end
 
   it "respects :ignore_invalid_options" do


### PR DESCRIPTION
The argument parsing had incorrectly swallowed an error caused by duplicate arguments which caused all arguments to be ignored. By changing the configuration of the argument parser to allow arguments to appear multiple times and then only taking the last value of each argument that error is avoided.

Taking the last value of any given argument preserves the behavior of 2.7.
