### PR TITLE
(#17458) Load 'puppet' at the right time

### DIFF
--- a/acceptance/tests/ticket_17458_puppet_command_prints_help.rb
+++ b/acceptance/tests/ticket_17458_puppet_command_prints_help.rb
@@ -1,0 +1,5 @@
+test_name "puppet command alone prints help"
+
+on agents, puppet('unknown') do
+  assert_match(/See 'puppet help' for help on available puppet subcommands/, stdout)
+end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -202,10 +202,6 @@ module Util
   AbsolutePathWindows = %r!^(?:(?:[A-Z]:#{slash})|(?:#{slash}#{slash}#{label}#{slash}#{label})|(?:#{slash}#{slash}\?#{slash}#{label}))!io
   AbsolutePathPosix   = %r!^/!
   def absolute_path?(path, platform=nil)
-    # Due to weird load order issues, I was unable to remove this require.
-    # This is fixed in Telly so it can be removed there.
-    require 'puppet' unless defined?(Puppet)
-
     # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
     # library uses that to test what platform it's on.  Normally in Puppet we
     # would use Puppet.features.microsoft_windows?, but this method needs to

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -183,3 +183,5 @@ EOM
     end
   end
 end
+
+require 'puppet'


### PR DESCRIPTION
Previously the Puppet::Util.which method tried to compensate for the 
puppet.rb file not being loaded at the right time by trying to load it 
itself. When a performance improvement was added (commit 20efe94) to check if
this needed to be done it broke the codepath for executing external puppet-*
commands.

This commit fixes this by requiring 'puppet' at the right place in the entry
point (Puppet::Util::CommandLine) and removing the workaround in 
Puppet::Util.which.

Paired-with: Josh Cooper josh@puppetlabs.com
