### PR TITLE
(maint) Puppet fails to properly surface backtraces

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -271,7 +271,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       catalog = Puppet::Resource::Catalog.convert_from(Puppet::Resource::Catalog.default_format,text)
       catalog = Puppet::Resource::Catalog.pson_create(catalog) unless catalog.is_a?(Puppet::Resource::Catalog)
     rescue => detail
-      raise Puppet::Error, "Could not deserialize catalog from pson: #{detail}"
+      raise Puppet::Error, "Could not deserialize catalog from pson: #{detail}", detail.backtrace
     end
 
     catalog.to_ral

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -47,7 +47,7 @@ class Puppet::Configurer
       Puppet::FileSystem.unlink(Puppet[:statefile])
       retry
     rescue => detail
-      raise Puppet::Error.new("Cannot remove #{Puppet[:statefile]}: #{detail}")
+      raise Puppet::Error.new("Cannot remove #{Puppet[:statefile]}: #{detail}", detail)
     end
   end
 

--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -23,7 +23,7 @@ module Puppet::Configurer::FactHandler
     rescue Exception => detail
       message = "Could not retrieve local facts: #{detail}"
       Puppet.log_exception(detail, message)
-      raise Puppet::Error, message
+      raise Puppet::Error, message, detail.backtrace
     end
   end
 

--- a/lib/puppet/external/pson/common.rb
+++ b/lib/puppet/external/pson/common.rb
@@ -319,7 +319,7 @@ module PSON
       result
     end
   rescue PSON::NestingError
-    raise ArgumentError, "exceed depth limit"
+    raise ArgumentError, "exceed depth limit", $!.backtrace
   end
 
 

