### PR TITLE
(#4506) Don't serialize transient vars in Puppet::Resource

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -102,6 +102,18 @@ class Puppet::Resource
     end
   end
 
+  YAML_ATTRIBUTES = [:@file, :@line, :@exported, :@type, :@title, :@tags, :@parameters]
+
+  # Explicitly list the instance variables that should be serialized when
+  # converting to YAML.
+  #
+  # @api private
+  # @return [Array<Symbol>] The intersection of our explicit variable list and
+  #   all of the instance variables defined on this class.
+  def to_yaml_properties
+    YAML_ATTRIBUTES & super
+  end
+
   def to_pson(*args)
     to_pson_data_hash.to_pson(*args)
   end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -607,7 +607,7 @@ describe Puppet::Resource do
     end
   end
 
-  describe "when serializing" do
+  describe "when serializing a native type" do
     before do
       @resource = Puppet::Resource.new("file", "/my/file")
       @resource["one"] = "test"
@@ -615,6 +615,31 @@ describe Puppet::Resource do
     end
 
     it "should produce an equivalent yaml object" do
+      text = @resource.render('yaml')
+
+      newresource = Puppet::Resource.convert_from('yaml', text)
+      newresource.should equal_attributes_of @resource
+    end
+  end
+
+  describe "when serializing a defined type" do
+    before do
+      type = Puppet::Resource::Type.new(:definition, "foo::bar")
+      Puppet::Node::Environment.new.known_resource_types.add type
+    end
+
+    before :each do
+      @resource = Puppet::Resource.new('foo::bar', 'xyzzy')
+      @resource['one'] = 'test'
+      @resource['two'] = 'other'
+      @resource.resource_type
+    end
+
+    it "doesn't include transient instance variables (#4506)" do
+      expect(@resource.to_yaml_properties).to_not include :@rstype
+    end
+
+    it "produces an equivalent yaml object" do
       text = @resource.render('yaml')
 
       newresource = Puppet::Resource.convert_from('yaml', text)


### PR DESCRIPTION
When serializing Ruby objects to YAML, Procs may be serialized that
cannot be deserialized. Given the following example:

```
YAML.load(YAML.dump lambda { "hi" })
```

A TypeError is raised with the message "allocator undefined for Proc".

Commit e161cbc introduced a new instance variable to Puppet::Resource,
`@rstype`, which was the serialized resource_type for the given object.
When a Puppet::Resource object was round tripped from YAML the
deserialization would fail with the above TypeError. Using Puppet's
built in deserialization (EG `Puppet::Resource.convert_from('yaml', serialized_data)`)
would work, but directly parsing the YAML would fail.

To resolve this an explicit list of instance variables is specified for
serialization, so instead of trying to serialize everything we only
serialize the things we need.

This supersedes GH-1868.
