### PR TITLE
PUP-1772 Change api for Puppet::Util::Profiler#profile to public

### DIFF
--- a/lib/puppet/util/profiler.rb
+++ b/lib/puppet/util/profiler.rb
@@ -2,7 +2,7 @@ require 'benchmark'
 
 # A simple profiling callback system.
 #
-# @api private
+# @api public
 module Puppet::Util::Profiler
   require 'puppet/util/profiler/wall_clock'
   require 'puppet/util/profiler/object_counts'
@@ -11,22 +11,34 @@ module Puppet::Util::Profiler
   NONE = Puppet::Util::Profiler::None.new
 
   # Reset the profiling system to the original state
+  #
+  # @api private
   def self.clear
     @profiler = nil
   end
 
   # @return This thread's configured profiler
+  # @api private
   def self.current
     @profiler || NONE
   end
 
   # @param profiler [#profile] A profiler for the current thread
+  # @api private
   def self.current=(profiler)
     @profiler = profiler
   end
 
+  # Profile a block of code and log the time it took to execute.
+  #
+  # This outputs logs entries to the Puppet masters logging destination
+  # providing the time it took, a message describing the profiled code
+  # and a leaf location marking where the profile method was called
+  # in the profiled hierachy.
+  #
   # @param message [String] A description of the profiled event
   # @param block [Block] The segment of code to profile
+  # @api public
   def self.profile(message, &block)
     current.profile(message, &block)
   end


### PR DESCRIPTION
This patch changes the YardDoc annotations so that the class
'Puppet::Util::Profiler' is now public, and its method #profile
is also public.

The remaining methods are still marked as private, as they
aren't really needed by most external consumers.

Signed-off-by: Ken Barber ken@bob.sh
