### PR TITLE
(PUP-1592) Speed up loading of user defined types by 2x

### DIFF
--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -142,6 +142,11 @@ module Manager
   # @return [Puppet::Type, nil] the type or nil if the type was not defined and could not be loaded
   #
   def type(name)
+    # Avoid loading if name obviously is not a type name
+    if name.to_s.include?(':')
+      return nil
+    end
+
     @types ||= {}
 
     # We are overwhelmingly symbols here, which usually match, so it is worth


### PR DESCRIPTION
When a user defined type is loaded a check is always first made
to see if the name loads a resource type implemented in ruby. The
majority of loads are for non ruby types. The loading must be done with
higher precedence of ruby based resource type over user defined.

This optimization capitalizes on the fact that ruby resource types are
in a flat name space and thus their names can never contain '::'. The
optimization is done in metatype/manager.rb where now an attempt to load
from the type loader is avoided if the name contains a ':'.

This achieves a 2x speedup and generates less permanent garbage (all
user defined type names where internalized as symbols, never to be
gc'd).
