### PR TITLE
(PUP-1782) Add deprecation for regexp match against non string

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -213,9 +213,21 @@ class Puppet::Parser::AST
     end
 
     def evaluate_match(value, scope, options = {})
+      orig_value = value
       value = value == :undef ? '' : value.to_s
 
       if matched = @value.match(value)
+        unless orig_value.is_a?(String)
+          msg = "Match against non String is deprecated. See http://links.puppetlabs.com/deprecate-match-nonstring.\n"+
+            "Got #{orig_value.class.name} "
+          loc = []
+          loc << "in file #{file}" if file
+          loc << "at line #{line}" if line
+          msg << loc.join(", ")
+
+          Puppet.deprecation_warning(msg, "match #{file}, #{line}")
+        end
+
         scope.ephemeral_from(matched, options[:file], options[:line])
       end
       matched

--- a/lib/puppet/parser/ast/match_operator.rb
+++ b/lib/puppet/parser/ast/match_operator.rb
@@ -14,9 +14,22 @@ class Puppet::Parser::AST
     # Returns a boolean which is the result of the boolean operation
     # of lval and rval operands
     def evaluate(scope)
-      lval = @lval.safeevaluate(scope)
+      tmp_lval = @lval.safeevaluate(scope)
 
-      return(rval.evaluate_match(lval, scope) ? @operator == "=~" : @operator == "!~")
+      unless tmp_lval.is_a?(String)
+        msg = "Match against non String is deprecated. See http://links.puppetlabs.com/deprecate-match-nonstring.\n"+
+          "Got #{tmp_lval.class.name} "
+        loc = []
+        loc << "in file #{file}" if file
+        loc << "at line #{line}" if line
+        msg << loc.join(", ")
+
+        # Note that regep (rval) also checks against deprecation of positive matches and the same
+        # key must be used to avoid multiple deprecations for the same occurence of a match operator.
+        Puppet.deprecation_warning(msg, "match #{rval.file}, #{rval.line}")
+      end
+
+      return(rval.evaluate_match(tmp_lval, scope) ? @operator == "=~" : @operator == "!~")
     end
 
     def initialize(hash)

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -422,6 +422,30 @@ describe Puppet::Parser::AST::Regex do
 
     val.match("value")
   end
+
+  context 'has deprecations for non string values' do
+    before :each do
+      node     = Puppet::Node.new('localhost')
+      compiler = Puppet::Parser::Compiler.new(node)
+      @scope = Puppet::Parser::Scope.new(compiler)
+      @regex = Puppet::Parser::AST::Regex.new :value => Regexp.new("2")
+    end
+
+    [2, 3.12, [1,2,3], {'2' => 2}].each do |val|
+      it "when matching lval #{val.to_s}" do
+        Puppet.expects(:deprecation_warning)
+        @regex.evaluate_match(val, @scope)
+      end
+    end
+
+    [3, 3.13, [1,3,4], {'3' => 3}].each do |val|
+      it "but not when not matching lval #{val.to_s}" do
+        Puppet.expects(:deprecation_warning).never
+        @regex.evaluate_match(val, @scope)
+      end
+    end
+  end
+
 end
 
 describe Puppet::Parser::AST::Variable do

--- a/spec/unit/parser/ast/match_operator_spec.rb
+++ b/spec/unit/parser/ast/match_operator_spec.rb
@@ -6,13 +6,8 @@ describe Puppet::Parser::AST::MatchOperator do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)
     @scope   = Puppet::Parser::Scope.new(compiler)
-
-    @lval = stub 'lval'
-    @lval.stubs(:safeevaluate).with(@scope).returns("this is a string")
-
-    @rval = stub 'rval'
-    @rval.stubs(:evaluate_match)
-
+    @lval = Puppet::Parser::AST::String.new(:value => "this is a string")
+    @rval = Puppet::Parser::AST::Regex.new(:value => "this is a string", :file => 'test.pp', :line => 1)
     @operator = Puppet::Parser::AST::MatchOperator.new :lval => @lval, :rval => @rval, :operator => "=~"
   end
 
@@ -34,18 +29,26 @@ describe Puppet::Parser::AST::MatchOperator do
 
   { "=~" => true, "!~" => false }.each do |op, res|
     it "should return #{res} if the regexp matches with #{op}" do
-      match = stub 'match'
-      @rval.stubs(:evaluate_match).with("this is a string", @scope).returns(match)
-
       operator = Puppet::Parser::AST::MatchOperator.new :lval => @lval, :rval => @rval, :operator => op
       operator.evaluate(@scope).should == res
     end
 
     it "should return #{!res} if the regexp doesn't match" do
-      @rval.stubs(:evaluate_match).with("this is a string", @scope).returns(nil)
-
-      operator = Puppet::Parser::AST::MatchOperator.new :lval => @lval, :rval => @rval, :operator => op
+      non_matching_string = Puppet::Parser::AST::String.new(:value => "not that string")
+      operator = Puppet::Parser::AST::MatchOperator.new :lval => non_matching_string, :rval => @rval, :operator => op
       operator.evaluate(@scope).should == !res
+    end
+  end
+
+  context 'has deprecations' do
+    [1, 3.14, [1,2,3], {:a => 1}].each do |val|
+      it "for non string lval #{val.to_s}" do
+        value_stub = stub 'value_stub'
+        value_stub.expects(:safeevaluate).with(@scope).returns(val)
+        Puppet.expects(:deprecation_warning)
+        operator = Puppet::Parser::AST::MatchOperator.new :lval => value_stub, :rval => @rval, :operator => "=~"
+        operator.evaluate(@scope)
+      end
     end
   end
 end


### PR DESCRIPTION
This adds deprecation to use of the match operators and the LHS
is not a string.
This also adds a deprecation warning when a match is made with
a regexp in a case or selector and a match is found - this because
these will not match in the future, but those that do not match
will continue to not match.
