### PR TITLE
Maint: Make doc string for Windows group provider match 3.4.0 fixes

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -1,7 +1,8 @@
 require 'puppet/util/adsi'
 
 Puppet::Type.type(:group).provide :windows_adsi do
-  desc "Local group management for Windows. Nested groups are not supported."
+  desc "Local group management for Windows. Group members can be both users and groups.
+    Additionally, local groups can contain domain users."
 
   defaultfor :operatingsystem => :windows
   confine    :operatingsystem => :windows


### PR DESCRIPTION
Nested groups and domain user members are now supported.
