### PR TITLE
(maint) Clarify the merge-up process in COMMITTERS

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -214,12 +214,12 @@ release branch, the committer merges in:
      1 file changed, 0 insertions(+), 0 deletions(-)
      create mode 100644 foo
 
-Once merged into the first base branch, the committer merges the same topic
+Once merged into the first base branch, the committer merges the `stable`
 branch into `master`, being careful to preserve the same commit identifiers.
 
     $ git checkout master
     Switched to branch 'master'
-    $ git merge --no-ff --log bug/stable/fix_foo_error
+    $ git merge --no-ff --log stable
     Merge made by the 'recursive' strategy.
      foo | 0
      1 file changed, 0 insertions(+), 0 deletions(-)


### PR DESCRIPTION
Without this patch some of the committers are using a process that involves
merging a topic branch based on stable into both `stable` and
`master`.  This is a problem because it's confusing and inconsistent from
other committers who are merging a topic branch into `stable`, then merging
`stable` into `master.

The two processes, while equivalent in nature, produce different and 
inconsistent log messages when reviewing `git lg`.  For example, the following
log is produced by the process that does not merge up:

```
*   e130aa5 Merge branch 'maint/stable/filebucket_clarifications' 30
```

minutes ago Hailee Kenney  (HEAD, origin/master, master)
   |\
   | \* b301ada Maint: Improve documentation of filebucket attributes 33
minutes ago Nick Fagerlund
- |   9aa9d69 Merge pull request #1636 from
  adrienthebo/maint-readme_developer_explain_side_effects_in_tests 3 days ago
  Hailee Kenney
  |\ \
- \ \   515cd97 Merge pull request #1639 from
  Sharpie/18895-fix-runit-documentation 3 days ago Hailee Kenney
  |\ \ \
  | \* | | 713bcbe (#18895) Fix documentation in runit provider 3 days ago
  Charlie Sharpsteen
  |/ / /
- | |   4c2655f Merge pull request #1637 from
  jeffweiss/tickets/bug/18393_diffargs_broken_on_aix53 4 days ago Chris Price
  |\ \ \
  | \* | | bb86ff6 (#18393) AIX 5.3 doesn't support diff -u 4 days ago Jeff
  Weiss
- | | |   325b8bf Merge pull request #1635 from hlindberg/issues/fix-20581
  5 days ago Adrien Thebo
  |\ \ \ \
  | |/ / /
  |/| | |
  | | \* | a3941d4 (maint) Add documentation on side effects in tests 6 days
  ago Adrien Thebo
  | \* | | 23005e6 (#20581) Correct parser future's validation of query
  expression 7 days ago Henrik Lindberg
  |/ / /
  | | \* edfabfd (packaging) Update PUPPETVERSION to 3.2.0-rc2 7 days ago
  Matthaus Owens  (3.2.0-rc2)
- | |   8c0e1b3 Merge branch 'stable' 7 days ago Jeff McCune
  |\ \ \
  | | |/
  | |/|
  | \* |   761de6b Merge branch 'fix_activerecord_centos' into stable 7 days
  ago Jeff McCune

Compare this to the log of the stable branch and observe how there are two
very similar merge commits with the log `Merge branch
'maint/stable/filebucket_clarifications'`  Please observe these similar commit 
messages have different commit ID's, e130aa5 and 47fd6f9 respectively, and
both merge commits are bringing in the change contained in b301ada.

```
*   47fd6f9 Merge branch 'maint/stable/filebucket_clarifications' into
```

stable 33 minutes ago Hailee Kenney  (origin/stable, stable)
   |\
   | \* b301ada Maint: Improve documentation of filebucket attributes 34
minutes ago Nick Fagerlund
   |/
- edfabfd (packaging) Update PUPPETVERSION to 3.2.0-rc2 7 days ago Matthaus
  Owens  (3.2.0-rc2)

Using the merge-up process made clear in this patch, the history will look as 
follows:

```
*   1f79310 Merge branch 'stable' 5 seconds ago Jeff McCune  (HEAD,
```

master)
   |\
   | \*   c6f6ffb Merge branch 'fix/stable/clarify_merge_up' into stable 45
seconds ago Jeff McCune  (stable)
   | |\
   | | \* 44b999c (maint) Clarify the merge-up process in COMMITTERS 53 seconds
ago Jeff McCune  (fix/stable/clarify_merge_up)
   | |/
- |   e130aa5 Merge branch 'maint/stable/filebucket_clarifications' 35
  minutes ago Hailee Kenney  (origin/master)
  |\ \
  | | \*   47fd6f9 Merge branch 'maint/stable/filebucket_clarifications' into
  stable 36 minutes ago Hailee Kenney  (origin/stable)

This minor difference also has the effect of making `git branch --contains 
c6f6ffb` much more useful, as both `master` and `stable` will contain merge 
commits made into `stable`.
