### PR TITLE
(PUP-1699) Ensure context in effect before accessing in app setup

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -353,23 +353,23 @@ class Application
       plugin_hook('initialize_app_defaults') { initialize_app_defaults }
     end
 
-    new_context = Puppet.base_context(Puppet.settings)
-    configured_environment = new_context[:environments].get(Puppet[:environment])
-    configured_environment = configured_environment.override_from_commandline(Puppet.settings)
-    new_context[:current_environment] = configured_environment
+    Puppet.override(Puppet.base_context(Puppet.settings)) do
+      configured_environment = Puppet.lookup(:environments).get(Puppet[:environment])
+      configured_environment = configured_environment.override_from_commandline(Puppet.settings)
 
-    # Setup a new context using the app's configuration
-    Puppet.override(new_context,
-                    "New base context and current environment from application's configuration") do
-      require 'puppet'
-      require 'puppet/util/instrumentation'
-      Puppet::Util::Instrumentation.init
+      # Setup a new context using the app's configuration
+      Puppet.override({ :current_environment => configured_environment },
+                      "New base context and current environment from application's configuration") do
+        require 'puppet'
+        require 'puppet/util/instrumentation'
+        Puppet::Util::Instrumentation.init
 
-      exit_on_fail("initialize")                                   { plugin_hook('preinit')       { preinit } }
-      exit_on_fail("parse application options")                    { plugin_hook('parse_options') { parse_options } }
-      exit_on_fail("prepare for execution")                        { plugin_hook('setup')         { setup } }
-      exit_on_fail("configure routes from #{Puppet[:route_file]}") { configure_indirector_routes }
-      exit_on_fail("run")                                          { plugin_hook('run_command')   { run_command } }
+        exit_on_fail("initialize")                                   { plugin_hook('preinit')       { preinit } }
+        exit_on_fail("parse application options")                    { plugin_hook('parse_options') { parse_options } }
+        exit_on_fail("prepare for execution")                        { plugin_hook('setup')         { setup } }
+        exit_on_fail("configure routes from #{Puppet[:route_file]}") { configure_indirector_routes }
+        exit_on_fail("run")                                          { plugin_hook('run_command')   { run_command } }
+      end
     end
   end
 


### PR DESCRIPTION
Discovered that the environment that was going to be created using the
commandline overrides would be incorrect when the application's run mode
was not user. This happened because it was using a new loader before
that loader was put into the context, which cause the settings to be
read incorrectly. The cacheing played into this because that incorrect
environment, without cacheing gets thrown away, but with cacheing
persisted into the actual catalog requests if they were made within the
timeout period.

To fix this we override with a preliminary context to ensure that
we are reading settings in the current run mode, before overriding with
the final current environment.

Paired-with: Andrew Parker andy@puppetlabs.com
