### PR TITLE
(maint) Skip enc test on lucid

### DIFF
--- a/acceptance/tests/store_configs/enc_provides_node_when_storeconfigs_enabled.rb
+++ b/acceptance/tests/store_configs/enc_provides_node_when_storeconfigs_enabled.rb
@@ -3,6 +3,7 @@ test_name "ENC node information is used when store configs enabled (#16698)"
 confine :except, :platform => 'solaris'
 confine :except, :platform => 'windows'
 confine :except, :platform => 'el-6'
+confine :except, :platform => 'lucid'
 
 testdir = master.tmpdir('use_enc')
 


### PR DESCRIPTION
Currently the lucid runs of this test are failing pretty frequently because
of difficulties getting to rubyforge.org.  This change would skip this
test on lucid.

We're already skipping this test on other platforms due to various difficulties
(read the log for this file). And activerecord is a deprecated feature, so this
test won't be around for too much longer.  Meanwhile, we have decent coverage
of this feature since it still runs against RHEL5 and newer Ubuntus.
