### PR TITLE
(PUP-2150) Fix yumrepo backwards compatibility issues.

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -13,6 +13,19 @@ Puppet::Type.newtype(:yumrepo) do
     are not supported. This type does not attempt to read or verify the
     exinstence of files listed in the `include` attribute."
 
+  def initialize(*args)
+    super
+    # For backwards compatibility we ensure the entire file is set absent
+    # if any of these properties are also set to absent.  This was because
+    # prior to the refactoring there was no ensure property.  Hopefully
+    # this will account for all known url based absent methods in use.
+    if self[:mirrorlist] == :absent or self[:baseurl] == :absent or
+    self[:gpgkey] == :absent or self[:include] == :absent or self[:proxy] ==
+    :absent or self[:metalink] == :absent
+      self[:ensure] = :absent
+    end
+  end
+
   # Ensure yumrepos can be removed too.
   ensurable
   # Doc string for properties that can be made 'absent'
@@ -46,8 +59,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -56,8 +71,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -92,8 +109,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -104,8 +123,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -201,9 +222,12 @@ Puppet::Type.newtype(:yumrepo) do
     desc "URL to the proxy server for this repository. #{ABSENT_DOC}"
 
     newvalues(/.*/, :absent)
+
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value.to_sym == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -262,8 +286,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -13,11 +13,12 @@ describe Puppet::Type.type(:yumrepo) do
       yumrepo[:name].should == "puppetlabs"
     end
 
-    [:baseurl, :cost, :descr, :enabled, :enablegroups, :exclude, :failovermethod,
-     :gpgcheck, :repo_gpgcheck, :gpgkey, :http_caching, :include, :includepkgs, :keepalive,
-     :metadata_expire, :mirrorlist, :priority, :protect, :proxy, :proxy_username,
-     :proxy_password, :timeout, :sslcacert, :sslverify, :sslclientcert,
-     :sslclientkey, :s3_enabled, :metalink].each do |param|
+    [:baseurl, :cost, :descr, :enabled, :enablegroups, :exclude,
+     :failovermethod, :gpgcheck, :repo_gpgcheck, :gpgkey, :http_caching,
+     :include, :includepkgs, :keepalive, :metadata_expire, :mirrorlist,
+     :priority, :protect, :proxy, :proxy_username, :proxy_password, :timeout,
+     :sslcacert, :sslverify, :sslclientcert, :sslclientkey, :s3_enabled,
+     :metalink].each do |param|
       it "should have a '#{param}' parameter" do
         Puppet::Type.type(:yumrepo).attrtype(param).should == :property
       end
@@ -25,8 +26,10 @@ describe Puppet::Type.type(:yumrepo) do
   end
 
   describe "When validating attribute values" do
-    [:cost, :enabled, :enablegroups, :failovermethod, :gpgcheck, :repo_gpgcheck, :http_caching,
-     :keepalive, :metadata_expire, :priority, :protect, :timeout].each do |param|
+    [:baseurl, :cost, :enabled, :enablegroups, :failovermethod, :gpgcheck,
+     :gpgkey, :include, :repo_gpgcheck, :http_caching, :keepalive,
+     :metadata_expire, :metalink, :mirrorlist, :priority, :protect, :proxy,
+     :timeout].each do |param|
       it "should support :absent as a value to '#{param}' parameter" do
         Puppet::Type.type(:yumrepo).new(:name => 'puppetlabs', param => :absent)
       end


### PR DESCRIPTION
Previously users relied on setting various urls to absent to stop
the yumrepo from being created.  (verified by 3.4.3 testing).  This
attempts to mimic that behavior by checking if any url properties
are set to absent and then forcing ensure to absent to match.
