### PR TITLE
(PUP-2578) Adjustments for new OpenBSD service provider

### DIFF
--- a/lib/puppet/provider/service/openbsd.rb
+++ b/lib/puppet/provider/service/openbsd.rb
@@ -171,10 +171,10 @@ Puppet::Type.type(:service).provide :openbsd, :parent => :init do
       content.reject! {|l| l.nil? }
     end
 
-    if flags.nil?
+    if flags.nil? or flags.size == 0
       if in_base?
-	append = resource[:name] + '_flags=""'
-     end
+        append = resource[:name] + '_flags=""'
+      end
     else
       append = resource[:name] + '_flags="' + flags + '"'
     end


### PR DESCRIPTION
After some more testing of @xaque208 new service provider I ran into an issue where a service from packages like:

```
service {'puppetboard':
  enable => true
}
```

would end up with the following in `/etc/rc.conf.local`:

```
puppetboard_flags=""
```

This breaks the script, as it has sets it's local `daemon_flags` which are then overridden by the flags from `rc.conf.local` (to `""`), so if there are no `:flags` set, then the `_flags=""` should not be written out.

Also, order is important for `pkg_scripts` as things like avahi-daemon need dbus_daemon to be started. Therefore `pkg_scripts` must not be sorted but just append to and let people define the order (if there needs to be one) by using dependency resources.

Thirdly, after some discussion it was deemed better (and faster) to turn `#in_base?` really into "in base" instead of "not in base" by looking at `/etc/rc.conf` which contains all the base daemons.
