### PR TITLE
(#15514) Add compatibility with change to operatingsystem fact

### DIFF
--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -35,7 +35,7 @@ module Puppet::ModuleTool
         build_dir.mkpath
         begin
           begin
-            if Facter.value('operatingsystem') == "Solaris"
+            if Facter.value('osfamily') == "Solaris"
               # Solaris tar is not as safe and works differently, so we prefer
               # gnutar instead.
               if Puppet::Util.which('gtar')

--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/parsedfile'
 
-tab = case Facter.value(:operatingsystem)
+tab = case Facter.value(:osfamily)
   when "Solaris"
     :suntab
   when "AIX"

--- a/lib/puppet/provider/host/parsed.rb
+++ b/lib/puppet/provider/host/parsed.rb
@@ -1,7 +1,7 @@
 require 'puppet/provider/parsedfile'
 
 hosts = nil
-case Facter.value(:operatingsystem)
+case Facter.value(:osfamily)
 when "Solaris"; hosts = "/etc/inet/hosts"
 when "windows"
   require 'win32/resolv'

--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -2,7 +2,7 @@ require 'puppet/provider/parsedfile'
 require 'puppet/provider/mount'
 
 fstab = nil
-case Facter.value(:operatingsystem)
+case Facter.value(:osfamily)
 when "Solaris"; fstab = "/etc/vfstab"
 else
   fstab = "/etc/fstab"
@@ -18,7 +18,7 @@ Puppet::Type.type(:mount).provide(
 
   commands :mountcmd => "mount", :umount => "umount"
 
-  case Facter.value(:operatingsystem)
+  case Facter.value(:osfamily)
   when "Solaris"
     @fields = [:device, :blockdevice, :name, :fstype, :pass, :atboot, :options]
   else
@@ -88,7 +88,7 @@ Puppet::Type.type(:mount).provide(
 
   def self.mountinstances
     # XXX: Will not work for mount points that have spaces in path (does fstab support this anyways?)
-    regex = case Facter.value(:operatingsystem)
+    regex = case Facter.value(:osfamily) 
       when "Darwin"
         / on (?:\/private\/var\/automount)?(\S*)/
       when "Solaris", "HP-UX"

--- a/lib/puppet/provider/package/blastwave.rb
+++ b/lib/puppet/provider/package/blastwave.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:package).provide :blastwave, :parent => :sun, :source => :sun
   pkgget = "pkg-get"
   pkgget = "/opt/csw/bin/pkg-get" if FileTest.executable?("/opt/csw/bin/pkg-get")
 
-  confine :operatingsystem => :solaris
+  confine :osfamily => :solaris
 
   commands :pkgget => pkgget
 

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -5,9 +5,9 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
 
   commands :pkg => "/usr/bin/pkg"
 
-  confine :operatingsystem => :solaris
+  confine :osfamily => :solaris
 
-  #defaultfor [:operatingsystem => :solaris, :kernelrelease => "5.11"]
+  #defaultfor [:osfamily => :solaris, :kernelrelease => "5.11"]
 
   def self.instances
     packages = []

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
     pkgutil_bin = "/opt/csw/bin/pkgutil"
   end
 
-  confine :operatingsystem => :solaris
+  confine :osfamily => :solaris
 
   has_command(:pkguti, pkgutil_bin) do
     environment :HOME => ENV['HOME']

--- a/lib/puppet/provider/package/sun.rb
+++ b/lib/puppet/provider/package/sun.rb
@@ -9,9 +9,9 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
     :pkgadd => "/usr/sbin/pkgadd",
     :pkgrm => "/usr/sbin/pkgrm"
 
-  confine :operatingsystem => :solaris
+  confine :osfamily => :solaris
 
-  defaultfor :operatingsystem => :solaris
+  defaultfor :osfamily => :solaris
 
   def self.instances
     packages = []

--- a/lib/puppet/provider/package/sunfreeware.rb
+++ b/lib/puppet/provider/package/sunfreeware.rb
@@ -5,5 +5,5 @@ Puppet::Type.type(:package).provide :sunfreeware, :parent => :blastwave, :source
     has not actually been tested."
   commands :pkgget => "pkg-get"
 
-  confine :operatingsystem => :solaris
+  confine :osfamily => :solaris
 end

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -12,9 +12,9 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
 
   EOT
 
-  defaultfor :operatingsystem => :solaris
+  defaultfor :osfamily => :solaris
 
-  confine :operatingsystem => :solaris
+  confine :osfamily => :solaris
 
   commands :adm => "/usr/sbin/svcadm", :svcs => "/usr/bin/svcs"
   commands :svccfg => "/usr/sbin/svccfg"

--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
 
   desc "User and role management on Solaris, via `useradd` and `roleadd`."
 
-  defaultfor :operatingsystem => :solaris
+  defaultfor :osfamily => :solaris
 
   commands :add => "useradd", :delete => "userdel", :modify => "usermod", :password => "passwd", :role_add => "roleadd", :role_delete => "roledel", :role_modify => "rolemod"
   options :home, :flag => "-d", :method => :dir

--- a/lib/puppet/provider/zfs/solaris.rb
+++ b/lib/puppet/provider/zfs/solaris.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:zfs).provide(:solaris) do
   desc "Provider for Solaris zfs."
 
   commands :zfs => "/usr/sbin/zfs"
-  defaultfor :operatingsystem => :solaris
+  defaultfor :osfamily => :solaris
 
   def add_properties
     properties = []

--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:zone).provide(:solaris) do
   desc "Provider for Solaris Zones."
 
   commands :adm => "/usr/sbin/zoneadm", :cfg => "/usr/sbin/zonecfg"
