### PR TITLE
This commit solves a problem with the commandline interpretation of the ...

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
       case val
       when Hash
         val.keys.sort.collect do |k|
-          "#{k} '#{val[k]}'"
+          "#{k}='#{val[k]}'"
         end.join(' ')
       else
         val


### PR DESCRIPTION
This commit solves a problem with the commandline interpretation of the "install_options". Command Line Arguments wich are given as hash are interpreted in the following way:

Option: [{'--from' => 'REPONAME'}]

Interpretation at the system: zypper in "--from 'REPONAME'" ....

The solution is simple:  "="

zypper in "--from='REPONAME'"
