### PR TITLE
(#16798) Fix certificate revocation by serial number

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -232,6 +232,8 @@ class Puppet::SSL::CertificateAuthority
 
     if cert = Puppet::SSL::Certificate.indirection.find(name)
       serial = cert.content.serial
+    elsif name =~ /^0x[0-9A-Fa-f]+$/
+      serial = name.hex
     elsif ! serial = inventory.serial(name)
       raise ArgumentError, "Could not find a serial number for #{name}"
     end

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -905,6 +905,13 @@ describe Puppet::SSL::CertificateAuthority do
         @ca.crl.expects(:revoke).with { |serial, key| serial == 16 }
         @ca.revoke('host')
       end
+
+      it "should allow the user to specify a serial number (in hex) to revoke" do
+        @ca.crl.expects(:revoke).with { |serial, key| serial == 15 }
+        Puppet::SSL::Certificate.indirection.expects(:find).with("0xf").returns nil
+
+        @ca.revoke('0xf')
+      end
     end
 
     it "should be able to generate a complete new SSL host" do


### PR DESCRIPTION
The documentation states that you should be able to revoke
a SSL certificate with 'puppet cert revoke <hex_serial>'
but in practice that doesn't work. This patch enables that
functionality and adds a unit test to check for that scenario.
