### PR TITLE
Suppress misleading warn. in openbsd provider

### DIFF
--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -35,9 +35,11 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
             packages << new(hash)
             hash = {}
           else
-            # Print a warning on lines we can't match, but move
-            # on, since it should be non-fatal
-            warning("Failed to match line #{line}")
+            unless line =~ /Updating the pkgdb/
+              # Print a warning on lines we can't match, but move
+              # on, since it should be non-fatal
+              warning("Failed to match line #{line}")
+            end
           end
         }
       end


### PR DESCRIPTION
I have observed that `pkginfo` command used as `listcmd` by `ports` package provider sometimes outputs extra messages to stdout (the message starts with `Updating the pkgdb`). This causes puppet to issue its own warning as the line obtained from `listcmd` is not a valid package name.

This patch suppresses this spurious message.
