### PR TITLE
(PUP-2382) FFI typedef for win32_bool / fix User

### DIFF
--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -83,7 +83,7 @@ Puppet.features.add(:manages_symlinks) do
       def self.is_implemented
         begin
           ffi_lib :kernel32
-          attach_function :CreateSymbolicLinkW, [:lpwstr, :lpwstr, :dword], :bool
+          attach_function :CreateSymbolicLinkW, [:lpwstr, :lpwstr, :dword], :win32_bool
 
           true
         rescue LoadError => err

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -37,7 +37,7 @@ module Puppet::Util::Windows::ADSI
     # );
     ffi_lib :kernel32
     attach_function_private :GetComputerNameW,
-      [:lpwstr, :lpdword], :bool
+      [:lpwstr, :lpdword], :win32_bool
 
     # taken from winbase.h
     MAX_COMPUTERNAME_LENGTH = 31
@@ -49,7 +49,7 @@ module Puppet::Util::Windows::ADSI
         buffer_size = FFI::MemoryPointer.new(:dword, 1)
         buffer_size.write_dword(max_length) # length in TCHARs
 
-        if ! GetComputerNameW(buffer, buffer_size)
+        if GetComputerNameW(buffer, buffer_size) == FFI::WIN32_FALSE
           raise Puppet::Util::Windows::Error.new("Failed to get computer name")
         end
         @computer_name = buffer.read_wide_string(buffer_size.read_dword)

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -2,12 +2,20 @@ require 'ffi'
 require 'puppet/util/windows/string'
 
 module Puppet::Util::Windows::APITypes
+  module ::FFI
+    WIN32_FALSE = 0
+  end
+
   module ::FFI::Library
     # Wrapper method for attach_function + private
     def attach_function_private(*args)
       attach_function(*args)
       private args[0]
     end
+  end
+
+  class ::FFI::Pointer
+    NULL_HANDLE = 0
   end
 
   class ::FFI::MemoryPointer
@@ -20,10 +28,10 @@ module Puppet::Util::Windows::APITypes
       ptr
     end
 
-    def read_bool
+    def read_win32_bool
       # BOOL is always a 32-bit integer in Win32
       # some Win32 APIs return 1 for true, while others are non-0
-      read_int32 != 0
+      read_int32 != FFI::WIN32_FALSE
     end
 
     alias_method :read_dword, :read_uint32
@@ -81,6 +89,10 @@ module Puppet::Util::Windows::APITypes
   # NOTE: not a good idea to redefine FFI :ulong since other typedefs may rely on it
   FFI.typedef :uint32, :win32_ulong
   FFI.typedef :int32, :win32_long
+  # FFI bool can be only 1 byte at times,
+  # Win32 BOOL is a signed int, and is always 4 bytes, even on x64
+  # http://blogs.msdn.com/b/oldnewthing/archive/2011/03/28/10146459.aspx
+  FFI.typedef :int32, :win32_bool
 
   # NOTE: FFI already defines ushort as a 16-bit unsigned like this:
   # FFI.typedef :uint16, :ushort

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -20,7 +20,7 @@ module Puppet::Util::Windows::File
       FFI::Pointer::NULL
     )
 
-    return true if result
+    return true if result != FFI::WIN32_FALSE
     raise Puppet::Util::Windows::Error.new("ReplaceFile(#{target}, #{source})")
   end
   module_function :replace_file
@@ -30,7 +30,7 @@ module Puppet::Util::Windows::File
                          wide_string(target.to_s),
                          flags)
 
-    return true if result
+    return true if result != FFI::WIN32_FALSE
     raise Puppet::Util::Windows::Error.
       new("MoveFileEx(#{source}, #{target}, #{flags.to_s(8)})")
   end
@@ -51,7 +51,7 @@ module Puppet::Util::Windows::File
   # );
   ffi_lib 'kernel32'
   attach_function_private :ReplaceFileW,
-    [:lpcwstr, :lpcwstr, :lpcwstr, :dword, :lpvoid, :lpvoid], :bool
+    [:lpcwstr, :lpcwstr, :lpcwstr, :dword, :lpvoid, :lpvoid], :win32_bool
 
   # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365240(v=vs.85).aspx
   # BOOL WINAPI MoveFileEx(
@@ -61,7 +61,7 @@ module Puppet::Util::Windows::File
   # );
   ffi_lib 'kernel32'
   attach_function_private :MoveFileExW,
