### PR TITLE
(#17716) Add password managment on HPUX

### DIFF
--- a/lib/puppet/provider/user/hpux.rb
+++ b/lib/puppet/provider/user/hpux.rb
@@ -6,7 +6,8 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
   defaultfor :operatingsystem => "hp-ux"
   confine :operatingsystem => "hp-ux"
 
-  commands :modify => "/usr/sam/lbin/usermod.sam", :delete => "/usr/sam/lbin/userdel.sam", :add => "/usr/sbin/useradd"
+
+  commands :modify => "/usr/sam/lbin/usermod.sam", :delete => "/usr/sam/lbin/userdel.sam", :add => "/usr/sam/lbin/useradd.sam"
   options :comment, :method => :gecos
   options :groups, :flag => "-G"
   options :home, :flag => "-d", :method => :dir
@@ -19,7 +20,7 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
     value !~ /\s/
   end
 
-  has_features :manages_homedir, :allows_duplicates
+  has_features :manages_homedir, :allows_duplicates, :manages_passwords
 
   def deletecmd
     super.insert(1,"-F")
@@ -27,5 +28,28 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
 
   def modifycmd(param,value)
     super.insert(1,"-F")
+  end
+
+  def password
+      # Password management routine for trusted and non-trusted systems
+      ent = Etc.getpwnam(resource.name)
+      if ent.passwd == "*"
+          # Either no password or trusted password, check trusted
+          file_name="/tcb/files/auth/#{resource.name.chars.first}/#{resource.name}"
+          if File.file?(file_name)
+              # Found the tcb user for the specific user, now get passwd
+              File.open(file_name).each do |line|
+                  if ( line =~ /u_pwd/ )
+                      temp_passwd=line.split(":")[1].split("=")[1]
+                      ent.passwd = temp_passwd
+                      return ent.passwd
+                  end
+              end
+          else 
+              debug "No trusted computing user file #{file_name} found."
+          end
+      else 
+          return ent.passwd
+      end
   end
 end


### PR DESCRIPTION
This patch adds in basic trusted and non-trusted computing password
management for HPUX 11.31 IA. Code should work on 11.11 and all 11i
but has not been tested on those platforms specifically yet.  All
commands and files modified are present on 11.11 and 11i versions
and modified process is similar to past Perl scripts to do similar
actions on those aforementioned platforms.
