### PR TITLE
(PUP-1707) Ensure ERB generated help content is UTF-8 encoded

### DIFF
--- a/lib/puppet/face/help/action.erb
+++ b/lib/puppet/face/help/action.erb
@@ -1,3 +1,4 @@
+<%# encoding: UTF-8%>
 <% if action.synopsis -%>
 USAGE: <%= action.synopsis %>
 

--- a/lib/puppet/face/help/face.erb
+++ b/lib/puppet/face/help/face.erb
@@ -1,3 +1,4 @@
+<%# encoding: UTF-8%>
 <% if face.synopsis -%>
 USAGE: <%= face.synopsis %>
 

--- a/lib/puppet/face/help/global.erb
+++ b/lib/puppet/face/help/global.erb
@@ -1,3 +1,4 @@
+<%# encoding: UTF-8%>
 Usage: puppet <subcommand> [options] <action> [options]
 
 Available subcommands:

--- a/lib/puppet/face/help/man.erb
+++ b/lib/puppet/face/help/man.erb
@@ -1,3 +1,4 @@
+<%# encoding: UTF-8%>
 puppet-<%= face.name %>(8) -- <%= face.summary || "Undocumented subcommand." %>
 <%= '=' * (_erbout.length - 1) %>
 

--- a/spec/lib/puppet_spec/matchers.rb
+++ b/spec/lib/puppet_spec/matchers.rb
@@ -59,6 +59,7 @@ class HavePrintedMatcher
   def matches?(block)
     begin
       $stderr = $stdout = StringIO.new
+      $stdout.set_encoding('UTF-8')
       block.call
       $stdout.rewind
       @actual = $stdout.read


### PR DESCRIPTION
Previously, `env LANG=C bundle exec puppet man module` could not output
non US-ASCII characters correctly due to two issues.

First, puppet uses ERB generate the help output. Since the templates did
not include a magic encoding comment[1], ERB would set the string
encoding of the content it generated to `Encoding.default_external`, which
in the case of LANG=C and ruby 1.9 is US-ASCII.

When generating ERB help output for the `module` application, the resulting
byte stream would be correctly UTF-8 encoded, but `String#encoding` would
report US-ASCII. So later when we tried to perform a regex against it, we'd
get the `invalid byte sequence in US-ASCII` error.

The second issue is that the `man` application uses `IO.popen` to shell out
to the pager, but it did not specify the encoding for bytes it was writing
to the child process' stdin.

This commit sets the ERB magic encoding comment, and specifies an explicit
UTF-8 encoding when invoking the pager.

[1] https://github.com/ruby/ruby/blob/v1_9_3_484/lib/erb.rb#L63-L68
