### PR TITLE
(#22557) Raise an error providing a package resource with multiple names

### DIFF
--- a/lib/puppet/provider/package.rb
+++ b/lib/puppet/provider/package.rb
@@ -13,6 +13,11 @@ class Puppet::Provider::Package < Puppet::Provider
     @property_hash.clear
   end
 
+  def query
+    validate_resource
+    query_a_package
+  end
+
   # Look up the current status.
   def properties
     if @property_hash.empty?
@@ -24,5 +29,12 @@ class Puppet::Provider::Package < Puppet::Provider
 
   def validate_source(value)
     true
+  end
+
+  private
+
+  # @api private
+  def validate_resource
+    raise(Puppet::ResourceError, "Package providers cannot query a package resource with multiple names (resource->name should not be set to an array).") if resource[:name].kind_of?(Array) && resource[:name].size > 1
   end
 end

--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -142,7 +142,8 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
     end
   end
 
-  def query
+  # @api private
+  def query_a_package
     self.class.pkglist(:pkgname => @resource[:name])
   end
 

--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -92,7 +92,8 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
     end
   end
 
-  def query
+  # @api private
+  def query_a_package
     FileTest.exists?("/var/db/.puppet_appdmg_installed_#{@resource[:name]}") ? {:name => @resource[:name], :ensure => :present} : nil
   end
 

--- a/lib/puppet/provider/package/apple.rb
+++ b/lib/puppet/provider/package/apple.rb
@@ -32,7 +32,8 @@ Puppet::Type.type(:package).provide :apple, :parent => Puppet::Provider::Package
     }
   end
 
-  def query
+  # @api private
+  def query_a_package
     FileTest.exists?("/Library/Receipts/#{@resource[:name]}.pkg") ? {:name => @resource[:name], :ensure => :present} : nil
   end
 

--- a/lib/puppet/provider/package/blastwave.rb
+++ b/lib/puppet/provider/package/blastwave.rb
@@ -92,7 +92,8 @@ Puppet::Type.type(:package).provide :blastwave, :parent => :sun, :source => :sun
     hash[:avail]
   end
 
-  def query
+  # @api private
+  def query_a_package
     if hash = self.class.blastlist(:justme => @resource[:name])
       hash
     else

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -149,7 +149,8 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     matches[1]
   end
 
-  def query
+  # @api private
+  def query_a_package
     hash = nil
 
     # list out our specific package

--- a/lib/puppet/provider/package/freebsd.rb
+++ b/lib/puppet/provider/package/freebsd.rb
@@ -32,7 +32,8 @@ Puppet::Type.type(:package).provide :freebsd, :parent => :openbsd do
     end
   end
 
-  def query
+  # @api private
+  def query_a_package
     self.class.instances.each do |provider|
       if provider.name == @resource.name
         return provider.properties

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -111,7 +111,8 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     hash[:ensure][0]
   end
 
-  def query
+  # @api private
+  def query_a_package
     self.class.gemlist(:justme => resource[:name], :local => true)
   end
 

--- a/lib/puppet/provider/package/hpux.rb
+++ b/lib/puppet/provider/package/hpux.rb
@@ -26,7 +26,8 @@ Puppet::Type.type(:package).provide :hpux, :parent => Puppet::Provider::Package 
     swinstall(*args)
   end
 
-  def query
+  # @api private
+  def query_a_package
     swlist resource[:name]
     {:ensure => :present}
   rescue

--- a/lib/puppet/provider/package/macports.rb
+++ b/lib/puppet/provider/package/macports.rb
@@ -69,7 +69,8 @@ Puppet::Type.type(:package).provide :macports, :parent => Puppet::Provider::Pack
     # situations where a port cannot be found or installed.
   end
 
-  def query
+  # @api private
+  def query_a_package
     result = self.class.parse_installed_query_line(execute([command(:port), "-q", :installed, @resource[:name]], :failonfail => false, :combine => false))
     return {} if result.nil?
     return result

--- a/lib/puppet/provider/package/msi.rb
+++ b/lib/puppet/provider/package/msi.rb
@@ -61,7 +61,8 @@ Puppet::Type.type(:package).provide(:msi, :parent => Puppet::Provider::Package) 
   # matches the resource name (case-insensitively due to hex) or the ProductName matches
   # the resource name. The ProductName is not guaranteed to be unique, but the PackageCode
   # should be if the package is authored correctly.
-  def query
+  # @api private
+  def query_a_package
     MsiPackage.enum_for.find do |package|
       resource[:name].casecmp(package[:packagecode]) == 0 || resource[:name] == package[:name]
     end

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -122,7 +122,8 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
     return nil
   end
 
-  def query
+  # @api private
+  def query_a_package
     # Search for the version info
     if pkginfo(@resource[:name]) =~ /Information for (inst:)?#{@resource[:name]}-(\S+)/
       return { :ensure => $2 }

--- a/lib/puppet/provider/package/opkg.rb
+++ b/lib/puppet/provider/package/opkg.rb
@@ -57,7 +57,8 @@ Puppet::Type.type(:package).provide :opkg, :source => :opkg, :parent => Puppet::
     self.install
   end
 
