### PR TITLE
(PUP-1559) Ensure ADSI Group SIDs may be looked up

### DIFF
--- a/lib/puppet/util/adsi.rb
+++ b/lib/puppet/util/adsi.rb
@@ -41,6 +41,18 @@ module Puppet::Util::ADSI
       "winmgmts:{impersonationLevel=impersonate}!//#{host}/root/cimv2"
     end
 
+    # @api private
+    def sid_uri_safe(sid)
+      return sid_uri(sid) if sid.kind_of?(Win32::Security::SID)
+
+      begin
+        sid = Win32::Security::SID.new(Win32::Security::SID.string_to_sid(sid))
+        sid_uri(sid)
+      rescue Win32::Security::SID::Error
+        return nil
+      end
+    end
+
     def sid_uri(sid)
       raise Puppet::Error.new( "Must use a valid SID object" ) if !sid.kind_of?(Win32::Security::SID)
       "WinNT://#{sid.to_s}"
@@ -96,6 +108,8 @@ module Puppet::Util::ADSI
     end
 
     def self.uri(name, host = '.')
+      if sid_uri = Puppet::Util::ADSI.sid_uri_safe(name) then return sid_uri end
+
       host = '.' if ['NT AUTHORITY', 'BUILTIN', Socket.gethostname].include?(host)
 
       Puppet::Util::ADSI.uri(name, 'user', host)
@@ -240,6 +254,8 @@ module Puppet::Util::ADSI
     end
 
     def self.uri(name, host = '.')
+      if sid_uri = Puppet::Util::ADSI.sid_uri_safe(name) then return sid_uri end
+
       Puppet::Util::ADSI.uri(name, 'group', host)
     end
 

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -138,6 +138,7 @@ describe Puppet::Type.type(:group).provider(:windows_adsi) do
   end
 
   it "should be able to test whether a group exists" do
+    Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
     Puppet::Util::ADSI.stubs(:connect).returns stub('connection')
     provider.should be_exists
 

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -122,6 +122,7 @@ describe Puppet::Type.type(:user).provider(:windows_adsi) do
   end
 
   it 'should be able to test whether a user exists' do
+    Puppet::Util::ADSI.stubs(:sid_uri_safe).returns(nil)
     Puppet::Util::ADSI.stubs(:connect).returns stub('connection')
     provider.should be_exists
 


### PR DESCRIPTION
- Previously, calling Puppet::Util::ADSI::Group.exists? for a
  well-known group SID would return false, because the WinNT:// style
  URI used to find the group would not examine / lookup the SID, but
  would instead create a broken Uri that the underlying OS could not
  understand
- Now, the given group name is checked to see if it's a SID before the
  Uri is constructed, and a SID style Uri is created where appropriate
