### PR TITLE
(#16019) Don't add Unix paths to Windows search path

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -72,7 +72,7 @@ module Puppet
         ENV["PATH"] = "" if ENV["PATH"].nil?
         ENV["PATH"] = value unless value == "none"
         paths = ENV["PATH"].split(File::PATH_SEPARATOR)
-        %w{/usr/sbin /sbin}.each do |path|
+        Puppet::Util::Platform.default_paths.each do |path|
           ENV["PATH"] += File::PATH_SEPARATOR + path unless paths.include?(path)
         end
         value

--- a/lib/puppet/util/platform.rb
+++ b/lib/puppet/util/platform.rb
@@ -10,6 +10,13 @@ module Puppet
         !!File::ALT_SEPARATOR
       end
       module_function :windows?
+
+      def default_paths
+        return [] if windows?
+
+        %w{/usr/sbin /sbin}
+      end
+      module_function :default_paths
     end
   end
 end

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -134,11 +134,23 @@ describe "Puppet defaults" do
     end
   end
 
-  it "should add /usr/sbin and /sbin to the path if they're not there" do
-    withenv("PATH" => "/usr/bin:/usr/local/bin") do
-      Puppet.settings[:path] = "none" # this causes it to ignore the setting
-      ENV["PATH"].split(File::PATH_SEPARATOR).should be_include("/usr/sbin")
-      ENV["PATH"].split(File::PATH_SEPARATOR).should be_include("/sbin")
+  describe "on a Unix-like platform it", :as_platform => :posix do
+    it "should add /usr/sbin and /sbin to the path if they're not there" do
+      withenv("PATH" => "/usr/bin#{File::PATH_SEPARATOR}/usr/local/bin") do
+        Puppet.settings[:path] = "none" # this causes it to ignore the setting
+        ENV["PATH"].split(File::PATH_SEPARATOR).should be_include("/usr/sbin")
+        ENV["PATH"].split(File::PATH_SEPARATOR).should be_include("/sbin")
+      end
+    end
+  end
+
+  describe "on a Windows-like platform it", :as_platform => :windows do
+    it "should not add anything" do
+      path = "c:\\windows\\system32#{File::PATH_SEPARATOR}c:\\windows"
+      withenv("PATH" => path) do
+        Puppet.settings[:path] = "none" # this causes it to ignore the setting
+        ENV["PATH"].should == path
+      end
     end
   end
 

--- a/spec/shared_contexts/platform.rb
+++ b/spec/shared_contexts/platform.rb
@@ -12,13 +12,17 @@ shared_context "windows", :as_platform => :windows do
 
   around do |example|
     file_alt_separator = File::ALT_SEPARATOR
+    file_path_separator = File::PATH_SEPARATOR
+
     # prevent Ruby from warning about changing a constant
     with_verbose_disabled do
       File::ALT_SEPARATOR = '\\'
+      File::PATH_SEPARATOR = ';'
     end
     example.run
     with_verbose_disabled do
       File::ALT_SEPARATOR = file_alt_separator
+      File::PATH_SEPARATOR = file_path_separator
     end
   end
 end
@@ -31,13 +35,17 @@ shared_context "posix", :as_platform => :posix do
 
   around do |example|
     file_alt_separator = File::ALT_SEPARATOR
+    file_path_separator = File::PATH_SEPARATOR
+
     # prevent Ruby from warning about changing a constant
     with_verbose_disabled do
       File::ALT_SEPARATOR = nil
+      File::PATH_SEPARATOR = ':'
     end
     example.run
     with_verbose_disabled do
       File::ALT_SEPARATOR = file_alt_separator
+      File::PATH_SEPARATOR = file_path_separator
     end
   end
 end


### PR DESCRIPTION
Previously, we were adding `/usr/sbin` and `/sbin` to Puppet's shell
search path on all platforms, including Windows.

This commit changes the behavior on Windows so that those paths are not
added. It also doesn't add Windows equivalents, because the environment
it inherits from its parent process already contains a suitable search
path.

This commit also sets File::PATH_SEPARATOR appropriately when using the
windows or posix shared context.
