### PR TITLE
(#22319) Constrain settings watchedfile integration on windows

### DIFF
--- a/spec/integration/util/settings_spec.rb
+++ b/spec/integration/util/settings_spec.rb
@@ -44,7 +44,7 @@ describe Puppet::Settings do
     expect(File.stat(settings[:maindir]).mode & 007777).to eq(Puppet.features.microsoft_windows? ? 0755 : 0750)
   end
 
-  it "reparses configuration if configuration file is touched" do
+  it "reparses configuration if configuration file is touched", :if => !Puppet.features.microsoft_windows? do
     config = tmpfile("config")
     define_settings(:main,
       :config => {


### PR DESCRIPTION
File.ctime provides creation time on Windows, and shows no change in
WatchedFile.  But we have no long running processes in Windows, so we
would not be reloading configs, and this test can be skipped.
