### PR TITLE
(#16553) Exclude portmap-wait from upstart services

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -29,14 +29,18 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     excludes += %w{functions.sh reboot.sh shutdown.sh}
     # this exclude list is all from /sbin/service (5.x), but I did not exclude kudzu
     excludes += %w{functions halt killall single linuxconf reboot boot}
-    # 'wait-for-state' is excluded from instances here because it takes
-    # parameters that have unclear meaning. It looks like 'wait-for-state' is
-    # mainly used internally for other upstart services as a 'sleep until something happens'
-    # (http://lists.debian.org/debian-devel/2012/02/msg01139.html). There is an open launchpad bug
+    # 'wait-for-state' and 'portmap-wait' are excluded from instances here
+    # because they take parameters that have unclear meaning. It looks like
+    # 'wait-for-state' is a generic waiter mainly used internally for other
+    # upstart services as a 'sleep until something happens'
+    # (http://lists.debian.org/debian-devel/2012/02/msg01139.html), while
+    # 'portmap-wait' is a specific instance of a waiter. There is an open
+    # launchpad bug
     # (https://bugs.launchpad.net/ubuntu/+source/upstart/+bug/962047) that may
-    # eventually explain how to use this service or perhaps why it should remain
-    # excluded. When that bug is adddressed this should be reexamined.
-    excludes += %w{wait-for-state}
+    # eventually explain how to use the wait-for-state service or perhaps why
+    # it should remain excluded. When that bug is adddressed this should be
+    # reexamined.
+    excludes += %w{wait-for-state portmap-wait}
     excludes
   end
 

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -42,7 +42,7 @@ describe Puppet::Type.type(:service).provider(:upstart) do
     end
 
     it "should not find excluded services" do
-      processes = "wait-for-state stop/waiting"
+      processes = "wait-for-state stop/waiting\nportmap-wait start/running"
       provider_class.stubs(:execpipe).yields(processes)
       provider_class.instances.should be_empty
     end


### PR DESCRIPTION
The portmap-wait upstart service is not a service by itself (it's a helper for
the portmap service) and does not respond to the status command, it returns 1
along with an error message. This commit adds portmap-wait to the excludes
method of the init provider, which is also used by the upstart provider to
exclude services from self.instances. This also adds the portmap-wait service
to the upstart provider spec test to verify that it is correctly excluded from
self.instances.
