### PR TITLE
(#18569) Better error messages for calling methods on `nil`

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -58,6 +58,21 @@ if RUBY_VERSION == '1.8.7'
   end
 end
 
+class NilClass
+  # Just in case something else monkey-patches this into place later...
+  method_defined?('method_missing') and fail "NilClass already has method_missing!"
+  def method_missing(name, *args)
+    msg = <<EOT
+NoMethodError: undefined method `#{name}' called for nil:NilClass
+This means that Puppet encountered a `nil` value where an object
+was expected, which is typically a missing internal type check.
+Please report this internal error to our bug tracker at
+https://projects.puppetlabs.com/projects/puppet/new_issue
+EOT
+    raise NoMethodError.new(msg, name, args)
+  end
+end
+
 class Object
   # ActiveSupport 2.3.x mixes in a dangerous method
   # that can cause rspec to fork bomb


### PR DESCRIPTION
For years we have had a plague of `Undefined method`blah' for nil:NilClass`
reports through Puppet.

Every single one of those is a nasty bug: one of the prices of Ruby is that
you have to hand-write all your type checking by hand, everywhere that
matters, because there isn t a compiler or any type annotation to do that for
you. Fun times.

This leads to the nasty bug this describes, in which you end up missing a
check somewhere in the system and (most often) end up with a NULL pointer
dereference equivalent. Sure, Ruby saves you by turning that into a polite
exception, but the net effect is still the same: welcome to the hell of random
failures made worse by missing type checking.

We should fix this. At the very least we should give more guidance about what
went wrong, and what the user should do. We probably should make this serious
internal bug report a stack trace and push the user to submit it to our
system, all the time. (Optimally, we would have this push into some sort of
automated system that can correlate these and rank them by priority, but that
is getting fancy. ;)

This implements the framework: tests to ensure that it works, and handling of
missing methods on `nil` that log an informative message and fail with clearer
user-facing text.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
