### PR TITLE
(acceptance) use facter to find the system name and fqdn

### DIFF
--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -43,7 +43,7 @@ create_remote_file master, manifest_file, manifest
 
 on master, "chmod 644 #{authfile} #{manifest_file}"
 
-with_master_running_on(master, "--rest_authconfig #{authfile} --manifest #{manifest_file} --daemonize --dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\" --autosign true") do
+with_master_running_on(master, "--rest_authconfig #{authfile} --manifest #{manifest_file} --daemonize --dns_alt_names=\"puppet, $(facter hostname), $(facter fqdn)\" --autosign true") do
   run_agent_on(agents, "--no-daemonize --verbose --onetime --node_name_fact kernel --server #{master}") do
     assert_match(/defined 'message'.*#{success_message}/, stdout)
   end

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -26,7 +26,7 @@ MANIFEST
 
 on master, "chmod 644 #{authfile} #{manifest_file}"
 
-with_master_running_on(master, "--rest_authconfig #{authfile} --manifest #{manifest_file} --daemonize --dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\" --autosign true") do
+with_master_running_on(master, "--rest_authconfig #{authfile} --manifest #{manifest_file} --daemonize --dns_alt_names=\"puppet, $(facter hostname), $(facter fqdn)\" --autosign true") do
   run_agent_on(agents, "--no-daemonize --verbose --onetime --node_name_value specified_node_name --server #{master}") do
     assert_match(/defined 'message'.*#{success_message}/, stdout)
   end

--- a/acceptance/tests/databinding/hiera/auto_lookup_for_class_parameters.rb
+++ b/acceptance/tests/databinding/hiera/auto_lookup_for_class_parameters.rb
@@ -61,7 +61,7 @@ PP
 
 step "Should lookup class paramters from Hiera"
 
-with_master_running_on(master, "--config #{testdir}/puppet.conf --debug --verbose --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+with_master_running_on(master, "--config #{testdir}/puppet.conf --debug --verbose --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
   agents.each do |agent|
     run_agent_on(agent, "--no-daemonize --onetime --verbose --server #{master}")
 

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -29,7 +29,7 @@ create_remote_file(master, "#{testdir}/more_different.pp", 'notify { "more_diffe
 on master, "chown -R root:puppet #{testdir}"
 on master, "chmod -R g+rwX #{testdir}"
 
-with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
 
   agents.each do |agent|
     run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different")

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -19,7 +19,7 @@ create_remote_file(master, "#{testdir}/more_different.pp", 'notify { "more_diffe
 on master, "chown -R root:puppet #{testdir}"
 on master, "chmod -R g+rwX #{testdir}"
 
-with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
 
   agents.each do |agent|
     run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different")

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -26,7 +26,7 @@ create_remote_file(master, "#{testdir}/different.pp", 'notify { "expected_string
 on master, "chown -R root:puppet #{testdir}"
 on master, "chmod -R g+rwX #{testdir}"
 
-with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
 
   agents.each do |agent|
     run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose")

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -30,7 +30,7 @@ on master, "chown -R root:puppet #{testdir}"
 on master, "chmod -R g+rwX #{testdir}"
 
 agents.each do |agent|
-  with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+  with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
     atmp = agent.tmpdir('respect_enc_test')
     puts "agent: #{agent} \tagent.tmpdir => #{atmp}"
     create_remote_file master, "#{testdir}/different.pp", <<END

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -28,7 +28,7 @@ create_remote_file(master, "#{testdir}/special/amod/lib/puppet/foo.rb", "#specia
 on master, "chown -R root:puppet #{testdir}"
 on master, "chmod -R g+rwX #{testdir}"
 
-with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
 
   agents.each do |agent|
     run_agent_on(agent, "--no-daemonize --onetime --server #{master}")

--- a/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
+++ b/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
@@ -55,7 +55,7 @@ assert_log_on_master_does_not_contain = lambda do |string|
   on master, "grep -v '#{string}' #{testdir}/log"
 end
 
-with_master_running_on(master, "--config #{testdir}/puppet.conf --debug --verbose --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+with_master_running_on(master, "--config #{testdir}/puppet.conf --debug --verbose --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
   agents.each do |agent|
     run_agent_on(agent, "--no-daemonize --onetime --verbose --server #{master}")
 

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -46,7 +46,7 @@ on master, %Q[echo "file { '#{posix_result_file}': source => 'puppet:///modules/
 # and then once with the posix manifest.  Could potentially get around this by
 # creating a manifest with nodes or by moving the windows bits into a separate
 # test.
-with_master_running_on master, "--autosign true --manifest #{windows_manifest} --dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\"" do
+with_master_running_on master, "--autosign true --manifest #{windows_manifest} --dns_alt_names=\"puppet, $(facter hostname), $(facter fqdn)\"" do
   agents.each do |agent|
     next unless agent['platform'].include?('windows')
     run_agent_on agent, "--test --server #{master}", :acceptable_exit_codes => [2] do
@@ -63,7 +63,7 @@ end
   #  end
   #end
 
-with_master_running_on master, "--autosign true --manifest #{posix_manifest} --dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\"" do
+with_master_running_on master, "--autosign true --manifest #{posix_manifest} --dns_alt_names=\"puppet, $(facter hostname), $(facter fqdn)\"" do
   agents.each do |agent|
     next if agent['platform'].include?('windows')
     run_agent_on agent, "--test --server #{master}", :acceptable_exit_codes => [2] do

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -2,7 +2,7 @@ test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 
 agent_hostnames = agents.map {|a| a.to_s}
 
-with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --verbose --noop" do
+with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --verbose --noop" do
   agents.each do |agent|
     if agent['platform'].include?('windows')
       Log.warn("Pending: Windows does not support hostname -f")

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -10,7 +10,7 @@ manifest_file = "/tmp/missing_site-5477-#{$$}.pp"
 
 on master, "rm -f #{manifest_file}"
 
-with_master_running_on(master, "--manifest #{manifest_file} --dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\" --verbose --filetimeout 1 --autosign true") do
+with_master_running_on(master, "--manifest #{manifest_file} --dns_alt_names=\"puppet, $(facter hostname), $(facter fqdn)\" --verbose --filetimeout 1 --autosign true") do
   # Run test on Agents
   step "Agent: agent --test"
   on agents, puppet_agent("--test --server #{master}")

--- a/acceptance/tests/ticket_7117_broke_env_criteria_authconf.rb
+++ b/acceptance/tests/ticket_7117_broke_env_criteria_authconf.rb
@@ -13,7 +13,7 @@ create_remote_file master, "/tmp/auth.conf-7117", add_2_authconf
 
 on master, "chmod 644 /tmp/auth.conf-7117"
 
-with_master_running_on(master, "--dns_alt_names=\"puppet, $(hostname -s), $(hostname -f)\" --rest_authconfig /tmp/auth.conf-7117 --verbose --autosign true") do
+with_master_running_on(master, "--dns_alt_names=\"puppet, $(facter hostname), $(facter fqdn)\" --rest_authconfig /tmp/auth.conf-7117 --verbose --autosign true") do
   agents.each do |agent|
     if agent['platform'].include?('windows')
       Log.warn("Pending: Window's doesn't support hostname -f")


### PR DESCRIPTION
Earlier, tests used hostname -s and hostname -f to find the
fqdn and hostname on master. This checkin substitutes them with
facter fqdn and facter hostname (checkin in connection with solaris acceptance tests.)
