### PR TITLE
(PUP-2096) Support alternate http client classes in http_pool

### DIFF
--- a/lib/puppet/network/http_pool.rb
+++ b/lib/puppet/network/http_pool.rb
@@ -17,8 +17,8 @@ module Puppet::Network::HttpPool
   def self.http_client_class
     @http_client_class
   end
-  def self.set_http_client_class(clazz)
-    @http_client_class = clazz
+  def self.http_client_class=(klass)
+    @http_client_class = klass
   end
 
   # Retrieve a connection for the given host and port.

--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -28,13 +28,13 @@ describe Puppet::Network::HttpPool do
         end
 
         orig_class = Puppet::Network::HttpPool.http_client_class
-        Puppet::Network::HttpPool.set_http_client_class(FooClient)
+        Puppet::Network::HttpPool.http_client_class = FooClient
         http = Puppet::Network::HttpPool.http_instance("me", 54321)
         http.should be_an_instance_of FooClient
         http.host.should == 'me'
         http.port.should == 54321
       ensure
-        Puppet::Network::HttpPool.set_http_client_class(orig_class)
+        Puppet::Network::HttpPool.http_client_class = orig_class
       end
     end
 


### PR DESCRIPTION
This commit modifies Puppet::Network::HttpPool by adding a
`set_http_client_class` method, which can be used to override
the implementation class that we use as our HTTP client.
