### PR TITLE
(PUP-665) Allow settings to be undefined

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1136,9 +1136,8 @@ Generated on #{Time.now}.
     # @api public
     def lookup(name)
       @value_sets.each do |set|
-        if set.include?(name)
-          return set.lookup(name)
-        end
+        value = set.lookup(name)
+        return value if !value.nil?
       end
       nil
     end
@@ -1248,7 +1247,10 @@ Generated on #{Time.now}.
     end
 
     def lookup(name)
-      @section.setting(name).value
+      setting = @section.setting(name)
+      if setting
+        setting.value
+      end
     end
   end
 end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -509,6 +509,12 @@ describe Puppet::Settings do
       @settings[:one].should == "other"
     end
 
+    it "setting a value to nil causes it to return to its default" do
+      @settings[:one] = "value will disappear"
+      @settings[:one] = nil
+      @settings[:one].should == "ONE"
+    end
+
     it "should interpolate default values for other parameters into returned parameter values" do
       @settings[:one].should == "ONE"
       @settings[:two].should == "ONE TWO"


### PR DESCRIPTION
Setting a value to nil used to result in falling back to the default (or 
whatever came later in the lookup chain). This behavior was lost when the
settings were pulled apart into multiple classes to handle the lookup. The
error showed up in tests for stdlib that use rspec-puppet, which depended on
the "nil is default" behavior.
