### PR TITLE
Add explicit mention of dirs to inline docs for exec creates param

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -313,7 +313,7 @@ module Puppet
 
     newcheck(:creates, :parent => Puppet::Parameter::Path) do
       desc <<-'EOT'
-        A file that this command creates.  If this
+        A file or directory that this command creates.  If this
         parameter is provided, then the command will only be run
         if the specified file does not exist.
 


### PR DESCRIPTION
As discussed with @nfagerlund, explicitly mention that the exec resource 'creates' parameter supports testing against directories as well as files. 
