### PR TITLE
(PUP-2622) Use non-zero exit codes for unknown subcommands.

### DIFF
--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -14,6 +14,7 @@ require 'puppet/util'
 require "puppet/util/plugins"
 require "puppet/util/rubygems"
 require "puppet/util/limits"
+require 'puppet/util/colors'
 
 module Puppet
   module Util
@@ -160,13 +161,20 @@ module Puppet
 
       # @api private
       class NilSubcommand
+        include Puppet::Util::Colors
+
         def initialize(command_line)
           @command_line = command_line
         end
 
         def run
-          if @command_line.args.include? "--version" or @command_line.args.include? "-V"
+          args = @command_line.args
+          if args.include? "--version" or args.include? "-V"
             puts Puppet.version
+          elsif @command_line.subcommand_name.nil? && args.count > 0
+            # If the subcommand is truly nil and there is an arg, it's an option; print out the invalid option message
+            puts colorize(:hred, "Error: Could not parse application options: invalid option: #{args[0]}")
+            exit 1
           else
             puts "See 'puppet help' for help on available puppet subcommands"
           end
@@ -181,8 +189,9 @@ module Puppet
         end
 
         def run
-          puts "Error: Unknown Puppet subcommand '#{@subcommand_name}'"
+          puts colorize(:hred, "Error: Unknown Puppet subcommand '#{@subcommand_name}'")
           super
+          exit 1
         end
       end
     end

--- a/spec/lib/puppet_spec/matchers.rb
+++ b/spec/lib/puppet_spec/matchers.rb
@@ -44,61 +44,80 @@ RSpec::Matchers.define :exit_with do |expected|
   end
 end
 
-class HavePrintedMatcher
-  attr_accessor :expected, :actual
 
-  def initialize(expected)
-    case expected
+RSpec::Matchers.define :have_printed do |expected|
+
+  case expected
     when String, Regexp
-      @expected = expected
+      expected = expected
     else
-      @expected = expected.to_s
+      expected = expected.to_s
+  end
+
+  chain :and_exit_with do |code|
+    @expected_exit_code = code
+  end
+
+  define_method :matches_exit_code? do |actual|
+    @expected_exit_code.nil? || @expected_exit_code == actual
+  end
+
+  define_method :matches_output? do |actual|
+    return false unless actual
+    case expected
+      when String
+        actual.include?(expected)
+      when Regexp
+        expected.match(actual)
+      else
+        raise ArgumentError, "No idea how to match a #{actual.class.name}"
     end
   end
 
-  def matches?(block)
+  match do |block|
+    $stderr = $stdout = StringIO.new
+    $stdout.set_encoding('UTF-8') if $stdout.respond_to?(:set_encoding)
+
     begin
-      $stderr = $stdout = StringIO.new
-      $stdout.set_encoding('UTF-8') if $stdout.respond_to?(:set_encoding)
       block.call
+    rescue SystemExit => e
+      raise unless @expected_exit_code
+      @actual_exit_code = e.status
+    ensure
       $stdout.rewind
       @actual = $stdout.read
-    ensure
+
       $stdout = STDOUT
       $stderr = STDERR
     end
 
-    if @actual then
-      case @expected
-      when String
-        @actual.include? @expected
-      when Regexp
-        @expected.match @actual
+    matches_output?(@actual) && matches_exit_code?(@actual_exit_code)
+  end
+
+  failure_message_for_should do |actual|
+    if actual.nil? then
+      "expected #{expected.inspect}, but nothing was printed"
+    else
+      if !@expected_exit_code.nil? && matches_output?(actual)
+        "expected exit with code #{@expected_exit_code} but " +
+          (@actual_exit_code.nil? ? " exit was not called" : "exited with #{@actual_exit_code} instead")
+      else
+        "expected #{expected.inspect} to be printed; got:\n#{actual}"
       end
-    else
-      false
     end
   end
 
-  def failure_message_for_should
-    if @actual.nil? then
-      "expected #{@expected.inspect}, but nothing was printed"
+  failure_message_for_should_not do |actual|
+    if @expected_exit_code && matches_exit_code?(@actual_exit_code)
+      "expected exit code to not be #{@actual_exit_code}"
     else
-      "expected #{@expected.inspect} to be printed; got:\n#{@actual}"
+      "expected #{expected.inspect} to not be printed; got:\n#{actual}"
     end
   end
 
-  def failure_message_for_should_not
-    "expected #{@expected.inspect} to not be printed; got:\n#{@actual}"
+  description do
+    "expect #{expected.inspect} to be printed" + (@expected_exit_code.nil ? '' : " with exit code #{@expected_exit_code}")
   end
-
-  def description
-    "expect #{@expected.inspect} to be printed"
-  end
-end
-
-def have_printed(what)
-  HavePrintedMatcher.new(what)
 end
 
 RSpec::Matchers.define :equal_attributes_of do |expected|

--- a/spec/unit/util/command_line_spec.rb
+++ b/spec/unit/util/command_line_spec.rb
@@ -93,35 +93,39 @@ describe Puppet::Util::CommandLine do
       end
 
       describe "and an external implementation cannot be found" do
+        before :each do
+          Puppet::Util::CommandLine::UnknownSubcommand.any_instance.stubs(:console_has_color?).returns false
+        end
+
         it "should abort and show the usage message" do
-          commandline = Puppet::Util::CommandLine.new("puppet", ['whatever', 'argument'])
           Puppet::Util.expects(:which).with('puppet-whatever').returns(nil)
+          commandline = Puppet::Util::CommandLine.new("puppet", ['whatever', 'argument'])
           commandline.expects(:exec).never
 
           expect {
             commandline.execute
-          }.to have_printed(/Unknown Puppet subcommand 'whatever'/)
+          }.to have_printed(/Unknown Puppet subcommand 'whatever'/).and_exit_with(1)
         end
 
         it "should abort and show the help message" do
-          commandline = Puppet::Util::CommandLine.new("puppet", ['whatever', 'argument'])
           Puppet::Util.expects(:which).with('puppet-whatever').returns(nil)
+          commandline = Puppet::Util::CommandLine.new("puppet", ['whatever', 'argument'])
           commandline.expects(:exec).never
 
           expect {
             commandline.execute
-          }.to have_printed(/See 'puppet help' for help on available puppet subcommands/)
+          }.to have_printed(/See 'puppet help' for help on available puppet subcommands/).and_exit_with(1)
         end
 
         %w{--version -V}.each do |arg|
           it "should abort and display #{arg} information" do
-            commandline = Puppet::Util::CommandLine.new("puppet", ['whatever', arg])
             Puppet::Util.expects(:which).with('puppet-whatever').returns(nil)
+            commandline = Puppet::Util::CommandLine.new("puppet", ['whatever', arg])
             commandline.expects(:exec).never
 
             expect {
               commandline.execute
-            }.to have_printed(/^#{Puppet.version}$/)
+            }.to have_printed(/^#{Puppet.version}$/).and_exit_with(1)
           end
         end
       end


### PR DESCRIPTION
Previously, if users execute 'puppet foo', an error message is displayed
about unknown subcommand 'foo', but puppet still exits with a zero exit
code indicating success.

Additionally, if users execute 'puppet --option <valid_subcommand>',
puppet silently ignores the option, prints a message, and exits with a
zero exit code.  As a result, a user accidentally transposed a valid
option for a subcommand with the subcommand itself in an automated context
and puppet did not report a failure.

This commit fixes both conditions by exiting with 1 from the nil and unknown
subcommands where appropriate.  It also prints error messages using the same
colorized output we use for usual puppet errors.
