### PR TITLE
(#21043) Use ruby.exe instead of rubyw.exe

### DIFF
--- a/ext/windows/service/daemon.bat
+++ b/ext/windows/service/daemon.bat
@@ -3,4 +3,4 @@ SETLOCAL
 
 call "%~dp0..\bin\environment.bat" %0 %*
 
-rubyw -rubygems "%~dp0daemon.rb" %*
+ruby -rubygems "%~dp0daemon.rb" %*


### PR DESCRIPTION
Previously, if you set a custom runinterval setting in puppet.conf, puppet
running on ruby 1.9 would ignore it, whereas it would work in ruby 1.8.

The root cause is due to http://bugs.ruby-lang.org/issues/7239. In ruby 1.9,
rubyw.exe is unable to read the stdout of any child process using ruby's
built-in process methods, e.g. %x. This affects us, because the windows
service, running as rubyw.exe, executes:

```
`%x{ puppet agent --configprint runinterval }`
```

to obtain the current runinterval setting.

The bug is fixed in ruby 2.0, so for now, we just switch to using
`ruby.exe` instead of `rubyw.exe`.
