### PR TITLE
(#16451) Use PATH to find systemctl for systemd service provider

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -1,9 +1,9 @@
 # Manage systemd services using /bin/systemctl
 
 Puppet::Type.type(:service).provide :systemd, :parent => :base do
-  desc "Manages `systemd` services using `/bin/systemctl`."
+  desc "Manages `systemd` services using `systemctl`."
 
-  commands :systemctl => "/bin/systemctl"
+  commands :systemctl => "systemctl"
 
   #defaultfor :osfamily => [:redhat, :suse]
 

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -31,4 +31,9 @@ describe provider_class do
     provider_class.instances.map {|provider| provider.name}.should =~ ["my_service","my_other_service"]
   end
 
+  it "(#16451) has command systemctl without being fully qualified" do
+    provider_class.instance_variable_get(:@commands).
+      should include(:systemctl => 'systemctl')
+  end
+
 end


### PR DESCRIPTION
```
Without this patch Puppet has a difficult time locating the systemctl
executable in recent versions of Archlinux.  This problem is caused by
the executable moving from /bin/systemctl to /usr/bin/systemctl.

This patch addresses the problem by eliminating the fully qualified path
and instead relying on the PATH environment variable to locate the
command.
```
