### PR TITLE
(#2406) Add the install_option attribute to the apt provider

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -6,6 +6,8 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
 
   has_feature :versionable
 
+  has_feature :install_options
+
   commands :aptget => "/usr/bin/apt-get"
   commands :aptcache => "/usr/bin/apt-cache"
   commands :preseed => "/usr/bin/debconf-set-selections"
@@ -62,6 +64,10 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
       # Add the package version and --force-yes option
       str += "=#{should}"
       cmd << "--force-yes"
+    end
+
+    if @resource[:install_options]
+      cmd << @resource[:install_options]
     end
 
     cmd << :install << str


### PR DESCRIPTION
Since the package provider install_option attribute exists I, have
added it to the apt provider. With this (4 line) patch the apt provider
becomes much more flexible and it will prevent 'hacks' and work
arounds in Puppet code for Debian machines.

Example use case:
When you use Percona SQL instead of MySQL it becomes hard to not
overwite the percona packages with the regular MySQL packages.

The problem:
  sudo apt-get install percona-server-server-5.5
  sudo apt-get install zabbix-server-mysql

The thing which is gonna happen now is that the zabbix-server-mysql
will replace percona-server-server-5.5 with mysql-server because
it is in the recommends of the zabbix-server-mysql package.

The solution:
  sudo apt-get install percona-server-server-5.5
  sudo apt-get --no-install-recommends install zabbix-server-mysql

Unfortunately specifying this option is not possible in Puppet.
With this patch it does, and it solves way more issues you can
have with apt and Puppet, for example feature request: #2406.

Example Puppet code:

  package { 'zabbix-server-mysql':
    ensure          => present,
    install_options => '--no-install-recommends';
  }

  package { 'zabbix-server-mysql':
    ensure          => present,
    install_options => ['--no-install-recommends', '--install-suggests'];
  }
