### PR TITLE
Make puppet master compile honor configured logdest

### DIFF
--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -162,7 +162,6 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def compile
-    Puppet::Util::Log.newdestination :console
     begin
       unless catalog = Puppet::Resource::Catalog.indirection.find(options[:node])
         raise "Could not compile catalog for #{options[:node]}"


### PR DESCRIPTION
puppet master --compile right now unconditionally spews logs to standard
output which makes it slightly more difficult for someone to use the
actual result of the command which is the catalog. Remove the
unconditional redirection to :console and honor whatever the configured
log destination is (either via the --logdest argument or configuration)