--- a/lib/puppet/external/pson/pure/generator.rb
+++ b/lib/puppet/external/pson/pure/generator.rb
@@ -46,7 +46,7 @@ module PSON
       string.gsub!(/["\\\x0-\x1f]/) { MAP[$MATCH] }
       string
     rescue => e
-      raise GeneratorError, "Caught #{e.class}: #{e}"
+      raise GeneratorError, "Caught #{e.class}: #{e}", e.backtrace
     end
   else
     def utf8_to_pson(string) # :nodoc:

--- a/lib/puppet/external/pson/pure/parser.rb
+++ b/lib/puppet/external/pson/pure/parser.rb
@@ -204,7 +204,7 @@ module PSON
           UNPARSED
         end
       rescue => e
-        raise GeneratorError, "Caught #{e.class}: #{e}"
+        raise GeneratorError, "Caught #{e.class}: #{e}", e.backtrace
       end
 
       def parse_value

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -88,12 +88,13 @@ Puppet::Face.define(:help, '0.0.1') do
     begin
       face = Puppet::Face[facename.to_sym, version]
     rescue Puppet::Error => detail
-      fail ArgumentError, <<-MSG
+      msg = <<-MSG
 Could not load help for the face #{facename}.
 Please check the error logs for more information.
 
 Detail: "#{detail.message}"
       MSG
+      fail ArgumentError, msg, detail.backtrace
     end
     if actionname
       action = face.get_action(actionname.to_sym)

--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -50,7 +50,7 @@ class Puppet::FileBucket::Dipper
     rescue => detail
       message = "Could not back up #{file}: #{detail}"
       Puppet.log_exception(detail, message)
-      raise Puppet::Error, message
+      raise Puppet::Error, message, detail.backtrace
     end
   end
 

--- a/lib/puppet/file_serving/fileset.rb
+++ b/lib/puppet/file_serving/fileset.rb
@@ -88,7 +88,7 @@ class Puppet::FileServing::Fileset
       begin
         send(method, value)
       rescue NoMethodError
-        raise ArgumentError, "Invalid option '#{option}'"
+        raise ArgumentError, "Invalid option '#{option}'", $!.backtrace
       end
     end
   end

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -106,7 +106,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       rescue => detail
         message = "Failed when searching for node #{name}: #{detail}"
         Puppet.log_exception(detail, message)
-        raise Puppet::Error, message
+        raise Puppet::Error, message, detail.backtrace
       end
 
 

--- a/lib/puppet/indirector/exec.rb
+++ b/lib/puppet/indirector/exec.rb
@@ -18,7 +18,7 @@ class Puppet::Indirector::Exec < Puppet::Indirector::Terminus
     begin
       output = execute(external_command, :failonfail => true, :combine => false)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Failed to find #{name} via exec: #{detail}"
+      raise Puppet::Error, "Failed to find #{name} via exec: #{detail}", detail.backtrace
     end
 
     if output =~ /\A\s*\Z/ # all whitespace

--- a/lib/puppet/indirector/face.rb
+++ b/lib/puppet/indirector/face.rb
@@ -43,7 +43,7 @@ class Puppet::Indirector::Face < Puppet::Face
     rescue => detail
       message = "Could not call '#{method}' on '#{indirection_name}': #{detail}"
       Puppet.log_exception(detail, message)
-      raise message
+      raise RuntimeError, message, detail.backtrace
     end
 
     return result
@@ -132,7 +132,8 @@ class Puppet::Indirector::Face < Puppet::Face
     begin
       indirection.terminus_class = from
     rescue => detail
-      raise "Could not set '#{indirection.name}' terminus to '#{from}' (#{detail}); valid terminus types are #{self.class.terminus_classes(indirection.name).join(", ") }"
+      msg = "Could not set '#{indirection.name}' terminus to '#{from}' (#{detail}); valid terminus types are #{self.class.terminus_classes(indirection.name).join(", ") }"
+      raise detail, msg, detail.backtrace
     end
   end
 end

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -24,7 +24,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     Puppet::FileSystem.unlink(path(request.key))
   rescue => detail
     unless detail.is_a? Errno::ENOENT
-      raise Puppet::Error, "Could not destroy #{self.name} #{request.key}: #{detail}"
+      raise Puppet::Error, "Could not destroy #{self.name} #{request.key}: #{detail}", detail.backtrace
     end
     1                           # emulate success...
   end
@@ -56,13 +56,13 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     rescue Errno::ENOENT
       return nil
     rescue => detail
-      raise Puppet::Error, "Could not read JSON data for #{indirection.name} #{key}: #{detail}"
+      raise Puppet::Error, "Could not read JSON data for #{indirection.name} #{key}: #{detail}", detail.backtrace
     end
 
     begin
       return from_json(json)
     rescue => detail
-      raise Puppet::Error, "Could not parse JSON data for #{indirection.name} #{key}: #{detail}"
+      raise Puppet::Error, "Could not parse JSON data for #{indirection.name} #{key}: #{detail}", detail.backtrace
     end
   end
 

--- a/lib/puppet/indirector/key/file.rb
+++ b/lib/puppet/indirector/key/file.rb
@@ -30,7 +30,7 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
     begin
       Puppet::FileSystem.unlink(key_path)
     rescue => detail
-      raise Puppet::Error, "Could not remove #{request.key} public key: #{detail}"
+      raise Puppet::Error, "Could not remove #{request.key} public key: #{detail}", detail.backtrace
     end
   end
 
@@ -43,7 +43,7 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
         f.print request.instance.content.public_key.to_pem
       end
     rescue => detail
-      raise Puppet::Error, "Could not write #{request.key}: #{detail}"
+      raise Puppet::Error, "Could not write #{request.key}: #{detail}", detail.backtrace
     end
   end
 end

--- a/lib/puppet/indirector/ldap.rb
+++ b/lib/puppet/indirector/ldap.rb
@@ -70,7 +70,7 @@ class Puppet::Indirector::Ldap < Puppet::Indirector::Terminus
       rescue => detail
         message = "Could not connect to LDAP: #{detail}"
         Puppet.log_exception(detail, message)
-        raise Puppet::Error, message
+        raise Puppet::Error, message, detail.backtrace
       end
     end
 

--- a/lib/puppet/indirector/node/exec.rb
+++ b/lib/puppet/indirector/node/exec.rb
@@ -64,6 +64,6 @@ class Puppet::Node::Exec < Puppet::Indirector::Exec
     end
 
   rescue => detail
-      raise Puppet::Error, "Could not load external node results for #{name}: #{detail}"
+      raise Puppet::Error, "Could not load external node results for #{name}: #{detail}", detail.backtrace
   end
 end

--- a/lib/puppet/indirector/queue.rb
+++ b/lib/puppet/indirector/queue.rb
@@ -39,7 +39,8 @@ class Puppet::Indirector::Queue < Puppet::Indirector::Terminus
       end
       result
   rescue => detail
-      raise Puppet::Error, "Could not write #{request.key} to queue: #{detail}\nInstance::#{request.instance}\n client : #{client}"
+      msg = "Could not write #{request.key} to queue: #{detail}\nInstance::#{request.instance}\n client : #{client}"
+      raise Puppet::Error, msg, detail.backtrace
   end
 
   def self.queue

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -274,7 +274,7 @@ class Puppet::Indirector::Request
     begin
       uri = URI.parse(URI.escape(key))
     rescue => detail
-      raise ArgumentError, "Could not understand URL #{key}: #{detail}"
+      raise ArgumentError, "Could not understand URL #{key}: #{detail}", detail.backtrace
     end
 
     # Just short-circuit these to full paths

--- a/lib/puppet/indirector/resource_type/parser.rb
+++ b/lib/puppet/indirector/resource_type/parser.rb
@@ -81,7 +81,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
     begin
       regex = Regexp.new(key)
     rescue => detail
-      raise ArgumentError, "Invalid regex '#{request.key}': #{detail}"
+      raise ArgumentError, "Invalid regex '#{request.key}': #{detail}", detail.backtrace
     end
 
     result.reject! { |t| t.name.to_s !~ regex }

--- a/lib/puppet/indirector/ssl_file.rb
+++ b/lib/puppet/indirector/ssl_file.rb
@@ -76,7 +76,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
     begin
       Puppet::FileSystem.unlink(path)
     rescue => detail
-      raise Puppet::Error, "Could not remove #{request.key}: #{detail}"
+      raise Puppet::Error, "Could not remove #{request.key}: #{detail}", detail.backtrace
     end
   end
 
@@ -166,7 +166,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
       begin
         Puppet.settings.setting(setting).open_file(path, 'w') { |f| yield f }
       rescue => detail
-        raise Puppet::Error, "Could not write #{path} to #{setting}: #{detail}"
+        raise Puppet::Error, "Could not write #{path} to #{setting}: #{detail}", detail.backtrace
       end
     else
       raise Puppet::DevError, "You must provide a setting to determine where the files are stored"

--- a/lib/puppet/indirector/yaml.rb
+++ b/lib/puppet/indirector/yaml.rb
@@ -11,7 +11,7 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
     begin
       return Puppet::Util::Yaml.load_file(file)
     rescue Puppet::Util::Yaml::YamlLoadError => detail
-      raise Puppet::Error, "Could not parse YAML data for #{indirection.name} #{request.key}: #{detail}"
+      raise Puppet::Error, "Could not parse YAML data for #{indirection.name} #{request.key}: #{detail}", detail.backtrace
     end
   end
 

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -53,7 +53,7 @@ module Puppet::ModuleTool
               begin
                 @metadata.extra_metadata = PSON.load(f)
               rescue PSON::ParserError
-                raise ArgumentError, "Could not parse JSON #{extra_metadata_path}"
+                raise ArgumentError, "Could not parse JSON #{extra_metadata_path}", $!.backtrace
               end
             end
           end

--- a/lib/puppet/module_tool/applications/generator.rb
+++ b/lib/puppet/module_tool/applications/generator.rb
@@ -10,7 +10,8 @@ module Puppet::ModuleTool
         begin
           @metadata = Metadata.new(:full_module_name => full_module_name)
         rescue ArgumentError
-          raise "Could not generate directory #{full_module_name.inspect}, you must specify a dash-separated username and module name."
+          msg = "Could not generate directory #{full_module_name.inspect}, you must specify a dash-separated username and module name."
+          raise $!, msg, $!.backtrace
         end
         super(options)
       end

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -40,7 +40,7 @@ module Puppet::ModuleTool
           begin
             Puppet::ModuleTool::Tar.instance(@module_name).unpack(@filename.to_s, build_dir.to_s, [@module_path.stat.uid, @module_path.stat.gid].join(':'))
           rescue Puppet::ExecutionFailure => e
-            raise RuntimeError, "Could not extract contents of module archive: #{e.message}"
+            raise RuntimeError, "Could not extract contents of module archive: #{e.message}", e.backtrace
           end
 
           # grab the first directory

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -52,9 +52,9 @@ module Puppet::ModuleTool
           begin
             get_remote_constraints(@forge)
           rescue => e
-            raise UnknownModuleError, results.merge(:repository => @forge.uri)
+            raise UnknownModuleError, results.merge(:repository => @forge.uri), e.backtrace
           else
-            raise UnknownVersionError, results.merge(:repository => @forge.uri) if @remote.empty?
+            raise UnknownVersionError, results.merge(:repository => @forge.uri), e.backtrace if @remote.empty?
           end
 
           if !@options[:force] && @versions["#{@module_name}"].last[:vstring].sub(/^(?=\d)/, 'v') == (@module.version || '0.0.0').sub(/^(?=\d)/, 'v')

--- a/lib/puppet/module_tool/shared_behaviors.rb
+++ b/lib/puppet/module_tool/shared_behaviors.rb
@@ -151,7 +151,7 @@ module Puppet::ModuleTool::Shared
           cache_path = forge.retrieve(release[:file])
         end
       rescue OpenURI::HTTPError => e
-        raise RuntimeError, "Could not download module: #{e.message}"
+        raise RuntimeError, "Could not download module: #{e.message}", e.backtrace
       end
 
       [

--- a/lib/puppet/network/auth_config_parser.rb
+++ b/lib/puppet/network/auth_config_parser.rb
@@ -76,7 +76,7 @@ class AuthConfigParser
         right.info msg % val
         right.send(method, val)
       rescue Puppet::AuthStoreError => detail
-        raise Puppet::ConfigurationError, "#{detail} at line #{count} of #{@file}"
+        raise Puppet::ConfigurationError, "#{detail} at line #{count} of #{@file}", detail.backtrace
       end
     end
   end

--- a/lib/puppet/network/http/api/v2/authorization.rb
+++ b/lib/puppet/network/http/api/v2/authorization.rb
@@ -7,7 +7,7 @@ class Puppet::Network::HTTP::API::V2::Authorization
     begin
       check_authorization(:find, request.path, request.params)
     rescue Puppet::Network::AuthorizationError => e
-      raise Puppet::Network::HTTP::Error::HTTPNotAuthorizedError, e.message
+      raise Puppet::Network::HTTP::Error::HTTPNotAuthorizedError, e.message, e.backtrace
     end
   end
 end

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -194,14 +194,15 @@ module Puppet::Network::HTTP
       if error.message.include? "certificate verify failed"
         msg = error.message
         msg << ": [" + @verify.verify_errors.join('; ') + "]"
-        raise Puppet::Error, msg
+        raise Puppet::Error, msg, error.backtrace
       elsif error.message =~ /hostname (\w+ )?not match/
         leaf_ssl_cert = @verify.peer_certs.last
 
         valid_certnames = [leaf_ssl_cert.name, *leaf_ssl_cert.subject_alt_names].uniq
         msg = valid_certnames.length > 1 ? "one of #{valid_certnames.join(', ')}" : valid_certnames.first
+        msg = "Server hostname '#{connection.address}' did not match server certificate; expected #{msg}"
 
-        raise Puppet::Error, "Server hostname '#{connection.address}' did not match server certificate; expected #{msg}"
+        raise Puppet::Error, msg, error.backtrace
       else
         raise
       end

--- a/lib/puppet/parameter.rb
+++ b/lib/puppet/parameter.rb
@@ -464,7 +464,7 @@ class Puppet::Parameter
     begin
       unsafe_validate(value)
     rescue ArgumentError => detail
-      fail detail.to_s
+      fail detail, detail.to_s, detail.backtrace
     rescue Puppet::Error, TypeError
       raise
     rescue => detail

--- a/lib/puppet/parser/functions/generate.rb
+++ b/lib/puppet/parser/functions/generate.rb
@@ -32,6 +32,6 @@ Puppet::Parser::Functions::newfunction(:generate, :arity => -2, :type => :rvalue
       begin
         Dir.chdir(File.dirname(args[0])) { Puppet::Util::Execution.execute(args) }
       rescue Puppet::ExecutionFailure => detail
-        raise Puppet::ParseError, "Failed to execute generator #{args[0]}: #{detail}"
+        raise Puppet::ParseError, "Failed to execute generator #{args[0]}: #{detail}", detail.backtrace
       end
 end

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -253,7 +253,7 @@ class Puppet::Parser::Resource < Puppet::Resource
       validate_parameter(name)
     end
   rescue => detail
-    fail Puppet::ParseError, detail.to_s
+    fail Puppet::ParseError, detail.to_s, detail.backtrace
   end
 
   def extract_parameters(params)

--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -231,7 +231,7 @@ class Puppet::Property < Puppet::Parameter
     rescue => detail
       message = "Could not convert change '#{name}' to string: #{detail}"
       Puppet.log_exception(detail, message)
-      raise Puppet::DevError, message
+      raise Puppet::DevError, message, detail.backtrace
     end
   end
 

--- a/lib/puppet/property/ensure.rb
+++ b/lib/puppet/property/ensure.rb
@@ -59,7 +59,7 @@ class Puppet::Property::Ensure < Puppet::Property
     rescue Puppet::Error, Puppet::DevError
       raise
     rescue => detail
-      raise Puppet::DevError, "Could not convert change #{self.name} to string: #{detail}"
+      raise Puppet::DevError, "Could not convert change #{self.name} to string: #{detail}", detail.backtrace
     end
   end
 

--- a/lib/puppet/provider/aixobject.rb
+++ b/lib/puppet/provider/aixobject.rb
@@ -317,7 +317,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
     begin
       execute(self.addcmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not create #{@resource.class.name} #{@resource.name}: #{detail}"
+      raise Puppet::Error, "Could not create #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
     end
   end
 
@@ -332,7 +332,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
     begin
       execute(self.deletecmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not delete #{@resource.class.name} #{@resource.name}: #{detail}"
+      raise Puppet::Error, "Could not delete #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
     end
   end
 
@@ -376,7 +376,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail
-        raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"
+        raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
       end
     end
 

--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -63,7 +63,7 @@ class Puppet::Provider::Exec < Puppet::Provider
 
       end
     rescue Errno::ENOENT => detail
-      self.fail detail.to_s
+      self.fail Puppet::Error, detail.to_s, detail.backtrace
     end
 
     # Return output twice as processstatus was returned before, but only exitstatus was ever called.

--- a/lib/puppet/provider/file/posix.rb
+++ b/lib/puppet/provider/file/posix.rb
@@ -81,7 +81,7 @@ Puppet::Type.type(:file).provide :posix do
     begin
       File.send(method, should, nil, resource[:path])
     rescue => detail
-      raise Puppet::Error, "Failed to set owner to '#{should}': #{detail}"
+      raise Puppet::Error, "Failed to set owner to '#{should}': #{detail}", detail.backtrace
     end
   end
 
@@ -112,7 +112,7 @@ Puppet::Type.type(:file).provide :posix do
     begin
       File.send(method, nil, should, resource[:path])
     rescue => detail
-      raise Puppet::Error, "Failed to set group to '#{should}': #{detail}"
+      raise Puppet::Error, "Failed to set group to '#{should}': #{detail}", detail.backtrace
     end
   end
 

--- a/lib/puppet/provider/file/windows.rb
+++ b/lib/puppet/provider/file/windows.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:file).provide :windows do
     begin
       set_owner(should, resolved_path)
     rescue => detail
-      raise Puppet::Error, "Failed to set owner to '#{should}': #{detail}"
+      raise Puppet::Error, "Failed to set owner to '#{should}': #{detail}", detail.backtrace
     end
   end
 
@@ -57,7 +57,7 @@ Puppet::Type.type(:file).provide :windows do
     begin
       set_group(should, resolved_path)
     rescue => detail
-      raise Puppet::Error, "Failed to set group to '#{should}': #{detail}"
+      raise Puppet::Error, "Failed to set group to '#{should}': #{detail}", detail.backtrace
     end
   end
 

--- a/lib/puppet/provider/group/aix.rb
+++ b/lib/puppet/provider/group/aix.rb
@@ -127,7 +127,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail
-        raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"
+        raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
       end
     end
   end

--- a/lib/puppet/provider/macauthorization/macauthorization.rb
+++ b/lib/puppet/provider/macauthorization/macauthorization.rb
@@ -143,7 +143,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
         authdb["rules"].delete(resource[:name])
         Plist::Emit.save_plist(authdb, AuthDB)
       rescue Errno::EACCES => e
-        raise Puppet::Error.new("Error saving #{AuthDB}: #{e}")
+        raise Puppet::Error.new("Error saving #{AuthDB}: #{e}", e)
       end
     end
   end
@@ -188,7 +188,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
       cmds << :security << "authorizationdb" << "write" << name
       execute(cmds, :failonfail => false, :combine => false, :stdinfile => tmp.path.to_s)
     rescue Errno::EACCES => e
-      raise Puppet::Error.new("Cannot save right to #{tmp.path}: #{e}")
+      raise Puppet::Error.new("Cannot save right to #{tmp.path}: #{e}", e)
     ensure
       tmp.close
       tmp.unlink

--- a/lib/puppet/provider/naginator.rb
+++ b/lib/puppet/provider/naginator.rb
@@ -23,7 +23,7 @@ class Puppet::Provider::Naginator < Puppet::Provider::ParsedFile
   def self.parse(text)
       Nagios::Parser.new.parse(text.gsub(NAME_STRING, "_naginator_name"))
   rescue => detail
-      raise Puppet::Error, "Could not parse configuration for #{resource_type.name}: #{detail}"
+      raise Puppet::Error, "Could not parse configuration for #{resource_type.name}: #{detail}", detail.backtrace
   end
 
   def self.to_file(records)

--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -169,7 +169,7 @@ class Puppet::Provider::NameService < Puppet::Provider
         execute(cmd)
       end
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not create #{@resource.class.name} #{@resource.name}: #{detail}"
+      raise Puppet::Error, "Could not create #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
     end
   end
 
@@ -183,7 +183,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     begin
       execute(self.deletecmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not delete #{@resource.class.name} #{@resource.name}: #{detail}"
+      raise Puppet::Error, "Could not delete #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
     end
   end
 
@@ -285,7 +285,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     begin
       execute(cmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"
+      raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
     end
   end
 end

--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -113,7 +113,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
       if hash[:pkgname]
         return nil
       else
-        raise Puppet::Error, "Could not list installed Packages: #{detail}"
+        raise Puppet::Error, "Could not list installed Packages: #{detail}", detail.backtrace
       end
     end
 

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
         map {|set| gemsplit(set) }.
         reject {|x| x.nil? }
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not list gems: #{detail}"
+      raise Puppet::Error, "Could not list gems: #{detail}", detail.backtrace
     end
 
     if options[:justme]
@@ -77,7 +77,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
       begin
         uri = URI.parse(source)
       rescue => detail
-        fail "Invalid source '#{uri}': #{detail}"
+        fail detail, "Invalid source '#{uri}': #{detail}", detail.backtrace
       end
 
       case uri.scheme

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     begin
       source_uri = URI.parse source
     rescue => detail
-      fail "Invalid source '#{source}': #{detail}"
+      fail detail, "Invalid source '#{source}': #{detail}", detail.backtrace
     end
 
     source = case source_uri.scheme

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:package).provide :pip,
     result = client.call("package_releases", @resource[:name])
     result.first
   rescue Timeout::Error => detail
-    raise Puppet::Error, "Timeout while contacting pypi.python.org: #{detail}";
+    raise Puppet::Error, "Timeout while contacting pypi.python.org: #{detail}", detail.backtrace
   end
 
   # Install a package.  The ensure parameter may specify installed,
@@ -113,7 +113,7 @@ Puppet::Type.type(:package).provide :pip,
       self.class.commands :pip => pathname
       pip *args
     else
-      raise e, 'Could not locate the pip command.'
+      raise e, 'Could not locate the pip command.', e.backtrace
     end
   end
 end

--- a/lib/puppet/provider/package/ports.rb
+++ b/lib/puppet/provider/package/ports.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
     begin
       output = portversion(*cmd)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new(output)
+      raise Puppet::Error.new(output, $!)
     end
     line = output.split("\n").pop
 

--- a/lib/puppet/provider/package/portupgrade.rb
+++ b/lib/puppet/provider/package/portupgrade.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
     begin
       output = portinfo(*cmdline)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new(output)
+      raise Puppet::Error.new(output, $!)
       return nil
     end
 
@@ -87,7 +87,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
     begin
       output = portinstall(*cmdline)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new(output)
+      raise Puppet::Error.new(output, $!)
     end
 
     if output =~ /\*\* No such /
@@ -110,7 +110,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
     begin
       output = portversion(*cmdline)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new(output)
+      raise Puppet::Error.new(output, $!)
     end
 
     # Check: output format.
@@ -175,7 +175,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
     begin
       output = portinfo(*cmdline)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new(output)
+      raise Puppet::Error.new(output, $!)
     end
 
     # Check: if output isn't in the right format, return nil
@@ -205,7 +205,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
     begin
       output = portinfo(*cmdline)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new(output)
+      raise Puppet::Error.new(output, $!)
     end
 
     if output =~ /^(\S+)/
@@ -223,7 +223,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
     begin
       output = portinfo(*cmdline)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new(output)
+      raise Puppet::Error.new(output, $!)
     end
 
     if output =~ /^(\S+)/
@@ -232,7 +232,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
       begin
         output = portupgrade(*cmdline)
       rescue Puppet::ExecutionFailure
-        raise Puppet::Error.new(output)
+        raise Puppet::Error.new(output, $!)
       end
     end
   end

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -62,7 +62,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
         }
       }
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error, "Failed to list packages"
+      raise Puppet::Error, "Failed to list packages", $!.backtrace
     end
 
     packages

--- a/lib/puppet/provider/selboolean/getsetsebool.rb
+++ b/lib/puppet/provider/selboolean/getsetsebool.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:selboolean).provide(:getsetsebool) do
         output = out.readlines.join('').chomp!
       end
     rescue Puppet::ExecutionFailure
-      raise Puppet::ExecutionFailure, output.split("\n")[0]
+      raise Puppet::ExecutionFailure, output.split("\n")[0], $!.backtrace
     end
     output
   end

--- a/lib/puppet/provider/selmodule/semodule.rb
+++ b/lib/puppet/provider/selmodule/semodule.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
     begin
       execoutput("#{command(:semodule)} --install #{selmod_name_to_filename}")
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not load policy module: #{detail}";
+      raise Puppet::Error, "Could not load policy module: #{detail}", detail.backtrace
     end
     :true
   end
@@ -15,7 +15,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
   def destroy
       execoutput("#{command(:semodule)} --remove #{@resource[:name]}")
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not remove policy module: #{detail}";
+      raise Puppet::Error, "Could not remove policy module: #{detail}", detail.backtrace
   end
 
   def exists?
@@ -47,7 +47,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
   def syncversion= (dosync)
       execoutput("#{command(:semodule)} --upgrade #{selmod_name_to_filename}")
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not upgrade policy module: #{detail}";
+      raise Puppet::Error, "Could not upgrade policy module: #{detail}", detail.backtrace
   end
 
   # Helper functions
@@ -59,7 +59,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
         output = out.readlines.join('').chomp!
       end
     rescue Puppet::ExecutionFailure
-      raise Puppet::ExecutionFailure, output.split("\n")[0]
+      raise Puppet::ExecutionFailure, output.split("\n")[0], $!.backtrace
     end
     output
   end
@@ -127,7 +127,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
         end
       end
     rescue Puppet::ExecutionFailure
-      raise Puppet::ExecutionFailure, "Could not list policy modules: #{lines.join(' ').chomp!}"
+      raise Puppet::ExecutionFailure, "Could not list policy modules: #{lines.join(' ').chomp!}", $!.backtrace
     end
     nil
   end

--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:service).provide :base, :parent => :service do
       begin
         output = kill pid
       rescue Puppet::ExecutionFailure
-        @resource.fail "Could not kill #{self.name}, PID #{pid}: #{output}"
+        @resource.fail Puppet::Error, "Could not kill #{self.name}, PID #{pid}: #{output}", $!
       end
       return true
     end

--- a/lib/puppet/provider/service/daemontools.rb
+++ b/lib/puppet/provider/service/daemontools.rb
@@ -119,7 +119,7 @@ Puppet::Type.type(:service).provide :daemontools, :parent => :base do
         return :running
       end
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new( "Could not get status for service #{resource.ref}: #{detail}" )
+      raise Puppet::Error.new( "Could not get status for service #{resource.ref}: #{detail}", detail)
     end
     :stopped
   end
@@ -132,7 +132,7 @@ Puppet::Type.type(:service).provide :daemontools, :parent => :base do
         system("#{command}")
       end
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new( "Cannot config #{self.service} to enable it: #{detail}" )
+      raise Puppet::Error.new( "Cannot config #{self.service} to enable it: #{detail}", detail)
   end
 
   def enabled?
@@ -158,7 +158,7 @@ Puppet::Type.type(:service).provide :daemontools, :parent => :base do
       end
     end
 rescue Puppet::ExecutionFailure
-    raise Puppet::Error.new( "No daemon directory found for #{self.service}")
+    raise Puppet::Error.new( "No daemon directory found for #{self.service}", $!)
   end
 
   def disable
@@ -174,7 +174,7 @@ rescue Puppet::ExecutionFailure
         end
       end
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new( "No daemon directory found for #{self.service}")
+      raise Puppet::Error.new( "No daemon directory found for #{self.service}", $!)
     end
     self.stop
   end

--- a/lib/puppet/provider/service/gentoo.rb
+++ b/lib/puppet/provider/service/gentoo.rb
@@ -15,7 +15,7 @@ Puppet::Type.type(:service).provide :gentoo, :parent => :init do
   def disable
       output = update :del, @resource[:name], :default
   rescue Puppet::ExecutionFailure
-      raise Puppet::Error, "Could not disable #{self.name}: #{output}"
+      raise Puppet::Error, "Could not disable #{self.name}: #{output}", $!.backtrace
   end
 
   def enabled?
@@ -40,6 +40,6 @@ Puppet::Type.type(:service).provide :gentoo, :parent => :init do
   def enable
       output = update :add, @resource[:name], :default
   rescue Puppet::ExecutionFailure
-      raise Puppet::Error, "Could not enable #{self.name}: #{output}"
+      raise Puppet::Error, "Could not enable #{self.name}: #{output}", $!.backtrace
   end
 end

--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -171,7 +171,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
         @job_list[line.split(/\s/).last] = :running
       end
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new("Unable to determine status of #{resource[:name]}")
+      raise Puppet::Error.new("Unable to determine status of #{resource[:name]}", $!)
     end
     @job_list
   end
@@ -222,7 +222,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
       @macosx_version_major = product_version_major
       return @macosx_version_major
     rescue Puppet::ExecutionFailure => detail
-      fail("Could not determine OS X version: #{detail}")
+      fail(detail, "Could not determine OS X version: #{detail}", detail.backtrace)
     end
   end
 
@@ -257,7 +257,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     begin
       execute(cmds)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new("Unable to start service: #{resource[:name]} at path: #{job_path}")
+      raise Puppet::Error.new("Unable to start service: #{resource[:name]} at path: #{job_path}", $!)
     end
     # As load -w clears the Disabled flag, we need to add it in after
     self.disable if did_enable_job and resource[:enable] == :false
@@ -278,7 +278,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     begin
       execute(cmds)
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error.new("Unable to stop service: #{resource[:name]} at path: #{job_path}")
+      raise Puppet::Error.new("Unable to stop service: #{resource[:name]} at path: #{job_path}", $!)
     end
     # As unload -w sets the Disabled flag, we need to add it in after
     self.enable if did_disable_job and resource[:enable] == :true

--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
     # service in run levels 0, 1 and/or 6
     output = chkconfig("--level", "0123456", @resource[:name], :off)
   rescue Puppet::ExecutionFailure
-    raise Puppet::Error, "Could not disable #{self.name}: #{output}"
+    raise Puppet::Error, "Could not disable #{self.name}: #{output}", $!.backtrace
   end
 
   def enabled?
@@ -38,7 +38,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
   def enable
       chkconfig(@resource[:name], :on)
   rescue Puppet::ExecutionFailure => detail
-    raise Puppet::Error, "Could not enable #{self.name}: #{detail}"
+    raise Puppet::Error, "Could not enable #{self.name}: #{detail}", detail.backtrace
   end
 
   def initscript

--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
       return :running if output =~ /^run: /
     rescue Puppet::ExecutionFailure => detail
       unless detail.message =~ /(warning: |runsv not running$)/
-        raise Puppet::Error.new( "Could not get status for service #{resource.ref}: #{detail}" )
+        raise Puppet::Error.new( "Could not get status for service #{resource.ref}: #{detail}", detail )
       end
     end
     :stopped

--- a/lib/puppet/provider/service/service.rb
+++ b/lib/puppet/provider/service/service.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:service).provide :service do
       # #565: Services generally produce no output, so squelch them.
       execute(command, :failonfail => fof, :override_locale => false, :squelch => true)
     rescue Puppet::ExecutionFailure => detail
-      @resource.fail "Could not #{type} #{@resource.ref}: #{detail}"
+      @resource.fail Puppet::Error, "Could not #{type} #{@resource.ref}: #{detail}", detail
     end
     nil
   end

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
         end
       end
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new( "Cannot config #{self.name} to enable it: #{detail}" )
+      raise Puppet::Error.new( "Cannot config #{self.name} to enable it: #{detail}", detail )
   end
 
   def self.instances

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -87,12 +87,12 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
           end
           return :true
         rescue Puppet::ExecutionFailure => detail
-          raise Puppet::Error.new("Unable to restart service #{@resource[:name]}, error was: #{detail}" )
+          raise Puppet::Error.new("Unable to restart service #{@resource[:name]}, error was: #{detail}", detail )
         end
       end
       self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}" )
