### PR TITLE
(PUP-1765) Directory env respects cmdline modulepath and manifest

### DIFF
--- a/acceptance/tests/environment/cmdline_overrides_environment.rb
+++ b/acceptance/tests/environment/cmdline_overrides_environment.rb
@@ -1,0 +1,196 @@
+test_name "Commandline modulepath and manifest settings override environment"
+
+testdir = master.tmpdir('cmdline_and_environment')
+environmentpath = "#{testdir}/environments"
+modulepath = "#{testdir}/modules"
+manifests = "#{testdir}/manifests"
+sitepp = "#{manifests}/site.pp"
+other_manifestdir = "#{testdir}/other_manifests"
+other_sitepp = "#{other_manifestdir}/site.pp"
+other_modulepath = "#{testdir}/some_other_modulepath"
+cmdline_manifest = "#{testdir}/cmdline.pp"
+
+step "Prepare manifests and modules"
+apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+File {
+  ensure => directory,
+  owner => puppet,
+  mode => 0700,
+}
+
+##############################################
+# The default production directory environment
+file {
+  "#{testdir}":;
+  "#{environmentpath}":;
+  "#{environmentpath}/production":;
+  "#{environmentpath}/production/manifests":;
+  "#{environmentpath}/production/modules":;
+  "#{environmentpath}/production/modules/amod":;
+  "#{environmentpath}/production/modules/amod/manifests":;
+}
+
+file { "#{environmentpath}/production/modules/amod/manifests/init.pp":
+  ensure => file,
+  content => 'class amod {
+    notify { "amod from production environment": }
+  }'
+}
+
+file { "#{environmentpath}/production/manifests/production.pp":
+  ensure => file,
+  content => '
+    notify { "in production.pp": }
+    include amod
+  '
+}
+
+##############################################################
+# To be set as default manifests and modulepath in puppet.conf
+file {
+  "#{modulepath}":;
+  "#{modulepath}/amod/":;
+  "#{modulepath}/amod/manifests":;
+}
+
+file { "#{modulepath}/amod/manifests/init.pp":
+  ensure => file,
+  content => 'class amod {
+    notify { "amod from modulepath": }
+  }'
+}
+
+file { "#{manifests}": }
+file { "#{sitepp}":
+  ensure => file,
+  content => '
+    notify { "in site.pp": }
+    include amod
+  '
+}
+
+file { "#{other_manifestdir}": }
+file { "#{other_sitepp}":
+  ensure => file,
+  content => '
+    notify { "in other manifestdir site.pp": }
+    include amod
+  '
+}
+
+################################
+# To be specified on commandline
+file {
+  "#{other_modulepath}":;
+  "#{other_modulepath}/amod/":;
+  "#{other_modulepath}/amod/manifests":;
+}
+
+file { "#{other_modulepath}/amod/manifests/init.pp":
+  ensure => file,
+  content => 'class amod {
+    notify { "amod from commandline modulepath": }
+  }'
+}
+
+file { "#{cmdline_manifest}":
+  ensure => file,
+  content => '
+    notify { "in cmdline.pp": }
+    include amod
+  '
+}
+MANIFEST
+
+master_opts = {
+  'master' => {
+    'environmentpath' => environmentpath,
+    'manifest' => sitepp,
+    'modulepath' => modulepath,
+  }
+}
+
+# Note: this is the semantics seen with legacy environments if commandline
+# manifest/modulepath are set.
+step "puppet master with --manifest and --modulepath overrides existing default production directory environment" do
+  master_opts = master_opts.merge(:__commandline_args__ => "--manifest=#{cmdline_manifest} --modulepath=#{other_modulepath}")
+  with_puppet_running_on master, master_opts, testdir do
+    agents.each do |agent|
+      on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [2] ) do
+        assert_match(/in cmdline\.pp/, stdout)
+        assert_match(/amod from commandline modulepath/, stdout)
+        assert_not_match(/production/, stdout)
+      end
+
+      step "even if environment is specified"
+      on(agent, puppet("agent -t --server #{master} --environment production"), :acceptable_exit_codes => [2]) do
+        assert_match(/in cmdline\.pp/, stdout)
+        assert_match(/amod from commandline modulepath/, stdout)
+        assert_not_match(/production/, stdout)
+      end
+    end
+  end
+
+  step "or if you set --manifestdir" do
+    master_opts = master_opts.merge(:__commandline_args__ => "--manifestdir=#{other_manifestdir} --modulepath=#{other_modulepath}")
+    step "it is ignored if manifest is set in puppet.conf to something not using $manifestdir"
+    with_puppet_running_on master, master_opts, testdir do
+      agents.each do |agent|
+        on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [2]) do
+          assert_match(/in production\.pp/, stdout)
+          assert_match(/amod from commandline modulepath/, stdout)
+        end
+      end
+    end
+
+    step "but does pull in the default manifest via manifestdir if manifest is not set"
+    master_opts = master_opts.merge(:__commandline_args__ => "--manifestdir=#{other_manifestdir} --modulepath=#{other_modulepath}")
+    master_opts['master'].delete('manifest')
+    with_puppet_running_on master, master_opts, testdir do
+      agents.each do |agent|
+        on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [2]) do
+          assert_match(/in other manifestdir site\.pp/, stdout)
+          assert_match(/amod from commandline modulepath/, stdout)
+          assert_not_match(/production/, stdout)
+        end
+      end
+    end
+  end
+end
+
+step "puppet master with manifest and modulepath set in puppet.conf is overriden by an existing default production directory" do
+  with_puppet_running_on master, master_opts, testdir do
+    agents.each do |agent|
+      step "this case is unfortunate, but will be irrelevant when we remove legacyenv in 4.0"
+      on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [2] ) do
+        assert_match(/in production\.pp/, stdout)
+        assert_match(/amod from production environment/, stdout)
+      end
+
+      step "if environment is specified"
+      on(agent, puppet("agent -t --server #{master} --environment production"), :acceptable_exit_codes => [2]) do
+        assert_match(/in production\.pp/, stdout)
+        assert_match(/amod from production environment/, stdout)
+      end
+    end
+  end
+end
+
+step "puppet master with default manifest, modulepath, environment, environmentpath and an existing default production directory environment directory" do
+  master_opts = {
+    :__commandline_args__ => "--confdir=#{testdir} --ssldir=#{master[:puppetpath]}/ssl"
+  }
+  with_puppet_running_on master, master_opts, testdir do
+    agents.each do |agent|
+      step "default production directory environment takes precedence"
+      on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [2] ) do
+        assert_match(/in production\.pp/, stdout)
+        assert_match(/amod from production environment/, stdout)
+      end
+      on(agent, puppet("agent -t --server #{master} --environment production"), :acceptable_exit_codes => [2]) do
+        assert_match(/in production\.pp/, stdout)
+        assert_match(/amod from production environment/, stdout)
+      end
+    end
+  end
+end

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -16,8 +16,8 @@ stub_forge_on(master)
 
 puppet_conf = generate_base_legacy_and_directory_environments(master['puppetpath'])
 
