### PR TITLE
(#21653) Skip modules with no manifest directory when loading resource t...

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -138,6 +138,12 @@ class Puppet::Module
       reject { |f| FileTest.directory?(f) }
   end
 
+  def all_manifests
+    return [] unless File.exists?(manifests)
+
+    Dir.glob(File.join(manifests, '**', '*.{rb,pp}'))
+  end
+
   def metadata_file
     return @metadata_file if defined?(@metadata_file)
 

--- a/lib/puppet/parser/type_loader.rb
+++ b/lib/puppet/parser/type_loader.rb
@@ -101,12 +101,8 @@ class Puppet::Parser::TypeLoader
     # behavior) only load files from the first module of a given name.  E.g.,
     # given first/foo and second/foo, only files from first/foo will be loaded.
     environment.modules.each do |mod|
-      if File.exists?(mod.manifests)
-        Find.find(mod.manifests) do |path|
-          if path =~ /\.pp$/ or path =~ /\.rb$/
-            import(path)
-          end
-        end
+      mod.all_manifests.each do |file|
+        import(file)
       end
     end
   end
@@ -121,7 +117,7 @@ class Puppet::Parser::TypeLoader
   # Try to load the object with the given fully qualified name.
   def try_load_fqname(type, fqname)
     return nil if fqname == "" # special-case main.
-    name2files(fqname).each do |filename|
+    files_to_try_for(fqname).each do |filename|
       begin
         imported_types = import(filename)
         if result = imported_types.find { |t| t.type == type and t.name == fqname }
@@ -129,7 +125,6 @@ class Puppet::Parser::TypeLoader
           return result
         end
       rescue Puppet::ImportError => detail
-        # We couldn't load the item
         # I'm not convienced we should just drop these errors, but this
         # preserves existing behaviours.
       end
@@ -140,7 +135,6 @@ class Puppet::Parser::TypeLoader
 
   def parse_file(file)
     Puppet.debug("importing '#{file}' in environment #{environment}")
-#    parser = Puppet::Parser::Parser.new(environment)
     parser = Puppet::Parser::ParserFactory.parser(environment)
     parser.file = file
     return parser.parse
@@ -150,13 +144,17 @@ class Puppet::Parser::TypeLoader
 
   # Return a list of all file basenames that should be tried in order
   # to load the object with the given fully qualified name.
-  def name2files(fqname)
-    result = []
-    ary = fqname.split("::")
-    while ary.length > 0
-      result << ary.join(File::SEPARATOR)
-      ary.pop
+  def files_to_try_for(qualified_name)
+    qualified_name.split('::').inject([]) do |paths, name|
+      add_path_for_name(paths, name)
     end
-    return result
+  end
+
+  def add_path_for_name(paths, name)
+    if paths.empty?
+      [name]
+    else
+      paths.unshift(File.join(paths.first, name))
+    end
   end
 end

--- a/spec/unit/parser/type_loader_spec.rb
+++ b/spec/unit/parser/type_loader_spec.rb
@@ -11,252 +11,228 @@ describe Puppet::Parser::TypeLoader do
   include PuppetSpec::Modules
   include PuppetSpec::Files
 
-  shared_examples_for 'the typeloader' do
-    before do
-      @loader = Puppet::Parser::TypeLoader.new(:myenv)
-      Puppet.expects(:deprecation_warning).never
+  let(:empty_hostclass) { Puppet::Parser::AST::Hostclass.new('') }
+  let(:loader) { Puppet::Parser::TypeLoader.new(:myenv) }
+
+  it "should support an environment" do
+    loader = Puppet::Parser::TypeLoader.new(:myenv)
+    loader.environment.name.should == :myenv
+  end
+
+  it "should include the Environment Helper" do
+    loader.class.ancestors.should be_include(Puppet::Node::Environment::Helper)
+  end
+
+  it "should delegate its known resource types to its environment" do
+    loader.known_resource_types.should be_instance_of(Puppet::Resource::TypeCollection)
+  end
+
+  describe "when loading names from namespaces" do
+    it "should do nothing if the name to import is an empty string" do
+      loader.try_load_fqname(:hostclass, "").should be_nil
     end
 
-    it "should support an environment" do
+    it "should attempt to import each generated name" do
+      loader.expects(:import).with("foo/bar",nil).returns([])
+      loader.expects(:import).with("foo",nil).returns([])
+      loader.try_load_fqname(:hostclass, "foo::bar")
+    end
+
+    it "should attempt to load each possible name going from most to least specific" do
+      path_order = sequence('path')
+      ['foo/bar/baz', 'foo/bar', 'foo'].each do |path|
+        Puppet::Parser::Files.expects(:find_manifests).with(path, anything).returns([nil, []]).in_sequence(path_order)
+      end
+
+      loader.try_load_fqname(:hostclass, 'foo::bar::baz')
+    end
+  end
+
+  describe "when importing" do
+    let(:stub_parser) { stub 'Parser', :file= => nil, :parse => empty_hostclass }
+
+    before(:each) do
+      Puppet::Parser::ParserFactory.stubs(:parser).with(anything).returns(stub_parser)
+    end
+
+    it "should return immediately when imports are being ignored" do
+      Puppet::Parser::Files.expects(:find_manifests).never
+      Puppet[:ignoreimport] = true
+      loader.import("foo").should be_nil
+    end
+
+    it "should use the directory of the current file if one is set" do
+      base_dir = make_absolute("/current")
+      Puppet::Parser::Files.expects(:find_manifests).with(anything, has_entry(:cwd => base_dir)).returns ["modname", %w{one}]
+
+      loader.import("myfile", File.join(base_dir, 'file'))
+    end
+
+    it "should pass the environment when looking for files" do
+      Puppet::Parser::Files.expects(:find_manifests).with(anything, has_entry(:environment => loader.environment)).returns ["modname", %w{one}]
+
+      loader.import("myfile")
+    end
+
+    it "should fail if no files are found" do
+      Puppet::Parser::Files.expects(:find_manifests).returns [nil, []]
+      lambda { loader.import("myfile") }.should raise_error(Puppet::ImportError)
+    end
+
+    it "should parse each found file" do
+      Puppet::Parser::Files.expects(:find_manifests).returns ["modname", [make_absolute("/one")]]
+      loader.expects(:parse_file).with(make_absolute("/one")).returns(Puppet::Parser::AST::Hostclass.new(''))
+      loader.import("myfile")
+    end
+
+    it "should make each file qualified before attempting to parse it" do
+      Puppet::Parser::Files.expects(:find_manifests).returns ["modname", %w{one}]
+      loader.expects(:parse_file).with(make_absolute("/current/one")).returns(Puppet::Parser::AST::Hostclass.new(''))
+      loader.import("myfile", make_absolute("/current/file"))
+    end
+
+    it "should not attempt to import files that have already been imported" do
       loader = Puppet::Parser::TypeLoader.new(:myenv)
-      loader.environment.name.should == :myenv
-    end
 
-    it "should include the Environment Helper" do
-      @loader.class.ancestors.should be_include(Puppet::Node::Environment::Helper)
-    end
+      Puppet::Parser::Files.expects(:find_manifests).twice.returns ["modname", %w{/one}]
+      loader.import("myfile").should_not be_empty
 
-    it "should delegate its known resource types to its environment" do
-      @loader.known_resource_types.should be_instance_of(Puppet::Resource::TypeCollection)
-    end
-
-    describe "when loading names from namespaces" do
-      it "should do nothing if the name to import is an empty string" do
-        @loader.expects(:name2files).never
-        @loader.try_load_fqname(:hostclass, "") { |filename, modname| raise :should_not_occur }.should be_nil
-      end
-
-      it "should attempt to import each generated name" do
-        @loader.expects(:import).with("foo/bar",nil).returns([])
-        @loader.expects(:import).with("foo",nil).returns([])
-        @loader.try_load_fqname(:hostclass, "foo::bar") { |f| false }
-      end
-    end
-
-    describe "when importing" do
-      before do
-        Puppet::Parser::Files.stubs(:find_manifests).returns ["modname", %w{file}]
-        parser_class.any_instance.stubs(:parse).returns(Puppet::Parser::AST::Hostclass.new(''))
-        parser_class.any_instance.stubs(:file=)
-      end
-
-      it "should return immediately when imports are being ignored" do
-        Puppet::Parser::Files.expects(:find_manifests).never
-        Puppet[:ignoreimport] = true
-        @loader.import("foo").should be_nil
-      end
-
-      it "should find all manifests matching the file or pattern" do
-        Puppet::Parser::Files.expects(:find_manifests).with { |pat, opts| pat == "myfile" }.returns ["modname", %w{one}]
-        @loader.import("myfile")
-      end
-
-      it "should use the directory of the current file if one is set" do
-        Puppet::Parser::Files.expects(:find_manifests).with { |pat, opts| opts[:cwd] == make_absolute("/current") }.returns ["modname", %w{one}]
-        @loader.import("myfile", make_absolute("/current/file"))
-      end
-
-      it "should pass the environment when looking for files" do
-        Puppet::Parser::Files.expects(:find_manifests).with { |pat, opts| opts[:environment] == @loader.environment }.returns ["modname", %w{one}]
-        @loader.import("myfile")
-      end
-
-      it "should fail if no files are found" do
-        Puppet::Parser::Files.expects(:find_manifests).returns [nil, []]
-        lambda { @loader.import("myfile") }.should raise_error(Puppet::ImportError)
-      end
-
-      it "should parse each found file" do
-        Puppet::Parser::Files.expects(:find_manifests).returns ["modname", [make_absolute("/one")]]
-        @loader.expects(:parse_file).with(make_absolute("/one")).returns(Puppet::Parser::AST::Hostclass.new(''))
-        @loader.import("myfile")
-      end
-
-      it "should make each file qualified before attempting to parse it" do
-        Puppet::Parser::Files.expects(:find_manifests).returns ["modname", %w{one}]
-        @loader.expects(:parse_file).with(make_absolute("/current/one")).returns(Puppet::Parser::AST::Hostclass.new(''))
-        @loader.import("myfile", make_absolute("/current/file"))
-      end
-
-      it "should not attempt to import files that have already been imported" do
-        @loader = Puppet::Parser::TypeLoader.new(:myenv)
-
-        Puppet::Parser::Files.expects(:find_manifests).returns ["modname", %w{/one}]
-        parser_class.any_instance.expects(:parse).once.returns(Puppet::Parser::AST::Hostclass.new(''))
-        other_parser_class.any_instance.expects(:parse).never.returns(Puppet::Parser::AST::Hostclass.new(''))
-        @loader.import("myfile")
-
-        # This will fail if it tries to reimport the file.
-        @loader.import("myfile")
-      end
-    end
-
-    describe "when importing all" do
-      before do
-        @base = tmpdir("base")
-
-        # Create two module path directories
-        @modulebase1 = File.join(@base, "first")
-        FileUtils.mkdir_p(@modulebase1)
-        @modulebase2 = File.join(@base, "second")
-        FileUtils.mkdir_p(@modulebase2)
-
-        Puppet[:modulepath] = "#{@modulebase1}#{File::PATH_SEPARATOR}#{@modulebase2}"
-      end
-
-      def mk_module(basedir, name)
-        PuppetSpec::Modules.create(name, basedir)
-      end
-
-      # We have to pass the base path so that we can
-      # write to modules that are in the second search path
-      def mk_manifests(base, mod, type, files)
-        exts = {"ruby" => ".rb", "puppet" => ".pp"}
-        files.collect do |file|
-          name = mod.name + "::" + file.gsub("/", "::")
-          path = File.join(base, mod.name, "manifests", file + exts[type])
-          FileUtils.mkdir_p(File.split(path)[0])
-
-          # write out the class
-          if type == "ruby"
-            File.open(path, "w") { |f| f.print "hostclass '#{name}' do\nend" }
-          else
-            File.open(path, "w") { |f| f.print "class #{name} {}" }
-          end
-          name
-        end
-      end
-
-      it "should load all puppet manifests from all modules in the specified environment" do
-        @module1 = mk_module(@modulebase1, "one")
-        @module2 = mk_module(@modulebase2, "two")
-
-        mk_manifests(@modulebase1, @module1, "puppet", %w{a b})
-        mk_manifests(@modulebase2, @module2, "puppet", %w{c d})
-
-        @loader.import_all
-
-        @loader.environment.known_resource_types.hostclass("one::a").should be_instance_of(Puppet::Resource::Type)
-        @loader.environment.known_resource_types.hostclass("one::b").should be_instance_of(Puppet::Resource::Type)
-        @loader.environment.known_resource_types.hostclass("two::c").should be_instance_of(Puppet::Resource::Type)
-        @loader.environment.known_resource_types.hostclass("two::d").should be_instance_of(Puppet::Resource::Type)
-      end
-
-      it "should load all ruby manifests from all modules in the specified environment" do
-        Puppet.expects(:deprecation_warning).at_least(1)
-
-        @module1 = mk_module(@modulebase1, "one")
-        @module2 = mk_module(@modulebase2, "two")
-
-        mk_manifests(@modulebase1, @module1, "ruby", %w{a b})
-        mk_manifests(@modulebase2, @module2, "ruby", %w{c d})
-
-        @loader.import_all
-
-        @loader.environment.known_resource_types.hostclass("one::a").should be_instance_of(Puppet::Resource::Type)
-        @loader.environment.known_resource_types.hostclass("one::b").should be_instance_of(Puppet::Resource::Type)
-        @loader.environment.known_resource_types.hostclass("two::c").should be_instance_of(Puppet::Resource::Type)
-        @loader.environment.known_resource_types.hostclass("two::d").should be_instance_of(Puppet::Resource::Type)
-      end
-
-      it "should not load manifests from duplicate modules later in the module path" do
-        @module1 = mk_module(@modulebase1, "one")
-
-        # duplicate
-        @module2 = mk_module(@modulebase2, "one")
-
-        mk_manifests(@modulebase1, @module1, "puppet", %w{a})
-        mk_manifests(@modulebase2, @module2, "puppet", %w{c})
-
-        @loader.import_all
-
-        @loader.environment.known_resource_types.hostclass("one::c").should be_nil
-      end
-
-      it "should load manifests from subdirectories" do
-        @module1 = mk_module(@modulebase1, "one")
-
-        mk_manifests(@modulebase1, @module1, "puppet", %w{a a/b a/b/c})
-
-        @loader.import_all
-
-        @loader.environment.known_resource_types.hostclass("one::a::b").should be_instance_of(Puppet::Resource::Type)
-        @loader.environment.known_resource_types.hostclass("one::a::b::c").should be_instance_of(Puppet::Resource::Type)
-      end
-
-      it "should skip modules that don't have manifests" do
-        @module1 = mk_module(@modulebase1, "one")
-
-        @loader.import_all
-      end
-    end
-
-    describe "when parsing a file" do
-      before do
-        @parser = Puppet::Parser::ParserFactory.parser(@loader.environment)
-        @parser.class.should == parser_class
-        @parser.stubs(:parse).returns(Puppet::Parser::AST::Hostclass.new(''))
-        @parser.stubs(:file=)
-        Puppet::Parser::ParserFactory.stubs(:parser).with(@loader.environment).returns @parser
-      end
-
-      it "should create a new parser instance for each file using the current environment" do
-        Puppet::Parser::ParserFactory.expects(:parser).with(@loader.environment).returns @parser
-        @loader.parse_file("/my/file")
-      end
-
-      it "should assign the parser its file and parse" do
-        @parser.expects(:file=).with("/my/file")
-        @parser.expects(:parse).returns(Puppet::Parser::AST::Hostclass.new(''))
-        @loader.parse_file("/my/file")
-      end
-    end
-
-    it "should be able to add classes to the current resource type collection" do
-      file = tmpfile("simple_file.pp")
-      File.open(file, "w") { |f| f.puts "class foo {}" }
-      @loader.import(file)
-
-      @loader.known_resource_types.hostclass("foo").should be_instance_of(Puppet::Resource::Type)
-    end
-
-    describe "when deciding where to look for files" do
-      { 'foo' => ['foo'],
-        'foo::bar' => ['foo/bar', 'foo'],
-        'foo::bar::baz' => ['foo/bar/baz', 'foo/bar', 'foo']
-      }.each do |fqname, expected_paths|
-        it "should look for #{fqname.inspect} in #{expected_paths.inspect}" do
-          @loader.instance_eval { name2files(fqname) }.should == expected_paths
-        end
-      end
+      loader.import("myfile").should be_empty
     end
   end
-  describe 'when using the classic parser' do
-    before :each do
-      Puppet[:parser] = 'current'
+
+  describe "when importing all" do
+    before do
+      @base = tmpdir("base")
+
+      # Create two module path directories
+      @modulebase1 = File.join(@base, "first")
+      FileUtils.mkdir_p(@modulebase1)
+      @modulebase2 = File.join(@base, "second")
+      FileUtils.mkdir_p(@modulebase2)
+
+      Puppet[:modulepath] = "#{@modulebase1}#{File::PATH_SEPARATOR}#{@modulebase2}"
     end
-    it_should_behave_like 'the typeloader' do
-      let(:parser_class) { Puppet::Parser::Parser}
-      let(:other_parser_class) { Puppet::Parser::EParserAdapter}
+
+    def mk_module(basedir, name)
+      PuppetSpec::Modules.create(name, basedir)
+    end
+
+    # We have to pass the base path so that we can
+    # write to modules that are in the second search path
+    def mk_manifests(base, mod, type, files)
+      exts = {"ruby" => ".rb", "puppet" => ".pp"}
+      files.collect do |file|
+        name = mod.name + "::" + file.gsub("/", "::")
+        path = File.join(base, mod.name, "manifests", file + exts[type])
+        FileUtils.mkdir_p(File.split(path)[0])
+
+        # write out the class
+        if type == "ruby"
+          File.open(path, "w") { |f| f.print "hostclass '#{name}' do\nend" }
+        else
+          File.open(path, "w") { |f| f.print "class #{name} {}" }
+        end
+        name
+      end
+    end
+
+    it "should load all puppet manifests from all modules in the specified environment" do
+      @module1 = mk_module(@modulebase1, "one")
+      @module2 = mk_module(@modulebase2, "two")
+
+      mk_manifests(@modulebase1, @module1, "puppet", %w{a b})
+      mk_manifests(@modulebase2, @module2, "puppet", %w{c d})
+
+      loader.import_all
+
+      loader.environment.known_resource_types.hostclass("one::a").should be_instance_of(Puppet::Resource::Type)
+      loader.environment.known_resource_types.hostclass("one::b").should be_instance_of(Puppet::Resource::Type)
+      loader.environment.known_resource_types.hostclass("two::c").should be_instance_of(Puppet::Resource::Type)
+      loader.environment.known_resource_types.hostclass("two::d").should be_instance_of(Puppet::Resource::Type)
+    end
+
+    it "should load all ruby manifests from all modules in the specified environment" do
+      Puppet.expects(:deprecation_warning).at_least(1)
+
+      @module1 = mk_module(@modulebase1, "one")
+      @module2 = mk_module(@modulebase2, "two")
+
+      mk_manifests(@modulebase1, @module1, "ruby", %w{a b})
+      mk_manifests(@modulebase2, @module2, "ruby", %w{c d})
+
+      loader.import_all
+
+      loader.environment.known_resource_types.hostclass("one::a").should be_instance_of(Puppet::Resource::Type)
+      loader.environment.known_resource_types.hostclass("one::b").should be_instance_of(Puppet::Resource::Type)
+      loader.environment.known_resource_types.hostclass("two::c").should be_instance_of(Puppet::Resource::Type)
+      loader.environment.known_resource_types.hostclass("two::d").should be_instance_of(Puppet::Resource::Type)
+    end
+
+    it "should not load manifests from duplicate modules later in the module path" do
+      @module1 = mk_module(@modulebase1, "one")
+
+      # duplicate
+      @module2 = mk_module(@modulebase2, "one")
+
+      mk_manifests(@modulebase1, @module1, "puppet", %w{a})
+      mk_manifests(@modulebase2, @module2, "puppet", %w{c})
+
+      loader.import_all
+
+      loader.environment.known_resource_types.hostclass("one::c").should be_nil
+    end
+
+    it "should load manifests from subdirectories" do
+      @module1 = mk_module(@modulebase1, "one")
+
+      mk_manifests(@modulebase1, @module1, "puppet", %w{a a/b a/b/c})
+
+      loader.import_all
+
+      loader.environment.known_resource_types.hostclass("one::a::b").should be_instance_of(Puppet::Resource::Type)
+      loader.environment.known_resource_types.hostclass("one::a::b::c").should be_instance_of(Puppet::Resource::Type)
+    end
+
+    it "should skip modules that don't have manifests" do
+      @module1 = mk_module(@modulebase1, "one")
+      @module2 = mk_module(@modulebase2, "two")
+      mk_manifests(@modulebase2, @module2, "ruby", %w{c d})
+
+      loader.import_all
+
+      loader.environment.known_resource_types.hostclass("one::a").should be_nil
+      loader.environment.known_resource_types.hostclass("two::c").should be_instance_of(Puppet::Resource::Type)
+      loader.environment.known_resource_types.hostclass("two::d").should be_instance_of(Puppet::Resource::Type)
     end
   end
-  describe 'when using the future parser' do
-    before :each do
-      Puppet[:parser] = 'future'
+
+  describe "when parsing a file" do
+    it "should create a new parser instance for each file using the current environment" do
+      parser = stub 'Parser', :file= => nil, :parse => empty_hostclass
+
+      Puppet::Parser::ParserFactory.expects(:parser).twice.with(loader.environment).returns(parser)
+
+      loader.parse_file("/my/file")
+      loader.parse_file("/my/other_file")
     end
-    it_should_behave_like 'the typeloader' do
-      let(:parser_class) { Puppet::Parser::EParserAdapter}
-      let(:other_parser_class) { Puppet::Parser::Parser}
+
+    it "should assign the parser its file and parse" do
+      parser = mock 'parser'
+
+      Puppet::Parser::ParserFactory.expects(:parser).with(loader.environment).returns(parser)
+      parser.expects(:file=).with("/my/file")
+      parser.expects(:parse).returns(empty_hostclass)
+
+      loader.parse_file("/my/file")
     end
+  end
+
+  it "should be able to add classes to the current resource type collection" do
+    file = tmpfile("simple_file.pp")
+    File.open(file, "w") { |f| f.puts "class foo {}" }
+    loader.import(file)
+
+    loader.known_resource_types.hostclass("foo").should be_instance_of(Puppet::Resource::Type)
   end
 end


### PR DESCRIPTION
...ypes

The resource_type face tries to parse all manifests from modules, but was
failing if a module didn't have a manifest directory. This is not an error
condition so we just skip those modules.
