### PR TITLE
(#19876) Fix crontab regression in resource matching

### DIFF
--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -110,6 +110,8 @@ Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFi
 
   # See if we can match the record against an existing cron job.
   def self.match(record, resources)
+    # if the record is named, do not even bother (#19876)
+    return false if record[:name]
     resources.each do |name, resource|
       # Match the command first, since it's the most important one.
       next unless record[:target] == resource[:target]

--- a/spec/unit/provider/cron/crontab_spec.rb
+++ b/spec/unit/provider/cron/crontab_spec.rb
@@ -120,4 +120,32 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
       compare_crontab_text subject.to_file(vixie_records), ""
     end
   end
+
+  context "when adding a cronjob with the same command as an existing job" do
+    let(:resource) { Puppet::Type::Cron.new(:name => "test", :user => "root", :command => "/bin/true") }
+    let(:record) { {:name => "existing", :user => "root", :command => "/bin/true", :record_type => :crontab} }
+    let(:resources) { { "test" => resource } }
+
+    before :each do
+      subject.stubs(:prefetch_all_targets).returns([record])
+    end
+
+# this would be a more fitting test, but I haven't yet
+# figured out how to get it working
+#    it "should include both jobs in the output" do
+#      subject.prefetch(resources)
+#      class Puppet::Provider::ParsedFile
+#        def self.records
+#          @records
+#        end
+#      end
+#      subject.to_file(subject.records).should match /Puppet name: test/
+#    end
+
+    it "should not base the new resource's provider on the existing record" do
+      subject.expects(:new).with(record).never
+      subject.stubs(:new)
+      subject.prefetch(resources)
+    end
+  end
 end


### PR DESCRIPTION
The logic for matching new resources with exiting unmanaged cronjobs
has been reworked during the fix for #16809. Somehow, this lead to
a new issue which caused spurious matches, e.g.:

10 \* \* \* \* /bin/true

and

cron { "blank": command => "/bin/true", ensure => present }

would now match. At least puppet will not try to change the name of the
record (i.e., the 'Puppet Name:' line). But the new entry will not get
added either. It still works if there is a non-matching time field, e.g.

cron { "blank": command => "/bin/true", hour => 1 }

but without such fields, the behaviour is wrong.

The match method (in the crontab provider) will expressly ignore named
records on disk. This is safe to do; if the resource does have the
same name as the on-disk record, the match method will not even get invoked.

There is no scenario in which we'd want differently named records to be
matched with a resource. If an on-disk record has a name, it either is
managed through another resource, or it used to be managed. Either way,
the resource in question needs adding or matching to a different record.
