### PR TITLE
Fix empty hash console rendering bug

### DIFF
--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -148,7 +148,7 @@ Puppet::Network::FormatHandler.create(:console,
     # Simple hash to table
     if datum.is_a? Hash and datum.keys.all? { |x| x.is_a? String or x.is_a? Numeric }
       output = ''
-      column_a = datum.map do |k,v| k.to_s.length end.max + 2
+      column_a = datum.empty? ? 2 : datum.map{ |k,v| k.to_s.length }.max + 2
       column_b = 79 - column_a
       datum.sort_by { |k,v| k.to_s } .each do |key, value|
         output << key.to_s.ljust(column_a)

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -311,6 +311,10 @@ describe "Puppet Network Format" do
       end
     end
 
+    it "should render empty hashes as empty strings" do
+      subject.render({}).should == ''
+    end
+
     it "should render a non-trivially-keyed Hash as JSON" do
       hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
       subject.render(hash).should == json.render(hash).chomp


### PR DESCRIPTION
Previously, if a face action returned an empty hash Puppet would print out an error something like the following:

```
err: undefined method `+' for nil:NilClass
err: Try 'puppet help stack build' for usage
```

The cause of the error was a method in network/formats.rb that did not account for the possibilty of an empty hash. This commit resolves the issue by adding logic to account for the empty hash scenario, rendering an empty hash as an empty string.

I am in no way attached to this particular choice of how to fix the problem. If there's a cleaner way to do it in code please someone do it, merge it, and close this pull request. I just want the bug fixed. :-)

I have no idea where this _should_ go, hence pull request against master.
