### PR TITLE
(#23236) Deprecate Puppet::Util::SUIDManager.run_and_capture

### DIFF
--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -162,5 +162,37 @@ module Puppet::Util::SUIDManager
     pwent = Etc.getpwuid(uid)
     Process.initgroups(pwent.name, pwent.gid)
   end
+
   module_function :initgroups
+
+  # Run a command and capture the output
+  # Parameters:
+  # [command] the command to execute
+  # [new_uid] (optional) a userid to run the command as
+  # [new_gid] (optional) a groupid to run the command as
+  # [options] (optional, defaults to {}) a hash of option key/value pairs; currently supported:
+  #   :override_locale (defaults to true) a flag indicating whether or puppet should temporarily override the
+  #     system locale for the duration of the command.  If true, the locale will be set to 'C' to ensure consistent
+  #     output / formatting from the command, which makes it much easier to parse the output.  If false, the system
+  #     locale will be respected.
+  #   :custom_environment (default {}) -- a hash of key/value pairs to set as environment variables for the duration
+  #     of the command
+  def run_and_capture(command, new_uid=nil, new_gid=nil, options = {})
+    Puppet.deprecation_warning("Puppet::Util::SUIDManager.run_and_capture is deprecated; please use Puppet::Util::Execution.execute instead.")
+    # specifying these here rather than in the method signature to allow callers to pass in a partial
+    # set of overrides without affecting the default values for options that they don't pass in
+    default_options = {
+        :override_locale => true,
+        :custom_environment => {},
+    }
+
+    options = default_options.merge(options)
+
+    output = Puppet::Util::Execution.execute(command, :failonfail => false, :combine => true,
+                                  :uid => new_uid, :gid => new_gid,
+                                  :override_locale => options[:override_locale],
+                                  :custom_environment => options[:custom_environment])
+    [output, $CHILD_STATUS.dup]
+  end
+  module_function :run_and_capture
 end

--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -207,32 +207,39 @@ describe Puppet::Util::SUIDManager do
     end
   end
 
-  # describe "when running commands" do
-  #   before :each do
-  #     # We want to make sure $CHILD_STATUS is set
-  #     Kernel.system '' if $CHILD_STATUS.nil?
-  #   end
+  describe "when running commands" do
+    before :each do
+      # We want to make sure $CHILD_STATUS is set
+      Kernel.system '' if $CHILD_STATUS.nil?
+    end
 
-  #   describe "with #run_and_capture" do
-  #     it "should capture the output and return process status" do
-  #       Puppet::Util::Execution.
-  #         expects(:execute).with() do |*args|
-  #             args[0] == 'yay' &&
-  #             args[1][:combine] == true &&
-  #             args[1][:failonfail] == false &&
-  #             args[1][:uid] == user[:uid] &&
-  #             args[1][:gid] == user[:gid] &&
-  #             args[1][:override_locale] == true &&
-  #             args[1].has_key?(:custom_environment)
-  #       end .
-  #         returns('output')
-  #       output = Puppet::Util::SUIDManager.run_and_capture 'yay', user[:uid], user[:gid]
+    describe "with #run_and_capture" do
+      it "should capture the output and return process status" do
+        Puppet::Util::Execution.
+          expects(:execute).with() do |*args|
+              args[0] == 'yay' &&
+              args[1][:combine] == true &&
+              args[1][:failonfail] == false &&
+              args[1][:uid] == user[:uid] &&
+              args[1][:gid] == user[:gid] &&
+              args[1][:override_locale] == true &&
+              args[1].has_key?(:custom_environment)
+        end .
+          returns('output')
+        output = Puppet::Util::SUIDManager.run_and_capture 'yay', user[:uid], user[:gid]
 
-  #       output.first.should == 'output'
-  #       output.last.should be_a(Process::Status)
-  #     end
-  #   end
-  # end
+        output.first.should == 'output'
+        output.last.should be_a(Process::Status)
+      end
+
+      it "should log a deprecation notice" do
+        Puppet::Util::Execution.stubs(:execute).returns("success")
+        Puppet.expects(:deprecation_warning).with('Puppet::Util::SUIDManager.run_and_capture is deprecated; please use Puppet::Util::Execution.execute instead.')
+
+        output = Puppet::Util::SUIDManager.run_and_capture 'yay', user[:uid], user[:gid]
+      end
+    end
+  end
 
   describe "#root?" do
     describe "on POSIX systems" do


### PR DESCRIPTION
This deprecates run_and_capture from SUIDManager for
Puppet::Util::Execution.execute(). Run and capture is returning $CHILDSTATUS
where execute returns an exit status as part of output. This means that run and
capture could have potential issues when being used, especially with Windows
which is known to have issues due to the truncation of exit codes greater than
256.

This returns the previous function and specs associated with it and adds a spec
for the deprecation warning.
