### PR TITLE
(#17887) Only log if message has been initialized

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -123,7 +123,7 @@ class Puppet::Transaction::ResourceHarness
     event.message = "change from #{property.is_to_s(current_value)} to #{property.should_to_s(property.should)} failed: #{detail}"
     event
   ensure
-    event.send_log
+    event.send_log if event.message
   end
 
   def evaluate(resource)


### PR DESCRIPTION
It's possible to run the "ensure" block without having executed either the
main or "rescue" blocks, if an Exception not derived from StandardError is
raised or when testing with Mocha expectations.

If this happens during the property.sync, this causes an immediate exit from
the main block, but the "ensure" block is still run.  The event message won't
have been initialized yet, so this then causes the logger to report:

  Puppet::Util::Log requires a message

This changes the "ensure" block to only log if it's got as far as writing a
message.

Replaces GH-1307 to rebase against master and add a test.
