### PR TITLE
(#18092) Use CGI.parse on network URI query

### DIFF
--- a/lib/puppet/util/network_device/cisco/device.rb
+++ b/lib/puppet/util/network_device/cisco/device.rb
@@ -19,7 +19,10 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
   end
 
   def parse_enable(query)
-    return $1 if query =~ /enable=(.*)/
+    if query
+      params = CGI.parse(query)
+      params['enable'].first unless params['enable'].empty?
+    end
   end
 
   def connect

--- a/spec/unit/util/network_device/cisco/device_spec.rb
+++ b/spec/unit/util/network_device/cisco/device_spec.rb
@@ -17,6 +17,32 @@ describe Puppet::Util::NetworkDevice::Cisco::Device do
       cisco.enable_password.should == "enable_password"
     end
 
+    describe "decoding the enable password" do
+      it "should not parse a password if no query is given" do
+        cisco = described_class.new("telnet://user:password@localhost:23")
+        cisco.enable_password.should be_nil
+      end
+
+      it "should not parse a password if no enable param is given" do
+        cisco = described_class.new("telnet://user:password@localhost:23/?notenable=notapassword")
+        cisco.enable_password.should be_nil
+      end
+      it "should decode sharps" do
+        cisco = described_class.new("telnet://user:password@localhost:23/?enable=enable_password%23with_a_sharp")
+        cisco.enable_password.should == "enable_password#with_a_sharp"
+      end
+
+      it "should decode spaces" do
+        cisco = described_class.new("telnet://user:password@localhost:23/?enable=enable_password%20with_a_space")
+        cisco.enable_password.should == "enable_password with_a_space"
+      end
+
+      it "should only use the query parameter" do
+        cisco = described_class.new("telnet://enable=:password@localhost:23/?enable=enable_password&notenable=notapassword")
+        cisco.enable_password.should == "enable_password"
+      end
+    end
+
     it "should find the enable password from the options" do
       cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23/?enable=enable_password", :enable_password => "mypass")
       cisco.enable_password.should == "mypass"


### PR DESCRIPTION
The current implementation of the network device enable password parsing
is unable to handle characters like sharps and spaces in the password,
which are valid passwords. This commit adds CGI parsing of the query
string to only extract and unescape the enable query parameter.

This supercedes GH-1327 and GH-1491.
