### PR TITLE
PUP-1389 Ensure Wide strings has double terminators

### DIFF
--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -6,6 +6,7 @@ module Puppet::Util::Windows
     require 'puppet/util/windows/security'
     require 'puppet/util/windows/user'
     require 'puppet/util/windows/process'
+    require 'puppet/util/windows/string'
     require 'puppet/util/windows/file'
     require 'puppet/util/windows/root_certs'
     require 'puppet/util/windows/access_control_entry'

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -4,34 +4,30 @@ module Puppet::Util::Windows::File
   require 'ffi'
   require 'windows/api'
 
-  def wide_string(str)
-    wstr = str.encode('UTF-16LE')
-
-    ptr = FFI::MemoryPointer.new(:uint16, wstr.length + 1)
-    ptr.put_string(0, wstr)
-    ptr.put_uint8(ptr.size - 1, 0)
-    ptr.put_uint8(ptr.size - 2, 0)
-
-    ffi_str = ptr.get_bytes(0, ptr.size)
-    ffi_str.force_encoding('UTF-16LE')
-    ffi_str
-  end
-  module_function :wide_string
-
-  ReplaceFileWithoutBackupW = Windows::API.new('ReplaceFileW', 'PPPLPP', 'B')
   def replace_file(target, source)
-    result = ReplaceFileWithoutBackupW.call(wide_string(target.to_s),
-                                   wide_string(source.to_s),
-                                   0, 0x1, 0, 0)
-    return true unless result == 0
+    target_encoded = Puppet::Util::Windows::String.wide_string(target.to_s)
+    source_encoded = Puppet::Util::Windows::String.wide_string(source.to_s)
+
+    flags = 0x1
+    backup_file = nil
+    result = API.replace_file(
+      target_encoded,
+      source_encoded,
+      backup_file,
+      flags,
+      0,
+      0
+    )
+
+    return true if result
     raise Puppet::Util::Windows::Error.new("ReplaceFile(#{target}, #{source})")
   end
   module_function :replace_file
 
   MoveFileEx = Windows::API.new('MoveFileExW', 'PPL', 'B')
   def move_file_ex(source, target, flags = 0)
