### PR TITLE
(#20897) Added lines to handle UTF_8 systems at startup

### DIFF
--- a/ext/rack/files/config.ru
+++ b/ext/rack/files/config.ru
@@ -1,6 +1,12 @@
 # a config.ru, for use with every rack-compatible webserver.
 # SSL needs to be handled outside this, though.
 
+# prevent error messages like "invalid byte sequence in US-ASCII"
+if RUBY_VERSION >= "1.9"
+  Encoding.default_external = Encoding::UTF_8
+  Encoding.default_internal = Encoding::UTF_8
+end
+
 # if puppet is not in your RUBYLIB:
 # $LOAD_PATH.unshift('/opt/puppet/lib')
 


### PR DESCRIPTION
I had weird error messages since upgrade of puppetmaster to 3.2.1, so I finally manage to make it work again as intended by specifying UTF8 content explicitly to ruby on startup.

Sory
