### PR TITLE
Re-introduce a Gemfile for managing dependencies for puppet contributors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,23 @@
+source :gemcutter
+
+# We're making an assumption that you will have a recent Facter checked out in
+# the parent directory. After 3.x is properly released, this should be changed
+# back to pointing ata released version of Facter
+gem 'facter', :path => '../facter'
+gem 'rack', '1.2.2'
+
+
+# NOTE: These groups are nothing but a little semantic sugar in the Gemfile,
+# unless you explicitly exclude a group `bundle install` will install all gems
+# across all groups
+
+group :development do
+  gem 'rake', :require => nil
+  gem 'rspec', '~> 2.9.0'
+  gem 'mocha', '~> 0.10.5'
+  gem 'sqlite3', '~> 1.3.3'
+  gem 'parallel_tests', '~> 0.8.4'
+  # This is the /known/ version of RDoc which the "allfeatures" gemset on CI
+  # runs, should be safe to pin it here
+  #gem 'rdoc', '3.6.1'
+end

--- a/README_DEVELOPER.md
+++ b/README_DEVELOPER.md
@@ -3,6 +3,17 @@
 This file is intended to provide a place for developers and contributors to
 document what other developers need to know about changes made to Puppet.
 
+# Installing Dependencies #
+
+To make development dependency management easier a `Gemfile` is included in the
+root of the tree. The Gemfile is used by [Bundler](http://gembundler.com/) for
+installing dependent gems of at least a certain version.
+
+To use (assuming you have Bundler installed):
+
+    % bundle install
+
+
 # UTF-8 Handling #
 
 As Ruby 1.9 becomes more commonly used with Puppet, developers should be aware


### PR DESCRIPTION
The Gemfile is only for use by contributors to the project, it has no effect on
the packaging of Puppet as a gem or anything else. It's sole purpose is to make
it easier for a new developer to get all the dependencies needed to develop for Puppet installed locally.

Pairs quite nicely when used with RVM: http://rvm.io

Fixes #15464

![jammin time](http://i.imgur.com/IU9bD.gif)
