### PR TITLE
(#7244) Make autosign command treat all non-zero returns the same

### DIFF
--- a/lib/puppet/ssl/certificate_authority/autosign_command.rb
+++ b/lib/puppet/ssl/certificate_authority/autosign_command.rb
@@ -39,10 +39,8 @@ class Puppet::SSL::CertificateAuthority::AutosignCommand
     case exitstatus
     when 0
       true
-    when 1
-      false
     else
-      raise CheckFailure, "autosign_command '#{cmd}' failed while checking #{name}: exit status #{exitstatus}"
+      false
     end
   end
 end


### PR DESCRIPTION
Previously the autosign command exit status was checked for three
states: 0, 1, or other.  The latter two would both fail to autosign,
but the other would also raise an exception, so different results
at the client.  We noticed this because the acceptance test
failed on Solaris (which returns 255 for /bin/false, rather than 1).

There doesn't seem to be a compelling reason to treat the non-zero
exit codes differently, so this patch simply removes that distiniction.
