### PR TITLE
tidy.rb: Added info about the default value of 'type' to the doc.

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -178,7 +178,7 @@ Puppet::Type.newtype(:tidy) do
   end
 
   newparam(:type) do
-    desc "Set the mechanism for determining age."
+    desc "Set the mechanism for determining age. Default: atime."
 
     newvalues(:atime, :mtime, :ctime)
 


### PR DESCRIPTION
The documentation doesn't inform users what is the default value of type in Tidy and thus they either need to always specify it or read the code to find it out. Stating it explicitely will help them.
