### PR TITLE
(#22925) Fall back to cached catalog if we can't connect to the master

### DIFF
--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -1,0 +1,16 @@
+test_name "fallback to the cached catalog"
+
+step "run agents once to cache the catalog" do
+  with_puppet_running_on master, {} do
+    on(agents, puppet("agent -t --server #{master}"))
+  end
+end
+
+step "run agents again, verify they use cached catalog" do
+  agents.each do |agent|
+    # can't use --test, because that will set usecacheonfailure=false
+    on(agent, puppet("agent --onetime --no-daemonize --server #{master} --verbose")) do |result|
+      assert_match(result.stdout, /Using cached catalog/)
+    end
+  end
+end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -157,7 +157,9 @@ class Puppet::Configurer
             query_options = nil
           end
         end
-      rescue Puppet::Error, Net::HTTPError => detail
+      rescue SystemExit,NoMemoryError
+        raise
+      rescue Exception => detail
         Puppet.warning("Unable to fetch my node definition, but the agent run will continue:")
         Puppet.warning(detail)
       end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -110,6 +110,16 @@ describe Puppet::Configurer do
       @agent.run.should == 0
     end
 
+    it "applies a cached catalog when it can't connect to the master" do
+      error = Errno::ECONNREFUSED.new('Connection refused - connect(2)')
+
+      Puppet::Node.indirection.expects(:find).raises(error)
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entry(:ignore_cache => true)).raises(error)
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entry(:ignore_terminus => true)).returns(@catalog)
+
+      @agent.run.should == 0
+    end
+
     it "should initialize a transaction report if one is not provided" do
       report = Puppet::Transaction::Report.new("apply")
       Puppet::Transaction::Report.expects(:new).returns report


### PR DESCRIPTION
Prior to commit 093a0745b4, puppet would attempt to download a catalog, and if
that failed, it would apply a previously cached catalog. Note this
behavior is controlled by the [`usecacheonfailure`](http://docs.puppetlabs.com/references/latest/configuration.html#usecacheonfailure) setting, which is
disabled when using `--test`.

In commit 093a0745b4, the ENC was made authoritative for specifying node
environment. In doing so, the agent makes a REST call to the master for
its Node object, and then reads the environment from it.

However, the call is made in a begin/rescue block that only catches
Puppet::Error and Net::HTTPErrors, but not errors like
Errno::ECONNREFUSED, etc.

This commit ensures that any standard error will be caught when
retrieving the node's environment, as is done when retrieving the
catalog. If we fail to obtain the node's environment, we warn, and
continue trying to apply the catalog.

This commit does not try to fix consistency issues between the node and
catalog requests. For example, the node request could fail, resulting in
the agent requesting a catalog using its agent-configured environment.
The catalog request could succeed, resulting in the agent applying a
catalog from an environment that doesn't match what the ENC thinks it
should be.
