### PR TITLE
Bug/3.0rc/15187 log fatal errors to console

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -354,8 +354,8 @@ class Application
     setup_logs
   end
 
-  def setup_logs
-    if options[:debug] or options[:verbose]
+  def setup_logs(is_daemon = false)
+    if options[:debug] or options[:verbose] or is_daemon
       Puppet::Util::Log.newdestination(:console)
       if options[:debug]
         Puppet::Util::Log.level = :debug

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -426,7 +426,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def setup
     setup_test if options[:test]
 
-    setup_logs
+    setup_logs(true)
 
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 


### PR DESCRIPTION
This commit ensures that the agent always opens a console
logging destination.  It will be closed when the agent
has successfully initialized itself and switched to
daemon mode, but if any errors occur before that point, the
log messages will be available on the console.  Prior to
this commit, fatal errors during startup were not logged
to the console, which made it seem like the error
was being swallowed or that the agent had started successfully
even when it had not.
