### PR TITLE
(#22729) Fix reject function shadows stdlib function with same name

### DIFF
--- a/lib/puppet/parser/functions/reject.rb
+++ b/lib/puppet/parser/functions/reject.rb
@@ -5,10 +5,21 @@ Puppet::Parser::Functions::newfunction(
 :type => :rvalue,
 :arity => 2,
 :doc => <<-'ENDHEREDOC') do |args|
-  Applies a parameterized block to each element in a sequence of entries from the first
-  argument and returns an array with the entires for which the block did *not* evaluate to true.
+  Applies a parameterized block or regular expression to each element in a sequence of entries from the first
+  argument and returns an array with the entries for which the block did *not* evaluate to true.
 
-  This function takes two mandatory arguments: the first should be an Array or a Hash, and the second
+  This function comes in two forms, a simpler variant where a regular expression given in string form
+  is used to reject matching entries, and one that takes a parameterized block (lambda).
+
+  The simple form takes two mandatory arguments; the first should be an Array or a Hash, and the
+  second a regular expression in String form.
+
+        reject($a, '^sodium.*')
+
+  When the first argument is an array, the regular expression is applied to each element, and when
+  the first argument is a Hash it is applied to each key.
+
+  The more advanced form takes two mandatory arguments: the first should be an Array or a Hash, and the second
   a parameterized block as produced by the puppet syntax:
 
         $a.reject |$x| { ... }
@@ -25,23 +36,49 @@ Puppet::Parser::Functions::newfunction(
         $a.reject |$x| { $x =~ /berry$/ }
 
   - Since 3.2
-  - requires `parser = future`.
+  - requires `parser = future` to use the parameterized block form
   ENDHEREDOC
 
+  def reject_lambda(receiver, pblock)
+    case receiver
+    when Array
+      receiver.reject {|x| pblock.call(self, x) }
+    when Hash
+      ensure_hash(receiver.reject {|x, y| pblock.call(self, [x, y]) })
+    else
+      raise ArgumentError, ("reject(): wrong argument type (#{receiver.class}; must be an Array or a Hash.")
+    end
+  end
+
+  def reject_pattern(receiver, pattern)
+    case receiver
+    when Array
+      receiver.reject { |e| e =~ pattern }
+    when Hash
+      ensure_hash( receiver.reject { |e| e =~ pattern } )
+    else
+      raise ArgumentError, ("reject(): wrong argument type (#{receiver.class}; must be an Array or a Hash.")
+    end
+  end
+
+  def ensure_hash(o)
+    # Ruby 1.8.7 returns Array in some cases
+    o.is_a?(Hash) ? o : Hash[o]
+  end
+
+  if args.size != 2
+    raise ArgumentError, "reject(): Wrong number of arguments given #{args.size} for 2"
+  end
+
   receiver = args[0]
-  pblock = args[1]
-
-  raise ArgumentError, ("reject(): wrong argument type (#{pblock.class}; must be a parameterized block.") unless pblock.is_a? Puppet::Parser::AST::Lambda
-
-  case receiver
-  when Array
-    receiver.reject {|x| pblock.call(self, x) }
-  when Hash
-    result = receiver.reject {|x, y| pblock.call(self, [x, y]) }
-    # Ruby 1.8.7 returns Array
-    result = Hash[result] unless result.is_a? Hash
-    result
+  predicate = args[1]
+  case predicate
+  when String
+    reject_pattern(receiver, Regexp.new(predicate))
+  when Puppet::Parser::AST::Lambda
+    reject_lambda(receiver, predicate)
   else
-    raise ArgumentError, ("reject(): wrong argument type (#{receiver.class}; must be an Array or a Hash.")
+    expected = Puppet[:parser] == 'future' ? 'a parameterized block or a string' : 'a string'
+    raise ArgumentError, ("reject(): wrong argument type (#{predicate.class}; must be #{expected}, got '#{predicate.class}'.")
   end
 end

--- a/spec/unit/parser/methods/shared.rb
+++ b/spec/unit/parser/methods/shared.rb
@@ -54,8 +54,8 @@ shared_examples_for 'all iterative functions argument checks' do |func|
   it 'raises an error when called without a block' do
     expect do
       compile_to_catalog(<<-MANIFEST)
-        [1].#{func}(1)
+        [1].#{func}([1])
       MANIFEST
-    end.to raise_error(Puppet::Error, /must be a parameterized block/)
+    end.to raise_error(Puppet::Error, /(must be a parameterized block)|(Wrong number of arguments)/)
   end
 end


### PR DESCRIPTION
The reject function in puppet core shadows the stdlib function with
the same name. This is bad because it prevents the reject function
from being used when not using future parser. (The core version requires
a puppet lambda).

This commit fixes the problem by letting the core reject function
also operate on a regular expression in string format. This makes the
function compatible with the stdlib variant.
