### PR TITLE
Remove version check regex from puppet

### DIFF
--- a/test/puppet/defaults.rb
+++ b/test/puppet/defaults.rb
@@ -13,10 +13,6 @@ class TestPuppetDefaults < Test::Unit::TestCase
   @@normals = %w{puppetport masterport server}
   @@booleans = %w{noop}
 
-  def testVersion
-    assert( Puppet.version =~ /^[0-9]+(\.[0-9]+)*/, "got invalid version number #{Puppet.version}")
-  end
-
   def testStringOrParam
     [@@dirs,@@files,@@booleans].flatten.each { |param|
       assert_nothing_raised { Puppet[param] }


### PR DESCRIPTION
This commit removes the version test method in
default.rb, which is the sudo-equivalent of e30d6ef
in the 3.x branch. AFAICT this method is not called
anywhere in puppet, and since we've started using
RC versions it won't work as-is if called.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
