### PR TITLE
(#20920) Include file and line number on invalid resource relationship

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1408,7 +1408,7 @@ class Type
       @value.each do |ref|
         unless @resource.catalog.resource(ref.to_s)
           description = self.class.direction == :in ? "dependency" : "dependent"
-          fail "Could not find #{description} #{ref} for #{resource.ref}"
+          fail ResourceError, "Could not find #{description} #{ref} for #{resource.ref}"
         end
       end
     end

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -811,7 +811,7 @@ describe Puppet::Type::RelationshipMetaparam do
     catalog.expects(:resource).with("Foo[bar]").returns "something"
     catalog.expects(:resource).with("Class[Test]").returns nil
 
-    param.expects(:fail).with { |string| string.include?("Class[Test]") }
+    param.expects(:fail).with { |exception,string| string.include?("Class[Test]") }
 
     param.validate_relationship
   end


### PR DESCRIPTION
Change the error type to ResourceError to make it include the file name
and line number.
