### PR TITLE
(#21272) Refactor created directory from 'puppet module generate'

### DIFF
--- a/lib/puppet/module_tool/applications/generator.rb
+++ b/lib/puppet/module_tool/applications/generator.rb
@@ -27,7 +27,7 @@ module Puppet::ModuleTool
         if destination.directory?
           raise ArgumentError, "#{destination} already exists."
         end
-        Puppet.notice "Generating module at #{Dir.pwd}/#{@metadata.dashed_name}"
+        Puppet.notice "Generating module at #{Dir.pwd}/#{destination}"
         files_created = []
         skeleton.path.find do |path|
           if path == skeleton
@@ -67,7 +67,7 @@ module Puppet::ModuleTool
       end
 
       def destination
-        @destination ||= Pathname.new(@metadata.dashed_name)
+        @destination ||= Pathname.new(@metadata.name)
       end
 
       class Node


### PR DESCRIPTION
Currently the created directory is 'username-modulename'.
This patch changes this to 'modulename' because that's mostly used.
