### PR TITLE
(#7175) ensure ensurable uses symbols in zone

### DIFF
--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -98,11 +98,7 @@ autorequire that directory."
     end
 
     def self.state_name(name)
-      if other = @state_aliases[name]
-        other
-      else
-        name
-      end
+      @state_aliases[name.to_sym] || name.to_sym
     end
 
     newvalue :absent, :down => :destroy

--- a/spec/unit/type/zone_spec.rb
+++ b/spec/unit/type/zone_spec.rb
@@ -56,6 +56,18 @@ describe zone do
     zone.new(:name => "dummy", :path => "/dummy", :ip => "if", :iptype => :exclusive)
   end
 
+  context "state_name" do
+    it "should correctly fetch alias from state_aliases when available" do
+      z = zone.new(:name => "dummy", :path => "/dummy", :ip => "if", :iptype => :exclusive)
+      z.parameter(:ensure).class.state_name('incomplete').should == :installed
+    end
+
+    it "should correctly use symbol when alias is unavailable" do
+      z = zone.new(:name => "dummy", :path => "/dummy", :ip => "if", :iptype => :exclusive)
+      z.parameter(:ensure).class.state_name('noalias').should == :noalias
+    end
+  end
+
   it "should auto-require :dataset entries" do
     fs = 'random-pool/some-zfs'
 


### PR DESCRIPTION
zone provider when asked to ensure the state to running/install or any
thing tries to find the value in state_index however, state_index values
stores keys as string. This is wrong. The root cause is that
ensurable returns values as string rather than symbols. This inturn is
caused by state_name checking for string value in state_alias which is a
symbol to symbol map, and not finding any, and returning itself.
