### PR TITLE
(PUP-2382) Remove uneeded 'win32/api' require

### DIFF
--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -25,7 +25,6 @@ Puppet.features.add(:microsoft_windows) do
     require 'win32/process'
     require 'win32/dir'
     require 'win32/service'
-    require 'win32/api'
     require 'win32/taskscheduler'
     true
   rescue LoadError => err


### PR DESCRIPTION
There isn't anything local that uses Win32API any longer
