### PR TITLE
(#18026) Don't warn on failed stats for selinux context

### DIFF
--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -43,13 +43,8 @@ module Puppet::Util::SELinux
     # matching.  If not, we can pass a mode of 0.
     begin
       filestat = file_lstat(file)
-    rescue Errno::EACCES, Errno::ENOENT => detail
-      warning "Could not stat; #{detail}"
-    end
-
-    if filestat
       mode = filestat.mode
-    else
+    rescue Errno::EACCES, Errno::ENOENT
       mode = 0
     end
 

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -135,7 +135,6 @@ describe Puppet::Util::SELinux do
       Selinux.stubs(:matchpathcon).with("/root/chuj", 0).returns(-1)
       self.stubs(:file_lstat).with("/root/chuj").raises(Errno::EACCES, "/root/chuj")
 
-      self.expects(:warning).with("Could not stat; Permission denied - /root/chuj")
       get_selinux_default_context("/root/chuj").should be_nil
     end
 
@@ -145,7 +144,6 @@ describe Puppet::Util::SELinux do
       Selinux.stubs(:matchpathcon).with("/root/chuj", 0).returns(-1)
       self.stubs(:file_lstat).with("/root/chuj").raises(Errno::ENOENT, "/root/chuj")
 
-      self.expects(:warning).with("Could not stat; No such file or directory - /root/chuj")
       get_selinux_default_context("/root/chuj").should be_nil
     end
 


### PR DESCRIPTION
We try to stat files to determine the default selinux context. This may happen
before the file exists. A warning was recently added, and it seems to just be
confusing and noisy, so this removes it.
