### PR TITLE
(PUP-2162) Fix multiple baseurl/gpgkeys.

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -56,8 +56,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      value.split(' ').each do |uri|
+        parsed = URI.parse(uri)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 
@@ -92,8 +94,10 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      parsed = URI.parse(value)
-      fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      value.split(' ').each do |uri|
+        parsed = URI.parse(uri)
+        fail("Must be a valid URL") unless ['file', 'http', 'https', 'ftp'].include?(parsed.scheme)
+      end
     end
   end
 

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -74,5 +74,14 @@ describe Puppet::Type.type(:yumrepo) do
         expect { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", param => "gopher://example.com/") }.to raise_error
       end
     end
+
+    [:baseurl, :gpgkey].each do |param|
+      it 'should accept multiple urls' do
+        Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", param => "http://localhost/1 http://localhost/2")
+      end
+      it 'should fail if one element is wrong' do
+        expect { Puppet::Type.type(:yumrepo).new(:name => "puppetlabs", param => "http://localhost/1 localhost/2") }.to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Yum supports multiple URLs for baseurl and gpgkey, but we weren't
accounting for this in the validation stage.  This work fixes that.
