### PR TITLE
(PUP-1369) Package options property / vash

### DIFF
--- a/lib/puppet/util/vash.rb
+++ b/lib/puppet/util/vash.rb
@@ -1,0 +1,36 @@
+require 'puppet/util'
+
+# Vash provides mixins that add Hash interface to classes. The mixins allow you
+# to enable simple data validation and munging, such that you may define
+# restrictions on keys, values and pairs entering your hash.
+#
+# There are two patterns to add Vash functionality to your class. The first one
+# is to use {Puppet::Util::Vash::Contained} mixin, as follows
+#
+#     class MyVash
+#       include Puppet::Util::Vash::Contained
+#     end
+#
+# The second pattern is to use {Puppet::Util::Vash::Inherited}
+#
+#     class MyVash < Hash
+#       include Puppet::Util::Vash::Inherited
+#     end
+#
+# With the first pattern, the data is keept in an instance variable
+# `@vash_underlying_hash` and you dont have to inherit Hash. In second pattern,
+# the superclass of `MyVash` is used to keep hash data and this superclass
+# should have Hash functionality.
+#
+#
+# See documentation for
+#
+# * {Contained}
+# * {Inherited}
+#
+# you may also wish to consult
+#
+# * {Validator}.
+#
+module Puppet::Util::Vash
+end

