### PR TITLE
(#18187) Clear *root* environment when clearing caches

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -52,11 +52,12 @@ class Puppet::Node::Environment
   end
 
   def self.root
-    @root
+    @root ||= new(:'*root*')
   end
 
   def self.clear
     @seen.clear
+    @root = nil
     Thread.current[:environment] = nil
   end
 
@@ -239,6 +240,4 @@ class Puppet::Node::Environment
     # perform_initial_import when no file was actually loaded.
     return Puppet::Parser::AST::Hostclass.new('')
   end
-
-  @root = new(:'*root*')
 end

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -32,6 +32,12 @@ describe Puppet::Node::Environment do
     Puppet::Node::Environment.new("one").should equal(Puppet::Node::Environment.new("one"))
   end
 
+  it "should treat environment instances as singletons only until cleared" do
+    before = Puppet::Node::Environment.new("one")
+    Puppet::Node::Environment.clear
+    before.should_not equal(Puppet::Node::Environment.new("one"))
+  end
+
   it "should treat an environment specified as names or strings as equivalent" do
     Puppet::Node::Environment.new(:one).should equal(Puppet::Node::Environment.new("one"))
   end
@@ -43,6 +49,32 @@ describe Puppet::Node::Environment do
   it "should just return any provided environment if an environment is provided as the name" do
     one = Puppet::Node::Environment.new(:one)
     Puppet::Node::Environment.new(one).should equal(one)
+  end
+
+  it "should return the *root* environment as the current env by default" do
+    Puppet::Node::Environment.current.name.to_s.should == '*root*'
+  end
+
+  it "should treat the *root* instance as a singleton only until cleared" do
+    before = Puppet::Node::Environment.current
+    Puppet::Node::Environment.clear
+    before.should_not equal(Puppet::Node::Environment.current)
+  end
+
+  it "should change the current environment" do
+    Puppet::Node::Environment.current.name.to_s.should == '*root*'
+    one = Puppet::Node::Environment.new(:one)
+    Puppet::Node::Environment.current = one
+    Puppet::Node::Environment.current.should equal(one)
+  end
+
+  it "should change the current environment only until cleared" do
+    Puppet::Node::Environment.current.name.to_s.should == '*root*'
+    one = Puppet::Node::Environment.new(:one)
+    Puppet::Node::Environment.current = one
+    Puppet::Node::Environment.current.should equal(one)
+    Puppet::Node::Environment.clear
+    Puppet::Node::Environment.current.name.to_s.should == '*root*'
   end
 
   describe "when managing known resource types" do


### PR DESCRIPTION
When changing settings or initializing Puppet via TestHelper, the
Puppet::Node::Environment.clear method is called to delete the cached
environment objects, as they may reference cached module paths based on old
values of settings.

The _root_ environment is a special case, as it acts as the current environment
when no other environment has been created and set yet.  It can still have a
module path based on current settings, so it too should be cleared along with
other cached environments.

This was an issue in 2.7.x in particular, where _root_ would be used usually.
In later versions, app_defaults_initialized? prevents _root_ from being used
too early.
