### PR TITLE
PUP-2583

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -77,7 +77,7 @@ module Puppet
 
     def desired_mode_from_current(desired, current)
       current = current.to_i(8) if current.is_a? String
-      is_a_directory = @resource.stat and @resource.stat.directory?
+      is_a_directory = @resource.stat.directory?
       symbolic_mode_to_int(desired, current, is_a_directory)
     end
 


### PR DESCRIPTION
Puppet file provider wrongly classifies file as directory. And thus chmod(u+X) adds execute right although it should be only added to directories. This PR should solve this issue.
