### PR TITLE
(#5752) Handle read errors in parsedfile provider

### DIFF
--- a/lib/puppet/provider/parsedfile.rb
+++ b/lib/puppet/provider/parsedfile.rb
@@ -216,7 +216,16 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
 
   # Prefetch an individual target.
   def self.prefetch_target(target)
-    target_records = retrieve(target).each do |r|
+
+    begin
+      target_records = retrieve(target)
+    rescue => detail
+      puts detail.backtrace if Puppet[:trace]
+      Puppet.err "Could not prefetch #{self.resource_type.name} provider '#{self.name}' target '#{target}': #{detail}. Treating as empty"
+      target_records = []
+    end
+
+    target_records.each do |r|
       r[:on_disk] = true
       r[:target] = target
       r[:ensure] = :present


### PR DESCRIPTION
The parsedfile provider can handle multiple targets (multiple files,
multiple crontabs, etc) but the provider does not handle the case when
retrieving a target during prefetch fails. When the provider does only
handle one target this doesn't really matter because a possible error is
caught at a higher level (inside Puppet::Transaction). But if the
provider handles multiple targets, one error will cause the whole
prefetching method to fail and all targets are treated as empty.

One example of the issue is described in #5752: Multiple crontabs are
manages with crontab resources and one cronresource describes a
cronentry of an absent user. Because prefetching the crontab of the
absent user fails, the crontab of _all_ users are purged and every
crontab entry which is not managed by puppet is lost.

The change now handles the error inside the parsedfile provider itself,
so only the target that is causing troubles is treated as empty.
