### PR TITLE
PUP-1661 Skeleton face implementation

### DIFF
--- a/lib/puppet/face/module/skeleton.rb
+++ b/lib/puppet/face/module/skeleton.rb
@@ -1,0 +1,35 @@
+# encoding: UTF-8
+require 'pathname'
+
+Puppet::Face.define(:module, '1.0.0') do
+  action(:skeleton) do
+    summary "Manage your skeleton files for modules."
+    description <<-EOT
+      Manage your skeleton files that are used to generate modules.
+    EOT
+
+    returns "A list of your current skeleton modules"
+
+    examples <<-'EOT'
+      Lists all of your current module skeletons:
+
+      $ puppet module skeletons
+      Fetching your skeletons...
+        Default skeleton: /var/lib/puppet/module_tool/skeleton/templates/generator
+        Custom skeletons: /home/puppet/.puppet/var/puppet-module/skeleton
+
+    EOT
+
+    when_invoked do |options|
+      Puppet::ModuleTool.set_option_defaults options
+
+      skeleton_wrangler = Puppet::ModuleTool::Applications::SkeletonWrangler.new(options)
+
+      skeleton_wrangler.run
+    end
+
+    when_rendering :console do |return_value|
+      return_value.map {|f| "#{f[0].to_s}: #{f[1]}" }.join("\n")
+    end
+  end
+end

--- a/lib/puppet/module_tool/applications.rb
+++ b/lib/puppet/module_tool/applications.rb
@@ -8,6 +8,7 @@ module Puppet::ModuleTool
     require 'puppet/module_tool/applications/generator'
     require 'puppet/module_tool/applications/installer'
     require 'puppet/module_tool/applications/searcher'
+    require 'puppet/module_tool/applications/skeleton_wrangler'
     require 'puppet/module_tool/applications/unpacker'
     require 'puppet/module_tool/applications/uninstaller'
     require 'puppet/module_tool/applications/upgrader'

--- a/lib/puppet/module_tool/applications/skeleton_wrangler.rb
+++ b/lib/puppet/module_tool/applications/skeleton_wrangler.rb
@@ -1,0 +1,26 @@
+require 'pathname'
+require 'tmpdir'
+
+module Puppet::ModuleTool
+  module Applications
+    class SkeletonWrangler < Application
+
+      def initialize(options = {})
+        super(options)
+      end
+
+      def skeleton
+        @skeleton ||= Skeleton.new
+      end
+
+      def run
+        results = {}
+        Puppet.notice "Fetching your skeletons..."
+        results["Default Path"] = skeleton.default_path
+        results["Custom Path"] = skeleton.custom_path
+        results
+      end
+
+    end
+  end
+end

--- a/spec/unit/face/module/skeleton_spec.rb
+++ b/spec/unit/face/module/skeleton_spec.rb
@@ -1,0 +1,32 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'puppet/face'
+require 'puppet/module_tool'
+require 'puppet_spec/modules'
+
+describe "puppet module skeleton" do
+  include PuppetSpec::Files
+
+  before do
+    dir = tmpdir("deep_path")
+
+    @skelepath1 = File.join(dir, "skelepath1")
+    @skelpath = "#{@skelepath1}"
+    @pathname_stub = Pathname(__FILE__).dirname.to_s.gsub(/spec\/unit\/face\/module/,'lib/puppet/module_tool/') + 'skeleton/templates/generator'
+    Puppet.settings[:module_skeleton_dir] = @skelpath
+
+    FileUtils.mkdir_p(@skelepath1)
+  end
+
+  around do |example|
+    Puppet.override(:environments => Puppet::Environments::Legacy.new()) do
+      example.run
+    end
+  end
+
+  it "should return a list of skeleton files" do
+    Puppet::Face[:module, :current].skeleton["Default Path"].should eql Pathname(@pathname_stub)
+    Puppet::Face[:module, :current].skeleton["Custom Path"].should eql Pathname(@skelepath1)
+  end
+end

--- a/spec/unit/module_tool/applications/skeleton_wrangler_spec.rb
+++ b/spec/unit/module_tool/applications/skeleton_wrangler_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require 'puppet/module_tool/applications'
+
+describe Puppet::ModuleTool::Applications::SkeletonWrangler do
+  let(:skeleton_wrangler) { Puppet::ModuleTool::Applications::SkeletonWrangler.new() }
+
+  it "should attempt to display skeleton path settings" do
+
+    Puppet.expects(:notice).with("Fetching your skeletons...")
+
+    skeleton_wrangler.run.should include "Default Path", "Custom Path"
+  end
+  
+end


### PR DESCRIPTION
So, as part of a larger feature of being able to define skeletons from external sources (https://tickets.puppetlabs.com/browse/PUP-1661) I've implemented a new face for the module command.

Right now, all the face does is list your current skeletons, but in the future it'll be able to take remote or local paths to add to your skeleton collection for module generation. It was all @apenney's idea :smile: 

This means less churn in adding in new files for the module template all the time.

So I've opened this PR to get some general advice on implementing this new face for the Module tool. Any help appreciated :+1: 
