### PR TITLE
(PUP-2009) Lookup environment from settings in interpolation

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1214,7 +1214,7 @@ Generated on #{Time.now}.
       return value unless value.is_a? String
       value.gsub(/\$(\w+)|\$\{(\w+)\}/) do |value|
         varname = $2 || $1
-        if varname == "environment"
+        if varname == "environment" && @environment
           @environment
         elsif varname == "run_mode"
           @mode


### PR DESCRIPTION
Settings#convert() used to have the behavior that if it was
interpolating $environment, and no environment was available to the
method, it would fall through and make another setting lookup for
environment.  This would result in the default or set environment being
obtained.

In 00c2abf of the #23373 command line manipulation of puppet.conf work
which involved a refactor of the setting parsing, this behavior changed,
such that whatever @environment was set in the ChainedValues instance
performing the setting lookup and interpolation, that value would be
returned for $environment, even if nil.

This is the case when asking an actual Setting instance what it's value
is, as it looks it up from settings without supplying an environment,
which results in something like
'manifestdir=/foo/environments/$environment/manifests' interpolating
as '/foo/environments/manifests'.  This can result in the bug seen in
PUP-2009 where a master can fail attempting to manage this typically
non-existent directory because of Settings#use() and to_catalog().

This commit restores the old behavior, allowing interpolation of
$environment to lookup environment from settings when no environment
value was explicitly passed in.
