### PR TITLE
(#17866) Fix permissions regression for logdir in puppet.spec.erb

### DIFF
--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -206,7 +206,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}/modules
 # These need to be owned by puppet so the server can
 # write to them
 %attr(-, puppet, puppet) %{_localstatedir}/run/puppet
-%attr(-, puppet, puppet) %{_localstatedir}/log/puppet
+%attr(0750, puppet, puppet) %{_localstatedir}/log/puppet
 %attr(-, puppet, puppet) %{_localstatedir}/lib/puppet
 %{_mandir}/man5/puppet.conf.5.gz
 %{_mandir}/man8/puppet.8.gz
@@ -385,6 +385,9 @@ rm -rf %{buildroot}
 %changelog
 * <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
+
+* Sat Dec 1 2012 Ryan Uber <ryuber@cisco.com>
+- Fix for logdir perms regression (#17866)
 
 * Wed Aug 29 2012 Moses Mendoza <moses@puppetlabs.com> - 3.0.0-0.1rc5
 - Update for 3.0.0 rc5


### PR DESCRIPTION
Fixes permissions on /var/log/puppet. Since puppet manages its own file / directory permissions and corrects them on its own, the RPM .spec file must have the right idea of what the permissions on everything should be in order to verify cleanly.

Related to RedHat bugzilla #495096.
