### PR TITLE
(maint) RPM package provider broken on AIX.

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -33,9 +33,15 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
       sig = ""
     end
 
+    # rpm < 4.0.2 don't support --nodigest
+    nodigest = "--nodigest"
+    if output =~ /RPM version (([123].*)|(4\.0\.[01].*))/
+      nodigest = ""
+    end
+
     # list out all of the packages
     begin
-      execpipe("#{command(:rpm)} -qa #{sig} --nodigest --qf '#{NEVRAFORMAT}\n'") { |process|
+      execpipe("#{command(:rpm)} -qa #{sig} #{nodigest} --qf '#{NEVRAFORMAT}\n'") { |process|
         # now turn each returned line into a package object
         process.each_line { |line|
           hash = nevra_to_hash(line)


### PR DESCRIPTION
Prior to this commit, the RPM package provider would barf when
attempting to run `self.instances` on AIX. The culprit is the archaic
version of RPM (3.0.5) on AIX. The RPM provider assumed that the
`--nodigest` option (introduced in 4.0.2, circa 2001) was available.
This commit removes the `--nodigest` option for RPM versions older than
4.0.2.

Sprintly: fixes item:195.
