### PR TITLE
(#18393) AIX 5.3 doesn't support diff -u

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -3,6 +3,14 @@
 
 module Puppet
 
+  def self.default_diffargs
+    if (Facter.value(:kernel) == "AIX" && Facter.value(:kernelmajversion) == "5300")
+      ""
+    else
+      "-u"
+    end
+  end
+
   ############################################################################################
   # NOTE: For information about the available values for the ":type" property of settings,
   #   see the docs for Settings.define_settings
@@ -170,7 +178,7 @@ module Puppet
             "this provides the default environment for nodes we know nothing about."
     },
     :diff_args => {
-        :default  => "-u",
+        :default  => default_diffargs,
         :desc     => "Which arguments to pass to the diff command when printing differences between\n" +
             "files. The command to use can be chosen with the `diff` setting.",
     },

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'puppet/settings'
+
+describe "Defaults" do
+  describe ".default_diffargs" do
+    describe "on AIX" do
+      before(:each) do
+        Facter.stubs(:value).with(:kernel).returns("AIX")
+      end
+      describe "on 5.3" do
+        before(:each) do
+          Facter.stubs(:value).with(:kernelmajversion).returns("5300")
+        end
+        it "should be empty" do
+          Puppet.default_diffargs.should == ""
+        end
+      end
+      [ "",
+        nil,
+        "6300",
+        "7300",
+      ].each do |kernel_version|
+        describe "on kernel version #{kernel_version.inspect}" do
+          before(:each) do
+            Facter.stubs(:value).with(:kernelmajversion).returns(kernel_version)
+          end
+
+          it "should be '-u'" do
+            Puppet.default_diffargs.should == "-u"
+          end
+        end
+      end
+    end
+    describe "on everything else" do
+      before(:each) do
+        Facter.stubs(:value).with(:kernel).returns("NOT_AIX")
+      end
+
+      it "should be '-u'" do
+        Puppet.default_diffargs.should == "-u"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, the diffargs where always `-u`, which is not
supported on AIX 5.3, an official PE supported platform. This commit
adds a utility method to abstract away the logic for what the default
diffargs should be and then calls that for the default value.
