### PR TITLE
(PUP-1389) Embed the extra NULL within the string

### DIFF
--- a/lib/puppet/util/windows/string.rb
+++ b/lib/puppet/util/windows/string.rb
@@ -2,10 +2,13 @@ require 'puppet/util/windows'
 
 module Puppet::Util::Windows::String
   def wide_string(str)
-    # bug in win32-api, see https://tickets.puppetlabs.com/browse/PUP-1389
-    wstr = str.encode('UTF-16LE')
-    wstr << 0
-    wstr.strip
+    # ruby (< 2.1) does not respect multibyte terminators, so it is possible
+    # for a string to contain a single trailing null byte, followed by garbage
+    # causing buffer overruns.
+    #
+    # See http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=41920&view=revision
+    newstr = str + "\0".encode(str.encoding)
+    newstr.encode!('UTF-16LE')
   end
   module_function :wide_string
 end

--- a/spec/unit/util/windows/string_spec.rb
+++ b/spec/unit/util/windows/string_spec.rb
@@ -5,9 +5,17 @@ require 'spec_helper'
 require 'puppet/util/windows'
 
 describe "Puppet::Util::Windows::String", :if => Puppet.features.microsoft_windows? do
+  UTF16_NULL = [0, 0]
 
   def wide_string(str)
     Puppet::Util::Windows::String.wide_string(str)
+  end
+
+  def converts_to_wide_string(string_value)
+    expected = string_value.encode(Encoding::UTF_16LE)
+    expected_bytes = expected.bytes.to_a + UTF16_NULL
+
+    wide_string(string_value).bytes.to_a.should == expected_bytes
   end
 
   context "wide_string" do
@@ -20,51 +28,27 @@ describe "Puppet::Util::Windows::String", :if => Puppet.features.microsoft_windo
     end
 
     it "should convert an ASCII string" do
-      string_value = "bob".encode(Encoding::US_ASCII)
-      result = wide_string(string_value)
-      expected = string_value.encode(Encoding::UTF_16LE)
-
-      result.bytes.to_a.should == expected.bytes.to_a
+      converts_to_wide_string("bob".encode(Encoding::US_ASCII))
     end
 
     it "should convert a UTF-8 string" do
-      string_value = "bob".encode(Encoding::UTF_8)
-      result = wide_string(string_value)
-      expected = string_value.encode(Encoding::UTF_16LE)
-
-      result.bytes.to_a.should == expected.bytes.to_a
+      converts_to_wide_string("bob".encode(Encoding::UTF_8))
     end
 
     it "should convert a UTF-16LE string" do
-      string_value = "bob\u00E8".encode(Encoding::UTF_16LE)
-      result = wide_string(string_value)
-      expected = string_value.encode(Encoding::UTF_16LE)
-
-      result.bytes.to_a.should == expected.bytes.to_a
+      converts_to_wide_string("bob\u00E8".encode(Encoding::UTF_16LE))
     end
 
     it "should convert a UTF-16BE string" do
-      string_value = "bob\u00E8".encode(Encoding::UTF_16BE)
-      result = wide_string(string_value)
-      expected = string_value.encode(Encoding::UTF_16LE)
-
-      result.bytes.to_a.should == expected.bytes.to_a
+      converts_to_wide_string("bob\u00E8".encode(Encoding::UTF_16BE))
     end
 
     it "should convert an UTF-32LE string" do
-      string_value = "bob\u00E8".encode(Encoding::UTF_32LE)
-      result = wide_string(string_value)
-      expected = string_value.encode(Encoding::UTF_16LE)
-
-      result.bytes.to_a.should == expected.bytes.to_a
+      converts_to_wide_string("bob\u00E8".encode(Encoding::UTF_32LE))
     end
 
     it "should convert an UTF-32BE string" do
-      string_value = "bob\u00E8".encode(Encoding::UTF_32BE)
-      result = wide_string(string_value)
-      expected = string_value.encode(Encoding::UTF_16LE)
-
-      result.bytes.to_a.should == expected.bytes.to_a
+      converts_to_wide_string("bob\u00E8".encode(Encoding::UTF_32BE))
     end
   end
 end


### PR DESCRIPTION
Previously, we were appending a NULL to the wide encoded string to work around
a ruby bug fixed in 2.1.

However, we were calling `String#strip`, which makes a copy of the string, and
in the process only preserves the first NULL.

This commit embeds a NULL within the string itself, e.g. "bob\0". Since the
NULL is part of the string data, ruby will preserve it.

Also, `String#+` cannot combine strings with different encodings,
e.g. "a".encode('UTF-16LE') + "\0" results in:

```
incompatible character encodings: UTF-16LE and US-ASCII
```

which is why we need to encode the terminator. The actual message depends on
the default encoding, e.g. US-ASCII, UTF-8.
