### PR TITLE
(PUP-2029) Add a CatalogModel for Puppet 4x

### DIFF
--- a/lib/puppet/biff/catalog_builder.rb
+++ b/lib/puppet/biff/catalog_builder.rb
@@ -1,0 +1,2 @@
+class Puppet::Biff::CatalogBuilder
+end

--- a/lib/puppet/biff/model/catalog.rb
+++ b/lib/puppet/biff/model/catalog.rb
@@ -1,0 +1,107 @@
+require 'rgen/metamodel_builder'
+
+# TODO: Fix these in a biff.rb where all modules and requirements are organized
+module Puppet::Biff
+end
+module Puppet::Biff::Model
+end
+
+module Puppet::Biff::Model::Catalog
+  extend RGen::MetamodelBuilder::ModuleExtension
+
+  # A base class for modeled objects that makes them Visitable, and Adaptable.
+  #
+  class CatalogObject < RGen::MetamodelBuilder::MMBase
+    include Puppet::Pops::Visitable
+    include Puppet::Pops::Adaptable
+    include Puppet::Pops::Containment
+    abstract
+  end
+
+  # Holds an URI fragment to a source location
+  class Location < CatalogObject
+    has_attr 'source_fragment', String, :lowerBound => 1
+  end
+
+  # A container of resources
+  class ResourceContainer < CatalogObject
+    abtract
+  end
+
+  # An abstract resource (derived classes define kind)
+  #
+  class AbstractResource < ResourceContainer
+    has_many_attr 'tags', String
+    has_attr 'origin', ResourceOrigin, :lowerBound => 1, :defaultValueLiteral => "here"
+    contains_one_uni 'created_at', Location, :lowerBound => 0
+    contains_one_uni 'imported_at', Location, :lowerBound => 0
+    contains_one_uni 'realized_at', Location, :lowerBound => 0
+    abstract
+  end
+
+  class AbstractResourceReference < AbstractResource
+    contains_one_uni 'resource_reference', Puppet::Pops::Types::PResourceType, :lowerBound => 1
+    abstract
+  end
+
+  # A placeholder resource that must be resolved before the catalog is valid
+  #
+  class UnresolvedResource < AbstractResourceReference
+  end
+
+  # A resource that may be added to a plan, and do actual work if the referenced resource is part
+  # of the plan, else represents a no-op
+  #
+  class OptionalResource < AbstractResourceReference
+  end
+
+  ResourceOrigin = RGen::MetamodelBuilder::DataTypes::Enum.new([:here, :imported, :here_exported, :here_virtual ])
+
+  class Resource < AbstractResource
+    has_attr 'title', String
+    has_attr 'realized', Boolean
+    has_many_attr 'aliases', String, :lowerBound => 0
+
+    # TODO: This should be abstract when it is possible to create derived types
+  end
+
+  class ProxyResource < AbstractResource
+  end
+
+  class SourceReference < CatalogObject
+    has_attr 'source_uri', String
+  end
+
+  class Relation < CatalogObject
+    # A ~> or <~ type of relationship
+    has_attr 'notification', Boolean, :defaultValueLiteral => "false"
+
+    # The source has an arrow pointing to the left - the semantics of
+    # followers and leaders does not change because of this.
+    #
+    has_attr 'right2left', Boolean, :defaultValueLiteral => "false"
+    contains_one_uni 'location', Location, :lowerBound => 0
+  end
+
+  # A CatalogSection is basically a "full catalog", but multiple of them may be combined into one Catalog
+  #
+  class CatalogSection < ResourceContainer
+    has_attr 'name', String
+    contains_many_uni 'sources', SourceReference
+    contains_many_uni 'relations', Relation, :lowerBound => 0
+  end
+
+  # The top level container in a "catalog"
+  #
+  class Catalog < CatalogObject
+    contains_many_uni 'sections', CatalogSection, :lowerBound => 0
+  end
+
+  # Additional Relationships
+  #
+  Location.has_one 'source', SourceReference
+  Resource.one_to_many 'proxy_resources', ProxyResource, 'real_resource'
+  ResourceContainer.contains_many 'resources', AbstractResource, 'container', :lowerBound => 0
+  AbstractResource.one_to_many 'followers', Relation, 'leader', :lowerBound => 0
+  AbstractResource.one_to_many 'leaders', Relation, 'follower', :lowerBound => 0
+end

--- a/lib/puppet/biff/model/pcore.rb
+++ b/lib/puppet/biff/model/pcore.rb
@@ -1,0 +1,68 @@
+require 'rgen/metamodel_builder'
+
+module Puppet::Biff::Model::PCore
+  extend RGen::MetamodelBuilder::ModuleExtension
+
+  # A base class for modeled objects that makes them Visitable, and Adaptable.
+  # (This could be shared across all models in Puppet)
+  #
+  class PModelElement < RGen::MetamodelBuilder::MMBase
+    include Puppet::Pops::Visitable
+    include Puppet::Pops::Adaptable
+    include Puppet::Pops::Containment
+    abstract
+  end
+
+  # TODO: This should really be part of the type system directly
+  # (Also, add EClassifier to PAbstractType)
+  #
+  class PTypeAlias < Puppet::Pops::Types::PAbstractType
+    contains_one_uni 'real_type', Puppet::Pops::Types::PAbstractType, :lowerBound => 1
+  end
+
+  class PClassifier < PModelElement
+    has_attr 'name', String, :lowerBound => 1
+    # TODO: Reference to FunctionDefinitions
+    # TODO: Reference to InvariantExpressions
+  end
+
+  class PTypeModel < PModelElement
+    has_attr 'name', String
+    has_attr 'ns_uri', String
+
+    contains_many_uni 'type_declarations', PAbstractType, :lowerBound => 0
+    contains_many_uni 'classifiers', PClassifier, :lowerBound => 0
+  end
+
+  class PAttribute < PModelElement
+    has_attr 'default_value_literal', String
+    has_attr 'synchronizeable', Boolean
+    has_attr 'derived', Boolean
+    has_attr 'transient', Boolean
+    has_attr 'volatile', Boolean
+    has_attr 'ordered', Boolean
+    has_attr 'unique', Boolean
+
+    # must be a reference to an PAbstractType contained by the PTypeModel containing this attribute's
+    # containing PClassifier
+    has_one 'p_attribute_type', PAbstractType, :lowerBound => 1
+  end
+
+  class PCatalogEntryClassifier < PClassifier
+    contains_many_uni 'attributes', PAttribute, :lowerBound => 0
+    abstract
+  end
+
+  # Concrete classifier for a HostClass
+  class PHostClassClassifier < PCatalogEntryClassifier
+  end
+
+  # Concrete classifier for a Resource (type)
+  class PResourceClassifier < PCatalogEntryClassifier
+  end
+
+  # Additional Relationships
+  #
+  PClassifier.has_one 'super_classifier', PClassifier, :lowerBound => 0
+
+end


### PR DESCRIPTION
This adds the new catalog model and the start of a PCore model for
modeling the resource types.
