### PR TITLE
(PUP-2129) Fix issues with false interpolation start (slurpfunc)

### DIFF
--- a/lib/puppet/pops/parser/interpolation_support.rb
+++ b/lib/puppet/pops/parser/interpolation_support.rb
@@ -44,8 +44,9 @@ module Puppet::Pops::Parser::InterpolationSupport
           break
         else
           # false $ variable start
-          text += value
+          text += terminator
           value,terminator = slurp_dqstring()
+          text += value
           after = scn.pos
         end
       end
@@ -84,8 +85,9 @@ module Puppet::Pops::Parser::InterpolationSupport
           break
         else
           # false $ variable start
+          text += terminator
+          value,terminator = slurp_dqstring
           text += value
-          value,terminator = self.send(slurpfunc)
           after = scn.pos
         end
       end
@@ -127,8 +129,9 @@ module Puppet::Pops::Parser::InterpolationSupport
           break
         else
           # false $ variable start
-          text += value
+          text += terminator
           value,terminator = slurp_uqstring()
+          text += value
           after = scn.pos
         end
       end
@@ -166,8 +169,9 @@ module Puppet::Pops::Parser::InterpolationSupport
           break
         else
           # false $ variable start
-          text += value
+          text += terminator
           value,terminator = slurp_uqstring
+          text += value
           after = scn.pos
         end
       end

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -208,6 +208,17 @@ describe 'Lexer2' do
     end
   end
 
+  { '"$"'      => '$',
+    '"a$"'     => 'a$',
+    '"a$%b"'  => "a$%b",
+    '"a$$"'  => "a$$",
+    '"a$$%"'  => "a$$%",
+  }.each do |source, expected|
+    it "should lex interpolation including false starts #{source}" do
+      tokens_scanned_from(source).should match_tokens2([:STRING, expected])
+    end
+  end
+
   it "differentiates between foo[x] and foo [x] (whitespace)" do
     tokens_scanned_from("$a[1]").should match_tokens2(:VARIABLE, :LBRACK, :NUMBER, :RBRACK)
     tokens_scanned_from("$a [1]").should match_tokens2(:VARIABLE, :LBRACK, :NUMBER, :RBRACK)

--- a/spec/unit/pops/parser/parse_heredoc_spec.rb
+++ b/spec/unit/pops/parser/parse_heredoc_spec.rb
@@ -58,7 +58,7 @@ describe "egrammar parsing heredoc" do
     ].join("\n")
   end
 
-  it "parses interpolated heredoc epression" do
+  it "parses interpolated heredoc expression" do
     src = <<-CODE
     @("END")
     Hello $name
@@ -70,4 +70,18 @@ describe "egrammar parsing heredoc" do
       ")"
     ].join("\n")
   end
+
+  it "parses interpolated heredoc expression with false start on $" do
+    src = <<-CODE
+    @("END")
+    Hello $name$%a
+    |- END
+    CODE
+    dump(parse(src)).should == [
+      "(@()",
+      "  (sublocated (cat 'Hello ' (str $name) '$%a'))",
+      ")"
+    ].join("\n")
+  end
+
 end


### PR DESCRIPTION
This is a fix for the reported issue that 'slurpfunc' is an unknown
method. Thankfuly that problem masked a much worse problem in that any
false interolation start e.g. $%a was not correctly implemented, and
there were no tests that covered this.

The same issue also existed for interpolation in heredoc.
This commit fixes the interpolation problem, and adds tests.
