### PR TITLE
(#22110) remove the catalog constructor set of @version

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -239,7 +239,6 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     @resource_table = {}
     @resources = []
     @relationship_graph = nil
-    @version = 0
 
     @host_config = true
 


### PR DESCRIPTION
In the first pass of the catalog endpoint documentation,
I added a '@version = 0' to the catalog constructor, both
because it seemed (naively) good to initialize everything, and
because it allowed the first draft of the spec tests to pass.

Well, as it turns out, this has unintended consequences for
_non_ host_config use of the catalog (e.g. settings); specifically,
it causes a confusing info message like:
    Info: Applying configuration version '0'
because the 'Applying' message is suppressed if version is nil.

Also, this is no longer needed for the committed spec tests, so
just removing it.
