### PR TITLE
Don't issue deprecation warnings for allow_ip

### DIFF
--- a/lib/puppet/network/authstore.rb
+++ b/lib/puppet/network/authstore.rb
@@ -159,12 +159,7 @@ module Puppet
       # Does this declaration match the name/ip combo?
       def match?(name, ip)
         if ip?
-          if pattern.include?(IPAddr.new(ip))
-            Puppet.deprecation_warning "Authentication based on IP address is deprecated; please use certname-based rules instead"
-            true
-          else
-            false
-          end
+          pattern.include?(IPAddr.new(ip))
         else
           matchname?(name)
         end


### PR DESCRIPTION
A deprecation warning was issued when IP addresses were used with allow. One
had slipped through and was still printing when allow_ip was used.
