### PR TITLE
(PUP-1954) use attr_accessor instead of attr

### DIFF
--- a/lib/puppet/status.rb
+++ b/lib/puppet/status.rb
@@ -4,7 +4,7 @@ class Puppet::Status
   extend Puppet::Indirector
   indirects :status, :terminus_class => :local
 
-  attr :status, true
+  attr_accessor :status
 
   def initialize( status = nil )
     @status = status || {"is_alive" => true}


### PR DESCRIPTION
A one-line change that fixes a deprecation warning on certain versions
of ruby, including jruby.

Stackoverflow says this code is equivalent:

http://stackoverflow.com/questions/13958061/attr-vs-attr-accessor
