### PR TITLE
issue warnings to certificate does't match

### DIFF
--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -222,7 +222,7 @@ To fix this, remove the certificate from both the master and the agent and then 
 On the master:
   puppet cert clean #{Puppet[:certname]}
 On the agent:
-  rm -f #{Puppet[:hostcert]}
+  find #{Puppet[:ssldir]} -name #{Puppet[:certname]}.pem -delete
   puppet agent -t
 ERROR_STRING
     end


### PR DESCRIPTION
issue warnings when certificate between master and agent doesn't match.
At the moment the message says to execute rm -r certificate but it doesn't solve the problem, need to erase the private key too.
This code shows the right command to execute.
to test this erase your certificate and key from the agent using the command below and try use puppet agent -t again.
`find $(puppet master --configprint ssldir) $(facter fqdn).pem -delete`
