### PR TITLE
(PUP-2703) Make 'tag' be a statement function

### DIFF
--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -725,6 +725,7 @@ class Puppet::Pops::Model::Factory
     'realize' => true,
     'include' => true,
     'contain' => true,
+    'tag'     => true,
 
     'debug'   => true,
     'info'    => true,

--- a/spec/unit/pops/transformer/transform_calls_spec.rb
+++ b/spec/unit/pops/transformer/transform_calls_spec.rb
@@ -34,6 +34,7 @@ describe "transformation to Puppet AST for function calls" do
         "realize bar"      => '(invoke realize bar)',
         "contain bar"      => '(invoke contain bar)',
         "include bar"      => '(invoke include bar)',
+        "tag bar"          => '(invoke tag bar)',
 
         "info bar"         => '(invoke info bar)',
         "notice bar"       => '(invoke notice bar)',
@@ -54,7 +55,6 @@ describe "transformation to Puppet AST for function calls" do
 
       {
         "foo bar"      => '(block foo bar)',
-        "tag bar"      => '(block tag bar)',
         "tag"          => 'tag',
       }.each do |source, result|
         it "should not transform #{source}, and instead produce #{result}" do


### PR DESCRIPTION
Tag function should not require parentheses.
