### PR TITLE
Docs cleanup on create_resources example

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -7,11 +7,11 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
         # A hash of user resources:
         $myusers = {
           'nick' => { uid    => '1330',
-                      group  => allstaff,
-                      groups => ['developers', 'operations', 'release'], }
+                      gid    => allstaff,
+                      groups => ['developers', 'operations', 'release'], },
           'dan'  => { uid    => '1308',
-                      group  => allstaff,
-                      groups => ['developers', 'prosvc', 'release'], }
+                      gid    => allstaff,
+                      groups => ['developers', 'prosvc', 'release'], },
         }
 
         create_resources(user, $myusers)


### PR DESCRIPTION
The two items in the hash must be separated by a comma and group isn't a valid parameter to the user resource.
