### PR TITLE
Unpacker should force mv when extracting module to install dir

### DIFF
--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -52,7 +52,7 @@ module Puppet::ModuleTool
 
           # grab the first directory
           extracted = build_dir.children.detect { |c| c.directory? }
-          FileUtils.mv extracted, @module_dir
+          FileUtils.mv extracted, @module_dir, :force => true
         ensure
           build_dir.rmtree
         end


### PR DESCRIPTION
See https://projects.puppetlabs.com/issues/17033

TL;DR
When the Unpacker tries to extract a module containing a broken symlink to its install dir the `FileUtils::mv` command fails for some reason. I’m not sure why, because moving a directly with broken symlinks is normally ok. But doing a force move fixes the problem.
