### PR TITLE
(maint) remove unused attributes from transaction

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -12,8 +12,7 @@ class Puppet::Transaction
   require 'puppet/transaction/resource_harness'
   require 'puppet/resource/status'
 
-  attr_accessor :component, :catalog, :ignoreschedules, :for_network_device
-  attr_accessor :configurator
+  attr_accessor :catalog, :ignoreschedules, :for_network_device
 
   # The report, once generated.
   attr_reader :report


### PR DESCRIPTION
The :component attr_accessor became obsolete in
4741eeff6bae987c9dfa9e06e2908ae91daa4d16, and the :configurator
attr_accessor became obsolete in
f17f19dae941b17a56c1fc83ed3a89712b98c427

This is a pretty trivial commit to remove some ancient code rot.
