### PR TITLE
(PUP-2079) Add mechanism to allow template files to be copied without getting parsed

### DIFF
--- a/lib/puppet/module_tool/applications/generator.rb
+++ b/lib/puppet/module_tool/applications/generator.rb
@@ -112,6 +112,19 @@ module Puppet::ModuleTool
         end
       end
 
+      class CopiedFileNode < Node
+        def self.matches?(path)
+          path.file? && path.extname == '.copy'
+        end
+        def target
+          path = super
+          path.parent + path.basename('.copy')
+        end
+        def install!
+          FileUtils.cp(@source, target)
+        end
+      end
+
       class ParsedFileNode < Node
         def self.matches?(path)
           path.file? && path.extname == '.erb'


### PR DESCRIPTION
When creating a new module with "puppet module generate", any files
in the skeleton dir named "*.erb" are parsed as Ruby erb templates and
renamed, removing the file extension. This is a pain if you want to
include template files in your skeleton directory.

This commit adds a new Node class: CopiedFileNode. Any files that are
named "*.copy" are copied without being parsed and are renamed, removing
the file extension.

This means you can include erb templates in your skeleton dir by naming
them "foo.erb.copy" and they wil be copied to the new module without
being parsed and will be renamed "foo.erb"
