### PR TITLE
(PUP-2610) Maintain context during application exit

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -234,6 +234,16 @@ module Puppet
     @context.override(bindings, description, &block)
   end
 
+  # @api private
+  def self.mark_context(name)
+    @context.mark(name)
+  end
+
+  # @api private
+  def self.rollback_context(name)
+    @context.rollback(name)
+  end
+
   require 'puppet/node'
 
   # The single instance used for normal operation

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -353,24 +353,22 @@ class Application
       plugin_hook('initialize_app_defaults') { initialize_app_defaults }
     end
 
-    Puppet.override(Puppet.base_context(Puppet.settings)) do
-      configured_environment = Puppet.lookup(:environments).get(Puppet[:environment])
-      configured_environment = configured_environment.override_from_commandline(Puppet.settings)
+    Puppet.push_context(Puppet.base_context(Puppet.settings), "Update for application settings (#{self.class.run_mode})")
+    configured_environment = Puppet.lookup(:environments).get(Puppet[:environment])
+    configured_environment = configured_environment.override_from_commandline(Puppet.settings)
 
-      # Setup a new context using the app's configuration
-      Puppet.override({ :current_environment => configured_environment },
-                      "New base context and current environment from application's configuration") do
-        require 'puppet'
-        require 'puppet/util/instrumentation'
-        Puppet::Util::Instrumentation.init
+    # Setup a new context using the app's configuration
+    Puppet.push_context({ :current_environment => configured_environment },
+                    "Update current environment from application's configuration")
 
-        exit_on_fail("initialize")                                   { plugin_hook('preinit')       { preinit } }
-        exit_on_fail("parse application options")                    { plugin_hook('parse_options') { parse_options } }
-        exit_on_fail("prepare for execution")                        { plugin_hook('setup')         { setup } }
-        exit_on_fail("configure routes from #{Puppet[:route_file]}") { configure_indirector_routes }
-        exit_on_fail("run")                                          { plugin_hook('run_command')   { run_command } }
-      end
-    end
+    require 'puppet/util/instrumentation'
+    Puppet::Util::Instrumentation.init
+
+    exit_on_fail("initialize")                                   { plugin_hook('preinit')       { preinit } }
+    exit_on_fail("parse application options")                    { plugin_hook('parse_options') { parse_options } }
+    exit_on_fail("prepare for execution")                        { plugin_hook('setup')         { setup } }
+    exit_on_fail("configure routes from #{Puppet[:route_file]}") { configure_indirector_routes }
+    exit_on_fail("run")                                          { plugin_hook('run_command')   { run_command } }
   end
 
   def main

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -61,6 +61,7 @@ module Puppet::Test
     # Call this method once per test, prior to execution of each invididual test.
     # @return nil
     def self.before_each_test()
+      Puppet.mark_context("initial testing state")
 
       # We need to preserve the current state of all our indirection cache and
       # terminus classes.  This is pretty important, because changes to these
@@ -153,7 +154,7 @@ module Puppet::Test
       $LOAD_PATH.clear
       $old_load_path.each {|x| $LOAD_PATH << x }
 
-      Puppet.pop_context
+      Puppet.rollback_context("initial testing state")
     end
 
 


### PR DESCRIPTION
Because of the way rack servers get configured by puppet, the application
system needs to maintain any context information that is setup while starting
even after the application has exited. This is because the rack app is
created by calling the "master" application and using the return value (which
threads all the way back through the application and command line layers) as
the rack app. When the contexts were removed on the way out of the
application they also removed the setup for how environments were loaded.

This also required that there be a way of undoing a series of context pushes
without knowing how many had been done. For this there is now a mark and
rollback capability in the Puppet::Context system. This is used in the tests
to always return to the context that was present at the start of every test.
