### PR TITLE
Fix Puppet::Util.execute is deprecated warning

### DIFF
--- a/lib/puppet/util/diff.rb
+++ b/lib/puppet/util/diff.rb
@@ -11,7 +11,7 @@ module Puppet::Util::Diff
       command << args
     end
     command << old << new
-    execute(command, :failonfail => false)
+    Puppet::Util::Execution.execute(command, :failonfail => false)
   end
 
   module_function :diff


### PR DESCRIPTION
Without this patch applied the 3.0rc branch gives this warning when a plugin
sync file has changed:

```
jeff@pe-debian6:~$ puppet agent --test
```

   Info: Retrieving plugin
   Warning: Puppet::Util.execute is deprecated; please use
Puppet::Util::Execution.execute
      (at /workspace/src/puppet/lib/puppet/util/diff.rb:14:in `diff')
   /File[/home/jeff/.puppet/var/lib/puppet/cloudpack.rb]/content:
   --- /home/jeff/.puppet/var/lib/puppet/cloudpack.rb      2012-06-28
03:40:01.000000000 -0700
   +++ /tmp/puppet-file20120628-1955-99huz5-0      2012-06-28
03:46:39.000000000 -0700
   @@ -1,5 +1,4 @@
    require 'tempfile'
   -require 'rubygems'
    require 'guid'
    require 'fog'
    require 'net/ssh'

This patch fixes the issue by calling the recommended method in the 
deprecation warning.
