### PR TITLE
(#20787) Restrict ADSI query to the localhost

### DIFF
--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -34,7 +34,9 @@ module Puppet::Util::ADSI
     end
 
     def computer_uri
-      "WinNT://#{computer_name}"
+      # We always want to enumerate the local accounts, so don't specify a
+      # server otherwise, it can result in NetBIOS lookups
+      "WinNT://."
     end
 
     def wmi_resource_uri( host = '.' )

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -15,7 +15,6 @@ describe Puppet::Type.type(:group).provider(:windows_adsi) do
   let(:connection) { stub 'connection' }
 
   before :each do
-    Puppet::Util::ADSI.stubs(:computer_name).returns('testcomputername')
     Puppet::Util::ADSI.stubs(:connect).returns connection
   end
 

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -16,7 +16,6 @@ describe Puppet::Type.type(:user).provider(:windows_adsi) do
   let(:connection) { stub 'connection' }
 
   before :each do
-    Puppet::Util::ADSI.stubs(:computer_name).returns('testcomputername')
     Puppet::Util::ADSI.stubs(:connect).returns connection
   end
 


### PR DESCRIPTION
Previously, we were constructing an ADSI connection string using the local
computer name, e.g. WinNT://hostname/Administrator,user, but Windows makes a
NetBIOS request that times after 2-3 second for each user & group.

Simply using '.' to denote the local computer eliminates all network
requests, to \Device\Mup\hostname\MAILSLOT\NET\NETLOGON and
\Device\Mailslot\NET\GETDCXXX. This reduces the time to run
`puppet resource user` from 198 seconds to 3.1 seconds for 39 users,
and from 98 seconds to 2.8 seconds for 16 groups.