-    result = MoveFileEx.call(wide_string(source.to_s),
-                             wide_string(target.to_s),
+    result = MoveFileEx.call(Puppet::Util::Windows::String.wide_string(source.to_s),
+                             Puppet::Util::Windows::String.wide_string(target.to_s),
                              flags)
     return true unless result == 0
     raise Puppet::Util::Windows::Error.
@@ -43,6 +39,20 @@ module Puppet::Util::Windows::File
     extend FFI::Library
     ffi_lib 'kernel32'
     ffi_convention :stdcall
+
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365512(v=vs.85).aspx
+    # BOOL WINAPI ReplaceFile(
+    #   _In_        LPCTSTR lpReplacedFileName,
+    #   _In_        LPCTSTR lpReplacementFileName,
+    #   _In_opt_    LPCTSTR lpBackupFileName,
+    #   _In_        DWORD dwReplaceFlags - 0x1 REPLACEFILE_WRITE_THROUGH,
+    #                                      0x2 REPLACEFILE_IGNORE_MERGE_ERRORS,
+    #                                      0x4 REPLACEFILE_IGNORE_ACL_ERRORS
+    #   _Reserved_  LPVOID lpExclude,
+    #   _Reserved_  LPVOID lpReserved
+    # );
+    attach_function :replace_file, :ReplaceFileW,
+      [:buffer_in, :buffer_in, :buffer_in, :uint, :uint, :uint], :bool
 
     # BOOLEAN WINAPI CreateSymbolicLink(
     #   _In_  LPTSTR lpSymlinkFileName, - symbolic link to be created
@@ -115,8 +125,8 @@ module Puppet::Util::Windows::File
 
   def symlink(target, symlink)
     flags = File.directory?(target) ? 0x1 : 0x0
-    result = API.create_symbolic_link(wide_string(symlink.to_s),
-      wide_string(target.to_s), flags)
+    result = API.create_symbolic_link(Puppet::Util::Windows::String.wide_string(symlink.to_s),
+      Puppet::Util::Windows::String.wide_string(target.to_s), flags)
     return true if result
     raise Puppet::Util::Windows::Error.new(
       "CreateSymbolicLink(#{symlink}, #{target}, #{flags.to_s(8)})")
@@ -125,7 +135,7 @@ module Puppet::Util::Windows::File
 
   INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF #define INVALID_FILE_ATTRIBUTES (DWORD (-1))
   def self.get_file_attributes(file_name)
-    result = API.get_file_attributes(wide_string(file_name.to_s))
+    result = API.get_file_attributes(Puppet::Util::Windows::String.wide_string(file_name.to_s))
     return result unless result == INVALID_FILE_ATTRIBUTES
     raise Puppet::Util::Windows::Error.new("GetFileAttributes(#{file_name})")
   end
@@ -134,7 +144,7 @@ module Puppet::Util::Windows::File
   def self.create_file(file_name, desired_access, share_mode, security_attributes,
     creation_disposition, flags_and_attributes, template_file_handle)
 
-    result = API.create_file(wide_string(file_name.to_s),
+    result = API.create_file(Puppet::Util::Windows::String.wide_string(file_name.to_s),
       desired_access, share_mode, security_attributes, creation_disposition,
       flags_and_attributes, template_file_handle)
 
@@ -186,7 +196,7 @@ module Puppet::Util::Windows::File
   def self.open_symlink(link_name)
     begin
       yield handle = create_file(
-      wide_string(link_name.to_s),
+      Puppet::Util::Windows::String.wide_string(link_name.to_s),
       GENERIC_READ,
       FILE_SHARE_READ,
       nil, # security_attributes

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -52,8 +52,8 @@ module Puppet::Util::Windows::Process
     #   _In_      LPCTSTR lpName,
     #   _Out_     PLUID lpLuid
     # );
-    attach_function :lookup_privilege_value, :LookupPrivilegeValueW,
-      [:buffer_in, :buffer_in, :pointer], :bool
+    attach_function :lookup_privilege_value, :LookupPrivilegeValueA,
+      [:string, :string, :pointer], :bool
 
     Token_Information = enum(
         :token_user, 1,
@@ -169,8 +169,11 @@ module Puppet::Util::Windows::Process
 
   def lookup_privilege_value(name, system_name = '')
     luid = FFI::MemoryPointer.new(API::LUID.size)
-    result = API.lookup_privilege_value(WideString.new(system_name),
-      WideString.new(name.to_s), luid)
+    result = API.lookup_privilege_value(
+      system_name,
+      name.to_s,
+      luid
+      )
 
     return API::LUID.new(luid) if result
     raise Puppet::Util::Windows::Error.new(

--- a/lib/puppet/util/windows/string.rb
+++ b/lib/puppet/util/windows/string.rb
@@ -1,0 +1,20 @@
+require 'puppet/util/windows'
+
+module Puppet::Util::Windows::String
+  require 'ffi'
+
+  def wide_string(str)
+    wstr = str.encode('UTF-16LE')
+
+    ptr = FFI::MemoryPointer.new(:uint16, wstr.length + 1)
+    ptr.put_string(0, wstr)
+    ptr.put_uint8(ptr.size - 1, 0)
+    ptr.put_uint8(ptr.size - 2, 0)
+
+    ffi_str = ptr.get_bytes(0, ptr.size)
+    ffi_str.force_encoding('UTF-16LE')
+
+    ffi_str.strip
+  end
+  module_function :wide_string
+end

--- a/spec/integration/util_spec.rb
+++ b/spec/integration/util_spec.rb
@@ -77,4 +77,35 @@ describe Puppet::Util do
       new_sd.dacl.should == expected_sd.dacl
     end
   end
+
+  it "replace_file should work with filenames that include - and . (PUP-1389)", :if => Puppet.features.microsoft_windows? do
+    expected_content = 'some content'
+    dir = tmpdir('ReplaceFile_playground')
+    destination_file = File.join(dir, 'some-file.xml')
+
+    Puppet::Util.replace_file(destination_file, nil) do |temp_file|
+        temp_file.open
+        temp_file.write(expected_content)
+    end
+
+    actual_content = File.read(destination_file)
+    actual_content.should == expected_content
+  end
+
+  it "replace_file should work with filenames that include special characters (PUP-1389)", :if => Puppet.features.microsoft_windows? do
+    expected_content = 'some content'
+    dir = tmpdir('ReplaceFile_playground')
+    # http://www.fileformat.info/info/unicode/char/00e8/index.htm
+    # dest_name = "somèfile.xml"
+    dest_name = "som\u00E8file.xml"
+    destination_file = File.join(dir, dest_name)
+
+    Puppet::Util.replace_file(destination_file, nil) do |temp_file|
+        temp_file.open
+        temp_file.write(expected_content)
+    end
+
+    actual_content = File.read(destination_file)
+    actual_content.should == expected_content
+  end
 end

--- a/spec/unit/util/windows/string_spec.rb
+++ b/spec/unit/util/windows/string_spec.rb
@@ -1,0 +1,70 @@
+# encoding: UTF-8
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+require 'puppet/util/windows'
+
+describe "Puppet::Util::Windows::String", :if => Puppet.features.microsoft_windows? do
+
+  def wide_string(str)
+    Puppet::Util::Windows::String.wide_string(str)
+  end
+
+  context "wide_string" do
+    it "should return encoding of UTF-16LE" do
+      wide_string("bob").encoding.should == Encoding::UTF_16LE
+    end
+
+    it "should return valid encoding" do
+      wide_string("bob").valid_encoding?.should be_true
+    end
+
+    it "should convert an ASCII string" do
+      string_value = "bob".encode(Encoding::US_ASCII)
+      result = wide_string(string_value)
+      expected = string_value.encode(Encoding::UTF_16LE)
+
+      result.bytes.to_a.should == expected.bytes.to_a
+    end
+
+    it "should convert a UTF-8 string" do
+      string_value = "bob".encode(Encoding::UTF_8)
+      result = wide_string(string_value)
+      expected = string_value.encode(Encoding::UTF_16LE)
+
+      result.bytes.to_a.should == expected.bytes.to_a
+    end
+
+    it "should convert a UTF-16LE string" do
+      string_value = "bob\u00E8".encode(Encoding::UTF_16LE)
+      result = wide_string(string_value)
+      expected = string_value.encode(Encoding::UTF_16LE)
+
+      result.bytes.to_a.should == expected.bytes.to_a
+    end
+
+    it "should convert a UTF-16BE string" do
+      string_value = "bob\u00E8".encode(Encoding::UTF_16BE)
+      result = wide_string(string_value)
+      expected = string_value.encode(Encoding::UTF_16LE)
+
+      result.bytes.to_a.should == expected.bytes.to_a
+    end
+
+    it "should convert an UTF-32LE string" do
+      string_value = "bob\u00E8".encode(Encoding::UTF_32LE)
+      result = wide_string(string_value)
+      expected = string_value.encode(Encoding::UTF_16LE)
+
+      result.bytes.to_a.should == expected.bytes.to_a
+    end
+
+    it "should convert an UTF-32BE string" do
+      string_value = "bob\u00E8".encode(Encoding::UTF_32BE)
+      result = wide_string(string_value)
+      expected = string_value.encode(Encoding::UTF_16LE)
+
+      result.bytes.to_a.should == expected.bytes.to_a
+    end
+  end
+end


### PR DESCRIPTION
It seems that calling String#encode('UTF-16LE') sometimes adds only a single
NULL terminator in both ruby 1.9 and 2.0 on Windows. However, a wide string
is supposed to have two NULL terminators.

For reasons unknown, versions prior to 2012 seem to accept wide strings with
only a single NULL terminator, but in 2012 and 2012R2 the string is often times
contains a non-zero high byte, which causes Windows to read past the single
terminator, and attempt to access a path that does not exist.

Puppet::Util::Windows::File.replace_file now calls FFI to replace files in place 
on Windows. 

In addition, we've removed Windows::API::WideString usages from
everywhere it was found as it is known to cause issues with Windows 2012.
Puppet::Util::Windows::Process.lookup_privilege_value in particular was
changed to use LookupPrivilegeValueA (ANSI) as we control the privilege name
being passed to it.

NOTE: This may have more implications for change once merged to master.
