### PR TITLE
Accept hiera configuration as Hash for easy rspec hiera data stubbing

### DIFF
--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -18,10 +18,12 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
     hiera_config = Puppet.settings[:hiera_config]
     config = {}
 
-    if File.exist?(hiera_config)
-      config = Hiera::Config.load(hiera_config)
-    else
-      Puppet.warning "Config file #{hiera_config} not found, using Hiera defaults"
+    if hiera_config.is_a?(Hash) or hiera_config.is_a?(String)
+      if hiera_config.is_a?(String) and not File.exist?(hiera_config)
+        Puppet.warning "Config file #{hiera_config} not found, using Hiera defaults"
+      else
+        config = Hiera::Config.load(hiera_config)
+      end
     end
 
     config[:logger] = 'puppet'

--- a/spec/unit/indirector/hiera_spec.rb
+++ b/spec/unit/indirector/hiera_spec.rb
@@ -121,6 +121,30 @@ describe Puppet::Indirector::Hiera do
         @hiera_class.hiera_config.should == { :logger => 'puppet' }
       end
     end
+
+    context "when the Hiera configuration is a Hash" do
+      let(:config) { {
+        :backends =>["rspec"],
+        :rspec => {}
+      } }
+
+      before do
+        Puppet.settings[:hiera_config] = config
+      end
+
+      it "should load hiera config hash by delegating to Hiera" do
+        Hiera::Config.expects(:load).with(config).returns({})
+        @hiera_class.hiera_config
+      end
+
+      it "should return a hiera configuration hash" do
+        @hiera_class.hiera_config.should eql(config.merge({
+          :hierarchy => "common",
+          :logger => "puppet",
+          :merge_behavior => :native
+        }))
+      end
+    end
   end
 
   describe "the behavior of the find method", :if => Puppet.features.hiera? do


### PR DESCRIPTION
Hiera already accepts config Hash (see https://github.com/puppetlabs/hiera/blob/master/lib/hiera/config.rb#L33)

Allows overriding the configuration in rspec tests easily using @mthibaut https://github.com/mthibaut/hiera-puppet-helper rspec backend and some configuration like

```
Puppet[:hiera_config] = {
  :backends=>['rspec'],
  :rspec=> respond_to?(:hiera_data) ? hiera_data : {} }
```

and 

```
let(:hiera_data) {{'myvar' => 'myvalue'}}
```
