### PR TITLE
(#18335) urpmi use osfamily for mandrake

### DIFF
--- a/lib/puppet/provider/package/urpmi.rb
+++ b/lib/puppet/provider/package/urpmi.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:package).provide :urpmi, :parent => :rpm, :source => :rpm do
       end
   end
 
-  defaultfor :operatingsystem => [:mandriva, :mandrake]
+  defaultfor :osfamily => :mandrake
 
   has_feature :versionable
 


### PR DESCRIPTION
This commit will allow the urpmi package provider to use osfamily
instead of operatingsystem. It is dependent on ticket #18336 which will
provide the mandrake osfamily entry in facter and is slated for 2.x.
