### PR TITLE
(PUP-2710) For audit only, compare Time objects as strings

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -164,10 +164,23 @@ class Puppet::Transaction::ResourceHarness
     event
   end
 
+  # This method is an ugly hack because, given a Time object with nanosecond
+  # resolution, roundtripped through YAML serialization, the Time object will
+  # be truncated to microseconds.
+  # For audit purposes, this code special cases this comparison, and compares
+  # the two objects by their second and microsecond components. tv_sec is the
+  # number of seconds since the epoch, and tv_usec is only the microsecond
+  # portion of time.  This compare satisfies compatibility requirements for
+  # Ruby 1.8.7, where to_r does not exist on the Time class.
+  def are_audited_values_equal(a, b)
+    a == b || (a.is_a?(Time) && a.tv_sec == b.tv_sec && a.tv_usec == b.tv_usec) 
+  end
+  private :are_audited_values_equal
+
   def audit_event(event, property)
     event.audited = true
     event.status = "audit"
-    if event.historical_value != event.previous_value
+    if !are_audited_values_equal(event.historical_value, event.previous_value)
       event.message = "audit change: previously recorded value #{property.is_to_s(event.historical_value)} has been changed to #{property.is_to_s(event.previous_value)}"
     end
 
@@ -175,7 +188,7 @@ class Puppet::Transaction::ResourceHarness
   end
 
   def audit_message(param, do_audit, historical_value, current_value)
-    if do_audit && historical_value && historical_value != current_value
+    if do_audit && historical_value && !are_audited_values_equal(historical_value, current_value)
       " (previously recorded value was #{param.is_to_s(historical_value)})"
     else
       ""
@@ -196,7 +209,7 @@ class Puppet::Transaction::ResourceHarness
   def capture_audit_events(resource, context)
     context.audited_params.each do |param_name|
       if context.historical_values.include?(param_name)
-        if context.historical_values[param_name] != context.current_values[param_name] && !context.synced_params.include?(param_name)
+        if !are_audited_values_equal(context.historical_values[param_name], context.current_values[param_name]) && !context.synced_params.include?(param_name)
           parameter = resource.parameter(param_name)
           event = audit_event(create_change_event(parameter,
                                                   context.current_values[param_name],


### PR DESCRIPTION
Previously, auditing the mtime or ctime properties of a file
on ext4 (or any nanosecond resolution filesystem) when running
under ruby 1.9+ would spuriously report a change on every catalog
run.

This was because the yaml library (or libraries, more on that
shortly) correctly serialize the nanosecond resolution of the Time
object to yaml, _but_ on deserialization they produce a Time object
truncated to microseconds. This led to a false inequality operation
leading to the spurious audit messages.

This patch is an unfortunate hack consisting of special-casing
the comparison of Time objects in the audit equality operation.

For context, I also considered alternatives:
- Monkey-patching the Time object == method to ignore nanoseconds.
  But this would affect all Time objects and could have undesired
  consequences.
- Monkey-patching the yaml library to correctly deserialize. But
  this got messy because there are several different yaml libraries
  that may be involved.
- Intercepting the serialization in Puppet::Util::Yaml, but this
  would mean discarding nanoseconds for all serialization of Time
  objects to yaml.

In the end, this spot fix seemed like the least evil solution.
