### PR TITLE
(maint) Banish "configuration parameter"

### DIFF
--- a/ext/nagios/naggen
+++ b/ext/nagios/naggen
@@ -21,7 +21,7 @@
 #
 # = Options
 #
-# Note that any configuration parameter that's valid in the configuration file
+# Note that any setting that's valid in the configuration file
 # is also a valid long argument.  For example, 'ssldir' is a valid configuration
 # parameter, so you can specify '--ssldir <directory>' as an argument.
 #

--- a/ext/puppet-test
+++ b/ext/puppet-test
@@ -18,7 +18,7 @@
 #
 # = Options
 #
-# Note that any configuration parameter that's valid in the configuration file
+# Note that any setting that's valid in the configuration file
 # is also a valid long argument.  For example, 'server' is a valid configuration
 # parameter, so you can specify '--server <servername>' as an argument.
 #
@@ -474,7 +474,7 @@ begin
     explicit_waitforcert = false
     result.each { |opt,arg|
         case opt
-            # First check to see if the argument is a valid configuration parameter;
+            # First check to see if the argument is a valid setting;
             # if so, set it.
             when "--compile"
                 $options[:suite] = :configuration

--- a/ext/upload_facts.rb
+++ b/ext/upload_facts.rb
@@ -53,7 +53,7 @@ uploaded.
 
 = Options
 
-Note that any configuration parameter that's valid in the configuration file
+Note that any setting that's valid in the configuration file
 is also a valid long argument.  For example, 'server' is a valid configuration
 parameter, so you can specify '--server <servername>' as an argument.
 

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -71,7 +71,7 @@ module Puppet
     end
   end
 
-  # configuration parameter access and stuff
+  # setting access and stuff
   def self.[]=(param,value)
     @@settings[param] = value
   end
@@ -107,7 +107,7 @@ module Puppet
     Puppet::Util::RunMode[@@settings.preferred_run_mode]
   end
 
-  # Load all of the configuration parameters.
+  # Load all of the settings.
   require 'puppet/defaults'
 
   def self.genmanifest

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -64,9 +64,9 @@ manifests.
 
 OPTIONS
 -------
-Note that any configuration parameter that's valid in the configuration
+Note that any setting that's valid in the configuration
 file is also a valid long argument. For example, 'tags' is a
-valid configuration parameter, so you can specify '--tags <class>,<tag>'
+valid setting, so you can specify '--tags <class>,<tag>'
 as an argument.
 
 See the configuration file documentation at

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -154,9 +154,9 @@ unless the '--all' option is set.
 
 OPTIONS
 -------
-Note that any configuration parameter that's valid in the configuration
+Note that any setting that's valid in the configuration
 file is also a valid long argument. For example, 'ssldir' is a valid
-configuration parameter, so you can specify '--ssldir <directory>' as an
+setting, so you can specify '--ssldir <directory>' as an
 argument.
 
 See the configuration file documentation at

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -107,7 +107,7 @@ Supported url must conforms to:
 
 OPTIONS
 -------
-Note that any configuration parameter that's valid in the configuration file
+Note that any setting that's valid in the configuration file
 is also a valid long argument.  For example, 'server' is a valid configuration
 parameter, so you can specify '--server <servername>' as an argument.
 

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -57,9 +57,9 @@ use your local file bucket by specifying '--local'.
 
 OPTIONS
 -------
-Note that any configuration parameter that's valid in the configuration
+Note that any setting that's valid in the configuration
 file is also a valid long argument. For example, 'ssldir' is a valid
-configuration parameter, so you can specify '--ssldir <directory>' as an
+setting, so you can specify '--ssldir <directory>' as an
 argument.
 
 See the configuration file documentation at

--- a/lib/puppet/application/kick.rb
+++ b/lib/puppet/application/kick.rb
@@ -102,9 +102,9 @@ about security settings.
 
 OPTIONS
 -------
-Note that any configuration parameter that's valid in the configuration
+Note that any setting that's valid in the configuration
 file is also a valid long argument. For example, 'ssldir' is a valid
-configuration parameter, so you can specify '--ssldir <directory>' as an
+setting, so you can specify '--ssldir <directory>' as an
 argument.
 
 See the configuration file documentation at

--- a/lib/puppet/application/queue.rb
+++ b/lib/puppet/application/queue.rb
@@ -70,9 +70,9 @@ http://docs.puppetlabs.com/puppetdb/latest
 
 OPTIONS
 -------
-Note that any configuration parameter that's valid in the configuration
+Note that any setting that's valid in the configuration
 file is also a valid long argument. For example, 'server' is a valid
-configuration parameter, so you can specify '--server <servername>' as
+setting, so you can specify '--server <servername>' as
 an argument.
 
 See the configuration file documentation at

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -71,9 +71,9 @@ and then apply the saved file as a Puppet transaction.
 
 OPTIONS
 -------
-Note that any configuration parameter that's valid in the configuration
+Note that any setting that's valid in the configuration
 file is also a valid long argument. For example, 'ssldir' is a valid
-configuration parameter, so you can specify '--ssldir <directory>' as an
+setting, so you can specify '--ssldir <directory>' as an
 argument.
 
 See the configuration file documentation at

--- a/lib/puppet/face/help/man.erb
+++ b/lib/puppet/face/help/man.erb
@@ -15,10 +15,10 @@ DESCRIPTION
 <% end -%>
 OPTIONS
 -------
-Note that any configuration parameter that's valid in the configuration
+Note that any setting that's valid in the configuration
 file is also a valid long argument, although it may or may not be
 relevant to the present action. For example, `server` and `run_mode` are valid
-configuration parameters, so you can specify `--server <servername>`, or
+settings, so you can specify `--server <servername>`, or
 `--run_mode <runmode>` as an argument.
 
 See the configuration file documentation at

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -1,4 +1,4 @@
-config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc => "A reference for all configuration parameters") do
+config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc => "A reference for all settings") do
   docs = {}
   Puppet.settings.each do |name, object|
     docs[name] = object

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -114,7 +114,7 @@ class Puppet::Settings
   # Generate the list of valid arguments, in a format that GetoptLong can
   # understand, and add them to the passed option list.
   def addargs(options)
