### PR TITLE
(PUP-1470): Make mk_resource_method deal with false.

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -419,7 +419,11 @@ class Puppet::Provider
       attr = attr.intern
       next if attr == :name
       define_method(attr) do
-        @property_hash[attr] || :absent
+        if @property_hash[attr].nil?
+          :absent
+        else
+          @property_hash[attr]
+        end
       end
 
       define_method(attr.to_s + "=") do |val|


### PR DESCRIPTION
If a property was set to `false` the getter generated by `mk_resource_method` would return `:absent` instead of `false`. It should only return `:absent` if the property doesn't exist/is `nil`.
