### PR TITLE
(Maint) Fix Puppet.version in 3.x

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -6,7 +6,7 @@
 # Raketasks and such to set the version based on the output of `git describe`
 #
 module Puppet
-  PUPPETVERSION = '2.7.19'
+  PUPPETVERSION = '3.0.0-rc3'
 
   def self.version
     @puppet_version || PUPPETVERSION


### PR DESCRIPTION
Without this patch applied the Puppet 3.x branch is mis-reporting its version
as 2.7.19.  This is a problem because the spec helper uses the
`Puppet.version` method to determine how it should construct a
Puppet::Parser::Scope instance for parser function testing.  The incorrect
version string is causing the scope instance to be constructed incorrectly
ultimately causing the test failures with stdlib 3.x and master.

This patch restores the Puppet.version to 3.0.0-rc3 which was the version
string prior to the problem being introduced in b33d517.
