### PR TITLE
(PUP-2027) support lambda function api

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -36,6 +36,29 @@ module Puppet::Functions
   # When a call is processed the given type signatures are tested in the order they were defined - the first signature
   # with matching type wins.
   #
+  # Argument Count and Capture Rest
+  # ---
+  # If nothing is specified, the number of arguments given to the function must be the same as the number of parameters
+  # (parameters that perform injection not included). If something else is wanted, the method `arg_count` specifies
+  # the minimum and maximum number of given arguments. Thus, to indicate that parameters are optional, set min to
+  # a value lower than the number of specified parameters, and max to the number of specified parameters.
+  #
+  # To express that the last parameter captures the rest, the method `last_captures_rest` can be called. This is
+  # an indicator to those that obtain information about the function (for the purpose of displaying error messages etc.)
+  # For a Function, there the call is processed the same way irrespective how the `last_captures_rest`, and it is up
+  # to the implementor of the target method to decide who the specified min/max number of arguments are laid out.
+  # This is shown in the following example:
+  #
+  # @example variable number of args to
+  #   dispatch :foo do
+  #     param Numeric, 'up_to_five_numbers'
+  #     arg_count 1, 5
+  #   end
+  #
+  #   def foo(a, b=0, c=0, *d)
+  #     ...
+  #   end
+  #
   # Polymorphic Dispatch
   # ---
   # The dispatcher also supports polymorphic dispatch where the method to call is selected based on the type of the
@@ -79,6 +102,7 @@ module Puppet::Functions
   # Injection of attributes
   # ---
   # Injection of attributes is performed by one of the methods `attr_injected`, and `attr_injected_producer`.
+  # The injected attributes are available via accessor method calls.
   #
   # @example using injected attributes
   #   Puppet::Functions.create_function('test') do
@@ -91,8 +115,9 @@ module Puppet::Functions
   #
   # Injection and Weaving of parameters
   # ---
-  # It is possible to inject and weave parameters into a call. These extra parameters are not passed from the
-  # Puppet logic.
+  # It is possible to inject and weave parameters into a call. These extra parameters are not part of
+  # the parameters passed from the Puppet logic, and they can not be overridden by parameters given as arguments
+  # in the call. They are invisible to the Puppet Language.
   #
   # @example using injected parameters
   #   Puppet::Functions.create_function('test') do
@@ -106,9 +131,53 @@ module Puppet::Functions
   #       a > b ? larger : smaller
   #     end
   #   end
+  #
   # The function in the example above is called like this:
   #
   #     test(10, 20)
+  #
+  # Using injected value as default
+  # ---
+  # Default value assignment is handled by using the regular Ruby mechanism (a value is assigned to the variable).
+  # The dispatch simply indicates that the value is optional. If the default value should be injected, it can be
+  # handled different ways depending on what is desired:
+  #
+  # * by calling the accessor method for an injected Function class attribute. This is suitable if the
+  #   value is constant across all instantiations of the function, and across all calls.
+  # * by injecting a parameter into the call to the left of the parameter, and then assigning that as the default value.
+  # * One of the above forms, but using an injected producer instead of a directly injected value.
+  #
+  # @example method with injected default values
+  #   Puppet::Functions.create_function('test') do
+  #     dispatch :test do
+  #       injected_param String, 'b_default', 'b_default_value_key'
+  #       param Scalar, 'a'
+  #       param Scalar, 'b'
+  #     end
+  #     def test(b_default, a, b = b_default)
+  #       # ...
+  #     end
+  #   end
+  #
+  # Access to Scope
+  # ---
+  # In general, functions should not need access to scope; they should be written to act on their given input
+  # only. If they absolutely must look up variable values, they should do so via the closure scope (the scope where they
+  # are defined) - this is done by calling `closure_scope()`. 
+  #
+  # For Puppet System Functions where access to the calling scope may be essential the implementor of the function may
+  # override the `Function.call` method to pass the scope on to the method(s) implementing the body of the function.
+  #
+  # Calling other Functions
+  # ---
+  # Calling other functions by name is directly supported via `call_funcion(name, *args)`. This allows a function
+  # to call other functions visible from its loader.
+  #
+  # @todo Optimizations
+  #
+  #   Unoptimized implementation. The delegation chain is longer than required, and arguments are passed with splat.
+  #   The chain Function -> class -> Dispatcher -> Dispatch -> Visitor can be shortened for non polymorph dispatching.
+  #   Also, when there is only one signature (single Dispatch), a different Dispatcher could short circuit the search.
   #
   # @param func_name [String, Symbol] a simple or qualified function name
   # @param &block [Proc] the block that defines the methods and dispatch of the Function to create
@@ -121,16 +190,6 @@ module Puppet::Functions
     # references to it.
     #
     the_class = Class.new(Function, &block)
-
-    # TODO: The func_name should be a symbol - else error
-    # Why symbol? They are sticky in memory and the qualified name used in PP is a Fully qualified string
-    # It should probably be either a QualifiedName (counting on it to already be validated? or check again? or
-    # a string
-    # Assume String for now, and that names are properly formed...
-    # Later, must handle name spacing of function, and only use last part as the actual name - better with two
-    # parameters, namespace, and func_name perhaps - or maybe namespace is derived from where it is found, which is
-    # even better
-    #
 
     # Make the anonymous class appear to have the class-name <func_name>
     # Even if this class is not bound to such a symbol in a global ruby scope and
@@ -153,7 +212,8 @@ module Puppet::Functions
     if the_class.dispatcher.empty?
       simple_name = func_name.split(/::/)[-1]
       type, names = default_dispatcher(the_class, simple_name)
-      the_class.dispatcher.add_dispatch(type, simple_name, names, nil, nil)
+      last_captures_rest = (type.size_range[1] == Puppet::Pops::Types::INFINITY)
+      the_class.dispatcher.add_dispatch(type, simple_name, names, nil, nil, nil, last_captures_rest)
     end
 
     # The function class is returned as the result of the create function method
