### PR TITLE
(PUP-1665) Viewing cert requests should not require traversing signed certs

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -184,9 +184,11 @@ class Puppet::SSL::CertificateAuthority
 
   # Lists the names of all signed certificates.
   #
+  # @param name [Array<string>] filter to cerificate names
+  #
   # @return [Array<String>]
-  def list
-    list_certificates.collect { |c| c.name }
+  def list(name='*')
+    list_certificates(name).collect { |c| c.name }
   end
 
   # Return all the certificate objects as found by the indirector
@@ -195,13 +197,16 @@ class Puppet::SSL::CertificateAuthority
   # Created to prevent the case of reading all certs from disk, getting
   # just their names and verifying the cert for each name, which then
   # causes the cert to again be read from disk.
+  # @param name [Array<string>] filter to cerificate names
   #
   # @author Jeff Weiss <jeff.weiss@puppetlabs.com>
   # @api Puppet Enterprise Licensing
   #
+  # @param name [Array<string>] filter to cerificate names
+  #
   # @return [Array<Puppet::SSL::Certificate>]
-  def list_certificates
-    Puppet::SSL::Certificate.indirection.search("*")
+  def list_certificates(name='*')
+    Puppet::SSL::Certificate.indirection.search(name)
   end
 
   # Read the next serial from the serial file, and increment the

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -45,7 +45,7 @@ module Puppet
 
         # List the hosts.
         def list(ca)
-          signed = ca.list
+          signed = ca.list if [:signed, :all].include?(subjects)
           requests = ca.waiting?
 
           case subjects
@@ -57,6 +57,7 @@ module Puppet
             hosts = requests
           else
             hosts = subjects
+            signed = ca.list(hosts)
           end
 
           certs = {:signed => {}, :invalid => {}, :request => {}}
@@ -72,7 +73,7 @@ module Puppet
 
             if verify_error
               certs[:invalid][host] = [ Puppet::SSL::Certificate.indirection.find(host), verify_error ]
-            elsif signed.include?(host)
+            elsif (signed and signed.include?(host))
               certs[:signed][host]  = Puppet::SSL::Certificate.indirection.find(host)
             else
               certs[:request][host] = Puppet::SSL::CertificateRequest.indirection.find(host)

--- a/spec/unit/ssl/certificate_authority/interface_spec.rb
+++ b/spec/unit/ssl/certificate_authority/interface_spec.rb
@@ -185,7 +185,7 @@ describe Puppet::SSL::CertificateAuthority::Interface do
         @digest = mock("digest")
         @digest.stubs(:to_s).returns("(fingerprint)")
         @ca.expects(:waiting?).returns %w{host1 host2 host3}
-        @ca.expects(:list).returns %w{host4 host5 host6}
+        @ca.expects(:list).returns(%w{host4 host5 host6}).at_most(1)
         @csr.stubs(:digest).returns @digest
         @cert.stubs(:digest).returns @digest
         @ca.stubs(:verify)
@@ -207,6 +207,7 @@ describe Puppet::SSL::CertificateAuthority::Interface do
 
       describe "and :all was provided" do
         it "should print a string containing all certificate requests and certificates" do
+          @ca.expects(:list).returns %w{host4 host5 host6}
           @ca.stubs(:verify).with("host4").raises(Puppet::SSL::CertificateAuthority::CertificateVerificationError.new(23), "certificate revoked")
 
           applier = @class.new(:list, :to => :all)
@@ -226,6 +227,7 @@ describe Puppet::SSL::CertificateAuthority::Interface do
 
       describe "and :signed was provided" do
         it "should print a string containing all signed certificate requests and certificates" do
+          @ca.expects(:list).returns %w{host4 host5 host6}
           applier = @class.new(:list, :to => :signed)
 
           applier.expects(:puts).with(<<-OUTPUT.chomp)


### PR DESCRIPTION
In our production environment we have >80000 certificates. Issuing `puppet cert list` on a large volume of signed certificates "hangs" even though viewing pending cert requests or individual certs does not require traversing the signed repo.

`puppet cert list` should only scan all the signed certs when necessary (signed or all options).
