### PR TITLE
(#15547) correct 'pending' values to correct if check for solaris.

### DIFF
--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -217,17 +217,17 @@ FSTAB
 
       # Following mountpoint are present in all fstabs/mountoutputs
       it "should include unmounted resources" do
-        pending("Solaris:Unable to stub Operating System Fact at runtime", Facter[:operatingsystem] == "Solaris")
+        pending("Solaris:Unable to stub Operating System Fact at runtime", :if => Facter.value(:osfamily) == 'Solaris' )
         @retrieve.should include(:name => '/', :ensure => :mounted)
       end
 
       it "should include mounted resources" do
-        pending("Solaris:Unable to stub Operating System Fact at runtime", Facter[:operatingsystem] == "Solaris")
+        pending("Solaris:Unable to stub Operating System Fact at runtime", :if => Facter.value(:osfamily) == "Solaris")
         @retrieve.should include(:name => '/boot', :ensure => :unmounted)
       end
 
       it "should include ghost resources" do
-        pending("Solaris:Unable to stub Operating System Fact at runtime", Facter[:operatingsystem] == "Solaris")
+        pending("Solaris:Unable to stub Operating System Fact at runtime", :if => Facter.value(:osfamily) == "Solaris")
         @retrieve.should include(:name => '/ghost', :ensure => :ghost)
       end
 
@@ -269,19 +269,19 @@ FSTAB
       end
 
       it "should set :ensure to :unmounted if found in fstab but not mounted" do
-        pending("Solaris:Unable to stub Operating System Fact at runtime", Facter[:operatingsystem] == "Solaris")
+        pending("Solaris:Unable to stub Operating System Fact at runtime", :if => Facter.value(:osfamily) == "Solaris")
         @provider.prefetch(@resource_hash)
         @res_unmounted.provider.get(:ensure).should == :unmounted
       end
 
       it "should set :ensure to :ghost if not found in fstab but mounted" do
-        pending("Solaris:Unable to stub Operating System Fact at runtime", Facter[:operatingsystem] == "Solaris")
+        pending("Solaris:Unable to stub Operating System Fact at runtime", :if => Facter.value(:osfamily) == "Solaris")
         @provider.prefetch(@resource_hash)
         @res_ghost.provider.get(:ensure).should == :ghost
       end
 
       it "should set :ensure to :mounted if found in fstab and mounted" do
-        pending("Solaris:Unable to stub Operating System Fact at runtime", Facter[:operatingsystem] == "Solaris")
+        pending("Solaris:Unable to stub Operating System Fact at runtime", :if => Facter.value(:osfamily) == "Solaris")
         @provider.prefetch(@resource_hash)
         @res_mounted.provider.get(:ensure).should == :mounted
       end


### PR DESCRIPTION
Previously, the pending did not have if conditions for solaris, which resulted in the tests in pending for all other operating systems. This commit changes it to use the correct pending format.
