### PR TITLE
Docs: Note in config reference that puppet master needs a restart to notice hiera.yaml edits

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -214,7 +214,7 @@ module Puppet
     :node_cache_terminus => {
       :type       => :terminus,
       :default    => nil,
-      :desc       => "How to store cached nodes. 
+      :desc       => "How to store cached nodes.
       Valid values are (none), 'json', 'yaml' or write only yaml ('write_only_yaml').
       The master application defaults to 'write_only_yaml', all others to none.",
     },
@@ -225,7 +225,7 @@ module Puppet
     },
     :hiera_config => {
       :default => "$confdir/hiera.yaml",
-      :desc    => "The hiera configuration file",
+      :desc    => "The hiera configuration file. Puppet only reads this file on startup, so you must restart the puppet master every time you edit it.",
       :type    => :file,
     },
     :catalog_terminus => {


### PR DESCRIPTION
This keeps biting users, and we should say it anywhere they might look when trying to debug.

Can we get this pulled into 3.2.0? Holler if I need to rebase. 
