### PR TITLE
Relax gem dependencies on Facter and Hiera

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -15,8 +15,8 @@ gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_forge_project: 'puppet'
 gem_runtime_dependencies:
-  facter: '~> 1.6.11'
-  hiera: '~> 1.0.0'
+  facter: '~> 1.6'
+  hiera: '~> 1.0'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"


### PR DESCRIPTION
Without this patch applied an older version of Hiera is automatically
installed as a dependency installing Puppet.  This is a problem because
there are important bug fixes happening in later minor versions of
Hiera.  The same is true of Facter.  The cause of the problem is a tight
specification of `gem :hiera, "~> 1.0.0"` which means "greater than
1.0.0 but less then 1.1.0".  1.1.2 is the current latest bug fix version
of Hiera.

This patch fixes the problem by relaxing the dependency to "~> 1.0"
which means "greater than 1.0.0 and less than 2.0.0"
