### PR TITLE
(PUP-1973) Fix getting scope vars to template for inherited scope

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -538,6 +538,9 @@ class Puppet::Parser::Scope
   def to_hash_future(recursive)
     if recursive and has_enclosing_scope?
       target = enclosing_scope.to_hash_future(recursive)
+      if !(inherited = inherited_scope).nil?
+        target.merge!(inherited.to_hash_future(recursive))
+      end
     else
       target = Hash.new
     end

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -75,6 +75,47 @@ describe "Two step scoping for variables" do
         MANIFEST
       end
     end
+
+    it "when using a template gets the var from an inherited class when using the @varname syntax" do
+      expect_the_message_to_be('Barbamama') do <<-MANIFEST
+          node default {
+            $var = "node_msg"
+            include bar_bamama
+            include foo
+          }
+          class bar_bamama {
+            $var = "Barbamama"
+          }
+          class foo {
+            $var = "foo_msg"
+            include bar
+          }
+          class bar inherits bar_bamama {
+            notify { 'something': message => inline_template("<%= @var %>"), }
+          }
+        MANIFEST
+      end
+    end
+
+    it "when using a template ignores the dynamic var when it is not present in an inherited class" do
+      expect_the_message_to_be('node_msg') do <<-MANIFEST
+          node default {
+            $var = "node_msg"
+            include bar_bamama
+            include foo
+          }
+          class bar_bamama {
+          }
+          class foo {
+            $var = "foo_msg"
+            include bar
+          }
+          class bar inherits bar_bamama {
+            notify { 'something': message => inline_template("<%= @var %>"), }
+          }
+        MANIFEST
+      end
+    end
   end
 
   shared_examples_for "the scope" do


### PR DESCRIPTION
The change in PUP-1220 (turning off access to dynamic scope)
accidentally also turned off access to inherited scope.

This is a big problem because it blocks the most used pattern of getting
parameters into classes in modules (and then accessing them in
templates).
