### PR TITLE
(#16353) Gem provider consistently no-ri no-rdoc

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -74,6 +74,8 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     command << "-v" << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion
     # Always include dependencies
     command << "--include-dependencies"
+    # Always omit ri and rdoc
+    command << "--no-rdoc" << "--no-ri"
 
     if source = resource[:source]
       begin
@@ -96,7 +98,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
         command << "--source" << "#{source}" << resource[:name]
       end
     else
-      command << "--no-rdoc" << "--no-ri" << resource[:name]
+      command << resource[:name]
     end
 
     output = execute(command)

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -50,17 +50,29 @@ describe provider_class do
     end
 
     describe "when a source is specified" do
+      it "should specify that documentation should not be included" do
+        resource[:source] = "/my/file"
+        provider.expects(:execute).with { |args| args[3] == "--no-rdoc" }.returns ""
+        provider.install
+      end
+
+      it "should specify that RI should not be included" do
+        resource[:source] = "/my/file"
+        provider.expects(:execute).with { |args| args[4] == "--no-ri" }.returns ""
+        provider.install
+      end
+
       describe "as a normal file" do
         it "should use the file name instead of the gem name" do
           resource[:source] = "/my/file"
-          provider.expects(:execute).with { |args| args[3] == "/my/file" }.returns ""
+          provider.expects(:execute).with { |args| args[5] == "/my/file" }.returns ""
           provider.install
         end
       end
       describe "as a file url" do
         it "should use the file name instead of the gem name" do
           resource[:source] = "file:///my/file"
-          provider.expects(:execute).with { |args| args[3] == "/my/file" }.returns ""
+          provider.expects(:execute).with { |args| args[5] == "/my/file" }.returns ""
           provider.install
         end
       end
@@ -73,7 +85,7 @@ describe provider_class do
       describe "as a non-file and non-puppet url" do
         it "should treat the source as a gem repository" do
           resource[:source] = "http://host/my/file"
-          provider.expects(:execute).with { |args| args[3..5] == ["--source", "http://host/my/file", "myresource"] }.returns ""
+          provider.expects(:execute).with { |args| args[5..7] == ["--source", "http://host/my/file", "myresource"] }.returns ""
           provider.install
         end
       end


### PR DESCRIPTION
Currently the gem provider omits the option --no-ri --no-rdoc when
installing from source. This update changes the behavior so this flag is
consistently used when installing gems.
