### PR TITLE
(PUP-1676) Allow main as a directory environment.

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1065,7 +1065,7 @@ Generated on #{Time.now}.
             values_from_section = ValuesFromSection.new(name, section)
           end
         end
-        if values_from_section.nil? && name != :main && @global_defaults_initialized
+        if values_from_section.nil? && @global_defaults_initialized
           values_from_section = ValuesFromCurrentEnvironment.new(name)
         end
         values_from_section


### PR DESCRIPTION
Looking again at the settings code, the static sections in puppet.conf
currently shadow a directory environment of the same name, because we
check the configuration file first.  But I'm not seeing any reason to
specifically forbid main as a directory environment name.  Once static
environments are removed, we will need to address how to obtain
puppet.conf [main] settings without shadowing directory environments.
