### PR TITLE
Ruby 1.9.3 has a different error when `require` fails.

### DIFF
--- a/lib/puppet/provider/confine.rb
+++ b/lib/puppet/provider/confine.rb
@@ -25,7 +25,7 @@ class Puppet::Provider::Confine
       begin
         require "puppet/provider/confine/#{name}"
       rescue LoadError => detail
-        unless detail.to_s =~ /No such file/i
+        unless detail.to_s =~ /No such file|cannot load such file/i
           warn "Could not load confine test '#{name}': #{detail}"
         end
         # Could not find file

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -32,9 +32,11 @@ describe Puppet::Application do
     end
 
     it "should exit if it can't find a class" do
-      reg = "Unable to find application 'ThisShallNeverEverEverExist'.  "
-      reg += "no such file to load -- puppet/application/thisshallneverevereverexist"
-      @klass.expects(:puts).with(reg)
+      @klass.expects(:puts).with do |value|
+        value =~ /Unable to find application 'ThisShallNeverEverEverExist'/ and
+          value =~ /puppet\/application\/thisshallneverevereverexist/ and
+          value =~ /no such file to load|cannot load such file/
+      end
 
       expect { @klass.find("ThisShallNeverEverEverExist") }.to exit_with 1
     end


### PR DESCRIPTION
The text of the error message when load fails has changed, resulting in the
test failing.  This adapts that to catch the different versions, allowing this
to pass in all cases.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
