### PR TITLE
specify source encoding for a test file with a snowman in it

### DIFF
--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env rspec
+# encoding: UTF-8
 require 'spec_helper'
 
 require 'puppet/ssl/certificate_authority'


### PR DESCRIPTION
As part of my quest to get the tests running, I ran into

<pre>
 /Users/dustin/.rvm/gems/ruby-1.9.3-p194@puppetlabs/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `load': /Users/dustin/code/moz/t/puppetlabs/puppet/spec/unit/ssl/certificate_authority_spec.rb:502: invalid multibyte char (US-ASCII) (SyntaxError)
</pre>


It seems like my default source encoding is UTF-8:

<pre>
dustin@Lorentz ~/code/moz/t/puppetlabs/puppet [set-source-encoding] $ ruby
p __ENCODING__
#&lt;Encoding:UTF-8&gt;
</pre>

but at any rate this change fixed things, and would certainly be required for anyone with a different default source encoding.
