### PR TITLE
Only search for the specific gem name, removes false positive upgrade.

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
       gem_list_command << "--source" << options[:source]
     end
     if name = options[:justme]
-      gem_list_command << name + "$"
+      gem_list_command << "^" + name + "$"
     end
 
     begin


### PR DESCRIPTION
# Old Way

Gem provider would continuously upgrade bundler because it would match on `0.1.0` not `1.5.3`.

```
gem list --remote bundler$

*** REMOTE GEMS ***

appbundler (0.1.0)
asset_bundler (0.2.0)
assetbundler (0.0.0)
atd-asset_bundler (0.0.3)
bowline-bundler (0.0.4)
bundler (1.5.3)
capistrano-bundler (1.1.2)
capistrano-ext-rvm-bundler (0.0.2)
ctags-bundler (0.0.1)
gem_bundler (0.2)
guard-bundler (2.0.0)
guard-ctags-bundler (1.0.2)
hello_world_bundler (0.1.2)
hoe-bundler (1.2.0)
jbundler (0.5.5)
moneypools-bundler (0.8.1)
motion-bundler (0.2.1)
mpapis-bundler (1.0.21.1)
ofxbundler (0.2.8)
peritor-bundler (0.7.0)
quick-bundler (0.0.3)
rails-assets-bundler (0.0.1)
rubygems-bundler (1.4.2)
rubysl-bundler (2.0.0)
smart_bundler (0.0.1)
tvd-bundler (0.0.8)
unbundler (0.0.2)
vagrant-bundler (0.1.1)
vagrant-plugin-bundler (0.1.1)
vim-bundler (0.3.0)
web_resource_bundler (0.0.23)
widget_bundler (0.0.10)
```
# New Way

Returns only the specific gem.

```
gem list --remote ^bundler$

*** REMOTE GEMS ***

bundler (1.5.3)
```
# JIRA Issue PUP-2014

https://tickets.puppetlabs.com/browse/PUP-2014
