### PR TITLE
Maint: Clarify that the managehome parameter will delete a home director...

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -295,7 +295,8 @@ module Puppet
 
     newparam(:managehome, :boolean => true) do
       desc "Whether to manage the home directory when managing the user.
-        Defaults to `false`."
+        This will create the home directory when `ensure => present`, and
+        delete the home directory when `ensure => absent`. Defaults to `false`."
 
       newvalues(:true, :false)
 


### PR DESCRIPTION
...y

Users have sometimes been surprised that managehome will delete a home
directory when removing a user. This commit makes that explicit.
