### PR TITLE
(maint) Make Puppet's gem package task the same name as other Puppetlabs' projects

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ task :default do
 end
 
 desc "Create the tarball and the gem - use when releasing"
-task :puppetpackages => [:create_gem, :package]
+task :puppetpackages => [:gem, :package]
 
 RSpec::Core::RakeTask.new do |t|
     t.pattern ='spec/{unit,integration}/**/*.rb'

--- a/tasks/rake/gem.rake
+++ b/tasks/rake/gem.rake
@@ -49,7 +49,7 @@ task :prepare_gem do
 end
 
 desc "Create the gem"
-task :create_gem => :prepare_gem do
+task :gem => :prepare_gem do
     Dir.mkdir("pkg") rescue nil
     Gem::Builder.new(spec).build
     FileUtils.move("puppet-#{Puppet::PUPPETVERSION}.gem", "pkg")


### PR DESCRIPTION
Currently Facter, Hiera, Hiera-Puppet and Hiera-Json all use the `rake gem` task to package a gem. Puppet however uses `rake create_gem`. This changes the name to be the same as other projects for consistency in internal tooling.

This commit should be merged up through all of Puppet's currently developed branches.
