### PR TITLE
(#11868) Use `Installer` automation interface to query package state

### DIFF
--- a/spec/unit/provider/package/msi_spec.rb
+++ b/spec/unit/provider/package/msi_spec.rb
@@ -1,170 +1,237 @@
 require 'spec_helper'
 
-describe 'Puppet::Provider::Package::Msi' do
-  include PuppetSpec::Files
+describe Puppet::Type.type(:package).provider(:msi) do
+  let (:name)        { 'mysql-5.1.58-win-x64' }
+  let (:source)      { 'E:\mysql-5.1.58-win-x64.msi' }
+  let (:productcode) { '{E437FFB6-5C49-4DAC-ABAE-33FF065FE7CC}' }
+  let (:packagecode) { '{5A6FD560-763A-4BC1-9E03-B18DFFB7C72C}' }
+  let (:resource)    {  Puppet::Type.type(:package).new(:name => name, :provider => :msi, :source => source) }
+  let (:provider)    { resource.provider }
+  let (:execute_options) do {:combine => true} end
 
-  before :each do
-    Puppet::Type.type(:package).stubs(:defaultprovider).returns(Puppet::Type.type(:package).provider(:msi))
-    Puppet[:vardir] = tmpdir('msi')
-    @state_dir = File.join(Puppet[:vardir], 'db', 'package', 'msi')
+  def installer(productcodes)
+    installer = mock
+    installer.expects(:UILevel=).with(2)
+
+    installer.stubs(:ProductState).returns(5)
+    installer.stubs(:Products).returns(productcodes)
+    productcodes.each do |guid|
+      installer.stubs(:ProductInfo).with(guid, 'ProductName').returns("name-#{guid}")
+      installer.stubs(:ProductInfo).with(guid, 'PackageCode').returns("package-#{guid}")
+    end
+
+    MsiPackage.stubs(:installer).returns(installer)
   end
 
-  describe 'when installing' do
-    it 'should create a state file' do
-      resource = Puppet::Type.type(:package).new(
-        :name   => 'mysql-5.1.58-winx64',
-        :source => 'E:\mysql-5.1.58-winx64.msi'
-      )
-      resource.provider.stubs(:execute)
-      resource.provider.install
+  before :each do
+    # make sure we never try to execute msiexec
+    provider.expects(:execute).never
+  end
 
-      File.should be_exists File.join(@state_dir, 'mysql-5.1.58-winx64.yml')
+  describe 'provider features' do
+    it { should be_installable }
+    it { should be_uninstallable }
+    it { should be_install_options }
+  end
+
+  context '::instances' do
+    it 'should return an array of provider instances' do
+      installer([1, 2])
+
+      MsiPackage.map do |pkg|
+        pkg[:name].should        == "name-#{pkg[:productcode]}"
+        pkg[:ensure].should      == :installed
+        pkg[:provider].should    == :msi
+        pkg[:packagecode].should == "package-#{pkg[:productcode]}"
+      end.count.should == 2
+    end
+
+    it 'should return an empty array of none found' do
+      installer([])
+
+      MsiPackage.to_a.size.should == 0
+    end
+  end
+
+  context '#query' do
+    let (:package) do {
+        :name        => name,
+        :ensure      => :installed,
+        :provider    => :msi,
+        :productcode => productcode,
+        :packagecode => packagecode.upcase
+      }
+    end
+
+    before :each do
+      MsiPackage.stubs(:each).yields(package)
+    end
+
+    it 'should match package codes case-insensitively' do
+      resource[:name] = packagecode.downcase
+
+      provider.query.should == package
+    end
+
+    it 'should match product name' do
+      resource[:name] = name
+
+      provider.query.should == package
+    end
+
+    it 'should return nil if none found' do
+      resource[:name] = 'not going to find it'
+
+      provider.query.should be_nil
+    end
+  end
+
+  context '#install' do
+    before :each do
+      provider.stubs(:execute)
+    end
+
+    it 'should require the source parameter' do
+      resource = Puppet::Type.type(:package).new(:name => name, :provider => :msi)
+
+      expect do
+        resource.provider.install
+      end.to raise_error(Puppet::Error, /The source parameter is required when using the MSI provider/)
+    end
+
+    it 'should install using the source and install_options' do
+      resource[:install_options] = { 'INSTALLDIR' => 'C:\mysql-5.1' }
+
+      provider.expects(:execute).with("msiexec.exe /qn /norestart /i #{source} INSTALLDIR=C:\\mysql-5.1", execute_options)
+      provider.expects(:exit_status).returns(0)
+
+      provider.install
+    end
+
+    it 'should warn if the package requests a reboot' do
+      provider.stubs(:exit_status).returns(194)
+
+      provider.expects(:warning).with('The package requested a reboot to finish the operation.')
+
+      provider.install
+    end
+
+    it 'should warn if reboot initiated' do
+      provider.stubs(:exit_status).returns(1641)
+
+      provider.expects(:warning).with('The package installed successfully and the system is rebooting now.')
+
+      provider.install
+    end
+
+    it 'should warn if reboot required' do
+      provider.stubs(:exit_status).returns(3010)
+
+      provider.expects(:warning).with('The package installed successfully, but the system must be rebooted.')
+
+      provider.install
+    end
+
+    it 'should fail otherwise', :if => Puppet.features.microsoft_windows? do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(5)
+
+      expect do
+        provider.install
+      end.to raise_error(Puppet::Util::Windows::Error, /Access is denied/)
+    end
+  end
+
+  context '#uninstall' do
+    before :each do
+      resource[:ensure] = :absent
+      provider.set(:productcode => productcode)
+    end
+
+    it 'should require the productcode' do
+      provider.set(:productcode => nil)
+      expect do
+        provider.uninstall
+      end.to raise_error(Puppet::Error, /The productcode property is missing./)
+    end
+
+    it 'should uninstall using the productcode' do
+      provider.expects(:execute).with("msiexec.exe /qn /norestart /x #{productcode}", execute_options)
+      provider.expects(:exit_status).returns(0)
+
+      provider.uninstall
+    end
+
+    it 'should warn if the package requests a reboot' do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(194)
+
+      provider.expects(:warning).with('The package requested a reboot to finish the operation.')
+
+      provider.uninstall
+    end
+
+    it 'should warn if reboot initiated' do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(1641)
+
+      provider.expects(:warning).with('The package uninstalled successfully and the system is rebooting now.')
+
+      provider.uninstall
+    end
+
+    it 'should warn if reboot required' do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(3010)
+
+      provider.expects(:warning).with('The package uninstalled successfully, but the system must be rebooted.')
+
+      provider.uninstall
+    end
+
+    it 'should fail otherwise', :if => Puppet.features.microsoft_windows? do
+      provider.stubs(:execute)
+      provider.stubs(:exit_status).returns(5)
+
+      expect do
+        provider.uninstall
+      end.to raise_error(Puppet::Util::Windows::Error, /Failed to uninstall.*Access is denied/)
+    end
+  end
+
+  context '#validate_source' do
+    it 'should fail if the source parameter is empty' do
+      expect do
+        resource[:source] = ''
+      end.to raise_error(Puppet::Error, /The source parameter cannot be empty when using the MSI provider/)
+    end
+
+    it 'should accept a source' do
+      resource[:source] = source
+    end
+  end
+
+  context '#install_options' do
+    it 'should return nil by default' do
+      provider.install_options.should be_nil
     end
 
     it 'should use the install_options as parameter/value pairs' do
-      resource = Puppet::Type.type(:package).new(
-        :name            => 'mysql-5.1.58-winx64',
-        :source          => 'E:\mysql-5.1.58-winx64.msi',
-        :install_options => { 'INSTALLDIR' => 'C:\mysql-here' }
-      )
+      resource[:install_options] = { 'INSTALLDIR' => 'C:\mysql-here' }
 
-      resource.provider.expects(:execute).with('msiexec.exe /qn /norestart /i E:\mysql-5.1.58-winx64.msi INSTALLDIR=C:\mysql-here')
-      resource.provider.install
+      provider.install_options.should == ['INSTALLDIR=C:\mysql-here']
     end
 
     it 'should only quote the value when an install_options value has a space in it' do
-      resource = Puppet::Type.type(:package).new(
-        :name            => 'mysql-5.1.58-winx64',
-        :source          => 'E:\mysql-5.1.58-winx64.msi',
-        :install_options => { 'INSTALLDIR' => 'C:\mysql here' }
-      )
+      resource[:install_options] = { 'INSTALLDIR' => 'C:\mysql here' }
 
-      resource.provider.expects(:execute).with('msiexec.exe /qn /norestart /i E:\mysql-5.1.58-winx64.msi INSTALLDIR="C:\mysql here"')
-      resource.provider.install
+      provider.install_options.should == ['INSTALLDIR="C:\mysql here"']
     end
 
     it 'should escape embedded quotes in install_options values with spaces' do
-      resource = Puppet::Type.type(:package).new(
-        :name            => 'mysql-5.1.58-winx64',
-        :source          => 'E:\mysql-5.1.58-winx64.msi',
-        :install_options => { 'INSTALLDIR' => 'C:\mysql "here"' }
-      )
+      resource[:install_options] = { 'INSTALLDIR' => 'C:\mysql "here"' }
 
-      resource.provider.expects(:execute).with('msiexec.exe /qn /norestart /i E:\mysql-5.1.58-winx64.msi INSTALLDIR="C:\mysql \"here\""')
-      resource.provider.install
+      provider.install_options.should == ['INSTALLDIR="C:\mysql \"here\""']
     end
-
-    it 'should not create a state file, if the installation fails' do
-      resource = Puppet::Type.type(:package).new(
-        :name   => 'mysql-5.1.58-winx64',
-        :source => 'E:\mysql-5.1.58-winx64.msi'
-      )
-      resource.provider.stubs(:execute).raises(Puppet::ExecutionFailure.new("Execution of 'msiexec.exe' returned 128: Blargle"))
-      expect { resource.provider.install }.to raise_error(Puppet::ExecutionFailure, /msiexec\.exe/)
-
-      File.should_not be_exists File.join(@state_dir, 'mysql-5.1.58-winx64.yml')
-    end
-
-    it 'should fail if the source parameter is not set' do
-      expect do
-        resource = Puppet::Type.type(:package).new(
-          :name => 'mysql-5.1.58-winx64'
-        ).provider.install
-      end.to raise_error(Puppet::Error, /The source parameter is required when using the MSI provider/)
-    end
-
-    it 'should fail if the source parameter is empty' do
-      expect do
-        resource = Puppet::Type.type(:package).new(
-          :name   => 'mysql-5.1.58-winx64',
-          :source => ''
-        )
-      end.to raise_error(Puppet::Error, /The source parameter cannot be empty when using the MSI provider/)
-    end
-  end
-
-  describe 'when uninstalling' do
-    before :each do
-      FileUtils.mkdir_p(@state_dir)
-      File.open(File.join(@state_dir, 'mysql-5.1.58-winx64.yml'), 'w') {|f| f.puts 'Hello'}
-    end
-
-    it 'should remove the state file' do
-      resource = Puppet::Type.type(:package).new(
-        :name   => 'mysql-5.1.58-winx64',
-        :source => 'E:\mysql-5.1.58-winx64.msi'
-      )
-      resource.provider.stubs(:msiexec)
-      resource.provider.uninstall
-
-      File.should_not be_exists File.join(Puppet[:vardir], 'db', 'package', 'msi', 'mysql-5.1.58-winx64.yml')
-    end
-
-    it 'should leave the state file if uninstalling fails' do
-      resource = Puppet::Type.type(:package).new(
-        :name   => 'mysql-5.1.58-winx64',
-        :source => 'E:\mysql-5.1.58-winx64.msi'
-      )
-      resource.provider.stubs(:msiexec).raises(Puppet::ExecutionFailure.new("Execution of 'msiexec.exe' returned 128: Blargle"))
-      expect { resource.provider.uninstall }.to raise_error(Puppet::ExecutionFailure, /msiexec\.exe/)
-
-      File.should be_exists File.join(@state_dir, 'mysql-5.1.58-winx64.yml')
-    end
-
-    it 'should fail if the source parameter is not set' do
-      expect do
-        resource = Puppet::Type.type(:package).new(
-          :name => 'mysql-5.1.58-winx64'
-        ).provider.install
-      end.to raise_error(Puppet::Error, /The source parameter is required when using the MSI provider/)
-    end
-
-    it 'should fail if the source parameter is empty' do
-      expect do
-        resource = Puppet::Type.type(:package).new(
-          :name   => 'mysql-5.1.58-winx64',
-          :source => ''
-        )
-      end.to raise_error(Puppet::Error, /The source parameter cannot be empty when using the MSI provider/)
-    end
-  end
-
-  describe 'when enumerating instances' do
-    it 'should consider the base of the state file name to be the name of the package' do
-      FileUtils.mkdir_p(@state_dir)
-      package_names = ['GoogleChromeStandaloneEnterprise', 'mysql-5.1.58-winx64', 'postgresql-8.3']
-
-      package_names.each do |state_file|
-        File.open(File.join(@state_dir, "#{state_file}.yml"), 'w') {|f| f.puts 'Hello'}
-      end
-
-      installed_package_names = Puppet::Type.type(:package).provider(:msi).instances.collect {|p| p.name}
-
-      installed_package_names.should =~ package_names
-    end
-  end
-
-  it 'should consider the package installed if the state file is present' do
-    FileUtils.mkdir_p(@state_dir)
-    File.open(File.join(@state_dir, 'mysql-5.1.58-winx64.yml'), 'w') {|f| f.puts 'Hello'}
-
-    resource = Puppet::Type.type(:package).new(
-      :name   => 'mysql-5.1.58-winx64',
-      :source => 'E:\mysql-5.1.58-winx64.msi'
-    )
-
-    resource.provider.query.should == {
-      :name   => 'mysql-5.1.58-winx64',
-      :ensure => :installed
-    }
-  end
-
-  it 'should consider the package absent if the state file is missing' do
-    resource = Puppet::Type.type(:package).new(
-      :name   => 'mysql-5.1.58-winx64',
-      :source => 'E:\mysql-5.1.58-winx64.msi'
-    )
-
-    resource.provider.query.should be_nil
   end
 end


### PR DESCRIPTION
Previously, Puppet recorded MSI packages it had installed in a YAML
file. However, if the file was deleted or the system modified, e.g.
Add/Remove Programs, then Puppet did not know the package state had
changed.

Also, if the name of the package did not change across versions, e.g.
VMware Tools, then puppet would report the package as insync even though
the installed version could be different than the one pointed to by the
source parameter.

Also, `msiexec.exe` returns non-zero exit codes when either the package
requests a reboot (194), the system requires a reboot (3010), e.g. due
to a locked file, or the system initiates a reboot (1641). This would
cause puppet to think the install failed, and it would try to reinstall
the packge the next time it ran (since the YAML file didn't get
updated).

This commit changes the msi package provider to use the `Installer`
Automation (COM) interface to query the state of the system[1]. It will
now accurately report on installed packages, even those it did not
install, including Puppet itself (#13444). If a package is removed via
Add/Remove Programs, Puppet will re-install it the next time it runs.

The MSI package provider will now warn in the various reboot scenarios,
but report the overall install/uninstall as successful (#14055).

When using the msi package resource, the resource title should match the
'ProductName' property in the MSI Property table, which is also the
value displayed in Add/Remove Programs, e.g.

<pre>
package { 'Microsoft Visual C++ 2008 Redistributable - x86 9.0.30729.4148':
  ensure => installed,
  ...
}
</pre>


In cases where the ProductName does not change across versions, e.g.
VMware Tools, you MUST use the PackageCode as the name of the resource
in order for puppet to accurately determine the state of the system:

<pre>
package { '{0E3AA38E-EAD3-4348-B5C5-051B6852CED6}':
  ensure => installed,
  ...
}
</pre>


You can obtain the PackageCode in ruby using:

<pre>
require 'win32ole'
installer = WIN32OLE.new('WindowsInstaller.Installer')
db = installer.OpenDatabase(path, 0)
puts db.SummaryInformation.Property(9)
</pre>


where <path> is the path to the MSI.

The msi provider does not automatically compare PackageCodes when
determining if the resource is insync, because the source MSI could be
on a network share, and we do not want to copy the potentially large
file just to see if changes need to be made.

The msi provider does not use the `Installer` interface to perform
install and uninstall, because I have not found a way to obtain useful
error codes when reboots are requested. Instead the methods
`InstallProduct` and `ConfigureProduct` raise exceptions with the
general 0x80020009 error, which means 'Exception occurred'. So for now
we continue to use msiexec.exe for install and uninstall, though the msi
provider may not uninstall multi-instance transforms correctly, since
the transform (MST) used to install the package needs to be respecified
during uninstall. This could be resolved by allowing uninstall_options
to be specified, or figuring out how to obtain useful error codes when
using the `Installer` interface.

[1] http://msdn.microsoft.com/en-us/library/windows/desktop/aa369432(v=vs.85).aspx
