### PR TITLE
(Maint) Fix warnings issued by yard

### DIFF
--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -129,7 +129,7 @@ Detail: "#{detail.message}"
 
   # Return a list of all applications (both legacy and Face applications), along with a summary
   #  of their functionality.
-  # @returns [Array] An Array of Arrays.  The outer array contains one entry per application; each
+  # @return [Array] An Array of Arrays.  The outer array contains one entry per application; each
   #  element in the outer array is a pair whose first element is a String containing the application
   #  name, and whose second element is a String containing the summary for that application.
   def all_application_summaries()

--- a/lib/puppet/interface/documentation.rb
+++ b/lib/puppet/interface/documentation.rb
@@ -133,11 +133,11 @@ class Puppet::Interface
     #   Sets examples.
     #   @param text [String] Example text
     #   @api public
-    #   @returns [void]
+    #   @return [void]
     #   @dsl Faces
     # @overload examples
     #   Returns documentation of examples
-    #   @returns [String] The examples
+    #   @return [String] The examples
     #   @api private
     attr_doc :examples
 
@@ -146,11 +146,11 @@ class Puppet::Interface
     #   Sets optional notes.
     #   @param text [String] The notes
     #   @api public
-    #   @returns [void]
+    #   @return [void]
     #   @dsl Faces
     # @overload notes
     #   Returns any optional notes
-    #   @returns [String] The notes
+    #   @return [String] The notes
     #   @api private
     attr_doc :notes
 
@@ -159,11 +159,11 @@ class Puppet::Interface
     #   Sets the license text
     #   @param text [String] the license text
     #   @api public
-    #   @returns [void]
+    #   @return [void]
     #   @dsl Faces
     # @overload license
     #   Returns the license
-    #   @returns [String] The license
+    #   @return [String] The license
     #   @api private
     attr_doc :license
 

--- a/lib/puppet/parameter/path.rb
+++ b/lib/puppet/parameter/path.rb
@@ -45,7 +45,7 @@ class Puppet::Parameter::Path < Puppet::Parameter
   # This default implementation does not perform any munging, it just checks the one/many paths
   # constraints. A derived implementation can perform this check as:
   # `paths.is_a?(Array) and ! self.class.arrays?` and raise a {Puppet::Error}.
-  # @param [String, Array<String>] one of multiple paths
+  # @param paths [String, Array<String>] one of multiple paths
   # @return [String, Array<String>] the given paths
   # @raise [Puppet::Error] if the given paths does not comply with the on/many paths rule.
   def unsafe_munge(paths)

--- a/lib/puppet/parameter/value.rb
+++ b/lib/puppet/parameter/value.rb
@@ -34,7 +34,7 @@ class Puppet::Parameter::Value
 
   # Initializes the instance with a literal accepted value, or a regular expression.
   # If anything else is passed, it is turned into a String, and then made into a Symbol.
-  # @param [Symbol, Regexp, Object] the value to accept, Symbol, a regular expression, or object to convert.
+  # @param name [Symbol, Regexp, Object] the value to accept, Symbol, a regular expression, or object to convert.
   # @api private
   #
   def initialize(name)

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -305,7 +305,7 @@ class Puppet::Parser::Scope
   # The scope of the inherited thing of this scope's resource. This could
   # either be a node that was inherited or the class.
   #
-  # @returns [Puppet::Parser::Scope] The scope or nil if there is not an inherited scope
+  # @return [Puppet::Parser::Scope] The scope or nil if there is not an inherited scope
   def inherited_scope
     if has_inherited_class?
       qualified_scope(resource.resource_type.parent)
@@ -320,7 +320,7 @@ class Puppet::Parser::Scope
   # scope in which it was included. The chain of parent scopes is followed
   # until a node scope or the topscope is found
   #
-  # @returns [Puppet::Parser::Scope] The scope or nil if there is no enclosing scope
+  # @return [Puppet::Parser::Scope] The scope or nil if there is no enclosing scope
   def enclosing_scope
     if has_enclosing_scope?
       if parent.is_topscope? or parent.is_nodescope?
