### PR TITLE
(maint) Quote class name in init.pp template

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
@@ -23,7 +23,7 @@
 #
 # === Examples
 #
-#  class { <%= metadata.name %>:
+#  class { '<%= metadata.name %>':
 #    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
 #  }
 #


### PR DESCRIPTION
According to the style guide:

All resource titles should be quoted. (Puppet supports unquoted resource
titles if they do not contain spaces or hyphens, but you should avoid
them in the interest of consistent look-and-feel.)

A class is a resource.
