### PR TITLE
(#20787) Do not generate NetBIOS name service requests

### DIFF
--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -33,16 +33,16 @@ module Puppet::Util::ADSI
       @computer_name
     end
 
-    def computer_uri
-      "WinNT://#{computer_name}"
+    def computer_uri(host = '.')
+      "WinNT://#{host}"
     end
 
     def wmi_resource_uri( host = '.' )
       "winmgmts:{impersonationLevel=impersonate}!//#{host}/root/cimv2"
     end
 
-    def uri(resource_name, resource_type)
-      "#{computer_uri}/#{resource_name},#{resource_type}"
+    def uri(resource_name, resource_type, host = '.')
+      "#{computer_uri(host)}/#{resource_name},#{resource_type}"
     end
 
     def wmi_connection
@@ -74,8 +74,8 @@ module Puppet::Util::ADSI
       @native_user ||= Puppet::Util::ADSI.connect(uri)
     end
 
-    def self.uri(name)
-      Puppet::Util::ADSI.uri(name, 'user')
+    def self.uri(name, host = '.')
+      Puppet::Util::ADSI.uri(name, 'user', host)
     end
 
     def uri
@@ -216,8 +216,8 @@ module Puppet::Util::ADSI
       self.class.uri(name)
     end
 
-    def self.uri(name)
-      Puppet::Util::ADSI.uri(name, 'group')
+    def self.uri(name, host = '.')
+      Puppet::Util::ADSI.uri(name, 'group', host)
     end
 
     def native_group
@@ -235,14 +235,14 @@ module Puppet::Util::ADSI
 
     def add_members(*names)
       names.each do |name|
-        native_group.Add(Puppet::Util::ADSI::User.uri(name))
+        native_group.Add(Puppet::Util::ADSI::User.uri(name, Puppet::Util::ADSI.computer_name))
       end
     end
     alias add_member add_members
 
     def remove_members(*names)
       names.each do |name|
-        native_group.Remove(Puppet::Util::ADSI::User.uri(name))
+        native_group.Remove(Puppet::Util::ADSI::User.uri(name, Puppet::Util::ADSI.computer_name))
       end
     end
     alias remove_member remove_members

--- a/spec/unit/util/adsi_spec.rb
+++ b/spec/unit/util/adsi_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Util::ADSI do
   end
 
   it "should generate the correct URI for a resource" do
-    Puppet::Util::ADSI.uri('test', 'user').should == "WinNT://testcomputername/test,user"
+    Puppet::Util::ADSI.uri('test', 'user').should == "WinNT://./test,user"
   end
 
   it "should be able to get the name of the computer" do
@@ -25,7 +25,11 @@ describe Puppet::Util::ADSI do
   end
 
   it "should be able to provide the correct WinNT base URI for the computer" do
-    Puppet::Util::ADSI.computer_uri.should == "WinNT://testcomputername"
+    Puppet::Util::ADSI.computer_uri.should == "WinNT://."
+  end
+
+  it "should generate a fully qualified WinNT URI" do
+    Puppet::Util::ADSI.computer_uri('testcomputername').should == "WinNT://testcomputername"
   end
 
   describe ".sid_for_account", :if => Puppet.features.microsoft_windows? do
@@ -52,7 +56,7 @@ describe Puppet::Util::ADSI do
     let(:username)  { 'testuser' }
 
     it "should generate the correct URI" do
-      Puppet::Util::ADSI::User.uri(username).should == "WinNT://testcomputername/#{username},user"
+      Puppet::Util::ADSI::User.uri(username).should == "WinNT://./#{username},user"
     end
 
     it "should be able to create a user" do
@@ -68,7 +72,7 @@ describe Puppet::Util::ADSI do
     end
 
     it "should be able to check the existence of a user" do
-      Puppet::Util::ADSI.expects(:connect).with("WinNT://testcomputername/#{username},user").returns connection
+      Puppet::Util::ADSI.expects(:connect).with("WinNT://./#{username},user").returns connection
       Puppet::Util::ADSI::User.exists?(username).should be_true
     end
 
@@ -114,7 +118,7 @@ describe Puppet::Util::ADSI do
       end
 
       it "should generate the correct URI" do
-        user.uri.should == "WinNT://testcomputername/#{username},user"
+        user.uri.should == "WinNT://./#{username},user"
       end
 
       describe "when given a set of groups to which to add the user" do
@@ -132,8 +136,8 @@ describe Puppet::Util::ADSI do
             group3 = stub 'group1'
             group3.expects(:Remove).with("WinNT://testcomputername/#{username},user")
 
-            Puppet::Util::ADSI.expects(:connect).with('WinNT://testcomputername/group1,group').returns group1
-            Puppet::Util::ADSI.expects(:connect).with('WinNT://testcomputername/group3,group').returns group3
+            Puppet::Util::ADSI.expects(:connect).with('WinNT://./group1,group').returns group1
+            Puppet::Util::ADSI.expects(:connect).with('WinNT://./group3,group').returns group3
 
             user.set_groups(groups_to_set, false)
           end
@@ -144,7 +148,7 @@ describe Puppet::Util::ADSI do
             group1 = stub 'group1'
             group1.expects(:Add).with("WinNT://testcomputername/#{username},user")
 
-            Puppet::Util::ADSI.expects(:connect).with('WinNT://testcomputername/group1,group').returns group1
+            Puppet::Util::ADSI.expects(:connect).with('WinNT://./group1,group').returns group1
 
             user.set_groups(groups_to_set, true)
           end
@@ -193,12 +197,12 @@ describe Puppet::Util::ADSI do
       end
 
       it "should generate the correct URI" do
-        group.uri.should == "WinNT://testcomputername/#{groupname},group"
+        group.uri.should == "WinNT://./#{groupname},group"
       end
     end
 
     it "should generate the correct URI" do
-      Puppet::Util::ADSI::Group.uri("people").should == "WinNT://testcomputername/people,group"
+      Puppet::Util::ADSI::Group.uri("people").should == "WinNT://./people,group"
     end
 
     it "should be able to create a group" do
@@ -214,7 +218,7 @@ describe Puppet::Util::ADSI do
     end
 
     it "should be able to confirm the existence of a group" do
-      Puppet::Util::ADSI.expects(:connect).with("WinNT://testcomputername/#{groupname},group").returns connection
+      Puppet::Util::ADSI.expects(:connect).with("WinNT://./#{groupname},group").returns connection
 
       Puppet::Util::ADSI::Group.exists?(groupname).should be_true
     end


### PR DESCRIPTION
Previously, we were constructing an ADSI connection uri using the local
computer name, e.g. 'WinNT://hostname/Administrator,user'. However, Windows
performs a NetBIOS name service request (NBNS), one request for each ADSI
connection, which is very slow when enumerating users and groups.

Simply using '.' to denote the local computer eliminates all NBNS
requests. This reduces the time to run `puppet resource user` from 198
seconds to 3.1 seconds for 39 users, and from 98 seconds to 2.8 seconds for
16 groups.

Note we still have to use the fully qualified uri when adding/removing
users from a group, though it does not result in NBNS requests.
