### PR TITLE
Fix a documentation bug in Puppet::Parser::Files

### DIFF
--- a/lib/puppet/parser/files.rb
+++ b/lib/puppet/parser/files.rb
@@ -28,9 +28,9 @@ module Puppet::Parser::Files
   end
 
   # Find the concrete file denoted by +file+. If +file+ is absolute,
-  # return it directly. Otherwise try to find it as a template in a
-  # module. If that fails, return it relative to the +templatedir+ config
-  # param.
+  # return it directly. Otherwise try to find relative to the +templatedir+
+  # config param.  If that fails try to find it as a template in a
+  # module.
   # In all cases, an absolute path is returned, which does not
   # necessarily refer to an existing file
   def find_template(template, environment = nil)


### PR DESCRIPTION
The documentation comment was inconsistent with the code.
