### PR TITLE
(maint) Fixing build error on windows caused by command with unix path

### DIFF
--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -755,7 +755,7 @@ describe Puppet::Type.type(:exec) do
   end
   describe "when providing a umask" do
     it "should fail if an invalid umask is used" do
-      resource = Puppet::Type.type(:exec).new :command => "/bin/true"
+      resource = Puppet::Type.type(:exec).new :command => @command
       expect { resource[:umask] = '0028'}.to raise_error(Puppet::ResourceError, /umask specification is invalid/)
       expect { resource[:umask] = '28' }.to raise_error(Puppet::ResourceError, /umask specification is invalid/)
     end


### PR DESCRIPTION
I believe this will fix the windows compatibility error of this spec since @command calls the make_absolute which prepends c for windows.

I don't have a windows server to test on though.  specs still pass on linux with this.
