### PR TITLE
(PUP-2577) Use versioncmp to test Mac OS X compatibility

### DIFF
--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -178,7 +178,9 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
   end
 
   def self.fail_if_wrong_version
-    fail("Puppet does not support OS X versions < 10.5") unless self.get_macosx_version_major >= "10.5"
+    if (Puppet::Util::Package.versioncmp(self.get_macosx_version_major, '10.5') == -1)
+      fail("Puppet does not support OS X versions < 10.5")
+    end
   end
 
   def self.get_exec_preamble(ds_action, resource_name = nil)


### PR DESCRIPTION
Prior to this commit, the version comparison which indicates
Puppet's support for various versions of Mac OS X used a
string comparison against 10.5 (the oldest version we technically
run on).  This caused versions such as "10.10" to be considered
lower than "10.5", which is incorrect.

This commit adjusts this comparison to use the same versioncmp
helper method that other methods in directoryservices.rb use to
ascertain the running version of OS X.
