### PR TITLE
(maint) Windows file provider :links => :follow

### DIFF
--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -148,8 +148,9 @@ module Puppet::Util::Windows::File
 
     return out_buffer if result
     raise Puppet::Util::Windows::Error.new(
-      "DeviceIoControl(#{handle}, #{io_control_code}, #{in_buffer}, #{in_buffer.size}, " +
-      "#{out_buffer}, #{out_buffer.size}")
+      "DeviceIoControl(#{handle}, #{io_control_code}, " +
+      "#{in_buffer}, #{in_buffer ? in_buffer.size : ''}, " +
+      "#{out_buffer}, #{out_buffer ? out_buffer.size : ''}")
   end
 
   FILE_ATTRIBUTE_REPARSE_POINT = 0x400


### PR DESCRIPTION
- Previously, the Windows file provider would raise an error when
  applying a catalog that contained file resources with `:links =>
  :follow`, when the given path was not actually a symlink
  - The behavior of readlink is essentially correct, as File.readlink on
    other operating systems yields Errno::EINVAL: Invalid argument
  - Therefore the appropriate behavior to match Puppet on other
    platforms is to behave like File.chown, which will operate on the
    link IFF it is one, or will operate on the file / dir directly if it
    is not a link
  - Corrected a minor issue in the creation of the error msg raised
    by the Windows implementation of readlink
