### PR TITLE
Fix install-options in zypper provider

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -92,9 +92,9 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
     options.collect do |val|
       case val
       when Hash
-        val.keys.sort.collect do |k|
-          "#{k} '#{val[k]}'"
-        end.join(' ')
+        val.keys.sort.collect do |k,v|
+          "#{k}=#{v}"
+        end.join
       else
         val
       end


### PR DESCRIPTION
install_options => { '--from' => 'foobar' }

into a zypper call

zypper install "--from 'foobar'"

which doesnt work.

new code does
zypper install --from=foobar
