### PR TITLE
Disable ActiveSupport::Dependencies hooks.

### DIFF
--- a/lib/puppet/feature/rails.rb
+++ b/lib/puppet/feature/rails.rb
@@ -4,6 +4,24 @@ Puppet.features.rubygems?
 
 Puppet.features.add(:rails) do
   begin
+    # Turn off the constant watching parts of ActiveSupport, which have a huge
+    # cost in terms of the system watching loaded code to figure out if it was
+    # a missing content, and which we don't actually *use* anywhere.
+    #
+    # In fact, we *can't* depend on the feature: we don't require
+    # ActiveSupport, just load it if we use rails, if we depend on a feature
+    # that it offers. --daniel 2012-07-16
+    require 'active_support'
+    begin
+      ActiveSupport::Dependencies.unhook!
+      ActiveSupport::Dependencies.mechanism = :require
+    rescue ScriptError, StandardError => e
+      # ignore any failure - worst case we run without disabling the CPU
+      # sucking features, so are slower but ... not actually failed, just
+      # because some random future version of ActiveRecord changes.
+      Puppet.debug("disabling ActiveSupport::Dependencies failed: #{e}")
+    end
+
     require 'active_record'
     require 'active_record/version'
   rescue LoadError => detail


### PR DESCRIPTION
The ActiveSupport::Dependencies code is loaded along with Rails, and hooks
into a bunch of the system.  This consumes a surprisingly large amount of CPU
time watching for constants and generally acting to support unloading code.

This is related to the code that automatically requires libraries when the
constant is first accessed.

We don't - can't, since Rails is a soft dependencies - depend on that feature,
or anything related to it, we have no benefit from paying that horrible price.

Dropping this is actually a significant drop in CPU consumption - some 8
percent of the CPU cost in my testing is attributed directly to this feature.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
