### PR TITLE
(maint) Fix rspec warnings

### DIFF
--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::Application::FaceBase do
     end
 
     describe "with just an action" do
-      before :all do
+      before(:each) do
         # We have to stub Signal.trap to avoid a crazy mess where we take
         # over signal handling and make it impossible to cancel the test
         # suite run.

--- a/spec/unit/face/node_spec.rb
+++ b/spec/unit/face/node_spec.rb
@@ -67,8 +67,8 @@ describe Puppet::Face[:node, '0.0.1'] do
 
     it "should accept the option --unexport" do
       expect {
-        subject.help('hostname', :unexport => true)
-      }.to_not raise_error(ArgumentError)
+        subject.clean('hostname', :unexport => true)
+      }.to_not raise_error
     end
 
     context "clean action" do

--- a/spec/unit/file_serving/configuration_spec.rb
+++ b/spec/unit/file_serving/configuration_spec.rb
@@ -167,13 +167,13 @@ describe Puppet::FileServing::Configuration do
     it "should fail if the mount name is not alpha-numeric" do
       request.expects(:key).returns "foo&bar/asdf"
 
-      lambda { config.split_path(request) }.should raise_error(ArgumentError)
+      expect { config.split_path(request) }.to raise_error(ArgumentError)
     end
 
     it "should support dashes in the mount name" do
       request.expects(:key).returns "foo-bar/asdf"
 
-      lambda { config.split_path(request) }.should_not raise_error(ArgumentError)
+      expect { config.split_path(request) }.to_not raise_error
     end
 
     it "should use the mount name and environment to find the mount" do

--- a/spec/unit/file_serving/mount/file_spec.rb
+++ b/spec/unit/file_serving/mount/file_spec.rb
@@ -11,7 +11,7 @@ end
 
 describe Puppet::FileServing::Mount::File do
   it "should be invalid if it does not have a path" do
-    lambda { Puppet::FileServing::Mount::File.new("foo").validate }.should raise_error(ArgumentError)
+    expect { Puppet::FileServing::Mount::File.new("foo").validate }.to raise_error(ArgumentError)
   end
 
   it "should be valid if it has a path" do
@@ -19,7 +19,7 @@ describe Puppet::FileServing::Mount::File do
     FileTest.stubs(:readable?).returns true
     mount = Puppet::FileServing::Mount::File.new("foo")
     mount.path = "/foo"
-    lambda { mount.validate }.should_not raise_error(ArgumentError)
+    expect { mount.validate }.not_to raise_error
   end
 
   describe "when setting the path" do
@@ -30,13 +30,13 @@ describe Puppet::FileServing::Mount::File do
 
     it "should fail if the path is not a directory" do
       FileTest.expects(:directory?).returns(false)
-      proc { @mount.path = @dir }.should raise_error(ArgumentError)
+      expect { @mount.path = @dir }.to raise_error(ArgumentError)
     end
 
     it "should fail if the path is not readable" do
       FileTest.expects(:directory?).returns(true)
       FileTest.expects(:readable?).returns(false)
-      proc { @mount.path = @dir }.should raise_error(ArgumentError)
+      expect { @mount.path = @dir }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -33,15 +33,15 @@ describe Puppet::Indirector::Request do
     end
 
     it "should support options specified as a hash" do
-      lambda { Puppet::Indirector::Request.new(:ind, :method, :key, nil, :one => :two) }.should_not raise_error(ArgumentError)
+      expect { Puppet::Indirector::Request.new(:ind, :method, :key, nil, :one => :two) }.to_not raise_error
     end
 
     it "should support nil options" do
-      lambda { Puppet::Indirector::Request.new(:ind, :method, :key, nil, nil) }.should_not raise_error(ArgumentError)
+      expect { Puppet::Indirector::Request.new(:ind, :method, :key, nil, nil) }.to_not raise_error
     end
 
     it "should support unspecified options" do
-      lambda { Puppet::Indirector::Request.new(:ind, :method, :key, nil) }.should_not raise_error(ArgumentError)
+      expect { Puppet::Indirector::Request.new(:ind, :method, :key, nil) }.to_not raise_error
     end
 
     it "should use an empty options hash if nil was provided" do
