### PR TITLE
(pup-1524) Correct resource_present? to account for purged

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -1,6 +1,8 @@
 require 'puppet/resource/status'
 
 class Puppet::Transaction::ResourceHarness
+  NO_ACTION = Object.new
+
   extend Forwardable
   def_delegators :@transaction, :relationship_graph
 
@@ -74,9 +76,14 @@ class Puppet::Transaction::ResourceHarness
       cache(resource, param, context.current_values[param])
     end
 
-    managed_via_ensure = manage_via_ensure_if_possible(resource, context)
+    ensure_param = resource.parameter(:ensure)
+    if ensure_param && ensure_param.should
+      ensure_event = sync_if_needed(ensure_param, context)
+    else
+      ensure_event = NO_ACTION
+    end
 
-    if !managed_via_ensure
+    if ensure_event == NO_ACTION
       if context.resource_present?
         resource.properties.each do |param|
           sync_if_needed(param, context)
@@ -101,15 +108,6 @@ class Puppet::Transaction::ResourceHarness
     end
   end
 
-  def manage_via_ensure_if_possible(resource, context)
-    ensure_param = resource.parameter(:ensure)
-    if ensure_param && ensure_param.should
-      sync_if_needed(ensure_param, context)
-    else
-      false
-    end
-  end
-
   def sync_if_needed(param, context)
     historical_value = context.historical_values[param.name]
     current_value = context.current_values[param.name]
@@ -130,9 +128,9 @@ class Puppet::Transaction::ResourceHarness
           sync(event, param, current_value, brief_audit_message)
         end
 
-        true
+        event
       else
-        false
+        NO_ACTION
       end
     rescue => detail
       # Execution will continue on StandardErrors, just store the event
@@ -141,7 +139,7 @@ class Puppet::Transaction::ResourceHarness
       event = create_change_event(param, current_value, historical_value)
       event.status = "failure"
       event.message = "change from #{param.is_to_s(current_value)} to #{param.should_to_s(param.should)} failed: #{detail}"
-      false
+      event
     rescue Exception => detail
       # Execution will halt on Exceptions, they get raised to the application
       event = create_change_event(param, current_value, historical_value)
@@ -214,13 +212,15 @@ class Puppet::Transaction::ResourceHarness
   end
 
   # @api private
-  ResourceApplicationContext = Struct.new(:current_values,
+  ResourceApplicationContext = Struct.new(:resource,
+                                          :current_values,
                                           :historical_values,
                                           :audited_params,
                                           :synced_params,
                                           :status) do
     def self.from_resource(resource, status)
-      ResourceApplicationContext.new(resource.retrieve_resource.to_hash,
+      ResourceApplicationContext.new(resource,
+                                     resource.retrieve_resource.to_hash,
                                      Puppet::Util::Storage.cache(resource).dup,
                                      (resource[:audit] || []).map { |p| p.to_sym },
                                      [],
@@ -228,7 +228,7 @@ class Puppet::Transaction::ResourceHarness
     end
 
     def resource_present?
-      current_values[:ensure] != :absent
+      resource.present?(current_values)
     end
 
     def record(event)

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1065,6 +1065,13 @@ class Type
     resource
   end
 
+  # Given the hash of current properties, should this resource be treated as if it
+  # currently exists on the system. May need to be overridden by types that offer up
+  # more than just :absent and :present.
+  def present?(current_values)
+    current_values[:ensure] != :absent
+  end
+
   # Returns a hash of the current properties and their values.
   # If a resource is absent, its value is the symbol `:absent`
   # @return [Hash{Puppet::Property => Object}] mapping of property instance to its value

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -369,6 +369,10 @@ Puppet::Type.newtype(:file) do
     stat ? true : false
   end
 
+  def present?(current_values)
+    super && current_values[:ensure] != :false
+  end
+
   # We have to do some extra finishing, to retrieve our bucket if
   # there is one.
   def finish

--- a/lib/puppet/type/interface.rb
+++ b/lib/puppet/type/interface.rb
@@ -109,4 +109,8 @@ Puppet::Type.newtype(:interface) do
         super(currentvalue, newvalue)
       end
     end
+
+  def present?(current_values)
+    super && current_values[:ensure] != :shutdown
+  end
 end

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -376,5 +376,9 @@ module Puppet
     def exists?
       @provider.get(:ensure) != :absent
     end
+
+    def present?(current_values)
+      super && current_values[:ensure] != :purged
+    end
   end
 end


### PR DESCRIPTION
The fix for http://projects.puppetlabs.com/issues/23081 included
e376b9d8, which refactored some of the resource_harness code and
introduced `ResourceApplicationContext.resource_present?`

At the time that method only checked `current_values[:ensure]` against
`:absent`, which meant that if `current_values[:ensure]` was `:purged`,
then `resource_present?` was `true` and the code thus attempted to
sync additional properties. This resulted in the double events
noted in this ticket (the first one in `manage_via_ensure_if_possible`,
the second (unnecessary) one in `sync_if_needed`).

This change adds a `present?` method to `Puppet::Type`, the default
implementation of which just checks for `:ensure != :absent`, but
which must be overridden by other types that have additional values
for `:ensure` that also imply that the resource is not present. It also
overrides that method in the package, file, and interface types,
each of which offer such additional values for `:ensure`.

In addition, there was another code path for duplicate events
because the previous code didn't distinguish between not using
ensure and the ensure check failing (e.g. due to a provider failure).
To address this, the code was refactored slightly to introduce
the `NO_ACTION` return from `sync_if_needed`.
