### PR TITLE
PUP-1322 Do not fail hard on unparseable files

### DIFF
--- a/lib/puppet/parser/type_loader.rb
+++ b/lib/puppet/parser/type_loader.rb
@@ -95,7 +95,16 @@ class Puppet::Parser::TypeLoader
     @loaded ||= {}
     loaded_asts = []
     files.reject { |file| @loaded[file] }.each do |file|
-      loaded_asts << parse_file(file)
+      begin
+        loaded_asts << parse_file(file)
+      rescue => e
+        # Resume from errors so that all parseable files would
+        # still be parsed. Mark this file as loaded so that
+        # it would not be parsed next time (handle it as if
+        # it was successfully parsed).
+        Puppet.debug("Unable to parse '#{file}': #{e.message}")
+      end
+
       @loaded[file] = true
     end
 


### PR DESCRIPTION
Current solution fails hard if at least one file is not parseable. This is unfortunate in the Puppet Enterprise class discovery (in the console UI). If a single manifest is broken then not a single class is discovered since the discovery process fails too hard. In the past refreshing the browser (as many times as the number of broken files) helped since the broken file was not examined again on the next attempt (the former "do_once" method). Although it was not considered as ideal it was at least usable (with a hint in the docs). But now it's too strict and it's even hard to report the correct error to user - although the first attempt to load a broken file reports the error (e.g. "syntax error in ..."), all subsequent attempts report an inappropriate message ("Import loop detected").

This PR tries to solve the problem (more details in https://tickets.puppetlabs.com/browse/PE-2123 and its related issues).

The first change (in environment.rb) invokes reparsing when it detects a change in the known resource type file set. Without this, even if user fixes the problem, the puppet API did not parse the file again (it could only parse newly added files but not changed ones).

The second change (in type_loader.rb) make loading files less strict to enable parsing all parseable files, considering all unparseable files as loaded with errors.

The caveat of this solution is that the errors are only reported as debugging messages so they never get to the user. However, it's still much better from the PE Console perspective since user can see all valid classes on the class discovery page. I don't know how to handle this in the best way - just as brainstorming, errors could be reported in the formatted json output along with discovered classes, or there could be a different REST API url for getting just errors...

Please, take a look at the solution. We do need something that solves the problem of PE Console class discovery feature.
