### PR TITLE
Zypper provider install options

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -94,7 +94,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
       when Hash
         val.keys.sort.collect do |k,v|
           "#{k}=#{v}"
-        end.join
+        end.join(' ')
       else
         val
       end


### PR DESCRIPTION
The old code would convert
install_options => { '--from' => 'foobar' }

into a zypper call

zypper install "--from 'foobar'"

which doesnt work.

new code does
zypper install --from=foobar
