### PR TITLE
(PUP-1421) Remove flawed source validation in package provider appdmg.

### DIFF
--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -49,9 +49,6 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
   end
 
   def self.installpkgdmg(source, name)
-    unless source =~ /\.dmg$/i
-      self.fail "Mac OS X PKG DMG's must specify a source string ending in .dmg"
-    end
     require 'open-uri'
     require 'facter/util/plist'
     cached_source = source


### PR DESCRIPTION
- appdmg's "source" may be a URL that redirects to the actual dmg (and thus not end in .dmg)
- actual download is renamed to "name" anyway
- hdiutil doesn't require the dmg file to have a filename ending in .dmg

More Details: https://tickets.puppetlabs.com/browse/PUP-1421
