### PR TITLE
(acceptance) Fix incorrect command invocation.

### DIFF
--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -10,8 +10,8 @@ with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet
     end
 
     step "Generate a certificate request for the agent"
-    myhost = facter('fqdn')
-    on agent, "puppet certificate generate #{myhost} --ca-location remote --server #{master}"
+    fqdn = on(agent, facter("fqdn")).stdout
+    on agent, "puppet certificate generate #{fqdn} --ca-location remote --server #{master}"
   end
 
   step "Collect the original certs"


### PR DESCRIPTION
use fqdn = on(agent, facter("fqdn")).stdout to get fqdn
in the previous commit.
