### PR TITLE
(maint) Change load order for puppet/provider/package/windows/package

### DIFF
--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -1,3 +1,29 @@
+# 'puppet/type/package' is being required here to avoid a load order issue that
+# manifests as 'uninitialized constant Puppet::Util::Windows::MsiPackage' or
+# 'uninitialized constant Puppet::Util::Windows::Package' (or similar case
+# where Puppet::Provider::Package::Windows somehow ends up pointing to
+# Puppet:Util::Windows) if puppet/provider/package/windows/package is loaded
+# before the puppet/type/package.
+#
+# Example:
+#
+#  jpartlow@percival:~/work/puppet$ bundle exec rspec spec/unit/provider/package/windows/package_spec.rb spec/unit/provider/package/rpm_spec.rb 
+#  Run options: exclude {:broken=>true}
+#  ..F..FFF........................
+#  
+#  Failures:
+#  
+#    1) Puppet::Util::Package::Windows::Package::each should yield each package it finds
+#       Failure/Error: Puppet::Provider::Package::Windows::MsiPackage.expects(:from_registry).with('Google', {}).returns(package)
+#       NameError:
+#         uninitialized constant Puppet::Util::Windows::MsiPackage
+#       # ./spec/unit/provider/package/windows/package_spec.rb:24:in `block (3 levels) in <top (required)>'
+#
+# ---
+#
+# Needs more investigation to pinpoint what's going on.
+#
+require 'puppet/type/package'
 require 'puppet/util/windows'
 
 class Puppet::Provider::Package::Windows


### PR DESCRIPTION
Uncovered a load order issue with
puppet/provider/package/windows/package being loaded before
puppet/type/package.  This was manifesting in various test runs as
'uninitialized constant Puppet::Util::Windows::MsiPackage' or
'uninitialized constant Puppet::Util::Windows::Package' (or similar case
where Puppet::Provider::Package::Windows somehow ends up pointing to
Puppet:Util::Windows).

This patch just require's 'puppet/type/package' at the beginning of
puppet/provider/package/windows/package.  Which fixes the immediate load
order issues seen in the specs, but is not a long term fix.

More investigation is needed to pinpoint what's going on.
