### PR TITLE
(maint) Pidlock#file_path uses correct instance var

### DIFF
--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -35,7 +35,7 @@ class Puppet::Util::Pidlock
   end
 
   def file_path
-    @lock_data.file_path
+    @lockfile.file_path
   end
 
   def clear_if_stale

--- a/spec/unit/util/pidlock_spec.rb
+++ b/spec/unit/util/pidlock_spec.rb
@@ -45,10 +45,13 @@ describe Puppet::Util::Pidlock do
       @lock.lock.should be_true
     end
 
-
     it "should create a lock file" do
       @lock.lock
       File.should be_exists(@lockfile)
+    end
+
+    it "should expose the lock file_path" do
+      @lock.file_path.should == @lockfile
     end
   end
 


### PR DESCRIPTION
Typo in Puppet::Util::Pidlock#file_path was referencing @lock_data which
doesn't exist.  This was resulting in messages like:

"Could not prepare for execution: undefined method `file_path' for
nil:NilClass"

instead of the slightly less confusing:

"Could not prepare for execution: Could not create PID file:
/home/jpartlow/.puppet/var/run/agent.pid"

From lib/puppet/daemon.rb:157 when attempting a second 'puppet agent'
call with existing daemonized agent.
