### PR TITLE
(PUP-665) Don't call hooks unless absolutely necessary

### DIFF
--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -73,10 +73,12 @@ class Puppet::Settings::BaseSetting
   end
 
   def hook=(block)
+    @has_hook = true
     meta_def :handle, &block
   end
 
-  def handle(value)
+  def has_hook?
+    @has_hook
   end
 
   # Create the new element.  Pretty much just sets the name.
@@ -91,6 +93,7 @@ class Puppet::Settings::BaseSetting
 
     #set the default value for call_hook
     @call_hook = :on_write_only if args[:hook] and not args[:call_hook]
+    @has_hook = false
 
     raise ArgumentError, "Cannot reference :call_hook for :#{@name} if no :hook is defined" if args[:call_hook] and not args[:hook]
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -939,6 +939,27 @@ describe Puppet::Settings do
       @settings[:deferred].should eq File.expand_path('/path/to/confdir/goose')
     end
 
+    it "does not require the value for a setting without a hook to resolve during global setup" do
+      hook_invoked = false
+      @settings.define_settings :section, :can_cause_problems  => {:desc => '' }
+
+      @settings.define_settings(:main,
+        :logdir       => { :type => :directory, :default => nil, :desc => "logdir" },
+        :confdir      => { :type => :directory, :default => nil, :desc => "confdir" },
+        :vardir       => { :type => :directory, :default => nil, :desc => "vardir" })
+
+      text = <<-EOD
+      [main]
+      can_cause_problems=$confdir/goose
+      EOD
+
+      @settings.stubs(:read_file).returns(text)
+      @settings.initialize_global_settings
+      @settings.initialize_app_defaults(:logdir => '/path/to/logdir', :confdir => '/path/to/confdir', :vardir => '/path/to/vardir')
+
+      @settings[:can_cause_problems].should eq File.expand_path('/path/to/confdir/goose')
+    end
+
     it "should allow empty values" do
       @settings.define_settings :section, :myarg => { :default => "myfile", :desc => "a" }
 


### PR DESCRIPTION
Calling hooks on configuration settings that don't have them forces the code
to interpolate any `$variable`s in the value of the setting. There are a
couple places where the hooks are called before everything has been fully
prepared (such as in initialize_global_defaults) and so run mode settings
such as confdir are not available.

This restores the old behavior in which only settings with hooks will end up
going down this path. This doesn't fully address the problem, but it does
make the surface area much smaller.
