### PR TITLE
(PUP-1275) Never try to fork on Windows

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -15,8 +15,12 @@ class Puppet::Agent
   def initialize(client_class, should_fork=true)
     @splayed = false
 
-    @should_fork = should_fork
+    @should_fork = can_fork? && should_fork
     @client_class = client_class
+  end
+
+  def can_fork?
+    Puppet.features.posix?
   end
 
   def needing_restart?

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -169,7 +169,7 @@ describe Puppet::Agent do
       @agent.run.should == :result
     end
 
-    describe "when should_fork is true" do
+    describe "when should_fork is true", :as_platform => :posix do
       before do
         @agent = Puppet::Agent.new(AgentTestClient, true)
 
@@ -223,6 +223,13 @@ describe Puppet::Agent do
         @agent.run_in_fork {
           777
         }
+      end
+    end
+
+    describe "on Windows", :as_platform => :windows do
+      it "should never fork" do
+        agent = Puppet::Agent.new(AgentTestClient, true)
+        expect(agent.should_fork).to be_false
       end
     end
   end


### PR DESCRIPTION
In 3.0.2, in commit 4d1a2f83d9 for #17361 restored the ability for *nix
agents to apply a catalog in a forked child process. But the change
caused Windows agents to also try to fork if run without the `--onetime`
flag.

This regression means you can't run Windows agents with `--listen` and
kick them.

This commit adds a `can_fork?` method to ensure we only attempt to fork
if we both can and should fork. There is no change in behavior for *nix
agents.
