### PR TITLE
(maint) Remove FS redefined constant warnings in spec runs

### DIFF
--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -3,9 +3,9 @@ require 'puppet/environments'
 require 'puppet/file_system'
 require 'matchers/include'
 
+module PuppetEnvironments
 describe Puppet::Environments do
   include Matchers::Include
-  include PuppetSpec::Files
 
   FS = Puppet::FileSystem
 
@@ -379,4 +379,5 @@ config_version=$vardir/random/scripts
       end
     end
   end
+end
 end

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 require 'puppet/face'
 
+module PuppetFaceSpecs 
 describe Puppet::Face[:config, '0.0.1'] do
 
   FS = Puppet::FileSystem
@@ -141,4 +142,5 @@ basemodulepath = #{File.expand_path("/some/base")}
       it_behaves_like :config_printing_a_section, :master
     end
   end
+end
 end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 
 require 'puppet/indirector/facts/facter'
 
+module PuppetNodeFactsFacter
 describe Puppet::Node::Facts::Facter do
   FS = Puppet::FileSystem
 
@@ -198,4 +199,5 @@ describe Puppet::Node::Facts::Facter do
       Facter.search_external_path.include?("#{one}/mymodule/facts.d")
     end
   end
+end
 end


### PR DESCRIPTION
We define FS as an alias for Puppet::FileSystem in three separate
specs. Unfortunately, describe blocks do not provide any namespacing in
rspec, and this were colliding, issuing two separate warnings for a
redefined constant.  Wrapping each spec in its own module provides
separation and elliminates the warnings.
