### PR TITLE
(PUP-2639) Change default timeout to 3 minutes

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -356,7 +356,7 @@ module Puppet
       a file (such as manifests or templates) has changed on disk. #{AS_DURATION}",
     },
     :environment_timeout => {
-      :default    => "5s",
+      :default    => "3m",
       :type       => :ttl,
       :desc       => "The time to live for a cached environment. The time is either given #{AS_DURATION}, or
       the word 'unlimited' which causes the environment to be cached until the master is restarted."


### PR DESCRIPTION
The 5 second timeout was selected assuming that the major use case would be
around a development workflow in which a user edits manifests on a master and
then immediately runs an agent to see the effect. It turns out that this
caused a lot of problems for a much more common and impactful case of users
updating to directory environments where they ended up with excessive CPU
usage. Nearly any value here is arbitrary except 0 (purely development
workflow) and unlimited (best choice for production systems).

This makes the almost arbitrary decision that a 3 minute timeout will create
less confusion for upgrading users. It means that a development workflow will
require more restarts, however. :(
