### PR TITLE
Offer better errors for certificate validation errors

### DIFF
--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -111,18 +111,7 @@ describe Puppet::Indirector::REST do
 
       expect do
         @searcher.http_request(:get, stub('request'))
-      end.to raise_error(/shady looking signature/)
-    end
-
-    it "should provide a suggestive error message when certificate verify failed without a better message" do
-      connection = Net::HTTP.new('my_server', 8140)
-      @searcher.stubs(:network).returns(connection)
-
-      connection.stubs(:get).raises(OpenSSL::SSL::SSLError.new('certificate verify failed'))
-
-      expect do
-        @searcher.http_request(:get, stub('request'))
-      end.to raise_error(/This is often because the time is out of sync on the server or client/)
+      end.to raise_error(Puppet::Error, /shady looking signature/)
     end
 
     it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet.features.microsoft_windows? do
@@ -133,6 +122,7 @@ describe Puppet::Indirector::REST do
       @searcher.stubs(:network).returns(connection)
       ssl_context = OpenSSL::SSL::SSLContext.new
       ssl_context.stubs(:current_cert).returns(cert)
+      ssl_context.stubs(:error).returns(nil)
       connection.stubs(:get).with do
         connection.verify_callback.call(true, ssl_context)
       end.raises(OpenSSL::SSL::SSLError.new('hostname was not match with server certificate'))


### PR DESCRIPTION
The verify_callback callback gets an OpenSSL::SSL::SSLContext for each
certificate in the chain that's verified.  If the verification failed,
then SSL provides a nice error to the callback, but that error doesn't
appear in the subsequent OpenSSL::SSL::SSLError.

This patch uses a technique similar to that used for peer_certs to
collect those errors and then add them to the Puppet::Error message
later.

This is my first patch to ruby, and I'm about 45 minutes away from first learning about Mocha, so be kind!  But I take review comments well :)