@@ -190,7 +190,7 @@ describe Puppet::Indirector::Request do
     Puppet::Indirector::Indirection.expects(:instance).with(:myind).returns nil
     request = Puppet::Indirector::Request.new(:myind, :method, :key, nil)
 
-    lambda { request.model }.should raise_error(ArgumentError)
+    expect { request.model }.to raise_error(ArgumentError)
   end
 
   it "should have a method for determining if the request is plural or singular" do
@@ -425,7 +425,7 @@ describe Puppet::Indirector::Request do
     it "should fail if no key is provided" do
       json = PSON.parse(@request.to_pson)
       json['data'].delete("key")
-      lambda { from_json(json.to_pson) }.should raise_error(ArgumentError)
+      expect { from_json(json.to_pson) }.to raise_error(ArgumentError)
     end
 
     it "should set its indirector name" do
@@ -435,7 +435,7 @@ describe Puppet::Indirector::Request do
     it "should fail if no type is provided" do
       json = PSON.parse(@request.to_pson)
       json['data'].delete("type")
-      lambda { from_json(json.to_pson) }.should raise_error(ArgumentError)
+      expect { from_json(json.to_pson) }.to raise_error(ArgumentError)
     end
 
     it "should set its method" do
@@ -445,7 +445,7 @@ describe Puppet::Indirector::Request do
     it "should fail if no method is provided" do
       json = PSON.parse(@request.to_pson)
       json['data'].delete("method")
-      lambda { from_json(json.to_pson) }.should raise_error(ArgumentError)
+      expect { from_json(json.to_pson) }.to raise_error(ArgumentError)
     end
 
     it "should initialize with all attributes and options" do

--- a/spec/unit/interface_spec.rb
+++ b/spec/unit/interface_spec.rb
@@ -24,11 +24,11 @@ describe Puppet::Interface do
     end
 
     it "should raise an exception when the requested version is unavailable" do
-      expect { subject[:huzzah, '17.0.0'] }.to raise_error, Puppet::Error
+      expect { subject[:huzzah, '17.0.0'] }.to raise_error(Puppet::Error, /Could not find version/)
     end
 
     it "should raise an exception when the requested face doesn't exist" do
-      expect { subject[:burrble_toot, :current] }.to raise_error, Puppet::Error
+      expect { subject[:burrble_toot, :current] }.to raise_error(Puppet::Error, /Could not find Puppet Face/)
     end
 
     describe "version matching" do

--- a/spec/unit/parameter/value_collection_spec.rb
+++ b/spec/unit/parameter/value_collection_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::Parameter::ValueCollection do
   end
 
   it "should be able to add values that are empty strings" do
-    lambda { @collection.newvalue('') }.should_not raise_error
+    expect { @collection.newvalue('') }.to_not raise_error
   end
 
   it "should be able to add values that are empty strings" do
@@ -107,33 +107,33 @@ describe Puppet::Parameter::ValueCollection do
 
     it "should fail if the value is not a defined value or alias and does not match a regex" do
       @collection.newvalues :foo
-      lambda { @collection.validate("bar") }.should raise_error(ArgumentError)
+      expect { @collection.validate("bar") }.to raise_error(ArgumentError)
     end
 
     it "should succeed if the value is one of the defined values" do
       @collection.newvalues :foo
-      lambda { @collection.validate(:foo) }.should_not raise_error(ArgumentError)
+      expect { @collection.validate(:foo) }.to_not raise_error
     end
 
     it "should succeed if the value is one of the defined values even if the definition uses a symbol and the validation uses a string" do
       @collection.newvalues :foo
-      lambda { @collection.validate("foo") }.should_not raise_error(ArgumentError)
+      expect { @collection.validate("foo") }.to_not raise_error
     end
 
     it "should succeed if the value is one of the defined values even if the definition uses a string and the validation uses a symbol" do
       @collection.newvalues "foo"
