### PR TITLE
Refactor network/http/connection peer verify specs

### DIFF
--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -45,7 +45,7 @@ describe Puppet::Network::HTTP::Connection do
 
       describe "peer verification" do
         def setup_standard_ssl_configuration
-          ca_cert_file = '/path/to/ssl/certs/ca_cert.pem'
+          ca_cert_file = File.expand_path('/path/to/ssl/certs/ca_cert.pem')
           FileTest.stubs(:exist?).with(ca_cert_file).returns(true)
 
           ssl_configuration = stub('ssl_configuration', :ca_auth_file => ca_cert_file)
@@ -53,7 +53,7 @@ describe Puppet::Network::HTTP::Connection do
         end
 
         def setup_standard_hostcert
-          host_cert_file = '/path/to/ssl/certs/host_cert.pem'
+          host_cert_file = File.expand_path('/path/to/ssl/certs/host_cert.pem')
           FileTest.stubs(:exist?).with(host_cert_file).returns(true)
 
           Puppet[:hostcert] = host_cert_file


### PR DESCRIPTION
The tests added in f064ef76c98205037cb94c30dfbc21d6ee504641 used Unix style paths, which caused the tests to fail on Windows since paths are expanded differently on Unix and Windows. This commit refactors the tests to extract test setup, and expands the file paths properly on Windows and Unix.
