### PR TITLE
(maint) Fix class relationships

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -379,7 +379,7 @@ module Puppet::Pops::Types
     # contains_one_uni 'super_type', PHostClassType
     module ClassModule
       def hash
-        [self.class, host_class].hash
+        [self.class, class_name].hash
       end
       def ==(o)
         self.class == o.class && class_name == o.class_name


### PR DESCRIPTION
Fixes the following manifest: Class[foo] -> Class[bar]

Would fail with undefined local variable or method `host_class'
exception.
