### PR TITLE
Update Rakefile to make rspec optional

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,8 @@ $LOAD_PATH << File.join(File.dirname(__FILE__), 'tasks')
 begin
   require 'rubygems'
   require 'rubygems/package_task'
+  require 'rspec'
+  require 'rspec/core/rake_task'
 rescue LoadError
   # Users of older versions of Rake (0.8.7 for example) will not necessarily
   # have rubygems installed, or the newer rubygems package_task for that
@@ -18,8 +20,6 @@ rescue LoadError
 end
 
 require 'rake'
-require 'rspec'
-require "rspec/core/rake_task"
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 Dir['ext/packaging/tasks/**/*'].sort.each { |t| load t }
@@ -60,9 +60,11 @@ task :default do
     sh %{rake -T}
 end
 
-RSpec::Core::RakeTask.new do |t|
-    t.pattern ='spec/{unit,integration}/**/*.rb'
-    t.fail_on_error = true
+if defined?(RSpec::Core::RakeTask)
+  RSpec::Core::RakeTask.new do |t|
+      t.pattern ='spec/{unit,integration}/**/*.rb'
+      t.fail_on_error = true
+  end
 end
 
 desc "Run the unit tests"


### PR DESCRIPTION
Currently rspec is a hard dependency to using the Rakefile for puppet. This
means that users on platforms without native rspec packages can't use the
Rakefile to do other things, like build packages. This commit moves the require
on rspec and rspec/core/rake_task into a begin/rescue block and wraps the call
to Rspec::Core::RakeTask in an `if defined?` conditional so it is only invoked
if Rspec is loaded and available.
