### PR TITLE
(pup-1712) Use beaker 1.10 in acceptance (needed for trusty)

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 1.7.0"
+gem "beaker", "~> 1.10.0"
 gem 'rake', "~> 10.1.0"
 
 group(:test) do


### PR DESCRIPTION
See https://github.com/puppetlabs/beaker/pull/219 for details.
