### PR TITLE
(#22804) Check for encoding support more robustly

### DIFF
--- a/lib/puppet/external/pson/pure/parser.rb
+++ b/lib/puppet/external/pson/pure/parser.rb
@@ -118,7 +118,7 @@ module PSON
         else
           raise TypeError, "#{source.inspect} is not like a string"
         end
-        if defined?(::Encoding)
+        if supports_encodings?(source)
           if source.encoding == ::Encoding::ASCII_8BIT
             b = source[0, 4].bytes.to_a
             source =
@@ -155,6 +155,14 @@ module PSON
             end
         end
         source
+      end
+
+      def supports_encodings?(string)
+        # Some modules, such as REXML on 1.8.7 (see #22804) can actually create
+        # a top-level Encoding constant when they are misused. Therefore
+        # checking for just that constant is not enough, so we'll be a bit more
+        # robust about if we can actually support encoding transformations.
+        string.respond_to?(:encoding) && defined?(::Encoding)
       end
 
       # Unescape characters in strings.


### PR DESCRIPTION
The REXML module, when included outside of a module or class, will create a
::Encoding module on ruby 1.8.7. That caused the encoding conversion code to
mistakenly think that it was running on a ruby that supported encodings
(which 1.8.7 does not). By being a bit more specific on this check we can
avoid mistaken attempts to control the encoding of the string.
