### PR TITLE
(PUP-2750) Add hierarchical metric ids to profiler

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -1,5 +1,6 @@
 require 'puppet/application'
 require 'puppet/configurer'
+require 'puppet/util/profiler/aggregate'
 
 class Puppet::Application::Apply < Puppet::Application
 
@@ -239,6 +240,12 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         exit(1)
       end
     end
+
+  ensure
+    if @profiler
+      Puppet::Util::Profiler.remove_profiler(@profiler)
+      @profiler.shutdown
+    end
   end
 
   # Enable all of the most common test options.
@@ -266,7 +273,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     set_log_level
 
     if Puppet[:profile]
-      Puppet::Util::Profiler.add_profiler(Puppet::Util::Profiler::WallClock.new(Puppet.method(:debug), "apply"))
+      @profiler = Puppet::Util::Profiler.add_profiler(Puppet::Util::Profiler::Aggregate.new(Puppet.method(:debug), "apply"))
     end
   end
 

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -17,7 +17,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       raise ArgumentError, "Facts but no fact format provided for #{request.key}"
     end
 
-    Puppet::Util::Profiler.profile("Found facts") do
+    Puppet::Util::Profiler.profile("Found facts", [:compiler, :find_facts]) do
       # If the facts were encoded as yaml, then the param reconstitution system
       # in Network::HTTP::Handler will automagically deserialize the value.
       if text_facts.is_a?(Puppet::Node::Facts)
@@ -65,7 +65,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   end
 
   def initialize
-    Puppet::Util::Profiler.profile("Setup server facts for compiling") do
+    Puppet::Util::Profiler.profile("Setup server facts for compiling", [:compiler, :init_server_facts]) do
       set_server_facts
     end
   end
@@ -90,7 +90,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     config = nil
 
     benchmark(:notice, str) do
-      Puppet::Util::Profiler.profile(str) do
+      Puppet::Util::Profiler.profile(str, [:compiler, :compile, node.environment, node.name]) do
         begin
           config = Puppet::Parser::Compiler.compile(node)
         rescue Puppet::Error => detail
@@ -105,7 +105,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
   # Turn our host name into a node object.
   def find_node(name, environment, transaction_uuid)
