### PR TITLE
(PUP-2182) Fix yum and zypper providers virtual_package feature.

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
   desc "Support for SuSE `zypper` package manager. Found in SLES10sp2+ and SLES11"
 
-  has_feature :versionable, :install_options
+  has_feature :versionable, :install_options, :virtual_packages
 
   commands :zypper => "/usr/bin/zypper"
 
@@ -23,7 +23,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
     # XXX: We don't actually deal with epochs here.
     case should
     when true, false, Symbol
-      # pass
+      should = nil
     else
       # Add the package version
       wanted = "#{wanted}-#{should}"
@@ -52,6 +52,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
     #zypper 0.6.13 (OpenSuSE 10.2) does not support auto agree with licenses
     options << '--auto-agree-with-licenses' unless major < 1 and minor <= 6 and patch <= 13
     options << '--no-confirm'
+    options << '--name' unless @resource.allow_virtual? || should
     options += install_options if resource[:install_options]
     options << wanted
 


### PR DESCRIPTION
The yum and zypper package providers were installing virtual packages even when
allow_virtual was default or set to false.

For yum, the fix is to do a "yum list" command before doing an installation whenever
allow_virtual is not true.  The list command will fail on virtual
package names.  This will prevent the package from being installed as
expected and is only performed if a version is not ensured, since
virtual packages cannot be installed by version.

For zypper, the fix is to pass the --name option to zypper if not
allowing virtual packages and a version string was not ensured.
