### PR TITLE
(maint) remove dead code for indirector cache

### DIFF
--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -201,7 +201,7 @@ class Puppet::Indirector::Indirection
       result = terminus.find(request)
       if not result.nil?
         result.expiration ||= self.expiration if result.respond_to?(:expiration)
-        if cache? and request.use_cache?
+        if cache?
           Puppet.info "Caching #{self.name} for #{request.key}"
           cache.save request(:save, key, result, options)
         end

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -149,15 +149,6 @@ class Puppet::Indirector::Request
     i.model
   end
 
-  # Should we allow use of the cached object?
-  def use_cache?
-    if defined?(@use_cache)
-      ! ! use_cache
-    else
-      true
-    end
-  end
-
   # Are we trying to interact with multiple resources, or just one?
   def plural?
     method == :search


### PR DESCRIPTION
@use_cache was never set, so use_cache? always returned true.
The option to set for not using cache is ignore_cache.