-    [:lpcwstr, :lpcwstr, :dword], :bool
+    [:lpcwstr, :lpcwstr, :dword], :win32_bool
 
   # BOOLEAN WINAPI CreateSymbolicLink(
   #   _In_  LPTSTR lpSymlinkFileName, - symbolic link to be created
@@ -72,7 +72,7 @@ module Puppet::Util::Windows::File
   begin
     ffi_lib 'kernel32'
     attach_function_private :CreateSymbolicLinkW,
-      [:lpwstr, :lpwstr, :dword], :bool
+      [:lpwstr, :lpwstr, :dword], :win32_bool
   rescue LoadError
   end
 
@@ -109,7 +109,7 @@ module Puppet::Util::Windows::File
   # );
   ffi_lib 'kernel32'
   attach_function_private :DeviceIoControl,
-    [:handle, :dword, :lpvoid, :dword, :lpvoid, :dword, :lpdword, :pointer], :bool
+    [:handle, :dword, :lpvoid, :dword, :lpvoid, :dword, :lpdword, :pointer], :win32_bool
 
   MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 16384
 
@@ -136,13 +136,13 @@ module Puppet::Util::Windows::File
   #   _In_  HANDLE hObject
   # );
   ffi_lib 'kernel32'
-  attach_function_private :CloseHandle, [:handle], :bool
+  attach_function_private :CloseHandle, [:handle], :win32_bool
 
   def symlink(target, symlink)
     flags = File.directory?(target) ? 0x1 : 0x0
     result = CreateSymbolicLinkW(wide_string(symlink.to_s),
       wide_string(target.to_s), flags)
-    return true if result
+    return true if result != FFI::WIN32_FALSE
     raise Puppet::Util::Windows::Error.new(
       "CreateSymbolicLink(#{symlink}, #{target}, #{flags.to_s(8)})")
   end
@@ -184,7 +184,7 @@ module Puppet::Util::Windows::File
       nil
     )
 
-    return out_buffer if result
+    return out_buffer if result != FFI::WIN32_FALSE
     raise Puppet::Util::Windows::Error.new(
       "DeviceIoControl(#{handle}, #{io_control_code}, " +
       "#{in_buffer}, #{in_buffer ? in_buffer.size : ''}, " +

--- a/lib/puppet/util/windows/root_certs.rb
+++ b/lib/puppet/util/windows/root_certs.rb
@@ -104,5 +104,5 @@ class Puppet::Util::Windows::RootCerts
   #   __in DWORD dwFlags
   #   );
   ffi_lib :crypt32
-  attach_function_private :CertCloseStore, [:handle, :dword], :bool
+  attach_function_private :CertCloseStore, [:handle, :dword], :win32_bool
 end

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -569,7 +569,7 @@ module Puppet::Util::Windows::Security
           revision = FFI::MemoryPointer.new(:dword, 1)
           ffsd = FFI::Pointer.new(ppsd.unpack('L')[0])
 
-          if ! GetSecurityDescriptorControl(ffsd, control, revision)
+          if GetSecurityDescriptorControl(ffsd, control, revision) == FFI::WIN32_FALSE
             raise Puppet::Util::Windows::Error.new("Failed to get security descriptor control")
           end
 
@@ -648,5 +648,5 @@ module Puppet::Util::Windows::Security
   # );
   ffi_lib :advapi32
   attach_function_private :GetSecurityDescriptorControl,
-    [:pointer, :lpword, :lpdword], :bool
+    [:pointer, :lpword, :lpdword], :win32_bool
 end

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -88,5 +88,12 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
         Puppet::Util::Windows::User.password_is?(username, nil).should be_false
       end
     end
+
+    describe "check_token_membership" do
+      it "should not raise an error" do
+        # added just to call an FFI code path on all platforms
+        lambda { Puppet::Util::Windows::User.check_token_membership }.should_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
- Previously check_token_membership was failing in 2003 spec tests
  due to 2 issues
  - FFI::Pointer::NULL cannot be used in place of our :handle typedef,
    and therefore we must add a new constant of 0 to be used for NULL
    handles
  - FFI defines a :bool as variable width "(?? 1 byte in C++)", while
    Win32 defines a BOOL as int, and is fixed to 4 bytes on x86 and x64
- Fortunately the bool issue really only bit us in the one spot where
  we were using a pointer to a bool, but by adding a new typedef for
  :win32_bool, all call sites comparing the return value needed to be
  updated for correctness to compare against FFI::WIN32_FALSE
- A test was added to ensure these APIs are called during spec tests
  on all Windows platforms, and not just 2003
