### PR TITLE
Perf/2.7.x/eliminate require in functions

### DIFF
--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require 'puppet/file_bucket'
 require 'puppet/file_bucket/file'
 require 'puppet/indirector/request'
@@ -99,7 +100,6 @@ class Puppet::FileBucket::Dipper
 
   private
   def absolutize_path( path )
-    require 'pathname'
     Pathname.new(path).realpath
   end
 

--- a/lib/puppet/interface/action_manager.rb
+++ b/lib/puppet/interface/action_manager.rb
@@ -1,11 +1,10 @@
 require 'puppet/interface/action'
+require 'puppet/interface/action_builder'
 
 module Puppet::Interface::ActionManager
   # Declare that this app can take a specific action, and provide
   # the code to do so.
   def action(name, &block)
-    require 'puppet/interface/action_builder'
-
     @actions ||= {}
     raise "Action #{name} already defined for #{self}" if action?(name)
 

--- a/lib/puppet/network/handler/fileserver.rb
+++ b/lib/puppet/network/handler/fileserver.rb
@@ -645,9 +645,9 @@ class Puppet::Network::Handler
         nil
       end
 
+      require 'puppet/file_serving'
+      require 'puppet/file_serving/fileset'
       def reclist(abspath, recurse, ignore)
-        require 'puppet/file_serving'
-        require 'puppet/file_serving/fileset'
         if recurse.is_a?(Fixnum)
           args = { :recurse => true, :recurselimit => recurse, :links => :follow }
         else

