### PR TITLE
Make envpuppet print warning to stderr

### DIFF
--- a/ext/envpuppet
+++ b/ext/envpuppet
@@ -67,6 +67,7 @@ EO_HELP
 fi
 
 if test -d puppet -o -d facter; then
+  (
     echo " WARNING!"
     echo "  Strange things happen if puppet or facter are in the"
     echo "  current working directory"
@@ -77,6 +78,7 @@ if test -d puppet -o -d facter; then
     echo ""
     echo "Sleeping 2 seconds."
     echo ""
+  ) 1>&2
     sleep 2
 fi
 


### PR DESCRIPTION
Otherwise eval $(envpuppet) will fail strangely if the warning is
printed.

(Would also be useful if added to back branches.)
