### PR TITLE
(Maint) Re-structure require statements to avoid loop

### DIFF
--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -1,20 +1,27 @@
 require 'puppet'
 require 'puppet/util/autoload'
-require 'puppet/interface/documentation'
 require 'prettyprint'
 require 'semver'
 
 # @api public
 class Puppet::Interface
-  include FullDocs
-
+  require 'puppet/interface/documentation'
   require 'puppet/interface/face_collection'
 
+  require 'puppet/interface/action'
+  require 'puppet/interface/action_builder'
   require 'puppet/interface/action_manager'
+
+  require 'puppet/interface/option'
+  require 'puppet/interface/option_builder'
+  require 'puppet/interface/option_manager'
+
+
+  include FullDocs
+
   include Puppet::Interface::ActionManager
   extend Puppet::Interface::ActionManager
 
-  require 'puppet/interface/option_manager'
   include Puppet::Interface::OptionManager
   extend Puppet::Interface::OptionManager
 

--- a/lib/puppet/interface/action.rb
+++ b/lib/puppet/interface/action.rb
@@ -1,5 +1,3 @@
-require 'puppet/interface'
-require 'puppet/interface/documentation'
 require 'puppet/util/methodhelper'
 require 'prettyprint'
 

--- a/lib/puppet/interface/action_builder.rb
+++ b/lib/puppet/interface/action_builder.rb
@@ -1,6 +1,3 @@
-require 'puppet/interface'
-require 'puppet/interface/action'
-
 # This class is used to build {Puppet::Interface::Action actions}.
 # When an action is defined with
 # {Puppet::Interface::ActionManager#action} the block is evaluated

--- a/lib/puppet/interface/action_manager.rb
+++ b/lib/puppet/interface/action_manager.rb
@@ -1,6 +1,3 @@
-require 'puppet/interface/action'
-require 'puppet/interface/action_builder'
-
 # This class is not actually public API, but the method
 # {Puppet::Interface::ActionManager#action action} is public when used
 # as part of the Faces DSL (i.e. from within a

--- a/lib/puppet/interface/face_collection.rb
+++ b/lib/puppet/interface/face_collection.rb
@@ -1,5 +1,3 @@
-require 'puppet/interface'
-
 module Puppet::Interface::FaceCollection
   @faces = Hash.new { |hash, key| hash[key] = {} }
 

--- a/lib/puppet/interface/option.rb
+++ b/lib/puppet/interface/option.rb
@@ -1,5 +1,3 @@
-require 'puppet/interface'
-
 # This represents an option on an action or face (to be globally applied
 # to its actions). Options should be constructed by calling
 # {Puppet::Interface::OptionManager#option}, which is available on

--- a/lib/puppet/interface/option_builder.rb
+++ b/lib/puppet/interface/option_builder.rb
@@ -1,5 +1,3 @@
-require 'puppet/interface/option'
-
 # @api public
 class Puppet::Interface::OptionBuilder
   # The option under construction

--- a/lib/puppet/interface/option_manager.rb
+++ b/lib/puppet/interface/option_manager.rb
@@ -1,5 +1,3 @@
-require 'puppet/interface/option_builder'
-
 # This class is not actually public API, but the method
 # {Puppet::Interface::OptionManager#option option} is public when used
 # as part of the Faces DSL (i.e. from within a

--- a/spec/unit/interface/action_builder_spec.rb
+++ b/spec/unit/interface/action_builder_spec.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'puppet/interface/action_builder'
+require 'puppet/interface'
 require 'puppet/network/format_handler'
 
 describe Puppet::Interface::ActionBuilder do

--- a/spec/unit/interface/action_manager_spec.rb
+++ b/spec/unit/interface/action_manager_spec.rb
@@ -1,9 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-# This is entirely an internal class for Interface, so we have to load it instead of our class.
 require 'puppet/interface'
-require 'puppet/face'
 
 class ActionManagerTester
   include Puppet::Interface::ActionManager

--- a/spec/unit/interface/action_spec.rb
+++ b/spec/unit/interface/action_spec.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'puppet/interface/action'
+require 'puppet/interface'
 
 describe Puppet::Interface::Action do
   describe "when validating the action name" do

