### PR TITLE
(maint) Change dev-puppet-master script not to log debug and trace

### DIFF
--- a/util/dev-puppet-master
+++ b/util/dev-puppet-master
@@ -5,13 +5,13 @@ if [ $# -gt 0 ]; then
     name=$1
     shift 1
 fi
- 
+
 export dir="${HOME}/test/master/${name}"
 mkdir -p ${dir}
  
 if [ ! -f $dir/auth.conf ]; then
   # Edit this file to change default puppet authorizations.
-  cp ~/auth.conf "${dir}/auth.conf"
+  cp ./conf/auth.conf "${dir}/auth.conf"
 fi
 mkdir -p ${dir}/manifests
 touch ${dir}/manifests/site.pp
@@ -20,4 +20,4 @@ touch ${dir}/manifests/site.pp
 # and there isn't at least one module with a libdir.
 mkdir -p ${dir}/modules/foo/lib
  
-bundle exec puppet master --no-daemonize --trace --autosign=true --debug --confdir=${dir} --vardir=${dir} --certname puppetmaster $@
+bundle exec puppet master --no-daemonize --autosign=true --confdir=${dir} --vardir=${dir} --certname puppetmaster $@


### PR DESCRIPTION
It is more useful to set this yourself when calling the script,
depending on whether you want --verbose or --debug and/or --trace.
So just:

$ util/dev-puppet-master foo --debug --trace

Also fixed copying of auth.conf (from basic case running script from
repository root).
