### PR TITLE
(#4424) Add umask parameter to Exec type

### DIFF
--- a/lib/puppet/provider/exec/posix.rb
+++ b/lib/puppet/provider/exec/posix.rb
@@ -1,6 +1,7 @@
 require 'puppet/provider/exec'
 
 Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
+  has_feature :umask
   confine :feature => :posix
   defaultfor :feature => :posix
 
@@ -35,5 +36,13 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
     # 'which' will only return the command if it's executable, so we can't
     # distinguish not found from not executable
     raise ArgumentError, "Could not find command '#{exe}'"
+  end
+
+  def run(command, check = false)
+    if resource[:umask]
+      Puppet::Util::withumask(resource[:umask]) { super(command, check) }
+    else
+      super(command, check)
+    end
   end
 end

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -220,6 +220,18 @@ module Puppet
       end
     end
 
+    newparam(:umask, :required_feature => :umask) do
+      desc "Sets the umask to be used while executing this command"
+
+      munge do |value|
+        if value =~ /^0?[0-7]{1,4}$/
+          return value.to_i(8)
+        else
+          raise Puppet::Error, "The umask specification is invalid: #{value.inspect}"
+        end
+      end
+    end
+
     newparam(:timeout) do
       desc "The maximum time the command should take.  If the command takes
         longer than the timeout, the command is considered to have failed

--- a/spec/unit/provider/exec/posix_spec.rb
+++ b/spec/unit/provider/exec/posix_spec.rb
@@ -115,6 +115,11 @@ describe Puppet::Type.type(:exec).provider(:posix) do
       @logs.map {|l| "#{l.level}: #{l.message}" }.should == ["warning: Overriding environment setting 'WHATEVER' with '/foo'"]
     end
 
+    it "should set umask before execution if umask parameter is in use" do
+      provider.resource[:umask] = '0027'
+      Puppet::Util.expects(:withumask).with(0027)
+      provider.run(provider.resource[:command])
+    end
 
     describe "posix locale settings", :unless => Puppet.features.microsoft_windows? do
       # a sentinel value that we can use to emulate what locale environment variables might be set to on an international

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -753,4 +753,11 @@ describe Puppet::Type.type(:exec) do
       type.new(:command => abs, :path => path).must be
     end
   end
+  describe "when providing a umask" do
+    it "should fail if an invalid umask is used" do
+      resource = Puppet::Type.type(:exec).new :command => "/bin/true"
+      expect { resource[:umask] = '0028'}.to raise_error(Puppet::ResourceError, /umask specification is invalid/)
+      expect { resource[:umask] = '28' }.to raise_error(Puppet::ResourceError, /umask specification is invalid/)
+    end
+  end
 end


### PR DESCRIPTION
Setting a umask value for execs can be useful when the exec creates files or directories.  Relying on the sytem umask can produce unexpected results as it may be different from system to system or just not what the user intends.
