### PR TITLE
Fix syntax for confining test to non-windows platforms

### DIFF
--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -2,10 +2,9 @@
 require 'spec_helper'
 
 
-describe Puppet::Type do
+describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
   include PuppetSpec::Files
 
-  pending("porting to Windows", :if => Puppet.features.microsoft_windows?) do
   it "should be Comparable" do
     a = Puppet::Type.type(:notify).new(:name => "a")
     b = Puppet::Type.type(:notify).new(:name => "b")
@@ -727,7 +726,6 @@ describe Puppet::Type do
       TestEnsurableType.should_not be_ensurable
     end
   end
-  end
 end
 
 describe Puppet::Type::RelationshipMetaparam do
@@ -741,8 +739,7 @@ describe Puppet::Type::RelationshipMetaparam do
     Puppet::Type::RelationshipMetaparam.should respond_to(:subclasses)
   end
 
-  describe "when munging relationships" do
-  pending("porting to Windows", :if => Puppet.features.microsoft_windows?) do
+  describe "when munging relationships", :unless => Puppet.features.microsoft_windows? do
     before do
       @path = make_absolute('/foo')
       @resource = Puppet::Type.type(:mount).new :name => @path
@@ -757,7 +754,6 @@ describe Puppet::Type::RelationshipMetaparam do
     it "should turn any string into a Puppet::Resource" do
       @metaparam.munge("File[/ref]")[0].should be_instance_of(Puppet::Resource)
     end
-  end
   end
 
   it "should be able to validate relationships" do


### PR DESCRIPTION
A recent commit to this file attempting to confine
some of these tests to non-windows platforms; however,
the syntax wasn't quite right and a large swath of these
tests were being skipped incorrectly.  This commit fixes
that issue.
