### PR TITLE
(maint) reduce duplication of logdest option handling

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -390,6 +390,15 @@ class Application
     Puppet::Util::Log.setup_default unless options[:setdest]
   end
 
+  def handle_logdest_arg(arg)
+    begin
+      Puppet::Util::Log.newdestination(arg)
+      options[:setdest] = true
+    rescue => detail
+      Puppet.log_exception(detail)
+    end
+  end
+
   def configure_indirector_routes
     route_file = Puppet[:route_file]
     if ::File.exists?(route_file)

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -67,12 +67,7 @@ class Puppet::Application::Agent < Puppet::Application
   end
 
   option("--logdest DEST", "-l DEST") do |arg|
-    begin
-      Puppet::Util::Log.newdestination(arg)
-      options[:setdest] = true
-    rescue => detail
-      Puppet.log_exception(detail)
-    end
+    handle_logdest_arg(arg)
   end
 
   option("--waitforcert WAITFORCERT", "-w") do |arg|

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -19,12 +19,7 @@ class Puppet::Application::Apply < Puppet::Application
   end
 
   option("--logdest LOGDEST", "-l") do |arg|
-    begin
-      Puppet::Util::Log.newdestination(arg)
-      options[:logset] = true
-    rescue => detail
-      $stderr.puts detail.to_s
-    end
+    handle_logdest_arg(arg)
   end
 
   option("--parseonly") do |args|
@@ -238,7 +233,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def setup
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
-    Puppet::Util::Log.newdestination(:console) unless options[:logset]
+    Puppet::Util::Log.newdestination(:console) unless options[:setdest]
 
     Signal.trap(:INT) do
       $stderr.puts "Exiting"

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -47,12 +47,7 @@ class Puppet::Application::Device < Puppet::Application
   end
 
   option("--logdest DEST", "-l DEST") do |arg|
-    begin
-      Puppet::Util::Log.newdestination(arg)
-      options[:setdest] = true
-    rescue => detail
-      Puppet.log_exception(detail)
-    end
+    handle_logdest_arg(arg)
   end
 
   option("--waitforcert WAITFORCERT", "-w") do |arg|

--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -8,12 +8,7 @@ class Puppet::Application::Inspect < Puppet::Application
   option("--verbose","-v")
 
   option("--logdest LOGDEST", "-l") do |arg|
-    begin
-      Puppet::Util::Log.newdestination(arg)
-      options[:logset] = true
-    rescue => detail
-      $stderr.puts detail.to_s
-    end
+    handle_logdest_arg(arg)
   end
 
   def help
@@ -86,7 +81,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     @report = Puppet::Transaction::Report.new("inspect")
 
     Puppet::Util::Log.newdestination(@report)
-    Puppet::Util::Log.newdestination(:console) unless options[:logset]
+    Puppet::Util::Log.newdestination(:console) unless options[:setdest]
 
     Signal.trap(:INT) do
       $stderr.puts "Exiting"

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -17,12 +17,7 @@ class Puppet::Application::Master < Puppet::Application
   end
 
   option("--logdest DEST",  "-l DEST") do |arg|
-    begin
-      Puppet::Util::Log.newdestination(arg)
-      options[:setdest] = true
-    rescue => detail
-      Puppet.log_exception(detail)
-    end
+    handle_logdest_arg(arg)
   end
 
   option("--parseonly") do |args|

--- a/lib/puppet/application/queue.rb
+++ b/lib/puppet/application/queue.rb
@@ -112,12 +112,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   option("--logdest DEST", "-l DEST") do |arg|
-    begin
-      Puppet::Util::Log.newdestination(arg)
-      options[:setdest] = true
-    rescue => detail
-      Puppet.log_exception(detail)
-    end
+    handle_logdest_arg(arg)
   end
 
   def main

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -45,8 +45,8 @@ describe Puppet::Application::Apply do
       @apply.handle_logdest("console")
     end
 
-    it "should put the logset options to true" do
-      @apply.options.expects(:[]=).with(:logset,true)
+    it "should set the setdest options to true" do
+      @apply.options.expects(:[]=).with(:setdest,true)
 
       @apply.handle_logdest("console")
     end

--- a/spec/unit/application/inspect_spec.rb
+++ b/spec/unit/application/inspect_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Application::Inspect do
   describe "when executing" do
     before :each do
       Puppet[:report] = true
-      @inspect.options[:logset] = true
+      @inspect.options[:setdest] = true
       Puppet::Transaction::Report::Rest.any_instance.stubs(:save)
       @inspect.setup
     end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -618,4 +618,28 @@ describe Puppet::Application do
     end
 
   end
+
+  describe "#handle_logdest_arg" do
+
+    let(:test_arg) { "arg_test_logdest" }
+
+    it "should log an exception that is raised" do
+      our_exception = Puppet::DevError.new("test exception")
+      Puppet::Util::Log.expects(:newdestination).with(test_arg).raises(our_exception)
+      Puppet.expects(:log_exception).with(our_exception)
+      @app.handle_logdest_arg(test_arg)
+    end
+
+    it "should set the new log destination" do
+      Puppet::Util::Log.expects(:newdestination).with(test_arg)
+      @app.handle_logdest_arg(test_arg)
+    end
+
+    it "should set the flag that a destination is set in the options hash" do
+      Puppet::Util::Log.stubs(:newdestination).with(test_arg)
+      @app.handle_logdest_arg(test_arg)
+      @app.options[:setdest].should be_true
+    end
+  end
+
 end


### PR DESCRIPTION
Prior to this commit there were 6 different puppet applications
with independent implementaions handling the `--logdest` option,
including two that were logging directly to stderr rather than
using `Puppet.log_exception` helper. This commit pulls those
implementations up into Puppet::Application and unifies against
the single implementation using `Puppet.log_exception`. Additionally
it now has unit tests.
