### PR TITLE
(maint) Reduce travis notifications to a one-liner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ notifications:
     channels:
       - "chat.freenode.net#puppet-dev"
     template:
-      - "%{repository} (%{branch} - %{commit} : %{author}): %{message}"
-      - "Change view : %{compare_url}"
-      - "Build details : %{build_url}"
+      - "%{repository_name} %{branch} %{message}: %{build_url}"
 rvm:
   - 2.1.0
   - 2.0.0


### PR DESCRIPTION
This version drops the repo owner (all ours are puppetlabs so
no info there), the sha (do we care?), the author (there can be
several), and the change url, and collapses the build url onto
that one line.

It's an attempt at improving the s/n ratio of these notifications
to see if they're worth sticking with.
