### PR TITLE
(maint) Fix plugin spec to work with facter 1.7.5

### DIFF
--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -39,18 +39,19 @@ Puppet::Face.define(:plugin, '0.0.1') do
     when_invoked do |options|
       require 'puppet/configurer/downloader'
       remote_environment_for_plugins = Puppet::Node::Environment.remote(Puppet[:environment])
-      Puppet::Configurer::Downloader.new("plugin",
+      result = Puppet::Configurer::Downloader.new("plugin",
                                          Puppet[:plugindest],
                                          Puppet[:pluginsource],
                                          Puppet[:pluginsignore],
                                          remote_environment_for_plugins).evaluate
       if Puppet.features.external_facts?
-          Puppet::Configurer::Downloader.new("pluginfacts",
+          result += Puppet::Configurer::Downloader.new("pluginfacts",
                                              Puppet[:pluginfactdest],
                                              Puppet[:pluginfactsource],
                                              Puppet[:pluginsignore],
                                              remote_environment_for_plugins).evaluate
       end
+      result
     end
 
     when_rendering :console do |value|


### PR DESCRIPTION
Puppet does not consider Facter 1.7.5 to provide external_facts, so the
pluginfacts step was being skipped when specs were run with Facter
1.7.5. Altered the plugin spec to work with the application rather than
the face so that we can check the rendered output, and to generate lib
and facts.d dirs to normalize the output (otherwise the downloader
reports the creation of the base plugin target directories, something
which normally would be handled by Puppet's Settings catalog).

As part of this, I noticed that the plugin face would return different
results. If external facts were supported, it would return the list of
any external facts pluginsynced. Otherwise it would return the list of
any plugins pluginsynced. Changed this to accumlate and list both sets
of changes.
