### PR TITLE
(#18931) Deprecate instead of remove original windows behavior

### DIFF
--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -128,8 +128,9 @@ module Puppet
             if [:use, :use_when_creating].include?(resource[:source_permissions]) &&
               (resource[:owner] == nil || resource[:group] == nil || resource[:mode] == nil)
 
-              Puppet.deprecation_warning("Copying owner/mode/group from the puppet master to Windows agents" <<
-                                         " is deprecated; use source_permissions => ignore.")
+              Puppet.deprecation_warning("Copying owner/mode/group from the puppet master" <<
+                                         " source file to Windows agents is deprecated;" <<
+                                         " use source_permissions => ignore.")
             end
             next if [:owner, :group].include?(metadata_method)
           end

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -343,8 +343,9 @@ describe Puppet::Type.type(:file).attrclass(:source) do
         before :each do
           Puppet.features.stubs(:microsoft_windows?).returns true
         end
-        let(:deprecation_message) { "Copying owner/mode/group from the puppet master to Windows agents" <<
-              " is deprecated; use source_permissions => ignore." }
+        let(:deprecation_message) { "Copying owner/mode/group from the puppet master" <<
+              " source file to Windows agents is deprecated;" <<
+              " use source_permissions => ignore." }
 
         it "should not copy owner and group from remote sources" do
           @source.stubs(:local?).returns false


### PR DESCRIPTION
The original windows behavior was to attempt to translate posix mode to
the windows file.  Although we want deprecate this behavior, this
previous work on #18931 was removing it entirely.

This patch returns original behavior and marks it as deprecated for
future removal.
