### PR TITLE
Ticket/3.0rc/15492 deprecate puppet util execute

### DIFF
--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -39,12 +39,12 @@ module Puppet::ModuleTool
               # Solaris tar is not as safe and works differently, so we prefer
               # gnutar instead.
               if Puppet::Util.which('gtar')
-                Puppet::Util.execute("gtar xzf #{@filename} -C #{build_dir}")
+                Puppet::Util::Execution.execute("gtar xzf #{@filename} -C #{build_dir}")
               else
                 raise RuntimeError, "Cannot find the command 'gtar'. Make sure GNU tar is installed, and is in your PATH."
               end
             else
-              Puppet::Util.execute("tar xzf #{@filename} -C #{build_dir}")
+              Puppet::Util::Execution.execute("tar xzf #{@filename} -C #{build_dir}")
             end
           rescue Puppet::ExecutionFailure => e
             raise RuntimeError, "Could not extract contents of module archive: #{e.message}"

--- a/spec/unit/module_tool/applications/unpacker_spec.rb
+++ b/spec/unit/module_tool/applications/unpacker_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::ModuleTool::Applications::Unpacker, :fails_on_windows => true d
 
     context "on linux" do
       it "should attempt to untar file to temporary location using system tar" do
-        Puppet::Util.expects(:execute).with("tar xzf #{filename} -C #{build_dir}").returns(true)
+        Puppet::Util::Execution.expects(:execute).with("tar xzf #{filename} -C #{build_dir}").returns(true)
         unpacker.run
       end
     end
@@ -47,7 +47,7 @@ describe Puppet::ModuleTool::Applications::Unpacker, :fails_on_windows => true d
 
       it "should attempt to untar file to temporary location using gnu tar" do
         Puppet::Util.stubs(:which).with('gtar').returns('/usr/sfw/bin/gtar')
-        Puppet::Util.expects(:execute).with("gtar xzf #{filename} -C #{build_dir}").returns(true)
+        Puppet::Util::Execution.expects(:execute).with("gtar xzf #{filename} -C #{build_dir}").returns(true)
         unpacker.run
       end
 


### PR DESCRIPTION
The Puppet::Util.execute method is moving to Puppet::Util::Execution.execute,
so to remove warning messages this patch changes the code that still uses
the old methodology to the new methodology introduced in 3.x.
