### PR TITLE
(#18234) Booleans used from within hashes not working correctly.

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -151,7 +151,12 @@ class Puppet::Parser::AST
 
       raise Puppet::ParseError, "#{variable} is not an hash or array when accessing it with #{accesskey}" unless object.is_a?(Hash) or object.is_a?(Array)
 
-      object[array_index_or_key(object, accesskey)] || :undef
+      value = object[array_index_or_key(object, accesskey)]
+      if value.nil?
+        :undef
+      else
+        value
+      end
     end
 
     # Assign value to this hashkey or array index

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -201,6 +201,22 @@ describe Puppet::Parser::AST::HashOrArrayAccess do
       access.evaluate(@scope).should == "45"
     end
 
+    it "should be able to return a hash value of false" do
+      @scope["a"] = { "key1" => false, "key2" => true  }
+
+      access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => "key1" )
+
+      access.evaluate(@scope).should be_false
+    end
+
+    it "should be able to return a hash value of true" do
+      @scope["a"] = { "key1" => false, "key2" => true  }
+
+      access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => "key2" )
+
+      access.evaluate(@scope).should be_true
+    end
+
     it "should raise an error if the variable lookup didn't return an hash or an array" do
       @scope["a"] = "I'm a string"
 


### PR DESCRIPTION
Returns false instead of undef when a key correctly exists and contains a false value.
Also includes parser test cases for boolean values within hashes.
