### PR TITLE
Add execenv node_terminus

### DIFF
--- a/acceptance/tests/environment/pass_enc_environment.rb
+++ b/acceptance/tests/environment/pass_enc_environment.rb
@@ -1,0 +1,48 @@
+test_name "ENC is passed environment from the agent"
+
+testdir = master.tmpdir('pass_enc_env')
+
+create_remote_file master, "#{testdir}/enc.rb", <<END
+#!/usr/bin/env ruby
+
+if ARGV[1] == 'special' then
+  puts <<YAML
+parameters:
+  foobar: 'special-foobar'
+YAML
+else
+  puts <<YAML
+parameters:
+  foobar: 'default-foobar'
+YAML
+end
+END
+on master, "chmod 755 #{testdir}/enc.rb"
+
+create_remote_file master, "#{testdir}/puppet.conf", <<END
+[main]
+node_terminus = execenv
+external_nodes = "#{testdir}/enc.rb"
+manifest = "#{testdir}/site.pp"
+END
+
+create_remote_file(master, "#{testdir}/site.pp", 'notify { $::foobar: }')
+
+on master, "chown -R root:puppet #{testdir}"
+on master, "chmod -R g+rwX #{testdir}"
+
+with_master_running_on(master, "--config #{testdir}/puppet.conf --daemonize --dns_alt_names=\"puppet,$(facter hostname),$(facter fqdn)\" --autosign true") do
+
+  agents.each do |agent|
+    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment special")
+    assert_match(/special-foobar/, stdout, "Did not find expected string special-foobar from \"special\" environment")
+  end
+
+  agents.each do |agent|
+    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment default")
+    assert_match(/default-foobar/, stdout, "Did not find expected string default-foobar from \"default\" environment")
+  end
+end
+
+on master, "rm -rf #{testdir}"
+

--- a/lib/puppet/indirector/execenv.rb
+++ b/lib/puppet/indirector/execenv.rb
@@ -1,0 +1,44 @@
+require 'puppet/indirector/terminus'
+require 'puppet/util'
+
+class Puppet::Indirector::Execenv < Puppet::Indirector::Terminus
+  # Look for external node definitions.
+  def find(request)
+    name = request.key
+    external_command = command
+
+    # Make sure it's an array
+    raise Puppet::DevError, "Exec commands must be an array" unless external_command.is_a?(Array)
+
+    # Make sure it's fully qualified.
+    raise ArgumentError, "You must set the exec parameter to a fully qualified command" unless Puppet::Util.absolute_path?(external_command[0])
+
+    # Add our name (FQDN) to the command
+    command << request.key
+
+    # Add the agent environment to the command
+    command << request.environment.name
+
+    begin
+      output = execute(external_command, :failonfail => true, :combine => false)
+    rescue Puppet::ExecutionFailure => detail
+      raise Puppet::Error, "Failed to find #{name} via exec: #{detail}"
+    end
+
+    if output =~ /\A\s*\Z/ # all whitespace
+      Puppet.debug "Empty response for #{name} from #{self.name} terminus"
+      return nil
+    else
+      return output
+    end
+  end
+
+  private
+
+  # Proxy the execution, so it's easier to test.
+  def execute(command, arguments)
+    Puppet::Util::Execution.execute(command,arguments)
+  end
+
+end
+

--- a/spec/unit/indirector/execenv_spec.rb
+++ b/spec/unit/indirector/execenv_spec.rb
@@ -1,0 +1,61 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/indirector/execenv'
+
+describe Puppet::Indirector::Execenv do
+  before :all do
+    @indirection = stub 'indirection', :name => :testing
+    Puppet::Indirector::Indirection.expects(:instance).with(:testing).returns(@indirection)
+    module Testing; end
+    @exec_class = class Testing::MyExecenv < Puppet::Indirector::Execenv
+      attr_accessor :command
+      self
+    end
+  end
+
+  let(:path) { File.expand_path('/echo') }
+  let(:arguments) { {:failonfail => true, :combine => false } }
+
+  before :each do
+    @searcher = @exec_class.new
+    @searcher.command = [path]
+
+    environment = stub 'environment', :name => "bar"
+    @request = stub 'request', :key => "foo", :environment => environment
+  end
+
+  it "should throw an exception if the command is not an array" do
+    @searcher.command = path
+    proc { @searcher.find(@request) }.should raise_error(Puppet::DevError)
+  end
+
+  it "should throw an exception if the command is not fully qualified" do
+    @searcher.command = ["mycommand"]
+    proc { @searcher.find(@request) }.should raise_error(ArgumentError)
+  end
+
+  it "should execute the command with the object name and environment as the only arguments" do
+    @searcher.expects(:execute).with([path, 'foo', 'bar'], arguments)
+    @searcher.find(@request)
+  end
+
+  it "should return the output of the script" do
+    @searcher.expects(:execute).with([path, 'foo', 'bar'], arguments).returns("whatever")
+    @searcher.find(@request).should == "whatever"
+  end
+
+  it "should return nil when the command produces no output" do
+    @searcher.expects(:execute).with([path, 'foo', 'bar'], arguments).returns(nil)
+    @searcher.find(@request).should be_nil
+  end
+
+  it "should raise an exception if there's an execution failure" do
+    @searcher.expects(:execute).with([path, 'foo', 'bar'], arguments).raises(Puppet::ExecutionFailure.new("message"))
+    expect {
+      @searcher.find(@request)
+    }.to raise_exception(Puppet::Error, 'Failed to find foo via exec: message')
+  end
+
+end
+


### PR DESCRIPTION
This commit introduces a new node_terminus execenv which will pass
the environment to the ENC along with the FQDN. This will help in
setups where a strict separation of environments is necessary.

As suggested in PR#1893 this is an alternate approach.

Only one of both should be merged,
but I think this is an addition worth being merged upstream.
