### PR TITLE
(PUP-2511) Add parser function digest: uses digest_algorithm to hash, not strictly md5

### DIFF
--- a/lib/puppet/parser/functions/digest.rb
+++ b/lib/puppet/parser/functions/digest.rb
@@ -1,0 +1,5 @@
+require 'puppet/util/checksums'
+Puppet::Parser::Functions::newfunction(:digest, :type => :rvalue, :arity => 1, :doc => "Returns a hash value from a provided string using the digest_algorithm setting from the Puppet config file.") do |args|
+  algo = Puppet[:digest_algorithm]
+  Puppet::Util::Checksums.method(algo.intern).call args[0]
+end

--- a/spec/unit/parser/functions/digest_spec.rb
+++ b/spec/unit/parser/functions/digest_spec.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+
+describe "the digest function", :uses_checksums => true do
+  before :all do
+    Puppet::Parser::Functions.autoloader.loadall
+  end
+
+  before :each do
+    n = Puppet::Node.new('unnamed')
+    c = Puppet::Parser::Compiler.new(n)
+    @scope = Puppet::Parser::Scope.new(c)
+  end
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("digest").should == "function_digest"
+  end
+
+  with_digest_algorithms do
+    it "should use the proper digest function" do
+      result = @scope.function_digest([plaintext])
+      result.should(eql( checksum ))
+    end
+
+    it "should only accept one parameter" do
+      expect do
+        @scope.function_digest(['foo', 'bar'])
+      end.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Puppet has an md5 parser function, which returns the MD5 digest of its
argument. On hosts configured for compliance with U.S. Federal
Information Processing Standard (FIPS) 140-2, attempts to use the MD5
algorithm cause errors, because MD5 is no longer FIPS Approved. This
patch adds a parser function called digest, which returns the digest
of its argument using the algorithm named by the digest_algorithm
setting in puppet.conf. Therefore, where md5 may fail on some hosts,
the digest function should always return a value; but the value may
vary if the digest_algorithm setting is changed.

The comment regarding the arity of the function has been addressed, hopefully satisfactorily.

This pull request supersedes GH-2603.
