### PR TITLE
(PUP-1144) Improve handling of underscore in variable names

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -244,7 +244,7 @@ module Puppet::Pops::Issues
   end
 
   ILLEGAL_VAR_NAME = hard_issue :ILLEGAL_VAR_NAME, :name do
-    "Illegal variable name, The given name '#{name}' does not conform to the naming rule /^((::)?[a-z_]\w*)(::[a-z]\w*)*$/"
+    "Illegal variable name, The given name '#{name}' does not conform to the naming rule /^((::)?[a-z]\w*)*((::)?[a-z_]\w*)$/"
   end
 
   ILLEGAL_NUMERIC_VAR_NAME = hard_issue :ILLEGAL_NUMERIC_VAR_NAME, :name do

--- a/lib/puppet/pops/patterns.rb
+++ b/lib/puppet/pops/patterns.rb
@@ -35,7 +35,8 @@ module Puppet::Pops::Patterns
   DOLLAR_VAR     = %r{\$(::)?(\w+::)*\w+}
 
   # VAR_NAME matches the name part of a variable (The $ character is not included)
-  VAR_NAME = %r{\A((::)?[a-z_]\w*)(::[a-z]\w*)*\z}
+  # Note, that only the final segment may start with an underscore.
+  VAR_NAME = %r{\A(:?(::)?[a-z]\w*)*(:?(::)?[a-z_]\w*)\z}
 
   # A Numeric var name must be the decimal number 0, or a decimal number not starting with 0
   NUMERIC_VAR_NAME = %r{\A(?:0|(?:[1-9][0-9]*))\z}

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -840,6 +840,16 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
         expect { parser.evaluate_string(scope, source, __FILE__) }.to raise_error(error_pattern)
       end
     end
+
+    context "an initial underscore in the last segment of a var name is allowed" do
+      { '$_a  = 1'   => 1,
+        '$__a = 1'   => 1,
+      }.each do |source, value|
+        it "as in this example '#{source}'" do
+          parser.evaluate_string(scope, source, __FILE__).should == value
+        end
+      end
+    end
   end
 
   context "When evaluating relationships" do


### PR DESCRIPTION
The last segment of a qualified variable name is allowed to start
with an underscore. Previously this was only allowed for a single
segment.
