### PR TITLE
(PUP-1279) Make Class[::p] remove the ::

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -531,7 +531,8 @@ class Puppet::Pops::Evaluator::AccessOperator
     result = keys.each_with_index.map do |c, i|
       ctype = Puppet::Pops::Types::PHostClassType.new()
       if c.is_a?(Puppet::Pops::Types::PResourceType) && !c.type_name.nil? && c.title.nil?
-        c = c.type_name.downcase
+        # Remove leading '::' since all references are global, and 3x runtime does the wrong thing
+        c = c.type_name.downcase.sub(/^::/, '')
       end
       unless c.is_a?(String)
         fail(Puppet::Pops::Issues::ILLEGAL_HOSTCLASS_NAME, @semantic.keys[i], {:name => c})
@@ -539,7 +540,7 @@ class Puppet::Pops::Evaluator::AccessOperator
       if c !~ Puppet::Pops::Patterns::NAME
         fail(Issues::ILLEGAL_NAME, @semantic.keys[i], {:name=>c})
       end
-      ctype.class_name = c
+      ctype.class_name = c.downcase.sub(/^::/,'')
       ctype
     end
     # returns single type as type, else an array of types

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -221,7 +221,9 @@ module Puppet::Pops::Types::TypeFactory
   #
   def self.host_class(class_name = nil)
     type = Types::PHostClassType.new()
-    type.class_name = class_name
+    unless class_name.nil?
+      type.class_name = class_name.sub(/^::/, '')
+    end
     type
   end
 

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -280,7 +280,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       # arguments are flattened
       expr = fqr('Class')[[fqn('apache')]]
       expect(evaluate(expr)).to be_the_type(types.host_class('apache'))
-      end
+    end
 
     it 'produces same class if no class name is given' do
       expr = fqr('Class')[fqn('apache')][]
@@ -292,6 +292,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       result = evaluate(expr)
       expect(result[0]).to be_the_type(types.host_class('apache'))
       expect(result[1]).to be_the_type(types.host_class('nginx'))
+    end
+
+    it 'removes leading :: in class name' do
+      expr = fqr('Class')['::evoe']
+      expect(evaluate(expr)).to be_the_type(types.host_class('evoe'))
     end
 
     it 'raises error if the name is not a valid name' do

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -119,6 +119,12 @@ describe 'The type factory' do
       hc.class_name.should == 'x'
     end
 
+    it 'host_class(::x) creates a PHostClassType[x]' do
+      hc = Puppet::Pops::Types::TypeFactory.host_class('::x')
+      hc.class().should == Puppet::Pops::Types::PHostClassType
+      hc.class_name.should == 'x'
+    end
+
     it 'array_of(fixnum) returns PArrayType[PIntegerType]' do
       at = Puppet::Pops::Types::TypeFactory.array_of(1)
       at.class().should == Puppet::Pops::Types::PArrayType


### PR DESCRIPTION
When transformed to 3x to form a reference to a class, the 3x runtime
does not handle ::p (it expects the :: to have been removed), and
subsequently it is not able to find classes starting with ::.

This fix removes leading '::' when a PHostClassType is created.