-check_module_install_in = lambda do |environment, environment_path|
-  on master, "puppet module install #{module_author}-#{module_name} --config=#{puppet_conf} --environment=#{environment}" do
+check_module_install_in = lambda do |environment_path, module_install_args|
+  on master, "puppet module install #{module_author}-#{module_name} --config=#{puppet_conf} #{module_install_args}" do
     assert_module_installed_ui(stdout, module_author, module_name)
     assert_match(/#{environment_path}/, stdout,
           "Notice of non default install path was not displayed")
@@ -26,9 +26,38 @@ check_module_install_in = lambda do |environment, environment_path|
 end
 
 step 'Install a module into a non default legacy environment' do
-  check_module_install_in.call('legacyenv', "#{master['puppetpath']}/legacyenv/modules")
+  check_module_install_in.call("#{master['puppetpath']}/legacyenv/modules",
+                               "--environment=legacyenv")
 end
 
 step 'Install a module into a non default directory environment' do
-  check_module_install_in.call('direnv', "#{master['puppetpath']}/environments/direnv/modules")
+  check_module_install_in.call("#{master['puppetpath']}/environments/direnv/modules",
+                              "--environment=direnv")
+end
+
+step 'Prepare a separate modulepath'
+modulepath_dir = master.tmpdir("modulepath")
+apply_manifest_on(master, <<-MANIFEST , :catch_failures => true)
+  file {
+    [
+      '#{master['puppetpath']}/environments/production',
+      '#{modulepath_dir}',
+    ]:
+
+    ensure => directory,
+    owner => puppet,
+  }
+MANIFEST
+
+step "Install a module into --modulepath #{modulepath_dir} despite the implicit production directory env existing" do
+  check_module_install_in.call(modulepath_dir, "--modulepath=#{modulepath_dir}")
+end
+
+step "Uninstall so we can try a different scenario" do
+  on master, "puppet module uninstall #{module_author}-#{module_name} --config=#{puppet_conf} --modulepath=#{modulepath_dir}"
+end
+
+step "Install a module into --modulepath #{modulepath_dir} with a directory env specified" do
+  check_module_install_in.call(modulepath_dir,
+                               "--modulepath=#{modulepath_dir} --environment=direnv")
 end

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -354,7 +354,10 @@ class Application
     end
 
     new_context = Puppet.base_context(Puppet.settings)
