### PR TITLE
(PUP-1255) Fix assumed default file mode to 0644

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -736,13 +736,11 @@ Puppet::Type.newtype(:file) do
   def write(property)
     remove_existing(:file)
 
-    assumed_default_mode = 0644
-
     mode = self.should(:mode) # might be nil
-    mode_int = mode ? symbolic_mode_to_int(mode, assumed_default_mode) : nil
+    mode_int = mode ? symbolic_mode_to_int(mode, Puppet::Util::DEFAULT_POSIX_MODE) : nil
 
     if write_temporary_file?
-      Puppet::Util.replace_file(self[:path], mode ? mode_int : assumed_default_mode) do |file|
+      Puppet::Util.replace_file(self[:path], mode_int) do |file|
         file.binmode
         content_checksum = write_content(file)
         file.flush

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -538,8 +538,20 @@ module Util
   # The default_mode is the mode to use when the target file doesn't already
   # exist; if the file is present we copy the existing mode/owner/group values
   # across.
+
+  DEFAULT_POSIX_MODE = 0644
+  DEFAULT_WINDOWS_MODE = nil
+
   def replace_file(file, default_mode, &block)
     raise Puppet::DevError, "replace_file requires a block" unless block_given?
+
+    unless default_mode
+      if Puppet.features.microsoft_windows?
+        default_mode = DEFAULT_WINDOWS_MODE
+      else
+        default_mode = DEFAULT_POSIX_MODE
+      end
+    end
 
     file     = Pathname(file)
     tempfile = Tempfile.new(file.basename.to_s, file.dirname.to_s)

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1192,31 +1192,26 @@ describe Puppet::Type.type(:file) do
     end
 
     describe "when resource mode is not supplied" do
-      before do
-        file.stubs(:property_fix)
-        file.delete(:mode) if file[:mode]
-      end
-
-      context "and writing temporary files" do
-        before { file.stubs(:write_temporary_file?).returns(true) }
-
+      context "and content is supplied" do
         it "should default to 0644 mode" do
-          Puppet::Util.expects(:replace_file).with(file[:path], 0644)
+          file = described_class.new(:path => path, :content => "file content")
+
           file.write :NOTUSED
+
+          expect(File.stat(file[:path]).mode & 0777).to eq(0644)
         end
       end
 
-      context "and not writing temporary files" do
-        before { file.stubs(:write_temporary_file?).returns(false) }
+      context "and no content is supplied" do
+        it "should use puppet's default umask of 022" do
+          file = described_class.new(:path => path)
 
-        it "should set a umask of 022" do
-          Puppet::Util.expects(:withumask).with(022)
-          file.write :NOTUSED
-        end
+          umask_from_the_user = 0777
+          Puppet::Util.withumask(umask_from_the_user) do
+            file.write :NOTUSED
+          end
 
-        it "should supply no mode to default to umask" do
-          File.expects(:open).with(file[:path], anything, nil)
-          file.write :NOTUSED
+          expect(File.stat(file[:path]).mode & 0777).to eq(0644)
         end
       end
     end


### PR DESCRIPTION
When a file is created with content, the assumed default mode should be 0644,
but this wasn't being explicitly set.  The secure file replacement (in
Puppet::Util.replace_file) was instead defaulting to a file mode of 0600.
The assumed default mode is now explicitly set when calling replace_file.

The code path for file creation without content continues to set a umask of
0022 if no mode is specified on the resource, so new files are implicitly
created with a mode of 0644.
