### PR TITLE
(#18131) Only truncate `puppet describe --list` on sentences

### DIFF
--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -70,7 +70,7 @@ class TypeDoc
     }.each do |name|
       type = @types[name]
       s = type.doc.gsub(/\s+/, " ")
-      n = s.index(".")
+      n = s.index(". ")
       if n.nil?
         s = ".. no documentation .."
       elsif n > 45

--- a/spec/unit/application/describe_spec.rb
+++ b/spec/unit/application/describe_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Application::Describe do
 
 
   describe "in preinit" do
-    it "should set options[:parameteers] to true" do
+    it "should set options[:parameters] to true" do
       @describe.preinit
 
       @describe.options[:parameters].should be_true


### PR DESCRIPTION
Previously the regexp which attempts to truncate the output
of `puppet describe --list` at the end of a sentence, if it
is within the first 45 characters of the doc string, actually
truncated at the first period/full-stop character. This caused
doc strings which include dots, such as `.k5login`, to be
prematurely truncated.

This commit causes it to instead only truncate at the first
dot-space combination, which is a more reliable indicator of
the end of a sentence.

This also fixes a typo in the spec tests for this code, but
digging further into the code to figure out how to test it
effectively sent me down a rabbit-hole and I gave up.

Paired-With: Michael Hall mph@puppetlabs.com
