### PR TITLE
(#4680) Reject CA network operations when master CA is disabled

### DIFF
--- a/lib/puppet/indirector/certificate/disabled_ca.rb
+++ b/lib/puppet/indirector/certificate/disabled_ca.rb
@@ -1,0 +1,22 @@
+require 'puppet/indirector/code'
+require 'puppet/ssl/certificate'
+
+class Puppet::SSL::Certificate::DisabledCa < Puppet::Indirector::Code
+  desc "Manage SSL certificates on disk, but reject any remote access
+to the SSL data store.  Used when a master has an explicitly disabled
+CA to prevent clients getting confusing 'success' behaviour."
+
+  def initialize
+    @file = Puppet::SSL::Certificate.indirection.terminus(:file)
+  end
+
+  [:find, :head, :search, :save, :destroy].each do |name|
+    define_method(name) do |request|
+      if request.remote?
+        raise Puppet::Error, "this master is not a CA"
+      else
+        @file.send(name, request)
+      end
+    end
+  end
+end

--- a/lib/puppet/indirector/certificate_request/disabled_ca.rb
+++ b/lib/puppet/indirector/certificate_request/disabled_ca.rb
@@ -1,0 +1,22 @@
+require 'puppet/indirector/code'
+require 'puppet/ssl/certificate_request'
+
+class Puppet::SSL::CertificateRequest::DisabledCa < Puppet::Indirector::Code
+  desc "Manage SSL certificate requests on disk, but reject any remote access
+to the SSL data store. Used when a master has an explicitly disabled CA to
+prevent clients getting confusing 'success' behaviour."
+
+  def initialize
+    @file = Puppet::SSL::CertificateRequest.indirection.terminus(:file)
+  end
+
+  [:find, :head, :search, :save, :destroy].each do |name|
+    define_method(name) do |request|
+      if request.remote?
+        raise Puppet::Error, "this master is not a CA"
+      else
+        @file.send(name, request)
+      end
+    end
+  end
+end

--- a/lib/puppet/indirector/certificate_revocation_list/disabled_ca.rb
+++ b/lib/puppet/indirector/certificate_revocation_list/disabled_ca.rb
@@ -1,0 +1,22 @@
+require 'puppet/indirector/code'
+require 'puppet/ssl/certificate_revocation_list'
+
+class Puppet::SSL::CertificateRevocationList::DisabledCa < Puppet::Indirector::Code
+  desc "Manage SSL certificate revocation lists, but reject any remote access
+to the SSL data store. Used when a master has an explicitly disabled CA to
+prevent clients getting confusing 'success' behaviour."
+
+  def initialize
+    @file = Puppet::SSL::CertificateRevocationList.indirection.terminus(:file)
+  end
+
+  [:find, :head, :search, :save, :destroy].each do |name|
+    define_method(name) do |request|
+      if request.remote?
+        raise Puppet::Error, "this master is not a CA"
+      else
+        @file.send(name, request)
+      end
+    end
+  end
+end

--- a/lib/puppet/indirector/key/disabled_ca.rb
+++ b/lib/puppet/indirector/key/disabled_ca.rb
@@ -1,0 +1,22 @@
+require 'puppet/indirector/code'
+require 'puppet/ssl/key'
+
+class Puppet::SSL::Key::DisabledCa < Puppet::Indirector::Code
+  desc "Manage the CA private key, but reject any remote access
+to the SSL data store. Used when a master has an explicitly disabled CA to
+prevent clients getting confusing 'success' behaviour."
+
+  def initialize
+    @file = Puppet::SSL::Key.indirection.terminus(:file)
+  end
+
+  [:find, :head, :search, :save, :destroy].each do |name|
+    define_method(name) do |request|
+      if request.remote?
+        raise Puppet::Error, "this master is not a CA"
+      else
+        @file.send(name, request)
+      end
+    end
+  end
+end

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -150,6 +150,10 @@ class Puppet::Indirector::Request
     return(uri ? uri : "/#{indirection_name}/#{key}")
   end
 
+  def remote?
+    self.node or self.ip
+  end
+
   private
 
   def set_attributes(options)

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -54,7 +54,7 @@ class Puppet::SSL::Host
     CertificateRequest.indirection.terminus_class = terminus
     CertificateRevocationList.indirection.terminus_class = terminus
 
-    host_map = {:ca => :file, :file => nil, :rest => :rest}
+    host_map = {:ca => :file, :disabled_ca => nil, :file => nil, :rest => :rest}
     if term = host_map[terminus]
       self.indirection.terminus_class = term
     else
@@ -94,7 +94,7 @@ class Puppet::SSL::Host
     # We are the CA, so we don't have read/write access to the normal certificates.
     :only => [:ca],
     # We have no CA, so we just look in the local file store.
-    :none => [:file]
+    :none => [:disabled_ca]
   }
 
   # Specify how we expect to interact with our certificate authority.

