### PR TITLE
(PUP-1821) Require Facter 1.7 or greater

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -42,14 +42,14 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<facter>, ["> 1.5", "< 3"])
+      s.add_runtime_dependency(%q<facter>, [">= 1.7", "< 3"])
       s.add_runtime_dependency(%q<hiera>, ["~> 1.0"])
     else
-      s.add_dependency(%q<facter>, ["> 1.5", "< 3"])
+      s.add_dependency(%q<facter>, [">= 1.7", "< 3"])
       s.add_dependency(%q<hiera>, ["~> 1.0"])
     end
   else
-    s.add_dependency(%q<facter>, ["> 1.5", "< 3"])
+    s.add_dependency(%q<facter>, [">= 1.7", "< 3"])
     s.add_dependency(%q<hiera>, ["~> 1.0"])
   end
 end

--- a/ext/debian/control
+++ b/ext/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
 Uploaders: Micah Anderson <micah@debian.org>, Andrew Pollock <apollock@debian.org>, Nigel Kersten <nigel@explanatorygap.net>, Stig Sandbeck Mathisen <ssm@debian.org>
-Build-Depends-Indep: ruby | ruby-interpreter, libopenssl-ruby, facter (>= 1.6.12)
+Build-Depends-Indep: ruby | ruby-interpreter, libopenssl-ruby, facter (>= 1.7.0)
 Build-Depends: debhelper (>= 7.0.0), openssl
 Standards-Version: 3.9.1
 Vcs-Git: git://github.com/puppetlabs/puppet
@@ -11,7 +11,7 @@ Homepage: http://projects.puppetlabs.com/projects/puppet
 
 Package: puppet-common
 Architecture: all
-Depends: ${misc:Depends}, ruby | ruby-interpreter, libxmlrpc-ruby, libopenssl-ruby, ruby-shadow | libshadow-ruby1.8, libaugeas-ruby | libaugeas-ruby1.9.1 | libaugeas-ruby1.8, adduser, lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0), facter (>= 1.6.12), ruby-rgen (>= 0.6.5), libjson-ruby | ruby-json
+Depends: ${misc:Depends}, ruby | ruby-interpreter, libxmlrpc-ruby, libopenssl-ruby, ruby-shadow | libshadow-ruby1.8, libaugeas-ruby | libaugeas-ruby1.9.1 | libaugeas-ruby1.8, adduser, lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0), facter (>= 1.7.0), ruby-rgen (>= 0.6.5), libjson-ruby | ruby-json
 Recommends: lsb-release, debconf-utils
 Suggests: ruby-selinux | libselinux-ruby1.8, librrd-ruby1.9.1 | librrd-ruby1.8
 Breaks: puppet (<< 2.6.0~rc2-1), puppetmaster (<< 0.25.4-1)
@@ -56,7 +56,7 @@ Description: Centralized configuration management - agent startup and compatibil
 
 Package: puppetmaster-common
 Architecture: all
-Depends: ${misc:Depends}, ruby | ruby-interpreter, puppet-common (= ${binary:Version}), facter (>= 1.6.12), lsb-base
+Depends: ${misc:Depends}, ruby | ruby-interpreter, puppet-common (= ${binary:Version}), facter (>= 1.7.0), lsb-base
 Breaks: puppet (<< 0.24.7-1), puppetmaster (<< 2.6.1~rc2-1)
 Replaces: puppetmaster (<< 2.6.1~rc2-1)
 Suggests: apache2 | nginx, puppet-el, vim-puppet, stompserver, ruby-stomp | libstomp-ruby1.8,
@@ -78,7 +78,7 @@ Description: Puppet master common scripts
 
 Package: puppetmaster
 Architecture: all
