### PR TITLE
(PUP-838) FFI Puppet::Util::Windows::Process module

### DIFF
--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -18,7 +18,7 @@ module Puppet::Util::Windows::Process
     end
 
     exit_status = FFI::MemoryPointer.new(:dword, 1)
-    unless GetExitCodeProcess(handle, exit_status)
+    if GetExitCodeProcess(handle, exit_status) == FFI::WIN32_FALSE
       raise Puppet::Util::Windows::Error.new("Failed to get child process exit code")
     end
     exit_status = exit_status.read_dword


### PR DESCRIPTION
~~Builds on PUP-836 #2675 which needs to be merged first.~~
~~Builds on PUP-2554 #2677 which needs to be merged first.~~
- Moved FFI code to the bottom of the class in 4422846
- Remove  dependency on windows/process, windows/handle, and
  windows/synchronize, all part of windows-pr (which is not a gem that is
  currently FFI-ed, even in the latest release)
- Add WAIT_TIMEOUT from Windows::Synchronize
- FFI WaitForSingleObject
- FFI GetExitCodeProcess
