### PR TITLE
(packaging) Use the packaging loader for tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,11 @@
 # Rakefile for Puppet -*- ruby -*-
+RAKE_ROOT = File.dirname(__FILE__)
 
 # We need access to the Puppet.version method
 $LOAD_PATH.unshift(File.expand_path("lib"))
 require 'puppet/version'
 
-$LOAD_PATH << File.join(File.dirname(__FILE__), 'tasks')
+$LOAD_PATH << File.join(RAKE_ROOT, 'tasks')
 
 begin
   require 'rubygems'
@@ -22,7 +23,11 @@ end
 require 'rake'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
-Dir['ext/packaging/tasks/**/*'].sort.each { |t| load t }
+
+begin
+  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
+rescue LoadError
+end
 
 build_defs_file = 'ext/build_defaults.yaml'
 if File.exist?(build_defs_file)


### PR DESCRIPTION
The packaging repo now uses an explicit loader which handles loading the
various rake tasks in packaging. This commit updates the puppet Rakefile to use
the loader instead of a blind glob of the ext/packaging/tasks directory. We
move this load into the rescue LoadError block because the packaging repo won't
always be there, and define RAKE_ROOT and use it since its used in more than
one place in the Rakefile.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
