### PR TITLE
(PUP-1100) Create_resource syntax error message spec test

### DIFF
--- a/spec/fixtures/unit/parser/functions/create_resources/foo/manifests/init.pp
+++ b/spec/fixtures/unit/parser/functions/create_resources/foo/manifests/init.pp
@@ -1,0 +1,3 @@
+class foo {
+  create_resources('foo::wrongdefine', {'blah'=>{'one'=>'two'}})
+}

--- a/spec/fixtures/unit/parser/functions/create_resources/foo/manifests/wrongdefine.pp
+++ b/spec/fixtures/unit/parser/functions/create_resources/foo/manifests/wrongdefine.pp
@@ -1,0 +1,3 @@
+define foo::wrongdefine($one){
+  $foo = $one,
+}

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -14,6 +14,10 @@ describe 'function for dynamically creating resources' do
     Puppet::Parser::Functions.function(:create_resources)
   end
 
+  after do
+    Puppet.settings.clear
+  end
+
   it "should exist" do
     Puppet::Parser::Functions.function(:create_resources).should == "function_create_resources"
   end
@@ -201,6 +205,13 @@ describe 'function for dynamically creating resources' do
 
       catalog.resource(:notify, "test")['message'].should == 'two'
       catalog.resource(:class, "bar").should_not be_nil
+    end
+
+    it 'should fail with a correct error message if the syntax of an imported file is incorrect' do
+      expect{
+        Puppet[:modulepath] = my_fixture_dir
+        compile_to_catalog('include foo')
+      }.to raise_error(Puppet::Error, /Syntax error at.*/)
     end
   end
 end


### PR DESCRIPTION
This commit adds a check for the create resource syntax error message.
If there is a syntax error, the error given by puppet master is unclear.
This commits adds a test to check that the error message is correct and
makes sense.

This only happens when the resources are auto imported, which is why I
use a fixture directory.
