### PR TITLE
(#18187) Clear *root* environment when clearing caches

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -52,11 +52,12 @@ class Puppet::Node::Environment
   end
 
   def self.root
-    @root
+    @root ||= new(:'*root*')
   end
 
   def self.clear
     @seen.clear
+    @root = nil
     Thread.current[:environment] = nil
   end
 
@@ -211,6 +212,4 @@ class Puppet::Node::Environment
     # perform_initial_import when no file was actually loaded.
     return Puppet::Parser::AST::Hostclass.new('')
   end
-
-  @root = new(:'*root*')
 end

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -32,6 +32,12 @@ describe Puppet::Node::Environment do
     Puppet::Node::Environment.new("one").should equal(Puppet::Node::Environment.new("one"))
   end
 
+  it "should treat environment instances as singletons only until cleared" do
+    before = Puppet::Node::Environment.new("one")
+    Puppet::Node::Environment.clear
+    before.should_not equal(Puppet::Node::Environment.new("one"))
+  end
+
   it "should treat an environment specified as names or strings as equivalent" do
     Puppet::Node::Environment.new(:one).should equal(Puppet::Node::Environment.new("one"))
   end
@@ -43,6 +49,32 @@ describe Puppet::Node::Environment do
   it "should just return any provided environment if an environment is provided as the name" do
     one = Puppet::Node::Environment.new(:one)
     Puppet::Node::Environment.new(one).should equal(one)
+  end
+
+  it "should return the *root* environment as the current env by default" do
+    Puppet::Node::Environment.current.name.to_s.should == '*root*'
+  end
+
+  it "should treat the *root* instance as a singleton only until cleared" do
+    before = Puppet::Node::Environment.current
+    Puppet::Node::Environment.clear
+    before.should_not equal(Puppet::Node::Environment.current)
+  end
+
+  it "should change the current environment" do
+    Puppet::Node::Environment.current.name.to_s.should == '*root*'
+    one = Puppet::Node::Environment.new(:one)
+    Puppet::Node::Environment.current = one
+    Puppet::Node::Environment.current.should equal(one)
+  end
+
+  it "should change the current environment only until cleared" do
+    Puppet::Node::Environment.current.name.to_s.should == '*root*'
+    one = Puppet::Node::Environment.new(:one)
+    Puppet::Node::Environment.current = one
+    Puppet::Node::Environment.current.should equal(one)
+    Puppet::Node::Environment.clear
+    Puppet::Node::Environment.current.name.to_s.should == '*root*'
   end
 
   describe "when managing known resource types" do


### PR DESCRIPTION
The bug is only seen on 2.7.x, specifically 2.7.20 which caused a regression.  3.x avoids the issue.

When changing settings or initializing Puppet via TestHelper, the
Puppet::Node::Environment.clear method is called to delete the cached
environment objects, as they may reference cached module paths based on old
values of settings.

The _root_ environment is a special case, as it acts as the current environment
when no other environment has been created and set yet.  It can still have a
module path based on current settings, so it too should be cleared along with
other cached environments.

Failure to reinitialize _root_ causes failures when initializing Puppet via the
TestHelper.  The Puppet::MetaType::Manager class uses the current environment
in calls to Puppet::Util::Autoload, which starts as the default _root_
enviroment.  The type loader is called a few times during TestHelper
initialization and so if the module path is then changed (which triggers a
.clear call), the _root_ environment will contain paths based on old settings,
so types won't load.

Loading types based on the environment is new in 8173a6e6 (2.7.19).  3.x is
unaffected as caching of module paths doesn't begin until
app_defaults_initialized? changes to true.