-Depends: ${misc:Depends}, ruby | ruby-interpreter, puppetmaster-common (= ${source:Version}), facter (>= 1.6.12), lsb-base
+Depends: ${misc:Depends}, ruby | ruby-interpreter, puppetmaster-common (= ${source:Version}), facter (>= 1.7.0), lsb-base
 Breaks: puppet (<< 0.24.7-1)
 Suggests: apache2 | nginx, puppet-el, vim-puppet, stompserver, ruby-stomp | libstomp-ruby1.8,
  rdoc, ruby-ldap | libldap-ruby1.8, puppetdb-terminus
@@ -99,7 +99,7 @@ Description: Centralized configuration management - master startup and compatibi
 
 Package: puppetmaster-passenger
 Architecture: all
-Depends: ${misc:Depends}, ruby | ruby-interpreter, puppetmaster-common (= ${source:Version}), facter (>= 1.6.12), lsb-base, libapache2-mod-passenger
+Depends: ${misc:Depends}, ruby | ruby-interpreter, puppetmaster-common (= ${source:Version}), facter (>= 1.7.0), lsb-base, libapache2-mod-passenger
 Conflicts: puppetmaster (<< 2.6.1~rc2-1)
 Replaces: puppetmaster (<< 2.6.1~rc2-1)
 Description: Centralised configuration management - master setup to run under mod passenger
@@ -136,7 +136,7 @@ Description: syntax highlighting for puppet manifests in emacs
 
 Package: puppet-testsuite
 Architecture: all
-Depends: ${misc:Depends}, ruby | ruby-interpreter, puppet-common (= ${source:Version}), facter (>= 1.6.12), lsb-base, rails (>= 1.2.3-2), rdoc, ruby-ldap | libldap-ruby1.8, ruby-rspec | librspec-ruby, git-core, ruby-mocha | libmocha-ruby1.8
+Depends: ${misc:Depends}, ruby | ruby-interpreter, puppet-common (= ${source:Version}), facter (>= 1.7.0), lsb-base, rails (>= 1.2.3-2), rdoc, ruby-ldap | libldap-ruby1.8, ruby-rspec | librspec-ruby, git-core, ruby-mocha | libmocha-ruby1.8
 Recommends: cron
 Description: Centralized configuration management - test suite
  This package provides all the tests from the upstream puppet source code.

--- a/ext/ips/transforms
+++ b/ext/ips/transforms
@@ -27,7 +27,7 @@
 <transform file path=var/svc/manifest/.*\.xml -> add restart_fmri svc:/system/manifest-import:default>
 
 # we depend on facter
-<transform pkg -> emit depend type=require fmri=application/facter@1.6.12>
+<transform pkg -> emit depend type=require fmri=application/facter@1.7.0>
 
 # preserve the old conf file on upgrade.
 <transform file path=etc/puppet/(puppet|auth).conf -> add overlay true>

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -36,7 +36,7 @@ Group:          System Environment/Base
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:  facter < 1:2.0
+BuildRequires:  facter >= 1:1.7.0
 # Puppet 3.x drops ruby 1.8.5 support and adds ruby 1.9 support
 BuildRequires:  ruby >= 1.8.7
 BuildArch:      noarch
@@ -53,7 +53,7 @@ Requires:       rubygem-json
 %endif
 %endif
 
-Requires:       facter >= 1.6.11
+Requires:       facter >= 1:1.7.0
 # Puppet 3.x drops ruby 1.8.5 support and adds ruby 1.9 support
 # Ruby 1.8.7 available for el5 at: yum.puppetlabs.com/el/5/devel/$ARCH
 Requires:       ruby >= 1.8.7

--- a/ext/suse/puppet.spec
+++ b/ext/suse/puppet.spec
@@ -14,7 +14,7 @@ Source0: http://puppetlabs.com/downloads/puppet/%{name}-%{version}.tar.gz
 
 PreReq: %{insserv_prereq} %{fillup_prereq}
 Requires: ruby >= 1.8.7
-Requires: facter >= 1.6.11
+Requires: facter >= 1:1.7.0
 Requires: cron
 Requires: logrotate
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)


### PR DESCRIPTION
We're starting to rely on facts that were released in Facter 1.7.0,
which means that we always need to pull in 1.7 to make those facts
available.