@@ -177,7 +237,7 @@ module Puppet::Functions
       method.parameters.each { |p| result[p[0]] += 1 }
       from = result[:req]
       to = result[:rest] > 0 ? :default : from + result[:opt]
-      names = method.parameters.map {|p| p[1] }
+      names = method.parameters.map {|p| p[1].to_s }
     else
       # Cannot correctly compute the signature in Ruby 1.8.7 because arity for optional values is
       # screwed up (there is no way to get the upper limit), an optional looks the same as a varargs
@@ -191,6 +251,9 @@ module Puppet::Functions
     [from, to, names]
   end
 
+  # Construct a signature consisting of Object type, with min, and max, and given names.
+  # (there is only one type entry). Note that this signature is Object, not Optional[Object].
+  #
   def self.object_signature(from, to, names)
     # Construct the type for the signature
     # Tuple[Object, from, to]
@@ -198,11 +261,18 @@ module Puppet::Functions
     [factory.callable(factory.object, from, to), names]
   end
 
+  # Function
+  # ===
+  # This class is the base class for all Puppet 4x Function API functions. A specialized class is
+  # created for each puppet function.
+  # Most methods act on the class, except `call`, `closure_scope`, and `loader` which are bound to a
+  # particular instance of the function (it is aware of its runtime context).
+  #
   class Function
-    # The scope where the function is defined
+    # The scope where the function was defined
     attr_reader :closure_scope
 
-    # The loader that loaded this function
+    # The loader that loaded this function.
     # Should be used if function wants to load other things.
     #
     attr_reader :loader
@@ -212,8 +282,39 @@ module Puppet::Functions
       @loader = loader
     end
 
+    # Invokes the function via the dispatching logic that performs type check and weaving.
+    # A specialized function may override this method to do its own dispatching and checking of
+    # the raw arguments. A specialized implementation can rearrange arguments, add or remove
+    # arguments and then delegate to the dispatching logic by calling:
+    #
+    # @example Delegating to the dispatcher
+    #     def call(scope, *args)
+    #       manipulated_args = args + ['easter_egg']
+    #       self.class.dispatcher.dispatch(self, scope, manipulated_args)
+    #     end
+    #
+    # System functions that must have access to the calling scope can use this technique. Functions
+    # in general should not need the calling scope. (The closure scope; what is visible where the function
+    # is defined) is available via the method `closure_scope`).
+    #
     def call(scope, *args)
       self.class.dispatcher.dispatch(self, scope, args)
+    end
+
+    # Allows the implementation of a function to call other functions by name. The callable functions
+    # are those visible to the same loader that loaded this function (the calling function).
+    # 
+    def call_function(function_name, *args)
+      if the_loader = loader
+        func = the_loader.load(:function, function_name)
+        if func
+          return func.call(closure_scope, *args)
+        end
+      end
+      # Raise a generic error to allow upper layers to fill in the details about where in a puppet manifest this
+      # error originates. (Such information is not available here).
+      #
+      raise ArgumentError, "Function #{self.class.name}(): cannot call function '#{function_name}' - not found"
     end
 
     def self.define_dispatch(&block)
@@ -279,6 +380,11 @@ module Puppet::Functions
       Puppet::Pops::Types::TypeFactory.respond_to?(meth, include_all) || super
     end
 
+    # Produces information about parameters in a way that is compatible with Closure
+    #
+    def self.signatures
+      @dispatcher.signatures
+    end
   end
 
   class DispatcherBuilder
@@ -310,10 +416,12 @@ module Puppet::Functions
       @injections = []
       @min = nil
       @max = nil
+      @last_captures = false
       @block_type = nil
       @block_name = nil
       self.instance_eval &block
-      @dispatcher.add_dispatch(self.class.create_callable(@types, @block_type, @min, @max), meth_name, @names, @injections, @weaving)
+      callable_t = self.class.create_callable(@types, @block_type, @min, @max)
+      @dispatcher.add_dispatch(callable_t, meth_name, @names, @block_name, @injections, @weaving, @last_captures)
     end
 
     def dispatch_polymorph(meth_name, &block)
@@ -323,8 +431,12 @@ module Puppet::Functions
       @injections = []
       @min = nil
       @max = nil
+      @last_captures = false
+      @block_type = nil
+      @block_name = nil
       self.instance_eval &block
-      @dispatcher.add_polymorph_dispatch(self.class.create_callable(@types, @block_type, @min, @max), meth_name, @names, @injections, @weaving)
+      callable_t = self.class.create_callable(@types, @block_type, @min, @max)
+      @dispatcher.add_polymorph_dispatch(callable_t, meth_name, @names, @block_name, @injections, @weaving, @last_captures)
     end
 
     # Defines one parameter with type and name
@@ -340,6 +452,9 @@ module Puppet::Functions
     #
     def required_block_param(*type_and_name)
       case type_and_name.size
+      when 0
+        type = all_callables()
+        name = 'block'
       when 1
         x = type_and_name[0]
         if x.is_a?(Puppet::Pops::Types::PCallableType)
@@ -353,7 +468,7 @@ module Puppet::Functions
           name = x.to_s()
         end
       when 2
-        type, name = name_and_type
+        type, name = type_and_name
       else
         raise ArgumentError, "block_param accepts max 2 arguments (type, name), got #{type_and_name.size}."
       end
@@ -362,7 +477,7 @@ module Puppet::Functions
         raise ArgumentError, "Expected PCallableType, got #{type.class}"
       end
 
-      unless x.is_a?(String)
+      unless name.is_a?(String)
         raise ArgumentError, "Expected block_param name to be a String, got #{name.class}"
       end
 
@@ -374,9 +489,10 @@ module Puppet::Functions
     end
 
     # Defines one optional block parameter that may appear last. If type or name is missing the