@@ -469,7 +469,7 @@ class Puppet::Parser::Scope
   # scope's symtable. If the parameter `use_ephemeral` is true, the "top most" ephemeral "table"
   # will be returned (irrespective of it being a match scope or a local scope).
   #
-  # @param [Boolean] whether the top most ephemeral (of any kind) should be used or not
+  # @param use_ephemeral [Boolean] whether the top most ephemeral (of any kind) should be used or not
   def effective_symtable use_ephemeral
     s = @ephemeral.last
     return s if use_ephemeral

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -91,8 +91,8 @@ module Puppet::Pops::Issues
   #
   # @param issue_code [Symbol] the issue code for the issue used as an identifier, should be the same as the constant
   #   the issue is bound to.
-  # @param *args [Symbol] required arguments that must be passed when formatting the message, may be empty
-  # @param &block [Proc] a block producing the message string, evaluated in a MessageData scope. The produced string
+  # @param args [Symbol] required arguments that must be passed when formatting the message, may be empty
+  # @param block [Proc] a block producing the message string, evaluated in a MessageData scope. The produced string
   #   should not end with a period as additional information may be appended.
   #
   # @see MessageData

--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -180,10 +180,14 @@ class Puppet::Pops::Model::Factory
   end
 
   # Builds body :) from different kinds of input
-  # @param body [nil] unchanged, produces nil
-  # @param body [Array<Expression>] turns into a BlockExpression
-  # @param body [Expression] produces the given expression
-  # @param body [Object] produces the result of calling #build with body as argument
+  # @overload f_build_body(nothing)
+  #   @param nothing [nil] unchanged, produces nil
+  # @overload f_build_body(array)
+  #   @param array [Array<Expression>] turns into a BlockExpression
+  # @overload f_build_body(expr)
+  #   @param expr [Expression] produces the given expression
+  # @overload f_build_body(obj)
+  #   @param obj [Object] produces the result of calling #build with body as argument
   def f_build_body(body)
     case body
     when NilClass
@@ -429,7 +433,7 @@ class Puppet::Pops::Model::Factory
   # Does nothing if file is nil.
   #
   # @param file [String,nil] the file/path to the origin, may contain URI scheme of file: or some other URI scheme
-  # @returns [Factory] returns self
+  # @return [Factory] returns self
   #
   def record_origin(file)
     return self unless file

--- a/lib/puppet/pops/parser/lexer.rb
+++ b/lib/puppet/pops/parser/lexer.rb
@@ -31,10 +31,14 @@ class Puppet::Pops::Parser::Lexer
     attr_accessor :regex, :name, :string, :skip, :skip_text
     alias skip? skip
 
-    # @param string_or_regex[String] a literal string token matcher
-    # @param string_or_regex[Regexp] a regular expression token text matcher
-    # @param name [String] the token name (what it is known as in the grammar)
-    # @param options [Hash] see {#set_options}
+    # @overload initialize(string)
+    #   @param string [String] a literal string token matcher
+    #   @param name [String] the token name (what it is known as in the grammar)
+    #   @param options [Hash] see {#set_options}
+    # @overload initialize(regex)
+    #   @param regex [Regexp] a regular expression token text matcher
+    #   @param name [String] the token name (what it is known as in the grammar)
+    #   @param options [Hash] see {#set_options}
     #
     def initialize(string_or_regex, name, options = {})
       if string_or_regex.is_a?(String)

--- a/lib/puppet/pops/validation.rb
+++ b/lib/puppet/pops/validation.rb
@@ -20,7 +20,7 @@ module Puppet::Pops::Validation
     end
 
     # Returns the severity of the given issue.
-    # @returns [Symbol] severity level :error, :warning, or :ignore
+    # @return [Symbol] severity level :error, :warning, or :ignore
     #
     def severity issue
       assert_issue(issue)
@@ -44,7 +44,7 @@ module Puppet::Pops::Validation
     end
 
     # Returns true if the issue should be reported or not.
-    # @returns [Boolean] this implementation returns true for errors and warnings
+    # @return [Boolean] this implementation returns true for errors and warnings
     #
     def should_report? issue
       diagnose = self[issue]

--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -611,7 +611,7 @@ class Puppet::Property < Puppet::Parameter
   end
 
   # (see #should=)
