### PR TITLE
(#14615) Don't run dangerous init scripts on Debian

### DIFF
--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -1,0 +1,29 @@
+test_name "`puppet resource service` should list running services without changing the system"
+
+confine :except, :platform => 'windows'
+
+hosts.each do |host|
+  step "make sure ssh reports running"
+
+  # We want to validate later that ssh is "still" running, which means it has
+  # to be running to start with
+  on host, 'puppet resource service ssh'
+  assert_match /service { 'ssh[^']*':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is not running"
+
+  step "list running services"
+
+  on host, 'puppet resource service'
+  expected_output = stdout
+
+  step "make sure nothing on the system was changed"
+
+  on host, 'puppet resource service'
+  assert_equal expected_output, stdout, "`puppet resource service` changed the state of the system"
+
+  step "make sure ssh is still running"
+
+  # We know ssh must be running, since we're using it to test. It should still
+  # be running after `puppet resource service`.
+  on host, 'puppet resource service ssh'
+  assert_match /service { 'ssh[^']*':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "`puppet resource service` changed the state of the system"
+end

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -41,7 +41,8 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     # it should remain excluded. When that bug is adddressed this should be
     # reexamined.
     excludes += %w{wait-for-state portmap-wait}
-    excludes
+    # these excludes were found with grep -r -L start /etc/init.d
+    excludes += %w{rcS module-init-tools}
   end
 
   # List all services of this type.

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::Type.type(:service).provider(:init) do
 
   let :excludes do
     # Taken from redhat, gentoo, and debian
-    %w{functions.sh reboot.sh shutdown.sh functions halt killall single linuxconf reboot boot wait-for-state}
+    %w{functions.sh reboot.sh shutdown.sh functions halt killall single linuxconf reboot boot wait-for-state rcS module-init-tools}
   end
 
   describe "when getting all service instances" do


### PR DESCRIPTION
The init service provider has an exclude list of init scripts which
shouldn't be executed because they don't actually have a status
subcommand. However, this list was missing a couple of scripts on Debian
which also shouldn't be run: rcS and module-init-tools.

This also adds an acceptance test verifying that `puppet resource
service` doesn't change the state of the system. It does this by running
it twice and making sure the output is the same. In certain cases, this
may actually fail to identify a problem (if the init script which causes
trouble runs first, for instance), so we also verify that a known
service (ssh) is unaffected by running the command.

This should be included in 3.2, as it's a bug in the RC. I'm not sure where to target the pull request to ensure that happens, so I've targeted master.
