### PR TITLE
(#14094) Remove unsafe attributes from TemplateWrapper

### DIFF
--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -5,8 +5,6 @@ require 'erb'
 
 class Puppet::Parser::TemplateWrapper
   attr_writer :scope
-  attr_reader :file
-  attr_accessor :string
   include Puppet::Util
   Puppet::Util.logmethods(self)
 
@@ -22,7 +20,7 @@ class Puppet::Parser::TemplateWrapper
     # find which line in the template (if any) we were called from
     # but defer to when necessary since fetching the caller information on
     # every variable lookup can be quite time consuming
-    Proc.new { (caller.find { |l| l =~ /#{file}:/ }||"")[/:(\d+):/,1] }
+    Proc.new { (caller.find { |l| l =~ /#{@__file__}:/ }||"")[/:(\d+):/,1] }
   end
 
   def script_line
@@ -63,51 +61,49 @@ class Puppet::Parser::TemplateWrapper
   # dead.
   def method_missing(name, *args)
     if scope.include?(name.to_s)
-      return scope[name.to_s, {:file => file,:lineproc => script_line_proc}]
+      return scope[name.to_s, {:file => @__file__, :lineproc => script_line_proc}]
     else
       # Just throw an error immediately, instead of searching for
       # other missingmethod things or whatever.
-      raise Puppet::ParseError.new("Could not find value for '#{name}'",@file,script_line)
+      raise Puppet::ParseError.new("Could not find value for '#{name}'", @__file__, script_line)
     end
   end
 
   def file=(filename)
-    unless @file = Puppet::Parser::Files.find_template(filename, scope.compiler.environment.to_s)
+    unless @__file__ = Puppet::Parser::Files.find_template(filename, scope.compiler.environment.to_s)
       raise Puppet::ParseError, "Could not find template '#{filename}'"
     end
 
     # We'll only ever not have a parser in testing, but, eh.
-    scope.known_resource_types.watch_file(file)
-
-    @string = File.read(file)
+    scope.known_resource_types.watch_file(@__file__)
   end
 
   def result(string = nil)
     if string
-      self.string = string
       template_source = "inline template"
     else
-      template_source = file
+      string = File.read(@__file__)
+      template_source = @__file__
     end
 
     # Expose all the variables in our scope as instance variables of the
     # current object, making it possible to access them without conflict
     # to the regular methods.
     benchmark(:debug, "Bound template variables for #{template_source}") do
-      scope.to_hash.each { |name, value|
+      scope.to_hash.each do |name, value|
         if name.kind_of?(String)
           realname = name.gsub(/[^\w]/, "_")
         else
           realname = name
         end
         instance_variable_set("@#{realname}", value)
-      }
+      end
     end
 
     result = nil
     benchmark(:debug, "Interpolated template #{template_source}") do
-      template = ERB.new(self.string, 0, "-")
-      template.filename = file
+      template = ERB.new(string, 0, "-")
+      template.filename = @__file__
       result = template.result(binding)
     end
 
@@ -115,6 +111,6 @@ class Puppet::Parser::TemplateWrapper
   end
 
   def to_s
-    "template[#{(file ? file : "inline")}]"
+    "template[#{(@__file__ ? @__file__ : "inline")}]"
   end
 end

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -65,6 +65,11 @@ describe "the template function" do
     end
   end
 
+  it "is not interfered with by having a variable named 'string' (#14094)" do
+    scope['string'] = "this output should not be seen"
+    eval_template("some text that is static").should == "some text that is static"
+  end
+
   it "does not have direct access to Scope#lookupvar" do
     expect {
       eval_template("<%= lookupvar('myvar') %>")


### PR DESCRIPTION
The attribute accessor for the :string attribute in the TemplateWrapper
conflicted with a variable being in scope that is named string. The
variable would take precedence and because of the way the TemplateWrapper
accessed the value of the attribute, the variable's value would be used as
the template.

This changes the TemplateWrapper to completely remove :string as an
attribute and only use local variables. This also removes the :file
attribute in favor of a "private"-style naming of the instance variable.
There are no collisions with @**file** that would cause problems, but this
should reduce the likelihood of them happening in the first place.
