### PR TITLE
(#16239) mock of facter :operatingsystem pending

### DIFF
--- a/spec/integration/provider/mount_spec.rb
+++ b/spec/integration/provider/mount_spec.rb
@@ -21,6 +21,7 @@ describe "mount provider (integration)", :unless => Puppet.features.microsoft_wi
     @current_device = "/dev/disk1s1"
     Puppet::Type.type(:mount).defaultprovider.stubs(:default_target).returns(@fake_fstab)
     Facter.stubs(:value).with(:operatingsystem).returns('Darwin')
+    Facter.stubs(:value).with(:osfamily).returns('Darwin')
     Puppet::Util::ExecutionStub.set do |command, options|
       case command[0]
       when %r{/s?bin/mount}
@@ -109,7 +110,7 @@ describe "mount provider (integration)", :unless => Puppet.features.microsoft_wi
               ["local", "journaled"].each do |options_setting|
                 describe "When setting options => #{options_setting}" do
                   it "should leave the system in the #{expected_final_state ? 'mounted' : 'unmounted'} state, #{expected_fstab_data ? 'with' : 'without'} data in /etc/fstab" do
-                    pending("Solaris: The mock :operatingsystem value does not get changed in lib/puppet/provider/mount/parsed.rb", family == "Solaris")
+                    pending("Solaris: The mock :operatingsystem value does not get changed in lib/puppet/provider/mount/parsed.rb", :if => family == "Solaris")
                     @desired_options = options_setting
                     run_in_catalog(:ensure=>ensure_setting, :options => options_setting)
                     @mounted.should == expected_final_state


### PR DESCRIPTION
Previous commit at 45e165016534b6c786d269a7825e72599c9beaa6 was missing the hash key :if while defining pending. This checkin corrects that mistake.
