### PR TITLE
Maint/puppet 4/remove property shadowing

### DIFF
--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -50,10 +50,6 @@ describe Puppet::Property do
     property.to_s.should == property.name.to_s
   end
 
-  it "should be able to shadow metaparameters" do
-    property.must respond_to(:shadow)
-  end
-
   describe "when returning the default event name" do
     it "should use the current 'should' value to pick the event name" do
       property.expects(:should).returns "myvalue"
@@ -149,32 +145,6 @@ describe Puppet::Property do
       collection.expects(:match?).with("foo").returns(foo)
       property.class.stubs(:value_collection).returns(collection)
       property.event.invalidate_refreshes.should be_true
-    end
-  end
-
-  describe "when shadowing metaparameters" do
-    let :shadow_class do
-      shadow_class = Class.new(Puppet::Property) do
-        @name = :alias
-      end
-      shadow_class.initvars
-      shadow_class
-    end
-
-    it "should create an instance of the metaparameter at initialization" do
-      Puppet::Type.metaparamclass(:alias).expects(:new).with(:resource => resource)
-
-      shadow_class.new :resource => resource
-    end
-
-    it "should munge values using the shadow's munge method" do
-      shadow = mock 'shadow'
-      Puppet::Type.metaparamclass(:alias).expects(:new).returns shadow
-
-      shadow.expects(:munge).with "foo"
-
-      property = shadow_class.new :resource => resource
-      property.munge("foo")
     end
   end
 


### PR DESCRIPTION
Commit aa8d0914 (in 2008) added a @shadow instance variable, ostensibly for handling cases where a type declared a property with the same name as a metaparameter. It was meant to allow the shadowed metaparameter to coexist but was not fleshed out as such. The shadowed parameter is not directly exposed in any meaningful way, and most metaparameters are not accessed in the same manner as parameters, they usually have dedicated methods for setting and retrieving those fields. In the cases where metaparameters are not accessed in a specific manner (such as the schedule metaparameter) defining a duplicate property makes Puppet crash instead of handling it, so the shadow variable doesn't actually address the duplication issue.

This commit removes all references of metaparameter shadowing from property.rb.
