### PR TITLE
(#15307) Fix puppet help when a face throws an exception

### DIFF
--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -3,44 +3,44 @@ require 'spec_helper'
 require 'puppet/face'
 
 describe Puppet::Face[:help, '0.0.1'] do
-  it "should have a help action" do
+  it "has a help action" do
     subject.should be_action :help
   end
 
-  it "should have a default action of help" do
+  it "has a default action of help" do
     subject.get_action('help').should be_default
   end
 
-  it "should accept a call with no arguments" do
+  it "accepts a call with no arguments" do
     expect {
       subject.help()
     }.should_not raise_error
   end
 
-  it "should accept a face name" do
+  it "accepts a face name" do
     expect { subject.help(:help) }.should_not raise_error
   end
 
-  it "should accept a face and action name" do
+  it "accepts a face and action name" do
     expect { subject.help(:help, :help) }.should_not raise_error
   end
 
-  it "should fail if more than a face and action are given" do
+  it "fails if more than a face and action are given" do
     expect { subject.help(:help, :help, :for_the_love_of_god) }.
       should raise_error ArgumentError
   end
 
-  it "should treat :current and 'current' identically" do
+  it "treats :current and 'current' identically" do
     subject.help(:help, :version => :current).should ==
       subject.help(:help, :version => 'current')
   end
 
-  it "should complain when the request version of a face is missing" do
+  it "raises an error when the face is unavailable" do
     expect { subject.help(:huzzah, :bar, :version => '17.0.0') }.
-      should raise_error Puppet::Error
+      should raise_error(ArgumentError, /Could not find version 17\.0\.0/)
   end
 
-  it "should find a face by version" do
+  it "finds a face by version" do
     face = Puppet::Face[:huzzah, :current]
     subject.help(:huzzah, :version => face.version).
       should == subject.help(:huzzah, :version => :current)
@@ -58,13 +58,13 @@ describe Puppet::Face[:help, '0.0.1'] do
     # Check a precondition for the next block; if this fails you have
     # something odd in your set of face, and we skip testing things that
     # matter. --daniel 2011-04-10
-    it "should have at least one face with a summary" do
+    it "has at least one face with a summary" do
       Puppet::Face.faces.should be_any do |name|
         Puppet::Face[name, :current].summary
       end
     end
 
-    it "should list all faces which are runnable from the command line" do
+    it "lists all faces which are runnable from the command line" do
       help_face = Puppet::Face[:help, :current]
       # The main purpose of the help face is to provide documentation for
       #  command line users.  It shouldn't show documentation for faces
@@ -88,13 +88,13 @@ describe Puppet::Face[:help, '0.0.1'] do
       Puppet[:modulepath] = "/dev/null"
 
       Puppet::Face.faces.each do |name|
-        it "should have a summary for #{name}" do
+        it "has a summary for #{name}" do
           Puppet::Face[name, :current].should have_a_summary
         end
       end
     end
 
-    it "should list all legacy applications" do
+    it "lists all legacy applications" do
       Puppet::Face[:help, :current].legacy_applications.each do |appname|
         subject.should =~ %r{ #{appname} }
 
@@ -129,7 +129,7 @@ describe Puppet::Face[:help, '0.0.1'] do
     # we don't get into a loop where we either test a face-based replacement
     # and fail to notice breakage, or where we have to constantly rewrite this
     # test and all. --daniel 2011-04-11
-    it "should return the legacy help when given the subcommand" do
+    it "returns the legacy help when given the subcommand" do
       help = subject.help(appname)
       help.should =~ /puppet-#{appname}/
       %w{SYNOPSIS USAGE DESCRIPTION OPTIONS COPYRIGHT}.each do |heading|
@@ -137,7 +137,7 @@ describe Puppet::Face[:help, '0.0.1'] do
       end
     end
 
-    it "should fail when asked for an action on a legacy command" do
+    it "fails when asked for an action on a legacy command" do
       expect { subject.help(appname, :whatever) }.
         to raise_error ArgumentError, /Legacy subcommands don't take actions/
     end


### PR DESCRIPTION
Without this patch applied the `puppet help` command displays nothing but an
exception when a 3rd party face throws an exception during the loading
process.

For example:

```
Error: Could not autoload puppet/face/node/classify: no such file to load
```

-- fog
   Error: Could not autoload puppet/face/node: Could not autoload
puppet/face/node/classify: no such file to load -- fog
   Error: Failed to load face node:
   Error: Could not find version current of node
   Error: Try 'puppet help help help' for usage

This is a problem because `puppet help` should be robust and provide helpful 
information in all cases.

This patch fixes the problem by catching loading errors when building the
list of available face subcommands and their summaries.  If an exception is
caught, it is handled by marking that face subcommand and presenting a
message indicating the face is unavailable in the help output.

This looks like:

```
Usage: puppet <subcommand> [options] <action> [options]

Available subcommands:

  agent             The puppet agent daemon
 apply             Apply Puppet manifests locally
 ca                Local Puppet Certificate Authority management.
 catalog           Compile, save, view, and convert catalogs.
 cert              Manage certificates and requests
 certificate       Provide access to the CA for certificate management.
 certificate_request  Manage certificate requests.
 certificate_revocation_list  Manage the list of revoked certificates.
 config            Interact with Puppet's configuration options.
 describe          Display help about resource types
 device            Manage remote network devices
 doc               Generate Puppet documentation and references
 facts             Retrieve and store facts.
 file              Retrieve and store files in a filebucket
 filebucket        Store and retrieve files in a filebucket
 help              Display Puppet help.
 inspect           Send an inspection report
 instrumentation_data  Manage instrumentation listener accumulated data.
 instrumentation_listener  Manage instrumentation listeners.
 instrumentation_probe  Manage instrumentation probes.
 key               Create, save, and remove certificate keys.
 kick              Remotely control puppet agent
 man               Display Puppet manual pages.
 master            The puppet master daemon
 module            Creates, installs and searches for modules on the
```

Puppet Forge.
     ! node            ! Subcommand unavailable due to error. Check error
logs.
     ! node_aws        ! Subcommand unavailable due to error. Check error
logs.
     ! node_vmware     ! Subcommand unavailable due to error. Check error
logs.
     parser            Interact directly with the parser.
     plugin            Interact with the Puppet plugin system.
     queue             Queuing daemon for asynchronous storeconfigs
     report            Create, display, and submit reports.
     resource          The resource abstraction layer shell
     resource_type     View classes, defined resource types, and nodes from
all manifests.
     secret_agent      Mimics puppet agent.
     status            View puppet server status.

```
See 'puppet help <subcommand> <action>' for help on a specific subcommand
```

action.
   See 'puppet help <subcommand>' for help on a specific subcommand.
   Puppet v3.0.0
