### PR TITLE
(#17474) Make it possible to return `false` from a terminus

### DIFF
--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -217,6 +217,11 @@ describe Puppet::Indirector::Indirection do
         @indirection.find("me").should equal(@instance)
       end
 
+      it "should return false if the instance is false" do
+        @terminus.expects(:find).returns(false)
+        @indirection.find("me").should equal(false)
+      end
+
       it "should set the expiration date on any instances without one set" do
         @terminus.stubs(:find).returns(@instance)
 


### PR DESCRIPTION
This manifested as an inability to retrieve the value `false` from hiera using
data bindings. The find method on Puppet::Indirection interpreted this as no
value being returned.
