### PR TITLE
(maint) Return last serial from SSL inventory

### DIFF
--- a/lib/puppet/ssl/inventory.rb
+++ b/lib/puppet/ssl/inventory.rb
@@ -36,15 +36,17 @@ class Puppet::SSL::Inventory
   end
 
   # Find the serial number for a given certificate.
+  # In case there are multiple matches, return most recent
   def serial(name)
     return nil unless Puppet::FileSystem.exist?(@path)
 
+    ret = nil
     File.readlines(@path).each do |line|
       next unless line =~ /^(\S+).+\/CN=#{name}$/
 
-      return Integer($1)
+      ret = Integer($1)
     end
 
-    return nil
+    return ret
   end
 end

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -132,6 +132,12 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
 
         @inventory.serial("me").should == 15
       end
+
+      it "should return the last serial if there more than one for the cert name" do
+        File.expects(:readlines).with(cert_inventory).returns ["0x00e blah blah /CN=me\n", "0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n"]
+
+        @inventory.serial("me").should == 15
+      end
     end
   end
 end


### PR DESCRIPTION
If a cert has been revoked and issued again with same name we should
return the new serial instead of the old revoked one.
