### PR TITLE
(#21023) Flush caches on preferred_run_mode change

### DIFF
--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -289,9 +289,15 @@ describe Puppet::Settings do
       @settings.define_settings :mysection,
           :one => { :default => "whah", :desc => "yay" },
           :two => { :default => "$one yay", :desc => "bah" }
+      @settings.expects(:unsafe_flush_cache)
       @settings[:two].should == "whah yay"
       @settings.handlearg("--one", "else")
       @settings[:two].should == "else yay"
+    end
+
+    it "should clear the cache when the preferred_run_mode is changed" do
+      @settings.expects(:flush_cache)
+      @settings.preferred_run_mode = :master
     end
 
     it "should not clear other values when setting getopt-specific values" do


### PR DESCRIPTION
`Setting.preferred_run_mode` affects a lot of settings values -- such as the
modulepath that gets used for environments. Prior to f4e229e the `run_mode` was
an actual setting rather than an attribute of the settings class. This meant
that changing the value of the `run_mode` would trigger a cache flush on
Settings objects so that things like `modulepath` would be updated.

This patch:
- Moves cache flushing out of the `Settings.set_value` method and into a new
  method `flush_cache`.
- Adds tests to ensure that `flush_cache` is called by both `set_value` and
  `preferred_run_mode=`.

Ref: http://projects.puppetlabs.com/issues/21023
