### PR TITLE
(22273) Puppet manages owner/group of own vardir

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -28,6 +28,8 @@ module Puppet
     :vardir   => {
         :default  => nil,
         :type     => :directory,
+        :owner    => "service",
+        :group    => "service",
         :desc     => "Where Puppet stores dynamic and growing data.  The default for this setting is calculated specially, like `confdir`_.",
     },
 


### PR DESCRIPTION
lib/puppet/defaults.rb has :vardir as a directory setting, but did not
specify an owner or group.  If the user/group is changed and puppet is
restarted with a --mkusers setting, vardir will be owned by the previous
user uid, and puppet master will fail to access information under
/var/lib/puppet (if permissions are strict enough).  This first
manifests as an inability to read the ca cert under
/var/lib/puppet/ssl/certs.  (This assumes running puppet master as root,
which will attempt to manage settings as the service user 'puppet' and
then daemonize as puppet).

This change addes :owner, :group settings of 'service' to the :vardir
entry.
