### PR TITLE
(maint) Add optional_parameter_count method to Closure

### DIFF
--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -39,4 +39,10 @@ class Puppet::Pops::Evaluator::Closure
     (@model.parameters || []).size
   end
 
+  # Returns the number of optional parameters.
+  # @return [Integer] the number of optional accepted parameters
+  def optional_parameter_count
+    @model.parameters.count { |p| !p.value.nil? }
+  end
+
 end


### PR DESCRIPTION
Add a method to return number of optional parameters on
Puppet::Pops::Evaluator::Closure just like Puppet::Parser::AST::Lambda
has.
