### PR TITLE
Ticket/2.7.x/14740 ordering error

### DIFF
--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -71,6 +71,7 @@ describe provider_class do
 
         name == provider.resource[:name]
       end
+      provider.expects(:execpipe).with(%w{/bin/pkg_info -I bash}).yields('')
 
       provider.install
       ENV.should_not be_key 'PKG_PATH'


### PR DESCRIPTION
fixes an order dependent spec failure caused by insufficient stubbing in openbsd specs
