### PR TITLE
(#FORGE-38) Add Rakefile to skeleton for generated modules

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/Rakefile
+++ b/lib/puppet/module_tool/skeleton/templates/generator/Rakefile
@@ -1,0 +1,18 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Validate manifests, templates, and ruby files"
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end


### PR DESCRIPTION
This patch adds a simple Rakefile that provides rake tasks `lint` for
puppet-lint, `validate` for validation of manifests, templates, and ruby
files, and the tasks provided by the puppetlabs_spec_helper.
