### PR TITLE
(#16425) ensure that first time install of speciifc version works

### DIFF
--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -122,7 +122,9 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     unless should.is_a? Symbol
       name += "@#{should}"
       is = self.query
-      self.uninstall if Puppet::Util::Package.versioncmp(should, is[:ensure]) < 0
+      unless is[:ensure].to_sym == :absent
+        self.uninstall if Puppet::Util::Package.versioncmp(should, is[:ensure]) < 0
+      end
     end
     r = exec_cmd(command(:pkg), 'install', '--accept', name)
     return r if nofail

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -205,6 +205,13 @@ describe Puppet::Type.type(:package).provider(:pkg) do
         $CHILD_STATUS.stubs(:exitstatus).returns 0
         provider.install
       end
+      it "should install if no version was previously installed, and a specific version was requested" do
+        resource[:ensure] = '0.0.7'
+        provider.expects(:query).with().returns({:ensure => :absent})
+        Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'install', '--accept', 'dummy@0.0.7'], {:failonfail => false, :combine => true}).returns ''
+        $CHILD_STATUS.stubs(:exitstatus).returns 0
+        provider.install
+      end
 
     end
 


### PR DESCRIPTION
Previously if a specific version was requested, and it was the first time, the package installation
errored out due to passing the current version :absent to version compare. This patch verifies that
we do not pass absent to version compare if we know it is absent in the system currently.
