### PR TITLE
[#22992] Correction of wrong exit code when testing state.yaml

### DIFF
--- a/ext/nagios/check_puppet.rb
+++ b/ext/nagios/check_puppet.rb
@@ -99,16 +99,16 @@ class CheckPuppet
       process = "process #{OPTIONS[:process]} is not running"
     end
 
-    case @proc or @file
-    when 0
-      status = "OK"
-      exitcode = 0
-    when 2
+    case
+    when (@proc == 2 or @file == 2)
       status = "CRITICAL"
       exitcode = 2
-    when 3
+    when (@proc == 0 and @file == 0)
+      status = "OK"
+      exitcode = 0
+    else
       status = "UNKNOWN"
-      exitcide = 3
+      exitcode = 3
     end
 
     puts "PUPPET #{status}: #{process}, #{state}"


### PR DESCRIPTION
Related issue: http://projects.puppetlabs.com/issues/22992

I think the previous version mishandled the "case" expression ( `case @proc or @file` ): `@proc` had precedence and always enters the first case.  Because of this `@file` was never evaluated. 

The proposed patch handles status priorities (CRITICAL is more important than UNKNOWN) and removes a typo that existed since the begininng.
