### PR TITLE
zypper should always be the default package provider for Suse osfamily

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -9,6 +9,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
 
   commands :zypper => "/usr/bin/zypper"
 
+  defaultfor :operatingsystem => [:suse, :sles, :sled, :opensuse]
   confine    :operatingsystem => [:suse, :sles, :sled, :opensuse]
 
   #on zypper versions <1.0, the version option returns 1


### PR DESCRIPTION
zypper package manager should always be the default package provider for Suse osfamily.

Additionally, this prevents puppet agent from moaning about the presence of multiple package providers
if others are also installed (e.g. Yum) along with zypper. In this case, Puppet will default to the first
provider it finds, which does not happen to be the same at every puppet run.
