### PR TITLE
Add logging for when Puppet is enabled/disabled.

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -373,8 +373,10 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   def enable_disable_client(agent)
     if options[:enable]
+      Puppet.notice "Enabling Puppet."
       agent.enable
     elsif options[:disable]
+      Puppet.notice "Disabling Puppet."
       agent.disable
     end
     exit(0)


### PR DESCRIPTION
At work we keep running into the problem of finding disabled machines.  It would be nice to get these to log somewhere so we can track them down easier.  I am not 100% sure that Puppet.notice stuff is logged but from what I can tell from lib/puppet/util/log.rb it should be default.
