### PR TITLE
(#12361) Remove masterlog option

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -775,15 +775,6 @@ EOT
       by `puppet`, and should only be set if you're writing your own Puppet
       executable",
     },
-    :masterlog => {
-      :default => "$logdir/puppetmaster.log",
-      :type => :file,
-      :owner => "service",
-      :group => "service",
-      :mode => 0660,
-      :desc => "Where puppet master logs.  This is generally not used,
-        since syslog is the default log destination."
-    },
     :masterhttplog => {
       :default => "$logdir/masterhttp.log",
       :type => :file,

--- a/spec/unit/network/http/webrick_spec.rb
+++ b/spec/unit/network/http/webrick_spec.rb
@@ -127,7 +127,7 @@ describe Puppet::Network::HTTP::WEBrick do
       server.setup_logger
     end
 
-    it "should use the masterlog if the run_mode is master" do
+    it "should use the masterhttplog if the run_mode is master" do
       Puppet.run_mode.stubs(:master?).returns(true)
       log = make_absolute("/master/log")
       Puppet[:masterhttplog] = log


### PR DESCRIPTION
Pull the `masterlog` configuration option as it is unused and causes confusion.
Also, re-word the description of a test in `webrick_spec.rb` as it is testing
the behavior of `masterhttplog` and not `masterlog`.
