### PR TITLE
(#18092) Use URI.decode on network URI query strings

### DIFF
--- a/lib/puppet/util/network_device/cisco/device.rb
+++ b/lib/puppet/util/network_device/cisco/device.rb
@@ -19,7 +19,9 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
   end
 
   def parse_enable(query)
-    return $1 if query =~ /enable=(.*)/
+    if query and (match = query.match(/enable=(.*)/))
+      URI.decode(match[1])
+    end
   end
 
   def connect

--- a/spec/unit/util/network_device/cisco/device_spec.rb
+++ b/spec/unit/util/network_device/cisco/device_spec.rb
@@ -17,6 +17,23 @@ describe Puppet::Util::NetworkDevice::Cisco::Device do
       cisco.enable_password.should == "enable_password"
     end
 
+    describe "decoding the enable password" do
+      it "should decode sharps" do
+        cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23/?enable=enable_password%23with_a_sharp")
+        cisco.enable_password.should == "enable_password#with_a_sharp"
+      end
+
+      it "should decode spaces" do
+        cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23/?enable=enable_password%20with_a_space")
+        cisco.enable_password.should == "enable_password with_a_space"
+      end
+
+      it "should only use the query parameter" do
+        cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://enable=:password@localhost:23/?enable=enable_password")
+        cisco.enable_password.should == "enable_password"
+      end
+    end
+
     it "should find the enable password from the options" do
       cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23/?enable=enable_password", :enable_password => "mypass")
       cisco.enable_password.should == "mypass"


### PR DESCRIPTION
The current implementation of the network device enable password parsing
is unable to handle characters like sharps and spaces in the password,
which are valid passwords. This commit adds URI decoding of the query
string to allow all uri-encodable values to be used in the enable
password.

This supercedes GH-1327.
