### PR TITLE
(#656) keep crontab from re-applying certain commands

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -225,6 +225,12 @@ Puppet::Type.newtype(:cron) do
         nil
       end
     end
+
+    def munge(value)
+      value.sub!(/^\s+/, '')
+      value.sub!(/\s+$/, '')
+      value
+    end
   end
 
   newproperty(:special) do

--- a/spec/unit/type/cron_spec.rb
+++ b/spec/unit/type/cron_spec.rb
@@ -50,6 +50,15 @@ describe Puppet::Type.type(:cron), :unless => Puppet.features.microsoft_windows?
       end
     end
 
+    describe "command" do
+      it "should discard leading spaces" do
+        described_class.new(:name => 'foo', :command => " /bin/true")[:command].should_not match Regexp.new(" ")
+      end
+      it "should discard trailing spaces" do
+        described_class.new(:name => 'foo', :command => "/bin/true ")[:command].should_not match Regexp.new(" ")
+      end
+    end
+
     describe "minute" do
       it "should support absent" do
         expect { described_class.new(:name => 'foo', :minute => 'absent') }.to_not raise_error


### PR DESCRIPTION
The cron type allows arbitrary text in its command property.
The crontab provider will silently discard leading and trailing spaces
in record fields. Therefor, when parsing the generated records from disk,
the spaces appear to be missing.

To avoid this, it is safe to munge the command and discard the spaces
on the type level. The provider never gets to see them and will not
assume the need to refresh.
