### PR TITLE
(#15398) fix typo in Scope#number? float detection regex

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -84,7 +84,7 @@ class Puppet::Parser::Scope
     return nil unless value.is_a?(Fixnum) or value.is_a?(Bignum) or value.is_a?(Float) or value.is_a?(String)
 
     if value.is_a?(String)
-      if value =~ /^-?\d+(:?\.\d+|(:?\.\d+)?e\d+)$/
+      if value =~ /^-?\d+(?:\.\d+|(?:\.\d+)?e\d+)$/
         return value.to_f
       elsif value =~ /^0x[0-9a-f]+$/i
         return value.to_i(16)

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -272,6 +272,11 @@ describe Puppet::Parser::Scope do
       Puppet::Parser::Scope.number?(2.34).should be_an_instance_of(Float)
     end
 
+    it "should not accept some invalid floats of ticket #15398" do
+      Puppet::Parser::Scope.number?('2:.34').should be_nil
+      Puppet::Parser::Scope.number?('2:.34e23').should be_nil
+    end
+
     it "should return 234 for '234'" do
       Puppet::Parser::Scope.number?("234").should == 234
     end


### PR DESCRIPTION
This allowed incorrect numbers (like 2:.34) to be recognized as
floats (with an incorrect value).
