### PR TITLE
(pup-1825) Allow use of facter 2.x

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -42,14 +42,14 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<facter>, ["~> 1.5"])
+      s.add_runtime_dependency(%q<facter>, ["> 1.5", "< 3"])
       s.add_runtime_dependency(%q<hiera>, ["~> 1.0"])
     else
-      s.add_dependency(%q<facter>, ["~> 1.5"])
+      s.add_dependency(%q<facter>, ["> 1.5", "< 3"])
       s.add_dependency(%q<hiera>, ["~> 1.0"])
     end
   else
-    s.add_dependency(%q<facter>, ["~> 1.5"])
+    s.add_dependency(%q<facter>, ["> 1.5", "< 3"])
     s.add_dependency(%q<hiera>, ["~> 1.0"])
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ platforms :ruby do
 end
 
 gem "puppet", :path => File.dirname(__FILE__), :require => false
-gem "facter", *location_for(ENV['FACTER_LOCATION'] || '~> 1.6')
+gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 1.6', '< 3'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
 gem "rake", :require => false
 gem "rgen", "0.6.5", :require => false

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -15,7 +15,7 @@ gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_forge_project: 'puppet'
 gem_runtime_dependencies:
-  facter: '~> 1.6'
+  facter: ['> 1.6', '< 3']
   hiera: '~> 1.0'
   rgen: '~> 0.6.5'
   json_pure:


### PR DESCRIPTION
Before this commit, Puppet uses pessimistic versioning
(the ~> syntax) to specify that it could work with any Facter
version in the 1.x series greater than some minimum, but
was pessimistic about (i.e. didn't assume it supported) a 2.x
Facter.

In fact, the facter API to puppet has not changed in facter 2.x
so puppet can in fact work with a suitable 1.x or any 2.x. This
change replaces use of the pessimistic operator with explicit
version ranges, effectively extending the range previously provided
by the pessmistic operator to include the 2.x series.
