### PR TITLE
(#18468) Clarify message in defaults for debian

### DIFF
--- a/ext/debian/puppet.default
+++ b/ext/debian/puppet.default
@@ -1,6 +1,8 @@
 # Defaults for puppet - sourced by /etc/init.d/puppet
 
-# Start puppet on boot?
+# Enable puppet?
+# Setting this to yes allows puppet to start.
+# Setting to no stops the puppet service from being started.
 START=no
 
 # Startup options

--- a/ext/debian/puppetmaster.default
+++ b/ext/debian/puppetmaster.default
@@ -1,7 +1,10 @@
 # Defaults for puppetmaster - sourced by /etc/init.d/puppetmaster
 
-# Start puppetmaster on boot? If you are using passenger, you should
-# have this set to "no"
+# Enable puppetmaster? 
+# Setting this to yes allows puppet to start.
+# Setting to no stops the puppet service from being started.
+#
+# If you are using passenger, you should have this set to "no"
 START=yes
 
 # Startup options


### PR DESCRIPTION
The comment that tried to explain the START property did not clearly align
with the message generated by the installation:

  Setting up puppet (3.1.0-0.1rc1puppetlabs1) ...
 Starting puppet agent
 puppet not configured to start, please edit /etc/default/puppet to
 enable
 .

This changes the comment in the file to include the word "Enable" so that a
user can more confidently match it up to the "enable" word that shows up in
the message. It also explains the effect of the different values.
