### PR TITLE
(#22319) Correct Puppet::Setting's use of WatchedFile

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -701,10 +701,11 @@ class Puppet::Settings
   private :files
 
   # Checks to see if any of the config files have been modified
-  # @return the filename of the first file that is found to have changed, or nil if no files have changed
+  # @return the filename of the first file that is found to have changed, or
+  #   nil if no files have changed
   def any_files_changed?
     files.each do |file|
-      return file.file if file.changed?
+      return file.to_str if file.changed?
     end
     nil
   end

--- a/spec/integration/util/settings_spec.rb
+++ b/spec/integration/util/settings_spec.rb
@@ -10,23 +10,27 @@ describe Puppet::Settings do
     { :noop => {:default => false, :desc => "noop"} }
   end
 
+  def define_settings(section, settings_hash)
+    settings.define_settings(section, minimal_default_settings.update(settings_hash))
+  end
+
+  let(:settings) { Puppet::Settings.new }
+
   it "should be able to make needed directories" do
-    settings = Puppet::Settings.new
-    settings.define_settings :main, minimal_default_settings.update(
-        :maindir => {
-            :default => tmpfile("main"),
-            :type => :directory,
-            :desc => "a",
-        }
+    define_settings(:main,
+      :maindir => {
+          :default => tmpfile("main"),
+          :type => :directory,
+          :desc => "a",
+      }
     )
     settings.use(:main)
 
-    File.should be_directory(settings[:maindir])
+    expect(File.directory?(settings[:maindir])).to be_true
   end
 
   it "should make its directories with the correct modes" do
-    settings = Puppet::Settings.new
-    settings.define_settings :main,  minimal_default_settings.update(
+    define_settings(:main,
         :maindir => {
             :default => tmpfile("main"),
             :type => :directory,
@@ -37,6 +41,49 @@ describe Puppet::Settings do
 
     settings.use(:main)
 
-    (File.stat(settings[:maindir]).mode & 007777).should == (Puppet.features.microsoft_windows? ? 0755 : 0750)
+    expect(File.stat(settings[:maindir]).mode & 007777).to eq(Puppet.features.microsoft_windows? ? 0755 : 0750)
+  end
+
+  it "reparses configuration if configuration file is touched" do
+    config = tmpfile("config")
+    define_settings(:main,
+      :config => {
+        :type => :file,
+        :default => config,
+        :desc => "a"
+      },
+      :environment => {
+        :default => 'dingos',
+        :desc => 'test',
+      }
+    )
+
+    Puppet[:filetimeout] = '1s'
+
+    File.open(config, 'w') do |file|
+      file.puts <<-EOF
+[main]
+environment=toast
+      EOF
+    end
+
+    settings.initialize_global_settings
+    expect(settings[:environment]).to eq('toast')
+
+    # First reparse establishes WatchedFiles
+    settings.reparse_config_files
+
+    sleep 1
+
+    File.open(config, 'w') do |file|
+      file.puts <<-EOF
+[main]
+environment=bacon
+      EOF
+    end
+
+    # Second reparse if later than filetimeout, reparses if changed
+    settings.reparse_config_files
+    expect(settings[:environment]).to eq('bacon')
   end
 end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1005,17 +1005,7 @@ describe Puppet::Settings do
       @settings.stubs(:user_config_file).returns(@userconfig)
     end
 
-    it "should use a WatchedFile instance to determine if the file has changed" do
-      file = mock 'file'
-      Puppet::Util::WatchedFile.expects(:new).with(@file).returns file
-
-      file.expects(:changed?)
-
-      @settings.stubs(:parse)
-      @settings.reparse_config_files
-    end
-
-    it "should not create the WatchedFile instance and should not parse if the file does not exist" do
+    it "does not create the WatchedFile instance and should not parse if the file does not exist" do
       FileTest.expects(:exist?).with(@file).returns false
       Puppet::Util::WatchedFile.expects(:new).never
 
@@ -1024,46 +1014,44 @@ describe Puppet::Settings do
       @settings.reparse_config_files
     end
 
-    it "should not reparse if the file has not changed" do
-      file = mock 'file'
-      Puppet::Util::WatchedFile.expects(:new).with(@file).returns file
+    context "and watched file exists" do
+      before do
+        @watched_file = Puppet::Util::WatchedFile.new(@file)
+        Puppet::Util::WatchedFile.expects(:new).with(@file).returns @watched_file
+      end
 
-      file.expects(:changed?).returns false
+      it "uses a WatchedFile instance to determine if the file has changed" do
+        @watched_file.expects(:changed?)
 
-      @settings.expects(:parse_config_files).never
+        @settings.reparse_config_files
+      end
 
-      @settings.reparse_config_files
-    end
+      it "does not reparse if the file has not changed" do
+        @watched_file.expects(:changed?).returns false
 
-    it "should reparse if the file has changed" do
-      file = stub 'file', :file => @file
-      Puppet::Util::WatchedFile.expects(:new).with(@file).returns file
+        @settings.expects(:parse_config_files).never
 
-      file.expects(:changed?).returns true
+        @settings.reparse_config_files
+      end
 
-      @settings.expects(:parse_config_files)
+      it "reparses if the file has changed" do
+        @watched_file.expects(:changed?).returns true
 
-      @settings.reparse_config_files
-    end
+        @settings.expects(:unsafe_parse).with(@file)
 
-    it "should replace in-memory values with on-file values" do
-      # Init the value
-      text = "[main]\none = disk-init\n"
-      file = mock 'file'
-      file.stubs(:changed?).returns(true)
-      file.stubs(:file).returns(@file)
-      @settings[:one] = "init"
-      @settings.files = [file]
+        @settings.reparse_config_files
+      end
 
-      # Now replace the value
-      text = "[main]\none = disk-replace\n"
+      it "replaces in-memory values with on-file values" do
+        @watched_file.stubs(:changed?).returns(true)
+        @settings[:one] = "init"
 
-      # This is kinda ridiculous - the reason it parses twice is that
-      # it goes to parse again when we ask for the value, because the
-      # mock always says it should get reparsed.
-      @settings.stubs(:read_file).returns(text)
-      @settings.reparse_config_files
-      @settings[:one].should == "disk-replace"
+        # Now replace the value
+        text = "[main]\none = disk-replace\n"
+        @settings.stubs(:read_file).returns(text)
+        @settings.reparse_config_files
+        @settings[:one].should == "disk-replace"
+      end
     end
 
     it "should retain parameters set by cli when configuration files are reparsed" do


### PR DESCRIPTION
WatchedFile was introduced after 3.2.0 as a new method of checking for
changes to file.  Puppet::Settings was calling a non-existent method on
the new WatchedFile, and would cause a daemonized Puppet to abort if one
of its watched configuration files was changed.

This is a minor change to call #to_str instead.