+      raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def status
@@ -113,7 +113,7 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
       end
       self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}" )
+      raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 
 end

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def disable
     output = systemctl(:disable, @resource[:name])
   rescue Puppet::ExecutionFailure
-    raise Puppet::Error, "Could not disable #{self.name}: #{output}"
+    raise Puppet::Error, "Could not disable #{self.name}: #{output}", $!.backtrace
   end
 
   def enabled?
@@ -47,7 +47,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def enable
     output = systemctl("enable", @resource[:name])
   rescue Puppet::ExecutionFailure
-    raise Puppet::Error, "Could not enable #{self.name}: #{output}"
+    raise Puppet::Error, "Could not enable #{self.name}: #{output}", $!.backtrace
   end
 
   def restartcmd

--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -22,21 +22,21 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
     w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_AUTO_START )
     raise Puppet::Error.new("Win32 service enable of #{@resource[:name]} failed" ) if( w32ss.nil? )
   rescue Win32::Service::Error => detail
-    raise Puppet::Error.new("Cannot enable #{@resource[:name]}, error was: #{detail}" )
+    raise Puppet::Error.new("Cannot enable #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def disable
     w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_DISABLED )
     raise Puppet::Error.new("Win32 service disable of #{@resource[:name]} failed" ) if( w32ss.nil? )
   rescue Win32::Service::Error => detail
