### PR TITLE
Make the example in CONTRIBUTING imperative and concrete

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ top of things.
     checkout fix/master/my_contribution`.  Please avoid working directly on the
     `master` branch.
 * Make commits of logical units.
-* Check for unnecessary whitespace with "git diff --check" before committing.
+* Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure your commit messages are in the proper format.
 
 ````


### PR DESCRIPTION
Without this patch applied the example commit message in the CONTRIBUTING
document is not a concrete example.  This is a problem because the
contributor is left to imagine what the commit message should look like
based on a description rather than an example.  This patch fixes the
problem by making the example concrete and imperative.

The first line is a real life imperative statement with a ticket number
from our issue tracker.  The body describes the behavior without the
patch, why this is a problem, and how the patch fixes the problem when
applied.

Add HOWTO hint on topic branches in CONTRIBUTING

Without this patch it's not very clear how to create a topic branch. This
has been a problem in the past because we often get pull requests from the
master branch to the master branch which can be confusing when working
outside of the GitHub Web UI.

This patch addresses the problem by providing a concrete example of how to
create a reasonable topic branch and start using it with two commands.
