### PR TITLE
(acceptance) refactor cron tests

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -1,0 +1,21 @@
+module Puppet
+  module Acceptance
+    module CronUtils
+      def clean(agent, o={})
+        o = {:user => 'tstuser'}.merge(o)
+        run_cron_on(agent, :remove, o[:user])
+        apply_manifest_on(agent, %[user { '%s': ensure => absent, managehome => false }] % o[:user])
+      end
+
+      def setup(agent, o={})
+        o = {:user => 'tstuser'}.merge(o)
+        apply_manifest_on(agent, %[user { '%s': ensure => present, managehome => false }] % o[:user])
+        apply_manifest_on(agent, %[case $operatingsystem {
+                                     centos, redhat: {$cron = 'cronie'}
+                                     solaris: { $cron = 'core-os' }
+                                     default: {$cron ='cron'} }
+                                     package {'cron': name=> $cron, ensure=>present, }])
+      end
+    end
+  end
+end

--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -1,0 +1,66 @@
+test_name "Cron: should allow changing parameters after creation"
+confine :except, :platform => 'windows'
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CronUtils
+
+teardown do
+  step "Cron: cleanup"
+  agents.each do |agent|
+    clean agent
+  end
+end
+
+
+agents.each do |agent|
+  step "ensure the user exist via puppet"
+  setup agent
+
+  step "Cron: basic - verify that it can be created"
+  apply_manifest_on(agent, 'cron { "myjob": command => "/bin/false", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present,}') do
+    assert_match( /ensure: created/, result.stdout, "err: #{agent}")
+  end
+  run_cron_on(agent,:list,'tstuser') do
+    assert_match(/.bin.false/, result.stdout, "err: #{agent}")
+  end
+
+  step "Cron: allow changing command"
+  apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present,}') do
+    assert_match(/command changed '.bin.false' to '.bin.true'/, result.stdout, "err: #{agent}")
+  end
+  run_cron_on(agent,:list,'tstuser') do
+    assert_match(/1 . . . . .bin.true/, result.stdout, "err: #{agent}")
+  end
+
+  step "Cron: allow changing time"
+  apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "1", minute  => [1], ensure  => present,}') do
+    assert_match(/hour: defined 'hour' as '1'/, result.stdout, "err: #{agent}")
+  end
+  run_cron_on(agent,:list,'tstuser') do
+    assert_match(/1 1 . . . .bin.true/, result.stdout, "err: #{agent}")
+  end
+
+  step "Cron: allow changing time(array)"
+  apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => ["1","2"], minute  => [1], ensure  => present,}') do
+    assert_match(/hour: hour changed '1' to '1,2'/, result.stdout, "err: #{agent}")
+  end
+  run_cron_on(agent,:list,'tstuser') do
+    assert_match(/1 1,2 . . . .bin.true/, result.stdout, "err: #{agent}")
+  end
+
+  step "Cron: allow changing time(array modification)"
+  apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => ["3","2"], minute  => [1], ensure  => present,}') do
+    assert_match(/hour: hour changed '1,2' to '3,2'/, result.stdout, "err: #{agent}")
+  end
+  run_cron_on(agent,:list,'tstuser') do
+    assert_match(/1 3,2 . . . .bin.true/, result.stdout, "err: #{agent}")
+  end
+  step "Cron: allow changing time(array modification to *)"
+  apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => "*", ensure  => present,}') do
+    assert_match(/minute: undefined 'minute' from '1'/,result.stdout, "err: #{agent}")
+    assert_match(/hour: undefined 'hour' from '3,2'/,result.stdout, "err: #{agent}")
+  end
+  run_cron_on(agent,:list,'tstuser') do
+    assert_match(/\* \* . . . .bin.true/, result.stdout, "err: #{agent}")
+  end
+
+end

--- a/acceptance/tests/resource/cron/should_be_idempotent.rb
+++ b/acceptance/tests/resource/cron/should_be_idempotent.rb
@@ -1,0 +1,31 @@
+test_name "Cron: check idempotency"
+confine :except, :platform => 'windows'
+
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CronUtils
+
+teardown do
+  step "Cron: cleanup"
+  agents.each do |agent|
+    clean agent
+  end
+end
+
+
+agents.each do |agent|
+  step "ensure the user exist via puppet"
+  setup agent
+
+  step "Cron: basic - verify that it can be created"
+  apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present,}') do
+    assert_match( /ensure: created/, result.stdout, "err: #{agent}")
+  end
+  run_cron_on(agent,:list,'tstuser') do
+    assert_match(/. . . . . .bin.true/, result.stdout, "err: #{agent}")
+  end
+
+  step "Cron: basic - should not create again"
+  apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present,}') do
+    assert_no_match( /ensure: created/, result.stdout, "err: #{agent}")
+  end
+end

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -1,33 +1,29 @@
 test_name "should create cron"
 confine :except, :platform => 'windows'
 
