### PR TITLE
Maint: Fix a markdown glitch in hiera_include doc string

### DIFF
--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -11,9 +11,10 @@ module Puppet::Parser::Functions
     definition and below any top-scope variables in use for Hiera lookups.
   - Class keys in the appropriate data sources. In a data source keyed to a node's role,
     one might have:
-            ---  
-            classes:  
-              - apache  
+
+            ---
+            classes:
+              - apache
               - apache::passenger
 
   In addition to the required `key` argument, `hiera_include` accepts two additional


### PR DESCRIPTION
Without a line break, markdown parsers would fail to render the
yaml example as a code block.
