### PR TITLE
(PUP-1151) Consolidate JSON schema validation

### DIFF
--- a/spec/lib/matchers/json.rb
+++ b/spec/lib/matchers/json.rb
@@ -1,111 +1,167 @@
-RSpec::Matchers.define :set_json_attribute do |*attributes|
-  def format
-    @format ||= Puppet::Network::FormatHandler.format('pson')
-  end
-
-  chain :to do |value|
-    @value = value
-  end
-
-  def json(instance)
-    PSON.parse(instance.to_pson)
-  end
-
-  def attr_value(attrs, instance)
-    attrs = attrs.dup
-    hash = json(instance)['data']
-    while attrs.length > 0
-      name = attrs.shift
-      hash = hash[name]
+module JSONMatchers
+  class SetJsonAttribute
+    def initialize(attributes)
+      @attributes = attributes
     end
-    hash
+
+    def format
+      @format ||= Puppet::Network::FormatHandler.format('pson')
+    end
+
+    def json(instance)
+      PSON.parse(instance.to_pson)
+    end
+
+    def attr_value(attrs, instance)
+      attrs = attrs.dup
+      hash = json(instance)['data']
+      while attrs.length > 0
+        name = attrs.shift
+        hash = hash[name]
+      end
+      hash
+    end
+
+    def to(value)
+      @value = value
+      self
+    end
+
+    def matches?(instance)
+      result = attr_value(@attributes, instance)
+      if @value
+        result == @value
+      else
+        ! result.nil?
+      end
+    end
+
+    def failure_message_for_should(instance)
+      if @value
+        "expected #{instance.inspect} to set #{@attributes.inspect} to #{@value.inspect}; got #{attr_value(@attributes, instance).inspect}"
+      else
+        "expected #{instance.inspect} to set #{@attributes.inspect} but was nil"
+      end
+    end
+
+    def failure_message_for_should_not(instance)
+      if @value
+        "expected #{instance.inspect} not to set #{@attributes.inspect} to #{@value.inspect}"
+      else
+        "expected #{instance.inspect} not to set #{@attributes.inspect} to nil"
+      end
+    end
   end
 
-  match do |instance|
-    result = attr_value(attributes, instance)
-    if @value
-      result == @value
+  class SetJsonDocumentTypeTo
+    def initialize(type)
+      @type = type
+    end
+
+    def format
+      @format ||= Puppet::Network::FormatHandler.format('pson')
+    end
+
+    def matches?(instance)
+      json(instance)['document_type'] == @type
+    end
+
+    def json(instance)
+      PSON.parse(instance.to_pson)
+    end
+
+    def failure_message_for_should(instance)
+      "expected #{instance.inspect} to set document_type to #{@type.inspect}; got #{json(instance)['document_type'].inspect}"
+    end
+
+    def failure_message_for_should_not(instance)
+      "expected #{instance.inspect} not to set document_type to #{@type.inspect}"
+    end
+  end
+
+  class ReadJsonAttribute
+    def initialize(attribute)
+      @attribute = attribute
+    end
+
+    def format
+      @format ||= Puppet::Network::FormatHandler.format('pson')
+    end
+
+    def from(value)
+      @json = value
+      self
+    end
+
+    def as(as)
+      @value = as
+      self
+    end
+
+    def matches?(klass)
+      raise "Must specify json with 'from'" unless @json
+
+      @instance = format.intern(klass, @json)
+      if @value
+        @instance.send(@attribute) == @value
+      else
+        ! @instance.send(@attribute).nil?
+      end
+    end
+
+    def failure_message_for_should(klass)
+      if @value
+        "expected #{klass} to read #{@attribute} from #{@json} as #{@value.inspect}; got #{@instance.send(@attribute).inspect}"
+      else
+        "expected #{klass} to read #{@attribute} from #{@json} but was nil"
+      end
+    end
+
+    def failure_message_for_should_not(klass)
+      if @value
+        "expected #{klass} not to set #{@attribute} to #{@value}"
+      else
+        "expected #{klass} not to set #{@attribute} to nil"
+      end
+    end
+  end
+
+  if !Puppet.features.microsoft_windows?
+    require 'json'
+    require 'json-schema'
+
+    class SchemaMatcher
+      JSON_META_SCHEMA = JSON.parse(File.read('api/schemas/json-meta-schema.json'))
+
+      def initialize(schema)
+        @schema = schema
+      end
+
+      def matches?(json)
+        JSON::Validator.validate!(JSON_META_SCHEMA, @schema)
+        JSON::Validator.validate!(@schema, json)
+      end
+    end
+  end
+
+  def validate_against(schema_file)
+    if Puppet.features.microsoft_windows?
+      pending("Schema checks cannot be done on windows because of json-schema problems")
     else
