### PR TITLE
(PUP-609) (#22744) Filter virtual resources in the static compiler

### DIFF
--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -1,8 +1,8 @@
 require 'puppet/node'
 require 'puppet/resource/catalog'
-require 'puppet/indirector/code'
+require 'puppet/indirector/catalog/compiler'
 
-class Puppet::Resource::Catalog::StaticCompiler < Puppet::Indirector::Code
+class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Compiler
 
   desc %q{Compiles catalogs on demand using the optional static compiler. This
     functions similarly to the normal compiler, but it replaces puppet:/// file
@@ -35,12 +35,8 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Indirector::Code
       that compiled a given catalog may not have stored the required file contents
       in their filebuckets.}
 
-  def compiler
-    @compiler ||= indirection.terminus(:compiler)
-  end
-
   def find(request)
-    return nil unless catalog = compiler.find(request)
+    return nil unless catalog = super
 
     raise "Did not get catalog back" unless catalog.is_a?(model)
 


### PR DESCRIPTION
Previously (on Lost), the static compiler was directly creating and
invoking the regular compiler and then modifying the file resources to
get the desired behavior. Because the static compiler was directly
invoking the regular compiler, it was not invoking all the methods that
would normally get called when the regular compiler was called by the
indirector.

This commit resolves this problem by making the static compiler inherit
from the regular compiler instead of delegating to the compiler. If
there are future changes to how the indirector invokes termini, the
static compiler will still be able to generate catalogs in the same
manner as the regular compiler.

Original patch by Chris Spence chris.spence@puppetlabs.com

This supersedes GH-1962.
