### PR TITLE
Update debian ruby dependencies to include 1.9

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -3,18 +3,17 @@ Section: admin
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
 Uploaders: Micah Anderson <micah@debian.org>, Andrew Pollock <apollock@debian.org>, Nigel Kersten <nigel@explanatorygap.net>, Stig Sandbeck Mathisen <ssm@debian.org>
-Build-Depends-Indep: ruby (>= 1.8.5), libopenssl-ruby, facter (>= 1.6.11)
+Build-Depends-Indep: ruby | ruby-interpreter, libopenssl-ruby, facter (>= 1.6.12)
 Build-Depends: debhelper (>= 7.0.0), openssl
 Standards-Version: 3.9.1
-Vcs-Git: git://git.debian.org/git/pkg-puppet/puppet.git
-Vcs-Browser: http://git.debian.org/?p=pkg-puppet/puppet.git
+Vcs-Git: git://github.com/puppetlabs/puppet
 Homepage: http://projects.puppetlabs.com/projects/puppet
 
 Package: puppet-common
 Architecture: all
-Depends: ${misc:Depends}, ruby1.8, libxmlrpc-ruby, libopenssl-ruby, libshadow-ruby1.8, libaugeas-ruby1.8, adduser, facter (>= 1.6.11), lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0)
+Depends: ${misc:Depends}, ruby | ruby-interpreter, libxmlrpc-ruby, libopenssl-ruby, libshadow-ruby1.8 | ruby-shadow , libaugeas-ruby1.8 | libaugeas-ruby1.9, adduser, lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0), facter (>= 1.6.12)
 Recommends: lsb-release, debconf-utils
-Suggests: libselinux-ruby1.8, librrd-ruby1.8
+Suggests: libselinux-ruby1.8 | ruby-selinux, librrd-ruby1.8 | librrd-ruby1.9
 Breaks: puppet (<< 2.6.0~rc2-1), puppetmaster (<< 0.25.4-1)
 Provides: hiera-puppet
 Conflicts: hiera-puppet
@@ -37,7 +36,7 @@ Description: Centralized configuration management
 
 Package: puppet
 Architecture: all
-Depends: ${misc:Depends},  puppet-common (= ${binary:Version}), ruby1.8
+Depends: ${misc:Depends},  puppet-common (= ${binary:Version}), ruby | ruby-interpreter
 Recommends: rdoc
 Suggests: puppet-el, vim-puppet
 Description: Centralized configuration management - agent startup and compatibility scripts
@@ -57,11 +56,11 @@ Description: Centralized configuration management - agent startup and compatibil
 
 Package: puppetmaster-common
 Architecture: all
-Depends: ${misc:Depends}, ruby1.8, puppet-common (= ${binary:Version}), facter (>= 1.6.11), lsb-base
+Depends: ${misc:Depends}, ruby | ruby-interpreter, puppet-common (= ${binary:Version}), facter (>= 1.6.12), lsb-base
 Breaks: puppet (<< 0.24.7-1), puppetmaster (<< 2.6.1~rc2-1)
 Replaces: puppetmaster (<< 2.6.1~rc2-1)
-Suggests: apache2 | nginx, mongrel, puppet-el, vim-puppet, stompserver, libstomp-ruby1.8,
- rails (>= 1.2.3-2) | ruby-activerecord | libactiverecord-ruby, rdoc, libldap-ruby1.8
+Suggests: apache2 | nginx, puppet-el, vim-puppet, stompserver, ruby-stomp | libstomp-ruby1.8,
+ rdoc, ruby-ldap | libldap-ruby1.8, puppetdb-terminus
 Description: Puppet master common scripts
  This package contains common scripts for the puppet master, 
  which is the server hosting manifests and files for the puppet nodes.
@@ -79,10 +78,10 @@ Description: Puppet master common scripts
 
 Package: puppetmaster
 Architecture: all
-Depends: ${misc:Depends}, ruby1.8, puppetmaster-common (= ${source:Version}), facter (>= 1.6.11), lsb-base
+Depends: ${misc:Depends}, ruby | ruby-interpreter, puppetmaster-common (= ${source:Version}), facter (>= 1.6.12), lsb-base
 Breaks: puppet (<< 0.24.7-1)
-Suggests: apache2 | nginx, mongrel, puppet-el, vim-puppet, stompserver, libstomp-ruby1.8,
- rails (>= 1.2.3-2) | ruby-activerecord | libactiverecord-ruby, rdoc, libldap-ruby1.8
+Suggests: apache2 | nginx, puppet-el, vim-puppet, stompserver, libstomp-ruby1.8 | ruby-stomp,
+ rdoc, libldap-ruby1.8 | ruby-ldap, puppetdb-terminus
 Description: Centralized configuration management - master startup and compatibility scripts
  This package contains the startup and compatibility scripts for the puppet
  master, which is the server hosting manifests and files for the puppet nodes.
@@ -100,7 +99,7 @@ Description: Centralized configuration management - master startup and compatibi
 
 Package: puppetmaster-passenger
 Architecture: all
-Depends: ${misc:Depends}, ruby1.8, puppetmaster-common (= ${source:Version}), facter (>= 1.6.11), lsb-base, libapache2-mod-passenger
+Depends: ${misc:Depends}, ruby | ruby-interpreter, puppetmaster-common (= ${source:Version}), facter (>= 1.6.12), lsb-base, libapache2-mod-passenger
 Conflicts: puppetmaster (<< 2.6.1~rc2-1)
 Replaces: puppetmaster (<< 2.6.1~rc2-1)
 Description: Centralised configuration management - master setup to run under mod passenger
