### PR TITLE
Define Puppet cert attribute OIDs

### DIFF
--- a/lib/puppet/ssl.rb
+++ b/lib/puppet/ssl.rb
@@ -5,4 +5,5 @@ require 'openssl'
 module Puppet::SSL # :nodoc:
   CA_NAME = "ca"
   require 'puppet/ssl/host'
+  require 'puppet/ssl/oids'
 end

--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -1,0 +1,45 @@
+require 'puppet/ssl'
+
+# This module defines OIDs for use within Puppet.
+#
+# == ASN.1 Definition
+#
+# The following is the formal definition of OIDs specified in this file.
+#
+# puppetCertExtensions OBJECT IDENTIFIER ::= {iso(1) identified-organization(3)
+#    dod(6) internet(1) private(4) enterprise(1) 34380 1}
+#
+# -- the tree under registeredExtensions 'belongs' to puppetlabs
+# -- privateExtensions can be extended by enterprises to suit their own needs
+# registeredExtensions OBJECT IDENTIFIER ::= { puppetCertExtensions 1 }
+# privateExtensions OBJECT IDENTIFIER ::= { puppetCertExtensions 2 }
+#
+# -- subtree of common registered extensions
+# -- The short names for these OIDs are intentionally lowercased and formatted
+# -- since they may be exposed inside the Puppet DSL as variables.
+# pp_uuid  OBJECT IDENTIFIER ::= { registeredExtensions 1 }
+# pp_instance_id OBJECT IDENTIFIER ::= { registeredExtensions 2 }
+# pp_image_name OBJECT IDENTIFIER ::= { registeredExtensions 3 }
+# pp_preshared_key OBJECT IDENTIFIER ::= { registeredExtensions 4 }
+#
+# @api private
+module Puppet::SSL::Oids
+
+  PUPPET_OIDS = [
+    ["1.3.6.1.4.1.34380", 'puppetlabs', 'Puppet Labs'],
+    ["1.3.6.1.4.1.34380.1", 'ppCertExt', 'Puppet Certificate Extension'],
+
+    ["1.3.6.1.4.1.34380.1.1", 'ppRegCertExt', 'Puppet Registered Certificate Extension'],
+
+    ["1.3.6.1.4.1.34380.1.1.1", 'pp_uuid', 'Puppet Node UUID'],
+    ["1.3.6.1.4.1.34380.1.1.2", 'pp_instance_id', 'Puppet Node Instance ID'],
+    ["1.3.6.1.4.1.34380.1.1.3", 'pp_image_name', 'Puppet Node Image Name'],
+    ["1.3.6.1.4.1.34380.1.1.4", 'pp_preshared_key', 'Puppet Node Preshared Key'],
+
+    ["1.3.6.1.4.1.34380.1.2", 'ppPrivCertExt', 'Puppet Private Certificate Extension'],
+  ]
+
+  PUPPET_OIDS.each do |oid_defn|
+    OpenSSL::ASN1::ObjectId.register(*oid_defn)
+  end
+end

--- a/spec/unit/ssl/oids_spec.rb
+++ b/spec/unit/ssl/oids_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'puppet/ssl/oids'
+
+describe Puppet::SSL::Oids do
+  describe "defining application OIDs" do
+
+    {
+      'puppetlabs' => '1.3.6.1.4.1.34380',
+      'ppCertExt' => '1.3.6.1.4.1.34380.1',
+      'ppRegCertExt' => '1.3.6.1.4.1.34380.1.1',
+      'pp_uuid' => '1.3.6.1.4.1.34380.1.1.1',
+      'pp_instance_id' => '1.3.6.1.4.1.34380.1.1.2',
+      'pp_image_name' => '1.3.6.1.4.1.34380.1.1.3',
+      'pp_preshared_key' => '1.3.6.1.4.1.34380.1.1.4',
+      'ppPrivCertExt' => '1.3.6.1.4.1.34380.1.2',
+    }.each_pair do |sn, oid|
+      it "defines #{sn} as #{oid}" do
+        object_id = OpenSSL::ASN1::ObjectId.new(sn)
+        expect(object_id.oid).to eq oid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit defines an initial set of OIDs for private use within Puppet. The
defined OIDs are focused toward identifying node information that is
embedded in a node certificate.
