### PR TITLE
(PUP-2306) Force return type of generate to String

### DIFF
--- a/lib/puppet/parser/functions/generate.rb
+++ b/lib/puppet/parser/functions/generate.rb
@@ -30,7 +30,7 @@ Puppet::Parser::Functions::newfunction(:generate, :arity => -2, :type => :rvalue
       end
 
       begin
-        Dir.chdir(File.dirname(args[0])) { Puppet::Util::Execution.execute(args) }
+        Dir.chdir(File.dirname(args[0])) { Puppet::Util::Execution.execute(args).to_str }
       rescue Puppet::ExecutionFailure => detail
         raise Puppet::ParseError, "Failed to execute generator #{args[0]}: #{detail}", detail.backtrace
       end

--- a/spec/unit/parser/functions/generate_spec.rb
+++ b/spec/unit/parser/functions/generate_spec.rb
@@ -110,6 +110,10 @@ describe "the generate function" do
     File.delete(command) if Puppet::FileSystem.exist?(command)
   end
 
+  it "returns the output as a String" do
+    scope.function_generate([command]).class.should == String
+  end
+
   it "should call generator with no arguments" do
     scope.function_generate([command]).should == "a- b-\n"
   end


### PR DESCRIPTION
When Puppet::Util::Execution.execute was changed to return a subtype of 
String in order to retain return code information, some callers ended up 
breaking. This is because they made the assertion that types were exactly the
String class, rather than a subtype of String. There is also the issue that
only the primitive data structures should probably be returned from puppet
functions in order to not leak complex objects into the puppet language and
have hard to track down issues arise.

This changes the generate() function to force it to return a String of the
command's output.
