### PR TITLE
Ensure the year in the module template is correct.

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
@@ -33,7 +33,7 @@
 #
 # === Copyright
 #
-# Copyright 2011 Your name here, unless otherwise noted.
+# Copyright <%= Time.now.year -%> Your name here, unless otherwise noted.
 #
 class <%= metadata.name %> {
 


### PR DESCRIPTION
Previous to this commit the year in the `puppet module generate`
template was hard-coded to be 2011. Since it is not 2011 anymore, this
is problematic.

This commit addresses this by calling Time.now.year inside the erb
template.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
