### PR TITLE
(#21801) Normalize headers that come through Rack

### DIFF
--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -51,7 +51,7 @@ class Puppet::Network::HTTP::RackREST < Puppet::Network::HTTP::RackHttpHandler
   # Retrieve all headers from the http request, as a map.
   def headers(request)
     request.env.select {|k,v| k.start_with? 'HTTP_'}.inject({}) do |m, (k,v)|
-      m[k.sub(/^HTTP_/, '').downcase] = v
+      m[k.sub(/^HTTP_/, '').gsub('_','-').downcase] = v
       m
     end
   end

--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -34,7 +34,7 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
     describe "#headers" do
       it "should return the headers (parsed from env with prefix 'HTTP_')" do
         req = mk_req('/', {'HTTP_Accept' => 'myaccept',
-                           'HTTP_X-Custom-Header' => 'mycustom',
+                           'HTTP_X_Custom_Header' => 'mycustom',
                            'NOT_HTTP_foo' => 'not an http header'})
         @handler.headers(req).should == {"accept" => 'myaccept',
                                          "x-custom-header" => 'mycustom'}


### PR DESCRIPTION
Previously, although we stripped the leading `HTTP_` from
HTTP headers which Rack turned into environment variables,
we did not restore hyphens from underscores.

The user-visible consequence of this was that the match
to detect whether profiling was request from an agent would
not work when running under Passenger, but did work under
Webrick.

This commit updates the translation routine to turn underscores
back into hyphens. It also fixes an erroneous test fixture; the
sample header 'HTTP_X-Custom-Header' would never been seen in
the wild because environment variables are not allowed to have
hyphens.
