### PR TITLE
(PUP-1574) Environment setting does not override apply/parser manifest

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -119,6 +119,18 @@ class Puppet::Node::Environment
     @manifest = manifest
   end
 
+  # Creates a new Puppet::Node::Environment instance, overriding any of the passed
+  # parameters.
+  #
+  # @param env_params [Hash<{Symbol => String,Array<String>}>] new environment
+  #   parameters (:modulepath, :manifest)
+  # @return [Puppet::Node::Environment]
+  def override_with(env_params)
+    return self.class.create(name,
+                      env_params[:modulepath] || modulepath,
+                      env_params[:manifest] || manifest)
+  end
+
   # @param [String] name Environment name to check for valid syntax.
   # @return [Boolean] true if name is valid
   # @api public

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -11,7 +11,7 @@ describe "apply" do
   end
 
   describe "when applying provided catalogs" do
-    it "should be able to apply catalogs provided in a file in pson" do
+    it "can apply catalogs provided in a file in pson" do
       file_to_create = tmpfile("pson_catalog")
       catalog = Puppet::Resource::Catalog.new
       resource = Puppet::Resource.new(:file, file_to_create, :parameters => {:content => "my stuff"})
@@ -26,8 +26,29 @@ describe "apply" do
 
       puppet.apply
 
-      Puppet::FileSystem.exist?(file_to_create).should be_true
-      File.read(file_to_create).should == "my stuff"
+      expect(Puppet::FileSystem.exist?(file_to_create)).to be_true
+      expect(File.read(file_to_create)).to eq("my stuff")
     end
+  end
+
+  it "applies a given file even when a directory environment is specified" do
+    manifest = tmpfile("manifest.pp")
+    File.open(manifest, "w") do |f|
+      f.puts <<-EOF
+      notice('it was applied')
+      EOF
+    end
+
+    env_loader = Puppet::Environments::Static.new(
+      Puppet::Node::Environment.create(:special, [], '')
+    )
+    Puppet.override(:environments => env_loader) do
+      Puppet[:environment] = 'special'
+      puppet = Puppet::Application[:apply]
+      puppet.stubs(:command_line).returns(stub('command_line', :args => [manifest]))
+      expect { puppet.run_command }.to exit_with(0)
+    end
+
+    expect(@logs.map(&:to_s)).to include('it was applied')
   end
 end

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -215,16 +215,6 @@ describe Puppet::Application::Apply do
         expect { @apply.main }.to exit_with 0
       end
 
-      it "should set the manifest if a file is passed on command line and the file exists" do
-        manifest = tmpfile('site.pp')
-        FileUtils.touch(manifest)
-        @apply.command_line.stubs(:args).returns([manifest])
-
-        Puppet.expects(:[]=).with(:manifest,manifest)
-
-        expect { @apply.main }.to exit_with 0
-      end
-
       it "should raise an error if a file is passed on command line and the file does not exist" do
         noexist = tmpfile('noexist.pp')
         @apply.command_line.stubs(:args).returns([noexist])
@@ -237,7 +227,6 @@ describe Puppet::Application::Apply do
 
         @apply.command_line.stubs(:args).returns([manifest, 'starwarsI', 'starwarsII'])
 
-        Puppet.expects(:[]=).with(:manifest,manifest)
         expect { @apply.main }.to exit_with 0
 
         msg = @logs.find {|m| m.message =~ /Only one file can be applied per run/ }

--- a/spec/unit/face/parser_spec.rb
+++ b/spec/unit/face/parser_spec.rb
@@ -8,39 +8,55 @@ describe Puppet::Face[:parser, :current] do
 
   let(:parser) { Puppet::Face[:parser, :current] }
 
-  it "validates the configured site manifest when no files are given" do
-    Puppet[:manifest] = file_containing('site.pp', "{ invalid =>")
-    from_an_interactive_terminal
+  context "from an interactive terminal" do
+    before :each do
+      from_an_interactive_terminal
+    end
 
