### PR TITLE
(packaging) Move systemd BuildRequires into conditional

### DIFF
--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -37,12 +37,6 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires:  facter < 1:2.0
 # Puppet 3.x drops ruby 1.8.5 support and adds ruby 1.9 support
 BuildRequires:  ruby >= 1.8.7
-%if 0%{?fedora} >= 18
-BuildRequires:  systemd
-%else
-BuildRequires:  systemd-units
-%endif
-
 BuildArch:      noarch
 Requires:       ruby >= 1.8
 Requires:       ruby-shadow
@@ -72,6 +66,11 @@ Requires:       shadow-utils
 %if 0%{?_with_systemd}
 # Required for %%post, %%preun, %%postun
 Requires:       systemd
+%if 0%{?fedora} >= 18
+BuildRequires:  systemd
+%else
+BuildRequires:  systemd-units
+%endif
 %else
 # Required for %%post and %%preun
 Requires:       chkconfig


### PR DESCRIPTION
Previously either systemd or systemd-units were BuildRequires on all rpms.
These packages are now available on el5 or el6, which would break rpm building
on those platforms. This commit moves those BuildRequires into an already
existing systemd conditional, so they are only required on systems that support
systemd.
