### PR TITLE
(#15676) Fix puppet module face SSL acceptance tests to use masters real hostname

### DIFF
--- a/acceptance/tests/modules/search/ssl_errors.rb
+++ b/acceptance/tests/modules/search/ssl_errors.rb
@@ -5,12 +5,12 @@ step "Search against a website where the certificate is not signed by a public a
 # This might seem silly, but a master has a self-signed certificate and is a
 # cheap way of testing against a web server without a publicly signed cert
 with_master_running_on(master) do
-  on master, puppet("module search yup --module_repository=https://localhost:8140"), :acceptable_exit_codes => [1] do
+  on master, puppet("module search yup --module_repository=https://#{master}:8140"), :acceptable_exit_codes => [1] do
     assert_match <<-STDOUT, stdout
-Searching https://localhost:8140 ...
+Searching https://#{master}:8140 ...
 STDOUT
     assert_match <<-STDERR.chomp, stderr
-Error: Unable to verify the SSL certificate at https://localhost:8140
+Error: Unable to verify the SSL certificate at https://#{master}:8140
   This could be because the certificate is invalid or that the CA bundle
   installed with your version of OpenSSL is not available, not valid or
   not up to date.


### PR DESCRIPTION
Previously we had been using 'localhost' as the location of the master, which
is a dangerous assumption with systest, since the master may be located on
another host or 'localhost' may not give us the expected results.

This patch changes the usage of localhost to use the variable 'master' which
should point to the canonical hostname of the master each and every time.
