### PR TITLE
(#22608) Accept pson file backups

### DIFF
--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -14,12 +14,16 @@ class Puppet::FileBucket::File
   attr :bucket_path
 
   def self.supported_formats
+    [:s, :pson]
+  end
+
+  def self.default_format
     # This should really be :raw, like is done for Puppet::FileServing::Content
     # but this class hasn't historically supported `from_raw`, so switching
     # would break compatibility between newer 3.x agents talking to older 3.x
     # masters. However, to/from_s has been supported and achieves the desired
     # result without breaking compatibility.
-    [:s]
+    :s
   end
 
   def initialize(contents, options = {})
@@ -52,6 +56,11 @@ class Puppet::FileBucket::File
 
   def self.from_s(contents)
     self.new(contents)
+  end
+
+  def to_pson
+    Puppet.deprecation_warning("Serializing Puppet::FileBucket::File objects to pson is deprecated.")
+    { "contents" => contents }.to_pson
   end
 
   # This method is deprecated, but cannot be removed for awhile, otherwise


### PR DESCRIPTION
Commit 769dcdf for #22375 removed the ability for newer masters to accept pson encoded file backups from older agents.

This commit ensures that masters can deserialize `s` or `pson` encoded file backups, while agents will serialize using `s` by default.
