### PR TITLE
(#19955) Give better error msg when Hiera databindings fail.

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -328,16 +328,39 @@ class Puppet::Resource
       result = scope.compiler.injector.lookup(scope, name)
     end
     if result.nil?
-      Puppet::DataBinding.indirection.find(
-        name,
-        :environment => scope.environment.to_s,
-        :variables => scope)
+      lookup_with_databinding(name, scope)
     else
       result
     end
   end
 
   private :lookup_external_default_for
+
+  # What is thrown depends on the Ruby/YAML version being used and which DataBinding terminus is used.
+  # Difficult to list all kinds of Exceptions to catch without catching Exception
+  #
+  if defined?(::Psych::SyntaxError)
+    DataBindingExceptions = [::StandardError, ::ArgumentError, ::Psych::SyntaxError, ::SyntaxError, Errno::ENOENT, Errno::ENOTDIR]
+  else
+    DataBindingExceptions = [::StandardError, ::ArgumentError, ::SyntaxError, Errno::ENOENT, Errno::ENOTDIR]
+  end
+
+  def lookup_with_databinding(name, scope)
+    begin
+      Puppet::DataBinding.indirection.find(
+        name,
+        :environment => scope.environment.to_s,
+        :variables => scope)
+    rescue *DataBindingExceptions => e
+      # Fail if config / data is wrong - there is no way of telling how bad a catalog may turn out if this goes
+      # undetected, but do fail more gracefully and informative than just letting the exception be turned into
+      # a Puppet::ParseError (higher in the call chain) which reports the problem as originating in a manifest.
+      #
+      raise Puppet::Error, "Error from DataBinding '#{Puppet[:data_binding_terminus]}' while looking up '#{name}', Error: #{e.class}, '#{e.message}'"
+    end
+  end
+
+  private :lookup_with_databinding
 
   def set_default_parameters(scope)
     return [] unless resource_type and resource_type.respond_to?(:arguments)

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -376,6 +376,14 @@ describe Puppet::Resource do
           resource[:port].should == '80'
         end
 
+        it "should fail with error message about data binding on a hiera failure" do
+          Puppet::DataBinding.indirection.expects(:find).raises(ArgumentError, 'Forgettabotit')
+          expect {
+            resource.set_default_parameters(scope)
+            resource[:port].should == '80'
+          }.to raise_error(Puppet::Error, /Error from DataBinding 'hiera' while looking up 'apache::port', Error: ArgumentError, 'Forgettabotit'/)
+        end
+
         it "should use the default value if the injector returns nil" do
           compiler.injector.expects(:lookup).returns(nil)
 


### PR DESCRIPTION
If a problem occurs while hiera databindings tries to look something
up (bad hiera.yaml, bad data, or indeed bad implementaton), the raised
error ended up as a Puppet::ParseError blaming a manifest with a cryptic
error message.

This changes this to throw a specific error if DataBinding raises an
exception when its find method is called.

It now points to which databinding terminus is in use, what the
exception class and original message was. It then fails the compilation
using a Puppet::Error.

A test is added to ensure a message is produced.
