### PR TITLE
(#7622) Deprecate and remove features.pson?

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -9,6 +9,9 @@ require 'puppet/settings'
 require 'puppet/util/feature'
 require 'puppet/util/suidmanager'
 require 'puppet/util/run_mode'
+require 'puppet/external/pson/common'
+require 'puppet/external/pson/version'
+require 'puppet/external/pson/pure'
 
 #------------------------------------------------------------
 # the top-level module

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -151,7 +151,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   def compile
     Puppet::Util::Log.newdestination :console
-    raise ArgumentError, "Cannot render compiled catalogs without pson support" unless Puppet.features.pson?
     begin
       unless catalog = Puppet::Resource::Catalog.indirection.find(options[:node])
         raise "Could not compile catalog for #{options[:node]}"

--- a/lib/puppet/feature/pson.rb
+++ b/lib/puppet/feature/pson.rb
@@ -1,6 +1,4 @@
 Puppet.features.add(:pson) do
-  require 'puppet/external/pson/common'
-  require 'puppet/external/pson/version'
-  require 'puppet/external/pson/pure'
+  Puppet.deprecation_warning "There is no need to check for pson support. It is always available."
   true
 end

--- a/lib/puppet/indirector/queue.rb
+++ b/lib/puppet/indirector/queue.rb
@@ -24,7 +24,6 @@ class Puppet::Indirector::Queue < Puppet::Indirector::Terminus
 
   def initialize(*args)
     super
-    raise ArgumentError, "Queueing requires pson support" unless Puppet.features.pson?
   end
 
   # Queue has no idiomatic "find"

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -16,8 +16,7 @@ class Puppet::Indirector::Request
 
   OPTION_ATTRIBUTES = [:ip, :node, :authenticated, :ignore_terminus, :ignore_cache, :instance, :environment]
 
-  # Load json before trying to register.
-  Puppet.features.pson? and ::PSON.register_document_type('IndirectorRequest',self)
+  ::PSON.register_document_type('IndirectorRequest',self)
 
   def self.from_pson(json)
     raise ArgumentError, "No indirection name provided in json data" unless indirection_name = json['type']

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -101,8 +101,6 @@ Puppet::Network::FormatHandler.create(:raw, :mime => "application/x-raw", :weigh
 end
 
 Puppet::Network::FormatHandler.create_serialized_formats(:pson, :weight => 10, :required_methods => [:render_method, :intern_method]) do
-  confine :true => Puppet.features.pson?
-
   def intern(klass, text)
     data_to_instance(klass, PSON.parse(text))
   end

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -18,9 +18,8 @@ class Puppet::Node
 
   attr_accessor :name, :classes, :source, :ipaddress, :parameters
   attr_reader :time, :facts
-  #
-  # Load json before trying to register.
-  Puppet.features.pson? and ::PSON.register_document_type('Node',self)
+
+  ::PSON.register_document_type('Node',self)
 
   def self.from_pson(pson)
     raise ArgumentError, "No name provided in pson data" unless name = pson['name']

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -6,7 +6,7 @@ require 'puppet/application/apply'
 describe "apply" do
   include PuppetSpec::Files
 
-  describe "when applying provided catalogs", :if => Puppet.features.pson? do
+  describe "when applying provided catalogs" do
     it "should be able to apply catalogs provided in a file in pson" do
       file_to_create = tmpfile("pson_catalog")
       catalog = Puppet::Resource::Catalog.new

--- a/spec/integration/indirector/catalog/queue_spec.rb
+++ b/spec/integration/indirector/catalog/queue_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet/resource/catalog'
 
-describe "Puppet::Resource::Catalog::Queue", :if => Puppet.features.pson? do
+describe "Puppet::Resource::Catalog::Queue" do
   before do
     Puppet::Resource::Catalog.indirection.terminus(:queue)
     @catalog = Puppet::Resource::Catalog.new

--- a/spec/integration/network/formats_spec.rb
+++ b/spec/integration/network/formats_spec.rb
@@ -45,60 +45,47 @@ describe Puppet::Network::FormatHandler.format(:s) do
 end
 
 describe Puppet::Network::FormatHandler.format(:pson) do
-  describe "when pson is absent", :if => (! Puppet.features.pson?) do
-
-    before do
-      @pson = Puppet::Network::FormatHandler.format(:pson)
-    end
-
-    it "should not be suitable" do
-      @pson.should_not be_suitable
-    end
+  before do
+    @pson = Puppet::Network::FormatHandler.format(:pson)
   end
 
-  describe "when pson is available", :if => Puppet.features.pson? do
-    before do
-      @pson = Puppet::Network::FormatHandler.format(:pson)
-    end
+  it "should be able to render an instance to pson" do
+    instance = PsonIntTest.new("foo")
+    PsonIntTest.canonical_order(@pson.render(instance)).should == PsonIntTest.canonical_order('{"type":"PsonIntTest","data":["foo"]}' )
+  end
 
-    it "should be able to render an instance to pson" do
-      instance = PsonIntTest.new("foo")
-      PsonIntTest.canonical_order(@pson.render(instance)).should == PsonIntTest.canonical_order('{"type":"PsonIntTest","data":["foo"]}' )
-    end
+  it "should be able to render arrays to pson" do
+    @pson.render([1,2]).should == '[1,2]'
+  end
 
-    it "should be able to render arrays to pson" do
-      @pson.render([1,2]).should == '[1,2]'
-    end
+  it "should be able to render arrays containing hashes to pson" do
+    @pson.render([{"one"=>1},{"two"=>2}]).should == '[{"one":1},{"two":2}]'
+  end
 
-    it "should be able to render arrays containing hashes to pson" do
-      @pson.render([{"one"=>1},{"two"=>2}]).should == '[{"one":1},{"two":2}]'
-    end
+  it "should be able to render multiple instances to pson" do
+    one = PsonIntTest.new("one")
+    two = PsonIntTest.new("two")
 
-    it "should be able to render multiple instances to pson" do
-      one = PsonIntTest.new("one")
-      two = PsonIntTest.new("two")
+    PsonIntTest.canonical_order(@pson.render([one,two])).should == PsonIntTest.canonical_order('[{"type":"PsonIntTest","data":["one"]},{"type":"PsonIntTest","data":["two"]}]')
+  end
 
-      PsonIntTest.canonical_order(@pson.render([one,two])).should == PsonIntTest.canonical_order('[{"type":"PsonIntTest","data":["one"]},{"type":"PsonIntTest","data":["two"]}]')
-    end
+  it "should be able to intern pson into an instance" do
+    @pson.intern(PsonIntTest, '{"type":"PsonIntTest","data":["foo"]}').should == PsonIntTest.new("foo")
+  end
 
-    it "should be able to intern pson into an instance" do
-      @pson.intern(PsonIntTest, '{"type":"PsonIntTest","data":["foo"]}').should == PsonIntTest.new("foo")
-    end
+  it "should be able to intern pson with no class information into an instance" do
+    @pson.intern(PsonIntTest, '["foo"]').should == PsonIntTest.new("foo")
+  end
 
-    it "should be able to intern pson with no class information into an instance" do
-      @pson.intern(PsonIntTest, '["foo"]').should == PsonIntTest.new("foo")
-    end
+  it "should be able to intern multiple instances from pson" do
+    @pson.intern_multiple(PsonIntTest, '[{"type": "PsonIntTest", "data": ["one"]},{"type": "PsonIntTest", "data": ["two"]}]').should == [
+      PsonIntTest.new("one"), PsonIntTest.new("two")
+    ]
+  end
 
-    it "should be able to intern multiple instances from pson" do
-      @pson.intern_multiple(PsonIntTest, '[{"type": "PsonIntTest", "data": ["one"]},{"type": "PsonIntTest", "data": ["two"]}]').should == [
-        PsonIntTest.new("one"), PsonIntTest.new("two")
-      ]
-    end
-
-    it "should be able to intern multiple instances from pson with no class information" do
-      @pson.intern_multiple(PsonIntTest, '[["one"],["two"]]').should == [
-        PsonIntTest.new("one"), PsonIntTest.new("two")
-      ]
-    end
+  it "should be able to intern multiple instances from pson with no class information" do
+    @pson.intern_multiple(PsonIntTest, '[["one"],["two"]]').should == [
+      PsonIntTest.new("one"), PsonIntTest.new("two")
+    ]
   end
 end

--- a/spec/integration/resource/catalog_spec.rb
+++ b/spec/integration/resource/catalog_spec.rb
@@ -2,10 +2,8 @@
 require 'spec_helper'
 
 describe Puppet::Resource::Catalog do
-  describe "when pson is available", :if => Puppet.features.pson? do
-    it "should support pson" do
-      Puppet::Resource::Catalog.supported_formats.should be_include(:pson)
-    end
+  it "should support pson" do
+    Puppet::Resource::Catalog.supported_formats.should be_include(:pson)
   end
 
   describe "when using the indirector" do

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -242,12 +242,6 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
         Puppet[:manifest] = "site.pp"
         Puppet.stubs(:err)
         @master.stubs(:jj)
-        Puppet.features.stubs(:pson?).returns true
-      end
-
-      it "should fail if pson isn't available" do
-        Puppet.features.expects(:pson?).returns false
-        lambda { @master.compile }.should raise_error
       end
 
       it "should compile a catalog for the specified node" do

--- a/spec/unit/indirector/queue_spec.rb
+++ b/spec/unit/indirector/queue_spec.rb
@@ -25,7 +25,7 @@ class FooExampleData
   end
 end
 
-describe Puppet::Indirector::Queue, :if => Puppet.features.pson? do
+describe Puppet::Indirector::Queue do
   before :each do
     @model = mock 'model'
     @indirection = stub 'indirection', :name => :my_queue, :register_terminus_type => nil, :model => @model
@@ -44,12 +44,6 @@ describe Puppet::Indirector::Queue, :if => Puppet.features.pson? do
     Puppet::Util::Queue.stubs(:queue_type_to_class).with(:test_client).returns(Puppet::Indirector::Queue::TestClient)
 
     @request = stub 'request', :key => :me, :instance => @subject
-  end
-
-  it "should require PSON" do
-    Puppet.features.expects(:pson?).returns false
-
-    expect { @store_class.new }.to raise_error(ArgumentError)
   end
 
   it 'should use the correct client type and queue' do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -521,7 +521,7 @@ describe Puppet::Module do
     mod
   end
 
-  describe "when loading the metadata file", :if => Puppet.features.pson? do
+  describe "when loading the metadata file" do
     before do
       @data = {
         :license       => "GPL2",

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -220,7 +220,7 @@ describe "Puppet Network Format" do
     Puppet::Network::FormatHandler.format(:pson).should_not be_nil
   end
 
-  describe "pson", :if => Puppet.features.pson? do
+  describe "pson" do
     before do
       @pson = Puppet::Network::FormatHandler.format(:pson)
     end

--- a/spec/unit/relationship_spec.rb
+++ b/spec/unit/relationship_spec.rb
@@ -151,7 +151,7 @@ describe Puppet::Relationship, " when matching edges with a non-standard event" 
   end
 end
 
-describe Puppet::Relationship, "when converting to pson", :if => Puppet.features.pson? do
+describe Puppet::Relationship, "when converting to pson" do
   before do
     @edge = Puppet::Relationship.new(:a, :b, :event => :random, :callback => :whatever)
   end
@@ -184,7 +184,7 @@ describe Puppet::Relationship, "when converting to pson", :if => Puppet.features
   end
 end
 
-describe Puppet::Relationship, "when converting from pson", :if => Puppet.features.pson? do
+describe Puppet::Relationship, "when converting from pson" do
   before do
     @event = "random"
     @callback = "whatever"

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -775,7 +775,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
   end
 end
 
-describe Puppet::Resource::Catalog, "when converting to pson", :if => Puppet.features.pson? do
+describe Puppet::Resource::Catalog, "when converting to pson" do
   before do
     @catalog = Puppet::Resource::Catalog.new("myhost")
   end
@@ -833,7 +833,7 @@ describe Puppet::Resource::Catalog, "when converting to pson", :if => Puppet.fea
   end
 end
 
-describe Puppet::Resource::Catalog, "when converting from pson", :if => Puppet.features.pson? do
+describe Puppet::Resource::Catalog, "when converting from pson" do
   def pson_result_should
     Puppet::Resource::Catalog.expects(:new).with { |hash| yield hash }
   end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -647,7 +647,7 @@ type: File
     end
   end
 
-  describe "when converting to pson", :if => Puppet.features.pson? do
+  describe "when converting to pson" do
     def pson_output_should
       @resource.class.expects(:pson_create).with { |hash| yield hash }
     end
@@ -726,7 +726,7 @@ type: File
     end
   end
 
-  describe "when converting from pson", :if => Puppet.features.pson? do
+  describe "when converting from pson" do
     def pson_result_should
       Puppet::Resource.expects(:new).with { |hash| yield hash }
     end


### PR DESCRIPTION
PSON is always available and so the pson feature was only used for the 
side-effect of requiring the pson files. This commit deprecates the pson 
feature and moves the requires to the puppet.rb file so that PSON is 
available early on.
