### PR TITLE
Fix regex for retrieving flavor.

### DIFF
--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
     begin
       execpipe(listcmd) do |process|
         # our regex for matching pkg_info output
-        regex = /^(.*)-(\d[^-]*)[-]?(\D*)(.*)$/
+        regex = /^(.*)-(\d[^-]*)[-]?(\w*)(.*)$/
         fields = [:name, :ensure, :flavor ]
         hash = {}
 

--- a/spec/fixtures/unit/provider/package/openbsd/pkginfo_flavors.list
+++ b/spec/fixtures/unit/provider/package/openbsd/pkginfo_flavors.list
@@ -1,0 +1,2 @@
+bash-3.1.17-static  GNU Bourne Again Shell
+vim-7.0.42-no_x11   vi clone, many additional features

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -62,6 +62,16 @@ describe provider_class do
       provider_class.instances.map(&:name).sort.should ==
         %w{bash bzip2 expat gettext libiconv lzo openvpn python vim wget}.sort
     end
+
+    it "should return all flavors if set" do
+      fixture = File.read(my_fixture('pkginfo_flavors.list'))
+      provider_class.expects(:execpipe).with(%w{/bin/pkg_info -a}).yields(fixture)
+      instances = provider_class.instances.map {|p| {:name => p.get(:name),
+        :ensure => p.get(:ensure), :flavor => p.get(:flavor)}}
+      instances.size.should == 2
+      instances[0].should == {:name => 'bash', :ensure => '3.1.17',  :flavor => 'static'}
+      instances[1].should == {:name => 'vim',  :ensure => '7.0.42', :flavor => 'no_x11'}
+    end
   end
 
   context "#install" do


### PR DESCRIPTION
Previously a flavor like 'no_x11' would be truncated to 'no_x'.
