### PR TITLE
(maint) Remove unused .testseries file

### DIFF
--- a/.testseries
+++ b/.testseries
@@ -1,2 +1,0 @@
-tickets/master/3015
-tickets/master/2596


### PR DESCRIPTION
The .testseries file was added to puppet 4 years ago and has not been
touched since, and there's no explanation as to why it's there. To
reduce the amount of unused cruft that's being packed around in the
source, this commit removes that file.
