### PR TITLE
(#16585) Remove dead ldapnodes setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1375,12 +1375,6 @@ EOT
 
         define_settings(
         :ldap,
-    :ldapnodes => {
-      :default  => false,
-      :type     => :boolean,
-      :desc     => "Whether to search for node configurations in LDAP.  See
-      http://projects.puppetlabs.com/projects/puppet/wiki/LDAP_Nodes for more information.",
-    },
     :ldapssl => {
       :default  => false,
       :type   => :boolean,
@@ -1397,11 +1391,11 @@ EOT
     },
     :ldapserver => {
       :default  => "ldap",
-      :desc     => "The LDAP server.  Only used if `ldapnodes` is enabled.",
+      :desc     => "The LDAP server.  Only used if `node_terminus` is set to `ldap`.",
     },
     :ldapport => {
       :default  => 389,
-      :desc     => "The LDAP port.  Only used if `ldapnodes` is enabled.",
+      :desc     => "The LDAP port.  Only used if `node_terminus` is set to `ldap`.",
     },
 
     :ldapstring => {


### PR DESCRIPTION
This setting has been dead code since 0.24.0, and its value is never read.
This commit removes it.
