### PR TITLE
Use the `message` method to get exception info

### DIFF
--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -321,7 +321,7 @@ ERROR_STRING
     rescue SystemExit,NoMemoryError
       raise
     rescue Exception => detail
-      Puppet.log_exception(detail, "Could not request certificate: #{detail}")
+      Puppet.log_exception(detail, "Could not request certificate: #{detail.message}")
       if time < 1
         puts "Exiting; failed to retrieve certificate and waitforcert is disabled"
         exit(1)
@@ -342,7 +342,7 @@ ERROR_STRING
         break if certificate
         Puppet.notice "Did not receive certificate"
       rescue StandardError => detail
-        Puppet.log_exception(detail, "Could not request certificate: #{detail}")
+        Puppet.log_exception(detail, "Could not request certificate: #{detail.message}")
       end
     end
   end


### PR DESCRIPTION
Without this, the error is "Could not request certificate: system lib",
which is not very helpful.

Sincere apologies for the lack of tests - time ran short, and this seems un-tested currently.
