### PR TITLE
(#17716) HPUX_user_provider

### DIFF
--- a/lib/puppet/provider/user/hpux.rb
+++ b/lib/puppet/provider/user/hpux.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
   defaultfor :operatingsystem => "hp-ux"
   confine :operatingsystem => "hp-ux"
 
-  commands :modify => "/usr/sam/lbin/usermod.sam", :delete => "/usr/sam/lbin/userdel.sam", :add => "/usr/sbin/useradd"
+  commands :modify => "/usr/sam/lbin/usermod.sam", :delete => "/usr/sam/lbin/userdel.sam", :add => "/usr/sam/lbin/useradd.sam"
   options :comment, :method => :gecos
   options :groups, :flag => "-G"
   options :home, :flag => "-d", :method => :dir
@@ -19,7 +19,7 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
     value !~ /\s/
   end
 
-  has_features :manages_homedir, :allows_duplicates
+  has_features :manages_homedir, :allows_duplicates, :manages_passwords
 
   def deletecmd
     super.insert(1,"-F")
@@ -27,5 +27,40 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
 
   def modifycmd(param,value)
     super.insert(1,"-F")
+  end
+
+  def password
+      # Password management routine for trusted and non-trusted systems
+      #temp=""
+      while ent = Etc.getpwent() do
+          if ent.name == resource.name
+             temp=ent.name
+             break
+          end
+      end
+      Etc.endpwent()
+      if !temp
+          return nil
+      end
+
+      ent = Etc.getpwnam(resource.name)
+      if ent.passwd == "*"
+          # Either no password or trusted password, check trusted
+          file_name="/tcb/files/auth/#{resource.name.chars.first}/#{resource.name}"
+          if File.file?(file_name)
+              # Found the tcb user for the specific user, now get passwd
+              File.open(file_name).each do |line|
+                  if ( line =~ /u_pwd/ )
+                      temp_passwd=line.split(":")[1].split("=")[1]
+                      ent.passwd = temp_passwd
+                      return ent.passwd
+                  end
+              end
+          else
+              debug "No trusted computing user file #{file_name} found."
+          end
+      else
+          return ent.passwd
+      end
   end
 end

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:user).provider(:hpuxuseradd)
@@ -20,5 +20,26 @@ describe provider_class do
     @provider.stubs(:exists?).returns(true)
     @provider.expects(:execute).with { |args| args.include?("-F") }
     @provider.delete
+  end
+
+end
+
+describe provider_class do
+
+  it "should have feature manages_passwords" do
+      provider_class.should be_manages_passwords
+  end
+
+  it "should return nil if user does not exist" do
+      @resource = stub("resource", :name => "no_user")
+      @provider = provider_class.new(@resource)
+      @provider.password.must be_nil
+  end
+
+
+  it "should return password entry if exists" do
+      @resource = stub("resource", :name => "root")
+      @provider = provider_class.new(@resource)
+      @provider.password.should be_true
   end
 end


### PR DESCRIPTION
*\* Added changes to Master now versus 2.7.x thread.

Updated to allow user provider to manage passwords on hpux in either
normal or trusted computing modes. Updated spec file to make sure
changes are in place. Specifically manages_passwords, user exists and
password function returns a password.
