### PR TITLE
Don't replace original stacktrace when error happens parsing inline template

### DIFF
--- a/lib/puppet/parser/functions/inline_template.rb
+++ b/lib/puppet/parser/functions/inline_template.rb
@@ -15,7 +15,7 @@ Puppet::Parser::Functions::newfunction(:inline_template, :type => :rvalue, :arit
         wrapper.result(string)
       rescue => detail
         raise Puppet::ParseError,
-          "Failed to parse inline template: #{detail}"
+          "Failed to parse inline template: #{detail}", detail.backtrace
       end
     end.join("")
 end


### PR DESCRIPTION
Helps with debugging errors in template

before

```
 Puppet::Error:
   Failed to parse inline template: `@32bit_packages' is not allowed as an instance variable name at /Users/csanchez/dev/maestrodev/puppet/android/spec/fixtures/modules/wget/manifests/fetch.pp:36 on node carlos-mbook-pro.home
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/functions/inline_template.rb:17:in `rescue in block (2 levels) in <top (required)>'
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/functions/inline_template.rb:14:in `block (2 levels) in <top (required)>'
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/functions/inline_template.rb:9:in `collect'
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/functions/inline_template.rb:9:in `block in <top (required)>'
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/functions.rb:144:in `block (2 levels) in newfunction'
```

after

```
 Puppet::Error:
   Failed to parse inline template: `@32bit_packages' is not allowed as an instance variable name at /Users/csanchez/dev/maestrodev/puppet/android/spec/fixtures/modules/wget/manifests/fetch.pp:36 on node carlos-mbook-pro.home
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/templatewrapper.rb:110:in `instance_variable_set'
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/templatewrapper.rb:110:in `block (2 levels) in result'
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/templatewrapper.rb:108:in `each'
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/parser/templatewrapper.rb:108:in `block in result'
 # /Users/csanchez/.rvm/gems/ruby-1.9.3-p484/gems/puppet-3.4.1/lib/puppet/util.rb:166:in `benchmark'
```
