### PR TITLE
(#21839) Stringify the :_timestamp fact name

### DIFF
--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -102,11 +102,11 @@ class Puppet::Node::Facts
   end
 
   def timestamp=(time)
-    self.values[:_timestamp] = time
+    self.values['_timestamp'] = time
   end
 
   def timestamp
-    self.values[:_timestamp]
+    self.values['_timestamp']
   end
 
   private

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -118,7 +118,7 @@ describe Puppet::Node::Facts, "when indirecting" do
   describe "when storing and retrieving" do
     it "should add metadata to the facts" do
       facts = Puppet::Node::Facts.new("me", "one" => "two", "three" => "four")
-      facts.values[:_timestamp].should be_instance_of(Time)
+      facts.values['_timestamp'].should be_instance_of(Time)
     end
 
     describe "using pson" do
@@ -133,7 +133,7 @@ describe Puppet::Node::Facts, "when indirecting" do
         facts = format.intern(Puppet::Node::Facts,pson)
         facts.name.should == 'foo'
         facts.expiration.should == @expiration
-        facts.values.should == {'a' => '1', 'b' => '2', 'c' => '3', :_timestamp => @timestamp}
+        facts.values.should == {'a' => '1', 'b' => '2', 'c' => '3', '_timestamp' => @timestamp}
       end
 
       it "should generate properly formatted pson" do


### PR DESCRIPTION
Change all instances of the `:_timestamp` fact to `_timestamp`. Symbols can be
converted to strings during a round-trip through a simple terminus such as
JSON. If the Fact is then updated using the symbol, there will be two names for
the same data.

After 5ac681f, in the 3.0 rc series, all varible names are explicitly
stringified when added to compiler scopes. This means that facts named
`:_timestamp` and `_timestamp` will end up mapping to the same scope variable
which violates static single assignment.
