### PR TITLE
(maint) Update packaging metadata

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,7 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: False
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-17-i386'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
The current metadata for the packaging repo is out of date. We need to update it so packaging is a little easier if/when we have to do another 2.7.x release
