### PR TITLE
(#19409) Raise Puppet::Forge::Error::ForgeError on bad HTTP response from forge

### DIFF
--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -1,0 +1,35 @@
+test_name "puppet module install (nonexistent module)"
+
+step 'Setup'
+
+stub_forge_on(master)
+
+# Ensure module path dirs are purged before and after the tests
+apply_manifest_on master, "file { ['/etc/puppet/modules', '/usr/share/puppet/modules']: ensure => directory, recurse => true, purge => true, force => true }"
+teardown do
+  on master, "rm -rf /etc/puppet/modules"
+  on master, "rm -rf /usr/share/puppet/modules"
+end
+
+step "Try to install a non-existent module"
+on master, puppet("module install pmtacceptance-nonexistent"), :acceptable_exit_codes => [1] do
+  assert_output <<-OUTPUT
+    STDOUT> \e[mNotice: Preparing to install into /etc/puppet/modules ...\e[0m
+    STDOUT> \e[mNotice: Downloading from https://forge.puppetlabs.com ...\e[0m
+    STDERR> \e[1;31mError: Could not execute operation for 'pmtacceptance/nonexistent'
+    STDERR>   The server being queried was https://forge.puppetlabs.com
+    STDERR>   The HTTP response we received was '410 Gone'
+    STDERR>   The message we received said 'Module pmtacceptance/nonexistent not found'
+    STDERR>     Check the author and module names are correct.\e[0m
+  OUTPUT
+end
+
+step "Try to install a non-existent module (JSON rendering)"
+on master, puppet("module --render-as json install pmtacceptance-nonexistent") do
+  assert_output <<-OUTPUT
+\e[mNotice: Preparing to install into /etc/puppet/modules ...\e[0m
+\e[mNotice: Downloading from https://forge.puppetlabs.com ...\e[0m
+{"module_version":null,"module_name":"pmtacceptance-nonexistent","result":"failure","error":{"multiline":"Could not execute operation for 'pmtacceptance/nonexistent'\\n  The server being queried was https://forge.puppetlabs.com\\n  The HTTP response we received was '410 Gone'\\n  The message we received said 'Module pmtacceptance/nonexistent not found'\\n    Check the author and module names are correct.","oneline":"Could not execute operation for 'pmtacceptance/nonexistent'. Detail: Module pmtacceptance/nonexistent not found / 410 Gone."},"install_dir":"/etc/puppet/modules"}
+  OUTPUT
+end
+

--- a/lib/puppet/forge/errors.rb
+++ b/lib/puppet/forge/errors.rb
@@ -66,4 +66,38 @@ Could not connect to #{@uri}
     end
   end
 
+  # This exception is raised when there is a bad HTTP response from the forge
+  # and optionally a message in the response.
+  class ResponseError < ForgeError
+    # @option options [String] :uri The URI that failed
+    # @option options [String] :input The user's input (e.g. module name)
+    # @option options [String] :message Error from the API response (optional)
+    # @option options [Net::HTTPResponse] :response The original HTTP response
+    def initialize(options)
+      @uri     = options[:uri]
+      @input   = options[:input]
+      @message = options[:message]
+      response = options[:response]
+      @response = "#{response.code} #{response.message}"
+
+      message = "Could not execute operation for '#{@input}'. Detail: "
+      message << @message << " / " if @message
+      message << @response << "."
+      super(message, original)
+    end
+
+    # Return a multiline version of the error message
+    #
+    # @return [String] the multiline version of the error message
+    def multiline
+      message = <<-EOS
+Could not execute operation for '#{@input}'
+  The server being queried was #{@uri}
+  The HTTP response we received was '#{@response}'
+      EOS
+      message << "  The message we received said '#{@message}'\n" if @message
+      message << "    Check the author and module names are correct."
+    end
+  end
+
 end

--- a/spec/unit/forge/errors_spec.rb
+++ b/spec/unit/forge/errors_spec.rb
@@ -39,4 +39,44 @@ Could not connect to http://fake.com:1111
     end
   end
 
+  describe 'ResponseError' do
+    subject { Puppet::Forge::Errors::ResponseError }
+    let(:response) { stub(:body => '{}', :code => '404', :message => "not found") }
+
+    context 'without message' do
+      let(:exception) { subject.new(:uri => 'http://fake.com:1111', :response => response, :input => 'user/module') }
+
+      it 'should return a valid single line error' do
+        exception.message.should == 'Could not execute operation for \'user/module\'. Detail: 404 not found.'
+      end
+
+      it 'should return a valid multiline error' do
+        exception.multiline.should == <<-eos.chomp
+Could not execute operation for 'user/module'
+  The server being queried was http://fake.com:1111
+  The HTTP response we received was '404 not found'
+    Check the author and module names are correct.
+        eos
+      end
+    end
+
+    context 'with message' do
+      let(:exception) { subject.new(:uri => 'http://fake.com:1111', :response => response, :input => 'user/module', :message => 'no such module') }
+
+      it 'should return a valid single line error' do
+        exception.message.should == 'Could not execute operation for \'user/module\'. Detail: no such module / 404 not found.'
+      end
+
+      it 'should return a valid multiline error' do
+        exception.multiline.should == <<-eos.chomp
+Could not execute operation for 'user/module'
+  The server being queried was http://fake.com:1111
+  The HTTP response we received was '404 not found'
+  The message we received said 'no such module'
+    Check the author and module names are correct.
+        eos
+      end
+    end
+  end
+
 end

--- a/spec/unit/forge_spec.rb
+++ b/spec/unit/forge_spec.rb
@@ -36,15 +36,25 @@ describe Puppet::Forge do
 
   context "when the connection to the forge fails" do
     before :each do
-      repository_responds_with(stub(:body => '{}', :code => '404'))
+      repository_responds_with(stub(:body => '{}', :code => '404', :message => "not found"))
     end
 
     it "raises an error for search" do
-      expect { forge.search('bacula') }.to raise_error RuntimeError
+      expect { forge.search('bacula') }.to raise_error Puppet::Forge::Errors::ResponseError, "Could not execute operation for 'bacula'. Detail: 404 not found."
     end
 
     it "raises an error for remote_dependency_info" do
-      expect { forge.remote_dependency_info('puppetlabs', 'bacula', '0.0.1') }.to raise_error RuntimeError
+      expect { forge.remote_dependency_info('puppetlabs', 'bacula', '0.0.1') }.to raise_error Puppet::Forge::Errors::ResponseError, "Could not execute operation for 'puppetlabs/bacula'. Detail: 404 not found."
+    end
+  end
+
+  context "when the API responses with an error" do
+    before :each do
+      repository_responds_with(stub(:body => '{"error":"invalid module"}', :code => '410', :message => "Gone"))
+    end
+
+    it "raises an error for remote_dependency_info" do
+      expect { forge.remote_dependency_info('puppetlabs', 'bacula', '0.0.1') }.to raise_error Puppet::Forge::Errors::ResponseError, "Could not execute operation for 'puppetlabs/bacula'. Detail: invalid module / 410 Gone."
     end
   end
 end


### PR DESCRIPTION
When a bad HTTP response indicating an error, or an "error" string in the
response is received from the forge, raise Puppet::Forge::Errors::ForgeError
subclases rather than RuntimeErrors.

This allows the error to be caught by the module face and the error rendered
appropriately, i.e. as JSON if requested by the user.  Else fallback code for
unhandled exceptions is used, causing the exception to only be written via
logging.
