### PR TITLE
(PUP-2705) External facts pluginsync not preserving source permissions

### DIFF
--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -25,8 +25,8 @@ class Puppet::Configurer::Downloader
     files
   end
 
-  def initialize(name, path, source, ignore = nil, environment = nil)
-    @name, @path, @source, @ignore, @environment = name, path, source, ignore, environment
+  def initialize(name, path, source, ignore = nil, environment = nil, source_permissions = :ignore)
+    @name, @path, @source, @ignore, @environment, @source_permissions = name, path, source, ignore, environment, source_permissions
   end
 
   def catalog
@@ -51,7 +51,7 @@ class Puppet::Configurer::Downloader
       :path => path,
       :recurse => true,
       :source => source,
-      :source_permissions => :use,
+      :source_permissions => source_permissions,
       :tag => name,
       :purge => true,
       :force => true,

--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -17,7 +17,8 @@ module Puppet::Configurer::PluginHandler
           Puppet[:pluginfactdest],
           Puppet[:pluginfactsource],
           Puppet[:pluginsignore],
-          environment
+          environment,
+          :use
        )
        plugin_fact_downloader.evaluate
     end

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -51,8 +51,8 @@ describe Puppet::Configurer::Downloader do
       @dler.file
     end
 
-    it "should set source_permissions to use" do
-      Puppet::Type.type(:file).expects(:new).with { |opts| opts[:source_permissions] == :use }
+    it "should set source_permissions to ignore by default" do
+      Puppet::Type.type(:file).expects(:new).with { |opts| opts[:source_permissions] == :ignore }
       @dler.file
     end
 


### PR DESCRIPTION
Ticket: https://tickets.puppetlabs.com/browse/PUP-2705

When using pluginsync to synchronize modules external facts (<module>/facts.d), source permissions should be preserved (e.g. for scripts etc.)
