### PR TITLE
(22740) create_resources input validation

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -44,6 +44,11 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
 
   ENDHEREDOC
   raise ArgumentError, ("create_resources(): wrong number of arguments (#{args.length}; must be 2 or 3)") if args.length > 3
+  raise ArgumentError, ('create_resources(): second argument must be a hash') unless args[1].is_a?(Hash)
+  if args.length == 3
+    raise ArgumentError, ('create_resources(): third argument, if provided, must be a hash') unless args[2].is_a?(Hash)
+  end
+
 
   type, instances, defaults = args
   defaults ||= {}

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -23,6 +23,14 @@ describe 'function for dynamically creating resources' do
     expect { @scope.function_create_resources(['foo', 'bar', 'blah', 'baz']) }.to raise_error(ArgumentError, 'create_resources(): wrong number of arguments (4; must be 2 or 3)')
   end
 
+  it 'should require second argument to be a hash' do
+    expect { @scope.function_create_resources(['foo','bar']) }.to raise_error(ArgumentError, 'create_resources(): second argument must be a hash')
+  end
+
+  it 'should require optional third argument to be a hash' do
+    expect { @scope.function_create_resources(['foo',{},'foo']) }.to raise_error(ArgumentError, 'create_resources(): third argument, if provided, must be a hash')
+  end
+
   describe 'when creating native types' do
     it 'empty hash should not cause resources to be added' do
       noop_catalog = compile_to_catalog("create_resources('file', {})")


### PR DESCRIPTION
Currently, Puppet's `create_resources()` function only valdiates the number of arguments. However, the function expects a hash for the second argument, and Puppet explodes with an unhelpful error if the second argument is not a hash, or nil.

For example, if the second argument is a string, you'll receive
something along the lines of:

```
undefined method `each' for "":String at /etc/puppetlabs/puppet/manifests/site.pp:45`.
```

This is less than helpful for users.

This patch raises an argument error if the second argument is not a
hash, warning the user that it should be one.

It also raises an argument error if the third argument is provided, the second is a hash, and the third is not.