-      lambda { @collection.validate(:foo) }.should_not raise_error(ArgumentError)
+      expect { @collection.validate(:foo) }.to_not raise_error
     end
 
     it "should succeed if the value is one of the defined aliases" do
       @collection.newvalues :foo
       @collection.aliasvalue :bar, :foo
-      lambda { @collection.validate("bar") }.should_not raise_error(ArgumentError)
+      expect { @collection.validate("bar") }.to_not raise_error
     end
 
     it "should succeed if the value matches one of the regexes" do
       @collection.newvalues %r{\d}
-      lambda { @collection.validate("10") }.should_not raise_error(ArgumentError)
+      expect { @collection.validate("10") }.to_not raise_error
     end
   end
 

--- a/spec/unit/parameter_spec.rb
+++ b/spec/unit/parameter_spec.rb
@@ -83,38 +83,38 @@ describe Puppet::Parameter do
 
     it "should catch abnormal failures thrown during validation" do
       @class.validate { |v| raise "This is broken" }
-      lambda { @parameter.validate("eh") }.should raise_error(Puppet::DevError)
+      expect { @parameter.validate("eh") }.to raise_error(Puppet::DevError)
     end
 
     it "should fail if the value is not a defined value or alias and does not match a regex" do
       @class.newvalues :foo
-      lambda { @parameter.validate("bar") }.should raise_error(Puppet::Error)
+      expect { @parameter.validate("bar") }.to raise_error(Puppet::Error)
     end
 
     it "should succeed if the value is one of the defined values" do
       @class.newvalues :foo
-      lambda { @parameter.validate(:foo) }.should_not raise_error(ArgumentError)
+      expect { @parameter.validate(:foo) }.to_not raise_error
     end
 
     it "should succeed if the value is one of the defined values even if the definition uses a symbol and the validation uses a string" do
       @class.newvalues :foo
-      lambda { @parameter.validate("foo") }.should_not raise_error(ArgumentError)
+      expect { @parameter.validate("foo") }.to_not raise_error
     end
 
     it "should succeed if the value is one of the defined values even if the definition uses a string and the validation uses a symbol" do
       @class.newvalues "foo"
-      lambda { @parameter.validate(:foo) }.should_not raise_error(ArgumentError)
+      expect { @parameter.validate(:foo) }.to_not raise_error
     end
 
     it "should succeed if the value is one of the defined aliases" do
       @class.newvalues :foo
       @class.aliasvalue :bar, :foo
-      lambda { @parameter.validate("bar") }.should_not raise_error(ArgumentError)
+      expect { @parameter.validate("bar") }.to_not raise_error
     end
 
     it "should succeed if the value matches one of the regexes" do
       @class.newvalues %r{\d}
-      lambda { @parameter.validate("10") }.should_not raise_error(ArgumentError)
+      expect { @parameter.validate("10") }.to_not raise_error
     end
   end
 
@@ -125,7 +125,7 @@ describe Puppet::Parameter do
 
     it "should catch abnormal failures thrown during munging" do
       @class.munge { |v| raise "This is broken" }
-      lambda { @parameter.munge("eh") }.should raise_error(Puppet::DevError)
+      expect { @parameter.munge("eh") }.to raise_error(Puppet::DevError)
     end
 
     it "should return return any matching defined values" do

--- a/spec/unit/parser/ast/function_spec.rb
+++ b/spec/unit/parser/ast/function_spec.rb
@@ -10,7 +10,7 @@ describe Puppet::Parser::AST::Function do
     it "should not fail if the function doesn't exist" do
       Puppet::Parser::Functions.stubs(:function).returns(false)
 
-      lambda{ Puppet::Parser::AST::Function.new :name => "dontexist" }.should_not raise_error(Puppet::ParseError)
+      expect{ Puppet::Parser::AST::Function.new :name => "dontexist" }.to_not raise_error
 
     end
   end
@@ -27,7 +27,7 @@ describe Puppet::Parser::AST::Function do
       Puppet::Parser::Functions.stubs(:function).returns(false)
       func = Puppet::Parser::AST::Function.new :name => "dontexist"
 
