### PR TITLE
(#20121) Invoke chkconfig with --check on SuSE

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -21,15 +21,12 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
   end
 
   def enabled?
-    begin
-      output = chkconfig(@resource[:name])
-    rescue Puppet::ExecutionFailure
-      return :false
-    end
+    # Checkconfig always returns 0 on SuSE unless the --check flag is used.
+    args = (Facter.value(:osfamily) == 'Suse' ? ['--check'] : [])
 
-    # If it's disabled on SuSE, then it will print output showing "off"
-    # at the end
-    if output =~ /.* off$/
+    begin
+      output = chkconfig(@resource[:name], *args)
+    rescue Puppet::ExecutionFailure
       return :false
     end
 

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -68,6 +68,13 @@ describe provider_class, :as_platform => :posix do
     @provider.should respond_to(:enabled?)
   end
 
+  it "should use --check on SuSE" do
+    Facter.expects(:value).with(:osfamily).returns 'Suse'
+    provider_class.expects(:chkconfig).with(@resource[:name], '--check')
+
+    @provider.enabled?
+  end
+
   it "should have an enable method" do
     @provider.should respond_to(:enable)
   end


### PR DESCRIPTION
On SuSE the `chkconfig` command needs to be passed the `--check` flag in order
to get exit codes that indicate if a service is enabled or not. Previously, we
were applying a regex to stderr but this was missing the case where the service
did not exist.

Ref: [#20121](https://projects.puppetlabs.com/issues/20121)
