### PR TITLE
Add ability to override default system confdir and vardir

### DIFF
--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -18,6 +18,23 @@ module Puppet
         end
       end
 
+      ##
+      # Provide the full path of an override file to third parties in order to
+      # allow them to easily override a default value for a specific puppet
+      # installation.  The purpose of this API call is to provide one place
+      # where override file pathes are constructed and expose the path to third
+      # parties.
+      #
+      # @param [String] type The type of override to construct a path for, e.g.
+      #   "confdir" or "vardir"
+      #
+      # @api public
+      #
+      # @return [String] the full path for the specified override file
+      def self.override_path(type)
+        File.join(File.dirname(__FILE__), "default_system_#{type}.override")
+      end
+
       def master?
         name == :master
       end
@@ -41,6 +58,55 @@ module Puppet
       private
 
       ##
+      # Return the path of an overriden default confdir
+      #
+      # @return [String, false] if there is an override return the string path.
+      #   if there is no override return false.
+      def system_confdir_override
+        if @system_confdir_override.nil?
+          @system_confdir_override = read_override("confdir")
+        else
+          @system_confdir_override
+        end
+      end
+
+      ##
+      # Return the path of an overriden default vardir
+      #
+      # @return [String, false] if there is an override return the string path.
+      #   if there is no override return false.
+      def system_vardir_override
+        if @system_vardir_override.nil?
+          @system_vardir_override = read_override("vardir")
+        else
+          @system_vardir_override
+        end
+      end
+
+      ##
+      # Read an override file if able or return false.  The file read is named
+      # `"default_#{type}_dir"` in the same folder as this source file at
+      # runtime.
+      #
+      # The contents of the file are expected to be a fully qualified path.
+      # For example, "/etc/puppetlabs/puppet" or "/var/lib/operations/puppet"
+      # for confdir and vardir respectively.
+      #
+      # @param [String] type The type of default override to read, e.g. "confdir"
+      #   or "vardir"
+      #
+      # @return [String, false] if readable return the first line without the
+      #   newline.  if not readable return false.
+      def read_override(type)
+        override_file = Pathname.new(self.class.override_path(type))
+        if override_file.readable?
+          File.open(override_file, 'r') {|f| f.readline.chomp}
+        else
+          false
+        end
+      end
+
+      ##
       # select the system or the user directory depending on the context of
       # this process.  The most common use is determining filesystem path
       # values for confdir and vardir.  The intended semantics are:
@@ -49,27 +115,43 @@ module Puppet
       # @todo this code duplicates {Puppet::Settings#which\_configuration\_file}
       #   as described in {http://projects.puppetlabs.com/issues/16637 #16637}
       def which_dir( system, user )
-        File.expand_path(if Puppet.features.root? then system else user end)
+        if Puppet.features.root?
+          File.expand_path(system)
+        else
+          File.expand_path(user)
+        end
       end
     end
 
     class UnixRunMode < RunMode
       def conf_dir
-        which_dir("/etc/puppet", "~/.puppet")
+        system_conf_dir = system_confdir_override || "/etc/puppet"
+        which_dir(system_conf_dir, "~/.puppet")
       end
 
       def var_dir
-        which_dir("/var/lib/puppet", "~/.puppet/var")
+        system_var_dir = system_vardir_override || "/var/lib/puppet"
+        which_dir(system_var_dir, "~/.puppet/var")
       end
     end
 
     class WindowsRunMode < RunMode
       def conf_dir
-        which_dir(File.join(windows_common_base("etc")), "~/.puppet")
+        if system_confdir_override
+          system_conf_dir = system_confdir_override
+        else
+          system_conf_dir = File.join(windows_common_base("etc"))
+        end
+        which_dir(system_conf_dir, "~/.puppet")
       end
 
       def var_dir
-        which_dir(File.join(windows_common_base("var")), "~/.puppet/var")
+        if system_vardir_override
+          system_var_dir = system_vardir_override
+        else
+          system_var_dir = File.join(windows_common_base("var"))
+        end
+        which_dir(system_var_dir, "~/.puppet/var")
       end
 
     private

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -6,6 +6,15 @@ describe Puppet::Util::RunMode do
     @run_mode = Puppet::Util::RunMode.new('fake')
   end
 
+  describe ".override_path (public API)" do
+    it "provides the path to a confdir override file" do
+      described_class.override_path('confdir').should match %r{lib/puppet/util/default_system_confdir\.override$}
+    end
+    it "provides the path to a vardir override file" do
+      described_class.override_path('vardir').should match %r{lib/puppet/util/default_system_vardir\.override$}
+    end
+  end
+
   it "has rundir depend on vardir" do
     @run_mode.run_dir.should == '$vardir/run'
   end
@@ -17,7 +26,13 @@ describe Puppet::Util::RunMode do
 
     describe "#conf_dir" do
       it "has confdir /etc/puppet when run as root" do
+        @run_mode.stubs(:system_confdir_override).returns(false)
         as_root { @run_mode.conf_dir.should == File.expand_path('/etc/puppet') }
+      end
+
+      it "has confdir of the value returned by the override file when run as root" do
+        @run_mode.stubs(:system_confdir_override).returns("/etc/example/puppet")
+        as_root { @run_mode.conf_dir.should == "/etc/example/puppet" }
       end
 
       it "has confdir ~/.puppet when run as non-root" do
@@ -44,7 +59,13 @@ describe Puppet::Util::RunMode do
 
     describe "#var_dir" do
       it "has vardir /var/lib/puppet when run as root" do
+        @run_mode.stubs(:system_vardir_override).returns(false)
         as_root { @run_mode.var_dir.should == File.expand_path('/var/lib/puppet') }
+      end
+
+      it "has vardir of the value returned by the override file when run as root" do
+        @run_mode.stubs(:system_vardir_override).returns("/var/lib/example/puppet")
+        as_root { @run_mode.var_dir.should == File.expand_path('/var/lib/example/puppet') }
       end
 
       it "has vardir ~/.puppet/var when run as non-root" do
@@ -78,6 +99,7 @@ describe Puppet::Util::RunMode do
 
     describe "#conf_dir" do
       it "has confdir /etc/puppet when run as root" do
+        @run_mode.stubs(:system_confdir_override).returns(false)
         as_root { @run_mode.conf_dir.should == File.expand_path(File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "etc")) }
       end
 
@@ -100,6 +122,7 @@ describe Puppet::Util::RunMode do
 
     describe "#var_dir" do
       it "has vardir /var/lib/puppet when run as root" do
+        @run_mode.stubs(:system_vardir_override).returns(false)
         as_root { @run_mode.var_dir.should == File.expand_path(File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "var")) }
       end
 


### PR DESCRIPTION
Without this patch it's difficult to change the behavior of determining the
default confdir and vardir settings.  This is a problem because it's difficult
to relocate Puppet which is necessary in certain cases, such as Puppet
Enterprise and our Ops team using /etc/operations/puppet as the default
confdir.

This patch exposes a public API to allow third party tools to easily determine
the file to write to override the default confdir and vardir. The API method is
Puppet::Util::RunMode.override_path(type) where type is either "confdir" or
"vardir"  An anticipated use case is that a simple rubygems plugin gem could
register a post_install hook to write an override file which will relocate
puppet.

A path relative to the gem source file has been chosen to facilitate multiple
copies of the Puppet library being installed and relocated to their own
isolated paths or gemset.
