### PR TITLE
(maint) remove fact stringifying deprecation warning

### DIFF
--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -39,7 +39,6 @@ class Puppet::Node::Facts
 
   # Convert all fact values into strings.
   def stringify
-    Puppet.deprecation_warning("Stringifying facts is deprecated, see the stringify_facts setting")
     values.each do |fact, value|
       values[fact] = value.to_s
     end

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -9,7 +9,6 @@ describe Puppet::Node::Facts, "when indirecting" do
   end
 
   it "should be able to convert all fact values to strings" do
-    Puppet.expects(:deprecation_warning).once
     @facts.values["one"] = 1
     @facts.stringify
     @facts.values["one"].should == "1"


### PR DESCRIPTION
Fact stringifying is on by default, but we're issuing a deprecation
warning on stringified facts. Since it looks like we'll have to
stringify facts for a while, this commit removes the deprecation
warning.

This is an update of GH-1658 that takes the comments into account.
