### PR TITLE
(maint) Use same prioritizer throughout catalog

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -184,11 +184,14 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
   # The relationship_graph form of the catalog. This contains all of the
   # dependency edges that are used for determining order.
   #
+  # @param given_prioritizer [Puppet::Graph::Prioritizer] The prioritization
+  #   strategy to use when constructing the relationship graph. Defaults the
+  #   being determined by the `ordering` setting.
   # @return [Puppet::Graph::RelationshipGraph]
   # @api public
-  def relationship_graph
+  def relationship_graph(given_prioritizer = nil)
     if @relationship_graph.nil?
-      @relationship_graph = Puppet::Graph::RelationshipGraph.new(prioritizer)
+      @relationship_graph = Puppet::Graph::RelationshipGraph.new(given_prioritizer || prioritizer)
       @relationship_graph.populate_from(self)
     end
     @relationship_graph

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -138,7 +138,7 @@ class Puppet::Transaction
   end
 
   def relationship_graph
-    catalog.relationship_graph
+    catalog.relationship_graph(@prioritizer)
   end
 
   def resource_status(resource)


### PR DESCRIPTION
Under normal system runs, there wasn't any problem with the prioritizer being
used, since the Puppet::Resource::Catalog created it and passed to all of the
correct places. However, the testing methods in PuppetSpec::Compiler ended up
lying to the user about the prioritizer that could be used. The prioritizer
that was passed in was not the one actually used by the catalog for
constructing the relationship graph. This was because the
Puppet::Parser::Catalog used the one it had internally. The answer is to have
the Puppet::Parser::Catalog act as one possible factory of prioritizers, and
pass the prioritizer around as it needs it. This allows the tests to then
pass in the correct prioritizer and use it consistently throughout.
