### PR TITLE
(maint) Parse PMT JSON output when testing

### DIFF
--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -26,10 +26,25 @@ end
 
 step "Try to install a non-existent module (JSON rendering)"
 on master, puppet("module --render-as json install pmtacceptance-nonexistent") do
-  assert_output <<-OUTPUT
-\e[mNotice: Preparing to install into /etc/puppet/modules ...\e[0m
-\e[mNotice: Downloading from https://forge.puppetlabs.com ...\e[0m
-{"module_version":null,"module_name":"pmtacceptance-nonexistent","result":"failure","error":{"multiline":"Could not execute operation for 'pmtacceptance/nonexistent'\\n  The server being queried was https://forge.puppetlabs.com\\n  The HTTP response we received was '410 Gone'\\n  The message we received said 'Module pmtacceptance/nonexistent not found'\\n    Check the author and module names are correct.","oneline":"Could not execute operation for 'pmtacceptance/nonexistent'. Detail: Module pmtacceptance/nonexistent not found / 410 Gone."},"install_dir":"/etc/puppet/modules"}
-  OUTPUT
+  require 'json'
+  str  = stdout.lines.to_a.last
+  json = JSON.parse(str)
+
+  oneline_expectation   = %[Could not execute operation for 'pmtacceptance/nonexistent'. Detail: Module pmtacceptance/nonexistent not found / 410 Gone.]
+  multiline_expectation = <<-OUTPUT.chomp
+Could not execute operation for 'pmtacceptance/nonexistent'
+  The server being queried was https://forge.puppetlabs.com
+  The HTTP response we received was '410 Gone'
+  The message we received said 'Module pmtacceptance/nonexistent not found'
+    Check the author and module names are correct.
+OUTPUT
+
+
+  assert_equal nil,                         json['module_version']
+  assert_equal 'pmtacceptance-nonexistent', json['module_name']
+  assert_equal 'failure',                   json['result']
+  assert_equal '/etc/puppet/modules',       json['install_dir']
+  assert_equal multiline_expectation,       json['error']['multiline']
+  assert_equal oneline_expectation,         json['error']['oneline']
 end
 


### PR DESCRIPTION
JSON hash structures are unordered and when testing the output of the
puppet module tool the output was assumed to be ordered. This commit
extracts the outputted JSON and converts it into a Ruby data structure
and performs checks on the data elements to ensure the output is
correct.
