### PR TITLE
(PUP-1166) Add better error for 3x --strict_variables

### DIFF
--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -268,6 +268,20 @@ describe Puppet::Parser::Scope do
         @scope["other::deep::klass::var"].should be_nil
       end
     end
+
+    context "and strict_variables is true" do
+      before(:each) do
+        Puppet[:strict_variables] = true
+      end
+
+      it "should raise an error when unknown variable is looked up" do
+        expect { @scope['john_doe'] }.to raise_error(/Undefined variable/)
+      end
+
+      it "should raise an error when unknown qualified variable is looked up" do
+        expect { @scope['nowhere::john_doe'] }.to raise_error(/Undefined variable/)
+      end
+    end
   end
 
   describe "when variables are set with append=true" do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -16,6 +16,12 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
   include PuppetSpec::Scope
   before(:each) do
     Puppet[:strict_variables] = true
+
+    # These must be set since the is 3x logic that triggers on these even if the tests are explicit
+    # about selection of parser and evaluator
+    #
+    Puppet[:parser] = 'future'
+    Puppet[:evaluator] = 'future'
   end
 
   let(:parser) { Puppet::Pops::Parser::EvaluatingParser::Transitional.new }


### PR DESCRIPTION
When using --strict_varibles and not also using the future evaluator the generated error was not good.
This change raises an "Undefined variable" exception like in the future evaluator.
