### PR TITLE
(PUP-1068) Add basic auth to HTTP Connection and HTTP Reports

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -19,25 +19,33 @@ module Puppet::Network::HTTP
   #   certificate configuration for their authentication, and
   # * Provides some useful error handling for any SSL errors that occur
   #   during a request.
+  # @api public
   class Connection
     include Puppet::Network::Authentication
 
     OPTION_DEFAULTS = {
       :use_ssl => true,
       :verify => nil,
-      :redirect_limit => 10
+      :redirect_limit => 10,
     }
 
     # Creates a new HTTP client connection to `host`:`port`.
     # @param host [String] the host to which this client will connect to
     # @param port [Fixnum] the port to which this client will connect to
-    # @param options [Hash] options influencing the properties of the created connection,
-    #   the following options are recognized:
-    #     :use_ssl [Boolean] true to connect with SSL, false otherwise, defaults to true
-    #     :verify [#setup_connection] An object that will configure any verification to do on the connection
-    #     :redirect_limit [Fixnum] the number of allowed redirections, defaults to 10
-    #   passing any other option in the options hash results in a Puppet::Error exception
-    # @note the HTTP connection itself happens lazily only when {#request}, or one of the {#get}, {#post}, {#delete}, {#head} or {#put} is called
+    # @param options [Hash] options influencing the properties of the created
+    #   connection,
+    # @option options [Boolean] :use_ssl true to connect with SSL, false
+    #   otherwise, defaults to true
+    # @option options [#setup_connection] :verify An object that will configure
+    #   any verification to do on the connection
+    # @option options [Fixnum] :redirect_limit the number of allowed
+    #   redirections, defaults to 10 passing any other option in the options
+    #   hash results in a Puppet::Error exception
+    #
+    # @note the HTTP connection itself happens lazily only when {#request}, or
+    #   one of the {#get}, {#post}, {#delete}, {#head} or {#put} is called
+    # @note The correct way to obtain a connection is to use one of the factory
+    #   methods on {Puppet::Network::HttpPool}
     # @api private
     def initialize(host, port, options = {})
       @host = host
@@ -52,41 +60,59 @@ module Puppet::Network::HTTP
       @redirect_limit = options[:redirect_limit]
     end
 
-    def get(*args)
-      request(:get, *args)
+    # @!macro [new] common_options
+    #   @param options [Hash] options influencing the request made
+    #   @option options [Hash{Symbol => String}] :basic_auth The basic auth
+    #     :username and :password to use for the request
+
+    # @param path [String]
+    # @param headers [Hash{String => String}]
+    # @!macro common_options
+    # @api public
+    def get(path, headers = {}, options = {})
+      request_with_redirects(Net::HTTP::Get.new(path, headers), options)
     end
 
-    def post(*args)
-      request(:post, *args)
+    # @param path [String]
+    # @param data [String]
+    # @param headers [Hash{String => String}]
+    # @!macro common_options
+    # @api public
+    def post(path, data, headers = nil, options = {})
+      request = Net::HTTP::Post.new(path, headers)
+      request.body = data
+      request_with_redirects(request, options)
     end
 
-    def head(*args)
-      request(:head, *args)
+    # @param path [String]
+    # @param headers [Hash{String => String}]
+    # @!macro common_options
+    # @api public
+    def head(path, headers = {}, options = {})
+      request_with_redirects(Net::HTTP::Head.new(path, headers), options)
     end
 
-    def delete(*args)
-      request(:delete, *args)
+    # @param path [String]
+    # @param headers [Hash{String => String}]
+    # @!macro common_options
+    # @api public
+    def delete(path, headers = {'Depth' => 'Infinity'}, options = {})
+      request_with_redirects(Net::HTTP::Delete.new(path, headers), options)
     end
 
-    def put(*args)
-      request(:put, *args)
+    # @param path [String]
+    # @param data [String]
+    # @param headers [Hash{String => String}]
+    # @!macro common_options
+    # @api public
+    def put(path, data, headers = nil, options = {})
+      request = Net::HTTP::Put.new(path, headers)
+      request.body = data
+      request_with_redirects(request, options)
     end
 
     def request(method, *args)
-      current_args = args.dup
-      @redirect_limit.times do |redirection|
-        response = execute_request(method, *args)
-        return response unless [301, 302, 307].include?(response.code.to_i)
-
-        # handle the redirection
-        location = URI.parse(response['location'])
-        @connection = initialize_connection(location.host, location.port, location.scheme == 'https')
-
-        # update to the current request path
-        current_args = [location.path] + current_args.drop(1)
-        # and try again...
-      end
-      raise RedirectionLimitExceededException, "Too many HTTP redirections for #{@host}:#{@port}"
+      self.send(method, *args)
     end
 
     # TODO: These are proxies for the Net::HTTP#request_* methods, which are
