### PR TITLE
(PUP-1814) Make double backslash in sq string behave as documented.

### DIFF
--- a/lib/puppet/pops/parser/slurp_support.rb
+++ b/lib/puppet/pops/parser/slurp_support.rb
@@ -12,7 +12,7 @@ module Puppet::Pops::Parser::SlurpSupport
   SLURP_DQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*(["]|[$]\{?)/
   SLURP_UQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*([$]\{?|\z)/
   SLURP_ALL_PATTERN = /.*(\z)/
-  SQ_ESCAPES = %w{ ' }
+  SQ_ESCAPES = %w{ \\ ' }
   DQ_ESCAPES = %w{ \\  $ ' " r n t s u}+["\r\n", "\n"]
   UQ_ESCAPES = %w{ \\  $ r n t s u}+["\r\n", "\n"]
 

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -164,7 +164,14 @@ describe 'Lexer2' do
   { "''"      => '',
     "'a'"     => 'a',
     "'a\\'b'" =>"a'b",
-    "'a\\r\\n\\t\\s\\$\\\"\\\\b'" => "a\\r\\n\\t\\s\\$\\\"\\\\b"
+    "'a\\rb'" =>"a\\rb",
+    "'a\\nb'" =>"a\\nb",
+    "'a\\tb'" =>"a\\tb",
+    "'a\\sb'" =>"a\\sb",
+    "'a\\$b'" =>"a\\$b",
+    "'a\\\"b'" =>"a\\\"b",
+    "'a\\\\b'" =>"a\\b",
+    "'a\\\\'" =>"a\\",
   }.each do |source, expected|
     it "should lex a single quoted STRING on the form #{source}" do
       tokens_scanned_from(source).should match_tokens2([:STRING, expected])


### PR DESCRIPTION
This makes it possible to escapce a backslash in a sq string. 
Previously this did not work which made it impossible to end a sq string
with a backslash.
