### PR TITLE
(PUP-665) Setting nil reverts to default

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -949,8 +949,7 @@ Generated on #{Time.now}.
     ChainedValues.new(
       section,
       environment,
-      value_sets_for(environment, section) +
-      [ValuesFromDefaults.new(@config)],
+      value_sets_for(environment, section),
       @config)
   end
 
@@ -1135,11 +1134,17 @@ Generated on #{Time.now}.
     # @return [Object] The configuration setting value or nil if the setting is not known
     # @api public
     def lookup(name)
-      @value_sets.each do |set|
-        value = set.lookup(name)
-        return value if !value.nil?
+      set = @value_sets.find do |set|
+        set.include?(name)
       end
-      nil
+      if set
+        value = set.lookup(name)
+        if !value.nil?
+          return value
+        end
+      end
+
+      @defaults[name].default
     end
 
     # Lookup the interpolated value. All instances of `$name` in the value will
@@ -1192,20 +1197,6 @@ Generated on #{Time.now}.
           raise InterpolationError, "Could not find value for #{value}"
         end
       end
-    end
-  end
-
-  class ValuesFromDefaults
-    def initialize(defaults)
-      @defaults = defaults
-    end
-
-    def include?(name)
-      @defaults.include?(name)
-    end
-
-    def lookup(name)
-      @defaults[name].default
     end
   end
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -510,8 +510,16 @@ describe Puppet::Settings do
     end
 
     it "setting a value to nil causes it to return to its default" do
+      default_values = { :one => "skipped value" }
+      [:logdir, :confdir, :vardir].each do |key|
+        default_values[key] = 'default value'
+      end
+      @settings.define_settings :main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS
+      @settings.initialize_app_defaults(default_values)
       @settings[:one] = "value will disappear"
+
       @settings[:one] = nil
+
       @settings[:one].should == "ONE"
     end
 


### PR DESCRIPTION
The behavior of looking up settings was not entirely right from the previous
commit. The true behavior is:
- Search through layers in the order of [cli, memory, environment,
  run_mode, main, application_defaults]
- Find the first layer that has ever had the setting manipulated for
  it.
- If the value for that layer is not nil use that value.
- If the value for that layer is nil use the value from puppet's
  defaults.

This commit restores that behavior and adds a test to check that it happens.
