### PR TITLE
(PUP-1438) yumrepos type does not handle white space in repo files

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -230,7 +230,7 @@ module Puppet
       desc "Whether this repository is enabled, as represented by a
         `0` or `1`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(/^(0|1)$/) { }
+      newvalue(/^\s*(0|1)$/) { }
     end
 
     newproperty(:gpgcheck, :parent => Puppet::IniProperty) do
@@ -238,7 +238,7 @@ module Puppet
         from this repository, as represented by a `0` or `1`.
         #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(/^(0|1)$/) { }
+      newvalue(/^\s*(0|1)$/) { }
     end
 
     newproperty(:gpgkey, :parent => Puppet::IniProperty) do
@@ -278,7 +278,7 @@ module Puppet
       desc "Whether yum will allow the use of package groups for this
         repository, as represented by a `0` or `1`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(/^(0|1)$/) { }
+      newvalue(/^\s*(0|1)$/) { }
     end
 
     newproperty(:failovermethod, :parent => Puppet::IniProperty) do
@@ -292,7 +292,7 @@ module Puppet
       desc "Whether HTTP/1.1 keepalive should be used with this repository, as
         represented by a `0` or `1`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(/^(0|1)$/) { }
+      newvalue(/^\s*(0|1)$/) { }
     end
 
      newproperty(:http_caching, :parent => Puppet::IniProperty) do
@@ -320,7 +320,7 @@ module Puppet
         that the `protectbase` plugin is installed and enabled.
         #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(/^(0|1)$/) { }
+      newvalue(/^\s*(0|1)$/) { }
     end
 
     newproperty(:priority, :parent => Puppet::IniProperty) do
@@ -359,7 +359,7 @@ module Puppet
     newproperty(:s3_enabled, :parent => Puppet::IniProperty) do
       desc "Access the repo via S3. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(/^(0|1)$/) { }
+      newvalue(/^\s*(0|1)$/) { }
     end
 
     newproperty(:sslcacert, :parent => Puppet::IniProperty) do
@@ -375,7 +375,7 @@ module Puppet
         Possible values are 'True' or 'False'.
         #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(%r(True|False)) { }
+      newvalue(%r(True|False|1|0)) { }
     end
 
     newproperty(:sslclientcert, :parent => Puppet::IniProperty) do

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -46,13 +46,15 @@ describe Puppet::Type.type(:yumrepo) do
       lambda { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :http_caching => "notavalidvalue") }.should raise_error
     end
 
-    it "should fail if 'sslverify' does not have one of the following values (True|False)" do
+    it "should fail if 'sslverify' does not have one of the following values (True|False|0|1)" do
       lambda { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :sslverify => "notavalidvalue") }.should raise_error
     end
 
-    it "should succeed if 'sslverify' has one of the following values (True|False)" do
+    it "should succeed if 'sslverify' has one of the following values (True|False|0|1)" do
       Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :sslverify => "True")[:sslverify].should == "True"
       Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :sslverify => "False")[:sslverify].should == "False"
+      Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :sslverify => "1")[:sslverify].should == "1"
+      Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", :sslverify => "0")[:sslverify].should == "0"
     end
   end
 


### PR DESCRIPTION
The yum repository definition files from Redhat come with space between
the key and the value (such as "enabled = 1"). The Redhat setting for
the sslVerify key is also a "1" even though the man page lists acceptable
values as (True|False)

This commit modifies the regex for the yumrepo type to allow puppet to
parse the Yum repo config files from Redhat.
