### PR TITLE
Maint: Large or complex HEREDOC strings w/ no interpolation should be single-quote type

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -85,7 +85,7 @@ class Puppet::Application::Agent < Puppet::Application
   end
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-agent(8) -- The puppet agent daemon
 ========

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -40,7 +40,7 @@ EOM
   end
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-apply(8) -- Apply Puppet manifests locally
 ========

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -53,7 +53,7 @@ class Puppet::Application::Cert < Puppet::Application
   end
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-cert(8) -- Manage certificates and requests
 ========

--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -181,7 +181,7 @@ class Puppet::Application::Describe < Puppet::Application
   option("--meta","-m")
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-describe(8) -- Display help about resource types
 ========

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -57,7 +57,7 @@ class Puppet::Application::Device < Puppet::Application
   end
 
     def help
-      <<-HELP
+      <<-'HELP'
 
 puppet-device(8) -- Manage remote network devices
 ========

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -50,7 +50,7 @@ class Puppet::Application::Doc < Puppet::Application
   end
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-doc(8) -- Generate Puppet documentation and references
 ========

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -13,7 +13,7 @@ class Puppet::Application::Filebucket < Puppet::Application
   attr :args
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-filebucket(8) -- Store and retrieve files in a filebucket
 ========

--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -18,7 +18,7 @@ class Puppet::Application::Inspect < Puppet::Application
   end
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-inspect(8) -- Send an inspection report
 ========

--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -38,7 +38,7 @@ class Puppet::Application::Kick < Puppet::Application
   end
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-kick(8) -- Remotely control puppet agent
 ========

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -31,7 +31,7 @@ class Puppet::Application::Master < Puppet::Application
   end
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-master(8) -- The puppet master daemon
 ========

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -35,7 +35,7 @@ class Puppet::Application::Resource < Puppet::Application
   end
 
   def help
-    <<-HELP
+    <<-'HELP'
 
 puppet-resource(8) -- The resource abstraction layer shell
 ========

--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -13,7 +13,7 @@ Puppet::Face.define(:module, '1.0.0') do
 
     returns "Pathname object representing the path to the installed module."
 
-    examples <<-EOT
+    examples <<-'EOT'
       Install a module:
 
       $ puppet module install puppetlabs-vcsrepo

--- a/lib/puppet/face/module/list.rb
+++ b/lib/puppet/face/module/list.rb
@@ -34,7 +34,7 @@ Puppet::Face.define(:module, '1.0.0') do
       summary "Whether to show dependencies as a tree view"
     end
 
-    examples <<-EOT
+    examples <<-'EOT'
       List installed modules:
 
       $ puppet module list

--- a/lib/puppet/face/module/uninstall.rb
+++ b/lib/puppet/face/module/uninstall.rb
@@ -8,7 +8,7 @@ Puppet::Face.define(:module, '1.0.0') do
 
     returns "Hash of module objects representing uninstalled modules and related errors."
 
-    examples <<-EOT
+    examples <<-'EOT'
       Uninstall a module:
 
       $ puppet module uninstall puppetlabs-ssh

--- a/lib/puppet/face/node/clean.rb
+++ b/lib/puppet/face/node/clean.rb
@@ -6,7 +6,7 @@ Puppet::Face.define(:node, '0.0.1') do
 
     summary "Clean up everything a puppetmaster knows about a node."
     arguments "<host1> [<host2> ...]"
-    description <<-EOT
+    description <<-'EOT'
       Clean up everything a puppet master knows about a node, including certificates
       and storeconfigs data.
       

--- a/lib/puppet/indirector/face.rb
+++ b/lib/puppet/indirector/face.rb
@@ -50,11 +50,11 @@ class Puppet::Indirector::Face < Puppet::Face
 
   option "--extra HASH" do
     summary "Extra arguments to pass to the indirection request"
-    description <<-end
+    description <<-EOT
       A terminus can take additional arguments to refine the operation, which
       are passed as an arbitrary hash to the back-end.  Anything passed as
       the extra value is just send direct to the back-end.
-    end
+    EOT
     default_to do Hash.new end
   end
 

--- a/lib/puppet/provider/exec/windows.rb
+++ b/lib/puppet/provider/exec/windows.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
   confine    :operatingsystem => :windows
   defaultfor :operatingsystem => :windows
 
-  desc <<-EOT
+  desc <<-'EOT'
     Execute external binaries on Windows systems. As with the `posix`
     provider, this provider directly calls the command with the arguments
     given, without passing it through a shell or performing any interpolation.

--- a/lib/puppet/provider/service/daemontools.rb
+++ b/lib/puppet/provider/service/daemontools.rb
@@ -2,7 +2,7 @@
 #
 # author Brice Figureau <brice-puppet@daysofwonder.com>
 Puppet::Type.type(:service).provide :daemontools, :parent => :base do
-  desc <<-EOT
+  desc <<-'EOT'
     Daemontools service management.
 
     This provider manages daemons supervised by D.J. Bernstein daemontools.

--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -1,6 +1,6 @@
 require 'facter/util/plist'
 Puppet::Type.type(:service).provide :launchd, :parent => :base do
-  desc <<-EOT
+  desc <<-'EOT'
     This provider manages jobs with `launchd`, which is the default service
     framework for Mac OS X (and may be available for use on other platforms).
 

--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -2,7 +2,7 @@
 #
 # author Brice Figureau <brice-puppet@daysofwonder.com>
 Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
