### PR TITLE
(maint) Fix the 'nothing to manage' message.

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -76,12 +76,14 @@ class Puppet::Transaction::ResourceHarness
 
     managed_via_ensure = manage_via_ensure_if_possible(resource, context)
 
-    if !managed_via_ensure && context.resource_present?
-      resource.properties.each do |param|
-        sync_if_needed(param, context)
+    if !managed_via_ensure
+      if context.resource_present?
+        resource.properties.each do |param|
+          sync_if_needed(param, context)
+        end
+      else
+        resource.debug("Nothing to manage: no ensure and the resource doesn't exist")
       end
-    else
-      resource.debug("Nothing to manage: no ensure and the resource doesn't exist")
     end
 
     capture_audit_events(resource, context)


### PR DESCRIPTION
In the refactoring for #23081, in commit 6ff0a103, the message
"Nothing to manage; no ensure and the resource doesn't exist"
was introduced.  However, this message would spuriously fire
if the resource was in fact managed by an ensure property, e.g.

rm -rf /tmp/foo; be puppet apply -e 'file {"/tmp/foo": ensure => present}' --debug

This patch corrects that spurious debug message.
