### PR TITLE
(#9546) Preserve permissions in 'puppet module build'

### DIFF
--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -60,7 +60,7 @@ module Puppet::ModuleTool
           when *Puppet::ModuleTool::ARTIFACTS
             next
           else
-            FileUtils.cp_r path, build_path
+            FileUtils.cp_r path, build_path, :preserve => true
           end
         end
       end


### PR DESCRIPTION
Previously, 'puppet module build' made no attempt to preserve
permissions. This could render any external fact scripts
unexecutable.  This patch simply preserves permissions when
creating the pkg directory which is tarred up to build the
module.
