### PR TITLE
(#17129) Handle bad perms on pem files

### DIFF
--- a/lib/puppet/indirector/ssl_file.rb
+++ b/lib/puppet/indirector/ssl_file.rb
@@ -82,12 +82,17 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
 
   # Find the file on disk, returning an instance of the model.
   def find(request)
-    path = path(request.key)
+    mypath = path(request.key)
 
-    return nil unless (FileTest.exist?(path) and FileTest.readable?(path)) or rename_files_with_uppercase(path)
+    exists = FileTest.exist?(mypath)
+    readable = exists && FileTest.readable?(mypath)
+    if exists and not readable
+      Puppet.warning("Certificate file has wrong permissions (not readable): #{mypath}")
+    end
+    return nil unless (exists and readable) or rename_files_with_uppercase(mypath)
 
     result = model.new(request.key)
-    result.read(path)
+    result.read(mypath)
     result
   end
 
@@ -108,7 +113,12 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
     dir = collection_directory
     Dir.entries(dir).
         reject { |file| file !~ /\.pem$/ }.
-        reject { |file| !FileTest.readable?(File.join(dir, file)) }.
+        reject do |file|
+          full_path = File.join(dir, file)
+          bad = !FileTest.readable?(full_path)
+          Puppet.warning("Certificate file has wrong permissions (not readable): #{full_path}") if bad
+          bad
+        end.
         collect do |file|
       name = file.sub(/\.pem$/, '')
       result = model.new(name)


### PR DESCRIPTION
Prior to this commit, if a .pem file existed, but had unreadable
permissions, the indirector search method would just crap out, returning
an empty collection. This commit rectifies that and ensures that
unreadable .pem files are excluded prior to attempting to read the file.
