### PR TITLE
(#22574) Add defaults and other features to the lookup function.

### DIFF
--- a/lib/puppet/parser/functions/lookup.rb
+++ b/lib/puppet/parser/functions/lookup.rb
@@ -1,44 +1,279 @@
 Puppet::Parser::Functions.newfunction(:lookup, :type => :rvalue, :arity => -2, :doc => <<-'ENDHEREDOC') do |args|
 Looks up data defined using Puppet Bindings.
-The function is callable with one or two arguments and optionally with a lambda to process the result.
-The second argument can be a type specification; a String that describes the type of the produced result.
-If a value is found, an assert is made that the value is compliant with the specified type.
+The function is callable with one to  three arguments and optionally with a code block to further process the result.
 
-When called with one argument; the name:
+The lookup function can be called in one of these ways:
 
-    lookup('the_name')
+    lookup(name)
+    lookup(name, type)
+    lookup(name, type, default)
+    lookup(options_hash)
+    lookup(name, options_hash)
 
-When called with two arguments; the name, and the expected type:
+The function may optionally be called with a code block / lambda with the following signatures:
 
-    lookup('the_name', 'String')
+    lookup(...) |$result| { ... }
+    lookup(...) |$name, $result| { ... }
+    lookup(...) |$name, $result, $default| { ... }
 
-Using a lambda to process the looked up result.
+The longer signatures are useful when the block needs to raise an error (it can report the name), or
+if it needs to know if the given default value was selected.
+The `$name` is the last name that was looked up.
+The `$result` is the looked up value (or the default value if not found). 
+The `$default` is the given default value (`undef` if not given).
 
-    lookup('the_name') |$result| { if $result == undef { 'Jane Doe' } else { $result }}
+The block, if present, is called with the result from the lookup. The value produced by the block is also what is produced by the `lookup` function.
+When a block is used, it is the users responsibility to call `error` if the result does not meet additional criteria, or if an undef value is not acceptable. If a value
+is not found, and a default has been specified, the default value is given to the block.
+
+The content of the options hash is:
+
+* `name` - The name to lookup.args. (Mutually exclusive with `first_found`)
+* `type` - The type to assert (a type specification in string form)
+* `default` - The default value if there was no value found (must comply with the data type)
+* `first_found` - An array of names to search, the value of the first found is used. (Mutually 
+  exclusive with `name`).
+* `accept_undef` - (default `false`) An `undef` result is accepted if this options is set to `true`.
+
+When the call is on the form `lookup(name, options_hash)`, the given name argument wins over the
+`options_hash['name']`.
 
 The type specification is one of:
 
-* the basic types; 'Integer', 'String', 'Float', 'Boolean', or 'Pattern' (regular expression)
-* an Array with an optional element type given in '[]', that when not given defaults to '[Data]'
-* a Hash with optional key and value types given in '[]', where key type defaults to 'Literal' and value to 'Data', if
-  only one type is given, the key defaults to 'Literal'
-* the abstract type 'Literal' which is one of the basic types
-* the abstract type 'Data' which is 'Literal', or type compatible with Array[Data], or Hash[Literal, Data]
-* the abstract type 'Collection' which is Array or Hash of any element type.
-* the abstract type 'Object' which is any kind of type
+  * The basic types; 'Integer', 'String', 'Float', 'Boolean', or 'Pattern' (regular expression)
+  * An Array with an optional element type given in '[]', that when not given defaults to '[Data]'
+  * A Hash with optional key and value types given in '[]', where key type defaults to 'Literal' and value to 'Data', if
+    only one type is given, the key defaults to 'Literal'
+  * The abstract type 'Literal' which is one of the basic types
+  * The abstract type 'Data' which is 'Literal', or type compatible with Array[Data], or Hash[Literal, Data]
+  * The abstract type 'Collection' which is Array or Hash of any element type.
+  * The abstract type 'Object' which is any kind of type
+
+If the function is called without specifying a default value, and nothing is bound to the given name 
+an error is raised unless the option `accept_undef` is true. If a block is given it must produce an acceptable value (or call `error`). If the block does not produce an acceptable value an error is
+raised.
+
+Examples:
+
+When called with one argument; the name, it
+returns the bound value with the given name after having  asserted it has the default datatype 'Data':
+
+    lookup('the_name')
+
+When called with two arguments; the name, and the expected type, it
+returns the the bound value with the given name after having asserted it has the given data
+type ('String' in the example):
+
+    lookup('the_name', 'String')
+
+When called with three arguments, the name, the expected type, and a default, it
+returns the the bound value with the given name, or the default after having asserted the value
+has the given data type ('String' in the example):
+
+    lookup('the_name', 'String', 'Fred')
+
+Using a lambda to process the looked up result - asserting that it starts with an upper case letter:
+
+    lookup('the_name') |$result| {
+      unless $result =~ /^[A-Z].*/
+        { error 'Must start with an upper case letter'}
+      $result
+    }
+
+Including the name in the error
+
+    lookup('the_name') |$name, $result| {
+      unless $result =~ /^[A-Z].*/
+        { error "The bound value for '${name}' must start with an upper case letter"}
+      $result
+    }
+
+When using a block, the value it produces is also asserted against the given type, and it may not be 
+`undef` unless the option `'accept_undef'` is `true`.
+
+All options work as the corresponding (direct) argument. The `first_found` option and
+`accept_undef` are however only available as options.
+
+Using the `first_found` option to return the first name that has a bound value:
+
+    lookup({ first_found => ['apache::port', 'nginx::port'], type => 'Integer', default => 80})
+
+Including the name in the error:
+
+    lookup({ first_found => ['apache::port', 'nginx::port'], type => 'Integer', default => 80}) |$name, $result| {
+      unless $result >= 80 and $result < 10000 {
+        error("The bound value for '${name}' must be between 80 and 9999")
+      }
+      $result
+    }
+
+If you want to make lookup return undef when no value was found instead of raising an error:
+
+      $are_you_there = lookup('peekaboo', { accept_undef => true} )
+      $are_you_there = lookup('peekaboo', { accept_undef => true}) |$result| { $result }
 
 ENDHEREDOC
 
   unless Puppet[:binder] || Puppet[:parser] == 'future'
     raise Puppet::ParseError, "The lookup function is only available with settings --binder true, or --parser future" 
   end
-  type_parser = Puppet::Pops::Types::TypeParser.new
-  pblock    = args[-1] if args[-1].is_a?(Puppet::Parser::AST::Lambda)
-  type_name = args[1] unless args[1].is_a?(Puppet::Parser::AST::Lambda)
-  type = type_parser.parse( type_name || "Data")
-  result = compiler.injector.lookup(self, type, args[0])
-  if pblock
-    result = pblock.call(self, result.nil? ? :undef : result)
+
+  def parse_lookup_args(args)
+    options = {}
+    pblock = if args[-1].is_a?(Puppet::Parser::AST::Lambda)
+      args.pop
+    end
+
+    case args.size
+    when 1
+      # name, or all options
+      if args[ 0 ].is_a?(Hash)
+        options = to_symbolic_hash(args[ 0 ])
+      else
+        options[ :name ] = args[ 0 ]
+      end
+
+    when 2
+      # name and type, or name and options
+      if args[ 1 ].is_a?(Hash)
+        options = to_symbolic_hash(args[ 1 ])
+        options[:name] = args[ 0 ] # silently overwrite option with given name
+      else
+        options[:name] = args[ 0 ]
+        options[:type] = args[ 1 ]
+      end
+
+    when 3
+      # name, type, default (no options)
+      options[ :name ] = args[ 0 ]
+      options[ :type ] = args[ 1 ]
+      options[ :default ] = args[ 2 ]
+    else
+      raise Puppet::PareError, "The lookup function accepts 1-3 arguments, got #{args.size}"
+    end
+    options[:pblock] = pblock
+    options
   end
-  result.nil? ? :undef : result
+
+  def to_symbolic_hash(input)
+    names = [:name, :type, :first_found, :default, :accept_undef]
+    options = {}
+    names.each {|n| options[n] = undef_as_nil(input[n.to_s] || input[n]) }
+    options
+  end
+
+  def type_mismatch(type_calculator, expected, got)
+    "has wrong type, expected #{type_calculator.string(expected)}, got #{type_calculator.string(got)}"
+  end
+
+  def fail(msg)
+    raise Puppet::ParseError, "Function lookup() " + msg
+  end
+
+  def fail_lookup(names)
+    name_part = if names.size == 1
+      "the name '#{names[0]}'"
+    else 
+      "any of the names ['" + names.join(', ') + "']"
+    end
+    fail("did not find a value for #{name_part}")
+  end
+
+  def validate_options(options, type_calculator)
+    type_parser = Puppet::Pops::Types::TypeParser.new
+    first_found_type = type_parser.parse('Array[String]')
+
+    if options[:name].nil? && options[:first_found].nil?
+      fail ("requires a name, or sequence of names in first_found. Neither was given.")
+    end
+
+    if options[:name] && options[:first_found]
+      fail("requires either a single name, or a sequence of names in first_found. Both were specified.")
+    end
+
+    if options[:name] && ! options[:name].is_a?(String)
+      t = type_calculator.infer(options[:name])
+      fail("name, expected String, got #{type_calculator.string(t)}")
+    end
+
+    if options[:first_found]
+      t = type_calculator.infer(options[:first_found])
+      if !type_calculator.assignable?(first_found_type, t)
+        fail("first_found #{type_mismatch(type_calculator, first_found_type, t)}")
+      end
+    end
+
+    # parse the type (or default 'Data'), fails if invalid type is given
+    options[:type] = type_parser.parse(options[:type] || 'Data')
+
+    # default value must comply with the given type
+    if options[:default]
+      t = type_calculator.infer(options[:default])
+      if ! type_calculator.assignable?(options[:type], t)
+        fail("default value #{type_mismatch(type_calculator, options[:type], t)}")
+      end
+    end
+  end
+
+  def nil_as_undef(x)
+    x.nil? ? :undef : x
+  end
+
+  def undef_as_nil(x)
+    is_nil_or_undef?(x) ? nil : x
+  end
+
+  def is_nil_or_undef?(x)
+    x.nil? || x == :undef
+  end
+
+  # THE FUNCTION STARTS HERE
+
+  type_calculator = Puppet::Pops::Types::TypeCalculator.new
+  options = parse_lookup_args(args)
+  validate_options(options, type_calculator)
+  names = options[:name] ? [options[:name]] : options[:first_found]
+  type = options[:type]
+
+  result_with_name = names.reduce([]) do |memo, name|
+    break memo if !memo[1].nil?
+    [name, compiler.injector.lookup(self, type, name)]
+  end
+
+  result = if result_with_name[1].nil?
+    # not found, use default (which may be nil), the default is already type checked
+    options[:default]
+  else
+    # injector.lookup is type-safe already do no need to type check the result
+    result_with_name[1]
+  end
+
+  result = if pblock = options[:pblock]
+    result2 = case pblock.parameter_count
+    when 1
+      pblock.call(self, nil_as_undef(result))
+    when 2
+      pblock.call(self, result_with_name[ 0 ], nil_as_undef(result))
+    else
+      pblock.call(self, result_with_name[ 0 ], nil_as_undef(result), nil_as_undef(options[ :default ]))
+    end
+
+    # if the given result was returned, there is not need to type-check it again
+    if !result2.equal?(result)
+      t = type_calculator.infer(undef_as_nil(result2))
+      if !type_calculator.assignable?(type, t)
+        fail "the value produced by the given code block #{type_mismatch(type_calculator, type, t)}"
+      end
+    end
+    result2
+  else
+    result
+  end
+
+  # Finally, the result if nil must be acceptable or an error is raised
+  if is_nil_or_undef?(result) && !options[:accept_undef]
+    fail_lookup(names)
+  else
+    nil_as_undef(result)
+  end
 end

--- a/spec/unit/parser/functions/lookup_spec.rb
+++ b/spec/unit/parser/functions/lookup_spec.rb
@@ -17,19 +17,33 @@ describe "lookup function" do
 
   it "looks up a value that exists" do
     scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
-
     expect(scope.function_lookup(['a_value'])).to eq('something')
   end
 
-  it "returns :undef when the requested value is not bound" do
+  it "returns :undef when the requested value is not bound and undef is accepted" do
     scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
+    expect(scope.function_lookup(['not_bound_value',{'accept_undef' => true}])).to eq(:undef)
+  end
 
-    expect(scope.function_lookup(['not_bound_value'])).to eq(:undef)
+  it "fails if the requested value is not bound and undef is not allowed" do
+    scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
+    expect do
+      scope.function_lookup(['not_bound_value'])
+    end.to raise_error(/did not find a value for the name 'not_bound_value'/)
+  end
+
+  it "returns the given default value when the requested value is not bound" do
+    scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
+    expect(scope.function_lookup(['not_bound_value','String', 'cigar'])).to eq('cigar')
+  end
+
+  it "accepts values given in a hash of options" do
+    scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
+    expect(scope.function_lookup(['not_bound_value',{'type' => 'String', 'default' => 'cigar'}])).to eq('cigar')
   end
 
   it "raises an error when the bound type is not assignable to the requested type" do
     scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
-
     expect do
       scope.function_lookup(['a_value', 'Integer'])
     end.to raise_error(ArgumentError, /incompatible type, expected: Integer, got: String/)
@@ -39,25 +53,39 @@ describe "lookup function" do
     typed_bindings = bindings
     typed_bindings.bind().string().name("a_value").to("something")
     scope = scope_with_injections_from(bound(typed_bindings))
-
     expect(scope.function_lookup(['a_value', 'Data'])).to eq("something")
   end
 
   it "yields to a given lambda and returns the result" do
     scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
-
     expect(scope.function_lookup(['a_value', ast_lambda('|$x|{something_else}')])).to eq('something_else')
+  end
+
+  it "fails if given lambda produces undef" do
+    scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
+    expect do
+      scope.function_lookup(['a_value', ast_lambda('|$x|{undef}')])
+    end.to raise_error(/did not find a value for the name 'a_value'/)
+  end
+
+  it "yields name and result to a given lambda" do
+    scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
+    expect(scope.function_lookup(['a_value', ast_lambda('|$name, $result|{[$name, $result]}')])).to eq(['a_value', 'something'])
+  end
+
+  it "yields name and result and default to a given lambda" do
+    scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
+    expect(scope.function_lookup(['a_value', {'default' => 'cigar'}, 
+      ast_lambda('|$name, $result, $d|{[$name, $result, $d]}')])).to eq(['a_value', 'something', 'cigar'])
   end
 
   it "yields to a given lambda and returns the result when giving name and type" do
     scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
-
     expect(scope.function_lookup(['a_value', 'String', ast_lambda('|$x|{something_else}')])).to eq('something_else')
   end
 
   it "yields :undef when value is not found and using a lambda" do
     scope = scope_with_injections_from(bound(bind_single("a_value", "something")))
-
     expect(scope.function_lookup(['not_bound_value', ast_lambda('|$x|{ if $x == undef {good} else {bad}}')])).to eq('good')
   end
 
@@ -65,7 +93,6 @@ describe "lookup function" do
     injector = Puppet::Pops::Binder::Injector.new(binder)
     scope = Puppet::Parser::Scope.new_for_test_harness('testing')
     scope.compiler.injector = injector
-
     scope
   end
 
@@ -83,7 +110,6 @@ describe "lookup function" do
     binder = Puppet::Pops::Binder::Binder.new
     binder.define_categories(Puppet::Pops::Binder::BindingsFactory.categories([]))
     binder.define_layers(Puppet::Pops::Binder::BindingsFactory.layered_bindings(Puppet::Pops::Binder::BindingsFactory.named_layer('test layer', local_bindings.model)))
-
     binder
   end
 


### PR DESCRIPTION
The lookup function can be called in one of these ways:

```
lookup(name)
lookup(name, type)
lookup(name, type, default)
lookup(options_hash)
lookup(name, options_hash)
```

The function may optionally be called with a code block / lambda with
the following signatures:

```
lookup(...) |$result| { ... }
lookup(...) |$name, $result| { ... }
lookup(...) |$name, $result, $default| { ... }
```

The longer signatures are useful when the block needs to raise an error
(it can report the name), or
if it needs to know if the given default value was selected.
The `$name` is the last name that was looked up.
The `$result` is the looked up value (or the default value if not
found). 
The `$default` is the given default value (`undef` if not given).

The block, if present, is called with the result from the lookup. The
value produced by the block is also what is produced by the `lookup`
function.
When a block is used, it is the users responsibility to call `error` if
the result does not meet additional criteria, or if an undef value is
not acceptable. If a value
is not found, and a default has been specified, the default value is
given to the block.

The content of the options hash is:
- `name` - The name to lookup.args. (Mutually exclusive with
  `first_found`)
- `type` - The type to assert (a type specification in string form)
- `default` - The default value if there was no value found (must comply
  with the data type)
- `first_found` - An array of names to search, the value of the first
  found is used. (Mutually 
  exclusive with `name`).
- `accept_undef` - (default `false`) An `undef` result is accepted if
  this options is set to `true`.

When the call is on the form `lookup(name, options_hash)`, the given
name argument wins over the
`options_hash['name']`.

The type specification is one of:
- The basic types; 'Integer', 'String', 'Float', 'Boolean', or
  'Pattern' (regular expression)
- An Array with an optional element type given in '[]', that when not
  given defaults to '[Data]'
- A Hash with optional key and value types given in '[]', where key
  type defaults to 'Literal' and value to 'Data', if
  only one type is given, the key defaults to 'Literal'
- The abstract type 'Literal' which is one of the basic types
- The abstract type 'Data' which is 'Literal', or type compatible with
  Array[Data], or Hash[Literal, Data]
- The abstract type 'Collection' which is Array or Hash of any element
  type.
- The abstract type 'Object' which is any kind of type

If the function is called without specifying a default value, and
nothing is bound to the given name 
an error is raised unless the option `accept_undef` is true. If a block
is given it must produce an acceptable value (or call `error`). If the
block does not produce an acceptable value an error is
raised.
