### PR TITLE
Enchance OpenBSD pkg.conf handling

### DIFF
--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -184,7 +184,29 @@ describe provider_class do
       provider.install
     end
 
-    %w{ installpath installpath= }.each do |line|
+    it "should append installpath" do
+      urls = ["ftp://your.ftp.mirror/pub/OpenBSD/5.2/packages/amd64/",
+              "http://another.ftp.mirror/pub/OpenBSD/5.2/packages/amd64/"]
+      lines = ["installpath  = #{urls[0]}\n",
+               "installpath += #{urls[1]}\n"]
+
+      expect_read_from_pkgconf(lines)
+      expect_pkgadd_with_env_and_name(urls.join(":")) do
+        provider.install
+      end
+    end
+
+    it "should handle append on first installpath" do
+      url = "ftp://your.ftp.mirror/pub/OpenBSD/5.2/packages/amd64/"
+      lines = ["installpath += #{url}\n"]
+
+      expect_read_from_pkgconf(lines)
+      expect_pkgadd_with_env_and_name(url) do
+        provider.install
+      end
+    end
+
+    %w{ installpath installpath= installpath+=}.each do |line|
       it "should reject '#{line}'" do
         expect_read_from_pkgconf([line])
         expect {


### PR DESCRIPTION
This PR moves the parsing of pkg.conf into a separate method as I intend to use this code for :upgradeable later too. While here I've modified the parser a bit to also handle "installpath += http://some/url/" which was previously ignored. With this it's possible to have a pkg.conf like:

```
installpath = foo
installpath += bar
```

Which will be turned into a PKG_PATH: foo:bar. The original tests still pass and I've added three new tests to test the new behaviour.
