### PR TITLE
OpenBSD has had flavors since the early 2000s at least; sync comment.

### DIFF
--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -294,8 +294,8 @@ module Puppet
     end
 
     newparam(:flavor) do
-      desc "Newer versions of OpenBSD support 'flavors', which are
-        further specifications for which type of package you want."
+      desc "OpenBSD supports 'flavors', which are further specifications for
+        which type of package you want."
     end
 
     newparam(:install_options, :parent => Puppet::Parameter::PackageOptions, :required_features => :install_options) do


### PR DESCRIPTION
Trivial comment fix in package.rb, but OpenBSD ports supported flavors for over a decade now. So that doesn't really seem worth the 'recent versions' to me.
