### PR TITLE
Allow users to enable profiling via a setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -49,10 +49,10 @@ module Puppet
         :type     => :boolean,
         :desc     => "Whether to print stack traces on some errors",
     },
-    :enable_profiling => {
+    :profile => {
         :default  => false,
         :type     => :boolean,
-        :desc     => "Whether to enable performance profiling",
+        :desc     => "Whether to enable experimental performance profiling",
     },
     :autoflush => {
       :default => true,

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'uri'
 
+require 'puppet/network/http'
 require 'puppet/network/http_pool'
 require 'puppet/network/http/api/v1'
 require 'puppet/network/http/compression'
@@ -76,28 +77,35 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     add_accept_encoding({"Accept" => model.supported_formats.join(", ")})
   end
 
+  def add_profiling_header(headers)
+    if (Puppet[:profile])
+      headers[Puppet::Network::HTTP::HEADER_ENABLE_PROFILING] = "true"
+    end
+    headers
+  end
+
   def network(request)
     Puppet::Network::HTTP::Connection.new(request.server || self.class.server, request.port || self.class.port)
   end
 
-  def http_get(request, *args)
-    http_request(:get, request, *args)
+  def http_get(request, path, headers = nil, *args)
+    http_request(:get, request, path, add_profiling_header(headers), *args)
   end
 
-  def http_post(request, *args)
-    http_request(:post, request, *args)
+  def http_post(request, path, data, headers = nil, *args)
+    http_request(:post, request, path, data, add_profiling_header(headers), *args)
   end
 
-  def http_head(request, *args)
-    http_request(:head, request, *args)
+  def http_head(request, path, headers = nil, *args)
+    http_request(:head, request, path, add_profiling_header(headers), *args)
   end
 
-  def http_delete(request, *args)
-    http_request(:delete, request, *args)
+  def http_delete(request, path, headers = nil, *args)
+    http_request(:delete, request, path, add_profiling_header(headers), *args)
   end
 
-  def http_put(request, *args)
-    http_request(:put, request, *args)
+  def http_put(request, path, data, headers = nil, *args)
+    http_request(:put, request, path, data, add_profiling_header(headers), *args)
   end
 
   def http_request(method, request, *args)

--- a/lib/puppet/network/http.rb
+++ b/lib/puppet/network/http.rb
@@ -1,2 +1,3 @@
 module Puppet::Network::HTTP
+  HEADER_ENABLE_PROFILING = "X-Puppet-Profiling"
 end

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -48,6 +48,14 @@ class Puppet::Network::HTTP::RackREST < Puppet::Network::HTTP::RackHttpHandler
     end
   end
 
+  # Retrieve all headers from the http request, as a map.
+  def headers(request)
+    request.env.select {|k,v| k.start_with? 'HTTP_'}.inject({}) do |m, (k,v)|
+      m[k.sub(/^HTTP_/, '').downcase] = v
+      m
+    end
+  end
+
   # Retrieve the accept header from the http request.
   def accept_header(request)
     request.env[HEADER_ACCEPT]

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -25,6 +25,14 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
     process(request, response)
   end
 
+  def headers(request)
+    result = {}
+    request.each do |k, v|
+      result[k.downcase] = v
+    end
+    result
+  end
+
   def accept_header(request)
     request["accept"]
   end

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
+require 'puppet/network/http'
 require 'puppet/network/http/handler'
 require 'puppet/network/authorization'
 require 'puppet/network/authentication'
@@ -47,8 +48,14 @@ describe Puppet::Network::HTTP::Handler do
 
       @result = stub 'result', :render => "mytext"
 
+      request[:headers] = {
+          "Content-Type"  => request[:content_type_header],
+          "Accept"        => request[:accept_header]
+      }
+
       handler.stubs(:check_authorization)
       handler.stubs(:warn_if_near_expiration)
+      handler.stubs(:headers).returns(request[:headers])
     end
 
     it "should check the client certificate for upcoming expiration" do
@@ -60,8 +67,8 @@ describe Puppet::Network::HTTP::Handler do
       handler.process(request, response)
     end
 
-    it "should setup a profiler when the profile parameter exists" do
-      request[:params] = { :profile => "" }
+    it "should setup a profiler when the puppet-profiling header exists" do
+      request[:headers][Puppet::Network::HTTP::HEADER_ENABLE_PROFILING] = "true"
 
       handler.process(request, response)
 

--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -31,6 +31,16 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
       Rack::Request.new(env)
     end
 
+    describe "#headers" do
+      it "should return the headers (parsed from env with prefix 'HTTP_')" do
+        req = mk_req('/', {'HTTP_Accept' => 'myaccept',
+                           'HTTP_X-Custom-Header' => 'mycustom',
+                           'NOT_HTTP_foo' => 'not an http header'})
+        @handler.headers(req).should == {"accept" => 'myaccept',
+                                         "x-custom-header" => 'mycustom'}
+      end
+    end
+
     describe "and using the HTTP Handler interface" do
       it "should return the HTTP_ACCEPT parameter as the accept header" do
         req = mk_req('/', 'HTTP_ACCEPT' => 'myaccept')

--- a/spec/unit/network/http/webrick/rest_spec.rb
+++ b/spec/unit/network/http/webrick/rest_spec.rb
@@ -41,6 +41,20 @@ describe Puppet::Network::HTTP::WEBrickREST do
       @handler.service(@request, @response).should == "stuff"
     end
 
+    describe "#headers" do
+      let(:fake_request) { {"Foo" => "bar", "BAZ" => "bam" } }
+
+      it "should iterate over the request object using #each" do
+        fake_request.expects(:each)
+        @handler.headers(fake_request)
+      end
+
+      it "should return a hash with downcased header names" do
+        result = @handler.headers(fake_request)
+        result.should == fake_request.inject({}) { |m,(k,v)| m[k.downcase] = v; m }
+      end
+    end
+
     describe "when using the Handler interface" do
       it "should use the 'accept' request parameter as the Accept header" do
         @request.expects(:[]).with("accept").returns "foobar"


### PR DESCRIPTION
Prior to this commit, there is no way for an end user to enable
the new profiling features other than by patching their source
code or passing an extra query parameter to a web request,
which requires them to know the precise URL / query params / POST
body of the request that they want to profile, as well as passing
all of the necessary SSL-related flags to `curl` (et al) so that
their request can be authenticated.

This commit simply adds a boolean setting called 'enable_profiling'
which can be used to turn on this functionality for all requests.

We should provide more precise ways for users to control this, but
this at least gives them a simple option until we have something
better.
