### PR TITLE
(maint) Add dependency information for yard and redcarpet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,13 @@ def location_for(place)
   end
 end
 
+# The YARD dependencies are only needed when developing the documentation, not
+# when testing or deploying.
+group :development do
+  gem "yard"
+  gem "redcarpet"
+end
+
 group(:development, :test) do
   gem "puppet", *location_for('file://.')
   gem "facter", *location_for(ENV['FACTER_LOCATION'] || '~> 1.6')


### PR DESCRIPTION
Without this patch `bundle exec yard server --reload` doesn't work. This
is a problem because people who are developing Puppet need to be able to
access the API documentation easily and the yard server is one such way.
This patch addresses the problem by adding a dependency on yard and
redcarpet for the development group only.  This will prevent the yard
and redcarpet gem from sucking in a large number of dependencies when
running in a CI environment because these environments are expected to
omit development only dependencies when bootstrapping using `bundle
install --path vendor --without development`
