### PR TITLE
Add deprecation warning for use of ruby dsl.

### DIFF
--- a/lib/puppet/parser/parser_support.rb
+++ b/lib/puppet/parser/parser_support.rb
@@ -158,6 +158,8 @@ class Puppet::Parser::Parser
   end
 
   def parse_ruby_file
+    Puppet.deprecation_warning("Use of the Ruby DSL is deprecated.")
+
     # Execute the contents of the file inside its own "main" object so
     # that it can call methods in the resource type API.
     main_object = Puppet::DSL::ResourceTypeAPI.new

--- a/spec/integration/parser/ruby_manifest_spec.rb
+++ b/spec/integration/parser/ruby_manifest_spec.rb
@@ -13,6 +13,7 @@ describe "Pure ruby manifests" do
     @scope_resource = stub 'scope_resource', :builtin? => true, :finish => nil, :ref => 'Class[main]'
     @scope = stub 'scope', :resource => @scope_resource, :source => mock("source")
     @test_dir = tmpdir('ruby_manifest_test')
+    Puppet.expects(:deprecation_warning).at_least(1)
   end
 
   after do

--- a/spec/unit/parser/type_loader_spec.rb
+++ b/spec/unit/parser/type_loader_spec.rb
@@ -11,6 +11,7 @@ describe Puppet::Parser::TypeLoader do
 
   before do
     @loader = Puppet::Parser::TypeLoader.new(:myenv)
+    Puppet.expects(:deprecation_warning).never
   end
 
   it "should support an environment" do
@@ -146,6 +147,8 @@ describe Puppet::Parser::TypeLoader do
     end
 
     it "should load all ruby manifests from all modules in the specified environment" do
+      Puppet.expects(:deprecation_warning).at_least(1)
+
       @module1 = mk_module(@modulebase1, "one")
       @module2 = mk_module(@modulebase2, "two")
 


### PR DESCRIPTION
This adds a deprecation warning for parsing of ruby based manifests.
Tests are updated to check that the deprecation warning is issued.
