### PR TITLE
Maint/2.7.x/fix gentoo test failure

### DIFF
--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -48,6 +48,7 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
 
     it "should get a list of services from /etc/init.d but exclude helper scripts" do
       FileTest.expects(:directory?).with('/etc/init.d').returns true
+      File.stubs(:symlink?).returns(false)
       Dir.expects(:entries).with('/etc/init.d').returns initscripts
       (initscripts - helperscripts).each do |script|
         FileTest.expects(:executable?).with("/etc/init.d/#{script}").returns true


### PR DESCRIPTION
The gentoo service provider spec test stubbing didn't stub symlinks. A recent
change in the init provider started discarding symlinks from upstart jobs and
because this element wasn't stubbed, the test went to the (ubuntu) filesystem
and found a symlink to an upstart job, which was not the intent of the test.
This commit adds a blanket stub that there are no symlinks in the filesystem
for the specific test.
