### PR TITLE
Maint: Change "installation" section of README to be more useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,32 +7,28 @@ Puppet, an automated administrative engine for your Linux, Unix, and Windows sys
 administrative tasks (such as adding users, installing packages, and updating server
 configurations) based on a centralized specification.
 
-Documentation (and detailed installation instructions) can be found online at the
-[Puppet Docs site](http://docs.puppetlabs.com).
+Documentation
+-------------
 
+Documentation for Puppet and related projects can be found online at the
+[Puppet Docs site](http://docs.puppetlabs.com).
 
 Installation
 ------------
 
-Generally, you need the following things installed:
+The best way to run Puppet is with [Puppet Enterprise](http://puppetlabs.com/puppet/puppet-enterprise),
+which also includes orchestration features, a web console, and professional support.
+[The PE documentation is available here.](http://docs.puppetlabs.com/pe/latest)
 
-* A supported Ruby version. Ruby 1.8.7, 1.9.3, and 2.0.0 (at least p195) are fully supported.
+To install an open source release of Puppet,
+[see the installation guide on the docs site.](http://docs.puppetlabs.com/guides/installation.html)
 
-* The Ruby OpenSSL library.  For some reason, this often isn't included
-  in the main ruby distributions.  You can test for it by running
-  `ruby -ropenssl -e "puts :yep"`.  If that errors out, you're missing the
-  library.
-
-  If your distribution doesn't come with the necessary library (e.g., on Debian
-  and Ubuntu you need to install libopenssl-ruby), then you'll probably have to
-  compile Ruby yourself, since it's part of the standard library and not
-  available separately.  You could probably just compile and install that one
-  library, though.
-
-* Facter => 1.6.11 (available via your package manager or from the [Facter site](http://puppetlabs.com/projects/facter)).
+If you need to run Puppet from source as a tester or developer,
+[see the running from source guide on the docs site.](http://docs.puppetlabs.com/guides/from_source.html)
 
 Contributions
 ------
+
 Please see our [Contribution
 Documents](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)
 and our [Developer


### PR DESCRIPTION
- Point to PE
- Point to open source installation guide
- Point to running-from-source guide
