### PR TITLE
Pack extension requests in a single sequence

### DIFF
--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -119,47 +119,16 @@ DOC
 
     # Prefer the standard extReq, but accept the Microsoft specific version as
     # a fallback, if the standard version isn't found.
-    attribute = @content.attributes.find {|x| x.oid == "extReq" } or
-      @content.attributes.find {|x| x.oid == "msExtReq" }
+    attribute   = @content.attributes.find {|x| x.oid == "extReq" }
+    attribute ||= @content.attributes.find {|x| x.oid == "msExtReq" }
     return [] unless attribute
 
-    # Assert the structure and extract the names into an array of arrays.
-    unless attribute.value.is_a? OpenSSL::ASN1::Set
-      raise Puppet::Error, "In #{attribute.oid}, expected Set but found #{attribute.value.class}"
-    end
-
-    unless attribute.value.value.is_a? Array
-      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array] but found #{attribute.value.value.class}"
-    end
-
-    extensions = attribute.value.value
+    extensions = unpack_extension_request(attribute)
 
     index = -1
-    extensions.map do |extension|
+    extensions.map do |ext_values|
       index += 1
       context = "#{attribute.oid} extension index #{index}"
-
-      unless extension.is_a? OpenSSL::ASN1::Sequence
-        raise Puppet::Error, "In #{context}, expected Set[Array[Sequence[...]]], but found #{extension.class}"
-      end
-
-      unless extension.value.is_a? Array
-        raise Puppet::Error, "In #{context}, expected Set[Array[Sequence[Array[...]]]], but found #{extension.value.class}"
-      end
-
-      unless extension.value.size == 1
-        raise Puppet::Error, "In #{context}, expected Set[Array[Sequence[Array[...]]]] with one value, but found #{extension.value.size} elements"
-      end
-
-      unless extension.value.first.is_a? OpenSSL::ASN1::Sequence
-        raise Puppet::Error, "In #{context}, expected Set[Array[Sequence[Array[Sequence[...]]]]] but found #{extension.value.first.class}"
-      end
-
-      unless extension.value.first.value.is_a? Array
-        raise Puppet::Error, "In #{context}, expected Set[Array[Sequence[Array[Sequence[Array[...]]]]]], but found #{extension.value.first.value.class}"
-      end
-
-      ext_values = extension.value.first.value
 
       # OK, turn that into an extension, to unpack the content.  Lovely that
       # we have to swap the order of arguments to the underlying method, or
@@ -254,7 +223,7 @@ DOC
         end
 
         ext = OpenSSL::X509::Extension.new(oid, value.to_s, false)
-        extensions << OpenSSL::ASN1::Sequence([ext])
+        extensions << ext
       end
     end
 
@@ -263,12 +232,60 @@ DOC
       names = names.sort.uniq.map {|name| "DNS:#{name}" }.join(", ")
       alt_names_ext = extension_factory.create_extension("subjectAltName", names, false)
 
-      extensions << OpenSSL::ASN1::Sequence([alt_names_ext])
+      extensions << alt_names_ext
     end
 
     unless extensions.empty?
-      ext_req = OpenSSL::ASN1::Set(extensions)
+      seq = OpenSSL::ASN1::Sequence(extensions)
+      ext_req = OpenSSL::ASN1::Set([seq])
       OpenSSL::X509::Attribute.new("extReq", ext_req)
     end
+  end
+
+  # Unpack the extReq attribute into an array of Extensions.
+  #
+  # The extension request attribute is structured like
+  # `Set[Sequence[Extensions]]` where the outer Set only contains a single
+  # sequence.
+  #
+  # In addition the Ruby implementation of ASN1 requires that all ASN1 values
+  # contain a single value, so Sets and Sequence have to contain an array
+  # that in turn holds the elements. This is why we have to unpack an array
+  # every time we unpack a Set/Seq.
+  #
+  # @see http://tools.ietf.org/html/rfc2985#ref-10 5.4.2 CSR Extension Request structure
+  # @see http://tools.ietf.org/html/rfc5280 4.1 Certificate Extension structure
+  #
+  # @api private
+  #
+  # @param attribute [OpenSSL::X509::Attribute] The X509 extension request
+  #
+  # @return [Array<Array<Object>>] A array of arrays containing the extension
+  #   OID the critical state if present, and the extension value.
+  def unpack_extension_request(attribute)
+
+    unless attribute.value.is_a? OpenSSL::ASN1::Set
+      raise Puppet::Error, "In #{attribute.oid}, expected Set but found #{attribute.value.class}"
+    end
+
+    unless attribute.value.value.is_a? Array
+      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array] but found #{attribute.value.value.class}"
+    end
+
+    unless attribute.value.value.size == 1
+      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array] with one value but found #{attribute.value.value.size} elements"
+    end
+
+    unless attribute.value.value.first.is_a? OpenSSL::ASN1::Sequence
+      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array[Sequence[...]]], but found #{extension.class}"
+    end
+
+    unless attribute.value.value.first.value.is_a? Array
+      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array[Sequence[Array[...]]]], but found #{extension.value.class}"
+    end
+
+    extensions = attribute.value.value.first.value
+
+    extensions.map(&:value)
   end
 end


### PR DESCRIPTION
The ASN.1 description of extension requests could be incorrectly read
that extensions should be packed in individual sequences, while in fact
the extensions themselves are sequences and should be all packed in a
single sequence. This commit fixes how CSRs create and return extension
requests.
