### PR TITLE
Disambiguation of handling source_or_content for fileservers vs local re...

### DIFF
--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -206,7 +206,11 @@ module Puppet
     end
 
     def get_from_source(source_or_content, &block)
-      request = Puppet::Indirector::Request.new(:file_content, :find, source_or_content.full_path.sub(/^\//,''), nil, :environment => resource.catalog.environment)
+      source = source_or_content.uri
+      if source.nil? then
+          source=source_or_content.full_path.sub(/^\//,'')
+      end
+      request = Puppet::Indirector::Request.new(:file_content, :find, source.to_s, nil, :environment => resource.catalog.environment)
 
       request.do_request(:fileserver) do |req|
         connection = Puppet::Network::HttpPool.http_instance(req.server, req.port)

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -207,14 +207,14 @@ module Puppet
     def port
       (uri and uri.port) or Puppet.settings[:masterport]
     end
-    private
-
-    def scheme
-      (uri and uri.scheme)
-    end
 
     def uri
       @uri ||= URI.parse(URI.escape(metadata.source))
+    end
+
+    private
+    def scheme
+      (uri and uri.scheme)
     end
 
     private

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -349,6 +349,50 @@ describe content do
       end
     end
 
+    describe "from an explicit fileserver" do
+      before(:each) do
+
+        @sourcename = "puppet://somehostname/test/foo"
+
+        @resource = Puppet::Type.type(:file).new :path => @filename, :backup => false, :catalog => @catalog
+        @response = stub_everything 'response', :code => "200"
+        @source_content = "source file content\n"*10000
+        @response.stubs(:read_body).multiple_yields(*(["source file content\n"]*10000))
+
+        @conn = mock('connection')
+        @conn.stubs(:request_get).yields @response
+
+
+        Puppet::Network::HttpPool.expects(:http_instance).with('somehostname',any_parameters).returns( @conn).at_least_once
+
+        @content = @resource.newattr(:content)
+        @source = @resource.newattr(:source)
+        @source.stubs(:metadata).returns stub_everything('metadata', :source => @sourcename, :ftype => 'file')
+      end
+      it "should write the contents to the file" do
+        @resource.write(@source)
+
+        Puppet::FileSystem.binread(@filename).should == @source_content
+      end
+
+      it "should not write anything if source is not found" do
+        @response.stubs(:code).returns("404")
+        lambda {@resource.write(@source)}.should raise_error(Net::HTTPError) { |e| e.message =~ /404/ }
+        File.read(@filename).should == "initial file content"
+      end
+
+      it "should raise an HTTP error in case of server error" do
+        @response.stubs(:code).returns("500")
+        lambda { @content.write(@fh) }.should raise_error { |e| e.message.include? @source_content }
+      end
+
+      it "should return the checksum computed" do
+        File.open(@filename, 'w') do |file|
+          @content.write(file).should == "{md5}#{Digest::MD5.hexdigest(@source_content)}"
+        end
+      end
+
+    end
     describe "from remote source" do
       before(:each) do
         @resource = Puppet::Type.type(:file).new :path => @filename, :backup => false, :catalog => @catalog


### PR DESCRIPTION
As of current release, due to the use of source_or_content.full_path, the hostname is stripped from attempts to handle file_content calls in type/file.rb.  Because of this, it correctly calls file_metadata from the proper server, but then calls the puppetmaster instead of the remote fileserver for content retrieval, which fails.

This resolution might still be a bit naive, but it mitigates the issue pretty neatly.  
