### PR TITLE
(#21961) Tests for ssl connections without peer verification

### DIFF
--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -22,6 +22,27 @@ describe Puppet::Network::HttpPool do
       Puppet::Network::HttpPool.http_instance("me", 54321, true).should be_use_ssl
     end
 
+    it "can enforce/suppress peer certificate verification using an option" do
+      ca_cert_file = '/path/to/ssl/certs/ca_cert.pem'
+      host_cert_file = '/path/to/ssl/certs/host_cert.pem'
+
+      ssl_configuration = stub('ssl_configuration', :ca_auth_file => ca_cert_file)
+      Puppet::Network::HTTP::Connection.any_instance.stubs(:ssl_configuration).returns(ssl_configuration)
+
+      cert = stub('cert', :content => 'real_cert')
+      key = stub('key',  :content => 'real_key')
+      host = stub('host', :certificate => cert, :key => key, :ssl_store => stub('store'))
+      Puppet::Network::HTTP::Connection.any_instance.stubs(:ssl_host).returns(host)
+
+      Puppet[:hostcert] = host_cert_file
+
+      FileTest.expects(:exist?).with(ca_cert_file).returns(true)
+      FileTest.expects(:exist?).with(host_cert_file).returns(true)
+
+      Puppet::Network::HttpPool.http_instance("me", 54321, true, true).send(:connection).verify_mode.should == OpenSSL::SSL::VERIFY_PEER
+      Puppet::Network::HttpPool.http_instance("me", 54321, true, false).send(:connection).verify_mode.should == OpenSSL::SSL::VERIFY_NONE
+    end
+
     it "should not cache http instances" do
       Puppet::Network::HttpPool.http_instance("me", 54321).
         should_not equal Puppet::Network::HttpPool.http_instance("me", 54321)


### PR DESCRIPTION
This patch adds tests for the newly introduced support for ssl connections without peer verification.
