### PR TITLE
(PUP-1246) Fixed hiding error details in fileserver.conf parser

### DIFF
--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -37,10 +37,10 @@ class Puppet::FileServing::Configuration::Parser
           when "deny"
             deny(mount, value)
           else
-            raise ArgumentError.new("Invalid argument '#{var}'", @count, @file)
+            raise ArgumentError.new("Invalid argument '#{var}' in #{@file.filename}, line #{@count}")
           end
         else
-          raise ArgumentError.new("Invalid line '#{line.chomp}'", @count, @file)
+          raise ArgumentError.new("Invalid line '#{line.chomp}' at #{@file.filename}, line #{@count}")
         end
       }
     }

--- a/spec/unit/file_serving/configuration/parser_spec.rb
+++ b/spec/unit/file_serving/configuration/parser_spec.rb
@@ -84,6 +84,12 @@ describe Puppet::FileServing::Configuration::Parser do
 
       lambda { @parser.parse }.should raise_error(RuntimeError)
     end
+
+    it "should return comprehensible error message, if invalid line detected" do
+      write_config_file "[one]\n\xc2\xa0\xc2\xa0path /etc/puppet/files\n\xc2\xa0\xc2\xa0allow *\n"
+
+      proc { @parser.parse }.should raise_error(ArgumentError, /Invalid line.*in.*, line.*/)
+    end
   end
 
   describe Puppet::FileServing::Configuration::Parser, " when parsing mount attributes" do
@@ -131,6 +137,12 @@ describe Puppet::FileServing::Configuration::Parser do
 
       proc { @parser.parse }.should raise_error(ArgumentError)
     end
+    it "should return comprehensible error message, if failed on invalid attribute" do
+      write_config_file "[one]\ndo something\n"
+
+      proc { @parser.parse }.should raise_error(ArgumentError, /Invalid argument 'do' in.*, line.*/)
+    end
+
   end
 
   describe Puppet::FileServing::Configuration::Parser, " when parsing the modules mount" do


### PR DESCRIPTION
This patch fixes wrong parser behavior in case when fileserver.conf
contains some broken lines. It helps to debug configuration problems
and makes puppet's user life a little bit easier.

Also added 2 unit tests for validating these buggy cases.
