### PR TITLE
(#21307) Refactor WatchedFile class

### DIFF
--- a/lib/puppet/util/watched_file/timer.rb
+++ b/lib/puppet/util/watched_file/timer.rb
@@ -1,0 +1,17 @@
+class Puppet::Util::WatchedFile
+  class Timer
+
+    def start(timeout)
+      @start_time = now
+      @timeout = timeout
+    end
+
+    def expired?
+      (now - @start_time) >= @timeout
+    end
+
+    def now
+      Time.now.to_i
+    end
+  end
+end


### PR DESCRIPTION
The watchedfile class was extracted from another location but had some
remnants of old behavior. In addition it would treat missing files as
always changed, which could lead to undesired behavior around trying to
reload missing files.

This commit refactors the WatchedFile to use a single timestamp value
and assume that the file is unchanged if the file timeout period has not
elapsed.

In addition this commit also treats file absence as a valid state.  If a
file is missing between two checks it will be treated as unchanged.
