### PR TITLE
(maint) Consolidate redundant join_options implementations.

### DIFF
--- a/lib/puppet/provider/package.rb
+++ b/lib/puppet/provider/package.rb
@@ -25,4 +25,28 @@ class Puppet::Provider::Package < Puppet::Provider
   def validate_source(value)
     true
   end
+
+  # Turns a array of options into flags to be passed to a command.
+  # The options can be passed as a string or hash. Note that passing a hash
+  # should only be used in case --foo=bar must be passed,
+  # which can be accomplished with:
+  #     install_options => [ { '--foo' => 'bar' } ]
+  # Regular flags like '--foo' must be passed as a string.
+  # @param options [Array]
+  # @return Concatenated list of options
+  # @api private
+  def join_options(options)
+    return unless options
+
+    options.collect do |val|
+      case val
+        when Hash
+          val.keys.sort.collect do |k|
+            "#{k}=#{val[k]}"
+          end
+        else
+          val
+      end
+    end.flatten
+  end
 end

--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -109,19 +109,4 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
   def install_options
     join_options(@resource[:install_options])
   end
-
-  def join_options(options)
-    return unless options
-
-    options.collect do |val|
-      case val
-      when Hash
-        val.keys.sort.collect do |k|
-          "#{k}=#{val[k]}"
-        end
-      else
-        val
-      end
-    end.flatten
-  end
 end

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -97,7 +97,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
       command << "--no-rdoc" << "--no-ri" << resource[:name]
     end
 
-    command << install_options if resource[:install_options]
+    command += install_options if resource[:install_options]
 
     output = execute(command)
     # Apparently some stupid gem versions don't exit non-0 on failure
@@ -127,20 +127,5 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
   def install_options
     join_options(resource[:install_options])
-  end
-
-  def join_options(options)
-    return unless options
-
-    options.collect do |val|
-      case val
-      when Hash
-        val.keys.sort.collect do |k|
-          "#{k}=#{val[k]}"
-        end.join(' ')
-      else
-        val
-      end
-    end
   end
 end

--- a/lib/puppet/provider/package/msi.rb
+++ b/lib/puppet/provider/package/msi.rb
@@ -122,19 +122,4 @@ Puppet::Type.type(:package).provide(:msi, :parent => Puppet::Provider::Package) 
   def shell_quote(value)
     value.include?(' ') ? %Q["#{value.gsub(/"/, '\"')}"] : value
   end
-
-  def join_options(options)
-    return unless options
-
-    options.collect do |val|
-      case val
-      when Hash
-        val.keys.sort.collect do |k|
-          "#{k}=#{val[k]}"
-        end.join(' ')
-      else
-        val
-      end
-    end
-  end
 end

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -141,30 +141,6 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
     join_options(resource[:uninstall_options])
   end
 
-  # Turns a array of options into flags to be passed to pkg_add(8) and
-  # pkg_delete(8). The options can be passed as a string or hash. Note
-  # that passing a hash should only be used in case -Dfoo=bar must be passed,
-  # which can be accomplished with:
-  #     install_options => [ { '-Dfoo' => 'bar' } ]
-  # Regular flags like '-L' must be passed as a string.
-  # @param options [Array]
-  # @return Concatenated list of options
-  # @api private
-  def join_options(options)
-    return unless options
-
-    options.collect do |val|
-      case val
-      when Hash
-        val.keys.sort.collect do |k|
-          "#{k}=#{val[k]}"
-        end.join(' ')
-      else
-        val
-      end
-    end
-  end
-
   def uninstall
     pkgdelete uninstall_options.flatten.compact.join(' '), @resource[:name]
   end

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -111,7 +111,6 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
   end
 
   def install
-    source = nil
     unless source = @resource[:source]
       @resource.fail "RPMs must specify a package source"
     end
@@ -124,8 +123,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
 
     flag = ["-i"]
     flag = ["-U", "--oldpackage"] if @property_hash[:ensure] and @property_hash[:ensure] != :absent
-
-    flag = flag + install_options
+    flag += install_options if resource[:install_options]
     rpm flag, source
   end
 
@@ -149,7 +147,8 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
       end
     end
 
-    flag = ["-e"] + uninstall_options
+    flag = ['-e']
+    flag += uninstall_options if resource[:uninstall_options]
     rpm flag, nvr
   end
 
@@ -166,31 +165,6 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
   end
 
   private
