### PR TITLE
(Bug #21761) Update puppet for F19

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,7 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-17-i386 pl-fedora-18-i386'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-17-i386 pl-fedora-18-i386i pl-fedora-19-i386'
 yum_host: 'burji.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: TRUE

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -37,9 +37,14 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires:  facter < 1:2.0
 # Puppet 3.x drops ruby 1.8.5 support and adds ruby 1.9 support
 BuildRequires:  ruby >= 1.8.7
+%if 0%{?fedora} >= 18
+BuildRequires:  systemd
+%else
+BuildRequires:  systemd-units
+%endif
 
 BuildArch:      noarch
-Requires:       ruby(abi) >= 1.8
+Requires:       ruby >= 1.8
 Requires:       ruby-shadow
 
 # Pull in ruby selinux bindings where available


### PR DESCRIPTION
Remove ruby(abi) requirement in favor of just ruby, add Fedora 19 mock, and add systemd BuildRequirement so that we can use `%{_unitdir}` in the spec file
