### PR TITLE
(PUP-2317) Make future parser issue discontinuation error for import

### DIFF
--- a/lib/puppet/functions/import.rb
+++ b/lib/puppet/functions/import.rb
@@ -1,0 +1,7 @@
+# The import function raises an error when called to inform the user that import is no longer supported.
+#
+Puppet::Functions.create_function(:import) do
+  def import(*args)
+    raise Puppet::Pops::SemanticError.new(Puppet::Pops::Issues::DISCONTINUED_IMPORT)
+  end
+end

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -22,6 +22,7 @@ module Puppet
     require 'puppet/pops/containment'
 
     require 'puppet/pops/issues'
+    require 'puppet/pops/semantic_error'
     require 'puppet/pops/label_provider'
     require 'puppet/pops/validation'
     require 'puppet/pops/issue_reporter'

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -82,8 +82,14 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
   def evaluate(target, scope)
     begin
       @@eval_visitor.visit_this_1(self, target, scope)
+
+    rescue Puppet::Pops::SemanticError => e
+      # a raised issue may not know the semantic target
+      fail(e.issue, e.semantic || target, e.options, e)
+
     rescue StandardError => e
       if e.is_a? Puppet::ParseError
+        # ParseError's are supposed to be fully configured with location information
         raise e
       end
       fail(Issues::RUNTIME_ERROR, target, {:detail => e.message}, e)

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -466,4 +466,8 @@ module Puppet::Pops::Issues
   ILLEGAL_EPP_PARAMETERS = issue :ILLEGAL_EPP_PARAMETERS do
     "Ambiguous EPP parameter expression. Probably missing '<%-' before parameters to remove leading whitespace"
   end
+
+  DISCONTINUED_IMPORT = hard_issue :DISCONTINUED_IMPORT do
+    "Use of 'import' has been discontinued in favor of a manifest directory. See http://links.puppetlabs.com/puppet-import-deprecation"
+  end
 end

--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -720,6 +720,7 @@ class Puppet::Pops::Model::Factory
     'error'   => true,
 
     'fail'    => true,
+    'import'  => true  # discontinued, but transform it to make it call error reporting function
   }
   # Returns true if the given name is a "statement keyword" (require, include, contain,
   # error, notice, info, debug

--- a/lib/puppet/pops/semantic_error.rb
+++ b/lib/puppet/pops/semantic_error.rb
@@ -1,0 +1,17 @@
+# Error that is used to raise an Issue. See {Puppet::Pops::Issues}.
+#
+class Puppet::Pops::SemanticError < RuntimeError
+  attr_accessor :issue
+  attr_accessor :semantic
+  attr_accessor :options
+
+  # @param issue [Puppet::Pops::Issues::Issue] the issue describing the severity and message
+  # @param semantic [Puppet::Pops::Model::Locatable, nil] the expression causing the failure, or nil if unknown
+  # @param options [Hash] an options hash with Symbol to valu mapping - these are the arguments to the issue
+  #
+  def initialize(issue, semantic=nil, options = {})
+    @issue = issue
+    @semantic = semantic
+    @options = options
+  end
+end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -972,6 +972,20 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
   end
+  context "Handles Deprecations and Discontinuations" do
+    around(:each) do |example|
+      Puppet.override({:loaders => Puppet::Pops::Loaders.new}, 'test') do
+        example.run
+      end
+    end
+
+    it 'of import statements' do
+      source = "\nimport foo"
+      # Error references position 5 at the opening '{'
+      # Set file to nil to make it easier to match with line number (no file name in output)
+      expect { parser.evaluate_string(scope, source) }.to raise_error(/'import' has been discontinued.*line 2:1/)
+    end
+  end
 
   context "Detailed Error messages are reported" do
     it 'for illegal type references' do


### PR DESCRIPTION
This makes the use of import statements raise an error.
The implementation reinstates "import" as a statement function. (This
is done by the factory when it finds a name followed by an expression
list). 
Then, to raise the error, a function written with the function API
called 'import' raises an error.

This also introduced a way to raise errors based on the issue/acceptor
system. This new error type is called Puppet::Pops::SemanticError.

It is used to issue the discontinuation error. The error itself
refers to the deprecation URL which points to the relevant documentation
for manifest directory and import.
