### PR TITLE
(#19805) Report failures to restart in exit code if requested

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -244,7 +244,8 @@ class Puppet::Transaction::Report
   def exit_status
     status = 0
     status |= 2 if @metrics["changes"]["total"] > 0
-    status |= 4 if @metrics["resources"]["failed"] > 0
+    status |= 4 if @metrics["resources"]["failed"] > 0 ||
+      @metrics["resources"]["failed_to_restart"] > 0
     status
   end
 


### PR DESCRIPTION
Documentation to --detailed-exitcodes states that mask 0x4 is applied in case
"there were failures during the transaction." Currently only failures to change
resource state are reported, failures to restart the resource are still ignored.

Only change (code=2) to Exec['/bin/true'] is considered here:

  $ puppet apply --detailed-exitcodes -e 'service { "duckfaced": restart => "/bin/false", ensure => running, status => "/bin/true" } exec { "/bin/true": notify => Service["duckfaced"] }'
  $ echo $?
  2

Needless to say, information about failed restarts is usually as important to
the user as the status changes, since they usually mean that desired
configuration is not in effect.

This change makes Puppet consider information about failed restarts when
setting the failure bit.

Another possibility to avoid loosing the information  would be to introduce
another bit in the exit code mask, but that would change semantics with respect
to existing documentation and thus probably be more confusing.
