### PR TITLE
(#22891) Use the most preferred supported format

### DIFF
--- a/spec/unit/network/format_handler_spec.rb
+++ b/spec/unit/network/format_handler_spec.rb
@@ -63,8 +63,8 @@ describe Puppet::Network::FormatHandler do
       Puppet::Network::FormatHandler.most_suitable_format_for(accepted, [:one, :two])
     end
 
-    it "finds either format when anything is accepted" do
-      [format_one, format_two].should include(suitable_in_setup_formats(["*/*"]))
+    it "finds the most preferred format when anything is acceptable" do
+      Puppet::Network::FormatHandler.most_suitable_format_for(["*/*"], [:two, :one]).should == format_two
     end
 
     it "finds no format when none are acceptable" do


### PR DESCRIPTION
Previously the code had assumed that the order of the supported formats 
didn't mean anything. However, the preferred_serialization_format, and other
factors, meant that the order really does matter. This makes the selected
format, when the Accept header is _/_ be the most preferred, supported
format.
