### PR TITLE
(Maint) Add logging for when Puppet is enabled/disabled.

### DIFF
--- a/lib/puppet/agent/locker.rb
+++ b/lib/puppet/agent/locker.rb
@@ -5,11 +5,13 @@ require 'puppet/util/pidlock'
 module Puppet::Agent::Locker
   # Let the daemon run again, freely in the filesystem.
   def enable
+    Puppet.notice "Enabling Puppet."
     lockfile.unlock(:anonymous => true)
   end
 
   # Stop the daemon from making any catalog runs.
   def disable
+    Puppet.notice "Disabling Puppet."
     lockfile.lock(:anonymous => true)
   end
 


### PR DESCRIPTION
Someone keeps disabling Puppet on our machines and we have no easy way to
quickly check logfiles to see what happened.

This patch fixes the problem by logging Puppet enable and disable state 
changes using `Puppet.notice`.

This pull request supersedes #1031
