### PR TITLE
(PUP-1579) Rename the Literal type to Scalar

### DIFF
--- a/lib/puppet/pops/binder/bindings_factory.rb
+++ b/lib/puppet/pops/binder/bindings_factory.rb
@@ -262,11 +262,11 @@ module Puppet::Pops::Binder::BindingsFactory
       type(T.pattern())
     end
 
-    # Sets the type of the binding to the abstract type Literal.
-    # @return [Puppet::Pops::Types::PLiteralType] the type
+    # Sets the type of the binding to the abstract type Scalar.
+    # @return [Puppet::Pops::Types::PScalarType] the type
     # @api public
-    def literal()
-      type(T.literal())
+    def scalar()
+      type(T.scalar())
     end
 
     # Sets the type of the binding to the abstract type Data.

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -149,8 +149,8 @@ module Puppet::Pops::Types::TypeFactory
   # Produces the Literal type
   # @api public
   #
-  def self.literal()
-    Types::PLiteralType.new()
+  def self.scalar()
+    Types::PScalarType.new()
   end
 
   # Produces the abstract type Collection
@@ -210,10 +210,10 @@ module Puppet::Pops::Types::TypeFactory
     type
   end
 
-  # Produces a type for Hash[Literal, o] where o is either a type, or an instance for which a type is inferred.
+  # Produces a type for Hash[Scalar, o] where o is either a type, or an instance for which a type is inferred.
   # @api public
   #
-  def self.hash_of(value, key = literal())
+  def self.hash_of(value, key = scalar())
     type = Types::PHashType.new()
     type.key_type = type_of(key)
     type.element_type = type_of(value)
@@ -229,12 +229,12 @@ module Puppet::Pops::Types::TypeFactory
     type
   end
 
-  # Produces a type for Hash[Literal, Data]
+  # Produces a type for Hash[Scalar, Data]
   # @api public
   #
   def self.hash_of_data()
     type = Types::PHashType.new()
-    type.key_type = literal()
+    type.key_type = scalar()
     type.element_type = data()
     type
   end

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -139,8 +139,8 @@ class Puppet::Pops::Types::TypeParser
     when "collection"
       TYPES.collection()
 
-    when "literal"
-      TYPES.literal()
+    when "scalar"
+      TYPES.scalar()
 
     when "catalogentry"
       TYPES.catalog_entry()
@@ -345,7 +345,7 @@ class Puppet::Pops::Types::TypeParser
       assert_type(parameters[0])
       TYPES.optional(parameters[0])
 
-    when "object", "data", "catalogentry", "boolean", "literal", "undef", "numeric"
+    when "object", "data", "catalogentry", "boolean", "scalar", "undef", "numeric"
       raise_unparameterized_type_error(parameterized_ast.left_expr)
 
     when "type"

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -3,7 +3,7 @@ require 'rgen/metamodel_builder'
 # The Types model is a model of Puppet Language types.
 #
 # The exact relationship between types is not visible in this model wrt. the PDataType which is an abstraction
-# of Literal, Array[Data], and Hash[Literal, Data] nested to any depth. This means it is not possible to
+# of Scalar, Array[Data], and Hash[Scalar, Data] nested to any depth. This means it is not possible to
 # infer the type by simply looking at the inheritance hierarchy. The {Puppet::Pops::Types::TypeCalculator} should
 # be used to answer questions about types. The {Puppet::Pops::Types::TypeFactory} should be used to create an instance
 # of a type whenever one is needed.
@@ -100,12 +100,12 @@ module Puppet::Pops::Types
 
   # Type that is PDataType compatible, but is not a PCollectionType.
   # @api public
-  class PLiteralType < PObjectType
+  class PScalarType < PObjectType
   end
 
   # A string type describing the set of strings having one of the given values
   #
-  class PEnumType < PLiteralType
+  class PEnumType < PScalarType
     has_many_attr 'values', String, :lowerBound => 1
 
     module ClassModule
@@ -120,7 +120,7 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PNumericType < PLiteralType
+  class PNumericType < PScalarType
   end
 
   # @api public
@@ -177,7 +177,7 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PStringType < PLiteralType
+  class PStringType < PScalarType
     has_many_attr 'values', String, :lowerBound => 0, :upperBound => -1, :unique => true
     contains_one_uni 'size_type', PIntegerType
 
