### PR TITLE
(#15561) allow printable ascii in CN's - slightly more permissive

### DIFF
--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -7,7 +7,7 @@ class Puppet::SSL::Base
   SEPARATOR = "\n---\n"
 
   # Only allow printing ascii characters, excluding /
-  VALID_CERTNAME = /\A[ -.0-~]+\Z/
+  VALID_CERTNAME = /\A[[:print:]]+\Z/
 
   def self.from_multiple_s(text)
     text.split(SEPARATOR).collect { |inst| from_s(inst) }

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -484,7 +484,8 @@ describe Puppet::SSL::CertificateAuthority do
          'this"is#just&madness%you[see]',
          'and even a (an?) \\!',
          'waltz, nymph, for quick jigs vex bud.',
-         '{552c04ca-bb1b-11e1-874b-60334b04494e}'
+         '{552c04ca-bb1b-11e1-874b-60334b04494e}',
+         'super/bad'
         ].each do |name|
           it "should accept #{name.inspect}" do
             csr = Puppet::SSL::CertificateRequest.new(name)
@@ -495,11 +496,11 @@ describe Puppet::SSL::CertificateAuthority do
         end
 
         [
-         'super/bad',
          "not\neven\tkind\rof",
          "ding\adong\a",
          "hidden\b\b\b\b\b\bmessage",
-         "☃ :("
+         "☃ :(",
+         "\x00zero byte"
         ].each do |name|
           it "should reject #{name.inspect}" do
             # We aren't even allowed to make objects with these names, so let's


### PR DESCRIPTION
In particular, this allows /, which appears in a lot of chained CNs.
