### PR TITLE
(#16568) Make typecollection optimization optional

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1095,6 +1095,13 @@ EOT
       on every run.  Puppet can be run with this enabled by default and then selectively
       disabled when a recompile is desired.",
     },
+    :ignoremissingtypes => {
+      :default    => false,
+      :type       => :boolean,
+      :desc       => "Skip searching for classes and definitions that were missing during a
+      prior compilation. The list of missing objects is maintained per-environment and
+      persists until the environment is cleared or the master is restarted.",
+    },
     :ignorecache => {
       :default    => false,
       :type       => :boolean,

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -199,7 +199,7 @@ class Puppet::Resource::TypeCollection
     searchspace.each do |fqname|
       result = send(type, fqname)
       unless result
-        if @notfound[fqname]
+        if @notfound[fqname] and Puppet[:ignoremissingtypes]
           # do not try to autoload if we already tried and it wasn't conclusive
           # as this is a time consuming operation. Warn the user.
           Puppet.warning "Not attempting to load #{type} #{fqname} as this object was missing during a prior compilation"

--- a/spec/unit/resource/type_collection_spec.rb
+++ b/spec/unit/resource/type_collection_spec.rb
@@ -167,7 +167,8 @@ describe Puppet::Resource::TypeCollection do
         @code.find_hostclass("foo", "bar").should == :foobar
       end
 
-      it "should not try to autoload names that we couldn't autoload in a previous step" do
+      it "should not try to autoload names that we couldn't autoload in a previous step if ignoremissingtypes is enabled" do
+        Puppet[:ignoremissingtypes] = true
         @code.loader.expects(:try_load_fqname).with(:hostclass, "ns::klass").returns(nil)
         @code.loader.expects(:try_load_fqname).with(:hostclass, "klass").returns(nil)
         @code.find_hostclass("Ns", "Klass").should be_nil


### PR DESCRIPTION
This pull request re-works an optimization made in 242692e that causes the `TypeCollection` skip searching for objects that were missing in a prior compilation. Several issues have been reported by users who found this behavior to be confusing (ref [#16568](https://projects.puppetlabs.com/issues/16568) and related issues).

The first patch adds a warning message that the master will print whenever it voluntarily skips searching for an object. This is absolutely critical as currently the `TypeCollection` silently skips the search and the only error message reported to the user is `Error 400 on SERVER: Could not find <thing>...`. This is very confusing to users who have missing or misconfigured modules when they take the appropriate corrective action but the server keeps giving them the same error.

The second patch adds a new configuration option, `:ignoremissingtypes`, that controls the behavior introduced in 242692e. This setting is set to `false` by default as the optimization appears to address a very narrow use case and probably isn't worth the confusion it causes to users who don't need it
