### PR TITLE
(#15569) ensure that augeas prints parse errors.

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -168,6 +168,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
       if resource[:incl]
         aug.set("/augeas/load/Xfm/lens", resource[:lens])
         aug.set("/augeas/load/Xfm/incl", resource[:incl])
+        restricted = true
       elsif glob_avail and opt_ctx
         restricted = true
         # Optimize loading if the context is given, requires the glob function


### PR DESCRIPTION
This seems to have fallen through the cracks. It was originally
present in [pull/733](https://github.com/puppetlabs/puppet/pull/733/files) [ticket:14136](http://projects.puppetlabs.com/issues/14136)

This fixes the build failure that was present in boxes that contained
augeas.