@@ -137,9 +136,8 @@ Description: syntax highlighting for puppet manifests in emacs
 
 Package: puppet-testsuite
 Architecture: all
-Depends: ${misc:Depends}, ruby1.8, puppet-common (= ${source:Version}), facter (>= 1.6.11), lsb-base, rails (>= 1.2.3-2), rdoc, libldap-ruby1.8, mongrel, librspec-ruby, git-core, libmocha-ruby1.8
+Depends: ${misc:Depends}, ruby | ruby-interpreter, puppet-common (= ${source:Version}), facter (>= 1.6.12), lsb-base, rails (>= 1.2.3-2), rdoc, libldap-ruby1.8 | ruby-ldap, librspec-ruby | ruby-rspec, git-core, libmocha-ruby1.8 | ruby-mocha
 Recommends: cron
-Suggests: ruby
 Description: Centralized configuration management - test suite
  This package provides all the tests from the upstream puppet source code.
  The tests are used for improving the QA of the puppet package.

--- a/ext/debian/puppet-common.dirs
+++ b/ext/debian/puppet-common.dirs
@@ -2,7 +2,7 @@ etc/puppet
 etc/puppet/manifests
 etc/puppet/templates
 etc/puppet/modules
-usr/lib/ruby/1.8
+usr/lib/ruby/vendor_ruby
 usr/share/puppet/ext
 var/lib/puppet
 var/log/puppet

--- a/ext/debian/puppet-common.install
+++ b/ext/debian/puppet-common.install
@@ -1,4 +1,4 @@
 debian/puppet.conf etc/puppet
 debian/tmp/usr/bin/puppet usr/bin
 debian/tmp/usr/bin/extlookup2hiera usr/bin
-debian/tmp/usr/lib/ruby/1.8/* usr/lib/ruby/1.8
+debian/tmp/usr/lib/ruby/vendor_ruby/* usr/lib/ruby/vendor_ruby

--- a/ext/debian/puppet-common.lintian-overrides
+++ b/ext/debian/puppet-common.lintian-overrides
@@ -3,5 +3,3 @@ puppet-common binary: manpage-has-bad-whatis-entry
 puppet-common binary: manpage-has-errors-from-man
 # These are "scripts" but do nothing other than providing documentation
 puppet-common: script-not-executable
-# Puppet-common depends on ruby1.8, so lintian may be confused
-puppet-common: ruby-script-but-no-ruby-dep

--- a/ext/debian/puppet.dirs
+++ b/ext/debian/puppet.dirs
@@ -1,1 +1,0 @@
-usr/sbin

--- a/ext/debian/puppetmaster.dirs
+++ b/ext/debian/puppetmaster.dirs
@@ -1,1 +1,0 @@
-usr/sbin

--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -7,11 +7,10 @@
 INSTALL=install -Dp
 
 prefix := $(CURDIR)/debian/tmp
-bindir := $(prefix)/usr/bin
-sbindir := $(prefix)/usr/sbin
+bindir := $(prefix)/$(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["bindir"]')
 libdir := $(prefix)/usr/lib
 localstatedir := $(prefix)/var
-rubylibdir := $(libdir)/ruby/1.8
+rubylibdir := $(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["vendordir"]')
 sysconfdir := $(prefix)/etc
 pkgconfdir := $(sysconfdir)/puppet
 
@@ -48,15 +47,12 @@ install: build
 	dh_clean -k
 	dh_installdirs
 
-	# Note sbindir does nothing right now. Leaving in for future
-	# puppet versions where it is respected.
-	$(CURDIR)/install.rb --destdir=debian/tmp --bindir=/usr/bin \
-          --sbindir=/usr/sbin --sitelibdir=/usr/lib/ruby/1.8
+	$(CURDIR)/install.rb --destdir=debian/tmp --bindir=/usr/bin --sitelibdir=$(rubylibdir) --ruby=/usr/bin/ruby
 
 	# strip executable bit from all the non-executable files.
-	find debian/tmp/usr/lib/ruby/1.8 -type f -perm /u+x,g+x,o+x -exec chmod a-x {} \;
+	find $(prefix)/$(rubylibdir) -type f -perm /u+x,g+x,o+x -exec chmod a-x {} \;
 	# fix the permissions on all of the directories
-	find debian/tmp/usr/lib/ruby/1.8 -type d -exec chmod 755 {} \;
+	find $(prefix)/$(rubylibdir) -type d -exec chmod 755 {} \;
 
 	# Vim auto-syntax-highlighting stuff
 	$(INSTALL) -m0644 ext/vim/syntax/puppet.vim				\


### PR DESCRIPTION
The previous set of debian dependencies were all ruby 1.8 specific. Puppet 3.x
has full ruby 1.9 support, so this commit adds the option of ruby 1.9 for all
of Puppet's dependencies. It moves the sitelibdir to be vendordir, which is the
current debian standard for ruby projects with ruby support for both 1.8 and
1.9. It also updates all of the dependencies to be just ruby instead of ruby1.8
| ruby 1.9.1 and adds 1.9 equivalents for all ruby libraries.