-tmpuser = "pl#{rand(999999).to_i}"
-tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CronUtils
 
-create_user = "user { '#{tmpuser}': ensure => present, managehome => false }"
-delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
-
-package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
+teardown do
+  step "Cron: cleanup"
+  agents.each do |agent|
+    clean agent
+  end
+end
 
 agents.each do |host|
     step "ensure the user exist via puppet"
-    apply_manifest_on host, create_user
-    apply_manifest_on host, package_cron
+    setup host
 
     step "apply the resource on the host using puppet resource"
-    on(host, puppet_resource("cron", "crontest", "user=#{tmpuser}",
+    on(host, puppet_resource("cron", "crontest", "user=tstuser",
                   "command=/bin/true", "ensure=present")) do
-      assert_match(/created/, stdout, "Did not create crontab for #{tmpuser} on #{host}")
+      assert_match(/created/, stdout, "Did not create crontab for tstuser on #{host}")
     end
 
     step "verify that crontab -l contains what you expected"
-    run_cron_on(host, :list, tmpuser) do
-      assert_match(/\* \* \* \* \* \/bin\/true/, stdout, "Incorrect crontab for #{tmpuser} on #{host}")
+    run_cron_on(host, :list, 'tstuser') do
+      assert_match(/\* \* \* \* \* \/bin\/true/, stdout, "Incorrect crontab for tstuser on #{host}")
     end
 
-    step "remove the crontab file for that user"
-    run_cron_on(host, :remove, tmpuser)
-
-    step "remove the user from the system"
-    apply_manifest_on host, delete_user
 end

--- a/acceptance/tests/resource/cron/should_match_existing.rb
+++ b/acceptance/tests/resource/cron/should_match_existing.rb
@@ -1,36 +1,24 @@
 test_name "puppet should match existing job"
 confine :except, :platform => 'windows'
 
-tmpuser = "pl#{rand(999999).to_i}"
-tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
-
-create_user = "user { '#{tmpuser}': ensure => present, managehome => false }"
-delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
-
-package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CronUtils
 
 agents.each do |host|
     step "ensure the user exist via puppet"
-    apply_manifest_on host, create_user
-    apply_manifest_on host, package_cron
+    setup host
 
     step "Create the existing cron job by hand..."
-    run_cron_on(host,:add,tmpuser,"* * * * * /bin/true")
+    run_cron_on(host,:add,'tstuser',"* * * * * /bin/true")
 
     step "Apply the resource on the host using puppet resource"
-    on(host, puppet_resource("cron", "crontest", "user=#{tmpuser}",
+    on(host, puppet_resource("cron", "crontest", "user=tstuser",
                   "command=/bin/true", "ensure=present")) do
-      assert_match(/present/, stdout, "Failed creating crontab for #{tmpuser} on #{host}")
+      assert_match(/present/, stdout, "Failed creating crontab for tstuser on #{host}")
     end
 
     step "Verify that crontab -l contains what you expected"
-    run_cron_on(host, :list, tmpuser) do
-      assert_match(/\* \* \* \* \* \/bin\/true/, stdout, "Did not find crontab for #{tmpuser} on #{host}")
+    run_cron_on(host, :list, 'tstuser') do
+      assert_match(/\* \* \* \* \* \/bin\/true/, stdout, "Did not find crontab for tstuser on #{host}")
     end
-
-    step "remove the crontab file for that user"
-    run_cron_on(host, :remove, tmpuser)
-
-    step "remove the user from the system"
-    apply_manifest_on host, delete_user
 end

--- a/acceptance/tests/resource/cron/should_not_rewrite_with_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_not_rewrite_with_trailing_whitespace.rb
@@ -1,36 +1,25 @@
 test_name "should not rewrite if the job has trailing whitespace"
 confine :except, :platform => 'windows'
 
-tmpuser = "pl#{rand(999999).to_i}"
-tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
-
-create_user = "user { '#{tmpuser}': ensure => present, managehome => false }"
-delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CronUtils
 
 agents.each do |host|
   step "ensure the user exist via puppet"
-  apply_manifest_on host, create_user
+  setup host
 
   step "apply the resource on the host using puppet resource"
-  on(host, puppet_resource("cron", "crontest", "user=#{tmpuser}",
-                           "command='date > /dev/null    '", "ensure=present")) do
-    assert_match(/created/, stdout, "Did not create crontab for #{tmpuser} on #{host}")
+  on(host, puppet_resource("cron", "crontest", "user=tstuser", "command='date > /dev/null    '", "ensure=present")) do
+    assert_match(/created/, stdout, "Did not create crontab for tstuser on #{host}")
   end
 
   step "verify that crontab -l contains what you expected"
-  run_cron_on(host, :list, tmpuser) do
-    assert_match(/\* \* \* \* \* date > .dev.null    /, stdout, "Incorrect crontab for #{tmpuser} on #{host}")
+  run_cron_on(host, :list, 'tstuser') do
+    assert_match(/\* \* \* \* \* date > .dev.null    /, stdout, "Incorrect crontab for tstuser on #{host}")
   end
 
   step "apply the resource again on the host using puppet resource and check nothing happened"
-  on(host, puppet_resource("cron", "crontest", "user=#{tmpuser}",
-                           "command='date > /dev/null    '", "ensure=present")) do
-    assert_no_match(/ensure: created/, stdout, "Rewrote the line with trailing space in crontab for #{tmpuser} on #{host}")
+  on(host, puppet_resource("cron", "crontest", "user=tstuser", "command='date > /dev/null'", "ensure=present")) do
+    assert_no_match(/ensure: created/, stdout, "Rewrote the line with trailing space in crontab for tstuser on #{host}")
   end
-
-  step "remove the crontab file for that user"
-  run_cron_on(host, :remove, tmpuser)
-
-  step "remove the user from the system"
-  apply_manifest_on host, delete_user
 end

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -1,36 +1,25 @@
 test_name "puppet should remove a crontab entry as expected"
 confine :except, :platform => 'windows'
 
-tmpuser = "pl#{rand(999999).to_i}"
-tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
-
-create_user = "user { '#{tmpuser}': ensure => present, managehome => false }"
-delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
-
-package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CronUtils
 
 agents.each do |host|
     step "ensure the user exist via puppet"
-    apply_manifest_on host, create_user
-    apply_manifest_on host, package_cron
+    setup host
 
     step "create the existing job by hand..."
-    run_cron_on(host,:add,tmpuser,"* * * * * /bin/true")
+    run_cron_on(host,:add,'tstuser',"* * * * * /bin/true")
 
     step "apply the resource on the host using puppet resource"
-    on(host, puppet_resource("cron", "crontest", "user=#{tmpuser}",
+    on(host, puppet_resource("cron", "crontest", "user=tstuser",
                   "command=/bin/true", "ensure=absent")) do
-      assert_match(/crontest\D+ensure:\s+removed/, stdout, "Didn't remove crobtab entry for #{tmpuser} on #{host}")
+      assert_match(/crontest\D+ensure:\s+removed/, stdout, "Didn't remove crobtab entry for tstuser on #{host}")
     end
 
     step "verify that crontab -l contains what you expected"
-    run_cron_on(host, :list, tmpuser) do
-      assert_no_match(/\/bin\/true/, stderr, "Error: Found entry for #{tmpuser} on #{host}")
+    run_cron_on(host, :list, 'tstuser') do
+      assert_no_match(/\/bin\/true/, stderr, "Error: Found entry for tstuser on #{host}")
     end
 
-    step "remove the crontab file for that user"
-    run_cron_on(host, :remove, tmpuser)
-
-    step "remove the user from the system"
-    apply_manifest_on host, delete_user
 end

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -1,39 +1,28 @@
 test_name "puppet should remove a crontab entry based on command matching"
 confine :except, :platform => 'windows'
 
-tmpuser = "pl#{rand(999999).to_i}"
-tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CronUtils
 
 cron = '# Puppet Name: crontest\n* * * * * /bin/true\n1 1 1 1 1 /bin/true\n'
 
-create_user = "user { '#{tmpuser}': ensure => present, managehome => false }"
-delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
-
-package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
-
 agents.each do |host|
     step "ensure the user exist via puppet"
-    apply_manifest_on host, create_user
-    apply_manifest_on host, package_cron
+    setup host
 
     step "create the existing job by hand..."
-    run_cron_on(host,:add,tmpuser,"* * * * * /bin/true")
+    run_cron_on(host,:add,'tstuser',"* * * * * /bin/true")
 
     step "Remove cron resource"
-    on(host, puppet_resource("cron", "bogus", "user=#{tmpuser}",
+    on(host, puppet_resource("cron", "bogus", "user=tstuser",
                   "command=/bin/true", "ensure=absent")) do
-      assert_match(/bogus\D+ensure: removed/, stdout, "Removing cron entry failed for #{tmpuser} on #{host}")
+      assert_match(/bogus\D+ensure: removed/, stdout, "Removing cron entry failed for tstuser on #{host}")
     end
 
     step "verify that crontab -l contains what you expected"
-    run_cron_on(host,:list,tmpuser) do
+    run_cron_on(host,:list,'tstuser') do
         count = stdout.scan("/bin/true").length
         fail_test "found /bin/true the wrong number of times (#{count})" unless count == 0
     end
 
-    step "remove the crontab file for that user"
-    run_cron_on(host,:remove,tmpuser)
-
-    step "remove the user from the system"
-    apply_manifest_on host, delete_user
 end

--- a/acceptance/tests/resource/cron/should_update_existing.rb
+++ b/acceptance/tests/resource/cron/should_update_existing.rb
@@ -1,41 +1,28 @@
 test_name "puppet should update existing crontab entry"
 confine :except, :platform => 'windows'
 
-tmpuser = "pl#{rand(999999).to_i}"
-tmpfile = "/tmp/cron-test-#{Time.new.to_i}"
-
-create_user = "user { '#{tmpuser}': ensure => present, managehome => false }"
-delete_user = "user { '#{tmpuser}': ensure => absent,  managehome => false }"
-
-package_cron = "case $operatingsystem { centos, redhat: {$cron = 'cronie'}\n default: {$cron ='cron'} } package {'cron': name=> $cron, ensure=>present, }"
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CronUtils
 
 agents.each do |host|
     step "ensure the user exist via puppet"
-    apply_manifest_on host, create_user
-    apply_manifest_on host, package_cron
+    setup host
 
     step "create the existing job by hand..."
-    run_cron_on(host,:add,tmpuser,"* * * * * /bin/true")
+    run_cron_on(host,:add,'tstuser',"* * * * * /bin/true")
 
     step "verify that crontab -l contains what you expected"
-    run_cron_on(host,:list,tmpuser) do
-      assert_match(/\* \* \* \* \* \/bin\/true/, stdout, "Didn't find correct crobtab entry for #{tmpuser} on #{host}")
+    run_cron_on(host,:list,'tstuser') do
+      assert_match(/\* \* \* \* \* \/bin\/true/, stdout, "Didn't find correct crobtab entry for tstuser on #{host}")
     end
 
     step "apply the resource change on the host"
-    on(host, puppet_resource("cron", "crontest", "user=#{tmpuser}",
-      "command=/bin/true", "ensure=present", "hour='0-6'")) do
-        assert_match(/hour\s+=>\s+\['0-6'\]/, stdout, "Modifying cron entry failed for #{tmpuser} on #{host}")
+    on(host, puppet_resource("cron", "crontest", "user=tstuser", "command=/bin/true", "ensure=present", "hour='0-6'")) do
+        assert_match(/hour\s+=>\s+\['0-6'\]/, stdout, "Modifying cron entry failed for tstuser on #{host}")
     end
 
     step "verify that crontab -l contains what you expected"
-    run_cron_on(host,:list,tmpuser) do
-      assert_match(/\* 0-6 \* \* \* \/bin\/true/, stdout, "Didn't find correctly modified time entry in crobtab entry for #{tmpuser} on #{host}")
+    run_cron_on(host,:list,tstuser) do
+      assert_match(/\* 0-6 \* \* \* \/bin\/true/, stdout, "Didn't find correctly modified time entry in crobtab entry for tstuser on #{host}")
     end
-
-    step "remove the crontab file for that user"
-    run_cron_on(host,:remove,tmpuser)
-
-    step "remove the user from the system"
-    apply_manifest_on host, delete_user
 end


### PR DESCRIPTION
This patch refactors the cron tests and moves the common code to common_utils. This also
adds test cases that checks for idempotence and array handling
