### PR TITLE
(#19542) useradd provider should support move-home option if managehome ...

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -81,6 +81,13 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     cmd << @resource[:name]
   end
 
+  def modifycmd(param, value)
+    cmd = super(param, value)
+    cmd += check_manage_home if param == :home
+
+    cmd
+  end
+
   def deletecmd
     cmd = [command(:delete)]
     cmd += @resource.managehome? ? ['-r'] : []

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -115,6 +115,12 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       provider.create
     end
 
+    it "should return an array with -m flag if home is managed and the home directory is modified" do
+      resource[:managehome] = :true
+      provider.expects(:execute).with(includes('-m'))
+      provider.home = '/tmp/myuser'
+    end
+
     it "should return an array with -r flag if home is managed" do
       resource[:managehome] = :true
       resource[:ensure] = :absent


### PR DESCRIPTION
...is enabled

usermod has a flag (-m) to move a users home directory when it's being modified, this
adds modifycmd to the useradd provider which will run usermod with the -m option.
## 

See http://projects.puppetlabs.com/issues/19542
