### PR TITLE
(PUP-2691) Re-adding the missing ‘description’ property to P::MT::Metadata

### DIFF
--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -56,6 +56,14 @@ module Puppet::ModuleTool
       return self
     end
 
+    # Provides an accessor for the now defunct 'description' property.  This
+    # addresses a regression in Puppet 3.6.x where previously valid templates
+    # refering to the 'description' property were broken.
+    # @deprecated
+    def description
+      @data['description']
+    end
+
     # Returns a hash of the module's metadata.  Used by Puppet's automated
     # serialization routines.
     #

--- a/spec/unit/module_tool/metadata_spec.rb
+++ b/spec/unit/module_tool/metadata_spec.rb
@@ -5,6 +5,19 @@ describe Puppet::ModuleTool::Metadata do
   let(:data) { {} }
   let(:metadata) { Puppet::ModuleTool::Metadata.new }
 
+  describe 'property lookups' do
+    subject { metadata }
+
+    %w[ name version author summary license source project_page issues_url
+    dependencies dashed_name release_name description ].each do |prop|
+      describe "##{prop}" do
+        it "responds to the property" do
+          subject.send(prop)
+        end
+      end
+    end
+  end
+
   describe "#update" do
     subject { metadata.update(data) }
 


### PR DESCRIPTION
Prior to Puppet 3.6.0, users had a ‘description’ property which they
could reliably expand into their module skeleton’s ERB templates.  This
property was removed from the default set of properties in Puppet 3.6.0,
which effectively broke template expansion for users relying on it.

This change ensures that users can continue to rely on this property.
