### PR TITLE
(maint) Strip fqdn before sending it to the sut

### DIFF
--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -10,7 +10,7 @@ with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet
     end
 
     step "Generate a certificate request for the agent"
-    fqdn = on(agent, facter("fqdn")).stdout
+    fqdn = on(agent, facter("fqdn")).stdout.strip
     on agent, "puppet certificate generate #{fqdn} --ca-location remote --server #{master}"
   end
 
@@ -32,7 +32,7 @@ with_master_running_on master, "--allow_duplicate_certs --dns_alt_names=\"puppet
       next
     end
 
-    fqdn = on(agent, facter("fqdn")).stdout
+    fqdn = on(agent, facter("fqdn")).stdout.strip
     step "Make another request with the same certname"
     on agent, "puppet certificate generate #{fqdn} --ca-location remote --server #{master}"
   end


### PR DESCRIPTION
Failure to strip the fqdn sends a newline, which causes the command line to be parsed as two separate commands and fail the test.
