### PR TITLE
 (PUP-1409) add authorityKeyIdentifier to client certificates

### DIFF
--- a/lib/puppet/ssl/certificate_factory.rb
+++ b/lib/puppet/ssl/certificate_factory.rb
@@ -60,7 +60,7 @@ module Puppet::SSL::CertificateFactory
     # certificate through where the CA constraint was true, though, if
     # something went wrong up there. --daniel 2011-10-11
     defaults = { "nsComment" => "Puppet Ruby/OpenSSL Internal Certificate" }
-    override = { "subjectKeyIdentifier" => "hash" }
+    override = { "subjectKeyIdentifier" => "hash", "authorityKeyIdentifier" => "keyid,issuer" }
 
     exts = [defaults, requested_exts, extensions, override].
       inject({}) {|ret, val| ret.merge(val) }

--- a/spec/unit/ssl/certificate_factory_spec.rb
+++ b/spec/unit/ssl/certificate_factory_spec.rb
@@ -91,6 +91,14 @@ describe Puppet::SSL::CertificateFactory do
         ef.create_extension("subjectKeyIdentifier", "hash", false).to_h
     end
 
+
+    it "should add an extension for the authorityKeyIdentifer" do
+      cert = subject.build(:server, csr, issuer, serial)
+      ef = OpenSSL::X509::ExtensionFactory.new(issuer, cert)
+      cert.extensions.map { |x| x.to_h }.find {|x| x["oid"] == "authorityKeyIdentifier" }.should ==
+        ef.create_extension("authorityKeyIdentifier", "keyid:always", false).to_h
+    end
+
     # See #2848 for why we are doing this: we need to make sure that
     # subjectAltName is set if the CSR has it, but *not* if it is set when the
     # certificate is built!


### PR DESCRIPTION
as discussed in the ticket this will add the authorityKeyIdentifier that
is not required, but recommended to add to certs signed by a CA
conforming to RFC 5280. This extension takes the subjectKeyIdentifier of
the CA certificate and adds it as keyid to authorityKeyIdentifier.
This PR also adds a test to make sure the extension is correctly added
to the resulting certificate.
Note that this change depends on PUP-1387 since it uses the
ExtensionFactory as well, without PUP-1387 this test would fail.
