### PR TITLE
Allow environment to be named with alphanumerics, dashes and underscore

### DIFF
--- a/lib/puppet/network/http/api/v1.rb
+++ b/lib/puppet/network/http/api/v1.rb
@@ -25,7 +25,7 @@ module Puppet::Network::HTTP::API::V1
   def uri2indirection(http_method, uri, params)
     environment, indirection, key = uri.split("/", 4)[1..-1] # the first field is always nil because of the leading slash
 
-    raise ArgumentError, "The environment must be purely alphanumeric, not '#{environment}'" unless environment =~ /^\w+$/
+    raise ArgumentError, "The environment must be alphanumeric (dashes and underscores are permitted), not '#{environment}'" unless environment =~ /^\w[\w\-_]*$/
     raise ArgumentError, "The indirection name must be purely alphanumeric, not '#{indirection}'" unless indirection =~ /^\w+$/
 
     method = indirection_method(http_method, indirection)


### PR DESCRIPTION
$environment is limited to /^\w+$/ only

it would be very great to extend the regex to /^\w[\w-_]*$/

We have a thousands of environments with a so called "sub enviroment" and it would be great to have dashes and underscores to be allowed in $environment
