### PR TITLE
(#18978) Load default root certs on Windows

### DIFF
--- a/acceptance/tests/ssl/should_connect_github.rb
+++ b/acceptance/tests/ssl/should_connect_github.rb
@@ -1,0 +1,26 @@
+test_name "puppet should be able to authenticate a well-known SSL server"
+
+script <<EOM
+#! /usr/bin/env ruby
+require 'rubygems'
+require 'openssl'
+require 'net/https'
+require 'puppet'
+
+cert_store = OpenSSL::X509::Store.new
+cert_store.set_default_paths
+
+conn = Net::HTTP.new('github.com', 443)
+conn.use_ssl     = true
+conn.verify_mode = OpenSSL::SSL::VERIFY_PEER
+conn.cert_store  = cert_store
+
+conn.start {|c| puts "connected" }
+EOM
+
+step "connect to github.com"
+agents.each do |agent|
+  on(agents, "ruby -e #{script}") do
+    assert_match(/\Aconnected\Z/, stdout)
+  end
+end

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -356,3 +356,23 @@ unless Dir.respond_to?(:mktmpdir)
     end
   end
 end
+
+require 'puppet/util/platform'
+if Puppet::Util::Platform.windows?
+  require 'puppet/util/windows'
+  require 'openssl'
+
+  class OpenSSL::X509::Store
+    alias __original_set_default_paths set_default_paths
+    def set_default_paths
+      # This can be removed once openssl integrates with windows
+      # cert store, see http://rt.openssl.org/Ticket/Display.html?id=2158
+      Puppet::Util::Windows::RootCerts.instance.each do |x509|
+        add_cert(x509)
+      end
+
+      __original_set_default_paths
+    end
+  end
+end
+

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -7,6 +7,7 @@ module Puppet::Util::Windows
     require 'puppet/util/windows/user'
     require 'puppet/util/windows/process'
     require 'puppet/util/windows/file'
+    require 'puppet/util/windows/root_certs'
   end
   require 'puppet/util/windows/registry'
 end

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -1,4 +1,7 @@
 require 'puppet/util/windows'
+require 'windows/process'
+require 'windows/handle'
+require 'windows/synchronize'
 
 module Puppet::Util::Windows::Process
   extend ::Windows::Process

--- a/lib/puppet/util/windows/root_certs.rb
+++ b/lib/puppet/util/windows/root_certs.rb
@@ -1,0 +1,85 @@
+require 'puppet/util/windows'
+require 'openssl'
+
+# Represents a collection of trusted root certificates.
+#
+# @api public
+class Puppet::Util::Windows::RootCerts
+  include Enumerable
+
+  CertOpenSystemStore         = Win32API.new('crypt32', 'CertOpenSystemStore', ['L','P'], 'L'),
+  CertEnumCertificatesInStore = Win32API.new('crypt32', 'CertEnumCertificatesInStore', ['L', 'L'], 'L'),
+  CertCloseStore              = Win32API.new('crypt32', 'CertCloseStore', ['L', 'L'], 'B')
+
+  def initialize(roots)
+    @roots = roots
+  end
+
+  # Enumerates each root certificate.
+  # @yieldparam cert [OpenSSL::X509::Certificate] each root certificate
+  # @api public
+  def each
+    @roots.each {|cert| yield cert}
+  end
+
+  class << self
+    require 'windows/msvcrt/buffer'
+    include Windows::MSVCRT::Buffer
+  end
+
+  # Returns a new instance.
+  # @return [Puppet::Util::Windows::RootCerts] object constructed from current root certificates
+  def self.instance
+    new(self.load_certs)
+  end
+
+  # Returns an array of root certificates.
+  #
+  # @return [Array<[OpenSSL::X509::Certificate]>] an array of root certificates
+  # @api private
+  def self.load_certs
+    certs = []
+
+    # This is based on a patch submitted to openssl:
+    # http://www.mail-archive.com/openssl-dev@openssl.org/msg26958.html
+    context = 0
+    store = CertOpenSystemStore.call(0, "ROOT")
+    begin
+      while (context = CertEnumCertificatesInStore.call(store, context) and context != 0)
+        # 466 typedef struct _CERT_CONTEXT {
+        # 467     DWORD      dwCertEncodingType;
+        # 468     BYTE       *pbCertEncoded;
+        # 469     DWORD      cbCertEncoded;
+        # 470     PCERT_INFO pCertInfo;
+        # 471     HCERTSTORE hCertStore;
+        # 472 } CERT_CONTEXT, *PCERT_CONTEXT;
+
+        # buffer to hold struct above
+        ctx_buf = 0.chr * 5 * 8
+
+        # copy from win to ruby
+        memcpy(ctx_buf, context, ctx_buf.size)
+
+        # unpack structure
+        arr = ctx_buf.unpack('LLLLL')
+
+        # create buf of length cbCertEncoded
+        cert_buf = 0.chr * arr[2]
+
+        # copy pbCertEncoded from win to ruby
+        memcpy(cert_buf, arr[1], cert_buf.length)
+
+        # create a cert
+        begin
+          certs << OpenSSL::X509::Certificate.new(cert_buf)
+        rescue => detail
+          Puppet.warning("Failed to import root certificate: #{detail.inspect}")
+        end
+      end
+    ensure
+      CertCloseStore.call(store, 0)
+    end
+
+    certs
+  end
+end

--- a/spec/unit/util/windows/root_certs_spec.rb
+++ b/spec/unit/util/windows/root_certs_spec.rb
@@ -1,0 +1,15 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util/windows'
+
+describe "Puppet::Util::Windows::RootCerts", :if => Puppet::Util::Platform.windows? do
+  let(:klass) { Puppet::Util::Windows::RootCerts }
+  let(:x509) { 'mycert' }
+
+  context '#each' do
+    it "should enumerate each root cert" do
+      klass.expects(:load_certs).returns([x509])
+      klass.instance.to_a.should == [x509]
+    end
+  end
+end


### PR DESCRIPTION
On Windows calling OpenSSL::X509::Store#set_default_paths does nothing. As
a result, puppet is unable to make authenticated SSL connections to
well-known SSL servers, like forge.puppetlabs.com.

This commit adds a RootCerts class that loads the root certs from the
Windows system cert store, and monkey patches the
OpenSSL::X509::Store#set_default_paths to behave as expected on Windows.

Note the actual semantics for set_default_paths are slightly different,
in that on *nix, it sets the paths that openssl will look for trusted root
certs, whereas this patch loads them into the X509::Store object on
Windows. But the net effect is the same, we're specifying the set of root
certs that we trust when authenticating SSL servers.

This commit monkey patches openssl, because there isn't a central way to
create SSL contexts in ruby. Specifically, open-uri hides the process of
setting up the SSL context, so the caller doesn't have to "worry" about
it. In doing so, it calls set_default_paths expecting that is all that is
needed. But it makes it next to impossible for the caller to add other
root certs.

Specifically, the module tool uses open-uri to download tar.gz content,
but that said the issue is not specific to the module tool.

This commit also adds an SSL acceptance test.
