### PR TITLE
(PUP-1775) Acquire and block for Yum's lock to prevent corruption

### DIFF
--- a/lib/puppet/provider/package/yumhelper.py
+++ b/lib/puppet/provider/package/yumhelper.py
@@ -6,22 +6,11 @@
 
 import sys
 import string
-import re
 import time
 
-# this maintains compatibility with really old platforms with python 1.x
-from os import popen, WEXITSTATUS
-
-# Try to use the yum libraries by default, but shell out to the yum executable
-# if they are not present (i.e. yum <= 2.0). This is only required for RHEL3
-# and earlier that do not support later versions of Yum. Once RHEL3 is EOL,
-# shell_out() and related code can be removed.
-try:
-    import yum
-except ImportError:
-    useyumlib = 0
-else:
-    useyumlib = 1
+# Try to use the yum libraries by default, which may fail if they are not
+# present (i.e. yum <= 2.0 on RHEL3 and earlier).
+import yum
 
 OVERRIDE_OPTS = {
     'debuglevel': 0,
@@ -51,103 +40,41 @@ def pkg_lists(my):
 
     return my.doPackageLists('updates')
 
-def shell_out():
+try:
+    my = yum.YumBase()
+
     try:
-        p = popen("/usr/bin/env yum check-update 2>&1")
-        output = p.readlines()
-        rc = p.close()
+        # Acquire yum lock to prevent simultaneous DB access
+        lock_count = 300  # 10 mins
+        while True:
+            if lock_count == 0:
+                print "_err timed out acquiring lock"
+                sys.exit(1)
 
-        if rc is not None:
-            # None represents exit code of 0, otherwise the exit code is in the
-            # format returned by wait(). Exit code of 100 from yum represents
-            # updates available.
-            if WEXITSTATUS(rc) != 100:
-                return WEXITSTATUS(rc)
-        else:
-            # Exit code is None (0), no updates waiting so don't both parsing output
-            return 0
-
-        # Yum prints a line of hyphens (old versions) or a blank line between
-        # headers and package data, so skip everything before them
-        skipheaders = 0
-        for line in output:
-            if not skipheaders:
-                if re.compile("^((-){80}|)$").search(line):
-                    skipheaders = 1
-                continue
-
-            # Skip any blank lines
-            if re.compile("^[ \t]*$").search(line):
-                continue
-
-            # Format is:
-            # Yum 1.x: name arch (epoch:)?version
-            # Yum 2.0: name arch (epoch:)?version repo
-            # epoch is optional if 0
-
-            p = string.split(line)
-            pname = p[0]
-            parch = p[1]
-            pevr = p[2]
-
-            # Separate out epoch:version-release
-            evr_re = re.compile("^(\d:)?(\S+)-(\S+)$")
-            evr = evr_re.match(pevr)
-
-            pepoch = ""
-            if evr.group(1) is None:
-                pepoch = "0"
-            else:
-                pepoch = evr.group(1).replace(":", "")
-            pversion = evr.group(2)
-            prelease = evr.group(3)
-
-            print "_pkg", pname, pepoch, pversion, prelease, parch
-
-        return 0
-    except:
-        print sys.exc_info()[0]
-        return 1
-
-if useyumlib:
-    try:
-        my = yum.YumBase()
-
-        try:
-            # Acquire yum lock to prevent simultaneous DB access
-            lock_count = 300  # 10 mins
-            while True:
-                if lock_count == 0:
-                    print "_err timed out acquiring lock"
+            try:
+                my.doLock()
+            except yum.Errors.LockError, e:
+                if e.errno:
+                    print "_err LockError %d %s" % (e.errno, e)
                     sys.exit(1)
-
-                try:
-                    my.doLock()
-                except yum.Errors.LockError, e:
-                    if e.errno:
-                        print "_err LockError %d %s" % (e.errno, e)
-                        sys.exit(1)
-                    else:
-                        time.sleep(2)
-                        lock_count = lock_count - 1
                 else:
-                    break
+                    time.sleep(2)
+                    lock_count = lock_count - 1
+            else:
+                break
 
-            ypl = pkg_lists(my)
-            for pkg in ypl.updates:
-                print "_pkg %s %s %s %s %s" % (pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)
-        finally:
-            my.closeRpmDB()
-            my.doUnlock()
-    except IOError, e:
-        print "_err IOError %d %s" % (e.errno, e)
-        sys.exit(1)
-    except AttributeError, e:
-        # catch yumlib errors in buggy 2.x versions of yum
-        print "_err AttributeError %s" % e
-        sys.exit(1)
-else:
-    rc = shell_out()
-    sys.exit(rc)
+        ypl = pkg_lists(my)
+        for pkg in ypl.updates:
+            print "_pkg %s %s %s %s %s" % (pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)
+    finally:
+        my.closeRpmDB()
+        my.doUnlock()
+except IOError, e:
+    print "_err IOError %d %s" % (e.errno, e)
+    sys.exit(1)
+except AttributeError, e:
+    # catch yumlib errors in buggy 2.x versions of yum
+    print "_err AttributeError %s" % e
+    sys.exit(1)
 
 # vim: tabstop=4:softtabstop=4:shiftwidth=4:expandtab


### PR DESCRIPTION
Yum tools always attempt to acquire a global lock to prevent database
corruption by blocking.  This change adds lock acquisition to the yumhelper
which is called by the yum package provider, looping until either a timeout
is reached or the lock acquisition was successful.

Replaces #2387