--- a/lib/puppet/util/vash/README.md
+++ b/lib/puppet/util/vash/README.md
@@ -1,0 +1,592 @@
+# ptomulik-vash
+
+[![Build Status](https://travis-ci.org/ptomulik/puppet-vash.png?branch=master)](https://travis-ci.org/ptomulik/puppet-vash)
+[![Coverage Status](https://coveralls.io/repos/ptomulik/puppet-vash/badge.png)](https://coveralls.io/r/ptomulik/puppet-vash)
+[![Code Climate](https://codeclimate.com/github/ptomulik/puppet-vash.png)](https://codeclimate.com/github/ptomulik/puppet-vash)
+
+#### Table of Contents
+
+1. [Overview](#overview)
+2. [Module Description](#module-description)
+3. [Beginning with vash](#beginning-with-vash)
+4. [Usage](#usage)
+5. [Reference](#reference)
+6. [Testing](#testing)
+7. [Limitations](#limitations)
+8. [Development](#development)
+
+## Overview
+
+*Vash* (a validating hash) provides mixins to create
+[Hash](http://www.ruby-doc.org/core/Hash.html)-like classes with simple
+validation and munging of input data.
+
+# Module Description
+
+Vash provides mixins that add [Hash](http://www.ruby-doc.org/core/Hash.html)
+interface to receiving classes. The mixins allow you to enable simple data
+validation and munging, such that you may define restrictions on keys, values
+and pairs entering your hash and coalesce them at input.
+
+## Beginning with vash
+
+There are two ways to add *Vash* functionality to your class. The first one is
+to use `Vash::Contained` mixin, as follows
+
+```ruby
+require 'puppet/util/vash/contained'
+class MyVash
+  include Puppet::Util::Vash::Contained
+end
+```
+
+The second pattern is to use `Vash::Inherited`
+
+```ruby
+require 'puppet/util/vash/inherited'
+class MyVash < Hash
+  include Puppet::Util::Vash::Inherited
+end
+```
+
+With the first pattern, hash data is kept in an instance variable named
+`@vash_underlying_hash` and may be internally accessed via
+`vash_underlying_hash` private method.
+
+With second pattern the superclass of `MyVash` must provide `Hash` interface
+(read - it should be a subclass of standard
+[Hash](http://www.ruby-doc.org/core/Hash.html)).
+
+Once you have included `Vash::Contained` or `Vash::Inherited` module to your
+class, you may use it as ordinary Hash:
+
+```ruby
+vash = MyVash[ [[:a,:A],[:b,:B]] ]
+vash[:c] = :C
+# .. and so on
+```
+
+The default rules for validation and munging are "allow anything" and "do not
+modify", so `MyVash` behaves exactly same way `Hash` does. Simple validation
+may be added by defining `vash_valid_key?`, `vash_valid_value?` and
+`vash_valid_pair?` methods (note, all methods that are specific to Vash, have
+`vash_` prefix):
+
+```ruby
+require 'puppet/util/vash/contained'
+class MyVash
+  include Puppet::Util::Vash::Contained
+  # accept only integers as keys
+  def vash_valid_key?(key)
+    true if Integer(key) rescue false
+  end
+end
+```
+
+```ruby
+vash = MyVash[1,2]
+# => {1=>2}
+vash[2] = 3
+# => 3
+vash
+# => {1=>2, 2=>3}
+vash['a'] = 1
+# InvalidKeyError: invalid key "a"
+```
+
+Restrictions may further be defined for values and pairs. The following
+subsections shall give more detailed explanations.
+
+## Usage
+
+Custom Hash with validation and munging (call it "custom Vash") may be created
+by including `Puppet::Util::Vash::Contained` or
+`Puppet::Util::Vash::Inherited` module to your class and then
+overwriting some of its methods. It's also good to prepare some specs/tests for
+your customized class (see [Testing](#testing)). 
+
+We'll start with simple customized Vash in 
+[Example 3.1](#example-31-defining-restrictions-for-keys-and-values)
+and will continue extending it in subsequent examples.
+
+#### Example 3.1: Defining restrictions for keys and values
+
+Let's prepare simple container for integer variables:
+
+```ruby
+require 'puppet/util/vash/contained'
+class Variables
+  include Puppet::Util::Vash::Contained
+  # accept only valid identifiers as keys
+  def vash_valid_key?(key)
+    key.is_a?(String) and (key=~/^[a-zA-Z]\w*$/)
+  end
+  # accept only what is convertible to integer
+  def vash_valid_value?(val)
+    true if Integer(val) rescue false
+  end
+end
+```
+
+When you perform simple experiments, you shall see:
+
+```ruby
+vars = Variables['ten', 10, 'nine', 9]
+# => {"nine"=>9,"ten"=>10}
+vars[2] = 20
+# InvalidKeyError: invalid key 2
+vars['eight'] = 'e'
+# InvalidValueError: invalid value "e" at key "eight"
+vars['seven'] = '7'
+# => "7"
+vars
+# => {"nine"=>9, "ten"=>10, "seven"=>"7"}
+```
+
+#### Example 3.2: Munging keys and values
+
+The class from [Example 3.1](#example-31-defining-restrictions-for-keys-and-values)
+has one drawback - it doesn't convert values to integers. For example
+`vars['seven']` is `"7"` (a string). Value munging may be added to `Variables`
+in order to convert data provided by user.
+
+```ruby
+class Variables
+  def vash_munge_value(val)
+    Integer(val)
+  end
+end
+```
+
+Now we have
+
+```ruby
+vars = Variables['seven','7']
+# => {"seven"=>7}
+```
+
+We may also munge keys, for example convert `camelCase` to `under\_score`:
+
+```ruby
+class Variables
+  def vash_munge_key(key)
+    key.gsub(/([a-z])([A-Z])/,'\1_\2').downcase
+  end
+end
+```
+
+```ruby
+vars = Variables['TwentyFive','25']
+# => {"twenty_five"=>25}
+```
+
+#### Example 3.3: Defining restrictions for pairs
+
+Some variables may not accept certain values. To prevent Vash from accepting
+such pairs, a pair validation may be used. In this example we prevent variables
+ending with `_price` from accepting negative values:
+
+```ruby
+class Variables
+  # for keys ending with _price we accept only non-negative values
+  def vash_valid_pair?(pair)
+    (pair[0]=~/price$/) ? (pair[1]>=0) : true
+  end
+end
+```
+
+```ruby
+vars = Variables['lemonPrice', '-4']
+# InvalidPairError: invalid (key,value) combination ("lemon_price",-4) at index 0
+```
+
+#### Example 3.4: Munging pairs
+
+We may also munge pairs entering our `Variables` container. In this example
+we'll append variable value to its name, such that `vars['my_var'] = 1` will 
+result with variable `my_var1=1` being added to `Variables`:
+
+```ruby
+class Variables
+  def vash_munge_pair(pair)
+    [pair[0] + pair[1].to_s, pair[1]]
+  end
+end
+```
+
+```ruby
+vars = Variables['myVar', 1]
+# => {"my_var1"=>1}
+vars['my_var'] = 2
+# => 2
+vars
+# => {"my_var2"=>2, "my_var1"=>1}
+```
+
+#### Example 3.5: Customizing error messages
+
+Default error messages may be misleading in certain applications. To circumvent
+this, we may override `vash_key_name`, `vash_value_name` and `vash_pair_name`,
+for example:
+
+```ruby
+class Variables
+  def vash_key_name(*args); 'variable name'; end
+  def vash_value_name(*args); 'variable value'; end
+  def vash_pair_name(*args); 'value for variable'; end
+end
+```
+
+```ruby
+vars = Variables[:xxx, 1]
+# InvalidKeyError: invalid variable name :xxx at index 0
+vars = Variables['var', 'xxx']
+# InvalidValueError: invalid variable value "xxx" at index 1
+vars = Variables['lemonPrice', '-4']
+# InvalidPairError: invalid value for variable ("lemon_price",-4) at index 0
+```
+
+The last message is still not well-formed. We may overwrite default
+`#vash_pair_exception` to have better effect:
+
+```ruby
+class Variables
+  # note: args[0] optionally contains index of a failing pair
+  def vash_pair_exception(pair, *args)
+    msg  = "invalid value #{pair[1].inspect} for variable #{pair[0].inspect}"
+    msg += " at index #{args[0]}" unless args[0].nil?
+    [Puppet::Util::Vash::InvalidPairError, msg]
+  end
+end
+```
+
+```ruby
+vars = Variables['lemonPrice', -1]
+# InvalidPairError: invalid value -1 for variable lemon_price at index 0
+```
+
+## Reference
+
+The detailed method documentation may be generated with *yardoc*. Here, we only
+present briefly how *Vash* works.
+
+When new data enters `Vash` (via `#[]=`, `#store` or any other method that
+modifies content of the underlying hash), the workflow is following:
+
+1. Input items are passed to `#vash_validate_item` (the term *item* is used
+   for original `[key,value]` pair as entered by user).
+2. The key and value are validated separately by `#vash_validate_key` and
+   `#vash_validate_value`. These methods call `#vash_valid_key?` and
+   `#vash_valid_value?` to ask, if the key and value may be further
+   processed.
+3. If key and value are acceptable, the `#vash_munge_key` and
+   `#vash_munge_value` are called to perform optional data munging.
+   The `#vash_validate_key` and `#vash_validate_value` return munged key and
+   value.
+4. The munged `[key,value]` pair is referred to as *pair*. It is passed to
+   `#vash_validate_pair` in order to ensure, that it satisfies pair
+   restrictions. The `#vash_validate_pair` asks `#vash_valid_pair?` whether the
+   given pair may be accepted or not (note: both methods operate on already
+   munged keys and values).
+5. If verification succeeds, the pair is passed to `#vash_munge_pair` and
+   added to Vash container.
+
+In any of these points, if the validation fails, an exception is raised. The
+`Vash` by default raises following exceptions:
+
+* `Puppet::Util::Vash::InvalidKeyError` (key validation failed),
+* `Puppet::Util::Vash::InvalidValueError` (value validation failed),
+* `Puppet::Util::Vash::InvalidPairError` (pair validation failed).
+
+All the above exceptions are subclasses of 
+
+* `Puppet::Util::Vash::VashArgumentError`.
+
+which is a subclass of `::ArumentError`.
+
+## Testing
+
+To run existing unit tests simply type
+
+```bash
+bundle exec rake spec
+```
+
+Note, that you may need to install necessary gems to run tests:
+
+```bash
+bundle install --path vendor/bundle
+```
+
+### Shared examples overview
+
+The module provides quite extensive set of rspec shared examples for
+developers. The tests are designed such that they compare behaviour of a
+subject class with an already-tested (model) class (such as standard `Hash`).
+Reusable *shared\_examples* are provided for developers who want to implement
+custom *Vashes*. If you're starting your new *Vash* class, it's recommended to
+prepare simple test that includes *Vash::Inherited* or *Vash::Contained* shared
+examples and run test each time you overwrite some of
+`Vash::Contained`, `Vash::Inherited` or `Vash::Validator` methods. This shall
+quickly reveal any (unintended) changes introduced to your *Vash* behaviour.
+
+The shared examples may be found in following files:
+
+* *spec/shared_behaviours/vash/hash.rb*
+* *spec/shared_behaviours/vash/validator.rb*
+* *spec/shared_behaviours/vash/contained.rb*
+* *spec/shared_behaviours/vash/inherited.rb*
+
+#### Example 6.1
+
+Say, we want to ensure, that our new class:
+
+```ruby
+class MyHash < Hash; end
+```
+
+has all the functionality of standard `Hash`. We may use `Vash::Hash` 
+*shared\_examples* to verify, that our class has the expected behaviour:
+
+```ruby
+# spec/unit/my_hash_spec.rb
+require 'spec_helper'
+require 'shared_behaviours/vash/hash'
+
+class MyHash < Hash; end
+
+describe MyHash do
+  it_behaves_like 'Vash::Hash', {
+    :sample_items   => [ [:a,:A,], ['b','B'] ],
+    :hash_arguments => [ { :a=>:X, :d=>:D } ],
+    :missing_key    => :c,
+    :missing_value  => :C
+  }
+end
+
+```
+
+The above snippet shall generate about 700 test cases. Because `MyHash` has all
+the functionality of `Hash`, we expect all tests to pass. 
+
+The `:sample_items` array is used to initialize hash during the tests and also
+to generate input arguments to some hash functions (keys/values from
+`sample_items` may be used as `existing_key` and `existing_value`). The
+`:hash_arguments` is an array of hashes used to test methods accepting hash as
+an argument (e.g. `merge!`). The `:missing_key` and `:missing_value` are sample
+key and value that are correct (should pass key/value and pair validation) but
+is not present in `:sample_items`.
+
+#### Example 6.2
+
+Now suppose, you want to add input validation to *MyHash* and then test its
+behaviour. For that, we include `Puppet::Util::Vash::Inherited`
+module, and use *Vash::Inherited* shared examples.
+
+```ruby
+# spec/unit/my_vash_spec.rb
+require 'spec_helper'
+require 'shared_behaviours/vash/inherited'
+require 'puppet/util/vash/inherited'
+
+class MyHash < Hash
+  include Puppet::Util::Vash::Inherited 
+  # accept only valid identifiers as keys
+  def vash_valid_key?(key)
+    key.is_a?(String) and (key=~/^[a-zA-Z]\w*$/)
+  end
+end
+
+describe MyHash do
+  it_behaves_like 'Vash::Inherited', {
+    :valid_keys        => ['iden_tifier', 'IdenTifier'],
+    :invalid_keys      => ['', '$#', :a, {}, [], nil],
+    :valid_items       => [ ['x', 1] ],
+    :invalid_items     => [ [[:x, 'a'], :key] ],
+    :hash_arguments    => [ { 'a'=>:A, 'b'=>'B' } ],
+    :missing_key       => 'c',
+    :missing_value     => :C,
+    :methods           => {
+      :vash_valid_key? => lambda{|key| key.is_a?(String) and (key=~/^[a-zA-Z]\w*$/)}
+    }
+  }
+end
+```
+
+In the above snippet, we've indicated that *MyHash* has the behaviour of
+*Vash::Inherited*, but the `vash_valid_key?` method was overridden. We indicate
+this by setting *:vash_valid_key?* parameter in *:methods*.
+
+### Shared examples reference
+
+#### *Vash::Hash* shared examples
+
+Ensures that a class behaves like standard `Hash`.
+
+*Synopsis*:
+
+```ruby
+it_behaves_like 'Vash::Hash', params
+```
+
+The `params` is a Hash with parameters used by test driver.
+
+*Example usage*:
+
+```ruby
+require 'shared_behaviours/vash/hash'
+# ...
+# MyHash is the class under test
+describe MyHash do
+  it_behaves_like 'Vash::Hash', {
+    :sample_items   => [ [:a,:A,], ['b','B'] ],
+    :hash_arguments => [ { :a=>:X, :d=>:D } ],
+    :missing_key    => :c,
+    :missing_value  => :C
+  }
+end
+```
+
+*Parameters*:
+
+* *sample_items* (required) - used to determine key/value arguments to tested
+  methods and *existing_key*/ *existing_value* (if not present in params); also
+  used to initialize instances of described class before they get tested
+  (unless *hash_initializers* parameter is provided); the *sample_items*
+  parameter may be a Hash or an array of items (array of 2-element arrays),
+* *missing_key* (required) - an example key that is not in *sample_items*,
+* *missing_value* (required) - an example value that is not in *sample_items*,
+* *hash_arguments* (required) - an array of hashes used as arguments to some
+  tested methods (those, that accept hash as argument, for example `merge!`),
+* *model_class* (optional) - a class which models expected Hash behaviour,
+   by default `Puppet::SharedBehaviours::Vash::Hash` is used,
+   which is direct subclass of standard `Hash`,
+* *methods* (optional) - a hash of procs/lambdas used to override methods in
+  the model class. This may be used to slightly modify model behaviour used
+  by shared examples, for example:
+
+  ```ruby
+  # slightly modified hash ...
+  class MyHash < Hash
+    def default; nil; end
+    def default=(v); raise RuntimeError, "can't change default value"; end
+  end
+  describe MyHash do
+    it_behaves_like 'Vash::Hash', {
+      # ... other params ...
+      :methods => {
+        :default  => lambda { nil } # our #default method always returns nil
+        :default= => lambda { |v| raise RuntimeError, "can't change default value" }
+      }
+    }
+  end
+  ```
+* *hash_initializers* (optional) - an Array of hashes, used to initialize
+  instances of the tested class and generate tests with such an initialized
+  instances; if not provided, *sample_items* parameter is used to initialize
+  one instance per method.
+
+* *disable_exception_matching* (optional) - if set to *true*, do not specify,
+  that subject's methods behave exactly as model's method with respect to the
+  raised exceptions,
+* *disable_value_matching* (optional) - if set to *true*, do not verify whether
+  the values returned by the subject's methods are same as values returned by
+  model's methods,
+* *disable_class_check* (optional) - if set to *true*, do not check whether the
+  classes of values returned by subject's methods are correct,
+* *disable_value_is_self_check* (optional) - some Hash methods are supposed to
+  return *self* object, (for example `merge!`); if this flag is set to *true*,
+  do not check whether these methods return *self* object properly,
+* *match_attributes* (optional) - an array of subject's attributes to match
+  against appropriate attributes; the attributes are not part of hash content;
+  an example attribute is *default* value.
+* *match_attributes_at_end* (optional) - an array of attributes to match
+  against model after the operation under test (e.g. `:match_attributes =>
+  :default` causes that *default* values of subject and model hashes are
+  compared after the tested method is invoked),
+* *disable_content_matching* - do not test whether the content of subject and
+  model hash is same after the operation under test,
+* *raises* - an array of exception classes that may be raised by function as a
+  part of its normal behaviour (for example as a result of argument validation)
+  
+
+Most of these parameters might be overwritten on per-method basis, for example:
+
+```ruby
+it_behaves_like 'Hash::Vash', {
+  # ...
+  :fetch => { :disable_value_matching => true },
+}
+```
+
+#### *Vash::Validator* shared examples
+
+Ensure that a class provides all functionalities of
+`Puppet::Util::Vash::Validator`.
+
+*Synopsis*
+```ruby
+it_behaves_like 'Vash::Validator', params
+```
+
+*Example:*:
+
+```ruby
+require 'puppet/util/vash/validator'
+require 'shared_behaviours/vash/validator'
+class MyValidator
+  include Puppet::Util::Vash::Validator
+  # accept only valid identifiers as keys
+  def vash_valid_key?(key)
+    key.is_a?(String) and (key=~/^[a-zA-Z]\w*$/)
+  end
+  # accept only what is convertible to integer
+  def vash_valid_value?(val)
+    true if Integer(val) rescue false
+  end
+end
+
+describe MyValidator do
+  it_behaves_like 'Vash::Validator', {
+    :valid_keys     => ['one', 'two'],
+    :invalid_keys   => ["7'th",''],
+    :valid_values   => [1,-1,'0'],
+    :invalid_values => [{},'x'],
+  }
+end
+```
+
+*Parameters*:
+
+See comments in source code: *spec/shared_behaviours/vash/validator.rb*.
+
+#### *Vash::Contained* and *Vash::Inherited* shared examples
+
+The *Vash::Contained* (or *Vash::Inherited*) combines *Vash:Hash* and
+*Vash::Validator* shared examples into single set of shared examples.
+
+*Synopsis*
+
+```ruby
+it_behaves_like 'Vash::Contained', params
+```
+
+or
+
+```ruby
+it_behaves_like 'Vash::Inherited', params
+```
+
+where `params` is a Hash of mixed parameters to `Vash::Hash` and
+`Vash::Validator` behaviours. Note, that you don't have to define
+*sample_items*, because they are internally generated from *valid_items* and
+*invalid_items*. The *hash_initializers*, if provided, must consists only of
+valid items or your tests will fail.
+
+## Development
+
+The project is held at github:
+
+* [https://github.com/ptomulik/puppet-vash](https://github.com/ptomulik/puppet-vash)
+
+Issue reports, patches, pull requests are welcome!

--- a/lib/puppet/util/vash/class_methods.rb
+++ b/lib/puppet/util/vash/class_methods.rb
@@ -1,0 +1,44 @@
+require 'puppet/util/vash'
+require 'puppet/util/vash/errors'
+
+module Puppet::Util::Vash
+
+  # Class methods for {Puppet:Util::Vash::Contained}
+  # and {Puppet::Util::Vash::Inherited}.
+  #
+  # Currently the following methods are added:
+  #
+  # - ::[]
+  #
+  # Requires the following instance methods to be defined in receiver class:
+  #
+  # - `#replace_with_flat_array(array)`
+  # - `#replace_with_item_array(array)`
+  # - `#replace(hash)`
+  #
+  # The abovementioned methods are also responsible for input validation and
+  # munging.
+  module ClassMethods
+
+    # Same as Hash::[] but with input validation.
+    def [](*args)
+      obj = new()
+      begin
+        if args.length > 1
+          obj.replace_with_flat_array(args)
+        elsif args.length == 1
+          if args[0].is_a?(Array)
+            obj.replace_with_item_array(args[0])
+          elsif args[0].is_a? Hash
+            obj.replace(args[0])
+          else
+            obj.replace(Hash[args[0]])
+          end
+        end
+      rescue VashArgumentError => err
+        raise err.class, err.to_s
+      end
+      obj
+    end
+  end
+end

--- a/lib/puppet/util/vash/contained.rb
+++ b/lib/puppet/util/vash/contained.rb
@@ -1,0 +1,264 @@
+require 'puppet/util/vash'
+require 'puppet/util/vash/errors'
+
+module Puppet::Util::Vash
+module Contained
+
+  include ::Enumerable
+
+  require 'puppet/util/vash/validator'
+  include Validator
+
+  # @api private
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+  require 'puppet/util/vash/class_methods'
+
+  # @api private
+  def vash_underlying_hash
+    @vash_underlying_hash ||= {}
+  end
+  private :vash_underlying_hash
+
+  # @api private
+  def initialize_copy(other)
+    super(other)
+    @vash_underlying_hash = Hash[other]
+    self
+  end
+
+  # @api private
+  def initialize(*args,&block)
+    super()
+    @vash_underlying_hash = Hash.new(*args,&block)
+  end
+
+  private :initialize_copy
+
+  require 'forwardable'
+  extend ::Forwardable
+  def_delegators :vash_underlying_hash,
+    :==,
+    :[],
+    :assoc,
+    :compare_by_identity?,
+    :default,
+    :default=,
+    :default_proc,
+    :default_proc=,
+    :delete,
+    :empty?,
+    :eql?,
+    :fetch,
+    :flatten,
+    :has_key?,
+    :has_value?,
+    :hash,
+    :include?,
+    :inspect,
+    :key,
+    :key?,
+    :keys,
+    :length,
+    :member?,
+    :rassoc,
+    :shift,
+    :size,
+    :to_a,
+    :to_h,
+    :to_hash,
+    :to_s,
+    :value?,
+    :values,
+    :values_at
+
+  ruby_version = 0;
+  RUBY_VERSION.split('.').each{|x| ruby_version <<= 8; ruby_version |= x.to_i}
+
+  # Same as {Hash#[]=}
+  def []=(key, value)
+    begin
+      key,value = vash_validate_item([key, value])
+    rescue VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash[key] = value
+  end
+
+  alias_method :store, :[]=
+
+  # Same as {Hash#clear}
+  def clear
+    vash_underlying_hash.clear
+    self
+  end
+
+  # Same as {Hash#compare_by_identity}
+  def compare_by_identity
+    vash_underlying_hash.compare_by_identity
+    self
+  end
+
+  # Same as {Hash#delete_if}
+  def delete_if(&block)
+    result = vash_underlying_hash.delete_if(&block)
+    block ? self : result
+  end
+
+  def each(&block)
+    result = vash_underlying_hash.each(&block)
+    block ? self : result
+  end
+
+  def each_key(&block)
+    result = vash_underlying_hash.each_key(&block)
+    block ? self : result
+  end
+
+  def each_pair(&block)
+    result = vash_underlying_hash.each_pair(&block)
+    block ? self : result
+  end
+
+  def each_value(&block)
+    result = vash_underlying_hash.each_value(&block)
+    block ? self : result
+  end
+
+  # Same as {Hash#rehash}
+  def rehash
+    vash_underlying_hash.rehash
+    self
+  end
+
+  # Same as {Hash#invert}
+  # @note Returning instance of self.class would have no sense, especially
+  # when key/value validation is in use; keys and values may come from
+  # mutually incompatible domains, and we can't simply swap them and put
+  # them back to an input validating hash. That's why this function must
+  # return an instance of standard {Hash}.
+  def invert
+    hash = vash_underlying_hash.invert
+  end
+
+  if ruby_version >= 0x010903
+  # @note This method is available on ruby>= 1.9.3 only.
+  # Same as {Hash#keep_if}
+  def keep_if(&block)
+    result = vash_underlying_hash.keep_if(&block)
+    block ? self : result
+  end
+  end
+
+  # Same as {Hash#merge!}
+  def merge!(other, &block)
+    begin
+      other = vash_validate_hash(other)
+    rescue VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash.merge!(other, &block)
+    self
+  end
+
+  alias_method :update, :merge!
+
+  # Same as {Hash#merge}
+  def merge(other, &block)
+    begin
+      self.dup.merge!(other, &block)
+    rescue VashArgumentError => err
+      raise err.class, err.to_s
+    end
+  end
+
+  # Same as {Hash#reject}
+  def reject(&block)
+    # note, using original 'reject' is more difficult here.
+    self.dup.delete_if(&block)
+  end
+
+  # Same as {Hash#reject!}
+  def reject!(&block)
+    return nil if (result = vash_underlying_hash.reject!(&block)).nil?
+    block ? self : result
+  end
+
+  # Same as {Hash#replace}
+  def replace(other)
+    begin
+      other = vash_validate_hash(other)
+    rescue VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash.replace(other)
+    self
+  end
+
+  # Similar to {Hash#select}
+  # @note On ruby  1.8. the {Hash#select} returns an array (or enumerator)
+  # and on 1.9.1+ returns hash (or enumerator). We always return hash or
+  # an enumerator.
+  #
+  # Note, that for standard Hash and its subclasses we have
+  # select{...}.class == Hash on ruby 1.9+.
+  if ruby_version >= 0x010901
+    def select(&block)
+      vash_underlying_hash.select(&block)
+    end
+  else
+    def select(&block)
+      result = vash_underlying_hash.select(&block)
+      block ? Hash[result] : result
+    end
+  end
+
+  if ruby_version >= 0x010903
+  # Same as {Hash#select!}
+  def select!(&block)
+    return nil if (result = vash_underlying_hash.select!(&block)).nil?
+    block ? self : result
+  end
+  end
+
+  #
+  # extra methods for ClassMethods
+  #
+
+  # Replace Vash content with the one defined in array.
+  #
+  # Example
+  #
+  #     vash.replace_with_flat_array([:a, :A, :b, :B])
+  #
+  # The `vash` contents would be `{:a => :A, :b => :B}`
+  def replace_with_flat_array(array)
+    begin
+      array = vash_validate_flat_array(array)
+    rescue VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash.replace(Hash[*array])
+    self
+  end
+
+  # Replace Vash content with the one defined in array.
+  #
+  # Example
+  #
+  #     vash.replace_with_item_array([[:a, :A], [:b, :B]])
+  #
+  # The `vash` content would be `{:a => :A, :b => :B}`
+  def replace_with_item_array(array)
+    begin
+      array = vash_validate_item_array(array)
+    rescue VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash.replace(Hash[array])
+    self
+  end
+
+end
+end

--- a/lib/puppet/util/vash/errors.rb
+++ b/lib/puppet/util/vash/errors.rb
@@ -1,0 +1,10 @@
+require 'puppet/util/vash'
+module Puppet::Util::Vash
+
+  class VashArgumentError < ::ArgumentError; end
+  class InvalidKeyError < VashArgumentError; end
+  class InvalidValueError < VashArgumentError; end
+  class InvalidPairError < VashArgumentError; end
+  class OddArgNoError < VashArgumentError; end
+
+end

--- a/lib/puppet/util/vash/inherited.rb
+++ b/lib/puppet/util/vash/inherited.rb
@@ -1,0 +1,99 @@
+require 'puppet/util/vash'
+require 'puppet/util/vash/errors'
+
+module Puppet::Util::Vash
+module Inherited
+
+  require 'forwardable'
+  include ::Enumerable
+
+  require 'puppet/util/vash/validator'
+  include Validator
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+  require 'puppet/util/vash/class_methods'
+
+  ruby_version = 0;
+  RUBY_VERSION.split('.').each{|x| ruby_version <<= 8; ruby_version |= x.to_i}
+
+  def []=(key, value)
+    begin
+      key, value = vash_validate_item([key, value])
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    self.class.superclass.instance_method(:store).bind(self).call(key,value)
+  end
+  alias_method :store, :[]=
+
+  # Similar to {Hash#select}
+  # @note On ruby  1.8. the {Hash#select} returns an array (or enumerator)
+  # and on 1.9.1+ returns hash (or enumerator). We always return hash or
+  # an enumerator.
+  #
+  # Note, that for Hash and its subclasses we have select{...}.class == Hash
+  # on ruby 1.9+.
+  if ruby_version < 0x010901
+    def select(&block)
+      result = self.class.superclass.instance_method(:select).bind(self).call(&block)
+      block ? Hash[result] : result
+    end
+  end
+
+  def merge!(other, &block)
+    begin
+      other = vash_validate_hash(other)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    self.class.superclass.instance_method(:merge!).bind(self).call(other, &block)
+  end
+
+  alias_method :update, :merge!
+
+  def merge(other, &block)
+    begin
+      self.dup.merge!(other, &block)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+  end
+
+  def replace(other)
+    begin
+      other = vash_validate_hash(other)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    self.class.superclass.instance_method(:replace).bind(self).call(other)
+  end
+
+  #
+  # extra methods for ClassMethods
+  #
+  def replace_with_flat_array(array)
+    begin
+      array = vash_validate_flat_array(array)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    hash = Hash[*array]
+    self.class.superclass.instance_method(:replace).bind(self).call(hash)
+    self
+  end
+
+  def replace_with_item_array(array)
+    begin
+      array = vash_validate_item_array(array)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    hash = Hash[array]
+    self.class.superclass.instance_method(:replace).bind(self).call(hash)
+    self
+  end
+
+end
+end

--- a/lib/puppet/util/vash/validator.rb
+++ b/lib/puppet/util/vash/validator.rb
@@ -1,0 +1,100 @@
+require 'puppet/util/vash'
+
+module Puppet::Util::Vash
+
+  module Validator
+
+    def vash_valid_key?(key); true; end
+    def vash_valid_value?(value); true; end
+    def vash_valid_pair?(pair); true; end
+    def vash_munge_key(key); key; end
+    def vash_munge_value(val); val; end
+    def vash_munge_pair(pair); pair; end
+    def vash_key_name(*args); 'key'; end
+    def vash_value_name(*args); 'value'; end
+    def vash_pair_name(*args); '(key,value) combination'; end
+
+    def vash_validate_key(key,*args)
+      raise *(vash_key_exception(key,*args)) unless vash_valid_key?(key)
+      vash_munge_key(key)
+    end
+
+    def vash_validate_value(val,*args)
+      raise *(vash_value_exception(val,*args)) unless vash_valid_value?(val)
+      vash_munge_value(val)
+    end
+
+    def vash_validate_pair(pair,*args)
+      raise *(vash_pair_exception(pair,*args)) unless vash_valid_pair?(pair)
+      vash_munge_pair(pair)
+    end
+
+    def vash_validate_item(item,*args)
+      k = vash_validate_key(*vash_select_key_args(item,*args))
+      v = vash_validate_value(*vash_select_value_args(item,*args))
+      vash_validate_pair(*vash_select_pair_args([k,v],*args))
+    end
+
+    def vash_validate_hash(hash)
+      Hash[hash.map { |item| vash_validate_item(item) }]
+    end
+
+    def vash_validate_flat_array(array)
+      def each_item_with_index(a)
+        i = 0; l = a.length-1; while i<l do; yield [a[i,2],i]; i+=2; end
+      end
+      array2 = Array.new(array.length) # pre-allocate
+      each_item_with_index(array) do |item,i|
+        array2[i,2] = vash_validate_item(item,i,i+1)
+      end
+      array2
+    end
+
+    def vash_validate_item_array(array)
+      def each_item_with_index(a)
+        i = 0; l = a.length; while i<l do; yield [a[i],i]; i+=1; end
+      end
+      array2 = Array.new(array.length) # pre-allocate
+      each_item_with_index(array) do |item,i|
+        array2[i] = vash_validate_item(item,i)
+      end
+      array2
+    end
+
+
+    def vash_key_exception(key, *args)
+      name = vash_key_name(key,*args)
+      msg  = "invalid #{name} #{key.inspect}"
+      msg += " at index #{args[0]}" unless args[0].nil?
+      msg += " (with value #{args[1].inspect})" unless args.length < 2
+      [InvalidKeyError, msg]
+    end
+
+    def vash_value_exception(value, *args)
+      name = vash_value_name(value,*args)
+      msg  = "invalid #{name} #{value.inspect}"
+      msg += " at index #{args[0]}" unless args[0].nil?
+      msg += " at key #{args[1].inspect}" unless args.length < 2
+      [InvalidValueError, msg]
+    end
+
+    def vash_pair_exception(pair, *args)
+      name =  vash_pair_name(pair,*args)
+      msg  = "invalid #{name} (#{pair.map{|x| x.inspect}.join(',')})"
+      msg += " at index #{args[0]}" unless args[0].nil?
+      [InvalidPairError, msg]
+    end
+
+    def vash_select_key_args(item, *indices)
+      indices.all?{|i| i.nil?}  ? item[0,1] : [item[0], indices[0]]
+    end
+
+    def vash_select_value_args(item, *indices)
+      indices.all?{|i| i.nil?} ? [item[1],nil,item[0]] : [item[1],indices.last]
+    end
+
+    def vash_select_pair_args(item, *indices)
+      [item, *indices]
+    end
+  end
+end

--- a/spec/shared_behaviours/vash/class_methods.rb
+++ b/spec/shared_behaviours/vash/class_methods.rb
@@ -1,0 +1,34 @@
+require 'puppet/util/vash/errors'
+
+module Puppet::SharedBehaviours; module Vash; end; end
+
+module Puppet::SharedBehaviours::Vash
+
+  module ClassMethodsMod
+
+    # Same as Hash::[] but with input validation.
+    def [](*args)
+      obj = new()
+      begin
+        if args.length > 1
+          obj.replace_with_flat_array(args)
+        elsif args.length == 1
+          if args[0].is_a?(Array)
+            obj.replace_with_item_array(args[0])
+          elsif args[0].is_a? Hash
+            obj.replace(args[0])
+          else
+            obj.replace(Hash[args[0]])
+          end
+        end
+      rescue Puppet::Util::Vash::VashArgumentError => err
+        raise err.class, err.to_s
+      end
+      obj
+    end
+  end
+end
+
+class Puppet::SharedBehaviours::Vash::ClassMethods
+  extend Puppet::SharedBehaviours::Vash::ClassMethodsMod
+end

--- a/spec/shared_behaviours/vash/contained.rb
+++ b/spec/shared_behaviours/vash/contained.rb
@@ -1,0 +1,290 @@
+require 'spec_helper'
+require 'puppet/util/vash/errors'
+
+module Puppet::SharedBehaviours;  end
+
+module Puppet::SharedBehaviours::Vash
+module ContainedMod
+
+  require 'shared_behaviours/vash/validator'
+  include ValidatorMod
+
+  # @api private
+  def self.included(base)
+    base.extend(ClassMethodsMod)
+  end
+  require 'shared_behaviours/vash/class_methods'
+
+  # @api private
+  def vash_underlying_hash
+    @vash_underlying_hash ||= {}
+  end
+  private :vash_underlying_hash
+
+  # @api private
+  def initialize_copy(other)
+    super(other)
+    @vash_underlying_hash = Hash[other]
+    self
+  end
+
+  # @api private
+  def initialize(*args,&block)
+    super()
+    @vash_underlying_hash = Hash.new(*args,&block)
+  end
+
+  private :initialize_copy
+
+  require 'forwardable'
+  extend ::Forwardable
+  def_delegators :vash_underlying_hash,
+    :==,
+    :[],
+    :assoc,
+    :compare_by_identity?,
+    :default,
+    :default=,
+    :default_proc,
+    :default_proc=,
+    :delete,
+    :empty?,
+    :eql?,
+    :fetch,
+    :flatten,
+    :has_key?,
+    :has_value?,
+    :hash,
+    :include?,
+    :inspect,
+    :key,
+    :key?,
+    :keys,
+    :length,
+    :member?,
+    :rassoc,
+    :shift,
+    :size,
+    :to_a,
+    :to_h,
+    :to_hash,
+    :to_s,
+    :value?,
+    :values,
+    :values_at
+
+  ruby_version = 0;
+  RUBY_VERSION.split('.').each{|x| ruby_version <<= 8; ruby_version |= x.to_i}
+
+  # Same as {Hash#[]=}
+  def []=(key, value)
+    begin
+      key,value = vash_validate_item([key, value])
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash[key] = value
+  end
+
+  alias_method :store, :[]=
+
+  # Same as {Hash#clear}
+  def clear
+    vash_underlying_hash.clear
+    self
+  end
+
+  # Same as {Hash#compare_by_identity}
+  def compare_by_identity
+    vash_underlying_hash.compare_by_identity
+    self
+  end
+
+  # Same as {Hash#delete_if}
+  def delete_if(&block)
+    result = vash_underlying_hash.delete_if(&block)
+    block ? self : result
+  end
+
+  def each(&block)
+    result = vash_underlying_hash.each(&block)
+    block ? self : result
+  end
+
+  def each_key(&block)
+    result = vash_underlying_hash.each_key(&block)
+    block ? self : result
+  end
+
+  def each_pair(&block)
+    result = vash_underlying_hash.each_pair(&block)
+    block ? self : result
+  end
+
+  def each_value(&block)
+    result = vash_underlying_hash.each_value(&block)
+    block ? self : result
+  end
+
+  # Same as {Hash#rehash}
+  def rehash
+    vash_underlying_hash.rehash
+    self
+  end
+
+  # Same as {Hash#invert}
+  # @note Returning instance of self.class whould have no sense, especially
+  # when key/value validation is in used, because keys and values may be
+  # in different non-compatible domains, and we can't simply swap them and
+  # put them back to an input validating hash. That's why this function must
+  # return an instance of standard {Hash}.
+  def invert
+    hash = vash_underlying_hash.invert
+  end
+
+  if ruby_version >= 0x010903
+  # @note This method is available on ruby>= 1.9.3 only.
+  # Same as {Hash#keep_if}
+  def keep_if(&block)
+    result = vash_underlying_hash.keep_if(&block)
+    block ?  self : result
+  end
+  end
+
+  # Same as {Hash#merge!}
+  def merge!(other, &block)
+    begin
+      other = vash_validate_hash(other)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash.merge!(other, &block)
+    self
+  end
+
+  alias_method :update, :merge!
+
+  # Same as {Hash#merge}
+  def merge(other, &block)
+    begin
+      self.dup.merge!(other, &block)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+  end
+
+  # Same as {Hash#reject}
+  def reject(&block)
+    # note, using original 'reject' is more difficult here.
+    self.dup.delete_if(&block)
+  end
+
+  # Same as {Hash#reject!}
+  def reject!(&block)
+    return nil if (result = vash_underlying_hash.reject!(&block)).nil?
+    block ? self : result
+  end
+
+  # Same as {Hash#replace}
+  def replace(other)
+    begin
+      other = vash_validate_hash(other)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash.replace(other)
+    self
+  end
+
+  # Similar to {Hash#select}
+  # @note On ruby  1.8. the {Hash#select} returns an array (or enumerator)
+  # and on 1.9.1+ returns hash (or enumerator). We always return hash or
+  # an enumerator.
+  #
+  # Note, that for standard Hash and its subclasses we have
+  # select{...}.class == Hash on ruby 1.9+.
+  if ruby_version >= 0x010901
+    def select(&block)
+      vash_underlying_hash.select(&block)
+    end
+  else
+    def select(&block)
+      result = vash_underlying_hash.select(&block)
+      block ? Hash[result] : result
+    end
+  end
+
+  if ruby_version >= 0x010903
+  # Same as {Hash#select!}
+  def select!(&block)
+    return nil if (result = vash_underlying_hash.select!(&block)).nil?
+    block ? self : result
+  end
+  end
+
+  #
+  # extra methods for ClassMethods
+  #
+
+  # Replace Vash content with the one defined in array.
+  #
+  # Example
+  #
+  #     vash.replace_with_flat_array([:a, :A, :b, :B])
+  #
+  # The `vash` contents would be `{:a => :A, :b => :B}`
+  def replace_with_flat_array(array)
+    begin
+      array = vash_validate_flat_array(array)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash.replace(Hash[*array])
+    self
+  end
+
+  # Replace Vash content with the one defined in array.
+  #
+  # Example
+  #
+  #     vash.replace_with_item_array([[:a, :A], [:b, :B]])
+  #
+  # The `vash` content would be `{:a => :A, :b => :B}`
+  def replace_with_item_array(array)
+    begin
+      array = vash_validate_item_array(array)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    vash_underlying_hash.replace(Hash[array])
+    self
+  end
+end
+end
+
+class Puppet::SharedBehaviours::Vash::Contained
+  include Puppet::SharedBehaviours::Vash::ContainedMod
+end
+
+require 'shared_behaviours/vash/hash'
+shared_examples 'Vash::Contained' do |_params|
+  _sample_items =  (_params[:valid_items] || []) +
+                   (_params[:invalid_items] || []).map{|item, guilty| item}
+  _params = {
+    :sample_items => _sample_items,
+    :hash_initializers => [_params[:valid_items]] || [],
+    :model_class  => Puppet::SharedBehaviours::Vash::Contained,
+    # method exceptions
+    :class_sqb=> { :raises=>[Puppet::Util::Vash::VashArgumentError, ArgumentError]},
+    :[]=      => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :store    => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :replace  => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :merge    => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :merge!   => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :update   => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :replace_with_flat_array => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :replace_with_item_array => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+  }.merge(_params)
+  include_examples 'Vash::Validator', _params
+  include_examples 'Vash::Hash', _params
+end

--- a/spec/shared_behaviours/vash/hash.rb
+++ b/spec/shared_behaviours/vash/hash.rb
@@ -1,0 +1,736 @@
+require 'spec_helper'
+require 'rspec/expectations'
+
+def ruby_version
+  ver = 0;
+  RUBY_VERSION.split('.').each{|x| ver <<= 8; ver |= x.to_i}
+  ver
+end
+
+def enumerator_class
+  if ruby_version < 0x010900
+    ::Enumerable::Enumerator
+  else
+    ::Enumerator
+  end
+end
+
+def key_error_from_fetch
+  begin
+    {}.fetch('x')
+  rescue => e
+    e.class
+  end
+end
+
+
+RSpec::Matchers.define :be_instance_of_one_of do |expected|
+  unless expected.is_a?(Array)
+    raise ArgumentError, 'argument must be an Array'
+  end
+  expected_repr = expected.map{|x| x.inspect}.join(' or ')
+  match do |actual|
+    expected.include? actual.class
+  end
+  failure_message_for_should do |actual|
+    "expected that #{actual.inspect} would be an instance of " +
+    "#{expected_repr} but it is an instance of #{actual.class}"
+  end
+  description do
+    "be an instance of #{expected_repr}"
+  end
+end
+
+RSpec::Matchers.define :be_enumerator_equivalent_to do |expected|
+  unless expected.respond_to?(:to_a)
+    raise ArgumentError, "wrong argument to match enumerator: #{expected.inspect}"
+  end
+  match do |actual|
+    # compare unordered arrays
+    a, e = actual, expected
+    if ruby_version < 0x010901
+      # on 1.8 we have random order of so a.to_a == e.to_a would work randomly
+      Hash[a.zip(a.map{|x| a.count(x)})] == Hash[e.zip(e.map{|x| e.count(x)})]
+    else
+      a.to_a == e.to_a
+    end
+  end
+  failure_message_for_should do |actual|
+    actual_repr = "<#{actual.map{|x| x.inspect}.join(', ')}>"
+    expected_repr = "<#{expected.map{|x| x.inspect}.join(', ')}>"
+    "expected that #{actual_repr} would be an enumerator for #{expected_repr}"
+  end
+  description do
+    expected_repr = "<#{expected.map{|x| x.inspect}.join(', ')}>"
+    "be an enumerator for #{expected_repr}"
+  end
+end
+
+module Puppet; module SharedBehaviours; module Vash; end; end; end
+
+class Puppet::SharedBehaviours::Vash::Hash < ::Hash
+  def self.to_s; 'Hash'; end
+end
+
+# Each method in this class returns an array of possible return classes
+# for corresponding Hash method. If this information cannot be determined
+# without knowing hash content, nil is returned.
+class HashReturnTypes
+
+
+  def initialize(subject_class)
+    @subject_class = subject_class
+  end
+
+  def [](key); nil; end
+  def []=(key,val); nil; end # can't predict, it may be munged
+  def ==(other); [TrueClass,FalseClass]; end
+  def assoc(obj); [Array, NilClass]; end
+  def clear; [@subject_class]; end
+  def compare_by_identity; [@subject_class]; end
+  def compare_by_identity?; [TrueClass, FalseClass]; end
+  def default(key=nil); nil; end
+  def default=(obj); [obj.class]; end
+  def default_proc; [Proc,NilClass]; end
+  def default_proc=(obj); [obj.class,NilClass]; end
+  def delete(key,&block); nil; end
+  def delete_if(&block); (block ? [@subject_class] : [enumerator_class]); end
+  def each(&block); (block ? [@subject_class] : [enumerator_class]); end
+  def each_key(&block); (block ? [@subject_class] : [enumerator_class]); end
+  def each_pair(&block); (block ? [@subject_class] : [enumerator_class]); end
+  def each_value(&block); (block ? [@subject_class] : [enumerator_class]); end
+  def empty?; [TrueClass,FalseClass]; end
+  def eql?(other); [TrueClass,FalseClass]; end
+  def fetch(key,default=nil,&block); nil; end
+  def flatten(level=nil); [Array]; end
+  def has_key?(key); [TrueClass, FalseClass]; end
+  def has_value?(val); [TrueClass, FalseClass]; end
+  def hash; [Fixnum]; end
+  def include?(key); [TrueClass, FalseClass]; end
+  def inspect; [String]; end
+  def invert; [Hash]; end
+  def keep_if(&block); (block ? [@subject_class] : [enumerator_class]); end
+  def key(val); nil; end
+  def key?(key); [TrueClass, FalseClass]; end
+  def keys; [Array]; end
+  def length; [Fixnum]; end
+  def member?(key); [TrueClass, FalseClass]; end
+  def merge(other,&block); [@subject_class]; end
+  def merge!(other,&block); [@subject_class]; end
+  def rassoc(obj); [Array,NilClass]; end
+  def rehash; [@subject_class]; end
+  def reject(&block); (block ? [@subject_class] : [enumerator_class]); end
+  def reject!(&block); (block ? [@subject_class,NilClass] : [enumerator_class]); end
+  def replace(other); [@subject_class]; end
+  if ruby_version >= 0x010901
+  def select(&block); (block ? [Hash] : [enumerator_class]); end
+  else
+  def select(&block); (block ? [Hash,Array] : [enumerator_class]); end
+  end
+  def select!(&block); (block ? [@subject_class,NilClass] : [enumerator_class]); end
+  def shift; nil; end
+  def size; [Fixnum]; end
+  def store(key,val); nil; end # don't predict, it may be munged!
+  def to_a; [Array]; end
+  def to_h; [Hash]; end
+  def to_hash; [(@subject_class<=Hash) ? @subject_class : Hash]; end
+  def to_s; [String]; end
+  def update(other,&block); [@subject_class]; end
+  def value?(val); [TrueClass, FalseClass]; end
+  def values; [Array]; end
+  def values_at(*args); [Array]; end
+end
+
+# ::[]
+shared_examples 'Vash::Hash::[]' do |_params|
+
+  _model_class    = _params[:model_class]
+  _initializers   = [ [], [{}], [[]] ] +
+                    _params[:hash_arguments].map{|h| [Hash[h]]} +
+                    _params[:hash_arguments].map{|h| [h.to_a]} +
+                    _params[:hash_arguments].map{|h| h.to_a.flatten}
+
+  let(:model_class) { _model_class }
+
+  _raises = _params[:raises] || []
+  _initializers.each do |_arguments|
+    _arguments_str = _arguments.map{|x| x.inspect}.join(',')
+    context "::[#{_arguments_str}]" do
+      let(:arguments) { _arguments }
+      begin
+        _model_class[*_arguments]
+      rescue *_raises => _except
+        unless _params[:disable_exception_matching]
+          let(:err) { _except.class }
+          let(:msg) { _except.message }
+          it { expect { described_class[*arguments] }.to raise_error err, msg }
+        end
+      else
+        it { expect { described_class[*arguments] }.to_not raise_error }
+        it { described_class[*arguments].should be_instance_of described_class }
+      end
+    end
+  end
+
+  _initializers.each do |_arguments|
+    _arguments_str  = _arguments.map{|x| x.inspect}.join(', ')
+    _left_hash_str  = "Hash[ #{described_class}[ #{_arguments_str} ] ]"
+    context "#{_left_hash_str}" do
+      let(:arguments) { _arguments }
+      # note: we test content after [], not the '==' operator; that's why
+      # Hash is used here (we use his '==' operator).
+      begin
+        _model_class[*_arguments]
+      rescue *_raises => _except
+        # already done ...
+      else
+        # note: we can't initialize right_hash as Hash[ *arguments ]
+        # because we may have munging enabled!
+        # we convert to hash, to use its == operator: our must be tested first!
+        let(:left_hash)  { Hash[ described_class[*arguments] ] }
+        let(:right_hash) { Hash[ model_class[*arguments] ]}
+        it { left_hash.should ==right_hash }
+      end
+    end
+  end
+
+  context "::[nil]" do
+    # we should raise same exceptions as the model_class does.
+    begin
+      _model_class[nil]
+    rescue *_raises => _except
+      unless _params[:disable_exception_matching]
+        let(:msg) { _except.message }
+        let(:err) { _except.class }
+        it { expect { described_class[nil] }.to raise_error err, msg }
+      end
+    else
+      it { expect { described_class[nil] }.to_not raise_error }
+    end
+  end
+
+end
+
+# ::new
+shared_examples 'Vash::Hash::new' do
+  it "::new should not raise error" do
+    expect { described_class.new }.to_not raise_error
+  end
+  it "::new.default should be nil" do
+    described_class.new.default.should be nil
+  end
+  it "::new(:A) should not raise error" do
+    expect { described_class.new(:A) }.to_not raise_error
+  end
+  it "::new(:A).default shoule be :A" do
+    described_class.new(:A).default.should equal :A
+  end
+  it "::new{|h,k| k*k} should not raise error" do
+    expect { described_class.new {|h,k| k*k} }.to_not raise_error
+  end
+  it "::new{|h,k| k*k}[2] should be 4" do
+    described_class.new{|h,k| k*k}[2].should == 4
+  end
+end
+
+def invoke(_method, _args, _block)
+  if _block
+    _method.call(*_args) { |*_args2| _block.call(*_args2) }
+  else
+    _method.call(*_args)
+  end
+end
+
+shared_examples 'Vash::Hash#spec_method:call:check_exception' do
+  it do
+    begin
+      invoke(model_method,args,block)
+    rescue *raises => except
+      err, msg = except.class, except.message
+    else
+      raise 'spec failed: expected model to raise exception but nothing was raised'
+    end
+    expect { invoke(subject_method,args,block) }.to raise_error err, msg
+  end
+end
+
+shared_examples 'Vash::Hash#spec_method:call:check_result' do \
+  |_params,_model,_method,_args,_block,_expected|
+  # returned types
+  _return_types_get = HashReturnTypes.new(_model.class).method(_method)
+
+  # return types - if we have some prescribed rules for the model, then similar
+  # rules must be obeyed by subject
+  unless _params[:disable_class_check]
+    if _return_types = invoke(_return_types_get,_args,_block)
+      let(:return_types_get) { HashReturnTypes.new(subject.class).method(_method) }
+      let(:return_types)     { invoke(return_types_get,args,block) }
+      it { invoke(subject_method,args,block).should be_instance_of_one_of return_types }
+    end
+  end
+  # match the value returned by subject_method to that returned by
+  # model_method
+  unless _params[:disable_value_matching]
+    it do
+      expected = invoke(model_method,args,block)
+      actual   = invoke(subject_method,args,block)
+      if expected.instance_of?(enumerator_class)
+        actual.should be_enumerator_equivalent_to expected
+      elsif expected.is_a?(Array)
+        actual.should =~ expected
+      else
+        actual.should == expected
+      end
+    end
+  end
+  # for some functions we must ensure, that 'self' is returned
+  unless _params[:disable_value_is_self_check]
+    if _expected.equal?(_model)
+      # if model_method returns model, then probably subject_method should
+      # return subject (by the "symmetry")
+      unless [:to_h, :to_hash].include?(_method) and not _params[:subject].is_a?(Hash)
+        it "should be self (identity match)" do
+          invoke(subject_method,args,block).should be subject
+        end
+      end
+    end
+  end
+end
+
+# The workhorse
+shared_examples 'Vash::Hash#spec_method:call' do |_params|
+  _model    = _params[:model].dup
+  _method   = _params[:method]
+  _args     = _params[:args]
+  _block    = _params[:block]
+  _raises   = _params[:raises] || []
+
+  let(:subject)         { _params[:subject].dup }
+  let(:model)           { _params[:model].dup }
+  let(:subject_method)  { subject.method(_params[:method]) }
+  let(:model_method)    { model.method(_params[:method]) }
+  let(:args)            { _args }
+  let(:block)           { _block }
+  let(:method_sym)      { _method }
+  let(:raises)          { _raises }
+
+  # check, if we should specify return value or exception
+  begin
+    _model_method = _model.method(_method)
+    _expected = invoke(_model_method, _args, _block)
+  rescue *_raises => _except # XXX: we trust our model a little bit too much!
+    # exception
+    unless _params[:disable_exception_matching]
+      include_examples 'Vash::Hash#spec_method:call:check_exception'
+    end
+  else
+    # return value
+    it { expect { invoke(subject_method,args,block) }.to_not raise_error }
+    context "the returned value" do
+      include_examples 'Vash::Hash#spec_method:call:check_result',
+        _params, _model, _method, _args, _block, _expected
+    end
+    # attributes
+    (_params[:match_attributes_at_end] || []).each do |_property|
+      context "the ##{_property} after operation" do
+        let(:property) { _property }
+        it do
+          invoke(model_method,args,block)
+          invoke(subject_method,args,block)
+          subject.method(property).call.should == model.method(property).call
+        end
+      end
+    end
+    # content
+    unless _params[:disable_content_matching]
+      context 'the content after operation' do
+        it do
+          invoke(model_method,args,block)
+          invoke(subject_method,args,block)
+          subject.should == model
+        end
+      end
+    end
+  end
+end
+#
+shared_examples 'Vash::Hash#spec_method:calls' do |_params|
+  _blocks = _params[:blocks] || [nil]
+  _tuples = _params[:tuples] || [[]]
+  _blocks.each do |_block,_code|
+    _tuples.each do |_args|
+      _args_str = _args.map{|x| x.inspect}.join(', ')
+      _context_title = case _params[:method]
+        when :[]; "#[#{_args_str}]"
+        when :==; "#{_params[:subject].inspect} == #{_args_str}"
+        else;     "##{_params[:method]}" + (_args.empty? ? '' : "(#{_args_str})")
+      end
+      _context_title += " { #{_code} }" if _block
+      context _context_title do
+        include_examples 'Vash::Hash#spec_method:call', {
+          :args     => _args,
+          :block    => _block,
+        }.merge(_params || {})
+      end
+    end
+  end
+end
+#
+shared_examples 'Vash::Hash#spec_method' do |_params|
+  _method  = _params[:method]
+  _params[:cases].each do |_case|
+    context "when self is initialized with #{_case[:subject].inspect}" do
+      (_params[:match_attributes] || []).each do |_property|
+        context "the ##{_property} initially" do
+          subject        { _case[:subject].dup }
+          let(:model)    { _case[:model].dup }
+          let(:property) { _property }
+          it { subject.method(property).call.should == model.method(property).call }
+        end
+      end
+      include_examples 'Vash::Hash#spec_method:calls', {
+        :tuples    => _case[:tuples],
+        :blocks    => _case[:blocks],
+        :subject   => _case[:subject],
+        :model     => _case[:model],
+      }.merge(_params || {})
+    end
+  end
+end
+
+# Test method with prescribed set of initializers and argument tuples
+shared_examples 'Vash::Hash#spec_method_with' do |_params,*_tuples|
+  _initializers = _params[:hash_initializers] || [_params[:sample_items]] || []
+  _cases = [
+    {
+      :subject   => described_class.new,
+      :model     => _params[:model_class].new,
+      :blocks    => _params[:blocks],
+      :tuples    => _tuples
+    },
+  ]
+  _initializers.each do |_initializer|
+    _cases << {
+      :subject   => described_class[_initializer],
+      :model     => _params[:model_class][_initializer],
+      :blocks    => _params[:blocks],
+      :tuples    => _tuples
+    }
+  end
+  include_examples 'Vash::Hash#spec_method', {
+    :cases => _cases
+  }.merge(_params||{})
+end
+
+# Test method that accept no arguments
+shared_examples 'Vash::Hash#spec_method_with_no_arg' do |_params|
+  include_examples 'Vash::Hash#spec_method_with', _params, []
+end
+
+# Test method that accept key as an argument
+shared_examples 'Vash::Hash#spec_method_with_key_arg' do |_params|
+  _missing_key  = _params[:missing_key]
+  _sample_items = _params[:sample_items] || []
+  _args = [[_missing_key], *(_sample_items.map{|k,v| [k]}) ]
+  include_examples 'Vash::Hash#spec_method_with', _params, *_args
+end
+
+# Test method that accept value as an argument
+shared_examples 'Vash::Hash#spec_method_with_value_arg' do |_params|
+  _missing_value  = _params[:missing_value]
+  _sample_items = _params[:sample_items] || []
+  _args = [[_missing_value], *(_sample_items.map{|k,v| [k]}) ]
+  include_examples 'Vash::Hash#spec_method_with', _params, *_args
+end
+
+# Test method that accept item as an argument
+shared_examples 'Vash::Hash#spec_method_with_item_arg' do |_params|
+  _missing_item  = [ _params[:missing_key],  _params[:missing_value] ]
+  _existing_item = [ _params[:existing_key], _params[:existing_value] ]
+  _args = [_missing_item, _existing_item]
+  include_examples 'Vash::Hash#spec_method_with', _params, *_args
+end
+
+# Test method that accept other hash as argument
+shared_examples 'Vash::Hash#spec_method_with_hash_arg' do |_params|
+  _hash_arguments = _params[:hash_arguments]
+  _args = (_params[:hash_arguments] || [{}]).map{|h| [h]}
+  include_examples 'Vash::Hash#spec_method_with', _params, *_args
+end
+
+
+#############################################################################
+shared_examples 'Vash::Hash' do |_params|
+
+  _params = _params.dup
+
+  _model_class = (_params.delete(:model_class) ||
+                  Puppet::SharedBehaviours::Vash::Hash).dup
+
+  # inject custom methods to the model
+  (_params.delete(:methods) || []).each do |_method_sym, _method_proc|
+    _model_class.send(:define_method, _method_sym.intern, _method_proc)
+  end
+
+
+  [
+    :==, :[], :[]=, :clear, :default, :default=, :default_proc, :delete,
+    :delete_if, :each, :each_key, :each_pair, :each_value, :empty?, :eql?,
+    :fetch, :has_key?, :has_value?, :hash, :include?, :inspect, :invert,
+    :key?, :keys, :length, :member?, :merge, :merge!, :rehash,
+    :reject!, :reject, :replace,  :select, :shift, :size, :store, :to_a,
+    :to_hash, :to_s, :update, :value?, :values, :values_at
+  ].each do |method|
+    it { should respond_to method }
+  end
+
+  if ruby_version >= 0x010901
+    it { should respond_to :assoc }
+    it { should respond_to :compare_by_identity }
+    it { should respond_to :compare_by_identity? }
+    it { should respond_to :default_proc= }
+    it { should respond_to :flatten }
+    it { should respond_to :key }
+    it { should respond_to :rassoc }
+  end
+
+  if ruby_version >= 0x010903
+    it { should respond_to :keep_if }
+    it { should respond_to :select! }
+  end
+
+  if ruby_version >= 0x020000
+    it { should respond_to :to_h }
+  end
+
+  _methods_with = {}
+  _methods_with[:no_arg] = [
+    :clear, :delete_if, :each, :each_key, :each_value, :each_pair, :empty?,
+    :hash, :inspect, :invert, :keys, :length, :rehash, :reject, :reject!,
+    :select, :shift, :size, :to_a, :to_hash, :values
+  ]
+  _methods_with[:key_arg] = [
+    :[], :delete, :fetch, :has_key?, :include?, :key?, :member?
+  ]
+  _methods_with[:value_arg] = [
+    :has_value?, :value?,
+  ]
+  _methods_with[:item_arg] = [
+    :[]=, :store,
+  ]
+  _methods_with[:hash_arg] = [
+    :==, :eql?, :merge!, :merge, :replace, :update,
+  ]
+
+  if ruby_version >= 0x010901
+    _methods_with[:no_arg]    += [ :flatten ]
+    _methods_with[:key_arg]   += [ :assoc, :rassoc ]
+    _methods_with[:value_arg] += [ :key ]
+  end
+
+  if ruby_version >= 0x010903
+    _methods_with[:no_arg]    += [ :select! ]
+  end
+
+  if ruby_version >= 0x020000
+    _methods_with[:no_arg] += [ :to_h, :keep_if ]
+  end
+
+  _method_params = {
+    :class_sqb=> {
+      :raises => [ArgumentError]
+    },
+    :fetch    => {
+      :raises => [key_error_from_fetch]
+    },
+  }
+
+  if ruby_version < 0x020000
+    # on these versions hash ordering is not guaranted, and shift may return
+    # arbitrary item from hash.
+    _method_params[:shift]||= {}
+    _method_params[:shift][:disable_value_matching]    = true
+    _method_params[:shift][:disable_content_matching] = true
+  end
+
+  _missing_key    = _params[:missing_key]
+  _missing_value  = _params[:missing_value]
+  _existing_key   = if _params.include? :existing_key; _params[:existing_key]
+                    else; _params[:sample_items].first[0]; end
+  _existing_value = if _params.include? :existing_value; _params[:existing_value]
+                    else; _params[:sample_items].first[1]; end
+
+  _method_blocks    = {
+    :delete    => [ nil,
+                    [ proc {|k| _missing_value},
+                           "|k| #{_missing_value.inspect}" ] ],
+    :delete_if => [ nil,
+                    [ proc {|k,v| k ==   _missing_key},
+                           "|k,v| k == #{_missing_key.inspect}"
+                    ], [
+                      proc {|k,v| k ==   _existing_key},
+                           "|k,v| k == #{_existing_key.inspect}" ]
+                  ],
+    :each      => [ nil,
+                    [
+                      proc {|x| x},
+                           "|x| x"
+                    ],
+                  ],
+    :each_key  => [ nil,
+                    [
+                      proc {|k| k},
+                           "|k| k"
+                    ],
+                  ],
+
+    :each_pair => [ nil,
+                    [
+                      proc {|k,v| [k,v]},
+                           "|k,v| [k,v]"
+                    ],
+                  ],
+    :each_value=> [ nil,
+                    [
+                      proc {|v| v},
+                           "|v| v"
+                    ],
+                  ],
+    :fetch     => [ nil, [ proc {|k| _missing_value},
+                                "|k| #{_missing_value.inspect}" ] ],
+    :merge     => [ nil, [ proc {|k,o,n| o },   "|k,o,n| o" ] ],
+    :merge!    => [ nil, [ proc {|k,o,n| o },   "|k,o,n| o" ] ],
+    :reject    => [ nil,
+                    [
+                      proc {|k,v| k == _existing_key},
+                           "|k,v| k == #{_existing_key.inspect}"
+                    ],[
+                      proc {|k,v| k == _missing_key},
+                           "|k,v| k == #{_missing_key.inspect}"
+                    ]
+                  ],
+    :reject!   => [ nil,
+                    [
+                      proc {|k,v| k == _existing_key},
+                           "|k,v| k == #{_existing_key.inspect}"
+                    ],[
+                      proc {|k,v| k == _missing_key},
+                           "|k,v| k == #{_missing_key.inspect}"
+                    ]
+                  ],
+    :select    => [ nil,
+                    [
+                      proc {|k,v| k == _existing_key},
+                           "|k,v| k == #{_existing_key.inspect}"
+                    ],[
+                      proc {|k,v| k == _missing_key},
+                           "|k,v| k == #{_missing_key.inspect}"
+                    ]
+                  ],
+    :select!   => [ nil,
+                    [
+                      proc {|k,v| k == _existing_key},
+                           "|k,v| k == #{_existing_key.inspect}"
+                    ],[
+                      proc {|k,v| k == _missing_key},
+                           "|k,v| k == #{_missing_key.inspect}"
+                    ]
+                  ],
+    :update    => [ nil, [ proc {|k,o,n| o },   "|k,o,n| o" ] ],
+    :update!   => [ nil, [ proc {|k,o,n| o },   "|k,o,n| o" ] ],
+  }
+
+  describe '::[]' do
+    include_examples 'Vash::Hash::[]', {
+      :model_class  => _model_class,
+      :sample_items => _params[:sample_items],
+    }.merge(_method_params[:class_sqb] || {}).
+      merge(_params).
+      merge(_params[:class_sqb] || {})
+  end
+
+  describe '::new' do
+    include_examples 'Vash::Hash::new'
+  end
+
+  [:no_arg, :key_arg, :value_arg, :item_arg, :hash_arg].each do |_variant|
+    _methods_with[_variant].each do |_method|
+      describe "##{_method}" do
+        include_examples "Vash::Hash#spec_method_with_#{_variant}", {
+          :method          => _method,
+          :blocks          => _method_blocks[_method],
+          :model_class     => _model_class,
+        }.merge(_method_params[_method] || {}).
+          merge(_params).
+          merge(_params[_method] || {})
+      end
+    end
+  end
+
+  if ruby_version >= 0x010901
+    describe "#compare_by_identity?" do
+      include_examples 'Vash::Hash#spec_method_with', {
+        :method                   => :compare_by_identity?,
+        :model_class              => _model_class,
+        :hash_initializers        => [],
+      }.merge(_params).merge(_params[:compare_by_identity]||{}), []
+    end
+    describe "#compare_by_identity" do
+      include_examples 'Vash::Hash#spec_method_with', {
+        :method                   => :compare_by_identity,
+        :model_class              => _model_class,
+        :hash_initializers        => [],
+        :match_attributes         => [:compare_by_identity?],
+        :match_attributes_at_end  => [:compare_by_identity?],
+        :disable_value_matching   => true, # we compare by identity!
+        :disable_content_matching => true  # we compare by identity!
+      }.merge(_params).merge(_params[:compare_by_identity]||{}), []
+    end
+  end
+
+  describe "#default" do
+    include_examples 'Vash::Hash#spec_method_with', {
+      :method                   => :default,
+      :model_class              => _model_class,
+      :hash_initializers        => [],
+    }.merge(_params).merge(_params[:default]||{}), []
+  end
+
+  describe "#default=" do
+    include_examples 'Vash::Hash#spec_method_with', {
+      :method                   => :default=,
+      :model_class              => _model_class,
+      :hash_initializers        => [],
+      :match_attributes         => [:default],
+      :match_attributes_at_end  => [:default]
+    }.merge(_params).merge(_params[:default=]||{}), [_missing_value]
+  end
+
+  describe "#default_proc" do
+    include_examples 'Vash::Hash#spec_method_with', {
+      :method                   => :default_proc,
+      :model_class              => _model_class,
+      :hash_initializers        => [],
+    }.merge(_params).merge(_params[:default_proc]||{}), []
+  end
+
+  # for < 1.9 there is no way to set default_proc via instance methods.
+  if ruby_version >= 0x010901
+    include_examples 'Vash::Hash#spec_method_with', {
+      :method                   => :default_proc=,
+      :model_class              => _model_class,
+      :hash_initializers        => [],
+      :match_attributes         => [:default_proc],
+      :match_attributes_at_end  => [:default_proc]
+    }.merge(_params).merge(_params[:default_proc=]||{}), [proc {|h,k| _missing_value}]
+  end
+
+  describe "#values_at" do
+    include_examples 'Vash::Hash#spec_method_with', {
+      :method                   => :values_at,
+      :model_class              => _model_class,
+    }.merge(_params).merge(_params[:default_proc=]||{}),
+    [], [_missing_key], [_existing_key], [_missing_key,_existing_key]
+  end
+
+end

--- a/spec/shared_behaviours/vash/inherited.rb
+++ b/spec/shared_behaviours/vash/inherited.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+require 'puppet/util/vash/errors'
+
+module Puppet::SharedBehaviours;  end
+
+module Puppet::SharedBehaviours::Vash
+module InheritedMod
+
+  require 'shared_behaviours/vash/validator'
+  include ValidatorMod
+
+  def self.included(base)
+    base.extend(ClassMethodsMod)
+  end
+  require 'shared_behaviours/vash/class_methods'
+
+  ruby_version = 0;
+  RUBY_VERSION.split('.').each{|x| ruby_version <<= 8; ruby_version |= x.to_i}
+
+  def []=(key, value)
+    begin
+      key, value = vash_validate_item([key, value])
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    self.class.superclass.instance_method(:[]=).bind(self).call(key,value)
+  end
+
+  alias_method :store, :[]=
+
+  # Similar to {Hash#select}
+  # @note On ruby  1.8. the {Hash#select} returns an array (or enumerator)
+  # and on 1.9.1+ returns hash (or enumerator). We always return hash or
+  # an enumerator.
+  #
+  # Note, that for standard Hash and its subclasses we have
+  # select{...}.class == Hash on ruby 1.9+.
+  if ruby_version < 0x010901
+    def select(&block)
+      result = self.class.superclass.instance_method(:select).bind(self).call(&block)
+      block ? Hash[result] : result
+    end
+  end
+
+  def merge!(other, &block)
+    begin
+      other = vash_validate_hash(other)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    # On 1.8 using 'super' breaks rspec tests :(.
+    self.class.superclass.instance_method(:merge!).bind(self).call(other, &block)
+  end
+
+  alias_method :update, :merge!
+
+  def merge(other, &block)
+    begin
+      self.dup.merge!(other, &block)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+  end
+
+  def replace(other)
+    begin
+      other = vash_validate_hash(other)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    # On 1.8 using 'super' breaks rspec tests :(.
+    self.class.superclass.instance_method(:replace).bind(self).call(other)
+  end
+
+  #
+  # extra methods for ClassMethods
+  #
+  def replace_with_flat_array(array)
+    begin
+      array = vash_validate_flat_array(array)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    hash = Hash[*array]
+    # On 1.8 using 'super' breaks rspec tests :(.
+    self.class.superclass.instance_method(:replace).bind(self).call(hash)
+    self
+  end
+
+  def replace_with_item_array(array)
+    begin
+      array = vash_validate_item_array(array)
+    rescue Puppet::Util::Vash::VashArgumentError => err
+      raise err.class, err.to_s
+    end
+    hash = Hash[array]
+    # On 1.8 using 'super' breaks rspec tests :(.
+    self.class.superclass.instance_method(:replace).bind(self).call(hash)
+    self
+  end
+
+end
+end
+
+class Puppet::SharedBehaviours::Vash::Inherited < ::Hash
+  include Puppet::SharedBehaviours::Vash::InheritedMod
+end
+
+require 'shared_behaviours/vash/hash'
+shared_examples 'Vash::Inherited' do |_params|
+  _sample_items = (_params[:valid_items] || []) +
+                  (_params[:invalid_items] || []).map{|item,guilty| item}
+  _params = {
+    :sample_items => _sample_items,
+    :hash_initializers => [_params[:valid_items]] || [],
+    :model_class  => Puppet::SharedBehaviours::Vash::Inherited,
+    # method exceptions
+    :class_sqb=> { :raises=>[Puppet::Util::Vash::VashArgumentError, ArgumentError]},
+    :[]=      => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :store    => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :replace  => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :merge    => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :merge!   => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :update   => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :replace_with_flat_array => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+    :replace_with_item_array => { :raises=>[Puppet::Util::Vash::VashArgumentError] },
+  }.merge(_params)
+  include_examples 'Vash::Validator', _params
+  include_examples 'Vash::Hash', _params
+end

--- a/spec/shared_behaviours/vash/validator.rb
+++ b/spec/shared_behaviours/vash/validator.rb
@@ -1,0 +1,809 @@
+require 'spec_helper'
+require 'puppet/util/vash/errors'
+
+module Puppet::SharedBehaviours; module Vash; end; end
+
+#############################################################################
+# Stable "snapshot" of the Puppet::Util::Vash::Validator module.
+#
+# This is a copy of stable and tested version of Validator module. In specs we
+# compare behaviour of Puppet::Util::Vash::Validator against this
+# module. If the behaviour of Puppet::Util::Vash::Validator diverges
+# from this one, the specs should notify you about differences, and you'll be
+# forced to revise your changes to implementation.
+#
+# You should update this copy each time you update successfuly
+# Puppet::Util::Vash::Validator.
+#
+module Puppet::SharedBehaviours::Vash::ValidatorMod
+
+  def vash_valid_key?(key); true; end
+  def vash_valid_value?(value); true; end
+  def vash_valid_pair?(pair); true; end
+  def vash_munge_key(key); key; end
+  def vash_munge_value(val); val; end
+  def vash_munge_pair(pair); pair; end
+  def vash_key_name(*args); 'key'; end
+  def vash_value_name(*args); 'value'; end
+  def vash_pair_name(*args); '(key,value) combination'; end
+
+  def vash_validate_key(key,*args)
+    raise *(vash_key_exception(key,*args)) unless vash_valid_key?(key)
+    vash_munge_key(key)
+  end
+
+  def vash_validate_value(val,*args)
+    raise *(vash_value_exception(val,*args)) unless vash_valid_value?(val)
+    vash_munge_value(val)
+  end
+
+  def vash_validate_pair(pair,*args)
+    raise *(vash_pair_exception(pair,*args)) unless vash_valid_pair?(pair)
+    vash_munge_pair(pair)
+  end
+
+  def vash_validate_item(item,*args)
+    k = vash_validate_key(*vash_select_key_args(item,*args))
+    v = vash_validate_value(*vash_select_value_args(item,*args))
+    vash_validate_pair(*vash_select_pair_args([k,v],*args))
+  end
+
+  def vash_validate_hash(hash)
+    Hash[hash.map { |item| vash_validate_item(item) }]
+  end
+
+  def vash_validate_flat_array(array)
+    def each_item_with_index(a)
+      i = 0; l = a.length-1; while i<l do; yield [a[i,2],i]; i+=2; end
+    end
+    array2 = Array.new(array.length) # pre-allocate
+    each_item_with_index(array) do |item,i|
+      array2[i,2] = vash_validate_item(item,i,i+1)
+    end
+    array2
+  end
+
+  def vash_validate_item_array(array)
+    def each_item_with_index(a)
+      i = 0; l = a.length; while i<l do; yield [a[i],i]; i+=1; end
+    end
+    array2 = Array.new(array.length) # pre-allocate
+    each_item_with_index(array) do |item,i|
+      array2[i] = vash_validate_item(item,i)
+    end
+    array2
+  end
+
+  def vash_key_exception(key, *args)
+    name = vash_key_name(key,*args)
+    msg  = "invalid #{name} #{key.inspect}"
+    msg += " at index #{args[0]}" unless args[0].nil?
+    msg += " (with value #{args[1].inspect})" unless args.length < 2
+    [Puppet::Util::Vash::InvalidKeyError, msg]
+  end
+
+  def vash_value_exception(value, *args)
+    name = vash_value_name(value,*args)
+    msg  = "invalid #{name} #{value.inspect}"
+    msg += " at index #{args[0]}" unless args[0].nil?
+    msg += " at key #{args[1].inspect}" unless args.length < 2
+    [Puppet::Util::Vash::InvalidValueError, msg]
+  end
+
+  def vash_pair_exception(pair, *args)
+    name =  vash_pair_name(pair,*args)
+    msg  = "invalid #{name} (#{pair.map{|x| x.inspect}.join(',')})"
+    msg += " at index #{args[0]}" unless args[0].nil?
+    [Puppet::Util::Vash::InvalidPairError, msg]
+  end
+
+  def vash_select_key_args(item, *indices)
+    indices.all?{|i| i.nil?}  ? item[0,1] : [item[0], indices[0]]
+  end
+
+  def vash_select_value_args(item, *indices)
+    indices.all?{|i| i.nil?} ? [item[1],nil,item[0]] : [item[1],indices.last]
+  end
+
+  def vash_select_pair_args(item, *indices)
+    [item, *indices]
+  end
+
+end
+#############################################################################
+
+
+#############################################################################
+# @todo write docs for Puppet::SharedBehaviours::Vash::Validator
+# TODO: write docs for Puppet::SharedBehaviours::Vash::Validator
+#
+class Puppet::SharedBehaviours::Vash::Validator
+  include Puppet::SharedBehaviours::Vash::ValidatorMod
+end
+#############################################################################
+
+
+#############################################################################
+# Test one of `vash_valid_key?`, `vash_valid_value?` or `vash_valid_pair?`
+# methods.
+#
+# *Example*:
+#
+# In the following example we test `vash_valid_key?` which should return true
+# only for strings.
+#
+#     describe "#vash_valid_key?" do
+#       include_examples "Vash::Validator#vash_valid_single?", {
+#         :type            => :key,
+#         :validator       => described_class.new,
+#         :valid_samples   => ['a', 'A'],
+#         :invalid_samples => [nil, {}, :a]
+#       }
+#     end
+#
+# Required `_params`:
+#
+#   * `:type` - one of `:key`, `:value`, or `:pair`. The tested method is
+#     `#{type}_valid?`, for example (`_params[:type] == `:key`) `key_valid?`.
+#   * `:validator` - an instance of tested class,
+#   * `:valid_samples` - an array of values for which the tested method
+#     returns true. Note: for pairs, this should be a `[key,value]` pair
+#     (array) as returned by `#munge_pair` method.
+#   * `:invalid_samples` - samples for which the tested method should return
+#     `false`. The other rules are identical as for `:valid_samples`.
+#
+# You may pass empty arrays as `:valid_samples` and/or `:invalid_sampled`
+# (this disables particular tests).
+#############################################################################
+shared_examples 'Vash::Validator#vash_valid_single?' do |_params|
+  _type         = _params[:type].intern
+  _validator    = _params[:validator]
+  _is_valid_sym = "vash_valid_#{_type}?".intern
+  _is_valid     = _validator.method(_is_valid_sym)
+
+  let(:validator) { _params[:validator] }
+  let(:is_valid)  { _is_valid }
+
+  [[:valid, :be_true], [:invalid, :be_false]].each do |_state, _return_value|
+    _samples = _params["#{_state}_samples".intern]
+    _samples.each do |_sample|
+      context "with #{_type}=#{_sample.inspect} (#{_state})" do
+        let(:sample)       { _sample }
+        let(:return_value) { _return_value }
+        it { expect { is_valid.call(sample) }.to_not raise_error}
+        it { is_valid.call(sample).should method(return_value).call }
+      end
+    end
+  end
+end
+#############################################################################
+
+#############################################################################
+# Test one of `vash_munge_key`, `vash_munge_value` and `vash_munge_pair`
+# methods.
+#
+# Example:
+#
+# In the following example we test `vash_munge_key` which is supposed to munge
+# strings and symbols, and it should do this in same way as the `:model`
+# object does.
+#
+#     describe "#vash_munge_key" do
+#       include_examples 'Vash::Validator#vash_munge_single', {
+#         :type       => :key,
+#         :validator  => described_class.new,
+#         :model      => model_class.new,
+#         :samples    => ['a', 'A', :a]
+#       }
+#     end
+#
+# Required _params:
+#
+#   * `:type` - either `:key`, `:value` or `:pair`.
+#   * `:validator` - an instance of tested class,
+#   * `:model` - an instance of class having desired behaviour,
+#   * `:samples` - an array of samples used to verify the behaviour.
+#
+#############################################################################
+shared_examples 'Vash::Validator#vash_munge_single' do |_params|
+  _type      = _params[:type].intern
+  _validator = _params[:validator]
+  _model     = _params[:model]
+  _munge_sym = "vash_munge_#{_type}".intern
+
+  _validator_munge = _validator.method(_munge_sym)
+  _model_munge = _model.method(_munge_sym)
+
+  let(:munge) { _validator_munge }
+
+  _params[:samples].each do |_sample|
+    _munged = _model_munge.call(_sample)
+    context "with #{_type}=#{_sample.inspect}" do
+      let(:sample) { _sample }
+      let(:munged) { _munged }
+      it { expect { munge.call(sample) }.to_not raise_error }
+      it { munge.call(sample).should == munged }
+    end
+  end
+end
+#############################################################################
+
+#############################################################################
+# Test one of `vash_key_name`, `vash_value_name`, `vash_pair_name`,
+# `vash_key_exception`, `vash_value_exception` or `vash_pair_exception`
+# methods.
+#
+# *Example*:
+#
+# In the following example `vash_key_name` is supposed to return key names same
+# way as the `:model` object does.
+#
+#     describe "#vash_key_name" do
+#       include_examples 'Vash::Validator#vash_single_name_or_exception', {
+#         :type       => :key,
+#         :what       => :exception,
+#         :validator  => described_class.new,
+#         :model      => model_class.new,
+#       }
+#     end
+#
+# Required _params:
+#
+#   * `:type` - one of `:key`, `:value` or `:pair`.
+#   * `:what` - one of `:name` or `:exception`,
+#   * `:validator` - the validator to be tested,
+#   * `:model` - a behaviour object taken as reference.
+#
+# Optional _params:
+#
+#   * `:samples` - an array of samples (keys, values or pairs, depending on
+#     `:type` option). This is used only if `:tuples` are not provided.
+#   * `:tuples` - an array of argument tuples for the tested method. For
+#     example `[ [:a], [:a,:A] ]` will generate `vash_key_name(:a)` and
+#     `vash_key_name(:a,:A)` cases, if `:type == :key` and `:what == :name`.
+#
+#############################################################################
+shared_examples 'Vash::Validator#vash_single_name_or_exception' do |_params|
+  _type      = _params[:type].intern
+  _what      = _params[:what].intern
+  _validator = _params[:validator]
+  _model     = _params[:model]
+
+  _query_sym = "vash_#{_type}_#{_what}".intern
+  _validator_query = _validator.method(_query_sym)
+  _model_query = _model.method(_query_sym)
+
+  let(:query) { _validator_query }
+
+  unless (_tuples = _params[:tuples])
+    # these are calls, that may be done by standard Vash::Validator
+    _tuples = case _what
+              when :name; [[]] # vash_xxx_name accepts 0+ arguments.
+              else;        []  # vash_xxx_exception accepts 1+ arguments.
+              end
+    _params[:samples].each do |_samp|
+      _tuples += [ [_samp], [_samp,0], [_samp,0,:x] ]
+    end
+  end
+
+  _tuples.each do |_arguments|
+    _arguments_str = _arguments.map{|_x| _x.inspect}.join(', ')
+    _return_value = _model_query.call(*_arguments)
+    context "with arguments (#{_arguments_str})" do
+      let(:arguments)     { _arguments }
+      let(:return_value)  { _return_value }
+      it { expect { err,msg = query.call(*arguments) }.to_not raise_error }
+      case _what
+      when :exception
+        it "should be a pair of [ArgumentError, <String>]" do
+          err, msg = query.call(*arguments)
+          err.should <= ArgumentError
+          msg.should be_a(::String)
+        end
+      when :name
+        it { query.call(*arguments).should(be_a(String) || be_a(Symbol)) }
+      end
+      it { query.call(*arguments).should == return_value }
+    end
+  end
+end
+#############################################################################
+
+##############################################################################
+# Test one of `vash_validate_key`, `vash_validate_value` or
+# `vash_validate_pair` methods.
+#
+# *Example*:
+#
+# In the following example, the tested method `vash_validate_key` is supposed
+# to allow symbols and strings and raise exceptions for other objects.
+#
+#     describe "#vash_validate_key" do
+#       include_examples 'Vash::Validator#vash_validate_single', {
+#         :type => :key,
+#         :validator       => described_class.new,
+#         :model           => model_class.new,
+#         :valid_samples   => [:a, :A, 'a'],
+#         :invalid_samples => [1,nil,{},[]]
+#       }
+#     end
+#
+# Required _params:
+#
+#   * `:type` - one of `:key`, `:value` or `:pair`.
+#   * `:validator` - an instance of the tested class,
+#   * `:model` - a model object taken as reference,
+#   * `:valid_samples` - an array with values, for which the method should
+#     return normally
+#   * `:invalid_samples` - an array with values, for which the method should
+#     raise an exception.
+#
+# Optional _params:
+#
+#   * `:no_query_call` - if set to true, the tested implementation does not
+#     invoke `vash_xxx_valid?` method (and this is intentionally).
+#   * `:no_exception_call` - if set to true, the tested implementation does not
+#     invoke `vash_xxx_exception` to get exception class and message (and this
+#     is intentional).
+#   * `:custom_exception` - if set to true, the tested implementation raises
+#     custom exception when the check fails (still the exception is checked if it
+#     is a kind of `::ArgumentError`)
+#
+##############################################################################
+shared_examples 'Vash::Validator#vash_validate_single' do |_params|
+  _type                = _params[:type]
+  _validator           = _params[:validator]
+  _model               = _params[:model]
+  _validate_sym        = "vash_validate_#{_type}".intern
+  _exception_sym       = "vash_#{_type}_exception".intern
+  _query_sym           = "vash_valid_#{_type}?".intern
+  _validator_validate  = _validator.method(_validate_sym)
+  _model_validate  = _model.method(_validate_sym)
+  _model_exception = _model.method(_exception_sym)
+
+  let(:validator)     { _validator }
+  let(:exception_sym) { _exception_sym }
+  let(:query_sym)     { _query_sym }
+  let(:validate)      { _validator_validate }
+
+  _params[:valid_samples].each do |_sample|
+    _tuples = [ [_sample], [_sample,0], [_sample,0,:x]  ]
+    _tuples.each do |_arguments|
+      _return_value  = _model_validate.call(*_arguments)
+      _arguments_str = _arguments.map{|x| x.inspect}.join(',')
+      context "##{_validate_sym}(#{_arguments_str}) [#{_type} valid]" do
+        let(:sample)        { _sample }
+        let(:arguments)     { _arguments }
+        let(:return_value)  { _return_value }
+        it { expect { validate.call(*arguments) }.to_not raise_error }
+        it { validate.call(*arguments).should == return_value }
+        unless _params[:no_query_call]
+          it "should invoke ##{_query_sym}(#{_sample}) once" do
+            validator.expects(query_sym).once.with(sample).returns(true)
+            validate.call(*arguments)
+          end
+        end
+      end
+    end
+  end
+
+  _params[:invalid_samples].each do |_sample|
+    _tuples = [ [_sample], [_sample,0], [_sample,0,:x]  ]
+    _tuples.each do |_arguments|
+      _arguments_str = _arguments.map{|x| x.inspect}.join(',')
+      _err, _msg = _model_exception.call(*_arguments)
+      context "##{_validate_sym}(#{_arguments_str}) [#{_type} invalid]" do
+        let(:err)       { _err }
+        let(:msg)       { _msg }
+        let(:sample)    { _sample }
+        let(:arguments) { _arguments }
+        if _params[:custom_exception]
+          it { expect { validate.call(*arguments) }.to raise_error ArgumentError }
+        else
+          it { expect { validate.call(*arguments) }.to raise_error err, msg }
+        end
+        unless _params[:no_query_call]
+          it "should invoke ##{_query_sym}(#{_sample.inspect}) once" do
+            validator.expects(query_sym).once.with(sample).returns(false)
+            begin
+              validate.call(*arguments)
+            rescue err, msg
+              # eat exception
+            end
+          end
+        end
+        unless _params[:no_exception_call]
+          it "should invoke ##{_exception_sym}(#{_arguments_str}) once" do
+            validator.expects(exception_sym).once.with(*arguments).returns([err,msg])
+            begin
+              validate.call(*arguments)
+            rescue err, msg
+              # eat exception
+            end
+          end
+        end
+      end
+    end
+  end
+end
+#############################################################################
+
+##############################################################################
+# Test one of `vash_validate_item`, `vash_validate_hash`,
+# `vash_validate_flat_array` or `vash_validate_item_array` methods.
+#
+# *Example*:
+#
+# In the following example we test item validator which accepts only items
+# with integer keys/values and keys being less than values.
+#
+#     describe "#vash_validate_item" do
+#       include_examples 'Vash::Validator#vash_validate_input', {
+#         :type            => :item,
+#         :validator       => described_class.new,
+#         :model           => model_class.new,
+#         :valid_samples   => [ [0,1], [0,2], [1,2] ],
+#         :invalid_samples => [
+#                               [ [:a,  0], :key ],
+#                               [ [:a, :A], :key ],
+#                               [ [ 0, :A], :value ],
+#                               [ [ 2,  1], :pair ]
+#                             ]
+#       }
+#     end
+#
+# The elements in `:invalid_samples` are `[ item, guilty ]` pairs, where
+# `item = [key,value]` pair and `guilty` tells what is wrong in this item.
+# Possible values for `guilty` are `:key`, `:value`, `:pair` (key and value
+# are correct, but they doesn't form valid pair).
+#
+# Required _params:
+#
+#   * `:type` - one of `:item`, `:hash`, `:flat_array` or `:iten_array`.
+#   * `:validator` - an instance of the tested class,
+#   * `:model` - a behaviour object taken as reference,
+#   * `:valid_samples` - an array with samples, for which the method should
+#     return normally. Following rules apply:
+#
+#     * if `:type` is `:item`, then `:valid_samples` must be an array of
+#       key-value pairs,
+#     * if `:type` is `:hash`, then `:valid_samples` must be an array of
+#       hashes,
+#     * if `:type` is `:flat_array`, then `:valid_samples` must be an array of
+#       flat arrays containing keys interleaved with values, for example:
+#       `[ [ :k1a, :v1a, :k2a, :v2a ], [ :k1b, :v1b, :k2b, :v2b ] ]`,
+#     * if `:type` is `:item_array`, then `:valid_samples` must be an array of
+#       item arrays, each one containing key,value pairs as 2-element arrays,
+#       for exapmle `[ [ [:k1a,:v1a], [:k2a,:v2a] ], [ [:k1b,:v1b] ]  ]`,
+#
+#   * `:invalid_samples` - an array with samples, for which the method should
+#     raise an exception. Each sample in array is a pair of type:
+#
+#         [
+#           object, [guilty, item, indices]
+#         ]
+#
+#      where object is an item (if `:type` is `:item`), a hash (if `:type` is
+#      `:hash`), a flat array or item array (if `:type` is `:flat_array` or
+#      `:item_array` respectively). The `guilty` may be one of `:key`,
+#      `:value` or `:pair` and indicates, what is wrong with the first item
+#      that doesn't pass validation. The `item` is a copy of item that causes
+#      validation to fail. The indices have sense only for `:flat_array` and
+#      `:item_array`. For `:flat_array` this should be a tuple with indices
+#      position indices of key and value for the failing item (this should
+#      be normally `i` and `i+1`, for an item starting at position `i`).
+#      For `:item_array`, this should be one-element array with the index
+#      of failing item. For `:hash`, this should be an empty array. For
+#      `:item` it is irrelevant.
+#
+#
+# Optional _params:
+#
+#   * `:custom_exception` - if set to true, the tested implementation raises
+#     custom exception when the check fails (still the exception is checked if
+#     it is a kind of `::ArgumentError`)
+#
+##############################################################################
+shared_examples 'Vash::Validator#vash_validate_input' do |_params|
+
+  _type                = _params[:type].intern
+  _validator           = _params[:validator]
+  _model               = _params[:model]
+  _validate_sym        = "vash_validate_#{_type}".intern
+  _validator_validate  = _validator.method(_validate_sym)
+  _model_validate  = _model.method(_validate_sym)
+  _validator_validate  = _validator.method(_validate_sym)
+
+  let(:validator)     { _validator }
+  let(:validate)      { _validator_validate }
+
+  case _type
+  when :item
+    _tuples_num  = 3
+    _arg_name    = :item
+    _return_type = Array
+  when :hash
+    _tuples_num  = 1
+    _arg_name    = :hash
+    _return_type = Hash
+  when :flat_array
+    _tuples_num  = 1
+    _arg_name    = :array
+    _return_type = Array
+  when :item_array
+    _tuples_num  = 1
+    _arg_name    = :array
+    _return_type = Array
+  else
+    raise ArgumentError, "unsupported type: #{_type}"
+  end
+
+  let(:return_type) { _return_type }
+
+  _params[:valid_samples].each do |_sample|
+    _tuples = [ [_sample], [_sample,0], [_sample,0,1] ][0,_tuples_num]
+    _tuples.each do |_arguments|
+      _sample,*_indices = _arguments
+      _arguments_str = _arguments.map{|x| x.inspect}.join(',')
+      # note, if the following command raises an exception (saying "invalid
+      # key/value/item") then either valid_samples are not valid in fact, or
+      # your `:model` object miss-behaves)
+      _return_value = _model_validate.call(*_arguments)
+      _return_size  = _sample.length
+      context "##{_validate_sym}(#{_arguments_str}) [#{_arg_name} valid]" do
+        let(:sample)       { _sample }
+        let(:arguments)    { _arguments }
+        let(:return_value) { _return_value }
+        let(:return_size)  { _return_size }
+        let(:expect_calls) { _expect_calls }
+        it { expect { validate.call(*arguments) }.to_not raise_error }
+        it { validate.call(*arguments).should be_an return_type }
+        it "size of the returned #{_return_type} should be #{_return_size}" do
+          validate.call(*arguments).size.should == return_size
+        end
+        it { validate.call(*arguments).should == return_value }
+      end
+    end
+  end
+
+  _params[:invalid_samples].each do |_sample, _guilty|
+    _g_type, _g_item, _g_indices = _guilty
+    _g_type = _g_type.intern
+    _tuples = [ [_sample], [_sample,0], [_sample,0,1]  ][0, _tuples_num]
+    _tuples.each do |_arguments|
+      if _type == :item
+        _g_item, *_g_indices = _arguments
+      end
+      _except = _model.method("vash_#{_g_type}_exception".intern)
+      _select = _model.method("vash_select_#{_g_type}_args".intern)
+      _g_args = case _g_type
+                when :pair
+                  _key = _model.vash_munge_key(_g_item[0])
+                  _val = _model.vash_munge_value(_g_item[1])
+                  _select.call([_key,_val],*_g_indices)
+                else
+                  _select.call(_g_item,*_g_indices)
+                end
+      _err, _msg = _except.call(*_g_args)
+      _arguments_str = _arguments.map{|x| x.inspect}.join(',')
+      context "##{_validate_sym}(#{_arguments_str}) [invalid #{_g_type}=#{_g_args[0].inspect}]" do
+        let (:err)       { _err }
+        let (:msg)       { _msg }
+        let (:arguments) { _arguments }
+        if _params[:custom_exception]
+          it { expect { validate.call(*arguments) }.to raise_error ArgumentError }
+        else
+          it { expect { validate.call(*arguments) }.to raise_error err, msg }
+        end
+      end
+    end
+  end
+end
+
+##############################################################################
+# Test all methods of Puppet::Util::Vash::Validator.
+#
+# This is unit test for Puppet::Util::Vash::Validator, but may be
+# used to test customized validators as well. The basic usage is
+#
+#     require 'shared_behaviours/vash/validator'
+#     # ...
+#     include_examples 'Vash::Validator', _params
+#
+# when testing Puppet::Util::Vash::Validator, or
+#
+#     require 'shared_behaviours/vash/validator'
+#     # ...
+#     it_behaves_like 'Vash::Validator', _params
+#
+# An example of both - original and customized validators may be found in
+# `spec/unit/util/vash/validator_spec.rb`.
+#
+# Options (all optional):
+#
+#   * `:valid_keys`    - sample keys, that must be accepted by key validator,
+#   * `:invalid_keys`  - sample keys, that must be rejected by key validator,
+#   * `:valid_pairs`   - sample pairs, that must be accepted by pair validator,
+#   * `:invalid_pairs` - sample pairs, that must be rejected by pair validator,
+#   * `:valid_items`   - sample items, that must be accepted by all validators
+#     in the chain,
+#   * `:invalid_items` - sample items, that must be rejected by one of the
+#     validators inthe chain, the array contains information which validator
+#     should reject given item,
+#   * `:methods`      - procs/lambdas that indicate customization of the
+#     default behaviour,
+#   * `:model_class` - a class that indicates the desired behaviour, it
+#     should have all the methods of `Vash::Validator` implemented,
+#     and then these examples will check behaviour of the `described_class`
+#     against the `:model`,
+##############################################################################
+shared_examples 'Vash::Validator' do |_params|
+  _params = _params.dup
+  model_class     = (_params.delete(:model_class) ||
+                     Puppet::SharedBehaviours::Vash::Validator).dup
+  # inject custom methods to the model
+  (_params.delete(:methods) || []).each do |_method, _proc|
+    model_class.send(:define_method, _method.intern, _proc)
+  end
+
+  let!(:subject) { described_class.new }
+
+  it { should respond_to :vash_valid_key? }
+  it { should respond_to :vash_valid_value? }
+  it { should respond_to :vash_valid_pair? }
+  it { should respond_to :vash_munge_key }
+  it { should respond_to :vash_munge_value }
+  it { should respond_to :vash_munge_pair }
+  it { should respond_to :vash_key_name }
+  it { should respond_to :vash_value_name }
+  it { should respond_to :vash_pair_name }
+  it { should respond_to :vash_validate_key }
+  it { should respond_to :vash_validate_value }
+  it { should respond_to :vash_validate_pair }
+  it { should respond_to :vash_validate_item }
+  it { should respond_to :vash_validate_hash }
+  it { should respond_to :vash_validate_flat_array }
+  it { should respond_to :vash_validate_item_array }
+  it { should respond_to :vash_key_exception }
+  it { should respond_to :vash_value_exception }
+  it { should respond_to :vash_pair_exception }
+  it { should respond_to :vash_select_key_args }
+  it { should respond_to :vash_select_value_args }
+
+
+  ######################################
+  # specs for:
+  #   vash_valid_key?,
+  #   vash_valid_value?,
+  #   vash_valid_pair?
+  #
+  [:key, :value, :pair].each do |_type|
+    _method = "vash_valid_#{_type}?".intern
+    describe "##{_method}(#{_type})" do
+      include_examples "Vash::Validator#vash_valid_single?", {
+        :type            => _type,
+        :validator       => described_class.new,
+        :valid_samples   => _params["valid_#{_type}s".intern] || [],
+        :invalid_samples => _params["invalid_#{_type}s".intern] || []
+      }.merge(_params[_method] || {})
+    end
+  end
+
+
+  ######################################
+  # specs for:
+  #   vash_munge_key,
+  #   vash_munge_value,
+  #   vash_munge_pair
+  #
+  [:key, :value, :pair].each do |_type|
+    _method = "vash_munge_#{_type}".intern
+    describe "##{_method}(#{_type})" do
+      include_examples "Vash::Validator#vash_munge_single", {
+        :type      => _type,
+        :validator => described_class.new,
+        :model     => model_class.new,
+        :samples   => _params["#{_type}_munge_samples".intern] || []
+      }.merge(_params[_method] || {})
+    end
+  end
+
+  ######################################
+  # specs for:
+  #   vash__key_name,
+  #   vash_value_name,
+  #   vash_pair_name,
+  #   vash__key_exception,
+  #   vash_value_exception,
+  #   vash_pair_exception,
+  #
+  [
+    [:key,   :a],
+    [:value, :A],
+    [:pair,  [:a,:A]]
+  ].each do |_type,_proto|
+    _samples  = (_params["valid_#{_type}s".intern] || [])[0,1]
+    _samples += (_params["invalid_#{_type}s".intern] || [])[0,1]
+    _samples  = [_proto] if _samples.empty? # generate at least one test!
+
+    [:name, :exception].each do |_what|
+      _method      = "vash_#{_type}_#{_what}".intern
+      _tuples      = _params["#{_method}_tuples".intern]
+      describe "##{_method}(*args)" do
+        include_examples 'Vash::Validator#vash_single_name_or_exception', {
+          :type       => _type,
+          :what       => _what,
+          :validator  => described_class.new,
+          :model      => model_class.new,
+          :samples    => (_tuples ? nil : _samples),
+          :tuples     => _tuples,
+        }.merge(_params[_method] || {})
+      end
+    end
+  end
+
+  ######################################
+  # specs for:
+  #   vash_validate_key,
+  #   vash_validate_value,
+  #   vash_validate_pair
+  #
+  [:key, :value, :pair].each do |_type|
+    _method = "vash_validate_#{_type}"
+    describe "##{_method}(#{_type},*args)" do
+      include_examples 'Vash::Validator#vash_validate_single', {
+        :type            => _type,
+        :validator       => described_class.new,
+        :model           => model_class.new,
+        :valid_samples   => _params["valid_#{_type}s".intern] || [],
+        :invalid_samples => _params["invalid_#{_type}s".intern] || []
+      }.merge(_params[_method] || {})
+    end
+  end
+
+
+  ######################################
+  # specs for:
+  #   vash_validate_item,
+  #   vash_validate_hash,
+  #   vash_validate_flat_array,
+  #   vash_validate_item_array,
+  #
+  [ :item, :hash, :flat_array, :item_array ].each do |_type|
+    _method = "vash_validate_#{_type}"
+    case _type
+    when :item
+      _valid_samples   = _params[:valid_items] || []
+      _invalid_samples = _params[:invalid_items] || []
+    when :hash
+      _valid_samples = [ Hash[ _params[:valid_items] || [] ] ]
+      _invalid_samples = (_params[:invalid_items] || []).map {|_item, _guilty|
+        [ _valid_samples[0].merge(Hash[ [_item] ]), [_guilty,_item,[]] ]
+      }
+    when :flat_array
+      _valid_samples = [ (_params[:valid_items] || []).flatten ]
+      _len = _valid_samples[0].length
+      _invalid_samples = (_params[:invalid_items] || []).map {|_item, _guilty|
+        [ (_valid_samples[0] + [_item]).flatten, [_guilty, _item, [_len,_len+1] ] ]
+      }
+    when :item_array
+      _valid_samples = [ _params[:valid_items] || [] ]
+      _len = _valid_samples[0].length
+      _invalid_samples = (_params[:invalid_items] || []).map {|_item, _guilty|
+        [ _valid_samples[0] + [_item], [_guilty, _item, [_len]] ]
+      }
+    else
+      raise NotImplementedError, "#{_type} case is not implemented!"
+    end
+    describe "##{_method}" do
+      include_examples 'Vash::Validator#vash_validate_input', {
+        :type            => _type,
+        :validator       => described_class.new,
+        :model           => model_class.new,
+        :valid_samples   => _valid_samples,
+        :invalid_samples => _invalid_samples,
+      }.merge(_params[_method] || {})
+    end
+  end
+
+end

--- a/spec/unit/util/vash/class_methods_spec.rb
+++ b/spec/unit/util/vash/class_methods_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+require 'puppet/util/vash/class_methods'
+
+describe Puppet::Util::Vash::ClassMethods do
+  ClassMethods =  Puppet::Util::Vash::ClassMethods
+
+  subject do
+    Class.new do
+      extend ClassMethods
+      def self.to_s; 'TestClass'; end
+    end
+  end
+  it { should respond_to :[] }
+
+  describe "#[]" do
+
+    let!(:obj) { mock('<Vash>') }
+    let!(:subject) do
+      Class.new do
+        extend ClassMethods
+        def self.to_s; 'TestClass'; end
+      end
+    end
+    before(:each) do
+      subject.expects(:new).once.with().returns(obj)
+    end
+
+    context "with no arguments" do
+      it "should not raise errors" do
+        expect { subject[] }.to_not raise_error
+      end
+      it "should return object created with new()" do
+        subject[].should be obj
+      end
+    end
+
+    context "#['a','A','b','B']" do
+      let(:input) {['a', 'A', 'b', 'B']}
+      it "should not raise errors, provided #replace_with_flat_array exists" do
+        obj.stubs(:replace_with_flat_array)
+        expect { subject[*input] }.to_not raise_error
+      end
+      it "should return hash = new() with hash.replace_with_flat_array called once" do
+        obj.expects(:replace_with_flat_array).once.with(input)
+        subject[*input].should be obj
+      end
+    end
+
+    context "#[ [['a','A'], ['b','B']] ]" do
+      let(:input) { [ ['a','A'], ['b','B'] ] }
+      it "should not raise errors, provided #replace_with_item_array exists" do
+        obj.stubs(:replace_with_item_array)
+        expect { subject[input] }.to_not raise_error
+      end
+      it "should return obj = new() with obj.replace_with_item_array called once" do
+        obj.expects(:replace_with_item_array).once.with(input)
+        subject[input].should be obj
+      end
+    end
+
+    context "#[ {'a'=>'A','b'=>'B'} ]" do
+      let(:input) { {'a'=>'A','b'=>'B'} }
+      it "should not raise errors, provided #repalce exists" do
+        obj.stubs(:replace)
+        expect { subject[input] }.to_not raise_error
+      end
+      it "should return obj = new() with obj.replace called once" do
+        obj.expects(:replace).once.with(input)
+        subject[input].should be obj
+      end
+    end
+
+    context "#[:symbol]" do
+      let(:input) { :symbol }
+      it "should not raise errors by its own, provided #replace exists" do
+        obj.stubs(:replace)
+        Hash.stubs(:[]).with(input)
+        expect { subject[input]}.to_not raise_error
+      end
+      it "Hash should raise ArgumentError with message 'odd number of arguments'" do
+        obj.stubs(:replace)
+        expect { subject[input] }.
+          to raise_error ArgumentError, /odd number of arguments/
+      end
+      it "should return obj=new() with obj.replace(Hash[:symbol]) called once" do
+        Hash.stubs(:[]).with(input)
+        obj.expects(:replace).once.with(Hash[input])
+        subject[input].should be obj
+      end
+    end
+  end
+end

--- a/spec/unit/util/vash/contained_spec.rb
+++ b/spec/unit/util/vash/contained_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'puppet/util/vash/contained'
+require 'shared_behaviours/vash/contained'
+
+class Vash_Contained
+  include Puppet::Util::Vash::Contained
+  def self.to_s; 'Vash::Contained'; end
+  # accept only valid identifiers as keys
+  def vash_valid_key?(key)
+    key.is_a?(String) and (key=~/^[a-zA-Z]\w*$/)
+  end
+  # accept only what is convertible to integer
+  def vash_valid_value?(val)
+    true if Integer(val) rescue false
+  end
+  def vash_munge_key(key)
+    key.gsub(/([a-z])([A-Z])/,'\1_\2').downcase
+  end
+  def vash_munge_value(val)
+    Integer(val)
+  end
+  # for keys ending with _price we accept only non-negative values
+  def vash_valid_pair?(pair)
+    (pair[0]=~/price$/) ? (pair[1]>=0) : true
+  end
+  def vash_munge_pair(pair)
+    [pair[0] + pair[1].to_s, pair[1]]
+  end
+end
+
+# VASH_UNCOMMENT_START
+# By default it's disabled in puppet distribution, as the number of tests
+# generated here plus other puppet tests is able to kill CI systems (this was
+# observed at least on travis-ci.org on ruby 1.8). 
+if ENV['PUPPET_TEST_VASH'] or ENV['PUPPET_TEST_ALL']
+# VASH_UNCOMMENT_END
+  describe Vash_Contained do
+    it_behaves_like 'Vash::Contained', {
+      :valid_keys     => ['one', 'net_price', 'GrossPrice'],
+      :invalid_keys   => [:one, 1, '#$', '' ],
+      :valid_items    => [ ['a',1], ['b','2'] ],
+      :invalid_items  => [
+                           [ ['',      1],     :key],
+                           [ ['price', 'one'], :value],
+                           [ ['NetPrice', -1], :pair]
+                         ],
+      :hash_arguments => [
+                           {'a'=>2, 'b'=>'-1'},   # all valid,
+                           {:x =>0, 'x'=> '1'},   # invalid key
+                           {'x'=>2, 'y'=> nil},   # invalid value,
+                           {'thePrice'=>-1}       # invalid pair
+                         ],
+      :missing_key    => 'c',
+      :missing_value  => '4',
+      :methods        => {
+        :vash_valid_key?   => lambda {|key| key.is_a?(String) and (key=~/^[a-zA-Z]\w*$/)},
+        :vash_valid_value? => lambda {|val| true if Integer(val) rescue false },
+        :vash_valid_pair?  => lambda {|pair| (pair[0]=~/price$/) ? (pair[1]>=0) : true},
+        :vash_munge_key    => lambda {|key| key.gsub(/([a-z])([A-Z])/,'\1_\2').downcase},
+        :vash_munge_value  => lambda {|val| Integer(val)},
+        :vash_munge_pair   => lambda {|pair| [pair[0] + pair[1].to_s, pair[1]]}
+      }
+    }
+  end
+# VASH_UNCOMMENT_START
+end
+# VASH_UNCOMMENT_END

--- a/spec/unit/util/vash/inherited_spec.rb
+++ b/spec/unit/util/vash/inherited_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'puppet/util/vash/inherited'
+require 'shared_behaviours/vash/inherited'
+
+class Vash_Inherited < Hash
+  include Puppet::Util::Vash::Inherited
+  def self.to_s; 'Vash::Inherited'; end
+  # accept only valid identifiers as keys
+  def vash_valid_key?(key)
+    key.is_a?(String) and (key=~/^[a-zA-Z]\w*$/)
+  end
+  # accept only what is convertible to integer
+  def vash_valid_value?(val)
+    true if Integer(val) rescue false
+  end
+  def vash_munge_key(key)
+    key.gsub(/([a-z])([A-Z])/,'\1_\2').downcase
+  end
+  def vash_munge_value(val)
+    Integer(val)
+  end
+  # for keys ending with _price we accept only non-negative values
+  def vash_valid_pair?(pair)
+    (pair[0]=~/price$/) ? (pair[1]>=0) : true
+  end
+  def vash_munge_pair(pair)
+    [pair[0] + pair[1].to_s, pair[1]]
+  end
+end
+
+# VASH_UNCOMMENT_START
+# By default it's disabled in puppet distribution, as the number of tests
+# generated here plus other puppet tests is able to kill CI systems (this was
+# observed at least on travis-ci.org on ruby 1.8). 
+if ENV['PUPPET_TEST_VASH'] or ENV['PUPPET_TEST_ALL']
+# VASH_UNCOMMENT_END
+  describe Vash_Inherited do
+    it_behaves_like 'Vash::Inherited', {
+      :valid_keys     => ['one', 'net_price', 'GrossPrice'],
+      :invalid_keys   => [:one, 1, '#$', '' ],
+      :valid_items    => [ ['a',1], ['b','2'] ],
+      :invalid_items  => [
+                           [ ['',      1],     :key],
+                           [ ['price', 'one'], :value],
+                           [ ['NetPrice', -1], :pair]
+                         ],
+      :hash_arguments => [
+                           {'a'=>2, 'b'=>'-1'},   # all valid,
+                           {:x =>0, 'x'=> '1'},   # invalid key
+                           {'x'=>2, 'y'=> nil},   # invalid value,
+                           {'thePrice'=>-1}       # invalid pair
+                         ],
+      :missing_key    => 'c',
+      :missing_value  => '4',
+      :methods        => {
+        :vash_valid_key?   => lambda {|key| key.is_a?(String) and (key=~/^[a-zA-Z]\w*$/)},
+        :vash_valid_value? => lambda {|val| true if Integer(val) rescue false },
+        :vash_valid_pair?  => lambda {|pair| (pair[0]=~/price$/) ? (pair[1]>=0) : true},
+        :vash_munge_key    => lambda {|key| key.gsub(/([a-z])([A-Z])/,'\1_\2').downcase},
+        :vash_munge_value  => lambda {|val| Integer(val)},
+        :vash_munge_pair   => lambda {|pair| [pair[0] + pair[1].to_s, pair[1]]}
+      }
+    }
+  end
+# VASH_UNCOMMENT_START
+end
+# VASH_UNCOMMENT_END

--- a/spec/unit/util/vash/validator_spec.rb
+++ b/spec/unit/util/vash/validator_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'puppet/util/vash/validator'
+require 'shared_behaviours/vash/validator'
+
+class Vash_Validator_Unmodified
+  include Puppet::Util::Vash::Validator
+  def self.to_s; 'Vash::Validator[original]'; end
+end
+
+describe Vash_Validator_Unmodified do
+  include_examples "Vash::Validator", { }
+end
+
+# sample hash which accepts integers or strings convertible to integers as an
+# input, and ensures the relation value = key*key.
+class Vash_Validator_Customized
+  include Puppet::Util::Vash::Validator
+  def self.to_s; 'Vash::Validator[customized]'; end
+  # Choose to have our own names for keys, values and pairs.
+  def vash_key_name(*args); 'power argument'; end
+  def vash_value_name(*args); 'power value'; end
+  def vash_pair_name(*args); 'power tuple'; end
+  # Define constraints on keys, values and tuples
+  def vash_valid_key?(key); true if Integer(key) rescue false; end
+  def vash_valid_value?(val); true if Integer(val) rescue false; end
+  def vash_valid_pair?(pair); pair[1] == pair[0]*pair[0]; end
+  # Define our munging (consistent with validation)
+  def vash_munge_key(key); Integer(key); end
+  def vash_munge_value(val); Integer(val); end
+  def vash_munge_pair(pair); pair.sort; end
+end
+
+# VASH_UNCOMMENT_START
+# By default it's disabled in puppet distribution, as the number of tests
+# generated here plus other puppet tests is able to kill CI systems (this was
+# observed at least on travis-ci.org on ruby 1.8). 
+if ENV['PUPPET_TEST_VASH'] or ENV['PUPPET_TEST_ALL']
+# VASH_UNCOMMENT_END
+  describe Vash_Validator_Customized do
+    it_behaves_like "Vash::Validator", {
+      :valid_keys          => [  0,  -1,'-1', 0.2 ],
+      :invalid_keys        => [ 'a', {}, [1] ],
+      :valid_values        => [  0,  -1,'-1', 0.2 ],
+      :invalid_values      => [ 'a', {}, [1] ],
+      :valid_pairs         => [ [1,1], [2,4], [3,9] ],
+      :invalid_pairs       => [ [1,2], [2,1] ],
+      :valid_items         => [ [2,4], ['3','9'] ],
+      :invalid_items       => [
+                                [ ['a', 0 ], :key   ],
+                                [ ['a','A'], :key   ],
+                                [ [ 0, 'A'], :value ],
+                                [ [ 1,  2 ], :pair  ],
+                                [ ['1','2'], :pair  ],
+                              ],
+      :key_munge_samples   => ['1', 1.1, 2],
+      :value_munge_samples => ['1', 1.1, 2],
+      :pair_munge_samples  => [[1,2], [4,3]],
+      :methods             => {
+        :vash_key_name     => lambda {|*args| 'power argument'},
+        :vash_value_name   => lambda {|*args| 'power value'},
+        :vash_pair_name    => lambda {|*args| 'power tuple'},
+        :vash_munge_key    => lambda {|key| Integer(key)},
+        :vash_munge_value  => lambda {|val| Integer(val)},
+        :vash_munge_pair   => lambda {|pair| pair.sort}
+      }
+    }
+  end
+# VASH_UNCOMMENT_START
+end
+# VASH_UNCOMMENT_END


### PR DESCRIPTION
I've split PR #2130 into several parts. This is one of them.

This PR adds a "Vash" container to puppet utilities. Vash is an acronym for 'Validating Hash'. It's a mixin which turns the receiving class into special hash that validate and munge keys and values as they enter the hash.

Vash was originally developed as a separate module [ptomulik-vash](https://github.com/ptomulik/puppet-vash), and you can find modules' documentation there.

The specs for Vash are disabled by default, because it generates too much of test cases (on ruby 1.8 travis fails to load all the test cases, that is these plus puppets' 19.000+ test cases). If youre going to run specs on another VM, you may re-enable vash specs as follows

```
    PUPPET_TEST_VASH=1 bundle exec rake spec
```

or

```
    PUPPET_TEST_ALL=1 bundle exec rake spec
```
