### PR TITLE
(PUP-1070) cleanup empty/invalid lockfiles

### DIFF
--- a/lib/puppet/util/lockfile.rb
+++ b/lib/puppet/util/lockfile.rb
@@ -59,7 +59,7 @@ class Puppet::Util::Lockfile
   #  by other methods in this class without as much risk of accidentally
   #  being overridden by child classes.
   # @return [boolean] true if the file is locked, false if it is not.
-  def file_locked?()
+  def file_locked?
     Puppet::FileSystem.exist? @file_path
   end
   private :file_locked?

--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -22,7 +22,7 @@ class Puppet::Util::Pidlock
     @lockfile.lock(Process.pid)
   end
 
-  def unlock()
+  def unlock
     if mine?
       return @lockfile.unlock
     else
@@ -31,7 +31,12 @@ class Puppet::Util::Pidlock
   end
 
   def lock_pid
-    @lockfile.lock_data.to_i
+    pid = @lockfile.lock_data
+    begin
+      Integer(pid)
+    rescue ArgumentError, TypeError
+      nil
+    end
   end
 
   def file_path
@@ -39,7 +44,7 @@ class Puppet::Util::Pidlock
   end
 
   def clear_if_stale
-    return if lock_pid.nil?
+    return @lockfile.unlock if lock_pid.nil?
 
     errors = [Errno::ESRCH]
     # Process::Error can only happen, and is only defined, on Windows


### PR DESCRIPTION
Currently lockfiles won't be cleaned up automatically if they're empty or contain
non numeric characters.

This commit solves this by verifying that the content of the lockfile
contains a number or otherwise return nil which will result in deleting
the pidfile.
