### PR TITLE
Removed Debian Service provider default on Ubuntu

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   # is resolved.
   commands :invoke_rc => "/usr/sbin/invoke-rc.d"
 
-  defaultfor :operatingsystem => [:debian, :ubuntu]
+  defaultfor :operatingsystem => :debian
 
   # Remove the symlinks
   def disable


### PR DESCRIPTION
Ubuntu uses Upstart instead of the regular Debian init scripts. It provides Debian init script compatibility through  a wrapper though. So this shouldn't cause problems for packages using the Debian init script style
