### PR TITLE
(#22530) Support both YAML and PSON

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -316,7 +316,11 @@ class Puppet::Transaction::Report
   end
 
   def self.supported_formats
-    [Puppet[:report_serialization_format].intern]
+    [:pson, :yaml]
+  end
+
+  def self.default_format
+    Puppet[:report_serialization_format].intern
   end
 
   private

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -376,7 +376,11 @@ describe Puppet::Transaction::Report do
   end
 
   it "defaults to serializing to pson" do
-    expect(Puppet::Transaction::Report.supported_formats).to eq([:pson])
+    expect(Puppet::Transaction::Report.default_format).to eq(:pson)
+  end
+
+  it "supports both yaml and pson" do
+    expect(Puppet::Transaction::Report.supported_formats).to eq([:pson, :yaml])
   end
 
   it "can make a round trip through pson" do


### PR DESCRIPTION
The problem with the previous version of this code was that it only allowed
the report to support exactly what the user had selected. This is alright
(for the most part) for the agent, but is incorrect for the master since the
master needs to understand both formats at once. The remedy this the
default_format is now selected based on the report_serialization_format
setting whereas the supported_formats are always both PSON and YAML.
