### PR TITLE
Bug/2.7.x/15264 fail on no matching title patterns

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -439,6 +439,10 @@ class Puppet::Resource
           return h
         end
       }
+      # If we've gotten this far, then none of the provided title patterns
+      # matched. Since there's no way to determine the title then the
+      # resource should fail here.
+      raise Puppet::Error, "No set of title patterns matched the title \"#{title}\"."
     else
       return { :name => title.to_s }
     end


### PR DESCRIPTION
If a type uses a composite namevar and none of the supplied title
patterns matched, #parse_title would return a nonsensical array value.
This would lead to unexpected behavior like output like:

```
/usr/lib/ruby/1.8/puppet/puppet/resource.rb:235:in `to_hash': undefined method `merge' for #<Array:0x007ffba3d80d78> (NoMethodError)
```

If a type overrides the title_patterns method and nothing matched,
there's no possible way to recover from this. To prevent misleading
errors from being thrown, this patch raises an error if none of the
title patterns matched.
