### PR TITLE
(#21427) Fix Puppet::Run pson implementation

### DIFF
--- a/lib/puppet/run.rb
+++ b/lib/puppet/run.rb
@@ -95,6 +95,10 @@ class Puppet::Run
   end
 
   def to_pson
-    @options.merge(:background => @background).to_pson
+    {
+      :options => @options,
+      :background => @background,
+      :status => @status
+    }.to_pson
   end
 end

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -155,5 +155,21 @@ describe Puppet::Run do
       run.background.should be_true
       run.status.should == 'success'
     end
+
+    it "should round trip through pson" do
+      run = Puppet::Run.new(
+        :tags => ['a', 'b', 'c'],
+        :ignoreschedules => true,
+        :pluginsync => false,
+        :background => true
+      )
+      run.instance_variable_set(:@status, true)
+
+      tripped = Puppet::Run.convert_from(:pson, run.render(:pson))
+
+      tripped.options.should == run.options
+      tripped.status.should == run.status
+      tripped.background.should == run.background
+    end
   end
 end


### PR DESCRIPTION
The pson format for Puppet::Run did not include the status, which caused the
kick command to display an error.
