### PR TITLE
(PUP-735) Fail when cannot apply complete catalog

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -177,10 +177,6 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       transaction.report.as_logging_destination do
         transaction.evaluate
       end
-    rescue Puppet::Error => detail
-      Puppet.log_exception(detail, "Could not apply complete catalog: #{detail}")
-    rescue => detail
-      Puppet.log_exception(detail, "Got an uncaught exception of type #{detail.class}: #{detail}")
     ensure
       # Don't try to store state unless we're a host config
       # too recursive.

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -229,7 +229,7 @@ describe Puppet::Transaction do
     notify.expects(:pre_run_check).raises(Puppet::Error, "fail for testing")
 
     catalog = mk_catalog(file, notify)
-    catalog.apply
+    expect { catalog.apply }.to raise_error(Puppet::Error, /Some pre-run checks failed/)
     expect(Puppet::FileSystem.exist?(path)).not_to be_truthy
   end
 


### PR DESCRIPTION
Under some circumstances (eg. dependency cycle) when catalog could not be
applied, Puppet didn't report failure (status unchanged, return code 0).

Raise Puppet::Error so the failure gets logged and reported (status is
"failed", return value is 1).