### PR TITLE
(#18781) Be more tolerant of old clients in WEBrick server

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -376,3 +376,12 @@ if Puppet::Util::Platform.windows?
   end
 end
 
+# Old puppet clients may make large GET requests, lets be reasonably tolerant
+# in our default WEBrick server.
+require 'webrick'
+if defined?(WEBrick::HTTPRequest::MAX_URI_LENGTH) and WEBrick::HTTPRequest::MAX_URI_LENGTH < 8192
+  # Silence ruby warning: already initialized constant MAX_URI_LENGTH
+  v, $VERBOSE = $VERBOSE, nil
+  WEBrick::HTTPRequest.const_set("MAX_URI_LENGTH", 8192)
+  $VERBOSE = v
+end


### PR DESCRIPTION
In #18781 and #6117 there are cases of relatively simplistic puppet
setups failing between old versions of the puppet client (which
always use HTTP GET) and new versions of the puppet WEBrick server
(which has a relatively low limit on the size of a valid GET: 2083
bytes).

While there are other non-WEBrick server options available, WEBrick
has the advantage of simplicity, so it would be nice to keep it working.

Here we patch the WEBrick constant which specifies the maximum size of
a HTTP GET request, increasing it to a value that should work for common
setups.
