### PR TITLE
UNFINISHED: Fix AIX services

### DIFF
--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -1,0 +1,36 @@
+test_name 'AIX Service Provider Testing'
+
+confine :to, :platform =>  'aix'
+
+sloth_daemon_script = <<SCRIPT
+#!/usr/bin/env sh
+while true; do sleep 1; done
+SCRIPT
+
+agents.each do |agent|
+
+	## Setup
+  step "Create the sloth_daemon service on #{agent}"
+	sloth_daemon_path = agent.tmpfile("sloth_daemon.sh")
+	create_remote_file(agent, sloth_daemon_path, sloth_daemon_script)
+	on agent, "chmod +x #{sloth_daemon_path}"
+	on agent, "mkssys -s sloth_daemon -p #{sloth_daemon_path} -u 0 -S -n 15 -f 9"
+
+	## Start the service
+
+
+	## Stop the service
+
+
+	## Enable the service
+
+
+	## Disable the service
+
+
+	## Cleanup
+	step "Remove the sloth_daemon service on #{agent}"
+	on agent, "rmssys -s sloth_daemon"
+	on agent, "rm #{sloth_daemon_path}"
+
+end

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -18,8 +18,21 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
   commands :startsrc => "/usr/bin/startsrc"
   commands :refresh  => "/usr/bin/refresh"
   commands :lssrc    => "/usr/bin/lssrc"
+  commands :lsitab   => "/usr/sbin/lsitab"
+  commands :mkitab   => "/usr/sbin/mkitab"
+  commands :rmitab   => "/usr/sbin/rmitab"
+  commands :chitab   => "/usr/sbin/chitab"
 
   has_feature :refreshable
+
+  def self.instances
+    services = lssrc('-S')
+    services.split("\n").reject { |x| x.strip.start_with? '#' }.collect do |line|
+      data = line.split(':')
+      service_name = data[0]
+      new(:name => service_name)
+    end
+  end
 
   def startcmd
     [command(:startsrc), "-s", @resource[:name]]
@@ -27,6 +40,27 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
 
   def stopcmd
     [command(:stopsrc), "-s", @resource[:name]]
+  end
+
+  def default_runlevel
+    "2"
+  end
+
+  def default_action
+    "once"
+  end
+
+  def enabled?
+    execute([command(:lsitab), @resource[:name]], {:failonfail => false, :combine => true})
+    $CHILD_STATUS.exitstatus == 0 ? :true : :false
+  end
+
+  def enable
+    mkitab("%s:%s:%s:%s" % [@resource[:name], default_runlevel, default_action, startcmd.join(" ")])
+  end
+
+  def disable
+    rmitab(@resource[:name])
   end
 
   def restart

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -21,77 +21,152 @@ describe provider_class do
     @provider.stubs(:command).with(:startsrc).returns "/usr/bin/startsrc"
     @provider.stubs(:command).with(:lssrc).returns "/usr/bin/lssrc"
     @provider.stubs(:command).with(:refresh).returns "/usr/bin/refresh"
+    @provider.stubs(:command).with(:lsitab).returns "/usr/sbin/lsitab"
+    @provider.stubs(:command).with(:mkitab).returns "/usr/sbin/mkitab"
+    @provider.stubs(:command).with(:rmitab).returns "/usr/sbin/rmitab"
+    @provider.stubs(:command).with(:chitab).returns "/usr/sbin/chitab"
 
     @provider.stubs(:stopsrc)
     @provider.stubs(:startsrc)
     @provider.stubs(:lssrc)
     @provider.stubs(:refresh)
+    @provider.stubs(:lsitab)
+    @provider.stubs(:mkitab)
+    @provider.stubs(:rmitab)
+    @provider.stubs(:chitab)
   end
 
