### PR TITLE
(PUP-1986) Ignore source_permissions when downloading plugins on POSIX

### DIFF
--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -48,23 +48,25 @@ class Puppet::Configurer::Downloader
   require 'sys/admin' if Puppet.features.microsoft_windows?
 
   def default_arguments
-    {
+    defargs = {
       :path => path,
       :recurse => true,
       :source => source,
+      :source_permissions => :ignore,
       :tag => name,
       :purge => true,
       :force => true,
       :backup => false,
       :noop => false
-    }.merge(
-      Puppet.features.microsoft_windows? ? {
-        :source_permissions => :ignore
-      } :
-      {
-        :owner => Process.uid,
-        :group => Process.gid
-      }
-    )
+    }
+    if !Puppet.features.microsoft_windows?
+      defargs.merge!(
+        {
+          :owner => Process.uid,
+          :group => Process.gid
+        }
+      )
+    end
+    return defargs
   end
 end

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -51,6 +51,11 @@ describe Puppet::Configurer::Downloader do
       @dler.file
     end
 
+    it "should set source_permissions to ignore" do
+      Puppet::Type.type(:file).expects(:new).with { |opts| opts[:source_permissions] == :ignore }
+      @dler.file
+    end
+
     describe "on POSIX", :as_platform => :posix do
       it "should always set the owner to the current UID" do
         Process.expects(:uid).returns 51
@@ -73,11 +78,6 @@ describe Puppet::Configurer::Downloader do
 
       it "should omit the group" do
         Puppet::Type.type(:file).expects(:new).with { |opts| opts[:group] == nil }
-        @dler.file
-      end
-
-      it "should set source_permissions to ignore" do
-        Puppet::Type.type(:file).expects(:new).with { |opts| opts[:source_permissions] == :ignore }
         @dler.file
       end
     end


### PR DESCRIPTION
Module pluginsync is handled by creating a Catalog with a File resource,
and Puppet's File resource defaults to replicating the source file
owner, group and mode. However, owner/group are additionally set to
Process.owner/group for a pluginsync download on POSIX, which will
typically be root during an agent run.

This combination of behavior meant that a root agent run on the puppet
master would cause Puppet's $libdir to be reset to the mode of the first
source module lib, but owned by root.

The puppet master, running as root, chuser's to the service user.  In a
Webrick setup, requests are handled by that service user; in a Rack
setup, it depends on how the Rack service has been setup, but typically
it is the service user again.  So, if the source module had restrictive
permissions, the puppet master, running as the service user, could end
up no longer being able to read $libdir.

On Windows, we were already setting the File type's source_permissions
parameter to :ignore when pluginsyncing.  This commit sets
source_permissions to ignore regardless of the platform, leaving
$libdir's mode unchanged on POSIX as well.

TODO unfortunately this means that owner/group of $libdir are still
being managed on POSIX by pluginsync, which will take precedence over
settings. This seems wrong.