--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -1,3 +1,5 @@
+require 'digest/md5'
+
 Puppet::Parser::Functions::newfunction(:fqdn_rand, :type => :rvalue, :doc =>
   "Generates random numbers based on the node's fqdn. Generated random values
   will be a range from 0 up to and excluding n, where n is the first parameter.
@@ -5,7 +7,6 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :type => :rvalue, :doc =>
 
       $random_number = fqdn_rand(30)
       $random_number_seed = fqdn_rand(30,30)") do |args|
-    require 'digest/md5'
     max = args.shift
     srand(Digest::MD5.hexdigest([lookupvar('::fqdn'),args].join(':')).hex)
     rand(max).to_s

--- a/lib/puppet/parser/functions/md5.rb
+++ b/lib/puppet/parser/functions/md5.rb
@@ -1,5 +1,5 @@
-Puppet::Parser::Functions::newfunction(:md5, :type => :rvalue, :doc => "Returns a MD5 hash value from a provided string.") do |args|
-      require 'md5'
+require 'md5'
 
+Puppet::Parser::Functions::newfunction(:md5, :type => :rvalue, :doc => "Returns a MD5 hash value from a provided string.") do |args|
       Digest::MD5.hexdigest(args[0])
 end

--- a/lib/puppet/parser/functions/sha1.rb
+++ b/lib/puppet/parser/functions/sha1.rb
@@ -1,5 +1,5 @@
-Puppet::Parser::Functions::newfunction(:sha1, :type => :rvalue, :doc => "Returns a SHA1 hash value from a provided string.") do |args|
-      require 'digest/sha1'
+require 'digest/sha1'
 
+Puppet::Parser::Functions::newfunction(:sha1, :type => :rvalue, :doc => "Returns a SHA1 hash value from a provided string.") do |args|
       Digest::SHA1.hexdigest(args[0])
 end

--- a/lib/puppet/parser/functions/template.rb
+++ b/lib/puppet/parser/functions/template.rb
@@ -5,8 +5,6 @@ Puppet::Parser::Functions::newfunction(:template, :type => :rvalue, :doc =>
   
   Note that if multiple templates are specified, their output is all
   concatenated and returned as the output of the function.") do |vals|
-    require 'erb'
-
     vals.collect do |file|
       # Use a wrapper, so the template can't get access to the full
       # Scope object.

--- a/lib/puppet/parser/type_loader.rb
+++ b/lib/puppet/parser/type_loader.rb
@@ -1,3 +1,4 @@
+require 'find'
 require 'puppet/node/environment'
 
 class Puppet::Parser::TypeLoader
@@ -93,8 +94,6 @@ class Puppet::Parser::TypeLoader
   end
 
   def import_all
-    require 'find'
-
     module_names = []
     # Collect the list of all known modules
     environment.modulepath.each do |path|

--- a/lib/puppet/rails/benchmark.rb
+++ b/lib/puppet/rails/benchmark.rb
@@ -1,4 +1,6 @@
 require 'benchmark'
+require 'yaml'
+
 module Puppet::Rails::Benchmark
   $benchmarks = {:accumulated => {}}
 
@@ -49,8 +51,6 @@ module Puppet::Rails::Benchmark
     branch = %x{git branch}.split("\n").find { |l| l =~ /^\*/ }.sub("* ", '')
 
     file = "/tmp/time_debugging.yaml"
-
-    require 'yaml'
 
     if FileTest.exist?(file)
       data = YAML.load_file(file)

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -1,3 +1,5 @@
+require 'puppet/parser/type_loader'
+
 class Puppet::Resource::TypeCollection
   attr_reader :environment
   attr_accessor :parse_failed
@@ -68,7 +70,6 @@ class Puppet::Resource::TypeCollection
   end
 
   def loader
-    require 'puppet/parser/type_loader'
     @loader ||= Puppet::Parser::TypeLoader.new(environment)
   end
 

--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -1,3 +1,4 @@
+require 'openssl/digest'
 require 'puppet/ssl'
 
 # The base class for wrapping SSL instances.
@@ -55,8 +56,6 @@ class Puppet::SSL::Base
   end
 
   def fingerprint(md = :MD5)
-    require 'openssl/digest'
-
     # ruby 1.8.x openssl digest constants are string
     # but in 1.9.x they are symbols
     mds = md.to_s.upcase

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -128,9 +128,11 @@ class Puppet::Util::Autoload
   end
 
   def module_directories(env=nil)
-    # We have to require this late in the process because otherwise we might have
-    # load order issues.
-    require 'puppet/node/environment'
+    # We have to require this late in the process because otherwise we might
+    # have load order issues. Since require is much slower than defined?, we
+    # can skip that - and save some 2,155 invocations of require in my real
+    # world testing. --daniel 2012-07-10
+    require 'puppet/node/environment' unless defined?(Puppet::Node::Environment)
 
     real_env = Puppet::Node::Environment.new(env)
 

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -1,3 +1,6 @@
+require 'digest/md5'
+require 'digest/sha1'
+
 # A stand-alone module for calculating checksums
 # in a generic way.
 module Puppet::Util::Checksums
@@ -24,7 +27,6 @@ module Puppet::Util::Checksums
 
   # Calculate a checksum using Digest::MD5.
   def md5(content)
-    require 'digest/md5'
     Digest::MD5.hexdigest(content)
   end
 
@@ -35,8 +37,6 @@ module Puppet::Util::Checksums
 
   # Calculate a checksum of a file's content using Digest::MD5.
   def md5_file(filename, lite = false)
-    require 'digest/md5'
-
     digest = Digest::MD5.new
     checksum_file(digest, filename,  lite)
   end
@@ -47,7 +47,6 @@ module Puppet::Util::Checksums
   end
 
   def md5_stream(&block)
-    require 'digest/md5'
     digest = Digest::MD5.new
     yield digest
     digest.hexdigest
@@ -74,7 +73,6 @@ module Puppet::Util::Checksums
 
   # Calculate a checksum using Digest::SHA1.
   def sha1(content)
-    require 'digest/sha1'
     Digest::SHA1.hexdigest(content)
   end
 
@@ -85,8 +83,6 @@ module Puppet::Util::Checksums
 
   # Calculate a checksum of a file's content using Digest::SHA1.
   def sha1_file(filename, lite = false)
-    require 'digest/sha1'
-
     digest = Digest::SHA1.new
     checksum_file(digest, filename, lite)
   end
@@ -97,7 +93,6 @@ module Puppet::Util::Checksums
   end
 
   def sha1_stream
-    require 'digest/sha1'
     digest = Digest::SHA1.new
     yield digest
     digest.hexdigest

--- a/lib/puppet/util/diff.rb
+++ b/lib/puppet/util/diff.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 # Provide a diff between two strings.
 module Puppet::Util::Diff
   include Puppet::Util
@@ -64,7 +66,6 @@ module Puppet::Util::Diff
   end
 
   def string_file_diff(path, string)
-    require 'tempfile'
     tempfile = Tempfile.new("puppet-diffing")
     tempfile.open
     tempfile.print string

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -2,6 +2,7 @@
 # to see here.
 
 require 'puppet/util/selinux'
+require 'tempfile'
 require 'fileutils'
 
 class Puppet::Util::FileType
@@ -103,7 +104,6 @@ class Puppet::Util::FileType
 
     # Overwrite the file.
     def write(text)
-      require "tempfile"
       tf = Tempfile.new("puppet")
       tf.print text; tf.flush
       FileUtils.cp(tf.path, @path)
@@ -223,7 +223,6 @@ class Puppet::Util::FileType
     # and the text with which to create the cron tab.
     def write(text)
       puts text
-      require "tempfile"
       output_file = Tempfile.new("puppet")
       fh = output_file.open
       fh.print text
@@ -262,7 +261,6 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      require "tempfile"
       output_file = Tempfile.new("puppet")
       fh = output_file.open
       fh.print text

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -1,3 +1,5 @@
+require 'etc'
+
 module Puppet
   module Util
     class RunMode
@@ -71,7 +73,6 @@ module Puppet
       end
 
       def expand_path( dir )
-        require 'etc'
         ENV["HOME"] ||= Etc.getpwuid(Process.uid).dir
         File.expand_path(dir)
       end

--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -1,3 +1,4 @@
+require 'facter'
 require 'puppet/util/warnings'
 require 'forwardable'
 require 'etc'
@@ -17,7 +18,6 @@ module Puppet::Util::SUIDManager
 
   def osx_maj_ver
     return @osx_maj_ver unless @osx_maj_ver.nil?
-    require 'facter'
     # 'kernel' is available without explicitly loading all facts
     if Facter.value('kernel') != 'Darwin'
       @osx_maj_ver = false

--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -1,14 +1,13 @@
 require 'puppet/util/windows'
 
 require 'win32/security'
+require 'facter'
 
 module Puppet::Util::Windows::User
   include Windows::Security
   extend Windows::Security
 
   def admin?
-    require 'facter'
-
     majversion = Facter.value(:kernelmajversion)
     return false unless majversion
 


### PR DESCRIPTION
Calling `require` is a surprisingly expensive operation, especially if
ActiveRecord has been loaded.  Consequently, the places where we do that in
the body of a function are hot-spots in the profile.

They are also, generally, pretty simple and clear wins: almost all of them can
simply require the library the first time they are loaded and everything will
work fine.

In my testing with a complex, real-world set of manifests this reduces time
spent by ~ 3 wall-clock seconds in require and all children.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
