### PR TITLE
(20967) Clear yamldir in configuration acceptance test.

### DIFF
--- a/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
+++ b/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
@@ -7,6 +7,8 @@ test_name "Puppet manages its own configuration in a robust manner"
 
 # when owner/group works on windows for settings, this confine should be removed.
 confine :except, :platform => 'windows'
+# when managhome roundtrips for solaris, this confine should be removed
+confine :except, :platform => 'solaris'
 
 step "Clear out yaml directory because of a bug in the indirector/yaml. (See #21145)"
 on master, 'rm -rf $(puppet master --configprint yamldir)'
@@ -38,6 +40,10 @@ with_master_running_on(master, '--mkusers --autosign true') do
 end
 
 teardown do
+  # And cleaning up yaml dir again here because we are changing service
+  # user and group ids back to the original uid and gid
+  on master, 'rm -rf $(puppet master --configprint yamldir)'
+
   hosts.each do |host|
     apply_manifest_on(host, <<-ORIG)
       #{original_state[host]}


### PR DESCRIPTION
Because yamldir subdirectories are not managed outside of
indirectory/yaml, service user changes can leave puppet unable to read
from them (#21145)

This change clears the yamldir in the puppet_manages_own_configuration_in_robust_manner
acceptance test to ensure that yamldir and all subdirs are rebuilt with
the new service user.
