### PR TITLE
(#17871) fix nagios types uniqness under ruby 1.9

### DIFF
--- a/lib/puppet/external/nagios/base.rb
+++ b/lib/puppet/external/nagios/base.rb
@@ -215,7 +215,7 @@ class Nagios::Base
       # Now access the parameters directly, to make it at least less
       # likely we'll end up in an infinite recursion.
       if mname.to_s =~ /=$/
-        @parameters[pname] = *args
+        @parameters[pname] = args.first
       else
         return @parameters[mname]
       end

--- a/spec/unit/provider/naginator_spec.rb
+++ b/spec/unit/provider/naginator_spec.rb
@@ -55,3 +55,11 @@ describe Puppet::Provider::Naginator do
     @class.should_not be_skip_record("foo")
   end
 end
+
+describe Nagios::Base do
+  it "should not turn set parameters into arrays #17871" do
+    obj = Nagios::Base.create('host')
+    obj.host_name = "my_hostname"
+    obj.host_name.should == "my_hostname"
+  end
+end


### PR DESCRIPTION
In ruby 1.8 and earlier, splatting a 1-element array would return the first
element, post 1.9 you always get an array back.

This lead to an issue in the nagios providers where the parameters['name']
would be set to an Array, so simple 'does this resource already exist
checks' would fail as parameters['name'] == string is false.

```
$ ruby-1.8.7-p371 -e 'a = ["a"]; b = *a; puts b.inspect'
"a"

$ ruby-1.9.3-p429 -e 'a = ["a"]; b = *a; puts b.inspect'
["a"]
```

This patch forces a destucturing assignment in method_missing by adding a comma
to the LHS.  This is portable between ruby 1.8 and 1.9.

```
$ ruby-1.8.7-p371 -e 'a = ["a"]; b, = *a; puts b.inspect'
"a"

$ ruby-1.9.3-p429 -e 'a = ["a"]; b, = *a; puts b.inspect'
"a"
```
