### PR TITLE
(PUP-2010) have test repos pushed to hosts during acceptance testing

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 1.7.0"
+gem "beaker", "~> 1.10.0"
 gem 'rake', "~> 10.1.0"
 
 group(:test) do

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -1,4 +1,6 @@
 require 'open-uri'
+require 'open3'
+require 'uri'
 
 module Puppet
   module Acceptance
@@ -68,6 +70,34 @@ module Puppet
         return dst
       end
 
+      def fetch_remote_dir(url, dst_dir)
+        logger.notify "fetch_remote_dir (url: #{url}, dst_dir #{dst_dir})"
+        if url[-1, 1] !~ /\//
+          url += '/'
+        end
+        url = URI.parse(url)
+        chunks = url.path.split('/')
+        dst = File.join(dst_dir, chunks.last)
+        #determine directory structure to cut
+        #only want to keep the last directory, thus cut total number of dirs - 2 (hostname + last dir name)
+        cut = chunks.length - 2
+        wget_command = "wget -nv -P #{dst_dir} --reject \"index.html*\",\"*.gif\" --cut-dirs=#{cut} -np -nH --no-check-certificate -r #{url}"
+
+        logger.notify "Fetching remote directory: #{url}"
+        logger.notify "  and saving to #{dst}"
+        logger.notify "  using command: #{wget_command}"
+
+        #in ruby 1.9+ we can upgrade this to popen3 to gain access to the subprocess pid
+        result = `#{wget_command} 2>&1`
+        result.each_line do |line|
+          logger.debug(line)
+        end
+        if $?.to_i != 0
+          raise "Failed to fetch_remote_dir '#{url}' (exit code #{$?}"
+        end
+        dst
+      end
+
       def stop_firewall_on(host)
         case host['platform']
         when /debian/
@@ -84,7 +114,7 @@ module Puppet
       end
 
       def install_repos_on(host, sha, repo_configs_dir)
-        platform = host['platform']
+        platform = host['platform'].with_version_codename
         platform_configs_dir = File.join(repo_configs_dir,platform)
 
         case platform
@@ -114,12 +144,23 @@ module Puppet
               platform_configs_dir
             )
 
-            on host, "rm -rf /root/*.repo; rm -rf /root/*.rpm"
+            link = "http://builds.puppetlabs.lan/puppet/%s/repos/%s/%s/products/%s/" % [sha, variant, version, arch]
+            if not link_exists?(link)
+              link = "http://builds.puppetlabs.lan/puppet/%s/repos/%s/%s/devel/%s/" % [sha, variant, version, arch]
+            end
+            if not link_exists?(link)
+              raise "Unable to reach a repo directory at #{link}"
+            end
+            repo_dir = fetch_remote_dir(link, platform_configs_dir)
+
+            on host, "rm -rf /root/*.repo; rm -rf /root/*.rpm; rm -rf /root/#{arch}"
 
             scp_to host, rpm, '/root'
             scp_to host, repo, '/root'
+            scp_to host, repo_dir, '/root'
 
             on host, "mv /root/*.repo /etc/yum.repos.d"
+            on host, "find /etc/yum.repos.d/ -name \"*.repo\" -exec sed -i \"s/baseurl\\s*=\\s*http:\\/\\/builds.puppetlabs.lan.*$/baseurl=file:\\/\\/\\/root\\/#{arch}/\" {} \\;"
             on host, "rpm -Uvh --force /root/*.rpm"
 
           when /^(debian|ubuntu)-([^-]+)-(.+)$/
@@ -139,13 +180,18 @@ module Puppet
               platform_configs_dir
             )
 
-            on host, "rm -rf /root/*.list; rm -rf /root/*.deb"
+            repo_dir = fetch_remote_dir("http://builds.puppetlabs.lan/puppet/%s/repos/apt/%s" % [sha, version], platform_configs_dir)
+
+            on host, "rm -rf /root/*.list; rm -rf /root/*.deb; rm -rf /root/#{version}"
 
             scp_to host, deb, '/root'
             scp_to host, list, '/root'
+            scp_to host, repo_dir, '/root'
 
             on host, "mv /root/*.list /etc/apt/sources.list.d"
+            on host, "find /etc/apt/sources.list.d/ -name \"*.list\" -exec sed -i \"s/deb\\s\\+http:\\/\\/builds.puppetlabs.lan.*$/deb file:\\/\\/\\/root\\/#{version} #{version} main/\" {} \\;"
             on host, "dpkg -i --force-all /root/*.deb"