-    raise Puppet::Error.new("Cannot disable #{@resource[:name]}, error was: #{detail}" )
+    raise Puppet::Error.new("Cannot disable #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def manual_start
     w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_DEMAND_START )
     raise Puppet::Error.new("Win32 service manual enable of #{@resource[:name]} failed" ) if( w32ss.nil? )
   rescue Win32::Service::Error => detail
-    raise Puppet::Error.new("Cannot enable #{@resource[:name]} for manual start, error was: #{detail}" )
+    raise Puppet::Error.new("Cannot enable #{@resource[:name]} for manual start, error was: #{detail}", detail )
   end
 
   def enabled?
@@ -56,7 +56,7 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
         raise Puppet::Error.new("Unknown start type: #{w32ss.start_type}")
     end
   rescue Win32::Service::Error => detail
-    raise Puppet::Error.new("Cannot get start type for #{@resource[:name]}, error was: #{detail}" )
+    raise Puppet::Error.new("Cannot get start type for #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def start
@@ -75,13 +75,13 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
 
     net(:start, @resource[:name])
   rescue Puppet::ExecutionFailure => detail
-    raise Puppet::Error.new("Cannot start #{@resource[:name]}, error was: #{detail}" )
+    raise Puppet::Error.new("Cannot start #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def stop
     net(:stop, @resource[:name])
   rescue Puppet::ExecutionFailure => detail
-    raise Puppet::Error.new("Cannot stop #{@resource[:name]}, error was: #{detail}" )
+    raise Puppet::Error.new("Cannot stop #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def status
@@ -96,7 +96,7 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
     debug("Service #{@resource[:name]} is #{w32ss.current_state}")
     return state
   rescue Win32::Service::Error => detail
-    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}" )
+    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   # returns all providers for all existing services and startup state

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -271,7 +271,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
         raise Puppet::ExecutionFailure, "chpasswd said #{output}"
       end
     rescue Puppet::ExecutionFailure  => detail
-      raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"
+      raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
     ensure
       tmpfile.delete()
     end
@@ -311,7 +311,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail
-        raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"
+        raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
       end
     end
   end

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -455,14 +455,14 @@ Puppet::Type.type(:user).provide :directoryservice do
           dscl '.', '-change', "/Users/#{resource.name}", self.class.ns_to_ds_attribute_map[setter_method.intern], @property_hash[setter_method.intern], value
         rescue Puppet::ExecutionFailure => e
           raise Puppet::Error, "Cannot set the #{setter_method} value of '#{value}' for user " +
-               "#{@resource.name} due to the following error: #{e.inspect}"
+               "#{@resource.name} due to the following error: #{e.inspect}", e.backtrace
         end
       else
         begin
           dscl '.', '-merge', "/Users/#{resource.name}", self.class.ns_to_ds_attribute_map[setter_method.intern], value
         rescue Puppet::ExecutionFailure => e
           raise Puppet::Error, "Cannot set the #{setter_method} value of '#{value}' for user " +
-               "#{@resource.name} due to the following error: #{e.inspect}"
+               "#{@resource.name} due to the following error: #{e.inspect}", e.backtrace
         end
       end
     end
@@ -486,7 +486,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     begin
       dscl '.', '-merge', "/#{path}/#{username}", keyname, value
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not set the dscl #{keyname} key with value: #{value} - #{detail.inspect}"
+      raise Puppet::Error, "Could not set the dscl #{keyname} key with value: #{value} - #{detail.inspect}", detail.backtrace
     end
   end
 
@@ -643,7 +643,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     begin
       File.open(filename, 'w') { |f| f.write(value)}
     rescue Errno::EACCES => detail
-      raise Puppet::Error, "Could not write to file #{filename}: #{detail}"
+      raise Puppet::Error, "Could not write to file #{filename}: #{detail}", detail.backtrace
     end
   end
 

--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
   def run(cmd, msg)
       execute(cmd)
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not #{msg} #{@resource.class.name} #{@resource.name}: #{detail}"
+      raise Puppet::Error, "Could not #{msg} #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
   end
 
   def transition(type)
@@ -203,7 +203,7 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
         end
       end
     rescue => detail
-      fail "Could not write replace #{target_file_path}: #{detail}"
+      fail detail, "Could not write replace #{target_file_path}: #{detail}", detail.backtrace
     end
   end
 end

--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -268,7 +268,7 @@ Puppet::Type.type(:zone).provide(:solaris) do
           end
         rescue => detail
           puts detail.stacktrace if Puppet[:debug]
-          raise Puppet::Error, "Could not create sysidcfg: #{detail}"
+          raise Puppet::Error, "Could not create sysidcfg: #{detail}", detail.backtrace
         end
       end
     end
@@ -345,7 +345,7 @@ Puppet::Type.type(:zone).provide(:solaris) do
   def zoneadm(*cmd)
     adm("-z", @resource[:name], *cmd)
   rescue Puppet::ExecutionFailure => detail
-    self.fail "Could not #{cmd[0]} zone: #{detail}"
+    self.fail Puppet::Error, "Could not #{cmd[0]} zone: #{detail}", detail
   end
 
   def zonecfg(*cmd)
@@ -354,7 +354,7 @@ Puppet::Type.type(:zone).provide(:solaris) do
     begin
       cfg("-z", self.name, *cmd)
     rescue Puppet::ExecutionFailure => detail
-      self.fail "Could not #{cmd[0]} zone: #{detail}"
+      self.fail Puppet::Error, "Could not #{cmd[0]} zone: #{detail}", detail
     end
   end
 end

--- a/lib/puppet/rails.rb
+++ b/lib/puppet/rails.rb
@@ -35,7 +35,7 @@ module Puppet::Rails
     rescue => detail
       message = "Could not connect to database: #{detail}"
       Puppet.log_exception(detail, message)
-      raise Puppet::Error, message
+      raise Puppet::Error, message, detail.backtrace
     end
   end
 
@@ -107,7 +107,7 @@ module Puppet::Rails
     rescue => detail
       message = "Could not migrate database: #{detail}"
       Puppet.log_exception(detail, message)
-      raise Puppet::Error, "Could not migrate database: #{detail}"
+      raise Puppet::Error, "Could not migrate database: #{detail}", detail.backtrace
     end
   end
 
@@ -122,7 +122,7 @@ module Puppet::Rails
         ActiveRecord::Base.establish_connection(database_arguments)
       rescue => detail
         Puppet.log_exception(detail)
-        raise Puppet::Error, "Could not connect to database: #{detail}"
+        raise Puppet::Error, "Could not connect to database: #{detail}", detail.backtrace
       end
 
       ActiveRecord::Base.connection.tables.each do |t|

--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -148,7 +148,7 @@ Puppet::Reports.register_report(:tagmail) do
         rescue => detail
           message = "Could not send report emails through smtp: #{detail}"
           Puppet.log_exception(detail, message)
-          raise Puppet::Error, message
+          raise Puppet::Error, message, detail.backtrace
         end
       elsif Puppet[:sendmail] != ""
         begin
@@ -165,7 +165,7 @@ Puppet::Reports.register_report(:tagmail) do
         rescue => detail
           message = "Could not send report emails via sendmail: #{detail}"
           Puppet.log_exception(detail, message)
-          raise Puppet::Error, message
+          raise Puppet::Error, message, detail.backtrace
         end
       else
         raise Puppet::Error, "SMTP server is unset and could not find sendmail"

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -148,7 +148,7 @@ class Puppet::Resource::TypeCollection
 
     @version
   rescue Puppet::ExecutionFailure => e
-    raise Puppet::ParseError, "Execution of config_version command `#{environment[:config_version]}` failed: #{e.message}"
+    raise Puppet::ParseError, "Execution of config_version command `#{environment[:config_version]}` failed: #{e.message}", e.backtrace
   end
 
   def watch_file(filename)

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -297,7 +297,7 @@ class Puppet::Settings
       begin
         setting.handle(self.value(setting.name))
       rescue InterpolationError => err
-        raise err unless options[:ignore_interpolation_dependency_errors]
+        raise InterpolationError, err, err.backtrace unless options[:ignore_interpolation_dependency_errors]
         #swallow. We're not concerned if we can't call hooks because dependencies don't exist yet
         #we'll get another chance after application defaults are initialized
       end
@@ -1079,9 +1079,9 @@ Generated on #{Time.now}.
     begin
       return File.read(file)
     rescue Errno::ENOENT
-      raise ArgumentError, "No such file #{file}"
+      raise ArgumentError, "No such file #{file}", $!.backtrace
     rescue Errno::EACCES
-      raise ArgumentError, "Permission denied to file #{file}"
+      raise ArgumentError, "Permission denied to file #{file}", $!.backtrace
     end
   end
 

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -174,7 +174,7 @@ class Puppet::SSL::CertificateAuthority
     begin
       Puppet.settings.setting(:capass).open('w') { |f| f.print pass }
     rescue Errno::EACCES => detail
-      raise Puppet::Error, "Could not write CA password: #{detail}"
+      raise Puppet::Error, "Could not write CA password: #{detail}", detail.backtrace
     end
 
     @password = pass
@@ -408,7 +408,7 @@ class Puppet::SSL::CertificateAuthority
   private :create_x509_store
 
   # Utility method which is API for PE license checking.
-  # This is used rather than `verify` because 
+  # This is used rather than `verify` because
   #  1) We have already read the certificate from disk into memory.
   #     To read the certificate from disk again is just wasteful.
   #  2) Because we're checking a large number of certificates against

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -205,7 +205,7 @@ DOC
         csr.add_attribute(OpenSSL::X509::Attribute.new(oid, attr_set))
         Puppet.debug("Added csr attribute: #{oid} => #{attr_set.inspect}")
       rescue OpenSSL::X509::AttributeError => e
-        raise Puppet::Error, "Cannot create CSR with attribute #{oid}: #{e.message}"
+        raise Puppet::Error, "Cannot create CSR with attribute #{oid}: #{e.message}", e.backtrace
       end
     end
   end
@@ -230,7 +230,7 @@ DOC
           ext = OpenSSL::X509::Extension.new(oid, value.to_s, false)
           extensions << ext
         rescue OpenSSL::X509::ExtensionError => e
-          raise Puppet::Error, "Cannot create CSR with extension request #{oid}: #{e.message}"
+          raise Puppet::Error, "Cannot create CSR with extension request #{oid}: #{e.message}", e.backtrace
         end
       end
     end

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -117,7 +117,7 @@ module Puppet
             end
           end
         rescue Timeout::Error
-          self.fail "Command exceeded timeout" % value.inspect
+          self.fail Puppet::Error, "Command exceeded timeout" % value.inspect, $!.backtrace
         end
 
         if log = @resource[:logoutput]
@@ -265,7 +265,7 @@ module Puppet
         begin
           value = Float(value)
         rescue ArgumentError
-          raise ArgumentError, "The timeout must be a number."
+          raise ArgumentError, "The timeout must be a number.", $!.backtrace
         end
         [value, 0.0].max
       end

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -126,7 +126,7 @@ module Puppet
       begin
         resource.parameter(:checksum).sum_file(resource[:path])
       rescue => detail
-        raise Puppet::Error, "Could not read #{ftype} #{@resource.title}: #{detail}"
+        raise Puppet::Error, "Could not read #{ftype} #{@resource.title}: #{detail}", detail.backtrace
       end
     end
 
@@ -233,7 +233,7 @@ module Puppet
 
       dipper.getfile(sum)
     rescue => detail
-      fail "Could not retrieve content for #{should} from filebucket: #{detail}"
+      fail detail, "Could not retrieve content for #{should} from filebucket: #{detail}", detail.backtrace
     end
   end
 end

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -58,7 +58,7 @@ module Puppet
         begin
           uri = URI.parse(URI.escape(source))
         rescue => detail
-          self.fail "Could not understand source #{source}: #{detail}"
+          self.fail Puppet::Error, "Could not understand source #{source}: #{detail}", detail.backtrace
         end
 
         self.fail "Cannot use relative URLs '#{source}'" unless uri.absolute?
@@ -175,7 +175,7 @@ module Puppet
             break
           end
         rescue => detail
-          fail detail, "Could not retrieve file metadata for #{source}: #{detail}"
+          fail detail, "Could not retrieve file metadata for #{source}: #{detail}", detail.backtrace
         end
       end
       fail "Could not retrieve information from environment #{resource.catalog.environment} source(s) #{value.join(", ")}" unless @metadata

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -95,7 +95,7 @@ module Puppet
         begin
           provider.update
         rescue => detail
-          self.fail "Could not update: #{detail}"
+          self.fail Puppet::Error, "Could not update: #{detail}", detail.backtrace
         end
 
         if current == :absent
@@ -109,7 +109,7 @@ module Puppet
         begin
           provider.install
         rescue => detail
-          self.fail "Could not update: #{detail}"
+          self.fail Puppet::Error, "Could not update: #{detail}", detail.backtrace
         end
 
         if self.retrieve == :absent

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -330,7 +330,7 @@ end
   def validate_ip(ip, name)
     IPAddr.new(ip) if ip
   rescue ArgumentError
-    self.fail "'#{ip}' is an invalid #{name}"
+    self.fail Puppet::Error, "'#{ip}' is an invalid #{name}", $!.backtrace
   end
 
   def validate_exclusive(interface, address, router)

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -263,7 +263,7 @@ module Util
     begin
       URI::Generic.build(params)
     rescue => detail
-      raise Puppet::Error, "Failed to convert '#{path}' to URI: #{detail}"
+      raise Puppet::Error, "Failed to convert '#{path}' to URI: #{detail}", detail.backtrace
     end
   end
   module_function :path_to_uri

--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -12,7 +12,7 @@ module Puppet::Util::ADSI
       begin
         WIN32OLE.connect(uri)
       rescue Exception => e
-        raise Puppet::Error.new( "ADSI connection error: #{e}" )
+        raise Puppet::Error.new( "ADSI connection error: #{e}", e )
       end
     end
 
@@ -121,7 +121,7 @@ module Puppet::Util::ADSI
       begin
         native_user.SetInfo unless native_user.nil?
       rescue Exception => e
-        raise Puppet::Error.new( "User update failed: #{e}" )
+        raise Puppet::Error.new( "User update failed: #{e}", e )
       end
       self
     end
@@ -251,7 +251,7 @@ module Puppet::Util::ADSI
       begin
         native_group.SetInfo unless native_group.nil?
       rescue Exception => e
-        raise Puppet::Error.new( "Group update failed: #{e}" )
+        raise Puppet::Error.new( "Group update failed: #{e}", e )
       end
       self
     end

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -65,7 +65,7 @@ class Puppet::Util::Autoload
       rescue Exception => detail
         message = "Could not autoload #{name}: #{detail}"
         Puppet.log_exception(detail, message)
-        raise Puppet::Error, message
+        raise Puppet::Error, message, detail.backtrace
       end
     end
 

--- a/lib/puppet/util/backups.rb
+++ b/lib/puppet/util/backups.rb
@@ -46,7 +46,7 @@ module Puppet::Util::Backups
     rescue => detail
       # since they said they want a backup, let's error out
       # if we couldn't make one
-      self.fail "Could not back #{file} up: #{detail.message}"
+      self.fail Puppet::Error, "Could not back #{file} up: #{detail.message}", detail.backtrace
     end
   end
 
@@ -74,7 +74,7 @@ module Puppet::Util::Backups
     rescue => detail
       message = "Could not remove old backup: #{detail}"
       self.log_exception(detail, message)
-      self.fail message
+      self.fail Puppet::Error, message, detail.backtrace
     end
   end
 

--- a/lib/puppet/util/command_line/trollop.rb
+++ b/lib/puppet/util/command_line/trollop.rb
@@ -455,7 +455,7 @@ class Parser
       end
       time ? Date.new(time.year, time.month, time.day) : Date.parse(param)
     rescue ArgumentError
-      raise CommandlineError, "option '#{arg}' needs a date"
+      raise CommandlineError, "option '#{arg}' needs a date", $!.backtrace
     end
   end
 
@@ -651,7 +651,7 @@ private
       begin
         open param
       rescue SystemCallError => e
-        raise CommandlineError, "file or url for option '#{arg}' cannot be opened: #{e.message}"
+        raise CommandlineError, "file or url for option '#{arg}' cannot be opened: #{e.message}", e.backtrace
       end
     end
   end

--- a/lib/puppet/util/errors.rb
+++ b/lib/puppet/util/errors.rb
@@ -85,6 +85,12 @@ module Puppet::Util::Errors
   #   the given arguments.
   #   @param [Class] type of error
   #   @param [String] message error message(s)
+  # @overload fail(error_klass, message, ..)
+  #   Throw an exception of type error_klass with a message concatenated from
+  #   the given arguments.
+  #   @param [Class] type of error
+  #   @param [String] message error message(s)
+  #   @param [Exception] original exception, source of backtrace info
   def fail(*args)
     if args[0].is_a?(Class)
       type = args.shift
@@ -92,7 +98,8 @@ module Puppet::Util::Errors
       type = Puppet::Error
     end
 
-    error = adderrorcontext(type.new(args.join(" ")))
+    other = args.count > 1 ? args.pop : nil
+    error = adderrorcontext(type.new(args.join(" ")), other)
 
     raise error
   end

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -94,7 +94,7 @@ module Puppet::Util::Execution
     output = execute(command)
     return output
   rescue Puppet::ExecutionFailure
-    raise exception, output
+    raise exception, output, exception.backtrace
   end
 
   # Default empty options for {execute}

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -47,7 +47,7 @@ class Puppet::Util::FileType
         rescue => detail
           message = "#{self.class} could not read #{@path}: #{detail}"
           Puppet.log_exception(detail, message)
-          raise Puppet::Error, message
+          raise Puppet::Error, message, detail.backtrace
         end
       end
 
@@ -63,7 +63,7 @@ class Puppet::Util::FileType
         rescue => detail
           message = "#{self.class} could not write #{@path}: #{detail}"
           Puppet.log_exception(detail, message)
-          raise Puppet::Error, message
+          raise Puppet::Error, message, detail.backtrace
         end
       end
     end

--- a/lib/puppet/util/ldap/connection.rb
+++ b/lib/puppet/util/ldap/connection.rb
@@ -66,6 +66,6 @@ class Puppet::Util::Ldap::Connection
       @connection.set_option(LDAP::LDAP_OPT_REFERRALS, LDAP::LDAP_OPT_ON)
       @connection.simple_bind(user, password)
   rescue => detail
-      raise Puppet::Error, "Could not connect to LDAP: #{detail}"
+      raise Puppet::Error, "Could not connect to LDAP: #{detail}", detail.backtrace
   end
 end

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -18,7 +18,7 @@ Puppet::Util::Log.newdesttype :syslog do
     begin
       facility = Syslog.const_get("LOG_#{str.upcase}")
     rescue NameError
-      raise Puppet::Error, "Invalid syslog facility #{str}"
+      raise Puppet::Error, "Invalid syslog facility #{str}", $!.backtrace
     end
 
     @syslog = Syslog.open(name, options, facility)

--- a/lib/puppet/util/metric.rb
+++ b/lib/puppet/util/metric.rb
@@ -71,7 +71,7 @@ class Puppet::Util::Metric
         RRD.create( self.path, '-s', Puppet[:rrdinterval].to_s, '-b', start.to_i.to_s, *args)
       end
     rescue => detail
-      raise "Could not create RRD file #{path}: #{detail}"
+      raise detail, "Could not create RRD file #{path}: #{detail}", detail.backtrace
     end
   end
 
@@ -185,7 +185,7 @@ class Puppet::Util::Metric
       end
       #system("rrdtool updatev #{self.path} '#{arg}'")
     rescue => detail
-      raise Puppet::Error, "Failed to update #{self.name}: #{detail}"
+      raise Puppet::Error, "Failed to update #{self.name}: #{detail}", detail.backtrace
     end
   end
 

--- a/lib/puppet/util/network_device.rb
+++ b/lib/puppet/util/network_device.rb
@@ -7,7 +7,7 @@ class Puppet::Util::NetworkDevice
     require "puppet/util/network_device/#{device.provider}/device"
     @current = Puppet::Util::NetworkDevice.const_get(device.provider.capitalize).const_get(:Device).new(device.url, device.options)
   rescue => detail
-    raise "Can't load #{device.provider} for #{device.name}: #{detail}"
+    raise detail, "Can't load #{device.provider} for #{device.name}: #{detail}", detail.backtrace
   end
 
   # Should only be used in tests

--- a/lib/puppet/util/network_device/transport/ssh.rb
+++ b/lib/puppet/util/network_device/transport/ssh.rb
@@ -33,11 +33,11 @@ class Puppet::Util::NetworkDevice::Transport::Ssh < Puppet::Util::NetworkDevice:
       Puppet.debug("connecting to #{host} as #{user}")
       @ssh = Net::SSH.start(host, user, :port => port, :password => password, :timeout => timeout)
     rescue TimeoutError
-      raise TimeoutError, "timed out while opening an ssh connection to the host"
+      raise TimeoutError, "timed out while opening an ssh connection to the host", $!.backtrace
     rescue Net::SSH::AuthenticationFailed
-      raise Puppet::Error, "SSH authentication failure connecting to #{host} as #{user}"
+      raise Puppet::Error, "SSH authentication failure connecting to #{host} as #{user}", $!.backtrace
     rescue Net::SSH::Exception
-      raise Puppet::Error, "SSH connection failure to #{host}"
+      raise Puppet::Error, "SSH connection failure to #{host}", $!.backtrace
     end
 
     @buf = ""

--- a/lib/puppet/util/queue/stomp.rb
+++ b/lib/puppet/util/queue/stomp.rb
@@ -17,7 +17,7 @@ class Puppet::Util::Queue::Stomp
     begin
       uri = URI.parse(Puppet[:queue_source])
     rescue => detail
-      raise ArgumentError, "Could not create Stomp client instance - queue source #{Puppet[:queue_source]} is invalid: #{detail}"
+      raise ArgumentError, "Could not create Stomp client instance - queue source #{Puppet[:queue_source]} is invalid: #{detail}", detail.backtrace
     end
     unless uri.scheme == "stomp"
       raise ArgumentError, "Could not create Stomp client instance - queue source #{Puppet[:queue_source]} is not a Stomp URL: #{detail}"
@@ -26,7 +26,7 @@ class Puppet::Util::Queue::Stomp
     begin
       self.stomp_client = Stomp::Client.new(uri.user, uri.password, uri.host, uri.port, true)
     rescue => detail
-      raise ArgumentError, "Could not create Stomp client instance with queue source #{Puppet[:queue_source]}: got internal Stomp client error #{detail}"
+      raise ArgumentError, "Could not create Stomp client instance with queue source #{Puppet[:queue_source]}: got internal Stomp client error #{detail}", detail.backtrace
     end
 
     # Identify the supported method for sending messages.

--- a/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
+++ b/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
@@ -218,7 +218,7 @@ module RDoc::PuppetParserCore
             container.add_resource(RDoc::PuppetResource.new(type, title, stmt.doc, param))
           end
         rescue => detail
-          raise Puppet::ParseError, "impossible to parse resource in #{stmt.file} at line #{stmt.line}: #{detail}"
+          raise Puppet::ParseError, "impossible to parse resource in #{stmt.file} at line #{stmt.line}: #{detail}", detail.backtrace
         end
       end
     end
@@ -252,7 +252,7 @@ module RDoc::PuppetParserCore
 
     cls.add_comment(comment, klass.file)
   rescue => detail
-    raise Puppet::ParseError, "impossible to parse class '#{name}' in #{klass.file} at line #{klass.line}: #{detail}"
+    raise Puppet::ParseError, "impossible to parse class '#{name}' in #{klass.file} at line #{klass.line}: #{detail}", detail.backtrace
   end
 
   # create documentation for a node
@@ -277,7 +277,7 @@ module RDoc::PuppetParserCore
 
     n.add_comment(comment, node.file)
   rescue => detail
-    raise Puppet::ParseError, "impossible to parse node '#{name}' in #{node.file} at line #{node.line}: #{detail}"
+    raise Puppet::ParseError, "impossible to parse node '#{name}' in #{node.file} at line #{node.line}: #{detail}", detail.backtrace
   end
 
   # create documentation for a define
@@ -318,7 +318,7 @@ module RDoc::PuppetParserCore
     meth.document_self = true
     meth.singleton = false
   rescue => detail
-    raise Puppet::ParseError, "impossible to parse definition '#{name}' in #{define.file} at line #{define.line}: #{detail}"
+    raise Puppet::ParseError, "impossible to parse definition '#{name}' in #{define.file} at line #{define.line}: #{detail}", detail.backtrace
   end
 
   # Traverse the AST tree and produce code-objects node

--- a/lib/puppet/util/retryaction.rb
+++ b/lib/puppet/util/retryaction.rb
@@ -23,7 +23,7 @@ module Puppet::Util::RetryAction
       # catch the excptions we care about and retry.
       # All others fail hard
 
-      raise RetryException::RetriesExceeded if parameters[:retries] == 0
+      raise RetryException::RetriesExceeded, "#{parameters[:retries]} exceeded", e.backtrace if parameters[:retries] == 0
 
       if (not parameters[:retry_exceptions].keys.empty?) and parameters[:retry_exceptions].keys.include?(e.class)
         Puppet.info("Caught exception #{e.class}:#{e}")

--- a/lib/puppet/util/storage.rb
+++ b/lib/puppet/util/storage.rb
@@ -62,7 +62,7 @@ class Puppet::Util::Storage
         begin
           File.rename(filename, filename + ".bad")
         rescue
-          raise Puppet::Error, "Could not rename corrupt #{filename}; remove manually"
+          raise Puppet::Error, "Could not rename corrupt #{filename}; remove manually", detail.backtrace
         end
       end
     end

--- a/lib/puppet/util/symbolic_file_mode.rb
+++ b/lib/puppet/util/symbolic_file_mode.rb
@@ -128,7 +128,7 @@ module SymbolicFileMode
           rest = ''
         end
 
-        raise Puppet::Error, "#{e}#{rest} in symbolic mode #{modification.inspect}"
+        raise Puppet::Error, "#{e}#{rest} in symbolic mode #{modification.inspect}", e.backtrace
       end
     end
 

--- a/lib/puppet/util/windows/error.rb
+++ b/lib/puppet/util/windows/error.rb
@@ -7,8 +7,8 @@ class Puppet::Util::Windows::Error < Puppet::Error
 
   attr_reader :code
 
-  def initialize(message, code = GetLastError.call)
-    super(message + ":  #{get_last_error(code)}")
+  def initialize(message, code = GetLastError.call, original = nil)
+    super(message + ":  #{get_last_error(code)}", original)
 
     @code = code
   end

--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -13,7 +13,7 @@ module Puppet::Util::Windows
     def root(name)
       Win32::Registry.const_get(name)
     rescue NameError
-      raise Puppet::Error, "Invalid registry key '#{name}'"
+      raise Puppet::Error, "Invalid registry key '#{name}'", $!.backtrace
     end
 
     def open(name, path, mode = KEY_READ | KEY64, &block)
@@ -23,7 +23,7 @@ module Puppet::Util::Windows
           return yield subkey
         end
       rescue Win32::Registry::Error => error
-        raise Puppet::Util::Windows::Error.new("Failed to open registry key '#{hkey.keyname}\\#{path}'", error.code)
+        raise Puppet::Util::Windows::Error.new("Failed to open registry key '#{hkey.keyname}\\#{path}'", error.code, error)
       end
     end
 


### PR DESCRIPTION
- In many cases, exceptions are handled with Ruby and rethrown in
  a manner that loses the original exceptions backtrace. This often
  masks the real backtrace associated with an error, and can be the
  source of misleading errors or fishing expeditions.
- Where appropriate, pass along the backtrace, or use the initializer
  of the raised Error to wrap / extract the backtrace from the existing
  exception.
- Puppet::Util::Windows::Error is given a new initializer that allows
  passing in the original Exception
- Puppet::Util::Errors.fail adds a new overload that allows for the
  original Exception to be passed in
- To summarize, calls structured like this preserve backtraces:

```
   rescue ArgumentError => e
     raise
     raise e, e.message, e.backtrace
     raise e
   rescue
     raise
     raise $!
     raise $!, "bad arg yo -- part 2", $!.backtrace
     raise $!, $!.message, $!.backtrace
     raise Puppet::Error.new("new msg / ex type", $!)
```
- To summarize, calls structured like this will eat backtraces:

```
   rescue
     raise $!, "Just smoked the backtrace on existing exception"
     raise "Just smoked the backtrace and changed to RuntimeError"
     raise RuntimeError.new($!)
```
