### PR TITLE
Removing -e options from pip provider.

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -64,7 +64,6 @@ Puppet::Type.type(:package).provide :pip,
   def install
     args = %w{install -q}
     if @resource[:source]
-      args << "-e"
       if String === @resource[:ensure]
         args << "#{@resource[:source]}@#{@resource[:ensure]}#egg=#{
           @resource[:name]}"

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -113,7 +113,7 @@ describe provider_class do
       @resource[:ensure] = :installed
       @resource[:source] = @url
       @provider.expects(:lazy_pip).
-        with("install", '-q', '-e', "#{@url}#egg=fake_package")
+        with("install", '-q', "#{@url}#egg=fake_package")
       @provider.install
     end
 
@@ -121,7 +121,7 @@ describe provider_class do
       @resource[:ensure] = "0123456"
       @resource[:source] = @url
       @provider.expects(:lazy_pip).
-        with("install", "-q", "-e", "#{@url}@0123456#egg=fake_package")
+        with("install", "-q", "#{@url}@0123456#egg=fake_package")
       @provider.install
     end
 


### PR DESCRIPTION
-e causes a few problems with puppet:
1. it tries to install to /root/src.
2. It makes the items editable, which isn't useful.
3. reapplying puppet will cause pip to re-install.

Removing -e should help.

If this isn't accepted, is there a way I can override pip.rb in my modules?

/cc @rcrowley
