### PR TITLE
(PUP-864) Add deprecation warning for mutation of array/hash

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -169,12 +169,27 @@ class Puppet::Parser::AST
         raise Puppet::ParseError, "Assigning to the hash '#{variable}' with an existing key '#{accesskey}' is forbidden"
       end
 
+      mutation_deprecation()
+
       # assign to hash or array
       object[array_index_or_key(object, accesskey)] = value
     end
 
     def to_s
       "\$#{variable.to_s}[#{key.to_s}]"
+    end
+
+    def mutation_deprecation
+      deprecation_location_text =
+      if file && line
+        " at #{file}:#{line}"
+      elsif file
+        " in file #{file}"
+      elsif line
+        " at #{line}"
+      end
+      Puppet.warning(["The use of mutating operations on Array/Hash is deprecated#{deprecation_location_text}.",
+         " See http://links.puppetlabs.com/puppet-mutation-deprecation"].join(''))
     end
   end
 

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -280,6 +280,7 @@ describe Puppet::Parser::AST::HashOrArrayAccess do
 
   describe "when assigning" do
     it "should add a new key and value" do
+      Puppet.expects(:warning).once
       node     = Puppet::Node.new('localhost')
       compiler = Puppet::Parser::Compiler.new(node)
       scope    = Puppet::Parser::Scope.new(compiler)
@@ -301,6 +302,7 @@ describe Puppet::Parser::AST::HashOrArrayAccess do
     end
 
     it "should be able to return an array member when index is a stringified number" do
+      Puppet.expects(:warning).once
       node     = Puppet::Node.new('localhost')
       compiler = Puppet::Parser::Compiler.new(node)
       scope    = Puppet::Parser::Scope.new(compiler)


### PR DESCRIPTION
This adds a deprecation warning to operations that mutates array
and hash - i.e. $a = [1,2,4] $a[3] = 5, and equivalent for hash.

The warning message has a URL that leads to PUP-864.
Existing tests that test that mutation is possible now also checks
that a warning is issued.
