### PR TITLE
(PUP-2302) Fix issue with Resource Defaults for qualified names

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -277,7 +277,6 @@ module Puppet::Pops::Evaluator::Runtime3Support
     # TODO: Revisit and possible improve the accuracy.
     #
     file, line = extract_file_line(o)
-
     # Build a resource for each title
     resource_titles.map do |resource_title|
         resource = Puppet::Parser::Resource.new(
@@ -312,7 +311,13 @@ module Puppet::Pops::Evaluator::Runtime3Support
     # for the type of the name.
     # Note, locations are available per parameter.
     #
-    scope.define_settings(type_name.capitalize, evaluated_parameters)
+    scope.define_settings(capitalize_qualified_name(type_name), evaluated_parameters)
+  end
+
+  # Capitalizes each segment of a qualified name
+  #
+  def capitalize_qualified_name(name)
+    name.split(/::/).map(&:capitalize).join('::')
   end
 
   # Creates resource overrides for all resource type objects in evaluated_resources. The same set of

--- a/spec/integration/parser/future_compiler_spec.rb
+++ b/spec/integration/parser/future_compiler_spec.rb
@@ -61,6 +61,21 @@ describe "Puppet::Parser::Compiler" do
       catalog.resource("Notify[bar_notify]").should_not be_nil
     end
 
+    it 'applies defaults for defines with qualified names (PUP-2302)' do
+      Puppet[:code] = <<-CODE
+        define my::thing($msg = 'foo') { notify {'check_me': message => $msg } }
+        My::Thing { msg => 'evoe' }
+        my::thing { 'name': }
+      CODE
+
+      node = Puppet::Node.new("testnodex")
+      catalog = Puppet::Parser::Compiler.compile(node)
+      node.classes = nil
+      the_notify = catalog.resource("Notify[check_me]")
+      expect(the_notify).to_not be(nil)
+      expect(the_notify[:message]).to eql('evoe')
+    end
+
     describe "when resolving class references" do
       it "should favor local scope, even if there's an included class in topscope" do
         Puppet[:code] = <<-PP


### PR DESCRIPTION
When defaults were set using future evaluator and the resource has
a qualified name, the registration of the default was not recognized
because scope requires every segment of a qualified name to be upper
cased.

This adds upper casing of every segment. An integration test checks
that the capitalization works.
