### PR TITLE
Update main readme to have links to contrib and dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ configurations) based on a centralized specification.
 Documentation (and detailed installation instructions) can be found online at the
 [Puppet Docs site](http://docs.puppetlabs.com).
 
+
 Installation
 ------------
 
@@ -31,6 +32,13 @@ Generally, you need the following things installed:
   library, though.
 
 * Facter => 2.0.0 (available via your package manager or from the [Facter site](http://puppetlabs.com/projects/facter)).
+
+Contributions
+------
+Please see our [Contibution
+Documents](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)
+and our [Developer
+Documentation](https://github.com/puppetlabs/puppet/blob/master/README_DEVELOPER.md).
 
 License
 -------


### PR DESCRIPTION
Our README currently rendered on github doesn't show people how get into
the contribution process.  I've added a very small section to point to
the other doc files that exist in our repositories.  This was based on
feedback at the Community Leadership Summit 2012.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
