### PR TITLE
Pass agent environment to ENC

### DIFF
--- a/acceptance/tests/environment/pass_enc_environment.rb
+++ b/acceptance/tests/environment/pass_enc_environment.rb
@@ -1,0 +1,48 @@
+test_name "ENC is passed environment from the agent"
+
+testdir = master.tmpdir('pass_enc_env')
+
+create_remote_file master, "#{testdir}/enc.rb", <<END
+#!/usr/bin/env ruby
+
+if ARGV[1] == 'special' then
+  puts <<YAML
+parameters:
+  foobar: 'special-foobar'
+YAML
+else
+  puts <<YAML
+parameters:
+  foobar: 'default-foobar'
+YAML
+end
+END
+on master, "chmod 755 #{testdir}/enc.rb"
+
+create_remote_file master, "#{testdir}/puppet.conf", <<END
+[main]
+node_terminus = exec
+external_nodes = "#{testdir}/enc.rb"
+manifest = "#{testdir}/site.pp"
+END
+
+create_remote_file(master, "#{testdir}/site.pp", 'notify { $::foobar: }')
+
+on master, "chown -R root:puppet #{testdir}"
+on master, "chmod -R g+rwX #{testdir}"
+
+with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
+
+  agents.each do |agent|
+    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment special")
+    assert_match(/special-foobar/, stdout, "Did not find expected string special-foobar from \"special\" environment")
+  end
+
+  agents.each do |agent|
+    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment default")
+    assert_match(/default-foobar/, stdout, "Did not find expected string default-foobar from \"default\" environment")
+  end
+end
+
+on master, "rm -rf #{testdir}"
+

--- a/lib/puppet/indirector/exec.rb
+++ b/lib/puppet/indirector/exec.rb
@@ -13,8 +13,11 @@ class Puppet::Indirector::Exec < Puppet::Indirector::Terminus
     # Make sure it's fully qualified.
     raise ArgumentError, "You must set the exec parameter to a fully qualified command" unless Puppet::Util.absolute_path?(external_command[0])
 
-    # Add our name to it.
+    # Add our name (FQDN) to it.
     external_command << name
+    # Also add the (current) environment, if available
+    external_command << request.environment.name if request.respond_to?(:environment) and request.environment.respond_to?(:name)
+
     begin
       output = execute(external_command, :failonfail => true, :combine => false)
     rescue Puppet::ExecutionFailure => detail

--- a/spec/unit/indirector/exec_spec.rb
+++ b/spec/unit/indirector/exec_spec.rb
@@ -39,6 +39,22 @@ describe Puppet::Indirector::Exec do
     @searcher.find(@request)
   end
 
+  it "should execute the command with the object name and environment as the only arguments" do
+    @searcher.expects(:execute).with([path, 'foo', 'bar'], arguments)
+    GoodEnv = Struct.new(:name)
+    env = GoodEnv.new('bar')
+    request = stub 'request', :key => "foo", :environment => env
+    @searcher.find(request)
+  end
+
+  it "should execute the command with the object name and a malformed environment" do
+    @searcher.expects(:execute).with([path, 'foo'], arguments)
+    BadEnv = Struct.new(:title)
+    env = BadEnv.new('bar')
+    request = stub 'request', :key => "foo", :environment => env
+    @searcher.find(request)
+  end
+
   it "should return the output of the script" do
     @searcher.expects(:execute).with([path, 'foo'], arguments).returns("whatever")
     @searcher.find(@request).should == "whatever"


### PR DESCRIPTION
This patch passes the environment sent by the agent as a second argument
to the ENC. This will allow the ENC to operate solely on one environment
without affecting other environments. This comes in handy in setups where
a strict separation between environments is desired.
