### PR TITLE
(#15594) Improve messages for SSL errors

### DIFF
--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -90,7 +90,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       peer_certs << Puppet::SSL::Certificate.from_s(ssl_context.current_cert.to_pem)
       # And also keep the detailed verification error if such an error occurs
       if ssl_context.error_string and not preverify_ok
-        verify_errors << "verify error #{ssl_context.error_string} for #{ssl_context.current_cert.subject}"
+        verify_errors << "#{ssl_context.error_string} for #{ssl_context.current_cert.subject}"
       end
       preverify_ok
     end

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -119,7 +119,7 @@ describe Puppet::Indirector::REST do
                                            :fails_with => 'certificate verify failed'))
       expect do
         @searcher.http_request(:get, stub('request'))
-      end.to raise_error(Puppet::Error, "certificate verify failed: [verify error shady looking signature for /CN=not_my_server]")
+      end.to raise_error(Puppet::Error, "certificate verify failed: [shady looking signature for /CN=not_my_server]")
     end
 
     it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet.features.microsoft_windows? do


### PR DESCRIPTION
Previously the messages for SSL errors were misleading and didn't include any
of the actual error information. This changes the reported error to include the
actual string form of the SSL error as well as the subject of the certificate
that caused the error.
