### PR TITLE
(#7788) Feature/3.0rc/autoloader works with rubygems

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -181,9 +181,11 @@ class Puppet::Configurer
       execute_postrun_command or return nil
     end
   ensure
-    # Make sure we forget the retained module_directories of any autoload
-    # we might have used.
+    # Between Puppet runs we need to forget the cached values.  This lets us
+    # pick up on new functions installed by gems or new modules being added
+    # without the daemon being restarted.
     Thread.current[:env_module_directories] = nil
+    Thread.current[:gem_directories] = nil
 
     Puppet::Util::Log.close(report)
     send_report(report)

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -19,6 +19,7 @@ class Puppet::Parser::Compiler
     # stick until the next entry to this function.
     Thread.current[:known_resource_types] = nil
     Thread.current[:env_module_directories] = nil
+    Thread.current[:gem_directories] = nil
 
     # ...and we actually do the compile now we have caching ready.
     new(node).compile.to_resource

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'puppet/util/rubygems'
 require 'puppet/util/warnings'
 
 # Autoload paths, either based on names or all at once.
@@ -149,8 +150,18 @@ class Puppet::Util::Autoload
       end
     end
 
+    # We have to cache this locally to the thread as the heavy use of the the
+    # autoloader by puppet means that without caching it would have a big negative
+    # impact on performance.
+    #
+    # This cache is being cleared before compiles and runs in puppet/configurer.rb and
+    # puppet/parser/compiler.rb
+    def gem_directories
+      Thread.current[:gem_directories] ||= Puppet::Util::RubyGems.directories
+    end
+
     def search_directories(env=nil)
-        [module_directories(env), libdirs(), $LOAD_PATH].flatten
+      [gem_directories, module_directories(env), libdirs(), $LOAD_PATH].flatten
     end
 
     # Normalize a path. This converts ALT_SEPARATOR to SEPARATOR on Windows

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -1,5 +1,6 @@
 require 'puppet'
 require "puppet/util/plugins"
+require "puppet/util/rubygems"
 
 module Puppet
   module Util
@@ -29,7 +30,10 @@ module Puppet
         # Eventually we probably want to replace this with a call to the autoloader.  however, at the moment
         #  the autoloader considers the module path when loading, and we don't want to allow apps / faces to load
         #  from there.  Once that is resolved, this should be replaced.  --cprice 2012-03-06
-        absolute_appdirs = $LOAD_PATH.collect do |x|
+        #
+        # But we do want to load from rubygems --hightower
+        search_path = Puppet::Util::RubyGems.directories + $LOAD_PATH
+        absolute_appdirs = search_path.uniq.collect do |x|
           File.join(x,'puppet','application')
         end.select{ |x| File.directory?(x) }
         absolute_appdirs.inject([]) do |commands, dir|

--- a/lib/puppet/util/rubygems.rb
+++ b/lib/puppet/util/rubygems.rb
@@ -1,0 +1,29 @@
+require 'puppet/util'
+
+module Puppet::Util::RubyGems
+  module_function
+
+  # Get the load paths for the latest versions of installed gems. We only want
+  # the latest versions of each gem to prevent mixing old and new code for
+  # things like Faces, and custom report processors.
+  def directories
+    begin
+      require 'rubygems'
+      # Rubygems >= 1.8.0
+      if Gem::Specification.respond_to? :latest_specs
+        dirs = Gem::Specification.latest_specs.collect do |spec|
+          File.join(spec.full_gem_path, '/lib')
+        end
+      elsif Gem.respond_to? :latest_load_paths
+        dirs = Gem.latest_load_paths
+      else
+        return []
+      end
+    rescue LoadError
+      return []
+    end
+
+    dirs.find_all { |d| FileTest.directory?(d) }
+  end
+end
+

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -333,6 +333,16 @@ describe Puppet::Configurer do
       @agent.environment.should == "second_env"
     end
 
+    it "should clear the thread local caches" do
+      Thread.current[:env_module_directories] = false
+      Thread.current[:gem_directories] = false
+
+      @agent.run
+
+      Thread.current[:env_module_directories].should == nil
+      Thread.current[:gem_directories].should == nil
+    end
+
     describe "when not using a REST terminus for catalogs" do
       it "should not pass any facts when retrieving the catalog" do
         Puppet::Resource::Catalog.indirection.terminus_class = :compiler

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -98,6 +98,24 @@ describe Puppet::Parser::Compiler do
     @compiler.classlist.sort.should == %w{one two}.sort
   end
 
+  it "should clear the thread local caches before compile" do
+    compiler = stub 'compiler'
+    Puppet::Parser::Compiler.expects(:new).with(@node).returns compiler
+    catalog = stub 'catalog'
+    compiler.expects(:compile).returns catalog
+    catalog.expects(:to_resource)
+
+    [:known_resource_types, :env_module_directories, :gem_directories].each do |var|
+      Thread.current[var] = "rspec"
+    end
+
+    Puppet::Parser::Compiler.compile(@node)
+
+    [:known_resource_types, :env_module_directories, :gem_directories].each do |var|
+      Thread.current[var].should == nil
+    end
+  end
+
   describe "when initializing" do
 
     it "should set its node attribute" do

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -55,8 +55,19 @@ describe Puppet::Util::Autoload do
 
     it "should include the module directories, the Puppet libdir, and all of the Ruby load directories" do
       Puppet[:libdir] = %w{/libdir1 /lib/dir/two /third/lib/dir}.join(File::PATH_SEPARATOR)
-      @autoload.class.expects(:module_directories).returns %w{/one /two}
-      @autoload.class.search_directories.should == %w{/one /two} + Puppet[:libdir].split(File::PATH_SEPARATOR) + $LOAD_PATH
+      @autoload.class.expects(:gem_directories).returns %w{/one /two}
+      @autoload.class.expects(:module_directories).returns %w{/three /four}
+      @autoload.class.search_directories.should == %w{/one /two /three /four} + Puppet[:libdir].split(File::PATH_SEPARATOR) + $LOAD_PATH
+    end
+
+    it "should save the gem load path to the thread local cache" do
+      Thread.current[:gem_directories] = nil
+      Puppet::Util::RubyGems.expects(:directories).returns(["foo/loaddir"])
+
+      @autoload = Puppet::Util::Autoload.new("foo", "loaddir")
+      @autoload.class.search_directories
+
+      Thread.current[:gem_directories].should == ["foo/loaddir"]
     end
   end
 

--- a/spec/unit/util/rubygems_spec.rb
+++ b/spec/unit/util/rubygems_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'puppet/util/rubygems'
+
+describe Puppet::Util::RubyGems do
+  describe 'directories' do
+
+    it "should return no directories if rubygems fails to load" do
+      # I could not figure out a better way to produce a LoadError, as rubygems
+      # is already loaded by the time we get here. 
+      Gem::Specification.expects(:latest_specs).raises LoadError
+      Puppet::Util::RubyGems.directories.should == []
+    end
+
+    context "when rubygems is installed", :if => Puppet.features.rubygems? do
+      let :fakegem do
+        stub(:full_gem_path => '/foo/gems')
+      end
+
+      it "should use Gem::Specification.latest_specs when available" do
+        FileTest.expects(:directory?).with('/foo/gems/lib').returns(true)
+        Gem::Specification.expects(:latest_specs).returns([fakegem])
+
+        Puppet::Util::RubyGems.directories.should == ['/foo/gems/lib']
+      end
+
+      it "should fallback to Gem.latest_load_paths" do
+        FileTest.expects(:directory?).with('/foo/gems/lib').returns(true)
+        Gem::Specification.expects(:respond_to?).with(:latest_specs).returns(false)
+        Gem.expects(:latest_load_paths).returns('/foo/gems/lib')
+
+        Puppet::Util::RubyGems.directories.should == ['/foo/gems/lib']
+      end
+
+      it "should return no directories if Gem.latest_load_paths and Gem::Specification.latest_specs not available" do
+        FileTest.expects(:directory?).never
+        Gem::Specification.expects(:respond_to?).with(:latest_specs).returns(false)
+        Gem.expects(:respond_to?).with(:latest_load_paths).returns(false)
+
+        Puppet::Util::RubyGems.directories.should == []
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
The autoloader includes rubygems in the search path when searching for
modules to load. Puppet can now load things like Faces, report
processors, and parser functions using rubygems.

Example:

```
$ gem install puppetlabs-cloud_provisioner-1.0.4.gem
...
Successfully installed fog-1.3.1
Successfully installed guid-0.1.1
Successfully installed puppetlabs-cloud_provisioner-1.0.4

$ puppet help
Usage: puppet <subcommand> [options] <action> [options]

Available subcommands:
...
node_aws          View and manage Amazon AWS EC2 nodes.
```

This patch adds a new `Puppet::Util::RubyGems#directories` method for
locating the latest gems and their load paths. This method is used in
two places:
- When searching for subcommands
- When auto loading plug-ins

Updated specs are included.
