### PR TITLE
Add ignore entry for Eclipse specific .project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pkg/
 Gemfile.lock
 .bundle/
 puppet-acceptance/
+/.project


### PR DESCRIPTION
The Eclipse IDE adds a .project file to the root of each project.
This commit ensures that the file is ignored and doesn't get
inadvertently committed.
