### PR TITLE
(WIP) (PUP-2150) Fix yumrepo backwards compatibility issues.

### DIFF
--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -141,6 +141,7 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
     PROPERTIES.each do |property|
       next if property == :ensure
       if value = @resource.should(property)
+        next if value == :absent
         new_section[property.to_s] = value
         @property_hash[property] = value
       end
@@ -174,7 +175,12 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
     next if property == :ensure
     # Builds the property= method.
     define_method("#{property.to_s}=") do |value|
-      section(@property_hash[:name])[property.to_s] = value
+      newvalue = @resource.should(property)
+      if newvalue == :absent
+        section(@property_hash[:name]).remove_line(property.to_s)
+      else
+        section(@property_hash[:name])[property.to_s] = value
+      end
       @property_hash[property] = value
     end
   end

--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -46,8 +46,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -56,8 +58,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -92,8 +96,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -104,8 +110,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -201,9 +209,12 @@ Puppet::Type.newtype(:yumrepo) do
     desc "URL to the proxy server for this repository. #{ABSENT_DOC}"
 
     newvalues(/.*/, :absent)
+
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value.to_sym == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -262,8 +273,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      unless value == :absent
+        parsed = URI.parse(value)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 

--- a/lib/puppet/util/inifile.rb
+++ b/lib/puppet/util/inifile.rb
@@ -47,6 +47,16 @@ module Puppet::Util::IniConfig
       @entries << line
     end
 
+    # Allow us to remove entire entries if required.
+    def remove_line(entry)
+      @entries.each do |e|
+        if e.include?(entry)
+          @entries.delete(e)
+          @dirty = true
+        end
+      end
+    end
+
     # Set the entry 'key=value'. If no entry with the
     # given key exists, one is appended to teh end of the section
     def []=(key, value)
@@ -148,7 +158,11 @@ module Puppet::Util::IniConfig
     def store
       @files.each do |file, lines|
         text = ""
-        dirty = false
+        unless Puppet::FileSystem.exist?(file)
+          dirty = true
+        else
+          dirty = false
+        end
         destroy = false
         lines.each do |l|
           if l.is_a?(Section)

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -13,11 +13,12 @@ describe Puppet::Type.type(:yumrepo) do
       yumrepo[:name].should == "puppetlabs"
     end
 
-    [:baseurl, :cost, :descr, :enabled, :enablegroups, :exclude, :failovermethod,
-     :gpgcheck, :repo_gpgcheck, :gpgkey, :http_caching, :include, :includepkgs, :keepalive,
-     :metadata_expire, :mirrorlist, :priority, :protect, :proxy, :proxy_username,
-     :proxy_password, :timeout, :sslcacert, :sslverify, :sslclientcert,
-     :sslclientkey, :s3_enabled, :metalink].each do |param|
+    [:baseurl, :cost, :descr, :enabled, :enablegroups, :exclude,
+     :failovermethod, :gpgcheck, :repo_gpgcheck, :gpgkey, :http_caching,
+     :include, :includepkgs, :keepalive, :metadata_expire, :mirrorlist,
+     :priority, :protect, :proxy, :proxy_username, :proxy_password, :timeout,
+     :sslcacert, :sslverify, :sslclientcert, :sslclientkey, :s3_enabled,
+     :metalink].each do |param|
       it "should have a '#{param}' parameter" do
         Puppet::Type.type(:yumrepo).attrtype(param).should == :property
       end
@@ -25,8 +26,10 @@ describe Puppet::Type.type(:yumrepo) do
   end
 
   describe "When validating attribute values" do
-    [:cost, :enabled, :enablegroups, :failovermethod, :gpgcheck, :repo_gpgcheck, :http_caching,
-     :keepalive, :metadata_expire, :priority, :protect, :timeout].each do |param|
+    [:baseurl, :cost, :enabled, :enablegroups, :failovermethod, :gpgcheck,
+     :gpgkey, :include, :repo_gpgcheck, :http_caching, :keepalive,
+     :metadata_expire, :metalink, :mirrorlist, :priority, :protect, :proxy,
+     :timeout].each do |param|
       it "should support :absent as a value to '#{param}' parameter" do
         Puppet::Type.type(:yumrepo).new(:name => 'puppetlabs', param => :absent)
       end


### PR DESCRIPTION
Previously the yumrepo type properly supported setting properties
to absent and having them be appropriately deleted from the files.
This work readds this functionality by extending inifile to allow
us to delete entries, as well as always mark the file dirty if it
didn't exist already, making sure even just a blank [x] file can
be written out.
