### PR TITLE
(Maint) Fix assertion about locale to correct value.

### DIFF
--- a/spec/unit/provider/exec/posix_spec.rb
+++ b/spec/unit/provider/exec/posix_spec.rb
@@ -145,11 +145,11 @@ describe Puppet::Type.type(:exec).provider(:posix) do
       end
 
       it "should respect locale overrides in user's 'environment' configuration" do
-        provider.resource[:environment] = ['LANG=foo', 'LC_ALL=de_DE']
+        provider.resource[:environment] = ['LANG=C', 'LC_ALL=C']
         output, status = provider.run(command % 'LANG')
-        output.strip.should == 'foo'
+        output.strip.should == 'C'
         output, status = provider.run(command % 'LC_ALL')
-        output.strip.should == 'de_DE'
+        output.strip.should == 'C'
       end
     end
 


### PR DESCRIPTION
Previous merge from 3.x to master updated the locales incorrectly and
overwrote a change for solaris specs (#15547) : validate locales as
sentinel #43d86d40570140918009f2048f8998fb2200f81f. This update corrects
it.
