### PR TITLE
(#15693) Allow windows service restart command to be specified

### DIFF
--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -1,5 +1,5 @@
-Puppet::Type.type(:service).provide :base do
-  desc "The simplest form of service support.
+Puppet::Type.type(:service).provide :base, :parent => :service do
+  desc "The simplest form of Unix service support.
 
   You have to specify enough about your service for this to work; the
   minimum you can specify is a binary for starting the process, and this
@@ -10,10 +10,6 @@ Puppet::Type.type(:service).provide :base do
   "
 
   commands :kill => "kill"
-
-  def self.instances
-    []
-  end
 
   # Get the process ID for a running process. Requires the 'pattern'
   # parameter.
@@ -33,20 +29,6 @@ Puppet::Type.type(:service).provide :base do
     }
 
     nil
-  end
-
-  # How to restart the process.
-  def restart
-    if @resource[:restart] or restartcmd
-      ucommand(:restart)
-    else
-      self.stop
-      self.start
-    end
-  end
-
-  # There is no default command, which causes other methods to be used
-  def restartcmd
   end
 
   # Check if the process is running.  Prefer the 'status' parameter,
@@ -118,27 +100,6 @@ Puppet::Type.type(:service).provide :base do
 
   # There is no default command, which causes other methods to be used
   def stopcmd
-  end
-
-  # A simple wrapper so execution failures are a bit more informative.
-  def texecute(type, command, fof = true)
-    begin
-      # #565: Services generally produce no output, so squelch them.
-      execute(command, :failonfail => fof, :squelch => true)
-    rescue Puppet::ExecutionFailure => detail
-      @resource.fail "Could not #{type} #{@resource.ref}: #{detail}"
-    end
-    nil
-  end
-
-  # Use either a specified command or the default for our provider.
-  def ucommand(type, fof = true)
-    if c = @resource[type]
-      cmd = [c]
-    else
-      cmd = [send("#{type}cmd")].flatten
-    end
-    texecute(type, cmd, fof)
   end
 end
 

--- a/lib/puppet/provider/service/service.rb
+++ b/lib/puppet/provider/service/service.rb
@@ -1,0 +1,43 @@
+Puppet::Type.type(:service).provide :service do
+  desc "The simplest form of service support."
+
+  def self.instances
+    []
+  end
+
+  # How to restart the process.
+  def restart
+    if @resource[:restart] or restartcmd
+      ucommand(:restart)
+    else
+      self.stop
+      self.start
+    end
+  end
+
+  # There is no default command, which causes other methods to be used
+  def restartcmd
+  end
+
+  # A simple wrapper so execution failures are a bit more informative.
+  def texecute(type, command, fof = true)
+    begin
+      # #565: Services generally produce no output, so squelch them.
+      execute(command, :failonfail => fof, :squelch => true)
+    rescue Puppet::ExecutionFailure => detail
+      @resource.fail "Could not #{type} #{@resource.ref}: #{detail}"
+    end
+    nil
+  end
+
+  # Use either a specified command or the default for our provider.
+  def ucommand(type, fof = true)
+    if c = @resource[type]
+      cmd = [c]
+    else
+      cmd = [send("#{type}cmd")].flatten
+    end
+    texecute(type, cmd, fof)
+  end
+end
+

--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -1,8 +1,6 @@
 # Windows Service Control Manager (SCM) provider
 
-require 'win32/service' if Puppet.features.microsoft_windows?
-
-Puppet::Type.type(:service).provide :windows do
+Puppet::Type.type(:service).provide :windows, :parent => :service do
 
   desc <<-EOT
     Support for Windows Service Control Manager (SCM). This provider can
@@ -84,11 +82,6 @@ Puppet::Type.type(:service).provide :windows do
     net(:stop, @resource[:name])
   rescue Puppet::ExecutionFailure => detail
     raise Puppet::Error.new("Cannot stop #{@resource[:name]}, error was: #{detail}" )
-  end
-
-  def restart
-    self.stop
-    self.start
   end
 
   def status

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -114,6 +114,25 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
     end
   end
 
+  describe "#restart" do
+    it "should use the supplied restart command if specified" do
+      resource[:restart] = 'c:/bin/foo'
+
+      provider.expects(:execute).never
+      provider.expects(:execute).with(['c:/bin/foo'], :failonfail => true, :squelch => true)
+
+      provider.restart
+    end
+
+    it "should restart the service" do
+      seq = sequence("restarting")
+      provider.expects(:stop).in_sequence(seq)
+      provider.expects(:start).in_sequence(seq)
+
+      provider.restart
+    end
+  end
+
   describe "#enabled?" do
     it "should report a service with a startup type of manual as manual" do
       config.start_type = Win32::Service.get_start_type(Win32::Service::SERVICE_DEMAND_START)


### PR DESCRIPTION
Previously, the windows service provider did not support specifying a
custom restart command, and instead would always just call stop & start.
The ability to customize restarts is desirable in cases where the service
must be stopped in order to overwrite a file the service is using.

This commit refactors the instances, restart, and restartcmd methods
from the base provider to a new parent service provider.  It also
refactors the ucommand and texecute methods.

There are no changes to the base service provider other than those
methods residing in the parent service.

The windows service provider no longer implements the restart method
directly as its parent service provider handles this correctly.

I didn't refactor the start and stop methods to make them
customizable, because it's not as critical for Windows and it was more
changes than I wanted to make now.
