### PR TITLE
(AIX) Add an acceptance test for the aix package provider

### DIFF
--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -82,4 +82,4 @@ apply_manifest_on hosts, absent_manifest
 
 step "verify the package is gone"
 
-on hosts, "lslpp -qLc PACKAGE_NAME", :acceptable_exit_codes => [1]
+on hosts, "lslpp -qLc #{package}", :acceptable_exit_codes => [1]


### PR DESCRIPTION
This file provides a baseline of test coverage for the aix package
provider, including installation, upgrade, downgrade (which ought to
fail) and removal, all using puppet apply.
