### PR TITLE
(#22362) Changes in const_defined?() on ruby 1.9 break Puppet::Util::Cla...

### DIFF
--- a/lib/puppet/util/classgen.rb
+++ b/lib/puppet/util/classgen.rb
@@ -67,7 +67,7 @@ module Puppet::Util::ClassGen
     options = symbolize_options(options)
     const = genconst_string(name, options)
     retval = false
-    if const_defined?(const)
+    if is_constant_defined?(const)
       remove_const(const)
       retval = true
     end


### PR DESCRIPTION
I have this example (three files):

```
#lib/puppet/type/packagex.rb
module Puppet
  newtype(:packagex, :parent => Puppet::Type.type(:package)) do
  end
end
```

and

```
# lib/puppet/provider/packagex/ports.rb
Puppet::Type.type(:packagex).provide :ports, 
  :parent => Puppet::Type.type(:package).provider(:ports) do
end
```

and

```
# test.rb
$LOAD_PATH.unshift('lib')
require 'puppet'
Puppet::Type.type(:packagex)
```

Running 'ruby test.rb' fails on ruby >=1.9 with the following exception:

```
/usr/local/lib/ruby/site_ruby/1.9/puppet/util/autoload.rb:68:in `rescue in load_file': Could not autoload puppet/type/packagex: Could not autoload puppet/provider/packagex/ports: constant Puppet::Type::Packagex::ProviderPorts not defined (Puppet::Error)
        from /usr/local/lib/ruby/site_ruby/1.9/puppet/util/autoload.rb:59:in `load_file'
        from /usr/local/lib/ruby/site_ruby/1.9/puppet/util/autoload.rb:201:in `load'
        from /usr/local/lib/ruby/site_ruby/1.9/puppet/metatype/manager.rb:159:in `type'
        from /tmp/test.rb:4:in `<main>'
```

The problem appears, when using `newtype` with `:parent` argument. I've tracked down the problem and found that the exception is raised from `Puppet::Util::Classgen.rmclass()`. The method uses `const_defined?()` whose behavior [changed in ruby 1.9](http://makandracards.com/makandra/14699-module-const_defined-behaves-differently-in-ruby-1-9-and-ruby-1-8).
