### PR TITLE
Don't allow resource titles which aren't strings

### DIFF
--- a/lib/puppet/parser/ast/resource.rb
+++ b/lib/puppet/parser/ast/resource.rb
@@ -32,7 +32,7 @@ class Resource < AST::Branch
       resource_titles = instance.title.safeevaluate(scope)
 
       # it's easier to always use an array, even for only one name
-      resource_titles = [resource_titles].flatten.map do |title|
+      resource_titles = [resource_titles].flatten.collect do |title|
         case title
         when ::String, ::Numeric, ::Symbol, true, false
           title.to_s

--- a/spec/unit/parser/ast/resource_spec.rb
+++ b/spec/unit/parser/ast/resource_spec.rb
@@ -46,11 +46,8 @@ describe Puppet::Parser::AST::Resource do
       it "should stringify the title if it is a #{title.class}" do
         @instance.title.stubs(:safeevaluate).returns title
 
-        begin
-          result = @resource.evaluate(@scope).map(&:title)
-        rescue => e
-        end
-        #result.first.should == title.to_s
+        result = @resource.evaluate(@scope).map(&:title)
+        result.first.should == title.to_s
       end
     end
 


### PR DESCRIPTION
It was possible to create resources whose titles weren't strings, by
using a variable containing a hash, or the result of a function which
doesn't return a string. This can cause problems resolving relationships
when the stringified version of the title differs between master and
agent.

Now we will only accept primitives, and will stringify them. That is:
string, symbol, number, boolean. Arrays or nested arrays will still be
flattened and used to create multiple resources. Any other value (for
instance: a hash) will cause a parse error.
