### PR TITLE
(#15911) automatic .service suffix for the systemd provider to keep serv...

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -5,6 +5,10 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   commands :systemctl => "systemctl"
 
+  def fqname
+    return @resource[:name].match(/\./) ? @resource[:name] : @resource[:name] + ".service"
+  end
+
   #defaultfor :osfamily => [:redhat, :suse]
 
   def self.instances
@@ -19,14 +23,14 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def disable
-    output = systemctl(:disable, @resource[:name])
+    output = systemctl(:disable, fqname)
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not disable #{self.name}: #{output}"
   end
 
   def enabled?
     begin
-      systemctl("is-enabled", @resource[:name])
+      systemctl("is-enabled", fqname)
     rescue Puppet::ExecutionFailure
       return :false
     end
@@ -36,7 +40,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   def status
     begin
-      output = systemctl("is-active", @resource[:name])
+      output = systemctl("is-active", fqname)
     rescue Puppet::ExecutionFailure
       return :stopped
     end
@@ -44,21 +48,21 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def enable
-    output = systemctl("enable", @resource[:name])
+    output = systemctl("enable", fqname)
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not enable #{self.name}: #{output}"
   end
 
   def restartcmd
-    [command(:systemctl), "restart", @resource[:name]]
+    [command(:systemctl), "restart", fqname]
   end
 
   def startcmd
-    [command(:systemctl), "start", @resource[:name]]
+    [command(:systemctl), "start", fqname]
   end
 
   def stopcmd
-    [command(:systemctl), "stop", @resource[:name]]
+    [command(:systemctl), "stop", fqname]
   end
 end
 


### PR DESCRIPTION
...ice names consistent

This patch appends '.service' as a suffix for any service name passed to it
that does not already have a dotted suffix. It is needed to allow service
definitions to use the same service naming across systemd and non-systemd
nodes, and to provide consistency on nodes that have mixed SysV and systemd
init layouts.

Upstream systemctl assumes the .service suffix, but that will only help
Fedora 19+.
