### PR TITLE
(#15078) Document USR2 log rotation signal

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -293,6 +293,8 @@ Puppet agent accepts the following signals:
   Shut down the puppet agent daemon.
 * SIGUSR1:
   Immediately retrieve and apply configurations from the puppet master.
+* SIGUSR2:
+  Close file descriptors for log files and reopen them. Used with logrotate.
 
 AUTHOR
 ------

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -112,6 +112,8 @@ following signals:
   Restart the puppet master server.
 * SIGINT and SIGTERM:
   Shut down the puppet master server.
+* SIGUSR2:
+  Close file descriptors for log files and reopen them. Used with logrotate.
 
 AUTHOR
 ------

--- a/man/man8/puppet-agent.8
+++ b/man/man8/puppet-agent.8
@@ -147,6 +147,10 @@ Shut down the puppet agent daemon\.
 SIGUSR1
 Immediately retrieve and apply configurations from the puppet master\.
 .
+.TP
+SIGUSR2
+Close file descriptors for log files and reopen them\. Used with logrotate\.
+.
 .SH "AUTHOR"
 Luke Kanies
 .

--- a/man/man8/puppet-master.8
+++ b/man/man8/puppet-master.8
@@ -67,6 +67,10 @@ Restart the puppet master server\.
 SIGINT and SIGTERM
 Shut down the puppet master server\.
 .
+.TP
+SIGUSR2
+Close file descriptors for log files and reopen them\. Used with logrotate\.
+.
 .SH "AUTHOR"
 Luke Kanies
 .

--- a/man/man8/puppetmasterd.8
+++ b/man/man8/puppetmasterd.8
@@ -67,6 +67,10 @@ Restart the puppet master server\.
 SIGINT and SIGTERM
 Shut down the puppet master server\.
 .
+.TP
+SIGUSR2
+Close file descriptors for log files and reopen them\. Used with logrotate\.
+.
 .SH "AUTHOR"
 Luke Kanies
 .


### PR DESCRIPTION
USR2 causes Puppet daemons to close log files and reopen them.  It was added in
issue #305.
