### PR TITLE
Do not ignore dot templates on module generation

### DIFF
--- a/lib/puppet/face/module/generate.rb
+++ b/lib/puppet/face/module/generate.rb
@@ -224,7 +224,7 @@ module Puppet::ModuleTool::Generate
     Puppet.notice "Populating ERB templates..."
 
     templates = destination + '**/*.erb'
-    Dir[templates.to_s].each do |erb|
+    Dir.glob(templates.to_s, File::FNM_DOTMATCH).each do |erb|
       path = Pathname.new(erb)
       content = ERB.new(path.read).result(binding)
 


### PR DESCRIPTION
Puppet module generation ignores templates starting with a dot, since
the glob misses them. Using the File::FNM_DOTMATCH will fix the issue.
