### PR TITLE
(#15797) Change the argument to chkconfig from 'on' to 'reset'

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -21,7 +21,10 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
 
   # Remove the symlinks
   def disable
-    output = chkconfig(@resource[:name], :off)
+    # The off method operates on run levels 2,3,4 and 5 by default We ensure
+    # all run levels are turned off because the reset method may turn on the
+    # service in run levels 0, 1 and/or 6
+    output = chkconfig("--level", "0123456", @resource[:name], :off)
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not disable #{self.name}: #{output}"
   end

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -50,6 +50,11 @@ describe provider_class, :as_platform => :posix do
     @provider.enable
   end
 
+  it "(#15797) should explicitly turn off the service in all run levels" do
+    provider_class.expects(:chkconfig).with("--level", "0123456", @resource[:name], :off)
+    @provider.disable
+  end
+
   it "should have an enabled? method" do
     @provider.should respond_to(:enabled?)
   end


### PR DESCRIPTION
This pull request supersedes #1043

Per the man page, 'reset' is more correct because it uses the runlevels
specified in the chkconfig header line, rather than always using '2345'.
This fixes #15797.

(#15787) Add test coverage for redhat service provider

Without this patch there is no test coverage to validate that the service
provider actually calls chkconfig with the reset argument instead of the
on argument.
