### PR TITLE
(maint) Update windows-api version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ platforms :mswin, :mingw do
   gem "win32-service", "~> 0.7.2", :require => false
   gem "win32-taskscheduler", "~> 0.2.2", :require => false
   gem "win32console", "~> 1.3.2", :require => false
-  gem "windows-api", "~> 0.4.1", :require => false
+  gem "windows-api", "~> 0.4.2", :require => false
   gem "windows-pr", "~> 1.2.1", :require => false
 end
 


### PR DESCRIPTION
The windows-api gem will be seeing an update to 0.4.2 in puppet_for_the_win, so
this commit updates the gemfile to match that version.