-      lambda{ func.evaluate(@scope) }.should raise_error(Puppet::ParseError)
+      expect{ func.evaluate(@scope) }.to raise_error(Puppet::ParseError)
     end
 
     it "should fail if the function is a statement used as rvalue" do
@@ -36,7 +36,7 @@ describe Puppet::Parser::AST::Function do
 
       func = Puppet::Parser::AST::Function.new :name => "exist", :ftype => :rvalue
 
-      lambda{ func.evaluate(@scope) }.should raise_error(Puppet::ParseError, "Function 'exist' does not return a value")
+      expect{ func.evaluate(@scope) }.to raise_error(Puppet::ParseError, "Function 'exist' does not return a value")
     end
 
     it "should fail if the function is an rvalue used as statement" do
@@ -45,7 +45,7 @@ describe Puppet::Parser::AST::Function do
 
       func = Puppet::Parser::AST::Function.new :name => "exist", :ftype => :statement
 
-      lambda{ func.evaluate(@scope) }.should raise_error(Puppet::ParseError,"Function 'exist' must be the value of a statement")
+      expect{ func.evaluate(@scope) }.to raise_error(Puppet::ParseError,"Function 'exist' must be the value of a statement")
     end
 
     it "should evaluate its arguments" do

--- a/spec/unit/parser/collector_spec.rb
+++ b/spec/unit/parser/collector_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Parser::Collector, "when initializing" do
   end
 
   it "should only accept :virtual or :exported as the collector form" do
-    proc { @collector = Puppet::Parser::Collector.new(@scope, @resource_type, @vquery, @equery, :other) }.should raise_error(ArgumentError)
+    expect { @collector = Puppet::Parser::Collector.new(@scope, @resource_type, @vquery, @equery, :other) }.to raise_error(ArgumentError)
   end
 
   it "should accept an optional virtual query" do
@@ -61,7 +61,7 @@ describe Puppet::Parser::Collector, "when collecting specific virtual resources"
   it "should not fail when it does not find any resources to collect" do
     @collector.resources = ["File[virtual1]", "File[virtual2]"]
     @scope.stubs(:findresource).returns(false)
-    proc { @collector.evaluate }.should_not raise_error
+    expect { @collector.evaluate }.to_not raise_error
   end
 
   it "should mark matched resources as non-virtual" do
@@ -429,7 +429,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       @compiler.add_resource(@scope, local)
 
       got = nil
-      expect { got = @collector.evaluate }.not_to raise_error(Puppet::ParseError)
+      expect { got = @collector.evaluate }.not_to raise_error
       got.length.should == 1
       got.first.type.should == "Notify"
       got.first.title.should == "boingy-boingy"

--- a/spec/unit/parser/functions_spec.rb
+++ b/spec/unit/parser/functions_spec.rb
@@ -38,7 +38,7 @@ describe Puppet::Parser::Functions do
     end
 
     it "should raise an error if the function type is not correct" do
-      lambda { Puppet::Parser::Functions.newfunction("name", :type => :unknown) { |args| } }.should raise_error Puppet::DevError, "Invalid statement type :unknown"
+      expect { Puppet::Parser::Functions.newfunction("name", :type => :unknown) { |args| } }.to raise_error Puppet::DevError, "Invalid statement type :unknown"
     end
 
     it "instruments the function to profiles the execution" do
@@ -85,32 +85,32 @@ describe Puppet::Parser::Functions do
 
     it "should raise an error if the function is called with too many arguments" do
       Puppet::Parser::Functions.newfunction("name", :arity => 2) { |args| }
-      lambda { callable_functions_from(function_module).function_name([1,2,3]) }.should raise_error ArgumentError
+      expect { callable_functions_from(function_module).function_name([1,2,3]) }.to raise_error ArgumentError
     end
 
     it "should raise an error if the function is called with too few arguments" do
       Puppet::Parser::Functions.newfunction("name", :arity => 2) { |args| }
-      lambda { callable_functions_from(function_module).function_name([1]) }.should raise_error ArgumentError
+      expect { callable_functions_from(function_module).function_name([1]) }.to raise_error ArgumentError
     end
 
     it "should not raise an error if the function is called with correct number of arguments" do
       Puppet::Parser::Functions.newfunction("name", :arity => 2) { |args| }
