### PR TITLE
Don't mask NoMethodErrors

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -68,9 +68,11 @@ class Puppet::Property < Puppet::Parameter
 
   # Call the provider method.
   def call_provider(value)
-      provider.send(self.class.name.to_s + "=", value)
-  rescue NoMethodError
-      self.fail "The #{provider.class.name} provider can not handle attribute #{self.class.name}"
+      method = self.class.name.to_s + "="
+      unless provider.respond_to? method
+        self.fail "The #{provider.class.name} provider can not handle attribute #{self.class.name}"
+      end
+      provider.send(method, value)
   end
 
   # Call the dynamically-created method associated with our value, if


### PR DESCRIPTION
This rescue was masking a bug in a provider (involving calling `[]` on
`nil.NilClass`) with a misleading error message.  The new code asks
permission rather than begging forgiveness, but is more specific to the
problem being detected.

This needs tests, and may break existing tests.  I'll update the pull request for that once I get tests running properly locally.
