### PR TITLE
(#15531) Graph (dot) escaping for double quotes

### DIFF
--- a/lib/puppet/simple_graph.rb
+++ b/lib/puppet/simple_graph.rb
@@ -431,17 +431,17 @@ class Puppet::SimpleGraph
     graph      = (directed? ? DOT::DOTDigraph : DOT::DOTSubgraph).new(params)
     edge_klass = directed? ? DOT::DOTDirectedEdge : DOT::DOTEdge
     vertices.each do |v|
-      name = v.to_s
+      name = v.to_s.gsub(/"/,'\"')
       params = {'name'     => '"'+name+'"',
         'fontsize' => fontsize,
         'label'    => name}
-      v_label = v.to_s
+      v_label = v.to_s.gsub(/"/,'\"')
       params.merge!(v_label) if v_label and v_label.kind_of? Hash
       graph << DOT::DOTNode.new(params)
     end
     edges.each do |e|
-      params = {'from'     => '"'+ e.source.to_s + '"',
-        'to'       => '"'+ e.target.to_s + '"',
+      params = {'from'     => '"'+ e.source.to_s.gsub(/"/,'\"') + '"',
+        'to'       => '"'+ e.target.to_s.gsub(/"/,'\"') + '"',
         'fontsize' => fontsize }
       e_label = e.to_s
       params.merge!(e_label) if e_label and e_label.kind_of? Hash


### PR DESCRIPTION
Graph generation was not escaping double quotes for node names. This simple
patch replaces all " with \" in all node names in dot graphs so they can be
generated even from catalogs with double quotes.
