### PR TITLE
(#16488) Add `--puppetport` to list of kick options

### DIFF
--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -144,6 +144,9 @@ with '--genconfig'.
   forking for each client to which to connect. The default is 1, meaning
   serial execution.
 
+* --puppetport:
+  Use the specified TCP port to connect to agents. Defaults to 8139.
+
 * --tag:
   Specify a tag for selecting the objects to apply. Does not work with
   the --test option.


### PR DESCRIPTION
The fact that the kick application uses the `--puppetport` agent
option in a special way (to _connect_ to agents, rather than
to listen) was not previously documented, as #16488 points out.

This commit adds a simple description to the option output in
`puppet help kick`
