### PR TITLE
(#15786) Allow plain http connections for report processors

### DIFF
--- a/lib/puppet/network/http_pool.rb
+++ b/lib/puppet/network/http_pool.rb
@@ -40,7 +40,7 @@ module Puppet::Network::HttpPool
 
   # Retrieve a cached http instance if caching is enabled, else return
   # a new one.
-  def self.http_instance(host, port, reset = false, use_ssl = true)
+  def self.http_instance(host, port, use_ssl = true)
     args = [host, port]
     if Puppet[:http_proxy_host] == "none"
       args << nil << nil

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -15,8 +15,8 @@ Puppet::Reports.register_report(:http) do
     req = Net::HTTP::Post.new(url.path)
     req.body = self.to_yaml
     req.content_type = "application/x-yaml"
-    conn = Puppet::Network::HttpPool.http_instance(url.host, url.port,
-                                                   ssl=(url.scheme == 'https'))
+    use_ssl = url.scheme == 'https'
+    conn = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl)
     conn.start {|http|
       response = http.request(req)
       unless response.kind_of?(Net::HTTPSuccess)

--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -26,8 +26,13 @@ describe Puppet::Network::HttpPool do
       http.port.should    == 54321
     end
 
-    it "should enable ssl on the http instance" do
+    it "should enable ssl on the http instance by default" do
       Puppet::Network::HttpPool.http_instance("me", 54321).should be_use_ssl
+    end
+
+    it "can set ssl using an option" do
+      Puppet::Network::HttpPool.http_instance("me", 54321, false).should_not be_use_ssl
+      Puppet::Network::HttpPool.http_instance("me", 54321, true).should be_use_ssl
     end
 
     context "proxy and timeout settings should propagate" do


### PR DESCRIPTION
A recent change to support https connections for report processors
accidentally enabled SSL for all http report processors. This patch fixes
protocol detection and adds tests to make sure both cases work.
