### PR TITLE
Do not reboot system when runnnig puppet resource service

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -18,10 +18,6 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
 
   defaultfor :operatingsystem => [:debian, :ubuntu]
 
-  def self.defpath
-    superclass.defpath
-  end
-
   # Remove the symlinks
   def disable
     if `dpkg --compare-versions $(dpkg-query -W --showformat '${Version}' sysv-rc) ge 2.88 ; echo $?`.to_i == 0

--- a/lib/puppet/provider/service/gentoo.rb
+++ b/lib/puppet/provider/service/gentoo.rb
@@ -12,15 +12,6 @@ Puppet::Type.type(:service).provide :gentoo, :parent => :init do
 
   confine :operatingsystem => :gentoo
 
-  def self.defpath
-    superclass.defpath
-  end
-
-  def self.instances
-    # this exclude list was found with grep -L '\/sbin\/runscript' /etc/init.d/*
-    self.get_services(self.defpath, ['functions.sh', 'reboot.sh', 'shutdown.sh'])
-  end
-
   def disable
       output = update :del, @resource[:name], :default
   rescue Puppet::ExecutionFailure

--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -10,15 +10,6 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
 
   defaultfor :osfamily => [:redhat, :suse]
 
-  def self.instances
-    # this exclude list is all from /sbin/service (5.x), but I did not exclude kudzu
-    self.get_services(['/etc/init.d'], ['functions', 'halt', 'killall', 'single', 'linuxconf', 'reboot', 'boot'])
-  end
-
-  def self.defpath
-    superclass.defpath
-  end
-
   # Remove the symlinks
   def disable
     # The off method operates on run levels 2,3,4 and 5 by default We ensure

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -25,15 +25,8 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   # http://www.linuxplanet.com/linuxplanet/tutorials/7033/2/
   has_feature :enableable
 
-  # 'wait-for-state' is excluded from instances here because it takes
-  # parameters that have unclear meaning. It looks like 'wait-for-state' is
-  # mainly used internally for other upstart services as a 'sleep until something happens'
-  # (http://lists.debian.org/debian-devel/2012/02/msg01139.html). There is an open launchpad bug
-  # (https://bugs.launchpad.net/ubuntu/+source/upstart/+bug/962047) that may
-  # eventually explain how to use this service or perhaps why it should remain
-  # excluded. When that bug is adddressed this should be reexamined.
   def self.instances
-    self.get_services(['wait-for-state'])
+    self.get_services(self.excludes) # Take exclude list from init provider
   end
 
   def self.get_services(exclude=[])


### PR DESCRIPTION
Some initscripts are not save to execute on different systems. Example:
If you run `/etc/init.d/reboot.sh status` on a gentoo system you will
immediatly reboot the system.

This can be a problem if you run `puppet resource service` as puppet
will try to get a list of services and then runs the status command on
all of them.

The issue was first addressed in redmine ticket #14615 and #14761 and
introduced different exclude lists for the gentoo provider and the
redhat provider. Unfortunately this did not resolve the problem because
when running `puppet resource service` puppet will not just query the
most suitable provider for a list of services but all suitable
providers. So if the gentoo provider now hides the `reboot.sh` script,
but the init provider (which is also suitable) does not, puppet will
ask the init provider to get the status of the service. As a result
the init provider will now happily reboot the system.

Move the exclude lists into the init provider so the init provider does
the filtering. Each provider that uses the `init` provider as its parent
does not have to do any filtering anymore.

This fix assumes that an initscript that has to be excluded on one
system is never a valid initscript on another system. Given the recent
list of excludes (reboot.sh, shutdown.sh, etc) this seems valid
