### PR TITLE
add caching to autoload

### DIFF
--- a/spec/integration/util/autoload_spec.rb
+++ b/spec/integration/util/autoload_spec.rb
@@ -36,7 +36,10 @@ describe Puppet::Util::Autoload do
 
   def with_loader(name, path)
     dir = tmpfile(name + path)
+    # changing LOAD_PATH is rather rare and should not be handled internally
+    # by autoload caching
     $LOAD_PATH << dir
+    Puppet::Util::Autoload.reset_search_directories_cache!
     Dir.mkdir(dir)
     rbdir = File.join(dir, path.to_s)
     Dir.mkdir(rbdir)

--- a/spec/integration/util/feature_spec.rb
+++ b/spec/integration/util/feature_spec.rb
@@ -12,6 +12,7 @@ describe Puppet::Util::Feature do
     Dir.mkdir(libdir)
 
     $LOAD_PATH << libdir
+    Puppet::Util::Autoload.reset_search_directories_cache!
 
     $features = Puppet::Util::Feature.new("feature_lib")
 

--- a/spec/unit/interface/face_collection_spec.rb
+++ b/spec/unit/interface/face_collection_spec.rb
@@ -196,10 +196,12 @@ describe Puppet::Interface::FaceCollection do
   context "faulty faces" do
     before :each do
       $:.unshift "#{PuppetSpec::FIXTURE_DIR}/faulty_face"
+      Puppet::Util::Autoload.reset_search_directories_cache!
     end
 
     after :each do
       $:.delete_if {|x| x == "#{PuppetSpec::FIXTURE_DIR}/faulty_face"}
+      Puppet::Util::Autoload.reset_search_directories_cache!
     end
 
     it "should not die if a face has a syntax error" do

--- a/spec/unit/pops/binder/bindings_composer_spec.rb
+++ b/spec/unit/pops/binder/bindings_composer_spec.rb
@@ -35,6 +35,7 @@ describe 'BinderComposer' do
       Puppet.settings[:confdir] = config_directory
       Puppet.settings[:libdir] = File.join(config_directory, 'lib')
       Puppet.settings[:modulepath] = File.join(config_directory, 'modules')
+      Puppet::Util::Autoload.reset_search_directories_cache!
       # this ensure the binder is active at the right time
       # (issues with getting a /dev/null path for "confdir" / "libdir")
       raise "Binder not active" unless scope.compiler.is_binder_active?

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -42,6 +42,7 @@ describe Puppet::Util::Autoload do
       Puppet[:libdir] = %w{/libdir1 /lib/dir/two /third/lib/dir}.join(File::PATH_SEPARATOR)
       @autoload.class.expects(:gem_directories).returns %w{/one /two}
       @autoload.class.expects(:module_directories).returns %w{/three /four}
+      Puppet::Util::Autoload.reset_search_directories_cache!
       @autoload.class.search_directories(nil).should == %w{/one /two /three /four} + Puppet[:libdir].split(File::PATH_SEPARATOR) + $LOAD_PATH
     end
   end


### PR DESCRIPTION
needs thorough review from more experienced puppet committers

i see 25% speed improvement when using puppet in --onetime mode

server and long-running agents might not benefit as much and potentially can have problems picking up new directories - i didn't test those use-cases yet
- cache is implemented as per-environment-name class-level instance variable `@search_directories`
- it is enabled only after puppet finishes initialization(code stolen from module_directories method)
- cache is reset when `#reload_changed` is called
- tests need occasional reset calls when they change `module_directories` or `LOAD_PATH` - which i suppose in real world only happens during initialization stage
