### PR TITLE
Fix typo in create_resources function's description string

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -18,7 +18,7 @@ Puppet::Parser::Functions::newfunction(:create_resources, :doc => <<-'ENDHEREDOC
 
     A third, optional parameter may be given, also as a hash:
 
-        $defaults => {
+        $defaults = {
           'ensure'   => present,
           'provider' => 'ldap',
         }


### PR DESCRIPTION
This documentation used a hash rocket in a variable assignment instead of the
required equals sign. This commit fixes the typo.
