### PR TITLE
(#21427) Make report format selectable

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -210,6 +210,13 @@ class Puppet::Configurer
     Puppet::Transaction::Report.indirection.save(report, nil, :environment => @environment) if Puppet[:report]
   rescue => detail
     Puppet.log_exception(detail, "Could not send report: #{detail}")
+    if detail.message =~ /Could not intern from pson.*Puppet::Transaction::Report/
+      Puppet.notice("There was an error sending the report.")
+      Puppet.notice("This error is possibly caused by sending the report in a format the master can not handle.")
+      Puppet.notice("A puppet master older than 3.2.2 can not handle pson reports.")
+      Puppet.notice("Set report_serialization_format=yaml on the agent to send reports to older masters.")
+      Puppet.notice("See http://links.puppetlabs.com/deprecate_yaml_on_network for more information.")
+    end
   end
 
   def save_last_run_summary(report)

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1081,6 +1081,19 @@ EOT
       can be guaranteed to support this format, but it will be used for all
       classes that support it.",
     },
+    :report_serialization_format => {
+      :default => "pson",
+      :type => :enum,
+      :values => ["pson", "yaml"],
+      :desc => "The serialization format to use when sending reports to the
+      'report_server'. Possible values are pson and yaml. PSON should be
+      preferred, but masters before 3.3.0 only understand yaml.",
+      :hook => proc do |value|
+        if value == "yaml"
+          Puppet.deprecation_warning("Sending reports in 'yaml' is deprecated; use 'pson' instead.")
+        end
+      end
+    },
     :agent_catalog_run_lockfile => {
       :default    => "$statedir/agent_catalog_run.lock",
       :type       => :string, # (#2888) Ensure this file is not added to the settings catalog.

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -315,6 +315,10 @@ class Puppet::Transaction::Report
     instance_variables - [:@external_times]
   end
 
+  def self.supported_formats
+    [Puppet[:report_serialization_format]]
+  end
+
   private
 
   def calculate_change_metric


### PR DESCRIPTION
Without making agents able to select the format to serialize reports, a newer
agent would be unable to submit reports to an older master. Although we ask
users to upgrade masters first, that is not often done in practice. In order
to allow those kinds of setups to work, this makes the report format
selectable.

Puppet 3.2.2 and later support reports as pson, so only older, insecure 
masters need to have the agent's change this new setting.
