### PR TITLE
(#21264) Update rgen dependency to 0.6.5

### DIFF
--- a/ext/debian/changelog.erb
+++ b/ext/debian/changelog.erb
@@ -4,6 +4,12 @@ puppet (<%= @debversion %>) hardy lucid natty oneiric unstable sid squeeze wheez
 
  -- Puppet Labs Release <info@puppetlabs.com>  <%= Time.now.strftime("%a, %d %b %Y %H:%M:%S %z")%>
 
+puppet (3.2.3-0.1rc0puppetlabs1) lucid unstable sid squeeze wheezy precise quantal raring; urgency=low
+
+  * Update ruby-rgen dependency to 0.6.5
+
+ -- Matthaus Owens <matthaus@puppetlabs.com>  Thu, 27 Jun 2013 14:45:14 +0000
+
 puppet (3.2.0-0.1rc0puppetlabs1) lucid oneiric precise unstable sid squeeze wheezy precise; urgency=low
 
   * Add ruby-rgen dependency for new parser in Puppet 3.2

--- a/ext/debian/control
+++ b/ext/debian/control
@@ -11,7 +11,7 @@ Homepage: http://projects.puppetlabs.com/projects/puppet
 
 Package: puppet-common
 Architecture: all
-Depends: ${misc:Depends}, ruby | ruby-interpreter, libxmlrpc-ruby, libopenssl-ruby, ruby-shadow | libshadow-ruby1.8, libaugeas-ruby | libaugeas-ruby1.9.1 | libaugeas-ruby1.8, adduser, lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0), facter (>= 1.6.12), ruby-rgen
+Depends: ${misc:Depends}, ruby | ruby-interpreter, libxmlrpc-ruby, libopenssl-ruby, ruby-shadow | libshadow-ruby1.8, libaugeas-ruby | libaugeas-ruby1.9.1 | libaugeas-ruby1.8, adduser, lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0), facter (>= 1.6.12), ruby-rgen (>= 0.6.5)
 Recommends: lsb-release, debconf-utils
 Suggests: ruby-selinux | libselinux-ruby1.8, librrd-ruby1.9.1 | librrd-ruby1.8
 Breaks: puppet (<< 2.6.0~rc2-1), puppetmaster (<< 0.25.4-1)

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -17,7 +17,7 @@ gem_forge_project: 'puppet'
 gem_runtime_dependencies:
   facter: '~> 1.6'
   hiera: '~> 1.0'
-  rgen: '~> 0.6'
+  rgen: '~> 0.6.5'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -56,7 +56,7 @@ Requires:       facter >= 1.6.11
 # Ruby 1.8.7 available for el5 at: yum.puppetlabs.com/el/5/devel/$ARCH
 Requires:       ruby >= 1.8.7
 Requires:       hiera >= 1.0.0
-Requires:       ruby-rgen
+Requires:       ruby-rgen >= 0.6.5
 Obsoletes:      hiera-puppet < 1.0.0
 Provides:       hiera-puppet >= 1.0.0
 %{!?_without_augeas:Requires: ruby-augeas}
@@ -390,6 +390,9 @@ rm -rf %{buildroot}
 %changelog
 * <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
+
+* Thu Jun 27 2013 Matthaus Owens <matthaus@puppetlabs.com> - 3.2.3-0.1rc0
+- Bump requires on ruby-rgen to 0.6.5
 
 * Fri Apr 12 2013 Matthaus Owens <matthaus@puppetlabs.com> - 3.2.0-0.1rc0
 - Add requires on ruby-rgen for new parser in Puppet 3.2


### PR DESCRIPTION
Commit ec6b51a8ded9245df9606a57d53674c62bddc11e updated the rgen dependency in
the Gemfile. This commit makes the same dependency explicit in the various
packages (deb, rpm, gem). We pin the version hard at 0.6.5 to prevent potential
breakages with future versions of rgen.
