### PR TITLE
(#19309) Allow agent/master cmd line opts with systemd

### DIFF
--- a/ext/systemd/puppetagent.service
+++ b/ext/systemd/puppetagent.service
@@ -5,9 +5,10 @@ After=basic.target network.target
 
 [Service]
 Type=forking
+EnvironmentFile=-/etc/sysconfig/puppetagent
 PIDFile=/run/puppet/agent.pid
 ExecStartPre=/usr/bin/install -d -o puppet -m 755 /run/puppet
-ExecStart=/usr/bin/puppet agent
+ExecStart=/usr/bin/puppet agent ${PUPPET_EXTRA_OPTS}
 
 [Install]
 WantedBy=multi-user.target

--- a/ext/systemd/puppetmaster.service
+++ b/ext/systemd/puppetmaster.service
@@ -5,9 +5,10 @@ After=basic.target network.target
 
 [Service]
 Type=forking
+EnvironmentFile=-/etc/sysconfig/puppetmaster
 PIDFile=/run/puppet/master.pid
 ExecStartPre=/usr/bin/install -d -o puppet -m 755 /run/puppet
-ExecStart=/usr/bin/puppet master
+ExecStart=/usr/bin/puppet master ${PUPPETMASTER_EXTRA_OPTS}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change tells systemd to read sysconfig files, so that user can
specify puppet agent/master command line options to start services with.
