### PR TITLE
(#22250) ensure a failed resource status always has an event

### DIFF
--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -58,7 +58,18 @@ module Puppet
         @events
       end
 
+      def failed_because(detail)
+        @real_resource.log_exception(detail, "Could not evaluate: #{detail}")
+        failed = true
+        # There's a contract (implicit unfortunately) that a status of failed
+        # will always be accompanied by an event with some explanatory power.  This
+        # is useful for reporting/diagnostics/etc.  So synthesize an event here
+        # with the exception detail as the message.
+        add_event(@real_resource.event(:status => "failure", :message => detail.to_s))
+      end
+
       def initialize(resource)
+        @real_resource = resource
         @source_description = resource.path
         @containment_path = resource.pathbuilder
         @resource = resource.to_s

--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -132,35 +132,24 @@ class Puppet::Transaction::ResourceHarness
   end
 
   def evaluate(resource)
-    start = Time.now
     status = Puppet::Resource::Status.new(resource)
 
-    perform_changes(resource).each do |event|
-      status << event
+    begin
+      perform_changes(resource).each do |event|
+        status << event
+      end
+
+      if status.changed? && ! resource.noop?
+        cache(resource, :synced, Time.now)
+        resource.flush if resource.respond_to?(:flush)
+      end
+    rescue => detail
+      status.failed_because(detail)
+    ensure
+      status.evaluation_time = Time.now - status.time
     end
 
-    if status.changed? && ! resource.noop?
-      cache(resource, :synced, Time.now)
-      resource.flush if resource.respond_to?(:flush)
-    end
-
-    return status
-  rescue => detail
-    resource.fail "Could not create resource status: #{detail}" unless status
-    resource.log_exception(detail, "Could not evaluate: #{detail}")
-    status.failed = true
-    # There's a contract (implicit unfortunately) that a status of failed
-    # will always be accompanied by an event with some explanatory power.  This
-    # is useful for reporting/diagnostics/etc.  So synthesize an event here
-    # with the exception detail as the message.
-    event = resource.event
-    event.status = "failure"
-    event.message = detail.to_s
-    status << event
-
-    return status
-  ensure
-    (status.evaluation_time = Time.now - start) if status
+    status
   end
 
   def initialize(transaction)


### PR DESCRIPTION
Typically, a Puppet::Resource::Status.failed is set to true
when an event is added whose status is 'failure' (this is done
in Puppet::Resource::Status.add_event).  However, there is also
a case where Puppet::Transaction::ResourceHarness.evaluate
directly sets the status failed field to true.

Generate an event for this latter case, so that report parsers
can rely on an event accompanying any failed resource status.
