### PR TITLE
(#17445) Update logrotate for debian

### DIFF
--- a/ext/debian/puppet.logrotate
+++ b/ext/debian/puppet.logrotate
@@ -1,9 +1,10 @@
 /var/log/puppet/*log {
   missingok
+  sharedscripts
   create 0644 puppet puppet
   compress
   rotate 4
-  
+
   postrotate
     pkill -USR2 -u puppet -f 'puppet master' || true
     [ -e /etc/init.d/puppet ] && /etc/init.d/puppet reload > /dev/null 2>&1 || true


### PR DESCRIPTION
Previously logrotate would run the postrotate script n times where n was equal
to the number of logs matching the pattern. This could cause puppet to
misbehave if it received several HUP or USR2 signals at once as noted in the
ticket. This commit adds a sharedscripts line to the logrotate rule, which
tells logrotate to only run the postrotate script once, for all matching log
files found.
