### PR TITLE
Fix up dependencies for Hiera and Facter in RubyGems

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -15,8 +15,8 @@ gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_forge_project: 'puppet'
 gem_runtime_dependencies:
-  facter: '>= 1.6.11'
-  hiera: '>= 1.0.0rc'
+  facter: '~> 1.6.11'
+  hiera: '~> 1.0.0'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"


### PR DESCRIPTION
Since Puppet 3.0 promises to follow semver, the dependencies should take
this into account. This means now that only patch releases of Facter and
Hiera will be pulled in for patch releases of 3.0, and the version
dependency must be bumped for any minor or major release appropriately.

This also fixes a bug in the Hiera dependency due to the segment
comparisons in the RubyGems version resolver. Because there was no `.`
before the `rc` in the current dependency (`1.0.0rc`) this resulted in
the comparator looking at `1.0` and selecting the first version `>=`
than it, in this case `1.1.0.rc`. I assume this is unintended and that
the target was meant to resolve to Hiera `1.0.0`.
