### PR TITLE
(PUP-1318) Service log error on failure

### DIFF
--- a/lib/puppet/provider/service/service.rb
+++ b/lib/puppet/provider/service/service.rb
@@ -20,10 +20,10 @@ Puppet::Type.type(:service).provide :service do
   end
 
   # A simple wrapper so execution failures are a bit more informative.
-  def texecute(type, command, fof = true, squelch = false)
+  def texecute(type, command, fof = true, squelch = false, combine = true)
     begin
       # #565: Services generally produce no output, so squelch them.
-      execute(command, :failonfail => fof, :override_locale => false, :squelch => squelch)
+      execute(command, :failonfail => fof, :override_locale => false, :squelch => squelch, :combine => combine)
     rescue Puppet::ExecutionFailure => detail
       @resource.fail "Could not #{type} #{@resource.ref}: #{detail}"
     end


### PR DESCRIPTION
After a day trying to debug a really weird issue with a service failing only when puppet ran it and trying to debug why, I tried my hand at adding functionality so that when a service returns an error, it's output to the logs.

However, it dumps the full log, rather than the line by line that exec does. And I'm not sure how to write the spec, as there doesn't seem to be any service specific specs for output.

Any help appreciated! :smile: 
