### PR TITLE
(#6808) Warn about file content sync no-ops

### DIFF
--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -100,6 +100,9 @@ module Puppet
       if resource.should_be_file?
         return false if is == :absent
       else
+        if resource[:ensure] == :present and resource[:content] and s = resource.stat
+          resource.warning "Ensure set to :present but file type is #{s.ftype} so no content will be synced"
+        end
         return true
       end
 

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -147,6 +147,17 @@ describe content do
       @content.must be_safe_insync("whatever")
     end
 
+    it "should warn that no content will be synced to links when ensure is :present" do
+      @resource[:ensure] = :present
+      @resource[:content] = 'foo'
+      @resource.stubs(:should_be_file?).returns false
+      @resource.stubs(:stat).returns mock("stat", :ftype => "link")
+
+      @resource.expects(:warning).with {|msg| msg =~ /Ensure set to :present but file type is/}
+
+      @content.insync? :present
+    end
+
     it "should return false if the current content is :absent" do
       @content.should = "foo"
       @content.should_not be_safe_insync(:absent)


### PR DESCRIPTION
Normally, a declaration of both `target` and `content` for a File resource in a
manifest will cause a compile error.  However, if a File resource is ensured to
be `present`, it is possible to specify `content` for a path that turns out to
be a symlink on the agent.  Currently, since this situation is not discoverable
untill the agent is applying the catalog, the resource will silently fail to
apply `content` changes.

This patch adds a warning indicating that no sync of `content` will occur.

Ref: https://projects.puppetlabs.com/issues/6808
