### PR TITLE
(#22383) Allow all boolean values for atboot

### DIFF
--- a/lib/puppet/coercion.rb
+++ b/lib/puppet/coercion.rb
@@ -1,0 +1,29 @@
+# Various methods used to coerce values into a canonical form.
+#
+# @api private
+module Puppet::Coercion
+  # Try to coerce various input values into boolean true/false
+  #
+  # Only a very limited subset of values are allowed. This method does not try
+  # to provide a generic "truthiness" system.
+  #
+  # @param value [Boolean, Symbol, String]
+  # @return [Boolean]
+  # @raise
+  # @api private
+  def self.boolean(value)
+    # downcase strings
+    if value.respond_to? :downcase
+      value = value.downcase
+    end
+
+    case value
+    when true, :true, 'true', :yes, 'yes'
+      true
+    when false, :false, 'false', :no, 'no'
+      false
+    else
+      fail('expected a boolean value')
+    end
+  end
+end

--- a/lib/puppet/parameter/boolean.rb
+++ b/lib/puppet/parameter/boolean.rb
@@ -1,20 +1,10 @@
+require 'puppet/coercion'
+
 # This specialized {Puppet::Parameter} handles boolean options, accepting lots
 # of strings and symbols for both truthiness and falsehood.
 #
 class Puppet::Parameter::Boolean < Puppet::Parameter
   def unsafe_munge(value)
-    # downcase strings
-    if value.respond_to? :downcase
-      value = value.downcase
-    end
-
-    case value
-    when true, :true, 'true', :yes, 'yes'
-      true
-    when false, :false, 'false', :no, 'no'
-      false
-    else
-      fail('expected a boolean value')
-    end
+    Puppet::Coercion.boolean(value)
   end
 end

--- a/lib/puppet/property/boolean.rb
+++ b/lib/puppet/property/boolean.rb
@@ -1,0 +1,7 @@
+require 'puppet/coercion'
+
+class Puppet::Property::Boolean < Puppet::Property
+  def unsafe_munge(value)
+    Puppet::Coercion.boolean(value)
+  end
+end

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -1,3 +1,5 @@
+require 'puppet/property/boolean'
+
 module Puppet
   # We want the mount to refresh when it changes.
   newtype(:mount, :self_refresh => true) do
@@ -182,11 +184,18 @@ module Puppet
       }
     end
 
-    newproperty(:atboot) do
+    newproperty(:atboot, :parent => Puppet::Property::Boolean) do
       desc "Whether to mount the mount at boot.  Not all platforms
         support this."
 
-      newvalues :yes, :no
+      def munge(value)
+        munged = super
+        if munged
+          :yes
+        else
+          :no
+        end
+      end
     end
 
     newproperty(:dump) do

--- a/spec/unit/property/boolean_spec.rb
+++ b/spec/unit/property/boolean_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'puppet/property/boolean'
+
+describe Puppet::Property::Boolean do
+  let (:resource) { mock('resource') }
+  subject { described_class.new(:resource => resource) }
+
+  [ true, :true, 'true', :yes, 'yes', 'TrUe', 'yEs' ].each do |arg|
+    it "should munge #{arg.inspect} as true" do
+      subject.munge(arg).should == true
+    end
+  end
+  [ false, :false, 'false', :no, 'no', 'FaLSE', 'nO' ].each do |arg|
+    it "should munge #{arg.inspect} as false" do
+      subject.munge(arg).should == false
+    end
+  end
+  [ nil, :undef, 'undef', '0', 0, '1', 1, 9284 ].each do |arg|
+    it "should fail to munge #{arg.inspect}" do
+      expect { subject.munge(arg) }.to raise_error Puppet::Error
+    end
+  end
+end
+

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -263,16 +263,32 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
     end
 
     describe "for atboot" do
-      it "should support yes as a value for atboot" do
-        expect { described_class.new(:name => "/foo", :ensure => :present, :atboot => :yes) }.to_not raise_error
+      it "does not allow non-boolean values" do
+        expect { described_class.new(:name => "/foo", :ensure => :present, :atboot => 'unknown') }.to raise_error Puppet::Error, /expected a boolean value/
       end
 
-      it "should support no as a value for atboot" do
-        expect { described_class.new(:name => "/foo", :ensure => :present, :atboot => :no) }.to_not raise_error
+      it "interprets yes as yes" do
+        resource = described_class.new(:name => "/foo", :ensure => :present, :atboot => :yes)
+
+        expect(resource[:atboot]).to eq(:yes)
       end
 
-      it "should not support other values for atboot" do
-        expect { described_class.new(:name => "/foo", :ensure => :present, :atboot => :true) }.to raise_error Puppet::Error, /Invalid value/
+      it "interprets true as yes" do
+        resource = described_class.new(:name => "/foo", :ensure => :present, :atboot => :true)
+
+        expect(resource[:atboot]).to eq(:yes)
+      end
+
+      it "interprets no as no" do
+        resource = described_class.new(:name => "/foo", :ensure => :present, :atboot => :no)
+
+        expect(resource[:atboot]).to eq(:no)
+      end
+
+      it "interprets false as no" do
+        resource = described_class.new(:name => "/foo", :ensure => :present, :atboot => false)
+
+        expect(resource[:atboot]).to eq(:no)
       end
     end
   end


### PR DESCRIPTION
The previous restrictions placed on the atboot property for mount caused some
previously valid manifests to begin to fail. The problem stems from the fact
that atboot is only used on solaris, but can always be specified by users. It
used to be able to be nearly anything, but only yes and no meant anything on
solaris. This fixes the problem by expanding the allowed values to include
all of the "boolean" values as expressed in the
Puppet::[Parameter|Property]::Boolean type and using a munge method to
convert the boolean to the correct yes or no value.
