### PR TITLE
(PUP-2271) Allow yumrepo proxy attribute to be set to _none_

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -277,7 +277,7 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/.*/, :absent)
     validate do |value|
-      next if value.to_s == 'absent'
+      next if value.to_s =~ /^(absent|_none_)$/
       parsed = URI.parse(value)
 
       unless VALID_SCHEMES.include?(parsed.scheme)

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -295,6 +295,12 @@ describe Puppet::Type.type(:yumrepo) do
 
     describe "proxy" do
       it_behaves_like "a yumrepo parameter that can be absent", :proxy
+      it "accepts _none_" do
+        described_class.new(
+          :name  => 'puppetlabs',
+          :proxy => "_none_"
+        )
+      end
       it_behaves_like "a yumrepo parameter that accepts a single URL", :proxy
     end
 


### PR DESCRIPTION
Add fix and test to allow proxy to be set to _none_ to bypass global proxy
configuration for YUM.

See https://tickets.puppetlabs.com/browse/PUP-2271
