### PR TITLE
(PUP-1676) Puppet::Settings retrieves diectory environment settings

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -175,7 +175,7 @@ module Puppet
   # @api private
   def self.base_context(settings)
     environments = settings[:environmentpath]
-    modulepath = Puppet::Node::Environment.split_path(settings[:modulepath])
+    modulepath = Puppet::Node::Environment.split_path(settings[:basemodulepath])
 
     loaders = Puppet::Environments::Directories.from_path(environments, modulepath)
     loaders << Puppet::Environments::Legacy.new

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -928,8 +928,14 @@ EOT
       :type       => :boolean,
       :desc       => "Whether the master should function as a certificate authority.",
     },
-    :modulepath => {
+    :basemodulepath => {
       :default => "$confdir/modules#{File::PATH_SEPARATOR}/usr/share/puppet/modules",
+      :type => :path,
+      :desc => "The base non-environment specific search path for modules, included
+      also in all directory environment and default legacy environment modulepaths.",
+    },
+    :modulepath => {
+      :default => "$basemodulepath",
       :type => :path,
       :desc => "The search path for modules, as a list of directories separated by the system
         path separator character. (The POSIX path separator is ':', and the

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -40,7 +40,7 @@ module Puppet::Test
       @environmentdir = Dir.mktmpdir('environments')
       Puppet.push_context(Puppet.base_context({
         :environmentpath => @environmentdir,
-        :modulepath => "",
+        :basemodulepath => "",
         :manifest => "/dev/null"
       }), "Initial for specs")
       Puppet::Parser::Functions.reset

--- a/spec/integration/directory_environments_spec.rb
+++ b/spec/integration/directory_environments_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe "directory environments" do
+  let(:args) { ['--configprint', 'modulepath', '--environment', 'direnv'] }
+  let(:puppet) do
+    app = Puppet::Application[:apply]
+    app.stubs(:command_line).returns(stub('command_line', :args => []))
+    app
+  end
+
+  context "with a single directory environmentpath" do
+    before(:each) do
+      environmentdir = Puppet[:environmentpath].split(File::PATH_SEPARATOR).first
+      FileUtils.mkdir_p(environmentdir + "/direnv/modules")
+    end
+
+    it "config prints the environments modulepath" do
+      Puppet.settings.initialize_global_settings(args)
+      expect do
+        expect { puppet.run }.to exit_with(0)
+      end.to have_printed('direnv/modules')
+    end
+
+    it "config prints the cli --modulepath despite environment" do
+      args << '--modulepath' << 'completely/different'
+      Puppet.settings.initialize_global_settings(args)
+      expect do
+        expect { puppet.run }.to exit_with(0)
+      end.to have_printed('completely/different')
+    end
+  end
+
+  context "with an environmentpath having multiple directories" do
+    let(:args) { ['--configprint', 'modulepath', '--environment', 'otherdirenv'] }
+
+    before(:each) do
+      envdir1 = File.join(Puppet[:confdir], 'env1')
+      envdir2 = File.join(Puppet[:confdir], 'env2')
+      Puppet[:environmentpath] = [envdir1, envdir2].join(File::PATH_SEPARATOR)
+      FileUtils.mkdir_p(envdir2 + "/otherdirenv/modules")
+    end
+
+    it "config prints a directory environment modulepath" do
+      Puppet.settings.initialize_global_settings(args)
+      expect do
+        expect { puppet.run }.to exit_with(0)
+      end.to have_printed('otherdirenv/modules')
+    end
+  end
+end


### PR DESCRIPTION
During a Puppet[:setting] call, legacy environment settings would be
loaded from a puppet.conf stanza.  But settings from directory
environments would never be seen.  Areas in the codebase could obtain
per environment settings by looking them up directly from an
environment.  However a call to puppet config or to an application with
--configprint, would return the default modulepath if redirected to a
directory environment using the --environment setting.

A ValuesFromDirectoryEnvironment class has been added to Settings to
lookup environment settings not found in puppet.conf and which a
Puppet::Environment::Directories loader can find in the
environmentpath.

Because the Directories loader itself depends on the global :modulepath,
a setting, :basemodulepath, has been added, so that we can initialize a
Directories loader without recursing infinitely looking up :modulepath.

The possibility for recursion has been there since at least 3.0.0:

[legacy]
modulepath=/foo:$modulepath

would overflow the stack. It could now be:

[legacy]
modulepath=/foo:$basemodulepath
