### PR TITLE
(#22205) Reinstate relationship_graph as a factory method

### DIFF
--- a/lib/puppet/graph/relationship_graph.rb
+++ b/lib/puppet/graph/relationship_graph.rb
@@ -5,7 +5,7 @@
 #
 # @api private
 class Puppet::Graph::RelationshipGraph < Puppet::Graph::SimpleGraph
-  attr_reader :blockers, :prioritizer
+  attr_reader :blockers
 
   def initialize(prioritizer)
     super()

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -51,7 +51,7 @@ class Puppet::Transaction
   # necessary events.
   def evaluate(&block)
     block ||= method(:eval_resource)
-    generator = AdditionalResourceGenerator.new(@catalog, relationship_graph)
+    generator = AdditionalResourceGenerator.new(@catalog, relationship_graph, @prioritizer)
     @catalog.vertices.each { |resource| generator.generate_additional_resources(resource) }
 
     Puppet.info "Applying configuration version '#{catalog.version}'" if catalog.version
@@ -125,12 +125,7 @@ class Puppet::Transaction
   end
 
   def relationship_graph
-    if @relationship_graph.nil?
-      @relationship_graph = Puppet::Graph::RelationshipGraph.new(@prioritizer)
-      @relationship_graph.populate_from(catalog)
-      catalog.relationship_graph = @relationship_graph
-    end
-    @relationship_graph
+    catalog.relationship_graph
   end
 
   def resource_status(resource)

--- a/lib/puppet/transaction/additional_resource_generator.rb
+++ b/lib/puppet/transaction/additional_resource_generator.rb
@@ -1,8 +1,8 @@
 class Puppet::Transaction::AdditionalResourceGenerator
-  def initialize(catalog, relationship_graph)
+  def initialize(catalog, relationship_graph, prioritizer)
     @catalog = catalog
     @relationship_graph = relationship_graph
-    @prioritizer = relationship_graph.prioritizer
+    @prioritizer = prioritizer
   end
 
   def generate_additional_resources(resource)

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -259,8 +259,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
     end
 
     it "should add resources to the relationship graph if it exists" do
-      relgraph = Puppet::Graph::RelationshipGraph.new(Puppet::Graph::RandomPrioritizer.new)
-      @catalog.relationship_graph = relgraph
+      relgraph = @catalog.relationship_graph
 
       @catalog.add_resource @one
 
@@ -617,7 +616,6 @@ describe Puppet::Resource::Catalog, "when compiling" do
     end
 
     it "should get removed when the catalog is cleaned up" do
-      @catalog.relationship_graph = mock('graph')
       @catalog.relationship_graph.expects(:clear)
 
       @catalog.clear

--- a/spec/unit/transaction/additional_resource_generator_spec.rb
+++ b/spec/unit/transaction/additional_resource_generator_spec.rb
@@ -9,6 +9,8 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
   include PuppetSpec::Files
   include RelationshipGraphMatchers
 
+  let(:prioritizer) { Puppet::Graph::SequentialPrioritizer.new }
+
   def find_vertex(graph, type, title)
     graph.vertices.find {|v| v.type == type and v.title == title}
   end
@@ -128,7 +130,7 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
         }
       MANIFEST
 
-      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph_for(catalog))
+      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph_for(catalog), prioritizer)
 
       expect(generator.eval_generate(catalog.resource('Generator[thing]'))).
         to eq(false)
@@ -141,7 +143,7 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
         }
       MANIFEST
 
-      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph_for(catalog))
+      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph_for(catalog), prioritizer)
 
       expect(generator.eval_generate(catalog.resource('Generator[thing]'))).
         to eq(true)
@@ -153,7 +155,7 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
       MANIFEST
       relationship_graph = relationship_graph_for(catalog)
 
-      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph)
+      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph, prioritizer)
 
       expect(generator.eval_generate(catalog.resource('Generator[thing]'))).
         to eq(false)
@@ -232,7 +234,7 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
     end
 
     def eval_generate_resources_in(catalog, relationship_graph, resource_to_generate)
-      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph)
+      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph, prioritizer)
       generator.eval_generate(catalog.resource(resource_to_generate))
     end
   end
@@ -341,13 +343,13 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
     end
 
     def generate_resources_in(catalog, relationship_graph, resource_to_generate)
-      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph)
+      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph, prioritizer)
       generator.generate_additional_resources(catalog.resource(resource_to_generate))
     end
   end
 
   def relationship_graph_for(catalog)
-    relationship_graph = Puppet::Graph::RelationshipGraph.new(Puppet::Graph::SequentialPrioritizer.new)
+    relationship_graph = Puppet::Graph::RelationshipGraph.new(prioritizer)
     relationship_graph.populate_from(catalog)
     relationship_graph
   end


### PR DESCRIPTION
The Puppet::Catalog#relationship_graph method used to be a factory for the
Puppet::Graph::RelationshipGraph. That was removed when the prioritizer was
added in an attempt to remove some of the responsibilities of catalog. Inside
puppet, all of the consumers were updated. Unfortunately many tests of types
rely on the old behavior in order to test eval_generate, which may be
implemented using introspection of the relationship graph. This reverts back
to the old behavior of the relationship_graph being a factory method and
instead memoizes the prioritizer so that the same instance can be used for
the relationship_graph as well as the transaction.
