### PR TITLE
(maint) Add vendoring support to puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ doc
 .bundle/
 ext/packaging/
 pkg/
-vendor/
 Gemfile.lock
-vendor/
 .bundle/
 puppet-acceptance/

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,6 +1,8 @@
 require 'puppet/version'
 
 # see the bottom of the file for further inclusions
+# Also see the new Vendor support - towards the end
+#
 require 'facter'
 require 'puppet/error'
 require 'puppet/util'
@@ -153,6 +155,12 @@ module Puppet
   def self.newtype(name, options = {}, &block)
     Puppet::Type.newtype(name, options, &block)
   end
+
+  # Load vendored (setup paths, and load what is needed upfront).
+  # See the Vendor class for how to add additional vendored gems/code
+  require "puppet/vendor"
+  Puppet::Vendor.load_vendored
+
 end
 
 # This feels weird to me; I would really like for us to get to a state where there is never a "require" statement

--- a/lib/puppet/vendor.rb
+++ b/lib/puppet/vendor.rb
@@ -1,0 +1,55 @@
+module Puppet
+  # Simple module to manage vendored code.
+  #
+  # To vendor a library:
+  #
+  # * Download its whole git repo or untar into `lib/puppet/vendor/<libname>`
+  # * Create a lib/puppetload_libraryname.rb file to add its libdir into the $:.
+  #   (Look at existing load_xxx files, they should all follow the same pattern).
+  # * To load the vendored lib upfront, add a `require '<vendorlib>'`line to
+  #   `vendor/require_vendored.rb`.
+  # * To load the vendored lib on demand, add a comment to `vendor/require_vendored.rb`
+  #    to make it clear it should not be loaded upfront.
+  # 
+  # At runtime, the #load_vendored method should be called. It will ensure
+  # all vendored libraries are added to the global `$:` path, and
+  # will then call execute the up-front loading specified in `vendor/require_vendored.rb`.
+  # 
+  # The intention is to not change vendored libraries and to eventually
+  # make adding them in optional so that distros can simply adjust their
+  # packaging to exclude this directory and the various load_xxx.rb scripts
+  # if they wish to install these gems as native packages.
+  #
+  class Vendor
+    class << self
+      # @api private
+      def vendor_dir
+        File.join([File.dirname(File.expand_path(__FILE__)), "vendor"])
+      end
+
+      # @api private
+      def load_entry(entry)
+        Puppet.debug("Loading vendored #{$1}")
+        load "#{vendor_dir}/#{entry}"
+      end
+
+      # @api private
+      def require_libs
+        require 'puppet/vendor/require_vendored'
+      end
+
+      # Configures the path for all vendored libraries and loads required libraries.
+      # (This is the entry point for loading vendored libraries).
+      #
+      def load_vendored
+        Dir.entries(vendor_dir).each do |entry|
+          if entry.match(/load_(\w+?)\.rb$/)
+            load_entry entry
+          end
+        end
+
+        require_libs
+      end
+    end
+  end
+end

--- a/lib/puppet/vendor/require_vendored.rb
+++ b/lib/puppet/vendor/require_vendored.rb
@@ -1,0 +1,2 @@
+# This adds upfront requirements on vendored code found under lib/vendor/x
+# Add one requirement per vendored package (or a comment if it is loaded on demand).


### PR DESCRIPTION
This adds vendoring support to puppet based on the implementation in
mcollective.

(It does not add any vendored packages/gems)
