### PR TITLE
(PUP-2426) Add missing fields to environment http json

### DIFF
--- a/api/schemas/environments.json
+++ b/api/schemas/environments.json
@@ -25,9 +25,31 @@
                 "modulepath": {
                   "type": "array",
                   "items": { "type": "string" }
-                }
+                },
+                "config_version": { "type": "string" },
+                "environment_timeout": { "type": ["integer", "string"] }
               },
-              "required": ["modulepath", "manifest"]
+              "required": ["modulepath", "manifest", "environment_timeout", "config_version"],
+              "oneOf": [
+                {
+                  "title": "numeric timeout",
+                  "properties": {
+                    "environment_timeout": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  }
+                },
+                {
+                  "title": "unlimited timeout",
+                  "properties": {
+                    "environment_timeout": {
+                      "type": "string",
+                      "enum": ["unlimited"]
+                    }
+                  }
+                }
+              ]
             }
           },
           "required": ["settings"]

--- a/lib/puppet/network/http/api/v2/environments.rb
+++ b/lib/puppet/network/http/api/v2/environments.rb
@@ -12,10 +12,24 @@ class Puppet::Network::HTTP::API::V2::Environments
         [env.name, {
           "settings" => {
             "modulepath" => env.full_modulepath,
-            "manifest" => env.manifest
+            "manifest" => env.manifest,
+            "environment_timeout" => timeout(env),
+            "config_version" => env.config_version || '',
           }
         }]
       end]
     }))
   end
+
+  private
+
+  def timeout(env)
+    ttl = @env_loader.get_conf(env.name).environment_timeout
+    if ttl == 1.0 / 0.0 # INFINITY
+      "unlimited"
+    else
+      ttl
+    end
+  end
+
 end


### PR DESCRIPTION
This adds the two new properties environment_timeout, and config_version
to the returned settings properties.
The timeout is either an integer measured in seconds from min 0, or
the string 'unlimited'.
