### PR TITLE
(#23183) Use FFI to manage pointers in RootCerts module

### DIFF
--- a/lib/puppet/util/colors.rb
+++ b/lib/puppet/util/colors.rb
@@ -82,6 +82,7 @@ module Puppet::Util::Colors
   if Puppet::Util::Platform.windows?
     # We're on windows, need win32console for color to work
     begin
+      require 'Win32API'
       require 'win32console'
       require 'windows/wide_string'
 

--- a/lib/puppet/util/windows/root_certs.rb
+++ b/lib/puppet/util/windows/root_certs.rb
@@ -1,17 +1,16 @@
 require 'puppet/util/windows'
 require 'openssl'
-require 'Win32API'
-require 'windows/msvcrt/buffer'
+require 'ffi'
 
 # Represents a collection of trusted root certificates.
 #
 # @api public
 class Puppet::Util::Windows::RootCerts
   include Enumerable
+  extend FFI::Library
 
-  CertOpenSystemStore         = Win32API.new('crypt32', 'CertOpenSystemStore', ['L','P'], 'L')
-  CertEnumCertificatesInStore = Win32API.new('crypt32', 'CertEnumCertificatesInStore', ['L', 'L'], 'L')
-  CertCloseStore              = Win32API.new('crypt32', 'CertCloseStore', ['L', 'L'], 'B')
+  typedef :ulong, :dword
+  typedef :uintptr_t, :handle
 
   def initialize(roots)
     @roots = roots
@@ -22,10 +21,6 @@ class Puppet::Util::Windows::RootCerts
   # @api public
   def each
     @roots.each {|cert| yield cert}
-  end
-
-  class << self
-    include Windows::MSVCRT::Buffer
   end
 
   # Returns a new instance.
@@ -43,34 +38,12 @@ class Puppet::Util::Windows::RootCerts
 
     # This is based on a patch submitted to openssl:
     # http://www.mail-archive.com/openssl-dev@openssl.org/msg26958.html
-    context = 0
-    store = CertOpenSystemStore.call(0, "ROOT")
+    ptr = FFI::Pointer::NULL
+    store = CertOpenSystemStoreA(nil, "ROOT")
     begin
-      while (context = CertEnumCertificatesInStore.call(store, context) and context != 0)
-        # 466 typedef struct _CERT_CONTEXT {
-        # 467     DWORD      dwCertEncodingType;
-        # 468     BYTE       *pbCertEncoded;
-        # 469     DWORD      cbCertEncoded;
-        # 470     PCERT_INFO pCertInfo;
-        # 471     HCERTSTORE hCertStore;
-        # 472 } CERT_CONTEXT, *PCERT_CONTEXT;
-
-        # buffer to hold struct above
-        ctx_buf = 0.chr * 5 * 8
-
-        # copy from win to ruby
-        memcpy(ctx_buf, context, ctx_buf.size)
-
-        # unpack structure
-        arr = ctx_buf.unpack('LLLLL')
-
-        # create buf of length cbCertEncoded
-        cert_buf = 0.chr * arr[2]
-
-        # copy pbCertEncoded from win to ruby
-        memcpy(cert_buf, arr[1], cert_buf.length)
-
-        # create a cert
+      while (ptr = CertEnumCertificatesInStore(store, ptr)) and not ptr.null?
+        context = CERT_CONTEXT.new(ptr)
+        cert_buf = context[:pbCertEncoded].read_bytes(context[:cbCertEncoded])
         begin
           certs << OpenSSL::X509::Certificate.new(cert_buf)
         rescue => detail
@@ -78,9 +51,51 @@ class Puppet::Util::Windows::RootCerts
         end
       end
     ensure
-      CertCloseStore.call(store, 0)
+      CertCloseStore(store, 0)
     end
 
     certs
   end
+
+  private
+
+  # typedef ULONG_PTR HCRYPTPROV_LEGACY;
+  # typedef void *HCERTSTORE;
+
+  class CERT_CONTEXT < FFI::Struct
+    layout(
+      :dwCertEncodingType, :dword,
+      :pbCertEncoded,      :pointer,
+      :cbCertEncoded,      :dword,
+      :pCertInfo,          :pointer,
+      :hCertStore,         :handle
+    )
+  end
+
+  # HCERTSTORE
+  # WINAPI
+  # CertOpenSystemStoreA(
+  #   __in_opt HCRYPTPROV_LEGACY hProv,
+  #   __in LPCSTR szSubsystemProtocol
+  #   );
+  ffi_lib :crypt32
+  attach_function :CertOpenSystemStoreA, [:pointer, :string], :handle
+
+  # PCCERT_CONTEXT
+  # WINAPI
+  # CertEnumCertificatesInStore(
+  #   __in HCERTSTORE hCertStore,
+  #   __in_opt PCCERT_CONTEXT pPrevCertContext
+  #   );
+  ffi_lib :crypt32
+  attach_function :CertEnumCertificatesInStore, [:handle, :pointer], :pointer
+
+  # BOOL
+  # WINAPI
+  # CertCloseStore(
+  #   __in_opt HCERTSTORE hCertStore,
+  #   __in DWORD dwFlags
+  #   );
+  ffi_lib :crypt32
+  attach_function :CertCloseStore, [:handle, :dword], :bool
 end

--- a/spec/unit/util/windows/root_certs_spec.rb
+++ b/spec/unit/util/windows/root_certs_spec.rb
@@ -3,13 +3,15 @@ require 'spec_helper'
 require 'puppet/util/windows'
 
 describe "Puppet::Util::Windows::RootCerts", :if => Puppet::Util::Platform.windows? do
-  let(:klass) { Puppet::Util::Windows::RootCerts }
-  let(:x509) { 'mycert' }
+  let(:x509_store) { Puppet::Util::Windows::RootCerts.instance.to_a }
 
-  context '#each' do
-    it "should enumerate each root cert" do
-      klass.expects(:load_certs).returns([x509])
-      klass.instance.to_a.should == [x509]
-    end
+  it "should return at least one X509 certificate" do
+    expect(x509_store.to_a).to have_at_least(1).items
+  end
+
+  it "should return an X509 certificate with a subject" do
+    x509 = x509_store.first
+
+    expect(x509.subject.to_s).to match(/CN=.*/)
   end
 end


### PR DESCRIPTION
Previously, we made assumptions about the layout of the CERT_CONTEXT
structure, specifically that PCERT_INFO (pointer to CERT_CONTEXT) was an
unsigned 32-bit integer ('L'), and magically accessed the size of the
returned structure as arr[2]. We were also memcpy 40-bytes which was
larger than the size of the CERT_CONTEXT structure in both x86 and x64 and
was the cause of infrequent segmentation faults.

This commit uses FFI to define the layout of the CERT_CONTEXT structure, uses
named fields, e.g. [:cbCertEncoded], to access offsets within the structure,
and uses the FFI::Pointer#null? method to check for NULL pointer.

Note that we use FFI::Pointer and not MemoryPointer, because the
CertEnumCertificatesInStore function is responsible for freeing the
previous CERT_CONTEXT pointer, not us.

Also in the motto of "don't stub what you don't own" it exercises the Win32
APIs to make the tests more meaningful.
