### PR TITLE
Change Crypto Spec in accordance to bettercrypto.org

### DIFF
--- a/ext/rack/example-passenger-vhost.conf
+++ b/ext/rack/example-passenger-vhost.conf
@@ -19,7 +19,7 @@ Listen 8140
 <VirtualHost *:8140>
         SSLEngine on
         SSLProtocol ALL -SSLv2 -SSLv3
-        SSLCipherSuite EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+AES256:+AES128:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!IDEA:!SEED:!ECDSA:ES256-SHA:AES128-SHA
+        SSLCipherSuite EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA
         SSLCertificateFile      /etc/puppet/ssl/certs/squigley.namespace.at.pem
         SSLCertificateKeyFile   /etc/puppet/ssl/private_keys/squigley.namespace.at.pem
         SSLCertificateChainFile /etc/puppet/ssl/ca/ca_crt.pem


### PR DESCRIPTION
The current puppet passanger crypto spec is 5yrs old (talked to the original author). I've adapted it to something sane and have taken the current recommendations for it by the bettercrypto(.org) project.
