### PR TITLE
PUP-1975 Add environment information to facts save during compilation

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -32,7 +32,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       end
 
       facts.add_timestamp
-      Puppet::Node::Facts.indirection.save(facts)
+      Puppet::Node::Facts.indirection.save(facts, nil, :environment => request.environment)
     end
   end
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -168,7 +168,9 @@ describe Puppet::Resource::Catalog::Compiler do
     it "should convert the facts into a fact instance and save it" do
       request = a_request_that_contains(@facts)
 
-      Puppet::Node::Facts.indirection.expects(:save).with(equals(@facts))
+      options = {:environment => request.environment}
+
+      Puppet::Node::Facts.indirection.expects(:save).with(equals(@facts), nil, options)
 
       @compiler.extract_facts_from_request(request)
     end


### PR DESCRIPTION
Previously the save method on the indirector was called without including
the environment information. This patch includes the environment so a custom
terminus may utilize this information during storage.

Signed-off-by: Ken Barber ken@bob.sh
