### PR TITLE
(PUP-672) TrustedInformation handles a nil certificate.

### DIFF
--- a/lib/puppet/context/trusted_information.rb
+++ b/lib/puppet/context/trusted_information.rb
@@ -25,9 +25,14 @@ class Puppet::Context::TrustedInformation
 
   def self.remote(authenticated, node_name, certificate)
     if authenticated
-      extensions = Hash[certificate.custom_extensions.collect do |ext|
-        [ext['oid'].freeze, ext['value'].freeze]
-      end]
+      extensions = {}
+      if certificate.nil?
+        Puppet.info('TrustedInformation expected a certificate, but none was given.')
+      else
+        extensions = Hash[certificate.custom_extensions.collect do |ext|
+          [ext['oid'].freeze, ext['value'].freeze]
+        end]
+      end
       new('remote', node_name, extensions)
     else
       new(false, nil, {})

--- a/spec/unit/context/trusted_information_spec.rb
+++ b/spec/unit/context/trusted_information_spec.rb
@@ -41,6 +41,16 @@ describe Puppet::Context::TrustedInformation do
         '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
       })
     end
+
+    it "is remote but lacks certificate information when it is authenticated" do
+      Puppet.expects(:info).once.with("TrustedInformation expected a certificate, but none was given.")
+
+      trusted = Puppet::Context::TrustedInformation.remote(true, 'cert name', nil)
+
+      expect(trusted.authenticated).to eq('remote')
+      expect(trusted.certname).to eq('cert name')
+      expect(trusted.extensions).to eq({})
+    end
   end
 
   context "when local" do


### PR DESCRIPTION
Acceptance caught an issue with an external ca not passing the
certificate info (the
acceptance/tests/external_ca_support/apache_external_root_ca.rb had this
issue prior to +ExportCertData being added to the SSLOptions in
acceptance/tests/external_ca_support/fixtures/httpd.conf).

Modifying the TrustedInformation class to handle a nil certificate
without failure, but issue an info level warning in the logs.

This also modifies the acceptance test to add the +ExportCertData, and
to ensure a teardown, as failure to reach the teardown is breaking
following tests when the httpd server was left up as master.
