### PR TITLE
[packaging] Update mocks for rpmbuilder mock format

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,8 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: False
 # a space separated list of mock configs
-final_mocks: 'pl-5-i386 pl-6-i386 fedora-16-i386 fedora-17-i386'
-rc_mocks: 'pl-5-i386-dev pl-6-i386-dev fedora-16-i386-dev fedora-17-i386-dev'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-16-i386 pl-fedora-17-i386'
 yum_host: 'burji.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
The Puppet Labs mocks created by rpmbuilder have assumed a new format, pl-el-*
vs el-*, in order to avoid overwriting the configurations supplied by the mock
package. This commit updates the mocks in puppet to reflect the new standard,
so that we can continue to build packages with builders created with the
rpmbuilder module. It also removes the "rc_mocks", which was deprecated in the
packaging repo some time ago and are no longer used.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
