### PR TITLE
(PUP-1840) Add an sha256 checksum type to Puppet::Util::Checksums

### DIFF
--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -4,6 +4,13 @@ require 'digest/sha1'
 # A stand-alone module for calculating checksums
 # in a generic way.
 module Puppet::Util::Checksums
+  # It's not a good idea to use some of these in some contexts: for example, I
+  # wouldn't try bucketing a file using the :none checksum type.
+  def known_checksum_types
+    [:sha256, :sha256lite, :md5, :md5lite, :sha1, :sha1lite,
+      :mtime, :ctime, :none]
+  end
+
   class FakeChecksum
     def <<(*args)
       self
@@ -12,7 +19,8 @@ module Puppet::Util::Checksums
 
   # Is the provided string a checksum?
   def checksum?(string)
-    string =~ /^\{(\w{3,5})\}\S+/
+    # 'sha256lite'.length == 10
+    string =~ /^\{(\w{3,10})\}\S+/
   end
 
   # Strip the checksum type from an existing checksum
@@ -24,6 +32,41 @@ module Puppet::Util::Checksums
   def sumtype(checksum)
     checksum =~ /^\{(\w+)\}/ ? $1 : nil
   end
+
+  # Calculate a checksum using Digest::SHA256.
+  def sha256(content)
+    require 'digest/sha2'
+    Digest::SHA256.hexdigest(content)
+  end
+
+  def sha256lite(content)
+    sha256(content[0..511])
+  end
+
+  def sha256_file(filename, lite = false)
+    require 'digest/sha2'
+
+    digest = Digest::SHA256.new
+    checksum_file(digest, filename,  lite)
+  end
+
+  def sha256lite_file(filename)
+    sha256_file(filename, true)
+  end
+
+  def sha256_stream(&block)
+    require 'digest/sha2'
+    digest = Digest::SHA256.new
+    yield digest
+    digest.hexdigest
+  end
+
+  def sha256_hex_length
+    64
+  end
+
+  alias :sha256lite_stream :sha256_stream
+  alias :sha256lite_hex_length :sha256_hex_length
 
   # Calculate a checksum using Digest::MD5.
   def md5(content)
@@ -52,7 +95,12 @@ module Puppet::Util::Checksums
     digest.hexdigest
   end
 
+  def md5_hex_length
+    32
+  end
+
   alias :md5lite_stream :md5_stream
+  alias :md5lite_hex_length :md5_hex_length
 
   # Return the :mtime timestamp of a file.
   def mtime_file(filename)
@@ -98,7 +146,12 @@ module Puppet::Util::Checksums
     digest.hexdigest
   end
 
+  def sha1_hex_length
+    40
+  end
+
   alias :sha1lite_stream :sha1_stream
+  alias :sha1lite_hex_length :sha1_hex_length
 
   # Return the :ctime of a file.
   def ctime_file(filename)
@@ -140,4 +193,5 @@ module Puppet::Util::Checksums
 
     digest.hexdigest
   end
+
 end

--- a/spec/unit/util/checksums_spec.rb
+++ b/spec/unit/util/checksums_spec.rb
@@ -11,12 +11,18 @@ describe Puppet::Util::Checksums do
     @summer.extend(Puppet::Util::Checksums)
   end
 
-  content_sums = [:md5, :md5lite, :sha1, :sha1lite]
+  content_sums = [:md5, :md5lite, :sha1, :sha1lite, :sha256, :sha256lite]
   file_only = [:ctime, :mtime, :none]
 
   content_sums.each do |sumtype|
     it "should be able to calculate #{sumtype} sums from strings" do
       @summer.should be_respond_to(sumtype)
+    end
+  end
+
+  content_sums.each do |sumtype|
+    it "should know the expected length of #{sumtype} sums" do
+      @summer.should be_respond_to(sumtype.to_s + "_hex_length")
     end
   end
 
@@ -36,13 +42,14 @@ describe Puppet::Util::Checksums do
     @summer.should respond_to(:checksum?)
   end
 
-  %w{{md5}asdfasdf {sha1}asdfasdf {ctime}asdasdf {mtime}asdfasdf}.each do |sum|
+  %w{{md5}asdfasdf {sha1}asdfasdf {ctime}asdasdf {mtime}asdfasdf 
+     {sha256}asdfasdf {sha256lite}asdfasdf}.each do |sum|
     it "should consider #{sum} to be a checksum" do
       @summer.should be_checksum(sum)
     end
   end
 
-  %w{{nosuchsum}asdfasdf {a}asdfasdf {ctime}}.each do |sum|
+  %w{{nosuchsumthislong}asdfasdf {a}asdfasdf {ctime}}.each do |sum|
     it "should not consider #{sum} to be a checksum" do
       @summer.should_not be_checksum(sum)
     end
@@ -60,7 +67,7 @@ describe Puppet::Util::Checksums do
     @summer.sumtype("asdfasdfa").should be_nil
   end
 
-  {:md5 => Digest::MD5, :sha1 => Digest::SHA1}.each do |sum, klass|
+  {:md5 => Digest::MD5, :sha1 => Digest::SHA1, :sha256 => Digest::SHA256}.each do |sum, klass|
     describe("when using #{sum}") do
       it "should use #{klass} to calculate string checksums" do
         klass.expects(:hexdigest).with("mycontent").returns "whatever"
@@ -99,7 +106,7 @@ describe Puppet::Util::Checksums do
     end
   end
 
-  {:md5lite => Digest::MD5, :sha1lite => Digest::SHA1}.each do |sum, klass|
+  {:md5lite => Digest::MD5, :sha1lite => Digest::SHA1, :sha256lite => Digest::SHA256}.each do |sum, klass|
     describe("when using #{sum}") do
       it "should use #{klass} to calculate string checksums from the first 512 characters of the string" do
         content = "this is a test" * 100


### PR DESCRIPTION
This patch makes SHA-256 available for use as a checksum algorithm by other parts of Puppet, alongside MD5 and SHA-1. (See commit message for further details.) The known_checksum_types method is used by code added in the configurable digest algorithm pull request, which will be filed after this one.
