### PR TITLE
(#18986) Write to the console using Unicode Win32 APIs

### DIFF
--- a/lib/puppet/util/colors.rb
+++ b/lib/puppet/util/colors.rb
@@ -83,6 +83,61 @@ module Puppet::Util::Colors
     # We're on windows, need win32console for color to work
     begin
       require 'win32console'
+      require 'windows/wide_string'
+
+      # The win32console gem uses ANSI functions for writing to the console
+      # which doesn't work for unicode strings, e.g. module tool. Ruby 1.9
+      # does the same thing, but doesn't account for ANSI escape sequences
+      class WideConsole < Win32::Console
+        WriteConsole                = Win32API.new( "kernel32", "WriteConsoleW", ['l', 'p', 'l', 'p', 'p'], 'l' )
+        WriteConsoleOutputCharacter = Win32API.new( "kernel32", "WriteConsoleOutputCharacterW", ['l', 'p', 'l', 'l', 'p'], 'l' )
+
+        def initialize(t = nil)
+          super(t)
+        end
+
+        def WriteChar(str, col, row)
+          dwWriteCoord = (row << 16) + col
+          lpNumberOfCharsWritten = ' ' * 4
+          utf16, nChars = string_encode(str)
+          WriteConsoleOutputCharacter.call(@handle, utf16, nChars, dwWriteCoord, lpNumberOfCharsWritten)
+          lpNumberOfCharsWritten.unpack('L')
+        end
+
+        def Write(str)
+          written = 0.chr * 4
+          reserved = 0.chr * 4
+          utf16, nChars = string_encode(str)
+          WriteConsole.call(@handle, utf16, nChars, written, reserved)
+        end
+
+        if String.method_defined?("encode")
+          def string_encode(str)
+            wstr = str.encode('UTF-16LE')
+            [wstr, wstr.length]
+          end
+        else
+          require 'iconv'
+          def string_encode(str)
+            wstr = Iconv.conv('UTF-16LE', 'UTF-8', str)
+            [wstr, wstr.length/2]
+          end
+        end
+      end
+
+      # Override the win32console's IO class so we can supply
+      # our own Console class
+      class WideIO < Win32::Console::ANSI::IO
+        def initialize(fd_std = :stdout)
+          super(fd_std)
+
+          handle = FD_STD_MAP[fd_std][1]
+          @Out = WideConsole.new(handle)
+        end
+      end
+
+      $stdout = WideIO.new(:stdout)
+      $stderr = WideIO.new(:stderr)
     rescue LoadError
       def console_has_color?
         false


### PR DESCRIPTION
Previously, puppet on windows could not output unicode characters to the
console reliably, such as the box drawing characters used by the module
tool when displaying dependencies.

Ruby 1.8 uses the ANSI Win32 APIs, e.g. WriteConsole, to write to the
console. However, it uses the current console codepage. So if the current
codepage cannot handle the unicode character we're trying to write, e.g.
cp1252, then it displays garbage.

Ruby 1.9 uses the Unicode Win32 APIs, e.g. WriteConsoleW. As such, it can
correctly write unicode output, without being sensitive to the current
codepage.

However, because puppet writes ANSI escape sequences, we use the
win32console gem to color the output. This win32console gem redefines the
stdout and stderr streams to accomplish this, and sadly uses ANSI versions
of Win32 APIs to write to the console. So it has the same problems as ruby
1.8.

This commit overrides the win32console classes, Console and IO, to ensure
the Unicode APIs are used. This enables us to display ANSI escape
sequences and unicode characters that may not be compatible with the
current codepage.

Longer term we should think about removing win32console gem altogether and
moving to ruby 1.9, as these hacks would no longer be required. Though
doing so would mean losing color output, or taking more drastic measures
like ansicon.
