### PR TITLE
(#19167) Fix skipped tests due to Tempfile.new block not being run

### DIFF
--- a/spec/unit/parser/functions/extlookup_spec.rb
+++ b/spec/unit/parser/functions/extlookup_spec.rb
@@ -1,6 +1,5 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'tempfile'
 
 describe "the extlookup function" do
   include PuppetSpec::Files
@@ -33,36 +32,40 @@ describe "the extlookup function" do
   end
 
   it "should lookup the key in a supplied datafile" do
-    t = Tempfile.new('extlookup.csv') do
+    dir = tmpdir("extlookup_spec")
+    File.open("#{dir}/extlookup.csv", "w") do |t|
       t.puts 'key,value'
       t.puts 'nonkey,nonvalue'
-      t.close
-
-      result = @scope.function_extlookup([ "key", "default", t.path])
-      result.should == "value"
     end
+
+    @scope.stubs(:[]).with('::extlookup_datadir').returns(dir)
+    @scope.stubs(:[]).with('::extlookup_precedence').returns(nil)
+    result = @scope.function_extlookup([ "key", "default", "extlookup"])
+    result.should == "value"
   end
 
   it "should return an array if the datafile contains more than two columns" do
-    t = Tempfile.new('extlookup.csv') do
+    dir = tmpdir("extlookup_spec")
+    File.open("#{dir}/extlookup.csv", "w") do |t|
       t.puts 'key,value1,value2'
       t.puts 'nonkey,nonvalue,nonvalue'
-      t.close
-
-      result = @scope.function_extlookup([ "key", "default", t.path])
-      result.should == ["value1", "value2"]
     end
+
+    @scope.stubs(:[]).with('::extlookup_datadir').returns(dir)
+    @scope.stubs(:[]).with('::extlookup_precedence').returns(nil)
+    result = @scope.function_extlookup([ "key", "default", "extlookup"])
+    result.should == ["value1", "value2"]
   end
 
   it "should raise an error if there's no matching key and no default" do
-    t = Tempfile.new('extlookup.csv') do
-      t.puts 'key,value'
+    dir = tmpdir("extlookup_spec")
+    File.open("#{dir}/extlookup.csv", "w") do |t|
       t.puts 'nonkey,nonvalue'
-      t.close
-
-      result = @scope.function_extlookup([ "key", nil, t.path])
-      result.should == "value"
     end
+
+    @scope.stubs(:[]).with('::extlookup_datadir').returns(dir)
+    @scope.stubs(:[]).with('::extlookup_precedence').returns(nil)
+    lambda { @scope.function_extlookup([ "key", nil, "extlookup"]) }.should raise_error(Puppet::ParseError, /No match found.*key/)
   end
 
   describe "should look in $extlookup_datadir for data files listed by $extlookup_precedence" do


### PR DESCRIPTION
Tests for extlookup() key lookups were passing a block into Tempfile.new,
which it doesn't run.  The initialization of the CSV file was performed and
then extlookup() was called inside the block.  Since it isn't run, the tests
aren't executed.

This moves the tests out of the block and changes how the CSV file is created,
since the extlookup() function doesn't take an absolute path to a CSV file.
Instead a temporary directory is now created and the CSV file created inside.

An incorrect test that should have checked for a raised error has also been
fixed.
