### PR TITLE
Maint/2.7.x/sqlite memory db

### DIFF
--- a/spec/lib/puppet_spec/database.rb
+++ b/spec/lib/puppet_spec/database.rb
@@ -22,9 +22,11 @@ end
 # ready to roll with a serious database and all.  Cleanup is handled
 # automatically for you.  Nothing to do there.
 def setup_scratch_database
-  dir = PuppetSpec::Files.tmpdir('puppet-sqlite')
-  Puppet[:dbadapter]    = 'sqlite3'
-  Puppet[:dblocation]   = (dir + 'storeconfigs.sqlite').to_s
+  Puppet::Rails.stubs(:database_arguments).returns(
+    :adapter => 'sqlite3',
+    :log_level => Puppet[:rails_loglevel],
+    :database => ':memory:'
+  )
   Puppet[:railslog]     = '/dev/null'
   Puppet::Rails.init
 end


### PR DESCRIPTION
Use a memory database for running unit tests. This results in a massive speedup if you're running tests with activerecord and sqlite installed.
