### PR TITLE
(PUP-2642) Make default in selector be out of band, raise error nomatch

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -482,4 +482,8 @@ module Puppet::Pops::Issues
   RESERVED_WORD = hard_issue :RESERWED_WORD, :word do
     "Use of reserved word: #{word}, must be quoted if intended to be a String value"
   end
+
+  UNMATCHED_SELECTOR = hard_issue :UNMATCHED_SELECTOR, :param_value do
+    "No matching entry for selector parameter with value '#{param_value}'"
+  end
 end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -471,9 +471,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
     {
       "2 ? { 1 => no, 2 => yes}"                          => 'yes',
-      "3 ? { 1 => no, 2 => no}"                           => nil,
       "3 ? { 1 => no, 2 => no, default => yes }"          => 'yes',
-      "3 ? { 1 => no, default => yes, 3 => no }"          => 'yes',
+      "3 ? { 1 => no, default => yes, 3 => no }"          => 'no',
+      "3 ? { 1 => no, 3 => no, default => yes }"          => 'no',
+      "4 ? { 1 => no, default => yes, 3 => no }"          => 'yes',
+      "4 ? { 1 => no, 3 => no, default => yes }"          => 'yes',
       "'banana' ? { /.*(ana).*/  => $1 }"                 => 'ana',
       "[2] ? { Array[String] => yes, Array => yes}"       => 'yes',
       "ringo ? *[paul, john, ringo, george] => 'beatle'"  => 'beatle',
@@ -482,6 +484,10 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
           parser.evaluate_string(scope, source, __FILE__).should == result
         end
       end
+
+    it 'fails if a selector does not match' do
+      expect{parser.evaluate_string(scope, "2 ? 3 => 4")}.to raise_error(/No matching entry for selector parameter with value '2'/)
+    end
   end
 
   context "When evaluator evaluated unfold" do


### PR DESCRIPTION
This makes the selector expression in the future evaluator have
the same semantics as the 3.6.1 current evaluator. The future evauator
did not process default out of band, and did not raise an error when
there was no match.

This fixes both problems.
