### PR TITLE
Add HTTP basic auth support to HTTP reporting in Puppet

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -28,7 +28,7 @@ module Puppet::Network::HTTP
       :redirect_limit => 10
     }
 
-    # Creates a new HTTP client connection to `host`:`port`. 
+    # Creates a new HTTP client connection to `host`:`port`.
     # @param host [String] the host to which this client will connect to
     # @param port [Fixnum] the port to which this client will connect to
     # @param options [Hash] options influencing the properties of the created connection,
@@ -53,26 +53,30 @@ module Puppet::Network::HTTP
     end
 
     def get(*args)
-      request(:get, *args)
+      process_request(:get, *args)
     end
 
     def post(*args)
-      request(:post, *args)
+      process_request(:post, *args)
     end
 
     def head(*args)
-      request(:head, *args)
+      process_request(:head, *args)
     end
 
     def delete(*args)
-      request(:delete, *args)
+      process_request(:delete, *args)
     end
 
     def put(*args)
-      request(:put, *args)
+      process_request(:put, *args)
     end
 
-    def request(method, *args)
+    def request(*args)
+      process_request(:request, *args)
+    end
+
+    def process_request(method, *args)
       current_args = args.dup
       @redirect_limit.times do |redirection|
         response = execute_request(method, *args)

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -261,7 +261,7 @@ describe Puppet::Network::HTTP::Connection do
                                                                             :with_error_string => 'shady looking signature'),
                                              :fails_with => 'certificate verify failed'))
       expect do
-        subject.request(:get, stub('request'))
+        subject.process_request(:get, stub('request'))
       end.to raise_error(Puppet::Error, "certificate verify failed: [shady looking signature for /CN=not_my_server]")
     end
 
@@ -271,7 +271,7 @@ describe Puppet::Network::HTTP::Connection do
                                              :in_context => a_store_context(:verify_raises => true),
                                              :fails_with => 'certificate verify failed'))
       expect do
-        subject.request(:get, stub('request'))
+        subject.process_request(:get, stub('request'))
       end.to raise_error(Puppet::Error, "certificate verify failed: [oh noes]")
     end
 
@@ -282,7 +282,7 @@ describe Puppet::Network::HTTP::Connection do
                                                                             :for_aliases => 'foo,bar,baz'),
                                              :fails_with => 'hostname was not match with server certificate'))
 
-      expect { subject.request(:get, stub('request')) }.
+      expect { subject.process_request(:get, stub('request')) }.
           to raise_error(Puppet::Error) do |error|
         error.message =~ /Server hostname 'my_server' did not match server certificate; expected one of (.+)/
         $1.split(', ').should =~ %w[DNS:foo DNS:bar DNS:baz DNS:not_my_server not_my_server]
@@ -296,7 +296,7 @@ describe Puppet::Network::HTTP::Connection do
       connection.stubs(:get).raises(OpenSSL::SSL::SSLError.new('some other message'))
 
       expect do
-        subject.request(:get, stub('request'))
+        subject.process_request(:get, stub('request'))
       end.to raise_error(/some other message/)
     end
 
@@ -316,7 +316,7 @@ describe Puppet::Network::HTTP::Connection do
 
       subject.expects(:warn_if_near_expiration).with(cert, cert)
 
-      subject.request(:get, stubs('request'))
+      subject.process_request(:get, stubs('request'))
     end
   end
 

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -62,6 +62,15 @@ describe processor do
       subject.process
     end
 
+    it "should use the username and password specified by the 'reporturl' setting" do
+      Puppet[:reporturl] = "https://user:pass@myhost.mydomain:1234/report/upload"
+      http.expects(:request).with {|req|
+        req['authorization'].should == "Basic dXNlcjpwYXNz"
+      }.returns(httpok)
+
+      subject.process
+    end
+
     it "should give the body as the report as YAML" do
       http.expects(:post).with {|path, data, headers|
         data.should == subject.to_yaml


### PR DESCRIPTION
Does the following:
- Rename request to process_request in Puppet::Network::Http::Connection
- Add request method to Puppet::Network::Http::Connection that works similarly to the other HTTP methods in it
- Add logic in Puppet::Reports::Http to properly handle HTTP basic auth using the form http://username:password@host/path
- Add a unit test to make sure HTTP basic auth is done if it is given in the url
