### PR TITLE
(#23086) Add default values for status member variables to constructor.

### DIFF
--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -27,6 +27,10 @@ class Puppet::Transaction::Event
 
   def initialize(options = {})
     @audited = false
+    @previous_value = ""
+    @desired_value = ""
+    @historical_value = ""
+    @name = ""
 
     set_options(options)
     @time = Time.now

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -194,6 +194,16 @@ describe Puppet::Resource::Status do
     events_as_hashes(tripped).should == events_as_hashes(@status)
   end
 
+  describe "when failed_because is tripped" do
+    it "should generate an event with default values" do
+      @status.failed_because("something bad happened")
+      @status.events[0].name.should == ""
+      @status.events[0].desired_value.should == ""
+      @status.events[0].historical_value.should == ""
+      @status.events[0].previous_value.should == ""
+    end
+  end
+
   def events_as_hashes(report)
     report.events.collect do |e|
       {


### PR DESCRIPTION
Previous to this patch, when severe errors caused Puppet::Resource::Status
failed_because to synthesize an event, the synthesized event would lack some
of the expected member variables.  This patch adds default values for those
member variables (an empty string).
