### PR TITLE
Maint/puppet 4/dead name code

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -34,7 +34,6 @@ module Puppet
   class << self
     include Puppet::Util
     attr_reader :features
-    attr_writer :name
   end
 
   # the hash that determines how our system behaves


### PR DESCRIPTION
The Puppet module @name variable has not been accessible since 46d344b9 in 2007; the method has no valid use and can be removed.
