### PR TITLE
(AIX) Convert RPM flags to array

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -104,7 +104,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
     end
 
     flag = "-i"
-    flag = "-U --oldpackage" if @property_hash[:ensure] and @property_hash[:ensure] != :absent
+    flag = ["-U", "--oldpackage"] if @property_hash[:ensure] and @property_hash[:ensure] != :absent
 
     rpm flag, source
   end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -126,7 +126,7 @@ describe provider_class do
      end
 
      it "should include the '-U --oldpackage' flags" do
-        Puppet::Type::Package::ProviderRpm.expects(:execute).with(["/bin/rpm", "-U --oldpackage", '/path/to/package'])
+        Puppet::Type::Package::ProviderRpm.expects(:execute).with(["/bin/rpm", ["-U", "--oldpackage"], '/path/to/package'])
         provider.install
      end
    end 


### PR DESCRIPTION
Prior to this commit the flags passed to `rpm` during upgrade or
downgrade were a monolithic string of "-U --oldpackage". The
provider attempts to send this to RPM as a single flag, which
causes `rpm` to barf.  The commit changes the flags sent to `rpm`
to an array of strings, which allows upgrades and downgrades to
actually function as expected.

Sprintly: fix ticket:269, ticket:271
