### PR TITLE
(#11108) Make the pkgdmg provider able to install a remote flat pkg file

### DIFF
--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -59,9 +59,10 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
     require 'open-uri'
     cached_source = source
     tmpdir = Dir.mktmpdir
+    ext = /(\.dmg|\.pkg)$/i.match(source)[0]
     begin
       if %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ cached_source
-        cached_source = File.join(tmpdir, name)
+        cached_source = File.join(tmpdir, "#{name}#{ext}")
         begin
           curl "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--url", source
           Puppet.debug "Success: curl transfered [#{name}]"


### PR DESCRIPTION
Without this patch applied when the pkgdmg provider is used to install a remote flat pkg file, the installation fails. This is becasue the installer expect a file with the .pkg extension and the curl command used to download the remote package set as output a filename without any extension. This patch fixes the problem by adding the correct extension to the curl output parameter.
