### PR TITLE
(PUP-1029) Make map function consistent with others

### DIFF
--- a/spec/unit/parser/methods/map_spec.rb
+++ b/spec/unit/parser/methods/map_spec.rb
@@ -38,6 +38,43 @@ describe 'the map method' do
       catalog.resource(:file, "/file_6")['ensure'].should == 'present'
     end
 
+    it 'map on an integer (multiply each by 3)' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        3.map |$x|{ $x*3}.each |$v|{
+          file { "/file_$v": ensure => present }
+        }
+      MANIFEST
+
+      catalog.resource(:file, "/file_0")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_3")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_6")['ensure'].should == 'present'
+    end
+
+    it 'map on a string' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = {a=>x, b=>y}
+        "ab".map |$x|{$a[$x]}.each |$v|{
+          file { "/file_$v": ensure => present }
+        }
+      MANIFEST
+
+      catalog.resource(:file, "/file_x")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_y")['ensure'].should == 'present'
+    end
+
+    it 'map on an array (multiplying value by 10 in even index position)' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [1,2,3]
+        $a.map |$i, $x|{ if $i % 2 == 0 {$x} else {$x*10}}.each |$v|{
+          file { "/file_$v": ensure => present }
+        }
+      MANIFEST
+
+      catalog.resource(:file, "/file_1")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_20")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_3")['ensure'].should == 'present'
+    end
+
     it 'map on a hash selecting keys' do
       catalog = compile_to_catalog(<<-MANIFEST)
       $a = {'a'=>1,'b'=>2,'c'=>3}
@@ -51,12 +88,33 @@ describe 'the map method' do
       catalog.resource(:file, "/file_c")['ensure'].should == 'present'
     end
 
+    it 'map on a hash selecting keys - using two block parameters' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+      $a = {'a'=>1,'b'=>2,'c'=>3}
+      $a.map |$k,$v|{ file { "/file_$k": ensure => present }
+        }
+      MANIFEST
+
+      catalog.resource(:file, "/file_a")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_b")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_c")['ensure'].should == 'present'
+    end
+
     it 'each on a hash selecting value' do
       catalog = compile_to_catalog(<<-MANIFEST)
       $a = {'a'=>1,'b'=>2,'c'=>3}
-      $a.map |$x|{ $x[1]}.each |$k|{
-          file { "/file_$k": ensure => present }
-        }
+      $a.map |$x|{ $x[1]}.each |$k|{ file { "/file_$k": ensure => present } }
+      MANIFEST
+
+      catalog.resource(:file, "/file_1")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_2")['ensure'].should == 'present'
+      catalog.resource(:file, "/file_3")['ensure'].should == 'present'
+    end
+
+    it 'each on a hash selecting value - using two bloc parameters' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+      $a = {'a'=>1,'b'=>2,'c'=>3}
+      $a.map |$k,$v|{ file { "/file_$v": ensure => present } }
       MANIFEST
 
       catalog.resource(:file, "/file_1")['ensure'].should == 'present'
@@ -103,12 +161,12 @@ describe 'the map method' do
     end
 
   context 'map checks arguments and' do
-    it 'raises an error when block has more than 1 argument' do
+    it 'raises an error when block has more than 2 argument' do
       expect do
         compile_to_catalog(<<-MANIFEST)
-          [1].map |$x, $yikes|{  }
+          [1].map |$index, $x, $yikes|{  }
         MANIFEST
-      end.to raise_error(Puppet::Error, /Too few arguments/)
+      end.to raise_error(Puppet::Error, /block must define at most two parameters/)
     end
 
     it 'raises an error when block has fewer than 1 argument' do
@@ -116,7 +174,7 @@ describe 'the map method' do
         compile_to_catalog(<<-MANIFEST)
           [1].map || {  }
         MANIFEST
-      end.to raise_error(Puppet::Error, /Too many arguments/)
+      end.to raise_error(Puppet::Error, /block must define at least one parameter/)
     end
   end
 


### PR DESCRIPTION
The map function only supported a single argument which made it
impossible to map based on index in an Array, and made in awkward
to map on only hash key or value.

Now the map function accepts either value (as before), or index/value,
or key/value (for hash).
