### PR TITLE
(PUP-1563) resolve_install_conflicts excessive recursive

### DIFF
--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -165,9 +165,8 @@ module Puppet::ModuleTool
                 :directory         => mod.path,
                 :metadata          => metadata
             end
-
-            resolve_install_conflicts(release[:dependencies], true)
           end
+          resolve_install_conflicts(release[:dependencies], true)
         end
       end
 


### PR DESCRIPTION
resolve_install_conflicts causes a very long (edited from "endless") recursion because the recursion loop is inside the modules_by_path iterator causing each module and dependency to be checked for conflict once for each module that is installed. With a tree of dependencies and mearly dozens of previously installed modules, this walk can take hours. This patch fixed the problem by moving the recusion outside of the modules_by_path iterator loop.
