### PR TITLE
allow configuration of Bundler source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 def location_for(place, fake_version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/

--- a/acceptance/config/el6/Gemfile
+++ b/acceptance/config/el6/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem "beaker", :git => "git://github.com/puppetlabs/beaker.git"
 gem "rake"


### PR DESCRIPTION
This uses the code that already exists in the Facter repo (for consistency) to allow the gem source when `bundle install`ing to be set by an environment variable.
