### PR TITLE
(PUP-2401) Add ssh_authorized_key acceptance tests

### DIFF
--- a/acceptance/tests/resource/ssh_authorized_key/create.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/create.rb
@@ -1,0 +1,32 @@
+test_name "should create an entry for an SSH authorized key"
+
+confine :except, :platform => ['windows']
+
+auth_keys = '~/.ssh/authorized_keys'
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the #{auth_keys} file
+    on(agent, "mv /tmp/auth_keys #{auth_keys}", :acceptable_exit_codes => [0,1])
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup #{auth_keys} file"
+  on(agent, "cp #{auth_keys} /tmp/auth_keys", :acceptable_exit_codes => [0,1])
+
+  #------- TESTS -------#
+  step "create an authorized key entry with puppet (present)"
+  args = ['ensure=present',
+          "user='root'",
+          "type='rsa'",
+          "key='mykey'",
+         ]
+  on(agent, puppet_resource('ssh_authorized_key', "#{name}", args))
+
+  step "verify entry in #{auth_keys}"
+  on(agent, "cat #{auth_keys}")  do |res|
+    fail_test "didn't find the ssh_authorized_key for #{name}" unless stdout.include? "#{name}"
+  end
+
+end

--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -1,0 +1,35 @@
+test_name "should delete an entry for an SSH authorized key"
+
+confine :except, :platform => ['windows']
+
+auth_keys = '~/.ssh/authorized_keys'
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the #{auth_keys} file
+    on(agent, "mv /tmp/auth_keys #{auth_keys}", :acceptable_exit_codes => [0,1])
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup #{auth_keys} file"
+  on(agent, "cp #{auth_keys} /tmp/auth_keys", :acceptable_exit_codes => [0,1])
+
+  step "(setup) create an authorized key in the #{auth_keys} file"
+  on(agent, "echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
+
+  #------- TESTS -------#
+  step "delete an authorized key entry with puppet (absent)"
+  args = ['ensure=absent',
+          "user='root'",
+          "type='rsa'",
+          "key='mykey'",
+         ]
+  on(agent, puppet_resource('ssh_authorized_key', "#{name}", args))
+
+  step "verify entry deleted from #{auth_keys}"
+  on(agent, "cat #{auth_keys}")  do |res|
+    fail_test "found the ssh_authorized_key for #{name}" if stdout.include? "#{name}"
+  end
+
+end

--- a/acceptance/tests/resource/ssh_authorized_key/modify.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/modify.rb
@@ -1,0 +1,35 @@
+test_name "should update an entry for an SSH authorized key"
+
+confine :except, :platform => ['windows']
+
+auth_keys = '~/.ssh/authorized_keys'
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the #{auth_keys} file
+    on(agent, "mv /tmp/auth_keys #{auth_keys}", :acceptable_exit_codes => [0,1])
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup #{auth_keys} file"
+  on(agent, "cp #{auth_keys} /tmp/auth_keys", :acceptable_exit_codes => [0,1])
+
+  step "(setup) create an authorized key in the #{auth_keys} file"
+  on(agent, "echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
+
+  #------- TESTS -------#
+  step "update an authorized key entry with puppet (present)"
+  args = ['ensure=present',
+          "user='root'",
+          "type='rsa'",
+          "key='mynewshinykey'",
+         ]
+  on(agent, puppet_resource('ssh_authorized_key', "#{name}", args))
+
+  step "verify entry updated in #{auth_keys}"
+  on(agent, "cat #{auth_keys}")  do |res|
+    fail_test "didn't find the updated key for #{name}" unless stdout.include? "mynewshinykey #{name}"
+  end
+
+end

--- a/acceptance/tests/resource/ssh_authorized_key/query.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/query.rb
@@ -1,0 +1,29 @@
+test_name "should be able to find an existing SSH authorized key"
+
+skip_test("This test is blocked by PUP-1605")
+
+confine :except, :platform => ['windows']
+
+auth_keys = '~/.ssh/authorized_keys'
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the #{auth_keys} file
+    on(agent, "mv /tmp/auth_keys #{auth_keys}", :acceptable_exit_codes => [0,1])
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup #{auth_keys} file"
+  on(agent, "cp #{auth_keys} /tmp/auth_keys", :acceptable_exit_codes => [0,1])
+
+  step "(setup) create an authorized key in the #{auth_keys} file"
+  on(agent, "echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
+
+  #------- TESTS -------#
+  step "verify SSH authorized key query with puppet"
+  on(agent, puppet_resource('ssh_authorized_key', "/#{name}")) do |res|
+    fail_test "found the ssh_authorized_key for #{name}" unless stdout.include? "#{name}"
+  end
+
+end


### PR DESCRIPTION
Add basic acceptance tests for ssh_authorized_key type.
This adds acceptance tests for create, query, modify, and destroy.

The query test is set to be skipped because the type cannot
currently be queried by username (see PUP-1605).
