### PR TITLE
(PUP-2190) Fix issue when there are no defaults (for meta params)

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -487,6 +487,7 @@ class Puppet::Pops::Evaluator::AccessOperator
       unless resource
         fail(Puppet::Pops::Issues::UNKNOWN_RESOURCE, @semantic, {:type_name => o.type_name, :title => o.title})
       end
+
       result = keys.map do |k|
         unless is_parameter_of_resource?(scope, resource, k)
           fail(Puppet::Pops::Issues::UNKNOWN_RESOURCE_PARAMETER, @semantic,

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -360,15 +360,20 @@ module Puppet::Pops::Evaluator::Runtime3Support
   # Returns the value of a resource's parameter by first looking up the parameter in the resource
   # and then in the defaults for the resource. Since the resource exists (it must in order to look up its
   # parameters, any overrides have already been applied). Defaults are not applied to a resource until it
-  # has been finished (which typically has not taked place when this is evaluated; hence the dual lookup).
+  # has been finished (which typically has not taken place when this is evaluated; hence the dual lookup).
   #
   def get_resource_parameter_value(scope, resource, parameter_name)
+    # This gets the parameter value, or nil (for both valid parameters and parameters that do not exist).
     val = resource[parameter_name]
     if val.nil? && defaults = scope.lookupdefaults(resource.type)
       # NOTE: 3x resource keeps defaults as hash using symbol for name as key to Parameter which (again) holds
       # name and value.
+      # NOTE: meta parameters that are unset ends up here, and there are no defaults for those encoded
+      # in the defaults, they may receive hardcoded defaults later (e.g. 'tag').
       param = defaults[parameter_name.to_sym]
-      val = param.value
+      # Some parameters (meta parameters like 'tag') does not return a param from which the value can be obtained
+      # at all times. Instead, they return a nil param until a value has been set.
+      val = param.nil? ? nil : param.value
     end
     val
   end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -659,6 +659,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
         "notify { id: message=>explicit} Notify[id][message]"                   => "explicit",
         "Notify { message=>by_default} notify {foo:} Notify[foo][message]"      => "by_default",
         "notify {foo:} Notify[foo]{message =>by_override} Notify[foo][message]" => "by_override",
+        "notify { foo: tag => evoe} Notify[foo][tag]"                           => "evoe",
+        # Does not produce the defaults for tag
+        "notify { foo: } Notify[foo][tag]"                                      => nil,
       }.each do |source, result|
         it "should parse and evaluate the expression '#{source}' to #{result}" do
           parser.evaluate_string(scope, source, __FILE__).should == result
@@ -669,6 +672,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       {
         "notify { xid: message=>explicit} Notify[id][message]"  => /Resource not found/,
         "notify { id: message=>explicit} Notify[id][mustard]"   => /does not have a parameter called 'mustard'/,
+        # NOTE: these meta-esque parameters are not recognized as such
+        "notify { id: message=>explicit} Notify[id][title]"   => /does not have a parameter called 'title'/,
+        "notify { id: message=>explicit} Notify[id]['type']"   => /does not have a parameter called 'type'/,
       }.each do |source, result|
         it "should parse '#{source}' and raise error matching #{result}" do
           expect { parser.evaluate_string(scope, source, __FILE__)}.to raise_error(result)


### PR DESCRIPTION
When looking up a metaparameter - Notify['foo'][tag], this failed
when no tags had been set. The same problem would occur for any
parameter that the resource api reported to be a vaid parameter but
for which asking for its default did not return a Parameter.
