### PR TITLE
(PUP-1978) Fix issues with [] operator error reporting

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -73,7 +73,7 @@ class Puppet::Pops::Evaluator::AccessOperator
   def access_PRegexpType(o, scope, keys)
     keys.flatten!
     unless keys.size == 1
-      blamed = keys.size == 0 ? @semantic : @semantic.keys[2]
+      blamed = keys.size == 0 ? @semantic : @semantic.keys[1]
       fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, blamed, :base_type => o, :min=>1, :actual => keys.size)
     end
     assert_keys(keys, o, 1, 1, String, Regexp)
@@ -214,7 +214,7 @@ class Puppet::Pops::Evaluator::AccessOperator
   def assert_keys(keys, o, min, max, *allowed_classes)
     size = keys.size
     unless size.between?(min, max || INFINITY)
-      fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, blamed, :base_type => o, :min=>1, :max => max, :actual => keys.size)
+      fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, @semantic, :base_type => o, :min=>1, :max => max, :actual => keys.size)
     end
     keys.each_with_index do |k, i|
       unless allowed_classes.any? {|clazz| k.is_a?(clazz) }
@@ -438,10 +438,12 @@ class Puppet::Pops::Evaluator::AccessOperator
   #   Resource[File, 'foo']['bar'] # => Value of the 'bar' parameter in the File['foo'] resource
   #
   def access_PResourceType(o, scope, keys)
+    blamed = keys.size == 0 ? @semantic : @semantic.keys[0]
     keys.flatten!
     if keys.size == 0
-      fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, o,
-        :base_type => Puppet::Pops::Types::TypeCalculator.new().string(o), :min => 1, :actual => 0)
+      max = o.type_name.nil? ? 2 : 1
+      fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, blamed,
+        :base_type => Puppet::Pops::Types::TypeCalculator.new().string(o), :min => 1, :max => max, :actual => 0)
     end
     if !o.title.nil?
       # lookup resource and return one or more parameter values
@@ -500,10 +502,12 @@ class Puppet::Pops::Evaluator::AccessOperator
   end
 
   def access_PHostClassType(o, scope, keys)
+    blamed = keys.size == 0 ? @semantic : @semantic.keys[0]
+
     keys.flatten!
     if keys.size == 0
-      fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, o,
-        :base_type => Puppet::Pops::Types::TypeCalculator.new().string(o), :min => 1, :actual => 0)
+      fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, blamed,
+        :base_type => Puppet::Pops::Types::TypeCalculator.new().string(o), :min => 1, :max => -1, :actual => 0)
     end
     if ! o.class_name.nil?
       # lookup class resource and return one or more parameter values

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -384,7 +384,7 @@ module Puppet::Pops::Issues
     base_type_label = base_type.is_a?(String) ? base_type : label.a_an_uc(base_type)
     if max == -1 || max == 1.0 / 0.0 # Infinity
       "#{base_type_label}[] accepts #{min} or more arguments. Got #{actual}"
-    elsif max
+    elsif max && max != min
       "#{base_type_label}[] accepts #{min} to #{max} arguments. Got #{actual}"
     else
       "#{base_type_label}[] accepts #{min} #{label.plural_s(min, 'argument')}. Got #{actual}"

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -282,9 +282,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       expect(evaluate(expr)).to be_the_type(types.host_class('apache'))
     end
 
-    it 'produces same class if no class name is given' do
+    it 'raises error if access is to no keys' do
       expr = fqr('Class')[fqn('apache')][]
-      expect { evaluate(expr) }.to raise_error(/Evaluation Error: Class\[apache\]\[\] accepts 1 argument\. Got 0/)
+      expect { evaluate(expr) }.to raise_error(/Evaluation Error: Class\[apache\]\[\] accepts 1 or more arguments\. Got 0/)
     end
 
     it 'produces a collection of classes when multiple class names are given' do
@@ -302,6 +302,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
     it 'raises error if the name is not a valid name' do
       expr = fqr('Class')['fail-whale']
       expect { evaluate(expr) }.to raise_error(/Illegal name/)
+    end
+
+    it 'gives an error if an empty array is given as argument' do
+      expr = fqr('Class')[literal([])]
+      expect {evaluate(expr)}.to raise_error(/Evaluation Error: Class\[\] accepts 1 or more arguments. Got 0/)
     end
 
     # Resource
@@ -333,6 +338,16 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       result = evaluate(expr)
       expect(result[0]).to be_the_type(types.resource('File', 'x'))
       expect(result[1]).to be_the_type(types.resource('File', 'y'))
+    end
+
+    it 'gives an error if an empty array is given as argument' do
+      expr = fqr('Resource')[literal([])]
+      expect {evaluate(expr)}.to raise_error(/Evaluation Error: Resource\[\] accepts 1 to 2 arguments. Got 0/)
+    end
+
+    it 'gives an error if an empty array is given as argument' do
+      expr = fqr('File')[literal([])]
+      expect {evaluate(expr)}.to raise_error(/Evaluation Error: File\[\] accepts 1 argument. Got 0/)
     end
 
     it 'gives an error if resource is not found' do


### PR DESCRIPTION
There were issues when errors where reported from using the [] operator
with LHS being a Type (Class, Resource) and the given keys were given
as an empty array (resulting in no arguments). The error reporting was
faulty in this case and blamed the wrong object. This resulted in the
error reporting logic to not find a source reference.

This also fixes the issue message text when min/max was the same value.
