### PR TITLE
(PUP-2213) Read environment settings from other sections in config print

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -68,9 +68,17 @@ module Puppet::Environments
       end
     end
 
+    # Returns a basic environment configuration object tied to the environment's
+    # implementation values.  Will not interpolate.
+    #
     # @!macro loader_get_conf
     def get_conf(name)
-      nil
+      env = get(name)
+      if env
+        Puppet::Settings::EnvironmentConf.static_for(env)
+      else
+        nil
+      end
     end
   end
 

--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -59,12 +59,25 @@ Puppet::Face.define(:config, '0.0.1') do
 
       args = Puppet.settings.to_a.collect(&:first) if args.empty? || args == ['all']
 
-      values = Puppet.settings.values(Puppet[:environment].to_sym, options[:section].to_sym)
-      if args.length == 1
-        puts values.interpolate(args[0].to_sym)
-      else
-        args.each do |setting_name|
-          puts "#{setting_name} = #{values.interpolate(setting_name.to_sym)}"
+      values_from_the_selected_section =
+        Puppet.settings.values(nil, options[:section].to_sym)
+
+      loader_settings = {
+        :environmentpath => values_from_the_selected_section.interpolate(:environmentpath),
+        :basemodulepath => values_from_the_selected_section.interpolate(:basemodulepath),
+      }
+
+      Puppet.override(Puppet.base_context(loader_settings),
+                     "New environment loaders generated from the requested section.") do
+        # And now we can lookup values that include those from environments configured from
+        # the requested section
+        values = Puppet.settings.values(Puppet[:environment].to_sym, options[:section].to_sym)
+        if args.length == 1
+          puts values.interpolate(args[0].to_sym)
+        else
+          args.each do |setting_name|
+            puts "#{setting_name} = #{values.interpolate(setting_name.to_sym)}"
+          end
         end
       end
       nil

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1123,7 +1123,7 @@ Generated on #{Time.now}.
             values_from_section = ValuesFromSection.new(name, section)
           end
         end
-        if values_from_section.nil? && @global_defaults_initialized
+        if values_from_section.nil? && global_defaults_initialized?
           values_from_section = ValuesFromEnvironmentConf.new(name)
         end
         values_from_section

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -33,6 +33,14 @@ class Puppet::Settings::EnvironmentConf
     new(path_to_env, section, global_module_path)
   end
 
+  # Provides a configuration object tied directly to the passed environment.
+  # Configuration values are exactly those returned by the environment object,
+  # without interpolation.  This is a special case for the default configured
+  # environment returned by the Puppet::Environments::StaticPrivate loader.
+  def self.static_for(environment)
+    Static.new(environment)
+  end
+
   attr_reader :section
 
   # Create through EnvironmentConf.load_from()
@@ -100,4 +108,26 @@ class Puppet::Settings::EnvironmentConf
       File.expand_path(path, @path_to_env)
     end
   end
+
+  # Models configuration for an environment that is not loaded from a directory.
+  #
+  # @api private
+  class Static
+    def initialize(environment)
+      @environment = environment
+    end
+
+    def manifest
+      @environment.manifest
+    end
+
+    def modulepath
+      @environment.modulepath.join(File::PATH_SEPARATOR)
+    end
+
+    def config_version
+      @environment.config_version
+    end
+  end
+
 end

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -298,6 +298,44 @@ config_version=$vardir/random/scripts
     end
   end
 
+  describe "static loaders" do
+    let(:static1) { Puppet::Node::Environment.create(:static1, []) }
+    let(:static2) { Puppet::Node::Environment.create(:static2, []) }
+    let(:loader) { Puppet::Environments::Static.new(static1, static2) }
+
+    it "lists environments" do
+      expect(loader.list).to eq([static1, static2])
+    end
+
+    it "gets an environment" do
+      expect(loader.get(:static2)).to eq(static2)
+    end
+
+    it "returns nil if env not found" do
+      expect(loader.get(:doesnotexist)).to be_nil
+    end
+
+    it "gets a basic conf" do
+      conf = loader.get_conf(:static1)
+      expect(conf.modulepath).to eq('')
+      expect(conf.manifest).to eq(:no_manifest)
+      expect(conf.config_version).to be_nil
+    end
+
+    it "returns nil if you request a configuration from an env that doesn't exist" do
+      expect(loader.get_conf(:doesnotexist)).to be_nil
+    end
+
+    context "that are private" do
+      let(:private_env) { Puppet::Node::Environment.create(:private, []) }
+      let(:loader) { Puppet::Environments::StaticPrivate.new(private_env) }
+
+      it "lists nothing" do
+        expect(loader.list).to eq([])
+      end
+    end
+  end
+
   RSpec::Matchers.define :environment do |name|
     match do |env|
       env.name == name &&

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -3,22 +3,23 @@ require 'spec_helper'
 require 'puppet/face'
 
 describe Puppet::Face[:config, '0.0.1'] do
+
+  FS = Puppet::FileSystem
+
   it "prints a single setting without the name" do
     Puppet[:trace] = true
 
-    subject.expects(:puts).with(true)
-
-    subject.print("trace").should be_nil
+    expect { subject.print("trace") }.to have_printed('true')
   end
 
   it "prints multiple settings with the names" do
     Puppet[:trace] = true
     Puppet[:syslogfacility] = "file"
 
