### PR TITLE
(#20607) - do not fail saving lastrunfile when mode is specified

### DIFF
--- a/lib/puppet/util/symbolic_file_mode.rb
+++ b/lib/puppet/util/symbolic_file_mode.rb
@@ -1,6 +1,8 @@
 require 'puppet/util'
 
-module Puppet::Util::SymbolicFileMode
+module Puppet
+module Util
+module SymbolicFileMode
   SetUIDBit = ReadBit  = 4
   SetGIDBit = WriteBit = 2
   StickyBit = ExecBit  = 1
@@ -137,4 +139,6 @@ module Puppet::Util::SymbolicFileMode
       final_mode['o'] << 0
     return result
   end
+end
+end
 end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -480,6 +480,19 @@ describe Puppet::Configurer do
       Puppet.expects(:err)
       expect { @configurer.save_last_run_summary(@report) }.to_not raise_error
     end
+
+    it "should create the last run file with the correct mode" do
+      Puppet.settings.setting(:lastrunfile).stubs(:mode).returns('664')
+      @configurer.save_last_run_summary(@report)
+      mode = File.stat(Puppet[:lastrunfile]).mode
+      (mode & 0777).should == 0664
+    end
+
+    it "should report invalid last run file permissions" do
+      Puppet.settings.setting(:lastrunfile).stubs(:mode).returns('892')
+      Puppet.expects(:err)
+      expect { @configurer.save_last_run_summary(@report) }.to_not raise_error
+    end
   end
 
   describe "when retrieving a catalog" do

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -497,6 +497,22 @@ describe Puppet::Util do
       # ...and check the replacement was complete.
       File.read(target.path).should == "hello, world\n"
     end
+
+    {:string => '664', :number => 0664, :symbolic => "ug=rw-,o=r--" }.each do |label,mode|
+      it "should support #{label} format permissions" do
+        new_target = target.path + "#{mode}.foo"
+        File.should_not be_exist(new_target)
+
+        begin
+          subject.replace_file(new_target, mode) {|fh| fh.puts "this is an interesting content" }
+
+          get_mode(new_target).should == 0664
+        ensure
+          File.unlink(new_target) if File.exists?(new_target)
+        end
+      end
+    end
+
   end
 
   describe "#pretty_backtrace" do


### PR DESCRIPTION
The current settings system to specify the mode of "settings" file
is quite forgiving, but the method (replace_File) used to save
the last run summary file wasn't.
Hopefully with the help of the symbolic_file_mode system, we're now
able to send replace_file a correct file permission mode.

Signed-off-by: Brice Figureau brice-puppet@daysofwonder.com
