### PR TITLE
(#7316) Load applications from the modulepath

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -219,17 +219,64 @@ class Application
       @option_parser_commands
     end
 
-    def find(file_name)
-      # This should probably be using the autoloader, but due to concerns about the fact that
-      #  the autoloader currently considers the modulepath when looking for things to load,
-      #  we're delaying that for now.
+    ##
+    # Load an application from disk using the convention of mapping
+    # `Puppet::Application::Foo` to the Ruby library `puppet/application/foo`.
+    # If the library cannot be loaded using `require "puppet/application/foo"`
+    # then the Puppet modulepath will be searched for
+    # `<modulepath>/*/lib/puppet/application/foo.rb`.
+    #
+    # Note, for the purposes of error handling, application files are expected
+    # to always load.  Faces, however, have better exception handling.  As a
+    # result the application stub should be a simple as possible to ensure it
+    # always loads.
+    #
+    # @param [String] file_name the file name (without .rb extension) of an
+    # application to load, e.g. "catalog" or "minicat"
+    #
+    # @param [String] face_app_name the name of the expected face application
+    # class, e.g. `Catalog` or `Agent`.
+    #
+    # @return [Boolean] result of the `require` statement of the relative or
+    # absolute file path
+    def load_application_file(file_name, face_app_name)
+      path = "puppet/application/#{file_name}"
       begin
-        require ::File.join('puppet', 'application', file_name.to_s.downcase)
-      rescue LoadError => e
-        Puppet.log_and_raise(e, "Unable to find application '#{file_name}'.  #{e}")
+        require path
+        return true
+      rescue LoadError => detail
+        first_error = detail
+        Puppet.debug "Could not `require \"puppet/application/#{file_name}\"` (Using the $LOAD_PATH)"
       end
 
-      class_name = Puppet::Util::ConstantInflector.file2constant(file_name.to_s)
+      module_apps = Puppet::Util::CommandLine.module_applications(Puppet.settings[:modulepath])
+
+      if absolute_path = module_apps[file_name]['app'] then
+        begin
+          require absolute_path
+          Puppet.debug "Loaded '#{absolute_path}' (Using absolute path)"
+        rescue LoadError => detail
+          Puppet.log_and_raise(detail, "Unable to find application '#{face_app_name}'.  #{detail}")
+        end
+      else
+        Puppet.log_and_raise(first_error, "Unable to find application '#{face_app_name}'.  #{first_error}")
+      end
+    end
+
+    ##
+    # Find a Puppet face application, loading the face script from the
+    # filesystem if necessary.
+    #
+    # @param [String] face_app_name the name of the application to find, e.g.
+    # "Agent" or "Catalog"
+    #
+    # @return [Class] the class of the face application, e.g.
+    # `Puppet::Application::Catalog`.
+    def find(face_app_name)
+      file_name = face_app_name.to_s.downcase
+      load_application_file(file_name, face_app_name)
+
+      class_name = Puppet::Util::ConstantInflector.file2constant(face_app_name.to_s)
 
       clazz = try_load_class(class_name)
 
@@ -239,7 +286,7 @@ class Application
       ####  and then get rid of this stanza in a subsequent release.
       ################################################################
       if (clazz.nil?)
-        class_name = file_name.capitalize
+        class_name = face_app_name.capitalize
         clazz = try_load_class(class_name)
       end
       ################################################################

--- a/lib/puppet/interface/face_collection.rb
+++ b/lib/puppet/interface/face_collection.rb
@@ -1,5 +1,11 @@
 require 'puppet/interface'
 
+# XXX The Puppet::Util::CommandLine.module_applications method needs to be
+# extracted out into its own class or module or something that both
+# Puppet::Application, Puppet::Util::CommandLine _and_
+# Puppet::Interface::FaceCollection can all use cleanly.
+require 'puppet/util/command_line'
+
 module Puppet::Interface::FaceCollection
   @faces = Hash.new { |hash, key| hash[key] = {} }
 
@@ -98,20 +104,49 @@ module Puppet::Interface::FaceCollection
     return get_face(name, version)
   end
 
+  ##
+  # Load a _face_ application from disk.  Face applications are usually have a
+  # reflected "legacy" application.  This method is similar to
+  # `Puppet::Application.load_application_file`.
+  #
+  # @param [Symbol] name the name of the face to load, e.g. "catalog" or "minicat"
+  #
+  # @param [String] version the specific version to load.  The face application
+  # file must reside in a subdirectory if specified.  e.g.
+  # `puppet/face/1.2.3/catalog`.  If the version is not specified, the face
+  # must reside in the `face` subdirectory, e.g. `puppet/face/face`.
+  #
+  # @return [Boolean] true if the face application is loaded, false if there
+  # were errors while loading the file.
+  #
+  # @see Puppet::Application.load_application_file
   def self.safely_require(name, version = nil)
     path = File.join 'puppet' ,'face', version.to_s, name.to_s
-    require path
-    true
+    begin
+      require path
+      return true
+    rescue ScriptError => detail
+      if detail =~ /file -- #{path}$/
+        Puppet.debug "Could not `require \"#{path}\"` (Using the $LOAD_PATH) #{detail}"
+      else
+        Puppet.err("Failed to load face #{name}:\n#{detail}")
+      end
+    end
 
-  rescue LoadError => e
-    raise unless e.message =~ %r{-- #{path}$}
-    # ...guess we didn't find the file; return a much better problem.
-    nil
-  rescue SyntaxError => e
-    raise unless e.message =~ %r{#{path}\.rb:\d+: }
-    Puppet.err "Failed to load face #{name}:\n#{e}"
-    # ...but we just carry on after complaining.
-    nil
+    module_apps = Puppet::Util::CommandLine.module_applications(Puppet.settings[:modulepath])
+
+    if absolute_path = module_apps[name.to_s]['face'] then
+      begin
+        require absolute_path
+        Puppet.debug "Loaded '#{absolute_path}' (Using absolute path)"
+        return true
+      rescue LoadError => detail
+        Puppet.debug "Unable to find face '#{name}'.  #{detail}"
+      rescue ScriptError => detail
+        Puppet.err("Failed to load face #{name}:\n#{detail}")
+      end
+    end
+    return nil
   end
 
   def self.register(face)

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -22,6 +22,49 @@ module Puppet
         File.join('puppet', 'application')
       end
 
+      ##
+      # Search through the Puppet modulepath and find all legacy application
+      # stubs that match `<modulepath>/*/lib/puppet/application/*.rb`
+      #
+      # @param [String] modulepath modulepaths separated by
+      #   `File::PATH_SEPARATOR` often simply `Puppet.settings[:modulepath]`.
+      #
+      # @return [Hash] of application names available in modules from the
+      #   modulepath.  The key is the application name, the value is a nested
+      #   hash for the app file and the face file, both fully qualified path to
+      #   the ruby file intended to be used with require or load because the
+      #   module lib directories are not available on the $LOAD_PATH.
+      #
+      #     { 'minicat' => {
+      #         'app'  => '/etc/puppet/modules/minicat/lib/puppet/application/minicat.rb',
+      #         'face' => '/etc/puppet/modules/minicat/lib/puppet/face/minicat.rb', }
+      #     }
+      def self.module_applications(modulepath)
+        ## Load applications from the modulepath
+        # We would like to use Puppet::Util::Autoload.module_directories to
+        # obtain a list of all module lib directories, but we cannot with the
+        # current design because that method explicitly returns an empty set if
+        # Puppet.settings.app_defaults_initialized? is not truthy.
+        app_files = modulepath.split(File::PATH_SEPARATOR).map do |mp|
+          Dir["#{mp}/*/lib/puppet/application/*.rb"]
+        end.flatten
+
+        return_hash = app_files.inject(Hash.new({})) do |memo, fn|
+          appname = File.basename(fn, '.rb')
+          memo[appname] = {
+            'app'  => fn,
+            'face' => fn.gsub(%r{/application/([^/]+)$}) { "/face/#{$1}" },
+          }
+          memo
+        end
+        return_hash
+      end
+
+      ##
+      # Locate all available subcommands, legacy and faces based, along the
+      # Ruby $LOAD_PATH, RubyGems $GEM_PATH, and Puppet modulepath.
+      #
+      # @return [Array] of unique subcommand string names.
       def self.available_subcommands
         # Eventually we probably want to replace this with a call to the
         # autoloader.  however, at the moment the autoloader considers the
@@ -31,13 +74,26 @@ module Puppet
         #
         # But we do want to load from rubygems --hightower
         search_path = Puppet::Util::RubyGems::Source.new.directories + $LOAD_PATH
+
         absolute_appdirs = search_path.uniq.collect do |x|
           File.join(x,'puppet','application')
         end.select{ |x| File.directory?(x) }
-        absolute_appdirs.inject([]) do |commands, dir|
+
+        load_path_apps = absolute_appdirs.inject([]) do |commands, dir|
           commands + Dir[File.join(dir, '*.rb')].map{|fn| File.basename(fn, '.rb')}
         end.uniq
+
+        module_path_apps = module_applications(Puppet.settings[:modulepath]).keys
+
+        # We load applications from the $LOAD_PATH or from the
+        # Puppet[:modulepath].  We're using uniq because it might be the case
+        # the user has explicitly put a module on the $LOAD_PATH using RUBYLIB.
+        # In this situation an application will be listed twice and it
+        # shouldn't be.
+        return_array = (load_path_apps + module_path_apps).sort.uniq
+        return_array
       end
+
       # available_subcommands was previously an instance method, not a class
       # method, and we have an unknown number of user-implemented applications
       # that depend on that behaviour.  Forwarding allows us to preserve a
@@ -65,7 +121,6 @@ module Puppet
         # applications / subcommands / faces.
 
         if subcommand_name and available_subcommands.include?(subcommand_name) then
-          require_application subcommand_name
           # This will need to be cleaned up to do something that is not so
           #  application-specific (i.e.. so that we can load faces).
           #  Longer-term, use the autoloader.  See comments in

--- a/spec/unit/application/indirection_base_spec.rb
+++ b/spec/unit/application/indirection_base_spec.rb
@@ -3,23 +3,27 @@ require 'spec_helper'
 require 'puppet/application/indirection_base'
 require 'puppet/indirector/face'
 
-########################################################################
-# Stub for testing; the names are critical, sadly. --daniel 2011-03-30
-class Puppet::Application::TestIndirection < Puppet::Application::IndirectionBase
-end
-
-face = Puppet::Indirector::Face.define(:test_indirection, '0.0.1') do
-  summary "fake summary"
-  copyright "Puppet Labs", 2011
-  license   "Apache 2 license; see COPYING"
-end
-# REVISIT: This horror is required because we don't allow anything to be
-# :current except for if it lives on, and is loaded from, disk. --daniel 2011-03-29
-face.instance_variable_set('@version', :current)
-Puppet::Face.register(face)
-########################################################################
-
 describe Puppet::Application::IndirectionBase do
+  before :all do
+    ########################################################################
+    # Stub for testing; the names are critical, sadly. --daniel 2011-03-30
+    class Puppet::Application::TestIndirection < Puppet::Application::IndirectionBase
+    end
+
+    Puppet[:modulepath] = ''
+
+    face = Puppet::Indirector::Face.define(:test_indirection, '0.0.1') do
+      summary "fake summary"
+      copyright "Puppet Labs", 2011
+      license   "Apache 2 license; see COPYING"
+    end
+    # REVISIT: This horror is required because we don't allow anything to be
+    # :current except for if it lives on, and is loaded from, disk. --daniel 2011-03-29
+    face.instance_variable_set('@version', :current)
+    Puppet::Face.register(face)
+    ########################################################################
+  end
+
   subject { Puppet::Application::TestIndirection.new }
 
   it "should accept a terminus command line option" do

--- a/spec/unit/face/catalog_spec.rb
+++ b/spec/unit/face/catalog_spec.rb
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby -S rspec
-require 'spec_helper'
-require 'puppet/face'
-
-describe Puppet::Face[:catalog, '0.0.1'] do
-  it "should actually have some testing..."
-end

--- a/spec/unit/face/certificate_request_spec.rb
+++ b/spec/unit/face/certificate_request_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:certificate_request, '0.0.1'] do
+describe "Puppet::Face[:certificate_request, '0.0.1']" do
+  subject { Puppet::Face[:certificate_request, '0.0.1'] }
   it "should actually have some tests..."
 end

--- a/spec/unit/face/certificate_revocation_list_spec.rb
+++ b/spec/unit/face/certificate_revocation_list_spec.rb
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby -S rspec
-require 'spec_helper'
-require 'puppet/face'
-
-describe Puppet::Face[:certificate_revocation_list, '0.0.1'] do
-  it "should actually have some tests..."
-end

--- a/spec/unit/face/certificate_spec.rb
+++ b/spec/unit/face/certificate_spec.rb
@@ -4,7 +4,9 @@ require 'puppet/face'
 
 require 'puppet/ssl/host'
 
-describe Puppet::Face[:certificate, '0.0.1'] do
+describe "Puppet::Face[:certificate, '0.0.1']" do
+  subject { Puppet::Face[:certificate, '0.0.1'] }
+
   include PuppetSpec::Files
 
   let(:ca) { Puppet::SSL::CertificateAuthority.instance }

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:config, '0.0.1'] do
+describe "Puppet::Face[:config, '0.0.1']" do
+  subject { Puppet::Face[:config, '0.0.1'] }
+
   it "should use Settings#print_config_options when asked to print" do
     Puppet.settings.stubs(:puts)
     Puppet.settings.expects(:print_config_options)

--- a/spec/unit/face/facts_spec.rb
+++ b/spec/unit/face/facts_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:facts, '0.0.1'] do
+describe "Puppet::Face[:facts, '0.0.1']" do
+  subject { Puppet::Face[:facts, '0.0.1'] }
+
   it "should define an 'upload' action" do
     subject.should be_action(:upload)
   end

--- a/spec/unit/face/file_spec.rb
+++ b/spec/unit/face/file_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:file, '0.0.1'] do
+describe "Puppet::Face[:file, '0.0.1']" do
+  subject { Puppet::Face[:file, '0.0.1'] }
+
   it_should_behave_like "an indirector face"
 
   [:download, :store].each do |action|

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:help, '0.0.1'] do
+describe "Puppet::Face[:help, '0.0.1']" do
+  subject { Puppet::Face[:help, '0.0.1'] }
+
   it "has a help action" do
     subject.should be_action :help
   end


### PR DESCRIPTION
Without this patch Puppet does not search the modulepath lib subdirectories
for application subcommands.  This is a problem because face applications
that aren't affected by #3947 should work.

This patch fixes the problem by searching through the modules along the 
modulepath to find available subcommands in addition to those available along
the Ruby $LOAD_PATH and RubyGems $GEM_PATH.

Both legacy application files and modern face applications are loaded from
the modulepath with this patch.

This patch does _not_ add the module's `lib/` subdirectory to the
$LOAD_PATH, so issue #3947 will still affect face applications that attempt
to use `require` with library files inside the module.
