### PR TITLE
(PUP-751) Check for reparse once per compile

### DIFF
--- a/lib/puppet/indirector/resource_type/parser.rb
+++ b/lib/puppet/indirector/resource_type/parser.rb
@@ -27,7 +27,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
       # This is a fix in 3.x that will be replaced with the use of a context
       # (That is not available until 3.5).
       $squelsh_parse_errors = true
-      krt = request.environment.known_resource_types
+      krt = resource_types_in(request.environment)
 
       # This is a bit ugly.
       [:hostclass, :definition, :node].each do |type|
@@ -65,7 +65,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
       # (That is not available until 3.5).
       $squelsh_parse_errors = true
 
-      krt = request.environment.known_resource_types
+      krt = resource_types_in(request.environment)
       # Make sure we've got all of the types loaded.
       krt.loader.import_all
 
@@ -102,5 +102,10 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
     end
   ensure
     $squelsh_parse_errors = false
+  end
+
+  def resource_types_in(environment)
+    environment.check_for_reparse
+    environment.known_resource_types
   end
 end

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -19,23 +19,6 @@ end
 # The 'environment' global variable represents the current environment that's
 # being used in the compiler.
 #
-# ### `$known_resource_types`
-#
-# The 'known_resource_types' global variable represents a singleton instance
-# of the Puppet::Resource::TypeCollection class. The variable is discarded
-# and regenerated if it is accessed by an environment that doesn't match the
-# environment of the 'known_resource_types'
-#
-# This behavior of discarding the known_resource_types every time the
-# environment changes is not ideal. In the best case this can cause valid data
-# to be discarded and reloaded. If Puppet is being used with numerous
-# environments then this penalty will be repeatedly incurred.
-#
-# In the worst case (#15106) demonstrates that if a different environment is
-# accessed during catalog compilation, for whatever reason, the
-# known_resource_types can be discarded which loses information that cannot
-# be recovered and can cause a catalog compilation to completely fail.
-#
 # ## The root environment
 #
 # In addition to normal environments that are defined by the user,there is a
@@ -204,33 +187,11 @@ class Puppet::Node::Environment
   # @api public
   # @return [Puppet::Resource::TypeCollection] The current global TypeCollection
   def known_resource_types
-    # This makes use of short circuit evaluation to get the right thread-safe
-    # per environment semantics with an efficient most common cases; we almost
-    # always just return our thread's known-resource types.  Only at the start
-    # of a compilation (after our thread var has been set to nil) or when the
-    # environment has changed or when the known resource types have become stale
-    # do we delve deeper.
-    $known_resource_types = nil if $known_resource_types &&
-      ($known_resource_types.environment != self || !@known_resource_types_being_imported && $known_resource_types.stale?)
-    $known_resource_types ||=
-      if @known_resource_types.nil? or @known_resource_types.require_reparse?
-        #set the global variable $known_resource_types immediately as it will be queried
-        #resursively from the parser which would set it anyway, just executing more code in vain
-        @known_resource_types = $known_resource_types = Puppet::Resource::TypeCollection.new(self)
-
-        #avoid an infinite recursion (called from the parser) if Puppet[:filetimeout] is set to -1 and
-        #$known_resource_types.stale? returns always true; let's set a flag that we're importing
-        #so if this method is called recursively we'll skip testing the stale status
-        begin
-          @known_resource_types_being_imported = true
-          @known_resource_types.import_ast(perform_initial_import, '')
-        ensure
-          @known_resource_types_being_imported = false
-        end
-        @known_resource_types
-      else
-        @known_resource_types
-      end
+    if @known_resource_types.nil?
+      @known_resource_types = Puppet::Resource::TypeCollection.new(self)
+      @known_resource_types.import_ast(perform_initial_import(), '')
+    end
+    @known_resource_types
   end
 
   # Yields each modules' plugin directory if the plugin directory (modulename/lib)
@@ -406,6 +367,13 @@ class Puppet::Node::Environment
     deps
   end
 
+
+  def check_for_reparse
+    if @known_resource_types && @known_resource_types.require_reparse?
+      @known_resource_types = nil
+    end
+  end
+
   # @return [String] The stringified value of the `name` instance variable
   # @api public
   def to_s
@@ -478,7 +446,7 @@ class Puppet::Node::Environment
     end
     parser.parse
   rescue => detail
-    known_resource_types.parse_failed = true
+    @known_resource_types.parse_failed = true
 
     msg = "Could not parse for environment #{self}: #{detail}"
     error = Puppet::Error.new(msg)

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -17,10 +17,9 @@ class Puppet::Parser::Compiler
   include Puppet::Resource::TypeCollectionHelper
 
   def self.compile(node)
-    $known_resource_types = nil
     $env_module_directories = nil
+    node.environment.check_for_reparse
 
-    # ...and we actually do the compile now we have caching ready.
     new(node).compile.to_resource
   rescue => detail
     message = "#{detail} on node #{node.name}"


### PR DESCRIPTION
Previously, whenever the known_resource_types
(Puppet::Resource::TypeCollection) was retrieved from the environment it
would check if there were any files that needed to be reparsed. If any files
needed a reparse, then the entire TypeCollection was thrown away and redone.

In most cases the reparse check did not need to touch the filesystem because
the Puppet::Util::PeriodicWatcher would return a cached result until the
filetimeout had expired. Unfortunately the check was done so often that the
overhead of simply checking if enough time had passed caused it to take a
considerable amount of time.

This changes it so that the environment's known resource types are only 
recalculated if the new check_for_reparse method determines that it should.
The new method is only called at the beginning of a compile and so the files
will never be checked while a compilation is being executed.
