### PR TITLE
(maint) Add dependency information for yard & pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,13 @@ def location_for(place)
   end
 end
 
+# C Ruby (MRI) or Rubinius, but NOT Windows
+platforms :ruby do
+  gem 'pry', :group => :development
+  gem 'yard', :group => :development
+  gem 'redcarpet', :group => :development
+end
+
 group(:development, :test) do
   gem "puppet", *location_for('file://.')
   gem "facter", *location_for(ENV['FACTER_LOCATION'] || '~> 1.6')


### PR DESCRIPTION
Without this patch `bundle exec yard server --reload` doesn't work.  Nor
is it easy to develop interactively using pry.

This is a problem because people who are developing Puppet need to be
able to access the API documentation easily and the yard server is one
such way.  This patch addresses the problem by adding a dependency on
yard and redcarpet for the development group only.  This will prevent
the yard and redcarpet gem from sucking in a large number of
dependencies when running in a CI environment because these environments
are expected to omit development only dependencies when bootstrapping
using `bundle install --path vendor --without development`

The previous attempt to add these dependencies in GH-1422 failed because
the dependencies could not be resolved in our Windows CI infrastructure.
This patch avoid the problem by limiting these development dependencies
to the :ruby platform, which are defined as "C Ruby (MRI) or Rubinius,
but NOT Windows" in the Bundler Gemfile manual.
