### PR TITLE
(pup-1369) Add package_settings property for package

### DIFF
--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -50,6 +50,11 @@ module Puppet
       passed to the installer command."
     feature :uninstall_options, "The provider accepts options to be
       passed to the uninstaller command."
+    feature :package_settings, "The provider accepts package_settings to be
+      ensured for the given package. The meaning and format of these settings is
+      provider-specific.",
+      :methods => [:package_settings_insync?, :package_settings, :package_settings=]
+
 
     ensurable do
       desc <<-EOT
@@ -233,8 +238,79 @@ module Puppet
       end
     end
 
+    newproperty(:package_settings, :required_features=>:package_settings) do
+      desc "Package settings. The definition of package settings is provider
+        specific. In general, these are certain properties which alter contents
+        of a package being installed. An example of package settings are the
+        FreeBSD ports options.
+
+        The package_settings attribute is a property. This means that the options
+        can be enforced during package installation and verified/retrieved
+        for packages that are already installed.
+
+        For example, ports provider on FreeBSD implements the package settings
+        as port build options (the ones you normally set with make config).
+        There is a simple usage example for this particular provider:
+
+            package { 'www/apache22':
+              package_settings => { 'SUEXEC' => false }
+            }
+
+        The above manifest ensures, that apache22 is compiled without SUEXEC
+        module.
+
+        Despite the package_settings are provider specific, the typical
+        behavior, when you change package's package_settings in your manifest,
+        is to reinstall package with new settings.
+        "
+
+      validate do |value|
+        if provider.respond_to?(:package_settings_validate)
+          provider.package_settings_validate(value)
+        else
+          super
+        end
+      end
+
+      munge do |value|
+        if provider.respond_to?(:package_settings_munge)
+          provider.package_settings_munge(value)
+        else
+          super
+        end
+      end
+
+      def insync?(is)
+        provider.package_settings_insync?(should, is)
+      end
+
+      def should_to_s(newvalue)
+        if provider.respond_to?(:package_settings_should_to_s)
+          provider.package_settings_should_to_s(should, newvalue)
+        else
+          super
+        end
+      end
+
+      def is_to_s(currentvalue)
+        if provider.respond_to?(:package_settings_is_to_s)
+          provider.package_settings_is_to_s(should, currentvalue)
+        else
+          super
+        end
+      end
+
+      def change_to_s(currentvalue, newvalue)
+        if provider.respond_to?(:package_settings_change_to_s)
+          provider.package_settings_change_to_s(currentvalue, newvalue)
+        else
+          super
+        end
+      end
+    end
+
     newparam(:source) do
-      desc "Where to find the actual package.  This must be a local file
+      desc "Where to find the actual package. This must be a local file
         (or on a network file system) or a URL that your specific
         packaging type understands; Puppet will not retrieve files for you,
         although you can manage packages as `file` resources."

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -26,6 +26,10 @@ describe Puppet::Type.type(:package) do
     Puppet::Type.type(:package).provider_feature(:versionable).should_not be_nil
   end
 
+  it "should have a :package_settings feature that requires :package_settings_insync?, :package_settings and :package_settings=" do
+    Puppet::Type.type(:package).provider_feature(:package_settings).methods.should == [:package_settings_insync?, :package_settings, :package_settings=]
+  end
+
   it "should default to being installed" do
     pkg = Puppet::Type.type(:package).new(:name => "yay", :provider => :apt)
     pkg.should(:ensure).should == :present
@@ -40,6 +44,10 @@ describe Puppet::Type.type(:package) do
 
     it "should have an ensure property" do
       Puppet::Type.type(:package).attrtype(:ensure).should == :property
+    end
+
+    it "should have a package_settings property" do
+      Puppet::Type.type(:package).attrtype(:package_settings).should == :property
     end
   end
 


### PR DESCRIPTION
This changeset adds the package_settings property to "package" type. It's
intended to be used mainly with FreeBSD ports to control port options on
installed packages (the options normally set with make config).

The sole implementation of package_settings is delegated to providers. This
changeset only introduces package_settings feature and property to package
type (this initially defines an interface between package type and
provider used to handle package_settings).
