### PR TITLE
(pup-2292) stronger tests on yumrepo's properties

### DIFF
--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -5,6 +5,9 @@ shared_examples_for "a yumrepo parameter that can be absent" do |param|
   it "can be set as :absent" do
     described_class.new(:name => 'puppetlabs', param => :absent)
   end
+  it "can be set as \"absent\"" do
+    described_class.new(:name => 'puppetlabs', param => 'absent')
+  end
 end
 
 shared_examples_for "a yumrepo parameter that expects a boolean parameter" do |param|


### PR DESCRIPTION
When you set => absent on a yumrepo property, the result is a string in
ruby. However, it happens that we expect only a :symbol there in the
tests.
