### PR TITLE
Revert "Fix Ruby 1.8.5-incompatible code in Transaction#eval_generate"

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -151,7 +151,7 @@ class Puppet::Transaction
     begin
       made = resource.eval_generate.uniq
       return false if made.empty?
-      made = made.inject({}) {|a,v| a.merge(v.name => v) }
+      made = Hash[made.map(&:name).zip(made)]
     rescue => detail
       resource.log_exception(detail, "Failed to generate additional resources using 'eval_generate: #{detail}")
       return false


### PR DESCRIPTION
This reverts commit 737c2f66476b2379f2546150856ea1cd7fdde08a.

The commit above was implemented to maintain compatibility with ruby
1.8.5, but resulted in a severe performance penalty ~500 times slower.
Since Puppet 3 is not compatible with ruby 1.8.5, this commit restores
the original version which is much faster.