-  defaultfor :operatingsystem => :solaris
+  defaultfor :osfamily => :solaris
 
   mk_resource_methods
 

--- a/lib/puppet/provider/zpool/solaris.rb
+++ b/lib/puppet/provider/zpool/solaris.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:zpool).provide(:solaris) do
   desc "Provider for Solaris zpool."
 
   commands :zpool => "/usr/sbin/zpool"
-  defaultfor :operatingsystem => :solaris
+  defaultfor :osfamily => :solaris
 
   def process_zpool_data(pool_array)
     if pool_array == []

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -128,7 +128,7 @@ module Puppet
 
       # Default to the device but with "dsk" replaced with "rdsk".
       defaultto do
-        if Facter["operatingsystem"].value == "Solaris"
+        if Facter["osfamily"].value == "Solaris"
           device = @resource.value(:device)
           if device =~ %r{/dsk/}
             device.sub(%r{/dsk/}, "/rdsk/")

--- a/spec/integration/provider/mount_spec.rb
+++ b/spec/integration/provider/mount_spec.rb
@@ -107,7 +107,7 @@ describe "mount provider (integration)", :unless => Puppet.features.microsoft_wi
               ["local", "journaled"].each do |options_setting|
                 describe "When setting options => #{options_setting}" do
                   it "should leave the system in the #{expected_final_state ? 'mounted' : 'unmounted'} state, #{expected_fstab_data ? 'with' : 'without'} data in /etc/fstab" do
-                    pending("Solaris: The mock :operatingsystem value does not get changed in lib/puppet/provider/mount/parsed.rb", Facter[:operatingsystem] == "Solaris")
+                    pending("Solaris: The mock :operatingsystem value does not get changed in lib/puppet/provider/mount/parsed.rb", Facter[:osfamily] == "Solaris")
                     @desired_options = options_setting
                     run_in_catalog(:ensure=>ensure_setting, :options => options_setting)
                     @mounted.should == expected_final_state

--- a/spec/unit/module_tool/applications/unpacker_spec.rb
+++ b/spec/unit/module_tool/applications/unpacker_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::ModuleTool::Applications::Unpacker, :fails_on_windows => true d
 
     before :each do
       # Mock redhat for most test cases
-      Facter.stubs(:value).with("operatingsystem").returns("Redhat")
+      Facter.stubs(:value).with("osfamily").returns("Redhat")
       build_dir.stubs(:mkpath => nil, :rmtree => nil, :children => [])
       unpacker.stubs(:build_dir).at_least_once.returns(build_dir)
       FileUtils.stubs(:mv)
@@ -42,7 +42,7 @@ describe Puppet::ModuleTool::Applications::Unpacker, :fails_on_windows => true d
 
     context "on solaris" do
       before :each do
-        Facter.expects(:value).with("operatingsystem").returns("Solaris")
+        Facter.expects(:value).with("osfamily").returns("Solaris")
       end
 
       it "should attempt to untar file to temporary location using gnu tar" do

--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -13,12 +13,12 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
 
   # LAK:FIXME I can't mock Facter because this test happens at parse-time.
   it "should default to /etc/vfstab on Solaris" do
-    pending "This test only works on Solaris" unless Facter.value(:operatingsystem) == 'Solaris'
+    pending "This test only works on Solaris" unless Facter.value(:osfamily) == 'Solaris'
     Puppet::Type.type(:mount).provider(:parsed).default_target.should == '/etc/vfstab'
   end
 
   it "should default to /etc/fstab on anything else" do
-    pending "This test does not work on Solaris" if Facter.value(:operatingsystem) == 'Solaris'
+    pending "This test does not work on Solaris" if Facter.value(:osfamily) == 'Solaris'
     Puppet::Type.type(:mount).provider(:parsed).default_target.should == '/etc/fstab'
   end
 
@@ -35,7 +35,7 @@ FSTAB
 #   it_should_behave_like "all parsedfile providers",
 #     provider_class, my_fixtures('*.fstab')
 
-    describe "on Solaris", :if => Facter.value(:operatingsystem) == 'Solaris' do
+    describe "on Solaris", :if => Facter.value(:osfamily) == 'Solaris' do
 
       before :each do
         @example_line = "/dev/dsk/c0d0s0 /dev/rdsk/c0d0s0 \t\t    /  \t    ufs     1 no\t-"
