### PR TITLE
(13070) Mark files as loaded before we load

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -107,8 +107,8 @@ class Puppet::Util::Autoload
       name = File.basename(file).chomp(".rb").intern
       next if loaded?(name)
       begin
-        Kernel.require file
         loaded(name, file)
+        Kernel.require file
       rescue SystemExit,NoMemoryError
         raise
       rescue Exception => detail


### PR DESCRIPTION
There is a loading cycle that occurs in some situations. It showed up as
not being able to describe certain types because the description
depended on the name of the type's class. For some reason (that is not
entirely clear) the multiple loading of code seems to cause the name of
the class to be wrong.

This patch changes it to mark the file as loaded first, so that we don't
get into a loading cycle.
