### PR TITLE
(#PUP-1046) Add spec test for skeleton for generated modules

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/spec/classes/init_spec.rb.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/spec/classes/init_spec.rb.erb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+describe '<%= metadata.name %>' do
+
+  context 'with defaults for all parameters' do
+    it { should contain_class('<%= metadata.name %>') }
+  end
+end


### PR DESCRIPTION
This patch adds a simple spec test to ensure that by including the
class with default values for all the parameters, that the class is
contained within the catalog.
