### PR TITLE
(#14728) Handle removed files in the PMT change command.

### DIFF
--- a/lib/puppet/module_tool/applications/checksummer.rb
+++ b/lib/puppet/module_tool/applications/checksummer.rb
@@ -22,7 +22,7 @@ module Puppet::ModuleTool
             next if File.basename(child_path) == "metadata.json"
 
             path = @path + child_path
-            if canonical_checksum != sums.checksum(path)
+            if !File.exist?(path) || canonical_checksum != sums.checksum(path)
               changes << child_path
             end
           end


### PR DESCRIPTION
This trivial patch ensures that PMT reports removed files as changed
rather than just printing a file not found error message.
