### PR TITLE
Pip provider query should be case insensitive.

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -48,7 +48,7 @@ Puppet::Type.type(:package).provide :pip,
   # it is not installed or `pip` itself is not available.
   def query
     self.class.instances.each do |provider_pip|
-      return provider_pip.properties if @resource[:name] == provider_pip.name
+      return provider_pip.properties if @resource[:name].downcase == provider_pip.name.downcase
     end
     return nil
   end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -90,6 +90,22 @@ describe provider_class do
       @provider.query.should == nil
     end
 
+    it "should be case insensitive" do
+      @resource[:name] = "Real_Package"
+
+      provider_class.expects(:instances).returns [provider_class.new({
+        :ensure   => "1.2.5",
+        :name     => "real_package",
+        :provider => :pip,
+      })]
+
+      @provider.query.should == {
+        :ensure   => "1.2.5",
+        :name     => "real_package",
+        :provider => :pip,
+      }
+    end
+
   end
 
   describe "latest" do


### PR DESCRIPTION
pip searches PyPi for packages by default. The default endpoint (simple) is case insensitive, so we should behave similarly. i.e. "flask" should match "Flask" in `pip freeze`
