### PR TITLE
(#18229) - Eroneous command given in puppet module error message

### DIFF
--- a/lib/puppet/module_tool/errors/installer.rb
+++ b/lib/puppet/module_tool/errors/installer.rb
@@ -46,7 +46,7 @@ module Puppet::ModuleTool::Errors
         message << "    Currently, '#{@metadata[:name]}' (#{v(@metadata[:version])}) is installed to that directory"
       end
 
-      message << "    Use `puppet module install --dir <DIR>` to install modules elsewhere"
+      message << "    Use `puppet module install --target-dir <DIR>` to install modules elsewhere"
 
       if @dependency
         message << "    Use `puppet module install --ignore-dependencies` to install only this module"


### PR DESCRIPTION
Fixed the error message to read --target-dir instead of --dir
