### PR TITLE
(#20284) Output one item per line for arrays in console output

### DIFF
--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -159,6 +159,16 @@ Puppet::Network::FormatHandler.create(:console,
       return output
     end
 
+    # Print one item per line for arrays
+    if datum.is_a? Array
+      output = ''
+      datum.each do |item|
+        output << item.to_s
+        output << "\n"
+      end
+      return output
+    end
+
     # ...or pretty-print the inspect outcome.
     return json.render(datum)
   end

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -304,8 +304,8 @@ describe Puppet::Application::FaceBase do
       end
 
       [[1, 2], ["one"], [{ 1 => 1 }]].each do |input|
-        it "should render #{input.class} using JSON" do
-          app.render(input, {}).should == input.to_pson.chomp
+        it "should render Array as one item per line" do
+          app.render(input, {}).should == input.collect { |item| item.to_s + "\n" }.join('')
         end
       end
 

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -306,8 +306,8 @@ describe "Puppet Network Format" do
     end
 
     [[1, 2], ["one"], [{ 1 => 1 }]].each do |input|
-      it "should render #{input.inspect} as JSON" do
-        subject.render(input).should == json.render(input).chomp
+      it "should render #{input.inspect} as one item per line" do
+        subject.render(input).should == input.collect { |item| item.to_s + "\n" }.join('')
       end
     end
 


### PR DESCRIPTION
To make it easier to read, pipe output and make shell loop from output
from faces it is good if they are printed one item per line for arrays.
