### PR TITLE
(PUP-2569) Revoke all certificate matching a given name

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -247,10 +247,12 @@ class Puppet::SSL::CertificateAuthority
       serial = cert.content.serial
     elsif name =~ /^0x[0-9A-Fa-f]+$/
       serial = name.hex
-    elsif ! serial = inventory.serial(name)
+    elsif serial = inventory.serials(name) and serial.empty?
       raise ArgumentError, "Could not find a serial number for #{name}"
     end
-    crl.revoke(serial, host.key.content)
+    [serial].flatten.each do |s|
+      crl.revoke(s, host.key.content)
+    end
   end
 
   # This initializes our CA so it actually works.  This should be a private

--- a/lib/puppet/ssl/inventory.rb
+++ b/lib/puppet/ssl/inventory.rb
@@ -37,14 +37,19 @@ class Puppet::SSL::Inventory
 
   # Find the serial number for a given certificate.
   def serial(name)
+    Puppet.deprecation_warning 'Inventory#serial is deprecated, use Inventory#serials instead.'
     return nil unless Puppet::FileSystem.exist?(@path)
-
-    File.readlines(@path).each do |line|
-      next unless line =~ /^(\S+).+\/CN=#{name}$/
-
-      return Integer($1)
-    end
-
-    return nil
+    serials(name).first
   end
+
+  # Find all serial numbers for a given certificate. If none can be found, returns
+  # an empty array.
+  def serials(name)
+    return [] unless Puppet::FileSystem.exist?(@path)
+
+    File.readlines(@path).collect do |line|
+      /^(\S+).+\/CN=#{name}$/.match(line)
+    end.compact.map { |m| Integer(m[1]) }
+  end
+
 end

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -133,5 +133,18 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
         @inventory.serial("me").should == 15
       end
     end
+
+    describe "and finding all serial numbers" do
+      it "should return nil if the inventory file is missing" do
+        Puppet::FileSystem.expects(:exist?).with(cert_inventory).returns false
+        @inventory.serials(:whatever).should be_empty
+      end
+
+      it "should return the all the serial numbers from the lines matching the provided name" do
+        File.expects(:readlines).with(cert_inventory).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
+
+        @inventory.serials("me").should == [15, 2]
+      end
+    end
   end
 end


### PR DESCRIPTION
`puppet cert revoke <name>` was revoking only the first certificate of the inventory file when the certificate file wasn't present on the system. This patch makes sure all issued certificates matching `name` are now revoked.

This PR replaces @dalen's one (with his permission) (https://github.com/puppetlabs/puppet/pull/2501), therefore I think it should be closed.

Please review and comment.
Thanks!
