### PR TITLE
(#21091) pass --fail to curl

### DIFF
--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -64,7 +64,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
       if %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ cached_source
         cached_source = File.join(tmpdir, "#{name}#{ext}")
         begin
-          curl "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--url", source
+          curl "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--fail", "--url", source
           Puppet.debug "Success: curl transfered [#{name}]"
         rescue Puppet::ExecutionFailure
           Puppet.debug "curl did not transfer [#{name}].  Falling back to slower open-uri transfer methods."

--- a/spec/unit/provider/package/pkgdmg_spec.rb
+++ b/spec/unit/provider/package/pkgdmg_spec.rb
@@ -64,11 +64,11 @@ describe Puppet::Type.type(:package).provider(:pkgdmg) do
         resource[:source] = "http://fake.puppetlabs.com/foo.dmg"
       end
 
-      it "should call tmpdir and use the returned directory" do
+      it "should call tmpdir and then call curl with that directory" do
         Dir.expects(:mktmpdir).returns tmpdir
         Dir.stubs(:entries).returns ["foo.pkg"]
         described_class.expects(:curl).with do |*args|
-          args[0] == "-o" and args[1].include? tmpdir
+          args[0] == "-o" and args[1].include? tmpdir and args.include? "--fail"
         end
         described_class.stubs(:hdiutil).returns fake_hdiutil_plist
         described_class.expects(:installpkg)


### PR DESCRIPTION
This causes curl to treat things like 404's as errors, causing a
fallback to open-uri and, eventually, a sensible error message.

This should fix the reported failure.  As a backstop, it might also make sense to check whether the downloaded file exists, and fail if not.  That seems like overkill to me, but I'll implement it if desired.
