### PR TITLE
(#23074) Do not expect rebuild during cert signing

### DIFF
--- a/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
+++ b/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
@@ -4,7 +4,6 @@ confine :except, :platform => 'windows'
 target  = "working3961.example.org"
 
 expect = ['Signed certificate request for ca',
-          'Rebuilding inventory file',
           'working3961.example.org has a waiting certificate request',
           'Signed certificate request for working3961.example.org',
           'Removing file Puppet::SSL::CertificateRequest working3961.example.org']


### PR DESCRIPTION
The removal of rebuilding the inventory during certificate signing to remove
a race condition caused an acceptance test to break. The break is not about
an intrinsic part of the test and so the assertion has simply been removed.
