### PR TITLE
(#18121) Collector overrides should work in Ruby 1.9

### DIFF
--- a/lib/puppet/parser/collector.rb
+++ b/lib/puppet/parser/collector.rb
@@ -32,7 +32,7 @@ class Puppet::Parser::Collector
     # we have an override for the collected resources
     if @overrides and !objects.empty?
       # force the resource to be always child of any other resource
-      overrides[:source].meta_def(:child_of?) do
+      overrides[:source].meta_def(:child_of?) do |klass|
         true
       end
 


### PR DESCRIPTION
Increase arity of child_of? meta_def to 1

child_of? defined for Puppet::Resource::Type objects has an arity of 1,
but the meta_def of the same function created by
Puppet::Parser::Collector objects has an arity of 0. This throws errors
when the meta_def method is called with arguments. This commit matches
the arity so that this error will not be present.
