### PR TITLE
(#18162) Honor fileserver SRV record for file metadata requests

### DIFF
--- a/lib/puppet/indirector/file_metadata/rest.rb
+++ b/lib/puppet/indirector/file_metadata/rest.rb
@@ -4,4 +4,6 @@ require 'puppet/indirector/rest'
 
 class Puppet::Indirector::FileMetadata::Rest < Puppet::Indirector::REST
   desc "Retrieve file metadata via a REST HTTP interface."
+
+  use_srv_service(:fileserver)
 end

--- a/spec/unit/indirector/file_metadata/rest_spec.rb
+++ b/spec/unit/indirector/file_metadata/rest_spec.rb
@@ -2,7 +2,12 @@
 require 'spec_helper'
 
 require 'puppet/indirector/file_metadata'
+require 'puppet/indirector/file_metadata/rest'
 
 describe "Puppet::Indirector::Metadata::Rest" do
   it "should add the node's cert name to the arguments"
+
+  it "should use the :fileserver SRV service" do
+    Puppet::Indirector::FileMetadata::Rest.srv_service.should == :fileserver
+  end
 end


### PR DESCRIPTION
File content requests uses the x-puppet-fileserver SRV record, but file
metadata requests used the x-puppet SRV record.

Adds test for the functionality.
