### PR TITLE
Timeout support in http report processor

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -834,6 +834,10 @@ EOT
       :default    => "http://localhost:3000/reports/upload",
       :desc       => "The URL used by the http reports processor to send reports",
     },
+    :reporturl_timeout => {
+        :default  => 60,
+        :desc     => "The timeout used by the http reports processor to post reports",
+    },
     :fileserverconfig => {
       :default    => "$confdir/fileserver.conf",
       :type       => :file,

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -12,16 +12,26 @@ Puppet::Reports.register_report(:http) do
 
   def process
     url = URI.parse(Puppet[:reporturl])
+    timeout = Puppet[:reporturl_timeout]
     req = Net::HTTP::Post.new(url.path)
     req.body = self.to_yaml
     req.content_type = "application/x-yaml"
     conn = Puppet::Network::HttpPool.http_instance(url.host, url.port,
                                                    ssl=(url.scheme == 'https'))
+    orig_read_timeout = conn.read_timeout
+    orig_open_timeout = conn.open_timeout
+    conn.read_timeout = timeout
+    conn.open_timeout = timeout
     conn.start {|http|
       response = http.request(req)
       unless response.kind_of?(Net::HTTPSuccess)
         Puppet.err "Unable to submit report to #{Puppet[:reporturl].to_s} [#{response.code}] #{response.msg}"
       end
     }
+  rescue Timeout::Error
+      Puppet.err "Timeout when submitting report to #{Puppet[:reporturl].to_s}"
+  ensure
+    conn.read_timeout = orig_read_timeout
+    conn.open_timeout = orig_open_timeout
   end
 end

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -21,6 +21,18 @@ describe processor do
     subject.process
   end
 
+  it "should use the report timeout for posting http reports" do
+    timeout = Puppet[:reporturl_timeout] = 40
+    uri = URI.parse(Puppet[:reporturl])
+    ssl = (uri.scheme == 'https')
+    Puppet::Network::HttpPool.expects(:http_instance).with(uri.host, uri.port, use_ssl = ssl).returns(stub_everything('http')) { |http|
+        http.read_timeout == timeout
+        http.open_timeout == timeout
+    }
+    subject.process
+  end
+
+
   describe "when making a request" do
     let(:http) { mock "http" }
     let(:httpok) { Net::HTTPOK.new('1.1', 200, '') }


### PR DESCRIPTION
Adds timeouts to the http report processor to prevent resource starvation on the puppetmaster

This fixes #15420, please see that bug for a better description of the problem

I added a test for the presence of the timeout, couldn't figure out how to get rspec to trigger a Timeout::Error
(due to my lack of ruby/rspec foo)
