### PR TITLE
(#20194) Do not perform reverse DNS lookups in webrick

### DIFF
--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -14,9 +14,11 @@ class Puppet::Network::HTTP::WEBrick
   end
 
   def listen(address, port)
-    arguments = {:BindAddress => address, :Port => port}
+    arguments = {:BindAddress => address, :Port => port, :DoNotReverseLookup => true}
     arguments.merge!(setup_logger)
     arguments.merge!(setup_ssl)
+
+    BasicSocket.do_not_reverse_lookup = true
 
     @server = WEBrick::HTTPServer.new(arguments)
     @server.listeners.each { |l| l.start_immediately = false }

--- a/spec/unit/network/http/webrick_spec.rb
+++ b/spec/unit/network/http/webrick_spec.rb
@@ -43,9 +43,18 @@ describe Puppet::Network::HTTP::WEBrick do
     end
 
     it "should tell webrick to listen on the specified address and port" do
-      WEBrick::HTTPServer.expects(:new).with {|args|
-        args[:Port] == 31337 and args[:BindAddress] == "127.0.0.1"
-      }.returns(mock_webrick)
+      WEBrick::HTTPServer.expects(:new).with(
+        has_entries(:Port => 31337, :BindAddress => "127.0.0.1")
+      ).returns(mock_webrick)
+      server.listen(address, port)
+    end
+
+    it "should not perform reverse lookups" do
+      WEBrick::HTTPServer.expects(:new).with(
+        has_entry(:DoNotReverseLookup => true)
+      ).returns(mock_webrick)
+      BasicSocket.expects(:do_not_reverse_lookup=).with(true)
+
       server.listen(address, port)
     end
 


### PR DESCRIPTION
Previously, the webrick-based puppet master would perform a reverse DNS lookup on
every connected socket, even authenticated connections. This occurs when
puppet calls IPSocket#peeraddr to get its peer's IP address. But ruby
would by default perform a reverse lookup at the same time.

This commit sets the global setting via
BasicSocket.do_not_reverse_lookup to handle ruby 1.8.x and up.

The commit also sets the webrick :DoNotReverseLookup configuration
option, which is necessary on at least 1.9.2p0.

Paired-with: Andy Parker andy@puppetlabs.com
