### PR TITLE
(PUP-2452) Reinstall support for Package type

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Package do
   desc "Provides packaging support for Gentoo's portage system."
 
-  has_feature :versionable
+  has_features :versionable, :reinstallable
 
   {
     :emerge => "/usr/bin/emerge",
@@ -71,6 +71,10 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
   def uninstall
     emerge "--unmerge", package_name
+  end
+
+  def reinstall
+    self.install
   end
 
   def update

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -21,6 +21,10 @@ describe provider do
     provider.should be_versionable
   end
 
+  it "is reinstallable" do
+    provider.should be_reinstallable
+  end
+
   it "uses :emerge to install packages" do
     @provider.expects(:emerge)
     


### PR DESCRIPTION
This is implemented behind a feature that each provider must implement. It is intended to allow source distributions to recompile packages on a notify or subscribe event.

It allows patterns like:

```
package { "www-servers/nginx":
   ensure    => latest,
   subscribe => File['/path/to/nginx/compile/options'];
}
```
