### PR TITLE
(#7911) Simplified libs section of installer 

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -107,6 +107,7 @@ end
 
 def do_libs(libs, strip = 'lib/')
   libs.each do |lf|
+    next if File.directory? lf
     olf = File.join(InstallOptions.site_dir, lf.sub(/^#{strip}/, ''))
     op = File.dirname(olf)
     if $haveftools
@@ -414,7 +415,7 @@ FileUtils.cd File.dirname(__FILE__) do
   rdoc  = glob(%w{bin/* lib/**/*.rb README* }).reject { |e| e=~ /\.(bat|cmd)$/ }
   ri    = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }
   man   = glob(%w{man/man[0-9]/*})
-  libs  = glob(%w{lib/**/*.rb lib/**/*.erb lib/**/*.py lib/puppet/util/command_line/*})
+  libs  = glob(%w{lib/**/*})
 
   check_prereqs
   prepare_installation


### PR DESCRIPTION
This will make sure that all files in the source lib directory
make it into the ruby sitelib directory

As the type of files being included in the lib directory has
grown, rather than call each filetype out specifically in the
installer (ie globs like lib/**/*.rb, lib/**/*.py), it seems
easier to just move everything from the source lib directory
to the the sitelib directory during installation.

The new glob lib/*_/_ now includes directories in the glob
list.  This caused an error in do_libs because File.install
would be called on a directory resulting in a 0 byte file being
placed where a directory should have been.  The error is generated
on the second pass of the loop when File.makedirs is called, and
the file exists and is NOT a directory.  This is the reason for
skipping directories in the do_libs section.
