### PR TITLE
(PUP-2660) user: set the user should-value when generating ssh_authorized_keys

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -647,6 +647,7 @@ module Puppet
         map { |f| unknown_keys_in_file(f) }.
         flatten.each do |res|
           res[:ensure] = :absent
+          res[:user] = self[:name]
           @parameters.each do |name, param|
             res[name] = param.value if param.metaparam?
           end

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -481,7 +481,7 @@ describe Puppet::Type.type(:user) do
 
     describe "generated keys" do
       subject do
-        res = described_class.new(:name => "test", :purge_ssh_keys => purge_param)
+        res = described_class.new(:name => "test_user_name", :purge_ssh_keys => purge_param)
         res.catalog = Puppet::Resource::Catalog.new
         res
       end
@@ -500,6 +500,13 @@ describe Puppet::Type.type(:user) do
         it "should not include keys in comment lines" do
           names = resources.collect { |res| res.name }
           names.should_not include("keyname3")
+        end
+        it "should each have a value for the user property" do
+          resources.map { |res|
+            res[:user]
+          }.reject { |user_name|
+            user_name == "test_user_name"
+          }.should be_empty
         end
       end
     end


### PR DESCRIPTION
When purging authorized SSH keys, the user type generates ssh_authorized_keys
resources using eval_generate. The ensure property receives a should value of
"absent" so the keys are removed. However, those resources are non-functional
because the user property lacks a should value. The resource fails during
Provider::Ssh_authorized_keys::Parsed#flush.

Fixed by setting the appropriate user value for each generated key.
