### PR TITLE
(#17361) Daemon forking for catalog run disabled by code merge

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -10,13 +10,13 @@ class Puppet::Agent
   require 'puppet/agent/disabler'
   include Puppet::Agent::Disabler
 
-  attr_reader :client_class, :client, :splayed
-  attr_accessor :should_fork
+  attr_reader :client_class, :client, :splayed, :should_fork
 
   # Just so we can specify that we are "the" instance.
-  def initialize(client_class)
+  def initialize(client_class, should_fork=true)
     @splayed = false
 
+    @should_fork = should_fork
     @client_class = client_class
   end
 

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -335,7 +335,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     @daemon.set_signal_traps
 
     begin
-      @agent.should_fork = false
       exitstatus = @agent.run
     rescue => detail
       Puppet.log_exception(detail)
@@ -404,7 +403,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # if --no-client is set.
     require 'puppet/agent'
     require 'puppet/configurer'
-    @agent = Puppet::Agent.new(Puppet::Configurer)
+    @agent = Puppet::Agent.new(Puppet::Configurer, (not(Puppet[:onetime])))
 
     enable_disable_client(@agent) if options[:enable] or options[:disable]
 

--- a/lib/puppet/run.rb
+++ b/lib/puppet/run.rb
@@ -11,7 +11,8 @@ class Puppet::Run
   attr_reader :status, :background, :options
 
   def agent
-    Puppet::Agent.new(Puppet::Configurer)
+    # Forking disabled for "puppet kick" runs
+    Puppet::Agent.new(Puppet::Configurer, false)
   end
 
   def background?

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -20,7 +20,7 @@ end
 
 describe Puppet::Agent do
   before do
-    @agent = Puppet::Agent.new(AgentTestClient)
+    @agent = Puppet::Agent.new(AgentTestClient, false)
 
     # So we don't actually try to hit the filesystem.
     @agent.stubs(:lock).yields
@@ -43,7 +43,7 @@ describe Puppet::Agent do
   end
 
   it "should set its client class at initialization" do
-    Puppet::Agent.new("foo").client_class.should == "foo"
+    Puppet::Agent.new("foo", false).client_class.should == "foo"
   end
 
   it "should include the Locker module" do
@@ -181,7 +181,11 @@ describe Puppet::Agent do
 
     describe "when should_fork is true" do
       before do
-        @agent.should_fork = true
+        @agent = Puppet::Agent.new(AgentTestClient, true)
+
+        # So we don't actually try to hit the filesystem.
+        @agent.stubs(:lock).yields
+
         Kernel.stubs(:fork)
         Process.stubs(:waitpid2).returns [123, (stub 'process::status', :exitstatus => 0)]
         @agent.stubs(:exit)

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -508,6 +508,19 @@ describe Puppet::Application::Agent do
         @puppetd.setup
       end
     end
+
+    describe "when configuring agent for catalog run" do
+      it "should set should_fork as true when running normally" do
+        Puppet::Agent.expects(:new).with(anything, true)
+        @puppetd.setup
+      end
+
+      it "should not set should_fork as false for --onetime" do
+        Puppet[:onetime] = true
+        Puppet::Agent.expects(:new).with(anything, false)
+        @puppetd.setup
+      end
+    end
   end
 
 
@@ -556,11 +569,6 @@ describe Puppet::Application::Agent do
 
       it "should setup traps" do
         @daemon.expects(:set_signal_traps)
-        expect { @puppetd.onetime }.to exit_with 0
-      end
-
-      it "should not let the agent fork" do
-        @agent.expects(:should_fork=).with(false)
         expect { @puppetd.onetime }.to exit_with 0
       end
 

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -20,7 +20,8 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
   include PuppetSpec::Files
 
   before do
-    @agent = Puppet::Agent.new(TestClient.new)
+    # Forking agent not needed here
+    @agent = Puppet::Agent.new(TestClient.new, false)
     @daemon = Puppet::Daemon.new
     @daemon.stubs(:close_streams).returns nil
   end

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -14,7 +14,7 @@ describe Puppet::Run do
 
   it "should use a configurer agent as its agent" do
     agent = mock 'agent'
-    Puppet::Agent.expects(:new).with(Puppet::Configurer).returns agent
+    Puppet::Agent.expects(:new).with(Puppet::Configurer, anything).returns agent
 
     @runner.agent.should equal(agent)
   end


### PR DESCRIPTION
The forking functionality was added in 6812ee9fc51f327f3a74fc6a6c0eefd9758d0134 but disabled by a merge at 23a1a17bebaadbb9b3a1611f34ae46d06b531136.  This re-enables the daemon to fork for catalog evaluation.

As before, it will not fork for --onetime runs.
