### PR TITLE
(#22604) Ohai facts terminus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ group(:development, :test) do
     gem "json-schema", "2.1.1", :require => false
   end
 
+  # For running the tests for the ohai facts terminus
+  gem "ohai"
 end
 
 group(:extra) do

--- a/lib/puppet/indirector/facts/ohai.rb
+++ b/lib/puppet/indirector/facts/ohai.rb
@@ -1,0 +1,20 @@
+require 'puppet/node/facts'
+require 'puppet/indirector/code'
+require 'ohai'
+
+class Puppet::Node::Facts::Ohai < Puppet::Indirector::Code
+  desc "Retrieve facts from Ohai.  This provides a somewhat abstract interface
+    between Puppet and Ohai.  It's only `somewhat` abstract because it always
+    returns the local host's facts, regardless of what you attempt to find."
+
+  # Look a host's facts up in Ohai.
+  def find(request)
+    ohai = Ohai::System.new
+    ohai.all_plugins
+    result = Puppet::Node::Facts.new(request.key, ohai.data)
+
+    result.add_local_facts
+
+    result
+  end
+end

--- a/spec/unit/indirector/facts/ohai_spec.rb
+++ b/spec/unit/indirector/facts/ohai_spec.rb
@@ -1,0 +1,49 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/indirector/facts/ohai'
+
+describe Puppet::Node::Facts::Ohai do
+  it "should be a subclass of the Code terminus" do
+    Puppet::Node::Facts::Ohai.superclass.should equal(Puppet::Indirector::Code)
+  end
+
+  it "should have documentation" do
+    Puppet::Node::Facts::Ohai.doc.should_not be_nil
+  end
+
+  it "should be registered with the configuration store indirection" do
+    indirection = Puppet::Indirector::Indirection.instance(:facts)
+    Puppet::Node::Facts::Ohai.indirection.should equal(indirection)
+  end
+
+  it "should have its name set to :ohai" do
+    Puppet::Node::Facts::Ohai.name.should == :ohai
+  end
+end
+
+describe Puppet::Node::Facts::Ohai do
+  before :each do
+    @ohai = Puppet::Node::Facts::Ohai.new
+    @name = "me"
+    @request = stub 'request', :key => @name
+  end
+
+  describe Puppet::Node::Facts::Ohai, " when finding facts" do
+    it "should return a Facts instance" do
+      @ohai.find(@request).should be_instance_of(Puppet::Node::Facts)
+    end
+
+    it "should return a Facts instance with the provided key as the name" do
+      @ohai.find(@request).name.should == @name
+    end
+
+    it "should add local facts" do
+      facts = Puppet::Node::Facts.new("foo")
+      Puppet::Node::Facts.expects(:new).returns facts
+      facts.expects(:add_local_facts)
+
+      @ohai.find(@request)
+    end
+  end
+end


### PR DESCRIPTION
Ohai supports a lot of stuff Facter doesn't. This patch adds support for
fetching facts from ohai instead.
