### PR TITLE
(PUP-2399) Add mailalias acceptance tests

### DIFF
--- a/acceptance/tests/resource/mailalias/create.rb
+++ b/acceptance/tests/resource/mailalias/create.rb
@@ -1,15 +1,11 @@
-test_name "should create an email alias and update db"
+test_name "should create an email alias"
 
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
   teardown do
-    #(teardown) delete the aliases database
-    on(agent, "rm /etc/aliases.db")
-
     #(teardown) restore the alias file
     on(agent, "mv /tmp/aliases /etc/aliases", :acceptable_exit_codes => [0,1])
-    on(agent, "newaliases")
   end
 
   #------- SETUP -------#
@@ -25,11 +21,6 @@ agents.each do |agent|
   step "verify the alias exists"
   on(agent, "cat /etc/aliases")  do |res|
     assert_match(/#{name}:.*foo,bar,baz/, res.stdout, "mailalias not in aliases file")
-  end
-
-  step "verify name is in aliases.db"
-  on(agent, "grep #{name} /etc/aliases.db", :acceptable_exit_codes => [0,1])  do |res|
-    assert_match(/matches/, res.output, "mailalias not in aliases.db")
   end
 
 end

--- a/acceptance/tests/resource/mailalias/destroy.rb
+++ b/acceptance/tests/resource/mailalias/destroy.rb
@@ -1,4 +1,4 @@
-test_name "should delete an email alias and update db"
+test_name "should delete an email alias"
 
 name = "pl#{rand(999999).to_i}"
 
@@ -6,7 +6,6 @@ agents.each do |agent|
   teardown do
     #(teardown) restore the alias file
     on(agent, "mv /tmp/aliases /etc/aliases", :acceptable_exit_codes => [0,1])
-    on(agent, "newaliases")
   end
 
   #------- SETUP -------#
@@ -15,16 +14,10 @@ agents.each do |agent|
 
   step "(setup) create a mailalias"
   on(agent, "echo '#{name}: foo,bar,baz' >> /etc/aliases")
-  on(agent, "newaliases")
 
   step "(setup) verify the alias exists"
   on(agent, "cat /etc/aliases")  do |res|
     assert_match(/#{name}:.*foo,bar,baz/, res.stdout, "mailalias not in aliases file")
-  end
-
-  step "(setup) verify name is in  aliases.db"
-  on(agent, "grep #{name} /etc/aliases.db", :acceptable_exit_codes => [0,1])  do |res|
-    assert_match(/matches/, res.output, "mailalias not in aliases.db")
   end
 
   #------- TESTS -------#
@@ -37,11 +30,6 @@ agents.each do |agent|
   step "verify the alias is absent"
   on(agent, "cat /etc/aliases")  do |res|
     assert_no_match(/#{name}:.*foo,bar,baz/, res.stdout, "mailalias was not removed from aliases file")
-  end
-
-  step "verify name is not in aliases.db"
-  on(agent, "grep #{name} /etc/aliases.db", :acceptable_exit_codes => [0,1])  do |res|
-    assert_no_match(/matches/, res.output, "mailalias was not removed from aliases.db")
   end
 
 end

--- a/acceptance/tests/resource/mailalias/modify.rb
+++ b/acceptance/tests/resource/mailalias/modify.rb
@@ -1,4 +1,4 @@
-test_name "should modify an email alias and update db"
+test_name "should modify an email alias"
 
 name = "pl#{rand(999999).to_i}"
 
@@ -6,7 +6,6 @@ agents.each do |agent|
   teardown do
     #(teardown) restore the alias file
     on(agent, "mv /tmp/aliases /etc/aliases", :acceptable_exit_codes => [0,1])
-    on(agent, "newaliases")
   end
 
   #------- SETUP -------#
@@ -15,16 +14,10 @@ agents.each do |agent|
 
   step "(setup) create a mailalias"
   on(agent, "echo '#{name}: foo,bar,baz' >> /etc/aliases")
-  on(agent, "newaliases")
 
   step "(setup) verify the alias exists"
   on(agent, "cat /etc/aliases")  do |res|
     assert_match(/#{name}:.*foo,bar,baz/, res.stdout, "mailalias not in aliases file")
-  end
-
-  step "(setup) verify name is in aliases.db"
-  on(agent, "grep #{name} /etc/aliases.db", :acceptable_exit_codes => [0,1])  do |res|
-    assert_match(/matches/, res.output, "mailalias not in aliases.db")
   end
 
   #------- TESTS -------#
@@ -37,11 +30,6 @@ agents.each do |agent|
   step "verify the updated alias is present"
   on(agent, "cat /etc/aliases")  do |res|
     assert_match(/#{name}:.*foo,bar,baz,blarvitz/, res.stdout, "updated mailalias not in aliases file")
-  end
-
-  step "verify name is not in aliases.db"
-  on(agent, "grep blarvitz /etc/aliases.db", :acceptable_exit_codes => [0,1])  do |res|
-    assert_match(/matches/, res.output, "updated mailalias not in aliases.db")
   end
 
 end

--- a/acceptance/tests/resource/mailalias/query.rb
+++ b/acceptance/tests/resource/mailalias/query.rb
@@ -6,7 +6,6 @@ agents.each do |agent|
   teardown do
     #(teardown) restore the alias file
     on(agent, "mv /tmp/aliases /etc/aliases", :acceptable_exit_codes => [0,1])
-    on(agent, "newaliases")
   end
 
   #------- SETUP -------#
@@ -15,16 +14,10 @@ agents.each do |agent|
 
   step "(setup) create a mailalias"
   on(agent, "echo '#{name}: foo,bar,baz' >> /etc/aliases")
-  on(agent, "newaliases")
 
   step "(setup) verify the alias exists"
   on(agent, "cat /etc/aliases")  do |res|
     assert_match(/#{name}:.*foo,bar,baz/, res.stdout, "mailalias not in aliases file")
-  end
-
-  step "(setup) verify name is in  aliases.db"
-  on(agent, "grep #{name} /etc/aliases.db", :acceptable_exit_codes => [0,1])  do |res|
-    assert_match(/matches/, res.output, "mailalias not in aliases.db")
   end
 
   #------- TESTS -------#


### PR DESCRIPTION
Add basic acceptance tests for mailalias type. This adds acceptance
tests for create, query, modify, and destroy.

The tests assume that the mailalias type manages the default
/etc/aliases text file as well as updating the binary database
that the aliases file is the source for.
