### PR TITLE
(maint) Changing rescue of Exception to StandardError

### DIFF
--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -240,7 +240,7 @@ class Puppet::Application::FaceBase < Puppet::Application
   rescue SystemExit => detail
     status = detail.status
 
-  rescue Exception => detail
+  rescue => detail
     Puppet.log_exception(detail)
     Puppet.err "Try 'puppet help #{@face.name} #{@action.name}' for usage"
 


### PR DESCRIPTION
Rescuing exception is in general a bad practice and can cause undesired behaviors.

A detailed discussion about this can be found here: https://github.com/puppetlabs/puppet/pull/1925#discussion_r6529813
