### PR TITLE
(AIX) RPM package provider broken on AIX.

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -30,13 +30,13 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
     ver402 = SemVer.new '4.0.2'
 
     output = rpm "--version"
-    current_version = SemVer.new(output.gsub('RPM version ', ''))
+    current_version = SemVer.new(output.gsub('RPM version ', '').strip)
 
     # rpm < 4.1 don't support --nosignature
-    sig = current_version < ver410 ? '' : '--nosignature'
+    sig = '--nosignature' unless current_version < ver410
 
     # rpm < 4.0.2 don't support --nodigest
-    nodigest = current_version < ver402 ? '': '--nodigest'
+    nodigest = '--nodigest' unless current_version < ver402
 
     # list out all of the packages
     begin

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -15,7 +15,7 @@ describe provider_class do
   end
 
   describe "self.instances" do
-    let(:rpm_version) { 'RPM version 5.0.0' }
+    let(:rpm_version) { "RPM version 5.0.0\n" }
     before(:each) do
       Puppet::Type::Package::ProviderRpm.expects(:execute).with(["/bin/rpm", "--version"]).returns(rpm_version)
       Puppet::Util.stubs(:which).with("rpm").returns("/bin/rpm")
@@ -30,7 +30,7 @@ describe provider_class do
     end
 
     describe "with a version of RPM < 4.1" do
-      let(:rpm_version) { 'RPM version 4.0.2' }
+      let(:rpm_version) { "RPM version 4.0.2\n" }
       it "should exclude the --nosignature flag" do
         Puppet::Type::Package::ProviderRpm.expects(:execpipe).with("/bin/rpm -qa  --nodigest --qf '%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\n'").yields(packages)
 
@@ -39,7 +39,7 @@ describe provider_class do
     end
 
     describe "with a version of RPM < 4.0.2" do
-      let(:rpm_version) { 'RPM version 3.0.5' }
+      let(:rpm_version) { "RPM version 3.0.5\n" }
       it "should exclude the --nodigest flag" do
         Puppet::Type::Package::ProviderRpm.expects(:execpipe).with("/bin/rpm -qa   --qf '%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\n'").yields(packages)
 


### PR DESCRIPTION
Prior to this commit, the RPM package provider would barf when
attempting to run `self.instances` on AIX. The culprit is the archaic
version of RPM (3.0.5) on AIX. The RPM provider assumed that the
`--nodigest` option (introduced in 4.0.2, circa 2001) was available.
This commit removes the `--nodigest` option for RPM versions older than
4.0.2.

Sprintly: fixes item:195.
