### PR TITLE
(#16119) Recognize carriage return escape sequence

### DIFF
--- a/lib/puppet/parser/lexer.rb
+++ b/lib/puppet/parser/lexer.rb
@@ -521,7 +521,7 @@ class Puppet::Parser::Lexer
 
   # we've encountered the start of a string...
   # slurp in the rest of the string and return it
-  def slurpstring(terminators,escapes=%w{ \\  $ ' " n t s }+["\n"],ignore_invalid_escapes=false)
+  def slurpstring(terminators,escapes=%w{ \\  $ ' " r n t s }+["\n"],ignore_invalid_escapes=false)
     # we search for the next quote that isn't preceded by a
     # backslash; the caret is there to match empty strings
     str = @scanner.scan_until(/([^\\]|^|[^\\])([\\]{2})*[#{terminators}]/) or lex_error "Unclosed quote after '#{last}' in '#{rest}'"
@@ -530,6 +530,7 @@ class Puppet::Parser::Lexer
       ch = $1
       if escapes.include? ch
         case ch
+        when 'r'; "\r"
         when 'n'; "\n"
         when 't'; "\t"
         when 's'; " "

--- a/spec/unit/parser/lexer_spec.rb
+++ b/spec/unit/parser/lexer_spec.rb
@@ -37,6 +37,18 @@ describe Puppet::Parser::Lexer do
 
       @lexer.line.should == 13
     end
+
+    {
+      'r'  => "\r",
+      'n'  => "\n",
+      't'  => "\t",
+      's'  => " "
+    }.each do |esc, expected_result|
+      it "should recognize \\#{esc} sequence" do
+        @lexer.string = "\\#{esc}'"
+        @lexer.slurpstring("'")[0].should == expected_result
+      end
+    end
   end
 end
 
@@ -457,6 +469,7 @@ describe Puppet::Parser::Lexer,"when lexing strings" do
     %q{'single quoted string with an escaped "\\'"'}                => [[:STRING,'single quoted string with an escaped "\'"']],
     %q{'single quoted string with an escaped "\$"'}                 => [[:STRING,'single quoted string with an escaped "\$"']],
     %q{'single quoted string with an escaped "\."'}                 => [[:STRING,'single quoted string with an escaped "\."']],
+    %q{'single quoted string with an escaped "\r\n"'}               => [[:STRING,'single quoted string with an escaped "\r\n"']],
     %q{'single quoted string with an escaped "\n"'}                 => [[:STRING,'single quoted string with an escaped "\n"']],
     %q{'single quoted string with an escaped "\\\\"'}               => [[:STRING,'single quoted string with an escaped "\\\\"']],
     %q{"string with an escaped '\\"'"}                              => [[:STRING,"string with an escaped '\"'"]],


### PR DESCRIPTION
Previously, the lexer would issue a warning when encountering a carriage
return escape sequence \r, such as when specifying inline file content. 
This commit modifies the lexer to accept \r.
