### PR TITLE
(#21252) Fix problems with false/nil args and returns in lambda

### DIFF
--- a/spec/unit/parser/methods/collect_spec.rb
+++ b/spec/unit/parser/methods/collect_spec.rb
@@ -38,6 +38,7 @@ describe 'the collect method' do
         catalog.resource(:file, "/file_b")['ensure'].should == 'present'
         catalog.resource(:file, "/file_c")['ensure'].should == 'present'
       end
+
       it 'foreach on a hash selecting value' do
         catalog = compile_to_catalog(<<-MANIFEST)
         $a = {'a'=>1,'b'=>2,'c'=>3}
@@ -51,6 +52,21 @@ describe 'the collect method' do
         catalog.resource(:file, "/file_3")['ensure'].should == 'present'
       end
     end
+
+    context "handles data type corner cases" do
+      it "collect gets values that are false" do
+        catalog = compile_to_catalog(<<-MANIFEST)
+          $a = [false,false]
+          $a.collect |$x| { $x }.each |$i, $v| {
+            file { "/file_$i.$v": ensure => present }
+          }
+        MANIFEST
+
+        catalog.resource(:file, "/file_0.false")['ensure'].should == 'present'
+        catalog.resource(:file, "/file_1.false")['ensure'].should == 'present'
+      end
+    end
+
     context "in Java style should be callable as" do
       shared_examples_for 'java style' do
         it 'collect on an array (multiplying each value by 2)' do
@@ -92,11 +108,13 @@ describe 'the collect method' do
           catalog.resource(:file, "/file_3")['ensure'].should == 'present'
         end
       end
+
       describe 'without fat arrow' do
         it_should_behave_like 'java style' do
           let(:farr) { '' }
         end
       end
+
       describe 'with fat arrow' do
         it_should_behave_like 'java style' do
           let(:farr) { '=>' }


### PR DESCRIPTION
The issue 21252 was triggered by a documentation error but should
have produced a different result than the error that was presented.

This was caused by a series of problems. It was not possible to
pass `false` as a parameter value as this was taken as missing parameter
value.

Also, it was not possible to return the value `false` as this was
translated to `nil` due to defective work around for missing initialized
variable on return.

The fix changes the handling of making sure that the variable that is
returned exists (by setting value explicelty to `nil` before the start
of the exception handling block.

This commit also modifies how a lambda call matches arguments to
parameters and checks what is missing (now with `false` as a valid value
in mind).

A test is added to `collect` that checks that a value of `false` can
both be passed and returned.
