### PR TITLE
(#21258) Update link to LSB exit code documentation

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -180,7 +180,7 @@ module Puppet
         automatically, usually by looking for the service in the process
         table.
 
-        [lsb-exit-codes]: http://refspecs.freestandards.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html"
+        [lsb-exit-codes]: http://refspecs.linuxfoundation.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html"
     end
 
     newparam(:stop) do


### PR DESCRIPTION
Link to linuxfoundation.org, as the content had moved and the
refspecs.freestandards.org domain can no longer be resolved by DNS.

Also updated to link to latest LSB release (4.1.0).

Fixes http://projects.puppetlabs.com/issues/21258.
