### PR TITLE
(Maint) Update config.ru to fix issue with vardir

### DIFF
--- a/ext/rack/files/config.ru
+++ b/ext/rack/files/config.ru
@@ -11,9 +11,11 @@ $0 = "master"
 
 ARGV << "--rack"
 
-# Rack applications typically don't start as root.  Set --confdir to prevent
-# reading configuration from ~/.puppet/puppet.conf
+# Rack applications typically don't start as root.  Set --confdir and --vardir
+# to prevent reading configuration from ~puppet/.puppet/puppet.conf and writing
+# to ~puppet/.puppet
 ARGV << "--confdir" << "/etc/puppet"
+ARGV << "--vardir"  << "/var/lib/puppet"
 
 # NOTE: it's unfortunate that we have to use the "CommandLine" class
 #  here to launch the app, but it contains some initialization logic


### PR DESCRIPTION
Without this patch the config.ru example only contains the --confdir
argument.  This is a problem because when Puppet starts from config.ru, it
will automatically be switched by Passenger to the EUID of the owner of the
file.  Puppet will still try to write to the default vardir of
~/.puppet/ in this situation which may be a problem because $HOME might be
~root.

This patch fixes the problem by adding the --vardir option to the example
with the default value of /var/lib/puppet
