### PR TITLE
(maint) Adjust new environment tests to work with PE

### DIFF
--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -29,8 +29,9 @@ environments_dir = master.tmpdir("environments")
 apply_manifest_on(master, <<-MANIFEST)
 File {
   ensure => directory,
-  owner => puppet,
-  mode => 0700,
+  owner => #{master['user']},
+  group => #{master['group']},
+  mode => 0750,
 }
 
 file {
@@ -40,11 +41,16 @@ file {
 }
 MANIFEST
 
-with_puppet_running_on(master, {
+master_opts =  {
   :master => {
     :environmentpath => environments_dir
   }
-}) do
+}
+if master.is_pe?
+  master_opts[:master][:basemodulepath] = master['sitemoduledir']
+end
+
+with_puppet_running_on(master, master_opts) do
   agents.each do |agent|
     step "Ensure that an unauthenticated client cannot access the environments list" do
       on agent, "curl -ksv https://#{master}:#{master_port(agent)}/v2.0/environments", :acceptable_exit_codes => [0,7] do

--- a/acceptance/tests/environment/dynamic_environments.rb
+++ b/acceptance/tests/environment/dynamic_environments.rb
@@ -20,14 +20,17 @@ file {
 
 file { "#{envdir}/#{env}/hiera/#{env}.yaml":
   ensure => file,
+  mode => 0640,
   content => 'foo: foo-#{env}',
 }
 file { "#{envdir}/#{env}/hiera/common.yaml":
   ensure => file,
+  mode => 0640,
   content => 'foo: foo-common',
 }
 file { "#{envdir}/#{env}/manifests/site.pp":
   ensure => file,
+  mode => 0640,
   content => '
     notify { "#{env}-site.pp": }
     notify { "hiera":
@@ -38,6 +41,7 @@ file { "#{envdir}/#{env}/manifests/site.pp":
 }
 file { "#{envdir}/#{env}/modules/amod/manifests/init.pp":
   ensure => file,
+  mode => 0640,
   content => '
     class amod {
       notify { "#{env}-amod": }
@@ -62,6 +66,7 @@ file {
 
 file { "#{testdir}/hiera.yaml":
   ensure => file,
+  mode => 0640,
   content => '
 ---
 :backends: yaml
@@ -96,6 +101,9 @@ common_opts = {
     'modulepath' => "#{testdir}/environments/$environment/modules",
     'hiera_config' => "#{testdir}/hiera.yaml",
 }
+if master.is_pe?
+  common_opts['modulepath'] << ":#{master['sitemoduledir']}"
+end
 
 master_opts = {
   'master' => {

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -29,6 +29,7 @@ def generate_module_content(module_name, options = {})
 
   "#{path_to_module}/#{module_name}/manifests/init.pp":
     ensure => file,
+    mode => 0640,
     content => 'class #{module_name} {
       notify { "template-#{module_name}": message => template("#{module_name}/our_template.erb") }
       file { "$agent_file_location/file-#{module_info}": source => "puppet:///modules/#{module_name}/data" }
@@ -36,14 +37,17 @@ def generate_module_content(module_name, options = {})
   ;
   "#{path_to_module}/#{module_name}/lib/facter/environment_fact_#{module_name}.rb":
     ensure => file,
+    mode => 0640,
     content => "Facter.add(:environment_fact_#{module_name}) { setcode { 'environment fact from #{module_info}' } }"
   ;
   "#{path_to_module}/#{module_name}/files/data":
     ensure => file,
+    mode => 0640,
     content => "data file from #{module_info}"
   ;
   "#{path_to_module}/#{module_name}/templates/our_template.erb":
     ensure => file,
+    mode => 0640,
     content => "<%= @environment_fact_#{module_name} %>"
   ;
   EOS
@@ -53,6 +57,7 @@ def generate_site_manifest(path_to_manifest, *modules_to_include)
   manifest_content = <<-EOS
   "#{path_to_manifest}/site.pp":
     ensure => file,
+    mode => 0640,
     content => "#{modules_to_include.map { |m| "include #{m}" }.join("\n")}"
   ;
   EOS
@@ -61,8 +66,9 @@ end
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
-  owner => puppet,
-  mode => 0700,
+  owner => #{master['user']},
+  group => #{master['group']},
+  mode => 0750,
 }
 
 file {
@@ -129,6 +135,9 @@ master_opts = {
     'basemodulepath' => "#{testdir}/modules",
   }
 }
+if master.is_pe?
+  master_opts['master']['basemodulepath'] << ":#{master['sitemoduledir']}"
+end
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
@@ -156,9 +165,13 @@ with_puppet_running_on master, master_opts, testdir do
       end
     end
 
-    run_with_environment(agent, nil, :expected_exit_code => 0) do |tmpdir, result|
-      assert_no_match(/module-atmp/, result.stdout, "module-atmp was included despite no environment being loaded")
-      assert_match(/Loading facts.*globalmod/, result.stdout)
+    if master.is_pe?
+      step("This test cannot run if the production environment directory does not exist, because the fallback production environment puppet creates has an empty modulepath and PE cannot run without it's basemodulepath in /opt.  PUP-2519, which implicitly creates the production environment directory should allow this to run again")
+    else
+      run_with_environment(agent, nil, :expected_exit_code => 0) do |tmpdir, result|
+        assert_no_match(/module-atmp/, result.stdout, "module-atmp was included despite no environment being loaded")
+        assert_match(/Loading facts.*globalmod/, result.stdout)
+      end
     end
   end
 end

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -52,7 +52,7 @@ apply_manifest_on(master, <<-MANIFEST , :catch_failures => true)
     ]:
 
     ensure => directory,
-    owner => puppet,
+    owner => #{master['user']},
   }
 MANIFEST
 


### PR DESCRIPTION
The changes to these tests are in two main categories:

1) Changes to file owner and group to use beaker host references so that
correct user/group settings are obtained regardless of whether a FOSS or
PE run is being performed.  Also changes to permissions to be more
permissive for group so that the puppet system user running under
Passenger can access key files.

2) Changes to basemodulepath to ensure that the modules PE master needs
to run under its /opt site module directory are always present.

In addition a few cases had to be exempted on PE altogether, notably
tests which were testing the effect of commandline environment settings.
Since running a PE master with commandline settings would require
modifying it's rack config.ru file, these tests make little sense in
this context.
