### PR TITLE
Generated modules comply with Style Guide

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
@@ -15,16 +15,16 @@
 # Here you should define a list of variables that this module would require.
 #
 # [*sample_variable*]
-#   Explanation of how this variable affects the funtion of this class and if it
-#   has a default. e.g. "The parameter enc_ntp_servers must be set by the
+#   Explanation of how this variable affects the funtion of this class and if
+#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
 #   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should not be used in preference to class parameters  as of
-#   Puppet 2.6.)
+#   global variables should not be used in preference to class parameters as
+#   of Puppet 2.6.)
 #
 # === Examples
 #
 #  class { <%= metadata.name %>:
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ]
+#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
 #  }
 #
 # === Authors

--- a/lib/puppet/module_tool/skeleton/templates/generator/tests/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/tests/init.pp.erb
@@ -2,10 +2,11 @@
 # should have a corresponding test manifest that declares that class or defined
 # type.
 #
-# Tests are then run by using puppet apply --noop (to check for compilation errors
-# and view a log of events) or by fully applying the test in a virtual environment
-# (to compare the resulting system state to the desired state).
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
 #
-# Learn more about module testing here: http://docs.puppetlabs.com/guides/tests_smoke.html
+# Learn more about module testing here:
+# http://docs.puppetlabs.com/guides/tests_smoke.html
 #
 include <%= metadata.name %>


### PR DESCRIPTION
Without this patch, all module generated with `puppet module generate`
will produce code that does not pass lint or comply to our Style Guide.
