### PR TITLE
Revert "Merge pull request #2125 from melissaanne/ticket/stable/re-597-a...

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,7 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-18-i386 pl-fedora-19-i386 pl-fedora-20-i386'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-18-i386 pl-fedora-19-i386'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: TRUE


### PR DESCRIPTION
...dd-f20"

The rest of the fedora 20 stack was not built up yet, so builds against fedora
20 were failing. This revert can be reverted when facter, ruby-rgen, and hiera
are built and available in the fedora 20 yum repositories.

This reverts commit ae173d8f78da375718a8d1e1c2bd65a60615f5d7, reversing
changes made to 710e16780e64c436090c27ce6315d7cd5747cd41.
