### PR TITLE
(#4695) Puppet should not reset locale for services

### DIFF
--- a/lib/puppet/provider/service/service.rb
+++ b/lib/puppet/provider/service/service.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide :service do
   def texecute(type, command, fof = true)
     begin
       # #565: Services generally produce no output, so squelch them.
-      execute(command, :failonfail => fof, :squelch => true)
+      execute(command, :failonfail => fof, :override_locale => false, :squelch => true)
     rescue Puppet::ExecutionFailure => detail
       @resource.fail "Could not #{type} #{@resource.ref}: #{detail}"
     end

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -72,12 +72,12 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
   describe "#start" do
     it "should use the supplied start command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
       provider.start
     end
     it "should start the service with <initscript> start otherwise" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      provider.expects(:execute).with(['/etc/init.d/sshd',:start], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/etc/init.d/sshd',:start], :failonfail => true, :override_locale => false, :squelch => true)
       provider.expects(:search).with('sshd').returns('/etc/init.d/sshd')
       provider.start
     end
@@ -86,12 +86,12 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
       provider.stop
     end
     it "should stop the service with <initscript> stop otherwise" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      provider.expects(:execute).with(['/etc/init.d/sshd',:stop], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/etc/init.d/sshd',:stop], :failonfail => true, :override_locale => false, :squelch => true)
       provider.expects(:search).with('sshd').returns('/etc/init.d/sshd')
       provider.stop
     end
@@ -153,23 +153,23 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
     describe "when a special status command is specified" do
       it "should use the status command from the resource" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :squelch => true).never
-        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
+        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => true)
         provider.status
       end
 
       it "should return :stopped when the status command returns with a non-zero exitcode" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :squelch => true).never
-        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
+        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => true)
         $CHILD_STATUS.stubs(:exitstatus).returns 3
         provider.status.should == :stopped
       end
 
       it "should return :running when the status command returns with a zero exitcode" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :squelch => true).never
-        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
+        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => true)
         $CHILD_STATUS.stubs(:exitstatus).returns 0
         provider.status.should == :running
       end
@@ -178,14 +178,14 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
     describe "when hasstatus is false" do
       it "should return running if a pid can be found" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :squelch => true).never
+        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
         provider.expects(:getpid).returns 1000
         provider.status.should == :running
       end
 
       it "should return stopped if no pid can be found" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :squelch => true).never
+        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
         provider.expects(:getpid).returns nil
         provider.status.should == :stopped
       end
@@ -195,7 +195,7 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
       it "should return running if <initscript> status exits with a zero exitcode" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         provider.expects(:search).with('sshd').returns('/etc/init.d/sshd')
-        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => true)
         $CHILD_STATUS.stubs(:exitstatus).returns 0
         provider.status.should == :running
       end
@@ -203,7 +203,7 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
       it "should return stopped if <initscript> status exits with a non-zero exitcode" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         provider.expects(:search).with('sshd').returns('/etc/init.d/sshd')
-        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => true)
         $CHILD_STATUS.stubs(:exitstatus).returns 3
         provider.status.should == :stopped
       end
@@ -213,24 +213,24 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      provider.expects(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :squelch => true).never
-      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => true).never
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
       provider.restart
     end
 
     it "should restart the service with <initscript> restart if hasrestart is true" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => true))
       provider.expects(:search).with('sshd').returns('/etc/init.d/sshd')
-      provider.expects(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => true)
       provider.restart
     end
 
     it "should restart the service with <initscript> stop/start if hasrestart is false" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => false))
       provider.expects(:search).with('sshd').returns('/etc/init.d/sshd')
-      provider.expects(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :squelch => true).never
-      provider.expects(:execute).with(['/etc/init.d/sshd',:stop], :failonfail => true, :squelch => true)
-      provider.expects(:execute).with(['/etc/init.d/sshd',:start], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => true).never
+      provider.expects(:execute).with(['/etc/init.d/sshd',:stop], :failonfail => true, :override_locale => false, :squelch => true)
+      provider.expects(:execute).with(['/etc/init.d/sshd',:start], :failonfail => true, :override_locale => false, :squelch => true)
       provider.restart
     end
   end

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -35,12 +35,12 @@ describe Puppet::Type.type(:service).provider(:openrc) do
   describe "#start" do
     it "should use the supplied start command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
       provider.start
     end
     it "should start the service with rc-service start otherwise" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      provider.expects(:execute).with(['/sbin/rc-service','sshd',:start], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/sbin/rc-service','sshd',:start], :failonfail => true, :override_locale => false, :squelch => true)
       provider.start
     end
   end
@@ -48,12 +48,12 @@ describe Puppet::Type.type(:service).provider(:openrc) do
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
       provider.stop
     end
     it "should stop the service with rc-service stop otherwise" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      provider.expects(:execute).with(['/sbin/rc-service','sshd',:stop], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/sbin/rc-service','sshd',:stop], :failonfail => true, :override_locale => false, :squelch => true)
       provider.stop
     end
   end
@@ -128,23 +128,23 @@ describe Puppet::Type.type(:service).provider(:openrc) do
     describe "when a special status command if specified" do
       it "should use the status command from the resource" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :squelch => true).never
-        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
+        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => true)
         provider.status
       end
 
       it "should return :stopped when status command returns with a non-zero exitcode" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :squelch => true).never