-    subject.expects(:puts).with("trace = true")
-    subject.expects(:puts).with("syslogfacility = file")
-
-    subject.print("trace", "syslogfacility")
+    expect { subject.print("trace", "syslogfacility") }.to have_printed(<<-OUTPUT)
+trace = true
+syslogfacility = file
+    OUTPUT
   end
 
   it "prints the setting from the selected section" do
@@ -27,12 +28,10 @@ describe Puppet::Face[:config, '0.0.1'] do
     syslogfacility = file
     CONF
 
-    subject.expects(:puts).with("file")
-
-    subject.print("syslogfacility", :section => "other")
+    expect { subject.print("syslogfacility", :section => "other") }.to have_printed('file')
   end
 
-  it "should default to all when no arguments are given" do
+  it "defaults to all when no arguments are given" do
     subject.expects(:puts).times(Puppet.settings.to_a.length)
 
     subject.print
@@ -42,5 +41,104 @@ describe Puppet::Face[:config, '0.0.1'] do
     subject.expects(:puts).times(Puppet.settings.to_a.length)
 
     subject.print('all')
+  end
+
+  shared_examples_for :config_printing_a_section do |section|
+
+    def add_section_option(args, section)
+      args << { :section => section } if section
+      args
+    end
+
+    it "prints directory env settings for an env that exists" do
+      FS.overlay(
+        FS::MemoryFile.a_directory("/dev/null/environments", [
+          FS::MemoryFile.a_directory("production", [
+            FS::MemoryFile.a_missing_file("environment.conf"),
+          ]),
+        ])
+      ) do
+        args = "environmentpath","manifest","modulepath","environment","basemodulepath"
+        expect { subject.print(*add_section_option(args, section)) }.to have_printed(<<-OUTPUT)
+environmentpath = /dev/null/environments
+manifest = /dev/null/environments/production/manifests
+modulepath = /dev/null/environments/production/modules#{File::PATH_SEPARATOR}/some/base
+environment = production
+basemodulepath = /some/base
+        OUTPUT
+      end
+    end
+
+    it "interpolates settings in environment.conf" do
+      FS.overlay(
+        FS::MemoryFile.a_directory("/dev/null/environments", [
+          FS::MemoryFile.a_directory("production", [
+            FS::MemoryFile.a_regular_file_containing("environment.conf", <<-CONTENT),
+            modulepath=/custom/modules#{File::PATH_SEPARATOR}$basemodulepath
+            CONTENT
+          ]),
+        ])
+      ) do
+        args = "environmentpath","manifest","modulepath","environment","basemodulepath"
+        expect { subject.print(*add_section_option(args, section)) }.to have_printed(<<-OUTPUT)
+environmentpath = /dev/null/environments
+manifest = /dev/null/environments/production/manifests
+modulepath = /custom/modules#{File::PATH_SEPARATOR}/some/base
+environment = production
+basemodulepath = /some/base
+        OUTPUT
+      end
+    end
+
+    it "prints the default configured env settings for an env that does not exist" do
+      Puppet[:environment] = 'doesnotexist'
+
+      FS.overlay(
+        FS::MemoryFile.a_directory("/dev/null/environments", [
+          FS::MemoryFile.a_missing_file("doesnotexist")
+        ])
+      ) do
+        args = "environmentpath","manifest","modulepath","environment","basemodulepath"
+        expect { subject.print(*add_section_option(args, section)) }.to have_printed(<<-OUTPUT)
+environmentpath = /dev/null/environments
+manifest = no_manifest
+modulepath = 
+environment = doesnotexist
+basemodulepath = /some/base
+        OUTPUT
+      end
+    end
+  end
+
+  context "when printing environment settings" do
+    before(:each) do
+      Puppet.settings.stubs(:global_defaults_initialized?).returns(:true)
+    end
+
+    context "from main section" do
+      before(:each) do
+        Puppet.settings.parse_config(<<-CONF)
+        [main]
+        environmentpath=$confdir/environments
+        basemodulepath=/some/base
+        CONF
+      end
+
+      it_behaves_like :config_printing_a_section
+    end
+
+    context "from master section" do
+
+      before(:each) do
+        Puppet.settings.parse_config(<<-CONF)
+        [master]
+        environmentpath=$confdir/environments
+        basemodulepath=/some/base
+        CONF
+        Puppet.settings.stubs(:global_defaults_initialized?).returns(:true)
+      end
+
+      it_behaves_like :config_printing_a_section, :master
+    end
   end
 end


### PR DESCRIPTION
Puppet's config print functionality has a --section option to allow you
to read the configuration as it would be seen in other run modes such as
master or agent.  But the environment loaders are provided an
environmentpath and basemodulepath setting prior to Puppet evaluating
the user's --section setting, and will only provide environments as
configured in [main].  So if you have environmentpath set in master, a
`puppet config print modulepath --section master --environment
production` would show you the modulepath for the production
environment as loaded from [main] not [master].

To fix this, when handling a config print call, we are now overriding
the environment loaders with settings obtained from the user selected
section.  This means that the interpolated settings can now find an
environment from an environmentpath specified in any section of
puppet.conf.

The static environment loader get_conf() method is also changed to
return a simple configuration that just returns the statically declared
environment's settings.  This ensures that `puppet config print
--environment doesnotexist` will correctly print the 'no_manifest' and
empty modulepath setting that reflect the private statically configured
environment settings for a non-existent directory environment.
