### PR TITLE
(PUP-1150) Fix race condition in Puppet::Util::Lockfile.

### DIFF
--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -311,4 +311,15 @@ module Puppet::FileSystem
     @impl.path_string(path)
   end
 
+  # Create and open a file for write only if it doesn't exist.
+  #
+  # @see Puppet::FileSystem::open
+  #
+  # @raise [Errno::EEXIST] path already exists.
+  #
+  # @api public
+  #
+  def self.exclusive_create(path, mode, &block)
+    @impl.exclusive_create(assert_path(path), mode, &block)
+  end
 end

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -38,6 +38,11 @@ class Puppet::FileSystem::FileImpl
     path.size
   end
 
+  def exclusive_create(path, mode, &block)
+    opt = File::CREAT | File::EXCL | File::WRONLY
+    self.open(path, mode, opt, &block)
+  end
+
   def exclusive_open(path, mode, options = 'r', timeout = 300, &block)
     wait = 0.001 + (Kernel.rand / 1000)
     written = false

--- a/lib/puppet/util/lockfile.rb
+++ b/lib/puppet/util/lockfile.rb
@@ -23,10 +23,14 @@ class Puppet::Util::Lockfile
 
   # @return [boolean] true if lock is successfully acquired, false otherwise.
   def lock(lock_data = nil)
-    return false if locked?
-
-    File.open(@file_path, 'w') { |fd| fd.print(lock_data) }
-    true
+    begin
+      Puppet::FileSystem.exclusive_create(@file_path, nil) do |fd|
+        fd.print(lock_data)
+      end
+      true
+    rescue Errno::EEXIST
+      false
+    end
   end
 
   def unlock

--- a/spec/unit/file_system/file_spec.rb
+++ b/spec/unit/file_system/file_spec.rb
@@ -482,5 +482,23 @@ describe "Puppet::FileSystem" do
         Puppet::FileSystem.exist?(dir).should be_true
       end
     end
+
+    describe "exclusive_create" do
+      it "should create a file that doesn't exist" do
+        Puppet::FileSystem.exist?(missing_file).should be_false
+
+        Puppet::FileSystem.exclusive_create(missing_file, nil) {}
+
+        Puppet::FileSystem.exist?(missing_file).should be_true
+      end
+
+      it "should raise Errno::EEXIST creating a file that does exist" do
+        Puppet::FileSystem.exist?(file).should be_true
+
+        expect do
+          Puppet::FileSystem.exclusive_create(file, nil) {}
+        end.to raise_error(Errno::EEXIST)
+      end
+    end
   end
 end

--- a/spec/unit/util/lockfile_spec.rb
+++ b/spec/unit/util/lockfile_spec.rb
@@ -3,6 +3,33 @@ require 'spec_helper'
 
 require 'puppet/util/lockfile'
 
+module LockfileSpecHelper
+  def self.run_in_forks(count, &blk)
+    forks = {}
+    results = []
+    count.times do |i|
+      forks[i] = {}
+      forks[i][:read], forks[i][:write] = IO.pipe
+
+      forks[i][:pid] = fork do
+        forks[i][:read].close
+        res = yield
+        Marshal.dump(res, forks[i][:write])
+        exit!
+      end
+    end
+
+    count.times do |i|
+      forks[i][:write].close
+      result = forks[i][:read].read
+      forks[i][:read].close
+      Process.wait2(forks[i][:pid])
+      results << Marshal.load(result)
+    end
+    results
+  end
+end
+
 describe Puppet::Util::Lockfile do
   require 'puppet_spec/files'
   include PuppetSpec::Files
@@ -13,19 +40,34 @@ describe Puppet::Util::Lockfile do
   end
 
   describe "#lock" do
-    it "should return false if already locked" do
-      @lock.stubs(:locked?).returns(true)
-      @lock.lock.should be_false
-    end
-
     it "should return true if it successfully locked" do
       @lock.lock.should be_true
+    end
+
+    it "should return false if already locked" do
+      @lock.lock
+      @lock.lock.should be_false
     end
 
     it "should create a lock file" do
       @lock.lock
 
       Puppet::FileSystem.exist?(@lockfile).should be_true
+    end
+
+    # We test simultaneous locks using fork which isn't supported on Windows.
+    it "should not be acquired by another process", :unless => Puppet.features.microsoft_windows? do
+      30.times do
+        forks = 3
+        results = LockfileSpecHelper.run_in_forks(forks) do
+          @lock.lock(Process.pid)
+        end
+        @lock.unlock
+
+        # Confirm one fork returned true and everyone else false.
+        (results - [true]).size.should == forks - 1
+        (results - [false]).size.should == 1
+      end
     end
 
     it "should create a lock file containing a string" do


### PR DESCRIPTION
Before this commit, Puppet::Util::Lockfile.lock called the locked?
method before opening the @lockfile for write. Checking that the file
doesn't exist and creating the file were not an atomic operation, which
allowed two processes to detect that the file didn't exist and open it
for write simultaneously.

This commit adds option to the File.open call:
- File:CREAT - Creates the file if it doesn't exist.
- File:EXCL - Fails if the file does exist.
- File:WRONLY - Opens the file for write only.

File:EXCL is the important option, assuming all code that expects to
create this file will fail atomically if the file exists, the race
condition removed.
