### PR TITLE
(maint) Honor TEST or TESTS and timesync when provisioning

### DIFF
--- a/acceptance/config/el6/Rakefile
+++ b/acceptance/config/el6/Rakefile
@@ -19,6 +19,7 @@ module HarnessOptions
       :keys => ["id_rsa-acceptance"],
     },
     :xml => true,
+    :timesync => true,
   }
 
   class Aggregator
@@ -79,14 +80,14 @@ EOS
     merged.puts(final_options.pretty_inspect)
   end
 
-
-  tests = "--tests=#{ENV['TEST']}" if ENV['TEST']
+  tests = ENV['TESTS'] || ENV['TEST'] 
+  tests_opt = "--tests=#{tests}" if tests
 
   config_opt = "--hosts=#{config}" if config
 
   overriding_options = ENV['OPTIONS']
 
-  args = ["--options-file", options_file, config_opt, tests, overriding_options].compact
+  args = ["--options-file", options_file, config_opt, tests_opt, overriding_options].compact
 
   begin
     sh("beaker", *args)

--- a/acceptance/config/el6/config/git/options.rb
+++ b/acceptance/config/el6/config/git/options.rb
@@ -4,5 +4,4 @@
     'git://github.com/puppetlabs/hiera.git#stable',
   ],
   :pre_suite => ['setup/git/pre-suite'],
-  :ntp => true,
 }


### PR DESCRIPTION
Harness indicated you should set TESTS to override beaker --tests, but
was only looking at ENV['TEST'].  Accepts either TEST or TESTS now.

Also sets :timesync => true in base beaker options, replacing the :ntp
setting which can only be passed as a command line flag.  So beaker will
now perform ntpdate or equivalent on new hosts.