--- a/spec/unit/indirector/certificate/disabled_ca_spec.rb
+++ b/spec/unit/indirector/certificate/disabled_ca_spec.rb
@@ -1,0 +1,33 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'puppet/indirector/certificate/disabled_ca'
+
+describe Puppet::SSL::Certificate::DisabledCa do
+  def request(type, remote)
+    r = Puppet::Indirector::Request.new(:certificate, type, "foo.com", nil)
+    if remote
+      r.ip   = '10.0.0.1'
+      r.node = 'agent.example.com'
+    end
+    r
+  end
+
+  context "when not a CA" do
+    before :each do
+      Puppet[:ca] = false
+      Puppet::SSL::Host.ca_location = :none
+    end
+
+    [:find, :head, :search, :save, :destroy].each do |name|
+      it "should fail remote #{name} requests" do
+        expect { subject.send(name, request(name, true)) }.
+          to raise_error Puppet::Error, /is not a CA/
+      end
+
+      it "should forward local #{name} requests" do
+        Puppet::SSL::Certificate.indirection.terminus(:file).expects(name)
+        subject.send(name, request(name, false))
+      end
+    end
+  end
+end

--- a/spec/unit/indirector/certificate_request/disabled_ca_spec.rb
+++ b/spec/unit/indirector/certificate_request/disabled_ca_spec.rb
@@ -1,0 +1,33 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'puppet/indirector/certificate_request/disabled_ca'
+
+describe Puppet::SSL::CertificateRequest::DisabledCa do
+  def request(type, remote)
+    r = Puppet::Indirector::Request.new(:certificate_request, type, "foo.com", nil)
+    if remote
+      r.ip   = '10.0.0.1'
+      r.node = 'agent.example.com'
+    end
+    r
+  end
+
+  context "when not a CA" do
+    before :each do
+      Puppet[:ca] = false
+      Puppet::SSL::Host.ca_location = :none
+    end
+
+    [:find, :head, :search, :save, :destroy].each do |name|
+      it "should fail remote #{name} requests" do
+        expect { subject.send(name, request(name, true)) }.
+          to raise_error Puppet::Error, /is not a CA/
+      end
+
+      it "should forward local #{name} requests" do
+        Puppet::SSL::CertificateRequest.indirection.terminus(:file).expects(name)
+        subject.send(name, request(name, false))
+      end
+    end
+  end
+end

--- a/spec/unit/indirector/certificate_revocation_list/disabled_ca_spec.rb
+++ b/spec/unit/indirector/certificate_revocation_list/disabled_ca_spec.rb
@@ -1,0 +1,33 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'puppet/indirector/certificate_revocation_list/disabled_ca'
+
+describe Puppet::SSL::CertificateRevocationList::DisabledCa do
+  def request(type, remote)
+    r = Puppet::Indirector::Request.new(:certificate_revocation_list, type, "foo.com", nil)
+    if remote
+      r.ip   = '10.0.0.1'
+      r.node = 'agent.example.com'
+    end
+    r
+  end
+
+  context "when not a CA" do
+    before :each do
+      Puppet[:ca] = false
+      Puppet::SSL::Host.ca_location = :none
+    end
+
+    [:find, :head, :search, :save, :destroy].each do |name|
+      it "should fail remote #{name} requests" do
+        expect { subject.send(name, request(name, true)) }.
+          to raise_error Puppet::Error, /is not a CA/
+      end
+
+      it "should forward local #{name} requests" do
+        Puppet::SSL::CertificateRevocationList.indirection.terminus(:file).expects(name)
+        subject.send(name, request(name, false))
+      end
+    end
+  end
+end

