### PR TITLE
(maint) Update bundle dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,17 +15,15 @@ end
 
 group(:development, :test) do
   gem "puppet", *location_for('file://.')
-  gem "facter", *location_for(ENV['FACTER_LOCATION'] || '~> 1.6.4')
-  gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0.0')
-  gem "rack", "~> 1.4.1", :require => false
+  gem "facter", *location_for(ENV['FACTER_LOCATION'] || '~> 1.6')
+  gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
+  gem "rack", "~> 1.4", :require => false
   gem "rake", "~> 0.9.2", :require => false
-  gem "rspec", "~> 2.10.0", :require => false
+  gem "rspec", "~> 2.11.0", :require => false
   gem "mocha", "~> 0.10.5", :require => false
 end
 
 platforms :mswin, :mingw do
-  # See http://jenkins.puppetlabs.com/ for current Gem listings for the Windows
-  # CI Jobs.
   gem "sys-admin", "~> 1.5.6", :require => false
   gem "win32-api", "~> 1.4.8", :require => false
   gem "win32-dir", "~> 0.3.7", :require => false


### PR DESCRIPTION
Without this patch applied the bundle dependencies for Facter and Hiera
are too conservative.  For example hiera 1.1.2 is currently released and
available via rubygems.org, but Bundler will never install this specific
version in our CI infrastructure because the specified dependency is '~>
1.0.0' which means greater than or equal to version 1.0.0 but less than
version 1.1.0.'  Similarly Facter 1.7 will never be used even though it
is backwards compatible and a valid satisfaction of the dependency
between Puppet 3 and Facter > 1.6.2.

This is a problem because Facter and Hiera follow semantic version
guidelines.  This means we should be able to depend on any minor version
of a particular major version and have some reasonable guarantee of
backwards compatibility.  settings to match Hiera master.

This patch simply updates the dependency specifications for all of the
libraries that are currently following semantic version guidelines.
