### PR TITLE
(PUP-1937) Calling 'ruby' in Windows Tests Fails for PE

### DIFF
--- a/acceptance/lib/puppet/acceptance/windows_utils.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils.rb
@@ -6,8 +6,20 @@ module Puppet
 require 'win32/dir'
 puts Dir::PROFILE.match(/(.*)\\\\[^\\\\]*/)[1]
 END
-        on(agent, "ruby -rubygems -e \"#{getbasedir}\"").stdout.chomp
+        on(agent, "#{ruby_cmd(agent)} -rubygems -e \"#{getbasedir}\"").stdout.chomp
       end
+
+      # ruby for Windows on a PE install lives in <path to Puppet Enterprise>/sys/ruby/bin/ruby.exe
+      # However, FOSS can just use "ruby".
+      def ruby_cmd(agent)
+        if options[:type] =~ /pe/
+          pre_env = agent['puppetbindir'] ? "env PATH=\"#{agent['puppetbindir']}:#{agent['puppetbindir']}/../sys/ruby/bin/:${PATH}\"" : ''
+          "#{pre_env} ruby.exe"
+        else
+          'ruby'
+        end
+      end
+
     end
   end
 end

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -20,9 +20,9 @@ agents.each do |agent|
 
   step "  install module '#{module_author}-#{module_name}'"
 
-  command = agent['platform'] =~ /windows/ ?
-    Command.new("cmd.exe /c 'puppet module install --version \"<#{module_version}\" #{module_author}-#{module_name}'") :
-    puppet("module install --version \"<#{module_version}\" #{module_author}-#{module_name}")
+  #command = agent['platform'] =~ /windows/ ?
+  #  Command.new("cmd.exe /c 'puppet module install --version \"<#{module_version}\" #{module_author}-#{module_name}'") :
+  command = puppet("module install --version \"<#{module_version}\" #{module_author}-#{module_name}")
 
   on(agent, command) do
     assert_module_installed_ui(stdout, module_author, module_name, module_version, '<')

--- a/acceptance/tests/security/cve-2013-1654_sslv2_downgrade_agent.rb
+++ b/acceptance/tests/security/cve-2013-1654_sslv2_downgrade_agent.rb
@@ -1,7 +1,14 @@
 test_name "CVE 2013-1654 SSL2 Downgrade of Agent connection" do
 
+require 'puppet/acceptance/windows_utils'
+extend Puppet::Acceptance::WindowsUtils
+
   def which_ruby(host)
-    host['puppetbindir'] ? "#{host['puppetbindir']}/ruby" : 'ruby'
+    if host['platform'] =~ /windows/
+      ruby_cmd(host)
+    else
+      host['puppetbindir'] ? "#{host['puppetbindir']}/ruby" : 'ruby'
+    end
   end
 
   def suitable?(host)
@@ -71,7 +78,7 @@ END
         Timeout.timeout(timeout) do
           loop do
             # 7 is "Could not connect to host", which will happen before it's running
-            # 28 is "Operation timeout", which could happen if the vm was running slowly 
+            # 28 is "Operation timeout", which could happen if the vm was running slowly
             result = on(agent, "curl -m1 -k https://#{agent}:#{port}", :acceptable_exit_codes => [0,7,28,35])
             break if result.exit_code == 0 or result.exit_code == 35
             sleep 1

--- a/acceptance/tests/windows/eventlog.rb
+++ b/acceptance/tests/windows/eventlog.rb
@@ -2,17 +2,12 @@ test_name "Write to Windows eventlog"
 
 confine :to, :platform => 'windows'
 
-def get_cmd(host)
-  if options[:type] =~ /pe/
-    "#{host['puppetbindir']}/ruby"
-  else
-    'ruby'
-  end
-end
+require 'puppet/acceptance/windows_utils'
+extend Puppet::Acceptance::WindowsUtils
 
 agents.each do |agent|
   # get remote time
-  now = on(agent, "#{get_cmd(agent)} -e \"puts Time.now.utc.strftime('%m/%d/%Y %H:%M:%S')\"").stdout.chomp
+  now = on(agent, "#{ruby_cmd(agent)} -e \"puts Time.now.utc.strftime('%m/%d/%Y %H:%M:%S')\"").stdout.chomp
 
   # it should fail to start since parent directories don't exist
   confdir = "/does/not/exist"


### PR DESCRIPTION
The 'ruby' executable does not exist on a PE installation. Instead, the
real name is 'ruby.exe' and it is located within the PE installation
directory. This commit includes a new method (ruby_cmd) in WindowsUtil
for finding the correct executable name and fixes two tests that call
'ruby' directly on Windows.

There is also a change to the 'with_version' test to use the puppet helper 
regardless of OS.
