### PR TITLE
(#22258) Create new console for each puppet run

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -55,7 +55,7 @@ class WindowsDaemon < Win32::Daemon
         runinterval = 1800
       end
 
-      pid = Process.create(:command_line => "\"#{puppet}\" agent --onetime #{args}").process_id
+      pid = Process.create(:command_line => "\"#{puppet}\" agent --onetime #{args}", :creation_flags => Process::CREATE_NEW_CONSOLE).process_id
       log_debug("Process created: #{pid}")
 
       log_debug("Service waiting for #{runinterval} seconds")


### PR DESCRIPTION
Powershell apparently has some issue trying to share the Windows
service's console when running under ruby.exe (as opposed to rubyw.exe).
This patch causes the service to create a new console for each puppet
child it kicks off, which resolves the issue.
