### PR TITLE
(PUP-1775) Respect Yum's lock

### DIFF
--- a/lib/puppet/provider/package/yumhelper.py
+++ b/lib/puppet/provider/package/yumhelper.py
@@ -110,8 +110,14 @@ def shell_out():
 
 if useyumlib:
     try:
+        my = yum.YumBase()
         try:
-            my = yum.YumBase()
+            my.doLock()
+        except yum.Errors.LockError:
+            # Let's fall back to yum itself which has logic to wait
+            rc = shell_out()
+            sys.exit(rc)
+        try:
             ypl = pkg_lists(my)
             for pkg in ypl.updates:
                 print "_pkg %s %s %s %s %s" % (pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)


### PR DESCRIPTION
We're seeing RPM DB corruption relatively frequently these days and have narrowed it down to the yumhelper not respecting Yum's lock. Let's make it respect the lock. Instead of copying the wait loop around the lock, fall back to shell_out and make yum do the right thing.
