### PR TITLE
(PUP-2039) Fix rpm package provider usage of --whatprovides.

### DIFF
--- a/spec/unit/provider/package/aptrpm_spec.rb
+++ b/spec/unit/provider/package/aptrpm_spec.rb
@@ -16,14 +16,17 @@ describe Puppet::Type.type(:package).provider(:aptrpm) do
       Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "--version"], {:combine => true, :custom_environment => {}, :failonfail => true}).returns("4.10.1\n").at_most_once
     end
 
-    def rpm
-      pkg.provider.expects(:rpm).
-        with('-q', '--whatprovides', 'faff', '--nosignature', '--nodigest', '--qf',
-             "%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\\n")
+    def rpm_args
+      ['-q', 'faff', '--nosignature', '--nodigest', '--qf', "%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\\n"]
+    end
+
+    def rpm(args = rpm_args)
+      pkg.provider.expects(:rpm).with(*args)
     end
 
     it "should report absent packages" do
       rpm.raises(Puppet::ExecutionFailure, "couldn't find rpm")
+      rpm(rpm_args + ['--whatprovides']).raises(Puppet::ExecutionFailure, 'no package provides faff')
       pkg.property(:ensure).retrieve.should == :absent
     end
 

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -188,7 +188,7 @@ describe provider_class do
 
     describe "on a modern RPM" do
       before(:each) do
-        Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "--whatprovides", "myresource", '--nosignature', '--nodigest', "--qf", nevra_format], execute_options).returns("myresource 0 1.2.3.4 5.el4 noarch\n")
+        Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "myresource", '--nosignature', '--nodigest', "--qf", nevra_format], execute_options).returns("myresource 0 1.2.3.4 5.el4 noarch\n")
       end
 
       let(:rpm_version) { "RPM version 4.10.0\n" }
@@ -201,7 +201,7 @@ describe provider_class do
 
     describe "on an ancient RPM" do
       before(:each) do
-        Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "--whatprovides", "myresource", '', '', '--qf', nevra_format], execute_options).returns("myresource 0 1.2.3.4 5.el4 noarch\n")
+        Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "myresource", '', '', '--qf', nevra_format], execute_options).returns("myresource 0 1.2.3.4 5.el4 noarch\n")
       end
 
       let(:rpm_version) { "RPM version 3.0.6\n" }
@@ -214,7 +214,7 @@ describe provider_class do
 
     describe "when uninstalled with options" do
       before(:each) do
-        Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "--whatprovides", "myresource", '--nosignature', '--nodigest', "--qf", nevra_format], execute_options).returns("myresource 0 1.2.3.4 5.el4 noarch\n")
+        Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "myresource", '--nosignature', '--nodigest', "--qf", nevra_format], execute_options).returns("myresource 0 1.2.3.4 5.el4 noarch\n")
       end
 
       let(:resource) do
@@ -236,7 +236,7 @@ describe provider_class do
   describe "parsing" do
     def parser_test(rpm_output_string, gold_hash, number_of_debug_logs = 0)
       Puppet.expects(:debug).times(number_of_debug_logs)
-      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "--whatprovides", resource_name, "--nosignature", "--nodigest", "--qf", nevra_format], execute_options).returns(rpm_output_string)
+      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", resource_name, "--nosignature", "--nodigest", "--qf", nevra_format], execute_options).returns(rpm_output_string)
       expect(provider.query).to eq(gold_hash)
     end
 
@@ -275,9 +275,26 @@ describe provider_class do
 
     it "does not log or fail if rpm returns package not found" do
       Puppet.expects(:debug).never
-      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "--whatprovides", resource_name, "--nosignature", "--nodigest", "--qf", nevra_format], execute_options).raises Puppet::ExecutionFailure.new('package not found')
-
+      expected_args = ["/bin/rpm", "-q", resource_name, "--nosignature", "--nodigest", "--qf", nevra_format]
+      Puppet::Util::Execution.expects(:execute).with(expected_args, execute_options).raises Puppet::ExecutionFailure.new("package #{resource_name} is not installed")
+      Puppet::Util::Execution.expects(:execute).with(expected_args + ["--whatprovides"], execute_options).raises Puppet::ExecutionFailure.new("no package provides #{resource_name}")
       expect(provider.query).to be_nil
+    end
+
+    it "parses virtual package" do
+      #Puppet.expects(:debug).never
+      expected_args = ["/bin/rpm", "-q", resource_name, "--nosignature", "--nodigest", "--qf", nevra_format]
+      Puppet::Util::Execution.expects(:execute).with(expected_args, execute_options).raises Puppet::ExecutionFailure.new("package #{resource_name} is not installed")
+      Puppet::Util::Execution.expects(:execute).with(expected_args + ["--whatprovides"], execute_options).returns "myresource 0 1.2.3.4 5.el4 noarch\n"
+      expect(provider.query).to eq({
+        :name     => "myresource",
+        :epoch    => "0",
+        :version  => "1.2.3.4",
+        :release  => "5.el4",
+        :arch     => "noarch",
+        :provider => :rpm,
+        :ensure   => "1.2.3.4-5.el4"
+      })
     end
   end
 


### PR DESCRIPTION
The fix for PUP-897 (commit ecb761e24a) introduced always passing
--whatprovides to rpm when querying for packages. This breaks querying
for packages that have architectures specified, e.g.
'vim-enhanced.x86_64'.

The proper way to do this is to first query without --whatprovides and
see if rpm finds a package by the given name.  If rpm fails to find a
package, fallback to using --whatprovides to support querying for
virtual package names.