-    # defaults are "any callable", and the name is "block"
+    # defaults are "any callable", and the name is "block". The implementor of the dispatch target
+    # must use block = nil when it is optional (or an error is raised when the call is made).
     #
-    def block_param(*type_and_name)
+    def optional_block_param(*type_and_name)
       # same as required, only wrap the result in an optional type
       required_block_param(*type_and_name)
       @block_type = optional(@block_type)
@@ -415,6 +531,12 @@ module Puppet::Functions
       unless max_occurs == :default || (max_occurs.is_a?(Integer) && max_occurs >= min_occurs)
         raise ArgumentError, "max arg_count must be :default (infinite) or >= min arg_count, got min: '#{min_occurs}, max: '#{max_occurs}'"
       end
+    end
+
+    # Specifies that the last argument captures the rest.
+    #
+    def last_captures_rest
+      @last_captures = true
     end
 
     # Handles creation of a callable type from strings, puppet types, or ruby types and allows
@@ -488,8 +610,9 @@ module Puppet::Functions
     # @param method_name [String] - the name of the method that will be called when type matches given arguments
     # @param names [Array<String>] - array with names matching the number of parameters specified by type (or empty array)
     #
-    def add_dispatch(type, method_name, param_names, injections, weaving)
-      @dispatchers << Dispatch.new(type, NonPolymorphicVisitor.new(method_name), param_names, injections, weaving)
+    def add_dispatch(type, method_name, param_names, block_name, injections, weaving, last_captures)
+      visitor = NonPolymorphicVisitor.new(method_name)
+      @dispatchers << Dispatch.new(type, visitor, param_names, block_name, injections, weaving, last_captures)
     end
 
     # Adds a polymorph dispatch for one method name
@@ -498,13 +621,13 @@ module Puppet::Functions
     # @param method_name [String] - the name of the (polymorph) method that will be called when type matches given arguments
     # @param names [Array<String>] - array with names matching the number of parameters specified by type (or empty array)
     #
-    def add_polymorph_dispatch(type, method_name, param_names, injections, weaving)
+    def add_polymorph_dispatch(type, method_name, param_names, block_name, injections, weaving, last_captures)
       # Type is a CollectionType, its size-type indicates min/max args
       # This includes the polymorph object which needs to be deducted from the
       # number of additional args
       # NOTE: the type is valuable if there are type constraints also on the first arg
       # (better error message)
-      range = type.param_types.size_range # get .from, .to, unbound if nil (from must be bound, to can be nil)
+      range = type.param_types.size_range
       raise ArgumentError, "polymorph dispath on collection type without range" unless range
       raise ArgumentError, "polymorph dispatch on signature without object" if range[0] < 1
       from = range[0] - 1 # The object itself is not included
@@ -514,7 +637,8 @@ module Puppet::Functions
         to += injections.size
       end
       to = (to == Puppet::Pops::Types::INFINITY) ? -1 : to
-      @dispatchers << Dispatch.new(type, Puppet::Pops::Visitor.new(self, method_name, from, to), param_names, injections, weaving)
+      visitor = Puppet::Pops::Visitor.new(self, method_name, from, to)
+      @dispatchers << Dispatch.new(type, visitor, param_names, block_name, injections, weaving, last_captures)
     end
 
     # Produces a CallableType for a single signature, and a Variant[<callables>] otherwise
@@ -530,21 +654,45 @@ module Puppet::Functions
       callables.size > 1 ?  Puppet::Pops::Types::TypeFactory.variant(*callables) : callables.pop
     end
 
+    def signatures
+      @dispatchers
+    end
+
     # @api private
     #
-    class Dispatch
+    class Dispatch < Puppet::Pops::Evaluator::CallableSignature
+      # @api public
       attr_reader :type
       attr_reader :visitor
+      # TODO: refactor to parameter_names since that makes it API
       attr_reader :param_names
       attr_reader :injections
-      attr_reader :weaving
 
-      def initialize(type, visitor, param_names, injections, weaving)
+      # Describes how arguments are woven if there are injections, a regular argument is a given arg index, an array
+      # an injection description.
+      #
+      attr_reader :weaving
+      # @api public
+      attr_reader :block_name
+
+      def initialize(type, visitor, param_names, block_name, injections, weaving, last_captures)
         @type = type
         @visitor = visitor
         @param_names = param_names || []
+        @block_name = block_name
         @injections = injections || []
         @weaving = weaving
+        @last_captures = last_captures
+      end
+
+      # @api public
+      def parameter_names
+        @param_names
+      end
+
+      # @api public
+      def last_captures_rest?
+        !! @last_captures
       end
 
       def invoke(instance, calling_scope, args)
@@ -582,14 +730,16 @@ module Puppet::Functions
     def diff_string(name, args_type)
       result = [ ]
       if @dispatchers.size < 2
-        params_type  = @dispatchers[ 0 ].type.param_types
-        params_names = @dispatchers[ 0 ].param_names
-        result << "expected:\n  #{name}(#{signature_string(params_type, params_names)}) - #{arg_count_string(params_type)}"
+        dispatch = @dispatchers[ 0 ]
+        params_type  = dispatch.type.param_types
+        block_type   = dispatch.type.block_type
+        params_names = dispatch.param_names
+        result << "expected:\n  #{name}(#{signature_string(dispatch)}) - #{arg_count_string(dispatch.type)}"
       else
         result << "expected one of:\n"
         result << (@dispatchers.map do |d|
           params_type = d.type.param_types
-          "  #{name}(#{signature_string(params_type, d.param_names)}) - #{arg_count_string(params_type)}"
+          "  #{name}(#{signature_string(d)}) - #{arg_count_string(d.type)}"
         end.join("\n"))
       end
       result << "\nactual:\n  #{name}(#{arg_types_string(args_type)}) - #{arg_count_string(args_type)}"
@@ -598,8 +748,17 @@ module Puppet::Functions
 
     # Produces a string for the signature(s)
     #
