### PR TITLE
(#22593) Fix interpolation issues in future parser lexer (braces/kw)

### DIFF
--- a/spec/unit/pops/parser/lexer_spec.rb
+++ b/spec/unit/pops/parser/lexer_spec.rb
@@ -600,6 +600,7 @@ describe Puppet::Pops::Parser::Lexer,"when lexing strings" do
     %q["${case true {true:{false}}}"] => [
       [:DQPRE,""],:CASE,[:BOOLEAN, true], :LBRACE, [:BOOLEAN, true], :COLON, :LBRACE, [:BOOLEAN, false],
         :RBRACE, :RBRACE, [:DQPOST,""]],
+    %q[{ "${a}" => 1 }] => [ :LBRACE, [:DQPRE,""], [:VARIABLE,"a"], [:DQPOST,""], :FARROW, [:NAME,"1"], :RBRACE ],
   }.each { |src,expected_result|
     it "should handle #{src} correctly" do
       EgrammarLexerSpec.tokens_scanned_from(src).should be_like(*expected_result)


### PR DESCRIPTION
The lexer did not honor nested braces inside an interpolation of a puppet
expression. This is bad because it leads to strange errors due to the
lexer telling the parser a lie. the fix ensures that end of interpolated
expression is based on balanced braces.

The interpolation functionality that the first bare word is a variable is
troublesome when wanting to use expressions like if, case, unless, true
false, as they become variable references. This changes the behavior to
interpret these as expression keywords instead of variable names. Users
who insist on using keywords as variable names should if they need to
interpolate $if, use either "$if" or "${$if}".
