### PR TITLE
Environment is empty for commands run via custom types.

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -148,7 +148,7 @@ class Puppet::Provider
       @path = path
       @optional = false
       @confiner = confiner
-      @custom_environment = {}
+      @custom_environment = ENV.to_hash
     end
 
     def is_optional


### PR DESCRIPTION
Environment is empty when a command from a custom type is run. See also http://projects.puppetlabs.com/issues/16262. This will set the initial environment to the current environment.
