### PR TITLE
PUP-1062 pip support for virtualenvs

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -48,9 +48,9 @@ Puppet::Type.type(:package).provide :pip,
 
   # venv pip if called with a venv, else self.cmd (system-wide)
   def venvcmd
-    Puppet.debug("Provider::Pip using virtualenv #{@resource[:virtualenv]}")
-    if @resource[:virtualenv]
-      "#{@resource[:virtualenv]}/bin/pip"
+    Puppet.debug("Provider::Pip using virtualenv #{@resource[:prefix]}")
+    if @resource[:prefix]
+      "#{@resource[:prefix]}/bin/pip"
     else
       case Facter.value(:osfamily)
         when "RedHat"
@@ -68,7 +68,7 @@ Puppet::Type.type(:package).provide :pip,
     # anyway)
     name = @resource[:name].downcase
 
-    if @resource[:virtualenv]
+    if @resource[:prefix]
       pip_cmd = which(venvcmd)
       execpipe "#{pip_cmd} freeze" do |process|
         process.collect do |line|

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -350,14 +350,16 @@ module Puppet
       EOT
     end
 
-    newparam(:virtualenv) do
+    newparam(:prefix) do
       desc <<-EOT
-        The path to the virtualenv where the python package has to
-        be installed (when using the pip `provider`).
+        Absolute path to an isolated environment or installation
+        prefix to install the package under. Currently only supported
+        by the pip provider, which expects this to the path to a Python
+        virtual environment (created by the virtualenv command).
       EOT
 
       validate do |value|
-        raise ArgumentError, "virtualenv parameter must be an absolute path: #{value}" if ! absolute_path?(value)
+        raise ArgumentError, "prefix parameter must be an absolute path: #{value}" if ! absolute_path?(value)
       end
     end
 

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -46,9 +46,9 @@ describe provider_class do
 
   describe "venvcmd" do
 
-    it "should return venv pip path when virtualenv specified" do
-      @resource[:virtualenv] = "/path/to/virtualenv"
-      @provider.venvcmd.should == "/path/to/virtualenv/bin/pip"
+    it "should return venv pip path when prefix specified" do
+      @resource[:prefix] = "/path/to/prefix"
+      @provider.venvcmd.should == "/path/to/prefix/bin/pip"
     end
 
     it "should return pip-python on RedHat systems" do
@@ -110,7 +110,7 @@ describe provider_class do
     end
 
     it "should return a hash when pip and the package are present in a venv" do
-      @resource[:virtualenv] = "/path/to/virtualenv"
+      @resource[:prefix] = "/path/to/virtualenv"
       @provider.expects(:venvcmd).returns("/path/to/virtualenv/bin/pip")
       @provider.expects(:which).with("/path/to/virtualenv/bin/pip").returns("/path/to/virtualenv/bin/pip")
       p = stub("process")
@@ -125,7 +125,7 @@ describe provider_class do
     end
 
     it "should return nil when the package is missing from a venv" do
-      @resource[:virtualenv] = "/path/to/virtualenv"
+      @resource[:prefix] = "/path/to/virtualenv"
       @provider.expects(:venvcmd).returns("/path/to/virtualenv/bin/pip")
       @provider.expects(:which).with("/path/to/virtualenv/bin/pip").returns("/path/to/virtualenv/bin/pip")
       p = stub("process")
@@ -231,7 +231,7 @@ describe provider_class do
     it "should install into a virtualenv" do
       @resource[:ensure] = :installed
       @resource[:source] = nil
-      @resource[:virtualenv] = "/path/to/virtualenv"
+      @resource[:prefix] = "/path/to/virtualenv"
       @provider.expects(:lazy_pip).
         with("install", '-q', "fake_package")
       @provider.install
@@ -249,7 +249,7 @@ describe provider_class do
     end
 
     it "should uninstall from a virtualenv" do
-      @resource[:virtualenv] = "/path/to/virtualenv"
+      @resource[:prefix] = "/path/to/virtualenv"
       @resource[:name] = "fake_package"
       @provider.expects(:lazy_pip).
         with('uninstall', '-y', '-q', 'fake_package')

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -101,9 +101,9 @@ describe Puppet::Type.type(:package) do
       expect { Puppet::Type.type(:package).new(:name => "yay", :source => "stuff") }.to_not raise_error
     end
 
-    it "should require :virtualenv to be an absolute path" do
-      expect { Puppet::Type.type(:package).new(:name => "yay", :virtualenv => "path/to/venv") }.to raise_error(Puppet::Error)
-      expect { Puppet::Type.type(:package).new(:name => "yay", :virtualenv => "/path/to/venv") }.to_not raise_error
+    it "should require :prefix to be an absolute path" do
+      expect { Puppet::Type.type(:package).new(:name => "yay", :prefix => "path/to/venv") }.to raise_error(Puppet::Error)
+      expect { Puppet::Type.type(:package).new(:name => "yay", :prefix => "/path/to/venv") }.to_not raise_error
     end
 
     it "should not accept a non-string name" do


### PR DESCRIPTION
This adds a "virtualenv" parameter to the package type (see discussion in https://projects.puppetlabs.com/issues/7286) and, if that parameter is specified, uses bin/pip under that path instead of the system-wide one. This makes pip work for Python virtual environments (http://www.virtualenv.org). 

This is really being submitted as a "early review" PR before I do any more work on it. At the moment it works when tested/confirmed manually, and all rspec tests pass. There are a few comments left in the code that need to be removed, and there are also some branches that still need to be tested.

But I'm looking for feedback on whether this would be considered for inclusion before I move forward. I'm prepared to take an alternate path of splitting this out to a custom type in a "virtualenv" module, but would for obvious reasons prefer to see this in core.

One other main piece that's missing is figuring out how to redefine/rewrite namevar as a composite of virtualenv and name, so the same package can be installed in multiple separate virtualenvs.
