### PR TITLE
(#15561) Remove check for invalid characters in Puppet::SSL::Base

### DIFF
--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -44,7 +44,6 @@ class Puppet::SSL::Base
 
   def initialize(name)
     @name = name.to_s.downcase
-    self.class.validate_certname(@name)
   end
 
   # Method to extract a 'name' from the subject of a certificate

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -31,6 +31,13 @@ class Puppet::SSL::CertificateRequest < Puppet::SSL::Base
     @ef ||= OpenSSL::X509::ExtensionFactory.new
   end
 
+  # We check that certificate requests don't contain invalid characters to avoid
+  # CVE-2012-3867 and CVE-2012-3865
+  def initialize(name)
+    super(name)
+    self.class.validate_certname(@name)
+  end
+
   # How to create a certificate request with our system defaults.
   def generate(key, options = {})
     Puppet.info "Creating a new SSL certificate request for #{name}"


### PR DESCRIPTION
We move it to Puppet::SSL::CertificateRequest instead as these are the
only type of SSL object that the master recieves and accepts from
agents.

The reason for this is to be still able to accept certificates
containing / and other characters when making SSL connections.

At least by default the master doesn't accept posts of certificates or
keys through the REST API.