-    expect { parser.validate() }.to exit_with(1)
-  end
+    it "validates the configured site manifest when no files are given" do
+      Puppet[:manifest] = file_containing('site.pp', "{ invalid =>")
 
-  it "validates the given file" do
-    manifest = file_containing('site.pp', "{ invalid =>")
-    from_an_interactive_terminal
+      expect { parser.validate() }.to exit_with(1)
+    end
 
-    expect { parser.validate(manifest) }.to exit_with(1)
+    it "validates the given file" do
+      manifest = file_containing('site.pp', "{ invalid =>")
+
+      expect { parser.validate(manifest) }.to exit_with(1)
+    end
+
+    it "runs error free when there are no validation errors" do
+      manifest = file_containing('site.pp', "notify { valid: }")
+
+      parser.validate(manifest)
+    end
+
+    it "reports missing files" do
+      expect do
+        parser.validate("missing.pp")
+      end.to raise_error(Puppet::Error, /One or more file\(s\) specified did not exist.*missing\.pp/m)
+    end
+
+    it "parses supplied manifest files in the context of a directory environment" do
+      manifest = file_containing('test.pp', "{ invalid =>")
+
+      env_loader = Puppet::Environments::Static.new(
+        Puppet::Node::Environment.create(:special, [], '')
+      )
+      Puppet.override(:environments => env_loader) do
+        Puppet[:environment] = 'special'
+        expect { parser.validate(manifest) }.to exit_with(1)
+      end
+
+      expect(@logs.join).to match(/environment special.*Syntax error at '{'/)
+    end
+
   end
 
   it "validates the contents of STDIN when no files given and STDIN is not a tty" do
     from_a_piped_input_of("{ invalid =>")
 
     expect { parser.validate() }.to exit_with(1)
-  end
-
-  it "runs error free when there are no validation errors" do
-    manifest = file_containing('site.pp', "notify { valid: }")
-    from_an_interactive_terminal
-
-    parser.validate(manifest)
-  end
-
-  it "reports missing files" do
-    from_an_interactive_terminal
-
-    expect do
-      parser.validate("missing.pp")
-    end.to raise_error(Puppet::Error, /One or more file\(s\) specified did not exist.*missing\.pp/m)
   end
 
   def from_an_interactive_terminal

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -43,6 +43,28 @@ describe Puppet::Node::Environment do
       Puppet::Node::Environment.new(one).should equal(one)
     end
 
+    describe "overriding an existing environment" do
+      let(:original_path) { [tmpdir('original')] }
+      let(:new_path) { [tmpdir('new')] }
+      let(:environment) { Puppet::Node::Environment.create(:overridden, original_path, 'orig.pp') }
+
+      it "overrides modulepath" do
+        overridden = environment.override_with(:modulepath => new_path)
+        expect(overridden).to_not be_equal(environment)
+        expect(overridden.name).to eq(:overridden)
+        expect(overridden.manifest).to eq('orig.pp')
+        expect(overridden.modulepath).to eq(new_path)
+      end
+
+      it "overrides manifest" do
+        overridden = environment.override_with(:manifest => 'new.pp')
+        expect(overridden).to_not be_equal(environment)
+        expect(overridden.name).to eq(:overridden)
+        expect(overridden.manifest).to eq('new.pp')
+        expect(overridden.modulepath).to eq(original_path)
+      end
+    end
+
     describe "watching a file" do
       let(:filename) { "filename" }
 


### PR DESCRIPTION
Both `puppet apply` and `puppet parser validate` were relying on the
legacy environment behavior to implicit draw in the setting of
Puppet[:manifest].  But the new directory environments do not pay
attention to Puppet[:manifest] and thus a call such as `puppet apply
foo.pp --environment dir_env` would not apply foo.pp if dir_env was in
the $environmentpath.

This change explicitly creates a new environment based off the currently
configured environment and overrides with the manifest this to be
applied or validated.
