### PR TITLE
(maint) Improve systemd test coverage

### DIFF
--- a/spec/fixtures/unit/provider/service/systemd/list_units
+++ b/spec/fixtures/unit/provider/service/systemd/list_units
@@ -1,0 +1,18 @@
+UNIT                                                                                      LOAD   ACTIVE   SUB       DESCRIPTION
+auditd.service                                                                            loaded active   running   Security Auditing Service
+crond.service                                                                             loaded active   running   Command Scheduler
+dbus.service                                                                              loaded active   running   D-Bus System Message Bus
+display-manager.service                                                                   error  inactive dead      display-manager.service
+ebtables.service                                                                          loaded inactive dead      SYSV: Ethernet Bridge filtering tables
+fedora-readonly.service                                                                   loaded active   exited    Configure read-only root support
+initrd-switch-root.service                                                                loaded inactive dead      Switch Root
+ip6tables.service                                                                         error  inactive dead      ip6tables.service
+puppet.service                                                                            loaded inactive dead      SYSV: Enables periodic system configuration checks through puppet.
+sshd.service                                                                              loaded failed   failed    OpenSSH server daemon
+
+LOAD   = Reflects whether the unit definition was properly loaded.
+ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
+SUB    = The low-level unit activation state, values depend on unit type.
+
+155 loaded units listed.
+To show all installed unit files use 'systemctl list-unit-files'.

--- a/spec/integration/provider/service/systemd_spec.rb
+++ b/spec/integration/provider/service/systemd_spec.rb
@@ -1,0 +1,20 @@
+#! /usr/bin/env ruby
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:service).provider(:systemd), '(integration)' do
+  # TODO: Unfortunately there does not seem a way to stub the executable
+  #       checks in the systemd provider because they happen at load time.
+  it "should be considered suitable if /bin/systemctl is present", :if => File.executable?('/bin/systemctl') do
+    described_class.should be_suitable
+  end
+
+  it "should be considered suitable if /usr/bin/systemctl is present", :if => File.executable?('/usr/bin/systemctl')  do
+    described_class.should be_suitable
+  end
+
+  it "should not be cosidered suitable if systemctl is absent",
+    :unless => (File.executable?('/bin/systemctl') or File.executable?('/usr/bin/systemctl')) do
+    described_class.should_not be_suitable
+  end
+end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -7,10 +7,11 @@ require 'spec_helper'
 describe Puppet::Type.type(:service).provider(:systemd) do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
+    described_class.stubs(:which).with('systemctl').returns '/bin/systemctl'
   end
 
   let :provider do
-    described_class.new(:name => 'myservice.service')
+    described_class.new(:name => 'sshd.service')
   end
 
   [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|
@@ -19,12 +20,118 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     end
   end
 
+  describe ".instances" do
+    it "should have an instances method" do
+      described_class.should respond_to :instances
+    end
 
-  it 'should return resources from self.instances' do
-    described_class.expects(:systemctl).with('list-units', '--full', '--all',  '--no-pager').returns(
-      "my_service loaded active running\nmy_other_service loaded active running"
-    )
-    described_class.instances.map {|provider| provider.name}.should =~ ["my_service","my_other_service"]
+    it "should get a list of services from systemctl list-units" do
+      pending('A service that has been killed (ACTIVE=failed) is not recognized')
+      described_class.expects(:systemctl).with('list-units', '--full', '--all', '--no-pager').returns File.read(my_fixture('list_units'))
+      described_class.instances.map(&:name).should =~ %w{
+        auditd.service
+        crond.service
+        dbus.service
+        display-manager.service
+        ebtables.service
+        fedora-readonly.service
+        initrd-switch-root.service
+        ip6tables.service
+        puppet.service
+        sshd.service
+      }
+    end
+  end
+
+  describe "#start" do
+    it "should use the supplied start command if specified" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :start => '/bin/foo'))
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
+      provider.start
+    end
+
+    it "should start the service with systemctl start otherwise" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:execute).with(['/bin/systemctl','start','sshd.service'], :failonfail => true, :override_locale => false, :squelch => true)
+      provider.start
+    end
+  end
+
+  describe "#stop" do
+    it "should use the supplied stop command if specified" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :stop => '/bin/foo'))
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
+      provider.stop
+    end
+
+    it "should stop the service with systemctl stop otherwise" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:execute).with(['/bin/systemctl','stop','sshd.service'], :failonfail => true, :override_locale => false, :squelch => true)
+      provider.stop
+    end
+  end
+
+  describe "#enabled?" do
+    it "should return :true if the service is enabled" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('is-enabled', 'sshd.service').returns 'enabled'
+      provider.enabled?.should == :true
+    end
+
+    it "should return :false if the service is disabled" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('is-enabled', 'sshd.service').raises Puppet::ExecutionFailure, "Execution of '/bin/systemctl is-enabled sshd.service' returned 1: disabled"
+      provider.enabled?.should == :false
+    end
+  end
+
+  describe "#enable" do
+    it "should run systemctl enable to enable a service" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('enable', 'sshd.service')
+      provider.enable
+    end
+  end
+
+  describe "#disable" do
+    it "should run systemctl disable to disable a service" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with(:disable, 'sshd.service')
+      provider.disable
+    end
+  end
+
+  # Note: systemd provider does not care about hasstatus or a custom status
+  # command. I just assume that it does not make sense for systemd.
+  describe "#status" do
+    it "should return running if active" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('is-active', 'sshd.service').returns 'active'
+      provider.status.should == :running
+    end
+
+    it "should return stopped if inactive" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('is-active', 'sshd.service').raises Puppet::ExecutionFailure, "Execution of '/bin/systemctl is-active sshd.service' returned 3: inactive"
+      provider.status.should == :stopped
+    end
+  end
+
+  # Note: systemd provider does not care about hasrestart. I just assume it
+  # does not make sense for systemd
+  describe "#restart" do
+    it "should use the supplied restart command if specified" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
+      provider.expects(:execute).with(['/bin/systemctl','restart','sshd.service'], :failonfail => true, :override_locale => false, :squelch => true).never
+      provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => true)
+      provider.restart
+    end
+
+    it "should restart the service with systemctl restart" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:execute).with(['/bin/systemctl','restart','sshd.service'], :failonfail => true, :override_locale => false, :squelch => true)
+      provider.restart
+    end
   end
 
   it "(#16451) has command systemctl without being fully qualified" do


### PR DESCRIPTION
I worked on the systemd spec tests while browsing through GH-1468. One think that I have noticed:

If I manually kill a daemon (the `sshd.service` daemon in my example) the `instances` method will not pick it up anymore. Not sure what the desired behaviour is here but it guess it should show up as stopped.

The test is currently marked as pending for that reason
