### PR TITLE
Fix missing forge stub and directory check due to test change in 3.x branch rollup

### DIFF
--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -2,6 +2,8 @@ test_name "puppet module install (nonexistent directory)"
 
 step 'Setup'
 
+stub_forge_on(master)
+
 apply_manifest_on master, <<-PP
 file {
   [
@@ -10,6 +12,10 @@ file {
   ]: ensure => absent, recurse => true, force => true;
 }
 PP
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /tmp/modules"
+end
 
 step "Try to install a module to a non-existent directory"
 on master, puppet("module install pmtacceptance-nginx --target-dir /tmp/modules") do
@@ -22,7 +28,7 @@ on master, puppet("module install pmtacceptance-nginx --target-dir /tmp/modules"
     └── pmtacceptance-nginx (\e[0;36mv0.0.1\e[0m)
   OUTPUT
 end
-on master, '[ ! -d /tmp/modules/nginx ]'
+on master, '[ -d /tmp/modules/nginx ]'
 
 step "Try to install a module to a non-existent implicit directory"
 on master, puppet("module install pmtacceptance-nginx") do
@@ -36,4 +42,4 @@ on master, puppet("module install pmtacceptance-nginx") do
   OUTPUT
 end
 
-on master, '[ ! -d /etc/puppet/modules/nginx ]'
+on master, '[ -d /etc/puppet/modules/nginx ]'


### PR DESCRIPTION
This fixes a test error that was being thrown by the
modules/install/nonexistent_directory.rb file.

In recent commits we added a more clever way to stub the forge host in 2.7.x,
and obtain a forge hostname. This test however went from being a non-network
capable test to a networked one in 3.x, so the rollup from 2.7.x->3.x meant our
changes weren't applied to this particular case. This patch fixes that by
adding the correct stubbing method 'stub_forge_on' to the top of the file.

It also corrects a negated directory check which creaped in during merge up and
ensures proper cleanup using the new teardown mechanism (like the other tests).
