### PR TITLE
(PUP-1937) Revert changes to with_version

### DIFF
--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -20,9 +20,9 @@ agents.each do |agent|
 
   step "  install module '#{module_author}-#{module_name}'"
 
-  #command = agent['platform'] =~ /windows/ ?
-  #  Command.new("cmd.exe /c 'puppet module install --version \"<#{module_version}\" #{module_author}-#{module_name}'") :
-  command = puppet("module install --version \"<#{module_version}\" #{module_author}-#{module_name}")
+  command = agent['platform'] =~ /windows/ ?
+    Command.new("cmd.exe /c 'puppet module install --version \"<#{module_version}\" #{module_author}-#{module_name}'") :
+    command = puppet("module install --version \"<#{module_version}\" #{module_author}-#{module_name}")
 
   on(agent, command) do
     assert_module_installed_ui(stdout, module_author, module_name, module_version, '<')


### PR DESCRIPTION
Changes were made to with_version for Windows to use beaker's puppet
command instead of Command.new directly. This change is now reverted.
