### PR TITLE
yumrepo: _none_ is also a valid value for parameter proxy

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -229,7 +229,7 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      next if value.to_s == 'absent'
+      next if value.to_s == 'absent' || value.to_s == '_none_'
       parsed = URI.parse(value)
 
       unless VALID_SCHEMES.include?(parsed.scheme)


### PR DESCRIPTION
This is nessary to exclude one or more repositories from a global set proxy in yum.conf.
