### PR TITLE
(PUP-1099) Fix incorrect permissions in RPMs

### DIFF
--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -253,6 +253,10 @@ cp -pr ext/puppet-nm-dispatcher \
 %defattr(-, puppet, puppet, 0750)
 %{_localstatedir}/log/puppet
 %{_localstatedir}/lib/puppet
+# Return the default attributes to 0755 to
+# prevent incorrect permission assignment on EL6
+%defattr(-, root, root, 0755)
+
 
 %files server
 %defattr(-, root, root, 0755)


### PR DESCRIPTION
The RPM spec template uses extremely restrictive permissions for `log`
and `lib` directories. These permissions were being incorrectly applied to
`examples` during packaging. This corrects that problem by resetting
default attributes after restricting `log` and `lib` directories.
