### PR TITLE
(PUP-2508) Ensure env & trn-uuid are sent when configurer failures occur

### DIFF
--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -204,9 +204,12 @@ describe Puppet::Configurer do
     end
 
     it "should send the report" do
-      report = Puppet::Transaction::Report.new("apply")
+      report = Puppet::Transaction::Report.new("apply", nil, "test", "aaaa")
       Puppet::Transaction::Report.expects(:new).returns(report)
       @agent.expects(:send_report).with(report)
+
+      report.environment.should == "test"
+      report.transaction_uuid.should == "aaaa"
 
       @agent.run
     end
@@ -214,9 +217,12 @@ describe Puppet::Configurer do
     it "should send the transaction report even if the catalog could not be retrieved" do
       @agent.expects(:retrieve_catalog).returns nil
 
-      report = Puppet::Transaction::Report.new("apply")
+      report = Puppet::Transaction::Report.new("apply", nil, "test", "aaaa")
       Puppet::Transaction::Report.expects(:new).returns(report)
-      @agent.expects(:send_report)
+      @agent.expects(:send_report).with(report)
+
+      report.environment.should == "test"
+      report.transaction_uuid.should == "aaaa"
 
       @agent.run
     end
@@ -224,9 +230,12 @@ describe Puppet::Configurer do
     it "should send the transaction report even if there is a failure" do
       @agent.expects(:retrieve_catalog).raises "whatever"
 
-      report = Puppet::Transaction::Report.new("apply")
+      report = Puppet::Transaction::Report.new("apply", nil, "test", "aaaa")
       Puppet::Transaction::Report.expects(:new).returns(report)
-      @agent.expects(:send_report)
+      @agent.expects(:send_report).with(report)
+
+      report.environment.should == "test"
+      report.transaction_uuid.should == "aaaa"
 
       @agent.run.should be_nil
     end
@@ -254,7 +263,7 @@ describe Puppet::Configurer do
 
       Puppet.settings[:prerun_command] = "/my/command"
       Puppet::Util::Execution.expects(:execute).with(["/my/command"]).raises(Puppet::ExecutionFailure, "Failed")
-      @agent.expects(:send_report)
+      @agent.expects(:send_report).with(report)
 
       @agent.run.should be_nil
     end
@@ -276,7 +285,7 @@ describe Puppet::Configurer do
 
       Puppet.settings[:postrun_command] = "/my/command"
       Puppet::Util::Execution.expects(:execute).with(["/my/command"]).raises(Puppet::ExecutionFailure, "Failed")
-      @agent.expects(:send_report)
+      @agent.expects(:send_report).with(report)
 
       @agent.run.should be_nil
     end
@@ -349,6 +358,19 @@ describe Puppet::Configurer do
       @agent.run
 
       @agent.environment.should == "second_env"
+    end
+
+    it "should fix the report if the server specifies a new environment in the catalog" do
+      report = Puppet::Transaction::Report.new("apply", nil, "test", "aaaa")
+      Puppet::Transaction::Report.expects(:new).returns(report)
+      @agent.expects(:send_report).with(report)
+
+      @catalog.stubs(:environment).returns("second_env")
+      @agent.stubs(:retrieve_catalog).returns(@catalog)
+
+      @agent.run
+
+      report.environment.should == "second_env"
     end
 
     it "should clear the global caches" do


### PR DESCRIPTION
Any failure in the configurer #run code might cause the ensure block to
evaluate early, and a report might be sent missing the details of what
the environment and transaction_uuid should be.

This patch moves where the report fields 'environment' and
'transaction_uuid' are set in the configurer code to ensure they are
populated early.

It also ensures the report environment is modified if the catalog or
server specifies it is different to the launched environment. This is
because we change this mid-flight, so our code simply updates the
report environment when this happens.

Signed-off-by: Ken Barber ken@bob.sh
