### PR TITLE
(maint) Fix Travis failures for 2.1.0 and 1.8.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ script: "bundle exec rake \"parallel:spec[1]\""
 notifications:
   email: false
 rvm:
-  - 2.1.0
+  - 2.1.1
   - 2.0.0
   - 1.9.3
-  - 1.8.7
+  - 1.8.7-p374
   - ruby-head
   - jruby-19mode
 matrix:


### PR DESCRIPTION
Working around RVM issues on Travis CI by explicitly specifying the
patch level for 1.8.7 so that REE isn't used.

Working around an install issue with 2.1.0 by specifying 2.1.1 instead
of 2.1.0.
