### PR TITLE
(PUP-2700) Fix double uri escape

### DIFF
--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -206,9 +206,8 @@ module Puppet
     end
 
     def get_from_source(source_or_content, &block)
-      source = source_or_content.uri
-
-      request = Puppet::Indirector::Request.new(:file_content, :find, source.to_s, nil, :environment => resource.catalog.environment)
+      source = source_or_content.metadata.source
+      request = Puppet::Indirector::Request.new(:file_content, :find, source, nil, :environment => resource.catalog.environment)
 
       request.do_request(:fileserver) do |req|
         connection = Puppet::Network::HttpPool.http_instance(req.server, req.port)

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -394,6 +394,17 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
         resource.write(source)
       end
 
+      it 'should percent encode reserved characters' do
+        response.stubs(:code).returns('200')
+        Puppet::Network::HttpPool.stubs(:http_instance).returns(conn)
+        source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
+
+        conn.unstub(:request_get)
+        conn.expects(:request_get).with('/none/file_content/test/foo%20bar', anything).yields(response)
+
+        resource.write(source)
+      end
+
       describe 'when handling file_content responses' do
         before(:each) do
           Puppet::Network::HttpPool.stubs(:http_instance).returns(conn)


### PR DESCRIPTION
The resolution of PUP-1892 caused percent encoding of file_content requests to
be doubled. This created a regression where Puppet file servers would respond
with a 404 not found status unless multiple decode operations were applied.

This patch fixes the issue by building the file_content indirector request
directly from the file source parameter instead of casting it to an escaped
URI. The `Indirector::Request` class handles the necessary URI escaping during
initialization.

Also, the test cases for fetching file content from a remote source have been fixed up and de-duplicated.
