### PR TITLE
clean up docs for new parser functions (backport)

### DIFF
--- a/lib/puppet/parser/functions/collect.rb
+++ b/lib/puppet/parser/functions/collect.rb
@@ -11,20 +11,21 @@ Puppet::Parser::Functions::newfunction(
   This function takes two mandatory arguments: the first should be an Array or a Hash, and the second
   a parameterized block as produced by the puppet syntax:
 
-    $a.collect |$x| { ... }
+        $a.collect |$x| { ... }
 
-  When the first argument is an Array, the block is called with each entry in turn. When the first argument
+  When the first argument `$a` is an Array, the block is called with each entry in turn. When the first argument
   is a hash the entry is an array with `[key, value]`.
 
   *Examples*
 
-    # Turns hash into array of values
-    $a.collect |$x|{ $x[1] }
+        # Turns hash into array of values
+        $a.collect |$x|{ $x[1] }
 
-    # Turns hash into array of keys
-    $a.collect |$x| { $x[0] }
+        # Turns hash into array of keys
+        $a.collect |$x| { $x[0] }
 
-  Since 3.2
+  - Since 3.2
+  - requires `parser = future`.
   ENDHEREDOC
 
   receiver = args[0]

--- a/lib/puppet/parser/functions/each.rb
+++ b/lib/puppet/parser/functions/each.rb
@@ -9,23 +9,24 @@ Puppet::Parser::Functions::newfunction(
   This function takes two mandatory arguments: the first should be an Array or a Hash, and the second
   a parameterized block as produced by the puppet syntax:
 
-    $a.each {|$x| ... }
+        $a.each {|$x| ... }
 
   When the first argument is an Array, the parameterized block should define one or two block parameters.
   For each application of the block, the next element from the array is selected, and it is passed to
   the block if the block has one parameter. If the block has two parameters, the first is the elements
   index, and the second the value. The index starts from 0.
 
-    $a.each {|$index, $value| ... }
+        $a.each {|$index, $value| ... }
 
   When the first argument is a Hash, the parameterized block should define one or two parameters.
   When one parameter is defined, the iteration is performed with each entry as an array of `[key, value]`,
   and when two parameters are defined the iteration is performed with key and value.
 
-    $a.each {|$entry|       ..."key ${$entry[0]}, value ${$entry[1]}" }
-    $a.each {|$key, $value| ..."key ${key}, value ${value}" }
+        $a.each {|$entry|       ..."key ${$entry[0]}, value ${$entry[1]}" }
+        $a.each {|$key, $value| ..."key ${key}, value ${value}" }
 
-  Since 3.2
+  - Since 3.2
+  - requires `parser = future`.
   ENDHEREDOC
   require 'puppet/parser/ast/lambda'
 

--- a/lib/puppet/parser/functions/foreach.rb
+++ b/lib/puppet/parser/functions/foreach.rb
@@ -9,23 +9,24 @@ Puppet::Parser::Functions::newfunction(
   This function takes two mandatory arguments: the first should be an Array or a Hash, and the second
   a parameterized block as produced by the puppet syntax:
 
-    $a.foreach {|$x| ... }
+        $a.foreach {|$x| ... }
 
   When the first argument is an Array, the parameterized block should define one or two block parameters.
   For each application of the block, the next element from the array is selected, and it is passed to
   the block if the block has one parameter. If the block has two parameters, the first is the elements
   index, and the second the value. The index starts from 0.
 
-    $a.foreach {|$index, $value| ... }
+        $a.foreach {|$index, $value| ... }
 
   When the first argument is a Hash, the parameterized block should define one or two parameters.
   When one parameter is defined, the iteration is performed with each entry as an array of `[key, value]`,
   and when two parameters are defined the iteration is performed with key and value.
 
-    $a.foreach {|$entry|       ..."key ${$entry[0]}, value ${$entry[1]}" }
-    $a.foreach {|$key, $value| ..."key ${key}, value ${value}" }
+        $a.foreach {|$entry|       ..."key ${$entry[0]}, value ${$entry[1]}" }
+        $a.foreach {|$key, $value| ..."key ${key}, value ${value}" }
 
-  Since 3.2
+  - Since 3.2
+  - requires `parser = future`.
   ENDHEREDOC
   require 'puppet/parser/ast/lambda'
 

--- a/lib/puppet/parser/functions/reduce.rb
+++ b/lib/puppet/parser/functions/reduce.rb
@@ -9,7 +9,7 @@ Puppet::Parser::Functions::newfunction(
   This function takes two mandatory arguments: the first should be an Array or a Hash, and the last
   a parameterized block as produced by the puppet syntax:
 
-    $a.reduce |$memo, $x| { ... }
+        $a.reduce |$memo, $x| { ... }
 
   When the first argument is an Array, the block is called with each entry in turn. When the first argument
   is a hash each entry is converted to an array with `[key, value]` before being fed to the block. An optional
@@ -24,30 +24,32 @@ Puppet::Parser::Functions::newfunction(
 
   *Examples*
 
-    # Reduce an array
-    $a = [1,2,3]
-    $a.reduce |$memo, $entry| { $memo + $entry }
-    #=> 6
+        # Reduce an array
+        $a = [1,2,3]
+        $a.reduce |$memo, $entry| { $memo + $entry }
+        #=> 6
 
-    # Reduce hash values
-    $a = {a => 1, b => 2, c => 3}
-    $a.reduce |$memo, $entry| { [sum, $memo[1]+$entry[1]] }
-    #=> [sum, 6]
+        # Reduce hash values
+        $a = {a => 1, b => 2, c => 3}
+        $a.reduce |$memo, $entry| { [sum, $memo[1]+$entry[1]] }
+        #=> [sum, 6]
 
   It is possible to provide a starting 'memo' as an argument.
 
   *Examples*
-    # Reduce an array
-    $a = [1,2,3]
-    $a.reduce(4) |$memo, $entry| { $memo + $entry }
-    #=> 10
 
-    # Reduce hash values
-    $a = {a => 1, b => 2, c => 3}
-    $a.reduce([na, 4]) |$memo, $entry| { [sum, $memo[1]+$entry[1]] }
-    #=> [sum, 10]
+        # Reduce an array
+        $a = [1,2,3]
+        $a.reduce(4) |$memo, $entry| { $memo + $entry }
+        #=> 10
 
-  Since 3.2
+        # Reduce hash values
+        $a = {a => 1, b => 2, c => 3}
+        $a.reduce([na, 4]) |$memo, $entry| { [sum, $memo[1]+$entry[1]] }
+        #=> [sum, 10]
+
+  - Since 3.2
+  - requires `parser = future`.
   ENDHEREDOC
 
   require 'puppet/parser/ast/lambda'

--- a/lib/puppet/parser/functions/reject.rb
+++ b/lib/puppet/parser/functions/reject.rb
@@ -11,7 +11,7 @@ Puppet::Parser::Functions::newfunction(
   This function takes two mandatory arguments: the first should be an Array or a Hash, and the second
   a parameterized block as produced by the puppet syntax:
 
-    $a.reject |$x| { ... }
+        $a.reject |$x| { ... }
 
   When the first argument is an Array, the block is called with each entry in turn. When the first argument
   is a hash the entry is an array with `[key, value]`.
@@ -20,11 +20,12 @@ Puppet::Parser::Functions::newfunction(
 
   *Examples*
 
-    # selects all that does not end with berry
-    $a = ["rasberry", "blueberry", "orange"]
-    $a.reject |$x| { $x =~ /berry$/ }
+        # selects all that does not end with berry
+        $a = ["rasberry", "blueberry", "orange"]
+        $a.reject |$x| { $x =~ /berry$/ }
 
-  Since 3.2
+  - Since 3.2
+  - requires `parser = future`.
   ENDHEREDOC
 
   receiver = args[0]

--- a/lib/puppet/parser/functions/select.rb
+++ b/lib/puppet/parser/functions/select.rb
@@ -11,7 +11,7 @@ Puppet::Parser::Functions::newfunction(
   This function takes two mandatory arguments: the first should be an Array or a Hash, and the second
   a parameterized block as produced by the puppet syntax:
 
-    $a.select |$x| { ... }
+        $a.select |$x| { ... }
 
   When the first argument is an Array, the block is called with each entry in turn. When the first argument
   is a hash the entry is an array with `[key, value]`.
@@ -20,11 +20,12 @@ Puppet::Parser::Functions::newfunction(
 
   *Examples*
 
-    # selects all that end with berry
-    $a = ["raspberry", "blueberry", "orange"]
-    $a.select |$x| { $x =~ /berry$/ }
+        # selects all that end with berry
+        $a = ["raspberry", "blueberry", "orange"]
+        $a.select |$x| { $x =~ /berry$/ }
 
-  Since 3.2
+  - Since 3.2
+  - requires `parser = future`.
   ENDHEREDOC
 
   receiver = args[0]

--- a/lib/puppet/parser/functions/slice.rb
+++ b/lib/puppet/parser/functions/slice.rb
@@ -7,11 +7,11 @@ Puppet::Parser::Functions::newfunction(
   argument and returns the first argument, or if no block is given returns a new array with a concatenation of
   the slices.
 
-  This function takes two mandatory arguments: the first should be an Array or a Hash, and the second
+  This function takes two mandatory arguments: the first, `$a`, should be an Array or a Hash, and the second, `$n`,
   the number of elements to include in each slice. The optional third argument should be a
   a parameterized block as produced by the puppet syntax:
 
-      |$x| { ... }
+      $a.slice($n) |$x| { ... }
 
   The parameterized block should have either one parameter (receiving an array with the slice), or the same number
   of parameters as specified by the slice size (each parameter receiving its part of the slice).
@@ -31,7 +31,8 @@ Puppet::Parser::Functions::newfunction(
 
       slice($[1,2,3,4,5,6], 2) # produces [[1,2], [3,4], [5,6]]
 
-  Since 3.2
+  - Since 3.2
+  - requires `parser = future`.
   ENDHEREDOC
   require 'puppet/parser/ast/lambda'
   require 'puppet/parser/scope'


### PR DESCRIPTION
Back-port of GH-1695 to stable. As noted in [21028](http://projects.puppetlabs.com/issues/21028), not calling out functions that require the future parser to be enabled has the potential to confuse users who browse the documentation.
