### PR TITLE
(#22847) Restrict WMI group / user queries

### DIFF
--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -175,7 +175,7 @@ module Puppet::Util::ADSI
     end
 
     def self.each(&block)
-      wql = Puppet::Util::ADSI.execquery("select name from win32_useraccount")
+      wql = Puppet::Util::ADSI.execquery('select name from win32_useraccount where localaccount = "TRUE"')
 
       users = []
       wql.each do |u|
@@ -283,7 +283,7 @@ module Puppet::Util::ADSI
     end
 
     def self.each(&block)
-      wql = Puppet::Util::ADSI.execquery( "select name from win32_group" )
+      wql = Puppet::Util::ADSI.execquery( 'select name from win32_group where localaccount = "TRUE"' )
 
       groups = []
       wql.each do |g|

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -24,7 +24,7 @@ describe Puppet::Type.type(:group).provider(:windows_adsi) do
       names = ['group1', 'group2', 'group3']
       stub_groups = names.map{|n| stub(:name => n)}
 
-      connection.stubs(:execquery).with("select name from win32_group").returns stub_groups
+      connection.stubs(:execquery).with('select name from win32_group where localaccount = "TRUE"').returns stub_groups
 
       described_class.instances.map(&:name).should =~ names
     end

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -24,7 +24,7 @@ describe Puppet::Type.type(:user).provider(:windows_adsi) do
     it "should enumerate all users" do
       names = ['user1', 'user2', 'user3']
       stub_users = names.map{|n| stub(:name => n)}
-      connection.stubs(:execquery).with("select name from win32_useraccount").returns(stub_users)
+      connection.stubs(:execquery).with('select name from win32_useraccount where localaccount = "TRUE"').returns(stub_users)
 
       described_class.instances.map(&:name).should =~ names
     end

--- a/spec/unit/util/adsi_spec.rb
+++ b/spec/unit/util/adsi_spec.rb
@@ -85,7 +85,7 @@ describe Puppet::Util::ADSI do
     it "should return an enumeration of IADsUser wrapped objects" do
       name = 'Administrator'
       wmi_users = [stub('WMI', :name => name)]
-      Puppet::Util::ADSI.expects(:execquery).with("select name from win32_useraccount").returns(wmi_users)
+      Puppet::Util::ADSI.expects(:execquery).with('select name from win32_useraccount where localaccount = "TRUE"').returns(wmi_users)
 
       native_user = stub('IADsUser')
       homedir = "C:\\Users\\#{name}"
@@ -248,7 +248,7 @@ describe Puppet::Util::ADSI do
     it "should return an enumeration of IADsGroup wrapped objects" do
       name = 'Administrators'
       wmi_groups = [stub('WMI', :name => name)]
-      Puppet::Util::ADSI.expects(:execquery).with("select name from win32_group").returns(wmi_groups)
+      Puppet::Util::ADSI.expects(:execquery).with('select name from win32_group where localaccount = "TRUE"').returns(wmi_groups)
 
       native_group = stub('IADsGroup')
       native_group.expects(:Members).returns([stub(:Name => 'Administrator')])


### PR DESCRIPTION
(#22847) Restrict WMI group / user queries
- Querying win32_useraccount or win32_group on a domain can yield
  a large request to AD for user / group objects, that may number in
  the tens of thousands in large organizations
- This can cause a lot of stress on AD and the network to retrieve all
  of these results, which are ultimately unused in the existing code
  anyhow
- The solution involves simply restricting the queries to the local
  machine