-
-  # Turns a array of options into flags to be passed to rpm install(8) and
-  # The options can be passed as a string or hash. Note that passing a hash
-  # should only be used in case -Dfoo=bar must be passed,
-  # which can be accomplished with:
-  #     install_options => [ { '-Dfoo' => 'bar' } ]
-  # Regular flags like '-L' must be passed as a string.
-  # @param options [Array]
-  # @return Concatenated list of options
-  # @api private
-  def join_options(options)
-    return [] unless options
-
-    options.collect do |val|
-      case val
-      when Hash
-        val.keys.sort.collect do |k|
-          "#{k}=#{val[k]}"
-        end.join(' ')
-      else
-        val
-      end
-    end
-  end
-
   # @param line [String] one line of rpm package query information
   # @return [Hash] of NEVRA_FIELDS strings parsed from package info
   # or an empty hash if we failed to parse

--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -105,19 +105,4 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
   def uninstall_options
     join_options(resource[:uninstall_options])
   end
-
-  def join_options(options)
-    return unless options
-
-    options.collect do |val|
-      case val
-      when Hash
-        val.keys.sort.collect do |k|
-          "#{k}=#{val[k]}"
-        end.join(' ')
-      else
-        val
-      end
-    end
-  end
 end

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -110,22 +110,4 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     yum "-y", :erase, @resource[:name]
   end
 
-  def install_options
-    join_options(resource[:install_options])
-  end
-
-  def join_options(options)
-    return unless options
-
-    options.collect do |val|
-      case val
-      when Hash
-        val.keys.sort.collect do |k|
-          "#{k} '#{val[k]}'"
-        end.join(' ')
-      else
-        val
-      end
-    end
-  end
 end

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -82,23 +82,4 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
     # zypper install can be used for update, too
     self.install
   end
-
-  def install_options
-    join_options(resource[:install_options])
-  end
-
-  def join_options(options)
-    return unless options
-
-    options.collect do |val|
-      case val
-      when Hash
-        val.keys.sort.collect do |k|
-          "#{k}=#{val[k]}"
-        end
-      else
-        val
-      end
-    end.flatten
-  end
 end

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -55,7 +55,7 @@ describe provider_class do
 
     it "should allow setting an install_options parameter" do
       resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      provider.expects(:execute).with { |args| args[5] == ["--force", "--bindir=/usr/bin"] }.returns ""
+      provider.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
       provider.install
     end
 

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -299,8 +299,8 @@ describe provider_class do
   end
 
   describe "#install_options" do
-    it "returns empty array by default" do
-      expect(provider.install_options).to eq([])
+    it "returns nil by default" do
+      expect(provider.install_options).to eq(nil)
     end
 
     it "returns install_options when set" do
@@ -314,7 +314,7 @@ describe provider_class do
     end
 
     it 'returns install_options when set as hash' do
-      provider.resource[:install_options] = { '-Darch' => 'vax' }
+      provider.resource[:install_options] = [{ '-Darch' => 'vax' }]
       expect(provider.install_options).to eq(['-Darch=vax'])
     end
 
@@ -325,8 +325,8 @@ describe provider_class do
   end
 
   describe "#uninstall_options" do
-    it "returns empty array by default" do
-      expect(provider.uninstall_options).to eq([])
+    it "returns nil by default" do
+      expect(provider.uninstall_options).to eq(nil)
     end
 
     it "returns uninstall_options when set" do
@@ -340,7 +340,7 @@ describe provider_class do
     end
 
     it 'returns uninstall_options when set as hash' do
-      provider.resource[:uninstall_options] = { '-Darch' => 'vax' }
+      provider.resource[:uninstall_options] = [{ '-Darch' => 'vax' }]
       expect(provider.uninstall_options).to eq(['-Darch=vax'])
     end
     it 'returns uninstall_options when an array with hashes' do

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -241,7 +241,7 @@ describe Puppet::Type.type(:package).provider(:windows) do
     end
 
     it 'should sort hash keys' do
-      provider.join_options([{'b' => '2', 'a' => '1', 'c' => '3'}]).should == ['a=1 b=2 c=3']
+      provider.join_options([{'b' => '2', 'a' => '1', 'c' => '3'}]).should == ['a=1', 'b=2', 'c=3']
     end
 
     it 'should return strings and hashes' do

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -72,7 +72,7 @@ describe provider_class do
       resource[:ensure] = :installed
       resource[:install_options] = ['-t', {'-x' => 'expackage'}]
 
-      provider.expects(:yum).with('-d', '0', '-e', '0', '-y', ["-t", "-x 'expackage'"], :install, 'mypackage')
+      provider.expects(:yum).with('-d', '0', '-e', '0', '-y', ['-t', '-x=expackage'], :install, 'mypackage')
       provider.install
     end
   end


### PR DESCRIPTION
Moving the implementation of join_options into the base package provider.
This gives a consistent behavior between all package providers that support install_options.
