### PR TITLE
(#15756) Call include function correctly

### DIFF
--- a/lib/hiera/backend/puppet_backend.rb
+++ b/lib/hiera/backend/puppet_backend.rb
@@ -58,9 +58,9 @@ class Hiera
           unless loaded_classes.include?(klass)
             begin
               if scope.respond_to?(:function_include)
-                scope.function_include(klass)
+                scope.function_include([klass])
               else
-                scope.real.function_include(klass)
+                scope.real.function_include([klass])
               end
 
               temp_answer = scope[varname]

--- a/spec/unit/hiera/backend/puppet_backend_spec.rb
+++ b/spec/unit/hiera/backend/puppet_backend_spec.rb
@@ -62,7 +62,7 @@ describe Hiera::Backend::Puppet_backend do
       catalog.expects(:classes).returns([])
 
       @scope.expects(:catalog).returns(catalog)
-      @scope.expects(:function_include).with("rspec")
+      @scope.expects(:function_include).with(["rspec"])
       @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec")
 
       @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec"])


### PR DESCRIPTION
The hiera puppet backend called the include function without passing the 
argument as an array. This changes it to call the function correctly.
