### PR TITLE
(#23138) Document status

### DIFF
--- a/api/docs/http_api_index.md
+++ b/api/docs/http_api_index.md
@@ -25,6 +25,7 @@ Puppet Agents.
 * {file:api/docs/http_facts.md Facts}
 * {file:api/docs/http_node.md Node}
 * {file:api/docs/http_resource_type.md Resource Type}
+* {file:api/docs/http_status.md Status}
 
 ### SSL Certificate Related Services
 
@@ -44,8 +45,3 @@ REST services support all of the formats.
 
 * {file:api/docs/pson.md PSON}
 * {http://www.yaml.org/spec/1.2/spec.html YAML}
-
-To Be Documented
-----------------
-
-* status

--- a/api/docs/http_status.md
+++ b/api/docs/http_status.md
@@ -1,0 +1,41 @@
+Status
+=============
+
+The `status` endpoint provides information about a running master.
+
+Find
+----
+
+Get status for a master
+
+    GET /:environment/status/:name
+
+The `:environment` and `:name` sections of the URL are both ignored, but a
+value must be provided for both.
+
+### Supported HTTP Methods
+
+GET
+
+### Supported Response Formats
+
+PSON
+
+### Parameters
+
+None
+
+### Example Response
+
+    GET /env/status/whatever
+
+    HTTP 200 OK
+    Content-Type: text/pson
+
+    {"is_alive":true,"version":"3.3.2"}
+
+Schema
+------
+
+The returned status conforms to the
+{file:api/schemas/status.json api/schemas/status.json} schema.

--- a/api/schemas/status.json
+++ b/api/schemas/status.json
@@ -1,0 +1,18 @@
+{
+    "$schema":     "http://json-schema.org/draft-04/schema#",
+    "title":       "Master status",
+    "description": "Information about a running master",
+    "type":        "object",
+    "properties": {
+        "is_alive": {
+            "description": "This will always be true since the master must be running to retrieve the object",
+            "type": "boolean"
+        },
+        "version": {
+            "description": "The version of the master",
+            "type": "string"
+        }
+    },
+    "required": ["is_alive", "version"],
+    "additionalProperties": false
+}

--- a/spec/unit/status_spec.rb
+++ b/spec/unit/status_spec.rb
@@ -37,4 +37,13 @@ describe Puppet::Status do
     new_status = Puppet::Status.convert_from('yaml', status.render('yaml'))
     new_status.should equal_attributes_of(status)
   end
+
+  it "serializes to PSON that conforms to the status schema", :unless => Puppet.features.microsoft_windows? do
+    schema = JSON.parse(File.read('api/schemas/status.json'))
+    status = Puppet::Status.new
+    status.version = Puppet.version
+
+    JSON::Validator.validate!(JSON_META_SCHEMA, schema)
+    JSON::Validator.validate!(schema, status.render('pson'))
+  end
 end


### PR DESCRIPTION
This adds documentation for the status endpoint. This endpoint has almost no
behavior, but could be extended in the future to provide more information.
