### PR TITLE
(maint) remove dead services code from puppet.rb

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -40,9 +40,6 @@ module Puppet
   # the hash that determines how our system behaves
   @@settings = Puppet::Settings.new
 
-  # The services running in this process.
-  @services ||= []
-
   require 'puppet/util/logging'
 
   extend Puppet::Util::Logging

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -558,7 +558,6 @@ describe Puppet::Application::Agent do
         Puppet[:onetime] = true
         @puppetd.options[:client] = :client
         @puppetd.options[:detailed_exitcodes] = false
-        Puppet.stubs(:newservice)
       end
 
       it "should exit if no defined --client" do


### PR DESCRIPTION
Commit c0fcb213 removed all uses of the @services instance variable from
Puppet as well as the Puppet.newservice method; we no longer need the
instance variable or test stub.
