### PR TITLE
(#17994) Fix wrong (decimal) mode causes sticky bit to be set.

### DIFF
--- a/lib/puppet/type/file/ensure.rb
+++ b/lib/puppet/type/file/ensure.rb
@@ -68,7 +68,7 @@ module Puppet
       end
       if mode
         Puppet::Util.withumask(000) do
-          Dir.mkdir(@resource[:path], symbolic_mode_to_int(mode, 755, true))
+          Dir.mkdir(@resource[:path], symbolic_mode_to_int(mode, 0755, true))
         end
       else
         Dir.mkdir(@resource[:path])


### PR DESCRIPTION
A decimal mode/mask of 755 is clearly wrong; it should have been 0755.
The problem causes the sticky bit (and what not) to be set instead of
what was intended.
