### PR TITLE
8200 : validate only if we can (especially path)

### DIFF
--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -440,22 +440,30 @@ autorequire that directory."
       self.fail "'#{ip}' is an invalid #{name}"
   end
 
-  validate do
-    value = self[:ip]
-    interface, address, defrouter = value.split(':')
-    if self[:iptype] == :shared
-      if (interface && address && defrouter.nil?) ||
-        (interface && address && defrouter)
-        validate_ip(address, "IP address")
-        validate_ip(defrouter, "default router")
-      else
-        self.fail "ip must contain interface name and ip address separated by a \":\""
-      end
-    else
-      self.fail "only interface may be specified when using exclusive IP stack: #{value}" unless interface && address.nil? && defrouter.nil?
+  def validate_exclusive(interface, address, router)
+    return if !interface.nil? and address.nil?
+    self.fail "only interface may be specified when using exclusive IP stack: #{interface}:#{address}"
+  end
+  def validate_shared(interface, address, router)
+    self.fail "ip must contain interface name and ip address separated by a \":\"" if interface.nil? or address.nil?
+    [address, router].each do |ip|
+      validate_ip(address, "IP address") unless ip.nil?
     end
+  end
 
-    self.fail "zone path is required" unless self[:path]
+  validate do
+    # we only validate ip.
+    return unless self[:ip]
+    # We cannot validate for the presence of parameter path here because
+    # validate is also executed when `puppet resource zone` is executed
+    # A better option is to mark path as an `isrequired` parameter.
+    # However isrequired is not hooked up as of now.
+    interface, address, router = self[:ip].split(':')
+    if self[:iptype] == :shared
+      validate_shared(interface, address, router)
+    else
+      validate_exclusive(interface, address, router)
+    end
   end
 
   def retrieve

--- a/spec/unit/type/zone_spec.rb
+++ b/spec/unit/type/zone_spec.rb
@@ -29,8 +29,14 @@ describe zone do
   end
 
   it "should be invalid when :path is missing" do
+    pending "until `isrequired` for parameters works, we cann't validate path"
     lambda { zone.new(:name => "dummy") }.should raise_error
   end
+
+  it "should be valid when only :path is given" do
+    zone.new(:name => "dummy", :path => '/dummy' )
+  end
+
 
   it "should be invalid when :ip is missing a \":\" and iptype is :shared" do
     lambda { zone.new(:name => "dummy", :ip => "if") }.should raise_error


### PR DESCRIPTION
The global validate block is called even when `puppet resource zone` is
called without any further arguments, and there is no good way to detect
when that happens. More over, the `isrequired` method in parameter.rb is
a better way to mark the parameter :path as a required option. Hence the
validation of path is removed from global validate block.

The ip validation is refactored to make it clearer to read.

Since `isrequired` doesnot seem to be hooked up, the spec test for path
validation is now in pending.
