### PR TITLE
(maint) cron: Make the munge method for the command property more readable

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -234,9 +234,7 @@ Puppet::Type.newtype(:cron) do
     end
 
     def munge(value)
-      value.sub!(/^\s+/, '')
-      value.sub!(/\s+$/, '')
-      value
+      value.strip
     end
   end
 


### PR DESCRIPTION
The removal of leading and trailing spaces in cron commands was
performed using a perlism instead of just using String#strip.
Do that instead.
