### PR TITLE
(#8200) validate only if we can (especially path)

### DIFF
--- a/spec/unit/type/zone_spec.rb
+++ b/spec/unit/type/zone_spec.rb
@@ -32,6 +32,11 @@ describe zone do
     lambda { zone.new(:name => "dummy") }.should raise_error
   end
 
+  it "should be valid when only :path is given" do
+    zone.new(:name => "dummy", :path => '/dummy' )
+  end
+
+
   it "should be invalid when :ip is missing a \":\" and iptype is :shared" do
     lambda { zone.new(:name => "dummy", :ip => "if") }.should raise_error
   end


### PR DESCRIPTION
The global validate block is called even when `puppet resource zone` is
called without any further arguments, and there is no good way to detect
when that happens. More over, the `isrequired` method in parameter.rb is
a better way to mark the parameter :path as a required option. Hence the
validation of path is removed from global validate block.

The ip validation is refactored to make it clearer to read.

Since `isrequired` doesnot seem to be hooked up, the spec test for path
validation is now in pending.