-  def query
+  # @api private
+  def query_a_package
     # list out our specific package
     output = opkg( 'list-installed', @resource[:name] )
     if output =~ /^(\S+) - (\S+)/

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -131,7 +131,8 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
   end
 
   # Querys the pacman master list for information about the package.
-  def query
+  # @api private
+  def query_a_package
     begin
       output = pacman("-Qi", @resource[:name])
 

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -46,7 +46,8 @@ Puppet::Type.type(:package).provide :pip,
 
   # Return structured information about a particular package or `nil` if
   # it is not installed or `pip` itself is not available.
-  def query
+  # @api private
+  def query_a_package
     self.class.instances.each do |provider_pip|
       return provider_pip.properties if @resource[:name].downcase == provider_pip.name.downcase
     end

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -177,7 +177,8 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
   end
 
   # list a specific package
-  def query
+  # @api private
+  def query_a_package
     r = exec_cmd(command(:pkg), 'list', '-H', @resource[:name])
     return {:ensure => :absent, :name => @resource[:name]} if r[:exit] != 0
     self.class.parse_line(r[:out])

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -112,7 +112,8 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
     end
   end
 
-  def query
+  # @api private
+  def query_a_package
     if FileTest.exists?("/var/db/.puppet_pkgdmg_installed_#{@resource[:name]}")
       Puppet.debug "/var/db/.puppet_pkgdmg_installed_#{@resource[:name]} found"
       return {:name => @resource[:name], :ensure => :present}

--- a/lib/puppet/provider/package/pkgin.rb
+++ b/lib/puppet/provider/package/pkgin.rb
@@ -37,7 +37,8 @@ Puppet::Type.type(:package).provide :pkgin, :parent => Puppet::Provider::Package
     end
   end
 
-  def query
+  # @api private
+  def query_a_package
     packages = pkgin(:search, resource[:name]).split("\n")
 
     # Remove the last three lines of help text.

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -168,7 +168,8 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
     hash[:avail] if hash
   end
 
-  def query
+  # @api private
+  def query_a_package
     if hash = pkgsingle(@resource)
       hash
     else

--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -77,7 +77,8 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     self.install
   end
 
-  def query
+  # @api private
+  def query_a_package
     result_format = self.class.eix_result_format
     result_fields = self.class.eix_result_fields
 

--- a/lib/puppet/provider/package/ports.rb
+++ b/lib/puppet/provider/package/ports.rb
@@ -69,7 +69,8 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
     newversion
   end
 
-  def query
+  # @api private
+  def query_a_package
     # support portorigin_glob such as "mail/postfix"
     name = self.name
     if name =~ /\//

--- a/lib/puppet/provider/package/portupgrade.rb
+++ b/lib/puppet/provider/package/portupgrade.rb
@@ -168,7 +168,8 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
   ###### Query subcommand - return a hash of details if exists, or nil if it doesn't.
   # Used to make sure the package is installed
 
-  def query
+  # @api private
+  def query_a_package
     Puppet.debug "portupgrade.query() - Called on #{@resource[:name]}"
 
     cmdline = ["-qO", @resource[:name]]

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -66,7 +66,8 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
   # Find the fully versioned package name and the version alone. Returns
   # a hash with entries :instance => fully versioned package name, and
   # :ensure => version-release
-  def query
+  # @api private
+  def query_a_package
     #NOTE: Prior to a fix for issue 1243, this method potentially returned a cached value
     #IF YOU CALL THIS METHOD, IT WILL CALL RPM
     #Use get(:property) to check if cached values are available

--- a/lib/puppet/provider/package/sun.rb
+++ b/lib/puppet/provider/package/sun.rb
@@ -83,7 +83,8 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
     info2hash(@resource[:source])[:ensure]
   end
 
-  def query
+  # @api private
+  def query_a_package
     info2hash
   end
 

--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -45,7 +45,8 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
 
   # Query for the provider hash for the current resource. The provider we
   # are querying, may not have existed during prefetch
-  def query
+  # @api private
+  def query_a_package
     Puppet::Provider::Package::Windows::Package.find do |pkg|
       if pkg.match?(resource)
         return self.class.to_hash(pkg)

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -1,0 +1,15 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/provider/package'
+
+describe "Base Puppet::Provider::Package" do
+
+  let(:resource) { stub 'resource', :[] => [ 'package1', 'package2' ]}
+  let(:provider) { Puppet::Provider::Package.new(resource) }
+
+  describe "querying" do
+    it "raises if query a resource with an array of names (#22557)" do
+      expect { provider.query }.to raise_error(Puppet::ResourceError, /package provider.*cannot query.*with multiple names/i)
+    end
+  end
+end


### PR DESCRIPTION
Redmine #22557 brought up a regression in package provider behavior
(specifically dpkg).  Previously it was possible, under some
circumstances to supply a package resource with an array for the name
attribute, and have puppet manage the set of packages.  However, this
was an accidental feature which could fail if some packages were in
different states because the providers' query methods ultimately operate
on the package property hash info of just one of the packages.

This commit makes explicit that a package resource should not have its
name attribute set to an array of more than one value, and will raise a
ResourceError if this is attempted.