-      lambda { callable_functions_from(function_module).function_name([1,2]) }.should_not raise_error ArgumentError
+      expect { callable_functions_from(function_module).function_name([1,2]) }.to_not raise_error
     end
 
     it "should raise an error if the variable arg function is called with too few arguments" do
       Puppet::Parser::Functions.newfunction("name", :arity => -3) { |args| }
-      lambda { callable_functions_from(function_module).function_name([1]) }.should raise_error ArgumentError
+      expect { callable_functions_from(function_module).function_name([1]) }.to raise_error ArgumentError
     end
 
     it "should not raise an error if the variable arg function is called with correct number of arguments" do
       Puppet::Parser::Functions.newfunction("name", :arity => -3) { |args| }
-      lambda { callable_functions_from(function_module).function_name([1,2]) }.should_not raise_error ArgumentError
+      expect { callable_functions_from(function_module).function_name([1,2]) }.to_not raise_error
     end
 
     it "should not raise an error if the variable arg function is called with more number of arguments" do
       Puppet::Parser::Functions.newfunction("name", :arity => -3) { |args| }
-      lambda { callable_functions_from(function_module).function_name([1,2,3]) }.should_not raise_error ArgumentError
+      expect { callable_functions_from(function_module).function_name([1,2,3]) }.to_not raise_error
     end
   end
 

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -181,7 +181,7 @@ describe Puppet::Parser::Resource do
       resource = Puppet::Parser::Resource.new(:class, "foo", :scope => @scope, :catalog => @catalog)
       resource[:stage] = 'other'
 
-      lambda { resource.evaluate }.should raise_error(ArgumentError, /Could not find stage other specified by/)
+      expect { resource.evaluate }.to raise_error(ArgumentError, /Could not find stage other specified by/)
     end
 
     it "should add edges from the class resources to the parent's stage if no stage is specified" do
@@ -328,19 +328,19 @@ describe Puppet::Parser::Resource do
     end
 
     it "should fail on tags containing '*' characters" do
-      lambda { @resource.tag("bad*tag") }.should raise_error(Puppet::ParseError)
+      expect { @resource.tag("bad*tag") }.to raise_error(Puppet::ParseError)
     end
 
     it "should fail on tags starting with '-' characters" do
-      lambda { @resource.tag("-badtag") }.should raise_error(Puppet::ParseError)
+      expect { @resource.tag("-badtag") }.to raise_error(Puppet::ParseError)
     end
 
     it "should fail on tags containing ' ' characters" do
-      lambda { @resource.tag("bad tag") }.should raise_error(Puppet::ParseError)
+      expect { @resource.tag("bad tag") }.to raise_error(Puppet::ParseError)
     end
 
     it "should allow alpha tags" do
-      lambda { @resource.tag("good_tag") }.should_not raise_error(Puppet::ParseError)
+      expect { @resource.tag("good_tag") }.to_not raise_error
     end
   end
 
@@ -354,7 +354,7 @@ describe Puppet::Parser::Resource do
     it "should fail when the override was not created by a parent class" do
       @override.source = "source2"
       @override.source.expects(:child_of?).with("source1").returns(false)
-      lambda { @resource.merge(@override) }.should raise_error(Puppet::ParseError)
+      expect { @resource.merge(@override) }.to raise_error(Puppet::ParseError)
     end
 
     it "should succeed when the override was created in the current scope" do
@@ -550,7 +550,7 @@ describe Puppet::Parser::Resource do
       resource = Puppet::Parser::Resource.new :foo, "bar", :scope => @scope, :source => stub("source")
       resource[:one] = :two
       resource.expects(:validate_parameter).with(:one).raises ArgumentError
-      lambda { resource.send(:validate) }.should raise_error(Puppet::ParseError)
+      expect { resource.send(:validate) }.to raise_error(Puppet::ParseError)
     end
   end
 
@@ -567,7 +567,7 @@ describe Puppet::Parser::Resource do
     end
 
     it "should fail when provided a parameter name but no value" do