-    # Add all of the config parameters as valid options.
+    # Add all of the settings as valid options.
     self.each { |name, setting|
       setting.getopt_args.each { |args| options << args }
     }
@@ -125,7 +125,7 @@ class Puppet::Settings
   # Generate the list of valid arguments, in a format that OptionParser can
   # understand, and add them to the passed option list.
   def optparse_addargs(options)
-    # Add all of the config parameters as valid options.
+    # Add all of the settings as valid options.
     self.each { |name, setting|
       options << setting.optparse_args
     }
@@ -133,7 +133,7 @@ class Puppet::Settings
     options
   end
 
-  # Is our parameter a boolean parameter?
+  # Is our setting a boolean setting?
   def boolean?(param)
     param = param.to_sym
     @config.include?(param) and @config[param].kind_of?(BooleanSetting)
@@ -405,7 +405,7 @@ class Puppet::Settings
           end
           puts "#{v} = #{value(v,env)}"
         else
-          puts "invalid parameter: #{v}"
+          puts "invalid setting: #{v}"
           return false
         end
       end
@@ -477,7 +477,7 @@ class Puppet::Settings
     mode
   end
 
-  # Return all of the parameters associated with a given section.
+  # Return all of the settings associated with a given section.
   def params(section = nil)
     if section
       section = section.intern if section.is_a? String
@@ -811,11 +811,11 @@ class Puppet::Settings
       name = name.to_sym
       hash[:name] = name
       hash[:section] = section
