### PR TITLE
Move singleton require to puppet/util/storage.rb

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -7,7 +7,6 @@ rescue LoadError
 end
 
 # see the bottom of the file for further inclusions
-require 'singleton'
 require 'facter'
 require 'puppet/error'
 require 'puppet/util'

--- a/lib/puppet/util/storage.rb
+++ b/lib/puppet/util/storage.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'sync'
+require 'singleton'
 
 # a class for storing state
 class Puppet::Util::Storage


### PR DESCRIPTION
All of the other required files are puppet related, except this one. Took me a while to figure out what uses it. Moved it to  `puppet/util/storage.rb`  as it is the only place where module `Singleton` is used.
