### PR TITLE
(#23366) Ensure we require ffi before using it

### DIFF
--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -63,6 +63,7 @@
 
 require 'puppet/util/windows'
 require 'pathname'
+require 'ffi'
 
 require 'win32/security'
 


### PR DESCRIPTION
We use ffi on windows in 4 files, but only required it in 3, which could
prevent puppet on windows from running with the error:

```
uninitialized constant Puppet::Util::Windows::Security::API::FFI (NameError)
```

This commit ensure we require ffi before using it.
