### PR TITLE
[packaging] Remove natty from the deb pkg list, its EOL

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-lucid-i386.cow base-natty-i386.cow base-oneiric-i386.cow base-precise-i386.cow base-quantal-i386.cow base-sid-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-unstable-i386.cow base-wheezy-i386.cow'
+cows: 'base-lucid-i386.cow base-oneiric-i386.cow base-precise-i386.cow base-quantal-i386.cow base-sid-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-unstable-i386.cow base-wheezy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'


### PR DESCRIPTION
Ubuntu Natty is EOL, and we are no longer going to build or ship for this
distribution. This commit removes it from the default list of distributions we
build for in puppet. This commit should be merged up through master.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
