### PR TITLE
(#20302) Fix failing acceptance test for windows providers

### DIFF
--- a/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
+++ b/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
@@ -14,7 +14,9 @@ TYPE
 
   on agent, "cat > #{dir}/lib/puppet/provider/test6907/only.rb", :stdin => <<PROVIDER
 Puppet::Type.type(:test6907).provide(:only) do
-  commands :anything => "#{dir}/must_exist"
+  # The name of the file is chosen to be *.exe so it works on windows and *nix
+  # becasue windows inspects the PATHEXT environment variable in 1.9.3 and later.
+  commands :anything => "#{dir}/must_exist.exe"
   require 'fileutils'
 
   def file
@@ -32,7 +34,9 @@ PROVIDER
     file => "#{dir}/test_file",
   }
 
-  file { "#{dir}/must_exist":
+  # The name of the file is chosen to be *.exe so it works on windows and *nix
+  # becasue windows inspects the PATHEXT environment variable in 1.9.3 and later.
+  file { "#{dir}/must_exist.exe":
     ensure => file,
     mode => 0755,
   }


### PR DESCRIPTION
Without this patch the windows acceptance test
ticket_6907_use_provider_in_same_run_it_becomes_suitable is failing on
windows because the behavior that determines of a file is a command or
not, and thus if the provider is suitable or not behaves differently on
Windows than it does on *nix.  This difference in behavior is caused by
Windows determining execute ability by inspecting the PATHEXT
environment variable, and a file with no extension will not be
considered executable.

This problem will not be observed in MRI 1.8.7 because File.executable?
always returns true for any file that exists.  The problem will be
observed in MRI 1.9.3 because this behavior changed in
http://bugs.ruby-lang.org/issues/show/2135

This patch addresses the problem by changing the file to have an exe
extension.  This makes the test agnostic to the underlying behavior of
windows or Unix.
