### PR TITLE
(PUP-736) Remove Description From RPM/DPKG

### DIFF
--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -28,9 +28,11 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
 
     # list out all of the packages
     dpkgquery_piped('-W', '--showformat', self::DPKG_QUERY_FORMAT_STRING) do |pipe|
-      until pipe.eof?
-        hash = parse_multi_line(pipe)
-        packages << new(hash) if hash
+      # now turn each returned line into a package object
+      pipe.each_line do |line|
+        if hash = parse_line(line)
+          packages << new(hash)
+        end
       end
     end
 
@@ -41,33 +43,9 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
 
   # Note: self:: is required here to keep these constants in the context of what will
   # eventually become this Puppet::Type::Package::ProviderDpkg class.
-  self::DPKG_DESCRIPTION_DELIMITER = ':DESC:'
-  self::DPKG_QUERY_FORMAT_STRING = %Q{'${Status} ${Package} ${Version} #{self::DPKG_DESCRIPTION_DELIMITER} ${Description}\\n#{self::DPKG_DESCRIPTION_DELIMITER}\\n'}
-  self::FIELDS_REGEX = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*) #{self::DPKG_DESCRIPTION_DELIMITER} (.*)$}
-  self::DPKG_PACKAGE_NOT_FOUND_REGEX = /no package.*match/i
-  self::FIELDS= [:desired, :error, :status, :name, :ensure, :description]
-  self::END_REGEX = %r{^#{self::DPKG_DESCRIPTION_DELIMITER}$}
-
-  # Handles parsing one package's worth of multi-line dpkg-query output.  Will
-  # emit warnings if it encounters an initial line that does not match
-  # DPKG_QUERY_FORMAT_STRING.  Swallows extra description lines silently.
-  #
-  # @param pipe [IO] the pipe yielded while processing dpkg output
-  # @return [Hash,nil] parsed dpkg-query entry as a hash of FIELDS strings or
-  # nil if we failed to parse
-  # @api private
-  def self.parse_multi_line(pipe)
-
-    line = pipe.gets
-    unless hash = parse_line(line)
-      Puppet.warning "Failed to match dpkg-query line #{line.inspect}" if !self::DPKG_PACKAGE_NOT_FOUND_REGEX.match(line)
-      return nil
-    end
-
-    consume_excess_description(pipe)
-
-    return hash
-  end
+  self::DPKG_QUERY_FORMAT_STRING = %Q{'${Status} ${Package} ${Version}\\n'}
+  self::FIELDS_REGEX = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*)$}
+  self::FIELDS= [:desired, :error, :status, :name, :ensure]
 
   # @param line [String] one line of dpkg-query output
   # @return [Hash,nil] a hash of FIELDS or nil if we failed to match
@@ -93,26 +71,6 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     end
 
     return hash
-  end
-
-  # Silently consumes the extra description lines from dpkg-query and brings
-  # us to the next package entry start.
-  #
-  # @note dpkg-query Description field has a one line summary and a multi-line
-  # description.  dpkg-query binary:Summary is what we want to use but was
-  # introduced in 2012 dpkg 1.16.2
-  # (https://launchpad.net/debian/+source/dpkg/1.16.2) and is not not available
-  # in older Debian versions.  So we're placing a delimiter marker at the end
-  # of the description so we can consume and ignore the multiline description
-  # without issuing warnings
-  #
-  # @param pipe [IO] the pipe yielded while processing dpkg output
-  # @return nil
-  def self.consume_excess_description(pipe)
-    until pipe.eof?
-      break if self::END_REGEX.match(pipe.gets)
-    end
-    return nil
   end
 
   public
@@ -160,7 +118,8 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
         self.class::DPKG_QUERY_FORMAT_STRING,
         @resource[:name]
       ) do |pipe|
-        hash = self.class.parse_multi_line(pipe)
+        line = pipe.gets
+        hash = self.class.parse_line(line)
       end
     rescue Puppet::ExecutionFailure
       # dpkg-query exits 1 if the package is not found.

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -16,12 +16,11 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
 
   # Note: self:: is required here to keep these constants in the context of what will
   # eventually become this Puppet::Type::Package::ProviderRpm class.
-  self::RPM_DESCRIPTION_DELIMITER = ':DESC:'
   # The query format by which we identify installed packages
