### PR TITLE
(maint) Consult lockfiles during init status check

### DIFF
--- a/ext/redhat/client.init
+++ b/ext/redhat/client.init
@@ -70,7 +70,7 @@ restart() {
 }
 
 rh_status() {
-    status $pidopts $puppetd
+    status $pidopts -l$lockfile $puppetd
     RETVAL=$?
     return $RETVAL
 }

--- a/ext/redhat/server.init
+++ b/ext/redhat/server.init
@@ -89,7 +89,7 @@ genconfig() {
 }
 
 rh_status() {
-    status $pidopts $PUPPETMASTER
+    status $pidopts -l$lockfile $PUPPETMASTER
     RETVAL=$?
     return $RETVAL
 }


### PR DESCRIPTION
On CentOS, the puppet master init script will default to looking for the
following lockfile:

```
/var/lock/subsys/puppet
```

This is because the puppet master shares the `puppet` executable name with the
puppet agent. This can be remedied by passing an explicit path to the lockfile
when performing status checks.
