### PR TITLE
Fixed #14199

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -195,8 +195,15 @@ module Puppet
 
     newparam(:name) do
       desc "The mount path for the mount."
-
       isnamevar
+      # if name contains symlink munge method returns real path
+      munge do |value|
+        if File.exist? value
+          Pathname(value).realpath.to_s
+        else
+          value
+        end
+      end
     end
 
     newparam(:remounts) do


### PR DESCRIPTION
if mount path contains symlinks mount resource doesn't recognize if device is already mounted (author: Christoph Rauch)

https://projects.puppetlabs.com/issues/14199
