### PR TITLE
(maint) Resolve some documentation TODOs in Puppet::Type

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -679,9 +679,7 @@ class Type
     end
   end
 
-  # Iterates over the existing properties.
-  # @todo what does this mean? As opposed to iterating over the "non existing properties" ??? Is it an
-  #   iteration over those properties that have state? CONFUSING.
+  # Iterates over the properties that were set on this resource.
   # @yieldparam property [Puppet::Property] each property
   # @return [void]
   def eachproperty
@@ -724,18 +722,18 @@ class Type
     (prop = @parameters[name] and prop.is_a?(Puppet::Property)) ? prop.should : nil
   end
 
-  # Creates an instance to represent/manage the given attribute.
-  # Requires either the attribute name or class as the first argument, then an optional hash of
-  # attributes to set during initialization.
-  # @todo The original comment is just wrong - the method does not accept a hash of options
-  # @todo Detective work required; this method interacts with provider to ask if it supports a parameter of
-  #   the given class. it then returns the parameter if it exists, otherwise creates a parameter
-  #    with its :resource => self.
+  # Registers an attribute to this resource type insance.
+  # Requires either the attribute name or class as its argument.
+  # This is a noop if the named property/parameter is not supported
+  # by this resource. Otherwise, an attribute instance is created
+  # and kept in this resource's parameters hash.
   # @overload newattr(name)
-  #   @param name [String] Unclear what name is (probably a symbol) - Needs investigation.
+  #   @param name [Symbol] symbolic name of the attribute
   # @overload newattr(klass)
-  #   @param klass [Class] a class supported as an attribute class - Needs clarification what that means.
-  # @return [???] Probably returns a new instance of the class - Needs investigation.
+  #   @param klass [Class] a class supported as an attribute class, i.e. a subclass of
+  #     Parameter or Property
+  # @return [Object] An instance of the named Parameter or Property class associated
+  #   to this resource type instance, or nil if the attribute is not supported
   #
   def newattr(name)
     if name.is_a?(Class)
@@ -772,17 +770,17 @@ class Type
     @parameters[name.to_sym]
   end
 
-  # Returns a shallow copy of this object's hash of parameters.
-  # @todo Add that this is not only "parameters", but also "properties" and "meta-parameters" ?
+  # Returns a shallow copy of this object's hash of attributes by name.
+  # Note that his not only comprises parameters, but also properties and metaparameters.
   # Changes to the contained parameters will have an effect on the parameters of this type, but changes to
   # the returned hash does not.
-  # @return [Hash{String => Puppet:???Parameter}] a new hash being a shallow copy of the parameters map name to parameter
+  # @return [Hash{String => Object}] a new hash being a shallow copy of the parameters map name to parameter
   def parameters
     @parameters.dup
   end
 
-  # @return [Boolean] Returns whether the property given by name is defined or not.
-  # @todo what does it mean to be defined?
+  # @return [Boolean] Returns whether the attribute given by name has been added
+  #   to this resource or not.
   def propertydefined?(name)
     name = name.intern unless name.is_a? Symbol
     @parameters.include?(name)


### PR DESCRIPTION
Fix some descriptions according to the @todo tags. Some todos were just
to check if the existing documentation was correct. Those were removed
after checking.
