### PR TITLE
(PUP-2079) Add no-op PMT generate template format.

### DIFF
--- a/lib/puppet/face/module/generate.rb
+++ b/lib/puppet/face/module/generate.rb
@@ -216,21 +216,29 @@ module Puppet::ModuleTool::Generate
     Puppet.notice "Generating module at #{dest}..."
     FileUtils.cp_r skeleton_path, dest
 
-    populate_erb_templates(metadata, dest)
+    populate_templates(metadata, dest)
     return dest
   end
 
-  def populate_erb_templates(metadata, destination)
-    Puppet.notice "Populating ERB templates..."
+  def populate_templates(metadata, destination)
+    Puppet.notice "Populating templates..."
 
-    templates = destination + '**/*.erb'
-    Dir[templates.to_s].each do |erb|
-      path = Pathname.new(erb)
-      content = ERB.new(path.read).result(binding)
+    formatters = {
+      :erb      => proc { |data, ctx| ERB.new(data).result(ctx) },
+      :template => proc { |data, _| data },
+    }
 
-      target = path.parent + path.basename('.erb')
-      target.open('w') { |f| f.write(content) }
-      path.unlink
+    formatters.each do |type, block|
+      templates = destination + "**/*.#{type}"
+
+      Dir.glob(templates.to_s, File::FNM_DOTMATCH).each do |erb|
+        path = Pathname.new(erb)
+        content = block[path.read, binding]
+
+        target = path.parent + path.basename(".#{type}")
+        target.open('w') { |f| f.write(content) }
+        path.unlink
+      end
     end
   end
 


### PR DESCRIPTION
Prior to this commit, the mechanisms available for writing skeletons containing ERB templates
were awkward at best (and broken at worst).

This change adds a new template extension for module skeletons that has the (somewhat counter-
intuitive, when described this way) behavior of performing no alterations to the given template.
In this way, one could place a file like `foo_bar.erb.template` in their module skeleton, and
generated modules would contain a file named `foo_bar.erb` with the exact contents of the
`.template` file.

This will also close pull requests #2468 and #2688.
