### PR TITLE
Ensure 'agent' subcommand is executed when PUPPET_SERVER is set

### DIFF
--- a/ext/suse/client.init
+++ b/ext/suse/client.init
@@ -39,7 +39,7 @@ puppetd=${PUPPETD-/usr/bin/puppet}
 RETVAL=0
 
 PUPPET_OPTS="agent"
-[ -n "${PUPPET_SERVER}" ] && PUPPET_OPTS="--server=${PUPPET_SERVER}"
+[ -n "${PUPPET_SERVER}" ] && PUPPET_OPTS="${PUPPET_OPTS} --server=${PUPPET_SERVER}"
 [ -n "$PUPPET_LOG" ] && PUPPET_OPTS="${PUPPET_OPTS} --logdest=${PUPPET_LOG}"
 [ -n "$PUPPET_PORT" ] && PUPPET_OPTS="${PUPPET_OPTS} --port=${PUPPET_PORT}"
 


### PR DESCRIPTION
This patch ensures that the 'agent' subcommand is executed when the PUPPET_SERVER variable is set.  Before this change, the puppet service would not start because the 'agent' subcommand was not retained when the value of PUPPET_SERVER was added to the PUPPET_OPTS variable.
