### PR TITLE
(PUP-1839) Flush cache when setting value

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -761,9 +761,9 @@ class Puppet::Settings
   end
 
   def set_value(param, value, type, options = {})
-    Puppet.deprecation_warning("Puppet.settings.set_value is deprecated. Use Puppet[]= instead.")
     if @value_sets[type]
       @value_sets[type].set(param, value)
+      unsafe_flush_cache
     end
   end
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -473,6 +473,12 @@ describe Puppet::Settings do
         @settings[:why_so_serious] = "foo"
       }.should raise_error(ArgumentError, /unknown setting/)
     end
+
+    it "allows overriding cli args based on the cli-set value" do
+      @settings.handlearg("--myval", "cliarg")
+      @settings.set_value(:myval, "modified #{@settings[:myval]}", :cli)
+      expect(@settings[:myval]).to eq("modified cliarg")
+    end
   end
 
   describe "when returning values" do


### PR DESCRIPTION
The `set_value` method was deprecated and rewritten as part of the work to
implement `puppet config set`. However the new implementation lost the call
to `unsafe_clear_cache` which caused any set values to not show up if the
setting's value had previously been read. Also, the method was still used by
the `puppet device` code.

This is a small fix to get `puppet device` working again. This flushes the
cache and removes the deprecation.
