### PR TITLE
(PUP-1485) Don't use master when we want compilation to fail

### DIFF
--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -9,7 +9,9 @@ end
 step "run agents again, verify they use cached catalog" do
   agents.each do |agent|
     # can't use --test, because that will set usecacheonfailure=false
-    on(agent, puppet("agent --onetime --no-daemonize --server #{master} --verbose")) do |result|
+    # We use a server that the agent can't possibly talk to in order
+    # to guarantee that no communication can take place.
+    on(agent, puppet("agent --onetime --no-daemonize --server puppet.example.com --verbose")) do |result|
       assert_match(/Using cached catalog/, result.stdout)
     end
   end


### PR DESCRIPTION
Previously, this test assumed that outside of a `with_puppet_running_on`
block, the puppet master would not be running. This is true in the
FOSS test environment, but when we test against PE there is always a
master running. By using a name that is guaranteed to not be a puppet
server, we can ensure the agent is always incapable of getting a
catalog.
