### PR TITLE
zaml: handle multi-line map keys and array values correctly.

### DIFF
--- a/lib/puppet/util/zaml.rb
+++ b/lib/puppet/util/zaml.rb
@@ -102,13 +102,21 @@ class ZAML
       label.this_label_number ||= (@next_free_label_number += 1)
       emit(label.reference)
     else
-      if @structured_key_prefix and not obj.is_a? String
+      with_structured_prefix(obj) do
+        emit(new_label_for(obj))
+        yield
+      end
+    end
+  end
+
+  def with_structured_prefix(obj)
+    if @structured_key_prefix
+      unless obj.is_a?(String) and obj !~ /\n/
         emit(@structured_key_prefix)
         @structured_key_prefix = nil
       end
-      emit(new_label_for(obj))
-      yield
     end
+    yield
   end
 
   def emit(s)
@@ -245,10 +253,11 @@ class String
   }
 
   def to_zaml(z)
-    case
-    when self == ''
-      z.emit('""')
-    when self.to_ascii8bit !~ /\A(?: # ?: non-capturing group (grouping with no back references)
+    z.with_structured_prefix(self) do
+      case
+      when self == ''
+        z.emit('""')
+      when self.to_ascii8bit !~ /\A(?: # ?: non-capturing group (grouping with no back references)
                  [\x09\x0A\x0D\x20-\x7E]            # ASCII
                | [\xC2-\xDF][\x80-\xBF]             # non-overlong 2-byte
                |  \xE0[\xA0-\xBF][\x80-\xBF]        # excluding overlongs
@@ -258,30 +267,31 @@ class String
                | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
                |  \xF4[\x80-\x8F][\x80-\xBF]{2}     # plane 16
                )*\z/mnx
-      # Emit the binary tag, then recurse. Ruby splits BASE64 output at the 60
-      # character mark when packing strings, and we can wind up a multi-line
-      # string here.  We could reimplement the multi-line string logic,
-      # but why would we - this does just as well for producing solid output.
-      z.emit("!binary ")
-      [self].pack("m*").to_zaml(z)
+        # Emit the binary tag, then recurse. Ruby splits BASE64 output at the 60
+        # character mark when packing strings, and we can wind up a multi-line
+        # string here.  We could reimplement the multi-line string logic,
+        # but why would we - this does just as well for producing solid output.
+        z.emit("!binary ")
+        [self].pack("m*").to_zaml(z)
 
-    # Only legal UTF-8 characters can make it this far, so we are safe
-    # against emitting something dubious. That means we don't need to mess
-    # about, just emit them directly. --daniel 2012-07-14
-    when self =~ /\n/
-      # embedded newline, split line-wise in quoted string block form.
-      if self[-1..-1] == "\n" then z.emit('|+') else z.emit('|-') end
-      z.nested { split("\n",-1).each { |line| z.nl; z.emit(line.chomp("\n")) } }
-    when ((self =~ /^[a-zA-Z\/][-\[\]_\/.:a-zA-Z0-9]*$/) and
-        (self !~ /^(?:true|false|yes|no|on|null|off)$/i))
-      # simple string literal, safe to emit unquoted.
-      z.emit(self)
-    else
-      # ...though we still have to escape unsafe characters.
-      escaped = gsub(/[\\"\x00-\x1F]/) do |c|
-        ZAML_ESCAPES[c] || "\\x#{c[0].ord.to_s(16)}"
+      # Only legal UTF-8 characters can make it this far, so we are safe
+      # against emitting something dubious. That means we don't need to mess
+      # about, just emit them directly. --daniel 2012-07-14
+      when ((self =~ /\A[a-zA-Z\/][-\[\]_\/.:a-zA-Z0-9]*\z/) and
+          (self !~ /^(?:true|false|yes|no|on|null|off)$/i))
+        # simple string literal, safe to emit unquoted.
+        z.emit(self)
+      when (self =~ /\n/ and self !~ /\A\s/ and self !~ /\s\z/)
+        # embedded newline, split line-wise in quoted string block form.
+        if self[-1..-1] == "\n" then z.emit('|+') else z.emit('|-') end
+        z.nested { split("\n",-1).each { |line| z.nl; z.emit(line) } }
+      else
+        # ...though we still have to escape unsafe characters.
+        escaped = gsub(/[\\"\x00-\x1F]/) do |c|
+          ZAML_ESCAPES[c] || "\\x#{c[0].ord.to_s(16)}"
+        end
+        z.emit("\"#{escaped}\"")
       end
-      z.emit("\"#{escaped}\"")
     end
   end
 

--- a/spec/unit/util/zaml_spec.rb
+++ b/spec/unit/util/zaml_spec.rb
@@ -194,3 +194,25 @@ describe "binary data" do
     end
   end
 end
+
+describe "multi-line values" do
+  [
+    "none",
+    "one\n",
+    "two\n\n",
+    ["one\n", "two"],
+    ["two\n\n", "three"],
+    { "\nkey"        => "value" },
+    { "key\n"        => "value" },
+    { "\nkey\n"      => "value" },
+    { "key\nkey"     => "value" },
+    { "\nkey\nkey"   => "value" },
+    { "key\nkey\n"   => "value" },
+    { "\nkey\nkey\n" => "value" },
+  ].each do |input|
+    it "handles #{input.inspect} without corruption" do
+      zaml = ZAML.dump(input)
+      YAML.load(zaml).should == input
+    end
+  end
+end


### PR DESCRIPTION
The ZAML encoder had some bugs when handling multi-line string values in map
keys and arrays. It also changed behaviour slightly when I modified it for
speed, causing a regression in another case that was correctly handled.

This fixes that, as well as making more robust the process of tagging
structural keys that can span multiple lines.

It also adds some tests to validate that we don't regress again.

This fixes a pre-existing bug in the encoder, as well as my regression.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
