### PR TITLE
(#14962) PMT doesn't support setting a relative modulepath

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -147,13 +147,14 @@ Puppet::Face.define(:module, '1.0.0') do
 
     when_invoked do |name, options|
       sep = File::PATH_SEPARATOR
+
       if options[:target_dir]
-        options[:target_dir] = File.expand_path(options[:target_dir])
         options[:modulepath] = "#{options[:target_dir]}#{sep}#{options[:modulepath]}"
       end
 
       Puppet.settings[:modulepath] = options[:modulepath]
       options[:target_dir] = Puppet.settings[:modulepath].split(sep).first
+      options[:target_dir] = File.expand_path(options[:target_dir])
 
       Puppet.notice "Preparing to install into #{options[:target_dir]} ..."
       Puppet::ModuleTool::Applications::Installer.run(name, options)

--- a/spec/unit/face/module/install_spec.rb
+++ b/spec/unit/face/module/install_spec.rb
@@ -88,15 +88,26 @@ describe "puppet module install" do
 
           Puppet.settings[:modulepath].should == fakemodpath
         end
+
+        it "should expand the target directory derived from the modulepath" do
+          options[:modulepath] = "modules"
+          expanded_path = File.expand_path("modules")
+          expected_options.merge!(options)
+          expected_options[:target_dir] = expanded_path
+          expected_options[:modulepath] = "modules"
+
+          Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
+          subject.install("puppetlabs-apache", options)
+        end
       end
 
       describe "when target-dir option is passed" do
-        it "should expand the target directory" do
+        it "should expand the target directory when target_dir is set" do
           options[:target_dir] = "modules"
           expanded_path = File.expand_path("modules")
           expected_options.merge!(options)
           expected_options[:target_dir] = expanded_path
-          expected_options[:modulepath] = "#{expanded_path}#{sep}#{fakemodpath}"
+          expected_options[:modulepath] = "modules#{sep}#{fakemodpath}"
 
           Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
           subject.install("puppetlabs-apache", options)


### PR DESCRIPTION
We previously fixed expansion for the target_dir, but this only worked when the
target_dir was set explicitly, it didn't support relative paths being passed in
the modulepath. This patch fixes that and adds tests.

As a side-effect, this should also fixes cases where the first modulepath
defined in the configuration file is relative.

It also corrects the tests previously applied for expanding the target_dir, as
it used to rely on expanding the target_dir before adding it to the modulepath.
This wasn't necessary, so now we don't bother testing that the targetdir is
expanded in the modulepath after being added.
