### PR TITLE
Docs: Update description of ctime and mtime properties for file type

### DIFF
--- a/lib/puppet/type/file/ctime.rb
+++ b/lib/puppet/type/file/ctime.rb
@@ -1,6 +1,8 @@
 module Puppet
   Puppet::Type.type(:file).newproperty(:ctime) do
-    desc "A read-only state to check the file ctime."
+    desc %q{A read-only state to check the file ctime. On most modern \*nix-like
+      systems, this is the time of the most recent change to the owner, group,
+      permissions, or content of the file.}
 
     def retrieve
       current_value = :absent

--- a/lib/puppet/type/file/mtime.rb
+++ b/lib/puppet/type/file/mtime.rb
@@ -1,6 +1,7 @@
 module Puppet
   Puppet::Type.type(:file).newproperty(:mtime) do
-    desc "A read-only state to check the file mtime."
+    desc %q{A read-only state to check the file mtime. On \*nix-like systems, this
+      is the time of the most recent change to the content of the file.}
 
     def retrieve
       current_value = :absent


### PR DESCRIPTION
Enough people understand ctime to mean "creation time" that it's worth clarifying.
