### PR TITLE
(#21470) Change validation of "storeconfigs" to reflect runtime state.

### DIFF
--- a/lib/puppet/pops/validation/validator_factory_3_1.rb
+++ b/lib/puppet/pops/validation/validator_factory_3_1.rb
@@ -31,8 +31,10 @@ class Puppet::Pops::Validation::ValidatorFactory_3_1
 
     # Configure each issue that should **not** be an error
     #
-    p[Issues::RT_NO_STORECONFIGS_EXPORT]    = :warning
-    p[Issues::RT_NO_STORECONFIGS]           = :warning
+    # Validate as per the current runtime configuration
+    p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning
+    p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
+
     p[Issues::NAME_WITH_HYPHEN]             = :deprecation
     p[Issues::DEPRECATED_NAME_AS_TYPE]      = :deprecation
 


### PR DESCRIPTION
The problem was that the validator is written with static validation
in mind - not considering if storeconfigs are on or not.
Since we are currently only using the validator to validate for the
current runtime, this commit changes the behavior to consider the
runtime storeconfigs state and marking the related issues as :ignored if
storeconfigs is on.

A user that wants to use Puppet as a library will need to configure the
validation / issue options accordingly (the manifests will be validated
as per the settings of the puppet runtime used to run the validation).

This is easily done by using a different severity producer.
