### PR TITLE
(PUP-1596) Fix MemoryFile to string conversion in Ruby 1.8

### DIFF
--- a/lib/puppet/file_system/memory_file.rb
+++ b/lib/puppet/file_system/memory_file.rb
@@ -60,6 +60,11 @@ class Puppet::FileSystem::MemoryFile
     to_path
   end
 
+  # Used by Ruby 1.8.7 file system abstractions when operating on Pathname like things.
+  def to_str
+    to_path
+  end
+
   def inspect
     "<Puppet::FileSystem::MemoryFile:#{to_s}>"
   end

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -208,7 +208,14 @@ config_version=/some/script
       end
 
       it "accepts an empty environment.conf without warning" do
-        content.clear
+        content = nil
+
+        envdir = FS::MemoryFile.a_directory(File.expand_path("envdir"), [
+          FS::MemoryFile.a_directory("env1", [
+            FS::MemoryFile.a_regular_file_containing("environment.conf", content),
+          ]),
+        ])
+
         manifestdir = FS::MemoryFile.a_directory(File.join(envdir, "env1", "manifests"))
         modulesdir = FS::MemoryFile.a_directory(File.join(envdir, "env1", "modules"))
         global_path_location = File.expand_path("global_path")
@@ -282,8 +289,7 @@ config_version=relative/script
       end
 
       it "interpolates other setting values correctly" do
-        content.clear
-        content << <<-EOF
+        content = <<-EOF
 manifest=$confdir/whackymanifests
 modulepath=/some/absolute:$basemodulepath:modules
 config_version=$vardir/random/scripts


### PR DESCRIPTION
There were two expectations in the previous PUP-1596 work; that a
to_path would permit File functions to operate on a MemoryFile as if it
were a Pathname like thing, and that String#clear was present (in the
spec unit).  A to_str is provided on MemoryFile now for a
File.expand_path and ilk on Ruby 1.8.7, and we're no longer trying to
clear the :content String in the environments_spec.
