### PR TITLE
(#22652) Parse query strings in rack w/o rack

### DIFF
--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -1,4 +1,5 @@
 require 'openssl'
+require 'cgi'
 require 'puppet/network/http/handler'
 require 'puppet/network/http/rack/httphandler'
 require 'puppet/util/ssl'
@@ -73,7 +74,9 @@ class Puppet::Network::HTTP::RackREST < Puppet::Network::HTTP::RackHttpHandler
 
   # Return the query params for this request.
   def params(request)
-    result = decode_params(request.params)
+    params = CGI.parse(request.query_string)
+    convert_singular_arrays_to_value(params)
+    result = decode_params(params)
     result.merge(extract_client_info(request))
   end
 
@@ -125,4 +128,11 @@ class Puppet::Network::HTTP::RackREST < Puppet::Network::HTTP::RackHttpHandler
     result
   end
 
+  def convert_singular_arrays_to_value(hash)
+    hash.each do |key, value|
+      if value.size == 1
+        hash[key] = value.first
+      end
+    end
+  end
 end

--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -148,6 +148,12 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
         result[:bar].should == "xyzzy"
       end
 
+      it "should return multi-values params as an array of the values" do
+        req = mk_req('/?foo=baz&foo=xyzzy')
+        result = @handler.params(req)
+        result[:foo].should == ["baz", "xyzzy"]
+      end
+
       it "should CGI-decode the HTTP parameters" do
         encoding = CGI.escape("foo bar")
         req = mk_req("/?foo=#{encoding}")


### PR DESCRIPTION
Rack does not actually support parsing multiple valued query strings into an
array of values (see https://github.com/rack/rack/pull/519). This is not
going to be supported before rack 2.0, but we need this behavior in order to
not have to deal with YAML query parameters.

This changes the rack based query parameter parsing to use CGI.parse instead
of the built in rack semantics (which also has a large number of other
semantics, which we weren't using). As a note, it does not appear that the
behavior of rack's query parameter parsing is documented anywhere.
