### PR TITLE
(AIX) Fix pson pure in 2.7.x for AIX.

### DIFF
--- a/lib/puppet/external/pson/pure.rb
+++ b/lib/puppet/external/pson/pure.rb
@@ -19,9 +19,9 @@ module PSON
     begin
       old_verbose, $VERBSOSE = $VERBOSE, nil
       # An iconv instance to convert from UTF8 to UTF16 Big Endian.
-      UTF16toUTF8 = Iconv.new('utf-8', 'utf-16') # :nodoc:
+      UTF16toUTF8 = Iconv.new('UTF-8', 'UTF-16') # :nodoc:
       # An iconv instance to convert from UTF16 Big Endian to UTF8.
-      UTF8toUTF16 = Iconv.new('utf-16', 'utf-8') # :nodoc:
+      UTF8toUTF16 = Iconv.new('UTF-16', 'UTF-8') # :nodoc:
       UTF8toUTF16.iconv('no bom')
       if UTF8toUTF16.iconv("\xe2\x82\xac") == "\xac\x20"
         swapper = Class.new do


### PR DESCRIPTION
Prior to this commit, PSON pure would fail on AIX for 2 reasons: 1)
AIX's Power processor is little endian and we specifically request
`utf16-be` for big endian, and 2) iconv on AIX is case-sensitive, which
means it knows about `UTF-8` and `UTF-16`, but not `utf-8` and `utf-16`.
This commit ignores the endian problem and instead just upcases the
requested encodings. This patch only applies to Puppet 2.7.x as iconv
has been removed from pson pure in 3.0+.
