### PR TITLE
(maint) Prefer json over pson for logstash_event

### DIFF
--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -96,7 +96,6 @@ Puppet::Util::Log.newdesttype :file do
 end
 
 Puppet::Util::Log.newdesttype :logstash_event do
-  require 'json'
   require 'time'
 
   def format(msg)
@@ -114,7 +113,7 @@ Puppet::Util::Log.newdesttype :logstash_event do
 
   def handle(msg)
     message = format(msg)
-    $stdout.puts message.to_json
+    $stdout.puts message.to_pson
   end
 end
 


### PR DESCRIPTION
We can't always rely on json being present; hence PSON being vendored
for this purpose. This  commits switches the logstash_event log
destination from trying to require and use json to simply use pson.
