### PR TITLE
(#21103) Add puppet yum provider retry operation

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -131,6 +131,11 @@ module Puppet
         :type     => :boolean,
         :desc     => "Whether Puppet should manage the owner, group, and mode of files it uses internally",
     },
+    :yumretries => {
+        :default  => 0,
+        :desc     => "Number of tries yum provider would expire yum cache and redo an operation, \n" +
+                     "if it had failed. Recommended 1. Default is 0 - do not retry failed operations. ",
+    },
     :onetime => {
         :default  => false,
         :type     => :boolean,


### PR DESCRIPTION
Without this feature, yum provider would have failed operation in progress if any yum operation had failed single time, which would cause, for example, wanted package installation failed and all dependencies skipped considering puppet agent run as failed.
This is a problem because provider should ensure operation completion a better way, at least it should try to expire local cache for yum and retry failed operation.
Solution/Improvement: If operation wanted had failed, puppet provider for yum would try to expire cache and redo failed operation for several times (3 is default. TODO - make it configurable via conf file.)
Why it is a good improvement: That might restore failed operation in some cases (f.e. broken or outdated metadata file in cache which would cause "Error 256 No more mirrors to try") and allow puppet to continue its operations.
TODO - add tests

Signed-off-by: Bogdan Dobrelya bogdando@mail.ru
