### PR TITLE
Fix for rc-status not showing puppet when puppet is run as a service (updated)

### DIFF
--- a/lib/puppet/provider/service/openrc.rb
+++ b/lib/puppet/provider/service/openrc.rb
@@ -10,8 +10,10 @@ Puppet::Type.type(:service).provide :openrc, :parent => :base do
   defaultfor :operatingsystem => :gentoo
   defaultfor :operatingsystem => :funtoo
 
+  has_command(:rcstatus, '/bin/rc-status') do
+    environment :RC_SVCNAME => nil
+  end
   commands :rcservice => '/sbin/rc-service'
-  commands :rcstatus  => '/bin/rc-status'
   commands :rcupdate  => '/sbin/rc-update'
 
   self::STATUSLINE = /^\s+(.*?)\s*\[\s*(.*)\s*\]$/


### PR DESCRIPTION
/bin/rc-status doesn't show the service specified in the environment
variable "RC_SVCNAME", which when puppet is started as a service is set
to "puppet".

Updated to use "has_command" instead of ENV.delete

Because my github-fu is weak, I ended up making a second pull request.
