### PR TITLE
(PUP-2344) Fix issue with inter-module calls (visibility error)

### DIFF
--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -87,6 +87,14 @@ class Puppet::Pops::Loader::Loader
     nil
   end
 
+  # Produces the private loader for loaders that have a one (the visibility given to loaded entities).
+  # For loaders that does not provide a private loader, self is returned.
+  #
+  # @api private
+  def private_loader
+    self
+  end
+
   # Binds a value to a name. The name should not start with '::', but may contain multiple segments.
   #
   # @param type [:Symbol] the type of the entity being set

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -31,6 +31,13 @@ module Puppet::Pops::Loader::ModuleLoaders
     # A map of type to smart-paths that help with minimizing the number of paths to scan
     attr_reader :smart_paths
 
+    # A Module Loader has a private loader, it is lazily obtained on request to provide the visibility
+    # for entities contained in the module. Since a ModuleLoader also represents an environment and it is
+    # created a different way, this loader can be set explicitly by the loaders bootstrap logic.
+    #
+    # @api private
+    attr_accessor :private_loader
+
     # Initialize a kind of ModuleLoader for one module
     # @param parent_loader [Puppet::Pops::Loader] loader with higher priority
     # @param module_name [String] the name of the module (non qualified name), may be nil for a global "component"
@@ -145,6 +152,12 @@ module Puppet::Pops::Loader::ModuleLoaders
     #
     def get_source_ref(relative_path)
       raise NotImplementedError.new
+    end
+
+    # Produces the private loader for the module. If this module is not already resolved, this will trigger resolution
+    #
+    def private_loader
+      @private_loader ||= Puppet.lookup(:loaders).private_loader_for_module(module_name)
     end
   end
 

--- a/lib/puppet/pops/loader/ruby_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_function_instantiator.rb
@@ -29,6 +29,6 @@ class Puppet::Pops::Loader::RubyFunctionInstantiator
 
     # TODO: Cheating wrt. scope - assuming it is found in the context
     closure_scope = Puppet.lookup(:global_scope) { {} }
-    created.new(closure_scope, loader)
+    created.new(closure_scope, loader.private_loader)
   end
 end

--- a/lib/puppet/pops/loader/simple_environment_loader.rb
+++ b/lib/puppet/pops/loader/simple_environment_loader.rb
@@ -6,6 +6,8 @@
 #
 class Puppet::Pops::Loader::SimpleEnvironmentLoader < Puppet::Pops::Loader::BaseLoader
 
+  attr_accessor :private_loader
+
   # Never finds anything, everything "loaded" is set externally
   def find(typed_name)
     nil
@@ -15,4 +17,4 @@ class Puppet::Pops::Loader::SimpleEnvironmentLoader < Puppet::Pops::Loader::Base
     "(SimpleEnvironmentLoader '#{loader_name}')"
   end
 
-end
+end 

--- a/spec/fixtures/unit/pops/loaders/loaders/wo_metadata_module/modules/moduleb/lib/puppet/functions/moduleb/rb_func_b.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/wo_metadata_module/modules/moduleb/lib/puppet/functions/moduleb/rb_func_b.rb
@@ -1,0 +1,6 @@
+Puppet::Functions.create_function(:'moduleb::rb_func_b') do
+  def rb_func_b()
+    # Should be able to call modulea::rb_func_a()
+    call_function('modulea::rb_func_a') + " + I am moduleb::rb_func_b()"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/wo_metadata_module/modules/moduleb/manifests/init.pp
+++ b/spec/fixtures/unit/pops/loaders/loaders/wo_metadata_module/modules/moduleb/manifests/init.pp
@@ -1,0 +1,3 @@
+class moduleb {
+
+}

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -5,9 +5,16 @@ require 'puppet/loaders'
 describe 'the assert_type function' do
 
   after(:all) { Puppet::Pops::Loaders.clear }
-  let(:func) do
+
+  around(:each) do |example|
     loaders = Puppet::Pops::Loaders.new()
