### PR TITLE
(PUP-2356) Added some extra yumrepo options

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -119,6 +119,13 @@ Puppet::Type.newtype(:yumrepo) do
     end
   end
 
+  newproperty(:mirrorlist_expire) do
+    desc "Time (in seconds) after which the mirrorlist locally cached
+      will expire.\n#{ABSENT_DOC}"
+
+    newvalues(/^[0-9]+$/, :absent)
+  end
+
   newproperty(:include) do
     desc "The URL of a remote file containing additional yum configuration
       settings. Puppet does not check for this file's existence or validity.
@@ -141,6 +148,20 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(/.*/, :absent)
+  end
+
+  newproperty(:gpgcakey) do
+    desc "The URL for the GPG CA key for this repository. #{ABSENT_DOC}"
+
+    newvalues(/.*/, :absent)
+    validate do |value|
+      next if value.to_s == 'absent'
+      parsed = URI.parse(value)
+
+      unless VALID_SCHEMES.include?(parsed.scheme)
+        raise "Must be a valid URL"
+      end
+    end
   end
 
   newproperty(:includepkgs) do
@@ -175,6 +196,14 @@ Puppet::Type.newtype(:yumrepo) do
     newvalues(YUM_BOOLEAN, :absent)
   end
 
+  newproperty(:retries) do
+    desc "Set the number of times any attempt to retrieve a file should
+      retry before returning an error. Setting this to `0` makes yum
+     try forever.\n#{ABSENT_DOC}"
+
+    newvalues(/^[0-9]+$/, :absent)
+  end
+
   newproperty(:http_caching) do
     desc "What to cache from this repository. #{ABSENT_DOC}"
 
@@ -192,7 +221,7 @@ Puppet::Type.newtype(:yumrepo) do
     desc "Number of seconds after which the metadata will expire.
       #{ABSENT_DOC}"
 
-    newvalues(/[0-9]+/, :absent)
+    newvalues(/^([0-9]+[dhm]?|never)$/, :absent)
   end
 
   newproperty(:protect) do
@@ -215,6 +244,25 @@ Puppet::Type.newtype(:yumrepo) do
         fail("Must be within range 1-99")
       end
     end
+  end
+
+  newproperty(:throttle) do
+    desc "Enable bandwidth throttling for downloads. This option
+      can be expressed as a absolute data rate in bytes/sec or a
+      percentage `60%`. An SI prefix (k, M or G) may be appended
+      to the data rate values.\n#{ABSENT_DOC}"
+
+    newvalues(/^\d+[kMG%]?$/, :absent)
+  end
+
+  newproperty(:bandwidth) do
+    desc "Use to specify the maximum available network bandwidth
+      in bytes/second. Used with the `throttle` option. If `throttle`
+      is a percentage and `bandwidth` is `0` then bandwidth throttling
+      will be disabled. If `throttle` is expressed as a data rate then
+      this option is ignored.\n#{ABSENT_DOC}"
+
+    newvalues(/^\d+[kMG]?$/, :absent)
   end
 
   newproperty(:cost) do

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -73,6 +73,44 @@ shared_examples_for "a yumrepo parameter that accepts multiple URLs" do |param|
   end
 end
 
+shared_examples_for "a yumrepo parameter that expects an integer" do |param|
+  it "can accept an integer" do
+    described_class.new(
+      :name => 'puppetlabs',
+      param => '123'
+    )
+  end
+
+  it "fails if wrong no integer passed" do
+    expect {
+      described_class.new(
+        :name => 'puppetlabs',
+        param => 'ABC'
+      )
+    }.to raise_error(Puppet::ResourceError, /Parameter #{param} failed/)
+  end
+end
+
+shared_examples_for "a yumrepo parameter that accepts kMG units" do |param|
+  %w[k M G].each do |unit|
+    it "can accept an integer with #{unit} units" do
+      described_class.new(
+        :name => 'puppetlabs',
+        param => "123#{unit}"
+      )
+    end
+  end
+
+  it "fails if wrong unit passed" do
+    expect {
+      described_class.new(
+        :name => 'puppetlabs',
+        param => '123J'
+      )
+    }.to raise_error(Puppet::ResourceError, /Parameter #{param} failed/)
+  end
+end
+
 describe Puppet::Type.type(:yumrepo) do
   it "has :name as its namevar" do
     expect(described_class.key_attributes).to eq [:name]
@@ -189,6 +227,20 @@ describe Puppet::Type.type(:yumrepo) do
 
     describe "metadata_expire" do
       it_behaves_like "a yumrepo parameter that can be absent", :metadata_expire
+      it_behaves_like "a yumrepo parameter that expects an integer", :metadata_expire
+
+      it "accepts dhm units" do
+        %W[d h m].each do |unit|
+          described_class.new(
+            :name            => 'puppetlabs',
+            :metadata_expire => "123#{unit}"
+          )
+        end
+      end
+
+      it "accepts never as value" do
+        described_class.new(:name => 'puppetlabs', :metadata_expire => 'never')
+      end
     end
 
     describe "protect" do
@@ -244,5 +296,41 @@ describe Puppet::Type.type(:yumrepo) do
       it_behaves_like "a yumrepo parameter that can be absent", :metalink
       it_behaves_like "a yumrepo parameter that accepts a single URL", :metalink
     end
+
+    describe "throttle" do
+      it_behaves_like "a yumrepo parameter that can be absent", :throttle
+      it_behaves_like "a yumrepo parameter that expects an integer", :throttle
+      it_behaves_like "a yumrepo parameter that accepts kMG units", :throttle
+
+      it "accepts percentage as unit" do
+        described_class.new(
+          :name     => 'puppetlabs',
+          :throttle => '123%'
+        )
+      end
+
+    end
+
+    describe "bandwidth" do
+      it_behaves_like "a yumrepo parameter that can be absent", :bandwidth
+      it_behaves_like "a yumrepo parameter that expects an integer", :bandwidth
+      it_behaves_like "a yumrepo parameter that accepts kMG units", :bandwidth
+    end
+
+    describe "gpgcakey" do
+      it_behaves_like "a yumrepo parameter that can be absent", :gpgcakey
+      it_behaves_like "a yumrepo parameter that accepts a single URL", :gpgcakey
+    end
+
+    describe "retries" do
+      it_behaves_like "a yumrepo parameter that can be absent", :retries
+      it_behaves_like "a yumrepo parameter that expects an integer", :retries
+    end
+
+    describe "mirrorlist_expire" do
+      it_behaves_like "a yumrepo parameter that can be absent", :mirrorlist_expire
+      it_behaves_like "a yumrepo parameter that expects an integer", :mirrorlist_expire
+    end
+
   end
 end


### PR DESCRIPTION
This change introduces some new yumrepo options:
- gpgcakey
- retries
- throttle
- bandwidth
- mirrorlist_expire
- Added also the possibility to specify dhm units and never as value for
  metadata_expire option
