### PR TITLE
Automatically agree to licenses in DMG files

### DIFF
--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -21,6 +21,7 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
   commands :hdiutil => "/usr/bin/hdiutil"
   commands :curl => "/usr/bin/curl"
   commands :ditto => "/usr/bin/ditto"
+  commands :yes => "/usr/bin/yes"
 
   # JJM We store a cookie for each installed .app.dmg in /var/db
   def self.instances_by_name
@@ -69,7 +70,7 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
       end
 
       open(cached_source) do |dmg|
-        xml_str = hdiutil "mount", "-plist", "-nobrowse", "-readonly", "-mountrandom", "/tmp", dmg.path
+        xml_str = execute("#{command :yes} | #{command :hdiutil} mount -plist -nobrowse -readonly -mountrandom /tmp #{dmg.path} 2> /dev/null")
           ptable = Plist::parse_xml xml_str
           # JJM Filter out all mount-paths into a single array, discard the rest.
           mounts = ptable['system-entities'].collect { |entity|

--- a/spec/unit/provider/package/appdmg_spec.rb
+++ b/spec/unit/provider/package/appdmg_spec.rb
@@ -32,6 +32,7 @@ describe Puppet::Type.type(:package).provider(:appdmg) do
         described_class.expects(:curl).with do |*args|
           args[0] == "-o" and args[1].include? tmpdir
         end
+        described_class.stubs(:execute).returns fake_hdiutil_plist
         described_class.stubs(:hdiutil).returns fake_hdiutil_plist
         described_class.expects(:installapp)
 


### PR DESCRIPTION
Otherwise installation just fails. :-(

See https://github.com/timshadel/puppet-vitamin-r for a manifest
file referencing such a DMG file.

Here's the failure output of that DMG (before this patch):

```
Debug: Executing '/usr/bin/curl -o /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/d20130604-54791-kkvyrl/Vitamin-R -C - -k -L -s --url http://www.publicspace.net/download/Vitamin.dmg'
Debug: Success: curl transfered [Vitamin-R]
Debug: Executing '/usr/bin/hdiutil mount -plist -nobrowse -readonly -mountrandom /tmp /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/d20130604-54791-kkvyrl/Vitamin-R'
Error: Execution of '/usr/bin/hdiutil mount -plist -nobrowse -readonly -mountrandom /tmp /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/d20130604-54791-kkvyrl/Vitamin-R' returned 1: 
Disclaimer of Warranty

This software is sold "as is" and without warranties as to performance
or merchantability or any other warranties whether expressed or
implied. Because of the various hardware and software environments
into which this program may be put, no warranty of fitness for a
particular purpose is offered. Good data processing procedure
dictates that any program be throughly tested with non-critical
data before relying on it. The user must assume the entire risk of
using the program. Any liability of the seller or author of the
program will be limited exclusively to product replacement or refund
of purchase price.
hdiutil: mount canceled

Error: /Stage[main]/Vitamin_r/Package[Vitamin-R]/ensure: change from absent to present failed: Execution of '/usr/bin/hdiutil mount -plist -nobrowse -readonly -mountrandom /tmp /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/d20130604-54791-kkvyrl/Vitamin-R' returned 1: 
Disclaimer of Warranty

This software is sold "as is" and without warranties as to performance
or merchantability or any other warranties whether expressed or
implied. Because of the various hardware and software environments
into which this program may be put, no warranty of fitness for a
particular purpose is offered. Good data processing procedure
dictates that any program be throughly tested with non-critical
data before relying on it. The user must assume the entire risk of
using the program. Any liability of the seller or author of the
program will be limited exclusively to product replacement or refund
of purchase price.
hdiutil: mount canceled
```

And again, after the patch:

```
Debug: Executing '/usr/bin/curl -o /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/d20130604-58407-1h1fssy/Vitamin-R -C - -k -L -s --url http://www.publicspace.net/download/Vitamin.dmg'
Debug: Success: curl transfered [Vitamin-R]
Debug: Executing '/usr/bin/yes | /usr/bin/hdiutil mount -plist -nobrowse -readonly -mountrandom /tmp /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/d20130604-58407-1h1fssy/Vitamin-R 2> /dev/null'
Debug: Executing '/usr/bin/ditto --rsrc /private/tmp/dmg.OiSb9K/Vitamin-R 2.app /Applications/Vitamin-R 2.app'
Debug: Executing '/usr/bin/hdiutil eject /private/tmp/dmg.OiSb9K'
Notice: /Stage[main]/Vitamin_r/Package[Vitamin-R]/ensure: created
Debug: /Stage[main]/Vitamin_r/Package[Vitamin-R]: The container Class[Vitamin_r] will propagate my refresh event
```
