### PR TITLE
(#17554) Use agent run_mode when resolving runinterval

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -45,7 +45,7 @@ class WindowsDaemon < Win32::Daemon
 
       log_debug("Using '#{puppet}'")
       begin
-        runinterval = %x{ "#{puppet}" config print runinterval }.to_i
+        runinterval = %x{ "#{puppet}" agent --configprint runinterval }.to_i
         if runinterval == 0
           runinterval = 1800
           log_err("Failed to determine runinterval, defaulting to #{runinterval} seconds")


### PR DESCRIPTION
Previously, the windows service was invoking `puppet config print
runinterval` to determine how frequently to invoke the puppet agent.
However, that only takes into account the main section, not the agent
section, and runinterval is agent-specific.

This commit changes the windows service to invoke `puppet agent
--configprint runinterval` which takes into account the agent
section of the settings.
