### PR TITLE
(#19742) Raise exceptions generated during report processing

### DIFF
--- a/lib/puppet/indirector/report/processor.rb
+++ b/lib/puppet/indirector/report/processor.rb
@@ -37,6 +37,7 @@ class Puppet::Transaction::Report::Processor < Puppet::Indirector::Code
         newrep.process
       rescue => detail
         Puppet.log_exception(detail, "Report #{name} failed: #{detail}")
+        raise detail
       end
     end
   end

--- a/spec/unit/indirector/report/processor_spec.rb
+++ b/spec/unit/indirector/report/processor_spec.rb
@@ -92,9 +92,9 @@ describe Puppet::Transaction::Report::Processor, " when processing a report" do
     @reporter.save(@request)
   end
 
-  it "should not raise exceptions" do
+  it "should raise exceptions" do
     Puppet[:trace] = false
     @dup_report.expects(:process).raises(ArgumentError)
-    proc { @reporter.save(@request) }.should_not raise_error
+    proc { @reporter.save(@request) }.should raise_error
   end
 end


### PR DESCRIPTION
This commit has the report processor raise exceptions it receives
while processing reports.

Before this commit, the report processor catches exceptions raised
during report processing and logs them, but does not pass them up
to whatever called them.

This does have the side effects of producing two error messages during a failed report submission from a puppet master, and causing a 400 error to be displayed by the agent, since other parts of puppet will catch this error. If someone knows a better way to do this than just raising the exception again, I would really appreciate suggestions.
