### PR TITLE
(maint) Add to_data_hash on Puppet::SSL::Base

### DIFF
--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -90,6 +90,10 @@ class Puppet::SSL::Base
     content.to_pem
   end
 
+  def to_data_hash
+    to_s
+  end
+
   # Provide the full text of the thing we're dealing with.
   def to_text
     return "" unless content


### PR DESCRIPTION
Without this to_pson fails on for example Puppet::SSL::Certificate. This caused a failure in for example the ca face when rendering a certificate.
