### PR TITLE
(PUP-724,#21922) Autoload compares only integer secs

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -45,7 +45,7 @@ class Puppet::Util::Autoload
       file, old_mtime = loaded[name]
       return true unless file == get_file(name)
       begin
-        old_mtime != File.mtime(file)
+        old_mtime.to_i != File.mtime(file).to_i
       rescue Errno::ENOENT
         true
       end


### PR DESCRIPTION
Although the ultimate reasons have not been tracked down, there have
been occasions where the Puppet::Util::Autoload.changed? method will
erroneously report that a file has changed based on an mtime having
seemed to change nsecs, despite no evidence of this being seen in the
file system.

The previous implementation was comparing mtime (Ruby Time instances)
and the nsecs seem to be volatile under unknown conditions. When it does
break, this was manifesting as a failure to autoload
puppet/util/instrumentation/listeners/log.rb (the instrumentation code
is relying on Puppet::Util::Autoload for initial loading but does not
expect its listeners to be reloaded, and they are not written in such a
way as to be reloadable...) (see PUP-724 and its associated tickets for
details).

The work around is to instead just compare integer secs.
