### PR TITLE
(Maint) Don't assume paths are absolute

### DIFF
--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -7,8 +7,7 @@ describe Puppet::Type.type(:service).provider(:openrc) do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     ['/sbin/rc-service', '/bin/rc-status', '/sbin/rc-update'].each do |command|
-      FileTest.stubs(:file?).with(command).returns true
-      FileTest.stubs(:executable?).with(command).returns true
+      described_class.stubs(:which).with(command).returns(command)
     end
   end
 


### PR DESCRIPTION
Previously, the spec test failed on Windows, because the test assumed that
paths such as '/sbin/rc-service' are absolute on every platform. Since
they are not absolute on Windows, the test would fail.

This commit changes the test to not rely on the internals of the
`Puppet::Util.which` command that is included in every provider.
