### PR TITLE
(#16922) Quote strings that contain ":"

### DIFF
--- a/lib/puppet/util/zaml.rb
+++ b/lib/puppet/util/zaml.rb
@@ -301,7 +301,7 @@ class String
       # Only legal UTF-8 characters can make it this far, so we are safe
       # against emitting something dubious. That means we don't need to mess
       # about, just emit them directly. --daniel 2012-07-14
-      when ((self =~ /\A[a-zA-Z\/][-\[\]_\/.:a-zA-Z0-9]*\z/) and
+      when ((self =~ /\A[a-zA-Z\/][-\[\]_\/.a-zA-Z0-9]*\z/) and
           (self !~ /^(?:true|false|yes|no|on|null|off)$/i))
         # simple string literal, safe to emit unquoted.
         z.emit(self)


### PR DESCRIPTION
Part of the performance work on the ZAML code caused a regression on how to
convert values that contain a colon into YAML strings. This becomes a problem
when a string ends in a colon and that line in the YAML output is followed by
another line.

An example of the incorrect output is:

---

 a: a:
 b: 1

This patch causes that to be output correctly as:

---

 a: "a:"
 b: 1
