### PR TITLE
(#15975) Add tests for http methods that accept blocks

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -92,8 +92,8 @@ module Puppet::Network::HTTP
       connection.request_head(*args, &block)
     end
 
-    def request_post(*args)
-      connection.request_post(*args)
+    def request_post(*args, &block)
+      connection.request_post(*args, &block)
     end
     # end of Net::HTTP#request_* proxies
 

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -146,6 +146,40 @@ describe Puppet::Network::HTTP::Connection do
   end
 
 
+  context "when methods that accept a block are called with a block" do
+    let (:host) { "my_server" }
+    let (:port) { 8140 }
+    let (:subject) { Puppet::Network::HTTP::Connection.new(host, port, false) }
+    let (:httpok) { Net::HTTPOK.new('1.1', 200, '') }
+
+    before :each do
+      httpok.stubs(:body).returns ""
+
+      # This stubbing relies a bit more on knowledge of the internals of Net::HTTP
+      # than I would prefer, but it works on ruby 1.8.7 and 1.9.3, and it seems
+      # valuable enough to have tests for blocks that this is probably warranted.
+      socket = stub_everything("socket")
+      TCPSocket.stubs(:open).returns(socket)
+
+      Net::HTTP::Post.any_instance.stubs(:exec).returns("")
+      Net::HTTP::Head.any_instance.stubs(:exec).returns("")
+      Net::HTTP::Get.any_instance.stubs(:exec).returns("")
+      Net::HTTPResponse.stubs(:read_new).returns(httpok)
+    end
+
+    [:request_get, :request_head, :request_post].each do |method|
+      context "##{method}" do
+        it "should yield to the block" do
+          block_executed = false
+          subject.send(method, "/foo", {}) do |response|
+            block_executed = true
+          end
+          block_executed.should == true
+        end
+      end
+    end
+  end
+
   context "when validating HTTPS requests" do
     include PuppetSpec::Files
 


### PR DESCRIPTION
This commit does the following:
- Add support for passing a block to the #request_post method
- Adds tests that verify that blocks are properly yielded to for
  the methods that do accept them.