-      lambda { @resource.set_parameter("myparam") }.should raise_error(ArgumentError)
+      expect { @resource.set_parameter("myparam") }.to raise_error(ArgumentError)
     end
 
     it "should allow parameters to be set to 'false'" do

--- a/spec/unit/provider/mcx/mcxcontent_spec.rb
+++ b/spec/unit/provider/mcx/mcxcontent_spec.rb
@@ -56,18 +56,22 @@ describe provider_class do
       @provider.class.expects(:dscl).returns('').once
       @provider.create
     end
+
     it "should execute external command dscl from :destroy" do
       @provider.class.expects(:dscl).with('localhost', '-mcxdelete', @ds_path).returns('').once
       @provider.destroy
     end
+
     it "should execute external command dscl from :exists?" do
       @provider.class.expects(:dscl).with('localhost', '-mcxexport', @ds_path).returns('').once
       @provider.exists?
     end
+
     it "should execute external command dscl from :content" do
       @provider.class.expects(:dscl).with('localhost', '-mcxexport', @ds_path).returns('')
       @provider.content
     end
+
     it "should execute external command dscl from :content=" do
       @provider.class.expects(:dscl).returns('')
       @provider.content=''
@@ -76,68 +80,83 @@ describe provider_class do
 
   describe "when creating and parsing the name for ds_type" do
     before :each do
+      @provider.class.stubs(:dscl).returns('')
       @resource.stubs(:[]).with(:name).returns "/Foo/bar"
     end
+
     it "should not accept /Foo/bar" do
-      lambda { @provider.create }.should raise_error(MCXContentProviderException)
+      expect { @provider.create }.to raise_error(MCXContentProviderException)
     end
+
     it "should accept /Foo/bar with ds_type => user" do
       @resource.stubs(:[]).with(:ds_type).returns "user"
-      lambda { @provider.create }.should_not raise_error(MCXContentProviderException)
+      expect { @provider.create }.to_not raise_error
     end
+
     it "should accept /Foo/bar with ds_type => group" do
       @resource.stubs(:[]).with(:ds_type).returns "group"
-      lambda { @provider.create }.should_not raise_error(MCXContentProviderException)
+      expect { @provider.create }.to_not raise_error
     end
+
     it "should accept /Foo/bar with ds_type => computer" do
       @resource.stubs(:[]).with(:ds_type).returns "computer"
-      lambda { @provider.create }.should_not raise_error(MCXContentProviderException)
+      expect { @provider.create }.to_not raise_error
     end
+
     it "should accept :name => /Foo/bar with ds_type => computerlist" do
       @resource.stubs(:[]).with(:ds_type).returns "computerlist"
-      lambda { @provider.create }.should_not raise_error(MCXContentProviderException)
+      expect { @provider.create }.to_not raise_error
     end
   end
 
   describe "when creating and :name => foobar" do
     before :each do
+      @provider.class.stubs(:dscl).returns('')
       @resource.stubs(:[]).with(:name).returns "foobar"
     end
+
     it "should not accept unspecified :ds_type and :ds_name" do
-      lambda { @provider.create }.should raise_error(MCXContentProviderException)
+      expect { @provider.create }.to raise_error(MCXContentProviderException)
     end
+
     it "should not accept unspecified :ds_type" do
       @resource.stubs(:[]).with(:ds_type).returns "user"
-      lambda { @provider.create }.should raise_error(MCXContentProviderException)
+      expect { @provider.create }.to raise_error(MCXContentProviderException)
     end
+
     it "should not accept unspecified :ds_name" do
       @resource.stubs(:[]).with(:ds_name).returns "foo"
-      lambda { @provider.create }.should raise_error(MCXContentProviderException)
+      expect { @provider.create }.to raise_error(MCXContentProviderException)
     end
+
     it "should accept :ds_type => user, ds_name => foo" do
       @resource.stubs(:[]).with(:ds_type).returns "user"
       @resource.stubs(:[]).with(:ds_name).returns "foo"
-      lambda { @provider.create }.should_not raise_error(MCXContentProviderException)
+      expect { @provider.create }.to_not raise_error
     end
