### PR TITLE
Warn when specifying both server and use_srv_records

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1015,6 +1015,11 @@ EOT
       :default    => false,
       :type       => :boolean,
       :desc       => "Whether the server will search for SRV records in DNS for the current domain.",
+      :hook => proc do |value|
+        if value.true? and Puppet[:server] != "puppet"
+          raise "Cannot specify both the server and use_srv_records"
+        end
+      end
     },
     :srv_domain => {
       :default    => "#{Puppet::Settings.domain_fact}",


### PR DESCRIPTION
These options are mutually exclusive, so best to warn people trying to use both at the same time.
