### PR TITLE
(Feature #8657) Support UNC paths on Windows

### DIFF
--- a/lib/puppet/file_serving/base.rb
+++ b/lib/puppet/file_serving/base.rb
@@ -21,11 +21,18 @@ class Puppet::FileServing::Base
 
   # Return the full path to our file.  Fails if there's no path set.
   def full_path(dummy_argument=:work_arround_for_ruby_GC_bug)
-    (if relative_path.nil? or relative_path == "" or relative_path == "."
-       path
+    if relative_path.nil? or relative_path == "" or relative_path == "."
+       full_path = path
      else
-       File.join(path, relative_path)
-     end).gsub(%r{//+}, "/")
+       full_path = File.join(path, relative_path)
+     end
+
+     if Puppet.features.microsoft_windows?
+       # Replace multiple slashes as long as they aren't at the beginning of a filename
+       full_path.gsub(%r{(./)/+}, '\1')
+     else
+       full_path.gsub(%r{//+}, '/')
+     end
   end
 
   def initialize(path, options = {})

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -54,7 +54,12 @@ Puppet::Type.newtype(:file) do
     end
 
     munge do |value|
-      ::File.join(::File.split(::File.expand_path(value)))
+      if value.start_with?('//') and ::File.basename(value) == "/"
+        # This is a UNC path pointing to a share, so don't add a trailing slash
+        ::File.expand_path(value)
+      else
+        ::File.join(::File.split(::File.expand_path(value)))
+      end
     end
   end
 

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -251,7 +251,7 @@ module Util
     if Puppet.features.microsoft_windows?
       path = path.gsub(/\\/, '/')
 
-      if unc = /^\/\/([^\/]+)(\/[^\/]+)/.match(path)
+      if unc = /^\/\/([^\/]+)(\/.+)/.match(path)
         params[:host] = unc[1]
         path = unc[2]
       elsif path =~ /^[a-z]:\//i

--- a/spec/unit/file_serving/base_spec.rb
+++ b/spec/unit/file_serving/base_spec.rb
@@ -102,6 +102,23 @@ describe Puppet::FileServing::Base do
     end
   end
 
+  describe "when handling a UNC file path on Windows" do
+    let(:path) { '//server/share/filename' }
+    let(:file) { Puppet::FileServing::Base.new(path) }
+
+    it "should preserve double slashes at the beginning of the path" do
+      Puppet.features.stubs(:microsoft_windows?).returns(true)
+      file.full_path.should == path
+    end
+
+    it "should strip double slashes not at the beginning of the path" do
+      Puppet.features.stubs(:microsoft_windows?).returns(true)
+      file = Puppet::FileServing::Base.new('//server//share//filename')
+      file.full_path.should == path
+    end
+  end
+
+
   describe "when stat'ing files" do
     let(:path) { File.expand_path('/this/file') }
     let(:file) { Puppet::FileServing::Base.new(path) }

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -78,10 +78,6 @@ describe Puppet::Type.type(:file) do
       end
 
       describe "when using UNC filenames", :if => Puppet.features.microsoft_windows? do
-        before :each do
-          pending("UNC file paths not yet supported")
-        end
-
         it "should remove trailing slashes" do
           file[:path] = "//server/foo/bar/baz/"
           file[:path].should == "//server/foo/bar/baz"


### PR DESCRIPTION
This patch makes a couple of small logic tweaks (adjusting regexes used to clean paths) so that UNC paths can be used successfully on Windows.
