### PR TITLE
zaml: unify on a single definition of `to_zaml` for Symbol

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -24,10 +24,6 @@ require "yaml"
 require "puppet/util/zaml.rb"
 
 class Symbol
-  def to_zaml(z)
-    z.emit("!ruby/sym ")
-    to_s.to_zaml(z)
-  end
   def <=> (other)
     self.to_s <=> other.to_s
   end unless method_defined? "<=>"

--- a/lib/puppet/util/zaml.rb
+++ b/lib/puppet/util/zaml.rb
@@ -172,7 +172,8 @@ end
 
 class Symbol
   def to_zaml(z)
-    z.emit(self.inspect)
+    z.emit("!ruby/sym ")
+    to_s.to_zaml(z)
   end
 end
 


### PR DESCRIPTION
There were two competitive definitions of the `to_zaml` function over Symbol,
one in monkey_patches and one in the core ZAML library.

The monkey patch version won in practice, so now they are unified, and the
monkey patch version is adopted to replace the core ZAML version, in the zaml
Ruby file.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
