### PR TITLE
(#18468) Further clarify messages in defaults for Debian init scripts. 

### DIFF
--- a/ext/debian/puppet.default
+++ b/ext/debian/puppet.default
@@ -1,8 +1,8 @@
 # Defaults for puppet - sourced by /etc/init.d/puppet
 
-# Enable puppet?
-# Setting this to yes allows puppet to start.
-# Setting to no stops the puppet service from being started.
+# Enable puppet agent service?
+# Setting this to "yes" allows the puppet agent service to run.
+# Setting this to "no" keeps the puppet agent service from running.
 START=no
 
 # Startup options

--- a/ext/debian/puppetmaster.default
+++ b/ext/debian/puppetmaster.default
@@ -1,14 +1,14 @@
 # Defaults for puppetmaster - sourced by /etc/init.d/puppetmaster
 
-# Enable puppetmaster? 
-# Setting this to yes allows puppet to start.
-# Setting to no stops the puppet service from being started.
+# Enable puppetmaster service? 
+# Setting this to "yes" allows the puppet master service to run.
+# Setting this to "no" keeps the puppet master service from running.
 #
-# If you are using passenger, you should have this set to "no"
+# If you are using Passenger, you should have this set to "no."
 START=yes
 
 # Startup options
 DAEMON_OPTS=""
 
-# What port should the puppetmaster listen on (default: 8140).
+# On what port should the puppet master listen? (default: 8140)
 PORT=8140


### PR DESCRIPTION
The comments explaining the START property in the Debian puppetmaster and puppet init scripts didn't adequately convey that the default settings would prevent the init scripts from starting, but not prevent execution of puppet by other means. Further, the language used was not in alignment with existing documentation (e.g. "puppet client" instead of "puppet agent.")

This changes the comments to note that the puppet master and agent services are prevented from running, not puppet itself, and aligns the language used with existing documentation style. 
