### PR TITLE
(PUP-2014) Make gem provider match on a single gem name

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
       gem_list_command << "--source" << options[:source]
     end
     if name = options[:justme]
-      gem_list_command << name + "$"
+      gem_list_command << "^" + name + "$"
     end
 
     begin


### PR DESCRIPTION
Currently the gem provider will match gemname$, for example with bundler
this will return quite a long list of anything ending with bundler. When
a match returns a longer list, it will actually connect and try to pull
the latest gem again, thus increasing the WAN usage and rubygems.org
usage when not necessary.

The proposed fix adds a ^ in front of the name var to ensure it begins
with the gemname.
