### PR TITLE
Replace dashes with dots for gem version

### DIFF
--- a/tasks/rake/gem.rake
+++ b/tasks/rake/gem.rake
@@ -21,13 +21,14 @@ EXECUTABLES = FileList[
 ]
 
 SBIN = Dir.glob("sbin/*")
+GEMVERSION = Puppet.version.gsub('-','.')
 
 spec = Gem::Specification.new do |spec|
     spec.platform = Gem::Platform::RUBY
     spec.name = 'puppet'
     spec.files = GEM_FILES.to_a
     spec.executables = EXECUTABLES.gsub(/sbin\/|bin\//, '').to_a
-    spec.version = Puppet.version
+    spec.version = GEMVERSION
     spec.add_dependency('facter', '~> 1.5')
     spec.summary = 'Puppet, an automated configuration management tool'
     spec.description = 'Puppet, an automated configuration management tool'
@@ -53,7 +54,7 @@ desc "Create the gem"
 task :create_gem => :prepare_gem do
     Dir.mkdir("pkg") rescue nil
     Gem::Builder.new(spec).build
-    FileUtils.move("puppet-#{Puppet.version}.gem", "pkg")
+    FileUtils.move("puppet-#{GEMVERSION}.gem", "pkg")
     SBIN.each do |f|
        fn = f.gsub(/sbin\/(.*)/, '\1')
        FileUtils.rm_r "bin/" + fn


### PR DESCRIPTION
When switching out to using git-describe for versioning from
source, gem versioning breaks because dashes are not allowed.
This simple fix replaces the dashes with dots, which are.
Note that in a merge-up to 3.0.x, this commit will conflict.
Default to 'ours' in a merge-up, this gem.rake file does not even exist
in 3.0.x and shouldn't.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
