### PR TITLE
(#19514) adding servernodename variable to the compiler object

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -109,6 +109,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       # Add any external data to the node.
       if node
         add_node_data(node)
+        node.merge!( { 'servernodename' => name } )
       end
       node
     end

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -101,6 +101,13 @@ class Puppet::Node
     @parameters["environment"] ||= self.environment.name.to_s
   end
 
+  # Force overwrite parameters into the parameter list
+  def merge!(params)
+    params.each do |name, value|
+      @parameters[name] = value
+    end
+  end
+
   # Calculate the list of names we might use for looking
   # up our node.  This is only used for AST nodes.
   def names

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -25,8 +25,8 @@ describe Puppet::Resource::Catalog::Compiler do
 
     it "should cache the server metadata and reuse it" do
       compiler = Puppet::Resource::Catalog::Compiler.new
-      node1 = stub 'node1', :merge => nil
-      node2 = stub 'node2', :merge => nil
+      node1 = stub 'node1', :merge => nil, :merge! => nil
+      node2 = stub 'node2', :merge => nil, :merge! => nil
       compiler.stubs(:compile)
       Puppet::Node.indirection.stubs(:find).with('node1', has_entry(:environment => anything)).returns(node1)
       Puppet::Node.indirection.stubs(:find).with('node2', has_entry(:environment => anything)).returns(node2)
@@ -192,6 +192,7 @@ describe Puppet::Resource::Catalog::Compiler do
 
     it "should look node information up via the Node class with the provided key" do
       @node.stubs :merge
+      @node.stubs :merge!
       Puppet::Node.indirection.expects(:find).with(@name, anything).returns(@node)
       @compiler.find(@request)
     end
@@ -211,17 +212,26 @@ describe Puppet::Resource::Catalog::Compiler do
     end
 
     it "should add the server's Puppet version to the node's parameters as 'serverversion'" do
+      @node.stubs :merge!
       @node.expects(:merge).with { |args| args["serverversion"] == "1" }
       @compiler.find(@request)
     end
 
     it "should add the server's fqdn to the node's parameters as 'servername'" do
+      @node.stubs :merge!
       @node.expects(:merge).with { |args| args["servername"] == "my.server.com" }
       @compiler.find(@request)
     end
 
     it "should add the server's IP address to the node's parameters as 'serverip'" do
+      @node.stubs :merge!
       @node.expects(:merge).with { |args| args["serverip"] == "my.ip.address" }
+      @compiler.find(@request)
+    end
+
+    it "should add the nodename to the node's parameters as 'servernodename'" do
+      @node.stubs :merge
+      @node.expects(:merge!).with { |args| args["servernodename"] == @name }
       @compiler.find(@request)
     end
   end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -194,6 +194,12 @@ describe Puppet::Node, "when merging facts" do
     @node.merge "environment" => "two"
     @node.parameters["environment"].should == "two"
   end
+
+  it "should override a parameter if it is already set in the parameters" do
+    @node = Puppet::Node.new("testnode", :parameters => { "servernodename" => "foo.blah.com" } )
+    @node.merge! "servernodename" => "moo.cow.com"
+    @node.parameters["servernodename"].should == "moo.cow.com"
+  end
 end
 
 describe Puppet::Node, "when indirecting" do


### PR DESCRIPTION
```
(#19514) adding servernodename variable to the compiler object

Adding a merge! method to the node object to overwrite existing client side
facts, which is then used by the compiler to force integrate the name of the
current node object into the client facts to give an in- scope 'servernodename'
variable.  Without this change, there is no in- scope variable available to
validate the identity of the node requesting a catalog.

Consider hiera lookups using $::fqdn where fqdn is a fact from the agent which
can be easily spoofed to request data for an alternative node.  Using server
side data such as $::servernodename gives unoverridable validated data to
do such lookups.
```
