### PR TITLE
(PUP-1879) Clear gem path cache when loading library features

### DIFF
--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -70,6 +70,9 @@ class Puppet::Util::Feature
   def load_library(lib, name)
     raise ArgumentError, "Libraries must be passed as strings not #{lib.class}" unless lib.is_a?(String)
 
+    @rubygems ||= Puppet::Util::RubyGems::Source.new
+    @rubygems.clear_paths
+
     begin
       require lib
     rescue SystemExit,NoMemoryError

--- a/lib/puppet/util/rubygems.rb
+++ b/lib/puppet/util/rubygems.rb
@@ -45,6 +45,10 @@ module Puppet::Util::RubyGems
         File.join(spec.full_gem_path, 'lib')
       end
     end
+
+    def clear_paths
+      Gem.clear_paths
+    end
   end
 
   # RubyGems < 1.8.0
@@ -53,6 +57,10 @@ module Puppet::Util::RubyGems
     def directories
       @paths ||= Gem.latest_load_paths
     end
+
+    def clear_paths
+      Gem.clear_paths
+    end
   end
 
   # @api private
@@ -60,6 +68,8 @@ module Puppet::Util::RubyGems
     def directories
       []
     end
+
+    def clear_paths; end
   end
 end
 

--- a/spec/unit/util/feature_spec.rb
+++ b/spec/unit/util/feature_spec.rb
@@ -83,6 +83,8 @@ describe Puppet::Util::Feature do
     @features.add(:myfeature, :libs => %w{foo bar})
     @features.expects(:require).twice().with("foo").raises(LoadError).then.returns(nil)
     @features.stubs(:require).with("bar")
+    Puppet::Util::RubyGems::Source.stubs(:source).returns(Puppet::Util::RubyGems::OldGemsSource)
+    Puppet::Util::RubyGems::OldGemsSource.any_instance.expects(:clear_paths).times(3)
 
     Puppet.expects(:debug)
 

--- a/spec/unit/util/rubygems_spec.rb
+++ b/spec/unit/util/rubygems_spec.rb
@@ -31,6 +31,10 @@ describe Puppet::Util::RubyGems::Source do
     it "#directories returns an empty list" do
       described_class.new.directories.should == []
     end
+
+    it "#clear_paths returns nil" do
+      described_class.new.clear_paths.should be_nil
+    end
   end
 
   describe '::Gems18Source' do
@@ -40,6 +44,11 @@ describe Puppet::Util::RubyGems::Source do
       Gem::Specification.expects(:latest_specs).with(true).returns([fake_gem])
 
       described_class.new.directories.should == [gem_lib]
+    end
+
+    it "#clear_paths calls Gem.clear_paths" do
+      Gem.expects(:clear_paths)
+      described_class.new.clear_paths
     end
   end
 
@@ -62,6 +71,11 @@ describe Puppet::Util::RubyGems::Source do
       source = described_class.new
 
       source.directories.should == [gem_lib]
+    end
+
+    it "#clear_paths calls Gem.clear_paths" do
+      Gem.expects(:clear_paths)
+      described_class.new.clear_paths
     end
   end
 end


### PR DESCRIPTION
Installing gems during a Puppet run should be picked up by features using the
'libs' option.  However gems are installed into separate directories, so
rubygems maintains an in-memory directory cache, which needs invalidating
when attempting to load a library after installation.
