### PR TITLE
(maint) Check --parser setting on the test host

### DIFF
--- a/acceptance/tests/apply/hashes/should_not_reassign.rb
+++ b/acceptance/tests/apply/hashes/should_not_reassign.rb
@@ -4,13 +4,16 @@ $my_hash = {'one' => '1', 'two' => '2' }
 $my_hash['one']='1.5'
 }
 
-apply_manifest_on(agents, manifest, :acceptable_exit_codes => [1]) do
-  expected_error_message =
-  case Puppet[:parser]
-  when 'future'
-    "Illegal attempt to assign via [index/key]. Not an assignable reference"
-  else
-    "Assigning to the hash 'my_hash' with an existing key 'one'"
+agents.each do |host|
+  parser = on(host, puppet('agent --configprint parser')).stdout.chomp
+  apply_manifest_on(host, manifest, :acceptable_exit_codes => [1]) do
+    expected_error_message =
+    case parser
+    when 'future'
+      "Illegal attempt to assign via [index/key]. Not an assignable reference"
+    else
+      "Assigning to the hash 'my_hash' with an existing key 'one'"
+    end
+    fail_test("didn't find the failure") unless stderr.include?(expected_error_message)
   end
-  fail_test("didn't find the failure") unless stderr.include?(expected_error_message)
 end


### PR DESCRIPTION
Tests was incorrectly trying to check Puppet[:parser] on host executing
beaker rather than the remote test hosts which were executing Puppet.
