### PR TITLE
add more control over certificate autosigning

### DIFF
--- a/lib/puppet/network/authcommand.rb
+++ b/lib/puppet/network/authcommand.rb
@@ -1,0 +1,11 @@
+module Puppet
+  class Network::AuthCommand
+    def initialize(path)
+      @path = path
+    end
+    def allowed?(name, addr)
+      Puppet::Util::Execution.execute([@path, name, addr], :failonfail => false)
+      $CHILD_STATUS.exitstatus == 0
+    end
+  end
+end

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -27,6 +27,7 @@ class Puppet::SSL::CertificateAuthority
   require 'puppet/ssl/certificate_revocation_list'
   require 'puppet/ssl/certificate_authority/interface'
   require 'puppet/network/authstore'
+	require 'puppet/network/authcommand'
 
   extend MonitorMixin
 
@@ -78,31 +79,24 @@ class Puppet::SSL::CertificateAuthority
 
   # If autosign is configured, then autosign all CSRs that match our configuration.
   def autosign
-    return unless auto = autosign?
-
-    store = nil
-    store = autosign_store(auto) if auto != true
-
     Puppet::SSL::CertificateRequest.indirection.search("*").each do |csr|
-      if auto == true or store.allowed?(csr.name, "127.1.1.1")
-        Puppet.info "Autosigning #{csr.name}"
-        sign(csr.name)
-      end
+      sign(csr.name) if autosign_basic?(csr.name) or autosign_command?(csr.name)
     end
   end
 
-  # Do we autosign?  This returns true, false, or a filename.
-  def autosign?
+  # This is the legacy autosign that either signs all certs, or signs based on pattern matching the cert name
+  def autosign_basic?(certname, addr = '127.1.1.1')
     auto = Puppet[:autosign]
-    return false if ['false', false].include?(auto)
+    return false if ['false', false, nil].include?(auto)
     return true if ['true', true].include?(auto)
+    return false if !FileTest.exist?(auto)
 
-    raise ArgumentError, "The autosign configuration '#{auto}' must be a fully qualified file" unless Puppet::Util.absolute_path?(auto)
-    FileTest.exist?(auto) && auto
+    store = autosign_basic_store(auto)
+    store.allowed?(certname, addr)
   end
 
-  # Create an AuthStore for autosigning.
-  def autosign_store(file)
+  # Create an AuthStore for basic autosigning.
+  def autosign_basic_store(file)
     auth = Puppet::Network::AuthStore.new
     File.readlines(file).each do |line|
       next if line =~ /^\s*#/
@@ -111,6 +105,17 @@ class Puppet::SSL::CertificateAuthority
     end
 
     auth
+  end
+
+  # Try to autosign a certificate based an external script
+  def autosign_command?(certname, addr = '127.1.1.1')
+    cmd = Puppet[:autosign_command]
+
+    return false if cmd.nil?
+    raise ArgumentError, "The autosign_command '#{Puppet[:autosign_command]}' is not a valid executable" unless FileTest.exist?(cmd) and FileTest.executable?(cmd)
+
+    auth_cmd = Puppet::Network::AuthCommand.new(cmd)
+    auth_cmd.allowed?(certname, addr)
   end
 
   # Retrieve (or create, if necessary) the certificate revocation list.

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -63,6 +63,15 @@ DOC
       csr.add_attribute(OpenSSL::X509::Attribute.new("extReq", extReq))
     end
 
+    if ![nil, false, 'false', ''].include?(Puppet[:csr_attributes_file]) and FileTest.exists?(Puppet[:csr_attributes_file])
+      if extensions = YAML.load_file(Puppet[:csr_attributes_file]) then
+        extensions.each { |oid, values|
+          attr_set = OpenSSL::ASN1::Set((values.is_a?(Array) ? values : [values]).map { |value| OpenSSL::ASN1::OctetString(value.to_s) })
+          csr.add_attribute(OpenSSL::X509::Attribute.new(oid, attr_set))
+        }
+      end
+    end
+
     signer = Puppet::SSL::CertificateSigner.new
     signer.sign(csr, key)
 


### PR DESCRIPTION
This adds 2 features:
## csr_attributes_file ([#7243](https://projects.puppetlabs.com/issues/7243))

This adds a `csr_attributes_file` parameter to the puppet config which allows for specifying user defined attributes to be added to the CSR. The file is yaml instead of flat key/value as this allows you to have an array of values for a parameter (which is also allowed in a CSR). However if the user were to provide a hash in the yaml, or a nested array, it would probably break.

Example file:

```

---
1.3.6.1.4.1.34380.2.0: us-west-1a/i-355fb16d
1.3.6.1.4.1.34380.2.1: MYSUPERSECRETKEY
1.3.6.1.4.1.34380.3.3: puppet-dashboard-group-name
```
## autosign_command ([#7244](https://projects.puppetlabs.com/issues/7244))

This adds a `autosign_command` parameter to the puppet config which allows for running an external command to determine whether a certificate should be automatically signed or not. The command is passed the certificate name as the first argument. The command should then exit with status `0` to indicate that the certificate should be signed, and status non-0 to indicate it should not be signed.

---

I use these 2 features for autosigning CSRs that come from EC2 autoscaled instances. Each instance runs a small userdata script which adds a secret key and the name of a dashboard group to the CSR. The autosigning script then looks for the secret to verify the box is indeed mine, adds the box to the requested group in the puppet dashboard, and then exits with 0 to indicate puppet is OK to sign the cert.

---

I have not had a chance to develop any tests for these changes. It has been on my todo list, but I have received numerous requests to create this pull request. Should I get time to create the tests before anyone else I will do so, but I do not know when that would be.
