### PR TITLE
(PUP-2361) Make shellquote function cope with empty arguments

### DIFF
--- a/lib/puppet/parser/functions/shellquote.rb
+++ b/lib/puppet/parser/functions/shellquote.rb
@@ -40,7 +40,9 @@ do |args|
 
   result = []
   args.flatten.each do |word|
-    if word.length != 0 and word.count(safe) == word.length
+    if word.length == 0 || word =~ /\A\s+\Z/
+      # do nothing
+    elsif word.count(safe) == word.length
       result << word
     elsif word.count(dangerous) == 0
       result << ('"' + word + '"')

--- a/spec/unit/parser/functions/shellquote_spec.rb
+++ b/spec/unit/parser/functions/shellquote_spec.rb
@@ -41,6 +41,16 @@ describe "the shellquote function" do
       should == "'$PATH' 'foo$bar' '\"x$\"'"
   end
 
+  it "should ignore empty words" do
+    scope.function_shellquote(['foo', '', '--bar']).
+      should == "foo --bar"
+  end
+
+  it "should ignore words with only whitespace" do
+    scope.function_shellquote(['foo', "  \t", '--bar']).
+	  should == "foo --bar"
+  end
+
   it "should deal with apostrophes (single quotes)" do
     scope.function_shellquote(["'foo'bar'", "`$'EDITOR'`"]).
       should == '"\'foo\'bar\'" "\\`\\$\'EDITOR\'\\`"'


### PR DESCRIPTION
When passing empty variables to the shellquote function,
it inserts escaped quotes into the result.
