### PR TITLE
Remove references to CHANGELOG in packaging

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -107,7 +107,6 @@ binary-indep: build install
 	dh_testdir
 	dh_testroot
 	dh_install -i
-	dh_installchangelogs -i CHANGELOG
 	dh_installdocs -i
 	dh_installemacsen
 	dh_installlogcheck

--- a/ext/osx/createpackage.sh
+++ b/ext/osx/createpackage.sh
@@ -60,7 +60,7 @@ function install_docs() {
   echo "Installing docs to ${pkgroot}"
   docdir="${pkgroot}/usr/share/doc/puppet" 
   mkdir -p "${docdir}"
-  for docfile in CHANGELOG CHANGELOG.old COPYING LICENSE README README.queueing README.rst; do
+  for docfile in COPYING LICENSE README README.queueing README.rst; do
     install -m 0644 "${puppet_root}/${docfile}" "${docdir}"
   done
   chown -R root:wheel "${docdir}"

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -181,7 +181,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}/modules
 
 %files
 %defattr(-, root, root, 0755)
-%doc CHANGELOG LICENSE README.md examples
+%doc LICENSE README.md examples
 %{_bindir}/puppet
 %{_bindir}/extlookup2hiera
 %{puppet_libdir}/*

--- a/ext/suse/puppet.spec
+++ b/ext/suse/puppet.spec
@@ -86,7 +86,7 @@ find %{buildroot}%{ruby_sitelibdir} -type f -perm +ugo+x -exec chmod a-x '{}' \;
 %{_initrddir}/puppet
 /var/adm/fillup-templates/sysconfig.puppet
 %config(noreplace) %{_sysconfdir}/puppet/puppet.conf
-%doc CHANGELOG COPYING LICENSE README examples
+%doc COPYING LICENSE README examples
 %config(noreplace) %{_sysconfdir}/logrotate.d/puppet
 %dir %{_sysconfdir}/puppet
 # These need to be owned by puppet so the server can


### PR DESCRIPTION
Now that the CHANGELOG is removed, references to
it in various packaging artifacts should be removed.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
