### PR TITLE
(PUP-1955) Fixes to purge_ssh_keys

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -570,7 +570,7 @@ module Puppet
     end
 
     def eval_generate
-      return if self[:purge_ssh_keys].empty?
+      return [] if self[:purge_ssh_keys].empty?
       find_unmanaged_keys
     end
 

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -481,19 +481,26 @@ describe Puppet::Type.type(:user) do
 
     describe "generated keys" do
       subject do
-        res = described_class.new(:name => "test", :purge_ssh_keys => my_fixture('authorized_keys'))
+        res = described_class.new(:name => "test", :purge_ssh_keys => purge_param)
         res.catalog = Puppet::Resource::Catalog.new
         res
       end
-      let(:resources) { subject.eval_generate }
-      it "should contain a resource for each key" do
-        names = resources.collect { |res| res.name }
-        names.should include("keyname1")
-        names.should include("keyname2")
+      context "when purging is disabled" do
+        let(:purge_param) { false }
+        its(:eval_generate) { should be_empty }
       end
-      it "should not include keys in comment lines" do
-        names = resources.collect { |res| res.name }
-        names.should_not include("keyname3")
+      context "when purging is enabled" do
+        let(:purge_param) { my_fixture('authorized_keys') }
+        let(:resources) { subject.eval_generate }
+        it "should contain a resource for each key" do
+          names = resources.collect { |res| res.name }
+          names.should include("keyname1")
+          names.should include("keyname2")
+        end
+        it "should not include keys in comment lines" do
+          names = resources.collect { |res| res.name }
+          names.should_not include("keyname3")
+        end
       end
     end
   end


### PR DESCRIPTION
The new `purge_ssh_keys` parameter introduced by PR #2247 revealed two issues that were causing `puppet resource user` to throw errors:
- The new parameter used `deafultto false` which is subtlety broken and actually causes `nil` to be used as a default value. This was causing an exception during `empty?` checks.
- The new `eval_generate` method was returning `nil` when purging was switched off. This was confusing later code paths that expect an empty array.
