### PR TITLE
(PUP-1151) Respond with 404 when path not known

### DIFF
--- a/lib/puppet/network/http/api/v1.rb
+++ b/lib/puppet/network/http/api/v1.rb
@@ -25,7 +25,7 @@ class Puppet::Network::HTTP::API::V1
   }
 
   def self.routes
-    [Puppet::Network::HTTP::Route.path(/.*/).any(new)]
+    Puppet::Network::HTTP::Route.path(/.*/).any(new)
   end
 
   # handle an HTTP request

--- a/lib/puppet/network/http/api/v2.rb
+++ b/lib/puppet/network/http/api/v2.rb
@@ -3,9 +3,9 @@ module Puppet::Network::HTTP::API::V2
   require 'puppet/network/http/api/v2/authorization'
 
   def self.routes
-    [path(%r{^/v2\.0}).
+    path(%r{^/v2\.0}).
       get(Authorization.new).
-      chain(ENVIRONMENTS, NOT_FOUND)]
+      chain(ENVIRONMENTS, NOT_FOUND)
   end
 
   private
@@ -23,7 +23,7 @@ module Puppet::Network::HTTP::API::V2
   NOT_FOUND = Puppet::Network::HTTP::Route.
     path(/.*/).
     any(lambda do |req, res|
-      raise Puppet::Network::HTTP::Handler::HTTPNotFoundError.new(req.path, Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(req.path, Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
     end)
 
   ENVIRONMENTS = path(%r{^/environments$}).get(provide do

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -28,7 +28,7 @@ class Puppet::Network::HTTP::RackREST
 
   def initialize(args={})
     super()
-    register(Puppet::Network::HTTP::API::V2.routes + Puppet::Network::HTTP::API::V1.routes)
+    register([Puppet::Network::HTTP::API::V2.routes, Puppet::Network::HTTP::API::V1.routes])
   end
 
   def set_content_type(response, format)

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -9,7 +9,7 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
 
   def initialize(server)
     raise ArgumentError, "server is required" unless server
-    register(Puppet::Network::HTTP::API::V2.routes + Puppet::Network::HTTP::API::V1.routes)
+    register([Puppet::Network::HTTP::API::V2.routes, Puppet::Network::HTTP::API::V1.routes])
     super(server)
   end
 

--- a/spec/unit/module_tool/tar_spec.rb
+++ b/spec/unit/module_tool/tar_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'puppet/module_tool/tar'
+require 'puppet/module_tool'
 
 describe Puppet::ModuleTool::Tar do
 

--- a/spec/unit/network/authorization_spec.rb
+++ b/spec/unit/network/authorization_spec.rb
@@ -10,11 +10,21 @@ describe Puppet::Network::Authorization do
   subject { AuthTest.new }
 
   describe "when creating an authconfig object" do
-    it "creates default ACL entries if no file has been read" do
+    before :each do
       # Other tests may have created an authconfig, so we have to undo that.
+      @orig_auth_config = Puppet::Network::AuthConfigLoader.instance_variable_get(:@auth_config)
+      @orig_auth_config_file = Puppet::Network::AuthConfigLoader.instance_variable_get(:@auth_config_file)
+
       Puppet::Network::AuthConfigLoader.instance_variable_set(:@auth_config, nil)
       Puppet::Network::AuthConfigLoader.instance_variable_set(:@auth_config_file, nil)
+    end
 
+    after :each do
+      Puppet::Network::AuthConfigLoader.instance_variable_set(:@auth_config, @orig_auth_config)
+      Puppet::Network::AuthConfigLoader.instance_variable_set(:@auth_config_file, @orig_auth_config_file)
+    end
+
+    it "creates default ACL entries if no file has been read" do
       Puppet::Network::AuthConfigParser.expects(:new_from_file).raises Errno::ENOENT
       Puppet::Network::AuthConfig.any_instance.expects(:insert_default_acl)
 

--- a/spec/unit/network/http/api/v2_spec.rb
+++ b/spec/unit/network/http/api/v2_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+require 'puppet/network/http'
+
+describe Puppet::Network::HTTP::API::V2 do
+  it "responds to unknown paths with a 404" do
+    response = Puppet::Network::HTTP::MemoryResponse.new
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "/v2.0/unknown")
+
+    expect do
+      Puppet::Network::HTTP::API::V2.routes.process(request, response)
+    end.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError)
+  end
+end


### PR DESCRIPTION
The v2.0 api implementation had a type that was not caught by any tests. This
fixes that issue (a typo) and adds a test that would have shown the problem.
