### PR TITLE
(PUP-2033) Use loglevel for diff output

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -394,7 +394,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             saved_files.map! {|key| @aug.get(key).sub(/^\/files/, root) }
             saved_files.uniq.each do |saved_file|
               if Puppet[:show_diff]
-                notice "\n" + diff(saved_file, saved_file + ".augnew")
+                self.send(@resource[:loglevel], "\n" + diff(saved_file, saved_file + ".augnew"))
               end
               File.delete(saved_file + ".augnew")
             end

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -386,6 +386,7 @@ describe provider_class do
         file = "/etc/hosts"
         File.stubs(:delete)
 
+        @resource[:loglevel] = "crit"
         @resource[:context] = "/files"
         @resource[:changes] = ["set #{file}/foo bar"]
 
@@ -397,7 +398,7 @@ describe provider_class do
         @provider.should be_need_to_run
 
         expect(@logs[0].message).to eq("\ndiff")
-        expect(@logs[0].level).to eq(:notice)
+        expect(@logs[0].level).to eq(:crit)
       end
 
       it "should display a diff for each file that is changed when changing many files" do


### PR DESCRIPTION
This brings the same changes made to the file type for PUP-1846 to the
augeas provider's diffing logic. If a loglevel is specified on the
resource then the diff will be logged at that level. If it is left off,
then the diff will be logged at the notice level.
