### PR TITLE
(maint) Simplify the CA use of the autosign setting

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -80,9 +80,9 @@ class Puppet::SSL::CertificateAuthority
     auto = Puppet[:autosign]
 
     decider = case auto
-      when 'false', false, nil
+      when false
         AutosignNever.new
-      when 'true', true
+      when true
         AutosignAlways.new
       else
         file = Puppet::FileSystem::File.new(auto)


### PR DESCRIPTION
Commit bca628dc adds proper conversion of autosign input values to
booleans, but Puppet::SSL::CertificateAuthority was still trying to
handle string values. This commit simplifies the checking logic and lets
the autosign setting handle data normalization.
