### PR TITLE
(#17616) Clean Bundler environment to fix gem package provider when run under bundler

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -278,5 +278,47 @@ module Util::Execution
     nil
   end
   private_class_method :wait_for_output
+
+  if defined?(Bundler) && Bundler.respond_to?(:with_clean_env)
+
+    def self.execpipe_with_bundler_clean_env(command, failonfail = true)
+      if respond_to? :debug
+        debug "Cleaning bundler environment to execute '#{command}'"
+      else
+        Puppet.debug "Cleaning bundler environment to execute '#{command}'"
+      end
+      Bundler.with_clean_env do
+        execpipe_without_bundler_clean_env(command, failonfail)
+      end
+    end
+
+    # don't need to do execfail, since it just calls execute
+  def self.execute_with_bundler_clean_env(command, options = NoOptionsSpecified)
+    if command.is_a?(Array)
+      command = command.flatten.map(&:to_s)
+      str = command.join(" ")
+    elsif command.is_a?(String)
+      str = command
+    end
+
+    if respond_to? :debug
+      debug "Cleaning bundler environment to execute '#{str}'"
+    else
+      Puppet.debug "Cleaning bundler environment to execute '#{str}'"
+    end
+      Bundler.with_clean_env do
+        execute_without_bundler_clean_env(command, options)
+      end
+    end
+
+    class << self
+      alias_method :execpipe_without_bundler_clean_env, :execpipe
+      alias_method :execpipe, :execpipe_with_bundler_clean_env
+
+      alias_method :execute_without_bundler_clean_env, :execute
+      alias_method :execute, :execute_with_bundler_clean_env
+    end
+
+  end
 end
 end


### PR DESCRIPTION
When puppet (or anything for that matter) is invoked with bundler,
bundler 'infects' the environment in order to make sure any subprocesses
get the same rubygems environment. In most cases, this is a boon, but is
a bane when trying to install rubygems via puppet.

The problem happens because the Bundler environmentment changes affect
the `gem` commands used by the gem package provider, to make any
dependencies of a gem to be installed appear as though they don't exist
anywhere. For example, the `foreground` gem depends on mixlib-cli, and
throws errors when using this simple command:

```
bundle exec puppet apply -e 'package { foreground: ensure => latest, provider => gem }'
```

The error is:

```
err: /Stage[main]//Package[foreground]/ensure: change from absent to latest failed: Could not update: Execution of '/Users/andy/.rvm/rubies/ruby-1.8.7-p358/bin/gem install --include-dependencies --no-rdoc --no-ri foreground' returned 1: ERROR:
Error installing foreground:
        foreground requires mixlib-cli (~> 1.2.2)
INFO:  `gem install -y` is now default and will be removed
INFO:  use --ignore-dependencies to install only the gems you list at line 1
```

The fix is to use a method provided by Bundler called `with_clean_env`,
which lets you call code in block with those environment variables
removed. This patch updates `Puppet::Util::Execution` to wrap `execute`
and `execpipe` with `with_clean_env`.
