### PR TITLE
#(16271) Implement restart action for launchd

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -49,6 +49,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   confine :operatingsystem    => :darwin
 
   has_feature :enableable
+  has_feature :refreshable
   mk_resource_methods
 
   # These are the paths in OS X where a launchd service plist could
@@ -272,6 +273,13 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     self.enable if did_disable_job and resource[:enable] == :true
   end
 
+  def restart
+    Puppet.debug("A restart has been triggered for the #{resource[:name]} service")
+    Puppet.debug("Stopping the #{resource[:name]} service")
+    self.stop
+    Puppet.debug("Starting the #{resource[:name]} service")
+    self.start
+  end
 
   # launchd jobs are enabled by default. They are only disabled if the key
   # "Disabled" is set to true, but it can also be set to false to enable it.

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -119,6 +119,16 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       subject.expects(:execute).with([:launchctl, :load, '-w', joblabel])
       subject.start
     end
+
+    it "(#16271) Should respond to restart" do
+      subject.should respond_to :restart
+    end
+
+    it "(#16271) Should stop and start the service when a restart is called" do
+      subject.expects(:stop)
+      subject.expects(:start)
+      subject.restart
+    end
   end
 
   describe "when stopping the service" do


### PR DESCRIPTION
Previously, the launchd service provider did not accommodate a restart
action. If a resource attempted the refresh the service, Puppet triggered
an alert but did not actually restart the service. This commit adds a
restart method that calls the stop and then start action on the service
(since launchd doesn't actually have a restart action). Puppet.debug
messages are also raised for debugging purposes.
