### PR TITLE
PUP-2583 mode attribute of file type doesn't behave like chmod when given X

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -77,7 +77,7 @@ module Puppet
 
     def desired_mode_from_current(desired, current)
       current = current.to_i(8) if current.is_a? String
-      is_a_directory = @resource.stat and @resource.stat.directory?
+      is_a_directory = @resource.stat && @resource.stat.directory?
       symbolic_mode_to_int(desired, current, is_a_directory)
     end
 


### PR DESCRIPTION
When changing permissions with puppet file type and using symbolic permissions e.g: g+rX, puppet consideres everything as directory. Which is wrong, because you can specify different set of permissions for directory and file (triggered by case of the letter you use).

Problem originates in ruby && and "and" operator precedence. Which was incorrectly used in this case.
