### PR TITLE
[#15929] [#17624] launchd provider: handle malformed plists

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -51,13 +51,26 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   has_feature :enableable
   mk_resource_methods
 
-  Launchd_Paths = [ "/Library/LaunchAgents",
-                    "/Library/LaunchDaemons",
-                    "/System/Library/LaunchAgents",
-                    "/System/Library/LaunchDaemons"]
+  # These are the paths in OS X where a launchd service plist could
+  # exist. This is a helper method, versus a constant, for easy testing
+  # and mocking
+  def self.launchd_paths
+    [
+      "/Library/LaunchAgents",
+      "/Library/LaunchDaemons",
+      "/System/Library/LaunchAgents",
+      "/System/Library/LaunchDaemons"
+    ]
+  end
+  private_class_method :launchd_paths
 
-  Launchd_Overrides = "/var/db/launchd.db/com.apple.launchd/overrides.plist"
-  
+  # This is the path to the overrides plist file where service enabling
+  # behavior is defined in 10.6 and greater
+  def self.launchd_overrides
+    "/var/db/launchd.db/com.apple.launchd/overrides.plist"
+  end
+  private_class_method :launchd_overrides
+
   # Caching is enabled through the following three methods. Self.prefetch will
   # call self.instances to create an instance for each service. Self.flush will
   # clear out our cache when we're done.
@@ -81,6 +94,16 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     end
   end
 
+  # This method will return a list of files in the passed directory. This method
+  # does not go recursively down the tree and does not return directories
+  def self.return_globbed_list_of_file_paths(path)
+    array_of_files = Dir.glob(File.join(path, '*')).collect do |filepath|
+      File.file?(filepath) ? filepath : nil
+    end
+    array_of_files.compact
+  end
+  private_class_method :return_globbed_list_of_file_paths
+
   # Sets a class instance variable with a hash of all launchd plist files that
   # are found on the system. The key of the hash is the job id and the value
   # is the path to the file. If a label is passed, we return the job id and
@@ -88,14 +111,20 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   def self.jobsearch(label=nil)
     @label_to_path_map ||= {}
     if @label_to_path_map.empty?
-      Launchd_Paths.each do |path|
-        Dir.glob(File.join(path,'*')).each do |filepath|
-          next if ! File.file?(filepath)
+      launchd_paths.each do |path|
+        return_globbed_list_of_file_paths(path).each do |filepath|
           job = read_plist(filepath)
-          if job.has_key?("Label") and job["Label"] == label
-            return { label => filepath }
+          next if job.nil?
+          if job.has_key?("Label")
+            if job["Label"] == label
+              return { label => filepath }
+            else
+              @label_to_path_map[job["Label"]] = filepath
+            end
           else
-            @label_to_path_map[job["Label"]] = filepath
+            Puppet.warning("The #{filepath} plist does not contain a 'label' key; " +
+                         "Puppet is skipping it")
+            next
           end
         end
       end
@@ -143,7 +172,13 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   # Read a plist, whether its format is XML or in Apple's "binary1"
   # format.
   def self.read_plist(path)
-    Plist::parse_xml(plutil('-convert', 'xml1', '-o', '/dev/stdout', path))
+    begin
+      Plist::parse_xml(plutil('-convert', 'xml1', '-o', '/dev/stdout', path))
+    rescue Puppet::ExecutionFailure => detail
+      Puppet.warning("Cannot read file #{path}; Puppet is skipping it. \n" +
+                     "Details: #{detail}")
+      return nil
+    end
   end
 
   # Clean out the @property_hash variable containing the cached list of services
@@ -245,7 +280,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     job_plist_disabled = job_plist["Disabled"] if job_plist.has_key?("Disabled")
 
     if has_macosx_plist_overrides?
-      if FileTest.file?(Launchd_Overrides) and overrides = self.class.read_plist(Launchd_Overrides)
+      if FileTest.file?(self.class.launchd_overrides) and overrides = self.class.read_plist(self.class.launchd_overrides)
         if overrides.has_key?(resource[:name])
           overrides_disabled = overrides[resource[:name]]["Disabled"] if overrides[resource[:name]].has_key?("Disabled")
         end
@@ -270,9 +305,9 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   # overrides plist, in earlier versions this is stored in the job plist itself.
   def enable
     if has_macosx_plist_overrides?
-      overrides = self.class.read_plist(Launchd_Overrides)
+      overrides = self.class.read_plist(self.class.launchd_overrides)
       overrides[resource[:name]] = { "Disabled" => false }
-      Plist::Emit.save_plist(overrides, Launchd_Overrides)
+      Plist::Emit.save_plist(overrides, self.class.launchd_overrides)
     else
       job_path, job_plist = plist_from_label(resource[:name])
       if self.enabled? == :false
@@ -285,9 +320,9 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
 
   def disable
     if has_macosx_plist_overrides?
-      overrides = self.class.read_plist(Launchd_Overrides)
+      overrides = self.class.read_plist(self.class.launchd_overrides)
       overrides[resource[:name]] = { "Disabled" => true }
-      Plist::Emit.save_plist(overrides, Launchd_Overrides)
+      Plist::Emit.save_plist(overrides, self.class.launchd_overrides)
     else
       job_path, job_plist = plist_from_label(resource[:name])
       job_plist["Disabled"] = true

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -60,6 +60,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => true}])
       provider.expects(:read_plist).returns({joblabel => {"Disabled" => false}})
