### PR TITLE
(PUP-1596) Expand all paths when creating environments

### DIFF
--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -93,11 +93,11 @@ class Puppet::Settings::EnvironmentConf
 
   def absolute(path)
     return nil if path.nil?
-    if path =~ /^\$/ || Puppet::FileSystem.pathname(path).absolute?
-      # Path begins with $something interpolatable, or is already absolute
+    if path =~ /^\$/
+      # Path begins with $something interpolatable
       path
     else
-      File.join(@path_to_env, path)
+      File.expand_path(path, @path_to_env)
     end
   end
 end

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -159,11 +159,11 @@ describe Puppet::Environments do
           ]),
         ])
       end
-      let(:manifestdir) { FS::MemoryFile.a_directory("/some/manifest/path") }
+      let(:manifestdir) { FS::MemoryFile.a_directory(File.expand_path("/some/manifest/path")) }
       let(:modulepath) do
         [
-          FS::MemoryFile.a_directory("/some/module/path"),
-          FS::MemoryFile.a_directory("/some/other/path"),
+          FS::MemoryFile.a_directory(File.expand_path("/some/module/path")),
+          FS::MemoryFile.a_directory(File.expand_path("/some/other/path")),
         ]
       end
 
@@ -289,13 +289,19 @@ config_version=relative/script
       end
 
       it "interpolates other setting values correctly" do
+        modulepath = [
+          File.expand_path('/some/absolute'),
+          '$basemodulepath',
+          'modules'
+        ].join(File::PATH_SEPARATOR)
+
         content = <<-EOF
 manifest=$confdir/whackymanifests
-modulepath=/some/absolute:$basemodulepath:modules
+modulepath=#{modulepath}
 config_version=$vardir/random/scripts
         EOF
 
-        some_absolute_dir = FS::MemoryFile.a_directory('/some/absolute')
+        some_absolute_dir = FS::MemoryFile.a_directory(File.expand_path('/some/absolute'))
         base_module_dirs = Puppet[:basemodulepath].split(File::PATH_SEPARATOR).map do |path|
           FS::MemoryFile.a_directory(path)
         end

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -169,8 +169,8 @@ describe Puppet::Node::Environment do
         CONF
 
         env = Puppet::Node::Environment.new("testing")
-        expect(env.full_modulepath).to eq(['/some/modulepath'])
-        expect(env.manifest).to eq('/some/manifest')
+        expect(env.full_modulepath).to eq([File.expand_path('/some/modulepath')])
+        expect(env.manifest).to eq(File.expand_path('/some/manifest'))
         expect(env.config_version).to eq('/some/script')
       end
 

--- a/spec/unit/settings/environment_conf_spec.rb
+++ b/spec/unit/settings/environment_conf_spec.rb
@@ -11,21 +11,21 @@ describe Puppet::Settings::EnvironmentConf do
       config.expects(:setting).with(:modulepath).returns(
         mock('setting', :value => '/some/modulepath')
       )
-      expect(envconf.modulepath).to eq('/some/modulepath')
+      expect(envconf.modulepath).to eq(File.expand_path('/some/modulepath'))
     end
 
     it "reads a manifest from config" do
       config.expects(:setting).with(:manifest).returns(
         mock('setting', :value => '/some/manifest')
       )
-      expect(envconf.manifest).to eq('/some/manifest')
+      expect(envconf.manifest).to eq(File.expand_path('/some/manifest'))
     end
 
     it "reads a config_version from config" do
       config.expects(:setting).with(:config_version).returns(
         mock('setting', :value => '/some/version.sh')
       )
-      expect(envconf.config_version).to eq('/some/version.sh')
+      expect(envconf.config_version).to eq(File.expand_path('/some/version.sh'))
     end
 
   end
@@ -34,11 +34,14 @@ describe Puppet::Settings::EnvironmentConf do
     let(:envconf) { Puppet::Settings::EnvironmentConf.new("/some/direnv", nil, ["/global/modulepath"]) }
 
     it "returns a default modulepath when config has none, with global_module_path" do
-      expect(envconf.modulepath).to eq('/some/direnv/modules:/global/modulepath')
+      expect(envconf.modulepath).to eq(
+        [File.expand_path('/some/direnv/modules'),
+        File.expand_path('/global/modulepath')].join(File::PATH_SEPARATOR)
+      )
     end
 
     it "returns a default manifest when config has none" do
-      expect(envconf.manifest).to eq('/some/direnv/manifests')
+      expect(envconf.manifest).to eq(File.expand_path('/some/direnv/manifests'))
     end
 
     it "returns nothing for config_version when config has none" do


### PR DESCRIPTION
And when reading EnvironmentConf settings.  Ensures that absolute paths
are expanded properly on Windows platforms as well.
