### PR TITLE
(PUP-2579) Improve regular expression for options of ssh_authorized_keys

### DIFF
--- a/lib/puppet/provider/ssh_authorized_key/parsed.rb
+++ b/lib/puppet/provider/ssh_authorized_key/parsed.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:ssh_authorized_key).provide(
     while !scanner.eos?
       scanner.skip(/[ \t]*/)
       # scan a long option
-      if out = scanner.scan(/[-a-z0-9A-Z_]+=\".*?\"/) or out = scanner.scan(/[-a-z0-9A-Z_]+/)
+      if out = scanner.scan(/[-a-z0-9A-Z_]+=\".*?[^\\]\"/) or out = scanner.scan(/[-a-z0-9A-Z_]+/)
         result << out
       else
         # found an unscannable token, let's abort


### PR DESCRIPTION
An option of an SSH key containing escaped double quotes were not correctly
parsed by the ssh_authorized_keys provider, because of an incomplete
regular expression. This commit improves the regular expression by ensuring
that the option is ended by an non-escaped double quotes. See
