### PR TITLE
Partial fix for #19489

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -1,5 +1,25 @@
 module Puppet::Parser::Functions
-  newfunction(:hiera, :type => :rvalue, :arity => -2) do |*args|
+  newfunction(:hiera, :type => :rvalue, :arity => -2, :doc => <<-'ENDHEREDOC') do |*args|
+    Looks up a value in the hiera hierarchy based on a key.
+    
+    This function takes one mandatory argument, a key name. To make use of the databindings
+    feature available in Puppet 3.0.0 and newer, use a key of the format `klass::paramater`:
+    
+        # Perform an explicit hiera lookup
+        $myvariable = hiera('klass::myvariable')
+    
+    A second, optional parameter may be given to supply a default value to be used if the key is not found.
+    
+        # Perform an explicit hiera lookup with a supplied defualt
+        $myvariable = hiera('klass::myvariable', 'mydefaultvalue')
+    
+    A third, optional parameter may also be given to override the hiearchy. If you are only using the yaml backend,
+    then the following will cause this lookup to first look in the `site_overrides.yaml` file in the hieradata location:
+    
+        # Perform an explicit hiera lookup with a supplied default and an override
+        $myvariable = hiera('klass::myvariable' , 'mydefaultvalue', 'site_overrides')
+        
+  ENDHEREDOC
     require 'hiera_puppet'
     key, default, override = HieraPuppet.parse_args(args)
     HieraPuppet.lookup(key, default, self, override, :priority)

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -1,5 +1,25 @@
 module Puppet::Parser::Functions
-  newfunction(:hiera_array, :type => :rvalue, :arity => -2) do |*args|
+  newfunction(:hiera_array, :type => :rvalue, :arity => -2, :doc => <<-'ENDHEREDOC') do |*args|
+    Returns an array of all values that match the given key.
+    
+    This function takes one mandatory argument, a key name. To make use of the databindings
+    feature available in Pupept 3.0.0 and newer, use a key of the format `klass::paramater`:
+    
+        # Perform an explicit hiera lookup
+        $myarray = hiera_array('some_array')
+    
+    A second, optional parameter may be given to supply a default value to be used if the key is not found.
+    
+        # Perform an explicit hiera lookup with a supplied defualt
+        $myarray = hiera('some_array', [ 'default1', 'default2' ])
+    
+    A third, optional parameter may also be given to override the hiearchy. If you are only using the yaml backend,
+    then the following will cause this lookup to first look in the `site_overrides.yaml` file in the hieradata location:
+    
+        # Perform an explicit hiera lookup with a supplied default and an override
+        $myarray = hiera('some_array' , [ 'default1', 'default2' ], 'site_overrides')
+    
+  ENDHEREDOC
     require 'hiera_puppet'
     key, default, override = HieraPuppet.parse_args(args)
     HieraPuppet.lookup(key, default, self, override, :array)

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -1,5 +1,24 @@
 module Puppet::Parser::Functions
-  newfunction(:hiera_hash, :type => :rvalue, :arity => -2) do |*args|
+  newfunction(:hiera_hash, :type => :rvalue, :arity => -2, :doc => <<-'ENDHEREDOC') do |*args|
+    Returns a hash of all values that match a given key, performing a shallow merge on the hashes
+    
+    This function takes one mandatory argument, a key name:
+    
+        # Perform an explicit hiera lookup
+        $myhash = hiera_hash(klass::myhash)
+    
+    A second, optional parameter may be given to supply a default value to be used if the key is not found.
+    
+        # Perform an explicit hiera lookup with a supplied defualt
+        $myhash = hiera_hash(klass::myhash, { key1 => 'default1', key2 => 'default2' } )
+    
+    A third, optional parameter may also be given to override the hiearchy. If you are only using the yaml backend,
+    then the following will cause this lookup to first look in the `site_overrides.yaml` file in the hieradata location:
+    
+        # Perform an explicit hiera lookup with a supplied default and an override
+        $myhash = hiera_hash(klass::myhash , { key1 => 'default1', key2 => 'default2' }, 'site_overrides')
+    
+  ENDHEREDOC
     require 'hiera_puppet'
     key, default, override = HieraPuppet.parse_args(args)
     HieraPuppet.lookup(key, default, self, override, :hash)


### PR DESCRIPTION
The commit adds documentation for the hiera(), hiera_array() an...d hiera_hash() functions. This addresses the lack of documentation in the generated function reference for three of the four hiera functions.
