### PR TITLE
(#17777) Update debian build-depends to only use ruby1.8

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
 Uploaders: Micah Anderson <micah@debian.org>, Andrew Pollock <apollock@debian.org>, Nigel Kersten <nigel@explanatorygap.net>, Stig Sandbeck Mathisen <ssm@debian.org>
-Build-Depends-Indep: ruby (>= 1.8.1), libopenssl-ruby, facter (>= 1.5), facter (<< 2.0)
+Build-Depends-Indep: ruby1.8, libopenssl-ruby, facter (>= 1.5), facter (<< 2.0)
 Build-Depends: debhelper (>= 7.0.0), openssl
 Standards-Version: 3.9.1
 Vcs-Git: git://git.debian.org/git/pkg-puppet/puppet.git


### PR DESCRIPTION
Previously puppet had a build-depends of ruby, which means that on wheezy and
quantal, the default ruby of ruby1.9 was used to build puppet. Unfortunately,
this means that the shebangs for bin/puppet refer to bin/ruby1.9.1 instead of
ruby1.8. Puppet 2.7.x is installed in the ruby 1.8 specific libdir for ruby, so
ruby1.9.1 has no way of loading puppet in this case. This commit updates the
build-depends to correctly use ruby1.8 only, so bin/puppet gets the correct
ruby which can load the correct libraries.
Note: in mergeups from 2.7.x, this
needs to be undone. The build-depends of ruby is correct for puppet 3 and
later.
