### PR TITLE
(#22330) add btrfs to SELinux filesystem whitelist

### DIFF
--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -148,7 +148,7 @@ module Puppet::Util::SELinux
   def selinux_label_support?(file)
     fstype = find_fs(file)
     return false if fstype.nil?
-    filesystems = ['ext2', 'ext3', 'ext4', 'gfs', 'gfs2', 'xfs', 'jfs']
+    filesystems = ['ext2', 'ext3', 'ext4', 'gfs', 'gfs2', 'xfs', 'jfs', 'btrfs']
     filesystems.include?(fstype)
   end
 


### PR DESCRIPTION
Many Linux distributions run SELinux in enforcing mode by default. On these systems, it is critical that Puppet properly sets SELinux file contexts on the files it manages, because incorrect contexts can lead to spurious problems that can be very difficult to diagnose (e.g., system services that mysteriously fail to start).

In order to avoid errors caused by attempting to set SELinux file contexts on filesystems that do not support them, Puppet maintains a whitelist of filesystems that support SELinux file contexts, and only attempts to set SELinux file contexts if the file resides on one of the whitelisted filesystems.

The btrfs filesystem has supported SELinux file contexts (file xattr) since 2009, and it is highly unlikely that any version of btrfs older than that will be seen in the wild. (In 2009, about the only people using btrfs were btrfs developers, and they have long since migrated to more recent versions.)

However, the btrfs filesystem is not in Puppet's whitelist of filesystems that support SELinux contexts.

This commit adds the btrfs filesystem to the whitelist of filesystem supports SELinux file contexts.
