### PR TITLE
(#23086) Ensure that failed_because events have a name

### DIFF
--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -67,7 +67,7 @@ module Puppet
         # will always be accompanied by an event with some explanatory power.  This
         # is useful for reporting/diagnostics/etc.  So synthesize an event here
         # with the exception detail as the message.
-        add_event(@real_resource.event(:status => "failure", :message => detail.to_s))
+        add_event(@real_resource.event(:name => :resource_error, :status => "failure", :message => detail.to_s))
       end
 
       def initialize(resource)

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -115,6 +115,14 @@ describe Puppet::Resource::Status do
     @status.events.should == [event]
   end
 
+  it "records an event for a failure caused by an error" do
+    @status.failed_because(StandardError.new("the message"))
+
+    expect(@status.events[0].message).to eq("the message")
+    expect(@status.events[0].status).to eq("failure")
+    expect(@status.events[0].name).to eq(:resource_error)
+  end
+
   it "should count the number of successful events and set changed" do
     3.times{ @status << Puppet::Transaction::Event.new(:status => 'success') }
     @status.change_count.should == 3


### PR DESCRIPTION
The name of an event is assumed to exist for any reports that are not created
by the inspect command. The inspect command constructs its reports itself and
does not currently use failed_because(). Therefore it should be safe (if
sad-making) to have _only_ failed_because() set a specific name on the event
it creates.
