### PR TITLE
(22329) Only delete puppet files in the preflight

### DIFF
--- a/ext/osx/preflight.erb
+++ b/ext/osx/preflight.erb
@@ -13,11 +13,22 @@
   <%- raise "Critical variable #{i} is unset!" if val.nil? or val.empty? -%>
 <%- end -%>
 
-# remove ruby library files
+# remove ruby library files. Because hiera and puppet both place a "hiera"
+# directory in the libdir, we have to be sure we only delete the files
+# belonging to this project. In this case, we only delete files from within
+# the 'hiera' directory, while deleting the entire puppet directory.
 <%- Dir.chdir("lib") do -%>
   <%- [@apple_old_libdir, @apple_libdir].compact.each do |libdir| -%>
+    <%- Dir["hiera/**/*"].select{ |i| File.file?(i) }.each do |file| -%>
+/bin/rm -f "${3}<%= libdir %>/<%= file %>"
+    <%- end -%>
     <%- Dir.glob("*").each do |file| -%>
+      <%- next if file == "hiera" -%>
+      <%- if File.directory?(file) -%>
 /bin/rm -Rf "${3}<%= libdir %>/<%= file %>"
+      <%- else -%>
+/bin/rm -f "${3}<%= libdir %>/<%= file %>"
+      <%- end -%>
     <%- end -%>
   <%- end -%>
 <%- end -%>
@@ -25,7 +36,7 @@
 # remove bin files
 <%- Dir.chdir("bin") do -%>
     <%- Dir.glob("*").each do |file| -%>
-/bin/rm -Rf "${3}<%= @apple_bindir %>/<%= file %>"
+/bin/rm -f "${3}<%= @apple_bindir %>/<%= file %>"
   <%- end -%>
 <%- end -%>
 
@@ -34,8 +45,8 @@
 
 # These files used to live in the sbindir but were
 # removed in Pupppet >= 3.0. Remove them
-/bin/rm -Rf "${3}<%= @apple_sbindir %>/puppetca"
-/bin/rm -Rf "${3}<%= @apple_sbindir %>/puppetd"
-/bin/rm -Rf "${3}<%= @apple_sbindir %>/puppetmasterd"
-/bin/rm -Rf "${3}<%= @apple_sbindir %>/puppetqd"
-/bin/rm -Rf "${3}<%= @apple_sbindir %>/puppetrun"
+/bin/rm -f "${3}<%= @apple_sbindir %>/puppetca"
+/bin/rm -f "${3}<%= @apple_sbindir %>/puppetd"
+/bin/rm -f "${3}<%= @apple_sbindir %>/puppetmasterd"
+/bin/rm -f "${3}<%= @apple_sbindir %>/puppetqd"
+/bin/rm -f "${3}<%= @apple_sbindir %>/puppetrun"


### PR DESCRIPTION
Previously, the OSX preflight removed the contents of the 'hiera' directory
which also happens to be where the puppet.pkg places the contents of
hiera_puppet. The fix is pretty easy - from the hiera dir, only remove the
files that exist in the 'puppet' project, no others, e.g. not those from the
hiera.pkg. This commit accomplishes this by only deleting files from 'hiera',
not the directories. It's a bit crufty, but its better than clobbering the
wrong files. With the puppet directory, we can still just remove it. This
commit also fixes some obvious oddities with the rm calls. Previously we just
called rm -Rf indiscriminately. This PR ensures we're calling rm -f on files
and rm -Rf on directories.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
