### PR TITLE
(#18041) Remove Autoload.list_loaded method

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -19,13 +19,6 @@ class Puppet::Util::Autoload
       @gem_source ||= Puppet::Util::RubyGems::Source.new
     end
 
-    # List all loaded files.
-    def list_loaded
-      loaded.keys.sort { |a,b| a[0] <=> b[0] }.collect do |path, hash|
-        "#{path}: #{hash[:file]}"
-      end
-    end
-
     # Has a given path been loaded?  This is used for testing whether a
     # changed file should be loaded or just ignored.  This is only
     # used in network/client/master, when downloading plugins, to


### PR DESCRIPTION
The list_loaded method was broken in 6700adca in 0.24.0, because the
yielded `hash` parameter was always nil -- we're collecting on a sorted
array of keys, not the `loaded` hash.

Since anyone calling this method would always receive a NoMethodError,
and the code is never called from anywhere in puppet or spec, it is safe
to remove without deprecation.
