### PR TITLE
Set HOME environment for eix/portage provider

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -6,7 +6,15 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
   has_feature :versionable
 
-  commands :emerge => "/usr/bin/emerge", :eix => "/usr/bin/eix", :update_eix => "/usr/bin/eix-update"
+  {
+    :emerge => "/usr/bin/emerge",
+    :eix => "/usr/bin/eix",
+    :update_eix => "/usr/bin/eix-update",
+  }.each_pair do |name, path|
+    has_command(name, path) do
+      environment :HOME => '/'
+    end
+  end
 
   confine :operatingsystem => :gentoo
 


### PR DESCRIPTION
Lack of this variable causes "No $HOME found in environment." message in
stderr of eix command, which is misleading in a situation when a package
is not found or some other error occurred.

This fixes Bug #20957: http://projects.puppetlabs.com/issues/20957
