### PR TITLE
(#15665) Fix issue with eix-update on newer eix (>=0.25.2).

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -20,7 +20,8 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     search_format = "<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] <homepage> <description>\n"
 
     begin
-      update_eix if !FileUtils.uptodate?("/var/cache/eix", %w{/usr/bin/eix /usr/portage/metadata/timestamp})
+      eix_file = File.directory?("/var/cache/eix") ? "/var/cache/eix/portage.eix" : "/var/cache/eix"
+      update_eix if !FileUtils.uptodate?(eix_file, %w{/usr/bin/eix /usr/portage/metadata/timestamp})
 
       search_output = nil
       Puppet::Util::Execution.withenv :LASTVERSION => version_format do
@@ -81,7 +82,8 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     search_value = package_name
 
     begin
-      update_eix if !FileUtils.uptodate?("/var/cache/eix", %w{/usr/bin/eix /usr/portage/metadata/timestamp})
+      eix_file = File.directory?("/var/cache/eix") ? "/var/cache/eix/portage.eix" : "/var/cache/eix"
+      update_eix if !FileUtils.uptodate?(eix_file, %w{/usr/bin/eix /usr/portage/metadata/timestamp})
 
       search_output = nil
       Puppet::Util::Execution.withenv :LASTVERSION => version_format do


### PR DESCRIPTION
Fix for [Issue 15665](http://projects.puppetlabs.com/issues/15665)

It's backward compatible with older eix as well as tests for new eix cache location (eix>=0.25.2).
