### PR TITLE
(#15559) Windows security test fails under SYSTEM

### DIFF
--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -284,10 +284,13 @@ module Puppet::Util::Windows::Security
               mode |= S_ISVTX
             end
           when well_known_system_sid
-            mode &= ~S_ISYSTEM_MISSING
           else
             #puts "Warning, unable to map SID into POSIX mode: #{ace[:sid]}"
             mode |= S_IEXTRA
+          end
+
+          if ace[:sid] == well_known_system_sid
+            mode &= ~S_ISYSTEM_MISSING
           end
 
           # if owner and group the same, then user and group modes are the OR of both

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -18,14 +18,29 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
       :current_user => Puppet::Util::Windows::Security.name_to_sid(Sys::Admin.get_login),
       :system => Win32::Security::SID::LocalSystem,
       :admin => Puppet::Util::Windows::Security.name_to_sid("Administrator"),
+      :administrators => Win32::Security::SID::BuiltinAdministrators,
       :guest => Puppet::Util::Windows::Security.name_to_sid("Guest"),
       :users => Win32::Security::SID::BuiltinUsers,
       :power_users => Win32::Security::SID::PowerUsers,
+      :none => Win32::Security::SID::Nobody,
     }
   end
 
   let (:sids) { @sids }
   let (:winsec) { WindowsSecurityTester.new }
+
+  def set_group_depending_on_current_user(path)
+    if sids[:current_user] == sids[:system]
+      # if the current user is SYSTEM, by setting the group to
+      # guest, SYSTEM is automagically given full control, so instead
+      # override that behavior with SYSTEM as group and a specific mode
+      winsec.set_group(sids[:system], path)
+      mode = winsec.get_mode(path)
+      winsec.set_mode(mode & ~WindowsSecurityTester::S_IRWXG, path)
+    else
+      winsec.set_group(sids[:guest], path)
+    end
+  end
 
   shared_examples_for "only child owner" do
     it "should allow child owner" do
@@ -33,7 +48,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
     end
 
     it "should deny parent owner" do
-      lambda { check_parent_owner }.should raise_error(Errno::EACCES)
+      pending("when running as SYSTEM the absence of a SYSTEM group/owner causes full access to be added for SYSTEM",
+        :if => sids[:current_user] == sids[:system]) do
+        lambda { check_parent_owner }.should raise_error(Errno::EACCES)
+      end
     end
 
     it "should deny group" do
@@ -41,7 +59,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
     end
 
     it "should deny other" do
-      lambda { check_other }.should raise_error(Errno::EACCES)
+      pending("when running as SYSTEM the absence of a SYSTEM group/owner causes full access to be added for SYSTEM",
+        :if => sids[:current_user] == sids[:system]) do
+        lambda { check_other }.should raise_error(Errno::EACCES)
+      end
     end
   end
 
@@ -127,10 +148,15 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           # new file has SYSTEM
           system_aces = winsec.get_aces_for_path_by_sid(path, sids[:system])
           system_aces.should_not be_empty
-          system_aces.each { |ace| ace[:mask].should == WindowsSecurityTester::FILE_ALL_ACCESS }
+
+          # when running under SYSTEM account, multiple ACEs come back
+          # so we only care that we have at least one of these
+          system_aces.any? do |ace|
+            ace[:mask] == Windows::File::FILE_ALL_ACCESS
+          end.should be_true
 
           winsec.set_group(sids[:power_users], path)
-          winsec.set_owner(sids[:current_user], path)
+          winsec.set_owner(sids[:administrators], path)
 
           # and should still have a noninherited SYSTEM ACE granting full control
           system_aces = winsec.get_aces_for_path_by_sid(path, sids[:system])
@@ -175,8 +201,13 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
             # new file has SYSTEM
             system_aces = winsec.get_aces_for_path_by_sid(path, sids[:system])
             system_aces.should_not be_empty
-            system_aces.each { |ace| ace[:mask].should == WindowsSecurityTester::FILE_ALL_ACCESS }
+            # when running under SYSTEM account, multiple ACEs come back
+            # so we only care that we have at least one of these
+            system_aces.any? do |ace|
+              ace[:mask] == WindowsSecurityTester::FILE_ALL_ACCESS
+            end.should be_true
 
+            winsec.set_group(sids[:none], path)
             winsec.set_mode(0600, path)
 
             # and should still have the same SYSTEM ACE(s)
@@ -204,6 +235,8 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
 
           describe "for read-only objects" do
             before :each do
+              winsec.set_group(sids[:none], path)
+              winsec.set_mode(0600, path)
               winsec.add_attributes(path, WindowsSecurityTester::FILE_ATTRIBUTE_READONLY)
               (winsec.get_attributes(path) & WindowsSecurityTester::FILE_ATTRIBUTE_READONLY).should be_nonzero
             end
@@ -218,7 +251,12 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
               (winsec.get_attributes(path) & WindowsSecurityTester::FILE_ATTRIBUTE_READONLY).should be_nonzero
 
               system_aces = winsec.get_aces_for_path_by_sid(path, sids[:system])
-              system_aces.each { |ace| ace[:mask].should == WindowsSecurityTester::FILE_ALL_ACCESS }
+
+              # when running under SYSTEM account, and set_group / set_owner hasn't been called
+              # SYSTEM full access will be restored
+              system_aces.any? do |ace|
+                ace[:mask] == Windows::File::FILE_ALL_ACCESS
+              end.should be_true
             end
           end
 
@@ -297,7 +335,7 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
       describe "for an administrator", :if => Puppet.features.root? do
         before :each do
           winsec.set_mode(WindowsSecurityTester::S_IRWXU | WindowsSecurityTester::S_IRWXG, path)
-          winsec.set_group(sids[:guest], path)
+          set_group_depending_on_current_user(path)
           winsec.set_owner(sids[:guest], path)
           lambda { File.open(path, 'r') }.should raise_error(Errno::EACCES)
         end
@@ -474,7 +512,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
             end
 
             it "should deny other" do
-              lambda { check_other }.should raise_error(Errno::EACCES)
+              pending("when running as SYSTEM the absence of a SYSTEM group/owner causes full access to be added for SYSTEM",
+                :if => sids[:current_user] == sids[:system]) do
+                lambda { check_other }.should raise_error(Errno::EACCES)
+              end
             end
           end
 


### PR DESCRIPTION
- Previously get_mode spuriously included the S_ISYSTEM_MISSING bit when
  the group or mode was SYSTEM
  - Behavior has been adjusted in integration/type/file_spec.rb so that
    when the current user is SYSTEM (like in a build server environment),
    it's verified that there is at least one SYSTEM ACE that has FULL
    access.  When running under SYSTEM there may be many SYSTEM ACEs,
    including inherited ones.
  - In some cases, owner group or mode has been set to something that
    can more legitimately setup our initial desired pre-test state.  When
    verifying that SYSTEM is granted FULL access, it's important that
    SYSTEM not be assigned to the group or owner.
  - Some tests have been marked pending where it's trickier to setup the
    appropriate initial state when running the tests as SYSTEM.  These
    will be resolved when new security descriptor code is introduced.
