### PR TITLE
(PUP-2168) Fix systemd service enumeration on system 212

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def self.instances
     i = []
     output = systemctl('list-units', '--type', 'service', '--full', '--all',  '--no-pager')
-    output.scan(/^(\S+)\s+(loaded|error)\s+(active|inactive)\s+(active|waiting|running|plugged|mounted|dead|exited|listening|elapsed)\s*?(\S.*?)?$/i).each do |m|
+    output.scan(/(\S+)\s+(loaded|error|not-found)\s+(active|inactive)\s+(active|waiting|running|plugged|mounted|dead|exited|listening|elapsed)\s*?(\S.*?)?$/i).each do |m|
       i << new(:name => m[0])
     end
     return i


### PR DESCRIPTION
systemd 212 has a different output format for the `systemctl list-services`
command, which includes some white space with some circle symbols, before the
unit names. Without this patch, `puppet resource service` does not enumerate
any services on the system at all, running or otherwise.

Additionally, the "not-found" state seems to be possible as well as "error"
and "loaded", so include that as well.
