### PR TITLE
PUP-1681 Stat doesn't expose correct mode on Win

### DIFF
--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -232,7 +232,7 @@ module Puppet::FileSystem
   end
 
   # @return [Boolean] true if the file is a symbolic link.
-  # 
+  #
   # @api public
   #
   def self.symlink?(path)
@@ -339,5 +339,19 @@ module Puppet::FileSystem
   #
   def self.exclusive_create(path, mode, &block)
     @impl.exclusive_create(assert_path(path), mode, &block)
+  end
+
+  # Changes permission bits on the named path to the bit pattern represented
+  # by mode.
+  #
+  # @param mode [Integer] The mode to apply to the file if it is created
+  # @param path [String] The path to the file, can also accept [PathName]
+  #
+  # @raise [Errno::ENOENT]: path doesn't exist
+  #
+  # @api public
+  #
+  def self.chmod(mode, path)
+    @impl.chmod(mode, path)
   end
 end

--- a/lib/puppet/file_system/file19windows.rb
+++ b/lib/puppet/file_system/file19windows.rb
@@ -91,6 +91,10 @@ class Puppet::FileSystem::File19Windows < Puppet::FileSystem::File19
     Puppet::Util::Windows::File.lstat(path)
   end
 
+  def chmod(mode, path)
+    Puppet::Util::Windows::Security.set_mode(mode, path.to_s)
+  end
+
   private
 
   def raise_if_symlinks_unsupported

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -135,4 +135,7 @@ class Puppet::FileSystem::FileImpl
     open(path, 0, 'rb') { |this| FileUtils.compare_stream(this, stream) }
   end
 
+  def chmod(mode, path)
+    FileUtils.chmod(mode, path)
+  end
 end

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -219,14 +219,23 @@ module Puppet::Util::Windows::File
   def stat(file_name)
     file_name = file_name.to_s # accomodate PathName or String
     stat = File.stat(file_name)
+    singleton_class = class << stat; self; end
+    target_path = file_name
+
     if symlink?(file_name)
-      link_ftype = File.stat(readlink(file_name)).ftype
+      target_path = readlink(file_name)
+      link_ftype = File.stat(target_path).ftype
+
       # sigh, monkey patch instance method for instance, and close over link_ftype
-      singleton_class = class << stat; self; end
       singleton_class.send(:define_method, :ftype) do
         link_ftype
       end
     end
+
+    singleton_class.send(:define_method, :mode) do
+      Puppet::Util::Windows::Security.get_mode(target_path)
+    end
+
     stat
   end
   module_function :stat
@@ -235,6 +244,12 @@ module Puppet::Util::Windows::File
     file_name = file_name.to_s # accomodate PathName or String
     # monkey'ing around!
     stat = File.lstat(file_name)
+
+    singleton_class = class << stat; self; end
+    singleton_class.send(:define_method, :mode) do
+      Puppet::Util::Windows::Security.get_mode(file_name)
+    end
+
     if symlink?(file_name)
       def stat.ftype
         "link"

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -60,7 +60,8 @@ describe Puppet::Configurer do
       @configurer.run :catalog => @catalog, :report => report
       t2 = Time.now.tv_sec
 
-      file_mode = Puppet.features.microsoft_windows? ? '100644' : '100666'
+      # sticky bit only applies to directories in windows
+      file_mode = Puppet.features.microsoft_windows? ? '666' : '100666'
 
       Puppet::FileSystem.stat(Puppet[:lastrunfile]).mode.to_s(8).should == file_mode
 

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -886,13 +886,14 @@ describe Puppet::Type.type(:file) do
     it "should be able to copy files with spaces in their names" do
       dest = tmpfile("destwith spaces")
       source = tmpfile_with_contents("filewith spaces", "foo")
-      File.chmod(0755, source)
+
+      expected_mode = 0755
+      Puppet::FileSystem.chmod(expected_mode, source)
 
       catalog.add_resource described_class.new(:path => dest, :source => source)
 
       catalog.apply
 
-      expected_mode = Puppet.features.microsoft_windows? ? 0644 : 0755
       File.read(dest).should == "foo"
       (Puppet::FileSystem.stat(dest).mode & 007777).should == expected_mode
     end
@@ -1021,6 +1022,7 @@ describe Puppet::Type.type(:file) do
       end
 
       it "should provide valid default values when ACLs are not supported" do
+        Puppet::Util::Windows::Security.stubs(:supports_acl?).returns(false)
         Puppet::Util::Windows::Security.stubs(:supports_acl?).with(source).returns false
 
         file = described_class.new(

--- a/spec/integration/type/nagios_spec.rb
+++ b/spec/integration/type/nagios_spec.rb
@@ -51,7 +51,9 @@ describe "Nagios file creation" do
           :mode   => '0640'
         )
         run_in_catalog(resource)
-        ( "%o" % get_mode(target_file) ).should == "100640"
+        # sticky bit only applies to directories in Windows
+        mode = Puppet.features.microsoft_windows? ? "640" : "100640"
+        ( "%o" % get_mode(target_file) ).should == mode
       end
     end
 

--- a/spec/integration/util/settings_spec.rb
+++ b/spec/integration/util/settings_spec.rb
@@ -41,7 +41,7 @@ describe Puppet::Settings do
 
     settings.use(:main)
 
-    expect(Puppet::FileSystem.stat(settings[:maindir]).mode & 007777).to eq(Puppet.features.microsoft_windows? ? 0755 : 0750)
+    expect(Puppet::FileSystem.stat(settings[:maindir]).mode & 007777).to eq(0750)
   end
 
   it "reparses configuration if configuration file is touched", :if => !Puppet.features.microsoft_windows? do

--- a/spec/unit/type/file/mode_spec.rb
+++ b/spec/unit/type/file/mode_spec.rb
@@ -185,7 +185,8 @@ describe Puppet::Type.type(:file).attrclass(:mode) do
 
     it "changes only the requested bits" do
       # lower nibble must be set to 4 for the sake of passing on Windows
-      FileUtils.chmod 0464, path
+      Puppet::FileSystem.chmod(0464, path)
+
       mode_sym.sync
       stat = Puppet::FileSystem.stat(path)
       (stat.mode & 0777).to_s(8).should == "644"


### PR DESCRIPTION
- An issue was discovered where the values returned from
  Puppet::FileSystem.stat and Puppet::Util::Windows::Security.get_mode
  were not aligning as they should.  The call to get_mode returns
  a mode value that should more correctly express a simulated POSIX
  mode on Windows
- The stat instance returned from Ruby has been further monkey-patched
  on Windows to add an appropriate mode value using the existing
  lower-level code that reads a files security descriptor.
- Some tests that were performing special handling of mode values were
  updated now that mode should be more consistent across platforms.
- In some cases, an existing call to File.chmod was changed to call
  set_mode under Windows.  In the future, our FileSystem abstraction
  should be modified to create an OS-agnostic single point of entry
  for setting mode on files.
