### PR TITLE
Preserve timestamps when installing files

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -84,7 +84,7 @@ def do_configs(configs, target, strip = 'conf/')
     if $haveftools
       File.install(cf, ocf, 0644, true)
     else
-      FileUtils.install(cf, ocf, {:mode => 0644, :verbose => true})
+      FileUtils.install(cf, ocf, {:mode => 0644, :preserve => true, :verbose => true})
     end
   end
 
@@ -94,7 +94,7 @@ def do_configs(configs, target, strip = 'conf/')
     if $haveftools
       File.install(src_dll, dst_dll, 0644, true)
     else
-      FileUtils.install(src_dll, dst_dll, {:mode => 0644, :verbose => true})
+      FileUtils.install(src_dll, dst_dll, {:mode => 0644, :preserve => true, :verbose => true})
     end
 
     require 'win32/registry'
@@ -130,7 +130,7 @@ def do_libs(libs, strip = 'lib/')
     else
       FileUtils.makedirs(op, {:mode => 0755, :verbose => true})
       FileUtils.chmod(0755, op)
-      FileUtils.install(lf, olf, {:mode => 0644, :verbose => true})
+      FileUtils.install(lf, olf, {:mode => 0644, :preserve => true, :verbose => true})
     end
   end
 end
@@ -146,7 +146,7 @@ def do_man(man, strip = 'man/')
     else
       FileUtils.makedirs(om, {:mode => 0755, :verbose => true})
       FileUtils.chmod(0755, om)
-      FileUtils.install(mf, omf, {:mode => 0644, :verbose => true})
+      FileUtils.install(mf, omf, {:mode => 0644, :preserve => true, :verbose => true})
     end
     gzip = %x{which gzip}
     gzip.chomp!
@@ -420,12 +420,12 @@ def install_binfile(from, op_file, target)
     installed_wrapper = false
 
     if File.exists?("#{from}.bat")
-      FileUtils.install("#{from}.bat", File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
+      FileUtils.install("#{from}.bat", File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)
       installed_wrapper = true
     end
 
     if File.exists?("#{from}.cmd")
-      FileUtils.install("#{from}.cmd", File.join(target, "#{op_file}.cmd"), :mode => 0755, :verbose => true)
+      FileUtils.install("#{from}.cmd", File.join(target, "#{op_file}.cmd"), :mode => 0755, :preserve => true, :verbose => true)
       installed_wrapper = true
     end
 
@@ -439,13 +439,13 @@ set RUBY_BIN=%RUBY_BIN:\\=/%
 "%RUBY_BIN%ruby.exe" -x "%RUBY_BIN%puppet" %*
 EOS
       File.open(tmp_file2.path, "w") { |cw| cw.puts cwv }
-      FileUtils.install(tmp_file2.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
+      FileUtils.install(tmp_file2.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)
 
       tmp_file2.unlink
       installed_wrapper = true
     end
   end
-  FileUtils.install(tmp_file.path, File.join(target, op_file), :mode => 0755, :verbose => true)
+  FileUtils.install(tmp_file.path, File.join(target, op_file), :mode => 0755, :preserve => true, :verbose => true)
   tmp_file.unlink
 end
 


### PR DESCRIPTION
This PR is the application of a patch from Todd Zullinger to install.rb in Fedora's Puppet. The patch preserves timestamps in install.rb. A similar patch was merged into Facter 1.6.x here: https://github.com/puppetlabs/facter/commit/97d9a1e785152356b04e385f5b650f170782aab5

From the original commit:

Without the preserve option, ruby's FileUtils.install method uses the
current time for all installed files.  For backup systems, package
installs, and general pedantic sysadmins, preserving timestamps makes a
small improvement in the world.
