### PR TITLE
(maint) Move duplicate code in /lib/puppet/provider/service/freebsd.rb i...

### DIFF
--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -27,24 +27,24 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
     rcvar
   end
 
+  # Extract value name from service or rcvar
+  def extract_value_name(name, rc_index, regex, regex_index)
+    value_name = self.rcvar[rc_index]
+    self.error("No #{name} name found in rcvar") if value_name.nil?
+    value_name = value_name.gsub!(regex, regex_index)
+    self.error("#{name} name is empty") if value_name.nil?
+    self.debug("#{name} name is #{value_name}")
+    value_name
+  end
+
   # Extract service name
   def service_name
-    name = self.rcvar[0]
-    self.error("No service name found in rcvar") if name.nil?
-    name = name.gsub!(/# (.*)/, '\1')
-    self.error("Service name is empty") if name.nil?
-    self.debug("Service name is #{name}")
-    name
+    extract_value_name('service', 0, /# (.*)/, '\1')
   end
 
   # Extract rcvar name
   def rcvar_name
-    name = self.rcvar[1]
-    self.error("No rcvar name found in rcvar") if name.nil?
-    name = name.gsub!(/(.*?)(_enable)?=(.*)/, '\1')
-    self.error("rcvar name is empty") if name.nil?
-    self.debug("rcvar name is #{name}")
-    name
+    extract_value_name('rcvar', 1, /(.*?)(_enable)?=(.*)/, '\1')
   end
 
   # Extract rcvar value


### PR DESCRIPTION
...nto single method

Prior to this commit, service_name and rcvar_name contained duplicate
code in lib/puppet/provider/service/freebsd.rb that accomplished the
same thing. This commit moves this code into a single method that
can be invoked from both service_name and rcvar_name.
