### PR TITLE
Revert "Merge pull request #1478 from dsd/fix/master/18781-webrick-old-client-compat"

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -414,12 +414,3 @@ if Puppet::Util::Platform.windows?
   end
 end
 
-# Old puppet clients may make large GET requests, lets be reasonably tolerant
-# in our default WEBrick server.
-require 'webrick'
-if defined?(WEBrick::HTTPRequest::MAX_URI_LENGTH) and WEBrick::HTTPRequest::MAX_URI_LENGTH < 8192
-  # Silence ruby warning: already initialized constant MAX_URI_LENGTH
-  v, $VERBOSE = $VERBOSE, nil
-  WEBrick::HTTPRequest.const_set("MAX_URI_LENGTH", 8192)
-  $VERBOSE = v
-end


### PR DESCRIPTION
This reverts commit 86331385e6263bf370a8e42f52f882d43882efd2, reversing
changes made to a10b85bd9e7198ca71ef0461bcdfe5ff75698724.

The commit being reverted causes webrick to be loaded during puppet
startup, e.g. puppet --version, and webrick performs a reverse DNS
lookup of the local IP address, which can cause unnecessary delays.
