### PR TITLE
(#22384) Log 404 and 406 responses at info

### DIFF
--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -97,7 +97,7 @@ module Puppet::Network::HTTP::Handler
   rescue SystemExit,NoMemoryError
     raise
   rescue HTTPError => e
-    return do_exception(response, e.message, e.status)
+    return do_http_control_exception(response, e)
   rescue Exception => e
     return do_exception(response, e)
   ensure
@@ -121,11 +121,7 @@ module Puppet::Network::HTTP::Handler
       status = 403 if status == 400
     end
 
-    if exception.is_a?(Exception)
-      Puppet.log_exception(exception)
-    else
-      Puppet.notice(exception.to_s)
-    end
+    Puppet.log_exception(exception)
 
     set_content_type(response, "text/plain")
     set_response(response, exception.to_s, status)
@@ -218,6 +214,13 @@ module Puppet::Network::HTTP::Handler
   end
 
   private
+
+  def do_http_control_exception(response, exception)
+    msg = exception.message
+    Puppet.info(msg)
+    set_content_type(response, "text/plain")
+    set_response(response, msg, exception.status)
+  end
 
   def report_if_deprecated(format)
     if format.name == :yaml || format.name == :b64_zlib_yaml

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -230,13 +230,13 @@ describe Puppet::Network::HTTP::Handler do
     it "should set the format to text/plain when serializing an exception" do
       handler.expects(:set_content_type).with(response, "text/plain")
 
-      handler.do_exception(response, "A test", 404)
+      handler.do_exception(response, Exception.new("A test"), 404)
     end
 
     it "sends an exception string with the given status" do
       handler.expects(:set_response).with(response, "A test", 404)
 
-      handler.do_exception(response, "A test", 404)
+      handler.do_exception(response, Exception.new("A test"), 404)
     end
 
     it "sends an exception error with the exception's status" do
@@ -245,6 +245,16 @@ describe Puppet::Network::HTTP::Handler do
 
       error = Puppet::Network::HTTP::Handler::HTTPNotFoundError.new("Could not find test_model not_found")
       handler.expects(:set_response).with(response, error.to_s, error.status)
+
+      handler.process(request, response)
+    end
+
+    it "logs an HTTP response exception at info level (most are harmless)" do
+      data = Puppet::TestModel.new("not_found", "not found")
+      error = Puppet::Network::HTTP::Handler::HTTPNotFoundError.new("Could not find test_model not_found")
+
+      request = a_request_that_finds(data, :accept_header => "pson")
+      Puppet.expects(:info).with(error.message)
 
       handler.process(request, response)
     end


### PR DESCRIPTION
When the specific exception classes for HTTP control flow were introduced,
they ended up changing the logging from info to notice. Notice is a much more
severe level, which doesn't warrant having simple file not found errors
showing up at it. This changes the level back to info.
