### PR TITLE
(#15852) Allow rc in Puppet and Facter version strings

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -24,7 +24,7 @@ require 'puppet/util/run_mode'
 # it's also a place to find top-level commands like 'debug'
 
 module Puppet
-  PUPPETVERSION = '3.0.0'
+  PUPPETVERSION = '3.0.0-rc3'
 
   def Puppet.version
     PUPPETVERSION

--- a/lib/puppet/feature/facter.rb
+++ b/lib/puppet/feature/facter.rb
@@ -3,7 +3,7 @@ require 'semver'
 
 # See if Facter is available, and check revision
 Puppet.features.add(:facter) do
-  required_facter = "2.0.0"
+  required_facter = "2.0.0-rc"
 
   begin
     require 'facter'

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -8,10 +8,6 @@ describe Puppet do
   include PuppetSpec::Files
 
   context "#version" do
-    it "should be a valid version number" do
-      Puppet.version.should =~ /^[0-9]+\.[0-9]+\.[0-9]+$/
-    end
-
     it "should be valid semver" do
       SemVer.should be_valid Puppet.version
     end


### PR DESCRIPTION
Previously putting rc in the Puppet version string would fail, mainly because
of a test that verified that the version only contained 3 dot separated
integers. This commit updates the Facter dependency to correctly use 2.0.0-rc
as the minimum version, as 2.0.0-rc is less than the previously required 2.0.0
as specified by SemVer. It also removes the test that verified the Puppet
version was a 'valid' 3 dotted integer version. That test is redundant, as the
test that follows verifies that the version string is valid SemVer.
