### PR TITLE
(PUP-1894) Fix issue with loading EPP from modules

### DIFF
--- a/lib/puppet/parser/functions/epp.rb
+++ b/lib/puppet/parser/functions/epp.rb
@@ -36,6 +36,6 @@ scope where the `epp` function is called from.
   unless Puppet[:parser] == "future"
     raise ArgumentError, "epp(): function is only available when --parser future is in effect"
   end
-  Puppet::Pops::Evaluator::EppEvaluator.epp(self, arguments[0], self.compiler.environment.to_s, arguments[1])
+  Puppet::Pops::Evaluator::EppEvaluator.epp(self, arguments[0], self.compiler.environment, arguments[1])
 
 end

--- a/spec/unit/parser/functions/epp_spec.rb
+++ b/spec/unit/parser/functions/epp_spec.rb
@@ -67,6 +67,21 @@ describe "the epp function" do
     eval_template("string was: <%= $string %>").should == "string was: the string value"
   end
 
+  describe 'when loading from modules' do
+    include PuppetSpec::Files
+    it 'an epp template is found' do
+      modules_dir = dir_containing('modules', {
+        'testmodule'  => {
+            'templates' => {
+              'the_x.epp' => 'The x is <%= $x %>'
+            }
+        }})
+      Puppet.override({:current_environment => (env = Puppet::Node::Environment.create(:testload, [ modules_dir ]))}, "test") do
+        node.environment = env
+        expect(scope.function_epp([ 'testmodule/the_x.epp', { 'x' => '3'} ])).to eql("The x is 3")
+      end
+    end
+  end
 
   def eval_template_with_args(content, args_hash)
     file_path = tmpdir('epp_spec_content')


### PR DESCRIPTION
The problem when loading EPP was that the name of the environment was
passed instead of the actual environment (which was expected).
This simply changes this, and adds a test that an epp can be loaded from
a module.
