### PR TITLE
(#21785) Module tool should include path part of URI

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -40,7 +40,7 @@ class Puppet::Forge
 
     # Return a Net::HTTPResponse read for this +request_path+.
     def make_http_request(request_path)
-      request = Net::HTTP::Get.new(URI.escape(request_path), { "User-Agent" => user_agent })
+      request = Net::HTTP::Get.new(URI.escape(@uri.path + request_path), { "User-Agent" => user_agent })
       if ! @uri.user.nil? && ! @uri.password.nil?
         request.basic_auth(@uri.user, @uri.password)
       end
@@ -98,7 +98,9 @@ class Puppet::Forge
     # Return the local file name containing the data downloaded from the
     # repository at +release+ (e.g. "myuser-mymodule").
     def retrieve(release)
-      return cache.retrieve(@uri + release)
+      uri = @uri.dup
+      uri.path = uri.path.chomp('/') + release
+      return cache.retrieve(uri)
     end
 
     # Return the URI string for this repository.

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -11,10 +11,19 @@ describe Puppet::Forge::Repository do
   let(:ssl_repository) { Puppet::Forge::Repository.new('https://fake.com', consumer_version) }
 
   it "retrieve accesses the cache" do
-    uri = URI.parse('http://some.url.com')
-    repository.cache.expects(:retrieve).with(uri)
+    path = '/module/foo.tar.gz'
+    repository.cache.expects(:retrieve)
 
-    repository.retrieve(uri)
+    repository.retrieve(path)
+  end
+
+  it "retrieve merges forge URI and path specified" do
+    path = '/module/foo.tar.gz'
+    repo_uri = 'http://fake.com/test'
+    repository = Puppet::Forge::Repository.new(repo_uri, consumer_version)
+    repository.cache.expects(:retrieve).with(URI.parse(repo_uri+path))
+
+    repository.retrieve(path)
   end
 
   describe "making a request" do


### PR DESCRIPTION
The module tool ignored the path part of the URI when specifying a
custom module_repository setting.

Example:
puppet module install foo-bar --module_repository=‘http://forge.example.com/forge’

fetched http://forge.example.com/api/v1/releases.json?module=foo/bar
instead of
http://forge.example.com/forge/api/v1/releases.json?module=foo/bar

Same issue when it tries to fetch the file itself.
