### PR TITLE
(#14764) Fix formatting of file mode audits

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -144,7 +144,13 @@ module Puppet
     end
 
     def is_to_s(currentvalue)
-      currentvalue.rjust(4, "0")
+      if currentvalue == :absent
+        # This can occur during audits---if a file is transitioning from
+        # present to absent the mode will have a value of `:absent`.
+        super
+      else
+        currentvalue.rjust(4, "0")
+      end
     end
   end
 end

--- a/spec/unit/type/file/mode_spec.rb
+++ b/spec/unit/type/file/mode_spec.rb
@@ -138,5 +138,11 @@ describe Puppet::Type.type(:file).attrclass(:mode) do
         mode.is_to_s('1755').should == '1755'
       end
     end
+
+    describe 'when passed :absent' do
+      it 'returns :absent' do
+        mode.is_to_s(:absent).should == :absent
+      end
+    end
   end
 end


### PR DESCRIPTION
When a File resource is set to audit all attributes:

```
file{"/tmp/foo": audit => "all"}
```

If the file moves between `ensure => present` and `ensure => absent` the value
of the `mode` parameter will be set to `:absent`.  This will cause the audit to
fail as the `is_to_s` method for file modes cannot comprehend symbols as it
expects a 3 or 4 digit string of numbers.

This commit causes `is_to_s` to delegate to `super` when `:absent` is passed.
