### PR TITLE
remove non-applicable artifacts in packaging

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -82,6 +82,17 @@ install: build
 
 	# Add ext directory
 	cp -pr ext $(CURDIR)/debian/puppet-common/usr/share/puppet
+	# Remove misc packaging artifacts not applicable to debian
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/gentoo
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/freebsd
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/solaris
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/suse
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/windows
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/redhat
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/ips
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/osx
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/build_defaults.yaml
+	rm -rf $(CURDIR)/debian/puppet-common/usr/share/puppet/ext/project_data.yaml
 
 	dh_installexamples -p puppet-common examples/*
 

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -122,6 +122,9 @@ install -d %{buildroot}%{_datadir}/%{name}
 cp -a ext/ %{buildroot}%{_datadir}/%{name}
 # emacs and vim bits are installed elsewhere
 rm -rf %{buildroot}%{_datadir}/%{name}/ext/{emacs,vim}
+# remove misc packaging artifacts not applicable to rpms
+rm -rf %{buildroot}%{_datadir}/%{name}/ext/{gentoo,freebsd,solaris,suse,windows,osx,ips,debian}
+rm -f %{buildroot}%{_datadir}/%{name}/ext/{build_defaults.yaml,project_data.yaml}
 
 # Install emacs mode files
 emacsdir=%{buildroot}%{_datadir}/emacs/site-lisp


### PR DESCRIPTION
This commit removes packaging artifacts for OSes other than
the ones we're building from their respective packages. We
send these along with source, no need to include them in the
packages as well.