-  desc <<-EOT
+  desc <<-'EOT'
     Runit service management.
 
     This provider manages daemons running supervised by Runit.

--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -20,7 +20,7 @@ Puppet::Type.newtype(:augeas) do
   feature :need_to_run?, "If the command should run"
   feature :execute_changes, "Actually make the changes"
 
-  @doc = <<-EOT
+  @doc = <<-'EOT'
     Apply a change or an array of changes to the filesystem
     using the augeas tool.
 

--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -3,7 +3,7 @@ require 'facter'
 require 'puppet/util/filetype'
 
 Puppet::Type.newtype(:cron) do
-  @doc = <<-EOT
+  @doc = <<-'EOT'
     Installs and manages cron jobs.  Every cron resource requires a command
     and user attribute, as well as at least one periodic attribute (hour,
     minute, month, monthday, weekday, or special).  While the name of the cron

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -274,7 +274,7 @@ module Puppet
 
 
     newcheck(:refreshonly) do
-      desc <<-EOT
+      desc <<-'EOT'
         The command should only be run as a
         refresh mechanism for when a dependent object is changed.  It only
         makes sense to use this option when this command depends on some
@@ -311,7 +311,7 @@ module Puppet
     end
 
     newcheck(:creates, :parent => Puppet::Parameter::Path) do
-      desc <<-EOT
+      desc <<-'EOT'
         A file that this command creates.  If this
         parameter is provided, then the command will only be run
         if the specified file does not exist.
@@ -336,7 +336,7 @@ module Puppet
     end
 
     newcheck(:unless) do
-      desc <<-EOT
+      desc <<-'EOT'
         If this parameter is set, then this `exec` will run unless
         the command returns 0.  For example:
 
@@ -378,7 +378,7 @@ module Puppet
     end
 
     newcheck(:onlyif) do
-      desc <<-EOT
+      desc <<-'EOT'
         If this parameter is set, then this `exec` will only run if
         the command returns 0.  For example:
 

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -39,7 +39,7 @@ Puppet::Type.newtype(:file) do
   end
 
   newparam(:path) do
-    desc <<-EOT
+    desc <<-'EOT'
       The path to the file to manage.  Must be fully qualified.
 
       On Windows, the path should include the drive letter and should use `/` as

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -15,7 +15,7 @@ module Puppet
 
     attr_reader :actual_content
 
-    desc <<-EOT
+    desc <<-'EOT'
       The desired contents of a file, as a string. This attribute is mutually
       exclusive with `source` and `target`.
 

--- a/lib/puppet/type/file/ensure.rb
+++ b/lib/puppet/type/file/ensure.rb
@@ -5,7 +5,7 @@ module Puppet
     require 'puppet/util/symbolic_file_mode'
     include Puppet::Util::SymbolicFileMode
 
-    desc <<-EOT
+    desc <<-'EOT'
       Whether to create files that don't currently exist.
       Possible values are *absent*, *present*, *file*, and *directory*.
       Specifying `present` will match any form of file existence, and

--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -6,7 +6,7 @@ module Puppet
     require 'puppet/util/symbolic_file_mode'
     include Puppet::Util::SymbolicFileMode
 
-    desc <<-EOT
+    desc <<-'EOT'
       The desired permissions mode for the file, in symbolic or numeric
       notation. Puppet uses traditional Unix permission schemes and translates
       them to equivalent permissions for systems which represent permissions

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -12,7 +12,7 @@ module Puppet
     include Puppet::Util::Diff
 
     attr_accessor :source, :local
-    desc <<-EOT
+    desc <<-'EOT'
       A source file, which will be copied into place on the local system.
       Values can be URIs pointing to remote files, or fully qualified paths to
       files available on the local system (including files on NFS shares or

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -306,7 +306,7 @@ module Puppet
     end
 
     newparam(:install_options, :required_features => :install_options) do
-      desc <<-EOT
+      desc <<-'EOT'
         A hash of additional options to pass when installing a package. These
         options are package-specific, and should be documented by the software
         vendor. The most commonly implemented option is `INSTALLDIR`:

--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -1,6 +1,6 @@
 module Puppet
   newtype(:schedule) do
-    @doc = <<-EOT
+    @doc = <<-'EOT'
       Define schedules for Puppet. Resources can be limited to a schedule by using the
       [`schedule`](http://docs.puppetlabs.com/references/latest/metaparameter.html#schedule)
       metaparameter.

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:scheduled_task) do
   end
 
   newproperty(:trigger, :array_matching => :all) do
-    desc <<-EOT
+    desc <<-'EOT'
       One or more triggers defining when the task should run. A single trigger is
       represented as a hash, and multiple triggers can be specified with an array of
       hashes.

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -43,7 +43,7 @@ Puppet::Type.newtype(:tidy) do
   end
 
   newparam(:matches) do
-    desc <<-EOT
+    desc <<-'EOT'
       One or more (shell type) file glob patterns, which restrict
       the list of files to be tidied to those whose basenames match
       at least one of the patterns specified. Multiple patterns can


### PR DESCRIPTION
We were getting accidental interpolation of \t and \n sequences in the desc string
for the file type's content parameter. To avoid this, any description string which:
- Does not deliberately interpolate values from the surrounding code

AND
- Is long enough or complex enough that it can't be read in a single glance

...should probably be the single-quoted type of HEREDOC instead of the
double-quoted type. This commit changes a bunch of HEREDOCs that match this
description.
