### PR TITLE
(PUP-1041) nagios: parse empty parameter values in definitions

### DIFF
--- a/lib/puppet/external/nagios/grammar.ry
+++ b/lib/puppet/external/nagios/grammar.ry
@@ -37,6 +37,7 @@ vars: var
     ;
 
 var: PARAM VALUE returns { result = {val[0] => val[1]} }
+    | PARAM returns { result = {val[0] => "" } }
     ;
 
 returns: RETURN
@@ -144,6 +145,7 @@ def tokenize_parameter_value
     ;
 
   when (text = @ss.scan(/\n/))                  # newline
+    @in_parameter_value = false
     [:RETURN, text]
 
   when (text = @ss.scan(/.+$/))                 # Value of parameter

--- a/lib/puppet/external/nagios/parser.rb
+++ b/lib/puppet/external/nagios/parser.rb
@@ -8,7 +8,7 @@ require 'racc/parser.rb'
 module Nagios
   class Parser < Racc::Parser
 
-module_eval(<<'...end grammar.ry/module_eval...', 'grammar.ry', 49)
+module_eval(<<'...end grammar.ry/module_eval...', 'grammar.ry', 50)
 require 'strscan'
 
 class ::Nagios::Parser::SyntaxError < RuntimeError; end
@@ -107,6 +107,7 @@ def tokenize_parameter_value
     ;
 
   when (text = @ss.scan(/\n/))                  # newline
+    @in_parameter_value = false
     [:RETURN, text]
 
   when (text = @ss.scan(/.+$/))                 # Value of parameter
@@ -211,33 +212,33 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-     8,     3,     3,    14,    12,    18,    10,     4,     4,     9,
-    14,    12,     6,    19,    12 ]
+     8,     3,     3,    14,    12,    18,    10,     4,     4,    20,
+    12,    14,    12,     9,     6,    12 ]
 
 racc_action_check = [
-     5,     0,     5,    13,     9,    13,     8,     0,     5,     6,
-    11,    12,     3,    14,    19 ]
+     5,     0,     5,    13,     9,    13,     8,     0,     5,    14,
+    14,    11,    12,     6,     3,    20 ]
 
 racc_action_pointer = [
-    -1,   nil,   nil,     9,   nil,     0,     4,   nil,     6,    -4,
-   nil,     6,     3,    -1,     6,   nil,   nil,   nil,   nil,     6,
-   nil ]
+    -1,   nil,   nil,    11,   nil,     0,     8,   nil,     6,    -4,
+   nil,     7,     4,    -1,     2,   nil,   nil,   nil,   nil,   nil,
+     7,   nil ]
 
 racc_action_default = [
-   -11,    -1,    -3,   -11,    -4,   -11,   -11,    -2,   -11,   -11,
-    21,   -11,    -9,   -11,   -11,    -6,   -10,    -7,    -5,   -11,
-    -8 ]
+   -12,    -1,    -3,   -12,    -4,   -12,   -12,    -2,   -12,   -12,
+    22,   -12,   -10,   -12,   -12,    -6,   -11,    -7,    -5,    -9,
+   -12,    -8 ]
 
 racc_goto_table = [
-    11,     1,    15,    16,    17,    13,     7,     5,   nil,   nil,
-    20 ]
+    11,     1,    15,    16,    17,    19,     7,    13,     5,   nil,
+   nil,    21 ]
 
 racc_goto_check = [
-     4,     2,     6,     4,     6,     5,     2,     1,   nil,   nil,
-     4 ]
+     4,     2,     6,     4,     6,     4,     2,     5,     1,   nil,
+   nil,     4 ]
 
 racc_goto_pointer = [
-   nil,     7,     1,   nil,    -9,    -6,    -9 ]
+   nil,     8,     1,   nil,    -9,    -4,    -9 ]
 
 racc_goto_default = [
    nil,   nil,   nil,     2,   nil,   nil,   nil ]
@@ -252,12 +253,13 @@ racc_reduce_table = [
   1, 14, :_reduce_none,
   2, 14, :_reduce_7,
   3, 15, :_reduce_8,
+  2, 15, :_reduce_9,
   1, 13, :_reduce_none,
   2, 13, :_reduce_none ]
 
-racc_reduce_n = 11
+racc_reduce_n = 12
 
-racc_shift_n = 21
+racc_shift_n = 22
 
 racc_token_table = {
   false => 0,
@@ -379,9 +381,16 @@ module_eval(<<'.,.,', 'grammar.ry', 38)
   end
 .,.,
 
-# reduce 9 omitted
+module_eval(<<'.,.,', 'grammar.ry', 39)
+  def _reduce_9(val, _values, result)
+     result = {val[0] => "" } 
+    result
+  end
+.,.,
 
 # reduce 10 omitted
+
+# reduce 11 omitted
 
 def _reduce_none(val, _values, result)
   val[0]

--- a/spec/fixtures/unit/provider/naginator/define_empty_param
+++ b/spec/fixtures/unit/provider/naginator/define_empty_param
@@ -1,0 +1,6 @@
+# fixture for the spec test for PUP-1041
+
+define host {
+  parents
+  use       linux-server
+}

--- a/spec/unit/provider/naginator_spec.rb
+++ b/spec/unit/provider/naginator_spec.rb
@@ -63,3 +63,17 @@ describe Nagios::Base do
     obj.host_name.should == "my_hostname"
   end
 end
+
+describe Nagios::Parser do
+  include PuppetSpec::Files
+
+  subject do
+    described_class.new
+  end
+
+  let(:config) { File.new( my_fixture('define_empty_param') ).read }
+
+  it "should handle empty parameter values" do
+    expect { subject.parse(config) }.to_not raise_error
+  end
+end


### PR DESCRIPTION
This is a valid nagios defintion:

define host {
    parents
    use       linux-server
}

According to Erik Dalen, the empty value explicitly selects the default
instead of the value that was inherited from the host template in use.

The naginator provider will not accept this definition, because the
nagios config parser expects a value for each and every parameter.

Fix this by adding an according rule to the grammar.

Also, the lexer must be altered, because parameters and values are lexed
differently and returned as distinct tokens. When encountering newline
while scanning for a parameter value, the lexer must give up and reset
its internal state. (Otherwise, it would not accept another parameter
name or the end of the current definition block.)
