### PR TITLE
(#21376) Sequence BlockExpressions without nesting

### DIFF
--- a/lib/puppet/parser/ast/block_expression.rb
+++ b/lib/puppet/parser/ast/block_expression.rb
@@ -34,6 +34,10 @@ class Puppet::Parser::AST
       self
     end
 
+    def sequence_with(other)
+      Puppet::Parser::AST::BlockExpression.new(:children => self.children + other.children)
+    end
+
     def to_s
       "[" + @children.collect { |c| c.to_s }.join(', ') + "]"
     end

--- a/lib/puppet/parser/ast/branch.rb
+++ b/lib/puppet/parser/ast/branch.rb
@@ -7,31 +7,16 @@ class Puppet::Parser::AST
     include Enumerable
     attr_accessor :pin, :children
 
-    # Yield each contained AST node in turn.  Used mostly by 'evaluate'.
-    # This definition means that I don't have to override 'evaluate'
-    # every time, but each child of Branch will likely need to override
-    # this method.
     def each
       @children.each { |child|
         yield child
       }
     end
 
-    # Initialize our object.  Largely relies on the method from the base
-    # class, but also does some verification.
     def initialize(arghash)
       super(arghash)
 
-      # Create the hash, if it was not set at initialization time.
       @children ||= []
-
-      # Verify that we only got valid AST nodes.
-      @children.each { |child|
-        unless child.is_a?(AST)
-          raise Puppet::DevError,
-            "child #{child} is a #{child.class} instead of ast"
-        end
-      }
     end
   end
 end

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -191,15 +191,7 @@ class Puppet::Resource::Type
       return
     end
 
-    self.code = Puppet::Parser::AST::BlockExpression.new(:children => [self.code, other.code])
-#    array_class = Puppet::Parser::AST::ASTArray
-#    self.code = array_class.new(:children => [self.code]) unless self.code.is_a?(array_class)
-#
-#    if other.code.is_a?(array_class)
-#      code.children += other.code.children
-#    else
-#      code.children << other.code
-#    end
+    self.code = self.code.sequence_with(other.code)
   end
 
   # Make an instance of the resource type, and place it in the catalog

--- a/spec/unit/parser/ast/block_expression_spec.rb
+++ b/spec/unit/parser/ast/block_expression_spec.rb
@@ -1,0 +1,67 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Parser::AST::BlockExpression do
+  class StackDepthAST < Puppet::Parser::AST
+    attr_reader :call_depth
+    def evaluate(*options)
+      @call_depth = caller.length
+    end
+  end
+
+  NO_SCOPE = nil
+
+  def depth_probe
+    StackDepthAST.new({})
+  end
+
+  def sequence_probe(name, sequence)
+    probe = mock("Sequence Probe #{name}")
+    probe.expects(:safeevaluate).in_sequence(sequence)
+    probe
+  end
+
+  def block_of(children)
+    Puppet::Parser::AST::BlockExpression.new(:children => children)
+  end
+
+  def assert_all_at_same_depth(*probes)
+    depth0 = probes[0].call_depth
+    probes.drop(1).each do |p|
+      p.call_depth.should == depth0
+    end
+  end
+
+  it "evaluates all its children at the same stack depth" do
+    depth_probes = [depth_probe, depth_probe]
+    expr = block_of(depth_probes)
+
+    expr.evaluate(NO_SCOPE)
+
+    assert_all_at_same_depth(*depth_probes)
+  end
+
+  it "evaluates sequenced children at the same stack depth" do
+    depth1 = depth_probe
+    depth2 = depth_probe
+    depth3 = depth_probe
+
+    expr1 = block_of([depth1])
+    expr2 = block_of([depth2])
+    expr3 = block_of([depth3])
+
+    expr1.sequence_with(expr2).sequence_with(expr3).evaluate(NO_SCOPE)
+
+    assert_all_at_same_depth(depth1, depth2, depth3)
+  end
+
+  it "evaluates sequenced children in order" do
+    evaluation_order = sequence("Child evaluation order")
+    expr1 = block_of([sequence_probe("Step 1", evaluation_order)])
+    expr2 = block_of([sequence_probe("Step 2", evaluation_order)])
+    expr3 = block_of([sequence_probe("Step 3", evaluation_order)])
+
+    expr1.sequence_with(expr2).sequence_with(expr3).evaluate(NO_SCOPE)
+  end
+end
+

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -715,15 +715,6 @@ describe Puppet::Resource::Type do
       dest.doc.should == "foonessyayness"
     end
 
-    it "should turn its code into a BlockExpression if necessary" do
-      dest = Puppet::Resource::Type.new(:hostclass, "bar", :code => code("foo"))
-      source = Puppet::Resource::Type.new(:hostclass, "foo", :code => code("bar"))
-
-      dest.merge(source)
-
-      dest.code.should be_instance_of(Puppet::Parser::AST::BlockExpression)
-    end
-
     it "should set the other class's code as its code if it has none" do
       dest = Puppet::Resource::Type.new(:hostclass, "bar")
       source = Puppet::Resource::Type.new(:hostclass, "foo", :code => code("bar"))
@@ -734,15 +725,15 @@ describe Puppet::Resource::Type do
     end
 
     it "should append the other class's code to its code if it has any" do
-      dcode = Puppet::Parser::AST::ASTArray.new :children => [code("dest")]
+      dcode = Puppet::Parser::AST::BlockExpression.new(:children => [code("dest")])
       dest = Puppet::Resource::Type.new(:hostclass, "bar", :code => dcode)
 
-      scode = Puppet::Parser::AST::ASTArray.new :children => [code("source")]
+      scode = Puppet::Parser::AST::BlockExpression.new(:children => [code("source")])
       source = Puppet::Resource::Type.new(:hostclass, "foo", :code => scode)
 
       dest.merge(source)
 
-      dest.code.children.collect { |l| l[0].value }.should == %w{dest source}
+      dest.code.children.collect { |l| l.value }.should == %w{dest source}
     end
   end
 end


### PR DESCRIPTION
When merging Puppet::Resource::Type instances the code attribute was merged in
a way that caused a deep tree of BlockExpressions. This could cause stack
overflows when evaluating this tree, since evaluation is recursive. This
changes the merge method so that they are sequenced as a flat array.
