### PR TITLE
Use provider property accessors in the Cron type

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -438,8 +438,8 @@ Puppet::Type.newtype(:cron) do
   #   property, unpurged file content (such as comments) can end up
   #   being written to the default target (i.e. the current login name).
   def purging
-    self[:target] = provider.property_hash[:target]
-    self[:user] = provider.property_hash[:target]
+    self[:target] = provider.target
+    self[:user] = provider.target
     super
   end
 


### PR DESCRIPTION
ParsedFile is the only provider which actually creates an accessor to expose
the internal `@property_hash` of provider instances. This patch replaces
uses of `property_hash` in the Cron type with the `target` accessor method that all
providers define for the `target` property.