-    def signature_string(args_type, param_names)
-      from, to = args_type.size_range
+    def signature_string(dispatch) # args_type, param_names
+      param_types  = dispatch.type.param_types
+      block_type   = dispatch.type.block_type
+      param_names = dispatch.param_names
+
+      from, to = param_types.size_range
+      if from == 0 && to == 0
+        # No parameters function
+        return ''
+      end
+
       required_count = from
       # there may be more names than there are types, and count needs to be subtracted from the count
       # to make it correct for the last named element
@@ -607,31 +766,44 @@ module Puppet::Functions
       last_range = [max(0, (from - adjust)), (to - adjust)]
 
       types =
-      case args_type
+      case param_types
       when Puppet::Pops::Types::PTupleType
-        args_type.types
+        param_types.types
       when Puppet::Pops::Types::PArrayType
-        [ args_type.element_type ]
+        [ param_types.element_type ]
       end
       tc = Puppet::Pops::Types::TypeCalculator
 
       # join type with names (types are always present, names are optional)
       # separate entries with comma
       #
+      result =
       if param_names.empty?
-        result = types.each_with_index.map {|t, index| tc.string(t) + opt_value_indicator(index, required_count, 0) }.join(', ')
+        types.each_with_index.map {|t, index| tc.string(t) + opt_value_indicator(index, required_count, 0) }
       else
         limit = param_names.size
         result = param_names.each_with_index.map do |name, index|
           [tc.string(types[index] || types[-1]), name].join(' ') + opt_value_indicator(index, required_count, limit)
-        end.join(', ')
-      end
+        end
+      end.join(', ')
 
       # Add {from, to} for the last type
       # This works for both Array and Tuple since it describes the allowed count of the "last" type element
       # for both. It does not show anything when the range is {1,1}.
       #
       result += range_string(last_range)
+
+      # If there is a block, include it with its own optional count {0,1}
+      case dispatch.type.block_type
+      when Puppet::Pops::Types::POptionalType
+        result << ', ' unless result == ''
+        result << "#{tc.string(dispatch.type.block_type.optional_type)} #{dispatch.block_name} {0,1}"
+      when Puppet::Pops::Types::PCallableType
+        result << ', ' unless result == ''
+        result << "#{tc.string(dispatch.type.block_type)} #{dispatch.block_name}"
+      when NilClass
+        # nothing
+      end
       result
     end
 
@@ -646,7 +818,24 @@ module Puppet::Functions
     end
 
     def arg_count_string(args_type)
-      "arg count #{range_string(args_type.size_range, false)}"
+      if args_type.is_a?(Puppet::Pops::Types::PCallableType)
+        size_range = args_type.param_types.size_range # regular parameters
+        adjust_range=
+        case args_type.block_type
+        when Puppet::Pops::Types::POptionalType
+          size_range[1] += 1
+        when Puppet::Pops::Types::PCallableType
+          size_range[0] += 1
+          size_range[1] += 1
+        when NilClass
+          # nothing
+        else
+          raise ArgumentError, "Internal Error, only nil, Callable, and Optional[Callable] supported by Callable block type"
+        end
+      else
+        size_range = args_type.size_range
+      end
+      "arg count #{range_string(size_range, false)}"
     end
 
     def arg_types_string(args_type)
@@ -679,8 +868,7 @@ module Puppet::Functions
     # * to is INFINITY => {from, }
     #
     def range_string(size_range, squelch_one = true)
-      from = size_range[ 0 ]
-      to = size_range[ 1 ]
+      from, to = size_range
       if from == to
         (squelch_one && from == 1) ? '' : "{#{from}}"
       elsif to == Puppet::Pops::Types::INFINITY

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -88,6 +88,7 @@ module Puppet
     end
 
     module Evaluator
+      require 'puppet/pops/evaluator/callable_signature'
       require 'puppet/pops/evaluator/runtime3_support'
       require 'puppet/pops/evaluator/evaluator_impl'
       require 'puppet/pops/evaluator/epp_evaluator'

--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -95,7 +95,7 @@ module Puppet::Pops::Adapters
   # @see Puppet::Pops::Utils#find_adapter
   #
   class LoaderAdapter < Puppet::Pops::Adaptable::Adapter
-    # @return [Puppet::Pops::Loader] the loader
+    # @return [Puppet::Pops::Loader::Loader] the loader
     attr_accessor :loader
   end
 end

