### PR TITLE
Feature #20916: This patch extends the zypper package provider with the install_options ...

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
   desc "Support for SuSE `zypper` package manager. Found in SLES10sp2+ and SLES11"
 
-  has_feature :versionable
+  has_feature :versionable, :install_options
 
   commands :zypper => "/usr/bin/zypper"
 
@@ -51,9 +51,9 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
 
     #zypper 0.6.13 (OpenSuSE 10.2) does not support auto agree with licenses
     if major < 1 and minor <= 6 and patch <= 13
-      zypper quiet, :install, noconfirm, wanted
+      zypper quiet, :install, noconfirm, install_options, wanted
     else
-      zypper quiet, :install, license, noconfirm, wanted
+      zypper quiet, :install, license, noconfirm, install_options, wanted
     end
 
     unless self.query
@@ -80,5 +80,24 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
   def update
     # zypper install can be used for update, too
     self.install
+  end
+
+  def install_options
+    join_options(resource[:install_options])
+  end
+
+  def join_options(options)
+    return unless options
+
+    options.collect do |val|
+      case val
+      when Hash
+        val.keys.sort.collect do |k|
+          "#{k} '#{val[k]}'"
+        end.join(' ')
+      else
+        val
+      end
+    end
   end
 end

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -39,13 +39,18 @@ describe provider_class do
     @provider.should respond_to(:latest)
   end
 
+  it "should have a install_options method" do
+    @provider = provider_class.new
+    @provider.should respond_to(:install_options)
+  end
+
   describe "when installing with zypper version >= 1.0" do
     it "should use a command-line with versioned package'" do
       @resource.stubs(:should).with(:ensure).returns "1.2.3-4.5.6"
       @provider.stubs(:zypper_version).returns "1.2.8"
 
       @provider.expects(:zypper).with('--quiet', :install,
-        '--auto-agree-with-licenses', '--no-confirm', 'mypackage-1.2.3-4.5.6')
+        '--auto-agree-with-licenses', '--no-confirm', nil, 'mypackage-1.2.3-4.5.6')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
@@ -54,7 +59,7 @@ describe provider_class do
       @resource.stubs(:should).with(:ensure).returns :latest
       @provider.stubs(:zypper_version).returns "1.2.8"
       @provider.expects(:zypper).with('--quiet', :install,
-        '--auto-agree-with-licenses', '--no-confirm', 'mypackage')
+        '--auto-agree-with-licenses', '--no-confirm', nil, 'mypackage')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
@@ -66,7 +71,7 @@ describe provider_class do
       @provider.stubs(:zypper_version).returns "0.6.104"
 
       @provider.expects(:zypper).with('--terse', :install,
-        '--auto-agree-with-licenses', '--no-confirm', 'mypackage-1.2.3-4.5.6')
+        '--auto-agree-with-licenses', '--no-confirm', nil, 'mypackage-1.2.3-4.5.6')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
@@ -75,7 +80,7 @@ describe provider_class do
       @resource.stubs(:should).with(:ensure).returns :latest
       @provider.stubs(:zypper_version).returns "0.6.104"
       @provider.expects(:zypper).with('--terse', :install,
-        '--auto-agree-with-licenses', '--no-confirm', 'mypackage')
+        '--auto-agree-with-licenses', '--no-confirm', nil, 'mypackage')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
@@ -87,7 +92,7 @@ describe provider_class do
       @provider.stubs(:zypper_version).returns "0.6.13"
 
       @provider.expects(:zypper).with('--terse', :install,
-        '--no-confirm', 'mypackage-1.2.3-4.5.6')
+        '--no-confirm', nil, 'mypackage-1.2.3-4.5.6')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
@@ -96,7 +101,7 @@ describe provider_class do
       @resource.stubs(:should).with(:ensure).returns :latest
       @provider.stubs(:zypper_version).returns "0.6.13"
       @provider.expects(:zypper).with('--terse', :install,
-        '--no-confirm', 'mypackage')
+        '--no-confirm', nil, 'mypackage')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
@@ -119,4 +124,18 @@ describe provider_class do
     end
   end
 
+  describe "when installing with zypper install options" do
+    it "should install the package without checking keys" do
+      @resource.stubs(:[]).with(:name).returns "php5"
+      @resource.stubs(:should).with(:install_options).returns ['--no-gpg-check', {'-p' => '/vagrant/files/localrepo/'}]
+      @resource.stubs(:should).with(:ensure).returns "5.4.10-4.5.6"
+      @provider.stubs(:zypper_version).returns "1.2.8"
+
+      @provider.expects(:install_options).returns "--no-gpg-check -p \"/vagrant/files/localrepo/\""
+      @provider.expects(:zypper).with('--quiet', :install,
+        '--auto-agree-with-licenses', '--no-confirm', '--no-gpg-check -p "/vagrant/files/localrepo/"', 'php5-5.4.10-4.5.6')
+      @provider.expects(:query).returns "php5 0 5.4.10 4.5.6 x86_64"
+      @provider.install
+    end
+  end
 end


### PR DESCRIPTION
...funktion.

With this patch you can now define a unsigned rpm repository like this:
package { "special-mysql":
  ensure => "present",
  install_options => ['--no-gpg-check', {'-p' => '/vagrant/files/localrepo/'}]
}
