### PR TITLE
(#23177) Specifies default value for package type's ensure attribute

### DIFF
--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -58,7 +58,7 @@ module Puppet
         retrieve by specifying a version number or `latest` as the ensure
         value. On packaging systems that manage configuration files separately
         from "normal" system files, you can uninstall config files by
-        specifying `purged` as the ensure value.
+        specifying `purged` as the ensure value. This defaults to `installed`.
       EOT
 
       attr_accessor :latest


### PR DESCRIPTION
This patch makes clear that the ensure attribute for packages defaults to 'installed'.
This will prevent confusion from users and make the documentaion more awesomeer.
