### PR TITLE
(maint) Remove f15 mocks from build_defaults.yaml

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,8 +9,8 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: False
 # a space separated list of mock configs
-final_mocks: 'pl-5-i386 pl-6-i386 fedora-15-i386 fedora-16-i386 fedora-17-i386'
-rc_mocks: 'pl-5-i386-dev pl-6-i386-dev fedora-15-i386-dev fedora-16-i386-dev fedora-17-i386-dev'
+final_mocks: 'pl-5-i386 pl-6-i386 fedora-16-i386 fedora-17-i386'
+rc_mocks: 'pl-5-i386-dev pl-6-i386-dev fedora-16-i386-dev fedora-17-i386-dev'
 yum_host: 'burji.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
Fedora 15 is EOL, and we no longer build packages for f15, so this commit
removes f15 from the list of final and rc mocks in ext/build_defaults.yaml.
