### PR TITLE
(PUP-1597) Fix contain functions lookup of class with leading ::

### DIFF
--- a/lib/puppet/parser/functions/contain.rb
+++ b/lib/puppet/parser/functions/contain.rb
@@ -18,7 +18,9 @@ begun, and will be finished before the containing class is finished.
   scope.function_include(classes)
 
   classes.each do |class_name|
-    class_resource = scope.catalog.resource("Class", class_name)
+    # Remove global anchor since it is not part of the resource title and what was just
+    # included is then not found.
+    class_resource = scope.catalog.resource("Class", class_name.sub(/^::/, ''))
     if ! scope.catalog.edge?(scope.resource, class_resource)
       scope.catalog.add_edge(scope.resource, class_resource)
     end

--- a/spec/unit/parser/functions/contain_spec.rb
+++ b/spec/unit/parser/functions/contain_spec.rb
@@ -25,6 +25,22 @@ describe 'The "contain" function' do
     expect(catalog.classes).to include("contained")
   end
 
+  it "includes the class when using a fully qualified anchored name" do
+    catalog = compile_to_catalog(<<-MANIFEST)
+      class contained {
+        notify { "contained": }
+      }
+
+      class container {
+        contain ::contained
+      }
+
+      include container
+    MANIFEST
+
+    expect(catalog.classes).to include("contained")
+  end
+
   it "makes the class contained in the current class" do
     catalog = compile_to_catalog(<<-MANIFEST)
       class contained {


### PR DESCRIPTION
When the contain function creates edges it looked up resources
without removing the leading :: in the name. The catalog never stores
these, and thus an edge was formed between a resource and nil.

This commit simply removes the ::. There is no checking that a resource
is actually returned since they should all be there due to the call to
include them in the catalog (which would fail if it was not possible to
include them).

A test is also added for the erronous (and now fixed case).
