### PR TITLE
(#19459) Accept an empty hash in create_resources() keys parameters

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -70,6 +70,9 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
   # iterate through the resources to create
   defaults = args[2] || {}
   args[1].each do |title, params|
+    if !params
+        params = {}
+    end
     params = Puppet::Util.symbolizehash(defaults.merge(params))
     raise ArgumentError, 'params should not contain title' if(params[:title])
     case type_of_resource


### PR DESCRIPTION
Without this patch, it is not possible to have the first hash passed to
create_resources() having keys with no values, because merge() then
fails assuming the variable is nil and not an empty hash.
In practice this makes the function quite unusable to define a batch of
resources with a default set of parameters (which you can define in
another hash).
