### PR TITLE
(#20581) Correct parser future's validation of query expression

### DIFF
--- a/lib/puppet/pops/validation/checker3_1.rb
+++ b/lib/puppet/pops/validation/checker3_1.rb
@@ -281,7 +281,7 @@ class Puppet::Pops::Validation::Checker3_1
   end
 
   def check_QueryExpression(o)
-    rvalue(o.expr) if o.expr  # is optional
+    query(o.expr) if o.expr  # is optional
   end
 
   def relation_Object(o, rel_expr)


### PR DESCRIPTION
The QueryExpression validation was performing validation by
checking if the query vas an r-value. It should check if the query
expression is a valid query. 

This corrects this (probable) copy/paste error.
