### PR TITLE
The openbsd spec tests mistakenly used File.new instead of File.open.

### DIFF
--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -86,7 +86,7 @@ describe provider_class do
     end
 
     it "should return the package version if in the output" do
-      fixture = File.open(my_fixture('pkginfo.list'))
+      fixture = File.read(my_fixture('pkginfo.list'))
       provider = subject.new(package(:name => 'bash'))
       provider.expects(:execpipe).with(%w{/bin/pkg_info -I bash}).yields(fixture)
       provider.get_version.should == '3.1.17'


### PR DESCRIPTION
Fixes two tests.
