### PR TITLE
(22878) Scope the call to CloseHandle

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -148,8 +148,8 @@ module Util::Execution
       begin
         exit_status = Puppet::Util::Windows::Process.wait_process(process_info.process_handle)
       ensure
-        Process.CloseHandle(process_info.process_handle)
-        Process.CloseHandle(process_info.thread_handle)
+        Puppet::Util::Windows::Process.CloseHandle(process_info.process_handle)
+        Puppet::Util::Windows::Process.CloseHandle(process_info.thread_handle)
       end
     end
 


### PR DESCRIPTION
Without this patch the ensure block calls a private method (throwing an error). By continuing the scope used in the main block the correct method is called.
