### PR TITLE
(PUP-1905) Split modulepath when supplied as an override from CLI

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -119,7 +119,7 @@ class Puppet::Node::Environment
   #   there are no commandline changes from settings.
   def override_from_commandline(settings)
     overrides = {}
-    overrides[:modulepath] = [settings[:modulepath]] if settings.set_by_cli?(:modulepath)
+    overrides[:modulepath] = self.class.split_path(settings[:modulepath]) if settings.set_by_cli?(:modulepath)
     if settings.set_by_cli?(:manifest) ||
       (settings.set_by_cli?(:manifestdir) && settings[:manifest].start_with?(settings[:manifestdir]))
       overrides[:manifest] = settings[:manifest]

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -94,6 +94,15 @@ describe "apply" do
         expect { apply.run }.to exit_with(0)
       end.to have_printed('amod class included')
     end
+
+    it "looks in --modulepath when given multiple paths in --modulepath" do
+      args = ['-e', execute, '--modulepath', [tmpdir('notmodulepath'), modulepath].join(File::PATH_SEPARATOR)]
+      apply = init_cli_args_and_apply_app(args, execute)
+
+      expect do
+        expect { apply.run }.to exit_with(0)
+      end.to have_printed('amod class included')
+    end
   end
 
 end


### PR DESCRIPTION
When a --modulepath option is supplied from the CLI to override the node
environment's modulepath, it can be made up of multiple directories with a
path separator.  The path is now split so multiple paths are correctly
searched.