+
     it "should accept :ds_type => group, ds_name => foo" do
       @resource.stubs(:[]).with(:ds_type).returns "group"
       @resource.stubs(:[]).with(:ds_name).returns "foo"
-      lambda { @provider.create }.should_not raise_error(MCXContentProviderException)
+      expect { @provider.create }.to_not raise_error
     end
+
     it "should accept :ds_type => computer, ds_name => foo" do
       @resource.stubs(:[]).with(:ds_type).returns "computer"
       @resource.stubs(:[]).with(:ds_name).returns "foo"
-      lambda { @provider.create }.should_not raise_error(MCXContentProviderException)
+      expect { @provider.create }.to_not raise_error
     end
+
     it "should accept :ds_type => computerlist, ds_name => foo" do
       @resource.stubs(:[]).with(:ds_type).returns "computerlist"
       @resource.stubs(:[]).with(:ds_name).returns "foo"
-      lambda { @provider.create }.should_not raise_error(MCXContentProviderException)
+      expect { @provider.create }.to_not raise_error
     end
+
     it "should not accept :ds_type => bogustype, ds_name => foo" do
       @resource.stubs(:[]).with(:ds_type).returns "bogustype"
       @resource.stubs(:[]).with(:ds_name).returns "foo"
-      lambda { @provider.create }.should raise_error(MCXContentProviderException)
+      expect { @provider.create }.to raise_error(MCXContentProviderException)
     end
   end
 
@@ -145,6 +164,7 @@ describe provider_class do
     it "should define an instances class method." do
       @provider.class.should respond_to(:instances)
     end
+
     it "should call external command dscl -list /Local/Default/<ds_type> on each known ds_type" do
       @provider.class.expects(:dscl).with('localhost', '-list', "/Local/Default/Users").returns('')
       @provider.class.expects(:dscl).with('localhost', '-list', "/Local/Default/Groups").returns('')

--- a/spec/unit/provider/package/opkg_spec.rb
+++ b/spec/unit/provider/package/opkg_spec.rb
@@ -82,7 +82,7 @@ describe Puppet::Type.type(:package).provider(:opkg) do
       context "with invalid URL for opkg" do
         before do
           # Emulate the `opkg` command returning a non-zero exit value
-          Puppet::Util::Execution.stubs(:execute).raises Puppet::ExecutionFailure
+          Puppet::Util::Execution.stubs(:execute).raises Puppet::ExecutionFailure, 'oops'
         end
 
         context "puppet://server/whatever" do
@@ -91,7 +91,7 @@ describe Puppet::Type.type(:package).provider(:opkg) do
           end
 
           it "should fail" do
-            expect { provider.install }.to raise_error, Puppet::ExecutionFailure
+            expect { provider.install }.to raise_error Puppet::ExecutionFailure
           end
         end
 
@@ -101,7 +101,7 @@ describe Puppet::Type.type(:package).provider(:opkg) do
           end
 
           it "should fail" do
-            expect { provider.install }.to raise_error, Puppet::ExecutionFailure
+            expect { provider.install }.to raise_error Puppet::ExecutionFailure
           end
         end
       end

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -333,7 +333,7 @@ describe Puppet::SSL::CertificateAuthority do
 
         expect do
           @ca.sign(@name, false, @request)
-        end.not_to raise_error(Puppet::SSL::CertificateAuthority::CertificateSigningError)
+        end.not_to raise_error
       end
 
       it "should save the resulting certificate" do

--- a/spec/unit/type/cron_spec.rb
+++ b/spec/unit/type/cron_spec.rb
@@ -457,13 +457,13 @@ describe Puppet::Type.type(:cron), :unless => Puppet.features.microsoft_windows?
       it "should accept empty environment variables that do not contain '='" do
         expect do
           described_class.new(:name => 'foo',:environment => 'MAILTO=')
-        end.to_not raise_error(Puppet::Error)
+        end.to_not raise_error
       end
 
       it "should accept 'absent'" do
         expect do
           described_class.new(:name => 'foo',:environment => 'absent')
