### PR TITLE
(PUP-2031) Fix broken range support in unless_uid parameter.

### DIFF
--- a/spec/unit/type/resources_spec.rb
+++ b/spec/unit/type/resources_spec.rb
@@ -89,49 +89,6 @@ describe resources do
     end
 
     describe "with unless_uid" do
-      describe "with a uid range" do
-        before do
-          @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_uid => 10_000..20_000
-          @res.catalog = Puppet::Resource::Catalog.new
-        end
-
-        it "should purge uids that are not in a specified range" do
-          user_hash = {:name => 'special_user', :uid => 25_000}
-          user = Puppet::Type.type(:user).new(user_hash)
-          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
-          @res.user_check(user).should be_true
-        end
-
-        it "should not purge uids that are in a specified range" do
-          user_hash = {:name => 'special_user', :uid => 15_000}
-          user = Puppet::Type.type(:user).new(user_hash)
-          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
-          @res.user_check(user).should be_false
-        end
-      end
-
-      describe "with a uid range array" do
-        before do
-          @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_uid => [10_000..15_000, 15_000..20_000]
-          @res.catalog = Puppet::Resource::Catalog.new
-        end
-
-        it "should purge uids that are not in a specified range array" do
-          user_hash = {:name => 'special_user', :uid => 25_000}
-          user = Puppet::Type.type(:user).new(user_hash)
-          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
-          @res.user_check(user).should be_true
-        end
-
-        it "should not purge uids that are in a specified range array" do
-          user_hash = {:name => 'special_user', :uid => 15_000}
-          user = Puppet::Type.type(:user).new(user_hash)
-          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
-          @res.user_check(user).should be_false
-        end
-
-      end
-
       describe "with a uid array" do
         before do
           @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_uid => [15_000, 15_001, 15_002]
@@ -154,7 +111,7 @@ describe resources do
 
       end
 
-      describe "with a single uid" do
+      describe "with a single integer uid" do
         before do
           @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_uid => 15_000
           @res.catalog = Puppet::Resource::Catalog.new
@@ -175,9 +132,30 @@ describe resources do
         end
       end
 
+      describe "with a single string uid" do
+        before do
+          @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_uid => '15000'
+          @res.catalog = Puppet::Resource::Catalog.new
+        end
+
+        it "should purge uids that are not specified" do
+          user_hash = {:name => 'special_user', :uid => 25_000}
+          user = Puppet::Type.type(:user).new(user_hash)
+          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
+          @res.user_check(user).should be_true
+        end
+
+        it "should not purge uids that are specified" do
+          user_hash = {:name => 'special_user', :uid => 15_000}
+          user = Puppet::Type.type(:user).new(user_hash)
+          user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
+          @res.user_check(user).should be_false
+        end
+      end
+
       describe "with a mixed uid array" do
         before do
-          @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_uid => [10_000..15_000, 16_666]
+          @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_uid => ['15000', 16_666]
           @res.catalog = Puppet::Resource::Catalog.new
         end
 


### PR DESCRIPTION
The unless_uid parameter on the resources type attempts to support
ranges, but the implementation is expecting ruby Range types during
munging, which the current parser implementation will not produce.

Additionally, it tries to parse strings of "[x,y]" and "[x..y]" as
ranges but fails to properly remove the brackets and fails to
munge the value.

As there is currently no way to efficiently represent a range for this
parameter, we've decided to back out this broken support for ranges and
instead limit the unless_uid values to integers, integer strings, and
arrays of integers or integer strings.

Users that want to use a range will have to make use of the stdlib
range() function, which is what they have to do currently given the
range support was broken.

In Puppet 4.x, we should look to making use of the future parser's
support for ranges in the Puppet language for this parameter.
