### PR TITLE
(#16809) Use only one record_type in cron provider

### DIFF
--- a/spec/fixtures/integration/provider/cron/crontab/create_normal_entry
+++ b/spec/fixtures/integration/provider/cron/crontab/create_normal_entry
@@ -1,0 +1,19 @@
+# HEADER: some simple
+# HEADER: header
+@daily /bin/unnamed_special_command >> /dev/null 2>&1
+
+# commend with blankline above and below
+
+17-19,22 0-23/2 * * 2 /bin/unnamed_regular_command
+
+# Puppet Name: My daily failure
+MAILTO=""
+@daily /bin/false
+# Puppet Name: Monthly job
+SHELL=/bin/sh
+MAILTO=mail@company.com
+15 14 1 * * $HOME/bin/monthly
+# Puppet Name: new entry
+MAILTO=""
+SHELL=/bin/bash
+12 * * * 2 /bin/new

--- a/spec/fixtures/integration/provider/cron/crontab/create_special_entry
+++ b/spec/fixtures/integration/provider/cron/crontab/create_special_entry
@@ -1,0 +1,18 @@
+# HEADER: some simple
+# HEADER: header
+@daily /bin/unnamed_special_command >> /dev/null 2>&1
+
+# commend with blankline above and below
+
+17-19,22 0-23/2 * * 2 /bin/unnamed_regular_command
+
+# Puppet Name: My daily failure
+MAILTO=""
+@daily /bin/false
+# Puppet Name: Monthly job
+SHELL=/bin/sh
+MAILTO=mail@company.com
+15 14 1 * * $HOME/bin/monthly
+# Puppet Name: new special entry
+MAILTO=bob@company.com
+@reboot echo "Booted" 1>&2

--- a/spec/fixtures/integration/provider/cron/crontab/crontab_user1
+++ b/spec/fixtures/integration/provider/cron/crontab/crontab_user1
@@ -1,0 +1,15 @@
+# HEADER: some simple
+# HEADER: header
+@daily /bin/unnamed_special_command >> /dev/null 2>&1
+
+# commend with blankline above and below
+
+17-19,22 0-23/2 * * 2 /bin/unnamed_regular_command
+
+# Puppet Name: My daily failure
+MAILTO=""
+@daily /bin/false
+# Puppet Name: Monthly job
+SHELL=/bin/sh
+MAILTO=mail@company.com
+15 14 1 * * $HOME/bin/monthly

--- a/spec/fixtures/integration/provider/cron/crontab/crontab_user2
+++ b/spec/fixtures/integration/provider/cron/crontab/crontab_user2
@@ -1,0 +1,4 @@
+# HEADER: some simple
+# HEADER: header
+# Puppet Name: some_unrelevant job
+* * * * * /bin/true

--- a/spec/fixtures/integration/provider/cron/crontab/modify_entry
+++ b/spec/fixtures/integration/provider/cron/crontab/modify_entry
@@ -1,0 +1,13 @@
+# HEADER: some simple
+# HEADER: header
+@daily /bin/unnamed_special_command >> /dev/null 2>&1
+
+# commend with blankline above and below
+
+17-19,22 0-23/2 * * 2 /bin/unnamed_regular_command
+
+# Puppet Name: My daily failure
+MAILTO=""
+@daily /bin/false
+# Puppet Name: Monthly job
+@monthly /usr/bin/monthly

--- a/spec/fixtures/integration/provider/cron/crontab/moved_cronjob_input1
+++ b/spec/fixtures/integration/provider/cron/crontab/moved_cronjob_input1
@@ -1,0 +1,12 @@
+# HEADER: some simple
+# HEADER: header
+@daily /bin/unnamed_special_command >> /dev/null 2>&1
+
+# commend with blankline above and below
+
+17-19,22 0-23/2 * * 2 /bin/unnamed_regular_command
+
+# Puppet Name: Monthly job
+SHELL=/bin/sh
+MAILTO=mail@company.com
+15 14 1 * * $HOME/bin/monthly

--- a/spec/fixtures/integration/provider/cron/crontab/moved_cronjob_input2
+++ b/spec/fixtures/integration/provider/cron/crontab/moved_cronjob_input2
@@ -1,0 +1,7 @@
+# HEADER: some simple
+# HEADER: header
+# Puppet Name: My daily failure
+MAILTO=""
+@daily /bin/false
+# Puppet Name: some_unrelevant job
+* * * * * /bin/true

--- a/spec/fixtures/integration/provider/cron/crontab/remove_named_resource
+++ b/spec/fixtures/integration/provider/cron/crontab/remove_named_resource
@@ -1,0 +1,12 @@
+# HEADER: some simple
+# HEADER: header
+@daily /bin/unnamed_special_command >> /dev/null 2>&1
+
+# commend with blankline above and below
+
+17-19,22 0-23/2 * * 2 /bin/unnamed_regular_command
+
+# Puppet Name: Monthly job
+SHELL=/bin/sh
+MAILTO=mail@company.com
+15 14 1 * * $HOME/bin/monthly

--- a/spec/fixtures/integration/provider/cron/crontab/remove_unnamed_resource
+++ b/spec/fixtures/integration/provider/cron/crontab/remove_unnamed_resource
@@ -1,0 +1,14 @@
+# HEADER: some simple
+# HEADER: header
+@daily /bin/unnamed_special_command >> /dev/null 2>&1
+
+# commend with blankline above and below
+
+
+# Puppet Name: My daily failure
+MAILTO=""
+@daily /bin/false
+# Puppet Name: Monthly job
+SHELL=/bin/sh
+MAILTO=mail@company.com
+15 14 1 * * $HOME/bin/monthly

--- a/spec/fixtures/unit/provider/cron/parsed/managed
+++ b/spec/fixtures/unit/provider/cron/parsed/managed
@@ -1,0 +1,6 @@
+# Puppet Name: real_job
+* * * * * /bin/true
+# Puppet Name: complex_job
+MAILTO=foo@example.com
+SHELL=/bin/sh
+@reboot /bin/true >> /dev/null 2>&1

--- a/spec/fixtures/unit/provider/cron/parsed/simple
+++ b/spec/fixtures/unit/provider/cron/parsed/simple
@@ -1,0 +1,9 @@
+# use /bin/sh to run commands, no matter what /etc/passwd says
+SHELL=/bin/sh
+# mail any output to `paul', no matter whose crontab this is
+MAILTO=paul
+#
+# run five minutes after midnight, every day
+5 0 * * *       $HOME/bin/daily.job >> $HOME/tmp/out 2>&1
+# run at 2:15pm on the first of every month -- output mailed to paul
+15 14 1 * *     $HOME/bin/monthly

--- a/spec/integration/provider/cron/crontab_spec.rb
+++ b/spec/integration/provider/cron/crontab_spec.rb
@@ -1,0 +1,186 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+require 'puppet/file_bucket/dipper'
+
+describe Puppet::Type.type(:cron).provider(:crontab), '(integration)' do
+  include PuppetSpec::Files
+
+  before :each do
+    Puppet::Type.type(:cron).stubs(:defaultprovider).returns described_class
+    Puppet::FileBucket::Dipper.any_instance.stubs(:backup) # Don't backup to filebucket
+
+    # I dont want to execute anything
+    described_class.stubs(:filetype).returns Puppet::Util::FileType::FileTypeFlat
+    described_class.stubs(:default_target).returns crontab_user1
+
+    # I dont want to stub Time.now to get a static header because I dont know
+    # where Time.now is used elsewere so just go with a very simple header
+    described_class.stubs(:header).returns "# HEADER: some simple\n# HEADER: header\n"
+    FileUtils.cp(my_fixture('crontab_user1'), crontab_user1)
+    FileUtils.cp(my_fixture('crontab_user2'), crontab_user2)
+  end
+
+  after :each do
+    described_class.clear
+  end
+
+  let :crontab_user1 do
+    tmpfile('cron_integration_specs')
+  end
+
+  let :crontab_user2 do
+    tmpfile('cron_integration_specs')
+  end
+
+  def run_in_catalog(*resources)
+    catalog = Puppet::Resource::Catalog.new
+    catalog.host_config = false
+    resources.each do |resource|
+      resource.expects(:err).never
+      catalog.add_resource(resource)
+    end
+    catalog.apply
+  end
+
+  def expect_output(fixture_name)
+    File.read(crontab_user1).should == File.read(my_fixture(fixture_name))
+  end
+
+  describe "when managing a cron entry" do
+    describe "with ensure absent" do
+      it "should do nothing if entry already absent" do
+        resource = Puppet::Type.type(:cron).new(
+          :name   => 'no_such_entry',
+          :ensure => :absent,
+          :target => crontab_user1,
+          :user   => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('crontab_user1')
+      end
+
+      it "should remove the resource from crontab if present" do
+        resource = Puppet::Type.type(:cron).new(
+          :name   => 'My daily failure',
+          :ensure => :absent,
+          :target => crontab_user1,
+          :user   => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('remove_named_resource')
+      end
+
+      it "should remove a matching cronentry if present" do
+        resource = Puppet::Type.type(:cron).new(
+          :name     => 'no_such_named_resource_in_crontab',
+          :ensure   => :absent,
+          :minute   => [ '17-19', '22' ],
+          :hour     => [ '0-23/2' ],
+          :weekday  => 'Tue',
+          :command  => '/bin/unnamed_regular_command',
+          :target   => crontab_user1,
+          :user     => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('remove_unnamed_resource')
+      end
+    end
+
+    describe "with ensure present" do
+      it "should do nothing if entry already present" do
+        resource = Puppet::Type.type(:cron).new(
+          :name    => 'My daily failure',
+          :special => 'daily',
+          :command => '/bin/false',
+          :target  => crontab_user1,
+          :user    => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('crontab_user1')
+      end
+
+      it "should do nothing if a matching entry already present" do
+        resource = Puppet::Type.type(:cron).new(
+          :name     => 'no_such_named_resource_in_crontab',
+          :ensure   => :present,
+          :minute   => [ '17-19', '22' ],
+          :hour     => [ '0-23/2' ],
+          :command  => '/bin/unnamed_regular_command',
+          :target   => crontab_user1,
+          :user     => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('crontab_user1')
+      end
+
+      it "should add a new normal entry if currently absent" do
+        resource = Puppet::Type.type(:cron).new(
+          :name        => 'new entry',
+          :ensure      => :present,
+          :minute      => '12',
+          :weekday     => 'Tue',
+          :command     => '/bin/new',
+          :environment => [
+            'MAILTO=""',
+            'SHELL=/bin/bash'
+          ],
+          :target      => crontab_user1,
+          :user        => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('create_normal_entry')
+      end
+
+      it "should add a new special entry if currently absent" do
+        resource = Puppet::Type.type(:cron).new(
+          :name        => 'new special entry',
+          :ensure      => :present,
+          :special     => 'reboot',
+          :command     => 'echo "Booted" 1>&2',
+          :environment => 'MAILTO=bob@company.com',
+          :target      => crontab_user1,
+          :user        => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('create_special_entry')
+      end
+
+      it "should change existing entry if out of sync" do
+        resource = Puppet::Type.type(:cron).new(
+          :name        => 'Monthly job',
+          :ensure      => :present,
+          :special     => 'monthly',
+#          :minute => ['22'],
+          :command     => '/usr/bin/monthly',
+          :environment => [],
+          :target      => crontab_user1,
+          :user        => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('modify_entry')
+      end
+      it "should be able to move an entry from one file to another" do
+        # force the parsedfile provider to also parse user1's crontab
+        random_resource = Puppet::Type.type(:cron).new(
+          :name   => 'foo',
+          :ensure => :absent,
+          :target => crontab_user1,
+          :user   => crontab_user1
+        )
+        resource = Puppet::Type.type(:cron).new(
+          :name         => 'My daily failure',
+          :special      => 'daily',
+          :target       => crontab_user2,
+          :user         => crontab_user2
+        )
+        run_in_catalog(resource)
+        File.read(crontab_user1).should == File.read(my_fixture('moved_cronjob_input1'))
+        File.read(crontab_user2).should == File.read(my_fixture('moved_cronjob_input2'))
+      end
+    end
+
+    it "should not add multiple headers"
+  end
+
+end

--- a/spec/unit/provider/cron/parsed_spec.rb
+++ b/spec/unit/provider/cron/parsed_spec.rb
@@ -1,0 +1,319 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:cron).provider(:crontab) do
+
+  let :provider do
+    described_class.new(:command => '/bin/true')
+  end
+
+  let :resource do
+    Puppet::Type.type(:cron).new(
+      :minute      => %w{0 15 30 45},
+      :hour        => %w{8-18 20-22},
+      :monthday    => %w{31},
+      :month       => %w{12},
+      :weekday     => %w{7},
+      :name        => 'basic',
+      :command     => '/bin/true',
+      :target      => 'root',
+      :provider    => provider
+    )
+  end
+
+  let :resource_special do
+    Puppet::Type.type(:cron).new(
+      :special => 'reboot',
+      :name    => 'special',
+      :command => '/bin/true',
+      :target  => 'nobody'
+    )
+  end
+
+  let :record_special do
+    {
+      :record_type => :crontab,
+      :special     => 'reboot',
+      :command     => '/bin/true',
+      :on_disk     => true,
+      :target      => 'nobody'
+    }
+  end
+
+  let :record do
+    {
+      :record_type => :crontab,
+      :minute      => %w{0 15 30 45},
+      :hour        => %w{8-18 20-22},
+      :monthday    => %w{31},
+      :month       => %w{12},
+      :weekday     => %w{7},
+      :special     => :absent,
+      :command     => '/bin/true',
+      :on_disk     => true,
+      :target      => 'root'
+    }
+  end
+
+  # I am not able to stub operatingsystem because the filetype is determined
+  # at load time
+  describe "when determining the correct filetype" do
+    it "should use the suntab filetype on Solaris", :if => Facter.value(:operatingsystem) == 'Solaris'  do
+      described_class.filetype.should == Puppet::Util::FileType::FileTypeSuntab
+    end
+
+    it "should use the aixtab filetype on AIX", :if => Facter.value(:operatingsystem) == 'AIX' do
+      described_class.filetype.should == Puppet::Util::FileType::FileTypeAixtab
+    end
+
+    it "should use the crontab filetype on other platforms", :unless => %w{AIX Solaris}.include?(Facter.value(:operatingsystem)) do
+      described_class.filetype.should == Puppet::Util::FileType::FileTypeCrontab
+    end
+  end
+
+  # I'd use ENV.expects(:[]).with('USER') but this does not work because
+  # ENV["USER"] is evaluated at load time.
+  describe "when determining the default target" do
+    it "should use the current user #{ENV['USER']}", :if => ENV['USER'] do
+      described_class.default_target.should == ENV['USER']
+    end
+
+    it "should fallback to root", :unless => ENV['USER'] do
+      described_class.default_target.should == "root"
+    end
+  end
+
+  describe "when parsing a record" do
+    it "should parse a comment" do
+      described_class.parse_line("# This is a test").should == {
+        :record_type => :comment,
+        :line        => "# This is a test",
+      }
+    end
+
+    it "should get the resource name of a PUPPET NAME comment" do
+      described_class.parse_line('# Puppet Name: My Fancy Cronjob').should == {
+        :record_type => :comment,
+        :name        => 'My Fancy Cronjob',
+        :line        => '# Puppet Name: My Fancy Cronjob',
+      }
+    end
+
+    it "should ignore blank lines" do
+      described_class.parse_line('').should == {:record_type => :blank, :line => ''}
+      described_class.parse_line(' ').should == {:record_type => :blank, :line => ' '}
+      described_class.parse_line("\t").should == {:record_type => :blank, :line => "\t"}
+      described_class.parse_line("  \t ").should == {:record_type => :blank, :line => "  \t "}
+    end
+
+    it "should extract environment assignments" do
+      # man 5 crontab: MAILTO="" with no value can be used to surpress sending
+      # mails at all
+      described_class.parse_line('MAILTO=""').should == {:record_type => :environment, :line => 'MAILTO=""'}
+      described_class.parse_line('FOO=BAR').should == {:record_type => :environment, :line => 'FOO=BAR'}
+      described_class.parse_line('FOO_BAR=BAR').should == {:record_type => :environment, :line => 'FOO_BAR=BAR'}
+    end
+
+    it "should extract a cron entry" do
+      described_class.parse_line('* * * * * /bin/true').should == {
+        :record_type => :crontab,
+        :hour        => :absent,
+        :minute      => :absent,
+        :month       => :absent,
+        :weekday     => :absent,
+        :monthday    => :absent,
+        :special     => :absent,
+        :command     => '/bin/true'
+      }
+      described_class.parse_line('0,15,30,45 8-18,20-22 31 12 7 /bin/true').should == {
+        :record_type => :crontab,
+        :minute      => %w{0 15 30 45},
+        :hour        => %w{8-18 20-22},
+        :monthday    => %w{31},
+        :month       => %w{12},
+        :weekday     => %w{7},
+        :special     => :absent,
+        :command     => '/bin/true'
+      }
+      # A percent sign will cause the rest of the string to be passed as
+      # standard input and will also act as a newline character. Not sure
+      # if puppet should convert % to a \n as the command property so the
+      # test covers the current behaviour: Do not do any conversions
+      described_class.parse_line('0 22 * * 1-5   mail -s "It\'s 10pm" joe%Joe,%%Where are your kids?%').should == {
+        :record_type => :crontab,
+        :minute      => %w{0},
+        :hour        => %w{22},
+        :monthday    => :absent,
+        :month       => :absent,
+        :weekday     => %w{1-5},
+        :special     => :absent,
+        :command     => 'mail -s "It\'s 10pm" joe%Joe,%%Where are your kids?%'
+      }
+    end
+
+    describe "it should support special strings" do
+      ['reboot','yearly','anually','monthly', 'weekly', 'daily', 'midnight', 'hourly'].each do |special|
+        it "should support @#{special}" do
+          described_class.parse_line("@#{special} /bin/true").should == {
+            :record_type => :crontab,
+            :hour        => :absent,
+            :minute      => :absent,
+            :month       => :absent,
+            :weekday     => :absent,
+            :monthday    => :absent,
+            :special     => special,
+            :command     => '/bin/true'
+          }
+        end
+      end
+    end
+  end
+
+  describe ".instances" do
+    before :each do
+      described_class.stubs(:default_target).returns 'foobar'
+    end
+
+    describe "on linux" do
+      it "should be empty if user has no crontab" do
+        # `crontab...` does only capture stdout here. On vixie-cron-4.1
+        # STDERR shows "no crontab for foobar" but stderr is ignored as
+        # well as the exitcode.
+        described_class.target_object('foobar').expects(:`).with('crontab -u foobar -l 2>/dev/null').returns ""
+        described_class.instances.should be_empty
+      end
+
+      it "should be empty if user is not present" do
+        # `crontab...` does only capture stdout. On vixie-cron-4.1
+        # STDERR shows "crontab:  user `foobar' unknown" but stderr is
+        # ignored as well as the exitcode
+        described_class.target_object('foobar').expects(:`).with('crontab -u foobar -l 2>/dev/null').returns ""
+        described_class.instances.should be_empty
+      end
+
+      it "should be able to create records from not-managed records" do
+        described_class.expects(:target_object).returns File.new(my_fixture('simple'))
+        described_class.instances.map do |p|
+          h = {:name => p.get(:name)}
+          Puppet::Type.type(:cron).validproperties.each do |property|
+            h[property] = p.get(property)
+          end
+          h
+        end.should == [
+          {
+            :name        => :absent,
+            :minute      => ['5'],
+            :hour        => ['0'],
+            :weekday     => :absent,
+            :month       => :absent,
+            :monthday    => :absent,
+            :special     => :absent,
+            :command     => '$HOME/bin/daily.job >> $HOME/tmp/out 2>&1',
+            :ensure      => :present,
+            :environment => :absent,
+            :user        => :absent,
+            :target      => 'foobar'
+          },
+          {
+            :name        => :absent,
+            :minute      => ['15'],
+            :hour        => ['14'],
+            :weekday     => :absent,
+            :month       => :absent,
+            :monthday    => ['1'],
+            :special     => :absent,
+            :command     => '$HOME/bin/monthly',
+            :ensure      => :present,
+            :environment => :absent,
+            :user        => :absent,
+            :target      => 'foobar'
+          }
+        ]
+      end
+
+      it "should be able to parse puppet manged cronjobs" do
+        described_class.expects(:target_object).returns File.new(my_fixture('managed'))
+        described_class.instances.map do |p|
+          h = {:name => p.get(:name)}
+          Puppet::Type.type(:cron).validproperties.each do |property|
+            h[property] = p.get(property)
+          end
+          h
+        end.should == [
+          {
+            :name        => 'real_job',
+            :minute      => :absent,
+            :hour        => :absent,
+            :weekday     => :absent,
+            :month       => :absent,
+            :monthday    => :absent,
+            :special     => :absent,
+            :command     => '/bin/true',
+            :ensure      => :present,
+            :environment => :absent,
+            :user        => :absent,
+            :target      => 'foobar'
+          },
+          {
+            :name        => 'complex_job',
+            :minute      => :absent,
+            :hour        => :absent,
+            :weekday     => :absent,
+            :month       => :absent,
+            :monthday    => :absent,
+            :special     => 'reboot',
+            :command     => '/bin/true >> /dev/null 2>&1',
+            :ensure      => :present,
+            :environment => [
+              'MAILTO=foo@example.com',
+              'SHELL=/bin/sh'
+            ],
+            :user        => :absent,
+            :target      => 'foobar'
+          }
+        ]
+      end
+    end
+  end
+
+  describe ".match" do
+    describe "normal records" do
+      it "should match when all fields are the same" do
+        described_class.match(record,{resource[:name] => resource}).must == resource
+      end
+
+      {
+        :minute      => %w{0 15 31 45},
+        :hour        => %w{8-18},
+        :monthday    => %w{30 31},
+        :month       => %w{12 23},
+        :weekday     => %w{4},
+        :command     => '/bin/false',
+        :target      => 'nobody'
+      }.each_pair do |field, new_value|
+        it "should not match a record when #{field} does not match" do
+          record[field] = new_value
+          described_class.match(record,{resource[:name] => resource}).must be_false
+        end
+      end
+    end
+
+    describe "special records" do
+      it "should match when all fields are the same" do
+        described_class.match(record_special,{resource_special[:name] => resource_special}).must == resource_special
+      end
+
+      {
+        :special => 'monthly',
+        :command => '/bin/false',
+        :target  => 'root'
+      }.each_pair do |field, new_value|
+        it "should not match a record when #{field} does not match" do
+          record_special[field] = new_value
+          described_class.match(record_special,{resource_special[:name] => resource_special}).must be_false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The cronprovider defines two record_types `:crontab` and `:freebsd_special`
to handle the following crontab records:

```
@daily /bin/my_daily_command
0 0 * * * /bin/my_daily_command
```

This has a few issues:

a)
The merging of the name (the comment before the cronentry itself) and
the environment variables only happens for the `:crontab` record_type
but not for the `:freebsd_special` record_type so information may get
lost (redmine ticket #16809)

b)
When parsing an existing record the record_type can be automatically
determined (depending on which regex matched) but when creating a new
entry, the record_type is undefined and the default `:crontab` is used.
So if a new cronentry is created with the `:special` property set it is
still treated as a crontab entry (so the to_line hook of the `:crontab`
record_type is used and not of the `:freebsd_special` record_type)
which is kind of confusing.

c)
It is really hard to change the time of a cronentry from the special
format to a normal format (or vise versa) e.g. if we already have the
following cronentry

```
# Puppet Name: foo
* * * * * /bin/foo
```

and we have defined the following resource

```
cron { "foo":
  special => daily,
}
```

the resource is treatd as in sync because the existing cronentry is
parsed as a :crontab record_type and this record_type doesn't define a
:special field that could be out of sync

This patch now only uses one record_type that internally parses the
timefield as either the old format (minute,hour,monthday,month,weekday)
or the special format. This way the above issues go away (but the
different to_line, post_parse hooks get a bit more difficult to handle
both entries)

= NOTE
After I'm done I'm not so conviced anymore that this was the best approach. I may try the other route: Patching the `parsedfile` provider to be able to migrate an existing record from one record_type to another and automatically determine the best-fit record_type of newly created records. I'd still like the pull request to be merged because then there are at least some spec tests as a starting point.
