### PR TITLE
16553 Exclude portmap-wait from self.instances

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   # eventually explain how to use this service or perhaps why it should remain
   # excluded. When that bug is adddressed this should be reexamined.
   def self.instances
-    self.get_services(['wait-for-state'])
+    self.get_services(['wait-for-state','portmap-wait'])
   end
 
   def self.get_services(exclude=[])


### PR DESCRIPTION
Previous to this commit, running self.instances on Ubuntu 10.04 broke
due to a bug in the portmap-wait init script. The bug made it impossible
to retrieve the state of the service. This service doesn't really have a
status since it's only meant to run once on boot.

This commit adds the portmap-wait service to the exclude list when
running self.instances
