### PR TITLE
(maint) Extract common acceptance setup script for Jenkins

### DIFF
--- a/acceptance/bin/ci-bootstrap-from-artifacts.sh
+++ b/acceptance/bin/ci-bootstrap-from-artifacts.sh
@@ -1,0 +1,39 @@
+#! /usr/bin/env bash
+
+###############################################################################
+# Initial preparation for a ci acceptance job in Jenkins.  Crucially, it
+# handles the untarring of the build artifact and bundle install, getting us to
+# a state where we can then bundle exec rake the particular ci:test we want to
+# run.
+#
+# Having this checked in in a script makes it much easier to have multiple
+# acceptance jobs.  It must be kept agnostic between Linux/Solaris/Windows
+# builds, however.
+
+set -x
+
+echo "SHA: ${SHA}"
+echo "BUILD_SELECTOR: ${BUILD_SELECTOR}"
+echo "PACKAGE_BUILD_STATUS: ${PACKAGE_BUILD_STATUS}"
+
+rm -rf acceptance
+mkdir acceptance
+cd acceptance
+tar -xzvf ../acceptance-artifacts.tar.gz
+
+echo "===== This artifact is from ====="
+cat creator.txt
+
+cd config/el6
+bundle install --without=development --path=.bundle/gems
+
+cat > local_options.rb <<-EOF
+{
+  :hosts_file => 'config/nodes/${platform}.yaml',
+  :ssh => {
+    :keys => ["${HOME}/.ssh/id_rsa-old.private"],
+  },
+}
+EOF
+
+[[ (-z "${PACKAGE_BUILD_STATUS}") || ("${PACKAGE_BUILD_STATUS}" = "success") ]] || exit 1

--- a/acceptance/config/el6/Rakefile
+++ b/acceptance/config/el6/Rakefile
@@ -20,6 +20,8 @@ module HarnessOptions
     },
     :xml => true,
     :timesync => true,
+    :repo_proxy => true,
+    :add_el_extras => true,
   }
 
   class Aggregator
@@ -68,7 +70,8 @@ def beaker_test(mode = :packages, options = {})
 
   if mode == :git
     puppet_fork = ENV['FORK'] || 'puppetlabs'
-    final_options[:install] << "git://github.com/#{puppet_fork}/puppet.git##{sha}"
+    git_server  = ENV['GIT_SERVER'] || 'github.com'
+    final_options[:install] << "git://#{git_server}/#{puppet_fork}/puppet.git##{sha}"
   end
 
   options_file = 'merged_options.rb'
@@ -233,10 +236,10 @@ Requires commit SHA to be put under test as environment variable: SHA='<sha>'.
 Also must set CONFIG=config/nodes/foo.yaml or include it in an options.rb for Beaker.
 You may set TESTS=path/to/test,and/more/tests.
 You may set additional Beaker OPTIONS='--more --options'
-If testing from git checkouts, you may optional set the github fork to checkout from using FORK='other-puppet-fork'.
-A beaker options hash in ./local_options.rb will be included, with online commandline options set through the above environment variables overriding.
+If testing from git checkouts, you may optionally set the github fork to checkout from using FORK='other-puppet-fork'.
+You may also optionally set the git server to checkout from using GIT_SERVER='my.host.with.git.daemon', if you have set up a `git daemon` to pull local commits from.  (In this case, the FORK should be set to the path to the repository, and you will need to allow the git daemon to serve the repo (see `git help daemon`)).
+If there is a Beaker options hash in a ./local_options.rb, it will be included.  Commandline options set through the above environment variables will override settings in this file.
 EOS
-
 
     desc <<-EOS
 Run the acceptance tests through Beaker and install packages on the configuration targets.


### PR DESCRIPTION
We have six Jenkins jobs which currently run acceptance, and will soon
have another four for per commit tests.  There is a shell script used to
prepare each job for Rake execution of the actual test run.  This script
currently exists in every job and is slightly divergent across jobs, and
makes updating the prep for each job time consuming and error prone.  So
I'm pulling it into acceptance as a single script to handle untarring of
the artifact and bundle set up for any acceptance job.

This change also provides a means for specifying the git daemon along
with the fork so that you can install from local commits.

Finally it moves repo_proxy and add_el_extras beaker settings into the
common options.
