### PR TITLE
remove --stable from portage package provider

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
       search_output = nil
       Puppet::Util::Execution.withenv :LASTVERSION => version_format do
-        search_output = eix "--nocolor", "--pure-packages", "--stable", "--installed", "--format", search_format
+        search_output = eix "--nocolor", "--pure-packages", "--installed", "--format", search_format
       end
 
       packages = []
@@ -85,7 +85,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
       search_output = nil
       Puppet::Util::Execution.withenv :LASTVERSION => version_format do
-        search_output = eix "--nocolor", "--pure-packages", "--stable", "--format", search_format, "--exact", search_field, search_value
+        search_output = eix "--nocolor", "--pure-packages", "--format", search_format, "--exact", search_field, search_value
       end
 
       packages = []


### PR DESCRIPTION
Currently the eix command options do not allow to manage ( install,search,uninstall ) packages that have been soft-masked.

It should be up to the user to decide whether or not he install packages with keywords set.

The current restriction causes the removal of package resources, or the replacement with exec resource to manage 
the affected packages.
