### PR TITLE
(PUP-2584) Make 404 warning on agent specific and an error.

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -144,7 +144,8 @@ class Puppet::Configurer
       unless options[:catalog]
         begin
           if node = Puppet::Node.indirection.find(Puppet[:node_name_value],
-              :environment => @environment, :ignore_cache => true, :transaction_uuid => @transaction_uuid)
+              :environment => @environment, :ignore_cache => true, :transaction_uuid => @transaction_uuid,
+              :fail_on_404 => true)
             if node.environment.to_s != @environment
               Puppet.warning "Local environment: \"#{@environment}\" doesn't match server specified node environment \"#{node.environment}\", switching agent to \"#{node.environment}\"."
               @environment = node.environment.to_s
@@ -239,7 +240,8 @@ class Puppet::Configurer
   def retrieve_catalog_from_cache(query_options)
     result = nil
     @duration = thinmark do
-      result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value], query_options.merge(:ignore_terminus => true, :environment => @environment))
+      result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value],
+        query_options.merge(:ignore_terminus => true, :environment => @environment))
     end
     Puppet.notice "Using cached catalog"
     result
@@ -251,7 +253,8 @@ class Puppet::Configurer
   def retrieve_new_catalog(query_options)
     result = nil
     @duration = thinmark do
-      result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value], query_options.merge(:ignore_cache => true, :environment => @environment))
+      result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value],
+        query_options.merge(:ignore_cache => true, :environment => @environment, :fail_on_404 => true))
     end
     result
   rescue SystemExit,NoMemoryError

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -105,18 +105,17 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       result
 
     elsif is_http_404?(response)
-      # 404 gets special treatment as the indirector API can not produce a meaningful
+      return nil unless request.options[:fail_on_404]
+
+      # 404 can get special treatment as the indirector API can not produce a meaningful
       # reason to why something is not found - it may not be the thing the user is
       # expecting to find that is missing, but something else (like the environment).
-      # While this way of handling the issue is not perfect, there is at least a warning
+      # While this way of handling the issue is not perfect, there is at least an error
       # that makes a user aware of the reason for the failure.
       #
       content_type, body = parse_response(response)
       msg = "Find #{uri_with_query_string} resulted in 404 with the message: #{body}"
-      # warn_once
-      Puppet::Util::Warnings.maybe_log(msg, self.class){ Puppet.warning msg }
-      nil
-
+      raise Puppet::Error, msg
     else
       nil
     end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -204,7 +204,7 @@ DOC
       # get the CA cert first, since it's required for the normal cert
       # to be of any use.
       return nil unless Certificate.indirection.find("ca") unless ca?
-      return nil unless @certificate = Certificate.indirection.find(name)
+      return nil unless @certificate = Certificate.indirection.find(name, :fail_on_404 => true)
 
       validate_certificate_with_key
     end

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -277,12 +277,26 @@ describe Puppet::Indirector::REST do
       terminus.find(request).should == nil
     end
 
-    it 'raises a warning for a 404' do
+    it 'raises no warning for a 404 (when not asked to do so)' do
       response = mock_response('404', 'this is the notfound you are looking for')
       connection.expects(:get).returns(response)
       expected_message = 'Find /production/test_model/foo? resulted in 404 with the message: this is the notfound you are looking for'
-      Puppet::Util::Warnings.expects(:maybe_log).with(expected_message, Puppet::TestModel::Rest)
-      terminus.find(request)
+      expect{terminus.find(request)}.to_not raise_error()
+    end
+
+    context 'when fail_on_404 is used in request' do
+      let(:request) { find_request('foo', :fail_on_404 => true) }
+
+      it 'raises an error for a 404 when asked to do so' do
+        response = mock_response('404', 'this is the notfound you are looking for')
+        connection.expects(:get).returns(response)
+        expected_message = [
+          'Find /production/test_model/foo?fail_on_404=true',
+          'resulted in 404 with the message: this is the notfound you are looking for'].join( ' ')
+        expect do
+          terminus.find(request)
+        end.to raise_error(Puppet::Error, expected_message)
+      end
     end
 
     it "asks the model to deserialize the response body and sets the name on the resulting object to the find key" do

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -512,7 +512,7 @@ describe Puppet::SSL::Host do
 
     it "should find the CA certificate if it does not have a certificate" do
       Puppet::SSL::Certificate.indirection.expects(:find).with(Puppet::SSL::CA_NAME).returns mock("cacert")
-      Puppet::SSL::Certificate.indirection.stubs(:find).with("myname").returns @cert
+      Puppet::SSL::Certificate.indirection.stubs(:find).with("myname", {:fail_on_404 => true}).returns @cert
       @host.certificate
     end
 
@@ -546,13 +546,13 @@ describe Puppet::SSL::Host do
 
     it "should find the certificate in the Certificate class and return the Puppet certificate instance" do
       Puppet::SSL::Certificate.indirection.expects(:find).with(Puppet::SSL::CA_NAME).returns mock("cacert")
-      Puppet::SSL::Certificate.indirection.expects(:find).with("myname").returns @cert
+      Puppet::SSL::Certificate.indirection.expects(:find).with("myname",{:fail_on_404 => true}).returns @cert
       @host.certificate.should equal(@cert)
     end
 
     it "should return any previously found certificate" do
       Puppet::SSL::Certificate.indirection.expects(:find).with(Puppet::SSL::CA_NAME).returns mock("cacert")
-      Puppet::SSL::Certificate.indirection.expects(:find).with("myname").returns(@cert).once
+      Puppet::SSL::Certificate.indirection.expects(:find).with("myname", {:fail_on_404 => true}).returns(@cert).once
 
       @host.certificate.should equal(@cert)
       @host.certificate.should equal(@cert)


### PR DESCRIPTION
This changes the general 404 warning issued by the indirection rest
baseclass into being an error if the option :fail_on_404 is passed
as a "query option".

This is then used when asking for a certificate, when asking for
the initial catalog, and when retreiving a catalog from the master.

The :fail_on_404 will raise an exception, and it is up to the caller to
determine what this means - when retrieving a catalog, there may be
retries etc. The request for a certificate fails cleanly.

To try this, contact the master with an unknown environment when using
directory environments for the master configuration.

This more specific behavior is wanted because:
- the rest indirection is used for many different things, one of them
  being probing through a list of files to use until one is found.
- the use cases where it really matters that master does not respond
  with 404 should error out.
