### PR TITLE
(#23403) 'autosign' setting should manage file parameters

### DIFF
--- a/lib/puppet/settings/autosign_setting.rb
+++ b/lib/puppet/settings/autosign_setting.rb
@@ -1,10 +1,12 @@
 require 'puppet/settings/base_setting'
 
-class Puppet::Settings::AutosignSetting < Puppet::Settings::BaseSetting
-
-  def type
-    :autosign
-  end
+# A specialization of the file setting to allow boolean values.
+#
+# The autosign value can be either a boolean or a file path, and if the setting
+# is a file path then it may have a owner/group/mode specified.
+#
+# @api private
+class Puppet::Settings::AutosignSetting < Puppet::Settings::FileSetting
 
   def munge(value)
     if ['true', true].include? value

--- a/spec/unit/settings/autosign_setting_spec.rb
+++ b/spec/unit/settings/autosign_setting_spec.rb
@@ -4,10 +4,19 @@ require 'puppet/settings'
 require 'puppet/settings/autosign_setting'
 
 describe Puppet::Settings::AutosignSetting do
-  let(:setting) { described_class.new(:settings => mock('settings'), :desc => "test") }
+  let(:settings) do
+    s = stub('settings')
+    s.stubs(:[]).with(:mkusers).returns true
+    s.stubs(:[]).with(:user).returns 'puppet'
+    s.stubs(:[]).with(:group).returns 'puppet'
+    s.stubs(:[]).with(:manage_internal_file_permissions).returns true
+    s
+  end
 
-  it "is of type :autosign" do
-    expect(setting.type).to eq :autosign
+  let(:setting) { described_class.new(:name => 'autosign', :section => 'section', :settings => settings, :desc => "test") }
+
+  it "is of type :file" do
+    expect(setting.type).to eq :file
   end
 
   describe "when munging the setting" do
@@ -41,6 +50,53 @@ describe Puppet::Settings::AutosignSetting do
           setting.munge(invalid)
         }.to raise_error Puppet::Settings::ValidationError, /Invalid autosign value/
       end
+    end
+  end
+
+  describe "setting additional setting values" do
+    it "can set the file mode" do
+      setting.mode = '0664'
+      expect(setting.mode).to eq '0664'
+    end
+
+    it "can set the file owner" do
+      setting.owner = 'service'
+      expect(setting.owner).to eq 'puppet'
+    end
+
+    it "can set the file group" do
+      setting.group = 'service'
+      expect(setting.group).to eq 'puppet'
+    end
+  end
+
+  describe "converting the setting to a resource" do
+    it "converts the file path to a file resource" do
+      settings.stubs(:value).with('autosign').returns('/path/to/autosign.conf')
+      Puppet::FileSystem::File.stubs(:exist?).with('/path/to/autosign.conf').returns true
+      Puppet.stubs(:features).returns(stub(:root? => true, :microsoft_windows? => false))
+
+      setting.mode = '0664'
+      setting.owner = 'service'
+      setting.group = 'service'
+
+      resource = setting.to_resource
+
+      expect(resource.title).to eq '/path/to/autosign.conf'
+      expect(resource[:ensure]).to eq :file
+      expect(resource[:mode]).to eq '664'
+      expect(resource[:owner]).to eq 'puppet'
+      expect(resource[:group]).to eq 'puppet'
+    end
+
+    it "returns nil when the setting is a boolean" do
+      settings.stubs(:value).with('autosign').returns 'true'
+
+      setting.mode = '0664'
+      setting.owner = 'service'
+      setting.group = 'service'
+
+      expect(setting.to_resource).to be_nil
     end
   end
 end


### PR DESCRIPTION
Puppet settings of type :file can specify the owner, group, and mode of
the file specified by the setting, like so:

```
[master]
autosign = $confdir/autosign.conf { mode = 664, owner = puppet, group = puppet }
```

Commit bca628dc extracted the autosign setting validation to a setting
class but dropped the ability for file settings to be specified. This
commit resolves the issue by making the autosign setting inherit from
the file setting.

This is targeted at stable, but should be merged either if we do a 3.4.0-RC3, or in 3.4.1 if we hit 3.4.0 final.