-  def value=(value)
-    self.should = value
+  def value=(values)
+    self.should = values
   end
 end

--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -185,7 +185,7 @@ class Puppet::Provider
   # is lazy (when a resource is evaluated) and the absence of commands
   # that will be present after other resources have been applied no longer needs to be specified as
   # optional.
-  # @param [Hash{String => String}] command_specs Named commands that the provider will
+  # @param [Hash{String => String}] hash Named commands that the provider will
   #   be executing on the system. Each command is specified with a name and the path of the executable.
   # (@see #has_command)
   # @see commands
@@ -564,7 +564,7 @@ class Puppet::Provider
 
   # Sets the given parameters values as the current values for those parameters.
   # Other parameters are unchanged.
-  # @param [Array<Puppet::Parameter] the parameters with values that should be set
+  # @param [Array<Puppet::Parameter>] params the parameters with values that should be set
   # @return [void]
   #
   def set(params)

--- a/lib/puppet/provider/command.rb
+++ b/lib/puppet/provider/command.rb
@@ -16,8 +16,8 @@ class Puppet::Provider::Command
     @options = options
   end
 
-  # @param [Array<String>] Any command line arguments to pass to the executable
-  # @returns The output from the command
+  # @param args [Array<String>] Any command line arguments to pass to the executable
+  # @return The output from the command
   def execute(*args)
     resolved_executable = @resolver.which(@executable) or raise Puppet::Error, "Command #{@name} is missing"
     @executor.execute([resolved_executable] + args, @options)

--- a/lib/puppet/provider/parsedfile.rb
+++ b/lib/puppet/provider/parsedfile.rb
@@ -160,15 +160,6 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
     [resource_type.validproperties, resource_type.parameters].flatten.each do |attr|
       attr = attr.intern
       define_method(attr) do
-#                if @property_hash.empty?
-#                    # Note that this swaps the provider out from under us.
-#                    prefetch
-#                    if @resource.provider == self
-#                        return @property_hash[attr]
-#                    else
-#                        return @resource.provider.send(attr)
-#                    end
-#                end
         # If it's not a valid field for this record type (which can happen
         # when different platforms support different fields), then just
         # return the should value, so the resource shuts up.
@@ -416,8 +407,6 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
     end
 
     self.class.flush(@property_hash)
-
-    #@property_hash = {}
   end
 
   def initialize(record)

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -249,7 +249,7 @@ class Puppet::Settings
   # "no-" prefix on flag/boolean options).
   #
   # @param [String] opt the command line option that we are munging
-  # @param [String, TrueClass, FalseClass] the value for the setting (as determined by the OptionParser)
+  # @param [String, TrueClass, FalseClass] val the value for the setting (as determined by the OptionParser)
   def self.clean_opt(opt, val)
     # rewrite --[no-]option to --no-option if that's what was given
     if opt =~ /\[no-\]/ and !val

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -383,7 +383,7 @@ class Puppet::SSL::CertificateAuthority
   #   x509store(:cache => false)
   #
   # @param [Hash] options the options used for retrieving the X509 Store
-  # @options options [Boolean] :cache whether or not to use a cached version
+  # @option options [Boolean] :cache whether or not to use a cached version
   #   of the X509 Store
   #
   # @return [OpenSSL::X509::Store]
@@ -429,7 +429,7 @@ class Puppet::SSL::CertificateAuthority
   # @author Jeff Weiss <jeff.weiss@puppetlabs.com>
   # @api Puppet Enterprise Licensing
   #
-  # @param [Puppet::SSL::Certificate] the certificate to check validity of
+  # @param cert [Puppet::SSL::Certificate] the certificate to check validity of
   #
   # @return [Boolean] true if signed, false if unsigned or revoked
   def certificate_is_alive?(cert)
@@ -440,7 +440,7 @@ class Puppet::SSL::CertificateAuthority
   # the indirector will be used to locate the actual contents of the
   # certificate with that name.
   #
-  # @param [String] certificate name to verify
+  # @param name [String] certificate name to verify
   #
   # @raise [ArgumentError] if the certificate name cannot be found
   #   (i.e. doesn't exist or is unsigned)

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -303,7 +303,7 @@ class Type
   # @param metaparam [??? Puppet::Parameter] the meta-parameter to get documentation for.
   # @return [String] the documentation associated with the given meta-parameter, or nil of not such documentation
   #   exists.
