### PR TITLE
(#18255) - Follow http redirections

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -3,8 +3,12 @@ require 'puppet/ssl/host'
 require 'puppet/ssl/configuration'
 require 'puppet/ssl/validator'
 require 'puppet/network/authentication'
+require 'uri'
 
 module Puppet::Network::HTTP
+
+  # This will be raised if too many redirects happen for a given HTTP request
+  class RedirectionLimitExceededException < Puppet::Error ; end
 
   # This class provides simple methods for issuing various types of HTTP
   # requests.  It's interface is intended to mirror Ruby's Net::HTTP
@@ -18,10 +22,20 @@ module Puppet::Network::HTTP
   class Connection
     include Puppet::Network::Authentication
 
-    def initialize(host, port, use_ssl = true)
+    MAX_HTTP_REDIRECTIONS = 10
+
+    # Creates a new HTTP client connection to `host`:`port`. 
+    # @param host [String] the host to which this client will connect to
+    # @param port [Fixnum] the port to which this client will connect to
+    # @param use_ssl [Boolean] true to connect with SSL, false otherwise
+    # @param redirect_limit [Fixnum] the number of allowed redirections
+    # @note the HTTP connection itself happens lazily only when {#request}, or one of the {#get}, {#post}, {#delete}, {#head} or {#put} is called
+    # @api private
+    def initialize(host, port, use_ssl = true, redirect_limit = MAX_HTTP_REDIRECTIONS)
       @host = host
       @port = port
       @use_ssl = use_ssl
+      @redirect_limit = redirect_limit
     end
 
     def get(*args)
@@ -45,31 +59,21 @@ module Puppet::Network::HTTP
     end
 
     def request(method, *args)
-      ssl_validator = Puppet::SSL::Validator.new(:ssl_configuration => ssl_configuration)
-      # Perform our own validation of the SSL connection in addition to OpenSSL
-      ssl_validator.register_verify_callback(connection)
-      response = connection.send(method, *args)
-      # Check the peer certs and warn if they're nearing expiration.
-      warn_if_near_expiration(*ssl_validator.peer_certs)
+      current_args = args.dup
+      @redirect_limit.times do |redirection|
+        response = execute_request(method, *args)
+        return response unless [301, 302, 307].include?(response.code.to_i)
 
-      response
-    rescue OpenSSL::SSL::SSLError => error
-      if error.message.include? "certificate verify failed"
-        msg = error.message
-        msg << ": [" + ssl_validator.verify_errors.join('; ') + "]"
-        raise Puppet::Error, msg
-      elsif error.message =~ /hostname (\w+ )?not match/
-        leaf_ssl_cert = ssl_validator.peer_certs.last
+        # handle the redirection
+        location = URI.parse(response['location'])
+        @connection = initialize_connection(location.host, location.port, location.scheme == 'https')
 
-        valid_certnames = [leaf_ssl_cert.name, *leaf_ssl_cert.subject_alt_names].uniq
-        msg = valid_certnames.length > 1 ? "one of #{valid_certnames.join(', ')}" : valid_certnames.first
-
-        raise Puppet::Error, "Server hostname '#{connection.address}' did not match server certificate; expected #{msg}"
-      else
-        raise
+        # update to the current request path
+        current_args = [location.path] + current_args.drop(1)
+        # and try again...
       end
+      raise RedirectionLimitExceededException, "Too many HTTP redirections for #{@host}:#{@port}"
     end
-
 
     # TODO: These are proxies for the Net::HTTP#request_* methods, which are
     # almost the same as the "get", "post", etc. methods that we've ported above,
@@ -91,7 +95,6 @@ module Puppet::Network::HTTP
     end
     # end of Net::HTTP#request_* proxies
 
-
     def address
       connection.address
     end
@@ -104,15 +107,42 @@ module Puppet::Network::HTTP
       connection.use_ssl?
     end
 
-
     private
 
     def connection
-      @connection || initialize_connection
+      @connection || initialize_connection(@host, @port, @use_ssl)
     end
 
-    def initialize_connection
-      args = [@host, @port]
+    def execute_request(method, *args)
+      ssl_validator = Puppet::SSL::Validator.new(:ssl_configuration => ssl_configuration)
+      # Perform our own validation of the SSL connection in addition to OpenSSL
+      ssl_validator.register_verify_callback(connection)
+
+      response = connection.send(method, *args)
+
+      # Check the peer certs and warn if they're nearing expiration.
+      warn_if_near_expiration(*ssl_validator.peer_certs)
+
+      response
+    rescue OpenSSL::SSL::SSLError => error
+      if error.message.include? "certificate verify failed"
+        msg = error.message
+        msg << ": [" + ssl_validator.verify_errors.join('; ') + "]"
+        raise Puppet::Error, msg
+      elsif error.message =~ /hostname (\w+ )?not match/
+        leaf_ssl_cert = ssl_validator.peer_certs.last
+
+        valid_certnames = [leaf_ssl_cert.name, *leaf_ssl_cert.subject_alt_names].uniq
+        msg = valid_certnames.length > 1 ? "one of #{valid_certnames.join(', ')}" : valid_certnames.first
+
+        raise Puppet::Error, "Server hostname '#{connection.address}' did not match server certificate; expected #{msg}"
+      else
+        raise
+      end
+    end
+
+    def initialize_connection(host, port, use_ssl)
+      args = [host, port]
       if Puppet[:http_proxy_host] == "none"
         args << nil << nil
       else
@@ -125,7 +155,7 @@ module Puppet::Network::HTTP
       # give us a reader for ca_file... Grr...
       class << @connection; attr_accessor :ca_file; end
 
-      @connection.use_ssl = @use_ssl
+      @connection.use_ssl = use_ssl
       # Use configured timeout (#1176)
       @connection.read_timeout = Puppet[:configtimeout]
       @connection.open_timeout = Puppet[:configtimeout]

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -89,7 +89,7 @@ describe processor do
         end
       end
 
-      if code.to_i >= 300
+      if code.to_i >= 300 && ![301, 302, 307].include?(code.to_i)
         it "should log error on http code #{code}" do
           response = klass.new('1.1', code, '')
           http.expects(:post).returns(response)


### PR DESCRIPTION
This patch adds support for HTTP redirection in the Puppet HTTP
client.

The http client includes a redirection limit, and recreate the
redirected connection with the same certificates and store as the
original (as long as the redirect new location is ssl protected).
It doesn't follow redirection for POST requests though.

Signed-off-by: Brice Figureau brice-puppet@daysofwonder.com
