### PR TITLE
(#22128) Confine yum provider prefetch spec from running on windows

### DIFF
--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -109,7 +109,7 @@ describe provider do
     end
   end
 
-  describe 'prefetching' do
+  describe 'prefetching', :unless => Puppet.features.microsoft_windows? do
     let(:nevra_format) { Puppet::Type::Package::ProviderRpm::NEVRA_FORMAT }
 
     let(:packages) do


### PR DESCRIPTION
The new yum prefetch spec was failing on windows:

Puppet::Type::Package::ProviderYum prefetching injects latest provider
info into passed resources when prefetching
    Failure/Error: myresource = package_type.new(:name => "myresource",
:ensure => :latest)
    Puppet::ResourceError:
      Parameter ensure failed on Package[myresource]: Provider must have
features 'upgradeable' to set 'ensure' to 'latest'

possibly because the windows default package provider does not provide
the same features.  Since this test is specific to yum, confining it from
running on windows.
