### PR TITLE
Explicitly cast Pathname in Puppet::Util#replace_file

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -481,7 +481,7 @@ module Util
         retry
       end
     else
-      File.rename(tempfile.path, file)
+      File.rename(tempfile.path, file.to_s)
     end
 
     # Ideally, we would now fsync the directory as well, but Ruby doesn't


### PR DESCRIPTION
Puppet::Util#replace_file contains a call to File#rename
where one of the arguments is of type `Pathname`.  The
actual method signature requires two String arguments,
and JRuby does not appear to implicitly cast in this
situation--so all calls to `replace_file` were failing
on JRuby.  This commit simply makes the cast explicit.
