### PR TITLE
(#17295) use SHA1 to sign CSRs when SHA256 is not available.

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -1,6 +1,7 @@
 require 'monitor'
 require 'puppet/ssl/host'
 require 'puppet/ssl/certificate_request'
+require 'puppet/ssl/certificate_signer'
 require 'puppet/util'
 
 # The class that knows how to sign certificates.  It creates
@@ -277,7 +278,9 @@ class Puppet::SSL::CertificateAuthority
     cert = Puppet::SSL::Certificate.new(hostname)
     cert.content = Puppet::SSL::CertificateFactory.
       build(cert_type, csr, issuer, next_serial)
-    cert.content.sign(host.key.content, OpenSSL::Digest::SHA256.new)
+
+    signer = Puppet::SSL::CertificateSigner.new
+    signer.sign(cert.content, host.key.content)
 
     Puppet.notice "Signed certificate request for #{hostname}"
 

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -1,4 +1,5 @@
 require 'puppet/ssl/base'
+require 'puppet/ssl/certificate_signer'
 
 # Manage certificate requests.
 class Puppet::SSL::CertificateRequest < Puppet::SSL::Base
@@ -59,7 +60,8 @@ class Puppet::SSL::CertificateRequest < Puppet::SSL::Base
       csr.add_attribute(OpenSSL::X509::Attribute.new("extReq", extReq))
     end
 
-    csr.sign(key, OpenSSL::Digest::SHA256.new)
+    signer = Puppet::SSL::CertificateSigner.new
+    signer.sign(csr, key)
 
     raise Puppet::Error, "CSR sign verification failed; you need to clean the certificate request for #{name} on the server" unless csr.verify(key.public_key)
 

--- a/lib/puppet/ssl/certificate_signer.rb
+++ b/lib/puppet/ssl/certificate_signer.rb
@@ -1,0 +1,19 @@
+# Take care of signing a certificate.
+#   http://projects.puppetlabs.com/issues/17295
+class Puppet::SSL::CertificateSigner
+  def initialize
+    if OpenSSL::Digest.const_defined?('SHA256')
+      @digest = OpenSSL::Digest::SHA256
+    elsif OpenSSL::Digest.const_defined?('SHA1')
+      @digest = OpenSSL::Digest::SHA1
+    else
+      raise Puppet::Error,
+        "No FIPS 140-2 compliant digest algorithm in OpenSSL::Digest"
+    end
+    @digest
+  end
+
+  def sign(content, key)
+    content.sign(key, @digest.new)
+  end
+end


### PR DESCRIPTION
Without this patch applied puppet fails to create a CSR
with the following message -

```
Error: Could not request certificate: uninitialized constant OpenSSL::Digest::SHA256
```

This patch adds a class Puppet::SSL::CertificateSigner that
takes care of signing certificates in CSR creation and via
the CA.  This class assumes a default hash algorithm of
SHA256 and if not available falls back to SHA1.  For the
sake of FIPS 140-2 compliance it does not try MD5 or any
earlier hash algorithms.
