### PR TITLE
Add extlookup2hiera manpages to redhat and debian packages

### DIFF
--- a/ext/debian/changelog.erb
+++ b/ext/debian/changelog.erb
@@ -4,6 +4,12 @@ puppet (<%= @debversion %>) hardy lucid natty oneiric unstable sid squeeze wheez
 
  -- Puppet Labs Release <info@puppetlabs.com>  <%= Time.now.strftime("%a, %d %b %Y %H:%M:%S %z")%>
 
+puppet (3.1.0-0.1rc1puppetlabs1) lucid natty oneiric precise unstable sid squeeze wheezy precise; urgency=low
+
+  * Add extlookup2hiera manpage to puppet-common.manpages
+
+ -- Matthaus Owens <matthaus@puppetlabs.com>  Fri, 25 Jan 2013 14:45:14 +0000
+
 puppet (2.7.19-1puppetlabs2) hardy jaunty karmic lucid maverick natty oneiric unstable lenny sid squeeze wheezy precise; urgency=low
 
   * (#16086) Add version parameter to rm_conffile call in puppetmaster preinst and postinst

--- a/ext/debian/puppet-common.manpages
+++ b/ext/debian/puppet-common.manpages
@@ -1,2 +1,3 @@
 man/man5/puppet.conf.5
 man/man8/puppet.8
+man/man8/extlookup2hiera.8

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -228,6 +228,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}/modules
 %{_mandir}/man8/puppet-resource_type.8.gz
 %{_mandir}/man8/puppet-secret_agent.8.gz
 %{_mandir}/man8/puppet-status.8.gz
+%{_mandir}/man8/extlookup2hiera.8.gz
 # These need to be owned by puppet so the server can
 # write to them. The separate %defattr's are required
 # to work around RH Bugzilla 681540
@@ -378,6 +379,9 @@ rm -rf %{buildroot}
 %changelog
 * <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
+
+* Fri Jan 25 2013 Matthaus Owens <matthaus@puppetlabs.com> - 3.1.0-0.1rc1
+- Add extlookup2hiera.8.gz to the files list
 
 * Wed Jan 9  2013 Ryan Uber <ru@ryanuber.com> - 3.1.0-0.1rc1
 - Work-around for RH Bugzilla 681540


### PR DESCRIPTION
Now that a manpage exists for extlookup2hiera, it needs to be part of the
redhat and debian packaging so it can be laid down correctly for those
packages. This commit adds the manpage to the puppet package on redhat and the
puppet-common package on debian.
