### PR TITLE
(#15185/#16137) Ensuring ENV["HOME"] is always set before calling File.expand_path

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -63,6 +63,9 @@ class Puppet::Settings
   end
 
   def self.default_user_config_dir
+    # ensure HOME is set, if not set, get user's home directory
+    require 'etc'
+    ENV["HOME"] ||= Etc.getpwuid(Process.uid).dir
     File.expand_path("~/.puppet")
   end
 
@@ -71,6 +74,9 @@ class Puppet::Settings
   end
 
   def self.default_user_var_dir
+    # ensure HOME is set, if not set, get user's home directory
+    require 'etc'
+    ENV["HOME"] ||= Etc.getpwuid(Process.uid).dir
     File.expand_path("~/.puppet/var")
   end
 


### PR DESCRIPTION
Addressing bug introduced by patch for issue #15185, and validated as bug in #16137
