### PR TITLE
(#15533) Change puppet module build to build the module in cwd (or parents)

### DIFF
--- a/acceptance/tests/modules/build/build_basic.rb
+++ b/acceptance/tests/modules/build/build_basic.rb
@@ -1,0 +1,46 @@
+begin test_name "puppet module build (basic)"
+
+step 'Setup'
+apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+apply_manifest_on master, <<-PP
+file {
+  [
+    '/etc/puppet/modules/nginx',
+  ]: ensure => directory;
+  '/etc/puppet/modules/nginx/Modulefile':
+    content => 'name "puppetlabs-nginx"
+version "0.0.1"
+source "git://github.com/puppetlabs/puppetlabs-nginx.git"
+author "Puppet Labs"
+license "Apache Version 2.0"
+summary "Nginx Module"
+description "Nginx"
+project_page "http://github.com/puppetlabs/puppetlabs-ntp"
+dependency "puppetlabs/stdlib", ">= 1.0.0"
+';
+}
+PP
+
+step "Try to build a module with an absolute path"
+on master, puppet("module build /etc/puppet/modules/nginx") do
+  assert_output <<-OUTPUT
+    Building /etc/puppet/modules/nginx for release
+    Module built: /etc/puppet/modules/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz
+  OUTPUT
+end
+on master, '[ -d /etc/puppet/modules/nginx/pkg/puppetlabs-nginx-0.0.1 ]'
+on master, '[ -f /etc/puppet/modules/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz ]'
+
+step "Try to build a module without providing a path"
+on master, ("cd /etc/puppet/modules/nginx && puppet module build") do
+  assert_output <<-OUTPUT
+    Building /etc/puppet/modules/nginx for release
+    Module built: /etc/puppet/modules/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz
+  OUTPUT
+end
+on master, '[ -d /etc/puppet/modules/nginx/pkg/puppetlabs-nginx-0.0.1 ]'
+on master, '[ -f /etc/puppet/modules/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz ]'
+
+ensure step "Teardown"
+apply_manifest_on master, "file { '/etc/puppet/modules': recurse => true, purge => true, force => true }"
+end

--- a/acceptance/tests/modules/build/build_no_modulefile.rb
+++ b/acceptance/tests/modules/build/build_no_modulefile.rb
@@ -1,0 +1,27 @@
+begin test_name "puppet module build (bad modulefiles)"
+
+step 'Setup'
+apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+apply_manifest_on master, <<-PP
+file {
+  [
+    '/etc/puppet/modules/nginx',
+  ]: ensure => directory;
+  '/etc/puppet/modules/nginx/Modulefile':
+    ensure => absent;
+}
+PP
+
+step "Try to build a module with no modulefile"
+on master, puppet("module build /etc/puppet/modules/nginx"), :acceptable_exit_codes => [1] do
+  assert_equal <<-OUTPUT, stderr
+\e[1;31mError: Unable to find module root at /etc/puppet/modules/nginx\e[0m
+\e[1;31mError: Try 'puppet help module build' for usage\e[0m
+  OUTPUT
+end
+on master, '[ ! -d /etc/puppet/modules/nginx/pkg/puppetlabs-nginx-0.0.1 ]'
+on master, '[ ! -f /etc/puppet/modules/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz ]'
+
+ensure step "Teardown"
+apply_manifest_on master, "file { '/etc/puppet/modules': recurse => true, purge => true, force => true }"
+end

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -38,13 +38,32 @@ module Puppet
       end
     end
 
+    # Find the module root when given a path by checking each directory up from
+    # its current location until it finds one that contains a file called
+    # 'Modulefile'.
+    #
+    # @param path [Pathname, String] path to start from
+    # @return [Pathname, nil] the root path of the module directory or nil if
+    #   we cannot find one
     def self.find_module_root(path)
-      for dir in [path, Dir.pwd].compact
-        if File.exist?(File.join(dir, 'Modulefile'))
-          return dir
-        end
+      path = Pathname.new(path) if path.class == String
+
+      path.expand_path.ascend do |p|
+        return p if is_module_root?(p)
       end
-      raise ArgumentError, "Could not find a valid module at #{path ? path.inspect : 'current directory'}"
+
+      nil
+    end
+
+    # Analyse path to see if it is a module root directory by detecting a
+    # file named 'Modulefile' in the directory.
+    #
+    # @param path [Pathname, String] path to analyse
+    # @return [Boolean] true if the path is a module root, false otherwise
+    def self.is_module_root?(path)
+      path = Pathname.new(path) if path.class == String
+
+      FileTest.file?(path + 'Modulefile')
     end
 
     # Builds a formatted tree from a list of node hashes containing +:text+

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -5,7 +5,7 @@ module Puppet::ModuleTool
     class Builder < Application
 
       def initialize(path, options = {})
-        @path = File.expand_path(Puppet::ModuleTool.find_module_root(path))
+        @path = File.expand_path(path)
         @pkg_path = File.join(@path, 'pkg')
         super(options)
       end

--- a/spec/unit/face/module/build_spec.rb
+++ b/spec/unit/face/module/build_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'puppet/face'
+
+describe "puppet module build" do
+  subject { Puppet::Face[:module, :current] }
+
+  describe "when called without any options" do
+    it "if current directory is a module root should call builder with it" do
+      Dir.expects(:pwd).returns('/a/b/c')
+      Puppet::ModuleTool.expects(:find_module_root).with('/a/b/c').returns('/a/b/c')
+      Puppet::ModuleTool.expects(:set_option_defaults).returns({})
+      Puppet::ModuleTool::Applications::Builder.expects(:run).with('/a/b/c', {})
+      subject.build
+    end
+
+    it "if parent directory of current dir is a module root should call builder with it" do
+      Dir.expects(:pwd).returns('/a/b/c')
+      Puppet::ModuleTool.expects(:find_module_root).with('/a/b/c').returns('/a/b')
+      Puppet::ModuleTool.expects(:set_option_defaults).returns({})
+      Puppet::ModuleTool::Applications::Builder.expects(:run).with('/a/b', {})
+      subject.build
+    end
+
+    it "if current directory or parents contain no module root, should return exception" do
+      Dir.expects(:pwd).returns('/a/b/c')
+      Puppet::ModuleTool.expects(:find_module_root).returns(nil)
+      expect { subject.build }.to raise_error RuntimeError, "Unable to find module root at /a/b/c or parent directories"
+    end
+  end
+
+  describe "when called with a path" do
+    it "if path is a module root should call builder with it" do
+      Puppet::ModuleTool.expects(:is_module_root?).with('/a/b/c').returns(true)
+      Puppet::ModuleTool.expects(:set_option_defaults).returns({})
+      Puppet::ModuleTool::Applications::Builder.expects(:run).with('/a/b/c', {})
+      subject.build('/a/b/c')
+    end
+
+    it "if path is not a module root should raise exception" do
+      Puppet::ModuleTool.expects(:is_module_root?).with('/a/b/c').returns(false)
+      expect { subject.build('/a/b/c') }.to raise_error RuntimeError, "Unable to find module root at /a/b/c"
+    end
+  end
+
+  describe "with options" do
+    it "should pass through options to builder when provided" do
+      Puppet::ModuleTool.stubs(:is_module_root?).returns(true)
+      Puppet::ModuleTool.expects(:set_option_defaults).returns({})
+      Puppet::ModuleTool::Applications::Builder.expects(:run).with('/a/b/c', {:modulepath => '/x/y/z'})
+      subject.build('/a/b/c', :modulepath => '/x/y/z')
+    end
+  end
+
+  describe "inline documentation" do
+    subject { Puppet::Face[:module, :current].get_action :build }
+
+    its(:summary)     { should =~ /build.*module/im }
+    its(:description) { should =~ /build.*module/im }
+    its(:returns)     { should =~ /pathname/i }
+    its(:examples)    { should_not be_empty }
+
+    %w{ license copyright summary description returns examples }.each do |doc|
+      context "of the" do
+        its(doc.to_sym) { should_not =~ /(FIXME|REVISIT|TODO)/ }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously 'puppet module build' required a full path to build a module. This
change will add the ability to run the command from within a module itself
and have the package built correctly.

Through changes to find_module_root it will also support running the command
is a sub-directory of the module as well.

Due to some lack of system and unit testing, I've added that as well as part
of this patch and included tests for the new behaviour.
