### PR TITLE
Maint/2.7.x/use git describe in packaging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,13 @@ require 'rspec'
 require "rspec/core/rake_task"
 
 module Puppet
-    PUPPETVERSION = File.read('lib/puppet.rb')[/PUPPETVERSION *= *'(.*)'/,1] or fail "Couldn't find PUPPETVERSION"
+    %x{which git &> /dev/null}
+    if $?.success? and File.exist?('.git')
+        # remove the git hash from git describe string
+        PUPPETVERSION=%x{git describe}.chomp.gsub('-','.').split('.')[0..3].join('.')
+    else
+        PUPPETVERSION=File.read('lib/puppet.rb')[/PUPPETVERSION *= *'(.*)'/,1] or fail "Couldn't find PUPPETVERSION"
+    end
 end
 
 Dir['tasks/**/*.rake'].each { |t| load t }


### PR DESCRIPTION
This commit modifies the rakefile to use git describe
to determine the package version instead of the hard-coded
version in lib/puppet.rb. This takes a couple steps
out of packaging RCs. The specific string manipulation
is borrowed from puppetdb packaging.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