-      ! result.nil?
+      schema = JSON.parse(File.read(schema_file))
+      SchemaMatcher.new(schema)
     end
   end
 
-  failure_message_for_should do |instance|
-    if @value
-      "expected #{instance.inspect} to set #{attributes.inspect} to #{@value.inspect}; got #{attr_value(attributes, instance).inspect}"
-    else
-      "expected #{instance.inspect} to set #{attributes.inspect} but was nil"
-    end
+  def set_json_attribute(*attributes)
+    SetJsonAttribute.new(attributes)
   end
 
-  failure_message_for_should_not do |instance|
-    if @value
-      "expected #{instance.inspect} not to set #{attributes.inspect} to #{@value.inspect}"
-    else
-      "expected #{instance.inspect} not to set #{attributes.inspect} to nil"
-    end
-  end
-end
-
-RSpec::Matchers.define :set_json_document_type_to do |type|
-  def format
-    @format ||= Puppet::Network::FormatHandler.format('pson')
+  def set_json_document_type_to(type)
+    SetJsonDocumentTypeTo.new(type)
   end
 
-  match do |instance|
-    json(instance)['document_type'] == type
-  end
-
-  def json(instance)
-    PSON.parse(instance.to_pson)
-  end
-
-  failure_message_for_should do |instance|
-    "expected #{instance.inspect} to set document_type to #{type.inspect}; got #{json(instance)['document_type'].inspect}"
-  end
-
-  failure_message_for_should_not do |instance|
-    "expected #{instance.inspect} not to set document_type to #{type.inspect}"
-  end
-end
-
-RSpec::Matchers.define :read_json_attribute do |attribute|
-  def format
-    @format ||= Puppet::Network::FormatHandler.format('pson')
-  end
-
-  chain :from do |value|
-    @json = value
-  end
-
-  chain :as do |as|
-    @value = as
-  end
-
-  match do |klass|
-    raise "Must specify json with 'from'" unless @json
-
-    @instance = format.intern(klass, @json)
-    if @value
-      @instance.send(attribute) == @value
-    else
-      ! @instance.send(attribute).nil?
-    end
-  end
-
-  failure_message_for_should do |klass|
-    if @value
-      "expected #{klass} to read #{attribute} from #{@json} as #{@value.inspect}; got #{@instance.send(attribute).inspect}"
-    else
-      "expected #{klass} to read #{attribute} from #{@json} but was nil"
-    end
-  end
-
-  failure_message_for_should_not do |klass|
-    if @value
-      "expected #{klass} not to set #{attribute} to #{@value}"
-    else
-      "expected #{klass} not to set #{attribute} to nil"
-    end
+  def read_json_attribute(attribute)
+    ReadJsonAttribute.new(attribute)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,18 +43,6 @@ Pathname.glob("#{dir}/shared_behaviours/**/*.rb") do |behaviour|
   require behaviour.relative_path_from(Pathname.new(dir))
 end
 
-# various spec tests now use json schema validation
-# the json-schema gem doesn't support windows
-if not Puppet.features.microsoft_windows?
-  require 'json'
-  require 'json-schema'
-
-  JSON_META_SCHEMA = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../api/schemas/json-meta-schema.json')))
-
-  # FACTS_SCHEMA is shared across two spec files so promote constant to here
-  FACTS_SCHEMA = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../api/schemas/facts.json')))
-end
-
 RSpec.configure do |config|
   include PuppetSpec::Fixtures
 

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -1,22 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-
 require 'puppet/file_serving/metadata'
