### PR TITLE
(pup-1505) Correct require

### DIFF
--- a/lib/puppet/feature/external_facts.rb
+++ b/lib/puppet/feature/external_facts.rb
@@ -1,4 +1,4 @@
-require 'facter/util/config'
+require 'facter'
 
 Puppet.features.add(:external_facts) {
   Facter.respond_to?(:search_external)


### PR DESCRIPTION
The previous patch for pup-1505 changes to use a facter
top-level method (rather than one buried inside facter) but
neglected to update the require to match. This patch updates
the require.
