### PR TITLE
(AIX) (#6936) AIX user provider fails if a gid is specified instead of a name.

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -146,7 +146,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   end
 
   # Get the groupname from its id
-  def self.groupname_by_id(gid)
+  def groupname_by_id(gid)
     groupname=nil
     execute(lsgroupscmd("ALL")).each_line { |entry|
       attrs = self.parse_attr_list(entry, nil)
@@ -166,7 +166,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   # Check that a group exists and is valid
   def verify_group(value)
     if value.is_a? Integer or value.is_a? Fixnum
-      groupname = self.groupname_by_id(value)
+      groupname = groupname_by_id(value)
       raise ArgumentError, "AIX group must be a valid existing group" unless groupname
     else
       raise ArgumentError, "AIX group must be a valid existing group" unless groupid_by_name(value)

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:user).provider(:aix)
+
+describe provider_class do
+  before do
+    @resource = stub('resource')
+    @provider = provider_class.new(@resource)
+  end
+
+  it "should be able to return a group name based on a group ID" do
+    @provider.stubs(:lsgroupscmd)
+
+    @provider.stubs(:execute).returns <<-OUTPUT
+root id=0 pgrp=system groups=system,bin,sys,security,cron,audit,lp home=/root shell=/usr/bin/bash
+guest id=100 pgrp=usr groups=usr home=/home/guest
+    OUTPUT
+
+    @provider.groupname_by_id(100).should == 'guest'
+  end
+end


### PR DESCRIPTION
Fix undefined method "groupname_by_id" error on AIX user provider

Without this patch, `puppet resource user lindsey gid=4242 ensure=present` fails with the following error:

`err: /User[lindsey]/gid: change from 600 to 4242 failed: undefined method 'groupname_by_id' for #<Puppet::Type::User::ProviderAix:0x20eae6e0>`

This patch fixes the problem by fixing the method definition which makes the above command succeed:

`notice: /User[lindsey]/gid: gid changed '600' to '4242'`
