### PR TITLE
Maint/3.0rc/modulepath cache before initialized

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -141,7 +141,7 @@ class Puppet::Util::Autoload
         end
       else
         # if we get here, the app defaults have not been initialized, so we basically use an empty module path.
-        Thread.current[:env_module_directories][real_env] = []
+        []
       end
     end
 
@@ -156,7 +156,7 @@ class Puppet::Util::Autoload
     end
 
     def search_directories(env=nil)
-        [module_directories(env), libdirs(), $LOAD_PATH].flatten
+      [module_directories(env), libdirs(), $LOAD_PATH].flatten
     end
 
     # Normalize a path. This converts ALT_SEPARATOR to SEPARATOR on Windows


### PR DESCRIPTION
Calling module_directories before settings are initialized (and therefore
before the modulepath is known) returns an empty array. We probably don't want
to cache this, and it might interfere with loading from the modulepath once it
is initialized.
