### PR TITLE
remove warning during package installation on machine with LANG=fr_*

### DIFF
--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -44,7 +44,12 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   self::DPKG_DESCRIPTION_DELIMITER = ':DESC:'
   self::DPKG_QUERY_FORMAT_STRING = %Q{'${Status} ${Package} ${Version} #{self::DPKG_DESCRIPTION_DELIMITER} ${Description}\\n#{self::DPKG_DESCRIPTION_DELIMITER}\\n'}
   self::FIELDS_REGEX = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*) #{self::DPKG_DESCRIPTION_DELIMITER} (.*)$}
-  self::DPKG_PACKAGE_NOT_FOUND_REGEX = /no package.*match/i
+  case ENV['LANG']
+  when /^fr_/
+    self::DPKG_PACKAGE_NOT_FOUND_REGEX = /Aucun paquet ne correspond/
+  else
+    self::DPKG_PACKAGE_NOT_FOUND_REGEX = /no package.*match/i
+  end
   self::FIELDS= [:desired, :error, :status, :name, :ensure, :description]
   self::END_REGEX = %r{^#{self::DPKG_DESCRIPTION_DELIMITER}$}
 


### PR DESCRIPTION
When installing packages on Ubuntu machine with LANG=fr_*, we have the following message for each package newly installed: "Failed to match dpkg-query line...".

This is linked to the fact that the string returned by dpkg-query for a non-existent package is in french: "Aucun paquet ne correspond à...".

This fix allow to by-pass this issue.
I have not found any internationalization capability in puppet, so my fix is a iittle bit straight forward ;-)

I cannot also replay the rspec test on my machine since it use all memory and start swapping after seeing twice the message: "/dev/mem: Permission denied".
