### PR TITLE
Maint/3.0rc/cleaner bindings api

### DIFF
--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -9,7 +9,8 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
   end
 
   def find(request)
-    hiera.lookup(request.key, nil, request.options[:scope], nil, nil)
+    fake_scope = FakeScope.new(request.options[:facts])
+    hiera.lookup(request.key, nil, fake_scope, nil, nil)
   end
 
   private
@@ -34,6 +35,35 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
 
   def hiera
     self.class.hiera
+  end
+
+  # A class that acts just enough like a Puppet::Parser::Scope to
+  # fool Hiera's puppet backend. This class doesn't actually do anything
+  # but it does allow people to use the puppet backend with the hiera
+  # data bindings withough causing problems.
+  class FakeScope
+    FAKE_RESOURCE = Struct.new(:name).new("fake").freeze
+    FAKE_CATALOG = Struct.new(:classes).new([].freeze).freeze
+
+    def initialize(variable_bindings)
+      @variable_bindings = variable_bindings
+    end
+
+    def [](name)
+      @variable_bindings[name]
+    end
+
+    def resource
+      FAKE_RESOURCE
+    end
+
+    def catalog
+      FAKE_CATALOG
+    end
+
+    def function_include(name)
+      # noop
+    end
   end
 end
 

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -17,7 +17,7 @@ class Puppet::Node
     A node is composed of its name, its facts, and its environment."
 
   attr_accessor :name, :classes, :source, :ipaddress, :parameters
-  attr_reader :time
+  attr_reader :time, :facts
   #
   # Load json before trying to register.
   Puppet.features.pson? and ::PSON.register_document_type('Node',self)
@@ -73,6 +73,8 @@ class Puppet::Node
 
     @parameters = options[:parameters] || {}
 
+    @facts = options[:facts]
+
     if env = options[:environment]
       self.environment = env
     end
@@ -82,8 +84,8 @@ class Puppet::Node
 
   # Merge the node facts with parameters from the node source.
   def fact_merge
-    if facts = Puppet::Node::Facts.indirection.find(name, :environment => environment)
-      merge(facts.values)
+    if @facts = Puppet::Node::Facts.indirection.find(name, :environment => environment)
+      merge(@facts.values)
     end
   rescue => detail
     error = Puppet::Error.new("Could not retrieve facts for #{name}: #{detail}")

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -69,6 +69,10 @@ class Puppet::Parser::Scope
     @compiler.node.name
   end
 
+  def facts
+    @compiler.node.facts
+  end
+
   def include?(name)
     ! self[name].nil?
   end

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -317,7 +317,7 @@ class Puppet::Resource
       if resource_type.type == :hostclass
         namespaced_param = "#{resource_type.name}::#{param}"
         external_value = Puppet::DataBinding.indirection.find(
-          namespaced_param, :scope => scope)
+          namespaced_param, :host => scope.host, :environment => scope.environment.to_s, :facts => scope.facts.values)
       end
 
       if external_value.nil?

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -57,7 +57,7 @@ describe Puppet::Parser::Compiler do
     now = Time.now
     Time.stubs(:now).returns(now)
 
-    @node = Puppet::Node.new "testnode"
+    @node = Puppet::Node.new("testnode", :facts => Puppet::Node::Facts.new("facts", {}))
     @known_resource_types = Puppet::Resource::TypeCollection.new "development"
     @compiler = Puppet::Parser::Compiler.new(@node)
     @scope = Puppet::Parser::Scope.new(:compiler => @compiler, :source => stub('source'))

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -268,7 +268,8 @@ describe Puppet::Resource do
 
   describe "when setting default parameters" do
     before do
-      @scope = Puppet::Parser::Scope.new
+      @scope = mock "Scope"
+      @scope.stubs(:source).returns(nil)
     end
 
     it "should fail when asked to set default values and it is not a parser resource" do
@@ -305,14 +306,18 @@ describe Puppet::Resource do
     end
 
     describe "when the resource type is :hostclass" do
-      before do
-        @scope.stubs(:host).returns('foo')
-        Puppet::Node::Environment.new.known_resource_types.add(apache)
-      end
-
+      let(:environmnet_name) { "testing env" }
+      let(:fact_values) { { :a => 1 } }
       let(:port) { Puppet::Parser::AST::String.new(:value => '80') }
-      let(:apache) do
-        Puppet::Resource::Type.new(:hostclass, 'apache', :arguments => { 'port' => port })
+      let(:apache) { Puppet::Resource::Type.new(:hostclass, 'apache', :arguments => { 'port' => port }) }
+
+      before do
+        environment = Puppet::Node::Environment.new(environmnet_name)
+        environment.known_resource_types.add(apache)
+
+        @scope.stubs(:host).returns('host')
+        @scope.stubs(:environment).returns(Puppet::Node::Environment.new(environmnet_name))
+        @scope.stubs(:facts).returns(Puppet::Node::Facts.new("facts", fact_values))
       end
 
       context "when no value is provided" do
@@ -322,26 +327,18 @@ describe Puppet::Resource do
 
         it "should query the data_binding terminus using a namespaced key" do
           Puppet::DataBinding.indirection.expects(:find).with(
-            'apache::port', :scope => @scope)
-          resource.set_default_parameters(@scope)
-        end
-
-        it "should query the data_binding terminus using the scope object" do
-          Puppet::DataBinding.indirection.expects(:find).with(
-            'apache::port', :scope => @scope)
+            'apache::port', :host => 'host', :environment => environmnet_name, :facts => fact_values)
           resource.set_default_parameters(@scope)
         end
 
         it "should use the value from the data_binding terminus" do
-          Puppet::DataBinding.indirection.expects(:find).with(
-            'apache::port', :scope => @scope).returns('443')
+          Puppet::DataBinding.indirection.expects(:find).returns('443')
           resource.set_default_parameters(@scope).should == [:port]
           resource[:port].should == '443'
         end
 
         it "should use the default value if the data_binding terminus returns nil" do
-          Puppet::DataBinding.indirection.expects(:find).with(
-            'apache::port', :scope => @scope).returns(nil)
+          Puppet::DataBinding.indirection.expects(:find).returns(nil)
           resource.set_default_parameters(@scope).should == [:port]
           resource[:port].should == '80'
         end


### PR DESCRIPTION
Previously the data binding terminus took the entire scope object which
provided far to much access to the internals of puppet to the
implemetors of data binding terminuses. This changes it to pass through
only the data that should be needed for discovering what value to use in
most reasonable implementations of data binding.
