### PR TITLE
Fix spec test failures from diff warning

### DIFF
--- a/spec/unit/util/diff_spec.rb
+++ b/spec/unit/util/diff_spec.rb
@@ -1,6 +1,7 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 require 'puppet/util/diff'
+require 'puppet/util/execution'
 
 describe Puppet::Util::Diff do
   describe ".diff" do
@@ -8,7 +9,7 @@ describe Puppet::Util::Diff do
       Puppet[:diff] = 'foo'
       Puppet[:diff_args] = 'bar'
 
-      subject.expects(:execute).with(['foo', 'bar', 'a', 'b'], {:failonfail => false}).returns('baz')
+      Puppet::Util::Execution.expects(:execute).with(['foo', 'bar', 'a', 'b'], {:failonfail => false}).returns('baz')
       subject.diff('a', 'b').should == 'baz'
     end
 
@@ -16,14 +17,14 @@ describe Puppet::Util::Diff do
       Puppet[:diff] = 'foo'
       Puppet[:diff_args] = ''
 
-      subject.expects(:execute).with(['foo', 'a', 'b'], {:failonfail => false}).returns('baz')
+      Puppet::Util::Execution.expects(:execute).with(['foo', 'a', 'b'], {:failonfail => false}).returns('baz')
       subject.diff('a', 'b').should == 'baz'
     end
 
     it "should return empty string if the diff command is empty" do
       Puppet[:diff] = ''
 
-      subject.expects(:execute).never
+      Puppet::Util::Execution.expects(:execute).never
       subject.diff('a', 'b').should == ''
     end
   end


### PR DESCRIPTION
I was bad and made a change to the execution behavior of diff without
bothering to update the spec tests.  This patch fixes the failing spec tests
to match the new expectation that Puppet::Util::Execution.execute is used
instead of Puppet::Util::Diff#execute as was previously used.