--- a/spec/unit/indirector/key/disabled_ca_spec.rb
+++ b/spec/unit/indirector/key/disabled_ca_spec.rb
@@ -1,0 +1,33 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'puppet/indirector/key/disabled_ca'
+
+describe Puppet::SSL::Key::DisabledCa do
+  def request(type, remote)
+    r = Puppet::Indirector::Request.new(:key, type, "foo.com", nil)
+    if remote
+      r.ip   = '10.0.0.1'
+      r.node = 'agent.example.com'
+    end
+    r
+  end
+
+  context "when not a CA" do
+    before :each do
+      Puppet[:ca] = false
+      Puppet::SSL::Host.ca_location = :none
+    end
+
+    [:find, :head, :search, :save, :destroy].each do |name|
+      it "should fail remote #{name} requests" do
+        expect { subject.send(name, request(name, true)) }.
+          to raise_error Puppet::Error, /is not a CA/
+      end
+
+      it "should forward local #{name} requests" do
+        Puppet::SSL::Key.indirection.terminus(:file).expects(name)
+        subject.send(name, request(name, false))
+      end
+    end
+  end
+end

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -311,4 +311,26 @@ describe Puppet::Indirector::Request do
       lambda { @request.query_string }.should raise_error(ArgumentError)
     end
   end
+
+  describe "#remote?" do
+    def request(options = {})
+      Puppet::Indirector::Request.new('node', 'find', 'localhost', options)
+    end
+
+    it "should not be unless node or ip is set" do
+      request.should_not be_remote
+    end
+
+    it "should be remote if node is set" do
+      request(:node => 'example.com').should be_remote
+    end
+
+    it "should be remote if ip is set" do
+      request(:ip => '127.0.0.1').should be_remote
+    end
+
+    it "should be remote if node and ip are set" do
+      request(:node => 'example.com', :ip => '127.0.0.1').should be_remote
+    end
+  end
 end

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -328,10 +328,10 @@ describe Puppet::SSL::Host do
       end
 
       it "should set the terminus class for Key, Certificate, CertificateRevocationList, and CertificateRequest as :file" do
-        Puppet::SSL::Key.indirection.terminus_class.should == :file
-        Puppet::SSL::Certificate.indirection.terminus_class.should == :file
-        Puppet::SSL::CertificateRequest.indirection.terminus_class.should == :file
-        Puppet::SSL::CertificateRevocationList.indirection.terminus_class.should == :file
+        Puppet::SSL::Key.indirection.terminus_class.should == :disabled_ca
+        Puppet::SSL::Certificate.indirection.terminus_class.should == :disabled_ca
+        Puppet::SSL::CertificateRequest.indirection.terminus_class.should == :disabled_ca
+        Puppet::SSL::CertificateRevocationList.indirection.terminus_class.should == :disabled_ca
       end
 
       it "should set the terminus class for Host to 'none'" do


### PR DESCRIPTION
When the master has CA function explicitly disabled, it would still respond to
networked REST requests. They accessed the local certificate store and,
generally, provided quite unexpected results.

For example, if a CSR was submitted it would be accepted successfully and
ignored; no further action, despite the fact that the master would never do
anything with it, and it could not be acted on.

Now, instead, we explicitly fail for remote requests.  This delivers a clear,
unambiguous error message to the agent and stops them functioning - a much
better outcome overall.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
