### PR TITLE
(maint) Fix rdoc generator for Ruby 2.1.0

### DIFF
--- a/lib/puppet/util/rdoc/code_objects.rb
+++ b/lib/puppet/util/rdoc/code_objects.rb
@@ -146,6 +146,10 @@ module RDoc
       @childs = []
     end
 
+    def aref_prefix
+      'puppet_class'
+    end
+
     def add_resource(resource)
       add_to(@resource_list, resource)
     end


### PR DESCRIPTION
Ruby 2.1.0 includes RDoc 4.1.0 which added a requirement that
subclasses of ClassModule implement 'add_prefix'. This requirement
was added in this commit:

https://github.com/rdoc/rdoc/commit/1701151b5b14cd20d624c4ce75fd61cc60cd07f3

The rdoc docs for other classes mention that aref_prefix should be
implemented by subclasses, but generally a base class implementation is
provided.  The rdoc doc for ClassModule hasn't been updated to reflect
the new requirement.

This patch simply implements the 'aref_prefix' method.
