### PR TITLE
Add the file and line number when reporting a duplicate resource

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -533,7 +533,7 @@ class Puppet::Resource::Catalog < Puppet::SimpleGraph
 
     msg << " in file #{existing_resource.file} at line #{existing_resource.line}" if existing_resource.file and existing_resource.line
 
-    msg << "; cannot redeclare" if resource.line or resource.file
+    msg << "; cannot redeclare in file #{resource.file} at line #{resource.line}" if resource.line and resource.file
 
     raise DuplicateResourceError.new(msg)
   end


### PR DESCRIPTION
The default error message will only tell you where one of the duplicate
resources is, when it's sometimes possible to report on both saving
having to search through the code to find the duplicate.
