### PR TITLE
(PUP-2505) Puppet HTTP API, certificate_status, DELETE request broken

### DIFF
--- a/lib/puppet/network/http/route.rb
+++ b/lib/puppet/network/http/route.rb
@@ -47,6 +47,11 @@ class Puppet::Network::HTTP::Route
     return self
   end
 
+  def delete(*handlers)
+    @method_handlers[:DELETE] = handlers
+    return self
+  end
+
   def any(*handlers)
     @method_handlers.each do |method, registered_handlers|
       @method_handlers[method] = handlers


### PR DESCRIPTION
Duplicates:
   PUP-2483 Deleting a certificate does not work with the API
   PUP-2516 Delete a clients certificate with HTTP API no longer working

HTTP API requests using the DELETE method are failing with "Server Error:
undefined method `each' for nil:NilClass"...

e.g.
 curl -k -X DELETE https://${PMASTER}:8140/production/certificate_status/$AGENT

Traced problem back to missing specification for :DELETE in @method_handlers
