### PR TITLE
(docs) Fix wording on environment_timeout setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -358,8 +358,10 @@ module Puppet
     :environment_timeout => {
       :default    => "5s",
       :type       => :ttl,
-      :desc       => "The time to live for a cached environment. The time is either given #{AS_DURATION}, or
-      the word 'unlimited' which causes the environment to be cached until the master is restarted."
+      :desc       => "The time to live for a cached environment.
+      #{AS_DURATION}
+      This setting can also be set to `unlimited`, which causes the environment to
+      be cached until the master is restarted."
     },
     :queue_type => {
       :default    => "stomp",


### PR DESCRIPTION
Including the AS_DURATION snippet (which is a complete sentence) midway through
a sentence results in wacky wording. This commit fixes it.

This PR has no equivalent DOC ticket. 
