### PR TITLE
(maint) Windows failing spec fixes

### DIFF
--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1004,8 +1004,8 @@ describe Puppet::Type.type(:file) do
         catalog.add_resource file
         catalog.apply
 
-        get_owner(path).should == 'S-1-5-32-544'
-        get_group(path).should == 'S-1-0-0'
+        get_owner(path).should =~ /^S\-1\-5\-.*$/
+        get_group(path).should =~ /^S\-1\-0\-0.*$/
         get_mode(path).should == 0644
       end
     end

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -143,7 +143,7 @@ describe Puppet::Node::Environment do
       it "should use the current working directory to fully-qualify unqualified paths" do
         FileTest.stubs(:directory?).returns true
   
-        two = File.expand_path(File.join(Dir.getwd, "two"))
+        two = File.expand_path("two")
         env.validate_dirs([@path_one, 'two']).should == [@path_one, two]
       end
     end

--- a/spec/unit/parser/files_spec.rb
+++ b/spec/unit/parser/files_spec.rb
@@ -70,9 +70,8 @@ describe Puppet::Parser::Files do
     it "should accept relative templatedirs" do
       FileTest.stubs(:exist?).returns true
       Puppet[:templatedir] = "my/templates"
-      # We expand_path to normalize backslashes and slashes on Windows
-      File.expects(:directory?).with(File.expand_path(File.join(Dir.getwd,"my/templates"))).returns(true)
-      Puppet::Parser::Files.find_template("mytemplate").should == File.expand_path(File.join(Dir.getwd,"my/templates/mytemplate"))
+      File.expects(:directory?).with(File.expand_path("my/templates")).returns(true)
+      Puppet::Parser::Files.find_template("mytemplate").should == File.expand_path("my/templates/mytemplate")
     end
 
     it "should use the environment templatedir if no module is found and an environment is specified" do

--- a/spec/unit/settings/file_setting_spec.rb
+++ b/spec/unit/settings/file_setting_spec.rb
@@ -170,9 +170,7 @@ describe Puppet::Settings::FileSetting do
 
     it "should fully qualified returned files if necessary (#795)" do
       @settings.stubs(:value).with(:myfile).returns "myfile"
-      path = File.join(Dir.getwd, "myfile")
-      # Dir.getwd can return windows paths with backslashes, so we normalize them using expand_path
-      path = File.expand_path(path) if Puppet.features.microsoft_windows?
+      path = File.expand_path('myfile')
       @file.to_resource.title.should == path
     end
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -59,6 +59,7 @@ describe Puppet::Util do
 
     it "should remove any new environment variables after the block ends" do
       @new_env[:FOO] = "bar"
+      ENV["FOO"] = nil
       Puppet::Util.withenv @new_env do
         ENV["FOO"].should == "bar"
       end


### PR DESCRIPTION
- The usage of Dir.getwd in tests has been simplified to
  File.expand_path to properly handle mixed case CWD
- util_spec.rb ensures 'FOO' Env var cleared before test starts
- Windows SID checks should be performed as a regex match to
  properly handle all accounts starting with S-1-5-*, which denotes
  accounts with an identifier authority of SECURITY_NT_AUTHORITY
  instead of hardcoding S-1-5-32-544, the Administrators group
