### PR TITLE
Implement `Fixnum#ord` for Ruby 1.8.5

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -81,6 +81,14 @@ if RUBY_VERSION == '1.8.1' || RUBY_VERSION == '1.8.2'
   }
 end
 
+class Fixnum
+  # Returns the int itself. This method is intended for compatibility to
+  # character constant in Ruby 1.9.  1.8.5 is missing it; add it.
+  def ord
+    self
+  end unless method_defined? 'ord'
+end
+
 class Array
   # Ruby < 1.8.7 doesn't have this method but we use it in tests
   def combination(num)


### PR DESCRIPTION
This is a compatibility method for addressing characters introduced in 1.8.7;
we also need the same compatibility back to 1.8.5, so we monkey-patch it in
when it isn't already there.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
