### PR TITLE
Propagate client noop value as a fact

### DIFF
--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -28,6 +28,7 @@ class Puppet::Node::Facts
   def add_local_facts
     values["clientcert"] = Puppet.settings[:certname]
     values["clientversion"] = Puppet.version.to_s
+    values["clientnoop"] = Puppet.settings[:noop]
   end
 
   def initialize(name, values = {})


### PR DESCRIPTION
This fixes: http://projects.puppetlabs.com/issues/6847

(which is also a workaround for: projects.puppetlabs.com/issues/20679)
