### PR TITLE
Add the s3_enabled property to the yumrepo type (#21452)

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -358,6 +358,12 @@ module Puppet
       newvalue(/.*/) { }
     end
 
+    newproperty(:s3_enabled, :parent => Puppet::IniProperty) do
+      desc "Access the repo via S3. #{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(/^(0|1)$/) { }
+    end
+
     newproperty(:sslcacert, :parent => Puppet::IniProperty) do
       desc "Path to the directory containing the databases of the
         certificate authorities yum should use to verify SSL certificates.\n#{ABSENT_DOC}"

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -14,7 +14,7 @@ describe Puppet::Type.type(:yumrepo) do
 
     [:baseurl, :cost, :descr, :enabled, :enablegroups, :exclude, :failovermethod, :gpgcheck, :gpgkey, :http_caching, 
        :include, :includepkgs, :keepalive, :metadata_expire, :mirrorlist, :priority, :protect, :proxy, :proxy_username, :proxy_password, :timeout, 
-       :sslcacert, :sslverify, :sslclientcert, :sslclientkey].each do |param|
+       :sslcacert, :sslverify, :sslclientcert, :sslclientkey, :s3_enabled].each do |param|
       it "should have a '#{param}' parameter" do
         Puppet::Type.type(:yumrepo).attrtype(param).should == :property
      end
@@ -36,7 +36,7 @@ describe Puppet::Type.type(:yumrepo) do
      end
     end
 
-    [:enabled, :enabledgroups, :gpgcheck, :keepalive, :protect].each do |param|
+    [:enabled, :enabledgroups, :gpgcheck, :keepalive, :protect, :s3_enabled].each do |param|
       it "should fail if '#{param}' does not have one of the following values (0|1)" do
         lambda { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", param => "2") }.should raise_error
       end


### PR DESCRIPTION
We’re using S3 backed yum repos in AWS via the yum-s3-iam plugin. This patch allows us to set the s3_enabled option to use repos in this way.
