### PR TITLE
(PUP-266) Ensure ADSI Group SIDs may be looked up

### DIFF
--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -138,6 +138,7 @@ describe Puppet::Type.type(:group).provider(:windows_adsi) do
   end
 
   it "should be able to test whether a group exists" do
+    Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
     Puppet::Util::ADSI.stubs(:connect).returns stub('connection')
     provider.should be_exists
 

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -122,6 +122,7 @@ describe Puppet::Type.type(:user).provider(:windows_adsi) do
   end
 
   it 'should be able to test whether a user exists' do
+    Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
     Puppet::Util::ADSI.stubs(:connect).returns stub('connection')
     provider.should be_exists
 

--- a/spec/unit/util/adsi_spec.rb
+++ b/spec/unit/util/adsi_spec.rb
@@ -73,10 +73,12 @@ describe Puppet::Util::ADSI do
     let(:domain_username) { "#{domain}\\#{username}"}
 
     it "should generate the correct URI" do
+      Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
       Puppet::Util::ADSI::User.uri(username).should == "WinNT://./#{username},user"
     end
 
     it "should generate the correct URI for a user with a domain" do
+      Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
       Puppet::Util::ADSI::User.uri(username, domain).should == "WinNT://#{domain}/#{username},user"
     end
 
@@ -107,13 +109,24 @@ describe Puppet::Util::ADSI do
     end
 
     it "should be able to check the existence of a user" do
+      Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
       Puppet::Util::ADSI.expects(:connect).with("WinNT://./#{username},user").returns connection
       Puppet::Util::ADSI::User.exists?(username).should be_true
     end
 
     it "should be able to check the existence of a domain user" do
+      Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
       Puppet::Util::ADSI.expects(:connect).with("WinNT://#{domain}/#{username},user").returns connection
       Puppet::Util::ADSI::User.exists?(domain_username).should be_true
+    end
+
+    it "should be able to confirm the existence of a user with a well-known SID",
+      :if => Puppet.features.microsoft_windows? do
+
+      system_user = Win32::Security::SID::LocalSystem
+      # ensure that the underlying OS is queried here
+      Puppet::Util::ADSI.unstub(:connect)
+      Puppet::Util::ADSI::User.exists?(system_user).should be_true
     end
 
     it "should be able to delete a user" do
@@ -123,6 +136,8 @@ describe Puppet::Util::ADSI do
     end
 
     it "should return an enumeration of IADsUser wrapped objects" do
+      Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
+
       name = 'Administrator'
       wmi_users = [stub('WMI', :name => name)]
       Puppet::Util::ADSI.expects(:execquery).with('select name from win32_useraccount where localaccount = "TRUE"').returns(wmi_users)
@@ -174,7 +189,7 @@ describe Puppet::Util::ADSI do
         user.password = 'pwd'
       end
 
-      it "should generate the correct URI",:if => Puppet.features.microsoft_windows? do
+      it "should generate the correct URI", :if => Puppet.features.microsoft_windows? do
         Puppet::Util::Windows::Security.stubs(:octet_string_to_sid_object).returns(sid)
         user.uri.should == "WinNT://testcomputername/#{username},user"
       end
@@ -321,11 +336,13 @@ describe Puppet::Util::ADSI do
       end
 
       it "should generate the correct URI" do
+        Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
         group.uri.should == "WinNT://./#{groupname},group"
       end
     end
 
     it "should generate the correct URI" do
+      Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
       Puppet::Util::ADSI::Group.uri("people").should == "WinNT://./people,group"
     end
 
@@ -342,9 +359,19 @@ describe Puppet::Util::ADSI do
     end
 
     it "should be able to confirm the existence of a group" do
+      Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
       Puppet::Util::ADSI.expects(:connect).with("WinNT://./#{groupname},group").returns connection
 
       Puppet::Util::ADSI::Group.exists?(groupname).should be_true
+    end
+
+    it "should be able to confirm the existence of a group with a well-known SID",
+      :if => Puppet.features.microsoft_windows? do
+
+      service_group = Win32::Security::SID::Service
+      # ensure that the underlying OS is queried here
+      Puppet::Util::ADSI.unstub(:connect)
+      Puppet::Util::ADSI::Group.exists?(service_group).should be_true
     end
 
     it "should be able to delete a group" do
@@ -354,6 +381,8 @@ describe Puppet::Util::ADSI do
     end
 
     it "should return an enumeration of IADsGroup wrapped objects" do
+      Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
+
       name = 'Administrators'
       wmi_groups = [stub('WMI', :name => name)]
       Puppet::Util::ADSI.expects(:execquery).with('select name from win32_group where localaccount = "TRUE"').returns(wmi_groups)


### PR DESCRIPTION
- Previously, calling Puppet::Util::ADSI::Group.exists? for a
  well-known group SID would return false, because the WinNT:// style
  URI used to find the group would not examine / lookup the SID, but
  would instead create a broken Uri that the underlying OS could not
  understand
- Now, the given group name is checked to see if it's a SID before the
  Uri is constructed, and a SID style Uri is created where appropriate
