### PR TITLE
(Maint) Enable colorized rspec output on Windows

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,12 @@ RSpec.configure do |config|
 
   config.mock_with :mocha
 
+  if Puppet::Util::Platform.windows?
+    config.output_stream = $stdout
+    config.error_stream = $stderr
+    config.formatters.each { |f| f.instance_variable_set(:@output, $stdout) }
+  end
+
   config.before :all do
     Puppet::Test::TestHelper.before_all_tests()
   end


### PR DESCRIPTION
Commit `83cfe9d` added colorized rspec output by default. Unfortunately,
this doesn't work on Windows and causes ANSI escape characters to be
printed to stdout.

Although we load the `win32console` gem while requiring puppet, rspec
always writes to `$stdout` and `$stderr` that it was started with. So
later when the `win32console` gem overwrites those streams, the formatters
have already been created with the old ones.

This commit modifies the spec helper to reset the stdout and stderr
streams on the configuration object, as well as each of the formatters.
Unfortunately, the formatter does not expose an accessor for its output
variable. I tested with 2.9 and 2.11, and both work as expected, i.e.
color on Windows.

This commit doesn't change behavior on non-Windows platforms.
