### PR TITLE
(PUP-2369) Ignore the 'of type Class' output added to property changes

### DIFF
--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -25,7 +25,7 @@ agents.each do |agent|
 
   step "Cron: allow changing command"
   apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present,}') do
-    assert_match(/command changed '.bin.false' to '.bin.true'/, result.stdout, "err: #{agent}")
+    assert_match(/command changed '.bin.false'.* to '.bin.true'/, result.stdout, "err: #{agent}")
   end
   run_cron_on(agent,:list,'tstuser') do
     assert_match(/1 . . . . .bin.true/, result.stdout, "err: #{agent}")
@@ -41,7 +41,7 @@ agents.each do |agent|
 
   step "Cron: allow changing time(array)"
   apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => ["1","2"], minute  => [1], ensure  => present,}') do
-    assert_match(/hour: hour changed '1' to '1,2'/, result.stdout, "err: #{agent}")
+    assert_match(/hour: hour changed '1'.* to '1,2'/, result.stdout, "err: #{agent}")
   end
   run_cron_on(agent,:list,'tstuser') do
     assert_match(/1 1,2 . . . .bin.true/, result.stdout, "err: #{agent}")
@@ -49,7 +49,7 @@ agents.each do |agent|
 
   step "Cron: allow changing time(array modification)"
   apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => ["3","2"], minute  => [1], ensure  => present,}') do
-    assert_match(/hour: hour changed '1,2' to '3,2'/, result.stdout, "err: #{agent}")
+    assert_match(/hour: hour changed '1,2'.* to '3,2'/, result.stdout, "err: #{agent}")
   end
   run_cron_on(agent,:list,'tstuser') do
     assert_match(/1 3,2 . . . .bin.true/, result.stdout, "err: #{agent}")

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -20,7 +20,7 @@ module FileModeAssertions
 
   def assert_mode_change(agent, manifest, path, symbolic_mode, start_mode, expected_mode)
     testcase.apply_manifest_on(agent, manifest) do
-      assert_match(/mode changed '#{'%04o' % start_mode}' to '#{'%04o' % expected_mode}'/, testcase.stdout,
+      assert_match(/mode changed '#{'%04o' % start_mode}'.* to '#{'%04o' % expected_mode}'/, testcase.stdout,
                    "couldn't set mode to #{symbolic_mode}")
     end
 


### PR DESCRIPTION
Acceptance tests had two cases which were checking the output of
property changes, and these were tripping over the new additoin of 'of
type <class>' added in PUP-2369.  This patch just changes the regex to
ignore that section of the output so we are just checking the values,
since the class info is more for developer debugging.
