### PR TITLE
Maint: Fix buggy auth.conf example in fileserver.conf

### DIFF
--- a/conf/fileserver.conf
+++ b/conf/fileserver.conf
@@ -30,12 +30,13 @@
 # Every static mount point should have an `allow *` line; setting more
 # granular permissions in this file is deprecated. Instead, you can
 # control file access in auth.conf by controlling the
-# /file_metadata/<mount point> and /file_content/<mount point> paths:
+# /file_metadata(s)/<mount point> and /file_content(s)/<mount point> paths.
+# For example:
 #
-# path ~ ^/file_(metadata|content)/extra_files/
+# path ~ ^/file_(metadata|content)s?/extra_files/
 # auth yes
 # allow /^(.+)\.example\.com$/
 # allow_ip 192.168.100.0/24
 #
-# If added to auth.conf BEFORE the "path /file" rule, the rule above
+# If added to auth.conf BEFORE the default "path /file" rule, this rule
 # will add stricter restrictions to the extra_files mount point.


### PR DESCRIPTION
To really get this to work right, you need to include the pluralized versions of
each. I missed that the first time around.
