### PR TITLE
(#17183) Pass on parameters to recursive children in static_compiler

### DIFF
--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -135,6 +135,12 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Indirector::Code
 
       # I think this is safe since it's a URL, not an actual file
       children[meta.relative_path][:source] = source + "/" + meta.relative_path
+      resource.each do |param, value|
+        # These should never be passed to our children.
+        unless [:parent, :ensure, :recurse, :recurselimit, :target, :alias, :source].include? param
+          children[meta.relative_path][param] = value
+        end
+      end
       replace_metadata(host, children[meta.relative_path], meta)
     end
 


### PR DESCRIPTION
Pass on parameters from the top level resource to recursive children in
the static compiler.
The list of parameters to exclude is taken from the file type
implementation.
