### PR TITLE
(PUP-1282) Express Windows specific gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,20 +59,18 @@ group(:extra) do
   gem "msgpack", :require => false
 end
 
-platforms :mswin, :mingw do
-  gem "ffi", "1.9.0", :require => false
-  gem "sys-admin", "1.5.6", :require => false
-  gem "win32-api", "1.4.8", :require => false
-  gem "win32-dir", "0.4.3", :require => false
-  gem "win32-eventlog", "0.5.3", :require => false
-  gem "win32-process", "0.6.5", :require => false
-  gem "win32-security", "0.1.4", :require => false
-  gem "win32-service", "0.7.2", :require => false
-  gem "win32-taskscheduler", "0.2.2", :require => false
-  gem "win32console", "1.3.2", :require => false
-  gem "windows-api", "0.4.2", :require => false
-  gem "windows-pr", "1.2.2", :require => false
-  gem "minitar", "0.5.4", :require => false
+require 'yaml'
+data = YAML.load_file(File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml'))
+bundle_platforms = data['bundle_platforms']
+data['gem_platform_dependencies'].each_pair do |gem_platform, info|
+  if bundle_deps = info['gem_runtime_dependencies']
+    bundle_platform = bundle_platforms[gem_platform] or raise "Missing bundle_platform"
+    platform(bundle_platform.intern) do
+      bundle_deps.each_pair do |name, version|
+        gem(name, version, :require => false)
+      end
+    end
+  end
 end
 
 if File.exists? "#{__FILE__}.local"

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -24,3 +24,21 @@ gem_rdoc_options:
   - --main
   - README.md
   - --line-numbers
+gem_platform_dependencies:
+  x86-mingw32:
+    gem_runtime_dependencies:
+      ffi: '1.9.0'
+      sys-admin: '1.5.6'
+      win32-api: '1.4.8'
+      win32-dir: '0.4.3'
+      win32-eventlog: '0.5.3'
+      win32-process: '0.6.5'
+      win32-security: '0.1.4'
+      win32-service: '0.7.2'
+      win32-taskscheduler: '0.2.2'
+      win32console:  '1.3.2'
+      windows-api: '0.4.2'
+      windows-pr: '1.2.2'
+      minitar: '0.5.4'
+bundle_platforms:
+  x86-mingw32: mingw


### PR DESCRIPTION
Previously, if a ruby module on windows tried to use puppet as a
library, the calling module had to know about puppet's platform specific
dependencies. This comes up when trying to develop and test puppet
modules on windows.

This commit adds the windows specific gems to project_data.yaml, and
updates the Gemfile to add these dependencies when during
bundle install

The build pipeline will automatically create an x86-mingw32 gem in
addition to the generic one.
