### PR TITLE
Added localdelete to optional_commands for forcelocal support

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -42,6 +42,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     }
 
   optional_commands :localadd => "luseradd"
+  optional_commands :localdelete => "luserdel"
   has_feature :libuser if Puppet.features.libuser?
 
   def exists?


### PR DESCRIPTION
Removing users using forcelocal throws an error Error: No command localdelete defined for provider 

Sample

```
user { 'blah':
  forcelocal => true,
  ensure     => absent
}
```

This adds the command to the provider useradd
