### PR TITLE
(maint) commit the complete commands at the end.

### DIFF
--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -102,6 +102,7 @@ autorequire that directory."
         sleep 1
       end
       provider.send(method)
+      provider.flush()
     end
 
     def sync


### PR DESCRIPTION
The provider.flush() comamnd was missing.