-
-# the json-schema gem doesn't support windows
-if not Puppet.features.microsoft_windows?
-  FILE_METADATA_SCHEMA = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../../../api/schemas/file_metadata.json')))
-
-  describe "catalog schema" do
-    it "should validate against the json meta-schema" do
-      JSON::Validator.validate!(JSON_META_SCHEMA, FILE_METADATA_SCHEMA)
-    end
-  end
-
-  def validate_json_for_file_metadata(file_metadata)
-    JSON::Validator.validate!(FILE_METADATA_SCHEMA, file_metadata.to_pson)
-  end
-end
+require 'matchers/json'
 
 describe Puppet::FileServing::Metadata do
   let(:foobar) { File.expand_path('/foo/bar') }
@@ -103,6 +88,7 @@ describe Puppet::FileServing::Metadata do
 end
 
 describe Puppet::FileServing::Metadata do
+  include JSONMatchers
   include PuppetSpec::Files
 
   shared_examples_for "metadata collector" do
@@ -154,8 +140,8 @@ describe Puppet::FileServing::Metadata do
           end
         end
 
-        it "should validate against the schema", :unless => Puppet.features.microsoft_windows? do
-          validate_json_for_file_metadata(metadata)
+        it "should validate against the schema" do
+          expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
         end
       end
 
@@ -179,9 +165,9 @@ describe Puppet::FileServing::Metadata do
           metadata.checksum.should == "{ctime}#{time}"
         end
 
-        it "should validate against the schema", :unless => Puppet.features.microsoft_windows? do
+        it "should validate against the schema" do
           metadata.collect
-          validate_json_for_file_metadata(metadata)
+          expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
         end
       end
     end
@@ -214,8 +200,8 @@ describe Puppet::FileServing::Metadata do
           metadata.destination.should == target
         end
 
-        it "should validate against the schema", :unless => Puppet.features.microsoft_windows? do
-          validate_json_for_file_metadata(metadata)
+        it "should validate against the schema" do
+          expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
         end
       end
     end
@@ -248,8 +234,8 @@ describe Puppet::FileServing::Metadata do
         proc { metadata.collect}.should raise_error(Errno::ENOENT)
       end
 
-      it "should validate against the schema", :unless => Puppet.features.microsoft_windows? do
-        validate_json_for_file_metadata(metadata)
+      it "should validate against the schema" do
+        expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
       end
     end
   end

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -5,6 +5,7 @@ require 'puppet/indirector/request'
 require 'puppet/util/pson'
 
 describe Puppet::Indirector::Request do
+  include JSONMatchers
 
   describe "when registering the document type" do
     it "should register its document type with JSON" do

--- a/spec/unit/network/http/api/v2/environments_spec.rb
+++ b/spec/unit/network/http/api/v2/environments_spec.rb
@@ -2,8 +2,11 @@ require 'spec_helper'
 
 require 'puppet/node/environment'
 require 'puppet/network/http'
+require 'matchers/json'
 
 describe Puppet::Network::HTTP::API::V2::Environments do
+  include JSONMatchers
+
   it "responds with all of the available environments environments" do
     handler = Puppet::Network::HTTP::API::V2::Environments.new(TestingEnvironmentLoader.new)
     response = Puppet::Network::HTTP::MemoryResponse.new
@@ -32,15 +35,7 @@ describe Puppet::Network::HTTP::API::V2::Environments do
 
     handler.call(Puppet::Network::HTTP::Request.from_hash(:headers => { 'accept' => 'application/json' }), response)
 
-    expect(response.body).to validates_against('api/schemas/environments.json')
-  end
-
-  matcher :validates_against do |schema_file|
-    match do |json|
-      schema = JSON.parse(File.read(schema_file))
-      JSON::Validator.validate!(JSON_META_SCHEMA, schema)
-      JSON::Validator.validate!(schema, json)
-    end
+    expect(response.body).to validate_against('api/schemas/environments.json')
   end
 
   class TestingEnvironmentLoader

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -2,18 +2,9 @@
 require 'spec_helper'
 require 'matchers/json'
 