@@ -194,7 +194,7 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PRegexpType < PLiteralType
+  class PRegexpType < PScalarType
     has_attr 'pattern', String, :lowerBound => 1
     has_attr 'regexp', Object, :derived => true
 
@@ -218,7 +218,7 @@ module Puppet::Pops::Types
   # If specified without a pattern it is basically the same as the String type.
   #
   # @api public
-  class PPatternType < PLiteralType
+  class PPatternType < PScalarType
     contains_many_uni 'patterns', PRegexpType
 
     module ClassModule
@@ -234,7 +234,7 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PBooleanType < PLiteralType
+  class PBooleanType < PScalarType
   end
 
   # @api public

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -166,13 +166,13 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
 
     # Hash Type
     #
-    it 'produces a Hash[Literal,String] from the expression Hash[String]' do
+    it 'produces a Hash[Scalar,String] from the expression Hash[String]' do
       expr = fqr('Hash')[fqr('String')]
-      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.literal))
+      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.scalar))
 
       # arguments are flattened
       expr = fqr('Hash')[[fqr('String')]]
-      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.literal))
+      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.scalar))
     end
 
     it 'produces a Hash[String,String] from the expression Hash[String, String]' do
@@ -180,9 +180,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.string))
     end
 
-    it 'produces a Hash[Literal,String] from the expression Hash[Integer][String]' do
+    it 'produces a Hash[Scalar,String] from the expression Hash[Integer][String]' do
       expr = fqr('Hash')[fqr('Integer')][fqr('String')]
