### PR TITLE
[metaparam] Change warning message to debug message

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -322,7 +322,7 @@ class Puppet::Resource::Type
 
     arguments.each do |arg, default|
       arg = arg.to_s
-      warn_if_metaparam(arg, default)
+      debug_if_metaparam(arg, default)
       @arguments[arg] = default
     end
   end
@@ -374,11 +374,11 @@ class Puppet::Resource::Type
     end
   end
 
-  def warn_if_metaparam(param, default)
+  def debug_if_metaparam(param, default)
     return unless Puppet::Type.metaparamclass(param)
 
     if default
-      warnonce "#{param} is a metaparam; this value will inherit to all contained resources in the #{self.name} definition"
+      debug_once "#{param} is a metaparam; this value will inherit to all contained resources in the #{self.name} definition"
     else
       raise Puppet::ParseError, "#{param} is a metaparameter; please choose another parameter name in the #{self.name} definition"
     end


### PR DESCRIPTION
Since this is the expected behaviour of a meta-parameter.

My suggestion is to decrease the level of the message by turning it into a debug message.
