### PR TITLE
(#15739) Bump report_version since #10064 changed its format

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -76,7 +76,7 @@ class Puppet::Transaction::Report
     @host = Puppet[:node_name_value]
     @time = Time.now
     @kind = kind
-    @report_format = 2
+    @report_format = 3
     @puppet_version = Puppet.version
     @configuration_version = configuration_version
     @environment = environment


### PR DESCRIPTION
With #10064, we changed the report format to include the
environment. However that patch did not bump the report_version
and it should have.  This retroactively bumps the version
without changing the format, which might be bad too, but it'd
be worse to change it again...
