### PR TITLE
(#11276) Tarball entries should be relative to the `pkg` directory

### DIFF
--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -41,7 +41,9 @@ module Puppet::ModuleTool
         FileUtils.rm archive_file rescue nil
 
         tar = Puppet::ModuleTool::Tar.instance(metadata.full_module_name)
-        tar.pack(build_path, archive_file)
+        Dir.chdir(@pkg_path) do
+          tar.pack(metadata.release_name, archive_file)
+        end
       end
 
       def create_directory

--- a/spec/unit/module_tool/applications/builder_spec.rb
+++ b/spec/unit/module_tool/applications/builder_spec.rb
@@ -5,10 +5,12 @@ require 'puppet_spec/modules'
 describe Puppet::ModuleTool::Applications::Builder do
   include PuppetSpec::Files
 
-  let(:path) { tmpdir("working_dir") }
-  let(:module_name) { 'myusername-mytarball' }
-  let(:builder)     { Puppet::ModuleTool::Applications::Builder.new(path) }
-  let(:version)     { '0.0.1' }
+  let(:path)         { tmpdir("working_dir") }
+  let(:module_name)  { 'myusername-mytarball' }
+  let(:version)      { '0.0.1' }
+  let(:release_name) { "#{module_name}-#{version}" }
+  let(:tarball)      { File.join(path, 'pkg', release_name) + ".tar.gz" }
+  let(:builder)      { Puppet::ModuleTool::Applications::Builder.new(path) }
 
   before :each do
     File.open(File.join(path, 'Modulefile'), 'w') do |f|
@@ -25,12 +27,11 @@ EOM
     end
   end
 
-  it "should attempt to create a module" do
+  it "should attempt to create a module relative to the pkg directory" do
     tarrer = mock('tarrer')
     Puppet::ModuleTool::Tar.expects(:instance).with(module_name).returns(tarrer)
-
-    build_path = File.join(path, 'pkg', "#{module_name}-#{version}")
-    tarrer.expects(:pack).with(build_path, build_path + ".tar.gz")
+    Dir.expects(:chdir).with(File.join(path, 'pkg')).yields
+    tarrer.expects(:pack).with(release_name, tarball)
 
     builder.run
   end


### PR DESCRIPTION
Commit 94f2f0a9 removed the call to `Dir.chdir`, which is necessary so
that entries in the tarball are relative to the `pkg` directory, i.e.
each entry starts with the metadata release_name, which is of the form:

```
myuser-mydir-X.Y.Z/
```

This issue was caught by the `loadable_from_modules` acceptance test as
the newly installed module did not install its metadata in the expected
locations.

This commit restores the `Dir.chdir` behavior and updates the test.
