### PR TITLE
Clarifying status of dependent files using yum 'uninstallable' feature.

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -1,7 +1,11 @@
 require 'puppet/util/package'
 
 Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
-  desc "Support via `yum`."
+  desc "Support via `yum`.
+  
+  Using this provider's `uninstallable` feature will not remove dependent packages. To 
+  remove dependent packages with this provider use the `purgeable` feature, but note this 
+  feature is destructive and should be used with the utmost care."
 
   has_feature :versionable
 


### PR DESCRIPTION
Addresses "Type docs vague with respect to package provider"
http://projects.puppetlabs.com/issues/12670
