### PR TITLE
(#7014) Allow @ symbols in certnames

### DIFF
--- a/lib/puppet/network/authstore.rb
+++ b/lib/puppet/network/authstore.rb
@@ -261,7 +261,7 @@ module Puppet
 
       def parse(value)
         @name,@exact,@length,@pattern = *case value
-        when /^(\w[-\w]*\.)+[-\w]+$/                              # a full hostname
+        when /^(\w[-@\w]*\.)+[-\w]+$/                             # a full hostname with '@'s
           # Change to /^(\w[-\w]*\.)+[-\w]+\.?$/ for FQDN support
           [:domain,:exact,nil,munge_name(value)]
         when /^\*(\.(\w[-\w]*)){1,}$/                             # *.domain.com
@@ -269,7 +269,7 @@ module Puppet
           [:domain,:inexact,host_sans_star.length,host_sans_star]
         when /\$\d+/                                              # a backreference pattern ala $1.reductivelabs.com or 192.168.0.$1 or $1.$2
           [:dynamic,:exact,nil,munge_name(value)]
-        when /^\w[-.@\w]*$/                                       # ? Just like a host name but allow '@'s and ending '.'s
+        when /^\w[-\.@\w]*$/                                      # ? Just like a host name but allow '@'s and ending '.'s
           [:opaque,:exact,nil,[value]]
         when /^\/.*\/$/                                           # a regular expression
           [:regex,:inexact,nil,value]

--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -89,7 +89,7 @@ class Puppet::Parser::AST
       # Note that this is an AST::Regex, not a Regexp
       unless @value.is_a?(Regex)
         @value = @value.to_s.downcase
-        @value =~ /[^-\w.]/ and
+        @value =~ /[^-\w.@]/ and
           raise Puppet::DevError, "'#{@value}' is not a valid hostname"
       end
     end

--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -69,7 +69,7 @@ module Puppet::Util::Tagging
     end
   end
 
-  ValidTagRegex = /^\w[-\w:.]*$/
+  ValidTagRegex = /^\w[-\w:.@]*$/
   def valid_tag?(tag)
     tag.is_a?(String) and tag =~ ValidTagRegex
   end

--- a/spec/unit/network/authstore_spec.rb
+++ b/spec/unit/network/authstore_spec.rb
@@ -314,6 +314,7 @@ describe Puppet::Network::AuthStore::Declaration do
 
   {
   'spirit.mars.nasa.gov' => 'a PQDN',
+  'rover@spirit.mars.nasa.gov' => 'a user@PQDN name',
   'ratchet.2ndsiteinc.com' => 'a PQDN with digits',
   'a.c.ru' => 'a PQDN with short segments',
   }.each {|pqdn,desc|


### PR DESCRIPTION
Certnames, node definitions(hostnames), and tags can now all contain
the @ symbol. It was necessary to add tags to get node definitions to
work.
