### PR TITLE
(#16676) Clarify file format restrictions around comments

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -855,6 +855,8 @@ These parameters affect the required permissions of any files specified after
 their specification.  Puppet will sometimes use these parameters to check its
 own configured state, so they can be used to make Puppet a bit more self-managing.
 
+The file format supports octothorpe-commented lines, but not partial-line comments.
+
 Generated on #{Time.now}.
 
 }.gsub(/^/, "# ")


### PR DESCRIPTION
Previously the help text at the top of the generated config files
did not describe what the file format ought to be. There is a
description in the documentation (guides/configuration.html),
but our inline docs should be consistent with that. This led
to confusion and bugs like #16676 and #16672.

Now we state clearly that whole-line comments are allowed but
not partial-line comments. Plus I got to use the word 'octothorpe'.
