### PR TITLE
(#22529) Handle no package message for different dpkg-query versions

### DIFF
--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   self::DPKG_DESCRIPTION_DELIMITER = ':DESC:'
   self::DPKG_QUERY_FORMAT_STRING = %Q{'${Status} ${Package} ${Version} #{self::DPKG_DESCRIPTION_DELIMITER} ${Description}\\n#{self::DPKG_DESCRIPTION_DELIMITER}\\n'}
   self::FIELDS_REGEX = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*) #{self::DPKG_DESCRIPTION_DELIMITER} (.*)$}
-  self::DPKG_PACKAGE_NOT_FOUND_REGEX = /No packages found matching/
+  self::DPKG_PACKAGE_NOT_FOUND_REGEX = /no package.*match/i
   self::FIELDS= [:desired, :error, :status, :name, :ensure, :description]
   self::END_REGEX = %r{^#{self::DPKG_DESCRIPTION_DELIMITER}$}
 

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -290,12 +290,24 @@ desired ok status name ensure :DESC: summary text
       parser_test(no_description, package_hash.merge(:description => ''))
     end
 
-    it "parses dpkg reporting that package does not exist without warning about a failed match (#22529)" do
-      Puppet.expects(:warning).never
-      pipe = StringIO.new("No packages found matching non-existent-package")
-      Puppet::Util::Execution.expects(:execpipe).with(query_args).yields(pipe).raises(Puppet::ExecutionFailure.new('no package found'))
+    context "dpkg-query versions < 1.16" do
+      it "parses dpkg-query 1.15 reporting that package does not exist without warning about a failed match (#22529)" do
+        Puppet.expects(:warning).never
+        pipe = StringIO.new("No packages found matching non-existent-package")
+        Puppet::Util::Execution.expects(:execpipe).with(query_args).yields(pipe).raises(Puppet::ExecutionFailure.new('no package found'))
 
-      expect(provider.query).to eq({:ensure=>:purged, :status=>"missing", :name=>"name", :error=>"ok"})
+        expect(provider.query).to eq({:ensure=>:purged, :status=>"missing", :name=>"name", :error=>"ok"})
+      end
+    end
+
+    context "dpkg-query versions >= 1.16" do
+      it "parses dpkg-query 1.16 reporting that package does not exist without warning about a failed match (#22529)" do
+        Puppet.expects(:warning).never
+        pipe = StringIO.new("dpkg-query: no packages found matching non-existent-package")
+        Puppet::Util::Execution.expects(:execpipe).with(query_args).yields(pipe).raises(Puppet::ExecutionFailure.new('no package found'))
+
+        expect(provider.query).to eq({:ensure=>:purged, :status=>"missing", :name=>"name", :error=>"ok"})
+      end
     end
   end
 


### PR DESCRIPTION
dpkg-query changes it's notification of missing package between versions
1.15 and 1.16.  We were testing for the earlier variant 'No packages
found matching'.  This change also handles the later variant of
'dpkg-query: no packages found matching'.

Also, sigh.
