### PR TITLE
tagmail: s/reportform/reportfrom/

### DIFF
--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -35,7 +35,7 @@ Puppet::Reports.register_report(:tagmail) do
 
     If you are using anti-spam controls such as grey-listing on your mail
     server, you should whitelist the sending email address (controlled by
-    `reportform` configuration option) to ensure your email is not discarded as spam.
+    `reportfrom` configuration option) to ensure your email is not discarded as spam.
     "
 
   # Find all matching messages.


### PR DESCRIPTION
Fix trivial typo in description of the `reportfrom` config option.

This coincides with a similar fix in
`puppet-docs/source/references/*/report.markdown` and is needed
to prevent the typo from propagating into the docs.

Signed-off-by: Paul Morgan jumanjiman@gmail.com
