### PR TITLE
(PUP-1387) fixes wrong hash in subjectKeyIdentifier

### DIFF
--- a/lib/puppet/ssl/certificate_factory.rb
+++ b/lib/puppet/ssl/certificate_factory.rb
@@ -37,7 +37,7 @@ module Puppet::SSL::CertificateFactory
 
   def self.add_extensions_to(cert, csr, issuer, extensions)
     ef = OpenSSL::X509::ExtensionFactory.
-      new(cert, issuer.is_a?(OpenSSL::X509::Request) ? cert : issuer)
+      new(issuer.is_a?(OpenSSL::X509::Request) ? cert : issuer, cert)
 
     # Extract the requested extensions from the CSR.
     requested_exts = csr.request_extensions.inject({}) do |hash, re|

--- a/spec/unit/ssl/certificate_factory_spec.rb
+++ b/spec/unit/ssl/certificate_factory_spec.rb
@@ -14,9 +14,9 @@ describe Puppet::SSL::CertificateFactory do
     csr
   end
   let :issuer do
-    cert = OpenSSL::X509::Certificate.new
-    cert.subject = OpenSSL::X509::Name.new([["CN", 'issuer.local']])
-    cert
+    cert = Puppet::SSL::CertificateAuthority.new
+    cert.generate_ca_certificate
+    cert.instance_variable_get(:@certificate).content
   end
 
   describe "when generating the certificate" do
@@ -76,12 +76,19 @@ describe Puppet::SSL::CertificateFactory do
       cert.not_after.to_i.should == now.to_i + 12
     end
 
-    it "should build extensions for the certificate" do
+    it "should add an extension for the nsComment" do
       cert = subject.build(:server, csr, issuer, serial)
       cert.extensions.map {|x| x.to_h }.find {|x| x["oid"] == "nsComment" }.should ==
         { "oid"      => "nsComment",
           "value"    => "Puppet Ruby/OpenSSL Internal Certificate",
           "critical" => false }
+    end
+
+    it "should add an extension for the subjectKeyIdentifer" do
+      cert = subject.build(:server, csr, issuer, serial)
+      ef = OpenSSL::X509::ExtensionFactory.new(issuer, cert)
+      cert.extensions.map { |x| x.to_h }.find {|x| x["oid"] == "subjectKeyIdentifier" }.should ==
+        ef.create_extension("subjectKeyIdentifier", "hash", false).to_h
     end
 
     # See #2848 for why we are doing this: we need to make sure that


### PR DESCRIPTION
this fixes the regression that appeared when the arguments to
ExtensionFactory where accidentally swapped.
Also added a test case to check if the subjectKeyIdentifier is present
and changed the unit test to use Puppet::SSL::CertificateAuthority instead
of generating a temporary cert using OpenSSL::X509::*
