### PR TITLE
Cast fqdn as string for gsub

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -48,7 +48,7 @@ class Puppet::Settings
     else
       fqdn = hostname
     end
-    fqdn.gsub(/\.$/, '')
+    fqdn.to_s.gsub(/\.$/, '')
   end
 
   def self.hostname_fact()


### PR DESCRIPTION
(#18452) Fix to prevent

```
undefined method `gsub' for nil:NilClass (NoMethodError)
```

when running `librarian-puppet install` with puppet
