### PR TITLE
[PUP-1120] Fix private key permissions for group read

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -560,6 +560,7 @@ EOT
       :type   => :directory,
       :mode => 0750,
       :owner => "service",
+      :group => "service",
       :desc => "The private key directory."
     },
     :privatedir => {
@@ -594,8 +595,9 @@ EOT
     :hostprivkey => {
       :default => "$privatekeydir/$certname.pem",
       :type   => :file,
-      :mode => 0600,
+      :mode => 0640,
       :owner => "service",
+      :group => "service",
       :desc => "Where individual hosts store and look for their private key."
     },
     :hostpubkey => {


### PR DESCRIPTION
Have the hostprivkey saved with 0640 permissions to allow
the service group to be able to read by other puppet services
like PuppetDB and Foreman.
