### PR TITLE
[21770] Add basic SIGINFO support to Puppet::Transaction

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -2,6 +2,7 @@
 # and performs them
 
 require 'puppet'
+require 'puppet/util/signals'
 require 'puppet/util/tagging'
 require 'puppet/application'
 require 'digest/sha1'
@@ -24,6 +25,7 @@ class Puppet::Transaction
   attr_reader :resource_harness
 
   include Puppet::Util
+  include Puppet::Util::Signals
   include Puppet::Util::Tagging
 
   # Wraps application run state check to flag need to interrupt processing
@@ -80,6 +82,13 @@ class Puppet::Transaction
       resource_status(resource).skipped = true
     else
       resource_status(resource).scheduled = true
+
+      if siginfo_supported?
+        Signal.trap "SIGINFO" do
+          puts "Currently evaluating #{resource.type.to_s.capitalize}[#{resource.title}]"
+        end
+      end
+
       apply(resource, ancestor)
     end
 
@@ -493,4 +502,3 @@ class Puppet::Transaction
 end
 
 require 'puppet/transaction/report'
-

--- a/lib/puppet/util/signals.rb
+++ b/lib/puppet/util/signals.rb
@@ -1,0 +1,6 @@
+module Puppet::Util::Signals
+  # Return a boolean representing whether or not SIGINFO is supported
+  def siginfo_available?
+    @siginfo_available ||= Signal.list.has_key?("INFO")
+  end
+end

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -139,6 +139,12 @@ describe Puppet::Transaction do
       @transaction.eval_resource(@resource)
     end
 
+    it "should check whether siginfo is available" do
+      @transaction.expects(:siginfo_available?).returns false
+
+      @transaction.eval_resource(@resource)
+    end
+
     describe "and the resource should be skipped" do
       before do
         @transaction.expects(:skip?).with(@resource).returns true
@@ -147,6 +153,15 @@ describe Puppet::Transaction do
       it "should mark the resource's status as skipped" do
         @transaction.eval_resource(@resource)
         @transaction.resource_status(@resource).should be_skipped
+      end
+    end
+
+    describe "and siginfo is available" do
+      it "should output a resource debug level message" do
+        @transaction.expects(:siginfo_available?).returns true
+        Kernel.expects(:puts).with(/Currently evaluating/)
+
+        @transaction.eval_resource(@resource)
       end
     end
   end

--- a/spec/unit/util/signals_spec.rb
+++ b/spec/unit/util/signals_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+require "puppet/util/signals"
+
+class SignalsTest
+  include Puppet::Util::Signals
+end
+
+describe Puppet::Util::Signals do
+  let(:instance) { SignalsTest.new}
+
+  context "#siginfo_available?" do
+    it "returns true if SIGINFO is available" do
+      Signal.stubs(:list).returns({"INFO" => "29"})
+
+      expect(instance.siginfo_available?).to be_true
+    end
+
+    it "returns false if SIGINFO is not available" do
+      Signal.stubs(:list).returns({"INT" => "1"})
+
+      expect(instance.siginfo_available?).to be_false
+    end
+  end
+end


### PR DESCRIPTION
If the user sends SIGINFO to the Puppet process during
the evaluation of a resource, Puppet will generate an
INFO level message with the type and title of the resource
currently being applied.

Below is an example of what this looks like in practice.
Please note I've added whitespace for emphasis, and in use
none of these empty lines are present.

```
~ $ puppet apply -e ' exec { ["/bin/sleep 20", "/bin/sleep 10"]: } '

load: 1.50  cmd: ruby 86469 running 1.59u 0.29s
Evaluating resource: exec[/bin/sleep 10]

Notice: /Stage[main]//Exec[/bin/sleep 10]/returns: executed successfully

load: 1.46  cmd: ruby 86469 running 1.59u 0.30s
Evaluating resource: exec[/bin/sleep 20]

Notice: /Stage[main]//Exec[/bin/sleep 20]/returns: executed successfully
Notice: Finished catalog run in 30.10 seconds
```

This functionality is geared at users who may not be running Puppet
in debug mode when they encounter slow resource application times.
While strace/dtrace can provide context into what resource is
currently being applied, that's not terribly user-friendly.
SIGINFO allows users to, on supported systems, simply invoke
`<Control>-T` during resource application to yield any long-running
resource apply phases.

SIGINFO is typically a BSD and BSD-derivative platform signal.
This change does not introduce breakages for non-BSD, POSIX systems;
nor does it introduce breakages for the Windows platform.

ref: http://projects.puppetlabs.com/issues/21770

/cc @jfryman @rodjek
