### PR TITLE
(#15852) Remove version check from puppet_spec.rb

### DIFF
--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -2,16 +2,9 @@
 require 'spec_helper'
 require 'puppet'
 require 'puppet_spec/files'
-require 'semver'
 
 describe Puppet do
   include PuppetSpec::Files
-
-  context "#version" do
-    it "should be valid semver" do
-      SemVer.should be_valid Puppet.version
-    end
-  end
 
   Puppet::Util::Log.eachlevel do |level|
     it "should have a method for sending '#{level}' logs" do


### PR DESCRIPTION
This commit removes the version test from puppet, as it doesn't ensure any
functionality of puppet, but only that the version string matches certain
criteria.
