### PR TITLE
source function library *before* client sysconfig overrides

### DIFF
--- a/ext/redhat/client.init
+++ b/ext/redhat/client.init
@@ -10,6 +10,9 @@
 # processname: puppet
 # config: /etc/sysconfig/puppet
 
+# Source function library.
+. /etc/rc.d/init.d/functions
+
 PATH=/usr/bin:/sbin:/bin:/usr/sbin
 export PATH
 
@@ -18,9 +21,6 @@ lockfile=${LOCKFILE-/var/lock/subsys/puppet}
 pidfile=${PIDFILE-/var/run/puppet/agent.pid}
 puppetd=${PUPPETD-/usr/bin/puppet}
 RETVAL=0
-
-# Source function library.
-. /etc/rc.d/init.d/functions
 
 PUPPET_OPTS="agent "
 [ -n "${PUPPET_SERVER}" ] && PUPPET_OPTS="${PUPPET_OPTS} --server=${PUPPET_SERVER}"


### PR DESCRIPTION
My client's environment mandates strict umask settings:
- 027 for init scripts
- 077 for normal users
  This causes problems when using exec resources or any add-on functions
  that exec external scripts/programs.

The fix is relatively simple - run umask in /etc/sysconfig/puppet
and set a more lenient umask for puppet.
However, the /etc/sysconfig/puppet is sourced before the init
function library so any umask changes made in the former are
overridden by any in the latter.

Looking in other init scripts (including the puppetmaster init
script), it is usual for the function library to be sourced at the
start of the init script, ie. before the sysconfig override.

This change simply moves the lines that source the init function
library to the start of the init script.
