### PR TITLE
#16027: restore the full backtrace on exception

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -363,11 +363,16 @@ module Util
   # will recognize as links to the line numbers in the trace)
   def self.pretty_backtrace(backtrace = caller(1))
     backtrace.collect do |line|
-      file_path, line_num = line.split(":")
+      _, path, rest = /^(.*):(\d+.*)$/.match(line).to_a
       # If the path doesn't exist - like in one test, and like could happen in
       # the world - we should just tolerate it and carry on. --daniel 2012-09-05
-      file_path = Pathname(file_path).realpath rescue path
-      "#{file_path}:#{line_num}"
+      # Also, if we don't match, just include the whole line.
+      if path
+        path = Pathname(path).realpath rescue path
+        "#{path}:#{rest}"
+      else
+        line
+      end
     end.join("\n")
   end
 

--- a/spec/unit/util/logging_spec.rb
+++ b/spec/unit/util/logging_spec.rb
@@ -133,18 +133,18 @@ describe Puppet::Util::Logging do
       exc1.set_backtrace(["7.rb:31:in `e'","8.rb:22:in `f'","9.rb:9"])
       # whoa ugly
       @logger.format_exception(exc1).should =~ /third
-.*7\.rb:31
-.*8\.rb:22
+.*7\.rb:31:in `e'
+.*8\.rb:22:in `f'
 .*9\.rb:9
 Wrapped exception:
 second
-.*4\.rb:8
-.*5\.rb:1
+.*4\.rb:8:in `c'
+.*5\.rb:1:in `d'
 .*6\.rb:3
 Wrapped exception:
 original
-.*1\.rb:4
-.*2\.rb:2
+.*1\.rb:4:in `a'
+.*2\.rb:2:in `b'
 .*3\.rb:1/
     end
   end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -492,4 +492,21 @@ describe Puppet::Util do
       File.read(target.path).should == "hello, world\n"
     end
   end
+
+  describe "#pretty_backtrace" do
+    it "should include lines that don't match the standard backtrace pattern" do
+      line = "non-standard line\n"
+      trace = caller[0..2] + [line] + caller[3..-1]
+      Puppet::Util.pretty_backtrace(trace).should =~ /#{line}/
+    end
+
+    it "should include function names" do
+      Puppet::Util.pretty_backtrace.should =~ /:in `\w+'/
+    end
+
+    it "should work with Windows paths" do
+      Puppet::Util.pretty_backtrace(["C:/work/puppet/c.rb:12:in `foo'\n"]).
+        should == "C:/work/puppet/c.rb:12:in `foo'"
+    end
+  end
 end


### PR DESCRIPTION
This restores the function context that, in the move to prettier backtraces, was lost.  This improves the debugging utility of Puppet's `--trace` option substantially.  It also eliminates some code that replicates a built-in facility of Ruby for eliminating symbolic links from file paths.
