### PR TITLE
PUP-1494 Guard against Win32 memory corruption from Ruby .encode('UTF-16LE')

### DIFF
--- a/lib/puppet/util/colors.rb
+++ b/lib/puppet/util/colors.rb
@@ -84,7 +84,7 @@ module Puppet::Util::Colors
     begin
       require 'Win32API'
       require 'win32console'
-      require 'windows/wide_string'
+      require 'puppet/util/windows/string'
 
       # The win32console gem uses ANSI functions for writing to the console
       # which doesn't work for unicode strings, e.g. module tool. Ruby 1.9
@@ -113,8 +113,8 @@ module Puppet::Util::Colors
         end
 
         def string_encode(str)
-          wstr = str.encode('UTF-16LE')
-          [wstr, wstr.length]
+          wstr = Puppet::Util::Windows::String.wide_string(str)
+          [wstr, wstr.length - 1]
         end
       end
 

--- a/spec/unit/util/colors_spec.rb
+++ b/spec/unit/util/colors_spec.rb
@@ -66,4 +66,18 @@ describe Puppet::Util::Colors do
       end
     end
   end
+
+  describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    it "expects a trailing embedded NULL character in the wide string" do
+      message = "hello"
+
+      console = Puppet::Util::Colors::WideConsole.new
+      wstr, nchars = console.string_encode(message)
+
+      expect(nchars).to eq(message.length)
+
+      expect(wstr.length).to eq(nchars + 1)
+      expect(wstr[-1].ord).to be_zero
+    end
+  end
 end


### PR DESCRIPTION
Ruby's .encode(UTF-16LE) call on String may generate a string that
not properly terminated with 2 NULLs, which may result in garbage
bytes read from the memory pointer passed into the Win32 API. This
can cause memory instability which results in failures in later
Win32 calls.  These calls have been replaced with an internal
helper that properly NULl terminates the string.  Note that this
bug is fixed in Ruby 2.1:
http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=41920&view=revision
