### PR TITLE
(#7911) Added a lib_configs section to installer

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -409,12 +409,13 @@ end
 # Change directory into the puppet root so we don't get the wrong files for install.
 FileUtils.cd File.dirname(__FILE__) do
   # Set these values to what you want installed.
-  configs = glob(%w{conf/auth.conf})
-  bins  = glob(%w{bin/*})
-  rdoc  = glob(%w{bin/* lib/**/*.rb README* }).reject { |e| e=~ /\.(bat|cmd)$/ }
-  ri    = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }
-  man   = glob(%w{man/man[0-9]/*})
-  libs  = glob(%w{lib/**/*.rb lib/**/*.erb lib/**/*.py lib/puppet/util/command_line/*})
+  configs     = glob(%w{conf/auth.conf})
+  lib_configs = glob(%w{lib/**/*.conf})
+  bins        = glob(%w{bin/*})
+  rdoc        = glob(%w{bin/* lib/**/*.rb README* }).reject { |e| e=~ /\.(bat|cmd)$/ }
+  ri          = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }
+  man         = glob(%w{man/man[0-9]/*})
+  libs        = glob(%w{lib/**/*.rb lib/**/*.erb lib/**/*.py lib/puppet/util/command_line/*})
 
   check_prereqs
   prepare_installation
@@ -424,5 +425,6 @@ FileUtils.cd File.dirname(__FILE__) do
   do_configs(configs, InstallOptions.config_dir) if InstallOptions.configs
   do_bins(bins, InstallOptions.bin_dir)
   do_libs(libs)
+  do_libs(lib_configs)
   do_man(man) unless $operatingsystem == "windows"
 end


### PR DESCRIPTION
libuser.conf not being installed

https://github.com/puppetlabs/puppet/pull/1442 introduced the use of luseradd and lgroupadd commands for managing local users in an LDAP managed environment where a duplicate name may exist in LDAP.   A lengthy discussion was had on where to put the libuser.conf file, the ulitmate decision was leaving it under lib/puppet/util/libuser.conf was the best option.  

The installation of this file was missed during an install.rb run because of the .conf extension.  This pull request fixes that error and makes sure libuser.conf gets installed under lib/puppet/util/libuser.conf
