### PR TITLE
(PUP-1960) Change API of Resource and Class types for undef/array

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -515,7 +515,12 @@ module Puppet::Pops::Evaluator::Runtime3Support
     def initialize
       super
       p = self
-      p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :warning
+      # Issues triggering warning only if --debug is on
+      if Puppet[:debug]
+        p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :warning
+      else
+        p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
+      end
     end
   end
 


### PR DESCRIPTION
This changes the API of Resource and Class types so that they:
- return a single type or undef when there is a single key
- return an array of types or empty array when there are multiple keys,
  or when a single key is an array.

The arguments are still flattened and compacted.

For Resource, the ability to also pass the type in the array was
removed. i.e. Resource[File, f1, f2] or Resource[File, [f1, f2]] are
allowed but not Resource[[File, f1, f2]].
