### PR TITLE
(maint) reduce log level duplication

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -381,13 +381,17 @@ class Application
       Puppet::Util::Log.newdestination(:console)
     end
 
+    set_log_level
+
+    Puppet::Util::Log.setup_default unless options[:setdest]
+  end
+
+  def set_log_level
     if options[:debug]
       Puppet::Util::Log.level = :debug
     elsif options[:verbose]
       Puppet::Util::Log.level = :info
     end
-
-    Puppet::Util::Log.setup_default unless options[:setdest]
   end
 
   def handle_logdest_arg(arg)

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -243,11 +243,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # we want the last report to be persisted locally
     Puppet::Transaction::Report.indirection.cache_class = :yaml
 
-    if options[:debug]
-      Puppet::Util::Log.level = :debug
-    elsif options[:verbose]
-      Puppet::Util::Log.level = :info
-    end
+    set_log_level
 
     if Puppet[:profile]
       Puppet::Util::Profiler.current = Puppet::Util::Profiler::WallClock.new(Puppet.method(:debug), "apply")

--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -88,11 +88,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       exit(1)
     end
 
-    if options[:debug]
-      Puppet::Util::Log.level = :debug
-    elsif options[:verbose]
-      Puppet::Util::Log.level = :info
-    end
+    set_log_level
 
     Puppet::Transaction::Report.indirection.terminus_class = :rest
     Puppet::Resource::Catalog.indirection.terminus_class = :yaml

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -151,12 +151,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   def setup
     Puppet::Util::Log.newdestination(:console)
-
-    if options[:debug]
-      Puppet::Util::Log.level = :debug
-    elsif options[:verbose]
-      Puppet::Util::Log.level = :info
-    end
+    set_log_level
   end
 
   private


### PR DESCRIPTION
Prior to this commit the interactive Puppet applications, `apply`,
`inspect`, `resource` had duplicate logic for setting log level based
on command line options.  This commit consolidates that logic into a
method in `Puppet::Application`.  

This functionality is covered by existing tests.
