### PR TITLE
(PUP-2017) Change TupleType size to mean total number of entries

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -307,10 +307,33 @@ module Puppet::Pops::Types
   # @api public
   class PTupleType < PObjectType
     contains_many_uni 'types', PAbstractType, :lowerBound => 1
-    # If set, describes repetition of the last type in types
+    # If set, describes min and max required of the given types - if max > size of
+    # types, the last type entry repeats
+    #
     contains_one_uni 'size_type', PIntegerType, :lowerBound => 0
 
     module ClassModule
+      # Returns the number of elements accepted [min, max] in the tuple
+      def size_range
+        types_size = types.size
+        size_type.nil? ? [types_size, types_size] : size_type.range
+      end
+
+      # Returns the number of accepted occurrences [min, max] of the last type in the tuple
+      # The defaults is [1,1]
+      #
+      def repeat_last_range
+        types_size = types.size
+        if size_type.nil?
+          return [1, 1]
+        end
+        from, to = size_type.range()
+        min = from - (types_size-1)
+        min = min <= 0 ? 0 : min
+        max = to - (types_size-1)
+        [min, max]
+      end
+
       def hash
         [self.class, size_type, Set.new(types)].hash
       end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -764,13 +764,22 @@ describe 'The type calculator' do
         calculator.assignable?(tuple2, tuple1).should == false
       end
 
-      it 'should accept matching tuples with optional entries' do
+      it 'should accept matching tuples with optional entries by repeating last' do
         tuple1 = tuple_t(1,2)
         factory.constrain_size(tuple1, 0, :default)
         tuple2 = tuple_t(Numeric,Numeric)
         factory.constrain_size(tuple2, 0, :default)
         calculator.assignable?(tuple1, tuple2).should == false
         calculator.assignable?(tuple2, tuple1).should == true
+      end
+
+      it 'should accept matching tuples with optional entries' do
+        tuple1 = tuple_t(Integer, Integer, String)
+        factory.constrain_size(tuple1, 1, 3)
+        array2 = factory.constrain_size(array_t(Integer),2,2)
+        calculator.assignable?(tuple1, array2).should == true
+        factory.constrain_size(tuple1, 3, 3)
+        calculator.assignable?(tuple1, array2).should == false
       end
 
       it 'should accept matching array' do


### PR DESCRIPTION
The TupleType was implemented so that the size constraint only
applied to the last type. This was difficult to work with. It is
far better if the size constraint works the same way as for an
array, only that the types can be different per index. Thus a size
constraint of 2,3 for the tuple types t1, t2, t3 means that t1, and t2
are required and t3 is optional. If the size range is > the number of
types, the last type repeats.
