### PR TITLE
Revert "Merge branch 'cprice-puppet-bug/3.0rc/15187-log-fatal-errors-to-...

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -376,8 +376,8 @@ class Application
     setup_logs
   end
 
-  def setup_logs(is_daemon = false)
-    if options[:debug] or options[:verbose] or is_daemon
+  def setup_logs
+    if options[:debug] or options[:verbose]
       Puppet::Util::Log.newdestination(:console)
       if options[:debug]
         Puppet::Util::Log.level = :debug

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -445,7 +445,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def setup
     setup_test if options[:test]
 
-    setup_logs(true)
+    setup_logs
 
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 


### PR DESCRIPTION
...console'"

This reverts commit 8d99bcbe6ebe6ca15868334bb52349911b58598c, reversing
changes made to 7d6515f076715c1feab0addc99312c42fb8b578c.

This change had two unintended side effects:

1) 20900 tagmail from 'puppet agent --onetime' run as a cron job begins
sending additional emails of verbose logs.

2) 20919 cron job of 'puppet agent --onetime --no-daemonize' produces
additional verbose logs to both console and syslog.

Issue #1 occured because the 15187 patch caused agent log level to
switch to info by default.

Issue #2 was due to the above log level issue, and the fact that by
default a console logger was also opened for all agents, which does not
get closed if --no-daemonize is specified.

Reverting fixes both of these unintended logging issues by returning to
the logging behavior seen in 3.1.1.