-  # @raises [?] if the given metaparam is not a meta-parameter in this type
+  # @raise if the given metaparam is not a meta-parameter in this type
   #
   def self.metaparamdoc(metaparam)
     @@metaparamhash[metaparam].doc
@@ -354,8 +354,7 @@ class Type
   # Returns parameters that act as a key.
   # All parameters that return true from #isnamevar? or is named `:name` are included in the returned result.
   # @todo would like a better explanation
-  # @return Array<??? Puppet::Parameter>
-  #
+  # @return [Array<Puppet::Parameter>] WARNING: this return type is uncertain
   def self.key_attribute_parameters
     @key_attribute_parameters ||= (
       @parameters.find_all { |param|
@@ -1138,7 +1137,7 @@ class Type
 
   # Converts a simple hash into a Resource instance.
   # @todo as opposed to a complex hash? Other raised exceptions?
-  # @param [Hash{Symbol, String => Object}] resource attribute to value map to initialize the created resource from
+  # @param [Hash{Symbol, String => Object}] hash resource attribute to value map to initialize the created resource from
   # @return [Puppet::Resource] the resource created from the hash
   # @raise [Puppet::Error] if a title is missing in the given hash
   def self.hash2resource(hash)
@@ -1809,7 +1808,7 @@ class Type
       end
 
       # @todo this does what? where and how?
-      # @returns [String] the name of the provider
+      # @return [String] the name of the provider
       defaultto {
         prov = @resource.class.defaultprovider
         prov.name if prov
@@ -2104,7 +2103,6 @@ class Type
   #
   def self.validate(&block)
     define_method(:validate, &block)
-    #@validate = block
   end
 
   # @return [String] The file from which this type originates from
@@ -2157,8 +2155,8 @@ class Type
   #   resources; one that causes the title to be set to resource.title, and one that
   #   causes the title to be resource.ref ("for components") - what is a component?
   #
-  # @overaload initialize(hsh)
-  #   @param hsh [Hash]
+  # @overload initialize(hash)
+  #   @param [Hash] hash
   #   @raise [Puppet::ResourceError] when the type validation raises
   #     Puppet::Error or ArgumentError
   # @overload initialize(resource)

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -161,7 +161,7 @@ module Puppet
     #
     # (see Puppet::Settings#service_group_available?)
     #
-    # @returns [Boolean] if the group exists on the system
+    # @return [Boolean] if the group exists on the system
     # @api private
     def exists?
       provider.exists?

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -365,7 +365,7 @@ module Puppet
     #
     # (see Puppet::Settings#service_user_available?)
     #
-    # @returns [Boolean] if the user exists on the system
+    # @return [Boolean] if the user exists on the system
     # @api private
     def exists?
       provider.exists?

--- a/lib/puppet/util/classgen.rb
+++ b/lib/puppet/util/classgen.rb
@@ -36,7 +36,7 @@ module Puppet::Util::ClassGen
 
   # Creates a new module.
   # @param name [String] the name of the generated module
-  # @param optinos [Hash] hash with options
+  # @param options [Hash] hash with options
   # @option options [Array<Class>] :array if specified, the generated class is appended to this array
   # @option options [Hash<{String => Object}>] :attributes a hash that is applied to the generated class
   #   by calling setter methods corresponding to this hash's keys/value pairs. This is done before the given

--- a/lib/puppet/util/profiler.rb
+++ b/lib/puppet/util/profiler.rb
@@ -10,7 +10,7 @@ module Puppet::Util::Profiler
 
   NONE = Puppet::Util::Profiler::None.new
 
-  # @returns This thread's configured profiler
+  # @return This thread's configured profiler
   def self.current
     Thread.current[:profiler] || NONE
   end


### PR DESCRIPTION
There were many uses of incorrect tags (@returns instead of @return), unnamed
params (@params without specifying which param) and inccorect use of multiple
variations (@params for the same param many times instead of using
@overload). This fixes many, but not all of the warnings issued by yard when
it generates documentation.
