### PR TITLE
(pup-1932) Don't report static services

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def self.instances
     i = []
     output = systemctl('list-unit-files', '--type', 'service', '--full', '--all',  '--no-pager')
-    output.scan(/^(\S+)\s+(disabled|enabled|static)\s*$/i).each do |m|
+    output.scan(/^(\S+)\s+(disabled|enabled)\s*$/i).each do |m|
       i << new(:name => m[0])
     end
     return i

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -55,7 +55,6 @@ describe Puppet::Type.type(:service).provider(:systemd) do
         autovt@.service
         avahi-daemon.service
         blk-availability.service
-        brandbot.service
       }
     end
   end


### PR DESCRIPTION
The initial fix for pup-1932 inadvertently included 'static' services,
which are services which can't be enabled/disabled. Since such services
aren't manageable, it doesn't make sense to include them in instances,
so this commit removes them.
