### PR TITLE
(PUP-716) Assert path before making stat expectation

### DIFF
--- a/spec/unit/file_system/file_spec.rb
+++ b/spec/unit/file_system/file_spec.rb
@@ -129,7 +129,7 @@ describe "Puppet::FileSystem" do
     end
 
     it "should fall back to stat when trying to lstat a file" do
-      Puppet::Util::Windows::File.expects(:stat).with(file)
+      Puppet::Util::Windows::File.expects(:stat).with(Puppet::FileSystem.assert_path(file))
 
       Puppet::FileSystem.lstat(file)
     end


### PR DESCRIPTION
File system changes ensure that Strings get converted to Pathnames; so
the Puppet::Util::Windows::File.stat call needs to expect a Pathname now.
