### PR TITLE
(PUP-1510) Fixed forcelocal bug with ensure => absent

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -171,11 +171,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   end
 
   def deletecmd
-    if @resource.forcelocal?
-       cmd = [command(:localdelete)]
-    else
-       cmd = [command(:delete)]
-    end
+    cmd = [command(:delete)]
     cmd += @resource.managehome? ? ['-r'] : []
     cmd << @resource[:name]
   end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -125,6 +125,13 @@ describe Puppet::Type.type(:user).provider(:useradd) do
         provider.expects(:execute).with(all_of(includes('/usr/sbin/usermod'), includes('-e')))
         provider.create
       end
+
+      it "should use userdel to delete users" do
+        resource[:ensure] = :absent
+        provider.stubs(:exists?).returns(true)
+        provider.expects(:execute).with(includes('/usr/sbin/userdel'))
+        provider.delete
+      end
     end
 
   end


### PR DESCRIPTION
The forcelocal option was referencing a command that was not
previously defined which was throwing an exception.  The forcelocal
feature does not need to use a special command to delete local users,
only to add them.  So the special logic for delete was removed and
forcelocal now uses userdel to ensure absent on a user.