@@ -123,12 +149,42 @@ module Puppet::Network::HTTP
 
     private
 
+    def request_with_redirects(request, options)
+      current_request = request
+      @redirect_limit.times do |redirection|
+        apply_options_to(current_request, options)
+
+        response = execute_request(current_request)
+        return response unless [301, 302, 307].include?(response.code.to_i)
+
+        # handle the redirection
+        location = URI.parse(response['location'])
+        @connection = initialize_connection(location.host, location.port, location.scheme == 'https')
+
+        # update to the current request path
+        current_request = current_request.class.new(location.path)
+        current_request.body = request.body
+        request.each do |header, value|
+          current_request[header] = value
+        end
+
+        # and try again...
+      end
+      raise RedirectionLimitExceededException, "Too many HTTP redirections for #{@host}:#{@port}"
+    end
+
+    def apply_options_to(request, options)
+      if options[:basic_auth]
+        request.basic_auth(options[:basic_auth][:user], options[:basic_auth][:password])
+      end
+    end
+
     def connection
       @connection || initialize_connection(@host, @port, @use_ssl)
     end
 
-    def execute_request(method, *args)
-      response = connection.send(method, *args)
+    def execute_request(request)
+      response = connection.request(request)
 
       # Check the peer certs and warn if they're nearing expiration.
       warn_if_near_expiration(*@verify.peer_certs)

--- a/lib/puppet/network/http_pool.rb
+++ b/lib/puppet/network/http_pool.rb
@@ -3,10 +3,10 @@ require 'puppet/network/http/connection'
 module Puppet::Network; end
 
 # This module contains the factory methods that should be used for getting a
-# Puppet::Network::HTTP::Connection instance.
+# {Puppet::Network::HTTP::Connection} instance.
 #
-# The name "HttpPool" is a misnomer, and a leftover of history, but we would
-# like to make this cache connections in the future.
+# @note The name "HttpPool" is a misnomer, and a leftover of history, but we would
+#   like to make this cache connections in the future.
 #
 # @api public
 #

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -1,4 +1,3 @@
-require 'base64'
 require 'puppet'
 require 'puppet/network/http_pool'
 require 'uri'
@@ -14,15 +13,17 @@ Puppet::Reports.register_report(:http) do
 
   def process
     url = URI.parse(Puppet[:reporturl])
-    body = self.to_yaml
     headers = { "Content-Type" => "application/x-yaml" }
+    options = {}
     if url.user && url.password
-      user_pass_encoded = Base64.encode64("#{url.user}:#{url.password}").strip
-      headers["Authorization"] = "Basic #{user_pass_encoded}"
+      options[:basic_auth] = {
+        :user => url.user,
+        :password => url.password
+      }
     end
     use_ssl = url.scheme == 'https'
     conn = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl)
-    response = conn.post(url.path, body, headers)
+    response = conn.post(url.path, self.to_yaml, headers, options)
     unless response.kind_of?(Net::HTTPSuccess)
       Puppet.err "Unable to submit report to #{Puppet[:reporturl].to_s} [#{response.code}] #{response.msg}"
     end

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -46,28 +46,30 @@ describe processor do
 
     it "should use the path specified by the 'reporturl' setting" do
       report_path = URI.parse(Puppet[:reporturl]).path
-      connection.expects(:post).with(report_path, anything, anything).returns(httpok)
+      connection.expects(:post).with(report_path, anything, anything, {}).returns(httpok)
 
       subject.process
     end
 
     it "should use the username and password specified by the 'reporturl' setting" do
       Puppet[:reporturl] = "https://user:pass@myhost.mydomain:1234/report/upload"
-      http.expects(:post).with {|path,data,headers|
-        headers['Authorization'].should == "Basic dXNlcjpwYXNz"
-      }.returns(httpok)
+
+      connection.expects(:post).with(anything, anything, anything, :basic_auth => {
+        :user => 'user',
+        :password => 'pass'
+      }).returns(httpok)
 
       subject.process
     end
 
     it "should give the body as the report as YAML" do
-      connection.expects(:post).with(anything, subject.to_yaml, anything).returns(httpok)
+      connection.expects(:post).with(anything, subject.to_yaml, anything, {}).returns(httpok)
 
       subject.process
     end
 
     it "should set content-type to 'application/x-yaml'" do
-      connection.expects(:post).with(anything, anything, has_entry("Content-Type" => "application/x-yaml")).returns(httpok)
+      connection.expects(:post).with(anything, anything, has_entry("Content-Type" => "application/x-yaml"), {}).returns(httpok)
 
       subject.process
     end


### PR DESCRIPTION
This adds logic in Puppet::Reports::Http to properly handle HTTP basic auth
using the form http://username:password@host/path

In order to make this work more clearly, this also adds actual parameters
to the connection class's #get, #post, etc methods. The defaults are taken
from the Net::HTTP defaults, which is what would have been used before.
