### PR TITLE
(PUP-1255) Fix assumed default file mode to 0644

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -719,7 +719,7 @@ Puppet::Type.newtype(:file) do
     mode_int = mode ? symbolic_mode_to_int(mode, assumed_default_mode) : nil
 
     if write_temporary_file?
-      Puppet::Util.replace_file(self[:path], mode_int) do |file|
+      Puppet::Util.replace_file(self[:path], mode ? mode_int : assumed_default_mode) do |file|
         file.binmode
         content_checksum = write_content(file)
         file.flush


### PR DESCRIPTION
When a file is created with content, the assumed default mode should be 0644,
but this wasn't being explicitly set.  The secure file replacement (in
Puppet::Util.replace_file) was instead defaulting to a file mode of 0600.
The assumed default mode is now explicitly set when calling replace_file.

The code path for file creation without content continues to set a umask of
0022 if no mode is specified on the resource, so new files are implicitly
created with a mode of 0644.
