### PR TITLE
(#15797) Change the argument to chkconfig from 'on' to 'reset'

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
   # Don't support them specifying runlevels; always use the runlevels
   # in the init scripts.
   def enable
-      output = chkconfig(@resource[:name], :on)
+      output = chkconfig(@resource[:name], :reset)
   rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not enable #{self.name}: #{detail}"
   end


### PR DESCRIPTION
Per the man page, 'reset' is more correct because it uses
the runlevels specified in the chkconfig header line, rather
than always using '2345'. This fixes #15797.
