### PR TITLE
(#16769) Fix header too long error with ExportCertData

### DIFF
--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -82,7 +82,10 @@ class Puppet::Network::HTTP::RackREST < Puppet::Network::HTTP::RackHttpHandler
   def client_cert(request)
     # This environment variable is set by mod_ssl, note that it
     # requires the `+ExportCertData` option in the `SSLOptions` directive
-    return nil unless cert = request.env['SSL_CLIENT_CERT']
+    cert = request.env['SSL_CLIENT_CERT']
+    # NOTE: The SSL_CLIENT_CERT environment variable will be the empty string
+    # when Puppet agent nodes have not yet obtained a signed certificate.
+    return nil if cert.nil? or cert.empty?
     OpenSSL::X509::Certificate.new(cert)
   end
 

--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -64,6 +64,19 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
         @handler.client_cert(req).should == cert
       end
 
+      it "returns nil when SSL_CLIENT_CERT is empty" do
+        cert = stub 'cert'
+        req = mk_req('/foo/bar', 'SSL_CLIENT_CERT' => '')
+        OpenSSL::X509::Certificate.expects(:new).never
+        @handler.client_cert(req).should be_nil
+      end
+
+      it "(#16769) does not raise error 'header too long'" do
+        cert = stub 'cert'
+        req = mk_req('/foo/bar', 'SSL_CLIENT_CERT' => '')
+        lambda { @handler.client_cert(req) }.should_not raise_error
+      end
+
       it "should set the response's content-type header when setting the content type" do
         @header = mock 'header'
         @response.expects(:header).returns @header


### PR DESCRIPTION
Without this patch new Puppet agent nodes who do not yet have a signed
certificate will receive this error message when Apache is configured with
the +ExportCertData option.

```
Error: Could not request certificate: Error 400 on SERVER: header too long
Exiting; failed to retrieve certificate and waitforcert is disabled
```

This is a problem because Puppet doesn't run at all.

The root cause is that we didn't take into account the edge case where a
Puppet agent is operating as an anonymous SSL client without a signed
certificate.  In this situation, the  SSL_CLIENT_CERT environment
variable is set, but is the empty string.

Worse, the OpenSSL error message is mis-leading because the certificate
is not present rather not "too long."

This patch fixes the problem by explicitly checking if the data is empty
or nil.
