### PR TITLE
#16031: Allow splitting of long lines in the puppet.conf configuration file.

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1201,12 +1201,12 @@ if @config.include?(:run_mode)
     result[section][:_meta] = {}
     text.split(/\n/).each do |line|
       count += 1
-      line = line.gsub(/^\s+/,"")  # leading spaces are not taken into account anywhere
+      line = line.gsub(/^\s+/,"") # leading spaces are not taken into account anywhere
       line = "#{prev}#{line}"     # eat the previous line (if there is one).
       prev = ""                   # *burp*. previous line cleanup.
       case line
-      when /^\s*(.*?)\\$/         # delay processing until the next line.
-        prev = $1.intern
+      when /^\s*(.*?) +\\$/       # delay processing until the next line.
+        prev = $1.sub(/\s+$/, '').gsub(/^["']|["']$/,'')
         next
       when /^\s*\[(\w+)\]\s*$/
         section = $1.intern # Section names

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -773,14 +773,17 @@ describe Puppet::Settings do
       text = "[main]
       one = long \\
         line
-      vardir = C:\\puppet\\var\\
-      confdir = C:\\puppet\\etc\\
+      two = 'long line with spaces ' \\
+        that should not be stripped by using quoting.
+      three = C:\\very\\long\\windows\\paths \\
+        \\can\\be\\splitted \\
+        \\too\\with\\little\\effort\\
       "
       @settings.expects(:read_file).returns(text)
       @settings.send(:parse_config_files)
-      @settings[:one].should == "long line"
-      @settings[:vardir].should == "C:\\puppet\\var\\"
-      @settings[:confdir].should == "C:\\puppet\\etc\\"
+      @settings[:one].should == "longline"
+      @settings[:two].should == "long line with spaces that should not be stripped by using quoting."
+      @settings[:three].should == "C:\\very\\long\\windows\\paths\\can\\be\\splitted\\too\\with\\little\\effort\\"
     end
 
     it "should support specifying all metadata (owner, group, mode) in the configuration file" do


### PR DESCRIPTION
http://projects.puppetlabs.com/issues/16031

This can be especially useful if you have multiple modulepaths in your config file.

```
modulepath = $confdir/modules/upstream:$confdir/modules/internal:$confdir/environments/$environment/modules/upstream:$confdir/environments/$environment/modules/internal
```

becomes

```
modulepath = \
    $confdir/modules/upstream:\
    $confdir/modules/internal:\
    $confdir/environments/$environment/modules/upstream:\
    $confdir/environments/$environment/modules/internal
```
