### PR TITLE
Fix faulty test for Puppet::Pops::Parser::Parser

### DIFF
--- a/spec/unit/pops/parser/parser_spec.rb
+++ b/spec/unit/pops/parser/parser_spec.rb
@@ -10,6 +10,6 @@ describe Puppet::Pops::Parser::Parser do
   it "should parse a code string and return a model" do
     parser = Puppet::Pops::Parser::Parser.new()
     model = parser.parse_string("$a = 10").current
-    model.class.should == Model::AssignmentExpression
+    model.class.should == Puppet::Pops::Model::AssignmentExpression
   end
 end


### PR DESCRIPTION
The reference to Model was unqualified which caused an "uninitalized
constant Model" failure when running rspec explicitly on the
spec/unit/pops/parser package. This commit adds the needed
qualification.
