### PR TITLE
(Maint) Run tests from installed packages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,4 +69,8 @@ namespace "ci" do
     ENV["LOG_SPEC_ORDER"] = "true"
     sh %{rspec -r yarjuf -f JUnit -o result.xml -fd spec}
   end
+
+  task :el6tests do
+    sh "cd acceptance/config/el6; tar -czvf el6.tar.gz *"
+  end
 end

--- a/acceptance/config/el6/Gemfile
+++ b/acceptance/config/el6/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "puppet_acceptance", :git => "git://github.com/puppetlabs/puppet-acceptance.git"
+gem "rake"

--- a/acceptance/config/el6/Rakefile
+++ b/acceptance/config/el6/Rakefile
@@ -1,0 +1,37 @@
+require 'open-uri'
+require 'rake/clean'
+
+def fetch(url, dst)
+  open(url) do |repo|
+    File.open(dst, "w") do |file|
+      IO.copy_stream(repo, file)
+    end
+  end
+end
+
+CLEAN.include('*.repo', '*.tar', '*.rpm')
+
+file "pl-puppet-build.repo" do |task|
+  sha = ENV['SHA']
+  fetch("http://builds.puppetlabs.lan/puppet/#{sha}/repo_configs/rpm/pl-puppet-#{sha}-el-6-x86_64-devel.repo",
+        task.name)
+end
+
+file "pl-puppet-repos.rpm" do |task|
+  fetch("http://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-7.noarch.rpm", task.name)
+end
+
+task :repo_configs => ["pl-puppet-repos.rpm", "pl-puppet-build.repo"] do |task|
+  sh "tar -cvf repos.tar #{task.prerequisites.join(' ')}"
+end
+
+task :test => [:repo_configs] do
+  sh "systest --setup-dir setup -o options.rb #{ENV['OPTIONS'] || ''} -t #{ENV['TEST'] || 'tests'}"
+end
+
+namespace :ci do
+  task :test do
+    ENV['OPTIONS'] = (ENV['OPTIONS'] || "") + " --no-color --xml"
+    Rake::Task['test'].invoke
+  end
+end

--- a/acceptance/config/el6/config.yaml
+++ b/acceptance/config/el6/config.yaml
@@ -1,0 +1,18 @@
+HOSTS:
+  'dhcp70.platform.backline.puppetlabs.net':
+    roles:
+      - master
+      - agent
+    platform: el-6-i386
+    hypervisor: vsphere
+    vmname: platform.dhcp70
+    snapshot: foss
+  'dhcp71.platform.backline.puppetlabs.net':
+    roles:
+      - agent
+    platform: el-6-i386
+    hypervisor: vsphere
+    vmname: platform.dhcp71
+    snapshot: foss
+CONFIG:
+  filecount: 12

--- a/acceptance/config/el6/lib/helper.rb
+++ b/acceptance/config/el6/lib/helper.rb
@@ -1,0 +1,1 @@
+$LOAD_PATH << File.expand_path(File.dirname(__FILE__))

--- a/acceptance/config/el6/options.rb
+++ b/acceptance/config/el6/options.rb
@@ -1,0 +1,6 @@
+{
+  :config => 'config.yaml',
+  :type => 'manual',
+  :helper => 'lib/helper.rb',
+  :debug => true
+}

--- a/acceptance/config/el6/setup/early/01_Install.rb
+++ b/acceptance/config/el6/setup/early/01_Install.rb
@@ -1,0 +1,15 @@
+test_name "Install packages and repositories on target machines..." do
+  on hosts, "rm -rf /root/*.repo; rm -rf /root/*.rpm"
+  scp_to hosts, 'repos.tar', '/root'
+  on hosts, "cd /root && tar -xvf repos.tar"
+  on hosts, "mv /root/*.repo /etc/yum.repos.d"
+  on hosts, "rpm -Uvh --force /root/*.rpm"
+  hosts.each do |host|
+    if host['roles'].include?('master')
+      on host, "yum install -q -y puppet-server"
+    end
+    if host['roles'].include?('agent')
+      on host, "yum install -q -y puppet"
+    end
+  end
+end

--- a/acceptance/config/el6/setup/early/02_StopFirewall.rb
+++ b/acceptance/config/el6/setup/early/02_StopFirewall.rb
@@ -1,0 +1,3 @@
+test_name "Stop firewall" do
+  on hosts, puppet_resource('service', 'iptables', 'ensure=stopped')
+end

--- a/acceptance/config/el6/setup/early/04_ValidateSignCert.rb
+++ b/acceptance/config/el6/setup/early/04_ValidateSignCert.rb
@@ -1,0 +1,19 @@
+test_name "Validate Sign Cert"
+
+step "Master: Start Puppet Master"
+with_master_running_on(master, "--certname #{master} --verbose") do
+  hosts.each do |host|
+    next if host['roles'].include? 'master'
+
+    step "Agents: Run agent --test first time to gen CSR"
+    on host, puppet_agent("--test --server #{master}"), :acceptable_exit_codes => [1]
+  end
+
+  # Sign all waiting certs
+  step "Master: sign all certs"
+  on master, puppet_cert("--sign --all"), :acceptable_exit_codes => [0,24]
+
+  step "Agents: Run agent --test second time to obtain signed cert"
+  on agents, puppet_agent("--test --server #{master}"), :acceptable_exit_codes => [0,2]
+end
+

--- a/acceptance/config/el6/tests/is_installed.rb
+++ b/acceptance/config/el6/tests/is_installed.rb
@@ -1,0 +1,3 @@
+test_name "is puppet installed?"
+
+on hosts, "puppet --version"


### PR DESCRIPTION
This creates the basic structure for running tests from packages. It
includes a Rakefile for fetching the appropriate artifacts and executing
systest, the setup steps for installing the repos and packages, and a
basic test that makes sure that puppet is installed.

  bundle install
  bundle exec rake test SHA=COMMITISH

where COMMITISH corresponds to the SHA of a package built via the
puppetlabs-packaging job.
