### PR TITLE
Fixed unhandled --ignoreschedules in puppet kick

### DIFF
--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -11,6 +11,7 @@ class Puppet::Application::Kick < Puppet::Application
   option("--debug","-d")
   option("--ping","-P")
   option("--test")
+  option("--ignoreschedules")
 
   option("--host HOST") do |arg|
     @hosts << arg

--- a/spec/unit/application/kick_spec.rb
+++ b/spec/unit/application/kick_spec.rb
@@ -83,7 +83,7 @@ describe Puppet::Application::Kick, :if => Puppet.features.posix? do
       @kick.preinit
     end
 
-    [:all, :foreground, :debug, :ping, :test].each do |option|
+    [:all, :foreground, :debug, :ping, :test, :ignoreschedules].each do |option|
       it "should declare handle_#{option} method" do
         @kick.should respond_to("handle_#{option}".to_sym)
       end


### PR DESCRIPTION
Simple fix to add --ignoreschedules functionality.  I need this specifically on branch 2.7.x, but this commit probably will work on most branches. It's a one line fix and a one line change to spec to test it.
