### PR TITLE
(#14872) PMT respect environment's module path

### DIFF
--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -1,0 +1,53 @@
+test_name 'puppet module install (with environment)'
+
+step 'Setup'
+
+stub_forge_on(master)
+
+# Configure a non-default environment
+on master, 'rm -rf /usr/share/puppet/modules /etc/puppet/testenv'
+apply_manifest_on master, %q{
+  file {
+    [
+      '/usr/share/puppet/modules',
+      '/etc/puppet/testenv',
+      '/etc/puppet/testenv/modules',
+    ]:
+      ensure => directory,
+  }
+  augeas {
+    'set-testenv-modulepath':
+      incl => $settings::config,
+      lens => 'Puppet.lns',
+      context => "/files${settings::config}",
+      changes => [
+        'set testenv/modulepath /etc/puppet/testenv/modules',
+      ],
+  }
+}
+teardown do
+apply_manifest_on master, %q{
+  augeas {
+    'delete-testenv-settings':
+      incl => $settings::config,
+      lens => 'Puppet.lns',
+      context => "/files${settings::config}",
+      changes => [
+        'rm testenv',
+      ],
+  }
+}
+on master, 'rm -rf /usr/share/puppet/modules /etc/puppet/testenv'
+end
+
+step 'Install a module into a non default environment'
+on master, 'puppet module install pmtacceptance-nginx --environment=testenv' do
+  assert_output <<-OUTPUT
+    \e[mNotice: Preparing to install into /etc/puppet/testenv/modules ...\e[0m
+    \e[mNotice: Downloading from https://forge.puppetlabs.com ...\e[0m
+    \e[mNotice: Installing -- do not interrupt ...\e[0m
+    /etc/puppet/testenv/modules
+    └── pmtacceptance-nginx (\e[0;36mv0.0.1\e[0m)
+  OUTPUT
+end
+on master, '[ -d /etc/puppet/testenv/modules/nginx ]'

--- a/acceptance/tests/modules/uninstall/with_environment.rb
+++ b/acceptance/tests/modules/uninstall/with_environment.rb
@@ -1,0 +1,62 @@
+test_name 'puppet module uninstall (with environment)'
+
+step 'Setup'
+
+stub_forge_on(master)
+
+# Configure a non-default environment
+on master, 'rm -rf /usr/share/puppet/modules /etc/puppet/testenv'
+apply_manifest_on master, %q{
+  file {
+    [
+      '/usr/share/puppet/modules',
+      '/etc/puppet/testenv',
+      '/etc/puppet/testenv/modules',
+      '/etc/puppet/testenv/modules/crakorn',
+    ]:
+      ensure => directory,
+  }
+  file {
+    '/etc/puppet/testenv/modules/crakorn/metadata.json':
+      content => '{
+        "name": "jimmy/crakorn",
+        "version": "0.4.0",
+        "source": "",
+        "author": "jimmy",
+        "license": "MIT",
+        "dependencies": []
+      }',
+  }
+  augeas {
+    'set-testenv-modulepath':
+      incl => $settings::config,
+      lens => 'Puppet.lns',
+      context => "/files${settings::config}",
+      changes => [
+        'set testenv/modulepath /etc/puppet/testenv/modules',
+      ],
+  }
+}
+teardown do
+apply_manifest_on master, %q{
+  augeas {
+    'delete-testenv-settings':
+      incl => $settings::config,
+      lens => 'Puppet.lns',
+      context => "/files${settings::config}",
+      changes => [
+        'rm testenv',
+      ],
+  }
+}
+on master, 'rm -rf /usr/share/puppet/modules /etc/puppet/testenv'
+end
+
+step 'Uninstall a module from a non default environment'
+on master, 'puppet module uninstall jimmy-crakorn --environment=testenv' do
+  assert_output <<-OUTPUT
+    \e[mNotice: Preparing to uninstall 'jimmy-crakorn' ...\e[0m
+    Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from /etc/puppet/testenv/modules
+  OUTPUT
+end
+on master, '[ ! -d /etc/puppet/testenv/modules/nginx ]'

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -104,20 +104,32 @@ module Puppet
 
     def self.set_option_defaults(options)
       sep = File::PATH_SEPARATOR
-      if options[:target_dir]
-        options[:target_dir] = File.expand_path(options[:target_dir])
+
+      if options[:environment]
+        Puppet.settings[:environment] = options[:environment]
+      else
+        options[:environment] = Puppet.settings[:environment]
       end
 
-      prepend_target_dir = !! options[:target_dir]
+      if options[:modulepath]
+        Puppet.settings[:modulepath] = options[:modulepath]
+      else
+        # (#14872) make sure the module path of the desired environment is used
+        # when determining the default value of the --target-dir option
+        Puppet.settings[:modulepath] = options[:modulepath] =
+          Puppet.settings.value(:modulepath, options[:environment])
+      end
 
-      options[:modulepath] ||= Puppet.settings[:modulepath]
-      options[:environment] ||= Puppet.settings[:environment]
-      options[:modulepath] = "#{options[:target_dir]}#{sep}#{options[:modulepath]}" if prepend_target_dir
-      Puppet[:modulepath] = options[:modulepath]
-      Puppet[:environment] = options[:environment]
-
-      options[:target_dir] = options[:modulepath].split(sep).first
-      options[:target_dir] = File.expand_path(options[:target_dir])
+      if options[:target_dir]
+        options[:target_dir] = File.expand_path(options[:target_dir])
+        # prepend the target dir to the module path
+        Puppet.settings[:modulepath] = options[:modulepath] =
+          options[:target_dir] + sep + options[:modulepath]
+      else
+        # default to the first component of the module path
+        options[:target_dir] =
+          File.expand_path(options[:modulepath].split(sep).first)
+      end
     end
   end
 end


### PR DESCRIPTION
This patch fixes the Puppet::ModuleTool#set_option_defaults method such that
it respects the specified environment (if any) when determining the default
value for the --target-dir (the modules install directory) option.
The patch overhauls the entire method in the process to make it more readable,
and it also updates relevant unit tests and adds a pair of new acceptance
tests.
