### PR TITLE
(packaging) (22726) Add saucy to default cows 

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-lucid-i386.cow base-precise-i386.cow base-quantal-i386.cow base-raring-i386.cow base-sid-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-unstable-i386.cow base-wheezy-i386.cow'
+cows: 'base-lucid-i386.cow base-precise-i386.cow base-quantal-i386.cow base-raring-i386.cow base-sid-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-unstable-i386.cow base-wheezy-i386.cow base-saucy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'


### PR DESCRIPTION
Saucy comes out soon, and we would like to provide packages for that
distro. In order to do this, we need to add the saucy cow to our default
cow list, so that each new release we have, we will build and ship saucy
packages, in addition to the packages we already ship.
