### PR TITLE
Maint: Remove dead ca_md setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -682,10 +682,6 @@ EOT
       :desc       => "The default TTL for new certificates. If this setting is set, ca_days is ignored.
       Can be specified as a duration."
     },
-    :ca_md => {
-      :default    => "md5",
-      :desc       => "The type of hash used in certificates.",
-    },
     :req_bits => {
       :default    => 4096,
       :desc       => "The bit length of the certificates.",


### PR DESCRIPTION
The `ca_md` setting was added in commit bb4b5a54 in Aug 2005, but was
never used in that commit or any subsequent commit.

The setting itself is also confusing, because we create digital
signatures on both the agent (when signing the CSR) and the CA (when
signing the x509 cert).

It's also confusing because both encryption and hash algorithms need to
be specified when creating a digital signature, e.g.
sha256WithRSAEncryption. But the existence of the `ca_md` property might
encourage patches to allow the hash algorithm to be configured, but not
the encryption algorithm.

Long term, we'd like to eliminate hard coding of cryptographic
parameters, as it makes it difficult to upgrade while maintaining
compatibility across different versions of master and agents.
