### PR TITLE
(PUP-2100) Use AddAccessDeniedAceEx for inheritance

### DIFF
--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -398,11 +398,13 @@ module Puppet::Util::Windows::Security
     end
   end
 
-  def add_access_denied_ace(acl, mask, sid)
+  def add_access_denied_ace(acl, mask, sid, inherit = nil)
+    inherit ||= NO_INHERITANCE
+
     string_to_sid_ptr(sid) do |sid_ptr|
       raise Puppet::Util::Windows::Error.new("Invalid SID") unless IsValidSid(sid_ptr)
 
-      unless AddAccessDeniedAce(acl, ACL_REVISION, mask, sid_ptr)
+      unless AddAccessDeniedAceEx(acl, ACL_REVISION, inherit, mask, sid_ptr)
         raise Puppet::Util::Windows::Error.new("Failed to add access control entry")
       end
     end
@@ -606,7 +608,7 @@ module Puppet::Util::Windows::Security
                   add_access_allowed_ace(acl, ace.mask, ace.sid, ace.flags)
                 when ACCESS_DENIED_ACE_TYPE
                   #puts "ace: deny, sid #{sid_to_name(ace.sid)}, mask 0x#{ace.mask.to_s(16)}"
-                  add_access_denied_ace(acl, ace.mask, ace.sid)
+                  add_access_denied_ace(acl, ace.mask, ace.sid, ace.flags)
                 else
                   raise "We should never get here"
                   # TODO: this should have been a warning in an earlier commit

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -826,6 +826,23 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
       end.should_not be_nil
     end
 
+    it "allows deny ACEs with inheritance" do
+      # inheritance can only be set on directories
+      dir = tmpdir('denyaces')
+
+      inherit_flags = Puppet::Util::Windows::AccessControlEntry::OBJECT_INHERIT_ACE |
+          Puppet::Util::Windows::AccessControlEntry::CONTAINER_INHERIT_ACE
+
+      sd = winsec.get_security_descriptor(dir)
+      sd.dacl.deny(sids[:guest], Windows::File::FILE_ALL_ACCESS, inherit_flags)
+      winsec.set_security_descriptor(dir, sd)
+
+      sd = winsec.get_security_descriptor(dir)
+      sd.dacl.find do |ace|
+        ace.sid == sids[:guest] && ace.flags != 0
+      end.should_not be_nil
+    end
+
     context "when managing mode" do
       it "removes aces for sids that are neither the owner nor group" do
         # add a guest ace, it's never owner or group


### PR DESCRIPTION
With Access Control Entries (ACEs) on Windows, we currently use AddAccessDeniedAce
which does not include inheritance and propagation, but AddAccessDeniedAceEx does.
We are already using AddAccessAllowedAceEx when setting access allowed ACEs and
we should use the same behavior for denied ACEs. This commit provides that ability.
Without this commit we will not be able to properly manage access denied
ACEs with inheritance to child objects.
