### PR TITLE
Simple fix for broken indirection docs

### DIFF
--- a/lib/puppet/reference/indirection.rb
+++ b/lib/puppet/reference/indirection.rb
@@ -15,8 +15,10 @@ reference = Puppet::Util::Reference.newreference :indirection, :doc => "Indirect
     Puppet::Indirector::Terminus.terminus_classes(ind.name).sort { |a,b| a.to_s <=> b.to_s }.each do |terminus|
       terminus_name = terminus.to_s
       term_class = Puppet::Indirector::Terminus.terminus_class(ind.name, terminus)
-      terminus_doc = Puppet::Util::Docs.scrub(term_class.doc)
-      text << markdown_definitionlist(terminus_name, terminus_doc)
+      if term_class
+        terminus_doc = Puppet::Util::Docs.scrub(term_class.doc)
+        text << markdown_definitionlist(terminus_name, terminus_doc)
+      end
     end
   end
 


### PR DESCRIPTION
Currently generting the indirection docs fails because of the
resource/validator terminus, for which the autoloader returns nil.
Rather than quietly failing the whole docs build on this error, just
fail the docs for that particular terminus.

---

This is the simplest fix, without delving into _why_ the autoload isn't working.  Think of it as more of a band-aid than a fix, but hopefully not a problematic fix.
