### PR TITLE
(PUP-1735) Reimplement deprecated Puppet::Node::Environment.current

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -110,6 +110,19 @@ class Puppet::Node::Environment
                       env_params[:manifest] || manifest)
   end
 
+  # Retrieve the environment for the current process.
+  #
+  # @note This should only used when a catalog is being compiled.
+  #
+  # @api private
+  #
+  # @return [Puppet::Node::Environment] the currently set environment if one
+  #   has been explicitly set, else it will return the '*root*' environment
+  def self.current
+    Puppet.deprecation_warning("Puppet::Node::Environment.current has been replaced by Puppet.lookup(:current_environment), see http://links.puppetlabs.com/current-env-deprecation")
+    Puppet.lookup(:current_environment)
+  end
+
   # @param [String] name Environment name to check for valid syntax.
   # @return [Boolean] true if name is valid
   # @api public

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -454,4 +454,13 @@ describe Puppet::Node::Environment do
     it_behaves_like 'the environment'
   end
 
+  describe '#current' do
+    it 'should return the current context' do
+      env = Puppet::Node::Environment.new(:test)
+      Puppet::Context.any_instance.expects(:lookup).with(:current_environment).returns(env)
+      Puppet.expects(:deprecation_warning).once
+      Puppet::Node::Environment.current.should equal(env)
+    end
+  end
+
 end


### PR DESCRIPTION
Puppet::Node::Environment.current is used in some external code, so
reimplement it, linking to the context lookup for the current environment
and issue a deprecation warning.

---

Replaces #2377