-    Puppet::Util::Profiler.profile("Found node information") do
+    Puppet::Util::Profiler.profile("Found node information", [:compiler, :find_node]) do
       node = nil
       begin
         node = Puppet::Node.indirection.find(name, :environment => environment,

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -208,7 +208,7 @@ class Puppet::Indirector::Indirection
 
         filtered = result
         if terminus.respond_to?(:filter)
-          Puppet::Util::Profiler.profile("Filtered result for #{self.name} #{request.key}") do
+          Puppet::Util::Profiler.profile("Filtered result for #{self.name} #{request.key}", [:indirector, :filter, self.name, request.key]) do
             filtered = terminus.filter(result)
           end
         end

--- a/lib/puppet/network/http/api/v1.rb
+++ b/lib/puppet/network/http/api/v1.rb
@@ -110,12 +110,12 @@ class Puppet::Network::HTTP::API::V1
 
     rendered_result = result
     if result.respond_to?(:render)
-      Puppet::Util::Profiler.profile("Rendered result in #{format}") do
+      Puppet::Util::Profiler.profile("Rendered result in #{format}", [:http, :v1_render, format]) do
         rendered_result = result.render(format)
       end
     end
 
-    Puppet::Util::Profiler.profile("Sent response") do
+    Puppet::Util::Profiler.profile("Sent response", [:http, :v1_response]) do
       response.respond_with(200, format, rendered_result)
     end
   end

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -107,25 +107,25 @@ class Puppet::Parser::Compiler
       @catalog.environment_instance = environment
 
       # Set the client's parameters into the top scope.
-      Puppet::Util::Profiler.profile("Compile: Set node parameters") { set_node_parameters }
+      Puppet::Util::Profiler.profile("Compile: Set node parameters", [:compiler, :set_node_params]) { set_node_parameters }
 
-      Puppet::Util::Profiler.profile("Compile: Created settings scope") { create_settings_scope }
+      Puppet::Util::Profiler.profile("Compile: Created settings scope", [:compiler, :create_settings_scope]) { create_settings_scope }
 
       if is_binder_active?
         # create injector, if not already created - this is for 3x that does not trigger
         # lazy loading of injector via context
-        Puppet::Util::Profiler.profile("Compile: Created injector") { injector }
+        Puppet::Util::Profiler.profile("Compile: Created injector", [:compiler, :create_injector]) { injector }
       end
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated main") { evaluate_main }
+      Puppet::Util::Profiler.profile("Compile: Evaluated main", [:compiler, :evaluate_main]) { evaluate_main }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated AST node") { evaluate_ast_node }
+      Puppet::Util::Profiler.profile("Compile: Evaluated AST node", [:compiler, :evaluate_ast_node]) { evaluate_ast_node }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated node classes") { evaluate_node_classes }
+      Puppet::Util::Profiler.profile("Compile: Evaluated node classes", [:compiler, :evaluate_node_classes]) { evaluate_node_classes }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated generators") { evaluate_generators }
+      Puppet::Util::Profiler.profile("Compile: Evaluated generators", [:compiler, :evaluate_generators]) { evaluate_generators }
 
-      Puppet::Util::Profiler.profile("Compile: Finished catalog") { finish }
+      Puppet::Util::Profiler.profile("Compile: Finished catalog", [:compiler, :finish_catalog]) { finish }
 
       fail_on_unevaluated
 
@@ -352,7 +352,7 @@ class Puppet::Parser::Compiler
       # We have to iterate over a dup of the array because
       # collections can delete themselves from the list, which
       # changes its length and causes some collections to get missed.
-      Puppet::Util::Profiler.profile("Evaluated collections") do
+      Puppet::Util::Profiler.profile("Evaluated collections", [:compiler, :evaluate_collections]) do
         found_something = false
         @collections.dup.each do |collection|
           found_something = true if collection.evaluate
@@ -367,9 +367,9 @@ class Puppet::Parser::Compiler
   # evaluate_generators loop.
   def evaluate_definitions
     exceptwrap do
-      Puppet::Util::Profiler.profile("Evaluated definitions") do
+      Puppet::Util::Profiler.profile("Evaluated definitions", [:compiler, :evaluate_definitions]) do
         !unevaluated_resources.each do |resource|
-          Puppet::Util::Profiler.profile("Evaluated resource #{resource}") do
+          Puppet::Util::Profiler.profile("Evaluated resource #{resource}", [:compiler, :evaluate_resource, resource]) do
             resource.evaluate
           end
         end.empty?
@@ -386,7 +386,7 @@ class Puppet::Parser::Compiler
     loop do
       done = true
 
-      Puppet::Util::Profiler.profile("Iterated (#{count + 1}) on generators") do
+      Puppet::Util::Profiler.profile("Iterated (#{count + 1}) on generators", [:compiler, :iterate_on_generators]) do
         # Call collections first, then definitions.
         done = false if evaluate_collections
         done = false if evaluate_definitions

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -160,7 +160,7 @@ module Puppet::Parser::Functions
     env_module = environment_module(environment)
 
     env_module.send(:define_method, fname) do |*args|
-      Puppet::Util::Profiler.profile("Called #{name}") do
+      Puppet::Util::Profiler.profile("Called #{name}", [:functions, name]) do
         if args[0].is_a? Array
           if arity >= 0 and args[0].size != arity
             raise ArgumentError, "#{name}(): Wrong number of arguments given (#{args[0].size} for #{arity})"

--- a/lib/puppet/util/profiler.rb
+++ b/lib/puppet/util/profiler.rb
@@ -44,9 +44,10 @@ module Puppet::Util::Profiler
   # in the profiled hierachy.
   #
   # @param message [String] A description of the profiled event
+  # @param metric_id [Array] A list of strings making up the ID of a metric to profile
   # @param block [Block] The segment of code to profile
   # @api public
-  def self.profile(message, &block)
-    @profiler.profile(message, &block)
+  def self.profile(message, metric_id = nil, &block)
+    @profiler.profile(message, metric_id, &block)
   end
 end

--- a/lib/puppet/util/profiler/aggregate.rb
+++ b/lib/puppet/util/profiler/aggregate.rb
@@ -1,0 +1,85 @@
+require 'puppet/util/profiler'
+require 'puppet/util/profiler/wall_clock'
+
+class Puppet::Util::Profiler::Aggregate < Puppet::Util::Profiler::WallClock
+  def initialize(logger, identifier)
+    super(logger, identifier)
+    @metrics_hash = Metric.new
+  end
+
+  def shutdown()
+    super
+    @logger.call("AGGREGATE PROFILING RESULTS:")
+    @logger.call("----------------------------")
+    print_metrics(@metrics_hash, "")
+    @logger.call("----------------------------")
+  end
+
+  def do_start(description, metric_id)
+    super(description, metric_id)
+  end
+
+  def do_finish(context, description, metric_id)
+    result = super(context, description, metric_id)
+    update_metric(@metrics_hash, metric_id, result[:time])
+    result
+  end
+
+  def update_metric(metrics_hash, metric_id, time)
+    first, *rest = *metric_id
+    if first
+      m = metrics_hash[first]
+      m.increment
+      m.add_time(time)
+      if rest.count > 0
+        update_metric(m, rest, time)
+      end
+    end
+  end
+
+  def values
+    @metrics_hash
+  end
+
+  def print_metrics(metrics_hash, prefix)
+    metrics_hash.sort_by {|k,v| v.time }.reverse.each do |k,v|
+      @logger.call("#{prefix}#{k}: #{v.time} ms (#{v.count} calls)")
+      print_metrics(metrics_hash[k], "#{prefix}#{k} -> ")
+    end
+  end
+
+  class Metric < Hash
+    def initialize
+      super
+      @count = 0
+      @time = 0
+    end
+    attr_reader :count, :time
+
+    def [](key)
+      if !has_key?(key)
+        self[key] = Metric.new
+      end
+      super(key)
+    end
+
+    def increment
+      @count += 1
+    end
+
+    def add_time(time)
+      @time += time
+    end
+  end
+
+  class Timer
+    def initialize
+      @start = Time.now
+    end
+
+    def stop
+      Time.now - @start
+    end
+  end
+end
+

--- a/lib/puppet/util/profiler/around_profiler.rb
+++ b/lib/puppet/util/profiler/around_profiler.rb
@@ -44,20 +44,21 @@ class Puppet::Util::Profiler::AroundProfiler
   # in the profiled hierachy.
   #
   # @param message [String] A description of the profiled event
+  # @param metric_id [Array] A list of strings making up the ID of a metric to profile
   # @param block [Block] The segment of code to profile
   # @api private
-  def profile(message)
+  def profile(message, metric_id = nil)
     retval = nil
     contexts = {}
     @profilers.each do |profiler|
-      contexts[profiler] = profiler.start(message)
+      contexts[profiler] = profiler.start(message, metric_id)
     end
 
     begin
       retval = yield
     ensure
       @profilers.each do |profiler|
-        profiler.finish(contexts[profiler], message)
+        profiler.finish(contexts[profiler], message, metric_id)
       end
     end
 

--- a/lib/puppet/util/profiler/logging.rb
+++ b/lib/puppet/util/profiler/logging.rb
@@ -5,16 +5,20 @@ class Puppet::Util::Profiler::Logging
     @sequence = Sequence.new
   end
 
-  def start(description)
+  def start(description, metric_id)
     @sequence.next
     @sequence.down
-    do_start
+    do_start(description, metric_id)
   end
 
-  def finish(context, description)
-    profile_explanation = do_finish(context)
+  def finish(context, description, metric_id)
+    profile_explanation = do_finish(context, description, metric_id)[:msg]
     @sequence.up
     @logger.call("PROFILE [#{@identifier}] #{@sequence} #{description}: #{profile_explanation}")
+  end
+
+  def shutdown()
+    # nothing to do
   end
 
   class Sequence

--- a/lib/puppet/util/profiler/wall_clock.rb
+++ b/lib/puppet/util/profiler/wall_clock.rb
@@ -6,13 +6,13 @@ require 'puppet/util/profiler/logging'
 #
 # @api private
 class Puppet::Util::Profiler::WallClock < Puppet::Util::Profiler::Logging
-  def do_start
+  def do_start(description, metric_id)
     Timer.new
   end
 
-  def do_finish(context)
-    context.stop
-    "took #{context} seconds"
+  def do_finish(context, description, metric_id)
+    {:time => context.stop,
+     :msg => "took #{context} seconds"}
   end
 
   class Timer
@@ -23,11 +23,12 @@ class Puppet::Util::Profiler::WallClock < Puppet::Util::Profiler::Logging
     end
 
     def stop
-      @finish = Time.now
+      @time = Time.now - @start
+      @time
     end
 
     def to_s
-      format(FOUR_DECIMAL_DIGITS, @finish - @start)
+      format(FOUR_DECIMAL_DIGITS, @time)
     end
   end
 end

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -116,7 +116,7 @@ describe Puppet::Network::HTTP::Handler do
       request = a_request
       request[:headers][Puppet::Network::HTTP::HEADER_ENABLE_PROFILING.downcase] = "true"
 
-      p = TestProfiler.new
+      p = HandlerTestProfiler.new
 
       Puppet::Util::Profiler.expects(:add_profiler).with { |profiler|
         profiler.is_a? Puppet::Util::Profiler::WallClock
@@ -228,16 +228,14 @@ describe Puppet::Network::HTTP::Handler do
     end
   end
 
-  class TestProfiler
-    attr_accessor :context, :description
-
-    def start(description)
-      description
+  class HandlerTestProfiler
+    def start(metric, description)
     end
 
-    def finish(context, description)
-      @context = context
-      @description = description
+    def finish(context, metric, description)
+    end
+
+    def shutdown()
     end
   end
 end

--- a/spec/unit/util/profiler/aggregate_spec.rb
+++ b/spec/unit/util/profiler/aggregate_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'puppet/util/profiler'
+require 'puppet/util/profiler/around_profiler'
+require 'puppet/util/profiler/aggregate'
+
+describe Puppet::Util::Profiler::Aggregate do
+  let(:logger) { AggregateSimpleLog.new }
+  let(:profiler) { Puppet::Util::Profiler::Aggregate.new(logger, nil) }
+  let(:profiler_mgr) do
+    p = Puppet::Util::Profiler::AroundProfiler.new
+    p.add_profiler(profiler)
+    p
+  end
+
+  it "tracks the aggregate counts and time for the hierarchy of metrics" do
+    profiler_mgr.profile("Looking up hiera data in production environment", ["function", "hiera_lookup", "production"]) {}
+    profiler_mgr.profile("Looking up hiera data in test environment", ["function", "hiera_lookup", "test"]) {}
+    profiler_mgr.profile("looking up stuff for compilation", ["compiler", "lookup"]) {}
+    profiler_mgr.profile("COMPILING ALL OF THE THINGS!", ["compiler", "compiling"]) {}
+
+    profiler.values["function"].count.should == 2
+    profiler.values["function"].time.should be > 0
+    profiler.values["function"]["hiera_lookup"].count.should == 2
+    profiler.values["function"]["hiera_lookup"]["production"].count.should == 1
+    profiler.values["function"]["hiera_lookup"]["test"].count.should == 1
+    profiler.values["function"].time.should be >= profiler.values["function"]["hiera_lookup"].time
+
+    profiler.values["compiler"].count.should == 2
+    profiler.values["compiler"].time.should be > 0
+    profiler.values["compiler"]["lookup"].count.should == 1
+    profiler.values["compiler"]["compiling"].count.should == 1
+    profiler.values["compiler"].time.should be >= profiler.values["compiler"]["lookup"].time
+
+    profiler.shutdown
+
+    logger.output.should =~ /function -> hiera_lookup: .*\(2 calls\)\nfunction -> hiera_lookup ->.*\(1 calls\)/
+    logger.output.should =~ /compiler: .*\(2 calls\)\ncompiler ->.*\(1 calls\)/
+  end
+
+  it "tolerates calls to `profile` that don't include a metric id" do
+    profiler_mgr.profile("yo") {}
+  end
+
+  it "supports both symbols and strings as components of a metric id" do
+    profiler_mgr.profile("yo", [:foo, "bar"]) {}
+  end
+
+  class AggregateSimpleLog
+    attr_reader :output
+
+    def initialize
+      @output = ""
+    end
+
+    def call(msg)
+      @output << msg << "\n"
+    end
+  end
+end

--- a/spec/unit/util/profiler/around_profiler_spec.rb
+++ b/spec/unit/util/profiler/around_profiler_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'puppet/util/profiler'
 
 describe Puppet::Util::Profiler::AroundProfiler do
-  let(:child) { TestProfiler.new() }
+  let(:child) { TestAroundProfiler.new() }
   let(:profiler) { Puppet::Util::Profiler::AroundProfiler.new }
 
   before :each do
@@ -10,19 +10,19 @@ describe Puppet::Util::Profiler::AroundProfiler do
   end
 
   it "returns the value of the profiled segment" do
-    retval = profiler.profile("Testing") { "the return value" }
+    retval = profiler.profile("Testing", ["testing"]) { "the return value" }
 
     retval.should == "the return value"
   end
 
-  it "propogates any errors raised in the profiled segment" do
+  it "propagates any errors raised in the profiled segment" do
     expect do
-      profiler.profile("Testing") { raise "a problem" }
+      profiler.profile("Testing", ["testing"]) { raise "a problem" }
     end.to raise_error("a problem")
   end
 
   it "makes the description and the context available to the `start` and `finish` methods" do
-    profiler.profile("Testing") { }
+    profiler.profile("Testing", ["testing"]) { }
 
     child.context.should == "Testing"
     child.description.should == "Testing"
@@ -30,29 +30,29 @@ describe Puppet::Util::Profiler::AroundProfiler do
 
   it "calls finish even when an error is raised" do
     begin
-      profiler.profile("Testing") { raise "a problem" }
+      profiler.profile("Testing", ["testing"]) { raise "a problem" }
     rescue
       child.context.should == "Testing"
     end
   end
 
   it "supports multiple profilers" do
-    profiler2 = TestProfiler.new
+    profiler2 = TestAroundProfiler.new
     profiler.add_profiler(profiler2)
-    profiler.profile("Testing") {}
+    profiler.profile("Testing", ["testing"]) {}
 
     child.context.should == "Testing"
     profiler2.context.should == "Testing"
   end
 
-  class TestProfiler
+  class TestAroundProfiler
     attr_accessor :context, :description
 
-    def start(description)
+    def start(description, metric_id)
       description
     end
 
-    def finish(context, description)
+    def finish(context, description, metric_id)
       @context = context
       @description = description
     end

--- a/spec/unit/util/profiler/wall_clock_spec.rb
+++ b/spec/unit/util/profiler/wall_clock_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Util::Profiler::WallClock do
   it "logs the number of seconds it took to execute the segment" do
     profiler = Puppet::Util::Profiler::WallClock.new(nil, nil)
 
-    message = profiler.do_finish(profiler.start("Testing"))
+    message = profiler.do_finish(profiler.start(["foo", "bar"], "Testing"), ["foo", "bar"], "Testing")[:msg]
 
     message.should =~ /took \d\.\d{4} seconds/
   end

--- a/spec/unit/util/profiler_spec.rb
+++ b/spec/unit/util/profiler_spec.rb
@@ -23,20 +23,31 @@ describe Puppet::Util::Profiler do
 
   it "supports profiling" do
     subject.add_profiler(profiler)
+    subject.profile("hi", ["mymetric"]) {}
+    profiler.context[:metric_id].should == ["mymetric"]
+    profiler.context[:description].should == "hi"
+    profiler.description.should == "hi"
+  end
+
+  it "supports profiling without a metric id" do
+    subject.add_profiler(profiler)
     subject.profile("hi") {}
-    profiler.context = "hi"
-    profiler.description = "hi"
+    profiler.context[:metric_id].should == nil
+    profiler.context[:description].should == "hi"
+    profiler.description.should == "hi"
   end
 
   class TestProfiler
-    attr_accessor :context, :description
+    attr_accessor :context, :metric, :description
 
-    def start(description)
-      description
+    def start(description, metric_id)
+      {:metric_id => metric_id,
+       :description => description}
     end
 
-    def finish(context, description)
+    def finish(context, description, metric_id)
       @context = context
+      @metric_id = metric_id
       @description = description
     end
   end


### PR DESCRIPTION
This commit modifies the signature of the
`Puppet::Util::Profiler.profile` method to accept a new argument,
which is basically a "metric id".  The argument takes the form
of an array of strings/symbols, allowing us to group specific sets of
profiling data into hierarchies and report aggregate profiling
statistics at any level of the hierarchy.

It also adds a new profiler, `Aggregate`, which extends the
existing `WallClock` profiler.  The new profiler tracks the
aggregate timing data based on the metric id hierarchy,
and logs a message containing the aggregate data
at the end of the run.
