### PR TITLE
(PUP-2189) Use locking when opening SSL files for writing

### DIFF
--- a/lib/puppet/indirector/ssl_file.rb
+++ b/lib/puppet/indirector/ssl_file.rb
@@ -159,9 +159,9 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
   # the work or opening a filehandle manually.
   def write(name, path)
     if ca?(name) and ca_location
-      Puppet.settings.setting(self.class.ca_setting).open('w') { |f| yield f }
+      Puppet.settings.setting(self.class.ca_setting).exclusive_open('w') { |f| yield f }
     elsif file_location
-      Puppet.settings.setting(self.class.file_setting).open('w') { |f| yield f }
+      Puppet.settings.setting(self.class.file_setting).exclusive_open('w') { |f| yield f }
     elsif setting = self.class.directory_setting
       begin
         Puppet.settings.setting(setting).open_file(path, 'w') { |f| yield f }


### PR DESCRIPTION
Failure to do this can cause corruptions of for example the CRL when
multiple workers try to write to it concurrently.
