### PR TITLE
(#21078) Use puppetlabs_spec_helper

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/spec/spec_helper.rb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/spec/spec_helper.rb
@@ -1,17 +1,2 @@
-dir = File.expand_path(File.dirname(__FILE__))
-$LOAD_PATH.unshift File.join(dir, 'lib')
-
-require 'mocha'
-require 'puppet'
-require 'rspec'
-require 'spec/autorun'
-
-Spec::Runner.configure do |config|
-    config.mock_with :mocha
-end
-
-# We need this because the RAL uses 'should' as a method.  This
-# allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
-end
+require 'rubygems'
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
Without this commit, `puppet module generate` creates a spec_helper.rb
that does not use puppetlabs_spec_helper, which should be used for spec
tests.