-        end.to_not raise_error(Puppet::Error)
+        end.to_not raise_error
       end
 
     end

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1124,7 +1124,7 @@ describe Puppet::Type.type(:file) do
         property = stub('content_property', :actual_content => "something", :length => "something".length, :write => 'checksum_a')
         file.stubs(:property).with(:content).returns(property)
 
-        expect { file.write :NOTUSED }.to_not raise_error(Puppet::Error)
+        expect { file.write :NOTUSED }.to_not raise_error
       end
     end
   end

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -74,7 +74,7 @@ describe Puppet::Type.type(:package) do
 
     it "should not support :purged as a value to :ensure if the provider does not have the :purgeable feature" do
       @provider.expects(:satisfies?).with([:purgeable]).returns(false)
-      proc { Puppet::Type.type(:package).new(:name => "yay", :ensure => :purged) }.should raise_error(Puppet::Error)
+      expect { Puppet::Type.type(:package).new(:name => "yay", :ensure => :purged) }.to raise_error(Puppet::Error)
     end
 
     it "should support :latest as a value to :ensure if the provider has the :upgradeable feature" do
@@ -84,7 +84,7 @@ describe Puppet::Type.type(:package) do
 
     it "should not support :latest as a value to :ensure if the provider does not have the :upgradeable feature" do
       @provider.expects(:satisfies?).with([:upgradeable]).returns(false)
-      proc { Puppet::Type.type(:package).new(:name => "yay", :ensure => :latest) }.should raise_error(Puppet::Error)
+      expect { Puppet::Type.type(:package).new(:name => "yay", :ensure => :latest) }.to raise_error(Puppet::Error)
     end
 
     it "should support version numbers as a value to :ensure if the provider has the :versionable feature" do
@@ -94,11 +94,11 @@ describe Puppet::Type.type(:package) do
 
     it "should not support version numbers as a value to :ensure if the provider does not have the :versionable feature" do
       @provider.expects(:satisfies?).with([:versionable]).returns(false)
-      proc { Puppet::Type.type(:package).new(:name => "yay", :ensure => "1.0") }.should raise_error(Puppet::Error)
+      expect { Puppet::Type.type(:package).new(:name => "yay", :ensure => "1.0") }.to raise_error(Puppet::Error)
     end
 
     it "should accept any string as an argument to :source" do
-      proc { Puppet::Type.type(:package).new(:name => "yay", :source => "stuff") }.should_not raise_error(Puppet::Error)
+      expect { Puppet::Type.type(:package).new(:name => "yay", :source => "stuff") }.to_not raise_error
     end
   end
 

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -42,23 +42,23 @@ describe Puppet::Util::Tagging, "when adding tags" do
   end
 
   it "should fail on tags containing '*' characters" do
-    lambda { @tagger.tag("bad*tag") }.should raise_error(Puppet::ParseError)
+    expect { @tagger.tag("bad*tag") }.to raise_error(Puppet::ParseError)
   end
 
   it "should fail on tags starting with '-' characters" do
-    lambda { @tagger.tag("-badtag") }.should raise_error(Puppet::ParseError)
+    expect { @tagger.tag("-badtag") }.to raise_error(Puppet::ParseError)
   end
 
   it "should fail on tags containing ' ' characters" do
-    lambda { @tagger.tag("bad tag") }.should raise_error(Puppet::ParseError)
+    expect { @tagger.tag("bad tag") }.to raise_error(Puppet::ParseError)
   end
 
   it "should allow alpha tags" do
-    lambda { @tagger.tag("good_tag") }.should_not raise_error(Puppet::ParseError)
+    expect { @tagger.tag("good_tag") }.to_not raise_error
   end
 
   it "should allow tags containing '.' characters" do
-    lambda { @tagger.tag("good.tag") }.should_not raise_error(Puppet::ParseError)
+    expect { @tagger.tag("good.tag") }.to_not raise_error
   end
 
   it "should provide a method for testing tag validity" do


### PR DESCRIPTION
Running specs with rspec 2.13 caused a lot of warnings. Many of them actually
exposed preexisting bugs, the most common being a syntax error when expecting
an Exception. These are worth fixing even if we don't bump to rspec 2.13.
