### PR TITLE
ensure Puppet::Util::Execution.execpipe always run the command with LANG...

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -66,8 +66,15 @@ module Puppet::Util::Execution
       Puppet.debug "Executing '#{command_str}'"
     end
 
-    output = open("| #{command_str} 2>&1") do |pipe|
-      yield pipe
+    # force the run of the command with 
+    # the user/system locale to "C" (via environment variables LANG and LC_*)
+    # it enables to have non localized output for some commands and therefore
+    # a predictable output
+    english_env = ENV.to_hash.merge( {'LANG' => 'C', 'LC_ALL' => 'C'} )
+    output = Puppet::Util.withenv(english_env) do
+      open("| #{command_str} 2>&1") do |pipe|
+        yield pipe
+      end
     end
 
     if failonfail


### PR DESCRIPTION
...="C" and LC_ALL="C" to avoid localized output

This a more generic fix than the one made here: https://github.com/puppetlabs/puppet/pull/2198
With this fix, no more annoying message on french environment (and other non-english machines)

It solves the following ticket: https://tickets.puppetlabs.com/browse/PUP-1401
Sorry for not knowing how to link JIRA ticket and github PR.

all rspec tests are running OK on my machine.
