### PR TITLE
add support for "restart" in daemontools provider

### DIFF
--- a/lib/puppet/provider/service/daemontools.rb
+++ b/lib/puppet/provider/service/daemontools.rb
@@ -179,8 +179,8 @@ Puppet::Type.type(:service).provide :daemontools, :parent => :base do
     self.stop
   end
 
-  def restart
-    svc "-t", self.service
+  def restartcmd
+    [svc "-t", self.service]
   end
 
   def start


### PR DESCRIPTION
Without this change, commands specified with "restart =>" are ignored by daemontools provider. With this change they are adhered.
