### PR TITLE
(maint) Add an acceptance pre-suite step to set the parser

### DIFF
--- a/acceptance/config/el6/setup/packages/pre-suite/05_SetParser.rb
+++ b/acceptance/config/el6/setup/packages/pre-suite/05_SetParser.rb
@@ -1,0 +1,17 @@
+test_name "add parser=#{ENV['PARSER']} to all puppet.conf (only if $PARSER is set)" do
+
+  parser = ENV['PARSER']
+  next if parser.nil?
+
+  hosts.each do |host|
+    step "adjust #{host} puppet.conf" do
+      temp = host.tmpdir('parser-set')
+      opts = {
+        'main' => {
+           'parser' => parser
+        }
+      }
+      lay_down_new_puppet_conf(host, opts, temp)
+    end
+  end
+end


### PR DESCRIPTION
Allows us to run acceptance tests with the parser set to the value of
$PARSER from the environment.  We can use this to test how the
acceptance tests fair against the current iteration of the future
parser, for instance.
