### PR TITLE
Deprecate puppet kick, and agent --listen. Issue 15735.

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -379,6 +379,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup_listen
+    Puppet.warning "Puppet --listen / kick is deprecated. See http://links.puppetlabs.com/puppet-kick-deprecation"
     unless FileTest.exists?(Puppet[:rest_authconfig])
       Puppet.err "Will not start without authorization file #{Puppet[:rest_authconfig]}"
       exit(14)

--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -298,7 +298,9 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup
+    super()
     raise Puppet::Error.new("Puppet kick is not supported on Microsoft Windows") if Puppet.features.microsoft_windows?
+    Puppet.warning "Puppet kick is deprecated. See http://links.puppetlabs.com/puppet-kick-deprecation"
 
     if options[:debug]
       Puppet::Util::Log.level = :debug

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -477,6 +477,11 @@ describe Puppet::Application::Agent do
 
         @puppetd.setup_listen
       end
+      
+      it "should issue a warning that listen is deprecated" do
+        Puppet.expects(:warning).with() { |msg| msg =~ /kick is deprecated/ }
+        @puppetd.setup_listen
+      end
     end
 
     describe "when setting up for fingerprint" do

--- a/spec/unit/application/kick_spec.rb
+++ b/spec/unit/application/kick_spec.rb
@@ -121,6 +121,11 @@ describe Puppet::Application::Kick, :if => Puppet.features.posix? do
       @kick.options.stubs(:[]).with(any_parameters)
     end
 
+    it "should issue a warning that kick is deprecated" do
+      Puppet.expects(:warning).with() { |msg| msg =~ /kick is deprecated/ }
+      @kick.setup
+    end
+
     it "should abort stating that kick is not supported on Windows" do
       Puppet.features.stubs(:microsoft_windows?).returns(true)
 
@@ -216,6 +221,9 @@ describe Puppet::Application::Kick, :if => Puppet.features.posix? do
         @kick.options.stubs(:[]).with(:ignoreschedules).returns(false)
         @kick.options.stubs(:[]).with(:foreground).returns(false)
         @kick.options.stubs(:[]).with(:debug).returns(false)
+        @kick.options.stubs(:[]).with(:verbose).returns(false) # needed when logging is initialized
+        @kick.options.stubs(:[]).with(:setdest).returns(false) # needed when logging is initialized
+         
         @kick.stubs(:print)
         @kick.preinit
         @kick.stubs(:parse_options)


### PR DESCRIPTION
This deprecates the puppet kick command and the agent's --listen option.
Deprecation messages are issues using Puppet.warning.
Tests check that Puppet.warning is called and that message includes
"deprecated".
