### PR TITLE
(#3010) cron: allow the absent value for the "special" property

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -243,14 +243,25 @@ Puppet::Type.newtype(:cron) do
   newproperty(:special) do
     desc "A special value such as 'reboot' or 'annually'.
        Only available on supported systems such as Vixie Cron.
-       Overrides more specific time of day/week settings."
+       Overrides more specific time of day/week settings.
+       Set to 'absent' to make puppet revert to a plain numeric schedule."
 
     def specials
-      %w{reboot yearly annually monthly weekly daily midnight hourly}
+      %w{reboot yearly annually monthly weekly daily midnight hourly absent} +
+        [ :absent ]
     end
 
     validate do |value|
       raise ArgumentError, "Invalid special schedule #{value.inspect}" unless specials.include?(value)
+    end
+
+    def munge(value)
+      # Support value absent so that a schedule can be
+      # forced to change to numeric.
+      if value == "absent" or value == :absent
+        return :absent
+      end
+      value
     end
   end
 

--- a/spec/fixtures/integration/provider/cron/crontab/unspecialized
+++ b/spec/fixtures/integration/provider/cron/crontab/unspecialized
@@ -1,0 +1,15 @@
+# HEADER: some simple
+# HEADER: header
+@daily /bin/unnamed_special_command >> /dev/null 2>&1
+
+# commend with blankline above and below
+
+17-19,22 0-23/2 * * 2 /bin/unnamed_regular_command
+
+# Puppet Name: My daily failure
+MAILTO=""
+* * * * * /bin/false
+# Puppet Name: Monthly job
+SHELL=/bin/sh
+MAILTO=mail@company.com
+15 14 1 * * $HOME/bin/monthly

--- a/spec/integration/provider/cron/crontab_spec.rb
+++ b/spec/integration/provider/cron/crontab_spec.rb
@@ -160,6 +160,17 @@ describe Puppet::Type.type(:cron).provider(:crontab), '(integration)', :unless =
         run_in_catalog(resource)
         expect_output('modify_entry')
       end
+      it "should change a special schedule to numeric if requested" do
+        resource = Puppet::Type.type(:cron).new(
+          :name        => 'My daily failure',
+          :special     => 'absent',
+          :command     => '/bin/false',
+          :target      => crontab_user1,
+          :user        => crontab_user1
+        )
+        run_in_catalog(resource)
+        expect_output('unspecialized')
+      end
       it "should not try to move an entry from one file to another" do
         # force the parsedfile provider to also parse user1's crontab
         random_resource = Puppet::Type.type(:cron).new(


### PR DESCRIPTION
The crontab provider fails to apply the change to a cronjob if
the schedule has been a special schedule such as @daily. Paraphrasing
from the bug report, assuming this crontab:

@reboot /bin/true

this manifest won't work correctly:

cron{ "test": minute  => 50 }

even though puppet will correctly detect that the 'minute' property
needs changing from "absent". The special schedule will remain.

The fix allows this workaround:

cron{ "test": minute  => 50, special => absent }
