### PR TITLE
(maint) Fix inconsistency when case option is a Type.

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -951,7 +951,7 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       matched = right.match(left)
       set_match_data(matched, o, scope) # creates or clears ephemeral
       !!matched # convert to boolean
-    elsif right.is_a?(Puppet::Pops::Types::PAbstractType) && !left.is_a?(Puppet::Pops::Types::PAbstractType)
+    elsif right.is_a?(Puppet::Pops::Types::PAbstractType)
       # right is a type and left is not - check if left is an instance of the given type
       # (The reverse is not terribly meaningful - computing which of the case options that first produces
       # an instance of a given type).

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -444,6 +444,13 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
          Array[String] : { no }
          Array[Integer]: { yes }
       }"                                                     => 'yes',
+      "case 1 {
+         Integer : { yes }
+         Type[Integer] : { no } }"                           => 'yes',
+      "case Integer {
+         Integer : { no }
+         Type[Integer] : { yes } }"                          => 'yes',
+
     }.each do |source, result|
         it "should parse and evaluate the expression '#{source}' to #{result}" do
           parser.evaluate_string(scope, source, __FILE__).should == result


### PR DESCRIPTION
The way the implementation worked made it impossible to differentiate
between an instance and its type.
