### PR TITLE
(packaging) adds ips support for shipping and signing

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -18,4 +18,6 @@ build_dmg: TRUE
 apt_host: 'burji.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
 apt_repo_path: '/opt/repository/incoming'
-ips_repo: 'file:///opt/repository/ips'
+ips_repo: '/var/pkgrepo'
+ips_store: '/opt/repository'
+ips_host: 'solaris-11-ips-repo.acctest.dc1.puppetlabs.net'


### PR DESCRIPTION
This patch is complementary to the patch that adds shipping and signing support
for IPS to the packaging repo. It adds the variables ips_repo, ips_store, ips_host
