### PR TITLE
(#4388) Remove the dead `authconfig` setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -155,12 +155,6 @@ module Puppet
             "all files referenced with `import` statements to exist. This setting was primarily\n" +
             "designed for use with commit hooks for parse-checking.",
     },
-    :authconfig => {
-        :default  => "$confdir/namespaceauth.conf",
-        :desc     => "The configuration file that defines the rights to the different\n" +
-            "namespaces and methods.  This can be used as a coarse-grained\n" +
-            "authorization system for both `puppet agent` and `puppet master`.",
-    },
     :environment => {
         :default  => "production",
         :desc     => "The environment Puppet is running in.  For clients\n" +


### PR DESCRIPTION
As of commit 4b6db1c6f3bb383d8309c5d98cb6236862caf085 or so, this setting is
no longer referenced anywhere in the Puppet code. It used to point to the
namespaceauth.conf file, which we no longer consult for any purpose. The setting
should go away.
