### PR TITLE
[PUP-1846] File content diffing should respect loglevel

### DIFF
--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -112,7 +112,7 @@ module Puppet
 
       if ! result and Puppet[:show_diff] and resource.show_diff?
         write_temporarily do |path|
-          notice "\n" + diff(@resource[:path], path)
+          send @resource[:loglevel], "\n" + diff(@resource[:path], path)
         end
       end
       result

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -196,12 +196,13 @@ describe content do
           before do
             Puppet[:show_diff] = cfg
             @resource.stubs(:show_diff?).returns param
+            @resource[:loglevel] = "debug"
           end
 
           if cfg and param
             it "should display a diff" do
               @content.expects(:diff).returns("my diff").once
-              @content.expects(:notice).with("\nmy diff").once
+              @content.expects(:debug).with("\nmy diff").once
               @content.should_not be_safe_insync("other content")
             end
           else


### PR DESCRIPTION
The current behavior is to log all diff output on file content changes
(if show_diff is set) at the info level, rather than the loglevel of the
resource.

This change alters the behavior to log at the same loglevel as the file
resource.
