### PR TITLE
(#17856) Fix docs re: hasrestart's default value

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -198,8 +198,9 @@ module Puppet
     newparam :hasrestart do
       desc "Specify that an init script has a `restart` command.  If this is
         false and you do not specify a command in the `restart` attribute,
-        the init script's `stop` and `start` commands will be used. Defaults
-        to true; note that this is a change from earlier versions of Puppet."
+        the init script's `stop` and `start` commands will be used.
+        
+        Defaults to false."
       newvalues(:true, :false)
     end
 


### PR DESCRIPTION
As part of a docs revision in commit 455c9aab, I put in the wrong default
value for hasrestart, probably after getting it confused with hasstatus.
In fact, it defaults to false. This commit corrects the error.