-# the json-schema gem doesn't support windows
-if not Puppet.features.microsoft_windows?
-  NODE_SCHEMA = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../../api/schemas/node.json')))
-
-  describe "node schema" do
-    it "should validate against the json meta-schema" do
-      JSON::Validator.validate!(JSON_META_SCHEMA, NODE_SCHEMA)
-    end
-  end
-end
-
 describe Puppet::Node do
+  include JSONMatchers
+
   it "should register its document type as Node" do
     PSON.registered_document_types["Node"].should equal(Puppet::Node)
   end
@@ -87,7 +78,7 @@ describe Puppet::Node do
                             :classes => ['erth', 'aiu'],
                             :parameters => {"hostname"=>"food"}
                            )
-    JSON::Validator.validate!(NODE_SCHEMA, node.to_pson)
+    expect(node.to_pson).to validate_against('api/schemas/node.json')
   end
 
   it "when missing optional parameters validates against the node json schema", :unless => Puppet.features.microsoft_windows? do
@@ -95,7 +86,7 @@ describe Puppet::Node do
     node = Puppet::Node.new("hello",
                             :environment => 'kjhgrg'
                            )
-    JSON::Validator.validate!(NODE_SCHEMA, node.to_pson)
+    expect(node.to_pson).to validate_against('api/schemas/node.json')
   end
 
   describe "when converting to json" do

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -2,19 +2,10 @@
 require 'spec_helper'
 require 'puppet_spec/compiler'
 
-# the json-schema gem doesn't support windows
-if not Puppet.features.microsoft_windows?
-  CATALOG_SCHEMA = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../../../api/schemas/catalog.json')))
-
-  describe "catalog schema" do
-    it "should validate against the json meta-schema" do
-      JSON::Validator.validate!(JSON_META_SCHEMA, CATALOG_SCHEMA)
-    end
-  end
-
-end
+require 'matchers/json'
 
 describe Puppet::Resource::Catalog, "when compiling" do
+  include JSONMatchers
   include PuppetSpec::Files
 
   before do
@@ -736,43 +727,40 @@ describe Puppet::Resource::Catalog, "when compiling" do
 end
 
 describe Puppet::Resource::Catalog, "when converting a resource catalog to pson" do
+  include JSONMatchers
   include PuppetSpec::Compiler
 
-  def validate_json_for_catalog(catalog)
-    JSON::Validator.validate!(CATALOG_SCHEMA, catalog.to_pson)
-  end
-
-  it "should validate an empty catalog against the schema", :unless => Puppet.features.microsoft_windows? do
+  it "should validate an empty catalog against the schema" do
     empty_catalog = compile_to_catalog("")
-    validate_json_for_catalog(empty_catalog)
+    expect(empty_catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
 
-  it "should validate a noop catalog against the schema", :unless => Puppet.features.microsoft_windows? do
+  it "should validate a noop catalog against the schema" do
     noop_catalog = compile_to_catalog("create_resources('file', {})")
-    validate_json_for_catalog(noop_catalog)
+    expect(noop_catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
 
-  it "should validate a single resource catalog against the schema", :unless => Puppet.features.microsoft_windows? do
+  it "should validate a single resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('file', {'/etc/foo'=>{'ensure'=>'present'}})")
-    validate_json_for_catalog(catalog)
+    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
 
-  it "should validate a virtual resource catalog against the schema", :unless => Puppet.features.microsoft_windows? do
+  it "should validate a virtual resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('@file', {'/etc/foo'=>{'ensure'=>'present'}})\nrealize(File['/etc/foo'])")
-    validate_json_for_catalog(catalog)
+    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
 
-  it "should validate a single exported resource catalog against the schema", :unless => Puppet.features.microsoft_windows? do
+  it "should validate a single exported resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('@@file', {'/etc/foo'=>{'ensure'=>'present'}})")
-    validate_json_for_catalog(catalog)
+    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
 
-  it "should validate a two resource catalog against the schema", :unless => Puppet.features.microsoft_windows? do
+  it "should validate a two resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('notify', {'foo'=>{'message'=>'one'}, 'bar'=>{'message'=>'two'}})")
-    validate_json_for_catalog(catalog)
+    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
 
