### PR TITLE
(#21133) Report on installed windows package versions

### DIFF
--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -22,6 +22,7 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
   has_feature :uninstallable
   has_feature :install_options
   has_feature :uninstall_options
+  has_feature :versionable
 
   attr_accessor :package
 
@@ -37,9 +38,7 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
   def self.to_hash(pkg)
     {
       :name     => pkg.name,
-      # we're not versionable, so we can't set the ensure
-      # parameter to the currently installed version
-      :ensure   => :installed,
+      :ensure   => pkg.version || :installed,
       :provider => :windows
     }
   end


### PR DESCRIPTION
Previously, the windows package provider knew what versions of
packages (MSI and exe) were installed, but did not report them,
e.g. when running `puppet resource package`.

This commit enables the package version to be included in the
output, e.g.

```
C:\>puppet resource package Notepad++
package { 'Notepad++':
  ensure => '6.4.5',
}
```

In order for the `ensure` property to contain a version number,
the provider must be versionable, which this commit enables.

Note that the `ensure` version specified must match the
version of the package specified by the source parameter. If
it doesn't then puppet will think the package is out of sync
and needs to be updated. This is similar to what happens if
the resource name doesn't match the DisplayName value in the
registry, or differs in case.
