### PR TITLE
(#15591) Skip test that causes segfault on Windows

### DIFF
--- a/spec/integration/util/file_locking_spec.rb
+++ b/spec/integration/util/file_locking_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Util::FileLocking, :'fails_on_ruby_1.9.2' => true do
     threads.each { |th| th.join }
   end
 
-  it "should be able to keep file corruption from happening when there are multiple writers processes" do
+  it "should be able to keep file corruption from happening when there are multiple writers processes", :unless => Puppet.features.microsoft_windows? do
     unless Process.fork
       50.times { |b|
         Puppet::Util::FileLocking.writelock(@file) { |f|


### PR DESCRIPTION
Previously, this test would segfault on Windows with ruby 1.8.7 p370, but
not p334. Since the test can never work on Windows as currently written
(it's forking), marking this test as pending.

Note in the merge up to 3.x, this spec file has been removed.
