### PR TITLE
(PUP-759) Remove reference to ca_days in ca_ttl default

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -778,7 +778,7 @@ EOT
     :ca_ttl => {
       :default    => "5y",
       :type       => :duration,
-      :desc       => "The default TTL for new certificates. If this setting is set, ca_days is ignored.
+      :desc       => "The default TTL for new certificates.
       #{AS_DURATION}"
     },
     :req_bits => {


### PR DESCRIPTION
Just removing a reference to the non-existent ca_days setting in the ca_ttl defaults.
