### PR TITLE
(PUP-1678) Puppet::Node::Environment.create expands manifest path

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -81,7 +81,7 @@ class Puppet::Node::Environment
     obj.send(:initialize,
              name,
              expand_dirs(extralibs() + modulepath),
-             manifest)
+             File.expand_path(manifest))
     obj
   end
 

--- a/spec/unit/network/http/api/v2/environments_spec.rb
+++ b/spec/unit/network/http/api/v2/environments_spec.rb
@@ -22,8 +22,8 @@ describe Puppet::Network::HTTP::API::V2::Environments do
       "environments" => {
         "production" => {
           "settings" => {
-            "modulepath" => ["/first", "/second"],
-            "manifest" => "/manifests"
+            "modulepath" => [File.expand_path("/first"), File.expand_path("/second")],
+            "manifest" => File.expand_path("/manifests")
           }
         }
       }

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -52,7 +52,7 @@ describe Puppet::Node::Environment do
         overridden = environment.override_with(:modulepath => new_path)
         expect(overridden).to_not be_equal(environment)
         expect(overridden.name).to eq(:overridden)
-        expect(overridden.manifest).to eq('orig.pp')
+        expect(overridden.manifest).to eq(File.expand_path('orig.pp'))
         expect(overridden.modulepath).to eq(new_path)
       end
 
@@ -60,7 +60,7 @@ describe Puppet::Node::Environment do
         overridden = environment.override_with(:manifest => 'new.pp')
         expect(overridden).to_not be_equal(environment)
         expect(overridden.name).to eq(:overridden)
-        expect(overridden.manifest).to eq('new.pp')
+        expect(overridden.manifest).to eq(File.expand_path('new.pp'))
         expect(overridden.modulepath).to eq(original_path)
       end
     end


### PR DESCRIPTION
Modulepath was already being expanded; this ensures manifest is expanded
as well and fixes some specs so that they will work on Windows too.
