### PR TITLE
Issue #22304 Add the metalink property to the yumrepo type

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -315,6 +315,12 @@ module Puppet
       newvalue(%r{[0-9]+}) { }
     end
 
+    newproperty(:metalink, :parent => Puppet::IniProperty) do
+      desc "The metalink URL. #{ABSENT_DOC}"
+      newvalue(:absent) { self.should = :absent }
+      newvalue(/.*/) { }
+    end
+
     newproperty(:protect, :parent => Puppet::IniProperty) do
       desc "Enable or disable protection for this repository. Requires
         that the `protectbase` plugin is installed and enabled.

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::Type.type(:yumrepo) do
     end
 
     [:baseurl, :cost, :descr, :enabled, :enablegroups, :exclude, :failovermethod, :gpgcheck, :gpgkey, :http_caching, 
-       :include, :includepkgs, :keepalive, :metadata_expire, :mirrorlist, :priority, :protect, :proxy, :proxy_username, :proxy_password, :timeout, 
+       :include, :includepkgs, :keepalive, :metadata_expire, :metalink, :mirrorlist, :priority, :protect, :proxy, :proxy_username, :proxy_password, :timeout, 
        :sslcacert, :sslverify, :sslclientcert, :sslclientkey, :s3_enabled].each do |param|
       it "should have a '#{param}' parameter" do
         Puppet::Type.type(:yumrepo).attrtype(param).should == :property


### PR DESCRIPTION
The test is only a stub for now as the yumrepo spec file needs to be converted to suit current practises. Which is going to be a 'chunk' of work.
