### PR TITLE
(#23222) Custom CSR attributes should only contain strings

### DIFF
--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -71,15 +71,14 @@ require 'openssl'
 
 def unwrap_attr(attr)
   set = attr.value
-  seq = set.value.first
-  str = seq.value.first
+  str = set.value.first
   str.value
 end
 
 csr_text = STDIN.read
 csr = OpenSSL::X509::Request.new(csr_text)
 passphrase = csr.attributes.find { |a| a.oid == '1.3.6.1.4.1.34380.2.1' }
-# And here we jump hoops to unwrap ASN1's Attr Set Seq Str
+# And here we jump hoops to unwrap ASN1's Attr Set Str
 if unwrap_attr(passphrase) == 'my passphrase'
   exit 0
 end

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -193,15 +193,6 @@ describe Puppet::SSL::CertificateRequest do
         attrs.should include({'oid' => '1.3.6.1.4.1.34380.1.2.2', 'value' => 'more CSR specific info'})
       end
 
-      it "adds attributes with multiple values" do
-        csr_attributes = {'1.3.6.1.4.1.34380.1.2.3' => %w[list of values]}
-
-        request.generate(key, :csr_attributes => csr_attributes)
-
-        attrs = request.custom_attributes
-        attrs.should include({'oid' => '1.3.6.1.4.1.34380.1.2.3', 'value' => %w[list of values]})
-      end
-
       ['extReq', '1.2.840.113549.1.9.14'].each do |oid|
         it "doesn't overwrite standard PKCS#9 CSR attribute '#{oid}'" do
           expect do


### PR DESCRIPTION
RFC 2985 indicates that CSR attributes may contain arbitrarily complex
data, but the `openssl req` command can only handle attributes with
string values. This commit changes the csr attribute structure to simple
key/value pairs so that the attributes are properly displayed by
OpenSSL. If richer data types are need then data can be serialized as
JSON or YAML and added as a CSR value.
