### PR TITLE
(#22557) Validate that a package name is a string

### DIFF
--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -225,6 +225,12 @@ module Puppet
 
       "
       isnamevar
+
+      validate do |value|
+        if !value.is_a?(String)
+          raise ArgumentError, "Name must be a String not #{value.class}"
+        end
+      end
     end
 
     newparam(:source) do

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -51,7 +51,7 @@ describe Puppet::Type.type(:package) do
         :clear           => nil,
         :validate_source => nil
       )
-      Puppet::Type.type(:package).defaultprovider.expects(:new).returns(@provider)
+      Puppet::Type.type(:package).defaultprovider.stubs(:new).returns(@provider)
     end
 
     it "should support :present as a value to :ensure" do
@@ -99,6 +99,12 @@ describe Puppet::Type.type(:package) do
 
     it "should accept any string as an argument to :source" do
       expect { Puppet::Type.type(:package).new(:name => "yay", :source => "stuff") }.to_not raise_error
+    end
+
+    it "should not accept a non-string name" do
+      expect do
+        Puppet::Type.type(:package).new(:name => ["error"])
+      end.to raise_error(Puppet::ResourceError, /Name must be a String/)
     end
   end
 


### PR DESCRIPTION
The package providers assume that the name of a package resource is a string,
but the type allowed the name to be anything. This caused some manifests to
pass several different names in and rely on an accident of the provider
implementation that allowed that to work in some situations. Since the
providers were never intended to work with multiple names, this changes the
type to validate that the name is simply a string.
