### PR TITLE
(#7962) Reopen: Added description of 'duration' settings format.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -670,7 +670,8 @@ EOT
     :ca_ttl => {
       :default    => "5y",
       :type       => :duration,
-      :desc       => "The default TTL for new certificates. Can be specified as a duration."
+      :desc       => "The default TTL for new certificates. If this setting is set, ca_days is ignored.
+      Can be specified as a duration."
     },
     :ca_md => {
       :default    => "md5",

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -53,6 +53,12 @@ config.header = <<EOT
 * Multiple values should be specified as comma-separated lists; multiple
   directories should be separated with the system path separator (usually
   a colon).
+* Settings that represent time intervals should be specified in duration format:
+  an integer immediately followed by one of the units 'y' (years of 365 days),
+  'd' (days), 'h' (hours), 'm' (minutes), or 's' (seconds). The unit cannot be
+  combined with other units, and defaults to seconds when omitted. Examples are
+  '3600' which is equivalent to '1h' (one hour), and '1825d' which is equivalent
+  to '5y' (5 years).
 * Settings that take a single file or directory can optionally set the owner,
   group, and mode for their value: `rundir = $vardir/run { owner = puppet,
   group = puppet, mode = 644 }`


### PR DESCRIPTION
This reopens [a PR that was closed with the removal of the 3.x branch](https://github.com/puppetlabs/puppet/pull/1154). As per instructions, I've rebased off master and made it the target branch of this PR. I would like to emphasize the importance of this commit: without it, the auto-generated configuration documentation page will contain references to 'duration format' that isn't explained anywhere. The original commit that made the changes I'm referring to [is already in master](https://github.com/puppetlabs/puppet/commit/2cb9b503c427c75b45ba47a0ea538ae95342bee2).

---

Descriptions for settings of the `DurationSetting` type indicate that they
'can be specified as a duration'. This adds the description of how a
duration should be specified to the configuration reference section.

This also adds back a pertinant sentence accidentally removed from the
`ca_ttl` setting description.
