### PR TITLE
(#5129) Freeze variables after creating them

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -159,12 +159,12 @@ class Puppet::Parser::AST
       object = evaluate_container(scope)
       accesskey = evaluate_key(scope)
 
-      if object.is_a?(Hash) and object.include?(accesskey)
-        raise Puppet::ParseError, "Assigning to the hash '#{variable}' with an existing key '#{accesskey}' is forbidden"
-      end
-
       # assign to hash or array
-      object[array_index_or_key(object, accesskey)] = value
+      begin
+        object[array_index_or_key(object, accesskey)] = value
+      rescue TypeError
+        raise Puppet::ParseError, "Cannot modify existing #{object.class.to_s.downcase} '#{variable}'"
+      end
     end
 
     def to_s

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -382,6 +382,10 @@ class Puppet::Parser::Scope
     else 
       table[name] = value
     end
+
+    # We freeze the variable to avoid any modification of it
+    # as variables are immutable within a scope.
+    table[name].freeze
   end
 
   # Sets the variable value of the name given as an argument to the given value. The value is

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -240,7 +240,7 @@ describe Puppet::Parser::AST::HashOrArrayAccess do
   end
 
   describe "when assigning" do
-    it "should add a new key and value" do
+    it "should raise an error when adding a new key and value" do
       node     = Puppet::Node.new('localhost')
       compiler = Puppet::Parser::Compiler.new(node)
       scope    = Puppet::Parser::Scope.new(compiler)
@@ -248,9 +248,7 @@ describe Puppet::Parser::AST::HashOrArrayAccess do
       scope['a'] = { 'a' => 'b' }
 
       access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => "b")
-      access.assign(scope, "c" )
-
-      scope['a'].should be_include("b")
+      lambda { access.assign(scope, "c" ) }.should raise_error
     end
 
     it "should raise an error when assigning an array element with a key" do
@@ -266,12 +264,11 @@ describe Puppet::Parser::AST::HashOrArrayAccess do
       compiler = Puppet::Parser::Compiler.new(node)
       scope    = Puppet::Parser::Scope.new(compiler)
 
-      scope['a'] = []
+      scope['a'] = ["val2"]
 
       access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => "0" )
 
-      access.assign(scope, "val2")
-      scope['a'].should == ["val2"]
+      access.evaluate(scope).should == "val2"
     end
 
     it "should raise an error when trying to overwrite an hash value" do


### PR DESCRIPTION
Variables are supposed to be immutable within a scope, so we freeze them
after creation to avoid any changes to them.
