### PR TITLE
(#23126) Allow facter and hiera gem locations to be SSH git URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 def location_for(place, fake_version = nil)
-  if place =~ /^(git:[^#]*)#(.*)/
+  if place =~ /^(git[:@][^#]*)#(.*)/
     [fake_version, { :git => $1, :branch => $2, :require => false }].compact
   elsif place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false }]


### PR DESCRIPTION
Previously, git urls could only be specified as `git://`. This works
fine for pulling down the puppetlabs facter and hiera repos, but
doesn't allow private forks of those to be pulled down. This is
problematic because the Gemfile is used for setting up our test
environments and the PE versions of facter and hiera are accessed over
SSH.

This commit allows git@ urls in addition to the current git: urls.
