### PR TITLE
(#15920) Make forward-sexp ignore comments in puppet-mode.el

### DIFF
--- a/ext/emacs/puppet-mode.el
+++ b/ext/emacs/puppet-mode.el
@@ -333,6 +333,7 @@ The variable puppet-indent-level controls the amount of indentation.
   (setq mode-name "Puppet")
   (setq major-mode 'puppet-mode)
   (set-syntax-table puppet-mode-syntax-table)
+  (set (make-local-variable 'parse-sexp-ignore-comments) t)
   (set (make-local-variable 'local-abbrev-table) puppet-mode-abbrev-table)
   (set (make-local-variable 'comment-start) "# ")
   (set (make-local-variable 'comment-start-skip) "#+ *")


### PR DESCRIPTION
Enables parse-sexp-ignore-comments.

Previously forward-sexp (a.k.a jumping between matching parenthesis) 
was broken by comments with unterminated strings. E.g. with the following
manifest:

```
foo {
  # won'
}
```

forward-sexp on the opening brace would get:
  forward-sexp: Scan error: “Unbalanced parentheses”

The problem got introduced in commit
1c02749e8b54616043f728ed18ddec1dc4353a2d (Committed patch from #1160).
