### PR TITLE
(#19447) Puppet::FileSystem::File.unlink

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -44,7 +44,7 @@ class Puppet::Configurer
   rescue => detail
     Puppet.log_exception(detail, "Removing corrupt state file #{Puppet[:statefile]}: #{detail}")
     begin
-      ::File.unlink(Puppet[:statefile])
+      Puppet::FileSystem::File.unlink(Puppet[:statefile])
       retry
     rescue => detail
       raise Puppet::Error.new("Cannot remove #{Puppet[:statefile]}: #{detail}")

--- a/lib/puppet/file_system/file.rb
+++ b/lib/puppet/file_system/file.rb
@@ -159,6 +159,25 @@ class Puppet::FileSystem::File
     File.readlink(@path)
   end
 
+  # Deletes the named files, returning the number of names passed as arguments.
+  # See also Dir::rmdir.
+  #
+  # @raise an exception on any error.
+  #
+  # @return [Integer] the number of names passed as arguments
+  def self.unlink(*file_names)
+    File.unlink(*file_names)
+  end
+
+  # Deletes the file.
+  # See also Dir::rmdir.
+  #
+  # @raise an exception on any error.
+  #
+  # @return [Integer] the number of names passed as arguments, in this case 1
+  def unlink
+    self.class.unlink(@path)
+  end
 
   # @return [File::Stat] object for the named file.
   def stat

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -21,7 +21,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
   end
 
   def destroy(request)
-    File.unlink(path(request.key))
+    Puppet::FileSystem::File.unlink(path(request.key))
   rescue => detail
     unless detail.is_a? Errno::ENOENT
       raise Puppet::Error, "Could not destroy #{self.name} #{request.key}: #{detail}"

--- a/lib/puppet/indirector/key/file.rb
+++ b/lib/puppet/indirector/key/file.rb
@@ -27,7 +27,7 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
     return unless Puppet::FileSystem::File.exist?(public_key_path(request.key))
 
     begin
-      File.unlink(public_key_path(request.key))
+      Puppet::FileSystem::File.unlink(public_key_path(request.key))
     rescue => detail
       raise Puppet::Error, "Could not remove #{request.key} public key: #{detail}"
     end

--- a/lib/puppet/indirector/ssl_file.rb
+++ b/lib/puppet/indirector/ssl_file.rb
@@ -74,7 +74,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
 
     Puppet.notice "Removing file #{model} #{request.key} at '#{path}'"
     begin
-      File.unlink(path)
+      Puppet::FileSystem::File.unlink(path)
     rescue => detail
       raise Puppet::Error, "Could not remove #{request.key}: #{detail}"
     end

--- a/lib/puppet/indirector/yaml.rb
+++ b/lib/puppet/indirector/yaml.rb
@@ -46,7 +46,7 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
 
   def destroy(request)
     file_path = path(request.key)
-    File.unlink(file_path) if Puppet::FileSystem::File.exist?(file_path)
+    Puppet::FileSystem::File.unlink(file_path) if Puppet::FileSystem::File.exist?(file_path)
   end
 
   def search(request)

--- a/lib/puppet/provider/service/daemontools.rb
+++ b/lib/puppet/provider/service/daemontools.rb
@@ -170,7 +170,7 @@ Puppet::Type.type(:service).provide :daemontools, :parent => :base do
       if self.daemon
         if Puppet::FileSystem::File.new(self.service).symlink?
           Puppet.notice "Disabling #{self.service}: removing link #{self.daemon} -> #{self.service}"
-          File.unlink(self.service)
+          Puppet::FileSystem::File.unlink(self.service)
         end
       end
     rescue Puppet::ExecutionFailure

--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -105,7 +105,7 @@ Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
   # before a disable
   def disable
     # unlink the daemon symlink to disable it
-    File.unlink(self.service) if Puppet::FileSystem::File.new(self.service).symlink?
+    Puppet::FileSystem::File.unlink(self.service) if Puppet::FileSystem::File.new(self.service).symlink?
   end
 end
 

--- a/lib/puppet/reports/store.rb
+++ b/lib/puppet/reports/store.rb
@@ -58,7 +58,7 @@ Puppet::Reports.register_report(:store) do
       Dir.entries(dir).each do |file|
         next if ['.','..'].include?(file)
         file = File.join(dir, file)
-        File.unlink(file) if File.file?(file)
+        Puppet::FileSystem::File.unlink(file) if File.file?(file)
       end
       Dir.rmdir(dir)
     end

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -736,7 +736,7 @@ Puppet::Type.newtype(:file) do
         fail "Could not rename temporary file #{path} to #{self[:path]}: #{detail}"
       ensure
         # Make sure the created file gets removed
-        ::File.unlink(path) if Puppet::FileSystem::File.exist?(path)
+        Puppet::FileSystem::File.unlink(path) if Puppet::FileSystem::File.exist?(path)
       end
     end
 
@@ -786,7 +786,7 @@ Puppet::Type.newtype(:file) do
   # @api private
   def remove_file(current_type, wanted_type)
     debug "Removing existing #{current_type} for replacement with #{wanted_type}"
-    ::File.unlink(self[:path])
+    Puppet::FileSystem::File.unlink(self[:path])
     stat_needed
     true
   end

--- a/lib/puppet/type/file/ensure.rb
+++ b/lib/puppet/type/file/ensure.rb
@@ -36,7 +36,7 @@ module Puppet
     nodefault
 
     newvalue(:absent) do
-      File.unlink(@resource[:path])
+      Puppet::FileSystem::File.unlink(@resource[:path])
     end
 
     aliasvalue(:false, :absent)

--- a/lib/puppet/type/k5login.rb
+++ b/lib/puppet/type/k5login.rb
@@ -51,7 +51,7 @@ Puppet::Type.newtype(:k5login) do
 
     # remove the file
     def destroy
-      File.unlink(@resource[:name])
+      Puppet::FileSystem::File.unlink(@resource[:name])
     end
 
     # Return the principals

--- a/lib/puppet/util/backups.rb
+++ b/lib/puppet/util/backups.rb
@@ -70,7 +70,7 @@ module Puppet::Util::Backups
     info "Removing old backup of type #{stat.ftype}"
 
     begin
-      File.unlink(newfile)
+      Puppet::FileSystem::File.unlink(newfile)
     rescue => detail
       message = "Could not remove old backup: #{detail}"
       self.log_exception(detail, message)

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -112,7 +112,7 @@ class Puppet::Util::FileType
 
     # Remove the file.
     def remove
-      File.unlink(@path) if Puppet::FileSystem::File.exist?(@path)
+      Puppet::FileSystem::File.unlink(@path) if Puppet::FileSystem::File.exist?(@path)
     end
 
     # Overwrite the file.

--- a/lib/puppet/util/lockfile.rb
+++ b/lib/puppet/util/lockfile.rb
@@ -31,7 +31,7 @@ class Puppet::Util::Lockfile
 
   def unlock
     if locked?
-      File.unlink(@file_path)
+      Puppet::FileSystem::File.unlink(@file_path)
       true
     else
       false

--- a/lib/puppet/util/reference.rb
+++ b/lib/puppet/util/reference.rb
@@ -46,7 +46,7 @@ class Puppet::Util::Reference
     # There used to be an attempt to use secure_open / replace_file to secure
     # the target, too, but that did nothing: the race was still here.  We can
     # get exactly the same benefit from running this effort:
-    File.unlink('/tmp/puppetdoc.tex') rescue nil
+    Puppet::FileSystem::File.unlink('/tmp/puppetdoc.tex') rescue nil
     output = %x{#{cmd}}
     unless $CHILD_STATUS == 0
       $stderr.puts "rst2latex failed"

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -254,7 +254,7 @@ describe Puppet::Transaction do
     Puppet::FileSystem::File.exist?(fname).should be_true
 
     # Now remove it, so it can get created again
-    File.unlink(fname)
+    Puppet::FileSystem::File.unlink(fname)
 
     file[:content] = "some content"
 
@@ -262,7 +262,7 @@ describe Puppet::Transaction do
     Puppet::FileSystem::File.exist?(fname).should be_true
 
     # Now remove it, so it can get created again
-    File.unlink(fname)
+    Puppet::FileSystem::File.unlink(fname)
 
     # And tag our exec
     exec.tag("testrun")

--- a/spec/unit/indirector/json_spec.rb
+++ b/spec/unit/indirector/json_spec.rb
@@ -135,16 +135,16 @@ describe Puppet::Indirector::JSON do
       end
 
       it "silently succeeds when files don't exist" do
-        File.unlink(file) rescue nil
+        Puppet::FileSystem::File.unlink(file) rescue nil
         subject.destroy(request).should be_true
       end
 
       it "raises an informative error for other failures" do
-        File.stubs(:unlink).with(file).raises(Errno::EPERM, 'fake permission problem')
+        Puppet::FileSystem::File.stubs(:unlink).with(file).raises(Errno::EPERM, 'fake permission problem')
         with_content('hello') do
           expect { subject.destroy(request) }.to raise_error Puppet::Error
         end
-        File.unstub(:unlink)    # thanks, mocha
+        Puppet::FileSystem::File.unstub(:unlink)    # thanks, mocha
       end
     end
   end

--- a/spec/unit/indirector/key/file_spec.rb
+++ b/spec/unit/indirector/key/file_spec.rb
@@ -76,20 +76,20 @@ describe Puppet::SSL::Key::File do
     end
 
     it "should destroy the public key when destroying the private key" do
-      File.stubs(:unlink).with(@private_key_path)
+      Puppet::FileSystem::File.stubs(:unlink).with(@private_key_path)
       Puppet::FileSystem::File.stubs(:exist?).with(@private_key_path).returns true
       Puppet::FileSystem::File.expects(:exist?).with(@public_key_path).returns true
-      File.expects(:unlink).with(@public_key_path)
+      Puppet::FileSystem::File.expects(:unlink).with(@public_key_path)
 
       @searcher.destroy(@request)
     end
 
     it "should not fail if the public key does not exist when deleting the private key" do
-      File.stubs(:unlink).with(@private_key_path)
+      Puppet::FileSystem::File.stubs(:unlink).with(@private_key_path)
 
       Puppet::FileSystem::File.stubs(:exist?).with(@private_key_path).returns true
       Puppet::FileSystem::File.expects(:exist?).with(@public_key_path).returns false
-      File.expects(:unlink).with(@public_key_path).never
+      Puppet::FileSystem::File.expects(:unlink).with(@public_key_path).never
 
       @searcher.destroy(@request)
     end

--- a/spec/unit/indirector/ssl_file_spec.rb
+++ b/spec/unit/indirector/ssl_file_spec.rb
@@ -267,13 +267,13 @@ describe Puppet::Indirector::SslFile do
       describe "that exist" do
         it "should unlink the certificate file" do
           Puppet::FileSystem::File.expects(:exist?).with(@certpath).returns true
-          File.expects(:unlink).with(@certpath)
+          Puppet::FileSystem::File.expects(:unlink).with(@certpath)
           @searcher.destroy(@request)
         end
 
         it "should log that is removing the file" do
           Puppet::FileSystem::File.stubs(:exist?).returns true
-          File.stubs(:unlink)
+          Puppet::FileSystem::File.stubs(:unlink)
           Puppet.expects(:notice)
           @searcher.destroy(@request)
         end

--- a/spec/unit/indirector/yaml_spec.rb
+++ b/spec/unit/indirector/yaml_spec.rb
@@ -150,14 +150,14 @@ describe Puppet::Indirector::Yaml do
 
       it "should unlink the right yaml file if it exists" do
         Puppet::FileSystem::File.expects(:exist?).with(path).returns true
-        File.expects(:unlink).with(path)
+        Puppet::FileSystem::File.expects(:unlink).with(path)
 
         @store.destroy(@request)
       end
 
       it "should not unlink the yaml file if it does not exists" do
         Puppet::FileSystem::File.expects(:exist?).with(path).returns false
-        File.expects(:unlink).with(path).never
+        Puppet::FileSystem::File.expects(:unlink).with(path).never
 
         @store.destroy(@request)
       end

--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -34,7 +34,7 @@ describe "base service provider" do
     end
 
     before :each do
-      File.unlink(flag) if Puppet::FileSystem::File.exist?(flag)
+      Puppet::FileSystem::File.unlink(flag) if Puppet::FileSystem::File.exist?(flag)
     end
 
     it { should be }

--- a/spec/unit/provider/service/daemontools_spec.rb
+++ b/spec/unit/provider/service/daemontools_spec.rb
@@ -117,7 +117,7 @@ describe provider_class do
       path = File.join(@servicedir,"myservice")
       mocked_file = mock(path, :symlink? => true)
       Puppet::FileSystem::File.expects(:new).with(path).returns(mocked_file)
-      File.expects(:unlink).with(path)
+      Puppet::FileSystem::File.expects(:unlink).with(path)
       @provider.stubs(:texecute).returns("")
       @provider.disable
     end
@@ -126,7 +126,7 @@ describe provider_class do
       FileTest.stubs(:directory?).returns(false)
       mocked_file = mock('anything', :symlink? => true)
       Puppet::FileSystem::File.expects(:new).returns(mocked_file)
-      File.stubs(:unlink)
+      Puppet::FileSystem::File.stubs(:unlink)
       @provider.expects(:stop)
       @provider.disable
     end

--- a/spec/unit/provider/service/runit_spec.rb
+++ b/spec/unit/provider/service/runit_spec.rb
@@ -114,7 +114,7 @@ describe provider_class do
       mocked_file = mock(path, :symlink? => true)
       FileTest.stubs(:directory?).returns(false)
       Puppet::FileSystem::File.expects(:new).with(path).returns(mocked_file)
-      File.expects(:unlink).with(path).returns(0)
+      Puppet::FileSystem::File.expects(:unlink).with(path).returns(0)
       @provider.disable
     end
   end

--- a/spec/unit/reports/store_spec.rb
+++ b/spec/unit/reports/store_spec.rb
@@ -55,7 +55,7 @@ describe processor do
 
   describe "::destroy" do
     it "rejects invalid hostnames" do
-      File.expects(:unlink).never
+      Puppet::FileSystem::File.expects(:unlink).never
       expect { processor.destroy("..") }.to raise_error(ArgumentError, /Invalid node/)
     end
   end

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -948,7 +948,7 @@ describe Puppet::Type.type(:file) do
       file.stat
       file.stubs(:stat).returns stub('stat', :ftype => 'file')
 
-      File.stubs(:unlink)
+      Puppet::FileSystem::File.stubs(:unlink)
 
       file.remove_existing(:directory).should == true
       file.instance_variable_get(:@stat).should == :needs_stat

--- a/spec/unit/util/backups_spec.rb
+++ b/spec/unit/util/backups_spec.rb
@@ -60,7 +60,7 @@ describe Puppet::Util::Backups do
       it "should remove any local backup if one exists" do
         stub_file = stub(backup, :lstat => stub('stat', :ftype => 'file'))
         Puppet::FileSystem::File.expects(:new).with(backup).returns stub_file
-        File.expects(:unlink).with(backup)
+        Puppet::FileSystem::File.expects(:unlink).with(backup)
         FileUtils.stubs(:cp_r)
         Puppet::FileSystem::File.expects(:exist?).with(path).returns(true)
 
@@ -70,7 +70,7 @@ describe Puppet::Util::Backups do
       it "should fail when the old backup can't be removed" do
         stub_file = stub(backup, :lstat => stub('stat', :ftype => 'file'))
         Puppet::FileSystem::File.expects(:new).with(backup).returns stub_file
-        File.expects(:unlink).with(backup).raises ArgumentError
+        Puppet::FileSystem::File.expects(:unlink).with(backup).raises ArgumentError
         FileUtils.expects(:cp_r).never
         Puppet::FileSystem::File.expects(:exist?).with(path).returns(true)
 
@@ -81,7 +81,7 @@ describe Puppet::Util::Backups do
         stub_file = stub(backup)
         Puppet::FileSystem::File.expects(:new).with(backup).returns stub_file
         stub_file.expects(:lstat).raises(Errno::ENOENT)
-        File.expects(:unlink).with(backup).never
+        Puppet::FileSystem::File.expects(:unlink).with(backup).never
         FileUtils.stubs(:cp_r)
         Puppet::FileSystem::File.expects(:exist?).with(path).returns(true)
 

--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -24,7 +24,7 @@ describe Puppet::Util::FileType do
 
       it "should unlink the file when asked to remove it" do
         Puppet::FileSystem::File.expects(:exist?).with(path).returns true
-        File.expects(:unlink).with(path)
+        Puppet::FileSystem::File.expects(:unlink).with(path)
 
         file.remove
       end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -470,7 +470,7 @@ describe Puppet::Util do
         subject.replace_file(new_target, 0555) {|fh| fh.puts "foo" }
         get_mode(new_target).should == 0555
       ensure
-        File.unlink(new_target) if Puppet::FileSystem::File.exist?(new_target)
+        Puppet::FileSystem::File.unlink(new_target) if Puppet::FileSystem::File.exist?(new_target)
       end
     end
 
@@ -509,7 +509,7 @@ describe Puppet::Util do
 
           get_mode(new_target).should == 0664
         ensure
-          File.unlink(new_target) if Puppet::FileSystem::File.exist?(new_target)
+          Puppet::FileSystem::File.unlink(new_target) if Puppet::FileSystem::File.exist?(new_target)
         end
       end
     end


### PR DESCRIPTION
- All previous File.unlink calls go through the new FileSystem::File
  abstraction so that the implementation can later be swapped for a
  Windows specific one to support symlinks
