### PR TITLE
Handle malformed CSR attributes and extension requests

### DIFF
--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -208,6 +208,14 @@ describe Puppet::SSL::CertificateRequest do
           end.to raise_error ArgumentError, /Cannot specify.*#{oid}/
         end
       end
+
+      it "raises an error if an attribute cannot be created" do
+        csr_attributes = { "thats.no.moon" => "death star" }
+
+        expect do
+          request.generate(key, :csr_attributes => csr_attributes)
+        end.to raise_error Puppet::Error, /Cannot create CSR with attribute thats\.no\.moon: first num too large/
+      end
     end
 
     context "with extension requests" do
@@ -263,6 +271,13 @@ describe Puppet::SSL::CertificateRequest do
         exts.should include('oid' => 'subjectAltName', 'value' => 'DNS:first.tld, DNS:myname, DNS:second.tld')
 
         request.subject_alt_names.should eq ['DNS:first.tld', 'DNS:myname', 'DNS:second.tld']
+      end
+
+      it "raises an error if the OID could not be created" do
+        exts = {"thats.no.moon" => "death star"}
+        expect do
+          request.generate(key, :extension_requests => exts)
+        end.to raise_error Puppet::Error, /Cannot create CSR with extension request thats\.no\.moon: first num too large/
       end
     end
 


### PR DESCRIPTION
When a CSR custom attribute or extension request was passed to a CSR for
inclusion, the resulting error would be raised up from the openssl error
and would not be handled by anything, resulting in error messages like
'first num too long'. Since this is all but useless from the perspective
of a user, this commit adds handling to CSR creation. Errors will be
wrapped to indicate which OID was causing the failure.
