### PR TITLE
(#18092) Enable password with a sharp is not correctly parsed

### DIFF
--- a/lib/puppet/util/network_device/cisco/device.rb
+++ b/lib/puppet/util/network_device/cisco/device.rb
@@ -14,7 +14,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
 
   def initialize(url, options = {})
     super(url)
-    @enable_password = options[:enable_password] || parse_enable(@url.query)
+    @enable_password = options[:enable_password] || parse_enable(@url.to_s)
     transport.default_prompt = /[#>]\s?\z/n
   end
 

--- a/spec/unit/util/network_device/cisco/device_spec.rb
+++ b/spec/unit/util/network_device/cisco/device_spec.rb
@@ -16,6 +16,11 @@ describe Puppet::Util::NetworkDevice::Cisco::Device do
       cisco.enable_password.should == "enable_password"
     end
 
+    it "should find the enable password from the url with a sharp" do
+      cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23/?enable=enable_password#with_a_sharp")
+      cisco.enable_password.should == "enable_password#with_a_sharp"
+    end
+
     it "should find the enable password from the options" do
       cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23/?enable=enable_password", :enable_password => "mypass")
       cisco.enable_password.should == "mypass"


### PR DESCRIPTION
Since the device is defined by an URI, when the enable password contains a sharp, the password used is not correct.

Using uri.to_s is maybe not the best solution, but only one parameter is used. A full-featured parser is not needed for the moment.
