### PR TITLE
Update network_device spec to check for nil

### DIFF
--- a/spec/unit/util/network_device/cisco/device_spec.rb
+++ b/spec/unit/util/network_device/cisco/device_spec.rb
@@ -27,8 +27,8 @@ describe Puppet::Util::NetworkDevice::Cisco::Device do
       cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23", :debug => true)
     end
 
-    it "should set the debug mode to false by default" do
-      Puppet::Util::NetworkDevice::Transport::Telnet.expects(:new).with(false).returns(@transport)
+    it "should set the debug mode to nil by default" do
+      Puppet::Util::NetworkDevice::Transport::Telnet.expects(:new).with(nil).returns(@transport)
       cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23")
     end
   end


### PR DESCRIPTION
Commit fe95a39 added a default value of false for instantiation of
network transport types. I omitted that value and defaulted to nil since
they're equivalent but didn't update the tests. This commits checks for
nil instead of false.
