### PR TITLE
(#17887) Only log if message has been initialized

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -123,7 +123,7 @@ class Puppet::Transaction::ResourceHarness
     event.message = "change from #{property.is_to_s(current_value)} to #{property.should_to_s(property.should)} failed: #{detail}"
     event
   ensure
-    event.send_log
+    event.send_log if event.message
   end
 
   def evaluate(resource)


### PR DESCRIPTION
Inside a test harness with Mocha, it's possible to run the "ensure" block
without having executed either the main or "rescue" blocks if an unexpected
method is executed etc.

If this happens during the property.sync, this causes an immediate exit from
the main block, but the "ensure" block is still run.  The event message won't
have been initialized yet, so this then causes the logger to report:

  Puppet::Util::Log requires a message

This changes the "ensure" block to only log if it's got as far as writing a
message.

I don't know how to write a test for this.  I've created the following one which reproduces the problem by making a mocha expectation fire: https://gist.github.com/4179351 (with the fix you'll see an rspec failure, without it you'll see the Puppet::Util::Log message).

But because it causes an rspec failure itself in a "successful" case, this isn't useful to merge.  If you have any ideas about how to recreate a similar abrupt exit as mocha does, then that'd be good - else I'd propose merging without a test.
