### PR TITLE
Maint: Change "inactive" to "stopped" in reinventory action's descriptio...

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -149,8 +149,8 @@ unless the '--all' option is set.
 * reinventory:
   Build an inventory of the issued certificates. This will destroy the current
   inventory file specified by 'cert_inventory' and recreate it from the
-  certificates found in the 'certdir'. This action should only be invoked
-  on an inactive master.
+  certificates found in the 'certdir'. Ensure the puppet master is stopped
+  before running this action.
 
 OPTIONS
 -------


### PR DESCRIPTION
...n

"Inactive" is ambiguous, and could describe a stopped master, a master which
is running but happens to be idle, a master which has no agents attempting to
reach it, a master which has been removed from the load balancer, or any number
of other things. Instead, we should use the unambiguous term "stopped."
