### PR TITLE
(PF-309) Make puppet module build use metadata.json as primary input

### DIFF
--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -10,7 +10,7 @@ module Puppet
     extend Puppet::Util::Colors
 
     # Directory and names that should not be checksummed.
-    ARTIFACTS = ['pkg', /^\./, /^~/, /^#/, 'coverage', 'metadata.json', 'REVISION']
+    ARTIFACTS = ['pkg', /^\./, /^~/, /^#/, 'coverage', 'checksums.json', 'REVISION']
     FULL_MODULE_NAME_PATTERN = /\A([^-\/|.]+)[-|\/](.+)\z/
     REPOSITORY_URL = Puppet.settings[:module_repository]
 
@@ -56,14 +56,14 @@ module Puppet
     end
 
     # Analyse path to see if it is a module root directory by detecting a
-    # file named 'Modulefile' in the directory.
+    # file named 'metadata.json' or 'Modulefile' in the directory.
     #
     # @param path [Pathname, String] path to analyse
     # @return [Boolean] true if the path is a module root, false otherwise
     def self.is_module_root?(path)
       path = Pathname.new(path) if path.class == String
 
-      FileTest.file?(path + 'Modulefile')
+      FileTest.file?(path + 'metadata.json') || FileTest.file?(path + 'Modulefile')
     end
 
     # Builds a formatted tree from a list of node hashes containing +:text+

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -11,7 +11,7 @@ module Puppet::ModuleTool
       end
 
       def run
-        load_modulefile!
+        load_metadata!
         create_directory
         copy_contents
         add_metadata
@@ -66,8 +66,15 @@ module Puppet::ModuleTool
       end
 
       def add_metadata
-        File.open(File.join(build_path, 'metadata.json'), 'w') do |f|
-          f.write(PSON.pretty_generate(metadata))
+        metadata_path = File.join(build_path, 'metadata.json')
+        unless File.file?(metadata_path)
+          # Legacy build: Metadata generated from Modulefile. Write it out
+          File.open(metadata_path, 'w') do |f|
+            f.write(PSON.pretty_generate(metadata))
+          end
+        end
+        File.open(File.join(build_path, 'checksums.json'), 'w') do |f|
+          f.write(PSON.pretty_generate(Checksums.new(@path)))
         end
       end
 

--- a/lib/puppet/module_tool/applications/checksummer.rb
+++ b/lib/puppet/module_tool/applications/checksummer.rb
@@ -11,23 +11,16 @@ module Puppet::ModuleTool
 
       def run
         changes = []
-        if metadata_file.exist?
-          sums = Puppet::ModuleTool::Checksums.new(@path)
-          (metadata['checksums'] || {}).each do |child_path, canonical_checksum|
+        sums = Puppet::ModuleTool::Checksums.new(@path)
+        checksums.each do |child_path, canonical_checksum|
 
-            # Work around an issue where modules built with an older version
-            # of PMT would include the metadata.json file in the list of files
-            # checksummed. This causes metadata.json to always report local
-            # changes.
-            next if File.basename(child_path) == "metadata.json"
+          # Avoid checksumming the checksums.json file
+          next if File.basename(child_path) == "checksums.json"
 
-            path = @path + child_path
-            unless path.exist? && canonical_checksum == sums.checksum(path)
-              changes << child_path
-            end
+          path = @path + child_path
+          unless path.exist? && canonical_checksum == sums.checksum(path)
+            changes << child_path
           end
-        else
-          raise ArgumentError, "No metadata.json found."
         end
 
         # Return an Array of strings representing file paths of files that have
@@ -44,12 +37,24 @@ module Puppet::ModuleTool
 
       private
 
-      def metadata
-        PSON.parse(metadata_file.read)
+      def checksums
+        if checksums_file.exist?
+          PSON.parse(checksums_file.read)
+
+        # Check metadata.json too. Legacy modules have their checksums stored there
+        elsif metadata_file.exist?
+          PSON.parse(metadata_file.read)['checksums'] || {}
+        else
+          raise ArgumentError, "No file containing checksums found."
+        end
       end
 
       def metadata_file
         (@path + 'metadata.json')
+      end
+
+      def checksums_file
+        (@path + 'checksums.json')
       end
     end
   end

--- a/lib/puppet/module_tool/checksums.rb
+++ b/lib/puppet/module_tool/checksums.rb
@@ -41,12 +41,9 @@ module Puppet::ModuleTool
       data.each(&block)
     end
 
-    # Update +Metadata+'s checksums with this object's.
-    def annotate(metadata)
-      metadata.checksums.replace(data)
+    # Return the PSON record representing this instance.
+    def to_pson(*args)
+      return data.to_pson(*args)
     end
-
-    # TODO: Move the Checksummer#run checksum checking to here?
-
   end
 end

--- a/spec/unit/module_tool/applications/builder_spec.rb
+++ b/spec/unit/module_tool/applications/builder_spec.rb
@@ -13,16 +13,18 @@ describe Puppet::ModuleTool::Applications::Builder do
   let(:builder)      { Puppet::ModuleTool::Applications::Builder.new(path) }
 
   before :each do
-    File.open(File.join(path, 'Modulefile'), 'w') do |f|
+    File.open(File.join(path, 'metadata.json'), 'w') do |f|
       f.write(<<EOM)
-name    '#{module_name}'
-version '#{version}'
-source 'http://github.com/testing/#{module_name}'
-author 'testing'
-license 'Apache License Version 2.0'
-summary 'Puppet testing module'
-description 'This module can be used for basic testing'
-project_page 'http://github.com/testing/#{module_name}'
+{
+  "name": "#{module_name}",
+  "version": "#{version}",
+  "source": "http://github.com/testing/#{module_name}",
+  "author": "testing",
+  "license": "Apache License Version 2.0",
+  "summary": "Puppet testing module",
+  "description": "This module can be used for basic testing",
+  "project_page": "http://github.com/testing/#{module_name}"
+}
 EOM
     end
   end

--- a/spec/unit/module_tool/metadata_spec.rb
+++ b/spec/unit/module_tool/metadata_spec.rb
@@ -8,17 +8,4 @@ describe Puppet::ModuleTool::Metadata do
       metadata.license.should == "Apache License, Version 2.0"
     end
   end
-
-  describe :to_hash do
-    it 'should merge extra_data in' do
-      metadata = Puppet::ModuleTool::Metadata.new
-      metadata.extra_metadata = {
-        'checksums' => 'badsums',
-        'special_key' => 'special'
-      }
-      meta_hash = metadata.to_hash
-      meta_hash['special_key'].should == 'special'
-      meta_hash['checksums'].should == {}
-    end
-  end
 end

--- a/spec/unit/module_tool_spec.rb
+++ b/spec/unit/module_tool_spec.rb
@@ -6,14 +6,25 @@ require 'puppet/module_tool'
 
 describe Puppet::ModuleTool do
   describe '.is_module_root?' do
-    it 'should return true if directory has a module file' do
+    it 'should return true if directory has a Modulefile file' do
+      FileTest.expects(:file?).with(responds_with(:to_s, '/a/b/c/metadata.json')).
+        returns(false)
       FileTest.expects(:file?).with(responds_with(:to_s, '/a/b/c/Modulefile')).
         returns(true)
 
       subject.is_module_root?(Pathname.new('/a/b/c')).should be_true
     end
 
-    it 'should return false if directory does not have a module file' do
+    it 'should return true if directory has a metadata.json file' do
+      FileTest.expects(:file?).with(responds_with(:to_s, '/a/b/c/metadata.json')).
+        returns(true)
+
+      subject.is_module_root?(Pathname.new('/a/b/c')).should be_true
+    end
+
+    it 'should return false if directory does not have a metadata.json or a Modulefile file' do
+      FileTest.expects(:file?).with(responds_with(:to_s, '/a/b/c/metadata.json')).
+        returns(false)
       FileTest.expects(:file?).with(responds_with(:to_s, '/a/b/c/Modulefile')).
         returns(false)
 


### PR DESCRIPTION
The Forge team has decided that the current way of building, using the
Modulefile as the source for metadata, should change. The Modulefile
will become obsolete and the metadata.json will take its place as the
primary source. This means that the tool should no longer make an
attempt to generate the metadata.json.

This commit changes the current behavior so that when a metadata.json
is discovered, then it will be used verbatim. No types or providers
will be added to it.

The metadata.json will still be generated in case it is missing and
the Modulefile is present. A warning will be emitted to notify the
user that the Modulefile is deprecated.

The checksums that used to end up in the generated metadata.json will
now always be emitted to a separate checksums.json file.

When both the Modulefile and the metadata.json are present, the former
is ignored and a warning is emitted.
