### PR TITLE
Fix feature detection error undefined method pointer on nil:NilClass.

### DIFF
--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -10,7 +10,7 @@ Puppet.features.add(:syslog, :libs => ["syslog"])
 # We can use POSIX user functions
 Puppet.features.add(:posix) do
   require 'etc'
-  Etc.getpwuid(0) != nil && Puppet.features.syslog?
+  !Etc.getpwuid(0).nil? && Puppet.features.syslog?
 end
 
 # We can use Microsoft Windows functions


### PR DESCRIPTION
On a fresh installation of Puppet from gems on Debian 7 (wheezy) I was unable to run the `puppet` command line tool that always exited with the following error:

```
# puppet
Failed to load feature test for posix: undefined method `pointer' on nil:NilClass.
Cannot run on Microsoft Windows without the sys-admin, win32-process, win32-dir, win32-service and win32-taskscheduler gems: no such file to load -- Win32API
An exception occurred running /opt/puppet-portable/gems/1.8/bin/puppet
    Cannot determine basic system flavour (Puppet::Error)

Backtrace:
                              Object#__script__ at gems/1.8/gems/puppet-3.1.0/lib/puppet/feature/base.rb:37
                   Rubinius::CodeLoader.require at kernel/common/codeloader.rb:212
  Kernel(Module)#gem_original_require (require) at kernel/common/kernel.rb:649
                         Kernel(Module)#require at lib/rubygems/custom_require.rb:36
                Puppet.__module_init__ (Puppet) at gems/1.8/gems/puppet-3.1.0/lib/puppet.rb:48
                              Object#__script__ at gems/1.8/gems/puppet-3.1.0/lib/puppet.rb:27
                   Rubinius::CodeLoader.require at kernel/common/codeloader.rb:212
  Kernel(Object)#gem_original_require (require) at kernel/common/kernel.rb:649
                         Kernel(Object)#require at lib/rubygems/custom_require.rb:36
                              Object#__script__ at gems/1.8/gems/puppet-3.1.0/lib/puppet/util/command_line.rb:12
                   Rubinius::CodeLoader.require at kernel/common/codeloader.rb:212
  Kernel(Object)#gem_original_require (require) at kernel/common/kernel.rb:649
                         Kernel(Object)#require at lib/rubygems/custom_require.rb:36
                              Object#__script__ at gems/1.8/gems/puppet-3.1.0/bin/puppet:3
                            Kernel(Object)#load at kernel/common/kernel.rb:598
                              Object#__script__ at gems/1.8/bin/puppet:23
               Rubinius::CodeLoader#load_script at kernel/delta/codeloader.rb:68
               Rubinius::CodeLoader.load_script at kernel/delta/codeloader.rb:118
                        Rubinius::Loader#script at kernel/loader.rb:615
                          Rubinius::Loader#main at kernel/loader.rb:816
```

The error `undefined method`pointer' on nil:NilClass`seems to come from comparison with`!= nil`, so I changed it into`.nil?` with negation.