--- a/lib/puppet/pops/evaluator/callable_signature.rb
+++ b/lib/puppet/pops/evaluator/callable_signature.rb
@@ -1,0 +1,101 @@
+# CallableSignature
+# ===
+# A CallableSignature describes how something callable expects to be called.
+# Different implementation of this class are used for different types of callables.
+#
+# @api public
+#
+class Puppet::Pops::Evaluator::CallableSignature
+
+  # Returns the names of the parameters as an array of strings. This does not include the name
+  # of an optional block parameter.
+  #
+  # All implementations are not required to supply names for parameters. They may be used if present,
+  # to provide user feedback in errors etc. but they are not authoritative about the number of
+  # required arguments, optional arguments, etc.
+  #
+  # A derived class must implement this method.
+  #
+  # @return Array<String> - an array of names (that may be empty if names are unavailable)
+  #
+  # @api public
+  #
+  def parameter_names
+    raise NotImplementedError.new
+  end
+
+  # Returns a PCallableType with the type information, required and optional count, and type information about
+  # an optional block.
+  #
+  # A derived class must implement this method.
+  #
+  # @return [Puppet::Pops::Types::PCallableType]
+  # @api public
+  #
+  def type
+    raise NotImplementedError.new
+  end
+
+  # Returns the expected type for an optional block. The type may be nil, which means that the callable does
+  # not accept a block. If a type is returned it is one of Callable, Optional[Callable], Variant[Callable,...],
+  # or Optional[Variant[Callable, ...]]. The Variant type is used when multiple signatures are acceptable.
+  # The Optional type is used when the block is optional.
+  #
+  # @return [Puppet::Pops::Types::PAbstractType, nil] the expected type of a block given as the last parameter in a call.
+  #
+  # @api public
+  #
+  def block_type
+    type.block_type
+  end
+
+  # Returns the name of the block parameter if the callable accepts a block.
+  # @return [String] the name of the block parameter
+  # A derived class must implement this method.
+  # @api public
+  #
+  def block_name
+    raise NotImplementedError.new
+  end
+
+  # Returns a range indicating the optionality of a block. One of [0,0] (does not accept block), [0,1] (optional
+  # block), and [1,1] (block required)
+  #
+  # @return Array[Integer, Integer] the range of the block parameter
+  #
+  def block_range
+    type.block_range
+  end
+
+  # Returns the range of required/optional argument values as an array of [min, max], where an infinite
+  # end is given as INFINITY. To test against infinity, use the infinity? method.
+  #
+  # @return Array[Integer, Numeric] - an Array with [min, max]
+  #
+  # @api public
+  #
+  def args_range
+    type.size_range
+  end
+
+  # Returns true if the last parameter captures the rest of the arguments, with a possible cap, as indicated
+  # by the `args_range` method.
+  # A derived class must implement this method.
+  #
+  # @return [Boolean] true if last parameter captures the rest of the given arguments (up to a possible cap)
+  # @api public
+  #
+  def last_captures_rest?
+    raise NotImplementedError.new
+  end
+
+  # Returns true if the given x is infinity
+  # @return [Boolean] true, if given value represents infinity
+  #
+  # @api public
+  #
+  def infinity?(x)
+    x == Puppet::Pops::Types::INFINITY
+  end
+
+end

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -2,11 +2,14 @@
 # A Closure represents logic bound to a particular scope.
 # As long as the runtime (basically the scope implementation) has the behaviour of Puppet 3x it is not
 # safe to use this closure when the scope given to it when initialized goes "out of scope".
-# 
+#
 # Note that the implementation is backwards compatible in that the call method accepts a scope, but this
 # scope is not used.
 #
-class Puppet::Pops::Evaluator::Closure
+# Note that this class is a CallableSignature, and the methods defined there should be used
+# as the API for obtaining information in a callable implementation agnostic way.
+#
+class Puppet::Pops::Evaluator::Closure < Puppet::Pops::Evaluator::CallableSignature
   attr_reader :evaluator
   attr_reader :model
   attr_reader :enclosing_scope
@@ -18,11 +21,14 @@ class Puppet::Pops::Evaluator::Closure
   end
 
   # marker method checked with respond_to :puppet_lambda
+  # @api private
+  # @deprecated Use the type system to query if an object is of Callable type, then use its signatures method for info
   def puppet_lambda()
     true
   end
 
   # compatible with 3x AST::Lambda
+  # @api public
   def call(scope, *args)
     @evaluator.call(self, args, @enclosing_scope)
   end
@@ -50,8 +56,57 @@ class Puppet::Pops::Evaluator::Closure
     @model.parameters.count { |p| !p.value.nil? }
   end
 
+  # @api public
   def parameter_names
     @model.parameters.collect {|p| p.name }
+  end
+
+  # @api public
+  def type
+    @callable || create_callable_type
+  end
+
+  # @api public
+  def last_captures_rest?
+    # TODO: No support for this yet
+    false
+  end
+
+  # @api public
+  def block_name
+    # TODO: Lambda's does not support blocks yet. This is a placeholder
+    'unsupported_block'
+  end
+
+  private
+
+  def create_callable_type()
+    t = Puppet::Pops::Types::PCallableType.new()
+    tuple_t = Puppet::Pops::Types::PTupleType.new()
+    # since closure lambdas are currently untyped, each parameter becomes Optional[Object]
+    parameter_names.each do |name|
+      # TODO: Change when Closure supports typed parameters
+      tuple_t.addTypes(Puppet::Pops::Types::TypeFactory.optional_object())
+    end
+
+    # TODO: A Lambda can not currently declare varargs
+    to = parameter_count
+    from = to - optional_parameter_count
+    if from != to
+      size_t = Puppet::Pops::Types::PIntegerType.new()
+      size_t.from = size
+      size_t.to = size
+      tuple_t.size_type = size_t
+    end
+    t.param_types = tuple_t
+    # TODO: A Lambda can not currently declare that it accepts a lambda, except as an explicit parameter
+    # being a Callable
+    t
+  end
+
+  # Produces information about parameters compatible with a 4x Function (which can have multiple signatures)
+  def signatures
+    [ self ]
   end
 
 end

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -756,14 +756,10 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       fail(Issues::ILLEGAL_EXPRESSION, o.functor_expr, {:feature=>'function name', :container => o})
     end
     name = o.functor_expr.value
-    assert_function_available(name, o, scope)
     evaluated_arguments = o.arguments.collect {|arg| evaluate(arg, scope) }
     # wrap lambda in a callable block if it is present
     evaluated_arguments << Puppet::Pops::Evaluator::Closure.new(self, o.lambda, scope) if o.lambda
-    call_function(name, evaluated_arguments, o, scope) do |result|
-      # prevent functions that are not r-value from leaking its return value
-      rvalue_function?(name, o, scope) ? result : nil
-    end
+    call_function(name, evaluated_arguments, o, scope)
   end
 
   # Evaluation of CallMethodExpression handles a NamedAccessExpression functor (receiver.function_name)
@@ -778,13 +774,9 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       fail(Issues::ILLEGAL_EXPRESSION, o.functor_expr, {:feature=>'function name', :container => o})
     end 
     name = name.value # the string function name
-    assert_function_available(name, o, scope)
     evaluated_arguments = [receiver] + (o.arguments || []).collect {|arg| evaluate(arg, scope) }
     evaluated_arguments << Puppet::Pops::Evaluator::Closure.new(self, o.lambda, scope) if o.lambda
