### PR TITLE
Remove svn specific code from install.rb

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -63,7 +63,6 @@ def glob(list)
   g = list.map { |i| Dir.glob(i) }
   g.flatten!
   g.compact!
-  g.reject! { |e| e =~ /\.svn/ }
   g
 end
 


### PR DESCRIPTION
We no longer need to exclude .svn files from puppet, as it is now using git.
