### PR TITLE
(#16570) Don't load the node object again in configurer

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -148,18 +148,21 @@ class Puppet::Configurer
         query_options = get_facts(options)
       end
 
-      begin
-        if node = Puppet::Node.indirection.find(Puppet[:node_name_value],
-            :environment => @environment, :ignore_cache => true)
-          if node.environment.to_s != @environment
-            Puppet.warning "Local environment: \"#{@environment}\" doesn't match server specified node environment \"#{node.environment}\", switching agent to \"#{node.environment}\"."
-            @environment = node.environment.to_s
-            query_options = nil
+      # We only need to find out the environment to run in if we don't already have a catalog
+      unless options[:catalog]
+        begin
+          if node = Puppet::Node.indirection.find(Puppet[:node_name_value],
+              :environment => @environment, :ignore_cache => true)
+            if node.environment.to_s != @environment
+              Puppet.warning "Local environment: \"#{@environment}\" doesn't match server specified node environment \"#{node.environment}\", switching agent to \"#{node.environment}\"."
+              @environment = node.environment.to_s
+              query_options = nil
+            end
           end
+        rescue Puppet::Error, Net::HTTPError => detail
+          Puppet.warning("Unable to fetch my node definition, but the agent run will continue:")
+          Puppet.warning(detail)
         end
-      rescue Puppet::Error, Net::HTTPError => detail
-        Puppet.warning("Unable to fetch my node definition, but the agent run will continue:")
-        Puppet.warning(detail)
       end
 
       query_options = get_facts(options) unless query_options


### PR DESCRIPTION
Avoid loading the node object again if we already have a catalog.

In the long run the configurer class should probably be rafactored to have separate methods for fetching a catalog and applying it (and possibly have fetching of catalogs elsewhere).

Not methods like this:

```
# Retrieve (optionally) and apply a catalog. If a catalog is passed in
# the options, then apply that one, otherwise retrieve it.
def apply_catalog(catalog, options)
```
