### PR TITLE
(#4561) Support structured facts

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -360,6 +360,11 @@ module Puppet
         :desc     => "Freezes the 'main' class, disallowing any code to be added to it.  This\n" +
             "essentially means that you can't have any code outside of a node, class, or definition other\n" +
             "than in the site manifest.",
+    },
+    :stringify_facts => {
+      :default => true,
+      :type    => :boolean,
+      :desc    => "Flatten fact values to strings using #to_s. Means you can't have arrays or hashes as fact values.",
     }
   )
   Puppet.define_settings(:module_tool,

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -55,7 +55,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     result = Puppet::Node::Facts.new(request.key, Facter.to_hash)
 
     result.add_local_facts
-    result.stringify
+    Puppet[:stringify_facts] ? result.stringify : result.sanitize
 
     result
   end

--- a/lib/puppet/indirector/facts/network_device.rb
+++ b/lib/puppet/indirector/facts/network_device.rb
@@ -9,7 +9,7 @@ class Puppet::Node::Facts::NetworkDevice < Puppet::Indirector::Code
     result = Puppet::Node::Facts.new(request.key, Puppet::Util::NetworkDevice.current.facts)
 
     result.add_local_facts
-    result.stringify
+    Puppet[:stringify_facts] ? result.stringify : result.sanitize
 
     result
   end

--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -39,8 +39,17 @@ class Puppet::Node::Facts
 
   # Convert all fact values into strings.
   def stringify
+    Puppet.deprecation_warning("Stringifying facts is deprecated, see the stringify_facts setting")
     values.each do |fact, value|
       values[fact] = value.to_s
+    end
+  end
+
+  # Sanitize fact values by converting everything not a string, boolean
+  # numeric, array or hash into strings.
+  def sanitize
+    values.each do |fact, value|
+      values[fact] = sanitize_fact value
     end
   end
 
@@ -88,5 +97,22 @@ class Puppet::Node::Facts
     newvals = values.dup
     newvals.find_all { |name, value| name.to_s =~ /^_/ }.each { |name, value| newvals.delete(name) }
     newvals
+  end
+
+  def sanitize_fact(fact)
+    if fact.is_a? Hash then
+      ret = {}
+      fact.each_pair { |k,v| ret[sanitize_fact k]=sanitize_fact v }
+      ret
+    elsif fact.is_a? Array then
+      fact.collect { |i| sanitize_fact i }
+    elsif fact.is_a? Numeric \
+      or fact.is_a? TrueClass \
+      or fact.is_a? FalseClass \
+      or fact.is_a? String
+      fact
+    else
+      fact.to_s
+    end
   end
 end

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -16,6 +16,7 @@ describe Puppet::Application::Facts do
   end
 
   it "should return facts if a key is given to find" do
+    Puppet[:stringify_facts] = false
     Puppet::Node::Facts.indirection.reset_terminus_class
     subject.command_line.stubs(:args).returns %w{find whatever --render-as yaml}
 

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -80,10 +80,20 @@ describe Puppet::Node::Facts::Facter do
       @facter.find(@request)
     end
 
-    it "should convert all facts into strings" do
+    it "should convert facts into strings when stringify_facts is true" do
+      Puppet[:stringify_facts] = true
       facts = Puppet::Node::Facts.new("foo")
       Puppet::Node::Facts.expects(:new).returns facts
       facts.expects(:stringify)
+
+      @facter.find(@request)
+    end
+
+    it "should sanitize facts when stringify_facts is false" do
+      Puppet[:stringify_facts] = false
+      facts = Puppet::Node::Facts.new("foo")
+      Puppet::Node::Facts.expects(:new).returns facts
+      facts.expects(:sanitize)
 
       @facter.find(@request)
     end

--- a/spec/unit/indirector/facts/network_device_spec.rb
+++ b/spec/unit/indirector/facts/network_device_spec.rb
@@ -55,10 +55,20 @@ describe Puppet::Node::Facts::NetworkDevice do
       @device.find(@request)
     end
 
-    it "should convert all facts into strings" do
+    it "should convert facts into strings when stringify_facts is true" do
+      Puppet[:stringify_facts] = true
       facts = Puppet::Node::Facts.new("foo")
       Puppet::Node::Facts.expects(:new).returns facts
       facts.expects(:stringify)
+
+      @device.find(@request)
+    end
+
+    it "should sanitizer facts when stringify_facts is false" do
+      Puppet[:stringify_facts] = false
+      facts = Puppet::Node::Facts.new("foo")
+      Puppet::Node::Facts.expects(:new).returns facts
+      facts.expects(:sanitize)
 
       @device.find(@request)
     end

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -9,6 +9,7 @@ describe Puppet::Node::Facts, "when indirecting" do
   end
 
   it "should be able to convert all fact values to strings" do
+    Puppet.expects(:deprecation_warning).once
     @facts.values["one"] = 1
     @facts.stringify
     @facts.values["one"].should == "1"
@@ -33,6 +34,50 @@ describe Puppet::Node::Facts, "when indirecting" do
     @facts.values["environment"] = "foo"
     @facts.add_local_facts
     @facts.values["environment"].should == "foo"
+  end
+
+  describe "when sanitizing facts" do
+    it "should convert fact values if needed" do
+      @facts.values["test"] = /foo/
+      @facts.sanitize
+      @facts.values["test"].should == "(?-mix:foo)"
+    end
+
+    it "should convert hash keys if needed" do
+      @facts.values["test"] = {/foo/ => "bar"}
+      @facts.sanitize
+      @facts.values["test"].should == {"(?-mix:foo)" => "bar"}
+    end
+
+    it "should convert hash values if needed" do
+      @facts.values["test"] = {"foo" => /bar/}
+      @facts.sanitize
+      @facts.values["test"].should == {"foo" => "(?-mix:bar)"}
+    end
+
+    it "should convert array elements if needed" do
+      @facts.values["test"] = [1, "foo", /bar/]
+      @facts.sanitize
+      @facts.values["test"].should == [1, "foo", "(?-mix:bar)"]
+    end
+
+    it "should handle nested arrays" do
+      @facts.values["test"] = [1, "foo", [/bar/]]
+      @facts.sanitize
+      @facts.values["test"].should == [1, "foo", ["(?-mix:bar)"]]
+    end
+
+    it "should handle nested hashes" do
+      @facts.values["test"] = {/foo/ => {"bar" => /baz/}}
+      @facts.sanitize
+      @facts.values["test"].should == {"(?-mix:foo)" => {"bar" => "(?-mix:baz)"}}
+    end
+
+    it "should handle nester arrays and hashes" do
+      @facts.values["test"] = {/foo/ => ["bar", /baz/]}
+      @facts.sanitize
+      @facts.values["test"].should == {"(?-mix:foo)" => ["bar", "(?-mix:baz)"]}
+    end
   end
 
   describe "when indirecting" do


### PR DESCRIPTION
Add the option stringify_facts which defaults to true. If it is turned
on the current behaviour with turning facts into strings is kept. If it
is false facts are kept in the format they were in which can also be
booleans, numerics, arrays and hashes.
