### PR TITLE
(Maint) Gemfile for noFeatures setup

### DIFF
--- a/Gemfile.noFeatures
+++ b/Gemfile.noFeatures
@@ -1,0 +1,6 @@
+source :rubygems
+
+gem "rspec", "2.9.0"
+gem "mocha", "0.10.5"
+gem "rack", "1.1.0"
+gem "rake"

--- a/Gemfile.noFeatures.lock
+++ b/Gemfile.noFeatures.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.1.3)
+    metaclass (0.0.1)
+    mocha (0.10.5)
+      metaclass (~> 0.0.1)
+    rack (1.1.0)
+    rake (0.9.2.2)
+    rspec (2.9.0)
+      rspec-core (~> 2.9.0)
+      rspec-expectations (~> 2.9.0)
+      rspec-mocks (~> 2.9.0)
+    rspec-core (2.9.0)
+    rspec-expectations (2.9.1)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.9.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mocha (= 0.10.5)
+  rack (= 1.1.0)
+  rake
+  rspec (= 2.9.0)


### PR DESCRIPTION
This creates a gemfile that installs what is used for the basic
"noFeatures" development setup for puppet. This does not include Facter or
Hiera in the path and so those will need to be placed into RUBYLIB 
independently.
