### PR TITLE
(Maint) Fix spec failures with Puppet::Face[]

### DIFF
--- a/spec/integration/faces/ca_spec.rb
+++ b/spec/integration/faces/ca_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:ca, '0.1.0'], :unless => Puppet.features.microsoft_windows? do
+describe "Puppet::Face[:ca, '0.1.0']", :unless => Puppet.features.microsoft_windows? do
+  subject { Puppet::Face[:ca, '0.1.0'] }
+
   include PuppetSpec::Files
 
   before :each do

--- a/spec/unit/face/instrumentation_data_spec.rb
+++ b/spec/unit/face/instrumentation_data_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:instrumentation_data, '0.0.1'] do
+describe "Puppet::Face[:instrumentation_data, '0.0.1']" do
+  subject { Puppet::Face[:instrumentation_data, '0.0.1'] }
+
   it_should_behave_like "an indirector face"
 end

--- a/spec/unit/face/instrumentation_listener_spec.rb
+++ b/spec/unit/face/instrumentation_listener_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:instrumentation_listener, '0.0.1'] do
+describe "Puppet::Face[:instrumentation_listener, '0.0.1']" do
+  subject { Puppet::Face[:instrumentation_listener, '0.0.1'] }
+
   it_should_behave_like "an indirector face"
 
   [:enable, :disable].each do |m|

--- a/spec/unit/face/instrumentation_probe_spec.rb
+++ b/spec/unit/face/instrumentation_probe_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:instrumentation_probe, '0.0.1'] do
+describe "Puppet::Face[:instrumentation_probe, '0.0.1']" do
+  subject { Puppet::Face[:instrumentation_probe, '0.0.1'] }
+
   it_should_behave_like "an indirector face"
 
   describe 'when running #enable' do

--- a/spec/unit/face/key_spec.rb
+++ b/spec/unit/face/key_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:key, '0.0.1'] do
+describe "Puppet::Face[:key, '0.0.1']" do
+  subject { Puppet::Face[:key, '0.0.1'] }
+
   it "should actually have some tests..."
 end

--- a/spec/unit/face/node_spec.rb
+++ b/spec/unit/face/node_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:node, '0.0.1'] do
+describe "Puppet::Face[:node, '0.0.1']" do
+  subject { Puppet::Face[:node, '0.0.1'] }
+
   after :all do
     Puppet::SSL::Host.ca_location = :none
   end

--- a/spec/unit/face/plugin_spec.rb
+++ b/spec/unit/face/plugin_spec.rb
@@ -2,7 +2,9 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:plugin, '0.0.1'] do
+describe "Puppet::Face[:plugin, '0.0.1']" do
+  subject { Puppet::Face[:plugin, '0.0.1'] }
+
   [:download].each do |action|
     it { should be_action action }
     it { should respond_to action }

--- a/spec/unit/face/report_spec.rb
+++ b/spec/unit/face/report_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:report, '0.0.1'] do
+describe "Puppet::Face[:report, '0.0.1']" do
+  subject { Puppet::Face[:report, '0.0.1'] }
+
   it "should actually have some tests..."
 end

--- a/spec/unit/face/resource_spec.rb
+++ b/spec/unit/face/resource_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:resource, '0.0.1'] do
+describe "Puppet::Face[:resource, '0.0.1']" do
+  subject { Puppet::Face[:resource, '0.0.1'] }
+
   it "should actually have some tests..."
 end

--- a/spec/unit/face/resource_type_spec.rb
+++ b/spec/unit/face/resource_type_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:resource_type, '0.0.1'] do
+describe "Puppet::Face[:resource_type, '0.0.1']" do
+  subject { Puppet::Face[:resource_type, '0.0.1'] }
+
   it "should actually have some tests..."
 end

--- a/spec/unit/face/secret_agent_spec.rb
+++ b/spec/unit/face/secret_agent_spec.rb
@@ -4,7 +4,9 @@ require 'puppet/face'
 require 'puppet/indirector/catalog/rest'
 require 'tempfile'
 
-describe Puppet::Face[:secret_agent, '0.0.1'] do
+describe "Puppet::Face[:secret_agent, '0.0.1']" do
+  subject { Puppet::Face[:secret_agent, '0.0.1'] }
+
   include PuppetSpec::Files
 
   describe "#synchronize" do


### PR DESCRIPTION
Without this patch the describe blocks are being executed before the spec
helper before hooks.  This is problem because the Puppet::Face.find method
now searches the modulepath.  The modulepath setting is not yet initialized
when the subject of the describe block is evaluated.

This patch fixes the problem by explicitly setting the subject inside the
example groups.  Doing so delays evaluation of the find method until after
settings have initialized.

I suppose all of this could be summed up as, "Load faces after settings have
been initialized by the spec helper, not before."

Paired-with: Andrew Parker andy@puppetlabs.com
