### PR TITLE
Make filetype tests succeed even when local uid == 9000

### DIFF
--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -100,6 +100,12 @@ describe Puppet::Util::FileType do
       type.should_not be_nil
     end
 
+    # make Puppet::Util::SUIDManager return something deterministic, not the
+    # uid of the user running the tests, except where overridden below.
+    before :each do
+      Puppet::Util::SUIDManager.stubs(:uid).returns 1234
+    end
+
     describe "#read" do
       it "should run crontab -l as the target user" do
         Puppet::Util::Execution.expects(:execute).with(['crontab', '-l'], user_options).returns crontab


### PR DESCRIPTION
My UID on my development system is 9000, which was making these tests
fail, because 9000 is used as the fake UID as well.

Lucky me!
