### PR TITLE
(#18334) package providers use osfamily

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
   commands :aptcache => "/usr/bin/apt-cache"
   commands :preseed => "/usr/bin/debconf-set-selections"
 
-  defaultfor :operatingsystem => [:debian, :ubuntu]
+  defaultfor :osfamily => :debian
 
   ENV['DEBIAN_FRONTEND'] = "noninteractive"
 

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
 
   commands :zypper => "/usr/bin/zypper"
 
-  confine    :operatingsystem => [:suse, :sles, :sled, :opensuse]
+  confine :osfamily => :suse
 
   #on zypper versions <1.0, the version option returns 1
   #some versions of zypper output on stderr


### PR DESCRIPTION
This commit will update apt and zypper package providers to use osfamily
instead of operatingsystem in order to avoid duplicating entries.
