### PR TITLE
Remove rspec requires from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,6 @@ $LOAD_PATH << File.join(RAKE_ROOT, 'tasks')
 begin
   require 'rubygems'
   require 'rubygems/package_task'
-  require 'rspec'
-  require 'rspec/core/rake_task'
 rescue LoadError
   # Users of older versions of Rake (0.8.7 for example) will not necessarily
   # have rubygems installed, or the newer rubygems package_task for that


### PR DESCRIPTION
In the Rakefile, we no longer use Rspec methods or classes, but instead shell
out to rspec, so requiring rspec serves no purpose in the rakefile. The require
was also incorrectly placed within an unrelated begin/rescue block, which
caused deprecated rake libraries to be loaded when rspec was not present. This
commit removes it from the Rakefile.
