### PR TITLE
(#15291) Add Vendor tag to Puppet spec file

### DIFF
--- a/conf/redhat/puppet.spec
+++ b/conf/redhat/puppet.spec
@@ -15,6 +15,7 @@ Name:           puppet
 Version:        2.7.19
 Release:        0.1rc2%{?dist}
 #Release:        2%{?dist}
+Vendor:         %{?_host_vendor}
 Summary:        A network tool for managing many disparate systems
 License:        ASL 2.0
 URL:            http://puppetlabs.com


### PR DESCRIPTION
Previously the spec file had no Vendor tag, which left it undefined. This
commit adds a Vendor tag that references the _host_vendor macro, so that it can
be easily set to 'Puppet Labs' internally and customized by users easily. The
Vendor tag makes it easier for users to tell where the package came from.
