### PR TITLE
(#11317) - Do not ever skip resources appliable to both host and device

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -454,13 +454,20 @@ class Puppet::Transaction
       end
     elsif resource.virtual?
       resource.debug "Skipping because virtual"
-    elsif resource.appliable_to_device? ^ for_network_device
-      resource.debug "Skipping #{resource.appliable_to_device? ? 'device' : 'host'} resources because running on a #{for_network_device ? 'device' : 'host'}"
+    elsif !host_and_device_resource?(resource) && resource.appliable_to_host? && for_network_device
+      resource.debug "Skipping host resources because running on a device"
+    elsif !host_and_device_resource?(resource) && resource.appliable_to_device? && !for_network_device
+      resource.debug "Skipping device resources because running on a posix host"
     else
       return false
     end
     true
   end
+
+  def host_and_device_resource?(resource)
+    resource.appliable_to_host? && resource.appliable_to_device?
+  end
+  private :host_and_device_resource?
 
   # The tags we should be checking.
   def tags

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -2406,14 +2406,15 @@ class Type
   def exported?; !!@exported; end
 
   # @return [Boolean] Returns whether the resource is applicable to `:device`
-  # @todo Explain what this means
+  # Returns true if a resource of this type can be evaluated on a 'network device' kind
+  # of hosts.
   # @api private
   def appliable_to_device?
     self.class.can_apply_to(:device)
   end
 
   # @return [Boolean] Returns whether the resource is applicable to `:host`
-  # @todo Explain what this means
+  # Returns true if a resource of this type can be evaluated on a regular generalized computer (ie not an appliance like a network device)
   # @api private
   def appliable_to_host?
     self.class.can_apply_to(:host)

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -594,21 +594,38 @@ describe Puppet::Transaction do
     end
 
     it "should skip device only resouce on normal host" do
+      @resource.stubs(:appliable_to_host?).returns false
       @resource.stubs(:appliable_to_device?).returns true
       @transaction.for_network_device = false
       @transaction.should be_skip(@resource)
     end
 
     it "should not skip device only resouce on remote device" do
+      @resource.stubs(:appliable_to_host?).returns false
       @resource.stubs(:appliable_to_device?).returns true
       @transaction.for_network_device = true
       @transaction.should_not be_skip(@resource)
     end
 
     it "should skip host resouce on device" do
+      @resource.stubs(:appliable_to_host?).returns true
       @resource.stubs(:appliable_to_device?).returns false
       @transaction.for_network_device = true
       @transaction.should be_skip(@resource)
+    end
+
+    it "should not skip resouce available on both device and host when on device" do
+      @resource.stubs(:appliable_to_host?).returns true
+      @resource.stubs(:appliable_to_device?).returns true
+      @transaction.for_network_device = true
+      @transaction.should_not be_skip(@resource)
+    end
+
+    it "should not skip resouce available on both device and host when on host" do
+      @resource.stubs(:appliable_to_host?).returns true
+      @resource.stubs(:appliable_to_device?).returns true
+      @transaction.for_network_device = false
+      @transaction.should_not be_skip(@resource)
     end
   end
 


### PR DESCRIPTION
Since the puppet device feature introduction some types are labelled
as usable on host only, device only or both.

The schedule type is the only type that was labelled 'both'. Unfortunately
the logic in the Transaction#skip? was flawed and this resulted in all
the 'both' kind of resources to always being skipped, which essentially
meant that the Schedule type was non-working for a long time.

Signed-off-by: Brice Figureau brice-puppet@daysofwonder.com
