### PR TITLE
Implement #18024 - alias for scope.lookupvar()

### DIFF
--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -62,6 +62,11 @@ class Puppet::Parser::TemplateWrapper
     scope.catalog.tags
   end
 
+  # A short alias for scope.lookupvar()
+  def sl(name, options = {})
+    scope.lookupvar(name,options)
+  end
+
   # Ruby treats variables like methods, so we used to expose variables
   # within scope to the ERB code via method_missing.  As per RedMine #1427,
   # though, this means that conflicts between methods in our inheritance

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -81,6 +81,11 @@ describe "the template function" do
     }.to raise_error(Puppet::ParseError, /Could not find value for 'lookupvar'/)
   end
 
+  it "should have an alias for scope.lookupvar" do
+    scope["foobar"] = 'value'
+    eval_template("<%= sl('foobar') %>").should eql('value')
+  end
+
   def eval_template(content)
     File.stubs(:read).with("template").returns(content)
     Puppet::Parser::Files.stubs(:find_template).returns("template")

--- a/spec/unit/parser/templatewrapper_spec.rb
+++ b/spec/unit/parser/templatewrapper_spec.rb
@@ -93,6 +93,11 @@ describe Puppet::Parser::TemplateWrapper do
     tw.result("<%= @one %>").should == "foo"
   end
 
+  it "should provide an alias for scope.lookupvar" do
+    scope.expects(:lookupvar).with('foo::bar',{}).returns('value')
+    tw.sl('foo::bar').should eql('value')
+  end
+
   %w{! . ; :}.each do |badchar|
     it "translates #{badchar} to _ in instance variables" do
       scope["one#{badchar}"] = "foo"


### PR DESCRIPTION
Tired of writing scope.lookupvar('foo') all over your templates? This
provides a shorthand alias for scope.lookupvar()

See http://projects.puppetlabs.com/issues/18024 for details
