### PR TITLE
(#6143) ensure that destroy works for zpools

### DIFF
--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -97,7 +97,7 @@ Puppet::Type.type(:zpool).provide(:zpool) do
     zpool(*([:create, @resource[:pool]] + build_vdevs + build_named("spare") + build_named("log")))
   end
 
-  def delete
+  def destroy
     zpool :destroy, @resource[:pool]
   end
 

--- a/spec/unit/provider/zpool/zpool_spec.rb
+++ b/spec/unit/provider/zpool/zpool_spec.rb
@@ -190,7 +190,7 @@ describe Puppet::Type.type(:zpool).provider(:zpool) do
   context '#delete' do
     it "should call zpool with destroy and the pool name" do
       provider.expects(:zpool).with(:destroy, name)
-      provider.delete
+      provider.destroy
     end
   end
 


### PR DESCRIPTION
Previously the method was named delete rather than destroy.
