### PR TITLE
(#19090) Fix user failure when group exists and gid is not specified

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -161,6 +161,9 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     else
       cmd = [command(:add)]
     end
+    if not @resource.should(gid) and Puppet::Util.gid(@resource[:name])
+      cmd += ["-g", @resource[:name]]
+    end
     cmd += add_properties
     cmd += check_allow_dup
     cmd += check_manage_home

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -44,6 +44,13 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       provider.stubs(:exists?).returns(false)
     end
 
+    it "should add -g when no gid is specified and group already exists" do
+      Puppet::Util.stubs(:gid).returns(true)
+      resource[:ensure] = :present
+      provider.expects(:execute).with(includes('-g'), kind_of(Hash))
+      provider.create
+    end 
+
     it "should add -o when allowdupe is enabled and the user is being created" do
       resource[:allowdupe] = true
       provider.expects(:execute).with(includes('-o'), kind_of(Hash))


### PR DESCRIPTION
When a group matching the name of a user already exists on a system
and the user resource does not contain a gid parameter, the execution
of useradd fails.

Normally useradd creates a group with an identical name to the user
when -g is not provided on the command line.  In the case where the group
already exists -g must be explicitly passed to useradd.
