### PR TITLE
Remove the asc file from the source of spec file

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -7,7 +7,7 @@ pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
-sign_tar: TRUE
+sign_tar: False
 # a space separated list of mock configs
 final_mocks: 'pl-5-i386 pl-5-x86_64 pl-6-i386 pl-6-x86_64 fedora-15-i386 fedora-15-x86_64 fedora-16-i386 fedora-16-x86_64 fedora-17-i386 fedora-17-x86_64'
 rc_mocks: 'pl-5-i386-dev pl-5-x86_64-dev pl-6-i386-dev pl-6-x86_64-dev fedora-15-i386-dev fedora-15-x86_64-dev fedora-16-i386-dev fedora-16-x86_64-dev fedora-17-i386-dev fedora-17-x86_64-dev'

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -23,7 +23,6 @@ Summary:        A network tool for managing many disparate systems
 License:        ASL 2.0
 URL:            http://puppetlabs.com
 Source0:        http://puppetlabs.com/downloads/%{name}/%{name}-%{realversion}.tar.gz
-Source1:        http://puppetlabs.com/downloads/%{name}/%{name}-%{realversion}.tar.gz.asc
 
 Group:          System Environment/Base
 
@@ -303,6 +302,9 @@ rm -rf %{buildroot}
 %changelog
 * <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
+
+* Tue Oct 30 2012 Michael Stahnke <stahnma@puppetlabs.com> - 2.7.19-1.0
+- Remove the asc file as a source since it was never used
 
 * Tue Aug 21 2012 Moses Mendoza <moses@puppetlabs.com> - 2.7.19-1
 - Update for 2.7.19


### PR DESCRIPTION
The asc file was never used during builds. This commit removes it as a
requirement to build puppet.  This will help with nightly builds and
allow easier community adoption of our build system (along with
automation).

This commit has already been made in the 3 series of puppet.

(This is explicitly targeted at 2.7.x)

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
