### PR TITLE
(maint) Check package build status earlier in bootstrap

### DIFF
--- a/acceptance/bin/ci-bootstrap-from-artifacts.sh
+++ b/acceptance/bin/ci-bootstrap-from-artifacts.sh
@@ -22,6 +22,8 @@ echo "FORK: ${FORK}"
 echo "BUILD_SELECTOR: ${BUILD_SELECTOR}"
 echo "PACKAGE_BUILD_STATUS: ${PACKAGE_BUILD_STATUS}"
 
+[[ (-z "${PACKAGE_BUILD_STATUS}") || ("${PACKAGE_BUILD_STATUS}" = "success") ]] || exit 1
+
 rm -rf acceptance
 mkdir acceptance
 cd acceptance
@@ -45,5 +47,3 @@ cat > local_options.rb <<-EOF
 ${repo_proxy}
 }
 EOF
-
-[[ (-z "${PACKAGE_BUILD_STATUS}") || ("${PACKAGE_BUILD_STATUS}" = "success") ]] || exit 1


### PR DESCRIPTION
I think this would allow failures in packaging to be a little more visible just because the log output of the job wouldn't include unpacking the tarball/etc, none of which has any value if the package build failed.
