### PR TITLE
Update packaging to account for hiera-puppet merge

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -12,10 +12,13 @@ Homepage: http://projects.puppetlabs.com/projects/puppet
 
 Package: puppet-common
 Architecture: all
-Depends: ${misc:Depends}, ruby1.8, libxmlrpc-ruby, libopenssl-ruby, libshadow-ruby1.8, libaugeas-ruby1.8, adduser, facter (>= 1.6.11), lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 0.99), hiera-puppet (>= 1.0)
+Depends: ${misc:Depends}, ruby1.8, libxmlrpc-ruby, libopenssl-ruby, libshadow-ruby1.8, libaugeas-ruby1.8, adduser, facter (>= 1.6.11), lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0)
 Recommends: lsb-release, debconf-utils
 Suggests: libselinux-ruby1.8, librrd-ruby1.8
 Breaks: puppet (<< 2.6.0~rc2-1), puppetmaster (<< 0.25.4-1)
+Provides: hiera-puppet
+Conflicts: hiera-puppet
+Replaces: hiera-puppet
 Description: Centralized configuration management
  Puppet lets you centrally manage every important aspect of your system
  using a cross-platform specification language that manages all the

--- a/ext/debian/puppet-common.install
+++ b/ext/debian/puppet-common.install
@@ -1,3 +1,4 @@
 debian/puppet.conf etc/puppet
 debian/tmp/usr/bin/puppet usr/bin
+debian/tmp/usr/bin/extlookup2hiera usr/bin
 debian/tmp/usr/lib/ruby/1.8/* usr/lib/ruby/1.8

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -48,7 +48,8 @@ Requires:       ruby-shadow
 Requires:       facter >= 1.6.11
 Requires:       ruby >= 1.8.5
 Requires:       hiera >= 1.0.0
-Requires:       hiera-puppet >= 1.0.0
+Obsoletes:      hiera-puppet <= 1.0.0
+Provides:       hiera-puppet >= 1.0.0
 %{!?_without_augeas:Requires: ruby-augeas}
 
 Requires(pre):  shadow-utils
@@ -148,6 +149,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}/modules
 %defattr(-, root, root, 0755)
 %doc CHANGELOG LICENSE README.md examples
 %{_bindir}/puppet
+%{_bindir}/extlookup2hiera
 %{puppet_libdir}/*
 %{_initrddir}/puppet
 %dir %{_sysconfdir}/puppet


### PR DESCRIPTION
Because hiera-puppet is now merged into 3.x, the debian and redhat packages
that used to depend upon hiera-puppet now provide hiera-puppet and should
uninstall/remove hiera-puppet upon upgrade. This commit adds the new
hiera-puppet binary to the packaging (extlookup2hiera) and also adds the
appropriate packaging directives to remove hiera-puppet packages before
installing.
