### PR TITLE
(#7911) Fixed exception when using forcelocal param

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -160,7 +160,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     else
       cmd = [command(:add)]
     end
-    if not @resource.should(gid) and Puppet::Util.gid(@resource[:name])
+    if not @resource.should(:gid) and Puppet::Util.gid(@resource[:name])
       cmd += ["-g", @resource[:name]]
     end
     cmd += add_properties


### PR DESCRIPTION
When the user resources had forcelocal set to true the provider would throw the error "undefined method `intern'".  This was because the gid method was being passed to a should call rather than a symbol.  Arguments passed to should need to be symbols.
