### PR TITLE
(maint) Adding File.expand_path to the Tar::Gnu specs.

### DIFF
--- a/spec/unit/module_tool/tar/gnu_spec.rb
+++ b/spec/unit/module_tool/tar/gnu_spec.rb
@@ -8,17 +8,17 @@ describe Puppet::ModuleTool::Tar::Gnu do
   let(:destfile)   { '/space path/the/dest/file.tar.gz' }
 
   it "unpacks a tar file" do
-    Dir.expects(:chdir).with(destdir).yields(mock)
-    Puppet::Util::Execution.expects(:execute).with(["gzip", "-dc", sourcefile])
+    Dir.expects(:chdir).with(File.expand_path(destdir)).yields(mock)
+    Puppet::Util::Execution.expects(:execute).with(["gzip", "-dc", File.expand_path(sourcefile)])
     Puppet::Util::Execution.expects(:execpipe).with(["tar", "xof", "-"], true, 'w+')
-    Puppet::Util::Execution.expects(:execute).with(["find", destdir, "-type", "d", "-exec", "chmod", "755", "{}", "+"])
-    Puppet::Util::Execution.expects(:execute).with(["find", destdir, "-type", "f", "-exec", "chmod", "a-wst", "{}", "+"])
-    Puppet::Util::Execution.expects(:execute).with(["chown", "-R", "<owner:group>", destdir])
+    Puppet::Util::Execution.expects(:execute).with(["find", File.expand_path(destdir), "-type", "d", "-exec", "chmod", "755", "{}", "+"])
+    Puppet::Util::Execution.expects(:execute).with(["find", File.expand_path(destdir), "-type", "f", "-exec", "chmod", "a-wst", "{}", "+"])
+    Puppet::Util::Execution.expects(:execute).with(["chown", "-R", "<owner:group>", File.expand_path(destdir)])
     subject.unpack(sourcefile, destdir, '<owner:group>')
   end
 
   it "packs a tar file" do
-    Puppet::Util::Execution.expects(:execute).with(["tar", "cf", "-", sourcedir])
+    Puppet::Util::Execution.expects(:execute).with(["tar", "cf", "-", File.expand_path(sourcedir)])
     Puppet::Util::Execution.expects(:execpipe).with(["gzip", "-c"], true, 'w+')
     subject.pack(sourcedir, destfile)
   end


### PR DESCRIPTION
Prior to this commit, the specs made assertions about absolute file
paths, which works perfectly until you try running the tests under
Windows. This change patches the tests so that they will continue to
run properly under both Windows and Linux.
