### PR TITLE
(maint) Confine pty-based test to non-Windows hosts.

### DIFF
--- a/acceptance/tests/ticket_11727_support_stdin_parsing_in_puppet_parser_validate.rb
+++ b/acceptance/tests/ticket_11727_support_stdin_parsing_in_puppet_parser_validate.rb
@@ -1,4 +1,5 @@
 test_name "#11727: support stdin parsing in puppet parser validate"
+confine :except, :platform => 'windows'
 
 step "validate with a tty parses the default manifest"
 on agents, puppet('parser', 'validate'), :pty => true do


### PR DESCRIPTION
Pty detection on Windows is broken in Ruby 1.8.7. This causes tests which use a pty to freeze, locking up the test suite.

This patch works around the issue by not running the affected test on Windows hosts.

Josh Cooper is looking in to how TTY detection works, so hopefully we'll be able to test this on Windows in the future.
