### PR TITLE
(maint) Adding forge_host configuration to the acceptance bootstrap script

### DIFF
--- a/acceptance/bin/ci-bootstrap-from-artifacts.sh
+++ b/acceptance/bin/ci-bootstrap-from-artifacts.sh
@@ -42,6 +42,7 @@ cat > local_options.rb <<-EOF
   :ssh => {
     :keys => ["${HOME}/.ssh/id_rsa-old.private"],
   },
+  :forge_host => 'forge-aio01-petest.puppetlabs.com',
 ${repo_proxy}
 }
 EOF


### PR DESCRIPTION
This is necessary to make the recent PMT changes actually run through
the acceptance framework.
