### PR TITLE
(#21170) Allow specifying module tool skeleton dir directly

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -403,6 +403,10 @@ module Puppet
     :module_working_dir => {
         :default  => '$vardir/puppet-module',
         :desc     => "The directory into which module tool data is stored",
+    },
+    :module_skeleton_dir => {
+        :default  => '$module_working_dir/skeleton',
+        :desc     => "The directory which the skeleton for module tool generate is stored.",
     }
   )
 

--- a/lib/puppet/module_tool/skeleton.rb
+++ b/lib/puppet/module_tool/skeleton.rb
@@ -23,7 +23,7 @@ module Puppet::ModuleTool
 
     # Return Pathname of custom templates directory.
     def custom_path
-      Pathname(Puppet.settings[:module_working_dir]) + 'skeleton'
+      Pathname(Puppet.settings[:module_skeleton_dir])
     end
 
     # Return Pathname of default template directory.


### PR DESCRIPTION
Allows specifying the module tool skeleton directory directly instead of
always having is as $module_working_dir/skeleton.
