### PR TITLE
(PUP-911) puppet agent exits with 0 despite pidfile creation failing

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -34,12 +34,13 @@ class Puppet::Daemon
 
   # Put the daemon into the background.
   def daemonize
+    # Create pidfile before forking so exceptions give user correct exit codes
+    create_pidfile
+
     if pid = fork
       Process.detach(pid)
       exit(0)
     end
-
-    create_pidfile
 
     # Get rid of console logging
     Puppet::Util::Log.close(:console)

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -62,6 +62,16 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
+  describe "when daemonizing" do
+    it "should fail if it cannot lock" do
+      pidfile.expects(:lock).returns(false)
+      daemon.agent = agent
+
+      expect { daemon.daemonize }.to raise_error(RuntimeError, "Could not create PID file: #{pidfile.file_path}")
+    end
+
+  end
+
   describe "when starting" do
     before do
       daemon.stubs(:set_signal_traps)


### PR DESCRIPTION
When puppet agent is run but cannot create a pidfile due to permission
errors or another running puppet process, the process exits with an
exit code of 0, despite reporting the failure.

This patch moves pidfile creation before the fork so that the appropriate
exit code is returned. 

This doesn't fix the whole class of problems; other failures after forking will still result in a 0 exit code despite problems starting the daemon. Since it's such a trivial fix it seems worth fixing this way until that's handled in a more comprehensive way later. 

Please let me know if there's a better way to structure the test - it's my first puppet PR and I'm totally open to a different approach.