-    new_context[:current_environment] = new_context[:environments].get(Puppet[:environment])
+    configured_environment = new_context[:environments].get(Puppet[:environment])
+    configured_environment = configured_environment.override_from_commandline(Puppet.settings)
+    new_context[:current_environment] = configured_environment
+
     # Setup a new context using the app's configuration
     Puppet.override(new_context,
                     "New base context and current environment from application's configuration") do

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -182,7 +182,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       facts.name = Puppet[:node_name_value]
     end
 
-    configured_environment = Puppet.lookup(:environments).get(Puppet[:environment])
+    configured_environment = Puppet.lookup(:current_environment)
     apply_environment = manifest ?
       configured_environment.override_with(:manifest => manifest) :
       configured_environment

--- a/lib/puppet/network/http/api/v1.rb
+++ b/lib/puppet/network/http/api/v1.rb
@@ -63,7 +63,9 @@ class Puppet::Network::HTTP::API::V1
 
     method = indirection_method(http_method, indirection)
 
-    params[:environment] = Puppet.lookup(:environments).get(environment)
+    configured_environment = Puppet.lookup(:environments).get(environment)
+    configured_environment = configured_environment.override_from_commandline(Puppet.settings)
+    params[:environment] = configured_environment
 
     params.delete(:bucket_path)
 

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -110,6 +110,25 @@ class Puppet::Node::Environment
                       env_params[:manifest] || manifest)
   end
 
+  # Creates a new Puppet::Node::Environment instance, overriding manfiest
+  # and modulepath from the passed settings if they were originally set from
+  # the commandline, or returns self if there is nothing to override.
+  #
+  # @param settings [Puppet::Settings] an initialized puppet settings instance
+  # @return [Puppet::Node::Environment] new overridden environment or self if
+  #   there are no commandline changes from settings.
+  def override_from_commandline(settings)
+    overrides = {}
+    overrides[:modulepath] = [settings[:modulepath]] if settings.set_by_cli?(:modulepath)
+    if settings.set_by_cli?(:manifest) ||
+      (settings.set_by_cli?(:manifestdir) && settings[:manifest].start_with?(settings[:manifestdir]))
+      overrides[:manifest] = settings[:manifest]
+    end
+    overrides.empty? ?
+      self :
+      self.override_with(overrides)
+  end
+
   # Retrieve the environment for the current process.
   #
   # @note This should only used when a catalog is being compiled.

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -195,8 +195,16 @@ class Puppet::Util::Autoload
     self.class.load_file(expand(name), env)
   end
 
