### PR TITLE
(#20303) Don't rely on automatic array conversion

### DIFF
--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -28,7 +28,7 @@ module Puppet::Util::ADSI
       unless @computer_name
         buf = " " * 128
         Win32API.new('kernel32', 'GetComputerName', ['P','P'], 'I').call(buf, buf.length.to_s)
-        @computer_name = buf.unpack("A*")
+        @computer_name = buf.unpack("A*")[0]
       end
       @computer_name
     end


### PR DESCRIPTION
Previously, we were unwittingly relying on ruby's automatic conversion
from an array to a string, which fails in ruby 1.9. This was noticed
when running `puppet resource user` as it reported all users were
absent.

Now we explicitly convert from an array to a string.

This commit doesn't have any tests, because the existing acceptance
tests catch this when run under 1.9
