### PR TITLE
Maint/puppet 4/dead genmanifest code

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -110,13 +110,6 @@ module Puppet
   # Load all of the settings.
   require 'puppet/defaults'
 
-  def self.genmanifest
-    if Puppet[:genmanifest]
-      puts Puppet.settings.to_manifest
-      exit(0)
-    end
-  end
-
   # Parse the config file for this process.
   # @deprecated Use {initialize_settings}
   def self.parse_config()


### PR DESCRIPTION
Commit 422dea05e7 (in 2008) moved the --genmanifest functionality from Puppet to Puppet::Settings; the Puppet.genmanifest method is no longer used by anything in Puppet and can be removed.
