### PR TITLE
(#14136) Emit debug/warnings when Augeas provider fails to load files

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -161,9 +161,11 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
       glob_avail = !aug.match("/augeas/version/pathx/functions/glob").empty?
 
+      restricted = false
       if resource[:incl]
         aug.set("/augeas/load/Xfm/lens", resource[:lens])
         aug.set("/augeas/load/Xfm/incl", resource[:incl])
+        restricted = true
       elsif glob_avail and resource[:context] and resource[:context].match("^/files/")
         # Optimize loading if the context is given, requires the glob function
         # from Augeas 0.8.2 or up
@@ -172,12 +174,14 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
         if aug.match(load_path).size < aug.match("/augeas/load/*").size
           aug.rm(load_path)
+          restricted = true
         else
           # This will occur if the context is less specific than any glob
           debug("Unable to optimize files loaded by context path, no glob matches")
         end
       end
       aug.load
+      print_load_errors(:warning => restricted)
     end
     @aug
   end
@@ -281,14 +285,29 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     @aug.set("/augeas/save", mode)
   end
 
+  def print_load_errors(args={})
+    errors = @aug.match("/augeas//error")
+    unless errors.empty?
+      if args[:warning]
+        warning("Loading failed for one or more files, see debug for /augeas//error output")
+      else
+        debug("Loading failed for one or more files, output from /augeas//error:")
+      end
+    end
+    print_errors(errors)
+  end
+
   def print_put_errors
     errors = @aug.match("/augeas//error[. = 'put_failed']")
     debug("Put failed on one or more files, output from /augeas//error:") unless errors.empty?
+    print_errors(errors)
+  end
+
+  def print_errors(errors)
     errors.each do |errnode|
       @aug.match("#{errnode}/*").each do |subnode|
-        sublabel = subnode.split("/")[-1]
         subvalue = @aug.get(subnode)
-        debug("#{sublabel} = #{subvalue}")
+        debug("#{subnode} = #{subvalue}")
       end
     end
   end

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -608,14 +608,34 @@ describe provider_class do
     end
   end
 
-  describe "save failure reporting" do
+  describe "load/save failure reporting" do
     before do
       @augeas = stub("augeas")
       @augeas.stubs("close")
       @provider.aug = @augeas
     end
 
-    it "should find errors and output to debug" do
+    describe "should find load errors" do
+      before do
+        @augeas.expects(:match).with("/augeas//error").returns(["/augeas/files/foo/error"])
+        @augeas.expects(:match).with("/augeas/files/foo/error/*").returns(["/augeas/files/foo/error/path", "/augeas/files/foo/error/message"])
+        @augeas.expects(:get).with("/augeas/files/foo/error/path").returns("/foo")
+        @augeas.expects(:get).with("/augeas/files/foo/error/message").returns("Failed to...")
+      end
+
+      it "and output to debug" do
+        @provider.expects(:debug).times(4)
+        @provider.print_load_errors
+      end
+
+      it "and output a warning and to debug" do
+        @provider.expects(:warning).once()
+        @provider.expects(:debug).times(3)
+        @provider.print_load_errors(:warning => true)
+      end
+    end
+
+    it "should find save errors and output to debug" do
       @augeas.expects(:match).with("/augeas//error[. = 'put_failed']").returns(["/augeas/files/foo/error"])
       @augeas.expects(:match).with("/augeas/files/foo/error/*").returns(["/augeas/files/foo/error/path", "/augeas/files/foo/error/message"])
       @augeas.expects(:get).with("/augeas/files/foo/error/path").returns("/foo")
@@ -638,11 +658,18 @@ describe provider_class do
       aug.match("/files/etc/test").should == []
     end
 
+    it "should report load errors to debug only" do
+      @provider.expects(:print_load_errors).with(:warning => false)
+      aug = @provider.open_augeas
+      aug.should_not == nil
+    end
+
     # Only the file specified should be loaded
     it "should load one file if incl/lens used" do
       @resource[:incl] = "/etc/hosts"
       @resource[:lens] = "Hosts.lns"
 
+      @provider.expects(:print_load_errors).with(:warning => true)
       aug = @provider.open_augeas
       aug.should_not == nil
       aug.match("/files/etc/fstab").should == []
@@ -665,6 +692,7 @@ describe provider_class do
       it "should only load one file if relevant context given" do
         @resource[:context] = "/files/etc/fstab"
 
+        @provider.expects(:print_load_errors).with(:warning => true)
         aug = @provider.open_augeas
         aug.should_not == nil
         aug.match("/files/etc/fstab").should == ["/files/etc/fstab"]


### PR DESCRIPTION
Originally submitted as #733 against master, re-targeting to 3.x now the branch exists.

The messages and information from /augeas//error are now printed to debug when
the provider opens Augeas, allowing file parse errors to be found.

The provider can also restrict the files that are loaded (from the default of
everything).  In these cases, the provider now emits a warning and then prints
all the detailed information to debug.  Since a few parse errors are common, no
warning is given when these optimisations aren't in use.
