### PR TITLE
(#15666) Include downstream error when raising CommunicationsError exception

### DIFF
--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -11,6 +11,7 @@ STDOUT
   assert_match <<-STDERR.chomp, stderr
 Error: Could not connect to https://forge.puppetlabs.com
   There was a network communications problem
+    The error we caught said 'Connection refused - connect(2)'
     Check your network connection and try again
 STDERR
 end

--- a/acceptance/tests/modules/search/ssl_errors.rb
+++ b/acceptance/tests/modules/search/ssl_errors.rb
@@ -10,10 +10,10 @@ with_master_running_on(master) do
 Searching https://#{master}:8140 ...
 STDOUT
     assert_match <<-STDERR.chomp, stderr
-Error: Unable to verify the SSL certificate at https://#{master}:8140
-  This could be because the certificate is invalid or that the CA bundle
-  installed with your version of OpenSSL is not available, not valid or
-  not up to date.
+Error: Could not connect via HTTPS to https://#{master}:8140
+  Unable to verify the SSL certificate
+    The certificate may not be signed by a valid CA
+    The CA bundle included with OpenSSL may not be valid or up to date
 STDERR
 end
 

--- a/lib/puppet/forge/errors.rb
+++ b/lib/puppet/forge/errors.rb
@@ -1,10 +1,14 @@
+require 'puppet/error'
+
 # Puppet::Forge specific exceptions
 module Puppet::Forge::Errors
 
   # This exception is the parent for all Forge API errors
-  class ForgeError < StandardError
+  class ForgeError < Puppet::Error
     # This is normally set by the child class, but if it is not this will
     # fall back to displaying the message as a multiline.
+    #
+    # @return [String] the multiline version of the error message
     def multiline
       self.message
     end
@@ -12,42 +16,51 @@ module Puppet::Forge::Errors
 
   # This exception is raised when there is an SSL verification error when
   # communicating with the forge.
-  #
-  # @option options [String] :uri The URI that failed
   class SSLVerifyError < ForgeError
+    # @option options [String] :uri The URI that failed
+    # @option options [String] :original the original exception
     def initialize(options)
-      @uri    = options[:uri]
+      @uri     = options[:uri]
+      original = options[:original]
 
-      super "Unable to verify the SSL certificate at #{@uri}"
+      super("Unable to verify the SSL certificate at #{@uri}", original)
     end
 
-    # A multiline version of the error message
+    # Return a multiline version of the error message
+    #
+    # @return [String] the multiline version of the error message
     def multiline
       message = <<-EOS.chomp
-Unable to verify the SSL certificate at #{@uri}
-  This could be because the certificate is invalid or that the CA bundle
-  installed with your version of OpenSSL is not available, not valid or
-  not up to date.
+Could not connect via HTTPS to #{@uri}
+  Unable to verify the SSL certificate
+    The certificate may not be signed by a valid CA
+    The CA bundle included with OpenSSL may not be valid or up to date
       EOS
     end
   end
 
   # This exception is raised when there is a communication error when connecting
   # to the forge
-  #
-  # @option options [String] :uri The URI that failed
   class CommunicationError < ForgeError
+    # @option options [String] :uri The URI that failed
+    # @option options [String] :original the original exception
     def initialize(options)
-      @uri    = options[:uri]
+      @uri     = options[:uri]
+      original = options[:original]
+      @detail  = original.message
 
-      super "Unable to connect to the server at #{@uri}"
+      message = "Unable to connect to the server at #{@uri}. Detail: #{@detail}."
+      super(message, original)
     end
 
-    # A multiline version of the error message
+    # Return a multiline version of the error message
+    #
+    # @return [String] the multiline version of the error message
     def multiline
       message = <<-EOS.chomp
 Could not connect to #{@uri}
   There was a network communications problem
+    The error we caught said '#{@detail}'
     Check your network connection and try again
       EOS
     end

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -1,4 +1,5 @@
 require 'net/https'
+require 'zlib'
 require 'digest/sha1'
 require 'uri'
 require 'puppet/forge/errors'
@@ -11,6 +12,21 @@ class Puppet::Forge
     include Puppet::Forge::Errors
 
     attr_reader :uri, :cache
+
+    # List of Net::HTTP exceptions to catch
+    NET_HTTP_EXCEPTIONS = [
+      EOFError,
+      Errno::ECONNABORTED,
+      Errno::ECONNREFUSED,
+      Errno::ECONNRESET,
+      Errno::EINVAL,
+      Errno::ETIMEDOUT,
+      Net::HTTPBadResponse,
+      Net::HTTPHeaderSyntaxError,
+      Net::ProtocolError,
+      SocketError,
+      Zlib::GzipFile::Error,
+    ]
 
     # Instantiate a new repository instance rooted at the +url+.
     # The agent will report +consumer_version+ in the User-Agent to
@@ -67,32 +83,51 @@ class Puppet::Forge
     end
 
     # Return a Net::HTTPResponse read from this HTTPRequest +request+.
+    #
+    # @param request [Net::HTTPRequest] request to make
+    # @return [Net::HTTPResponse] response from request
+    # @raise [Puppet::Forge::Errors::CommunicationError] if there is a network
+    #   related error
+    # @raise [Puppet::Forge::Errors::SSLVerifyError] if there is a problem
+    #  verifying the remote SSL certificate
     def read_response(request)
-      begin
-        proxy_class = Net::HTTP::Proxy(http_proxy_host, http_proxy_port)
-        proxy = proxy_class.new(@uri.host, @uri.port)
+      http_object = get_http_object
 
-        if @uri.scheme == 'https'
-          cert_store = OpenSSL::X509::Store.new
-          cert_store.set_default_paths
-
-          proxy.use_ssl = true
-          proxy.verify_mode = OpenSSL::SSL::VERIFY_PEER
-          proxy.cert_store = cert_store
-        end
-
-        proxy.start do |http|
-          http.request(request)
-        end
-      rescue Errno::ECONNREFUSED, SocketError
-        raise CommunicationError.new(:uri => @uri.to_s)
-      rescue OpenSSL::SSL::SSLError => e
-        if e.message =~ /certificate verify failed/
-          raise SSLVerifyError.new(:uri => @uri.to_s)
-        else
-          raise e
-        end
+      http_object.start do |http|
+        http.request(request)
       end
+    rescue *NET_HTTP_EXCEPTIONS => e
+      raise CommunicationError.new(:uri => @uri.to_s, :original => e)
+    rescue OpenSSL::SSL::SSLError => e
+      if e.message =~ /certificate verify failed/
+        raise SSLVerifyError.new(:uri => @uri.to_s, :original => e)
+      else
+        raise e
+      end
+    end
+
+    # Return a Net::HTTP::Proxy object constructed from the settings provided
+    # accessing the repository.
+    #
+    # This method optionally configures SSL correctly if the URI scheme is
+    # 'https', including setting up the root certificate store so remote server
+    # SSL certificates can be validated.
+    #
+    # @return [Net::HTTP::Proxy] object constructed from repo settings
+    def get_http_object
+      proxy_class = Net::HTTP::Proxy(http_proxy_host, http_proxy_port)
+      proxy = proxy_class.new(@uri.host, @uri.port)
+
+      if @uri.scheme == 'https'
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.set_default_paths
+
+        proxy.use_ssl = true
+        proxy.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        proxy.cert_store = cert_store
+      end
+
+      proxy
     end
 
     # Return the local file name containing the data downloaded from the

--- a/spec/unit/forge/errors_spec.rb
+++ b/spec/unit/forge/errors_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'puppet/forge/errors'
+
+describe Puppet::Forge::Errors do
+  describe 'SSLVerifyError' do
+    subject { Puppet::Forge::Errors::SSLVerifyError }
+    let(:exception) { subject.new(:uri => 'https://fake.com:1111') }
+
+    it 'should return a valid single line error' do
+      exception.message.should == 'Unable to verify the SSL certificate at https://fake.com:1111'
+    end
+
+    it 'should return a valid multiline error' do
+      exception.multiline.should == <<-EOS.chomp
+Could not connect via HTTPS to https://fake.com:1111
+  Unable to verify the SSL certificate
+    The certificate may not be signed by a valid CA
+    The CA bundle included with OpenSSL may not be valid or up to date
+      EOS
+    end
+  end
+
+  describe 'CommunicationError' do
+    subject { Puppet::Forge::Errors::CommunicationError }
+    let(:socket_exception) { SocketError.new('There was a problem') }
+    let(:exception) { subject.new(:uri => 'http://fake.com:1111', :original => socket_exception) }
+
+    it 'should return a valid single line error' do
+      exception.message.should == 'Unable to connect to the server at http://fake.com:1111. Detail: There was a problem.'
+    end
+
+    it 'should return a valid multiline error' do
+      exception.multiline.should == <<-EOS.chomp
+Could not connect to http://fake.com:1111
+  There was a network communications problem
+    The error we caught said 'There was a problem'
+    Check your network connection and try again
+      EOS
+    end
+  end
+
+end

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -81,7 +81,9 @@ describe Puppet::Forge::Repository do
         http.expects(:request).with(responds_with(:path, "the_path")).raises SocketError
       end
 
-      expect { repository.make_http_request("the_path") }.to raise_error Puppet::Forge::Errors::CommunicationError, 'Unable to connect to the server at http://fake.com'
+      expect { repository.make_http_request("the_path") }.
+        to raise_error Puppet::Forge::Errors::CommunicationError,
+        'Unable to connect to the server at http://fake.com. Detail: SocketError.'
     end
 
     it "sets the user agent for the request" do


### PR DESCRIPTION
Previously we were seeing errors being returned in the acceptance framework,
when the puppet module face had problems but the existing error message is far
too generic to be used to understand the root cause of such problems.

This patch changes the read_response code and CommunicationsError exceptions so
that the underlying comms error message is exposed to the client. The generic
message has been kept, but a new line 'Details:' has been added that will
expose the underlying error.

To make sure the generic error will catch and wrap the correct exceptions, we
have added a list of what we believe are the common exceptions that Net::HTTP
raises when remote or network problems occur. Other exceptions will continue to
be raised up to the face as per normal.

Test coverage has been added to make sure the exceptions behave as expected, as
this was lacking beforehand.
