### PR TITLE
(#16275) Don't set $environment as a local fact

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -99,7 +99,7 @@ class Puppet::Node
       @parameters[name] = value unless @parameters.include?(name)
     end
 
-    @parameters["environment"] ||= self.environment.name.to_s if self.environment
+    @parameters["environment"] ||= self.environment.name.to_s
   end
 
   # Calculate the list of names we might use for looking

--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -28,7 +28,6 @@ class Puppet::Node::Facts
   def add_local_facts
     values["clientcert"] = Puppet.settings[:certname]
     values["clientversion"] = Puppet.version.to_s
-    values["environment"] ||= Puppet.settings[:environment]
   end
 
   def initialize(name, values = {})

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -24,9 +24,9 @@ describe Puppet::Node::Facts, "when indirecting" do
     @facts.values["clientversion"].should == Puppet.version.to_s
   end
 
-  it "should add the current environment as a fact if one is not set when adding local facts" do
+  it "should not add the current environment" do
     @facts.add_local_facts
-    @facts.values["environment"].should == Puppet[:environment]
+    @facts.values.should_not include("environment")
   end
 
   it "should not replace any existing environment fact when adding local facts" do


### PR DESCRIPTION
The environment set by set_local_facts was not always correct. Since the node
object should always have the correct environment now we should just use that.