-      raise ArgumentError, "Parameter #{name} is already defined" if @config.include?(name)
+      raise ArgumentError, "Setting #{name} is already defined" if @config.include?(name)
       tryconfig = newsetting(hash)
       if short = tryconfig.short
         if other = @shortnames[short]
-          raise ArgumentError, "Parameter #{other.name} is already using short name '#{short}'"
+          raise ArgumentError, "Setting #{other.name} is already using short name '#{short}'"
         end
         @shortnames[short] = tryconfig
       end
@@ -863,7 +863,7 @@ class Puppet::Settings
   # Convert our list of config settings into a configuration file.
   def to_config
     str = %{The configuration file for #{Puppet.run_mode.name}.  Note that this file
-is likely to have unused configuration parameters in it; any parameter that's
+is likely to have unused settings in it; any setting that's
 valid anywhere in Puppet can be in any config file, even if it's not used.
 
 Every section can specify three special parameters: owner, group, and mode.
@@ -972,7 +972,7 @@ Generated on #{Time.now}.
 
     setting = @config[param]
 
-    # Short circuit to nil for undefined parameters.
+    # Short circuit to nil for undefined settings.
     return nil if setting.nil?
 
     # Check the cache first.  It needs to be a per-environment
@@ -1218,7 +1218,7 @@ Generated on #{Time.now}.
     def set(name, value)
       if !@defaults[name]
         raise ArgumentError,
-          "Attempt to assign a value to unknown configuration parameter #{name.inspect}"
+          "Attempt to assign a value to unknown setting #{name.inspect}"
       end
 
       if @defaults[name].has_hook?

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -250,7 +250,7 @@ Puppet::Type.newtype(:file) do
     desc "Whether to display differences when the file changes, defaulting to
         true.  This parameter is useful for files that may contain passwords or
         other secret data, which might otherwise be included in Puppet reports or
-        other insecure outputs.  If the global ``show_diff` configuration parameter
+        other insecure outputs.  If the global ``show_diff` setting
         is false, then no diffs will be shown even if this parameter is true."
 
     defaultto :true

--- a/spec/unit/hiera_puppet_spec.rb
+++ b/spec/unit/hiera_puppet_spec.rb
@@ -46,7 +46,7 @@ describe 'HieraPuppet' do
       begin
         Puppet.settings[:hiera_config] = nil
       rescue ArgumentError => detail
-        raise unless detail.message =~ /unknown configuration parameter/
+        raise unless detail.message =~ /unknown setting/
       end
       HieraPuppet.send(:hiera_config_file).should be_nil
     end
@@ -55,7 +55,7 @@ describe 'HieraPuppet' do
       begin
         Puppet.settings[:hiera_config] = "/dev/null/my_hiera.yaml"
       rescue ArgumentError => detail
-        raise unless detail.message =~ /unknown configuration parameter/
+        raise unless detail.message =~ /unknown setting/
         pending("This example does not apply to Puppet #{Puppet.version} because it does not have this setting")
       end
 
@@ -67,7 +67,7 @@ describe 'HieraPuppet' do
       begin
         Puppet.settings[:hiera_config] = nil
       rescue ArgumentError => detail
-        raise unless detail.message =~ /unknown configuration parameter/
+        raise unless detail.message =~ /unknown setting/
       end
       Puppet.settings[:confdir] = "/dev/null/puppet"
       hiera_config = File.join(Puppet[:confdir], 'hiera.yaml')

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -471,7 +471,7 @@ describe Puppet::Settings do
     it "should raise an error if we try to set a setting that hasn't been defined'" do
       lambda{
         @settings[:why_so_serious] = "foo"
-      }.should raise_error(ArgumentError, /unknown configuration parameter/)
+      }.should raise_error(ArgumentError, /unknown setting/)
     end
   end
 


### PR DESCRIPTION
They are called settings!

Note: Two spec files relied on the wording of an error message I changed.
I revised them to find the new wording.
