### PR TITLE
(PUP-2074) resourses unless_uid depends on unless_system_user

### DIFF
--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -139,7 +139,7 @@ Puppet::Type.newtype(:resources) do
   # Make sure we don't purge users with specific uids
   def user_check(resource)
     return true unless self[:name] == "user"
-    return true unless self[:unless_system_user]
+    return true unless self[:unless_system_user] || self[:unless_uid]
     resource[:audit] = :uid
     current_values = resource.retrieve_resource
     current_uid = current_values[resource.property(:uid)]
@@ -154,7 +154,11 @@ Puppet::Type.newtype(:resources) do
       end
     end
 
-    current_uid > self[:unless_system_user]
+    if self[:unless_system_user] 
+      current_uid > self[:unless_system_user]
+    else
+      true
+    end
   end
 
   def system_users


### PR DESCRIPTION
Fixing a situation where using 'unless_uid' on resources type requires unless_system_user also being true.
