### PR TITLE
(PUP-2080) Reinstate function as a QNAME

### DIFF
--- a/lib/puppet/pops/parser/egrammar.ra
+++ b/lib/puppet/pops/parser/egrammar.ra
@@ -594,7 +594,7 @@ node_definition_expression
 #---FUNCTION DEFINITION
 #
 function_definition
-  : FUNCTION { result = Factory.literal(val[0][:value]) ; loc result, val[0] }
+  : FUNCTION { result = Factory.QNAME(val[0][:value]) ; loc result, val[0] }
   # For now the function word will just be reserved, in the future it will
   # produce a function definition
   # FUNCTION classname parameter_list LBRACE opt_statements RBRACE {

--- a/lib/puppet/pops/parser/eparser.rb
+++ b/lib/puppet/pops/parser/eparser.rb
@@ -2201,7 +2201,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 591)
 
 module_eval(<<'.,.,', 'egrammar.ra', 596)
   def _reduce_157(val, _values, result)
-     result = Factory.literal(val[0][:value]) ; loc result, val[0] 
+     result = Factory.QNAME(val[0][:value]) ; loc result, val[0] 
     result
   end
 .,.,


### PR DESCRIPTION
The 'function' word was accidentally made a literal value when the function
in the puppet language changes were removed. It should have been a QNAME,
since that is what bare words are. This allows it to once again be used as
the name of a class, for instance.
