### PR TITLE
(maint) Fix ENC acceptance test failure on 1.9.3

### DIFF
--- a/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
+++ b/acceptance/tests/language/node_overrides_topscope_when_using_enc.rb
@@ -18,7 +18,7 @@ create_remote_file(master, "#{testdir}/enc", <<-PP)
 cat <<END
 ---
 classes:
-  a
+  - a
 parameters:
   enc_var: "Set from ENC."
 END


### PR DESCRIPTION
Without this patch the `node_overrides_topscope_when_using_enc`
acceptance test is failing when run on MRI 1.9.3 and is passing when run
on MRI 1.8.  This is a problem because Puppet 3 fully supports MRI 1.9
and we need the tests to pass.

The root cause of the problem is an incorrect YAML input file when
providing data to the ENC api.  Without this patch the YAML uses a hash
value that is a string.  In MRI 1.8 String#each iterates over each
character.  The string passed is a single character, "a" so the behavior
in 1.8 has the desired effect by accident.

In MRI 1.9 there is no String#each method so the test fails.  This patch
addresses the problem by changing the YAML to be the correct input of a
hash value that is an Array.

Paired-with: Henrik Lindberg henrik.lindberg@cloudsmith.com
