### PR TITLE
(PUP-2514) Remove ability to search for String type in String.

### DIFF
--- a/lib/puppet/pops/evaluator/compare_operator.rb
+++ b/lib/puppet/pops/evaluator/compare_operator.rb
@@ -132,16 +132,8 @@ class Puppet::Pops::Evaluator::CompareOperator
     when Numeric
       # convert string to number, true if ==
       equals(a, b)
-    when Puppet::Pops::Types::PStringType
-      # is there a string in a string? (yes, each char is a string, and an empty string contains an empty string)
-      true
     else
-      if b == Puppet::Pops::Types::PDataType || b == Puppet::Pops::Types::PObjectType
-        # A String is Data and Object (but not of all subtypes of those types).
-        true
-      else
-        false
-      end
+      false
     end
   end
 

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -241,6 +241,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "/ana/ in bananas"              => true,
       "/xxx/ in bananas"              => false,
       "ANA in bananas"                => false, # ANA is a type, not a String
+      "String[1] in bananas"          => false, # Philosophically true though :-)
       "'ANA' in bananas"              => true,
       "ana in 'BANANAS'"              => true,
       "/ana/ in 'BANANAS'"            => false,


### PR DESCRIPTION
While philosophically true, a String consists of a number of
substrings, it is not very meaningful to support only the ability to
assert that. In order to be useful it would need to answer a much wider
variety is Enum[red, blue, green] in "it was blue, orange, and red", is
there a String of 1-5 characters in length inside the string "1234" etc.

This commit removes the naive support for String/Data-type search
in String as it is more confusing than helpful. If we later find it to
be of value, a more elaborate implementation is needed.
