### PR TITLE
(QA-508) Add test for puppet doc RDOC support

### DIFF
--- a/acceptance/tests/doc/rdoc-support.rb
+++ b/acceptance/tests/doc/rdoc-support.rb
@@ -1,0 +1,9 @@
+test_name "Verify that puppet RDOC support is available"
+# See:
+#     https://jira.puppetlabs.com/browse/PE-1329
+#     https://jira.puppetlabs.com/browse/QA-508
+
+step "Run puppet doc --mode rdoc" do
+  manifestdir = master.tmpdir('manifestdir')
+  on(master, "puppet doc --mode rdoc --manifestdir #{manifestdir} --modulepath #{master['distmoduledir']} --outputdir doc")
+end


### PR DESCRIPTION
Add acceptance test to validate rdoc support for puppet doc.

See:
     https://jira.puppetlabs.com/browse/PE-1329
     https://jira.puppetlabs.com/browse/QA-508
