### PR TITLE
(pup-1839) Undeprecate and fix set_value

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -761,9 +761,9 @@ class Puppet::Settings
   end
 
   def set_value(param, value, type, options = {})
-    Puppet.deprecation_warning("Puppet.settings.set_value is deprecated. Use Puppet[]= instead.")
     if @value_sets[type]
       @value_sets[type].set(param, value)
+      unsafe_flush_cache
     end
   end
 


### PR DESCRIPTION
Prior to this commit, some of the refactoring of the settings logic
marked `set_value` as deprecated. At the same time, that refactoring
(unintentionally) omitted the cache invalidation step when `set_value`
was called.

The lack of cache invalidation ended up breaking `puppet device`
behavior, resulting in the "stack level too deep" error described
in this ticket (because `Puppet[:certname]` wasn't being updated
by the puppet device logic per-device as intended).

This change simply restores the cache invalidation step, and removes
(temporarily) the deprecation warning for set_value. A longer term
fix that restores that deprecation should be Coming Soon.
