### PR TITLE
(#18047) Revert change to user confdir

### DIFF
--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -65,21 +65,17 @@ module Puppet
 
     class WindowsRunMode < RunMode
       def conf_dir
-        which_dir(File.join(windows_common_base("etc")), File.join(*windows_local_base))
+        which_dir(File.join(windows_common_base("etc")), "~/.puppet")
       end
 
       def var_dir
-        which_dir(File.join(windows_common_base("var")), File.join(*windows_local_base("var")))
+        which_dir(File.join(windows_common_base("var")), "~/.puppet/var")
       end
 
     private
 
       def windows_common_base(*extra)
         [Dir::COMMON_APPDATA, "PuppetLabs", "puppet"] + extra
-      end
-
-      def windows_local_base(*extra)
-        [Dir::LOCAL_APPDATA, "PuppetLabs", "puppet"] + extra
       end
     end
   end

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -73,7 +73,6 @@ describe Puppet::Util::RunMode do
     before do
       if not Dir.const_defined? :COMMON_APPDATA
         Dir.const_set :COMMON_APPDATA, "/CommonFakeBase"
-        Dir.const_set :LOCAL_APPDATA, "/LocalFakeBase"
         @remove_const = true
       end
       @run_mode = Puppet::Util::WindowsRunMode.new('fake')
@@ -82,7 +81,6 @@ describe Puppet::Util::RunMode do
     after do
       if @remove_const
         Dir.send :remove_const, :COMMON_APPDATA
-        Dir.send :remove_const, :LOCAL_APPDATA
       end
     end
 
@@ -91,8 +89,8 @@ describe Puppet::Util::RunMode do
         as_root { @run_mode.conf_dir.should == File.expand_path(File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "etc")) }
       end
 
-      it "has confdir in the local appdata when run as non-root" do
-        as_non_root { @run_mode.conf_dir.should == File.expand_path(File.join(Dir::LOCAL_APPDATA, "PuppetLabs", "puppet")) }
+      it "has confdir in ~/.puppet when run as non-root" do
+        as_non_root { @run_mode.conf_dir.should == File.expand_path("~/.puppet") }
       end
     end
 
@@ -101,8 +99,8 @@ describe Puppet::Util::RunMode do
         as_root { @run_mode.var_dir.should == File.expand_path(File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "var")) }
       end
 
-      it "has vardir local appdata when run as non-root" do
-        as_non_root { @run_mode.var_dir.should == File.expand_path(File.join(Dir::LOCAL_APPDATA, "PuppetLabs", "puppet", "var")) }
+      it "has vardir in ~/.puppet/var when run as non-root" do
+        as_non_root { @run_mode.var_dir.should == File.expand_path("~/.puppet/var") }
       end
     end
   end


### PR DESCRIPTION
In 3.0, the default user confdir (and vardir) was changed from ~/.puppet
to the Dir::LOCAL_APPDATA/PuppetLabs. However, when puppet is run as a
non-administrator, puppet will attempt to create its confdir, e.g.
C:\Users\albert\AppData\Local\PuppetLabs\puppet, and fail because the
parent PuppetLabs directory doesn't exist.

This wasn't an issue in 2.7.x, because the confdir was ~/.puppet, so the
parent directory always existed.

This commit restores the previous behavior for non-administrators. No
changes are required for administrators, because the MSI installer creates
the necessary directories within COMMON_APPDATA.
