### PR TITLE
(PUP-716) File19Windows#symlink calls exist? on instance not class.

### DIFF
--- a/lib/puppet/file_system/file19windows.rb
+++ b/lib/puppet/file_system/file19windows.rb
@@ -24,7 +24,7 @@ class Puppet::FileSystem::File19Windows < Puppet::FileSystem::File19
   def symlink(path, dest, options = {})
     raise_if_symlinks_unsupported
 
-    dest_exists = self.class.exist?(dest) # returns false on dangling symlink
+    dest_exists = exist?(dest) # returns false on dangling symlink
     dest_stat = Puppet::Util::Windows::File.stat(dest) if dest_exists
     dest_symlink = Puppet::Util::Windows::File.symlink?(dest)
 


### PR DESCRIPTION
Fixes a bug that was calling exist? on the File19Windows impl class when
it was now an instance method of the same.
