### PR TITLE
(PUP-1448) Validates the user type shell property

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
 
   # Provider features
   has_features :manages_aix_lam
-  has_features :manages_homedir, :manages_passwords
+  has_features :manages_homedir, :manages_passwords, :manages_shell
   has_features :manages_expiry,  :manages_password_age
 
   # Attribute verification (TODO)

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -30,6 +30,9 @@ Puppet::Type.type(:user).provide :directoryservice do
   # 10.8 Passwords use a PBKDF2 salt value
   has_features :manages_password_salt
 
+  #provider can set the user's shell
+  has_feature :manages_shell
+
 ##               ##
 ## Class Methods ##
 ##               ##

--- a/lib/puppet/provider/user/ldap.rb
+++ b/lib/puppet/provider/user/ldap.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:user).provide :ldap, :parent => Puppet::Provider::Ldap do
 
   confine :feature => :ldap, :false => (Puppet[:ldapuser] == "")
 
-  has_feature :manages_passwords
+  has_feature :manages_passwords, :manages_shell
 
   manages(:posixAccount, :person).at("ou=People").named_by(:uid).and.maps :name => :uid,
     :password => :userPassword,

--- a/lib/puppet/provider/user/pw.rb
+++ b/lib/puppet/provider/user/pw.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:user).provide :pw, :parent => Puppet::Provider::NameService::
   desc "User management via `pw` on FreeBSD and DragonFly BSD."
 
   commands :pw => "pw"
-  has_features :manages_homedir, :allows_duplicates, :manages_passwords, :manages_expiry
+  has_features :manages_homedir, :allows_duplicates, :manages_passwords, :manages_expiry, :manages_shell
 
   defaultfor :operatingsystem => [:freebsd, :dragonfly]
 

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -80,6 +80,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     false
   end
 
+  def shell=(value)
+    check_valid_shell
+    set("shell", value)
+  end
+
   verify :gid, "GID must be an integer" do |value|
     value.is_a? Integer
   end
@@ -92,6 +97,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   has_features :system_users unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
 
   has_features :manages_passwords, :manages_password_age if Puppet.features.libshadow?
+  has_features :manages_shell
 
   def check_allow_dup
     # We have to manually check for duplicates when using libuser
@@ -106,6 +112,15 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
        return ["-o"]
     end
     []
+  end
+
+  def check_valid_shell
+    unless File.exists?(@resource.should(:shell))
+      raise(Puppet::Error, "Shell #{@resource.should(:shell)} must exist")
+    end
+    unless File.executable?(@resource.should(:shell).to_s)
+      raise(Puppet::Error, "Shell #{@resource.should(:shell)} must be executable")
+    end
   end
 
   def check_manage_home
@@ -202,6 +217,9 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   end
 
   def create
+    if @resource[:shell]
+      check_valid_shell
+    end
      super
      if @resource.forcelocal? and self.groups?
        set(:groups, @resource[:groups])

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -54,6 +54,9 @@ module Puppet
       "Allows local users to be managed on systems that also use some other
        remote NSS method of managing accounts."
 
+    feature :manages_shell,
+      "The provider allows for setting shell and validates if possible"
+
     newproperty(:ensure, :parent => Puppet::Property::Ensure) do
       newvalue(:present, :event => :user_created) do
         provider.create
@@ -169,7 +172,7 @@ module Puppet
       end
     end
 
-    newproperty(:shell) do
+    newproperty(:shell, :required_features => :manages_shell) do
       desc "The user's login shell.  The shell must exist and be
         executable.
 


### PR DESCRIPTION
Adds the feature :manages_shell to the user type and asserts that
providers manipulating the shell property must have this feature.  The
useradd provider is then patched to specifically check that the shell
property is valid (file exists and is executable).  Other providers
which use shell (user/aix, user/directory_service, user/ldap, user/pw)
have the :manages_shell feature added to ensure that they continue to
function, but no additional validation is performed.

Rebased to a more recent master from Alejandro Ramirez's PR
https://github.com/puppetlabs/puppet/pull/1942
(Commits squashed)
