### PR TITLE
(PUP-2505) Implement DELETE verb for HTTP routing

### DIFF
--- a/lib/puppet/network/http/route.rb
+++ b/lib/puppet/network/http/route.rb
@@ -3,6 +3,8 @@ class Puppet::Network::HTTP::Route
     raise Puppet::Network::HTTP::Error::HTTPMethodNotAllowedError.new("method #{req.method} not allowed for route #{req.path}", Puppet::Network::HTTP::Issues::UNSUPPORTED_METHOD)
   end
 
+  NO_HANDLERS = [MethodNotAllowedHandler]
+
   attr_reader :path_matcher
 
   def self.path(path_matcher)
@@ -12,12 +14,12 @@ class Puppet::Network::HTTP::Route
   def initialize(path_matcher)
     @path_matcher = path_matcher
     @method_handlers = {
-      :GET => [MethodNotAllowedHandler],
-      :HEAD => [MethodNotAllowedHandler],
-      :OPTIONS => [MethodNotAllowedHandler],
-      :POST => [MethodNotAllowedHandler],
-      :PUT => [MethodNotAllowedHandler],
-      :DELETE => [MethodNotAllowedHandler]
+      :GET => NO_HANDLERS,
+      :HEAD => NO_HANDLERS,
+      :OPTIONS => NO_HANDLERS,
+      :POST => NO_HANDLERS,
+      :PUT => NO_HANDLERS,
+      :DELETE => NO_HANDLERS
     }
     @chained = []
   end
@@ -75,7 +77,8 @@ class Puppet::Network::HTTP::Route
   end
 
   def process(request, response)
-    @method_handlers[request.method.upcase.intern].each do |handler|
+    handlers = @method_handlers[request.method.upcase.intern] || NO_HANDLERS
+    handlers.each do |handler|
       handler.call(request, response)
     end
 

--- a/spec/unit/network/http/route_spec.rb
+++ b/spec/unit/network/http/route_spec.rb
@@ -49,6 +49,14 @@ describe Puppet::Network::HTTP::Route do
       expect(res.body).to eq("used")
     end
 
+    it "does something when it doesn't know the verb" do
+      route = Puppet::Network::HTTP::Route.path(%r{^/vtest/foo})
+
+      expect do
+        route.process(request("UNKNOWN", "/vtest/foo"), res)
+      end.to raise_error(Puppet::Network::HTTP::Error::HTTPMethodNotAllowedError, /UNKNOWN/)
+    end
+
     it "calls the method handlers in turn" do
       call_count = 0
       handler = lambda { |request, response| call_count += 1 }


### PR DESCRIPTION
This builds on top of GH-2655 by adding some tests and also extending it so
that any unknown HTTP verbs recieve a 405 response rather than resulting in an
internal server error.
