### PR TITLE
#14531 Fix default ensure value for symlinks

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -437,7 +437,7 @@ Puppet::Type.newtype(:file) do
     # from it.
     unless self[:ensure]
       if self[:target]
-        self[:ensure] = :symlink
+        self[:ensure] = :link
       elsif self[:content]
         self[:ensure] = :file
       end

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -65,8 +65,9 @@ describe Puppet::Type.type(:file) do
 
     file.parameter(:mode).expects(:retrieve).never
 
-    report = catalog.apply.report
-    report.resource_statuses["File[#{path}]"].should_not be_failed
+    status = catalog.apply.report.resource_statuses["File[#{path}]"]
+    status.should_not be_failed
+    status.should_not be_changed
     File.should_not be_exist(path)
   end
 
@@ -182,14 +183,11 @@ describe Puppet::Type.type(:file) do
         describe "when managing links" do
           let(:target) { tmpfile('target') }
 
-          before :each do
+          it "should not set the executable bit on the link nor the target" do
             FileUtils.touch(target)
             File.chmod(0444, target)
-
             File.symlink(target, link)
-          end
 
-          it "should not set the executable bit on the link nor the target" do
             catalog.add_resource described_class.new(:path => link, :ensure => :link, :mode => 0666, :target => target, :links => :manage)
             catalog.apply
 
@@ -198,12 +196,22 @@ describe Puppet::Type.type(:file) do
           end
 
           it "should ignore dangling symlinks (#6856)" do
-            File.delete(target)
+            File.symlink(target, link)
 
             catalog.add_resource described_class.new(:path => link, :ensure => :link, :mode => 0666, :target => target, :links => :manage)
             catalog.apply
 
             File.should_not be_exist(link)
+          end
+
+          it "should create a link to the target if ensure is omitted" do
+            FileUtils.touch(target)
+            catalog.add_resource described_class.new(:path => link, :target => target)
+            catalog.apply
+
+            File.should be_exist link
+            File.lstat(link).ftype.should == 'link'
+            File.readlink(link).should == target
           end
         end
 

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -433,7 +433,7 @@ describe Puppet::Type.type(:file) do
 
     it "should set a desired 'ensure' value if none is set and 'target' is set" do
       file = described_class.new(:path => path, :target => File.expand_path(__FILE__))
-      file[:ensure].should == :symlink
+      file[:ensure].should == :link
     end
   end
 
@@ -1260,7 +1260,7 @@ describe Puppet::Type.type(:file) do
     describe "target" do
       it "should require file resource when specified with the target property" do
         file = described_class.new(:path => File.expand_path("/foo"), :ensure => :directory)
-        link = described_class.new(:path => File.expand_path("/bar"), :ensure => :symlink, :target => File.expand_path("/foo"))
+        link = described_class.new(:path => File.expand_path("/bar"), :ensure => :link, :target => File.expand_path("/foo"))
         catalog.add_resource file
         catalog.add_resource link
         reqs = link.autorequire
@@ -1281,7 +1281,7 @@ describe Puppet::Type.type(:file) do
       end
 
       it "should not require target if target is not managed" do
-        link = described_class.new(:path => File.expand_path('/foo'), :ensure => :symlink, :target => '/bar')
+        link = described_class.new(:path => File.expand_path('/foo'), :ensure => :link, :target => '/bar')
         catalog.add_resource link
         link.autorequire.size.should == 0
       end


### PR DESCRIPTION
As mentioned in bugreport #14531 specifying `target` without `ensure` of a file resource can lead to unexpected results. Sample:

```
file { '/tmp/a':
  target => '/tmp/b',
}
```

Running puppet on that manifest will _always_ print the following

```
File[/tmp/a]/ensure: created
```

while in fact the link was not created. Even worse: If `/tmp/a` _does_ already exist, puppet will just _remove_ the link, still saying it created something.

Reading `type/file.rb` puppet should create the link even if ensure is not specified:

```
# If they've specified a source, we get our 'should' values
# from it.
unless self[:ensure]
  if self[:target]
    self[:ensure] = :symlink
  elsif self[:content]
    self[:ensure] = :file
  end
end

@stat = :needs_stat
```

The problem here is: If ensure is omitted, puppet will set the should value to `:symlink` in the initialize method but the ensure property itself uses the symbol `:link` to identify a link. So puppet will always treat the above resource as out in sync. In order to fix the resource puppet will now call `sync` on the ensure property which will remove `/tmp/a` first (method `remove_existing` but the block passed to `newvalue(:link)` is never executed. Because there is no `newvalue(:symlink)` block, puppet will run the block in `newvalue(/./)` which does nothing at all.

As a result puppet will _always_ say it created something while in fact making sure that the resource is _removed_.

Change the default ensure value from :symlink to :link if target is
set.
