### PR TITLE
(#19271) Proper check for which cert to use in ssl error

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -73,7 +73,7 @@ module Puppet::Network::HTTP
         msg << ": [" + verify_errors.join('; ') + "]"
         raise Puppet::Error, msg
       elsif error.message =~ /hostname (was )?not match/
-        raise unless cert = peer_certs.find { |c| c.name !~ /^puppet ca/i }
+        cert = peer_certs.last
 
         valid_certnames = [cert.name, *cert.subject_alt_names].uniq
         msg = valid_certnames.length > 1 ? "one of #{valid_certnames.join(', ')}" : valid_certnames.first


### PR DESCRIPTION
Don't assume the puppet ca subject name starts with 'puppet ca'.

I think that assuming that the chain is in the correct order is better, as that how it always should be.
