### PR TITLE
(#7422) Support arrow syntax with metaparams

### DIFF
--- a/lib/puppet/parser/relationship.rb
+++ b/lib/puppet/parser/relationship.rb
@@ -54,7 +54,9 @@ class Puppet::Parser::Relationship
       raise ArgumentError, "Could not find resource '#{target}' for relationship from '#{source}'"
     end
     Puppet.debug "Adding relationship from #{source} to #{target} with '#{param_name}'"
-    source_resource[param_name] ||= []
+    if source_resource[param_name].class != Array
+      source_resource[param_name] = [source_resource[param_name]].compact
+    end
     source_resource[param_name] << target
   end
 end

--- a/spec/unit/parser/relationship_spec.rb
+++ b/spec/unit/parser/relationship_spec.rb
@@ -7,6 +7,8 @@ describe Puppet::Parser::Relationship do
   before do
     @source = Puppet::Resource.new(:mytype, "source")
     @target = Puppet::Resource.new(:mytype, "target")
+    @extra_resource  = Puppet::Resource.new(:mytype, "extra")
+    @extra_resource2 = Puppet::Resource.new(:mytype, "extra2")
     @dep = Puppet::Parser::Relationship.new(@source, @target, :relationship)
   end
 
@@ -15,6 +17,8 @@ describe Puppet::Parser::Relationship do
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@source)
       @catalog.add_resource(@target)
+      @catalog.add_resource(@extra_resource)
+      @catalog.add_resource(@extra_resource2)
     end
 
     it "should fail if the source resource cannot be found" do
@@ -44,8 +48,28 @@ describe Puppet::Parser::Relationship do
     it "should supplement rather than clobber existing relationship values" do
       @source[:before] = "File[/bar]"
       @dep.evaluate(@catalog)
+      # this test did not work before. It was appending the resources
+      # together as a string
+      (@source[:before].class == Array).should be_true
       @source[:before].should be_include("Mytype[target]")
       @source[:before].should be_include("File[/bar]")
+    end
+
+    it "should supplement rather than clobber existing resource relationships" do
+      @source[:before] = @extra_resource
+      @dep.evaluate(@catalog)
+      (@source[:before].class == Array).should be_true
+      @source[:before].should be_include("Mytype[target]")
+      @source[:before].should be_include(@extra_resource)
+    end
+
+    it "should supplement rather than clobber multiple existing resource relationships" do
+      @source[:before] = [@extra_resource, @extra_resource2]
+      @dep.evaluate(@catalog)
+      (@source[:before].class == Array).should be_true
+      @source[:before].should be_include("Mytype[target]")
+      @source[:before].should be_include(@extra_resource)
+      @source[:before].should be_include(@extra_resource2)
     end
 
     it "should use the collected retargets if the target is a Collector" do


### PR DESCRIPTION
Attempts to combine the arrow syntax with
metaparams lead to the following error message:

Error: undefined method `<<' for {}:Hash

For example, the following code:

  Notify['one'] -> Notify['three']

  notify { 'one':
    before => Notify['two']
  }
  notify { 'two': }

  notify { ['three', 'four']: } 

Causes this issue. This is because relationships
appended with the -> syntax assume that the current
list of dependencies are an array.

Given that, it is not surprising that the following
code is valid at the moment:

  Notify['one'] -> Notify['three']

  notify { 'one':
    before => Notify['two', 'four']
  }
  notify { 'two': }

  notify { ['three', 'four']: } 

In this case, the resources that are already reps
are expressed as an array.

This commit converts everything to an array before
trying to append additional relationships to that
array. The fact that the second code snippet already
works demonstrates that Puppet already supports
appending additional refs to an array of refs.
