### PR TITLE
(maint) Handle empty or malformed JSON lockfiles

### DIFF
--- a/lib/puppet/util/json_lockfile.rb
+++ b/lib/puppet/util/json_lockfile.rb
@@ -34,8 +34,11 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
   def lock_data
     return nil unless file_locked?
     file_contents = super
-    return nil if file_contents.nil?
+    return nil if file_contents.nil? or file_contents.empty?
     PSON.parse(file_contents)
+  rescue PSON::ParserError => e
+    Puppet.warning "Unable to read lockfile data from #{@file_path}: not in PSON"
+    nil
   end
 
 end

--- a/spec/unit/util/json_lockfile_spec.rb
+++ b/spec/unit/util/json_lockfile_spec.rb
@@ -21,9 +21,30 @@ describe Puppet::Util::JsonLockfile do
     end
   end
 
-  it "should return the lock data" do
-    data = { "foo" => "foofoo", "bar" => "barbar" }
-    @lock.lock(data)
-    @lock.lock_data.should == data
+  describe "reading lock data" do
+    it "returns deserialized JSON from the lockfile" do
+      data = { "foo" => "foofoo", "bar" => "barbar" }
+      @lock.lock(data)
+      expect(@lock.lock_data).to eq data
+    end
+
+    it "returns nil if the file read returned nil" do
+      @lock.lock
+      File.stubs(:read).returns nil
+      expect(@lock.lock_data).to be_nil
+    end
+
+    it "returns nil if the file was empty" do
+      @lock.lock
+      File.stubs(:read).returns ''
+      expect(@lock.lock_data).to be_nil
+    end
+
+    it "returns nil if the file was not in PSON" do
+      @lock.lock
+      File.stubs(:read).returns ']['
+      expect(@lock.lock_data).to be_nil
+    end
+
   end
 end


### PR DESCRIPTION
If a JSON lockfile was empty or had malformed JSON, it would raise a
PSON::ParserError and could lead to application failures with an unclear
cause. This commit changes the JSON lockfile behavior to treat empty or
malformed file contents to be nil and generate warnings when the file
contents are malformed JSON.
