### PR TITLE
(#22474) Update forge/repository.rb to conditionally include zlib

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -1,9 +1,12 @@
 require 'net/https'
-require 'zlib'
 require 'digest/sha1'
 require 'uri'
 require 'puppet/util/http_proxy'
 require 'puppet/forge/errors'
+
+if Puppet.features.zlib? && Puppet[:zlib]
+  require 'zlib'
+end
 
 class Puppet::Forge
   # = Repository
@@ -26,8 +29,11 @@ class Puppet::Forge
       Net::HTTPHeaderSyntaxError,
       Net::ProtocolError,
       SocketError,
-      Zlib::GzipFile::Error,
     ]
+
+    if Puppet.features.zlib? && Puppet[:zlib]
+      NET_HTTP_EXCEPTIONS << Zlib::GzipFile::Error
+    end
 
     # Instantiate a new repository instance rooted at the +url+.
     # The agent will report +consumer_version+ in the User-Agent to


### PR DESCRIPTION
Previously using the --no-zlib flag or using puppet on a ruby without zlib
support would result in a load error and stacktrace, because
lib/puppet/forge/repository.rb requires zlib and uses a constant defined by
Zlib. This commit updates repository.rb to only require zlib and use its
constant if the zlib feature is available and the --no-zlib flag was not passed
(zlib is enabled by default in defaults.rb).
With this commit running puppet on a ruby without zlib does not throw a
stacktrace or other error related to zlib.
