### PR TITLE
(maint) Simply confine test to any platform with Ruby shadow

### DIFF
--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -1,14 +1,10 @@
 test_name "#6857: redact password hashes when applying in noop mode"
 
 hosts_to_test = agents.reject do |agent|
-  if agent['platform'].match /(?:ubuntu|centos|debian|el-|fc-)/
-    result = on(agent, %Q{#{agent['puppetbindir']}/ruby -e 'require "shadow" or raise'}, :silent => true)
-    result.exit_code != 0
-  else
-    false
-  end
+  result = on(agent, %Q{#{agent['puppetbindir']}/ruby -e 'require "shadow" or raise'}, :silent => true)
+  result.exit_code != 0
 end
-skip_test "No suitable hosts found" if hosts_to_test.empty?
+skip_test "No suitable hosts found.  Without the Ruby shadow library, passwords cannot be set." if hosts_to_test.empty?
 
 adduser_manifest = <<MANIFEST
 user { 'passwordtestuser':


### PR DESCRIPTION
Original confine was prone to errors in platform pattern, which we saw
when testing fedora18 whose platform tag no longer contains 'fc-' in our
current acceptance/config/nodes.  This would fall through to the false
case, which meant the host was /not/ rejected.  And then fedora18 from a
source checkout would run the test and fail, because Ruby shadow lib is not
installed by default.  This only turned up because the future parser
acceptance job was running from source checkouts (because one of the
nodes it was testing is Windows...)  At any rate, it proved confusing.

This change just simplifies the confine to reject a host if the Ruby
shadow library is not present.  Because without that, we can't
manipulate passwords, and have nothing to test.
