### PR TITLE
(#14728) Handle removed files in the PMT changes command.

### DIFF
--- a/acceptance/tests/modules/changes/invalid_module_install_path.rb
+++ b/acceptance/tests/modules/changes/invalid_module_install_path.rb
@@ -1,0 +1,20 @@
+test_name 'puppet module changes (on an invalid module install path)'
+
+step 'Setup'
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
+apply_manifest_on master, %q{file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }}
+teardown do
+  on master, 'rm -rf /etc/puppet/modules'
+  on master, 'rm -rf /usr/share/puppet/modules'
+end
+
+step 'Run module changes on an invalid module install path'
+on master, puppet('module changes /etc/puppet/modules/nginx'), :acceptable_exit_codes => [1] do
+  assert_equal <<-STDERR, stderr
+\e[1;31mError: Could not find a valid module at "/etc/puppet/modules/nginx"\e[0m
+\e[1;31mError: Try 'puppet help module changes' for usage\e[0m
+  STDERR
+end

--- a/acceptance/tests/modules/changes/missing_metadata_json.rb
+++ b/acceptance/tests/modules/changes/missing_metadata_json.rb
@@ -1,0 +1,22 @@
+test_name 'puppet module changes (on a module which is missing metadata.json)'
+
+step 'Setup'
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
+apply_manifest_on master, %q{file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }}
+teardown do
+  on master, 'rm -rf /etc/puppet/modules'
+  on master, 'rm -rf /usr/share/puppet/modules'
+end
+
+apply_manifest_on master, %q{file { '/etc/puppet/modules/nginx': ensure => directory; '/etc/puppet/modules/nginx/Modulefile': ensure => present }}
+
+step 'Run module changes on a module witch is missing metadata.json'
+on master, puppet('module changes /etc/puppet/modules/nginx'), :acceptable_exit_codes => [1] do
+  assert_equal <<-STDERR, stderr
+\e[1;31mError: No metadata.json found.\e[0m
+\e[1;31mError: Try 'puppet help module changes' for usage\e[0m
+  STDERR
+end

--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,0 +1,25 @@
+test_name 'puppet module changes (on a module with a modified file)'
+
+step 'Setup'
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
+apply_manifest_on master, %q{file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }}
+teardown do
+  on master, 'rm -rf /etc/puppet/modules'
+  on master, 'rm -rf /usr/share/puppet/modules'
+end
+
+on master, puppet('module install pmtacceptance-nginx')
+on master, 'echo >> /etc/puppet/modules/nginx/README'
+
+step 'Run module changes to check a module with a modified file'
+on master, puppet('module changes /etc/puppet/modules/nginx'), :acceptable_exit_codes => [0] do
+  assert_equal <<-STDERR, stderr
+\e[1;31mWarning: 1 files modified\e[0m
+  STDERR
+  assert_equal <<-OUTPUT, stdout
+README
+  OUTPUT
+end

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,0 +1,25 @@
+test_name 'puppet module changes (on a module with a removed file)'
+
+step 'Setup'
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
+apply_manifest_on master, %q{file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }}
+teardown do
+  on master, 'rm -rf /etc/puppet/modules'
+  on master, 'rm -rf /usr/share/puppet/modules'
+end
+
+on master, puppet('module install pmtacceptance-nginx')
+on master, 'rm -rf /etc/puppet/modules/nginx/README'
+
+step 'Run module changes to check a module with a removed file'
+on master, puppet('module changes /etc/puppet/modules/nginx'), :acceptable_exit_codes => [0] do
+  assert_equal <<-STDERR, stderr
+\e[1;31mWarning: 1 files modified\e[0m
+  STDERR
+  assert_equal <<-OUTPUT, stdout
+README
+  OUTPUT
+end

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,0 +1,19 @@
+test_name 'puppet module changes (on an unmodified module)'
+
+step 'Setup'
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
+apply_manifest_on master, %q{file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }}
+teardown do
+  on master, 'rm -rf /etc/puppet/modules'
+  on master, 'rm -rf /usr/share/puppet/modules'
+end
+
+on master, puppet('module install pmtacceptance-nginx')
+
+step 'Run module changes to check an unmodified module'
+on master, puppet('module changes /etc/puppet/modules/nginx'), :acceptable_exit_codes => [0] do
+  assert_match /No modified files/, stdout
+end

--- a/lib/puppet/face/module/changes.rb
+++ b/lib/puppet/face/module/changes.rb
@@ -21,7 +21,9 @@ Puppet::Face.define(:module, '1.0.0') do
 
     when_invoked do |path, options|
       Puppet::ModuleTool.set_option_defaults options
-      root_path = Puppet::ModuleTool.find_module_root(path)
+      unless root_path = Puppet::ModuleTool.find_module_root(path)
+        raise ArgumentError, "Could not find a valid module at #{path.inspect}"
+      end
       Puppet::ModuleTool::Applications::Checksummer.run(root_path, options)
     end
 

--- a/lib/puppet/module_tool/applications/checksummer.rb
+++ b/lib/puppet/module_tool/applications/checksummer.rb
@@ -22,7 +22,7 @@ module Puppet::ModuleTool
             next if File.basename(child_path) == "metadata.json"
 
             path = @path + child_path
-            if canonical_checksum != sums.checksum(path)
+            unless path.exist? && canonical_checksum == sums.checksum(path)
               changes << child_path
             end
           end

--- a/spec/unit/module_tool/applications/checksummer_spec.rb
+++ b/spec/unit/module_tool/applications/checksummer_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+require 'puppet/module_tool/applications'
+
+describe Puppet::ModuleTool::Applications::Checksummer, :fails_on_windows => true do
+  subject {
+    Puppet::ModuleTool::Applications::Checksummer.new(module_install_path)
+  }
+
+  let(:module_install_path) { 'foo' }
+  let(:module_metadata_file) { 'metadata.json' }
+
+  let(:module_install_pathname) {
+    module_install_pathname = mock()
+    Pathname.expects(:new).with(module_install_path).\
+      returns(module_install_pathname)
+    module_install_pathname
+  }
+
+  def stub_module_file_pathname(relative_path, present)
+    module_file_pathname = mock() do
+      expects(:exist?).with().returns(present)
+    end
+
+    module_install_pathname.expects(:+).with(relative_path).\
+      returns(module_file_pathname)
+
+    module_file_pathname
+  end
+
+  context %q{when metadata.json doesn't exist in the specified module install path} do
+    before(:each) do
+      stub_module_file_pathname(module_metadata_file, false)
+      subject.expects(:metadata_file).with().\
+        returns(module_install_pathname + module_metadata_file)
+    end
+
+    it 'raises an ArgumentError exception' do
+      lambda {
+        subject.run
+      }.should raise_error(ArgumentError, 'No metadata.json found.')
+    end
+  end
+
+  context 'when metadata.json exists in the specified module install path' do
+    module_files = {
+      'README'     => '1',
+      'CHANGELOG'  => '2',
+      'Modulefile' => '3',
+    }
+    let(:module_files) { module_files }
+    let(:checksum_computer) {
+      checksum_computer = mock()
+      Puppet::ModuleTool::Checksums.\
+        expects(:new).with(module_install_pathname).\
+        returns(checksum_computer)
+      checksum_computer
+    }
+    # all possible combinations (of all lengths) of the module files
+    module_files_combination =
+      1.upto(module_files.size()).inject([]) { |module_files_combination, n|
+        module_files.keys.combination(n) { |combination|
+          module_files_combination << combination
+        }
+        module_files_combination
+      }
+
+    def stub_module_file_pathname_with_checksum(relative_path, checksum)
+      module_file_pathname =
+        stub_module_file_pathname(relative_path, present = !checksum.nil?)
+      # mock the call of Puppet::ModuleTool::Checksums#checksum
+      expectation = checksum_computer.\
+        expects(:checksum).with(module_file_pathname)
+      if present
+        # return the cheksum directly
+        expectation.returns(checksum)
+      else
+        # if the file is not present, then the method should not be called
+        expectation.times(0)
+      end
+      module_file_pathname
+    end
+
+    def stub_module_files(overrides = {})
+      overrides.reject! { |key, value|
+        !module_files.include?(key)
+      }
+      module_files.merge(overrides).each { |relative_path, checksum|
+        stub_module_file_pathname_with_checksum(relative_path, checksum)
+      }
+    end
+
+    before(:each) do
+      stub_module_file_pathname(module_metadata_file, true)
+      subject.expects(:metadata_file).with().\
+        returns(module_install_pathname + module_metadata_file)
+      subject.expects(:metadata).with().\
+        returns({ 'checksums' => module_files })
+    end
+
+    module_files_combination.each do |removed_files|
+      it "reports removed file(s) #{removed_files.inspect}" do
+        stub_module_files(
+          removed_files.inject({}) { |overrides, removed_file|
+            overrides[removed_file] = nil
+            overrides
+          }
+        )
+
+        subject.run.should == removed_files
+      end
+    end
+
+    module_files_combination.each do |modified_files|
+      it "reports modified file(s) #{modified_files.inspect}" do
+        stub_module_files(
+          modified_files.inject({}) { |overrides, modified_file|
+            modified_checksum = module_files[modified_file].to_s.succ
+            modified_checksum = ' ' if modified_checksum.empty?
+            overrides[modified_file] = modified_checksum
+            overrides
+          }
+        )
+
+        subject.run.should == modified_files
+      end
+    end
+
+    it 'does not report unmodified files' do
+      stub_module_files()
+
+      subject.run.should == []
+    end
+  end
+end


### PR DESCRIPTION
This patch ensures that "puppet module changes" command reports removed files
as changed rather than exiting with a "file not found" error message when it
encounters a file that should exist according to the metadata.json but which
is not present.
The patch also adds unit & acceptance tests for the "puppet module changes"
command.
