### PR TITLE
(maint) Fix enc with storedconfigs failure on Fedora 18

### DIFF
--- a/acceptance/tests/store_configs/enc_provides_node_when_storeconfigs_enabled.rb
+++ b/acceptance/tests/store_configs/enc_provides_node_when_storeconfigs_enabled.rb
@@ -51,11 +51,16 @@ if $osfamily == "Debian" {
       require => Package[sqlite3]
   }
 } elsif $osfamily == "RedHat" {
+  $sqlite_gem_pkg_name = $operatingsystem ? {
+    Fedora => "rubygem-sqlite3",
+    default => "rubygem-sqlite3-ruby"
+  }
+
   package {
     sqlite:
       ensure => present;
 
-    rubygem-sqlite3-ruby:
+    $sqlite_gem_pkg_name:
       ensure => present,
       require => Package[sqlite]
   }


### PR DESCRIPTION
Without this patch the acceptance test that exercises the behavior of
the ENC script when ActiveRecord storedconfigs is enabled fails on
Fedora 18.  We need this to pass for the Puppet 3.2 release.

The root cause of this problem is that the test setup phase assumes the
package name for the sqlite ruby gem is rubygem-sqlite3-ruby.  This is
true for CentOS and RHEL systems, but Fedora 18 uses a package name of
rubygem-sqlite3.

This patch addresses the problem by using a Puppet selector to change
the package name depending on the operating system of the system under
test.

Paired-with: Josh Partlow
