### PR TITLE
Correct formulation in AIX lsuser command

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -95,7 +95,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   end
 
   def lscmd(value=@resource[:name])
-    [self.class.command(:list) + "-c" ] + self.get_ia_module_args + [ value]
+    [self.class.command(:list), "-c"] + self.get_ia_module_args + [ value]
   end
 
   def lsallcmd()


### PR DESCRIPTION
Currently, the command string composition for the lsuser command is incorrect.
It attempts to add a flag (-c) as part of the first binary to execute, when
puppet expects flags to separate elements in the command string array.. This
commit updates the forumlation so that "-c" is a separate element. How it ever
worked as it is now is a mystery.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
