### PR TITLE
(PUP-1609) Add PID to Forge cache handler to make multi-process safe

### DIFF
--- a/lib/puppet/forge/cache.rb
+++ b/lib/puppet/forge/cache.rb
@@ -44,7 +44,7 @@ class Puppet::Forge
 
     # Return the base Pathname for all the caches.
     def self.base_path
-      Pathname(Puppet.settings[:module_working_dir]) + 'cache'
+      Pathname(Puppet.settings[:module_working_dir]) + "cache-#{Process.pid}"
     end
 
     # Clean out all the caches.


### PR DESCRIPTION
The cache directory is used by the Forge repository backend and the module
tool unpacker, but is only unique to a single vardir.  Multiple Puppet
processes running in parallel can cause clashes as they remove the entire
cache directory on completion.
