### PR TITLE
(PUP-1944) Fix issue with manifest being a directory when initializing

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -870,9 +870,10 @@ EOT
     },
     :manifest => {
       :default    => "$manifestdir/site.pp",
-      :type       => :file,
+      :type       => :file_or_directory,
       :desc       => "The entry-point manifest file for puppet master or a directory of manifests
-        to be evaluated in alphabetical order.",
+        to be evaluated in alphabetical order. Puppet manages this path as a directory
+        if it exists or if the path ends with a / or \\.",
     },
     :code => {
       :default    => "",

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -13,6 +13,7 @@ class Puppet::Settings
   require 'puppet/settings/enum_setting'
   require 'puppet/settings/file_setting'
   require 'puppet/settings/directory_setting'
+  require 'puppet/settings/file_or_directory_setting'
   require 'puppet/settings/path_setting'
   require 'puppet/settings/boolean_setting'
   require 'puppet/settings/terminus_setting'
@@ -639,6 +640,7 @@ class Puppet::Settings
       :string     => StringSetting,
       :file       => FileSetting,
       :directory  => DirectorySetting,
+      :file_or_directory => FileOrDirectorySetting,
       :path       => PathSetting,
       :boolean    => BooleanSetting,
       :terminus   => TerminusSetting,

--- a/lib/puppet/settings/file_or_directory_setting.rb
+++ b/lib/puppet/settings/file_or_directory_setting.rb
@@ -1,0 +1,34 @@
+class Puppet::Settings::FileOrDirectorySetting < Puppet::Settings::FileSetting
+
+  def initialize(args)
+    super
+  end
+
+  def type
+    if Puppet::FileSystem.directory?(self.value) || @path_ends_with_slash
+      :directory
+    else
+      :file
+    end
+  end
+
+  # Overrides munge to be able to read the un-munged value (the FileSetting.munch removes trailing slash)
+  #
+  def munge(value)
+    if value.is_a?(String) && value =~ /[\\\/]$/
+      @path_ends_with_slash = true
+    end
+    super
+  end
+
+  # @api private
+  def open_file(filename, option = 'r', &block)
+    if type == :file
+      super
+    else
+      controlled_access do |mode|
+        Puppet::FileSystem.open(filename, mode, option, &block)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The issue was that Puppet manages files and directories mentioned in
settings (to set the correct owner and mode). The :manifest setting
was a :file settings type and this did not work well when the :manifest
was a reference to an existing directory ("cannot change a directory to
a file") and the puppet master refused to start.

This commit changes this by introducing a new settings type;
:file_or_directory that manages the path as a directory if it exists or
if the path ends with slash (/ or ).
