### PR TITLE
(#17190) Re-introduce environment for catalog compile

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -94,11 +94,11 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   end
 
   # Turn our host name into a node object.
-  def find_node(name, *args)
+  def find_node(name, environment)
     Puppet::Util::Profiler.profile("Found node information") do
       node = nil
       begin
-        node = Puppet::Node.indirection.find(name)
+        node = Puppet::Node.indirection.find(name, :environment => environment)
       rescue => detail
         message = "Failed when searching for node #{name}: #{detail}"
         Puppet.log_exception(detail, message)
@@ -133,7 +133,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     # node's catalog with only one certificate and a modification to auth.conf 
     # If no key is provided we can only compile the currently connected node.
     name = request.key || request.node
-    if node = find_node(name, :environment => request.environment)
+    if node = find_node(name, request.environment)
       return node
     end
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -28,8 +28,8 @@ describe Puppet::Resource::Catalog::Compiler do
       node1 = stub 'node1', :merge => nil
       node2 = stub 'node2', :merge => nil
       compiler.stubs(:compile)
-      Puppet::Node.indirection.stubs(:find).with('node1', anything).returns(node1)
-      Puppet::Node.indirection.stubs(:find).with('node2', anything).returns(node2)
+      Puppet::Node.indirection.stubs(:find).with('node1', has_entry(:environment => anything)).returns(node1)
+      Puppet::Node.indirection.stubs(:find).with('node2', has_entry(:environment => anything)).returns(node2)
 
       compiler.find(Puppet::Indirector::Request.new(:catalog, :find, 'node1', nil, :node => 'node1'))
       compiler.find(Puppet::Indirector::Request.new(:catalog, :find, 'node2', nil, :node => 'node2'))


### PR DESCRIPTION
Commit f64e0a94c60506eec44645b07c36ff996ee2b5cd accidentally removed the 
pass-through of `*args`, which removed the passing of `:environment` to the
Puppet::Node indirection. This adds a test that would have failed and
restructures the code so that the mistake would have been more obvious.
