### PR TITLE
(#22229) Ensure generated resources contained

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -70,6 +70,13 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     end
   end
 
+  # @param resource [A Resource] a resource in the catalog
+  # @return [A Resource, nil] the resource that contains the given resource
+  # @api public
+  def container_of(resource)
+    adjacent(resource, :direction => :in)[0]
+  end
+
   def add_one_resource(resource)
     fail_on_duplicate_type_and_title(resource)
 

--- a/lib/puppet/transaction/additional_resource_generator.rb
+++ b/lib/puppet/transaction/additional_resource_generator.rb
@@ -107,13 +107,9 @@ class Puppet::Transaction::AdditionalResourceGenerator
       res.tag(*parent_resource.tags)
       @catalog.add_resource(res)
       @relationship_graph.add_vertex(res, priority)
-      @catalog.add_edge(container_of(parent_resource), res)
+      @catalog.add_edge(@catalog.container_of(parent_resource), res)
       res.finish
     end
-  end
-
-  def container_of(resource)
-    @catalog.adjacent(resource, :direction => :in)[0]
   end
 
   # Copy an important relationships from the parent to the newly-generated

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -277,6 +277,21 @@ describe Puppet::Resource::Catalog, "when compiling" do
       @catalog.vertices.find { |r| r.ref == @one.ref }.must equal(@one)
     end
 
+    it "tracks the container through edges" do
+      @catalog.add_resource(@two)
+      @catalog.add_resource(@one)
+
+      @catalog.add_edge(@one, @two)
+
+      @catalog.container_of(@two).must == @one
+    end
+
+    it "a resource without a container is contained in nil" do
+      @catalog.add_resource(@one)
+
+      @catalog.container_of(@one).must be_nil
+    end
+
     it "should canonize how resources are referred to during retrieval when both type and title are provided" do
       @catalog.add_resource(@one)
       @catalog.resource("notify", "one").must equal(@one)

--- a/spec/unit/transaction/additional_resource_generator_spec.rb
+++ b/spec/unit/transaction/additional_resource_generator_spec.rb
@@ -393,10 +393,10 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
     order_seen
   end
 
-  RSpec::Matchers.define :contain_resources_equally do |*resources|
+  RSpec::Matchers.define :contain_resources_equally do |*resource_refs|
     match do |catalog|
-      @containers = resources.collect do |resource|
-        catalog.adjacent(catalog.resource(resource), :direction => :in)[0].ref
+      @containers = resource_refs.collect do |resource_ref|
+        catalog.container_of(catalog.resource(resource_ref)).ref
       end
 
       @containers.all? { |resource_ref| resource_ref == @containers[0] }


### PR DESCRIPTION
The generated resources were left out in the cold with respect to
containers: they had none at all. This changes that to make sure that the
generated resources (via #generate and #eval_generate) have the same
container as the resource that generated them.
