### PR TITLE
(#21869) Fix recursion in cert expiration check

### DIFF
--- a/lib/puppet/network/authentication.rb
+++ b/lib/puppet/network/authentication.rb
@@ -13,8 +13,13 @@ module Puppet::Network::Authentication
     # Check CA cert if we're functioning as a CA
     certs << Puppet::SSL::CertificateAuthority.instance.host.certificate if Puppet::SSL::CertificateAuthority.ca?
 
-    # Always check the host cert if we have one, this will be the agent or master cert depending on the run mode
-    certs << Puppet::SSL::Host.localhost.certificate if Puppet::FileSystem::File.exist?(Puppet[:hostcert])
+    # Depending on the run mode, the localhost certificate will be for the
+    # master or the agent. Don't load the certificate if the CA cert is not
+    # present: infinite recursion will occur as another authenticated request
+    # will be spawned to download the CA cert.
+    if Puppet::FileSystem::File.exist?(Puppet[:hostcert]) && Puppet::FileSystem::File.exist?(Puppet[:localcacert])
+      certs << Puppet::SSL::Host.localhost.certificate
+    end
 
     # Remove nil values for caller convenience
     certs.compact.each do |cert|

--- a/spec/unit/network/authentication_spec.rb
+++ b/spec/unit/network/authentication_spec.rb
@@ -31,11 +31,25 @@ describe Puppet::Network::Authentication do
       subject.warn_if_near_expiration
     end
 
-    it "should check the expiration of the localhost certificate" do
-      Puppet::SSL::Host.stubs(:localhost).returns(host)
-      cert.expects(:near_expiration?).returns(false)
-      Puppet::FileSystem::File.stubs(:exist?).with(Puppet[:hostcert]).returns(true)
-      subject.warn_if_near_expiration
+    context "when examining the local host" do
+      before do
+        Puppet::SSL::Host.stubs(:localhost).returns(host)
+        Puppet::FileSystem::File.stubs(:exist?).with(Puppet[:hostcert]).returns(true)
+      end
+
+      it "should not load the localhost certificate if the local CA certificate is missing" do
+        # Redmine-21869: Infinite recursion occurs if CA cert is missing.
+        Puppet::FileSystem::File.stubs(:exist?).with(Puppet[:localcacert]).returns(false)
+        host.unstub(:certificate)
+        host.expects(:certificate).never
+        subject.warn_if_near_expiration
+      end
+
+      it "should check the expiration of the localhost certificate if the local CA certificate is present" do
+        Puppet::FileSystem::File.stubs(:exist?).with(Puppet[:localcacert]).returns(true)
+        cert.expects(:near_expiration?).returns(false)
+        subject.warn_if_near_expiration
+      end
     end
 
     it "should check the expiration of any certificates passed in as arguments" do


### PR DESCRIPTION
During every authenticated request, the expiration date of the involved
certificates is checked. However, if the localhost cert is loaded when the CA
cert is not present an authenticated request will be initiated to download the
CA cert. This triggers another expiration check for authenticated requests,
which loads the localhost cert, which initiates another authenticated request
to download the CA cert... and so on until stack space is exhausted.

This patch skips the expiration check for the localhost cert if the CA cert is
missing.

[Redmine issue #21869](http://projects.puppetlabs.com/issues/21869)
