### PR TITLE
(maint) stop enforcing the random prioritizer for evaluation in spectests

### DIFF
--- a/spec/integration/type/user_spec.rb
+++ b/spec/integration/type/user_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
     let(:manifest) { "user { 'root': purge_ssh_keys => '#{tempfile}' }" }
 
     it "should purge authorized ssh keys" do
-      apply_compiled_manifest(manifest, Puppet::Graph::RandomPrioritizer.new)
+      apply_compiled_manifest(manifest)
       File.read(tempfile).should_not =~ /key-name/
     end
 
@@ -23,7 +23,7 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
       let(:manifest) { "host { 'test': before => User[root] } user { 'root': purge_ssh_keys => '#{tempfile}' }" }
 
       it "should purge authorized ssh keys" do
-        apply_compiled_manifest(manifest, Puppet::Graph::RandomPrioritizer.new)
+        apply_compiled_manifest(manifest)
         File.read(tempfile).should_not =~ /key-name/
       end
     end


### PR DESCRIPTION
Before 95ddc530 the integration tests for Type::User purging SSH keys did not work when using the SequentialPrioritizer that is actually the default in the transaction runner methods defined in PuppetSpec::Compiler.

Since the cause has been removed, so should we do with the workaround.
The tests should rely on the defaults and not impose a (random) preference
unnecessarily.
