### PR TITLE
(doc) Document key purging in the description of the ssh_authorized_key ...

### DIFF
--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -1,24 +1,50 @@
 module Puppet
   newtype(:ssh_authorized_key) do
-    @doc = "Manages SSH authorized keys. Currently only type 2 keys are
-    supported.
+    @doc = "Manages SSH authorized keys. Currently only type 2 keys are supported.
 
-    **Autorequires:** If Puppet is managing the user account in which this
-    SSH key should be installed, the `ssh_authorized_key` resource will autorequire
-    that user."
+      In their native habitat, SSH keys usually appear as a single long line. This
+      resource type requires you to split that line into several attributes. Thus, a
+      key that appears in your `~/.ssh/id_rsa.pub` file like this...
+
+          ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAy5mtOAMHwA2ZAIfW6Ap70r+I4EclYHEec5xIN59ROUjss23Skb1OtjzYpVPaPH8mSdSmsN0JHaBLiRcu7stl4O8D8zA4mz/vw32yyQ/Kqaxw8l0K76k6t2hKOGqLTY4aFbFISV6GDh7MYLn8KU7cGp96J+caO5R5TqtsStytsUhSyqH+iIDh4e4+BrwTc6V4Y0hgFxaZV5d18mLA4EPYKeG5+zyBCVu+jueYwFqM55E0tHbfiaIN9IzdLV+7NEEfdLkp6w2baLKPqWUBmuvPF1Mn3FwaFLjVsMT3GQeMue6b3FtUdTDeyAYoTxrsRo/WnDkS6Pa3YhrFwjtUqXfdaQ== nick@magpie.puppetlabs.lan
+
+      ...would translate to the following resource:
+
+          ssh_authorized_key { 'nick@magpie.puppetlabs.lan':
+            user => 'nick',
+            type => 'ssh-rsa',
+            key  => 'AAAAB3NzaC1yc2EAAAABIwAAAQEAy5mtOAMHwA2ZAIfW6Ap70r+I4EclYHEec5xIN59ROUjss23Skb1OtjzYpVPaPH8mSdSmsN0JHaBLiRcu7stl4O8D8zA4mz/vw32yyQ/Kqaxw8l0K76k6t2hKOGqLTY4aFbFISV6GDh7MYLn8KU7cGp96J+caO5R5TqtsStytsUhSyqH+iIDh4e4+BrwTc6V4Y0hgFxaZV5d18mLA4EPYKeG5+zyBCVu+jueYwFqM55E0tHbfiaIN9IzdLV+7NEEfdLkp6w2baLKPqWUBmuvPF1Mn3FwaFLjVsMT3GQeMue6b3FtUdTDeyAYoTxrsRo/WnDkS6Pa3YhrFwjtUqXfdaQ==',
+          }
+
+      To ensure that only the currently approved keys are present, you can purge
+      unmanaged SSH keys on a per-user basis. Do this with the `user` resource
+      type's `purge_ssh_keys` attribute:
+
+          user { 'nick':
+            ensure         => present,
+            purge_ssh_keys => true,
+          }
+
+      This will remove any keys in `~/.ssh/authorized_keys` that aren't being
+      managed with `ssh_authorized_key` resources. See the documentation of the
+      `user` type for more details.
+
+      **Autorequires:** If Puppet is managing the user account in which this
+      SSH key should be installed, the `ssh_authorized_key` resource will autorequire
+      that user."
 
     ensurable
 
     newparam(:name) do
       desc "The SSH key comment. This attribute is currently used as a
-      system-wide primary key and therefore has to be unique."
+        system-wide primary key and therefore has to be unique."
 
       isnamevar
 
     end
 
     newproperty(:type) do
-      desc "The encryption type used: ssh-dss or ssh-rsa."
+      desc "The encryption type used."
 
       newvalues :'ssh-dss', :'ssh-rsa', :'ecdsa-sha2-nistp256', :'ecdsa-sha2-nistp384', :'ecdsa-sha2-nistp521', :'ssh-ed25519'
 
@@ -28,9 +54,15 @@ module Puppet
     end
 
     newproperty(:key) do
-      desc "The public key itself; generally a long string of hex characters. The key attribute
-      may not contain whitespace: Omit key headers (e.g. 'ssh-rsa') and key identifiers
-      (e.g. 'joe@joescomputer.local') found in the public key file."
+      desc "The public key itself; generally a long string of hex characters. The `key`
+        attribute may not contain whitespace.
+
+        Make sure to omit the following in this attribute (and specify them in
+        other attributes):
+
+        * Key headers (e.g. 'ssh-rsa') --- put these in the `type` attribute.
+        * Key identifiers / comments (e.g. 'joe@joescomputer.local') --- put these in
+          the `name` attribute/resource title."
 
       validate do |value|
         raise Puppet::Error, "Key must not contain whitespace: #{value}" if value =~ /\s/
@@ -38,15 +70,15 @@ module Puppet
     end
 
     newproperty(:user) do
-      desc "The user account in which the SSH key should be installed.
-      The resource will automatically depend on this user."
+      desc "The user account in which the SSH key should be installed. The resource
+        will autorequire this user if it is being managed as a `user` resource."
     end
 
     newproperty(:target) do
       desc "The absolute filename in which to store the SSH key. This
-      property is optional and should only be used in cases where keys
-      are stored in a non-standard location (i.e.` not in
-      `~user/.ssh/authorized_keys`)."
+        property is optional and should only be used in cases where keys
+        are stored in a non-standard location (i.e.` not in
+        `~user/.ssh/authorized_keys`)."
 
       defaultto :absent
 
@@ -69,7 +101,7 @@ module Puppet
     end
 
     newproperty(:options, :array_matching => :all) do
-      desc "Key options, see sshd(8) for possible values. Multiple values
+      desc "Key options; see sshd(8) for possible values. Multiple values
         should be specified as an array."
 
       defaultto do :absent end

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -578,12 +578,17 @@ module Puppet
     end
 
     newparam(:purge_ssh_keys) do
-      desc "Purge ssh keys authorized for the user
-            if they are not managed via ssh_authorized_keys. When true,
-            looks for keys in .ssh/authorized_keys in the user's home
-            directory. Possible values are true, false, or an array of
-            paths to file to search for authorized keys. If a path starts
-            with ~ or %h, this token is replaced with the user's home directory."
+      desc "Whether to purge authorized SSH keys for this user if they are not managed
+        with the `ssh_authorized_key` resource type. Allowed values are:
+
+        * `false` (default) --- don't purge SSH keys for this user.
+        * `true` --- look for keys in the `.ssh/authorized_keys` file in the user's
+          home directory. Purge any keys that aren't managed as `ssh_authorized_key`
+          resources.
+        * An array of file paths --- look for keys in all of the files listed. Purge
+          any keys that aren't managed as `ssh_authorized_key` resources. If any of
+          these paths starts with `~` or `%h`, that token will be replaced with
+          the user's home directory."
 
       defaultto :false
 


### PR DESCRIPTION
...type

This commit puts an explanation of key purging over where people will likely be
looking for it. It also tightens up the description of the user type's
purge_ssh_keys attribute, and adds an example key to the ssh_authorized_key type
(since the way that type breaks up key lines is somewhat unintuitive).

The example public key is a dud, to prevent accidental access grants.

When you merge this commit, please resolve DOC-745. 
