### PR TITLE
Add guide to running local acceptance tests.

### DIFF
--- a/README_DEVELOPER.md
+++ b/README_DEVELOPER.md
@@ -539,15 +539,18 @@ rspec ./test.rb:16 # fixture data using instance variables should not keep state
 
 ### Puppet-acceptance
 
-[puppet-acceptance]: https://github.com/puppetlabs/puppet-acceptance
+[beaker]: https://github.com/puppetlabs/beaker
 [test::unit]: http://test-unit.rubyforge.org/
 
-Puppet has a custom acceptance testing framework called
-[puppet-acceptance][puppet-acceptance] for running acceptance tests.
-Puppet-acceptance runs the tests by configuring one or more VMs, copying the
-test cases onto the VMs, performing the tests and collecting the results, and
-ensuring that the results match the intended behavior. It uses
-[test::unit][test::unit] to perform the actual assertions.
+Puppet has a custom acceptance testing framework called [beaker][beaker] for
+running acceptance tests.
+Beaker runs the tests by configuring one or more VMs, copying the test cases
+onto the VMs, performing the tests and collecting the results, and ensuring that
+the results match the intended behavior. It uses [test::unit][test::unit] to
+perform the actual assertions.
+
+For a detailed guide to running the acceptance tests locally on vagrant boxes,
+see the `acceptance/README.md` document in this repo.
 
 # UTF-8 Handling #
 


### PR DESCRIPTION
Point to it in the README_DEVELOPER, and also update the same to refer to beaker rather than the deprecated puppet-acceptance.

Note that this guide actually working is blocking on puppetlabs/beaker#100 shipping in the beaker gem.

@jpartlow Should the guide be incorporated into the `acceptance/README.md`? That claims to address running the tests locally, but when I followed it I was only able to run the tests on VMs in our cloud, rather than on local VMs (reducing its utility for community members without access to our cloud).
