### PR TITLE
(PUP-2702) Change to unlimited caching as the default

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -366,7 +366,7 @@ module Puppet
       a file (such as manifests or templates) has changed on disk. #{AS_DURATION}",
     },
     :environment_timeout => {
-      :default    => "3m",
+      :default    => "unlimited",
       :type       => :ttl,
       :desc       => "The time to live for a cached environment.
       #{AS_DURATION}


### PR DESCRIPTION
The most effective and safe caching strategy for environments is
"unlimited" since it gives the user control over the resource utiliztion of
the master, provides a clear deployment point, and allows the master to pick
up any ruby code changes that are part of the new environment code.
