### PR TITLE
(#17866) RPM spec file work-around for RH Bugzilla 681540 (defattr overrides in-line attr)

### DIFF
--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -192,11 +192,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}/modules
 %{_datadir}/emacs
 %{_datadir}/vim
 %{_datadir}/%{name}
-# These need to be owned by puppet so the server can
-# write to them
-%attr(-, puppet, puppet) %{_localstatedir}/run/puppet
-%attr(0750, puppet, puppet) %{_localstatedir}/log/puppet
-%attr(-, puppet, puppet) %{_localstatedir}/lib/puppet
+# man pages
 %{_mandir}/man5/puppet.conf.5.gz
 %{_mandir}/man8/puppet.8.gz
 %{_mandir}/man8/puppet-agent.8.gz
@@ -232,6 +228,14 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}/modules
 %{_mandir}/man8/puppet-resource_type.8.gz
 %{_mandir}/man8/puppet-secret_agent.8.gz
 %{_mandir}/man8/puppet-status.8.gz
+# These need to be owned by puppet so the server can
+# write to them. The separate %defattr's are required
+# to work around RH Bugzilla 681540
+%defattr(-, puppet, puppet, 0755)
+%{_localstatedir}/run/puppet
+%defattr(-, puppet, puppet, 0750)
+%{_localstatedir}/log/puppet
+%{_localstatedir}/lib/puppet
 
 %files server
 %defattr(-, root, root, 0755)
@@ -374,6 +378,9 @@ rm -rf %{buildroot}
 %changelog
 * <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
+
+* Wed Jan 9  2013 Ryan Uber <ru@ryanuber.com> - 3.1.0-0.1rc1
+- Work-around for RH Bugzilla 681540
 
 * Tue Dec 18 2012 Matthaus Owens <matthaus@puppetlabs.com>
 - Remove for loop on examples/ code which no longer exists. Add --no-run-if-empty to xargs invocations.


### PR DESCRIPTION
Once puppet #17866 was resolved (Puppet RPM's break themselves), yet another RPM problem surfaced. This issue is isolated to builds on RHEL 6.x due to the newer version of rpmbuild (4.8 on RHEL6). Previous versions of rpmbuild (4.4 from RHEL5.x) did not have this issue.

What the issue boils down to is that using the `%attr` tag after a `%defattr` tag has no effect.

To illustrate, the file attributes of the /test directory would come out as 0755 in the below example:

```
%defattr(-, root, root, 0755)
%attr(0750, root, root) /test
```

The work-around simply involves using `%defattr` multiple times rather than trying to override it with `%attr` in-line.
