### PR TITLE
(#17616) Clean Bundler environment to fix gem package provider when run under bundler

### DIFF
--- a/lib/puppet/feature/bundled_environment.rb
+++ b/lib/puppet/feature/bundled_environment.rb
@@ -1,0 +1,11 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:bundled_environment) do
+  if defined?(Bundler) && Bundler.respond_to?(:with_clean_env)
+    true
+  else
+    false
+  end
+
+end
+

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -124,4 +124,28 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
   def update
     self.install(false)
   end
+
+  # Override default `execute` to run super method in a clean
+  # environment without Bundler, if Bundler is present
+  def execute(*args)
+    if Puppet.features.bundled_environment?
+      Bundler.with_clean_env do
+        super
+      end
+    else
+      super
+    end
+  end
+
+  # Override default `execute` to run super method in a clean
+  # environment without Bundler, if Bundler is present
+  def self.execute(*args)
+    if Puppet.features.bundled_environment?
+      Bundler.with_clean_env do
+        super
+      end
+    else
+      super
+    end
+  end
 end


### PR DESCRIPTION
_Note:_ This is reworked from #1488, based on feedback from @adrienthebo

When puppet (or anything for that matter) is invoked with bundler,
bundler 'infects' the environment in order to make sure any subprocesses
get the same rubygems environment. In most cases, this is a boon, but is
a bane when trying to install rubygems via puppet.

The problem happens because the Bundler environmentment changes affect
the `gem` commands used by the gem package provider, to make any
dependencies of a gem to be installed appear as though they don't exist
anywhere. For example, the `foreground` gem depends on mixlib-cli, and
throws errors when using this simple command:

```
bundle exec puppet apply -e 'package { foreground: ensure => latest, provider => gem }'
```

The error is:

```
err: /Stage[main]//Package[foreground]/ensure: change from absent to latest failed: Could not update: Execution of '/Users/andy/.rvm/rubies/ruby-1.8.7-p358/bin/gem install --include-dependencies --no-rdoc --no-ri foreground' returned 1: ERROR:
Error installing foreground:
        foreground requires mixlib-cli (~> 1.2.2)
INFO:  `gem install -y` is now default and will be removed
INFO:  use --ignore-dependencies to install only the gems you list at line 1
```

The way to uninfect the environment is to use a method provided by Bundler
called `with_clean_env`, which lets you call code in block with those
environment variables removed. This patch adds a `bundled_environment`
feature to detect when bundler is available, and updates the gem package
provider to override `Puppet::Provider`s execute methods to wrap the call
with `Bundler.with_clean_env` if running in a `bundled_environment`.
