### PR TITLE
15686 : ensure that the error string comparison is done on a string.

### DIFF
--- a/lib/puppet/provider/package/sun.rb
+++ b/lib/puppet/provider/package/sun.rb
@@ -106,7 +106,7 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
       }
       return hash
     rescue Puppet::ExecutionFailure => detail
-      return {:ensure => :absent} if detail.message =~ /information for "#{Regexp.escape(@resource[:name])}" was not found/
+      return {:ensure => :absent} if detail.message.join(' ') =~ /information for "#{Regexp.escape(@resource[:name])}" was not found/
       message = "Unable to get information about package #{@resource[:name]} because of: #{detail}"
       Puppet.log_exception(detail, message)
       raise Puppet::Error, message


### PR DESCRIPTION
The return value of the execpipe block is an array for us due to us
doing readlines on the block. Hence, we have to convert the message to
a string before we do the regex compare
