### PR TITLE
(PUP-927) Read files in binary mode

### DIFF
--- a/lib/puppet/parser/functions/file.rb
+++ b/lib/puppet/parser/functions/file.rb
@@ -1,4 +1,5 @@
 # Returns the contents of a file
+require 'puppet/file_system'
 
 Puppet::Parser::Functions::newfunction(
   :file, :arity => -2, :type => :rvalue,
@@ -11,7 +12,7 @@ Puppet::Parser::Functions::newfunction(
         raise Puppet::ParseError, "Files must be fully qualified"
       end
       if Puppet::FileSystem.exist?(file)
-        ret = File.read(file)
+        ret = Puppet::FileSystem.binread(file)
         break
       end
     end

--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -1,4 +1,5 @@
 require 'puppet/parser/files'
+require 'puppet/file_system'
 require 'erb'
 
 # A simple wrapper for templates, so they don't have full access to
@@ -97,7 +98,7 @@ class Puppet::Parser::TemplateWrapper
     if string
       template_source = "inline template"
     else
-      string = File.read(@__file__)
+      string = Puppet::FileSystem.binread(@__file__)
       template_source = @__file__
     end
 

--- a/spec/unit/parser/functions/file_spec.rb
+++ b/spec/unit/parser/functions/file_spec.rb
@@ -19,15 +19,15 @@ describe "the 'file' function" do
 
   def with_file_content(content)
     path = tmpfile('file-function')
-    file = File.new(path, 'w')
+    file = File.new(path, 'wb')
     file.sync = true
     file.print content
     yield path
   end
 
-  it "should read a file" do
-    with_file_content('file content') do |name|
-      scope.function_file([name]).should == "file content"
+  it "should read a file in binary mode" do
+    with_file_content("file content\r\n") do |name|
+      scope.function_file([name]).should == "file content\r\n"
     end
   end
 

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -82,7 +82,7 @@ describe "the template function" do
   end
 
   def eval_template(content)
-    File.stubs(:read).with("template").returns(content)
+    Puppet::FileSystem.stubs(:binread).with("template").returns(content)
     Puppet::Parser::Files.stubs(:find_template).returns("template")
     scope.function_template(['template'])
   end

--- a/spec/unit/parser/templatewrapper_spec.rb
+++ b/spec/unit/parser/templatewrapper_spec.rb
@@ -111,7 +111,7 @@ describe Puppet::Parser::TemplateWrapper do
     Puppet::Parser::Files.stubs(:find_template).
       with(name, anything()).
       returns(full_name)
-    File.stubs(:read).with(full_name).returns(contents)
+    Puppet::FileSystem.stubs(:binread).with(full_name).returns(contents)
 
     full_name
   end


### PR DESCRIPTION
Previously, puppet's built-in `file` and `template` functions read file
contents in text mode. This is not a problem when using a *nix master,
because there is no difference between text and binary modes.

However, when using `puppet apply` on Windows, puppet would convert
Windows style line endings '\r\n' to '\n' with no way to not do that.

This commit switches to using `binread`. This is the same as `read` on
*nix. On Windows, it will ensure that the original line endings are
preserved.
