### PR TITLE
(maint) Improve Puppet::Util::Docs.scrub's handling of one-liners

### DIFF
--- a/lib/puppet/util/docs.rb
+++ b/lib/puppet/util/docs.rb
@@ -112,8 +112,8 @@ module Puppet::Util::Docs
   #
   # See tests in spec/unit/util/docs_spec.rb for examples.
   def scrub(text)
-    # One-liners are easy!
-    return text.strip if text !~ /\n/
+    # One-liners are easy! (One-liners may be buffered with extra newlines.)
+    return text.strip if text.strip !~ /\n/
     excluding_first_line = text.partition("\n").last
     indent = excluding_first_line.scan(/^[ \t]*(?=\S)/).min || '' # prevent nil
     # Clean hanging indent, if any

--- a/spec/unit/util/docs_spec.rb
+++ b/spec/unit/util/docs_spec.rb
@@ -85,6 +85,15 @@ EOT
       expect(Puppet::Util::Docs.scrub(my_cleaned_output)).to eq my_cleaned_output
     end
 
+    it "trims leading space from one-liners (even when they're buffered with extra newlines)" do
+      input = "
+        Updates values in the `puppet.conf` configuration file.
+      "
+      expected_output = "Updates values in the `puppet.conf` configuration file."
+      output = Puppet::Util::Docs.scrub(input)
+      expect(output).to eq expected_output
+    end
+
 
   end
 end


### PR DESCRIPTION
One-liner handling wasn't behaving as expected. Sometimes one-liners are
buffered with extra newlines before and/or after, and in these cases, scrub
wasn't catching the leading whitespace.

This commit makes it behave as intended, and adds a test showing the intended
behavior.
