### PR TITLE
(#17522) Only print load errors to debug with non-specific context

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -171,7 +171,6 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         aug.set("/augeas/load/Xfm/incl", resource[:incl])
         restricted = true
       elsif glob_avail and opt_ctx
-        restricted = true
         # Optimize loading if the context is given, requires the glob function
         # from Augeas 0.8.2 or up
         ctx_path = resource[:context].sub(/^\/files(.*?)\/?$/, '\1/')

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -744,6 +744,7 @@ describe provider_class do
         @resource[:context] = "/files/etc/test"
         @resource[:load_path] = my_fixture_dir
 
+        @provider.expects(:print_load_errors).with(:warning => true)
         aug = @provider.open_augeas
         aug.should_not == nil
         aug.match("/files/etc/fstab").should == []
@@ -754,6 +755,7 @@ describe provider_class do
       it "should load standard files if context isn't specific" do
         @resource[:context] = "/files/etc"
 
+        @provider.expects(:print_load_errors).with(:warning => false)
         aug = @provider.open_augeas
         aug.should_not == nil
         aug.match("/files/etc/fstab").should == ["/files/etc/fstab"]
@@ -763,6 +765,7 @@ describe provider_class do
       it "should not optimise if the context is a complex path" do
         @resource[:context] = "/files/*[label()='etc']"
 
+        @provider.expects(:print_load_errors).with(:warning => false)
         aug = @provider.open_augeas
         aug.should_not == nil
         aug.match("/files/etc/fstab").should == ["/files/etc/fstab"]


### PR DESCRIPTION
Replaces GH-1280, rebased to master.

Fixes a variable assignment that landed in the wrong branch during a conflict
merge (a4451fb1).  Commit a8575f41 fixed a spec failure but the original code
wasn't restored.

This restores the original functionality in #14136 where a non-specific
context (i.e. /files/etc) would be optimised (only load lenses for files under
/etc) but since it was vague, would only log load errors to debug.  Instead,
load errors were reported as warnings for non-specific contexts.

Load errors will continue to be reported as warnings for supplied contexts if
they're specific.
