### PR TITLE
(#17371) Re-initialize settings metadata after run_mode determined

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -220,6 +220,7 @@ class Puppet::Settings
         set_value(key, value, :application_defaults)
       end
     end
+    apply_metadata
     call_hooks_deferred_to_application_initialization
 
     @app_defaults_initialized = true
@@ -345,6 +346,9 @@ class Puppet::Settings
 
     # Keep track of set values.
     @values = Hash.new { |hash, key| hash[key] = {} }
+
+    # Hold parsed metadata until run_mode is known
+    @metas = {}
 
     # And keep a per-environment cache
     @cache = Hash.new { |hash, key| hash[key] = {} }
@@ -554,9 +558,8 @@ class Puppet::Settings
     unsafe_clear(false, false)
 
     # And now we can repopulate with the values from our last parsing of the config files.
-    metas = {}
     data.each do |area, values|
-      metas[area] = values.delete(:_meta)
+      @metas[area] = values.delete(:_meta)
       values.each do |key,value|
         set_value(key, value, area, :dont_trigger_handles => true, :ignore_bad_settings => true )
       end
@@ -584,19 +587,24 @@ class Puppet::Settings
       end
     end
 
+    # Take a best guess at metadata based on uninitialized run_mode
+    apply_metadata
+  end
+  private :unsafe_parse
+
+  def apply_metadata
     # We have to do it in the reverse of the search path,
     # because multiple sections could set the same value
     # and I'm too lazy to only set the metadata once.
     searchpath.reverse.each do |source|
       source = preferred_run_mode if source == :run_mode
       source = @name if (@name && source == :name)
-      if meta = metas[source]
+      if meta = @metas[source]
         set_metadata(meta)
       end
     end
   end
-  private :unsafe_parse
-
+  private :apply_metadata
 
   # Create a new setting.  The value is passed in because it's used to determine
   # what kind of setting we're creating, but the value itself might be either
@@ -1134,7 +1142,9 @@ Generated on #{Time.now}.
   def set_metadata(meta)
     meta.each do |var, values|
       values.each do |param, value|
-        @config[var].send(param.to_s + "=", value)
+        @sync.synchronize do # yay, thread-safe
+          @config[var].send(param.to_s + "=", value)
+        end
       end
     end
   end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -777,6 +777,33 @@ describe Puppet::Settings do
       @settings.metadata(:myfile).should == {:owner => "suser"}
     end
 
+    it "should support loading metadata (owner, group, or mode) from a run_mode section in the configuration file" do
+      default_values = {}
+      PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS.keys.each do |key|
+        default_values[key] = 'default value'
+      end
+      @settings.define_settings :main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS
+      @settings.define_settings :master, :myfile => { :type => :file, :default => make_absolute("/myfile"), :desc => "a" }
+
+      otherfile = make_absolute("/other/file")
+      text = "[master]
+      myfile = #{otherfile} {mode = 664}
+      "
+      @settings.expects(:read_file).returns(text)
+
+      # will start initialization as user
+      @settings.preferred_run_mode.should == :user
+      @settings.send(:parse_config_files)
+
+      # change app run_mode to master 
+      @settings.initialize_app_defaults(default_values.merge(:run_mode => :master))
+      @settings.preferred_run_mode.should == :master
+
+      # initializing the app should have reloaded the metadata based on run_mode
+      @settings[:myfile].should == otherfile
+      @settings.metadata(:myfile).should == {:mode => "664"}
+    end
+
     it "should call hooks associated with values set in the configuration file" do
       values = []
       @settings.define_settings :section, :mysetting => {:default => "defval", :desc => "a", :hook => proc { |v| values << v }}


### PR DESCRIPTION
Currently metadata for settings (e.g. mode, owner) is initialized during
parsing of the config file, at which point the run_mode isn't known.  The
initialization loops over each section of the config and since one of the
sections is determined by the run_mode, this means it doesn't get searched.
Setting file metadata inside a section such as [master] has no effect.

This patch causes the setting metadata to be set twice - once during early
startup before the run_mode is known (for settings used globally) and again
once the run_mode is known so that configuration in specialised sections take
effect.

Supersedes GH-1278, rebased onto master as it missed 3.0.x.
