### PR TITLE
(maint) Change Travis CI to output documentation format for specs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+env:
+  - SPEC_OPTS="--format documentation"


### PR DESCRIPTION
We've been observing a sporadic "rake aborted" failure on Travis CI.
This change turns on "documentation" format for rspec so that we can
at least see if the test run is aborting on the same test each time.