+            on host, "apt-get update"
           else
             host.logger.notify("No repository installation step for #{platform} yet...")
         end

--- a/acceptance/lib/puppet/acceptance/install_utils_spec.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils_spec.rb
@@ -7,6 +7,13 @@ describe 'InstallUtils' do
     include Puppet::Acceptance::InstallUtils
   end
 
+  class Platform < String
+
+    def with_version_codename
+      self
+    end
+  end
+
   class TestHost
     attr_accessor :config
     def initialize(config = {})
@@ -41,7 +48,7 @@ describe 'InstallUtils' do
       before do
         logger = mock('logger', :notify => nil)
         host.stubs(:logger).returns(logger)
-        host.config['platform'] = platform
+        host.config['platform'] = Platform.new(platform)
       end
 
       it "installs packages on a host" do
@@ -89,12 +96,38 @@ describe 'InstallUtils' do
     end
   end
 
+  describe "fetch_remote_dir" do
+    before do
+      logger = stub('logger', {:notify => nil, :debug => nil})
+      testcase.stubs(:logger).returns(logger)
+    end
+
+    it "calls wget with the right amount of cut dirs for url that ends in '/'" do
+      url = 'http://builds.puppetlabs.lan/puppet/7807591405af849da2ad6534c66bd2d4efff604f/repos/el/6/devel/x86_64/'
+      testcase.expects(:`).with("wget -nv -P dir --reject \"index.html*\",\"*.gif\" --cut-dirs=6 -np -nH --no-check-certificate -r #{url} 2>&1").returns("log")
+
+      expect( testcase.fetch_remote_dir(url, 'dir')).to eql('dir/x86_64')
+    end
+
+    it "calls wget with the right amount of cut dirs for url that doesn't end in '/'" do
+      url = 'http://builds.puppetlabs.lan/puppet/7807591405af849da2ad6534c66bd2d4efff604f/repos/apt/wheezy'
+      testcase.expects(:`).with("wget -nv -P dir --reject \"index.html*\",\"*.gif\" --cut-dirs=4 -np -nH --no-check-certificate -r #{url}/ 2>&1").returns("log")
+
+      expect( testcase.fetch_remote_dir(url, 'dir')).to eql('dir/wheezy')
+    end
+
+  end
+
   shared_examples_for :redhat_platforms do |platform,sha,files|
+    before do
+      host.config['platform'] = Platform.new(platform)
+    end
+
     it "fetches and installs repo configurations for #{platform}" do
-      host.config['platform'] = platform
       platform_configs_dir = "repo-configs/#{platform}"
 
-      rpm_file = files[:rpm]
+      rpm_url = files[:rpm][0]
+      rpm_file = files[:rpm][1]
       testcase.expects(:fetch).with(
         "http://yum.puppetlabs.com",
         rpm_file,
@@ -109,10 +142,21 @@ describe 'InstallUtils' do
         platform_configs_dir
       ).returns("#{platform_configs_dir}/#{repo_file}")
 
