### PR TITLE
(#19001) Allow autorequire to work with classes

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1944,9 +1944,9 @@ class Type
   # See {autorequire} for how to add an auto-requirement.
   # @todo needs details - see the param rel_catalog, and type of this param
   # @param rel_catalog [Puppet::Catalog, nil] the catalog to add dependencies to. Defaults to the
-  #   catalog (TODO: what is the type of the catalog).
+  #   catalog (TODO: what is the type of the catalog). 
   # @raise [Puppet::DevError] if there is no catalog
-  #
+  # 
   def autorequire(rel_catalog = nil)
     rel_catalog ||= catalog
     raise(Puppet::DevError, "You cannot add relationships without a catalog") unless rel_catalog


### PR DESCRIPTION
Under the current implementation, though classes are to be considered first-class resources, you cannot use `Puppet::Type.autorequire` with class resources.

The reason for this is the old implementation checked to see "is this a valid type". The method of checking this doesn't support 'class' as a valid resource type though, as evidenced by the following:

``` ruby
require "puppet" #=> true
Puppet::Type.type(:file) #=> Puppet::Type::File
Puppet::Type.type(:class) #=> nil
```

This change set introduces a simple check to see if the type we're dealing with is a class before doing the current type checking.

This change has been confirmed with the use a custom Puppet type `Repository` that includes the following:

``` ruby
  autorequire :class do
    if provider.respond_to? :autorequire
      provider.autorequire.each do |requirement|
        Puppet.warning("got an autorequire of: #{requirement}")
      end
    else
      []
    end
  end
```

With the patch above applied to Puppet 3.0.2, it results in the following output appearing before every `Repository` resource in the run output:

```
Warning: got an autorequire of: git
```

I've tested all releases of Puppet 3.0.x, and none exhibit the expected behavior without this change. Given the nature of this change, I would like to see it included in the following releases:
- 3.0.3
- 3.1.0

Related RedMine ticket: https://projects.puppetlabs.com/issues/19001
