### PR TITLE
(#22665) mounts should autorequire parent mounts

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -268,5 +268,15 @@ module Puppet
         return property.value
       end
     end
+
+    # Ensure that mounts higher up in the filesystem are mounted first
+    autorequire(:mount) do
+      dependencies = []
+      Pathname.new(@parameters[:name].value).ascend do |parent|
+        dependencies.unshift parent.to_s
+      end
+      dependencies[0..-2]
+    end
+
   end
 end

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -536,4 +536,57 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
       run_in_catalog(resource)
     end
   end
+
+  describe "establishing autorequires" do
+
+    def create_resource(path)
+      described_class.new(
+        :name => path,
+        :provider => providerclass.new(path)
+      )
+    end
+
+    def create_catalog(*resources)
+      catalog = Puppet::Resource::Catalog.new
+      resources.each do |resource|
+        catalog.add_resource resource
+      end
+
+      catalog
+    end
+
+    let(:root_mount) { create_resource("/") }
+    let(:var_mount)  { create_resource("/var") }
+    let(:log_mount)  { create_resource("/var/log") }
+
+    before do
+      create_catalog(root_mount, var_mount, log_mount)
+    end
+
+    it "adds no autorequires for the root mount" do
+      expect(root_mount.autorequire).to be_empty
+    end
+
+    it "adds the parent autorequire for a mount with one parent" do
+      parent_relationship = var_mount.autorequire[0]
+
+      expect(var_mount.autorequire).to have_exactly(1).item
+
+      expect(parent_relationship.source).to eq root_mount
+      expect(parent_relationship.target).to eq var_mount
+    end
+
+    it "adds both parent autorequires for a mount with two parents" do
+      grandparent_relationship = log_mount.autorequire[0]
+      parent_relationship = log_mount.autorequire[1]
+
+      expect(log_mount.autorequire).to have_exactly(2).items
+
+      expect(grandparent_relationship.source).to eq root_mount
+      expect(grandparent_relationship.target).to eq log_mount
+
+      expect(parent_relationship.source).to eq var_mount
+      expect(parent_relationship.target).to eq log_mount
+    end
+  end
 end


### PR DESCRIPTION
Given two mount points:

```
mount { "/var/log":
  # ...
}

mount { "/var":
  # ...
}
```

The mount '/var/log' should autorequire '/var' so that the child mount
is not masked by the parent mount.
