### PR TITLE
(#17811) Fix group id conversion for OS X users

### DIFF
--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -297,11 +297,8 @@ Puppet::Type.type(:user).provide :directoryservice do
                 end
       end
 
-      # If a non-numerical gid value is passed, assume it is a group name and
-      # lookup that group's GID value to use when setting the GID
-      if (attribute == :gid) and value.class == 'Fixnum'
-        value = self.class.get_attribute_from_dscl('Groups', value, 'PrimaryGroupID')['dsAttrTypeStandard:PrimaryGroupID'][0]
-      end
+      # Ensure group names are converted to integers.
+      value = Puppet::Util.gid(value) if attribute == :gid
 
       ## Set values ##
       # For the :password and :groups properties, call the setter methods

--- a/spec/unit/provider/user/directoryservice_spec.rb
+++ b/spec/unit/provider/user/directoryservice_spec.rb
@@ -228,7 +228,7 @@ describe Puppet::Type.type(:user).provider(:directoryservice) do
       {
         'UniqueID'         => '1000',
         'RealName'         => resource[:name],
-        'PrimaryGroupID'   => '20',
+        'PrimaryGroupID'   => 20,
         'UserShell'        => '/bin/bash',
         'NFSHomeDirectory' => "/Users/#{resource[:name]}"
       }


### PR DESCRIPTION
On OS X, the primary group for a user must be specified as a numeric id and not
a string. There is code to ensure this happens, but it is guarded by a faulty
logic statement and there is no test to catch the bug.

ref [#17811](https://projects.puppetlabs.com/issues/17811).
