### PR TITLE
(#22052) Fix future parser false error on invoke with call as arg.

### DIFF
--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -661,14 +661,20 @@ class Puppet::Pops::Model::Factory
           memo[-1] = Puppet::Pops::Model::Factory.IMPORT(expr.is_a?(Array) ? expr : [expr])
         else
           memo[-1] = Puppet::Pops::Model::Factory.CALL_NAMED(name, false, expr.is_a?(Array) ? expr : [expr])
+          if expr.is_a?(Model::CallNamedFunctionExpression)
+            # Patch statement function call to expression style
+            # This is needed because it is first parsed as a "statement" and the requirement changes as it becomes
+            # an argument to the name to call transform above.
+            expr.rval_required = true
+          end
         end
       else
         memo << expr
-      end
-      if expr.is_a?(Model::CallNamedFunctionExpression)
-        # patch expression function call to statement style
-        # TODO: This is kind of meaningless, but to make it compatible...
-        expr.rval_required = false
+        if expr.is_a?(Model::CallNamedFunctionExpression)
+          # Patch rvalue expression function call to statement style.
+          # This is not really required but done to be AST model compliant
+          expr.rval_required = false
+        end
       end
       memo
     end

--- a/spec/unit/pops/parser/parse_calls_spec.rb
+++ b/spec/unit/pops/parser/parse_calls_spec.rb
@@ -29,6 +29,10 @@ describe "egrammar parsing function calls" do
       it "foo(bar, fum,)" do
         dump(parse("foo(bar,fum,)")).should == "(invoke foo bar fum)"
       end
+
+      it "foo fqdn_rand(30)" do
+        dump(parse("foo fqdn_rand(30)")).should == '(invoke foo (call fqdn_rand 30))'
+      end
     end
 
     context "in nested scopes" do


### PR DESCRIPTION
Previously an expression like `notice fqdn_rand(30)` generated an
error because the rvalue requirement was not modified for the fqdn_rand
call (it was believed to be a separate statement).

The problem was caused by the opposite status change being applied to
all calls (rvalue producing calls that appear as statements should have
the rvalue required status turned off).