-      testcase.expects(:on).with(host, regexp_matches(/rm.*repo; rm.*rpm/))
+      repo_dir_url = files[:repo_dir][0]
+      repo_dir     = files[:repo_dir][1]
+      testcase.expects(:link_exists?).returns( true )
+      testcase.expects(:fetch_remote_dir).with(
+        repo_dir_url,
+        platform_configs_dir
+      ).returns("#{platform_configs_dir}/#{repo_dir}")
+      testcase.expects(:link_exists?).returns( true )
+  
+      testcase.expects(:on).with(host, regexp_matches(/rm.*repo; rm.*rpm; rm.*#{repo_dir}/))
       testcase.expects(:scp_to).with(host, "#{platform_configs_dir}/#{rpm_file}", '/root')
       testcase.expects(:scp_to).with(host, "#{platform_configs_dir}/#{repo_file}", '/root')
+      testcase.expects(:scp_to).with(host, "#{platform_configs_dir}/#{repo_dir}", '/root')
       testcase.expects(:on).with(host, regexp_matches(%r{mv.*repo /etc/yum.repos.d}))
+      testcase.expects(:on).with(host, regexp_matches(%r{find /etc/yum.repos.d/ -name .*}))
       testcase.expects(:on).with(host, regexp_matches(%r{rpm.*/root/.*rpm}))
 
       testcase.install_repos_on(host, sha, 'repo-configs')
@@ -126,10 +170,17 @@ describe 'InstallUtils' do
       'el-6-i386',
       'abcdef10',
       {
-        :rpm => "puppetlabs-release-el-6.noarch.rpm",
+        :rpm => [
+          "http://yum.puppetlabs.com",
+          "puppetlabs-release-el-6.noarch.rpm",
+        ],
         :repo => [
           "http://builds.puppetlabs.lan/puppet/abcdef10/repo_configs/rpm/",
           "pl-puppet-abcdef10-el-6-i386.repo",
+        ],
+        :repo_dir => [
+          "http://builds.puppetlabs.lan/puppet/abcdef10/repos/el/6/products/i386/",
+          "i386",
         ],
       },
     )
@@ -138,10 +189,17 @@ describe 'InstallUtils' do
       'fedora-18-x86_64',
       'abcdef10',
       {
-        :rpm => "puppetlabs-release-fedora-18.noarch.rpm",
+        :rpm => [
+          "http://yum.puppetlabs.com",
+          "puppetlabs-release-fedora-18.noarch.rpm",
+        ],
         :repo => [
           "http://builds.puppetlabs.lan/puppet/abcdef10/repo_configs/rpm/",
           "pl-puppet-abcdef10-fedora-f18-x86_64.repo",
+        ],
+        :repo_dir => [
+          "http://builds.puppetlabs.lan/puppet/abcdef10/repos/fedora/18/products/x86_64/",
+          "x86_64",
         ],
       },
     )
@@ -150,16 +208,23 @@ describe 'InstallUtils' do
       'centos-5-x86_64',
       'abcdef10',
       {
-        :rpm => "puppetlabs-release-el-5.noarch.rpm",
+        :rpm => [
+          "http://yum.puppetlabs.com",
+          "puppetlabs-release-el-5.noarch.rpm",
+        ],
         :repo => [
           "http://builds.puppetlabs.lan/puppet/abcdef10/repo_configs/rpm/",
           "pl-puppet-abcdef10-el-5-x86_64.repo",
+        ],
+        :repo_dir => [
+          "http://builds.puppetlabs.lan/puppet/abcdef10/repos/el/5/products/x86_64/",
+          "x86_64",
         ],
       },
     )
 
     it "installs on a debian host" do
-      host.config['platform'] = platform = 'ubuntu-precise-x86_64'
+      host.config['platform'] = platform = Platform.new('ubuntu-precise-x86_64')
       platform_configs_dir = "repo-configs/#{platform}"
 
       deb = "puppetlabs-release-precise.deb"
@@ -176,11 +241,19 @@ describe 'InstallUtils' do
         platform_configs_dir
       ).returns("#{platform_configs_dir}/#{list}")
 
-      testcase.expects(:on).with(host, regexp_matches(/rm.*list; rm.*deb/))
+      testcase.expects(:fetch_remote_dir).with(
+        "http://builds.puppetlabs.lan/puppet/#{sha}/repos/apt/precise",
+        platform_configs_dir
+      ).returns("#{platform_configs_dir}/precise")
+
+      testcase.expects(:on).with(host, regexp_matches(/rm.*list; rm.*deb; rm.*/))
       testcase.expects(:scp_to).with(host, "#{platform_configs_dir}/#{deb}", '/root')
       testcase.expects(:scp_to).with(host, "#{platform_configs_dir}/#{list}", '/root')
+      testcase.expects(:scp_to).with(host, "#{platform_configs_dir}/precise", '/root')
       testcase.expects(:on).with(host, regexp_matches(%r{mv.*list /etc/apt/sources.list.d}))
+      testcase.expects(:on).with(host, regexp_matches(%r{find /etc/apt/sources.list.d/ -name .*}))
       testcase.expects(:on).with(host, regexp_matches(%r{dpkg -i.*/root/.*deb}))
+      testcase.expects(:on).with(host, regexp_matches(%r{apt-get update}))
 
       testcase.install_repos_on(host, sha, 'repo-configs')
     end


### PR DESCRIPTION
This patch changes the logic of how test packages are installed on SUTs.
Currently, repo packages are pulled by the individual SUTs - this works
because we assume that the SUTs are located within the Puppet Labs
network and can access builds.puppetlabs.lan.  To run acceptance tests
in the cloud the workflow needs to be changed to have the test packages
pushed to the SUTs by the jenkins master node.

Tested successfully on jenkins, also updated spec tests.

This code relies on Beaker 1.8+ DSL methods.
