### PR TITLE
(#21947) Add missing error message for ILLEGAL_NAME

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -91,8 +91,8 @@ module Puppet::Pops::Issues
   #
   # @param issue_code [Symbol] the issue code for the issue used as an identifier, should be the same as the constant
   #   the issue is bound to.
-  # @param args [Symbol] required arguments that must be passed when formatting the message, may be empty
-  # @param block [Proc] a block producing the message string, evaluated in a MessageData scope. The produced string
+  # @param *args [Symbol] required arguments that must be passed when formatting the message, may be empty
+  # @param &block [Proc] a block producing the message string, evaluated in a MessageData scope. The produced string
   #   should not end with a period as additional information may be appended.
   #
   # @see MessageData
@@ -123,7 +123,7 @@ module Puppet::Pops::Issues
   # @todo configuration
   #
   NAME_WITH_HYPHEN = issue :NAME_WITH_HYPHEN, :name do
-    "#{label.a_an_uc(semantic)} may not have a name contain a hyphen. The name '#{name}' is not legal"
+    "#{label.a_an_uc(semantic)} may not have a name containing a hyphen. The name '#{name}' is not legal"
   end
 
   # When a variable name contains a hyphen and these are illegal.

--- a/spec/unit/pops/issues_spec.rb
+++ b/spec/unit/pops/issues_spec.rb
@@ -16,7 +16,7 @@ describe "Puppet::Pops::Issues" do
     x.format(:name => 'Boo-Hoo',
       :label => Puppet::Pops::Model::ModelLabelProvider.new,
       :semantic => "dummy"
-      ).should == "A Ruby String may not have a name contain a hyphen. The name 'Boo-Hoo' is not legal"
+      ).should == "A Ruby String may not have a name containing a hyphen. The name 'Boo-Hoo' is not legal"
   end
 
   it "should should format a message that does not require an argument" do


### PR DESCRIPTION
The faulty behavior was triggered by interpolation of an illegal name.
e.g. "Contains $CONTRABAND".
