### PR TITLE
(#17492) Fix --run_mode=foo global option parsing

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -172,15 +172,17 @@ class Puppet::Settings
                      "The effective 'run mode' of the application: master, agent, or user.",
                      :REQUIRED) do |arg|
       Puppet.settings.preferred_run_mode = arg
-
-      # remove this option from the arguments so that later parses don't think
-      # it is an unknown option
-      option_index = args.index '--run_mode'
-      args.delete_at option_index
-      args.delete_at option_index
     end
 
     option_parser.parse(args)
+
+    # remove run_mode options from the arguments so that later parses don't think
+    # it is an unknown option.
+    while option_index = args.index('--run_mode') do
+      args.delete_at option_index
+      args.delete_at option_index
+    end
+    args.reject! { |arg| arg.start_with? '--run_mode=' }
   end
   private :parse_global_options
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1539,6 +1539,22 @@ describe Puppet::Settings do
     it "should transform boolean option to no- form" do
       Puppet::Settings.clean_opt("--[no-]option", false).should == ["--no-option", false]
     end
+
+    it "should set preferred run mode from --run_mode <foo> string without error" do
+      args = ["--run_mode", "master"]
+      settings.expects(:handlearg).with("--run_mode", "master").never
+      expect { settings.send(:parse_global_options, args) } .to_not raise_error
+      Puppet.settings.preferred_run_mode.should == :master
+      args.empty?.should == true
+    end
+
+    it "should set preferred run mode from --run_mode=<foo> string without error" do
+      args = ["--run_mode=master"]
+      settings.expects(:handlearg).with("--run_mode", "master").never
+      expect { settings.send(:parse_global_options, args) } .to_not raise_error
+      Puppet.settings.preferred_run_mode.should == :master
+      args.empty?.should == true
+    end
   end
 
   describe "default_certname" do


### PR DESCRIPTION
parse_global_options doesn't properly find the index position for the run_mode
argument.

https://projects.puppetlabs.com/issues/17492
