### PR TITLE
(#19056) strip trailing space while parsing AIX password file

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -214,6 +214,11 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     expiry_date
   end
 
+  def open_security_passwd
+    # helper method for tests
+    File.open("/etc/security/passwd", 'r')
+  end
+
   #--------------------------------
   # Getter and Setter
   # When the provider is initialized, create getter/setter methods for each
@@ -229,15 +234,15 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   def password
     password = :absent
     user = @resource[:name]
-    f = File.open("/etc/security/passwd", 'r')
+    f = open_security_passwd
     # Skip to the user
     f.each_line { |l| break if l  =~ /^#{user}:\s*$/ }
     if ! f.eof?
       f.each_line { |l|
         # If there is a new user stanza, stop
         break if l  =~ /^\S*:\s*$/
-        # If the password= entry is found, return it
-        if l  =~ /^\s*password\s*=\s*(.*)$/
+        # If the password= entry is found, return it, stripping trailing space
+        if l  =~ /^\s*password\s*=\s*(\S*)\s*$/
           password = $1; break;
         end
       }

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -128,4 +128,35 @@ guest id=100 pgrp=usr groups=usr home=/home/guest
       @provider.should_include?(:rlogin, managed_keys).should be_true
     end
   end
+  describe "when handling passwords" do
+    let(:passwd_without_spaces) do
+        # from http://pic.dhe.ibm.com/infocenter/aix/v7r1/index.jsp?topic=%2Fcom.ibm.aix.files%2Fdoc%2Faixfiles%2Fpasswd_security.htm
+        <<-OUTPUT
+smith:
+  password = MGURSj.F056Dj
+  lastupdate = 623078865
+  flags = ADMIN,NOCHECK
+        OUTPUT
+    end
+
+    let(:passwd_with_spaces) do
+        # add trailing space to the password
+        passwd_without_spaces.gsub(/password = (.*)/, 'password = \1   ')
+    end
+
+
+    it "should be able to read the hashed password" do
+      @provider.stubs(:open_security_passwd).returns(StringIO.new(passwd_without_spaces))
+      @resource.stubs(:[]).returns('smith')
+
+      @provider.password.should == 'MGURSj.F056Dj'
+    end
+
+    it "should be able to read the hashed password, even with trailing spaces" do
+      @provider.stubs(:open_security_passwd).returns(StringIO.new(passwd_with_spaces))
+      @resource.stubs(:[]).returns('smith')
+
+      @provider.password.should == 'MGURSj.F056Dj'
+    end
+  end
 end


### PR DESCRIPTION
Copied out of the redmine ticket, with the addition of a comment.

I know next to nothing about AIX, so writing tests for this could be tricky :/
