### PR TITLE
Patch for issue #15940

### DIFF
--- a/lib/puppet/util/rdoc.rb
+++ b/lib/puppet/util/rdoc.rb
@@ -30,7 +30,8 @@ module Puppet::Util::RDoc
       # specify our own format & where to output
       options = [ "--fmt", "puppet",
                   "--quiet",
-                  "--exclude", "/modules/[^/]*/files/.*\.pp$",
+                  "--exclude", "/modules/[^/]*/files/.*$",
+                   "--exclude", "/modules/[^/]*/templates/.*$",
                   "--op", outputdir ]
 
       options << "--force-update" if Options::OptionList.options.any? { |o| o[0] == "--force-update" }


### PR DESCRIPTION
Updated puppet/lib/puppet/util/rdoc.rb to exclude all of $modulename/files/\* and $modulename/templates/\* and not just /$modulename/files/*.pp