-  [:start, :stop, :status, :restart].each do |method|
-    it "should have a #{method} method" do
-      @provider.should respond_to(method)
+  describe ".instances" do
+    it "should has a .instances method" do
+      provider_class.should respond_to :instances
+    end
+
+    it "should get a list of running services" do
+      sample_output = <<_EOF_
+#subsysname:synonym:cmdargs:path:uid:auditid:standin:standout:standerr:action:multi:contact:svrkey:svrmtype:priority:signorm:sigforce:display:waittime:grpname:
+myservice.1:::/usr/sbin/inetd:0:0:/dev/console:/dev/console:/dev/console:-O:-Q:-K:0:0:20:0:0:-d:20:tcpip:
+myservice.2:::/usr/sbin/inetd:0:0:/dev/console:/dev/console:/dev/console:-O:-Q:-K:0:0:20:0:0:-d:20:tcpip:
+myservice.3:::/usr/sbin/inetd:0:0:/dev/console:/dev/console:/dev/console:-O:-Q:-K:0:0:20:0:0:-d:20:tcpip:
+myservice.4:::/usr/sbin/inetd:0:0:/dev/console:/dev/console:/dev/console:-O:-Q:-K:0:0:20:0:0:-d:20:tcpip:
+_EOF_
+      provider_class.stubs(:lssrc).returns sample_output
+      provider_class.instances.map(&:name).should == [
+        'myservice.1',
+        'myservice.2',
+        'myservice.3',
+        'myservice.4'
+      ]
+    end
+
+  end
+
+  describe "should have a set of methods" do
+    [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|
+      it "should have a #{method} method" do
+        @provider.should respond_to(method)
+      end
     end
   end
 
-  it "should execute the startsrc command" do
-    @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
-    @provider.start
+  describe "when enabling" do
+    it "should execute the mkitab command" do
+      @provider.expects(:mkitab).with("myservice:2:once:/usr/bin/startsrc -s myservice").once
+      @provider.enable
+    end
   end
 
-  it "should execute the stopsrc command" do
-    @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
-    @provider.stop
+  describe "when disabling" do
+    it "should execute the rmitab command" do
+      @provider.expects(:rmitab).with("myservice")
+      @provider.disable
+    end
   end
 
-  it "should execute status and return running if the subsystem is active", :'fails_on_ruby_1.9.2' => true do
-    sample_output = <<_EOF_
-Subsystem         Group            PID          Status
-myservice         tcpip            1234         active
+  describe "when checking if it is enabled" do
+    it "should execute the lsitab command" do
+      @provider.expects(:execute).with(['/usr/sbin/lsitab', 'myservice'], {:combine => true, :failonfail => false})
+      @provider.enabled?
+    end
+
+    it "should return false when lsitab returns non-zero" do
+      @provider.stubs(:execute)
+      $CHILD_STATUS.stubs(:exitstatus).returns(1)
+      @provider.enabled?.should == :false
+    end
+
+    it "should return true when lsitab returns zero" do
+      @provider.stubs(:execute)
+      $CHILD_STATUS.stubs(:exitstatus).returns(0)
+      @provider.enabled?.should == :true
+    end
+  end
+
+  describe "when starting a service" do
+    it "should execute the startsrc command" do
+      @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
+      @provider.start
+    end
+  end
+
+  describe "when stopping a service" do
+    it "should execute the stopsrc command" do
+      @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
+      @provider.stop
+    end
+  end
+
+  describe "when checking a subsystem's status" do
+    it "should execute status and return running if the subsystem is active", :'fails_on_ruby_1.9.2' => true do
+      sample_output = <<_EOF_
+  Subsystem         Group            PID          Status
+  myservice         tcpip            1234         active
 _EOF_
 
-    @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', "myservice"]).returns sample_output
-    @provider.status.should == :running
-  end
+      @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', "myservice"]).returns sample_output
+      @provider.status.should == :running
+    end
 
-  it "should execute status and return stopped if the subsystem is inoperative", :'fails_on_ruby_1.9.2' => true do
-    sample_output = <<_EOF_
-Subsystem         Group            PID          Status
-myservice         tcpip                         inoperative
+    it "should execute status and return stopped if the subsystem is inoperative", :'fails_on_ruby_1.9.2' => true do
+      sample_output = <<_EOF_
+  Subsystem         Group            PID          Status
+  myservice         tcpip                         inoperative
 _EOF_
 
-    @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', "myservice"]).returns sample_output
-    @provider.status.should == :stopped
-  end
+      @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', "myservice"]).returns sample_output
+      @provider.status.should == :stopped
+    end
 
-  it "should execute status and return nil if the status is not known", :'fails_on_ruby_1.9.2' => true do
-    sample_output = <<_EOF_
-Subsystem         Group            PID          Status
-myservice         tcpip                         randomdata
+    it "should execute status and return nil if the status is not known", :'fails_on_ruby_1.9.2' => true do
+      sample_output = <<_EOF_
+  Subsystem         Group            PID          Status
+  myservice         tcpip                         randomdata
 _EOF_
 
-    @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', "myservice"]).returns sample_output
-    @provider.status.should == nil
+      @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', "myservice"]).returns sample_output
+      @provider.status.should == nil
+    end
   end
 
-  it "should execute restart which runs refresh", :'fails_on_ruby_1.9.2' => true do
-    sample_output = <<_EOF_
+  describe "when restarting a service" do
+    it "should execute restart which runs refresh", :'fails_on_ruby_1.9.2' => true do
+      sample_output = <<_EOF_
 #subsysname:synonym:cmdargs:path:uid:auditid:standin:standout:standerr:action:multi:contact:svrkey:svrmtype:priority:signorm:sigforce:display:waittime:grpname:
 myservice:::/usr/sbin/inetd:0:0:/dev/console:/dev/console:/dev/console:-O:-Q:-K:0:0:20:0:0:-d:20:tcpip:
 _EOF_
-    @provider.expects(:execute).with(['/usr/bin/lssrc', '-Ss', "myservice"]).returns sample_output
-    @provider.expects(:execute).with(['/usr/bin/refresh', '-s', "myservice"])
-    @provider.restart
-  end
+      @provider.expects(:execute).with(['/usr/bin/lssrc', '-Ss', "myservice"]).returns sample_output
+      @provider.expects(:execute).with(['/usr/bin/refresh', '-s', "myservice"])
+      @provider.restart
+    end
 
-  it "should execute restart which runs stopsrc then startsrc", :'fails_on_ruby_1.9.2' => true do
-    sample_output =  <<_EOF_
+    it "should execute restart which runs stopsrc then startsrc", :'fails_on_ruby_1.9.2' => true do
+      sample_output =  <<_EOF_
 #subsysname:synonym:cmdargs:path:uid:auditid:standin:standout:standerr:action:multi:contact:svrkey:svrmtype:priority:signorm:sigforce:display:waittime:grpname:
 myservice::--no-daemonize:/usr/sbin/puppetd:0:0:/dev/null:/var/log/puppet.log:/var/log/puppet.log:-O:-Q:-S:0:0:20:15:9:-d:20::"
 _EOF_
-    @provider.expects(:execute).with(['/usr/bin/lssrc', '-Ss', "myservice"]).returns sample_output
-    @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
-    @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
-    @provider.restart
+      @provider.expects(:execute).with(['/usr/bin/lssrc', '-Ss', "myservice"]).returns sample_output
+      @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
+      @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:squelch => true, :failonfail => true})
+      @provider.restart
+    end
   end
 end


### PR DESCRIPTION
If you get impatient with me putting the final touches on the acceptance tests, go ahead and finish 'em. I can give you hints.

Sprint.ly item:231: Fix service provider to allow enabling and disabling services on AIX
- item:265 Add new commands and common helper methods
- item:230 Allow enabling services
- item:232 Allow disabling services
- item:273 Allow service introspection via self.instances
- item:266 Write spec tests and ...
- Start on accpetance tests
