### PR TITLE
Maint: Deprecate dynamicfacts setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1085,9 +1085,14 @@ EOT
     },
     :dynamicfacts => {
       :default    => "memorysize,memoryfree,swapsize,swapfree",
-      :desc       => "Facts that are dynamic; these facts will be ignored when deciding whether
+      :desc       => "(Deprecated) Facts that are dynamic; these facts will be ignored when deciding whether
       changed facts should result in a recompile.  Multiple facts should be
       comma-separated.",
+      :hook => proc { |value|
+        if value
+          Puppet.deprecation_warning "The dynamicfacts setting is deprecated and will be ignored."
+        end
+      }
     },
     :splaylimit => {
       :default    => "$runinterval",


### PR DESCRIPTION
The dynamicfacts setting was used to avoid recompiling catalogs when
only transient related facts were modified, e.g. free memory. According
to Luke, this optimization was removed when "we disabled staleness
checking for catalogs, which was early in the 0.24 release cycle", see
ticket #569.

This commit deprecates the setting rather than removing it, because it
the setting was actually used at one time, unlike `ca_md`.
