### PR TITLE
(#17887) Only log if message has been initialized

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -117,11 +117,17 @@ class Puppet::Transaction::ResourceHarness
     end
     event
   rescue => detail
+    # Execution will continue on StandardErrors, just store the event
     Puppet.log_exception(detail)
     event.status = "failure"
 
     event.message = "change from #{property.is_to_s(current_value)} to #{property.should_to_s(property.should)} failed: #{detail}"
     event
+  rescue Exception => detail
+    # Execution will halt on Exceptions, they get raised to the application
+    event.status = "failure"
+    event.message = "change from #{property.is_to_s(current_value)} to #{property.should_to_s(property.should)} failed: #{detail}"
+    raise
   ensure
     event.send_log
   end

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -104,11 +104,26 @@ describe Puppet::Transaction::ResourceHarness do
           false
         end
       end
+
+      newproperty(:baz) do
+        desc "A property that raises an Exception (not StandardError) when you try to change it"
+        def sync
+          raise Exception.new('baz')
+        end
+
+        def retrieve
+          :absent
+        end
+
+        def insync?(reference_value)
+          false
+        end
+      end
     end
     stubProvider
   end
 
-  describe "when an error occurs" do
+  describe "when a caught error occurs" do
     before :each do
       stub_provider = make_stub_provider
       resource = stub_provider.new :name => 'name', :foo => 1, :bar => 2
@@ -124,6 +139,20 @@ describe Puppet::Transaction::ResourceHarness do
     it "should record a failure event" do
       @status.events[1].property.should == 'bar'
       @status.events[1].status.should == 'failure'
+    end
+  end
+
+  describe "when an Exception occurs during sync" do
+    before :each do
+      stub_provider = make_stub_provider
+      @resource = stub_provider.new :name => 'name', :baz => 1
+      @resource.expects(:err).never
+    end
+
+    it "should log and pass the exception through" do
+      lambda { @harness.evaluate(@resource) }.should raise_error(Exception, /baz/)
+      @logs.first.message.should == "change from absent to 1 failed: baz"
+      @logs.first.level.should == :err
     end
   end
 


### PR DESCRIPTION
It's possible to run the "ensure" block without having executed either the
main or "rescue" blocks, if an Exception not derived from StandardError is
raised or when testing with Mocha expectations.

If this happens during the property.sync, this causes an immediate exit from
the main block, but the "ensure" block is still run.  The event message won't
have been initialized yet, so this then causes the logger to report:

  Puppet::Util::Log requires a message

This changes the "ensure" block to only log if it's got as far as writing a
message.

---

Resubmitting as others keep running into this problem and my replies to the ticket after my last PR being closed haven't received any response.  I don't agree that catching the network timeouts is the responsibility of this PR... that can be addressed separately by whoever it affects.
