### PR TITLE
(#12493) Docs: Note that `user` defined in a scheduled_task resource must be a privileged user

### DIFF
--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -62,7 +62,11 @@ Puppet::Type.newtype(:scheduled_task) do
       completed successfully'.  It is recommended that you either
       choose another user to run the scheduled task, or alter the
       security policy to allow v1 scheduled tasks to run as the
-      'SYSTEM' account.  Defaults to 'SYSTEM'."
+      'SYSTEM' account.  Defaults to 'SYSTEM'.
+
+      Please also note that Puppet must be running as a privileged user
+      in order to manage `scheduled_task` resources. Running as an
+      unprivileged user will result in 'access denied' errors."
 
     defaultto :system
 


### PR DESCRIPTION
The scheduled_task resource includes a note about issues surrounding the use of the 'SYSTEM' user and recommends choosing another user to run the scheduled task, or altering the security policy to allow the 'SYSTEM' account to run scheduled tasks. The note does not mention that puppet must be running as a privileged user to manage scheduled tasks in order to avoid 'access denied' errors.

This commit corrects the issue by adding a note that puppet must be running as a privileged
user to manage scheduled tasks and avoid 'access denied' errors.
