### PR TITLE
(PUP-2582) Update example vhost SSL settings

### DIFF
--- a/ext/rack/example-passenger-vhost.conf
+++ b/ext/rack/example-passenger-vhost.conf
@@ -18,8 +18,10 @@ Listen 8140
 
 <VirtualHost *:8140>
         SSLEngine on
-        SSLProtocol -ALL +SSLv3 +TLSv1
-        SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+        SSLProtocol             ALL -SSLv2
+        SSLCipherSuite          ALL:!aNULL:!eNULL:!DES:!3DES:!IDEA:!SEED:!DSS:!PSK:!RC4:!MD5:+HIGH:+MEDIUM:!LOW:!SSLv2:!EXP
+        SSLCompression          off
+        SSLHonorCipherOrder     on
 
         SSLCertificateFile      /etc/puppet/ssl/certs/squigley.namespace.at.pem
         SSLCertificateKeyFile   /etc/puppet/ssl/private_keys/squigley.namespace.at.pem


### PR DESCRIPTION
Previously the example vhost defined an SSLCipherSuite which included
several weak ciphers. This commit updates the SSL settings in the vhost
in the following ways. First, SSLCipherSuite has includes disabling the
following suites (aNULL, eNULL, DES, 3DES, IDEA, SEED, DSS, PSK, RC4,
MD5). Second, previously LOW, SSLv2, and EXP were removed, but not
killed from the list, which meant that they could be added again in
subsequent declarations. This changes them from - to !, which kills them
instead of removes them. !ADH does not include AECDH, so instead we use
!aNULL, which excludes all anonymous ciphersuites.

SSLCompression is also set to off, because this defaults to on in
certain versions of httpd. Finally, SSLHonorCipherOrder is set to on,
because certain clients may send ciphers not in preferred order, and
this setting will help mitigate that problem.

Thanks to Aaron Zauner for bringing this to our attention.
