### PR TITLE
(#20967) Apply Redhat carried patch for rundir permissions

### DIFF
--- a/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
+++ b/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
@@ -1,0 +1,44 @@
+# User story:
+# A new user has installed puppet either from source or from a gem, which does
+# not put the "puppet" user or group on the system. They run the puppet master,
+# which fails because of the missing user and then correct their actions. They
+# expect that after correcting their actions, puppet will work correctly.
+test_name "Puppet manages its own configuration in a robust manner"
+
+# when owner/group works on windows for settings, this confine should be removed.
+confine :except, :platform => 'windows'
+
+step "Record original state of system users"
+original_state = {}
+hosts.each do |host|
+  original_state[host] = on(host, puppet('resource', 'user', 'puppet')).output
+  original_state[host] += on(host, puppet('resource', 'group', 'puppet')).output
+end
+
+step "Remove system users"
+hosts.each do |host|
+  on host, puppet('resource', 'user', 'puppet', 'ensure=absent')
+  on host, puppet('resource', 'group', 'puppet', 'ensure=absent')
+end
+
+step "Ensure master fails to start when missing system user"
+on master, puppet('master'), :acceptable_exit_codes => [74] do
+  assert_match(/could not change to group "puppet"/, result.output)
+  assert_match(/Could not change to user puppet/, result.output)
+end
+
+step "Ensure master starts when making users after having previously failed startup"
+with_master_running_on(master, '--mkusers --autosign true') do
+  agents.each do |agent|
+    on agent, puppet_agent('-t', '--server', master)
+  end
+end
+
+teardown do
+  hosts.each do |host|
+    apply_manifest_on(host, <<-ORIG)
+      #{original_state[host]}
+      Group['puppet'] -> User['puppet']
+    ORIG
+  end
+end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -89,6 +89,8 @@ module Puppet
       :default  => nil,
       :type     => :directory,
       :mode     => 0755,
+      :owner    => "service",
+      :group    => "service",
       :desc     => "Where Puppet PID files are kept."
     },
     :genconfig => {

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -92,12 +92,6 @@ describe "Puppet defaults" do
     Puppet.settings.setting(:yamldir).group.should == Puppet.settings[:group]
   end
 
-  # See #1232
-  it "should not specify a user or group for the rundir" do
-    Puppet.settings.setting(:rundir).owner.should be_nil
-    Puppet.settings.setting(:rundir).group.should be_nil
-  end
-
   it "should specify that the host private key should be owned by the service user" do
     Puppet.settings.stubs(:service_user_available?).returns true
     Puppet.settings.setting(:hostprivkey).owner.should == Puppet.settings[:user]


### PR DESCRIPTION
Since 2009 Redhat has been carrying a patch that modified the permissions
that puppet tried to enforce on the rundir from 01777 to 0755. This is a
much more secure option and by taking this patch allows packagers to use
sane permissions for the rundir without patching puppet.

See: https://bugzilla.redhat.com/show_bug.cgi?id=495096
