### PR TITLE
(#18440) Don't make class methods private

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -54,6 +54,8 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   # These are the paths in OS X where a launchd service plist could
   # exist. This is a helper method, versus a constant, for easy testing
   # and mocking
+  #
+  # @api private
   def self.launchd_paths
     [
       "/Library/LaunchAgents",
@@ -62,14 +64,14 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
       "/System/Library/LaunchDaemons"
     ]
   end
-  private_class_method :launchd_paths
 
-  # This is the path to the overrides plist file where service enabling
-  # behavior is defined in 10.6 and greater
+  # Defines the path to the overrides plist file where service enabling
+  # behavior is defined in 10.6 and greater.
+  #
+  # @api private
   def self.launchd_overrides
     "/var/db/launchd.db/com.apple.launchd/overrides.plist"
   end
-  private_class_method :launchd_overrides
 
   # Caching is enabled through the following three methods. Self.prefetch will
   # call self.instances to create an instance for each service. Self.flush will
@@ -108,7 +110,6 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     end
     array_of_files.compact
   end
-  private_class_method :return_globbed_list_of_file_paths
 
   # Sets a class instance variable with a hash of all launchd plist files that
   # are found on the system. The key of the hash is the job id and the value

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -60,7 +60,6 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => true}])
       provider.expects(:read_plist).returns({joblabel => {"Disabled" => false}})
-      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.enabled?.should == :true
     end
@@ -68,7 +67,6 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => false}])
       provider.expects(:read_plist).returns({joblabel => {"Disabled" => true}})
-      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.enabled?.should == :false
     end
@@ -76,7 +74,6 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       provider.expects(:get_macosx_version_major).returns("10.6")
       subject.expects(:plist_from_label).returns([joblabel, {}])
       provider.expects(:read_plist).returns({})
-      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       FileTest.expects(:file?).with(launchd_overrides).returns(true)
       subject.enabled?.should == :true
     end
@@ -191,7 +188,6 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       resource[:enable] = true
       provider.expects(:get_macosx_version_major).returns("10.6")
       provider.expects(:read_plist).returns({})
-      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       Plist::Emit.expects(:save_plist).once
       subject.enable
     end
@@ -202,7 +198,6 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       resource[:enable] = false
       provider.stubs(:get_macosx_version_major).returns("10.6")
       provider.stubs(:read_plist).returns({})
-      provider.stubs(:launchd_overrides).returns(launchd_overrides)
       Plist::Emit.expects(:save_plist).once
       subject.enable
     end


### PR DESCRIPTION
Previously, the launchd service provider `enabled?` instance method was
calling the `launchd_overrides` private class method, which is not
allowed. This issue wasn't noticed, because the spec test was overly
stubbing the provider.

This commit makes the class methods public to avoid these sorts of
problems in the future.
