### PR TITLE
(#21170) Enhancement of the module generate functionality

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -393,7 +393,18 @@ module Puppet
     :module_working_dir => {
         :default  => '$vardir/puppet-module',
         :desc     => "The directory into which module tool data is stored",
+    },
+    :module_tool_skeleton => {
+      :default => "",
+      :type    => :path,
+      :desc    => "The directory where the custom skeleton resides",
+    },
+    :module_tool_config => {
+      :default => "$confdir/module-tool/config",
+      :type    => :path,
+      :desc    => "Config file used to fill in extra data for the skeleton",
     }
+     
   )
 
     Puppet.define_settings(

--- a/lib/puppet/module_tool/applications/generator.rb
+++ b/lib/puppet/module_tool/applications/generator.rb
@@ -96,9 +96,11 @@ module Puppet::ModuleTool
         def target
           target = @generator.destination + @source.relative_path_from(@generator.skeleton.path)
 
-          # Pick up the settings
+          # Get the settings of the config file from the 'module_tool_config' file.
+          # These variables can be accessed in the skeleton like:
+          # <%= settings['key'] %>
           settings = @generator.skeleton.generate_settings
-          @generator.settings.merge! settings
+          @generator.settings.merge! settings unless settings.nil?
 
           components = target.to_s.split(File::SEPARATOR).map do |part|
             part == 'NAME' ? @generator.metadata.name : part

--- a/lib/puppet/module_tool/skeleton.rb
+++ b/lib/puppet/module_tool/skeleton.rb
@@ -31,18 +31,19 @@ module Puppet::ModuleTool
       Pathname(__FILE__).dirname + 'skeleton/templates/generator'
     end
 
-    # Return settings from ~/.puppet-template/config
+    # Return settings for the module tool generate
+    # These key=value pairs can be used in the skeleton files to fill in extra data
     def generate_settings
-      file = ENV['HOME'] + '/.puppet-module-tool/config'
+      file = Puppet.settings[:module_tool_config]
       if File.exist?(file)
         text = File.read(file)
         Hash[text.scan(/^\s*(\w+)\s*=\s*(.*?)\s*$/)]
       end
     end
 
-    # Return path name of custom skeleton based on the homedir of the user
+    # Return path name of custom skeleton path
     def home_path
-      Pathname(ENV['HOME'] + '/.puppet-module-tool/skeleton')
+      Pathname(Puppet.settings[:module_tool_skeleton])
     end
 
   end


### PR DESCRIPTION
At the moment when people use 'puppet module generate' they are forced to use the skeleton provided by PuppetLabs.
When they want to use their own skeleton they need to overwrite the current one which can cause issues when upgrading.

This patch allows the user to set a 'module_tool_skeleton' directory where the custom skeleton directory resides.

Next to that the 'module_tool_config' option allows you to supply a config file with key=value data which can be accessed in the skeleton files

``` ruby
<%= settings['key'] %>
```
