### PR TITLE
(#23320) NetworkManager dispatcher script needs to reload Puppet agent, not restart

### DIFF
--- a/ext/puppet-nm-dispatcher
+++ b/ext/puppet-nm-dispatcher
@@ -1,13 +1,24 @@
-#!/bin/bash
+#! /bin/sh
 #
-# Restart puppet on network changes to pickup changes to /etc/resolv.conf
+# Reload puppet on network changes to pick up changes to /etc/resolv.conf,
+# facter facts, et. al.
+#
+# As of 2013-11-26, NetworkManager has a hard-coded 3-second timeout for
+# dispatcher scripts.  For that reason, we specifically prefer to reload puppet
+# instead of restarting it, because on a slow system a restart might actually
+# take longer than 3 seconds, which will result in NetworkManager killing the
+# dispatcher script.
 #
 # https://projects.puppetlabs.com/issues/2776
-# https://bugzilla.redhat.com/532085
+# https://bugzilla.redhat.com/show_bug.cgi?id=532085
+#
 
-
-if [ -f "/bin/systemctl" ]  ; then
-  [[ $2 =~ ^(up|down)$ ]] && /bin/systemctl try-restart puppet.service || :
-else
-  [[ $2 =~ ^(up|down)$ ]] && /sbin/service puppet condrestart || :
-fi
+case "x${2}" in
+xup|xdown)
+  if type systemctl &>/dev/null; then
+    systemctl --quiet is-active puppet.service && systemctl reload puppet.service &>/dev/null || :
+  else
+    /sbin/service puppet status &>/dev/null && /sbin/service puppet reload &>/dev/null || :
+  fi
+  ;;
+esac


### PR DESCRIPTION
Restarting the Puppet agent can easily take longer than 3 seconds on a slow system (e.g., a laptop), because the restart doesn't return until the new Puppet agent forks into the background.

This is a significant problem, because NetworkManager has a hardcoded 3-second timeout that it applies to each dispatcher script it runs. If a dispatcher script takes longer than 3 seconds to execute, NetworkManager forcibly kills the script.

Therefore, to reduce the amount of time it takes the Puppet dispatcher script to run, reload the Puppet agent service instead of restarting it. Reloading sends a SIGHUP to the running Puppet agent and immediately returns, thereby allowing the dispatcher script to exit well before NetworkManager's timeout. (The running Puppet agent will restart upon receiving the SIGHUP, but this restart occurs asynchronously to the execution of the dispatcher script.)

Also, use a simple (and fast) case statement to determine the NetworkManager action, instead of the slower (and bash-specific) regular expression matching.
