### PR TITLE
(#7841) Always read SELinux module header as little endian

### DIFF
--- a/lib/puppet/provider/selmodule/semodule.rb
+++ b/lib/puppet/provider/selmodule/semodule.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
   end
 
   def selmod_readnext (handle)
-    len = handle.read(4).unpack('L')[0]
+    len = handle.read(4).unpack('V')[0]
     handle.read(len)
   end
 
@@ -83,7 +83,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
     filename = selmod_name_to_filename
     mod = File.new(filename, "r")
 
-    (hdr, ver, numsec) = mod.read(12).unpack('LLL')
+    (hdr, ver, numsec) = mod.read(12).unpack('VVV')
 
     raise Puppet::Error, "Found #{hdr} instead of magic #{magic} in #{filename}" if hdr != magic
 


### PR DESCRIPTION
These are always little endian, but are currently being read as native
byte order, which obviously causes failures.
