### PR TITLE
(#6371) Update lastchg field when updating password

### DIFF
--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -1,5 +1,6 @@
 require 'puppet/util'
 require 'puppet/util/user_attr'
+require 'date'
 
 Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source => :useradd do
 
@@ -195,6 +196,7 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
           line_arr = line.split(':')
           if line_arr[0] == @resource[:name]
             line_arr[1] = cryptopw
+            line_arr[2] = (Date.today - Date.new(1970,1,1)).to_i.to_s
             line = line_arr.join(':')
           end
           fh.print line

--- a/spec/unit/provider/user/user_role_add_spec.rb
+++ b/spec/unit/provider/user/user_role_add_spec.rb
@@ -267,6 +267,7 @@ FIXTURE
     end
 
     it "should only update the target user" do
+      Date.expects(:today).returns Date.new(2011,12,07)
       write_fixture <<FIXTURE
 before:seriously:15315:0:99999:7:::
 fakeval:seriously:15315:0:99999:7:::
@@ -293,6 +294,23 @@ FIXTURE
       write_fixture fixture
       provider.password = "totally"
       File.read(path).should == fixture
+    end
+
+    it "should update the lastchg field" do
+      Date.expects(:today).returns Date.new(2013,5,12) # 15837 days after 1970-01-01
+      write_fixture <<FIXTURE
+before:seriously:15315:0:99999:7:::
+fakeval:seriously:15629:0:99999:7:::
+fakevalish:seriously:15315:0:99999:7:::
+after:seriously:15315:0:99999:7:::
+FIXTURE
+      provider.password = "totally"
+      File.read(path).should == <<EOT
+before:seriously:15315:0:99999:7:::
+fakeval:totally:15837:0:99999:7:::
+fakevalish:seriously:15315:0:99999:7:::
+after:seriously:15315:0:99999:7:::
+EOT
     end
   end
 


### PR DESCRIPTION
On Solaris the `password=` method updates the `/etc/shadow` file directly
to set the new password but it does not update the `lastchg` field to
the current day. This way a password can expire even though it was
updated with puppet.

The fix was first supplied in commit 6ef1d3a but was later removed after
a refactor in 7900a66.