@@ -71,7 +71,7 @@ FSTAB
 
     end
 
-    describe "on other platforms than Solaris", :if => Facter.value(:operatingsystem) != 'Solaris' do
+    describe "on other platforms than Solaris", :if => Facter.value(:osfamily) != 'Solaris' do
 
       before :each do
         @example_line = "/dev/vg00/lv01\t/spare   \t  \t   ext3    defaults\t1 2"
@@ -107,7 +107,7 @@ FSTAB
 
   describe "mountinstances" do
     it "should get name from mountoutput found on Solaris" do
-      Facter.stubs(:value).with(:operatingsystem).returns 'Solaris'
+      Facter.stubs(:value).with(:osfamily).returns 'Solaris'
       @provider.stubs(:mountcmd).returns(File.read(my_fixture('solaris.mount')))
       mounts = @provider.mountinstances
       mounts.size.should == 6
@@ -120,7 +120,7 @@ FSTAB
     end
 
     it "should get name from mountoutput found on HP-UX" do
-      Facter.stubs(:value).with(:operatingsystem).returns 'HP-UX'
+      Facter.stubs(:value).with(:osfamily).returns 'HP-UX'
       @provider.stubs(:mountcmd).returns(File.read(my_fixture('hpux.mount')))
       mounts = @provider.mountinstances
       mounts.size.should == 17
@@ -144,7 +144,7 @@ FSTAB
     end
 
     it "should get name from mountoutput found on Darwin" do
-      Facter.stubs(:value).with(:operatingsystem).returns 'Darwin'
+      Facter.stubs(:value).with(:osfamily).returns 'Darwin'
       @provider.stubs(:mountcmd).returns(File.read(my_fixture('darwin.mount')))
       mounts = @provider.mountinstances
       mounts.size.should == 6
@@ -157,7 +157,7 @@ FSTAB
     end
 
     it "should get name from mountoutput found on Linux" do
-      Facter.stubs(:value).with(:operatingsystem).returns 'Gentoo'
+      Facter.stubs(:value).with(:osfamily).returns 'Gentoo'
       @provider.stubs(:mountcmd).returns(File.read(my_fixture('linux.mount')))
       mounts = @provider.mountinstances
       mounts[0].should == { :name => '/', :mounted => :yes }
@@ -168,7 +168,7 @@ FSTAB
     end
 
     it "should get name from mountoutput found on AIX" do
-      Facter.stubs(:value).with(:operatingsystem).returns 'AIX'
+      Facter.stubs(:value).with(:osfamily).returns 'AIX'
       @provider.stubs(:mountcmd).returns(File.read(my_fixture('aix.mount')))
       mounts = @provider.mountinstances
       mounts[0].should == { :name => '/', :mounted => :yes }
@@ -192,7 +192,7 @@ FSTAB
 
     describe "when calling instances on #{platform}" do
       before :each do
-        if Facter[:operatingsystem] == "Solaris" then
+        if Facter[:osfamily] == "Solaris" then
           platform == 'solaris' or
             pending "We need to stub the operatingsystem fact at load time, but can't"
         else
@@ -235,7 +235,7 @@ FSTAB
 
     describe "when prefetching on #{platform}" do
       before :each do
-        if Facter[:operatingsystem] == "Solaris" then
+        if Facter[:osfamily] == "Solaris" then
           platform == 'solaris' or
             pending "We need to stub the operatingsystem fact at load time, but can't"
         else

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -157,11 +157,11 @@ describe Puppet::Provider do
 
   it "should consider two defaults to be higher specificity than one default" do
     one = provider_of do
-      defaultfor :operatingsystem => "solaris"
+      defaultfor :osfamily => "solaris"
     end
 
     two = provider_of do
-      defaultfor :operatingsystem => "solaris", :operatingsystemrelease => "5.10"
+      defaultfor :osfamily => "solaris", :operatingsystemrelease => "5.10"
     end
 
     two.specificity.should > one.specificity
@@ -319,11 +319,11 @@ describe Puppet::Provider do
 
     it "should consider two defaults to be higher specificity than one default" do
       one = type.provide(:one) do
-        defaultfor :operatingsystem => "solaris"
+        defaultfor :osfamily => "solaris"
       end
 
       two = type.provide(:two) do
-        defaultfor :operatingsystem => "solaris", :operatingsystemrelease => "5.10"
+        defaultfor :osfamily => "solaris", :operatingsystemrelease => "5.10"
       end
 
       two.specificity.should > one.specificity


### PR DESCRIPTION
Priror to this commit, Puppet had many conditionals based of the
operatingsystem fact returning `:solaris`. This fact now
supports (and can return) several different version of Solaris.

Change the conditionals in Puppet which rely on Solaris to rely on
the osfamily fact instead, to prevent issues with this change in
Facter.
