### PR TITLE
(PUP-1151) Fix environment enumeration endpoint test

### DIFF
--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -1,14 +1,12 @@
-test_name "Can enumerate enviromnents via an HTTP endpoint"
+test_name "Can enumerate environments via an HTTP endpoint"
 
-def master_url_for(agent, path)
-  master_port = on(agent, "puppet config print masterport --section agent").stdout.chomp
-  master_host = on(agent, "puppet config print server --section agent").stdout.chomp
-  "https://#{master_host}:#{master_port}#{path}"
+def master_port(agent)
+  on(agent, "puppet config print masterport --section agent").stdout.chomp
 end
 
 with_puppet_running_on(master, {}) do
   agents.each do |agent|
-    on agent, "curl -ksv #{master_url_for(agent, '/v2/environments')}", :acceptable_exit_codes => [0,7] do
+    on agent, "curl -ksv https://#{master}:#{master_port(agent)}/v2/environments", :acceptable_exit_codes => [0,7] do
       assert_match(/< HTTP\/1\.\d 403/, stderr)
     end
   end


### PR DESCRIPTION
Use the beaker-provided `master` variable to construct the endpoint, rather than grab it from the agent's configuration.
