### PR TITLE
(#16160) handle aclmode and shareiscsi removal.

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -37,11 +37,38 @@ Puppet::Type.type(:zfs).provide(:zfs) do
     end
   end
 
-  [:aclinherit, :aclmode, :atime, :canmount, :checksum,
+  PARAMETER_UNSET_OR_NOT_AVAILABLE = '-'
+
+  # http://docs.oracle.com/cd/E19963-01/html/821-1448/gbscy.html
+  # shareiscsi (added in build 120) was removed from S11 build 136
+  # aclmode was removed from S11 in build 139 but it may have been added back
+  # http://webcache.googleusercontent.com/search?q=cache:-p74K0DVsdwJ:developers.slashdot.org/story/11/11/09/2343258/solaris-11-released+&cd=13
+  [:aclmode, :shareiscsi].each do |field|
+    # The zfs commands use the property value '-' to indicate that the
+    # property is not set. We make use of this value to indicate that the
+    # property is not set since it is not avaliable. Conversely, if these
+    # properties are attempted to be unset, and resulted in an error, our
+    # best bet is to catch the exception and continue.
+    define_method(field) do
+      begin
+        zfs(:get, "-H", "-o", "value", field, @resource[:name]).strip
+      rescue
+        PARAMETER_UNSET_OR_NOT_AVAILABLE
+      end
+    end
+    define_method(field.to_s + "=") do |should|
+      begin
+        zfs(:set, "#{field}=#{should}", @resource[:name])
+      rescue
+      end
+    end
+  end
+
+  [:aclinherit, :atime, :canmount, :checksum,
    :compression, :copies, :dedup, :devices, :exec, :logbias,
    :mountpoint, :nbmand,  :primarycache, :quota, :readonly,
    :recordsize, :refquota, :refreservation, :reservation,
-   :secondarycache, :setuid, :shareiscsi, :sharenfs, :sharesmb,
+   :secondarycache, :setuid, :sharenfs, :sharesmb,
    :snapdir, :version, :volsize, :vscan, :xattr, :zoned].each do |field|
     define_method(field) do
       zfs(:get, "-H", "-o", "value", field, @resource[:name]).strip


### PR DESCRIPTION
Two properties aclmode and shareiscsi was removed from solaris 11 in two different builds.
of these aclmode may have been added back in some builds. Earlier, puppet used to fail to list
instances in solaris 11 due to these properties being absent. This patch ensures that failures
due to these properties are caught and a default value returned if we get an error.
