### PR TITLE
(#16376) Fix rails compatibility layer for activerecord < 3.0

### DIFF
--- a/lib/puppet/rails/inventory_node.rb
+++ b/lib/puppet/rails/inventory_node.rb
@@ -4,23 +4,36 @@ class Puppet::Rails::InventoryNode < ::ActiveRecord::Base
   has_many :facts, :class_name => "Puppet::Rails::InventoryFact", :foreign_key => :node_id, :dependent => :delete_all
 
   if Puppet::Util.activerecord_version < 3.0
-    # For backward compatibility, add the newer name to older implementations.
-    ActiveRecord::NamedScope::ClassMethods.module_eval { alias :scope :named_scope }
+    # For backward compatibility, use the old named_scope with pre 3.0 activerecord
+    named_scope :has_fact_with_value, lambda { |name,value|
+      {
+        :conditions => ["inventory_facts.name = ? AND inventory_facts.value = ?", name, value.to_s],
+        :joins => :facts
+      }
+    }
+
+    named_scope :has_fact_without_value, lambda { |name,value|
+      {
+        :conditions => ["inventory_facts.name = ? AND inventory_facts.value != ?", name, value.to_s],
+        :joins => :facts
+      }
+    }
+  else
+    # Use scope for activerecord >= 3.0
+    scope :has_fact_with_value, lambda { |name,value|
+      {
+        :conditions => ["inventory_facts.name = ? AND inventory_facts.value = ?", name, value.to_s],
+        :joins => :facts
+      }
+    }
+
+    scope :has_fact_without_value, lambda { |name,value|
+      {
+        :conditions => ["inventory_facts.name = ? AND inventory_facts.value != ?", name, value.to_s],
+        :joins => :facts
+      }
+    }
   end
-
-  scope :has_fact_with_value, lambda { |name,value|
-    {
-      :conditions => ["inventory_facts.name = ? AND inventory_facts.value = ?", name, value.to_s],
-      :joins => :facts
-    }
-  }
-
-  scope :has_fact_without_value, lambda { |name,value|
-    {
-      :conditions => ["inventory_facts.name = ? AND inventory_facts.value != ?", name, value.to_s],
-      :joins => :facts
-    }
-  }
 
   def facts_to_hash
     facts.inject({}) do |fact_hash,fact|


### PR DESCRIPTION
Previously an alias was attempted between scope and named_scope to allow older
activerecord versions (< 3.0) to work with the inventory service while also
supporting modern activerecord. The scope alias failed because
Puppet::Rails::InventoryNode inherits from ActiveRecord::Base, which has a
scope method already. So activerecord's scope method is found instead of the
intended alias target. This commit removes the alias and simply switches on
activerecord version to use the correct scope (AR >= 3.0) or named_scope (AR <
3.0) method.
