### PR TITLE
(#15791) isolate deterministic random function

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -8,6 +8,13 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
       $random_number = fqdn_rand(30)
       $random_number_seed = fqdn_rand(30,30)") do |args|
     max = args.shift.to_i
-    srand(Digest::MD5.hexdigest([self['::fqdn'],args].join(':')).hex)
-    rand(max).to_s
+    seed = Digest::MD5.hexdigest([self['::fqdn'],args].join(':')).hex
+    if RUBY_VERSION > '1.9.1'
+      Random.new(seed).rand(max).to_s
+    else
+      srand(seed)
+      result = rand(max).to_s
+      srand()
+      result
+    end
 end

--- a/spec/unit/parser/functions/fqdn_rand_spec.rb
+++ b/spec/unit/parser/functions/fqdn_rand_spec.rb
@@ -55,4 +55,26 @@ describe "the fqdn_rand function" do
     val2 = @scope.function_fqdn_rand([10000000,42])
     val1.should_not eql(val2)
   end
+
+  it "should not fiddle with future rand calls" do
+    @scope.function_fqdn_rand([20])
+    rand_one = rand()
+    @scope.function_fqdn_rand([20])
+    rand().should_not eql(rand_one)
+  end
+
+  if RUBY_VERSION > '1.9.1'
+    it "should not fiddle with the global seed" do
+      srand(1234)
+      @scope.function_fqdn_rand([20])
+      srand().should eql(1234)
+    end
+  # ruby below 1.9.2 variant
+  else
+    it "should set a new global seed" do
+      srand(1234)
+      @scope.function_fqdn_rand([20])
+      srand().should_not eql(1234)
+    end
+  end
 end


### PR DESCRIPTION
We should not fiddle with the global seed, as other people
might still depend on Kernel.rand() not being that deterministic
as it is the idea with the fqdn_rand function.
