### PR TITLE
(#14962) pmt relative modulepath

### DIFF
--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -1,0 +1,37 @@
+begin test_name "puppet module install (with modulepath)"
+
+step 'Setup'
+require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
+apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+apply_manifest_on master, "file { ['/etc/puppet/modules2']: ensure => directory, recurse => true, purge => true, force => true }"
+
+step "Install a module with relative modulepath"
+on master, "cd /etc/puppet/modules2 && puppet module install pmtacceptance-nginx --modulepath=." do
+  assert_output <<-OUTPUT
+    Preparing to install into /etc/puppet/modules2 ...
+    Downloading from http://forge.puppetlabs.com ...
+    Installing -- do not interrupt ...
+    /etc/puppet/modules2
+    └── pmtacceptance-nginx (\e[0;36mv0.0.1\e[0m)
+  OUTPUT
+end
+on master, '[ -d /etc/puppet/modules2/nginx ]'
+apply_manifest_on master, "file { ['/etc/puppet/modules2']: ensure => directory, recurse => true, purge => true, force => true }"
+
+step "Install a module with absolute modulepath"
+on master, puppet('module install pmtacceptance-nginx --modulepath=/etc/puppet/modules2') do
+  assert_output <<-OUTPUT
+    Preparing to install into /etc/puppet/modules2 ...
+    Downloading from http://forge.puppetlabs.com ...
+    Installing -- do not interrupt ...
+    /etc/puppet/modules2
+    └── pmtacceptance-nginx (\e[0;36mv0.0.1\e[0m)
+  OUTPUT
+end
+on master, '[ -d /etc/puppet/modules2/nginx ]'
+apply_manifest_on master, "file { ['/etc/puppet/modules2']: ensure => directory, recurse => true, purge => true, force => true }"
+
+ensure step "Teardown"
+apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
+apply_manifest_on master, "file { ['/etc/puppet/modules2']: ensure => directory, recurse => true, purge => true, force => true }"
+end

--- a/acceptance/tests/modules/list/with_modulepath.rb
+++ b/acceptance/tests/modules/list/with_modulepath.rb
@@ -1,0 +1,76 @@
+begin test_name "puppet module list (with modulepath)"
+
+step "Setup"
+apply_manifest_on master, <<-PP
+file {
+  [
+    '/etc/puppet/modules2',
+    '/etc/puppet/modules2/crakorn',
+    '/etc/puppet/modules2/appleseed',
+    '/etc/puppet/modules2/thelock',
+  ]: ensure => directory,
+     recurse => true,
+     purge => true,
+     force => true;
+  '/etc/puppet/modules2/crakorn/metadata.json':
+    content => '{
+      "name": "jimmy/crakorn",
+      "version": "0.4.0",
+      "source": "",
+      "author": "jimmy",
+      "license": "MIT",
+      "dependencies": []
+    }';
+  '/etc/puppet/modules2/appleseed/metadata.json':
+    content => '{
+      "name": "jimmy/appleseed",
+      "version": "1.1.0",
+      "source": "",
+      "author": "jimmy",
+      "license": "MIT",
+      "dependencies": [
+        { "name": "jimmy/crakorn", "version_requirement": "0.4.0" }
+      ]
+    }';
+  '/etc/puppet/modules2/thelock/metadata.json':
+    content => '{
+      "name": "jimmy/thelock",
+      "version": "1.0.0",
+      "source": "",
+      "author": "jimmy",
+      "license": "MIT",
+      "dependencies": [
+        { "name": "jimmy/appleseed", "version_requirement": "1.x" }
+      ]
+    }';
+}
+PP
+on master, '[ -d /etc/puppet/modules2/crakorn ]'
+on master, '[ -d /etc/puppet/modules2/appleseed ]'
+on master, '[ -d /etc/puppet/modules2/thelock ]'
+
+step "List the installed modules with relative modulepath"
+on master, 'cd /etc/puppet/modules2 && puppet module list --modulepath=.' do
+  assert_equal '', stderr
+  assert_equal <<-STDOUT, stdout
+/etc/puppet/modules2
+├── jimmy-appleseed (\e[0;36mv1.1.0\e[0m)
+├── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
+└── jimmy-thelock (\e[0;36mv1.0.0\e[0m)
+STDOUT
+end
+
+step "List the installed modules with absolute modulepath"
+on master, puppet('module list --modulepath=/etc/puppet/modules2') do
+  assert_equal '', stderr
+  assert_equal <<-STDOUT, stdout
+/etc/puppet/modules2
+├── jimmy-appleseed (\e[0;36mv1.1.0\e[0m)
+├── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
+└── jimmy-thelock (\e[0;36mv1.0.0\e[0m)
+STDOUT
+end
+
+ensure step "Teardown"
+apply_manifest_on master, "file { ['/etc/puppet/modules2']: ensure => directory, recurse => true, purge => true, force => true }"
+end

--- a/acceptance/tests/modules/uninstall/with_modulepath.rb
+++ b/acceptance/tests/modules/uninstall/with_modulepath.rb
@@ -1,0 +1,54 @@
+begin test_name "puppet module uninstall (with modulepath)"
+
+step "Setup"
+apply_manifest_on master, <<-PP
+file {
+  [
+    '/etc/puppet/modules2',
+    '/etc/puppet/modules2/crakorn',
+    '/etc/puppet/modules2/absolute',
+  ]: ensure => directory;
+  '/etc/puppet/modules2/crakorn/metadata.json':
+    content => '{
+      "name": "jimmy/crakorn",
+      "version": "0.4.0",
+      "source": "",
+      "author": "jimmy",
+      "license": "MIT",
+      "dependencies": []
+    }';
+  '/etc/puppet/modules2/absolute/metadata.json':
+    content => '{
+      "name": "jimmy/absolute",
+      "version": "0.4.0",
+      "source": "",
+      "author": "jimmy",
+      "license": "MIT",
+      "dependencies": []
+    }';
+}
+PP
+on master, '[ -d /etc/puppet/modules2/crakorn ]'
+on master, '[ -d /etc/puppet/modules2/absolute ]'
+
+step "Try to uninstall the module jimmy-crakorn using relative modulepath"
+on master, 'cd /etc/puppet/modules2 && puppet module uninstall jimmy-crakorn --modulepath=.' do
+  assert_output <<-OUTPUT
+    Preparing to uninstall 'jimmy-crakorn' ...
+    Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from /etc/puppet/modules2
+  OUTPUT
+end
+on master, '[ ! -d /etc/puppet/modules2/crakorn ]'
+
+step "Try to uninstall the module jimmy-absolute using an absolute modulepath"
+on master, 'cd /etc/puppet/modules2 && puppet module uninstall jimmy-absolute --modulepath=/etc/puppet/modules2' do
+  assert_output <<-OUTPUT
+    Preparing to uninstall 'jimmy-absolute' ...
+    Removed 'jimmy-absolute' (\e[0;36mv0.4.0\e[0m) from /etc/puppet/modules2
+  OUTPUT
+end
+on master, '[ ! -d /etc/puppet/modules2/absolute ]'
+
+ensure step "Teardown"
+apply_manifest_on master, "file { ['/etc/puppet/modules2']: ensure => directory, recurse => true, purge => true, force => true }"
+end

--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -147,13 +147,14 @@ Puppet::Face.define(:module, '1.0.0') do
 
     when_invoked do |name, options|
       sep = File::PATH_SEPARATOR
+
       if options[:target_dir]
-        options[:target_dir] = File.expand_path(options[:target_dir])
         options[:modulepath] = "#{options[:target_dir]}#{sep}#{options[:modulepath]}"
       end
 
       Puppet.settings[:modulepath] = options[:modulepath]
       options[:target_dir] = Puppet.settings[:modulepath].split(sep).first
+      options[:target_dir] = File.expand_path(options[:target_dir])
 
       Puppet.notice "Preparing to install into #{options[:target_dir]} ..."
       Puppet::ModuleTool::Applications::Installer.run(name, options)

--- a/spec/unit/face/module/install_spec.rb
+++ b/spec/unit/face/module/install_spec.rb
@@ -88,15 +88,26 @@ describe "puppet module install" do
 
           Puppet.settings[:modulepath].should == fakemodpath
         end
+
+        it "should expand the target directory derived from the modulepath" do
+          options[:modulepath] = "modules"
+          expanded_path = File.expand_path("modules")
+          expected_options.merge!(options)
+          expected_options[:target_dir] = expanded_path
+          expected_options[:modulepath] = "modules"
+
+          Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
+          subject.install("puppetlabs-apache", options)
+        end
       end
 
       describe "when target-dir option is passed" do
-        it "should expand the target directory" do
+        it "should expand the target directory when target_dir is set" do
           options[:target_dir] = "modules"
           expanded_path = File.expand_path("modules")
           expected_options.merge!(options)
           expected_options[:target_dir] = expanded_path
-          expected_options[:modulepath] = "#{expanded_path}#{sep}#{fakemodpath}"
+          expected_options[:modulepath] = "modules#{sep}#{fakemodpath}"
 
           Puppet::ModuleTool::Applications::Installer.expects(:run).with("puppetlabs-apache", expected_options).once
           subject.install("puppetlabs-apache", options)


### PR DESCRIPTION
We previously fixed expansion for the target_dir, but this only worked when the
target_dir was set explicitly, it didn't support relative paths being passed in
the modulepath. This patch fixes that and adds tests.

As a side-effect, this should also fixes cases where the first modulepath
defined in the configuration file is relative.

It also corrects the tests previously applied for expanding the target_dir, as
it used to rely on expanding the target_dir before adding it to the modulepath.
This wasn't necessary, so now we don't bother testing that the targetdir is
expanded in the modulepath after being added.

Acceptance tests have been added for testing modulepath, with absolute
and relative paths.
