### PR TITLE
23053 - couldn't find HOME environment -- expanding `~/.puppet'

### DIFF
--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -55,21 +55,21 @@ module Puppet
 
     class UnixRunMode < RunMode
       def conf_dir
-        which_dir("/etc/puppet", "~/.puppet")
+        which_dir("/etc/puppet", "#{ENV['HOME']}/.puppet")
       end
 
       def var_dir
-        which_dir("/var/lib/puppet", "~/.puppet/var")
+        which_dir("/var/lib/puppet", "#{ENV['HOME']}/.puppet/var")
       end
     end
 
     class WindowsRunMode < RunMode
       def conf_dir
-        which_dir(File.join(windows_common_base("etc")), "~/.puppet")
+        which_dir(File.join(windows_common_base("etc")), "#{ENV['HOME']}/.puppet")
       end
 
       def var_dir
-        which_dir(File.join(windows_common_base("var")), "~/.puppet/var")
+        which_dir(File.join(windows_common_base("var")), "#{ENV['HOME']}/.puppet/var")
       end
 
     private


### PR DESCRIPTION
 when running puppet command as non root.  Puppet cannot find its home directory because ruby doesn't have a pure bash shell with is required to expand the the tilde.
 The fix is to just use the ruby environment HOME path to expand the path correctly.

This will fix many problems regarding running puppet commands from puppet as non root.
