### PR TITLE
Allow splitting of long lines in configuration files using the \ character

### DIFF
--- a/lib/puppet/util/settings.rb
+++ b/lib/puppet/util/settings.rb
@@ -852,15 +852,20 @@ if @config.include?(:run_mode)
     result = Hash.new { |names, name|
       names[name] = {}
     }
-
     count = 0
-
+    prev = ""
     # Default to 'main' for the section.
     section = :main
     result[section][:_meta] = {}
     text.split(/\n/).each { |line|
       count += 1
+      line = line.gsub(/^\s+/,"") ## leading spaces:  we don't care about them anyhow.
+      line = "#{prev}#{line}"     ## eat the previous line (if there is one).
+      prev = ""                   ## burp, clean this now.
       case line
+      when /^\s*(.*?)\\$/
+        prev = $1.intern          ## wait with processing until we have the complete 'line'.
+        next
       when /^\s*\[(\w+)\]\s*$/
         section = $1.intern # Section names
         # Add a meta section

--- a/test/util/settings.rb
+++ b/test/util/settings.rb
@@ -194,6 +194,8 @@ class TestSettings < Test::Unit::TestCase
       owner = root
       group = root
       yay = /a/path
+      longline = long \\
+        line
 
       [main]
   four = five
@@ -205,6 +207,8 @@ class TestSettings < Test::Unit::TestCase
   group = puppet
   attrdir = /some/dir
   attr3 = $attrdir/other
+  longline = long \\
+    line
     }
 
     file = tempfile
@@ -223,6 +227,7 @@ class TestSettings < Test::Unit::TestCase
       :owner => "root",
       :group => "root",
       :yay => "/a/path",
+      :longline => "long line",
       :four => "five",
       :six => "seven"
     }.each do |param, value|
@@ -237,7 +242,8 @@ class TestSettings < Test::Unit::TestCase
       :owner => "puppet",
       :group => "puppet",
       :attrdir => "/some/dir",
-      :attr3 => "$attrdir/other"
+      :attr3 => "$attrdir/other",
+      :longline => "long line"
     }.each do |param, value|
       assert_equal(value, section1[param], "Param #{param} was not set correctly in section1")
     end


### PR DESCRIPTION
This can be especially useful if you have multiple modulepaths in your config file.

```
modulepath = $confdir/modules/upstream:$confdir/modules/internal:$confdir/environments/$environment/modules/upstream:$confdir/environments/$environment/modules/internal
```

becomes

```
modulepath = \
    $confdir/modules/upstream:\
    $confdir/modules/internal:\
    $confdir/environments/$environment/modules/upstream:\
    $confdir/environments/$environment/modules/internal
```
