### PR TITLE
maint: remove .rspec entirely

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,0 @@
---format
-p
---colour
---backtrace


### PR DESCRIPTION
There isn't much good reason to force a set of rspec options on everyone,
especially because these override any user configuration.

If you really want to configure the way rspec works, modify ~/.rspec instead.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
