### PR TITLE
(PUP-798) Add call to watch_files to ensure reparsing

### DIFF
--- a/lib/puppet/parser/e4_parser_adapter.rb
+++ b/lib/puppet/parser/e4_parser_adapter.rb
@@ -6,7 +6,9 @@ module Puppet; module Parser; end; end;
 #
 class Puppet::Parser::E4ParserAdapter
 
-  def initialize()
+  # @param file_watcher [#watch_file] something that can watch a file
+  def initialize(file_watcher = nil)
+    @file_watcher = file_watcher
     @file = ''
     @string = ''
     @use = :undefined
@@ -16,6 +18,8 @@ class Puppet::Parser::E4ParserAdapter
   def file=(file)
     @file = file
     @use = :file
+    # watch if possible, but only if the file is something worth watching
+    @file_watcher.watch_file(file) if @file_watcher.respond_to?(:watch_file) && !file.nil? && file != ''
   end
 
   def parse(string = nil)

--- a/lib/puppet/parser/parser_factory.rb
+++ b/lib/puppet/parser/parser_factory.rb
@@ -11,7 +11,8 @@ module Puppet::Parser
     def self.parser(environment)
       case Puppet[:parser]
       when 'future'
-        evaluating_parser()
+        # must check if the given environment is real or just a string, in which case watching is not supported
+        evaluating_parser(environment.respond_to?(:known_resource_types) ? environment.known_resource_types : nil)
 #        eparser(environment)
       else
         classic_parser(environment)
@@ -27,14 +28,14 @@ module Puppet::Parser
     end
 
     # Returns an instance of an EvaluatingParser
-    def self.evaluating_parser
+    def self.evaluating_parser(file_watcher)
       # Since RGen is optional, test that it is installed
       @@asserted ||= false
       assert_rgen_installed() unless @@asserted
       @@asserted = true
       require 'puppet/parser/e4_parser_adapter'
       require 'puppet/pops/parser/code_merger'
-      E4ParserAdapter.new()
+      E4ParserAdapter.new(file_watcher)
     end
 
     # Creates an instance of the expression based parser 'eparser'


### PR DESCRIPTION
This adds a call to watch_file in the code path for the future
parser/evaluator at the same place such call is made in the 3x
implementation. 

The ParserFactory is given an environment, and when this is 
a real environment, its known_resource_types are given to the parser
adapter being created to allow it to make the call to watch_file.
