### PR TITLE
(#22818) Skip metadata that cannot be parsed.

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -52,11 +52,14 @@ class Puppet::Module
 
   def has_metadata?
     return false unless metadata_file
-
     return false unless FileTest.exist?(metadata_file)
 
-    metadata = PSON.parse File.read(metadata_file)
-
+    begin
+      metadata =  PSON.parse(File.read(metadata_file))
+    rescue PSON::PSONError => e
+      Puppet.debug("#{name} has an invalid and unparsable metadata.json file.  The parse error: #{e.message}")
+      return false
+    end
 
     return metadata.is_a?(Hash) && !metadata.keys.empty?
   end

--- a/spec/fixtures/unit/module/trailing-comma.json
+++ b/spec/fixtures/unit/module/trailing-comma.json
@@ -1,0 +1,24 @@
+{
+    "name": "puppetlabs/ruby",
+    "version": "0.0.2",
+    "summary": "Manage Ruby",
+    "source": "git@github.com/puppetlabs/puppetlabs-ruby.git",
+    "project_page": "http://github.com/puppetlabs/puppetlabs-ruby",
+    "author": "Puppet Labs",
+    "license": "Apache-2.0",
+    "operatingsystem_support": [
+        "RedHat",
+        "OpenSUSE",
+        "SLES",
+        "SLED",
+        "Debian",
+        "Ubuntu"
+    ],
+    "puppet_version": [
+        2.7,
+        3.0,
+        3.1,
+        3.2,
+        3.3,
+    ],
+}

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -519,6 +519,13 @@ describe Puppet::Module do
     Puppet::Module.new("yay", "/path", mock("env"))
   end
 
+  it "should tolerate failure to parse" do
+    FileTest.expects(:exist?).with(@module.metadata_file).returns true
+    File.stubs(:read).with(@module.metadata_file).returns(my_fixture('trailing-comma.json'))
+
+    @module.has_metadata?.should be_false
+  end
+
   def a_module_with_metadata(data)
     text = data.to_pson
 


### PR DESCRIPTION
When adding metadata.json to modules I observed that incorrect JSON can
cause Puppet to die while parsing the invalid JSON.  Wrap this in a
rescue, raise a message, and return false if the parsing fails so that
Puppet continues as if the metadata doesn't exist.
