### PR TITLE
Make sure mounts higher up the Filesystem are mounted first

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -259,5 +259,16 @@ module Puppet
         return property.value
       end
     end
+
+    autorequire(:mount) do
+      # Taken from zfs type. Make sure mounts higher up the Filesystem are mounted first
+      names = @parameters[:name].value.split('/')
+      dependencies = []
+      if names.length > 0
+        dependencies = names.slice(1..-2).inject([]) { |a,v| a << "#{a.last}/#{v}" }.collect { |fs| names[0] + fs }
+      end
+      dependencies
+    end
+
   end
 end


### PR DESCRIPTION
Took code from zfs type to ensure that mounts higher up the fielsystem are mounted 1st.

i.e. 

Its possible to have a /var/log mount after /var/log/puppet, so '/var/log/puppet' seems to disappear.
