### PR TITLE
(#4111) Add option to change properties when 'ensure' changes

### DIFF
--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -64,6 +64,49 @@ describe Puppet::Type do
     end
   end
 
+  it "should have a method for retrieving all independent properties" do
+    Puppet::Type.type(:mount).new(:name => "foo").should respond_to(:independent_properties)
+  end
+
+
+  describe "when retrieving independent properties" do
+    before do
+      @test_type = Puppet::Type.newtype(:independent_test_type) do
+        newproperty(:ensure)
+        newproperty(:foo, :independent => :true)
+        newproperty(:bar, :independent => :true)
+        newproperty(:dependent)
+        newproperty(:also_dependent)
+        newparam(:name) { isnamevar }
+      end
+    end
+
+    it "should be able to retrieve all the properties with independent set to :true" do
+      props = @test_type.independent_properties
+      props.should_not be_include(nil)
+      props.should have(2).items
+      props.should be_include(@test_type.propertybyname(:foo))
+      props.should be_include(@test_type.propertybyname(:bar))
+    end
+
+    it "should not include properties without independent set to :true and also no :ensure property" do
+      props = @test_type.independent_properties
+      props.should_not be_include(nil)
+      props.should have(2).items
+      props.should_not be_include(@test_type.propertybyname(:dependent))
+      props.should_not be_include(@test_type.propertybyname(:also_dependent))
+      props.should_not be_include(@test_type.propertybyname(:ensure))
+    end
+  end
+
+  it "should raise an error if property option :independent is not given the value :true" do
+    expect {
+      test_type = Puppet::Type.newtype(:independent_test_type) do
+        newproperty(:foo, :independent => :bar)
+      end
+    }.to raise_error(Puppet::DevError, /The only valid value for the 'independent' property option is true/)
+  end
+
   it "should have a method for setting default values for resources" do
     Puppet::Type.type(:mount).new(:name => "foo").should respond_to(:set_default)
   end


### PR DESCRIPTION
This commit will add the ability to mark a general property as independent from the :ensure
property. This is being done to modify the behavior that currently exists in the way general
properties are handled in the presence of the :ensure property. Currently, if the :ensure property
is :absent or out of sync, no other properties will be processed. This means properties that
do not rely on the status of :ensure will not be processed.

As an example, currently there is a workaround in place. This workaround is seen in the
core 'service' type.The :enable property does not rely on :ensure. In the :ensure property,
there is code that will manually sync the :enable property when :ensure is out of sync. This
is a problem because the change is never reported. The event can't be recorded or audited.

This new functionality is achieved by adding an option to the `newproperty` function in the
Type class. The :independent option will add the property to a list in the type class that
will track independent properties. It will only accept the value of :true, and will have no effect
on the :ensure property. The ResourceHarness class was modified to process the independent property
list if the :ensure property is changed or is :absent. To help preserve the behavior of the :ensure
property, independent properties will always be processed after the :ensure property. This is
similar to how property processing was ordered before this commit.

Example: newproperty(:example, :independent => true)

This change is backwards compatible with the previous method of processing independent
properties. Also, properties dependent of the :ensure property will not have their behavior
modified in this change.

This commit includes new unit tests that this change has passed on. It has also passed on the
unit tests already in place for the modified classes.
