### PR TITLE
(maint) Correct ssl/puppet_cert_generate_and_autosign test to do what it...

### DIFF
--- a/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
+++ b/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
@@ -134,9 +134,9 @@ test_name "Puppet cert generate behavior (#6112)" do
   step "puppet cert generate with autosign true and dns_alt_names"
   hosts.each do |host|
     if host_is_master?(host)
-      generate_and_clean_cert_with_dns_alt_names(host, test_cn, false)
+      generate_and_clean_cert_with_dns_alt_names(host, test_cn, true)
     else
-      fail_to_generate_cert_on_agent_that_is_not_ca(host, test_cn, false)
+      fail_to_generate_cert_on_agent_that_is_not_ca(host, test_cn, true)
     end
   end
 


### PR DESCRIPTION
... says it's doing.

Prior to this commit, the test was incorrectly specifying autosign=false
when attempting to test the behavior when autosign is true. This looks
like a simple copy-paste error as the test right above is exactly the
same. This commit correctly specifies the autosign value.
