### PR TITLE
(PUP-876) Skip resource service check on EL 6

### DIFF
--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -4,7 +4,7 @@ step "Validate services running agreement ralsh vs. OS service count"
 # ticket_4123_should_list_all_running_redhat.sh
 
 hosts.each do |host|
-  if host['platform'] =~ /el-[56]/
+  if host['platform'] =~ /el-5/
     run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4123_should_list_all_running_redhat.sh'))
   else
     skip_test "Test not supported on this plaform" 

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -4,9 +4,9 @@ step "Validate disabled services agreement ralsh vs. OS service count"
 # ticket_4124_should_list_all_disabled.sh
 
 hosts.each do |host|
-  unless host['platform'] =~ /el-[56]/
-    skip_test "Test not supported on this plaform"
-   else
+  if host['platform'] =~ /el-5/
     run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4124_should_list_all_disabled.sh'))
+  else
+    skip_test "Test not supported on this plaform"
   end
 end


### PR DESCRIPTION
Redmine issues (#4123) and (#4124) added acceptance tests on RHEL
systems to ensure that the services listed by chkconfig matched the list
of services returned by `puppet resource service`, but this assumed that
chkconfig would be authoritative for all running services. Commit
7bdcbea enabled the upstart service provider on EL 6 systems which
breaks this assumption and causes the acceptance tests to fail. This
commit disables these tests on EL 6 since the test is no longer
meaningful.
