### PR TITLE
(#7173) Add HTTP basic auth support to HTTP reporting in Puppet.

### DIFF
--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'puppet'
 require 'puppet/network/http_pool'
 require 'uri'
@@ -15,6 +16,10 @@ Puppet::Reports.register_report(:http) do
     url = URI.parse(Puppet[:reporturl])
     body = self.to_yaml
     headers = { "Content-Type" => "application/x-yaml" }
+    if url.user && url.password
+      user_pass_encoded = Base64.encode64("#{url.user}:#{url.password}").strip
+      headers["Authorization"] = "Basic #{user_pass_encoded}"
+    end
     use_ssl = url.scheme == 'https'
     conn = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl)
     response = conn.post(url.path, body, headers)

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -62,6 +62,15 @@ describe processor do
       subject.process
     end
 
+    it "should use the username and password specified by the 'reporturl' setting" do
+      Puppet[:reporturl] = "https://user:pass@myhost.mydomain:1234/report/upload"
+      http.expects(:post).with {|path,data,headers|
+        headers['Authorization'].should == "Basic dXNlcjpwYXNz"
+      }.returns(httpok)
+
+      subject.process
+    end
+
     it "should give the body as the report as YAML" do
       http.expects(:post).with {|path, data, headers|
         data.should == subject.to_yaml


### PR DESCRIPTION
This is a second attempt at PR #1975.  Does the following:
- Add logic in Puppet::Reports::Http to properly handle HTTP basic auth using the form http://username:password@host/path
- Add a unit test to make sure HTTP basic auth is done if it is given in the url
