### PR TITLE
(#15561) Extract CN from certificate subjects more carefully

### DIFF
--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -1,6 +1,7 @@
 require 'puppet/network/http/handler'
 require 'resolv'
 require 'webrick'
+require 'puppet/util/ssl'
 
 class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
 
@@ -73,8 +74,8 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
     # then we get the hostname from the cert, instead of via IP
     # info
     result[:authenticated] = false
-    if cert = request.client_cert and nameary = cert.subject.to_a.find { |ary| ary[0] == "CN" }
-      result[:node] = nameary[1]
+    if cert = request.client_cert and cn = Puppet::Util::SSL.cn_from_subject(cert.subject)
+      result[:node] = cn
       result[:authenticated] = true
     else
       result[:node] = resolve_node(result)

--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -1,6 +1,7 @@
 require 'openssl'
 require 'puppet/ssl'
 require 'puppet/ssl/digest'
+require 'puppet/util/ssl'
 
 # The base class for wrapping SSL instances.
 class Puppet::SSL::Base
@@ -47,9 +48,10 @@ class Puppet::SSL::Base
     self.class.validate_certname(@name)
   end
 
-  # Method to extract a 'name' from the subject of a certificate
+  # Class method to extract a 'name' from the CN field of the subject of a
+  # certificate
   def self.name_from_subject(subject)
-    subject.to_s.sub(/\/CN=/i, '')
+    Puppet::Util::SSL.cn_from_subject(subject)
   end
 
   # Create an instance of our Puppet::SSL::* class using a given instance of the wrapped class

--- a/lib/puppet/util/ssl.rb
+++ b/lib/puppet/util/ssl.rb
@@ -1,0 +1,25 @@
+module Puppet::Util::SSL
+  # Given a DN string, parse it into an OpenSSL certificate subject.
+  # This method will flexibly handle both OpenSSl and RFC2253 formats, as
+  # given by nginx and Apache, respectively.
+  #
+  # @param dn [String] the DN string
+  # @return [OpenSSL::X509::Name] the certificate subject
+  def self.subject_from_dn(dn)
+    # try to parse both rfc2253 (Apache) and OpenSSL (nginx) formats
+    begin
+      subject = OpenSSL::X509::Name.parse_rfc2253(dn)
+    rescue OpenSSL::X509::NameError
+      subject = OpenSSL::X509::Name.parse_openssl(dn)
+    end
+    subject
+  end
+
+  # Extract the CN from the given OpenSSL certtificate subject.
+  #
+  # @param subject [OpenSSL::X509::Name] the subject to extract from
+  # @return [String, nil] the CN, or nil if not found
+  def self.cn_from_subject(subject)
+    (subject.to_a.assoc('CN') || [])[1]
+  end
+end

--- a/spec/unit/ssl/base_spec.rb
+++ b/spec/unit/ssl/base_spec.rb
@@ -38,16 +38,10 @@ describe Puppet::SSL::Certificate do
   end
 
   describe "when determining a name from a certificate subject" do
-    it "should convert it to a string" do
+    it "should extract only the CN and not any other components" do
       subject = stub 'sub'
-      subject.expects(:to_s).returns('foo')
-
-      @class.name_from_subject(subject).should == 'foo'
-    end
-
-    it "should strip the prefix" do
-      subject = '/CN=foo'
-      @class.name_from_subject(subject).should == 'foo'
+      Puppet::Util::SSL.expects(:cn_from_subject).with(subject).returns 'host.domain.com'
+      @class.name_from_subject(subject).should == 'host.domain.com'
     end
   end
 

--- a/spec/unit/util/ssl_spec.rb
+++ b/spec/unit/util/ssl_spec.rb
@@ -1,0 +1,51 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'openssl'
+require 'puppet/util/ssl'
+
+describe Puppet::Util::SSL do
+  describe "when getting a subject from a DN" do
+    [['/CN=Root CA/OU=Server Operations/O=Example Org',
+            [['CN', 'Root CA'], ['OU', 'Server Operations'], ['O', 'Example Org']]],
+     ['/CN=client.example.org',
+            [['CN', 'client.example.org']]],
+     ['CN=client.example.org',
+            [['CN', 'client.example.org']]],
+     ['O=Foo\, Inc,CN=client2a.example.org',
+            [['CN', 'client2a.example.org'], ['O', 'Foo, Inc']]],
+    ].each do |dn, exp|
+      it "parses #{dn} correctly to #{exp.inspect}" do
+        # parse out the important bits of the Name object to compare
+        described_class.subject_from_dn(dn).to_a.map { |a| [a[0], a[1]] }.should === exp
+      end
+    end
+  end
+
+  describe "when getting a CN from a subject" do
+    it "should correctly parse a subject containing only a CN" do
+      subj = OpenSSL::X509::Name.parse('/CN=foo')
+      described_class.cn_from_subject(subj).should == 'foo'
+    end
+
+    it "should correctly parse a subject containing other components" do
+      subj = OpenSSL::X509::Name.parse('/CN=Root CA/OU=Server Operations/O=Example Org')
+      described_class.cn_from_subject(subj).should == 'Root CA'
+    end
+
+    it "should correctly parse a subject containing other components with CN not first" do
+      subj = OpenSSL::X509::Name.parse('/emailAddress=foo@bar.com/CN=foo.bar.com/O=Example Org')
+      described_class.cn_from_subject(subj).should == 'foo.bar.com'
+    end
+
+    it "should return nil for a subject with no CN" do
+      subj = OpenSSL::X509::Name.parse('/OU=Server Operations/O=Example Org')
+      described_class.cn_from_subject(subj).should == nil
+    end
+
+    it "should return nil for a bare string" do
+      described_class.cn_from_subject("/CN=foo").should == nil
+    end
+  end
+end
+


### PR DESCRIPTION
When using certificate chaning or otherwise generating SSL certificates
outside of Puppet, the subject often has multiple components, e.g.,
  /CN=hostname.foo.com/O=Foo, Inc./OU=Marketing/emailAddress=it@foo.com
The hostname, which is later verified against a strict set of allowed
characters, is only extracted from the "CN" field, with all othe fields
ignored.
