### PR TITLE
(#18755) Consider prerelease gems in the search path

### DIFF
--- a/lib/puppet/util/rubygems.rb
+++ b/lib/puppet/util/rubygems.rb
@@ -39,7 +39,9 @@ module Puppet::Util::RubyGems
   # @api private
   class Gems18Source < Source
     def directories
-      Gem::Specification.latest_specs.collect do |spec|
+      # `require 'mygem'` will consider and potentally load
+      # prerelease gems, so we need to match that behavior.
+      Gem::Specification.latest_specs(true).collect do |spec|
         File.join(spec.full_gem_path, 'lib')
       end
     end

--- a/spec/unit/util/rubygems_spec.rb
+++ b/spec/unit/util/rubygems_spec.rb
@@ -37,7 +37,7 @@ describe Puppet::Util::RubyGems::Source do
     before(:each) { described_class.stubs(:source).returns(Puppet::Util::RubyGems::Gems18Source) }
 
     it "#directories returns the lib subdirs of Gem::Specification.latest_specs" do
-      Gem::Specification.expects(:latest_specs).returns([fake_gem])
+      Gem::Specification.expects(:latest_specs).with(true).returns([fake_gem])
 
       described_class.new.directories.should == [gem_lib]
     end


### PR DESCRIPTION
Previously, if puppet 3.0.2 and 3.1.0.rc1 gems were installed using
rubygems version 1.8 or greater, then puppet's autoloader would load
code from both gems, giving precedence to the older gem.

Puppet's settings code was loading the `Puppet::Type::Group` class from
the 3.0.2 gem, but trying to call the `#exists?` method that was added
in 3.1.0rc1, resulting in the "undefined method 'exists?' for nil"
error.

The root cause was due to `Gem::Specification.latest_specs` ignoring
prerelease gems, by default, so it would report that the latest spec was
3.0.2. Yet, executing `require 'puppet'` would activate the prerelease
gem, 3.1.0.rc1, causing its lib dir to be appended to $LOAD_PATH.

And since Puppet's autoloader combines the rubygems directories and
$LOAD_PATH (roughly in that order), version 3.0.2 would take precedence.

Note this issue is specific to rubygems 1.8 and up, since when using
previous versions, puppet calls the deprecated method
`Gem.latest_load_paths`, which alread considers prerelease gems when
determining the latest installed gem.

This commit simply modifies the call to `Gem::Specification.latest_spec`
to consider prerelease gems when determining the latest installed
version.
