### PR TITLE
(#15352) Documentation strings for hiera_hash, hiera_array, hiera_include, hiera

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -1,5 +1,22 @@
 module Puppet::Parser::Functions
-  newfunction(:hiera, :type => :rvalue, :arity => -2) do |*args|
+  newfunction(:hiera, :type => :rvalue, :arity => -2, :doc => "Performs a
+  standard priority lookup and returns the most specific value for a given key.
+  The returned value can be data of any type (strings, arrays, or hashes). 
+
+  In addition to the required `key` argument, `hiera` accepts two additional
+  arguments:
+
+  - a `default` argument in the second position, providing a value to be
+    returned in the absence of matches to the `key` argument
+  - an `override` argument in the third position, providing a data source
+    to consult for matching values, even if it would not ordinarily be
+    part of the matched hierarchy. If Hiera doesn't find a matching key
+    in the named override data source, it will continue to search through the
+    rest of the hierarchy.
+
+  More thorough examples of `hiera` are available at:  
+  <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
+  ") do |*args|
     require 'hiera_puppet'
     key, default, override = HieraPuppet.parse_args(args)
     HieraPuppet.lookup(key, default, self, override, :priority)

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -1,5 +1,23 @@
 module Puppet::Parser::Functions
-  newfunction(:hiera_array, :type => :rvalue, :arity => -2) do |*args|
+  newfunction(:hiera_array, :type => :rvalue, :arity => -2,:doc => "Returns all 
+  matches throughout the hierarchy --- not just the first match --- as a flattened array of unique values.
+  If any of the matched values are arrays, they're flattened and included in the results.
+  
+  In addition to the required `key` argument, `hiera_array` accepts two additional 
+  arguments:
+  
+  - a `default` argument in the second position, providing a string or array to be returned 
+    in the absence of  matches to the `key` argument
+  - an `override` argument in the third position, providing a data source to consult for 
+    matching values, even if it would not ordinarily be part of the matched hierarchy. 
+    If Hiera doesn't find a matching key in the named override data source, it will 
+    continue to search through the rest of the hierarchy.
+    
+  If any matched value is a hash, puppet will raise a type mismatch error.
+
+  More thorough examples of `hiera` are available at:  
+  <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
+  ") do |*args|
     require 'hiera_puppet'
     key, default, override = HieraPuppet.parse_args(args)
     HieraPuppet.lookup(key, default, self, override, :array)

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -1,5 +1,25 @@
 module Puppet::Parser::Functions
-  newfunction(:hiera_hash, :type => :rvalue, :arity => -2) do |*args|
+  newfunction(:hiera_hash, :type => :rvalue, :arity => -2, :doc => 
+  "Returns a merged hash of matches from throughout the hierarchy. In cases where two or 
+  more hashes share keys, the hierarchy  order determines which key/value pair will be 
+  used in the returned hash, with the pair in the highest priority data source winning.
+  
+  In addition to the required `key` argument, `hiera_hash` accepts two additional 
+  arguments:
+  
+  - a `default` argument in the second position, providing a  hash to be returned in the 
+  absence of any matches for the `key` argument
+  - an `override` argument in the third position, providing  a data source to insert at 
+  the top of the hierarchy, even if it would not ordinarily match during a Hiera data 
+  source lookup. If Hiera doesn't find a match in the named override data source, it will 
+  continue to search through the rest of the hierarchy.
+    
+  `hiera_hash` expects that all values returned will be hashes. If any of the values 
+  found in the data sources are strings or arrays, puppet will raise a type mismatch error.
+
+  More thorough examples of `hiera_hash` are available at:  
+  <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
+  ") do |*args|
     require 'hiera_puppet'
     key, default, override = HieraPuppet.parse_args(args)
     HieraPuppet.lookup(key, default, self, override, :hash)

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -1,5 +1,34 @@
 module Puppet::Parser::Functions
-  newfunction(:hiera_include, :arity => -2) do |*args|
+  newfunction(:hiera_include, :arity => -2, :doc => "Assigns classes to a node
+  using an array merge lookup that retrieves the value for a user-specified key
+  from a Hiera data source.
+
+  To use `hiera_include`, the following configuration is required:
+
+  - A key name to use for classes, e.g. `classes`.
+  - A line in the puppet `sites.pp` file (e.g. `/etc/puppet/manifests/sites.pp`)
+    reading `hiera_include('classes')`. Note that this line must be outside any node
+    definition and below any top-scope variables in use for Hiera lookups.
+  - Class keys in the appropriate data sources. In a data source keyed to a node's role,
+    one might have:
+            ---  
+            classes:  
+              - apache  
+              - apache::passenger
+
+  In addition to the required `key` argument, `hiera_include` accepts two additional
+  arguments:
+
+  - a `default` argument in the second position, providing an array to be returned
+    in the absence of matches to the `key` argument
+  - an `override` argument in the third position, providing a data source to consult
+    for matching values, even if it would not ordinarily be part of the matched hierarchy.
+    If Hiera doesn't find a matching key in the named override data source, it will continue
+    to search through the rest of the hierarchy.
+
+  More thorough examples of `hiera_include` are available at:
+  <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
+  ") do |*args|
     require 'hiera_puppet'
     key, default, override = HieraPuppet.parse_args(args)
     if answer = HieraPuppet.lookup(key, default, self, override, :array)


### PR DESCRIPTION
When running puppet doc, the hiera functions show as "undocumented." 

This commit provides documentation strings for the hiera functions,  describing how to use these functions and explaining their optional arguments. It further includes links to the corresponding documentation at docs.puppetlabs.com, where fuller examples can be provided more easily.
