### PR TITLE
(#15980) The pip provider doesn't work correctly on redhat based systems (ignore pip from easy_install).

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -25,7 +25,9 @@ Puppet::Type.type(:package).provide :pip,
   # that's managed by `pip` or an empty array if `pip` is not available.
   def self.instances
     packages = []
-    pip_cmd = which(cmd) or return []
+    pip_cmd ||= which('pip')
+    pip_cmd ||= which('pip-python')
+    pip_cmd or return []
     execpipe "#{pip_cmd} freeze" do |process|
       process.collect do |line|
         next unless options = parse(line)
@@ -33,15 +35,6 @@ Puppet::Type.type(:package).provide :pip,
       end
     end
     packages
-  end
-
-  def self.cmd
-    case Facter.value(:osfamily)
-      when "RedHat"
-        "pip-python"
-      else
-        "pip"
-    end
   end
 
   # Return structured information about a particular package or `nil` if
@@ -109,7 +102,9 @@ Puppet::Type.type(:package).provide :pip,
   def lazy_pip(*args)
     pip *args
   rescue NoMethodError => e
-    if pathname = which(self.class.cmd)
+    pathname ||= which('pip')
+    pathname ||= which('pip-python')
+    if pathname
       self.class.commands :pip => pathname
       pip *args
     else

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -31,36 +31,35 @@ describe provider_class do
 
   end
 
-  describe "cmd" do
-    it "should return pip-python on RedHat systems" do
-      Facter.stubs(:value).with(:osfamily).returns("RedHat")
-      provider_class.cmd.should == 'pip-python'
-    end
-
-    it "should return pip by default" do
-      Facter.stubs(:value).with(:osfamily).returns("Not RedHat")
-      provider_class.cmd.should == 'pip'
-    end
-
-  end
-
   describe "instances" do
 
-    osfamilies.each do |osfamily, pip_cmd|
-      it "should return an array on #{osfamily} when #{pip_cmd} is present" do
-        Facter.stubs(:value).with(:osfamily).returns(osfamily)
-        provider_class.expects(:which).with(pip_cmd).returns("/fake/bin/pip")
-        p = stub("process")
-        p.expects(:collect).yields("real_package==1.2.5")
-        provider_class.expects(:execpipe).with("/fake/bin/pip freeze").yields(p)
-        provider_class.instances
-      end
-
-      it "should return an empty array on #{osfamily} when #{pip_cmd} is missing" do
-        Facter.stubs(:value).with(:osfamily).returns(osfamily)
-        provider_class.expects(:which).with(pip_cmd).returns nil
-        provider_class.instances.should == []
-      end
+    it "should return an array when pip is present" do
+      provider_class.expects(:which).with('pip').returns("/fake/bin/pip")
+      p = stub("process")
+      p.expects(:collect).yields("real_package==1.2.5")
+      provider_class.expects(:execpipe).with("/fake/bin/pip freeze").yields(p)
+      provider_class.instances
+    end
+    it "should propote pip as a command instead of other pip_commands e.g. pip-python" do
+      provider_class.expects(:which).with('pip').returns("/fake/bin/pip")
+      provider_class.expects(:which).with('pip-python').never
+      p = stub("process")
+      p.expects(:collect).yields("real_package==1.2.5")
+      provider_class.expects(:execpipe).with("/fake/bin/pip freeze").yields(p)
+      provider_class.instances
+    end
+    it "should return an array when pip-python is present and other pip_commands are missing" do
+      provider_class.expects(:which).with('pip').returns(nil)
+      provider_class.expects(:which).with('pip-python').returns("/fake/bin/pip")
+      p = stub("process")
+      p.expects(:collect).yields("real_package==1.2.5")
+      provider_class.expects(:execpipe).with("/fake/bin/pip freeze").yields(p)
+      provider_class.instances
+    end
+    it "should return an empty array when all pip_commands are missing" do
+      provider_class.expects(:which).with('pip').returns(nil)
+      provider_class.expects(:which).with('pip-python').returns(nil)
+      provider_class.instances.should == []
     end
 
   end
@@ -197,29 +196,33 @@ describe provider_class do
       @provider.method(:lazy_pip).call "freeze"
     end
 
-    osfamilies.each do |osfamily, pip_cmd|
-      it "should retry on #{osfamily} if #{pip_cmd} has not yet been found" do
-        Facter.stubs(:value).with(:osfamily).returns(osfamily)
-        @provider.expects(:pip).twice.with('freeze').raises(NoMethodError).then.returns(nil)
-        @provider.expects(:which).with(pip_cmd).returns("/fake/bin/pip")
-        @provider.method(:lazy_pip).call "freeze"
-      end
+    it "should retry if pip has not yet been found" do
+      @provider.expects(:pip).twice.with('freeze').raises(NoMethodError).then.returns(nil)
+      @provider.expects(:which).with('pip').returns("/fake/bin/pip")
+      @provider.expects(:which).with('pip-python').never
+      @provider.method(:lazy_pip).call "freeze"
+    end
 
-      it "should fail on #{osfamily} if #{pip_cmd} is missing" do
-        Facter.stubs(:value).with(:osfamily).returns(osfamily)
-        @provider.expects(:pip).with('freeze').raises(NoMethodError)
-        @provider.expects(:which).with(pip_cmd).returns(nil)
-        expect { @provider.method(:lazy_pip).call("freeze") }.to raise_error(NoMethodError)
-      end
+    it "should retry if pip-python has not yet been found" do
+      @provider.expects(:pip).twice.with('freeze').raises(NoMethodError).then.returns(nil)
+      @provider.expects(:which).with('pip').returns(nil)
+      @provider.expects(:which).with('pip-python').returns("/fake/bin/pip")
+      @provider.method(:lazy_pip).call "freeze"
+    end
 
-      it "should output a useful error message on #{osfamily} if #{pip_cmd} is missing" do
-        Facter.stubs(:value).with(:osfamily).returns(osfamily)
-        @provider.expects(:pip).with('freeze').raises(NoMethodError)
-        @provider.expects(:which).with(pip_cmd).returns(nil)
-        expect { @provider.method(:lazy_pip).call("freeze") }.
-          to raise_error(NoMethodError, 'Could not locate the pip command.')
-      end
+    it "should fail if all pip commands are missing" do
+      @provider.expects(:pip).with('freeze').raises(NoMethodError)
+      @provider.expects(:which).with('pip').returns(nil)
+      @provider.expects(:which).with('pip-python').returns(nil)
+      expect { @provider.method(:lazy_pip).call("freeze") }.to raise_error(NoMethodError)
+    end
 
+    it "should output a useful error message if all pip commands are missing" do
+      @provider.expects(:pip).with('freeze').raises(NoMethodError)
+      @provider.expects(:which).with('pip').returns(nil)
+      @provider.expects(:which).with('pip-python').returns(nil)
+      expect { @provider.method(:lazy_pip).call("freeze") }.
+        to raise_error(NoMethodError, 'Could not locate the pip command.')
     end
 
   end


### PR DESCRIPTION
Redhat may use pip-python from epel or pip from easy_install. Without this patch
the pip provider require pip-python command and ignore pip command installed by easy_install.
This patch fixes the problem and accept pip command from easy_install as a solution on redhat based systems.
Moreover, pip installed by easy_install is promoted when both version are installed.
