### PR TITLE
(#18394) Remove puppet-queue.conf from redhat spec

### DIFF
--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -103,9 +103,6 @@ done
 
 find examples/ -type f | xargs --no-run-if-empty chmod a-x
 
-# puppet-queue.conf is more of an example, used for stompserver
-mv conf/puppet-queue.conf examples/
-
 %install
 rm -rf %{buildroot}
 ruby install.rb --destdir=%{buildroot} --quick --no-rdoc --sitelibdir=%{puppet_libdir}


### PR DESCRIPTION
conf/puppet-queue.conf was removed from source in commit ade52f7, This broke
puppet redhat packaging, which references the file explicitly. This commit
updates the packaging to reflect its absence.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
