### PR TITLE
Support for pip Provider under Centos

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -100,7 +100,7 @@ Puppet::Type.type(:package).provide :pip,
   def lazy_pip(*args)
     pip *args
   rescue NoMethodError => e
-    if pathname = which('pip')
+    if pathname = which('pip') or pathname = which('pip-python')
       self.class.commands :pip => pathname
       pip *args
     else


### PR DESCRIPTION
The puppet pip (python install program) provider has issues under Centos. This is because the pip program gets installed as 'pip-python' for some reason. I've patched the pip.rb provider file to support systems with either pip or pip-python.
