### PR TITLE
(PUP-2562) Omit templatedir setting from debian packages

### DIFF
--- a/ext/debian/puppet.conf
+++ b/ext/debian/puppet.conf
@@ -4,7 +4,6 @@ vardir=/var/lib/puppet
 ssldir=/var/lib/puppet/ssl
 rundir=/var/run/puppet
 factpath=$vardir/lib/facter
-templatedir=$confdir/templates
 
 [master]
 # These are needed when the puppetmaster is run by passenger


### PR DESCRIPTION
Previously, debian puppet packages were setting the templatedir
setting, which would trigger the deprecation warning every time it
ran.
