### PR TITLE
(maint) Includes missing spec_helper in three specs.

### DIFF
--- a/spec/unit/interface/option_builder_spec.rb
+++ b/spec/unit/interface/option_builder_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'puppet/interface'
 
 describe Puppet::Interface::OptionBuilder do

--- a/spec/unit/interface/option_spec.rb
+++ b/spec/unit/interface/option_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'puppet/interface'
 
 describe Puppet::Interface::Option do

--- a/spec/unit/pops/containment_spec.rb
+++ b/spec/unit/pops/containment_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'puppet/pops'
 require File.join(File.dirname(__FILE__), 'factory_rspec_helper')
 


### PR DESCRIPTION
spec/spec_helper was missing from three of the specs. This showed up
because spec/unit/pops/containment_spec.rb just happened to come first
in the order of specs to be executed on our Solaris build, and began
causing failures because puppet/pops was being loaded prior to
spec_helper and puppet.  It was also causing rspec/mocha setup and
teardown failures, presumably because of rspec configuration being
called after this initial spec was loaded.

This commit ensures that each of these specs requires spec_helper first
so that spec and the puppet environment initialize properly regardless
of whether these specs run first or come later in the spec ordering.
