### PR TITLE
(PUP-1278) Windows Puppet Agent Service gracefully terminates after succ...

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -57,8 +57,6 @@ class WindowsDaemon < Win32::Daemon
     log_notice("Starting service with arguments: #{args}")
 
     while running? do
-      return if state != RUNNING
-
       log_notice('Service running')
 
       puppet = File.join(basedir, 'bin', 'puppet.bat')
@@ -79,8 +77,12 @@ class WindowsDaemon < Win32::Daemon
         runinterval = 1800
       end
 
-      pid = Process.create(:command_line => "\"#{puppet}\" agent --onetime #{args}", :creation_flags => Process::CREATE_NEW_CONSOLE).process_id
-      log_debug("Process created: #{pid}")
+      if state == RUNNING or state == IDLE
+        pid = Process.create(:command_line => "\"#{puppet}\" agent --onetime #{args}", :creation_flags => Process::CREATE_NEW_CONSOLE).process_id
+        log_debug("Process created: #{pid}")
+      else
+        log_debug("Service is paused.  Not invoking Puppet agent")
+      end
 
       log_debug("Service waiting for #{runinterval} seconds")
       sleep(runinterval)


### PR DESCRIPTION
...esfully being put into a Paused state

If you successfully pause the Windows Puppet Agent Service then after a period of time the Puppet Agent service will gracefully stop. This does not appear to be appropriate behaviour. The service should remain in a paused state until a Continue or Stop message is sent to the service.

This change fixes this behaviour and the Windows Puppet Agent Service will behave appropriately when put into a paused state, and resume correctly when the service is continued.