+      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.enabled?.should == :true
     end
@@ -67,6 +68,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => false}])
       provider.expects(:read_plist).returns({joblabel => {"Disabled" => true}})
+      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.enabled?.should == :false
     end
@@ -74,6 +76,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {}])
       provider.expects(:read_plist).returns({})
+      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.enabled?.should == :true
     end
@@ -92,7 +95,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       subject.expects(:execute).with([:launchctl, :load, joblabel])
       subject.start
     end
-    it "should execute 'launchctl load' once without writing to the plist if the job is enabled" do  
+    it "should execute 'launchctl load' once without writing to the plist if the job is enabled" do
       subject.expects(:plist_from_label).returns([joblabel, {}])
       subject.expects(:enabled?).returns :true
       subject.expects(:execute).with([:launchctl, :load, joblabel]).once
@@ -188,6 +191,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       resource[:enable] = true
       provider.expects(:get_macosx_version_major).returns("10.6")
       provider.expects(:read_plist).returns({})
+      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       Plist::Emit.expects(:save_plist).once
       subject.enable
     end
@@ -198,8 +202,35 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       resource[:enable] = false
       provider.stubs(:get_macosx_version_major).returns("10.6")
       provider.stubs(:read_plist).returns({})
+      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       Plist::Emit.expects(:save_plist).once
       subject.enable
+    end
+  end
+
+  describe "when encountering malformed plists" do
+    let(:plist_without_label) do
+      {
+        'LimitLoadToSessionType' => 'Aqua'
+      }
+    end
+    let(:busted_plist_path) { '/Library/LaunchAgents/org.busted.plist' }
+
+    it "[17624] should warn that the plist in question is being skipped" do
+      provider.expects(:launchd_paths).returns('/Library/LaunchAgents')
+      provider.expects(:return_globbed_list_of_file_paths).with('/Library/LaunchAgents').returns(busted_plist_path)
+      provider.expects(:read_plist).with(busted_plist_path).returns(plist_without_label)
+      Puppet.expects(:warning).with("The #{busted_plist_path} plist does not contain a 'label' key; Puppet is skipping it")
+      provider.jobsearch
+    end
+
+    it "[15929] should skip plists that plutil cannot read" do
+      provider.expects(:plutil).with('-convert', 'xml1', '-o', '/dev/stdout',
+        busted_plist_path).raises(Puppet::ExecutionFailure, 'boom')
+      Puppet.expects(:warning).with("Cannot read file #{busted_plist_path}; " +
+                                    "Puppet is skipping it. \n" +
+                                    "Details: boom")
+      provider.read_plist(busted_plist_path)
     end
   end
 end


### PR DESCRIPTION
Previously, if launchd encountered a plist that did NOT have a 'label' key, or
a malformed plist that plutil couldn't read, Puppet would throw a stacktrace or
log a nebulous error that looked like:

`Error: Could not run: No resource and no name in property hash in launchd
instance`

That was not ideal. This commit will catch the situation where a plist is
missing a 'label' key Puppet is skipping the plist.  It will also catch the
case the where a plist is malformed and plutil cannot read it.  With either
condition, the commit adds code that logs a Puppet.warning and skips the
malformed plist gracefully.