-  # Load all instances that we can.  This uses require, rather than load,
-  # so that already-loaded files don't get reloaded unnecessarily.
+  # Load all instances from a path of Autoload.search_directories matching the
+  # relative path this Autoloader was initialized with.  For example, if we
+  # have created a Puppet::Util::Autoload for Puppet::Type::User with a path of
+  # 'puppet/provider/user', the search_directories path will be searched for
+  # all ruby files matching puppet/provider/user/*.rb and they will then be
+  # loaded from the first directory in the search path providing them.  So
+  # earlier entries in the search path may shadow later entries.
+  #
+  # This uses require, rather than load, so that already-loaded files don't get
+  # reloaded unnecessarily.
   def loadall
     self.class.loadall(@path)
   end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -39,10 +39,8 @@ describe "apply" do
       EOF
     end
 
-    env_loader = Puppet::Environments::Static.new(
-      Puppet::Node::Environment.create(:special, [], '')
-    )
-    Puppet.override(:environments => env_loader) do
+    special = Puppet::Node::Environment.create(:special, [], '')
+    Puppet.override(:current_environment => special) do
       Puppet[:environment] = 'special'
       puppet = Puppet::Application[:apply]
       puppet.stubs(:command_line).returns(stub('command_line', :args => [manifest]))
@@ -51,4 +49,51 @@ describe "apply" do
 
     expect(@logs.map(&:to_s)).to include('it was applied')
   end
+
+  context "with a module" do
+    let(:modulepath) { tmpdir('modulepath') }
+    let(:execute) { 'include amod' }
+    let(:args) { ['-e', execute, '--modulepath', modulepath] }
+
+    before(:each) do
+      Puppet::FileSystem.mkpath("#{modulepath}/amod/manifests")
+      File.open("#{modulepath}/amod/manifests/init.pp", "w") do |f|
+        f.puts <<-EOF
+        class amod{
+          notice('amod class included')
+        }
+        EOF
+      end
+      create_default_directory_environment
+    end
+
+    def create_default_directory_environment
+      Puppet::FileSystem.mkpath("#{Puppet[:environmentpath]}/#{Puppet[:environment]}")
+    end
+
+    def init_cli_args_and_apply_app(args, execute)
+      Puppet.initialize_settings(args)
+      puppet = Puppet::Application.find(:apply).new(stub('command_line', :subcommand_name => :apply, :args => args))
+      puppet.options[:code] = execute
+      return puppet
+    end
+
+    it "looks in --modulepath even when the default directory environment exists" do
+      apply = init_cli_args_and_apply_app(args, execute)
+
+      expect do
+        expect { apply.run }.to exit_with(0)
+      end.to have_printed('amod class included')
+    end
+
+    it "looks in --modulepath even when given a specific directory --environment" do
+      args << '--environment' << 'production'
+      apply = init_cli_args_and_apply_app(args, execute)
+
+      expect do
+        expect { apply.run }.to exit_with(0)
+      end.to have_printed('amod class included')
+    end
+  end
+
 end

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -199,6 +199,13 @@ describe Puppet::Application::Apply do
         Puppet::Node::Facts.indirection.cache_class = nil
       end
 
+      around :each do |example|
+        Puppet.override(:current_environment =>
+                        Puppet::Node::Environment.create(:production, [], '')) do
+          example.run
+        end
+      end
+
       it "should set the code to run from --code" do
         @apply.options[:code] = "code to run"
         Puppet.expects(:[]=).with(:code,"code to run")


### PR DESCRIPTION
The addition of directory environments in PUP-1118 caused a regression
in the behavior of --modulepath and --manifest set from the commandline.

Three cases are seen:

1) given a '$confdir/environments/production' directory, `puppet apply
-e 'include "modclass"' --modulepath /some/other/modpath` fails to find
the modclass from /some/other/modpath.  The same problem is seen if a
specific directory environment such as '--environment direnv' is set
(assuming that direnv exists).

2) given a '$confdir/environments/production' directory, `puppet module
install foo --modulepath /some/other/modpath` installs to
'$confdir/environments/production'.  If a specific directory
environments such as '--environment direnv' is set, then it incorrectly
installs to "$confdir/environments/direnv'.

3) given a '$confdir/environments/production' directory, `puppet master
--manifest /some/other.pp` does not execute '/some/other.pp' when an
agent calls in without specifying an environment.

To fix these cases we are now explicitly overriding the configured
environment with the stored :cli modulepath and/or manifest setting,
both at application run time and when handling a v1 http api call.
