### PR TITLE
(#18320) makes yum default for all RedHat derivatives

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       end
   end
 
-  defaultfor :operatingsystem => [:fedora, :centos, :redhat]
+  defaultfor :osfamily => :redhat
 
   def self.prefetch(packages)
     raise Puppet::Error, "The yum provider can only be used as root" if Process.euid != 0


### PR DESCRIPTION
This commit changes the defaultfor from using the operatingsystem fact
to the osfamily fact. This is done so that we do not have to duplicate
effort of all the RedHat derivatives that use yum.
