### PR TITLE
(maint) Print yard error message to STDERR, not STDOUT

### DIFF
--- a/tasks/yard.rake
+++ b/tasks/yard.rake
@@ -54,6 +54,6 @@ begin
   end
 rescue LoadError => e
   if verbose
-    puts "Document generation not available without yard. #{e.message}"
+    STDERR.puts "Document generation not available without yard. #{e.message}"
   end
 end


### PR DESCRIPTION
As this is an error/warning, the output should be put to STDERR instead
of STDOUT so it can be easily filtered.
