### PR TITLE
(#15521) Convert to using host stub wrapper

### DIFF
--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -1,9 +1,16 @@
-begin test_name "puppet module install (already installed elsewhere)"
+test_name "puppet module install (already installed elsewhere)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 apply_manifest_on master, <<-PP
 file {
   [
@@ -59,8 +66,3 @@ on master, puppet("module install pmtacceptance-nginx --force") do
   OUTPUT
 end
 on master, '[ -d /etc/puppet/modules/nginx ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { '/etc/puppet/modules': recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -1,9 +1,15 @@
-begin test_name "puppet module install (already installed with local changes)"
+test_name "puppet module install (already installed with local changes)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 apply_manifest_on master, <<-PP
 file {
   [
@@ -63,8 +69,3 @@ on master, puppet("module install pmtacceptance-nginx --force") do
   OUTPUT
 end
 on master, '[ -d /etc/puppet/modules/nginx ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { '/etc/puppet/modules': recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/install/ignoring_dependencies.rb
+++ b/acceptance/tests/modules/install/ignoring_dependencies.rb
@@ -1,9 +1,15 @@
-begin test_name "puppet module install (ignoring dependencies)"
+test_name "puppet module install (ignoring dependencies)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 
 step "Install a module, but ignore dependencies"
 on master, puppet("module install pmtacceptance-java --ignore-dependencies") do
@@ -17,8 +23,3 @@ on master, puppet("module install pmtacceptance-java --ignore-dependencies") do
 end
 on master, '[ -d /etc/puppet/modules/java ]'
 on master, '[ ! -d /etc/puppet/modules/stdlib ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { '/etc/puppet/modules': recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -1,9 +1,7 @@
-begin test_name "puppet module install (nonexistent directory)"
+test_name "puppet module install (nonexistent directory)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+
 apply_manifest_on master, <<-PP
 file {
   [
@@ -21,7 +19,7 @@ on master, puppet("module install pmtacceptance-nginx --target-dir /tmp/modules"
     STDERR>   Directory /tmp/modules does not exist\e[0m
   OUTPUT
 end
-on master, '[ ! -d /etc/puppet/modules/nginx ]'
+on master, '[ ! -d /tmp/modules/nginx ]'
 
 step "Try to install a module to a non-existent implicit directory"
 on master, puppet("module install pmtacceptance-nginx"), :acceptable_exit_codes => [1] do
@@ -32,9 +30,3 @@ on master, puppet("module install pmtacceptance-nginx"), :acceptable_exit_codes 
   OUTPUT
 end
 on master, '[ ! -d /etc/puppet/modules/nginx ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { '/etc/puppet/modules': ensure => directory }"
-apply_manifest_on master, "file { '/etc/puppet/modules': recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/install/with_dependencies.rb
+++ b/acceptance/tests/modules/install/with_dependencies.rb
@@ -1,9 +1,15 @@
-begin test_name "puppet module install (with dependencies)"
+test_name "puppet module install (with dependencies)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 
 step "Install a module with dependencies"
 on master, puppet("module install pmtacceptance-java") do
@@ -18,8 +24,3 @@ on master, puppet("module install pmtacceptance-java") do
 end
 on master, '[ -d /etc/puppet/modules/java ]'
 on master, '[ -d /etc/puppet/modules/stdlib ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -1,9 +1,16 @@
 begin test_name "puppet module install (with existing module directory)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 apply_manifest_on master, <<-PP
 file {
   [

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -1,9 +1,15 @@
-begin test_name "puppet module install (with necessary dependency upgrade)"
+test_name "puppet module install (with necessary dependency upgrade)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 
 step "Install an older module version"
 on master, puppet("module install pmtacceptance-java --version 1.6.0") do
@@ -47,9 +53,4 @@ on master, puppet('module list') do
     └── pmtacceptance-stdlib (\e[0;36mv1.0.0\e[0m)
     /usr/share/puppet/modules (no modules installed)
   OUTPUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -1,9 +1,15 @@
-begin test_name "puppet module install (with no dependencies)"
+test_name "puppet module install (with no dependencies)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 
 step "Install a module with no dependencies"
 on master, puppet("module install pmtacceptance-nginx") do
@@ -16,8 +22,3 @@ on master, puppet("module install pmtacceptance-nginx") do
   OUTPUT
 end
 on master, '[ -d /etc/puppet/modules/nginx ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -1,9 +1,15 @@
-begin test_name "puppet module install (with unnecessary dependency upgrade)"
+test_name "puppet module install (with unnecessary dependency upgrade)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 
 step "Install an older module version"
 on master, puppet("module install pmtacceptance-java --version 1.7.0") do
@@ -46,9 +52,4 @@ on master, puppet('module list') do
     └── pmtacceptance-stdlib (\e[0;36mv1.0.0\e[0m)
     /usr/share/puppet/modules (no modules installed)
   OUTPUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -1,9 +1,16 @@
-begin test_name "puppet module install (with unsatisfied constraints)"
+test_name "puppet module install (with unsatisfied constraints)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
 apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 apply_manifest_on master, <<-PP
 file {
   [
@@ -90,8 +97,3 @@ on master, puppet("module install pmtacceptance-stdlib --force") do
   OUTPUT
 end
 on master, '[ -d /etc/puppet/modules/stdlib ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { '/etc/puppet/modules': recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/list/with_circular_dependencies.rb
+++ b/acceptance/tests/modules/list/with_circular_dependencies.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module list (with circular dependencies)"
+test_name "puppet module list (with circular dependencies)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -39,6 +39,10 @@ file {
 PP
 on master, '[ -d /etc/puppet/modules/appleseed ]'
 on master, '[ -d /usr/share/puppet/modules/crakorn ]'
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 
 step "List the installed modules"
 on master, puppet('module list') do
@@ -62,8 +66,4 @@ on master, puppet('module list --tree') do
 └─┬ jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
   └── jimmy-appleseed (\e[0;36mv1.1.0\e[0m) [/etc/puppet/modules]
 STDOUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/list/with_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_installed_modules.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module list (with installed modules)"
+test_name "puppet module list (with installed modules)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -59,6 +59,10 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 on master, '[ -d /etc/puppet/modules/crakorn ]'
 on master, '[ -d /etc/puppet/modules/appleseed ]'
 on master, '[ -d /etc/puppet/modules/thelock ]'
@@ -89,8 +93,4 @@ on master, puppet('module list --tree') do
 └─┬ jimmy-crick (\e[0;36mv1.0.1\e[0m)
   └── jimmy-crakorn (\e[0;36mv0.4.0\e[0m) [/etc/puppet/modules]
 STDOUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/list/with_invalid_dependencies.rb
+++ b/acceptance/tests/modules/list/with_invalid_dependencies.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module list (with invalid dependencies)"
+test_name "puppet module list (with invalid dependencies)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -59,6 +59,10 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 on master, '[ -d /etc/puppet/modules/appleseed ]'
 on master, '[ -d /etc/puppet/modules/crakorn ]'
 on master, '[ -d /etc/puppet/modules/thelock ]'
@@ -95,8 +99,4 @@ STDERR
 └─┬ jimmy-crick (\e[0;36mv1.0.1\e[0m)
   └── jimmy-crakorn (\e[0;36mv0.3.0\e[0m) [/etc/puppet/modules]  \e[0;31minvalid\e[0m
 STDOUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/list/with_missing_dependencies.rb
+++ b/acceptance/tests/modules/list/with_missing_dependencies.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module list (with missing dependencies)"
+test_name "puppet module list (with missing dependencies)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -50,6 +50,10 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 on master, '[ -d /etc/puppet/modules/appleseed ]'
 on master, '[ -d /etc/puppet/modules/thelock ]'
 on master, '[ -d /usr/share/puppet/modules/crick ]'
@@ -91,8 +95,4 @@ STDERR
 └─┬ jimmy-crick (\e[0;36mv1.0.1\e[0m)
   └── \e[0;41mUNMET DEPENDENCY\e[0m jimmy-crakorn (\e[0;36mv0.4.x\e[0m)
 STDOUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/list/with_modulepath.rb
+++ b/acceptance/tests/modules/list/with_modulepath.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module list (with modulepath)"
+test_name "puppet module list (with modulepath)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -45,6 +45,9 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules2"
+end
 on master, '[ -d /etc/puppet/modules2/crakorn ]'
 on master, '[ -d /etc/puppet/modules2/appleseed ]'
 on master, '[ -d /etc/puppet/modules2/thelock ]'
@@ -69,8 +72,4 @@ on master, puppet('module list --modulepath=/etc/puppet/modules2') do
 ├── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
 └── jimmy-thelock (\e[0;36mv1.0.0\e[0m)
 STDOUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules2']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/list/with_repeated_dependencies.rb
+++ b/acceptance/tests/modules/list/with_repeated_dependencies.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module list (with repeated dependencies)"
+test_name "puppet module list (with repeated dependencies)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -72,6 +72,10 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 on master, '[ -d /etc/puppet/modules/crakorn ]'
 on master, '[ -d /etc/puppet/modules/steward ]'
 on master, '[ -d /etc/puppet/modules/appleseed ]'
@@ -106,8 +110,4 @@ on master, puppet('module list --tree') do
   └─┬ jimmy-crakorn (\e[0;36mv0.4.0\e[0m) [/etc/puppet/modules]
     └── jimmy-steward (\e[0;36mv0.9.0\e[0m) [/etc/puppet/modules]
 STDOUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/list/without_installed_modules.rb
+++ b/acceptance/tests/modules/list/without_installed_modules.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module list (without installed modules)"
+test_name "puppet module list (without installed modules)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -12,6 +12,10 @@ file {
      force => true;
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 
 step "List the installed modules"
 on master, puppet('module list') do
@@ -29,8 +33,4 @@ on master, puppet('module list') do
 /etc/puppet/modules (no modules installed)
 /usr/share/puppet/modules (no modules installed)
 STDOUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/search/by_description.rb
+++ b/acceptance/tests/modules/search/by_description.rb
@@ -1,8 +1,7 @@
-begin test_name 'puppet module search should do substring matches on description'
+test_name 'puppet module search should do substring matches on description'
 
-step 'Stub http://forge.puppetlabs.com'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+step 'Setup'
+stub_forge_on(master)
 
 step 'Search for a module by description'
 on master, puppet("module search dummy") do
@@ -21,8 +20,4 @@ on master, puppet("module search dummy") do
 # pmtacceptance-php     This is a dummy php modu...  @pmtacceptance  apache php
 # pmtacceptance-geordi  This is a module that do...  @pmtacceptance  star trek
 # STDOUT
-end
-
-ensure step 'Unstub http://forge.puppetlabs.com'
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
 end

--- a/acceptance/tests/modules/search/by_keyword.rb
+++ b/acceptance/tests/modules/search/by_keyword.rb
@@ -1,17 +1,17 @@
-begin test_name 'puppet module search should do exact keyword matches'
+test_name 'puppet module search should do exact keyword matches'
 
-step 'Stub http://forge.puppetlabs.com'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+step 'Setup'
+stub_forge_on(master)
 
 step 'Search for a module by exact keyword'
+
 on master, puppet("module search github") do
   assert_equal '', stderr
   assert_equal <<-STDOUT, stdout
 Searching http://forge.puppetlabs.com ...
 NAME               DESCRIPTION                    AUTHOR          KEYWORDS      
 pmtacceptance-git  This is a dummy git module...  @pmtacceptance  git \e[0;32mgithub\e[0m    
-STDOUT
+  STDOUT
 end
 
 # FIXME: The Forge presently matches partial keywords.
@@ -23,7 +23,3 @@ end
 # No results found for 'hub'.
 # STDOUT
 # end
-
-ensure step 'Unstub http://forge.puppetlabs.com'
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-end

--- a/acceptance/tests/modules/search/by_module_name.rb
+++ b/acceptance/tests/modules/search/by_module_name.rb
@@ -1,8 +1,7 @@
-begin test_name 'puppet module search should do substring matches on module name'
+test_name 'Searching for modules by part of the name'
 
-step 'Stub http://forge.puppetlabs.com'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+step 'Setup'
+stub_forge_on(master)
 
 step 'Search for modules by partial name'
 on master, puppet("module search geordi") do
@@ -33,8 +32,4 @@ Searching http://forge.puppetlabs.com ...
 NAME                  DESCRIPTION                  AUTHOR          KEYWORDS     
 pmtaccep\e[0;32mtance-ge\e[0mordi  This is a module that do...  @pmtacceptance  star trek    
 STDOUT
-end
-
-ensure step 'Unstub http://forge.puppetlabs.com'
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
 end

--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -1,7 +1,7 @@
-begin test_name 'puppet module search should print a reasonable message on communication errors'
+test_name 'puppet module search should print a reasonable message on communication errors'
 
-step 'Stub http://forge.puppetlabs.com'
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '127.0.0.2' }"
+step 'Setup'
+stub_hosts_on(master, 'forge.puppetlabs.com' => '127.0.0.2')
 
 step "Search against a non-existent Forge"
 on master, puppet("module search yup"), :acceptable_exit_codes => [1] do
@@ -13,8 +13,4 @@ Error: Could not connect to http://forge.puppetlabs.com
   There was a network communications problem
     Check your network connection and try again
 STDERR
-end
-
-ensure step 'Unstub http://forge.puppetlabs.com'
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
 end

--- a/acceptance/tests/modules/search/formatting.rb
+++ b/acceptance/tests/modules/search/formatting.rb
@@ -1,8 +1,7 @@
-begin test_name 'puppet module search output should be well structured'
+test_name 'puppet module search output should be well structured'
 
-step 'Stub http://forge.puppetlabs.com'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+step 'Setup'
+stub_forge_on(master)
 
 step 'Search results should line up by column'
 on master, puppet("module search apache") do
@@ -15,8 +14,4 @@ on master, puppet("module search apache") do
   stdout.gsub(/\e.*?m/, '').lines.to_a[1..-1].each do |line|
     assert_match(pattern, line.chomp, 'columns were misaligned')
   end
-end
-
-ensure step 'Unstub http://forge.puppetlabs.com'
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
 end

--- a/acceptance/tests/modules/search/multiple_search_terms.rb
+++ b/acceptance/tests/modules/search/multiple_search_terms.rb
@@ -1,8 +1,7 @@
-begin test_name 'puppet module search should handle multiple search terms sensibly'
+test_name 'puppet module search should handle multiple search terms sensibly'
 
-step 'Stub http://forge.puppetlabs.com'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+#step 'Setup'
+#stub_forge_on(master)
 
 # FIXME: The Forge doesn't properly handle multi-term searches.
 # step 'Search for a module by description'
@@ -19,7 +18,3 @@ apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
 # on master, puppet("module search 'star trek'") do
 #   assert stdout !~ /'star trek'/
 # end
-
-ensure step 'Unstub http://forge.puppetlabs.com'
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-end

--- a/acceptance/tests/modules/search/no_results.rb
+++ b/acceptance/tests/modules/search/no_results.rb
@@ -1,8 +1,7 @@
-begin test_name 'puppet module search should print a reasonable message for no results'
+test_name 'puppet module search should print a reasonable message for no results'
 
-step 'Stub http://forge.puppetlabs.com'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+step 'Setup'
+stub_forge_on(master)
 
 step "Search for a module that doesn't exist"
 on master, puppet("module search module_not_appearing_in_this_forge") do
@@ -11,8 +10,4 @@ on master, puppet("module search module_not_appearing_in_this_forge") do
 Searching http://forge.puppetlabs.com ...
 No results found for 'module_not_appearing_in_this_forge'.
 STDOUT
-end
-
-ensure step 'Unstub http://forge.puppetlabs.com'
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
 end

--- a/acceptance/tests/modules/uninstall/using_directory_name.rb
+++ b/acceptance/tests/modules/uninstall/using_directory_name.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module uninstall (using directory name)"
+test_name "puppet module uninstall (using directory name)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -19,6 +19,9 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+end
 on master, '[ -d /etc/puppet/modules/apache ]'
 on master, '[ -d /etc/puppet/modules/crakorn ]'
 
@@ -41,7 +44,3 @@ on master, puppet('module uninstall crakorn'), :acceptable_exit_codes => [1] do
   OUTPUT
 end
 on master, '[ -d /etc/puppet/modules/crakorn ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/uninstall/using_version_filter.rb
+++ b/acceptance/tests/modules/uninstall/using_version_filter.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module uninstall (with module installed)"
+test_name "puppet module uninstall (with module installed)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -30,6 +30,10 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
 on master, '[ -d /etc/puppet/modules/crakorn ]'
 on master, '[ -d /usr/share/puppet/modules/crakorn ]'
 
@@ -53,7 +57,3 @@ on master, puppet('module uninstall jimmy-crakorn --version 0.5.x'), :acceptable
   OUTPUT
 end
 on master, '[ -d /etc/puppet/modules/crakorn ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/uninstall/with_active_dependency.rb
+++ b/acceptance/tests/modules/uninstall/with_active_dependency.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module uninstall (with active dependency)"
+test_name "puppet module uninstall (with active dependency)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -30,6 +30,9 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+end
 on master, '[ -d /etc/puppet/modules/crakorn ]'
 on master, '[ -d /etc/puppet/modules/appleseed ]'
 
@@ -68,7 +71,3 @@ on master, puppet('module uninstall jimmy-crakorn --force') do
 end
 on master, '[ ! -d /etc/puppet/modules/crakorn ]'
 on master, '[ -d /etc/puppet/modules/appleseed ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/uninstall/with_module_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_module_installed.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module uninstall (with module installed)"
+test_name "puppet module uninstall (with module installed)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -18,6 +18,9 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+end
 on master, '[ -d /etc/puppet/modules/crakorn ]'
 
 step "Uninstall the module jimmy-crakorn"
@@ -28,7 +31,3 @@ on master, puppet('module uninstall jimmy-crakorn') do
   OUTPUT
 end
 on master, '[ ! -d /etc/puppet/modules/crakorn ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/uninstall/with_modulepath.rb
+++ b/acceptance/tests/modules/uninstall/with_modulepath.rb
@@ -1,4 +1,4 @@
-begin test_name "puppet module uninstall (with modulepath)"
+test_name "puppet module uninstall (with modulepath)"
 
 step "Setup"
 apply_manifest_on master, <<-PP
@@ -28,6 +28,9 @@ file {
     }';
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules2"
+end
 on master, '[ -d /etc/puppet/modules2/crakorn ]'
 on master, '[ -d /etc/puppet/modules2/absolute ]'
 
@@ -48,7 +51,3 @@ on master, 'cd /etc/puppet/modules2 && puppet module uninstall jimmy-absolute --
   OUTPUT
 end
 on master, '[ ! -d /etc/puppet/modules2/absolute ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "file { ['/etc/puppet/modules2']: ensure => directory, recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
@@ -1,8 +1,9 @@
-begin test_name "puppet module upgrade (introducing new dependencies)"
+test_name "puppet module upgrade (introducing new dependencies)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
 apply_manifest_on master, <<-'MANIFEST1'
 file { '/usr/share/puppet':
   ensure  => directory,
@@ -14,6 +15,11 @@ file { ['/etc/puppet/modules', '/usr/share/puppet/modules']:
   force   => true,
 }
 MANIFEST1
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 on master, puppet("module install pmtacceptance-stdlib --version 1.0.0")
 on master, puppet("module install pmtacceptance-java --version 1.7.0")
 on master, puppet("module install pmtacceptance-postgresql --version 0.0.2")
@@ -38,9 +44,4 @@ on master, puppet("module upgrade pmtacceptance-postgresql") do
     └─┬ pmtacceptance-postgresql (\e[0;36mv0.0.2 -> v1.0.0\e[0m)
       └── pmtacceptance-geordi (\e[0;36mv0.0.1\e[0m)
   OUTPUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/upgrade/to_a_specific_version.rb
+++ b/acceptance/tests/modules/upgrade/to_a_specific_version.rb
@@ -1,8 +1,9 @@
-begin test_name "puppet module upgrade (to a specific version)"
+test_name "puppet module upgrade (to a specific version)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
 apply_manifest_on master, <<-'MANIFEST1'
 file { '/usr/share/puppet':
   ensure  => directory,
@@ -14,6 +15,11 @@ file { ['/etc/puppet/modules', '/usr/share/puppet/modules']:
   force   => true,
 }
 MANIFEST1
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 on master, puppet("module install pmtacceptance-java --version 1.6.0")
 on master, puppet("module list") do
   assert_output <<-OUTPUT
@@ -46,9 +52,4 @@ on master, puppet("module upgrade pmtacceptance-java --version 1.6.0") do
     /etc/puppet/modules
     └── pmtacceptance-java (\e[0;36mv1.7.0 -> v1.6.0\e[0m)
   OUTPUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/upgrade/to_installed_version.rb
+++ b/acceptance/tests/modules/upgrade/to_installed_version.rb
@@ -1,8 +1,9 @@
-begin test_name "puppet module upgrade (to installed version)"
+test_name "puppet module upgrade (to installed version)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
 apply_manifest_on master, <<-'MANIFEST1'
 file { '/usr/share/puppet':
   ensure  => directory,
@@ -14,6 +15,11 @@ file { ['/etc/puppet/modules', '/usr/share/puppet/modules']:
   force   => true,
 }
 MANIFEST1
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 on master, puppet("module install pmtacceptance-java --version 1.6.0")
 on master, puppet("module list") do
   assert_output <<-OUTPUT
@@ -83,9 +89,4 @@ on master, puppet("module upgrade pmtacceptance-java --force") do
     /etc/puppet/modules
     └── pmtacceptance-java (\e[0;36mv1.7.1 -> v1.7.1\e[0m)
   OUTPUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end

--- a/acceptance/tests/modules/upgrade/with_local_changes.rb
+++ b/acceptance/tests/modules/upgrade/with_local_changes.rb
@@ -1,8 +1,9 @@
-begin test_name "puppet module upgrade (with local changes)"
+test_name "puppet module upgrade (with local changes)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
 apply_manifest_on master, <<-'MANIFEST1'
 file { '/usr/share/puppet':
   ensure  => directory,
@@ -14,6 +15,11 @@ file { ['/etc/puppet/modules', '/usr/share/puppet/modules']:
   force   => true,
 }
 MANIFEST1
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 on master, puppet("module install pmtacceptance-java --version 1.6.0")
 on master, puppet("module list") do
   assert_output <<-OUTPUT
@@ -56,8 +62,3 @@ on master, puppet("module upgrade pmtacceptance-java --force") do
 end
 on master, '[[ "$(cat /etc/puppet/modules/java/README)" != "I CHANGE MY READMES" ]]'
 on master, '[ ! -f /etc/puppet/modules/java/NEWFILE ]'
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
-end

--- a/acceptance/tests/modules/upgrade/with_update_available.rb
+++ b/acceptance/tests/modules/upgrade/with_update_available.rb
@@ -1,8 +1,9 @@
-begin test_name "puppet module upgrade (with update available)"
+test_name "puppet module upgrade (with update available)"
 
 step 'Setup'
-require 'resolv'; ip = Resolv.getaddress('forge-dev.puppetlabs.lan')
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ip => '#{ip}' }"
+
+stub_forge_on(master)
+
 apply_manifest_on master, <<-'MANIFEST1'
   file { '/usr/share/puppet':
     ensure  => directory,
@@ -14,6 +15,11 @@ apply_manifest_on master, <<-'MANIFEST1'
     force   => true,
   }
 MANIFEST1
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
 on master, puppet("module install pmtacceptance-java --version 1.6.0")
 on master, puppet("module list") do
   assert_output <<-OUTPUT
@@ -34,9 +40,4 @@ on master, puppet("module upgrade pmtacceptance-java") do
     /etc/puppet/modules
     └── pmtacceptance-java (\e[0;36mv1.6.0 -> v1.7.1\e[0m)
   OUTPUT
-end
-
-ensure step "Teardown"
-apply_manifest_on master, "host { 'forge.puppetlabs.com': ensure => absent }"
-apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
 end


### PR DESCRIPTION
NOTE: this depends on the following pull request to be merged first:

https://github.com/puppetlabs/puppet-acceptance/pull/260

This patch converts the module acceptance code to using the host stub wrapper
now provided in puppet-acceptance: `stub_forge_on`.

This will allow us to change the forge host we are stubbing dynamically as
apposed to manually changing it everywhere in acceptance code.

This also changes the cases where we have teardown code to use the new
`teardown` block.
