### PR TITLE
Improve CVE 2013 1654 SSLv2 Downgrade Master test

### DIFF
--- a/acceptance/tests/security/cve-2013-1654_sslv2_downgrade_master.rb
+++ b/acceptance/tests/security/cve-2013-1654_sslv2_downgrade_master.rb
@@ -8,20 +8,34 @@ END
     on(host, cmd).stdout.chomp == "true"
   end
 
-  if suitable?( master )
+  def suitable_agent?(agent)
+    res = on( agent,
+             'openssl -v', :acceptable_exit_codes => (0..255).to_a )
+    res.exit_code == 0
+  end
+
+  suitable_agent = agents.select {|agent| suitable_agent?( agent ) }.first
+
+  if suitable?( master ) and suitable_agent
     with_master_running_on( master, '--autosign true' ) do
 
-      agent = agents.first
-      on agent, puppet_agent( '-t' )
+      # Ensure the agent has its certs
+      on suitable_agent, puppet_agent( '-t' )
 
-      certfile = on(agent, puppet_agent("--configprint hostcert")).stdout.chomp
-      keyfile = on(agent, puppet_agent("--configprint hostprivkey")).stdout.chomp
-      cafile = on(agent, puppet_agent("--configprint localcacert")).stdout.chomp
+      certfile = on(suitable_agent,
+                    puppet_agent('--configprint hostcert')).stdout.chomp
+      keyfile = on(suitable_agent,
+                   puppet_agent('--configprint hostprivkey')).stdout.chomp
+      cafile = on(suitable_agent,
+                  puppet_agent('--configprint localcacert')).stdout.chomp
 
       openssl_call = "openssl s_client -connect #{master}:8140 " +
-                     "-cert \"#{certfile}\" -key \"#{keyfile}\" -CAfile \"#{cafile}\" -ssl2 -msg < /dev/null"
+                     "-cert \"#{certfile}\" -key \"#{keyfile}\" " +
+                     "-CAfile \"#{cafile}\" -ssl2 -msg < /dev/null"
 
-      on(agent, openssl_call, :acceptable_exit_codes => (0..255)) do |test|
+      on(suitable_agent,
+         openssl_call, :acceptable_exit_codes => (0..255)) do |test|
+
         assert_match /CLIENT-HELLO/, test.stdout
         assert_no_match /SERVER-HELLO/, test.stdout
       end


### PR DESCRIPTION
Previously we were only checking for the applicability of the master
(since we're testing the master), but we run the check from an agent.
This ensures the agent we run the check from has the necessary openssl
client for the test.

Signed-off-by: Justin Stoller justin@puppetlabs.com

This should fix the flapping we've seen in this test and should be merged up through the branches.
