### PR TITLE
(#17853) Allow install.rb to execute from outside of source root

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -66,15 +66,6 @@ def glob(list)
   g
 end
 
-# Set these values to what you want installed.
-configs = glob(%w{conf/auth.conf})
-bins  = glob(%w{bin/*})
-rdoc  = glob(%w{bin/* lib/**/*.rb README README-library CHANGELOG TODO Install}).reject { |e| e=~ /\.(bat|cmd)$/ }
-ri    = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }
-man   = glob(%w{man/man[0-9]/*})
-libs  = glob(%w{lib/**/*.rb lib/**/*.erb lib/**/*.py lib/puppet/util/command_line/*})
-tests = glob(%w{test/**/*.rb})
-
 def do_configs(configs, target, strip = 'conf/')
   Dir.mkdir(target) unless File.directory? target
   configs.each do |cf|
@@ -440,13 +431,25 @@ EOS
   tmp_file.unlink
 end
 
-check_prereqs
-prepare_installation
+# Change directory into the puppet root so we don't get the wrong files for install.
+FileUtils.cd File.dirname(__FILE__) do
+  # Set these values to what you want installed.
+  configs = glob(%w{conf/auth.conf})
+  bins  = glob(%w{bin/*})
+  rdoc  = glob(%w{bin/* lib/**/*.rb README README-library CHANGELOG TODO Install}).reject { |e| e=~ /\.(bat|cmd)$/ }
+  ri    = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }
+  man   = glob(%w{man/man[0-9]/*})
+  libs  = glob(%w{lib/**/*.rb lib/**/*.erb lib/**/*.py lib/puppet/util/command_line/*})
+  tests = glob(%w{test/**/*.rb})
 
-#run_tests(tests) if InstallOptions.tests
-#build_rdoc(rdoc) if InstallOptions.rdoc
-#build_ri(ri) if InstallOptions.ri
-do_configs(configs, InstallOptions.config_dir) if InstallOptions.configs
-do_bins(bins, InstallOptions.bin_dir)
-do_libs(libs)
-do_man(man) unless $operatingsystem == "windows"
+  check_prereqs
+  prepare_installation
+
+  #run_tests(tests) if InstallOptions.tests
+  #build_rdoc(rdoc) if InstallOptions.rdoc
+  #build_ri(ri) if InstallOptions.ri
+  do_configs(configs, InstallOptions.config_dir) if InstallOptions.configs
+  do_bins(bins, InstallOptions.bin_dir)
+  do_libs(libs)
+  do_man(man) unless $operatingsystem == "windows"
+end


### PR DESCRIPTION
Previously if install.rb was invoked when outside of the source root, all of
the globs would fail to find bins, libs, etc, or worse if run from / it will
find the binaries in /bin and copy them to bindir. This commit addresses that
by running the install after cding into the directory containing the install.rb
file.
