### PR TITLE
(23033) Check if running if not configured to start.

### DIFF
--- a/ext/debian/puppetmaster.init
+++ b/ext/debian/puppetmaster.init
@@ -100,6 +100,7 @@ status_puppet_master() {
     else
         echo ""
         echo "puppetmaster not configured to start"
+        status_of_proc -p "/var/run/puppet/${NAME}.pid" "${DAEMON}" "${NAME}"
     fi
 }
 


### PR DESCRIPTION
The reasoning for this is explained in:
https://projects.puppetlabs.com/issues/23033

Currently the init-script does not actually check if we're running and
return accordingly when status is called if the puppet master is not
configured to start.

This causes it to always return 0, meaning we're actually running
regardless of if that is the case.
