### PR TITLE
(PUP-2182) Add virtual_packages feature to package type.

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -13,6 +13,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
   has_feature :versionable
   has_feature :install_options
   has_feature :uninstall_options
+  has_feature :virtual_packages
 
   # Note: self:: is required here to keep these constants in the context of what will
   # eventually become this Puppet::Type::Package::ProviderRpm class.
@@ -80,6 +81,8 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
     begin
       output = rpm(*cmd)
     rescue Puppet::ExecutionFailure
+      return nil unless @resource.allow_virtual?
+
       # rpm -q exits 1 if package not found
       # retry the query for virtual packages
       cmd << '--whatprovides'

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :install_options, :versionable
+  has_feature :install_options, :versionable, :virtual_packages
 
   commands :yum => "yum", :rpm => "rpm", :python => "python"
 

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -4,6 +4,7 @@
 # systems.
 
 require 'puppet/parameter/package_options'
+require 'puppet/parameter/boolean'
 
 module Puppet
   newtype(:package) do
@@ -54,7 +55,7 @@ module Puppet
       ensured for the given package. The meaning and format of these settings is
       provider-specific.",
       :methods => [:package_settings_insync?, :package_settings, :package_settings=]
-
+    feature :virtual_packages, "The provider accepts virtual package names for install and uninstall."
 
     ensurable do
       desc <<-EOT
@@ -419,6 +420,16 @@ module Puppet
         strings _must_ be double-escaped and backslashes in single-quoted
         strings _may_ be double-escaped.
       EOT
+    end
+
+    newparam(:allow_virtual, :boolean => true, :parent => Puppet::Parameter::Boolean, :required_features => :virtual_packages) do
+      desc 'Specifies if virtual package names are allowed for install and uninstall.'
+
+      # In a future release, this should be defaulted to true and the below deprecation warning removed
+      defaultto do
+        Puppet.deprecation_warning('The package type\'s allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.') unless value
+        false
+      end
     end
 
     autorequire(:file) do

--- a/spec/unit/provider/package/aptrpm_spec.rb
+++ b/spec/unit/provider/package/aptrpm_spec.rb
@@ -26,7 +26,6 @@ describe Puppet::Type.type(:package).provider(:aptrpm) do
 
     it "should report absent packages" do
       rpm.raises(Puppet::ExecutionFailure, "couldn't find rpm")
-      rpm(rpm_args + ['--whatprovides']).raises(Puppet::ExecutionFailure, 'no package provides faff')
       pkg.property(:ensure).retrieve.should == :absent
     end
 

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -44,6 +44,13 @@ describe provider_class do
     Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "--version"], execute_options).returns(rpm_version).at_most_once
   end
 
+  describe 'provider features' do
+    it { should be_versionable }
+    it { should be_install_options }
+    it { should be_uninstall_options }
+    it { should be_virtual_packages }
+  end
+
   describe "self.instances" do
     describe "with a modern version of RPM" do
       it "includes all the modern flags" do
@@ -277,12 +284,11 @@ describe provider_class do
       Puppet.expects(:debug).never
       expected_args = ["/bin/rpm", "-q", resource_name, "--nosignature", "--nodigest", "--qf", nevra_format]
       Puppet::Util::Execution.expects(:execute).with(expected_args, execute_options).raises Puppet::ExecutionFailure.new("package #{resource_name} is not installed")
-      Puppet::Util::Execution.expects(:execute).with(expected_args + ["--whatprovides"], execute_options).raises Puppet::ExecutionFailure.new("no package provides #{resource_name}")
       expect(provider.query).to be_nil
     end
 
     it "parses virtual package" do
-      #Puppet.expects(:debug).never
+      provider.resource[:allow_virtual] = true
       expected_args = ["/bin/rpm", "-q", resource_name, "--nosignature", "--nodigest", "--qf", nevra_format]
       Puppet::Util::Execution.expects(:execute).with(expected_args, execute_options).raises Puppet::ExecutionFailure.new("package #{resource_name} is not installed")
       Puppet::Util::Execution.expects(:execute).with(expected_args + ["--whatprovides"], execute_options).returns "myresource 0 1.2.3.4 5.el4 noarch\n"

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -27,6 +27,12 @@ describe provider_class do
     provider.stubs(:get).with(:arch).returns 'i386'
   end
 
+  describe 'provider features' do
+    it { should be_versionable }
+    it { should be_install_options }
+    it { should be_virtual_packages }
+  end
+
   # provider should repond to the following methods
    [:install, :latest, :update, :purge, :install_options].each do |method|
      it "should have a(n) #{method}" do

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Type.type(:package) do
   end
 
   describe "when validating attributes" do
-    [:name, :source, :instance, :status, :adminfile, :responsefile, :configfiles, :category, :platform, :root, :vendor, :description, :allowcdrom].each do |param|
+    [:name, :source, :instance, :status, :adminfile, :responsefile, :configfiles, :category, :platform, :root, :vendor, :description, :allowcdrom, :allow_virtual].each do |param|
       it "should have a #{param} parameter" do
         Puppet::Type.type(:package).attrtype(param).should == :param
       end
@@ -117,6 +117,26 @@ describe Puppet::Type.type(:package) do
       expect do
         Puppet::Type.type(:package).new(:name => ["error"])
       end.to raise_error(Puppet::ResourceError, /Name must be a String/)
+    end
+
+    it "should issue deprecation warning for default allow_virtual for a provider that supports virtual packages" do
+      Puppet.expects(:deprecation_warning).with('The package type\'s allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.')
+      Puppet::Type.type(:package).new(:name => 'yay', :provider => :yum)
+    end
+
+    it "should not issue deprecation warning for allow_virtual set to false for a provider that supports virtual packages" do
+      Puppet.expects(:deprecation_warning).never
+      Puppet::Type.type(:package).new(:name => 'yay', :provider => :yum, :allow_virtual => false)
+    end
+
+    it "should not issue deprecation warning for allow_virtual set to true for a provider that supports virtual packages" do
+      Puppet.expects(:deprecation_warning).never
+      Puppet::Type.type(:package).new(:name => 'yay', :provider => :yum, :allow_virtual => true)
+    end
+
+    it "should not issue deprecation warning for default allow_virtual for a provider that does not support virtual packages" do
+      Puppet.expects(:deprecation_warning).never
+      Puppet::Type.type(:package).new(:name => 'yay', :provider => :apt)
     end
   end
 


### PR DESCRIPTION
In 3.5.x, the yum package provider changed to accept virtual package
names (packages that provide other package names).

That change in behavior caused some undesirable side-effects. As we did
not give users fair warning that this behavior was changing, we have
decided to change the yum provider back to only accepting "real" package
names by default.

To keep the support for virtual package names, a "virtual_packages"
feature has been implemented on the package type and supported on the
yum package provider.  The feature adds the "allow_virtual" parameter
that controls whether or not virtual package names will be allowed for
install/uninstall.

For now, the default value for this parameter will be false to restore
the previous behavior.  However, a deprecation warning will be issued to
let users know that the default will eventually be changed to true.
Users can prevent the deprecation warning by explicitly setting the
parameter to either true or false.
