### PR TITLE
(#20520) Update rgen to 0.6.2, remove Array monkey patches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
 gem "rake", :require => false
 gem "rspec", "~> 2.11.0", :require => false
 gem "mocha", "~> 0.10.5", :require => false
-gem "rgen", "0.6.1", :require => false
+gem "rgen", "0.6.2", :require => false
 
 gem "yarjuf", "~> 1.0"
 

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -126,25 +126,6 @@ class Array
 
     slice(n, length - n) or []
   end unless method_defined? :drop
-  
-  # Array does not have a to_hash method and Hash uses this instead of checking with "respond_to?" if an
-  # array can convert itself or not. (This is a bad thing in Hash). When Array is extended with a method_missing,
-  # (like when using the RGen package 0.6.1 where meta methods are available on arrays), this trips up the
-  # Hash implementation.
-  # This patch simply does what the regular to_hash does, and it is accompanied by a respond_to? method that
-  # returns false for :to_hash.
-  # This is really ugly, and should be removed when the implementation in lib/rgen/array_extension.rb is
-  # fixed to handle to_hash correctly.
-  def to_hash
-    raise NoMethodError.new
-  end
-  
-  # @see #to_hash   
-  def respond_to? m, include_private=false
-    return false if m == :to_hash
-    super
-  end
-
 end
 
 

--- a/spec/unit/pops/parser/rgen_sanitycheck_spec.rb
+++ b/spec/unit/pops/parser/rgen_sanitycheck_spec.rb
@@ -2,8 +2,7 @@
 require 'spec_helper'
 require 'puppet/pops'
 
-# relative to this spec file (./) does not work as this file is loaded by rspec
-require File.join(File.dirname(__FILE__), '/parser_rspec_helper')
+require 'rgen/array_extensions'
 
 describe "RGen working with hashes" do
   it "should be possible to create an empty hash after having required the files above" do


### PR DESCRIPTION
Monkey patches to Array were used to make Array#to_hash fail, which otherwise
broke Hash[[[]].  The later version of rgen removes the need for these, which
prevents bad interactions with other libraries and applications.

---

Targeted for stable as this (3.2.0-rc1) is breaking Foreman in a couple of ways.
