### PR TITLE
(maint) Remove ext/rack/README reference from debian/rules

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -66,9 +66,6 @@ install: build
 	$(INSTALL) -m0644 ext/emacs/puppet-mode.el			\
 		$(CURDIR)/debian/puppet-el/usr/share/emacs/site-lisp/puppet-mode.el
 
-	# Install the rack README as README.rack
-	$(INSTALL) -m0644 ext/rack/README \
-		$(CURDIR)/debian/puppetmaster-passenger/usr/share/doc/puppetmaster-passenger/README.rack
 	# Install the config.ru
 	$(INSTALL) -m0644 ext/rack/config.ru \
 		$(CURDIR)/debian/puppetmaster-passenger/usr/share/puppet/rack/puppetmasterd


### PR DESCRIPTION
In a previous commit, files in ext/rack/files were moved up a directory to
ext/rack and some unneeded files were removed. Among the removed files was
README, which was unfortunately still used in the debian/rules file as a
supplemental doc for the puppetmaster-passenger package. The lack of
ext/rack/README caused the rules evaluation to fail, which caused debian
packaging to fail. This commit addresses that by removing the README references
from the debian/rules file.
