### PR TITLE
(#17820) Avoid allocating and copying hashes unnecessarily

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -151,7 +151,7 @@ class Puppet::Transaction
     begin
       made = resource.eval_generate.uniq
       return false if made.empty?
-      made = made.inject({}) {|a,v| a.merge(v.name => v) }
+      made = made.inject({}) {|a,v| a[v.name] = v; a}
     rescue => detail
       puts detail.backtrace if Puppet[:trace]
       resource.err "Failed to generate additional resources using 'eval_generate: #{detail}"


### PR DESCRIPTION
Commit 737c2f66 was implemented to ensure portability with ruby 1.8.5,
but in doing so, it caused severe performance problems, likely due to
allocating a hash, and then merging that, and returning a copy of the
merged hashes.

This commit eliminates the performance issue by not attempting to
merge the hashes, while maintaining compatibility with ruby 1.8.5.

The original code implemented in commit 7002eff7 should be restored in
3.x as that is even faster than this commit, but does not maintain
compatibility with ruby 1.8.5.

Reviewed-by: Josh Cooper josh@puppetlabs.com
