### PR TITLE
(#18288) Allow multiple stanzas for the same endpoint in auth.conf

### DIFF
--- a/lib/puppet/indirector/file_server.rb
+++ b/lib/puppet/indirector/file_server.rb
@@ -15,7 +15,7 @@ class Puppet::Indirector::FileServer < Puppet::Indirector::Terminus
 
     # If we're not serving this mount, then access is denied.
     return false unless mount
-    mount.allowed?(request.node, request.ip)
+    mount.allowed?(request.node, request.ip) == true
   end
 
   # Find our key using the fileserver.

--- a/lib/puppet/network/authstore.rb
+++ b/lib/puppet/network/authstore.rb
@@ -45,8 +45,8 @@ module Puppet
         return decl.result
       end
 
-      info "defaulting to no access for #{name}"
-      false
+      info "no declaration matches #{name}, defaulting to :dunno"
+      :dunno
     end
 
     # Deny a given pattern.

--- a/lib/puppet/network/handler/fileserver.rb
+++ b/lib/puppet/network/handler/fileserver.rb
@@ -208,7 +208,7 @@ class Puppet::Network::Handler
         client = nil
         clientip = nil
       end
-      unless mount.allowed?(client, clientip)
+      unless mount.allowed?(client, clientip) == true
         mount.warning "#{client} cannot access #{file}"
         raise Puppet::AuthorizationError, "Cannot access #{mount}"
       end


### PR DESCRIPTION
Prior to this commit, a stanza for an API endpoint would implicitly deny any cert not explicitly allowed. This makes it difficult to use the concat pattern to manage auth.conf. The original behavior also violates the principle of least surprise by not behaving like the firewall rules that auth.conf is similar to.

With this change, auth.conf rules now "waterfall", meaning if a cert is not explicitly allowed or denied in a rule further rules will be checked until a match is found.

This commit also changes the behavior of the fileserver authorization to ensure it does not allow on a `:dunno` result.