-  it "should validate a two parameter class catalog against the schema", :unless => Puppet.features.microsoft_windows? do
+  it "should validate a two parameter class catalog against the schema" do
     catalog = compile_to_catalog(<<-MANIFEST)
       class multi_param_class ($one, $two) {
         notify {'foo':
@@ -785,7 +773,7 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
         two => 'world',
       }
     MANIFEST
-    validate_json_for_catalog(catalog)
+    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
 end
 

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -2,19 +2,11 @@
 require 'spec_helper'
 require 'puppet/resource/type'
 
-# the json-schema gem doesn't support windows
-if not Puppet.features.microsoft_windows?
-  RESOURCE_TYPE_SCHEMA = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../../../api/schemas/resource_type.json')))
-
-  describe "resource type schema" do
-    it "should validate against the json meta-schema" do
-      JSON::Validator.validate!(JSON_META_SCHEMA, RESOURCE_TYPE_SCHEMA)
-    end
-  end
-
-end
+require 'matchers/json'
 
 describe Puppet::Resource::Type do
+  include JSONMatchers
+
   it "should have a 'name' attribute" do
     Puppet::Resource::Type.new(:hostclass, "foo").name.should == "foo"
   end
@@ -42,10 +34,6 @@ describe Puppet::Resource::Type do
   end
 
   describe "when converting to json" do
-    def validate_json_for_type(type)
-      JSON::Validator.validate!(RESOURCE_TYPE_SCHEMA, type.to_pson)
-    end
-
     before do
       @type = Puppet::Resource::Type.new(:hostclass, "foo")
     end
@@ -63,18 +51,18 @@ describe Puppet::Resource::Type do
       double_convert.type.should == @type.type
     end
 
-    it "should validate with only name and kind", :unless => Puppet.features.microsoft_windows? do
-      validate_json_for_type(@type)
+    it "should validate with only name and kind" do
+      expect(@type.to_pson).to validate_against('api/schemas/resource_type.json')
     end
 
-    it "should validate with all fields set", :unless => Puppet.features.microsoft_windows? do
+    it "should validate with all fields set" do
       @type.set_arguments("one" => nil, "two" => "foo")
       @type.line = 100
       @type.doc = "A weird type"
       @type.file = "/etc/manifests/thing.pp"
       @type.parent = "one::two"
 
-      validate_json_for_type(@type)
+      expect(@type.to_pson).to validate_against('api/schemas/resource_type.json')
     end
 
     it "should include any arguments" do

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 require 'puppet/ssl/host'
+require 'matchers/json'
 
 def base_pson_comparison(result, pson_hash)
   result["fingerprint"].should == pson_hash["fingerprint"]
@@ -9,23 +10,9 @@ def base_pson_comparison(result, pson_hash)
   result["state"].should       == pson_hash["desired_state"]
 end
 
-# the json-schema gem doesn't support windows
-if not Puppet.features.microsoft_windows?
-  HOST_SCHEMA = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../../../api/schemas/host.json')))
-
-  describe "host schema" do
-    it "should validate against the json meta-schema" do
-      JSON::Validator.validate!(JSON_META_SCHEMA, HOST_SCHEMA)
-    end
-  end
-end
-
 describe Puppet::SSL::Host do
+  include JSONMatchers
   include PuppetSpec::Files
-
-  def validate_json_for_host(host)
-    JSON::Validator.validate!(HOST_SCHEMA, host.to_pson)
-  end
 
   before do
     Puppet::SSL::Host.indirection.terminus_class = :file
@@ -855,9 +842,10 @@ describe Puppet::SSL::Host do
         base_pson_comparison result, pson_hash
       end
 
-      it "should validate against the schema", :unless => Puppet.features.microsoft_windows? do
+      it "should validate against the schema" do
         host.generate_certificate_request
-        validate_json_for_host(host)
+
+        expect(host.to_pson).to validate_against('api/schemas/host.json')
       end
 
       describe "explicit fingerprints" do
@@ -903,8 +891,8 @@ describe Puppet::SSL::Host do
               result["dns_alt_names"].should == pson_hash["desired_alt_names"]
             end
 
-            it "should validate against the schema", :unless => Puppet.features.microsoft_windows? do
-              validate_json_for_host(host)
+            it "should validate against the schema" do
+              expect(host.to_pson).to validate_against('api/schemas/host.json')
             end
           end
         end

--- a/spec/unit/status_spec.rb
+++ b/spec/unit/status_spec.rb
@@ -1,7 +1,11 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
+require 'matchers/json'
+
 describe Puppet::Status do
+  include JSONMatchers
+
   it "should implement find" do
     Puppet::Status.indirection.find( :default ).should be_is_a(Puppet::Status)
     Puppet::Status.indirection.find( :default ).status["is_alive"].should == true
@@ -38,12 +42,10 @@ describe Puppet::Status do
     new_status.should equal_attributes_of(status)
   end
 
-  it "serializes to PSON that conforms to the status schema", :unless => Puppet.features.microsoft_windows? do
-    schema = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../../api/schemas/status.json')))
+  it "serializes to PSON that conforms to the status schema" do
     status = Puppet::Status.new
     status.version = Puppet.version
 
-    JSON::Validator.validate!(JSON_META_SCHEMA, schema)
-    JSON::Validator.validate!(schema, status.render('pson'))
+    expect(status.render('pson')).to validate_against('api/schemas/status.json')
   end
 end

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -3,22 +3,12 @@ require 'spec_helper'
 
 require 'puppet'
 require 'puppet/transaction/report'
-
-# the json-schema gem doesn't support windows
-if not Puppet.features.microsoft_windows?
-  REPORT_SCHEMA_URI = File.join(File.dirname(__FILE__),    '../../../api/schemas/report.json')
-  REPORT_SCHEMA = JSON.parse(File.read(REPORT_SCHEMA_URI))
-
-  describe "report schema" do
-    it "should validate against the json meta-schema" do
-      JSON::Validator.validate!(JSON_META_SCHEMA, REPORT_SCHEMA)
-    end
-  end
-
-end
+require 'matchers/json'
 
 describe Puppet::Transaction::Report do
+  include JSONMatchers
   include PuppetSpec::Files
+
   before do
     Puppet::Util::Storage.stubs(:store)
   end
@@ -405,10 +395,10 @@ describe Puppet::Transaction::Report do
     expect_equivalent_reports(tripped, report)
   end
 
-  it "generates pson which validates against the report schema", :unless => Puppet.features.microsoft_windows? do
+  it "generates pson which validates against the report schema" do
     Puppet[:report_serialization_format] = "pson"
     report = generate_report
-    JSON::Validator.validate!(REPORT_SCHEMA, report.render)
+    expect(report.render).to validate_against('api/schemas/report.json')
   end
 
   it "can make a round trip through yaml" do

--- a/spec/unit/util/instrumentation/data_spec.rb
+++ b/spec/unit/util/instrumentation/data_spec.rb
@@ -6,6 +6,8 @@ require 'puppet/util/instrumentation'
 require 'puppet/util/instrumentation/data'
 
 describe Puppet::Util::Instrumentation::Data do
+  include JSONMatchers
+
   Puppet::Util::Instrumentation::Data
 
   before(:each) do

--- a/spec/unit/util/instrumentation/indirection_probe_spec.rb
+++ b/spec/unit/util/instrumentation/indirection_probe_spec.rb
@@ -6,6 +6,8 @@ require 'puppet/util/instrumentation'
 require 'puppet/util/instrumentation/indirection_probe'
 
 describe Puppet::Util::Instrumentation::IndirectionProbe do
+  include JSONMatchers
+
   Puppet::Util::Instrumentation::IndirectionProbe
 
   it "should indirect instrumentation_probe" do

--- a/spec/unit/util/instrumentation/listener_spec.rb
+++ b/spec/unit/util/instrumentation/listener_spec.rb
@@ -7,6 +7,7 @@ require 'puppet/util/instrumentation'
 require 'puppet/util/instrumentation/listener'
 
 describe Puppet::Util::Instrumentation::Listener do
+  include JSONMatchers
 
   Listener = Puppet::Util::Instrumentation::Listener
 


### PR DESCRIPTION
This adds a new matcher to the JSONMatchers to validate json against a given
json-schema. All of the json schema validation now goes through this one
matcher, which also handles skipping the checks on windows.