-        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
+        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => true)
         $CHILD_STATUS.stubs(:exitstatus).returns 3
         provider.status.should == :stopped
       end
 
       it "should return :running when status command returns with a zero exitcode" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :squelch => true).never
-        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
+        provider.expects(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => true)
         $CHILD_STATUS.stubs(:exitstatus).returns 0
         provider.status.should == :running
       end
@@ -153,14 +153,14 @@ describe Puppet::Type.type(:service).provider(:openrc) do
     describe "when hasstatus is false" do
       it "should return running if a pid can be found" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :squelch => true).never
+        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
         provider.expects(:getpid).returns 1000
         provider.status.should == :running
       end
 
       it "should return stopped if no pid can be found" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :squelch => true).never
+        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => true).never
         provider.expects(:getpid).returns nil
         provider.status.should == :stopped
       end
@@ -169,14 +169,14 @@ describe Puppet::Type.type(:service).provider(:openrc) do
     describe "when hasstatus is true" do
       it "should return running if rc-service status exits with a zero exitcode" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
-        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => true)
         $CHILD_STATUS.stubs(:exitstatus).returns 0
         provider.status.should == :running
       end
 
       it "should return stopped if rc-service status exits with a non-zero exitcode" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
-        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :squelch => true)
+        provider.expects(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => true)
         $CHILD_STATUS.stubs(:exitstatus).returns 3
         provider.status.should == :stopped
       end
@@ -186,22 +186,22 @@ describe Puppet::Type.type(:service).provider(:openrc) do
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      provider.expects(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :squelch => true).never
-      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => true).never
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
       provider.restart
     end
 
     it "should restart the service with rc-service restart if hasrestart is true" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => true))
-      provider.expects(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => true)
       provider.restart
     end
 
     it "should restart the service with rc-service stop/start if hasrestart is false" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => false))
-      provider.expects(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :squelch => true).never
-      provider.expects(:execute).with(['/sbin/rc-service','sshd',:stop], :failonfail => true, :squelch => true)
-      provider.expects(:execute).with(['/sbin/rc-service','sshd',:start], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => true).never
+      provider.expects(:execute).with(['/sbin/rc-service','sshd',:stop], :failonfail => true, :override_locale => false, :squelch => true)
+      provider.expects(:execute).with(['/sbin/rc-service','sshd',:start], :failonfail => true, :override_locale => false, :squelch => true)
       provider.restart
     end
   end

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -35,12 +35,12 @@ describe provider_class do
   end
 
   it "should execute the startsrc command" do
-    @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
+    @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:override_locale => false, :squelch => true, :failonfail => true})
     @provider.start
   end
 
   it "should execute the stopsrc command" do
-    @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
+    @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:override_locale => false, :squelch => true, :failonfail => true})
     @provider.stop
   end
 
@@ -90,8 +90,8 @@ _EOF_
 myservice::--no-daemonize:/usr/sbin/puppetd:0:0:/dev/null:/var/log/puppet.log:/var/log/puppet.log:-O:-Q:-S:0:0:20:15:9:-d:20::"
 _EOF_
     @provider.expects(:execute).with(['/usr/bin/lssrc', '-Ss', "myservice"]).returns sample_output
-    @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
-    @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
+    @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:override_locale => false, :squelch => true, :failonfail => true})
+    @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:override_locale => false, :squelch => true, :failonfail => true})
     @provider.restart
   end
 end

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -119,7 +119,7 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
       resource[:restart] = 'c:/bin/foo'
 
       provider.expects(:execute).never
-      provider.expects(:execute).with(['c:/bin/foo'], :failonfail => true, :squelch => true)
+      provider.expects(:execute).with(['c:/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
 
       provider.restart
     end


### PR DESCRIPTION
Don't reset locale when starting services, we don't parse their output
so there is no need.

This avoids having different locales for services depending on if they
are started on boot or started by puppet.
