### PR TITLE
(#15791) isolate deterministic random function

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -8,6 +8,6 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
       $random_number = fqdn_rand(30)
       $random_number_seed = fqdn_rand(30,30)") do |args|
     max = args.shift.to_i
-    srand(Digest::MD5.hexdigest([self['::fqdn'],args].join(':')).hex)
-    rand(max).to_s
+    seed = Digest::MD5.hexdigest([self['::fqdn'],args].join(':')).hex
+    Puppet::Util.deterministic_rand(seed,max)
 end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -519,7 +519,17 @@ module Util
   end
   module_function :exit_on_fail
 
-
+  def deterministic_rand(seed,max)
+    if defined?(Random) == 'constant' && Random.class == Class
+      Random.new(seed).rand(max).to_s
+    else
+      srand(seed)
+      result = rand(max).to_s
+      srand()
+      result
+    end
+  end
+  module_function :deterministic_rand
 
 
   #######################################################################################################

--- a/spec/unit/parser/functions/fqdn_rand_spec.rb
+++ b/spec/unit/parser/functions/fqdn_rand_spec.rb
@@ -55,4 +55,9 @@ describe "the fqdn_rand function" do
     val2 = @scope.function_fqdn_rand([10000000,42])
     val1.should_not eql(val2)
   end
+
+  it "should use the Puppet::Util function" do
+    Puppet::Util.expects(:deterministic_rand).with(177093203648075535190027737376590689559,4)
+    @scope.function_fqdn_rand([4])
+  end
 end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -526,4 +526,29 @@ describe Puppet::Util do
       subject.execute(command)
     end
   end
+
+  describe "#deterministic_rand" do
+
+    it "should not fiddle with future rand calls" do
+      Puppet::Util.deterministic_rand(123,20)
+      rand_one = rand()
+      Puppet::Util.deterministic_rand(123,20)
+      rand().should_not eql(rand_one)
+    end
+
+    if defined?(Random) == 'constant' && Random.class == Class
+      it "should not fiddle with the global seed" do
+        srand(1234)
+        Puppet::Util.deterministic_rand(123,20)
+        srand().should eql(1234)
+      end
+    # ruby below 1.9.2 variant
+    else
+      it "should set a new global seed" do
+        srand(1234)
+        Puppet::Util.deterministic_rand(123,20)
+        srand().should_not eql(1234)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We should not fiddle with the global seed, as other people
might still depend on Kernel.rand() not being that deterministic
as it is the idea with the fqdn_rand function.

However, as ruby < 1.9.2 does not provide such a nice solution, as
a dedicated Random class we simply call Kernel.srand() again on ruby
< 1.9.2 -> Reinitialize with a less deterministic seed.

In this second attempt I'm addressing the comments that have been raised in #1349 . Sorry for taking a bitter longer, to implement that...
