### PR TITLE
(PUP-1407) add required authorityKeyIdentifier extension to CRL

### DIFF
--- a/lib/puppet/ssl/certificate_revocation_list.rb
+++ b/lib/puppet/ssl/certificate_revocation_list.rb
@@ -60,13 +60,15 @@ DOC
 private
 
   def create_crl_issued_by(cert)
+    ef = OpenSSL::X509::ExtensionFactory.new(cert)
     @content = wrapped_class.new
     @content.issuer = cert.subject
+    @content.add_extension(ef.create_ext("authorityKeyIdentifier", "keyid:always"))
     @content.version = 1
   end
 
   def start_at_initial_crl_number
-    @content.extensions = [crl_number_of(0)]
+    @content.add_extension(crl_number_of(0))
   end
 
   def add_certificate_revocation_for(serial, reason, time)

--- a/spec/unit/ssl/certificate_revocation_list_spec.rb
+++ b/spec/unit/ssl/certificate_revocation_list_spec.rb
@@ -73,6 +73,12 @@ describe Puppet::SSL::CertificateRevocationList do
           "critical"  => false }
     end
 
+    it "should add an extension for the authority key identifier" do
+      ef = OpenSSL::X509::ExtensionFactory.new(@cert)
+      @crl.generate(@cert, @key).extensions.map { |x| x.to_h }.find { |x| x["oid"] == "authorityKeyIdentifier" }.should ==
+        ef.create_extension("authorityKeyIdentifier", "keyid:always", false).to_h
+    end
+
     it "should set the last update time" do
       @crl.generate(@cert, @key).last_update.should_not == nil
     end


### PR DESCRIPTION
as pointed out in the PUP-1407 issue, currently the CA does not conform to RFC 5280 since it does not add the required authorityKeyIdentifier extension. This causes the CRL to not be able to be parsed properly by strict applications.
This request adds the extension to the CRL when it's generated as well as creates a test case for it.
In order to properly test it, I had to rewrite the test case to not just mock the OpenSSL classes but instead use a temporary CA (basically like other SSL test cases do)