-  self::NEVRA_FORMAT = %Q{%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH} #{self::RPM_DESCRIPTION_DELIMITER} %{SUMMARY}\\n}
-  self::NEVRA_REGEX  = %r{^(\S+) (\S+) (\S+) (\S+) (\S+)(?: #{self::RPM_DESCRIPTION_DELIMITER} ?(.*))?$}
+  self::NEVRA_FORMAT = %Q{%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\\n}
+  self::NEVRA_REGEX  = %r{^(\S+) (\S+) (\S+) (\S+) (\S+)$}
   self::RPM_PACKAGE_NOT_FOUND_REGEX = /package .+ is not installed/
-  self::NEVRA_FIELDS = [:name, :epoch, :version, :release, :arch, :description]
+  self::NEVRA_FIELDS = [:name, :epoch, :version, :release, :arch]
 
   commands :rpm => "rpm"
 

--- a/spec/unit/provider/package/aptitude_spec.rb
+++ b/spec/unit/provider/package/aptitude_spec.rb
@@ -14,12 +14,12 @@ describe Puppet::Type.type(:package).provider(:aptitude) do
       described_class.stubs(:command).with(:dpkgquery).returns 'myquery'
     end
 
-    { :absent   => "deinstall ok config-files faff 1.2.3-1 :DESC: faff summary\n:DESC:\n",
-      "1.2.3-1" => "install ok installed faff 1.2.3-1 :DESC: faff summary\n:DESC:\n",
+    { :absent   => "deinstall ok config-files faff 1.2.3-1\n",
+      "1.2.3-1" => "install ok installed faff 1.2.3-1\n",
     }.each do |expect, output|
       it "should detect #{expect} packages" do
         Puppet::Util::Execution.expects(:execpipe).
-          with(['myquery', '-W', '--showformat', "'${Status} ${Package} ${Version} :DESC: ${Description}\\n:DESC:\\n'", 'faff']).
+          with(['myquery', '-W', '--showformat', "'${Status} ${Package} ${Version}\\n'", 'faff']).
           yields(StringIO.new(output))
 
         pkg.property(:ensure).retrieve.should == expect

--- a/spec/unit/provider/package/aptrpm_spec.rb
+++ b/spec/unit/provider/package/aptrpm_spec.rb
@@ -19,7 +19,7 @@ describe Puppet::Type.type(:package).provider(:aptrpm) do
     def rpm
       pkg.provider.expects(:rpm).
         with('-q', 'faff', '--nosignature', '--nodigest', '--qf',
-             "%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH} :DESC: %{SUMMARY}\\n")
+             "%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\\n")
     end
 
     it "should report absent packages" do
@@ -28,7 +28,7 @@ describe Puppet::Type.type(:package).provider(:aptrpm) do
     end
 
     it "should report present packages correctly" do
-      rpm.returns("faff-1.2.3-1 0 1.2.3-1 5 i686 :DESC: faff desc\n")
+      rpm.returns("faff-1.2.3-1 0 1.2.3-1 5 i686\n")
       pkg.property(:ensure).retrieve.should == "1.2.3-1-5"
     end
   end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -114,11 +114,11 @@ describe provider do
 
     let(:packages) do
       <<-RPM_OUTPUT
-      cracklib-dicts 0 2.8.9 3.3 x86_64 :DESC: The standard CrackLib dictionaries
-      basesystem 0 8.0 5.1.1.el5.centos noarch :DESC: The skeleton package which defines a simple Red Hat Enterprise Linux system
-      chkconfig 0 1.3.30.2 2.el5 x86_64 :DESC: A system tool for maintaining the /etc/rc*.d hierarchy
-      myresource 0 1.2.3.4 5.el4 noarch :DESC: Now with summary
-      mysummaryless 0 1.2.3.4 5.el4 noarch :DESC:
+      cracklib-dicts 0 2.8.9 3.3 x86_64
+      basesystem 0 8.0 5.1.1.el5.centos noarch
+      chkconfig 0 1.3.30.2 2.el5 x86_64
+      myresource 0 1.2.3.4 5.el4 noarch
+      mysummaryless 0 1.2.3.4 5.el4 noarch
       RPM_OUTPUT
     end
 
@@ -187,7 +187,6 @@ _pkg mysummaryless 0 1.2.3.4 5.el4 noarch
         :version=>"1.2.3.4",
         :release=>"5.el4",
         :arch=>"noarch",
-        :description=>nil,
         :provider=>:yum,
         :ensure=>"1.2.3.4-5.el4"
       })


### PR DESCRIPTION
Encoding mis-match causes package prefetching to fail with
'invalid byte sequence in US-ASCII'. The guidelines for the
Debian Project [1](http://www.debian.org/doc/debian-policy/ch-controlfields.html) and the Fedora Project [2](http://fedoraproject.org/wiki/Packaging:Guidelines#Encoding) specify that
metadata files should be UTF-8 encoded, but it is not
enforced.

Since we are not able to force encoding "UTF-8" to work around
this we have decided to back out the description from package
formats for now while working on a longer term solution for
encoding.

Without this fix the package formats fail if there is a package
with UTF-8 encoding in the description.

Paired with Josh Partlow joshua.partlow@puppetlabs.com
