### PR TITLE
(#21264) Monkey-patch rgen 0.6.2 to handle implicit array#to_str

### DIFF
--- a/lib/puppet/parser/parser_factory.rb
+++ b/lib/puppet/parser/parser_factory.rb
@@ -41,6 +41,7 @@ module Puppet::Parser
     def self.assert_rgen_installed
       begin
         require 'rgen/metamodel_builder'
+        require 'puppet/util/monkey_patches/rgen_patches'
       rescue LoadError
         raise Puppet::DevError.new("The gem 'rgen' version >= 0.6.1 is required when using the setting '--parser future'. Please install 'rgen'.")
       end

--- a/lib/puppet/util/monkey_patches/rgen_patches.rb
+++ b/lib/puppet/util/monkey_patches/rgen_patches.rb
@@ -1,0 +1,45 @@
+require 'rgen/array_extensions'
+
+# This monkey-patch is required because of the quirky way Ruby handles implicit conversion from Array to
+# a Hash or a String. Instead of checking if the class implements #to_hash or #to_string a call is made and
+# it is expected to fail with a NoMethod error.
+# Naturally, combining this with #method_missing will not work well.
+#
+# The #method_missing method below is a fixed version of the RGen array_extensions.rb with a fix for :to_str (the same
+# way as #to_hash is handled).
+#
+# This monkey patch should be removed once this fix is in RGen (> 0.6.2).
+#
+class Array
+
+  def method_missing(m, *args)
+
+  # This extensions has the side effect that it allows to call any method on any
+  # empty array with an empty array as the result. This behavior is required for
+  # navigating models.
+  #
+  # This is a problem for Hash[] called with an (empty) array of tupels.
+  # It will call to_hash expecting a Hash as the result. When it gets an array instead,
+  # it fails with an exception. Make sure it gets a NoMethodException as without this
+  # extension and it will catch that and return an empty hash as expected.
+  #
+  return super unless (size == 0 &&
+    !(m == :to_hash || m == :to_str)) ||
+    compact.any?{|e| e.is_a? RGen::MetamodelBuilder::MMBase}
+  # use an array to build the result to achiev similar ordering
+  result = []
+  inResult = {}
+  compact.each do |e|
+    if e.is_a? RGen::MetamodelBuilder::MMBase
+      ((o=e.send(m)).is_a?(Array) ? o : [o] ).each do |v|
+        next if inResult[v.object_id]
+        inResult[v.object_id] = true
+        result << v
+      end
+    else
+      raise StandardError.new("Trying to call a method on an array element not a RGen MMBase")
+    end
+  end
+  result.compact
+  end
+end

--- a/spec/unit/pops/parser/rgen_sanitycheck_spec.rb
+++ b/spec/unit/pops/parser/rgen_sanitycheck_spec.rb
@@ -3,13 +3,21 @@ require 'spec_helper'
 require 'puppet/pops'
 
 require 'rgen/array_extensions'
+require 'puppet/util/monkey_patches/rgen_patches'
 
-describe "RGen working with hashes" do
-  it "should be possible to create an empty hash after having required the files above" do
+describe "RGen's array extension" do
+  it "should allow empty array to be converted to empty hash" do
     # If this fails, it means the rgen addition to Array is not monkey patched as it
     # should (it will return an array instead of fail in a method_missing), and thus
     # screw up Hash's check if it can do "to_hash' or not.
     #
     Hash[[]]
+  end
+
+  it "should allow empty array to be converted to a string by join" do
+    # If this fails, it means that rgen addition to Array is not monkey patched as it
+    # should (it will return an array instea of fail in Array#method_missing, and thus
+    # screw up implicit conversion of Array to String.
+    ["a", []].join(':').should == 'a:'
   end
 end


### PR DESCRIPTION
The problem was that ruby does implicit Array to String conversion
by testing that a call to #to_str fails. This does not work well
with Rgen's implementation (in version 0.6.2) of Array#method_missing
where the special case of empty array is not handled for #to_str. RGen
recently fixed a similar issue for #to_hash. 

This commit adds a monkey-patch of Rgen's array extension that checks
for #to_str the same way as #to_hash.

This commit also includes a test that checks that the monkey patch
works.

Since RGen is loaded on-demand (not upfront), the monkey_patch must
naturally also be applied dynamically. The main entry point for this in
the normal flow is in the parser-factory.

Later, when RGen becomes a requirement (and if the issue is not fixed in
RGen), the monkey patch can move to use the same mechanism as all other
monkey-patches.
