### PR TITLE
(#21749) Make attributes readable on Puppet::ModuleTool::Dependency

### DIFF
--- a/lib/puppet/module_tool/dependency.rb
+++ b/lib/puppet/module_tool/dependency.rb
@@ -2,6 +2,8 @@ module Puppet::ModuleTool
 
   class Dependency
 
+    attr_reader :full_module_name, :username, :name, :version_requirement, :repository
+
     # Instantiates a new module dependency with a +full_module_name+ (e.g.
     # "myuser-mymodule"), and optional +version_requirement+ (e.g. "0.0.1") and
     # optional repository (a URL string).


### PR DESCRIPTION
Make it possible to read the attributes of these objects
without turning them to PSON and parsing that back again.
