### PR TITLE
(maint) Add Puppet::Parser::Scope.new_for_test_harness

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -53,6 +53,18 @@ class Puppet::Parser::Scope
     end
   end
 
+  # Initialize a new scope suitable for parser function testing.  This method
+  # should be considered a public API for external modules.  A shared spec
+  # helper should consume this API method.
+  def self.new_for_test_harness(node_name)
+    node = Puppet::Node.new(node_name)
+    compiler = Puppet::Parser::Compiler.new(node)
+    scope = new(compiler)
+    scope.source = Puppet::Resource::Type.new(:node, node_name)
+    scope.parent = compiler.topscope
+    scope
+  end
+
   def each
     to_hash.each { |name, value| yield(name, value) }
   end

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -12,6 +12,28 @@ describe Puppet::Parser::Scope do
     @scope.parent = @topscope
   end
 
+  describe ".new_for_test_harness" do
+    let(:node_name) { "node_name_foo" }
+    let(:scope) { described_class.new_for_test_harness(node_name) }
+
+    it "should be a kind of Scope" do
+      scope.should be_a_kind_of Puppet::Parser::Scope
+    end
+    it "should set the source to a node resource" do
+      scope.source.should be_a_kind_of Puppet::Resource::Type
+    end
+    it "should have a compiler" do
+      scope.compiler.should be_a_kind_of Puppet::Parser::Compiler
+    end
+    it "should set the parent to the compiler topscope" do
+      scope.parent.should be scope.compiler.topscope
+    end
+  end
+
+  it "should return a scope for use in a test harness" do
+    described_class.new_for_test_harness("node_name_foo").should be_a_kind_of Puppet::Parser::Scope
+  end
+
   it "should be able to retrieve class scopes by name" do
     @scope.class_set "myname", "myscope"
     @scope.class_scope("myname").should == "myscope"


### PR DESCRIPTION
Without this patch there is no clear path into the internals of Puppet for
third parties who intended to exercise Puppet parser functions.

This is a problem because many 3rd parties, such as the stdlib module and
hiera-puppet extend Puppet using parser functions.  These modules create
instances of Puppet::Parser::Scope objects in their test harness to invoke
the parser functions they're testing.

The specific problem this patch means to address is the dependency of Puppet
modules on the specific method signature of Puppet::Parser::Scope#initialize 
This patch addresses the problem my adding a new method,
Puppet::Parser::Scope.new_for_test_harness which accepts a single argument,
the node name, and returns a scope instance bound to a compiler instance and
a node instance.

The common spec helper should be augmented to invoke this method.  All Puppet
modules that exercise parser functions should then decouple themselves from
Puppet itself and instead depend upon the common spec helper behavior.