--- a/spec/unit/interface/documentation_spec.rb
+++ b/spec/unit/interface/documentation_spec.rb
@@ -1,8 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/interface'
-require 'puppet/interface/option'
-require 'puppet/interface/documentation'
 
 class Puppet::Interface::TinyDocs::Test
   include Puppet::Interface::TinyDocs

--- a/spec/unit/interface/face_collection_spec.rb
+++ b/spec/unit/interface/face_collection_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 require 'tmpdir'
-require 'puppet/interface/face_collection'
+require 'puppet/interface'
 
 describe Puppet::Interface::FaceCollection do
   # To avoid cross-pollution we have to save and restore both the hash

--- a/spec/unit/interface/option_builder_spec.rb
+++ b/spec/unit/interface/option_builder_spec.rb
@@ -1,4 +1,4 @@
-require 'puppet/interface/option_builder'
+require 'puppet/interface'
 
 describe Puppet::Interface::OptionBuilder do
   let :face do Puppet::Interface.new(:option_builder_testing, '0.0.1') end

--- a/spec/unit/interface/option_spec.rb
+++ b/spec/unit/interface/option_spec.rb
@@ -1,5 +1,4 @@
 require 'puppet/interface'
-require 'puppet/interface/option'
 
 describe Puppet::Interface::Option do
   let :face do Puppet::Interface.new(:option_testing, '0.0.1') end


### PR DESCRIPTION
The way in which the require statements for the puppet/interface module 
worked caused a dependency loop that could only be resolved by using the 
modules and classes in a very specific order. The tests showed this problem
if they were run in a different order:

```
  /export/home/jenkins/workspace/Puppet Specs Solaris
(master)/solaris10-i386/solaris10-i386/lib/puppet/interface/action_builder.rb:128:
uninitialized constant Puppet::Interface::Action (NameError)
   from /opt/csw/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in
`gem_original_require'
   from /opt/csw/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in
`require'
   from /export/home/jenkins/workspace/Puppet Specs Solaris
(master)/solaris10-i386/solaris10-i386/lib/puppet/interface/action_manager.rb:2
   from /opt/csw/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in
`gem_original_require'
   from /opt/csw/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in
`require'
   from /export/home/jenkins/workspace/Puppet Specs Solaris
(master)/solaris10-i386/solaris10-i386/lib/puppet/interface.rb:13
   from /opt/csw/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in
`gem_original_require'
   from /opt/csw/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in
`require'
   from /export/home/jenkins/workspace/Puppet Specs Solaris
(master)/solaris10-i386/solaris10-i386/lib/puppet/interface/action.rb:1
   from /opt/csw/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in
`gem_original_require'
   from /opt/csw/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in
`require'
   from /export/home/jenkins/workspace/Puppet Specs Solaris
(master)/solaris10-i386/solaris10-i386/spec/unit/interface/action_spec.rb:3
   from
/opt/csw/lib/ruby/gems/1.8/gems/rspec-core-2.9.0/lib/rspec/core/configuration.rb:746:in
`load'
   from
/opt/csw/lib/ruby/gems/1.8/gems/rspec-core-2.9.0/lib/rspec/core/configuration.rb:746:in
`load_spec_files'
   from
/opt/csw/lib/ruby/gems/1.8/gems/rspec-core-2.9.0/lib/rspec/core/configuration.rb:746:in
`map'
   from
/opt/csw/lib/ruby/gems/1.8/gems/rspec-core-2.9.0/lib/rspec/core/configuration.rb:746:in
`load_spec_files'
   from
/opt/csw/lib/ruby/gems/1.8/gems/rspec-core-2.9.0/lib/rspec/core/command_line.rb:22:in
`run'
   from
/opt/csw/lib/ruby/gems/1.8/gems/rspec-core-2.9.0/lib/rspec/core/runner.rb:69:in
`run'
   from
/opt/csw/lib/ruby/gems/1.8/gems/rspec-core-2.9.0/lib/rspec/core/runner.rb:10:in
`autorun'
   from /opt/csw/bin/rspec:19
```

This re-orders the requires so that only the top level module
(Puppet::Interface) requires all of the components that are part of it.

Paired-with: patrick@puppetlabs.com
