### PR TITLE
commit 9ed6fcea48591cda58db1379b58cd39dfbdca684 which added arity checks

### DIFF
--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -35,7 +35,7 @@ module Puppet::Parser::Functions
     key, default, override = HieraPuppet.parse_args(args)
     if answer = HieraPuppet.lookup(key, default, self, override, :array)
       method = Puppet::Parser::Functions.function(:include)
-      send(method, answer)
+      send(method, [answer])
     else
       raise Puppet::ParseError, "Could not find data item #{key}"
     end

--- a/spec/unit/parser/functions/hiera_include_spec.rb
+++ b/spec/unit/parser/functions/hiera_include_spec.rb
@@ -21,4 +21,16 @@ describe 'Puppet::Parser::Functions#hiera_include' do
     HieraPuppet.expects(:lookup).with() { |*args| args[4].should be :array }.returns(['someclass'])
     expect { scope.function_hiera_include(['key']) }.to raise_error Puppet::Error, /Could not find class someclass/
   end
+
+  it 'should call the `include` function with the classes' do
+    HieraPuppet.expects(:lookup).returns %w[foo bar baz]
+
+    scope.expects(:function_include).with([%w[foo bar baz]])
+    scope.function_hiera_include(['key'])
+  end
+
+  it 'should not raise an error if the resulting hiera lookup returns an empty array' do
+    HieraPuppet.expects(:lookup).returns []
+    expect { scope.function_hiera_include(['key']) }.to_not raise_error
+  end
 end


### PR DESCRIPTION
on puppet functions, caused a regression on using hiera includes when
the array of classes is empty
