### PR TITLE
(Maint) Remove reference to Patchwork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,8 +191,6 @@ Additional Resources
 
 * [Bug tracker (Redmine)](http://projects.puppetlabs.com)
 
-* [Patchwork](https://patchwork.puppetlabs.com)
-
 * [Contributor License Agreement](https://projects.puppetlabs.com/contributor_licenses/sign)
 
 * [General GitHub documentation](http://help.github.com/)


### PR DESCRIPTION
The patchwork system hasn't been used for a while and doesn't appear to be
available anymore. This removes the reference to it.
