### PR TITLE
(PUP-1852) Deprecate the 'search' function.

### DIFF
--- a/lib/puppet/parser/functions/search.rb
+++ b/lib/puppet/parser/functions/search.rb
@@ -1,6 +1,11 @@
 Puppet::Parser::Functions::newfunction(:search, :arity => -2, :doc => "Add another namespace for this class to search.
     This allows you to create classes with sets of definitions and add
-    those classes to another class's search path.") do |vals|
+    those classes to another class's search path.
+
+    Deprecated in Puppet 3.7.0, to be removed in Puppet 4.0.0.") do |vals|
+
+    Puppet.deprecation_warning("The 'search' function is deprecated. See http://links.puppetlabs.com/search-function-deprecation")
+
     vals.each do |val|
       add_namespace(val)
     end

--- a/spec/unit/parser/functions/search_spec.rb
+++ b/spec/unit/parser/functions/search_spec.rb
@@ -20,4 +20,9 @@ describe "the 'search' function" do
     scope.expects(:add_namespace).with("who")
     scope.function_search(["where", "what", "who"])
   end
+
+  it "is deprecated" do
+    Puppet.expects(:deprecation_warning).with("The 'search' function is deprecated. See http://links.puppetlabs.com/search-function-deprecation")
+    scope.function_search(['wat'])
+  end
 end


### PR DESCRIPTION
This function is deprecated because support for dynamic scoping
has been removed in general and this function makes it possible
to abuse the systems ability to search multiple disjunct name-spaces.