-    call_function(name, evaluated_arguments, o, scope) do |result|
-      # prevent functions that are not r-value from leaking its return value
-      rvalue_function?(name, o, scope) ? result : nil
-    end
+    call_function(name, evaluated_arguments, o, scope)
   end
 
   # @example

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -252,13 +252,12 @@ class Puppet::Pops::Types::TypeCalculator
     end
   end
 
-  # Answers 'can an instance of type t2 be assigned to a variable of type t'
+  # Answers 'can an instance of type t2 be assigned to a variable of type t'.
+  # Does not accept nil/undef unless the type accepts it.
+  #
   # @api public
   #
   def assignable?(t, t2)
-    # nil is assignable to anything except to required types
-    return true if is_pnil?(t2)
-
     if t.is_a?(Class)
       t = type(t)
     end
@@ -690,27 +689,9 @@ class Puppet::Pops::Types::TypeCalculator
     Types::PType.new()
   end
 
+  # @api private
   def infer_Closure(o)
-    t = Types::PCallableType.new()
-    tuple_t = Types::PTupleType.new()
-    # since closure lambdas are currently untyped, each parameter becomes Optional[Object]
-    o.parameter_names.each do |name|
-      # TODO: Change when Closure supports typed parameters
-      tuple_t.addTypes(Puppet::Pops::Types::TypeFactory.optional_object())
-    end
-
-    to = o.parameter_count
-    from = to - o.optional_parameter_count
-    if from != to
-      size_t = Types::PIntegerType.new()
-      size_t.from = size
-      size_t.to = size
-      tuple_t.size_type = size_t
-    end
-    t.param_types = tuple_t
-    # TODO: A Lambda can not currently declare that it accepts a lambda, except as an explicit parameter
-    # being a Callable
-    t
+    o.type()
   end
 
   # @api private
@@ -855,6 +836,7 @@ class Puppet::Pops::Types::TypeCalculator
     if o.empty?
       type = Types::PArrayType.new()
       type.element_type = Types::PNilType.new()
+      type.size_type = size_as_type(o)
     else
       type = Types::PTupleType.new()
       type.types = o.map() {|x| infer_set(x) }
@@ -989,7 +971,10 @@ class Puppet::Pops::Types::TypeCalculator
       # of the tuple type.
       #
       args_tuple = args_tuple.copy
-      block_t = args_tuple.types.pop()
+      # to drop the callable, it must be removed explicitly since this is an rgen array
+      args_tuple.removeTypes(block_t = args_tuple.types.last())
+    else
+      # no block was given, if it is required, the below will fail
     end
     # unless argument types match parameter types
     return false unless assignable?(callable_t.param_types, args_tuple)
@@ -1138,6 +1123,9 @@ class Puppet::Pops::Types::TypeCalculator
           # no string can match this enum anyway since it does not accept anything
           false
         end
+      else
+        # no other type matches string
+        false
       end
     elsif t2.is_a?(Types::PStringType)
       # A specific string acts as a set of strings - must have exactly the same strings
@@ -1286,7 +1274,7 @@ class Puppet::Pops::Types::TypeCalculator
       struct_size = t2.elements.size
       element_type = t.element_type
       ( struct_size >= min && struct_size <= max &&
-        assignable?(t.key_type, @non_emptry_string_t)  &&
+        assignable?(t.key_type, @non_empty_string_t)  &&
         t2.hashed_elements.all? {|k,v| assignable?(element_type, v) })
     else
       false

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -207,8 +207,14 @@ module Puppet::Pops::Types::TypeFactory
   # Params are given as a sequence of arguments to {#type_of}.
   #
   def self.callable(*params)
-    callable = Types::PCallableType.new()
-    block_t = params[-1].is_a?(Types::PCallableType) ? params.pop : nil
+    case params.last
+    when Types::PCallableType
+      last_callable = true
+    when Types::POptionalType
+      last_callable = true if params.last.optional_type.is_a?(Types::PCallableType)
+    end
+    block_t = last_callable ? params.pop : nil
+
     # compute a size_type for the signature based on the two last parameters
     if is_range_parameter?(params[-2]) && is_range_parameter?(params[-1])
       size_type = range(params[-2], params[-1])

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -256,6 +256,7 @@ module Puppet::Pops::Types
   class PCollectionType < PObjectType
     contains_one_uni 'element_type', PAbstractType
     contains_one_uni 'size_type', PIntegerType
+
     module ClassModule
       # Returns an array with from (min) size to (max) size
       # A negative range value in from is 
@@ -370,6 +371,30 @@ module Puppet::Pops::Types
     contains_one_uni 'block_type', PAbstractType, :lowerBound => 0
 
     module ClassModule
+      # Returns the number of accepted arguments [min, max]
+      def size_range
+        param_types.size_range
+      end
+
+      # Returns the number of accepted arguments for the last parameter type [min, max]
+      #
+      def last_range
+        param_types.repeat_last_range
+      end
+
+      # Range [0,0], [0,1], or [1,1] for the block
+      #
+      def block_range
+        case block_type
+        when Puppet::Pops::Types::POptionalType
+          [0,1]
+        when Puppet::Pops::Types::PVariantType, Puppet::Pops::Types::PCallableType
+          [1,1]
+        else
+          [0,0]
+        end
+      end
+
       def hash
         [self.class, Set.new(param_types), block_type].hash
       end

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -1,13 +1,37 @@
 require 'spec_helper'
 require 'puppet/pops'
+require 'puppet/loaders'
+require 'puppet_spec/pops'
+require 'puppet_spec/scope'
 
 module FunctionAPISpecModule
   class TestDuck
