### PR TITLE
Added missing newline in sendmail usage to tagmail

### DIFF
--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -158,7 +158,7 @@ Puppet::Reports.register_report(:tagmail) do
               p.puts "From: #{Puppet[:reportfrom]}"
               p.puts "Subject: Puppet Report for #{self.host}"
               p.puts "To: " + emails.join(", ")
-
+              p.puts
               p.puts messages
             end
           end


### PR DESCRIPTION
Sendmail usage lacked a blank line after "To:" field. Which sometimes caused blank emails being sent.
