### PR TITLE
Touch filebuckets contents when we get a new path

### DIFF
--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -67,9 +67,10 @@ module Puppet::FileBucketFile
       dir_path = path_for(bucket_file.bucket_path, bucket_file.checksum_data)
       paths_path = ::File.join(dir_path, 'paths')
 
-      # If the file already exists, do nothing.
+      # If the file already exists, touch it.
       if ::File.exist?(filename)
         verify_identical_file!(bucket_file)
+        ::FileUtils.touch(filename)
       else
         # Make the directories if necessary.
         unless ::File.directory?(dir_path)


### PR DESCRIPTION
Touch the contents file when we get a new path for the file. This
simplifies cleanup scripts for deleting old filebucket files for
example.
