### PR TITLE
(PUP-1484) Fix serialization of TagSet

### DIFF
--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -1,6 +1,9 @@
 require 'set'
+require 'puppet/network/format_support'
 
 class Puppet::Util::TagSet < Set
+  include Puppet::Network::FormatSupport
+
   def self.from_yaml(yaml)
     self.new(YAML.load(yaml))
   end
@@ -13,14 +16,18 @@ class Puppet::Util::TagSet < Set
     self.new(data)
   end
 
+  def to_data_hash
+    to_a
+  end
+
   def to_pson(*args)
-    to_a.to_pson
+    to_data_hash.to_pson
   end
 
   # this makes puppet serialize it as an array for backwards
   # compatibility
   def to_zaml(z)
-    to_a.to_zaml(z)
+    to_data_hash.to_zaml(z)
   end
 
   def join(*args)

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -48,6 +48,29 @@ describe "Puppet Network Format" do
         @msgpack.intern_multiple(Hash, MessagePack.pack(["foo"]))
       end.to raise_error(NoMethodError)
     end
+
+    it "should be able to serialize a catalog" do
+      cat = Puppet::Resource::Catalog.new('foo')
+      cat.add_resource(Puppet::Resource.new(:file, 'my_file'))
+      catunpack = MessagePack.unpack(cat.to_msgpack)
+      catunpack.should include(
+        "tags"=>[],
+        "name"=>"foo",
+        "version"=>nil,
+        "environment"=>"",
+        "edges"=>[],
+        "classes"=>[]
+      )
+      catunpack["resources"][0].should include(
+        "type"=>"File",
+        "title"=>"my_file",
+        "exported"=>false
+      )
+      catunpack["resources"][0]["tags"].should include(
+        "file",
+        "my_file"
+      )
+    end
   end
 
   it "should include a yaml format" do


### PR DESCRIPTION
The TagSet class didn't include FormatSupport and didn't have a
to_data_hash method, so it couldn't be serialized to msgpack.
