### PR TITLE
(PUP-1576) Make hyphen in bare words legal (future parser)

### DIFF
--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -107,6 +107,24 @@ describe 'Lexer2' do
     end
   end
 
+  [ 'a-b', 'a--b', 'a-b-c'].each do |string|
+    it "should lex a BARE WORD STRING on the form '#{string}'" do
+      tokens_scanned_from(string).should match_tokens2([:STRING, string])
+    end
+  end
+
+  { '-a'   =>      [:MINUS, :NAME],
+    '--a'  =>      [:MINUS, :MINUS, :NAME],
+    'a-'   =>      [:NAME, :MINUS],
+    'a- b'   =>    [:NAME, :MINUS, :NAME],
+    'a--'  =>      [:NAME, :MINUS, :MINUS],
+    'a-$3' =>      [:NAME, :MINUS, :VARIABLE],
+  }.each do |source, expected|
+    it "should lex leading and trailing hyphens from #{source}" do
+      tokens_scanned_from(source).should match_tokens2(*expected)
+    end
+  end
+
   { 'false'=>false, 'true'=>true}.each do |string, value|
     it "should lex a BOOLEAN on the form '#{string}'" do
       tokens_scanned_from(string).should match_tokens2([:BOOLEAN, value])


### PR DESCRIPTION
This adds the ability to use a hyphen in a bare word. The result is the
same as if the bare word had been quoted in single quotes. It is not
allowed to start or end a bare word with a hyphen, those are always
interpreted as :MINUS.
