### PR TITLE
(#1453) Document behavior of removed Cron params

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -43,6 +43,13 @@ Puppet::Type.newtype(:cron) do
           hour    => ['2-4'],
           minute  => '*/10'
         }
+
+    An important note: _the Cron type will not reset parameters that are
+    removed from a manifest_. For example, removing a `minute => 10` parameter
+    will not reset the minute component of the associated cronjob to `*`.
+    These changes must be expressed by setting the parameter to
+    `minute => absent` because Puppet only manages parameters that are out of
+    sync with manifest entries.
   EOT
   ensurable
 


### PR DESCRIPTION
Removing a parameter such as `minute => 10` from a manifest will not reset the
minute component of the associated cronjob to `*`. This is because Puppet only
manages parameters that are out of sync with manifest entries (see issue
[19198](https://projects.puppetlabs.com/issues/19198)).

This patch updates the documentation for the Cron type to be explicit on this
point as it has been surprising to a lot of people.
