### PR TITLE
Ignore splay time on SIGUSR1

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -37,7 +37,7 @@ class Puppet::Agent
 
     result = nil
     block_run = Puppet::Application.controlled_run do
-      splay
+      splay client_options.fetch :splay, Puppet[:splay]
       result = run_in_fork(should_fork) do
         with_client do |client|
           begin
@@ -66,8 +66,8 @@ class Puppet::Agent
   end
 
   # Sleep when splay is enabled; else just return.
-  def splay
-    return unless Puppet[:splay]
+  def splay(do_splay = Puppet[:splay])
+    return unless do_splay
     return if splayed?
 
     time = rand(Puppet[:splaylimit] + 1)

--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -79,7 +79,7 @@ class Puppet::Daemon
       return
     end
 
-    agent.run
+    agent.run({:splay => false})
   end
 
   # Remove the pid file for our daemon.

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -203,7 +203,7 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
 
     it "should run the agent if one is available and it is not running" do
       @agent.expects(:running?).returns false
-      @agent.expects :run
+      @agent.expects(:run).with({:splay => false})
 
       @daemon.agent = @agent
 


### PR DESCRIPTION
If the agent is configured to use splay, receiving a SIGUSR1 while
beeing in the splay loop will cause the agent to wait and instantly
run as documented.

The agent now skips the splay sleep when the signal is received.

This is a reworked version of pull request 1438
