### PR TITLE
Maint/3.0rc/pluginsync tests on windows

### DIFF
--- a/acceptance/lib/puppet/acceptance/temp_file_utils.rb
+++ b/acceptance/lib/puppet/acceptance/temp_file_utils.rb
@@ -17,8 +17,8 @@ module Puppet
 
         # set default options
         options[:mkdirs] ||= false
-        options[:owner] ||= "root"
-        options[:group] ||= "puppet"
+        options[:owner] ||= host['user']
+        options[:group] ||= host['group'] || "puppet"
         options[:mode] ||= "755"
 
         file_path = get_test_file_path(host, file_rel_path)

--- a/acceptance/tests/pluginsync/apply_should_sync_plugins.rb
+++ b/acceptance/tests/pluginsync/apply_should_sync_plugins.rb
@@ -14,7 +14,7 @@ agents.each do |agent|
   create_test_file(agent, "#{module1libdir}/a/lib/foo.rb", "#1a", :mkdirs => true)
   create_test_file(agent, "#{module2libdir}/b/lib/foo.rb", "#2a", :mkdirs => true)
 
-  on agent, puppet_apply("--modulepath=#{get_test_file_path(agent, module1libdir)}:#{get_test_file_path(agent, module2libdir)} --pluginsync -e 'notify { \"hello\": }'")
+  on agent, puppet_apply("--modulepath='#{get_test_file_path(agent, module1libdir)}#{agent['pathseparator']}#{get_test_file_path(agent, module2libdir)}' --pluginsync -e 'notify { \"hello\": }'")
 
   on agent, "cat #{agent['puppetvardir']}/lib/foo.rb" do
     assert_match(/#1a/, stdout, "The synced plugin was not found or the wrong version was synced")


### PR DESCRIPTION
The pluginsync acceptance tests were not using the right path separator
and directory ownership on windows. By using the values on the host we
can make sure that the setup is done correctly on both linux and
windows.
