### PR TITLE
puppet module build includes existing metadata.json

### DIFF
--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -47,6 +47,16 @@ module Puppet::ModuleTool
           elsif require_modulefile
             raise ArgumentError, "No Modulefile found."
           end
+          extra_metadata_path = File.join(@path, 'metadata.json')
+          if File.file?(extra_metadata_path)
+            File.open(extra_metadata_path) do |f|
+              begin
+                @metadata.extra_metadata = PSON.load(f)
+              rescue PSON::ParserError
+                raise ArgumentError, "Could not parse JSON #{extra_metadata_path}"
+              end
+            end
+          end
         end
         @metadata
       end

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -79,6 +79,14 @@ module Puppet::ModuleTool
       @description = description
     end
 
+    def extra_metadata
+      @extra_metadata || {}
+    end
+
+    def extra_metadata=(extra_metadata)
+      @extra_metadata = extra_metadata
+    end
+
     def project_page
       @project_page || 'UNKNOWN'
     end
@@ -121,21 +129,25 @@ module Puppet::ModuleTool
       end
     end
 
+    def to_hash()
+      return extra_metadata.merge({
+        'name'         => @full_module_name,
+        'version'      => @version,
+        'source'       => source,
+        'author'       => author,
+        'license'      => license,
+        'summary'      => summary,
+        'description'  => description,
+        'project_page' => project_page,
+        'dependencies' => dependencies,
+        'types'        => types,
+        'checksums'    => checksums
+      })
+    end
+
     # Return the PSON record representing this instance.
     def to_pson(*args)
-      return {
-        :name         => @full_module_name,
-        :version      => @version,
-        :source       => source,
-        :author       => author,
-        :license      => license,
-        :summary      => summary,
-        :description  => description,
-        :project_page => project_page,
-        :dependencies => dependencies,
-        :types        => types,
-        :checksums    => checksums
-      }.to_pson(*args)
+      return to_hash.to_pson(*args)
     end
   end
 end

--- a/spec/unit/module_tool/metadata_spec.rb
+++ b/spec/unit/module_tool/metadata_spec.rb
@@ -8,4 +8,17 @@ describe Puppet::ModuleTool::Metadata do
       metadata.license.should == "Apache License, Version 2.0"
     end
   end
+
+  describe :to_hash do
+    it 'should merge extra_data in' do
+      metadata = Puppet::ModuleTool::Metadata.new
+      metadata.extra_metadata = {
+        'checksums' => 'badsums',
+        'special_key' => 'special'
+      }
+      meta_hash = metadata.to_hash
+      meta_hash['special_key'].should == 'special'
+      meta_hash['checksums'].should == {}
+    end
+  end
 end


### PR DESCRIPTION
Forge will soon be expecting new fields to metadata.json. This will allow existing versions of puppet to use those fields and is the first step towards deprecating the ModuleFile in favor of directly editing metadata.json.
