### PR TITLE
(maint) Rename expected apache vhost in debian/rules

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -70,7 +70,7 @@ install: build
 	$(INSTALL) -m0644 ext/rack/config.ru \
 		$(CURDIR)/debian/puppetmaster-passenger/usr/share/puppet/rack/puppetmasterd
 	# Install apache2 site configuration template
-	$(INSTALL) -m0644 ext/rack/apache2.conf \
+	$(INSTALL) -m0644 ext/rack/example-passenger-vhost.conf \
 		$(CURDIR)/debian/puppetmaster-passenger/usr/share/puppetmaster-passenger/apache2.site.conf.tmpl
 
 	# Add ext directory


### PR DESCRIPTION
In a previous commit, files in ext/rack/files were moved up a directory to
ext/rack and some files were renamed. Among the renamed files was
apache2.conf, which was renamed to example-passenger-vhost.conf.  This caused
the rules evaluation to fail, which caused debian packaging to fail. This
commit addresses that by renaming the vhost references in the debian/rules
file.
