### PR TITLE
(#7580) Fix for unnecessary ldap updates described in issue 7580

### DIFF
--- a/lib/puppet/provider/ldap.rb
+++ b/lib/puppet/provider/ldap.rb
@@ -94,9 +94,17 @@ class Puppet::Provider::Ldap < Puppet::Provider
       # Only use the first value if the attribute class doesn't manage
       # arrays of values.
       if paramclass.superclass == Puppet::Parameter or paramclass.array_matching == :first
-        result[param] = values[0]
+        if param.to_s == "gid"
+          result[param] = values[0].to_i
+        else
+          result[param] = values[0]
+        end
       else
-        result[param] = values
+        if param.to_s == "gid"
+          result[param] = values.to_i
+        else
+          result[param] = values
+        end
       end
       result
     end


### PR DESCRIPTION
Without this patch applied, every time puppet runs it will detect
a change in the gidNumber of every user defined with provider => ldap
and will update the LDAP directory server even though no change is
required. If puppet runs every 30 minutes, that's 48 updates per
user per system per day - my farm is small and has 60 servers so
I'm seeing around 3000 updates per day that do not need to be made.
These changes then replicate around my multi-master LDAP servers
causing even more unnecessary updates. Multiply this by the number
of users that are defined in puppet with a gid ...

The change is occurring because the gidNumber field as pulled from
LDAP is a String but the puppet variable is a Fixnum. This means
that comparisons of the two always fail so the update is always
performed. This may not be the best way to fix it but this change
converts the gid field to a Fixnum as it's pulled from the LDAP
directory server.
