### PR TITLE
(PP-186) Fix HashArrayAccess produces :undef when value is false

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -156,7 +156,8 @@ class Puppet::Parser::AST
       accesskey = evaluate_key(scope)
       raise Puppet::ParseError, "#{variable} is not a hash or array when accessing it with #{accesskey}" unless object.is_a?(Hash) or object.is_a?(Array)
 
-      object[array_index_or_key(object, accesskey)] || :undef
+      result = object[array_index_or_key(object, accesskey)]
+      result.nil? ? :undef : result
     end
 
     # Assign value to this hashkey or array index

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -268,6 +268,14 @@ describe Puppet::Parser::AST::HashOrArrayAccess do
         access2.evaluate(@scope)
       }.to raise_error(Puppet::ParseError, /not a hash or array/)
     end
+
+    it "should produce boolean values when value is a boolean" do
+      @scope["a"] = [true, false]
+      access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => 0 )
+      expect(access.evaluate(@scope)).to be == true
+      access = Puppet::Parser::AST::HashOrArrayAccess.new(:variable => "a", :key => 1 )
+      expect(access.evaluate(@scope)).to be == false
+    end
   end
 
   describe "when assigning" do


### PR DESCRIPTION
It should naturally have produced false. The test for "having value" was
wrong and equated nil with false.
