### PR TITLE
(RFC) Update COMMITTERS with stable and master branch strategy

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -37,8 +37,21 @@ making the decision what base branch to merge the change set into.
 
 **base branch** - A branch in Git that contains an active history of changes
 and will eventually be released using semantic version guidelines.  The branch
-named master will always exist as a base branch.  All other base branches will
-be associated with a specific released version of Puppet, e.g. 2.7.x and 3.0.x.
+named `master` will always exist as a base branch.  The other base branches are
+`stable`, and `security` described below.
+
+**master branch** - The branch where new functionality that are not bug fixes
+is merged.
+
+**stable branch** - The branch where bug fixes against the latest release or
+release candidate are merged.
+
+**security** - Where critical security fixes are merged.  These change sets
+will then be merged into release branches independently from one another. (i.e.
+no merging up).  Please do not submit pull requests against the security branch
+and instead report all security related issues to security@puppetlabs.com as
+per our security policy published at
+[https://puppetlabs.com/security/](https://puppetlabs.com/security/).
 
 Committer Guide
 ====
@@ -53,32 +66,60 @@ This section provides a guide to help a committer decide the specific base
 branch that a change set should be merged into.
 
 The latest minor release of a major release is the only base branch that should
-be patched. Older minor releases in a major release do not get patched. Before
-the switch to [semantic versions](http://semver.org/) committers did not have
-to think about the difference between minor and major releases.  Committing to
-the latest minor release of a major release is a policy intended to limit the
-number of active base branches that must be managed.
+be patched.  These patches will be merged into `master` if they contain new
+functionality.  They will be merged into `stable` if they fix a bug.  Older
+minor releases in a major release do not get patched.
+
+Before the switch to [semantic versions](http://semver.org/) committers did not
+have to think about the difference between minor and major releases.
+Committing to the latest minor release of a major release is a policy intended
+to limit the number of active base branches that must be managed.
 
 Security patches are handled as a special case.  Security patches may be
-applied to earlier minor releases of a major release.
+applied to earlier minor releases of a major release, but the patches should
+first be merged into the `security` branch.  Security patches should be merged
+by Puppet Labs staff members.  Pull requests should not be submitted with the
+security branch as the base branch.  Please send all security related
+information or patches to security@puppetlabs.com as per our [Security
+Policy](https://puppetlabs.com/security/).
+
+The CI systems are configured to run against `master` and `stable`.  Over time,
+these branches will refer to different versions, but their name will remain
+fixed to avoid having to update CI jobs and tasks as new versions are released.
 
 How to commit a change set to multiple base branches
 ---
 
 A change set may apply to multiple releases.  In this situation the change set
 needs to be committed to multiple base branches.  This section provides a guide
-for how to merge patches across releases, e.g. 2.7 is patched, how should the
-changes be applied to 3.0?
+for how to merge patches up into the development branch, e.g. `stable` is
+patched, how should the changes be applied to `master`?
 
-First, merge the change set into the lowest numbered base branch, e.g. 2.7.
-Next, merge the changed base branch up through all later base branches by using
-the `--no-ff --log` git merge options.  We commonly refer to this as our "merge
-up process" because we merge in once, then merge up multiple times.
+First, merge the change set into the `stable` branch.  Next, merge the stable
+branch up into the `master` branch.  This merge strategy loosely follows the
+[git flow](http://nvie.com/posts/a-successful-git-branching-model/) model.
+Both of these change set merges should have a merge commit which makes it much
+easier to track a set of commits as a logical change set through the history of
+a branch.  Merge commits should be created using the `--no-ff --log` git merge
+options.
 
-When a new minor release branch is created (e.g. 3.1.x) then the previous one
-is deleted (e.g. 3.0.x). Any security or urgent fixes that might have to be
-applied to the older code line is done by creating an ad-hoc branch from the
-tag of the last patch release of the old minor line.
+Benefits of resetting stable
+---
+
+The primary benefit of resetting the stable branch is a clean history combined
+with a consistent branch name.
+
+The stable and master branch merge strategy has a number of benefits over the
+previous strategy of merging release branches up and into the master branch.
+There are two main way to handle the scenario when we release a new minor or
+major version of Puppet.  In this scenario the goal is for the stable branch to
+contain all of the work included in the master branch.  We could reset the
+stable branch to match the master branch, or we could merge the master branch
+into the stable branch.  We've chosen to rest stable to match master because we
+often "merge up" bug fixes from stable into master.  If we were to merge down
+from master to stable while also merging up from stable to master, then the
+history would be very confusing.  We reset the stable branch to the master
+branch upon a new minor or major release to avoid this confusion.
 
 Code review checklist
 ---
@@ -100,7 +141,6 @@ branch:
    or modify it.)  HINT: `git diff master --check`
  * Does the change set conform to the contributing guide?
 
-
 Commit citizen guidelines:
 ---
 
@@ -117,7 +157,8 @@ paying attention to our automated build tools.
    backwards compatible change set into master, then the target version should
    be 3.2.0 in the issue tracker.)
  * Ensure the pull request is closed (Hint: amend your merge commit to contain
-   the string `closes: #123` where 123 is the pull request number.
+   the string `closes #123` where 123 is the pull request number and github
+   will automatically close the pull request when the branch is pushed.)
 
 Example Procedure
 ====
@@ -130,7 +171,7 @@ Suppose a contributor submits a pull request based on master.  The change set
 fixes a bug reported against Puppet 3.1.1 which is the most recently released
 version of Puppet.
 
-In this example the committer should rebase the change set onto the 3.1.x
+In this example the committer should rebase the change set onto the `stable`
 branch since this is a bug rather than new functionality.
 
 First, the committer pulls down the branch using the `hub` gem.  This tool
@@ -142,44 +183,45 @@ branch to track the remote branch.
     Switched to a new branch 'jeffmccune-fix_foo_error'
 
 At this point the topic branch is a descendant of master, but we want it to
-descend from 3.1.x.  The committer creates a new branch then re-bases the
-change set:
+descend from `stable`.  The committer rebases the change set onto `stable`.
 
-    $ git branch bug/3.1.x/fix_foo_error
-    $ git rebase --onto 3.1.x master bug/3.1.x/fix_foo_error
+    $ git branch bug/stable/fix_foo_error
+    $ git rebase --onto stable master bug/stable/fix_foo_error
     First, rewinding head to replay your work on top of it...
     Applying: (#23456) Fix FooError that always bites users in 3.1.1
 
 The `git rebase` command may be interpreted as, "First, check out the branch
-named `bug/3.1.x/fix_foo_error`, then take the changes that were previously
-based on `master` and re-base them onto `3.1.x`.
+named `bug/stable/fix_foo_error`, then take the changes that were previously
+based on `master` and re-base them onto `stable`.
 
 Now that we have a topic branch containing the change set based on the correct
 release branch, the committer merges in:
 
-    $ git checkout 3.1.x
-    Switched to branch '3.1.x'
-    $ git merge --no-ff --log bug/3.1.x/fix_foo_error
+    $ git checkout stable
+    Switched to branch 'stable'
+    $ git merge --no-ff --log bug/stable/fix_foo_error
     Merge made by the 'recursive' strategy.
      foo | 0
      1 file changed, 0 insertions(+), 0 deletions(-)
      create mode 100644 foo
 
-Once merged into the first base branch, the committer merges up:
+Once merged into the first base branch, the committer merges stable up into
+master.
 
     $ git checkout master
     Switched to branch 'master'
-    $ git merge --no-ff --log 3.1.x
+    $ git merge --no-ff --log stable
     Merge made by the 'recursive' strategy.
      foo | 0
      1 file changed, 0 insertions(+), 0 deletions(-)
      create mode 100644 foo
 
-Once the change set has been merged "in and up." the committer pushes.  (Note,
-the checklist should be complete at this point.)  Note that both the 3.1.x and
-master branches are being pushed at the same time.
+Once the change set has been merged into `stable` and up into `master`, the
+committer pushes.  (Note, the checklist should be complete at this point.)
+Note that both the `stable` and `master` branches are being pushed at the same
+time.
 
-    $ git push puppetlabs master:master 3.1.x:3.1.x
+    $ git push puppetlabs master:master stable:stable
 
 That's it!  The committer then updates the pull request, updates the issue in
 our issue tracker, and keeps an eye on the build status.


### PR DESCRIPTION
Without this patch the current branching strategy of creating unique
branches for each minor release requires CI systems be reconfigured for
each new minor release.  This is a problem because it is time consuming,
error prone, and expensive to reconfigure the CI system for each minor
release.  This, in turn, creates a road block to releasing more often.

This patch addresses the problem by documenting and prescribing a new
branching strategy for committers.  The strategy results in branch names
that do not change over time.  The `stable` branch always refers to the
current release which is receiving bug fixes.  The `master` branch
always refers to the next release which is receiving new functionality.

The release branches are no longer direct descendants (fast forwards) of
one another.  Instead, they are independent histories as in the git flow
model.  The security branch is special and receives change sets which
are then rebased and merged into specific branches for the specific
release versions which are affected by the vulnerability.
