### PR TITLE
(#18161) Honor CA SRV record for all types of CA requests

### DIFF
--- a/lib/puppet/indirector/certificate_request/rest.rb
+++ b/lib/puppet/indirector/certificate_request/rest.rb
@@ -6,4 +6,5 @@ class Puppet::SSL::CertificateRequest::Rest < Puppet::Indirector::REST
 
   use_server_setting(:ca_server)
   use_port_setting(:ca_port)
+  use_srv_service(:ca)
 end

--- a/lib/puppet/indirector/certificate_revocation_list/rest.rb
+++ b/lib/puppet/indirector/certificate_revocation_list/rest.rb
@@ -6,4 +6,5 @@ class Puppet::SSL::CertificateRevocationList::Rest < Puppet::Indirector::REST
 
   use_server_setting(:ca_server)
   use_port_setting(:ca_port)
+  use_srv_service(:ca)
 end

--- a/lib/puppet/indirector/certificate_status/rest.rb
+++ b/lib/puppet/indirector/certificate_status/rest.rb
@@ -7,4 +7,5 @@ class Puppet::Indirector::CertificateStatus::Rest < Puppet::Indirector::REST
 
   use_server_setting(:ca_server)
   use_port_setting(:ca_port)
+  use_srv_service(:ca)
 end

--- a/spec/unit/indirector/certificate_request/rest_spec.rb
+++ b/spec/unit/indirector/certificate_request/rest_spec.rb
@@ -19,4 +19,8 @@ describe Puppet::SSL::CertificateRequest::Rest do
   it "should set port_setting to :ca_port" do
     Puppet::SSL::CertificateRequest::Rest.port_setting.should == :ca_port
   end
+
+  it "should use the :ca SRV service" do
+    Puppet::SSL::CertificateRequest::Rest.srv_service.should == :ca
+  end
 end

--- a/spec/unit/indirector/certificate_revocation_list/rest_spec.rb
+++ b/spec/unit/indirector/certificate_revocation_list/rest_spec.rb
@@ -19,4 +19,8 @@ describe Puppet::SSL::CertificateRevocationList::Rest do
   it "should set port_setting to :ca_port" do
     Puppet::SSL::CertificateRevocationList::Rest.port_setting.should == :ca_port
   end
+
+  it "should use the :ca SRV service" do
+    Puppet::SSL::CertificateRevocationList::Rest.srv_service.should == :ca
+  end
 end

--- a/spec/unit/indirector/certificate_status/rest_spec.rb
+++ b/spec/unit/indirector/certificate_status/rest_spec.rb
@@ -11,4 +11,8 @@ describe "Puppet::CertificateStatus::Rest" do
   it "should be a terminus on Puppet::SSL::Host" do
     @terminus.should be_instance_of(Puppet::Indirector::CertificateStatus::Rest)
   end
+
+  it "should use the :ca SRV service" do
+    Puppet::Indirector::CertificateStatus::Rest.srv_service.should == :ca
+  end
 end


### PR DESCRIPTION
For certificate requests, certificate status requests & certificate
revocation list requests puppet used the x-puppet srv record instead of
the x-puppet-ca record.
