### PR TITLE
(PUP-2506) Error when evaluating #type in Puppet::Error message interpolation for Puppet::Resource::Ral

### DIFF
--- a/lib/puppet/indirector/resource/ral.rb
+++ b/lib/puppet/indirector/resource/ral.rb
@@ -59,6 +59,6 @@ class Puppet::Resource::Ral < Puppet::Indirector::Code
   end
 
   def type( request )
-    Puppet::Type.type(type_name(request)) or raise Puppet::Error, "Could not find type #{type}"
+    Puppet::Type.type(type_name(request)) or raise Puppet::Error, "Could not find type #{type_name(request)}"
   end
 end

--- a/spec/unit/indirector/resource/ral_spec.rb
+++ b/spec/unit/indirector/resource/ral_spec.rb
@@ -25,6 +25,11 @@ describe "Puppet::Resource::Ral" do
       Puppet::Resource::Ral.new.find(@request).should == my_resource
     end
 
+    it "should produce Puppet::Error instead of ArgumentError" do
+      @bad_request = stub 'thiswillcauseanerror', :key => "thiswill/causeanerror"
+      expect{Puppet::Resource::Ral.new.find(@bad_request)}.to raise_error(Puppet::Error)
+    end
+
     it "if there is no instance, it should create one" do
       wrong_instance = stub "wrong user", :name => "bob"
       root = mock "Root User"


### PR DESCRIPTION
Prior to this commit, a bug is triggered when the Puppet::Error string
is interpolated. The #type method was called recursively and failed with
an ArgumentError: wrong number of arguments (0 for 1).

This commit fixes the bug by changing which variable is interpolated in
the string.  It also adds a spec test for this case.
