### PR TITLE
(PUP-1332) Add instantiated upstart services to exclude list

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -47,6 +47,9 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     # by the fix for this (bug https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/982889)
     # due to puppet's inability to deal with upstart services with instances.
     excludes += %w{plymouth-ready}
+    # Prevent puppet failing to get status of these services, which need parameters
+    # passed in (see https://bugs.launchpad.net/ubuntu/+source/puppet/+bug/1276766).
+    excludes += %w{idmapd-mounting startpar-bridge}
   end
 
   # List all services of this type.

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -50,7 +50,7 @@ describe Puppet::Type.type(:service).provider(:upstart) do
     end
 
     it "should not find excluded services" do
-      processes = "wait-for-state stop/waiting\nportmap-wait start/running"
+      processes = "wait-for-state stop/waiting\nportmap-wait start/running\nidmapd-mounting stop/waiting\nstartpar-bridge start/running"
       provider_class.stubs(:execpipe).yields(processes)
       provider_class.instances.should be_empty
     end


### PR DESCRIPTION
Previously puppet would fail when trying to list all services because some
services require parameters for status queries to succeed. These include
idmapd-mounting and startpar-bridge. This commit adds those services to the
exclude list so that they are ignored when querying upstart for their status.
