### PR TITLE
(#20447) Wait for server to shutdown before exiting daemon

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -144,6 +144,8 @@ class Puppet::Daemon
 
     # Finally, loop forever running events - or, at least, until we exit.
     run_event_loop
+
+    server.wait_for_shutdown if server
   end
 
   def run_event_loop

--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -43,7 +43,7 @@ class Puppet::Network::HTTP::WEBrick
     @mutex.synchronize do
       raise "WEBrick server is not listening" unless @listening
       @server.shutdown
-      @thread.join
+      wait_for_shutdown
       @server = nil
       @listening = false
     end
@@ -53,6 +53,10 @@ class Puppet::Network::HTTP::WEBrick
     @mutex.synchronize do
       @listening
     end
+  end
+
+  def wait_for_shutdown
+    @thread.join
   end
 
   # Configure our http log file.

--- a/lib/puppet/network/server.rb
+++ b/lib/puppet/network/server.rb
@@ -108,4 +108,8 @@ class Puppet::Network::Server
     unlisten
     remove_pidfile
   end
+
+  def wait_for_shutdown
+    @http_server.wait_for_shutdown
+  end
 end


### PR DESCRIPTION
Previously, if the filetimeout was set to 0 and the puppet master was run,
the master would exit immediately. This was caused by the scheduler having
nothing to do and the new logic for it causes it to stop running at that
point (because once there is nothing to do, there is also no chance that
something will cause it to having something to do). There was a slightly
wrong assumption that was being made for that logic: the scheduler is in
control of all activity in the daemonized process. This is not the case.

The daemon has 3 parts to it:
- configuration reparse
- agent runs
- server control

The server does not take part in the scheduler inside the daemon. It is 
assumed to be a separate thread/process, which the daemon will kick off when
it starts, and stop when the daemon is told to stop. When the
"start" method of the daemon exits, the daemon itself exits and the server
will be required to shut down.

There are 2 ways that could be used to solve this problem: have the scheduler
sit in a busy loop (or sleep forever) when it has nothing to do, or wait for
the server to finish before the daemon considers itself done. This commit
uses the latter option.

The new code will wait for the server to finish before the Daemon#start 
method returns. This makes the dependency explicit rather than hidden in an
infinite loop in the scheduler.
