### PR TITLE
(#21427) make supported_formats return an array of symbols

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -316,7 +316,7 @@ class Puppet::Transaction::Report
   end
 
   def self.supported_formats
-    [Puppet[:report_serialization_format]]
+    [Puppet[:report_serialization_format].intern]
   end
 
   private

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -376,7 +376,7 @@ describe Puppet::Transaction::Report do
   end
 
   it "defaults to serializing to pson" do
-    expect(Puppet::Transaction::Report.supported_formats).to eq(["pson"])
+    expect(Puppet::Transaction::Report.supported_formats).to eq([:pson])
   end
 
   it "can make a round trip through pson" do


### PR DESCRIPTION
Prior to this commit, supported_formats was returning an array of
strings, which violated the contract for FormatHandler's
most_suitable_format_for method.  This commit fixes supported_formats
to return an array of symbols.
