### PR TITLE
(#19323) ext/systemd: adding a way to specify cmd line options

### DIFF
--- a/ext/systemd/puppetagent.service
+++ b/ext/systemd/puppetagent.service
@@ -5,9 +5,9 @@ After=basic.target network.target
 
 [Service]
 Type=forking
+EnvironmentFile=-/etc/sysconfig/puppetagent
 PIDFile=/run/puppet/agent.pid
-ExecStartPre=/usr/bin/install -d -o puppet -m 755 /run/puppet
-ExecStart=/usr/bin/puppet agent
+ExecStart=/usr/bin/puppet agent $PUPPET_EXTRA_OPTS
 
 [Install]
 WantedBy=multi-user.target

--- a/ext/systemd/puppetmaster.service
+++ b/ext/systemd/puppetmaster.service
@@ -5,9 +5,9 @@ After=basic.target network.target
 
 [Service]
 Type=forking
+EnvironmentFile=-/etc/sysconfig/puppetmaster
 PIDFile=/run/puppet/master.pid
-ExecStartPre=/usr/bin/install -d -o puppet -m 755 /run/puppet
-ExecStart=/usr/bin/puppet master
+ExecStart=/usr/bin/puppet master $PUPPETMASTER_EXTRA_OPTS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This patch adds a way to easily specify extra command line options for
both puppetagent and puppetmaster services when starting them with
systemd.

It removes ExecPre command as the directory creation is now handled by
the RPM install, so it’s pointless to have systemd do that as well.

Previously there was no way to pass in valid puppet agent/master command
line parameters like '--config=/etc/puppet/puppetmaster.conf', etc. A
lot of people use separate config files for the agent and the master
services.

To make it somewhat consistent I added a systemd supported way to read
environment variables from a file '/etc/sysconfig/<servicename>', so
people who use extra cmd line options already will be able to do that with
systemd as well.

When services are started by systemd, systemd will read the files which
contain the below variables and will pass their values when starting
puppet services (I used the same variable names as it's been used in
redhat-like distros already):

PUPPET_EXTRA_OPTS in /etc/sysconfig/puppetagent
PUPPETMASTER_EXTRA_OPTS in /etc/sysconfig/puppetmaster
