### PR TITLE
(#15547) make sure that the LANG sentinels being used are present in the system

### DIFF
--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -297,7 +297,7 @@ describe Puppet::Util::Execution do
 
       # a sentinel value that we can use to emulate what locale environment variables might be set to on an international
       # system.
-      lang_sentinel_value = "es_ES.UTF-8"
+      lang_sentinel_value = "en_US.UTF-8"
       # a temporary hash that contains sentinel values for each of the locale environment variables that we override in
       # "execute"
       locale_sentinel_env = {}


### PR DESCRIPTION
Previously, we used es_ES.UTF-8 as the sentinel value while checking for override
of LANG values in user environment. commands in Solaris errors out when the LANG
being used is not present in the locales installed in the system.

This patch changes the LANG sentinel being used to en_US.UTF-8 which is present in
a normal Solaris install.

For checking the overriding, the procedure is to change the LANG to "C" which is
different from either so we modify the behavior of the test itself.
