### PR TITLE
PSON serialization for `Resource::Status` missing time field

### DIFF
--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -106,7 +106,7 @@ module Puppet
           'resource_type' => @resource_type,
           'evaluation_time' => @evaluation_time,
           'tags' => @tags,
-          'time' => @time.iso8601,
+          'time' => @time.iso8601(9),
           'failed' => @failed,
           'changed' => @changed,
           'out_of_sync' => @out_of_sync,

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -1,6 +1,5 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'time'
 
 require 'puppet/resource/status'
 
@@ -173,7 +172,7 @@ describe Puppet::Resource::Status do
     tripped.resource_type.should == @status.resource_type
     tripped.evaluation_time.should == @status.evaluation_time
     tripped.tags.should == @status.tags
-    tripped.time.iso8601.should == @status.time.iso8601
+    tripped.time.should == @status.time
     tripped.failed.should == @status.failed
     tripped.changed.should == @status.changed
     tripped.out_of_sync.should == @status.out_of_sync


### PR DESCRIPTION
Prior to this commit, the PSON serialization for the class
`Puppet::Resource::Status` was missing the `time` field.  This
would result in `nil` values in reports, which was causing
failures in the PuppetDB report processor.  This commit
simply adds in the field to the serialization, and adds
corresponding test coverage.
