### PR TITLE
(#21641) Windows puppet service should log to the eventlog 

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -145,6 +145,7 @@ class WindowsDaemon < Win32::Daemon
 
   def report_windows_event(type,id,message)
     begin
+      eventlog = nil
       eventlog = Win32::EventLog.open("Application")
       eventlog.report_event(
         :source      => "Puppet",
@@ -155,7 +156,9 @@ class WindowsDaemon < Win32::Daemon
     rescue Exception => e
       # Ignore all errors
     ensure
-      eventlog.close
+      if (!eventlog.nil?)
+        eventlog.close
+      end
     end
   end
 end


### PR DESCRIPTION
(#21641) Windows puppet service should log to the eventlog 

The windows service code (daemon.rb) logs to a file, since that was implemented prior to eventlog support. Now that support has been added, the daemon code should use it.

The service code has been modified so that any log_notice, log_debug etc. call will log the event to the Windows Application Event log (assuming it is of the right level) and optionally, it can log to the windows.log file as it was previously. The optional text logging is there for legacy reasons or in case the event log code is broken, then log files can still be generated. To use the log file method, the --logtofile service start argument should be set e.g. sc.exe start pe-puppet --logtofile --debug

Some of the wording of the logging messages has been changed e.g. removing ambiguity about the service resuming and additional logging for the Pause, Continue and Shutdown service control messages. Previously there was no logging for these events.

There is an issue with the win32-service gem regarding services coming out of Paused state and is fixed in version 0.8.3 [1]. I am not sure which version Puppet uses, but in the 3.0.1 Puppet Enterprise Windows MSI, v0.7.2 is used. While I could write code to work around this issue, I decided that it is not warranted as most people never put Puppet into a Paused state.

[1] https://github.com/djberg96/win32-service/issues/11
