### PR TITLE
AST Scope variable names must be strings.

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -436,7 +436,7 @@ class Puppet::Parser::Compiler
   # Set the node's parameters into the top-scope as variables.
   def set_node_parameters
     node.parameters.each do |param, value|
-      @topscope[param] = value
+      @topscope[param.to_s] = value
     end
 
     # These might be nil.

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -236,6 +236,10 @@ class Puppet::Parser::Scope
   end
 
   def lookupvar(name, options = {})
+    unless name.is_a? String
+      raise Puppet::DevError, "Scope variable name is a #{name.class}, not a string"
+    end
+
     # Save the originating scope for the request
     options[:origin] = self unless options[:origin]
     table = ephemeral?(name) ? @ephemeral.last : @symtable
@@ -327,6 +331,10 @@ class Puppet::Parser::Scope
   #   It's preferred that you use self[]= instead of this; only use this
   # when you need to set options.
   def setvar(name, value, options = {})
+    unless name.is_a? String
+      raise Puppet::DevError, "Scope variable name is a #{name.class}, not a string"
+    end
+
     table = options[:ephemeral] ? @ephemeral.last : @symtable
     if table.include?(name)
       if options[:append]

--- a/spec/unit/parser/ast/vardef_spec.rb
+++ b/spec/unit/parser/ast/vardef_spec.rb
@@ -11,11 +11,11 @@ describe Puppet::Parser::AST::VarDef do
   describe "when evaluating" do
 
     it "should evaluate arguments" do
-      name = mock 'name'
-      value = mock 'value'
+      name  = Puppet::Parser::AST::String.new :value => 'name'
+      value = Puppet::Parser::AST::String.new :value => 'value'
 
-      name.expects(:safeevaluate).with(@scope)
-      value.expects(:safeevaluate).with(@scope)
+      name.expects(:safeevaluate).with(@scope).returns('name')
+      value.expects(:safeevaluate).with(@scope).returns('value')
 
       vardef = Puppet::Parser::AST::VarDef.new :name => name, :value => value, :file => nil, :line => nil
       vardef.evaluate(@scope)

--- a/spec/unit/parser/functions/fqdn_rand_spec.rb
+++ b/spec/unit/parser/functions/fqdn_rand_spec.rb
@@ -10,7 +10,7 @@ describe "the fqdn_rand function" do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)
     @scope   = Puppet::Parser::Scope.new(compiler)
-    @scope[:fqdn] = "127.0.0.1"
+    @scope["fqdn"] = "127.0.0.1"
   end
 
   it "should exist" do

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -129,6 +129,11 @@ describe Puppet::Parser::Scope do
       @scope.lookupvar("var").should == "yep"
     end
 
+    it "should fail if invoked with a non-string name" do
+      expect { @scope[:foo] }.to raise_error Puppet::DevError
+      expect { @scope[:foo] = 12 }.to raise_error Puppet::DevError
+    end
+
     it "should return nil for unset variables" do
       @scope["var"].should be_nil
     end


### PR DESCRIPTION
The Parser AST scope had an embedded assumption that variable names were
always strings, but didn't actually enforce that.  A consequence of this is
that a couple of tests violated that agreement.

This adds an internal error report when someone tries the wrong thing, and
cleans up the handful of tests that failed.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