-      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.literal))
+      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.scalar))
     end
 
     it "gives an error if parameter is not a type" do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -276,12 +276,12 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     {
-      'Object'  => ['Data', 'Literal', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Collection',
+      'Object'  => ['Data', 'Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Collection',
                     'Array', 'Hash', 'CatalogEntry', 'Resource', 'Class', 'Undef', 'File', 'NotYetKnownResourceType'],
 
       # Note, Data > Collection is false (so not included)
-      'Data'    => ['Literal', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Array', 'Hash',],
-      'Literal' => ['Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern'],
+      'Data'    => ['Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Array', 'Hash',],
+      'Scalar' => ['Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern'],
       'Numeric' => ['Integer', 'Float'],
       'CatalogEntry' => ['Class', 'Resource', 'File', 'NotYetKnownResourceType'],
       'Integer[1,10]' => ['Integer[2,3]'],

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -65,7 +65,7 @@ describe 'The type calculator' do
       [ Puppet::Pops::Types::PObjectType,
         Puppet::Pops::Types::PNilType,
         Puppet::Pops::Types::PDataType,
-        Puppet::Pops::Types::PLiteralType,
+        Puppet::Pops::Types::PScalarType,
         Puppet::Pops::Types::PStringType,
         Puppet::Pops::Types::PNumericType,
         Puppet::Pops::Types::PIntegerType,
@@ -84,10 +84,10 @@ describe 'The type calculator' do
       ]
     end
 
-    def literal_types
-      # PVariantType is also literal, if its types are all Literal
+    def scalar_types
+      # PVariantType is also scalar, if its types are all Scalar
       [
-        Puppet::Pops::Types::PLiteralType,
+        Puppet::Pops::Types::PScalarType,
         Puppet::Pops::Types::PStringType,
         Puppet::Pops::Types::PNumericType,
         Puppet::Pops::Types::PIntegerType,
@@ -127,7 +127,7 @@ describe 'The type calculator' do
     end
 
     def data_compatible_types
-      result = literal_types
+      result = scalar_types
       result << Puppet::Pops::Types::PDataType
       result << array_t(types::PDataType.new)
       result << types::TypeFactory.hash_of_data
@@ -223,24 +223,24 @@ describe 'The type calculator' do
         calculator.infer([1,2.0]).element_type.class.should == Puppet::Pops::Types::PNumericType
       end
 
-      it 'with fixnum and string values translates to PArrayType[PLiteralType]' do
-        calculator.infer([1,'two']).element_type.class.should == Puppet::Pops::Types::PLiteralType
+      it 'with fixnum and string values translates to PArrayType[PScalarType]' do
+        calculator.infer([1,'two']).element_type.class.should == Puppet::Pops::Types::PScalarType
       end
 
-      it 'with float and string values translates to PArrayType[PLiteralType]' do
-        calculator.infer([1.0,'two']).element_type.class.should == Puppet::Pops::Types::PLiteralType
+      it 'with float and string values translates to PArrayType[PScalarType]' do
+        calculator.infer([1.0,'two']).element_type.class.should == Puppet::Pops::Types::PScalarType
       end
 
-      it 'with fixnum, float, and string values translates to PArrayType[PLiteralType]' do
-        calculator.infer([1, 2.0,'two']).element_type.class.should == Puppet::Pops::Types::PLiteralType
+      it 'with fixnum, float, and string values translates to PArrayType[PScalarType]' do
+        calculator.infer([1, 2.0,'two']).element_type.class.should == Puppet::Pops::Types::PScalarType
       end
 
-      it 'with fixnum and regexp values translates to PArrayType[PLiteralType]' do
-        calculator.infer([1, /two/]).element_type.class.should == Puppet::Pops::Types::PLiteralType
+      it 'with fixnum and regexp values translates to PArrayType[PScalarType]' do
+        calculator.infer([1, /two/]).element_type.class.should == Puppet::Pops::Types::PScalarType
       end
 
-      it 'with string and regexp values translates to PArrayType[PLiteralType]' do
-        calculator.infer(['one', /two/]).element_type.class.should == Puppet::Pops::Types::PLiteralType
+      it 'with string and regexp values translates to PArrayType[PScalarType]' do
+        calculator.infer(['one', /two/]).element_type.class.should == Puppet::Pops::Types::PScalarType
       end
 
       it 'with string and symbol values translates to PArrayType[PObjectType]' do
@@ -260,13 +260,13 @@ describe 'The type calculator' do
         et.class.should == Puppet::Pops::Types::PStringType
       end
 
-      it 'with array of string values and array of fixnums translates to PArrayType[PArrayType[PLiteralType]]' do
+      it 'with array of string values and array of fixnums translates to PArrayType[PArrayType[PScalarType]]' do
         et = calculator.infer([['first' 'array'], [1,2]])
         et.class.should == Puppet::Pops::Types::PArrayType
         et = et.element_type
         et.class.should == Puppet::Pops::Types::PArrayType
         et = et.element_type
-        et.class.should == Puppet::Pops::Types::PLiteralType
+        et.class.should == Puppet::Pops::Types::PScalarType
       end
 
       it 'with hashes of string values translates to PArrayType[PHashType[PStringType]]' do
@@ -278,13 +278,13 @@ describe 'The type calculator' do
         et.class.should == Puppet::Pops::Types::PStringType
       end
 
-      it 'with hash of string values and hash of fixnums translates to PArrayType[PHashType[PLiteralType]]' do
+      it 'with hash of string values and hash of fixnums translates to PArrayType[PHashType[PScalarType]]' do
         et = calculator.infer([{:first => 'first', :second => 'second' }, {:first => 1, :second => 2 }])
         et.class.should == Puppet::Pops::Types::PArrayType
         et = et.element_type
         et.class.should == Puppet::Pops::Types::PHashType
         et = et.element_type
-        et.class.should == Puppet::Pops::Types::PLiteralType
+        et.class.should == Puppet::Pops::Types::PScalarType
       end
     end
 
@@ -430,12 +430,12 @@ describe 'The type calculator' do
     end
 
     context "for Data, such that" do
-      it 'all literals + array and hash are assignable to Data' do
+      it 'all scalars + array and hash are assignable to Data' do
         t = Puppet::Pops::Types::PDataType.new()
         data_compatible_types.each { |t2| type_from_class(t2).should be_assignable_to(t) }
       end
 
-      it 'a Variant of literal, hash, or array is assignable to Data' do
+      it 'a Variant of scalar, hash, or array is assignable to Data' do
         t = Puppet::Pops::Types::PDataType.new()
         data_compatible_types.each { |t2| variant_t(type_from_class(t2)).should be_assignable_to(t) }
       end
@@ -453,27 +453,27 @@ describe 'The type calculator' do
       end
 
       it 'Data is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PObjectType, Puppet::Pops::Types::PDataType] - literal_types
+        tested_types = all_types - [Puppet::Pops::Types::PObjectType, Puppet::Pops::Types::PDataType] - scalar_types
         t = Puppet::Pops::Types::PDataType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
     end
 
-    context "for Literal, such that" do
-      it "all literals are assignable to Literal" do
-        t = Puppet::Pops::Types::PLiteralType.new()
-        literal_types.each {|t2| t2.new.should be_assignable_to(t) }
+    context "for Scalar, such that" do
+      it "all scalars are assignable to Scalar" do
+        t = Puppet::Pops::Types::PScalarType.new()
+        scalar_types.each {|t2| t2.new.should be_assignable_to(t) }
       end
 
-      it 'Literal is not assignable to any of its subtypes' do
-        t = Puppet::Pops::Types::PLiteralType.new() 
-        types_to_test = literal_types - [Puppet::Pops::Types::PLiteralType]
+      it 'Scalar is not assignable to any of its subtypes' do
+        t = Puppet::Pops::Types::PScalarType.new() 
+        types_to_test = scalar_types - [Puppet::Pops::Types::PScalarType]
         types_to_test.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
 
-      it 'Literal is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PObjectType, Puppet::Pops::Types::PDataType] - literal_types
-        t = Puppet::Pops::Types::PLiteralType.new()
+      it 'Scalar is not assignable to any disjunct type' do
+        tested_types = all_types - [Puppet::Pops::Types::PObjectType, Puppet::Pops::Types::PDataType] - scalar_types
+        t = Puppet::Pops::Types::PScalarType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
     end
@@ -494,7 +494,7 @@ describe 'The type calculator' do
         tested_types = all_types - [
           Puppet::Pops::Types::PObjectType,
           Puppet::Pops::Types::PDataType,
-          Puppet::Pops::Types::PLiteralType,
+          Puppet::Pops::Types::PScalarType,
           ] - numeric_types
         t = Puppet::Pops::Types::PNumericType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -915,10 +915,10 @@ describe 'The type calculator' do
       t.element_type.class.should == Puppet::Pops::Types::PDataType
     end
 
-    it 'should yield \'PHashType[PLiteralType,PDataType]\' for Hash' do
+    it 'should yield \'PHashType[PScalarType,PDataType]\' for Hash' do
       t = calculator.type(Hash)
       t.class.should == Puppet::Pops::Types::PHashType
-      t.key_type.class.should == Puppet::Pops::Types::PLiteralType
+      t.key_type.class.should == Puppet::Pops::Types::PScalarType
       t.element_type.class.should == Puppet::Pops::Types::PDataType
     end
   end
@@ -932,8 +932,8 @@ describe 'The type calculator' do
       calculator.string(Puppet::Pops::Types::PObjectType.new()).should == 'Object'
     end
 
-    it 'should yield \'Literal\' for PLiteralType' do
-      calculator.string(Puppet::Pops::Types::PLiteralType.new()).should == 'Literal'
+    it 'should yield \'Scalar\' for PScalarType' do
+      calculator.string(Puppet::Pops::Types::PScalarType.new()).should == 'Scalar'
     end
 
     it 'should yield \'Boolean\' for PBooleanType' do
@@ -1096,7 +1096,7 @@ describe 'The type calculator' do
       ptype = Puppet::Pops::Types::PType
       calculator.infer(Puppet::Pops::Types::PNilType.new()       ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PDataType.new()      ).is_a?(ptype).should() == true
-      calculator.infer(Puppet::Pops::Types::PLiteralType.new()   ).is_a?(ptype).should() == true
+      calculator.infer(Puppet::Pops::Types::PScalarType.new()   ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PStringType.new()    ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PNumericType.new()   ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PIntegerType.new()   ).is_a?(ptype).should() == true
@@ -1118,7 +1118,7 @@ describe 'The type calculator' do
       ptype = Puppet::Pops::Types::PType
       calculator.string(calculator.infer(Puppet::Pops::Types::PNilType.new()       )).should == "Type[Undef]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PDataType.new()      )).should == "Type[Data]"
-      calculator.string(calculator.infer(Puppet::Pops::Types::PLiteralType.new()   )).should == "Type[Literal]"
+      calculator.string(calculator.infer(Puppet::Pops::Types::PScalarType.new()   )).should == "Type[Scalar]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PStringType.new()    )).should == "Type[String]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PNumericType.new()   )).should == "Type[Numeric]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PIntegerType.new()   )).should == "Type[Integer]"
@@ -1140,7 +1140,7 @@ describe 'The type calculator' do
       int_t    = Puppet::Pops::Types::PIntegerType.new()
       string_t = Puppet::Pops::Types::PStringType.new()
       calculator.string(calculator.infer([int_t])).should == "Array[Type[Integer], 1, 1]"
-      calculator.string(calculator.infer([int_t, string_t])).should == "Array[Type[Literal], 2, 2]"
+      calculator.string(calculator.infer([int_t, string_t])).should == "Array[Type[Scalar], 2, 2]"
     end
 
     it 'should infer PType as the type of ruby classes' do
@@ -1235,7 +1235,7 @@ describe 'The type calculator' do
 
     it "does not reduce by combining types when using infer_set" do
       element_type = calculator.infer(['a','b',1,2]).element_type
-      element_type.class.should == Puppet::Pops::Types::PLiteralType
+      element_type.class.should == Puppet::Pops::Types::PScalarType
       element_type = calculator.infer_set(['a','b',1,2]).element_type
       element_type.class.should == Puppet::Pops::Types::PVariantType
       element_type.types[0].class.should == Puppet::Pops::Types::PStringType

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -35,8 +35,8 @@ describe 'The type factory' do
       Puppet::Pops::Types::TypeFactory.variant().class().should == Puppet::Pops::Types::PVariantType
     end
 
-    it 'literal() returns PLiteralType' do
-      Puppet::Pops::Types::TypeFactory.literal().class().should == Puppet::Pops::Types::PLiteralType
+    it 'scalar() returns PScalarType' do
+      Puppet::Pops::Types::TypeFactory.scalar().class().should == Puppet::Pops::Types::PScalarType
     end
 
     it 'data() returns PDataType' do
@@ -129,10 +129,10 @@ describe 'The type factory' do
       at.element_type.class.should == Puppet::Pops::Types::PDataType
     end
 
-    it 'hash_of_data returns PHashType[PLiteralType,PDataType]' do
+    it 'hash_of_data returns PHashType[PScalarType,PDataType]' do
       ht = Puppet::Pops::Types::TypeFactory.hash_of_data
       ht.class().should == Puppet::Pops::Types::PHashType
-      ht.key_type.class.should == Puppet::Pops::Types::PLiteralType
+      ht.key_type.class.should == Puppet::Pops::Types::PScalarType
       ht.element_type.class.should == Puppet::Pops::Types::PDataType
     end
 

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -30,7 +30,7 @@ describe Puppet::Pops::Types::TypeParser do
   end
 
   [
-    'Object', 'Data', 'CatalogEntry', 'Boolean', 'Literal', 'Undef', 'Numeric',
+    'Object', 'Data', 'CatalogEntry', 'Boolean', 'Scalar', 'Undef', 'Numeric',
   ].each do |name|
     it "does not support parameterizing unparameterized type <#{name}>" do
       expect { parser.parse("#{name}[Integer]") }.to raise_unparameterized_error_for(name)
@@ -53,11 +53,11 @@ describe Puppet::Pops::Types::TypeParser do
     expect(parser.parse("Array")).to be_the_type(types.array_of_data)
   end
 
-  it "interprets an unparameterized Hash as a Hash of Literal to Data" do
+  it "interprets an unparameterized Hash as a Hash of Scalar to Data" do
     expect(parser.parse("Hash")).to be_the_type(types.hash_of_data)
   end
 
-  it "interprets a parameterized Hash[t] as a Hash of Literal to t" do
+  it "interprets a parameterized Hash[t] as a Hash of Scalar to t" do
     expect(parser.parse("Hash[Integer]")).to be_the_type(types.hash_of(types.integer))
   end
 


### PR DESCRIPTION
Calling the type "Literal" was bad because it is used not only
for literal values entered in source code, but naturally also
for computed values. A commonly used name for these types is "Scalar".

This commit changes "Literal" to "Scalar" everywhere:
- class name PLiteralType => PScalarType
- its label
- factory methods "literal" => "scalar"
