### PR TITLE
(maint) Clearer error message to reflect origin.

### DIFF
--- a/lib/puppet/parser/collector.rb
+++ b/lib/puppet/parser/collector.rb
@@ -112,7 +112,7 @@ class Puppet::Parser::Collector
           unless existing.collector_id == item.collector_id
             # unless this is the one we've already collected
             raise Puppet::ParseError,
-              "Another local or imported resource exists with the type and title #{item.ref}"
+              "A duplicate resource was found while collecting exported resources, with the type and title #{item.ref}"
           end
         else
           item.exported = false

--- a/spec/unit/parser/collector_spec.rb
+++ b/spec/unit/parser/collector_spec.rb
@@ -407,7 +407,7 @@ describe Puppet::Parser::Collector, "when collecting exported resources", :if =>
       @compiler.add_resource(@scope, local)
 
       expect { @collector.evaluate }.
-        to raise_error Puppet::ParseError, /exists with the type and title/
+        to raise_error Puppet::ParseError, /A duplicate resource was found while collecting exported resources/
     end
 
     it "should ignore exported resources that match already-collected resources" do


### PR DESCRIPTION
Zachary ran across a case where this error message was being thrown up
and it wasn't immediately clear that it occured during the collection of
exported resources, due to references to local resources.  Make this
clearer for future cases.
