### PR TITLE
(docs) Update description for Exec type's logoutput parameter

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -207,8 +207,8 @@ module Puppet
       desc "Whether to log command output in addition to logging the
         exit code.  Defaults to `on_failure`, which only logs the output
         when the command has an exit code that does not match any value
-        specified by the `returns` attribute.  In addition to the values
-        below, you may set this attribute to any legal log level."
+        specified by the `returns` attribute. As with any resource type,
+        the log level can be controlled with the `loglevel` metaparameter."
 
       defaultto :on_failure
 


### PR DESCRIPTION
The logoutput parameter can't accept log levels as legal values. This has been
wrong since 2008 (commit bb8051bc406d1da67db8212e852bb36d1368e953) and it sounds
like it was practically wrong long before that.
