### PR TITLE
Remove hardcoded version from source in Puppet

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -6,7 +6,17 @@
 # Raketasks and such to set the version based on the output of `git describe`
 #
 module Puppet
-  PUPPETVERSION = '2.7.19'
+  version = 'DEVELOPMENT'
+  if version == 'DEVELOPMENT'
+    %x{git rev-parse --is-inside-work-tree > /dev/null 2>&1}
+    if $?.success?
+      version = %x{git describe --tags --always 2>&1}.chomp
+    end
+  end
+
+  if not defined? PUPPETVERSION
+    PUPPETVERSION = version
+  end
 
   def self.version
     @puppet_version || PUPPETVERSION


### PR DESCRIPTION
This commit removes the hardcoded version in the puppet source
code. This allows us to lay down the version file in packaging
while avoiding a commit to source prior to tagging a release.
Once a release passes tests, it should be tagged and shipped,
without needing an extra commit below the tag.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
