### PR TITLE
(#21087) Debug output for all augeas error nodes

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -327,6 +327,8 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
   def print_errors(errors)
     errors.each do |errnode|
+      error = @aug.get(errnode)
+      debug("#{errnode} = #{error}") unless error.nil?
       @aug.match("#{errnode}/*").each do |subnode|
         subvalue = @aug.get(subnode)
         debug("#{subnode} = #{subvalue}")

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -650,28 +650,39 @@ describe provider_class do
       before do
         @augeas.expects(:match).with("/augeas//error").returns(["/augeas/files/foo/error"])
         @augeas.expects(:match).with("/augeas/files/foo/error/*").returns(["/augeas/files/foo/error/path", "/augeas/files/foo/error/message"])
+        @augeas.expects(:get).with("/augeas/files/foo/error").returns("some_failure")
         @augeas.expects(:get).with("/augeas/files/foo/error/path").returns("/foo")
         @augeas.expects(:get).with("/augeas/files/foo/error/message").returns("Failed to...")
       end
 
       it "and output to debug" do
-        @provider.expects(:debug).times(4)
+        @provider.expects(:debug).times(5)
         @provider.print_load_errors
       end
 
       it "and output a warning and to debug" do
         @provider.expects(:warning).once()
-        @provider.expects(:debug).times(3)
+        @provider.expects(:debug).times(4)
         @provider.print_load_errors(:warning => true)
       end
+    end
+
+    it "should find load errors from lenses" do
+      @augeas.expects(:match).with("/augeas//error").returns(["/augeas/load/Xfm/error"])
+      @augeas.expects(:match).with("/augeas/load/Xfm/error/*").returns([])
+      @augeas.expects(:get).with("/augeas/load/Xfm/error").returns(["Could not find lens php.aug"])
+      @provider.expects(:warning).once()
+      @provider.expects(:debug).twice()
+      @provider.print_load_errors(:warning => true)
     end
 
     it "should find save errors and output to debug" do
       @augeas.expects(:match).with("/augeas//error[. = 'put_failed']").returns(["/augeas/files/foo/error"])
       @augeas.expects(:match).with("/augeas/files/foo/error/*").returns(["/augeas/files/foo/error/path", "/augeas/files/foo/error/message"])
+      @augeas.expects(:get).with("/augeas/files/foo/error").returns("some_failure")
       @augeas.expects(:get).with("/augeas/files/foo/error/path").returns("/foo")
       @augeas.expects(:get).with("/augeas/files/foo/error/message").returns("Failed to...")
-      @provider.expects(:debug).times(4)
+      @provider.expects(:debug).times(5)
       @provider.print_put_errors
     end
   end


### PR DESCRIPTION
Adds debug output in cases where augeas has error nodes without children. This
specifically addresses the case where an incorrect lens name is specified, and
may provide better output for other cases as well.

Thanks to Jan Vansteenkiste for the implementation of the fix.

See http://projects.puppetlabs.com/issues/21087
