### PR TITLE
(PUP-866) Deprecate Import

### DIFF
--- a/lib/puppet/parser/parser_support.rb
+++ b/lib/puppet/parser/parser_support.rb
@@ -98,6 +98,16 @@ class Puppet::Parser::Parser
   def_delegators :known_resource_types, :watch_file, :version
 
   def import(file)
+    deprecation_location_text =
+    if @lexer.file && @lexer.line
+      " at #{@lexer.file}:#{@lexer.line}"
+    elsif @lexer.file
+      " in file #{@lexer.file}"
+    elsif @lexer.line
+      " at #{@lexer.line}"
+    end
+
+    Puppet.deprecation_warning("The use of 'import' is deprecated#{deprecation_location_text}. See http://links.puppetlabs.com/puppet-import-deprecation")
     if @lexer.file
       # use a path relative to the file doing the importing
       dir = File.dirname(@lexer.file)

--- a/spec/unit/parser/parser_spec.rb
+++ b/spec/unit/parser/parser_spec.rb
@@ -528,4 +528,12 @@ describe Puppet::Parser do
     @parser.known_resource_types.hostclass('funtest').
       should == @parser.find_hostclass("", "fUntEst")
   end
+
+  context "deprecations" do
+    it "should flag use of import as deprecated" do
+      Puppet.expects(:deprecation_warning).once
+      @parser.known_resource_types.loader.expects(:import).with('foo', Dir.pwd)
+      @parser.parse("import 'foo'")
+    end
+  end
 end


### PR DESCRIPTION
This deprecates the use of import.
A deprecation warning is generated with a URL to a link that in
turn points to the original Redmine issue.

A test is added.

Note this does not deprecate the underlying "import" mechanism as it is
used for all types of loading of manifests. The deprecation is for
the puppet language construct.