+  end
+
+  class TestFunctionLoader < Puppet::Pops::Loader::StaticLoader
+    def initialize
+      @functions = {}
+    end
+
+    def add_function(name, function)
+      typed_name = Puppet::Pops::Loader::Loader::TypedName.new(:function, name)
+      entry = Puppet::Pops::Loader::Loader::NamedEntry.new(typed_name, function, __FILE__)
+      @functions[typed_name] = entry
+    end
+
+    # override StaticLoader
+    def load_constant(typed_name)
+      @functions[typed_name]
+    end
   end
 end
 
 describe 'the 4x function api' do
   include FunctionAPISpecModule
+  include PuppetSpec::Pops
+  include PuppetSpec::Scope
+
+  let(:loader) { FunctionAPISpecModule::TestFunctionLoader.new }
 
   it 'allows a simple function to be created without dispatch declaration' do
     f = Puppet::Functions.create_function('min') do
@@ -21,6 +45,22 @@ describe 'the 4x function api' do
     expect(f.superclass).to be(Puppet::Functions::Function)
     # and this class had the given name (not a real Ruby class name)
     expect(f.name).to eql('min')
+  end
+
+  it 'a function without arguments can be defined and called without dispatch declaration' do
+    f = create_noargs_function_class()
+    func = f.new(:closure_scope, :loader)
+    expect(func.call({})).to eql(10)
+  end
+
+  it 'an error is raised when calling a no arguments function with arguments' do
+    f = create_noargs_function_class()
+    func = f.new(:closure_scope, :loader)
+    expect{func.call({}, 'surprise')}.to raise_error(ArgumentError, "function 'test' called with mis-matched arguments
+expected:
+  test() - arg count {0}
+actual:
+  test(String) - arg count {1}")
   end
 
   it 'a simple function can be called' do
@@ -252,6 +292,217 @@ actual:
         expect(t2.block_type).to be_nil
       end
     end
+
+    context 'supports lambdas' do
+      it 'such that, a required block can be defined and given as an argument' do
+        # use a Function as callable
+        the_callable = create_min_function_class().new(:closure_scope, :loader)
+        the_function = create_function_with_required_block_all_defaults().new(:closure_scope, :loader)
+        result = the_function.call({}, 10, the_callable)
+        expect(result).to be(the_callable)
+      end
+
+      it 'such that, a missing required block when called raises an error' do
+        # use a Function as callable
+        the_function = create_function_with_required_block_all_defaults().new(:closure_scope, :loader)
+        expect do
+          the_function.call({}, 10)
+        end.to raise_error(ArgumentError,
+"function 'test' called with mis-matched arguments
+expected:
+  test(Integer x, Callable block) - arg count {2}
+actual:
+  test(Integer) - arg count {1}")
+      end
+
+      it 'such that, an optional block can be defined and given as an argument' do
+        # use a Function as callable
+        the_callable = create_min_function_class().new(:closure_scope, :loader)
+        the_function = create_function_with_optional_block_all_defaults().new(:closure_scope, :loader)
+        result = the_function.call({}, 10, the_callable)
+        expect(result).to be(the_callable)
+      end
+
+      it 'such that, an optional block can be omitted when called and gets the value nil' do
+        # use a Function as callable
+        the_function = create_function_with_optional_block_all_defaults().new(:closure_scope, :loader)
+        expect(the_function.call({}, 10)).to be_nil
+      end
+    end
+
+    context 'provides signature information' do
+      it 'about capture rest (varargs)' do
+        fc = create_function_with_optionals_and_varargs
+        signatures = fc.signatures
+        expect(signatures.size).to eql(1)
+        signature = signatures[0]
+        expect(signature.last_captures_rest?).to be_true
+      end
+
+      it 'about optional and required parameters' do
+        fc = create_function_with_optionals_and_varargs
+        signature = fc.signatures[0]
+        expect(signature.args_range).to eql( [2, Puppet::Pops::Types::INFINITY ] )
+        expect(signature.infinity?(signature.args_range[1])).to be_true
+      end
+
+      it 'about block not being allowed' do
+        fc = create_function_with_optionals_and_varargs
+        signature = fc.signatures[0]
+        expect(signature.block_range).to eql( [ 0, 0 ] )
+        expect(signature.block_type).to be_nil
+      end
+
+      it 'about required block' do
+        fc = create_function_with_required_block_all_defaults
+        signature = fc.signatures[0]
+        expect(signature.block_range).to eql( [ 1, 1 ] )
+        expect(signature.block_type).to_not be_nil
+      end
+
+      it 'about optional block' do
+        fc = create_function_with_optional_block_all_defaults
+        signature = fc.signatures[0]
+        expect(signature.block_range).to eql( [ 0, 1 ] )
+        expect(signature.block_type).to_not be_nil
+      end
+
+      it 'about the type' do
+        fc = create_function_with_optional_block_all_defaults
+        signature = fc.signatures[0]
+        expect(signature.type.class).to be(Puppet::Pops::Types::PCallableType)
+      end
+
+      # conditional on Ruby 1.8.7 which does not do parameter introspection
+      if Method.method_defined?(:parameters)
+        it 'about parameter names obtained from ruby introspection' do
+          fc = create_min_function_class
+          signature = fc.signatures[0]
+          expect(signature.parameter_names).to eql(['x', 'y'])
+        end
+      end
+
+      it 'about parameter names specified with dispatch' do
+        fc = create_min_function_class_using_dispatch
+        signature = fc.signatures[0]
+        expect(signature.parameter_names).to eql(['a', 'b'])
+      end
+
+      it 'about block_name when it is *not* given in the definition' do
+        # neither type, nor name
+        fc = create_function_with_required_block_all_defaults
+        signature = fc.signatures[0]
+        expect(signature.block_name).to eql('block')
+        # no name given, only type
+        fc = create_function_with_required_block_given_type
+        signature = fc.signatures[0]
+        expect(signature.block_name).to eql('block')
+      end
+
+      it 'about block_name when it *is* given in the definition' do
+        # neither type, nor name
+        fc = create_function_with_required_block_default_type
+        signature = fc.signatures[0]
+        expect(signature.block_name).to eql('the_block')
+        # no name given, only type
+        fc = create_function_with_required_block_fully_specified
+        signature = fc.signatures[0]
+        expect(signature.block_name).to eql('the_block')
+      end
+    end
+
+    context 'supports calling other functions' do
+      before(:all) do
+        Puppet.push_context( {:loaders => Puppet::Pops::Loaders.new()})
+      end
+
+      after(:all) do
+        Puppet.pop_context()
+      end
+
+      it 'such that, other functions are callable by name' do
+        fc = Puppet::Functions.create_function(:test) do
+          def test()
+            # Call a function available in the puppet system
+            call_function('assert_type', 'Integer', 10)
+          end
+        end
+        # initiate the function the same way the loader initiates it
+        f = fc.new(:closure_scope, Puppet.lookup(:loaders).puppet_system_loader)
+        expect(f.call({})).to eql(10)
+      end
+
+      it 'such that, calling a non existing function raises an error' do
+        fc = Puppet::Functions.create_function(:test) do
+          def test()
+            # Call a function not available in the puppet system
+            call_function('no_such_function', 'Integer', 'hello')
+          end
+        end
+        # initiate the function the same way the loader initiates it
+        f = fc.new(:closure_scope, Puppet.lookup(:loaders).puppet_system_loader)
+        expect{f.call({})}.to raise_error(ArgumentError, "Function test(): cannot call function 'no_such_function' - not found")
+      end
+    end
+
+    context 'supports calling ruby functions with lambda from puppet' do
+      before(:all) do
+        Puppet.push_context( {:loaders => Puppet::Pops::Loaders.new()})
+      end
+
+      after(:all) do
+        Puppet.pop_context()
+      end
+
+      before(:each) do
+        Puppet[:strict_variables] = true
+
+        # These must be set since the is 3x logic that triggers on these even if the tests are explicit
+        # about selection of parser and evaluator
+        #
+        Puppet[:parser] = 'future'
+        Puppet[:evaluator] = 'future'
+        # Puppetx cannot be loaded until the correct parser has been set (injector is turned off otherwise)
+        require 'puppetx'
+      end
+
+      let(:parser) {  Puppet::Pops::Parser::EvaluatingParser::Transitional.new }
+      let(:node) { 'node.example.com' }
+      let(:scope) { s = create_test_scope_for_node(node); s }
+
+      it 'function with required block can be called' do
+        # construct ruby function to call
+        fc = Puppet::Functions.create_function('testing::test') do
+          dispatch :test do
+            param Integer, 'x'
+            # block called 'the_block', and using "all_callables"
+            required_block_param #(all_callables(), 'the_block')
+          end
+          def test(x, block)
+            # call the block with x
+            block.call(closure_scope, x)
+          end
+        end
+        # add the function to the loader (as if it had been loaded from somewhere)
+        the_loader = loader()
+        f = fc.new({}, the_loader)
+        loader.add_function('testing::test', f)
+        # evaluate a puppet call
+        source = "testing::test(10) |$x| { $x+1 }"
+        program = parser.parse_string(source, __FILE__)
+        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        expect(parser.evaluate(scope, program)).to eql(11)
+      end
+    end
+
+  end
+
+  def create_noargs_function_class
+    f = Puppet::Functions.create_function('test') do
+      def test()
+        10
+      end
+    end
   end
 
   def create_min_function_class
@@ -407,6 +658,77 @@ actual:
       def test(x,y,a,b)
         y_produced = y.produce(nil)
         "#{x}! #{a}, and #{b} < #{y_produced} = #{ !!(a < y_produced && b < y_produced)}"
+      end
+    end
+  end
+
+  def create_function_with_required_block_all_defaults
+    f = Puppet::Functions.create_function('test') do
+      dispatch :test do
+        param Integer, 'x'
+        # use defaults, any callable, name is 'block'
+        required_block_param
+      end
+      def test(x, block)
+        # returns the block to make it easy to test what it got when called
+        block
+      end
+    end
+  end
+
+  def create_function_with_required_block_default_type
+    f = Puppet::Functions.create_function('test') do
+      dispatch :test do
+        param Integer, 'x'
+        # use defaults, any callable, name is 'block'
+        required_block_param 'the_block'
+      end
+      def test(x, block)
+        # returns the block to make it easy to test what it got when called
+        block
+      end
+    end
+  end
+
+  def create_function_with_required_block_given_type
+    f = Puppet::Functions.create_function('test') do
+      dispatch :test do
+        param Integer, 'x'
+        # use defaults, any callable, name is 'block'
+        required_block_param callable()
+      end
+      def test(x, block)
+        # returns the block to make it easy to test what it got when called
+        block
+      end
+    end
+  end
+
+  def create_function_with_required_block_fully_specified
+    f = Puppet::Functions.create_function('test') do
+      dispatch :test do
+        param Integer, 'x'
+        # use defaults, any callable, name is 'block'
+        required_block_param(callable(), 'the_block')
+      end
+      def test(x, block)
+        # returns the block to make it easy to test what it got when called
+        block
+      end
+    end
+  end
+
+  def create_function_with_optional_block_all_defaults
+    f = Puppet::Functions.create_function('test') do
+      dispatch :test do
+        param Integer, 'x'
+        # use defaults, any callable, name is 'block'
+        optional_block_param
+      end
+      def test(x, block=nil)
+        # returns the block to make it easy to test what it got when called
+        # a default of nil must be used or the call will fail with a missing parameter
+        block
       end
     end
   end


### PR DESCRIPTION
Updates the Puppet 4x Function API with the ability to call a lambda given as an extra argument.
This support is implemented via the Callable type, and Function and Closure are now unified in how they describe their callable signature(s). See the individual commits for more information.

Function API documentation updated.