-    loaders.puppet_system_loader.load(:function, 'assert_type')
+    Puppet.override({:loaders => loaders}, "test-example") do
+      example.run
+    end
+  end
+
+  let(:func) do
+    Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'assert_type')
   end
 
   it 'asserts compliant type by returning the value' do

--- a/spec/unit/pops/loaders/dependency_loader_spec.rb
+++ b/spec/unit/pops/loaders/dependency_loader_spec.rb
@@ -8,7 +8,15 @@ describe 'dependency loader' do
 
   let(:static_loader) { Puppet::Pops::Loader::StaticLoader.new() }
 
+
   describe 'FileBased module loader' do
+    around(:each) do |example|
+      loaders = Puppet::Pops::Loaders.new()
+      Puppet.override({:loaders => loaders}, "test-example") do
+        example.run
+      end
+    end
+
     it 'load something in global name space raises an error' do
       module_dir = dir_containing('testmodule', {
       'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -43,7 +43,6 @@ describe 'loaders' do
     end
   end
 
-  # TODO: LOADING OF MODULES ON MODULEPATH
   context 'loading from path with single module' do
     before do
       env = Puppet::Node::Environment.create(:'*test*', [File.join(config_dir('single_module'), 'modules')], '')
@@ -59,16 +58,72 @@ describe 'loaders' do
 
     it 'can load from a module path' do
       loaders = Puppet::Pops::Loaders.new()
-      modulea_loader = loaders.public_loader_for_module('modulea')
-      expect(modulea_loader.class).to eql(Puppet::Pops::Loader::ModuleLoaders::FileBased)
+      Puppet.override({:loaders => loaders}, 'testcase') do
+        modulea_loader = loaders.public_loader_for_module('modulea')
+        expect(modulea_loader.class).to eql(Puppet::Pops::Loader::ModuleLoaders::FileBased)
 
-      function = modulea_loader.load_typed(typed_name(:function, 'rb_func_a')).value
-      expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
-      expect(function.class.name).to eq('rb_func_a')
+        function = modulea_loader.load_typed(typed_name(:function, 'rb_func_a')).value
+        expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+        expect(function.class.name).to eq('rb_func_a')
 
-      function = modulea_loader.load_typed(typed_name(:function, 'modulea::rb_func_a')).value
-      expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
-      expect(function.class.name).to eq('modulea::rb_func_a')
+        function = modulea_loader.load_typed(typed_name(:function, 'modulea::rb_func_a')).value
+        expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+        expect(function.class.name).to eq('modulea::rb_func_a')
+      end
+    end
+  end
+
+  context 'loading from path with two module, one without meta-data' do
+    before do
+      module_path = [File.join(config_dir('single_module'), 'modules'), File.join(config_dir('wo_metadata_module'), 'modules')]
+      env = Puppet::Node::Environment.create(:'*test*', module_path, '')
+      overrides = {
+        :current_environment => env,
+      }
+      Puppet.push_context(overrides, "two-modules-test-loaders")
+    end
+
+    after do
+      Puppet.pop_context()
+    end
+
+    it 'can load from module with metadata' do
+      loaders = Puppet::Pops::Loaders.new
+      Puppet.override({:loaders => loaders}, 'testcase') do
+        modulea_loader = loaders.public_loader_for_module('modulea')
+        expect(modulea_loader.class).to eql(Puppet::Pops::Loader::ModuleLoaders::FileBased)
+
+        function = modulea_loader.load_typed(typed_name(:function, 'rb_func_a')).value
+        expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+        expect(function.class.name).to eq('rb_func_a')
+
+        function = modulea_loader.load_typed(typed_name(:function, 'modulea::rb_func_a')).value
+        expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+        expect(function.class.name).to eq('modulea::rb_func_a')
+      end
+    end
+
+    it 'can load from module with metadata' do
+      loaders = Puppet::Pops::Loaders.new
+      Puppet.override({:loaders => loaders}, 'testcase') do
+        moduleb_loader = loaders.public_loader_for_module('moduleb')
+        expect(moduleb_loader.class).to eql(Puppet::Pops::Loader::ModuleLoaders::FileBased)
+
+        function = moduleb_loader.load_typed(typed_name(:function, 'moduleb::rb_func_b')).value
+        expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+        expect(function.class.name).to eq('moduleb::rb_func_b')
+      end
+    end
+
+    it 'module without metadata has all modules visible' do
+      loaders = Puppet::Pops::Loaders.new
+      Puppet.override({:loaders => loaders}, 'testcase') do
+        moduleb_loader = loaders.private_loader_for_module('moduleb')
+
+        function = moduleb_loader.load_typed(typed_name(:function, 'moduleb::rb_func_b')).value
+        result = function.call({})
+        expect(result).to eql("I am modulea::rb_func_a() + I am moduleb::rb_func_b()")
+      end
     end
   end
 

--- a/spec/unit/pops/loaders/module_loaders_spec.rb
+++ b/spec/unit/pops/loaders/module_loaders_spec.rb
@@ -3,118 +3,120 @@ require 'puppet_spec/files'
 require 'puppet/pops'
 require 'puppet/loaders'
 
-describe 'module loaders' do
+describe 'FileBased module loader' do
   include PuppetSpec::Files
 
   let(:static_loader) { Puppet::Pops::Loader::StaticLoader.new() }
+  around(:each) do |example|
+    loaders = Puppet::Pops::Loaders.new()
+    Puppet.override({:loaders => loaders}, "test-example") do
+      example.run
+    end
+  end
 
-  describe 'FileBased module loader' do
-    it 'can load a 4x function API ruby function in global name space' do
-      module_dir = dir_containing('testmodule', {
-        'lib' => {
-          'puppet' => {
-            'functions' => {
+  it 'can load a 4x function API ruby function in global name space' do
+    module_dir = dir_containing('testmodule', {
+      'lib' => {
+        'puppet' => {
+          'functions' => {
+            'foo4x.rb' => <<-CODE
+               Puppet::Functions.create_function(:foo4x) do
+                 def foo4x()
+                   'yay'
+                 end
+               end
+            CODE
+          }
+            }
+          }
+        })
+
+    module_loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(static_loader, 'testmodule', module_dir, 'test1')
+    function = module_loader.load_typed(typed_name(:function, 'foo4x')).value
+    expect(function.class.name).to eq('foo4x')
+    expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+  end
+
+  it 'can load a 4x function API ruby function in qualified name space' do
+    module_dir = dir_containing('testmodule', {
+      'lib' => {
+        'puppet' => {
+          'functions' => {
+            'testmodule' => {
               'foo4x.rb' => <<-CODE
-                 Puppet::Functions.create_function(:foo4x) do
+                 Puppet::Functions.create_function('testmodule::foo4x') do
                    def foo4x()
                      'yay'
                    end
                  end
               CODE
-            }
               }
             }
-          })
+          }
+      }})
 
-      module_loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(static_loader, 'testmodule', module_dir, 'test1')
-      function = module_loader.load_typed(typed_name(:function, 'foo4x')).value
-      expect(function.class.name).to eq('foo4x')
-      expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
-    end
+    module_loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(static_loader, 'testmodule', module_dir, 'test1')
+    function = module_loader.load_typed(typed_name(:function, 'testmodule::foo4x')).value
+    expect(function.class.name).to eq('testmodule::foo4x')
+    expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+  end
 
-    it 'can load a 4x function API ruby function in qualified name space' do
+  it 'makes parent loader win over entries in child' do
+    module_dir = dir_containing('testmodule', {
+      'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {
+        'foo.rb' => <<-CODE
+           Puppet::Functions.create_function('testmodule::foo') do
+             def foo()
+               'yay'
+             end
+           end
+        CODE
+      }}}}})
+    module_loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(static_loader, 'testmodule', module_dir, 'test1')
+
+    module_dir2 = dir_containing('testmodule2', {
+      'lib' => { 'puppet' => { 'functions' => { 'testmodule2' => {
+        'foo.rb' => <<-CODE
+           raise "should not get here"
+        CODE
+      }}}}})
+    module_loader2 = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(module_loader, 'testmodule2', module_dir2, 'test2')
+
+    function = module_loader2.load_typed(typed_name(:function, 'testmodule::foo')).value
+
+    expect(function.class.name).to eq('testmodule::foo')
+    expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+  end
+
+  context 'when delegating 3x to 4x' do
+    before(:each) { Puppet[:biff] = true }
+
+    it 'can load a 3x function API ruby function in global name space' do
       module_dir = dir_containing('testmodule', {
         'lib' => {
           'puppet' => {
-            'functions' => {
-              'testmodule' => {
-                'foo4x.rb' => <<-CODE
-                   Puppet::Functions.create_function('testmodule::foo4x') do
-                     def foo4x()
-                       'yay'
-                     end
-                   end
+            'parser' => {
+              'functions' => {
+                'foo3x.rb' => <<-CODE
+                  Puppet::Parser::Functions::newfunction(
+                    :foo3x, :type => :rvalue,
+                    :arity => 1
+                  ) do |args|
+                    args[0]
+                  end
                 CODE
-                }
+              }
               }
             }
         }})
 
-      module_loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(static_loader, 'testmodule', module_dir, 'test1')
-      function = module_loader.load_typed(typed_name(:function, 'testmodule::foo4x')).value
-      expect(function.class.name).to eq('testmodule::foo4x')
-      expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
+     module_loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(static_loader, 'testmodule', module_dir, 'test1')
+     function = module_loader.load_typed(typed_name(:function, 'foo3x')).value
+     expect(function.class.name).to eq('foo3x')
+     expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
     end
-
-    it 'makes parent loader win over entries in child' do
-      module_dir = dir_containing('testmodule', {
-        'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {
-          'foo.rb' => <<-CODE
-             Puppet::Functions.create_function('testmodule::foo') do
-               def foo()
-                 'yay'
-               end
-             end
-          CODE
-        }}}}})
-      module_loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(static_loader, 'testmodule', module_dir, 'test1')
-
-      module_dir2 = dir_containing('testmodule2', {
-        'lib' => { 'puppet' => { 'functions' => { 'testmodule2' => {
-          'foo.rb' => <<-CODE
-             raise "should not get here"
-          CODE
-        }}}}})
-      module_loader2 = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(module_loader, 'testmodule2', module_dir2, 'test2')
-
-      function = module_loader2.load_typed(typed_name(:function, 'testmodule::foo')).value
-
-      expect(function.class.name).to eq('testmodule::foo')
-      expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
-    end
-
-    context 'when delegating 3x to 4x' do
-      before(:each) { Puppet[:biff] = true }
-
-      it 'can load a 3x function API ruby function in global name space' do
-        module_dir = dir_containing('testmodule', {
-          'lib' => {
-            'puppet' => {
-              'parser' => {
-                'functions' => {
-                  'foo3x.rb' => <<-CODE
-                    Puppet::Parser::Functions::newfunction(
-                      :foo3x, :type => :rvalue,
-                      :arity => 1
-                    ) do |args|
-                      args[0]
-                    end
-                  CODE
-                }
-                }
-              }
-          }})
-
-       module_loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(static_loader, 'testmodule', module_dir, 'test1')
-       function = module_loader.load_typed(typed_name(:function, 'foo3x')).value
-       expect(function.class.name).to eq('foo3x')
-       expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
-      end
-    end
-
-  # Gives error when loading something with mismatched name
-
   end
+
 
   def typed_name(type, name)
     Puppet::Pops::Loader::Loader::TypedName.new(type, name)


### PR DESCRIPTION
This fixes the problem where inter-module function calls could
not be made. The main problem was that a function when loaded
was given the public loader and thus had no visibility into its
containing module's dependencies.

The design is that module resolution should be on-demand, only
when something actually needs the proviate loader should it be resolved.
The resolution is triggered by asking for the private loader,  but no
such call was made on the call-path when a function was loaded.

This commit adds the notion of private_loader to the loaders (those that
do not have one respond with self). Those that do either provide the
private loader explicitly (environment loader), or on demand (by
obtaining the private loader from loaders).

This change required tests to be modified since the logic now depends
on :loaders being bound in the Puppet context
logic that made this happen on demand was not implemented
