### PR TITLE
Add support for comment attribute in aix user provider

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -72,6 +72,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     {:aix_attr => :maxage,     :puppet_prop => :password_max_age},
     {:aix_attr => :minage,     :puppet_prop => :password_min_age},
     {:aix_attr => :attributes, :puppet_prop => :attributes},
+    {:aix_attr => :gecos,      :puppet_prop => :comment},
   ]
 
   #--------------
@@ -94,7 +95,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   end
 
   def lscmd(value=@resource[:name])
-    [self.class.command(:list)] + self.get_ia_module_args + [ value]
+    [self.class.command(:list) + "-c" ] + self.get_ia_module_args + [ value]
   end
 
   def lsallcmd()
@@ -297,13 +298,6 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     end
   end
 
-  #- **comment**
-  #    A description of the user.  Generally is a user's full name.
-  #def comment=(value)
-  #end
-  #
-  #def comment
-  #end
   # UNSUPPORTED
   #- **profile_membership**
   #    Whether specified roles should be treated as the only roles


### PR DESCRIPTION
The AIX user attribute "gecos" maps to "comment", similar to how the useradd
provider manages this. This commit adds a "gecos" => "comment" mapping in the
provider so that comment is one of the aix user attributes we can manage.  A
difficulty arises though because the "gecos" attribute can legally contain both
"=" characters and spaces. Currently the output of lsuser cmd, which we use to
retrieve user attributes, is parsed using AixObject#parse_attr_list. This
parses the AIX space-separated attribute list output format. When the value for
"gecos" contains spaces, this breaks by returning only the first of the
delimited tokens, e.g. "comment => John" when "John Doe" is the comment. This
commit adds the "-c" flag to the lsuser call, which tells AIX to format the
output in colon-delimited format. This switches the parsing to using the
AixObject#parse_colon_list, which returns the output of the "gecos" value
correctly, because ":" is not a legal value (gecos internal values are
separated by ";"). This commit also removes commented out getter/setter section
for "comment" since we're not using it. This PR resolves failing tests in
the pe_acceptance_tests, specifically resource/user/should_modify.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
