### PR TITLE
don't use smf properties for config on solaris

### DIFF
--- a/ext/ips/puppet-agent
+++ b/ext/ips/puppet-agent
@@ -1,7 +1,4 @@
 #!/sbin/sh
-# It needs the smf property puppet-agent/server to be set to where the server is.
-# svccfg -s svc:/network/puppet/agent setprop server/name=asstring:localhost
-
 
 . /lib/svc/share/smf_include.sh
 
@@ -11,12 +8,10 @@ typeset -r CONF_FILE=/etc/puppet/puppet.conf
 [[ ! -f "${CONF_FILE}" ]] && exit $SMF_EXIT_ERR_CONFIG
 
 typeset -r PUPPET=/usr/bin/puppet
-typeset -r PUPPET_SERVER=$(svcprop -p server/name $SMF_FMRI)
-[[ -z "${PUPPET_SERVER}" ]] && exit $SMF_EXIT_ERR_CONFIG
 
 case "$1" in
 start)
-  exec $PUPPET agent --daemonize --server $PUPPET_SERVER
+  exec $PUPPET agent
   ;;
 
 stop)

--- a/ext/ips/puppetagent.xml
+++ b/ext/ips/puppetagent.xml
@@ -26,10 +26,6 @@
 
     <exec_method type="method" name="stop" exec="/lib/svc/method/puppet-agent stop" timeout_seconds="60"/>
 
-    <property_group name='server' type='framework'>
-      <propval name='name' type='astring' value='puppet' />
-    </property_group>
-
     <stability value="Evolving"/>
 
     <template>


### PR DESCRIPTION
Command line options override puppet.conf, so having a svc property and
using it is not the right way. In contrast, the Debian packaged
puppet agent runs with no options; let's do that here as well.
