### PR TITLE
(#16139) Provide accessors for @puppet_version and @report_format in reports

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -11,7 +11,8 @@ class Puppet::Transaction::Report
   indirects :report, :terminus_class => :processor
 
   attr_accessor :configuration_version, :host, :environment
-  attr_reader :resource_statuses, :logs, :metrics, :time, :kind, :status
+  attr_reader :resource_statuses, :logs, :metrics, :time, :kind, :status,
+              :puppet_version, :report_format
 
   # This is necessary since Marshall doesn't know how to
   # dump hash with default proc (see below @records)


### PR DESCRIPTION
Prior to this commit, some of the data that was useful / necessary
to write a complete report processor was only accessible via
instance variables, while the vast majority of the data was available
through accessor methods.  This commit simply adds accessors for
puppet_version and report_format so that authors of report processors
aren't forced to interact with instance variables.  This should
make report processor implementation a bit more consistent, and
provides a little bit of abstraction from the underlying implementation
details.
