### PR TITLE
(maint) Broaden managehome acceptance test on windows 2003

### DIFF
--- a/acceptance/tests/ticket_15560_managehome.rb
+++ b/acceptance/tests/ticket_15560_managehome.rb
@@ -25,7 +25,7 @@ agents.each do |host|
   deleteable_profile = true
 
   version = on(host, facter('operatingsystemrelease')).stdout.chomp
-  if version =~ /^5\.[012]/
+  if version =~ /^5\.[012]|2003/
     homedir = "C:/Documents and Settings/#{username}"
     deleteable_profile = false
   else


### PR DESCRIPTION
The previous regex only captured older facter operatingsystemrelease
values.  Now we're also sensistive to facter-2 operatingsystemrelease
output.
