### PR TITLE
(#21478) Add plymouth-ready to excludes list

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -43,6 +43,10 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     excludes += %w{wait-for-state portmap-wait}
     # these excludes were found with grep -r -L start /etc/init.d
     excludes += %w{rcS module-init-tools}
+    # Prevent puppet failing to get status of the new service introduced
+    # by the fix for this (bug https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/982889)
+    # due to puppet's inability to deal with upstart services with instances.
+    excludes += %w{plymouth-ready}
   end
 
   # List all services of this type.


### PR DESCRIPTION
An update to Ubuntu 12.04's plymouth package, version 0.8.2-2ubuntu31,
introduces a new upstart service, plymouth-ready in order to fix
the bug detailed here:
https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/982889

This new service uses instances, which puppet does not yet fully
support, and attempting to retrieve the status of this job causes
puppet to fail (for example when running "puppet resource service").

Adding plymouth-ready to the excludes list allows puppet to output
the status of services that it can handle competently while avoiding
the service introduced by this package.
