### PR TITLE
Fix for rc-status not showing puppet when puppet is run as a service

### DIFF
--- a/lib/puppet/provider/service/openrc.rb
+++ b/lib/puppet/provider/service/openrc.rb
@@ -29,6 +29,7 @@ Puppet::Type.type(:service).provide :openrc, :parent => :base do
   # runlevel our service is listed
   def enabled?
     enabled = :false
+    ENV.delete('RC_SVCNAME')
     rcstatus('-C', '-a').each_line do |line|
       case line.chomp
       when /^Runlevel: /


### PR DESCRIPTION
/bin/rc-status doesn't show the service specified in the environment variable "RC_SVCNAME", which when puppet is started as a service is set to "puppet".
