### PR TITLE
(maint) Remove warning about expect().to in specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,6 @@ gem "rake", "10.1.1", :require => false
 gem "rgen", "0.6.5", :require => false
 
 group(:development, :test) do
-
-  # Jenkins workers may be using RSpec 2.9, so RSpec 2.11 syntax
-  # (like `expect(value).to eq matcher`) should be avoided.
   gem "rspec", "~> 2.11.0", :require => false
 
   # Mocha is not compatible across minor version changes; because of this only


### PR DESCRIPTION
This is mainly a _fixme_ PR. If we've updated Jenkins to run Puppet under RSpec 2.11.x, which is the version pinned in the Gemfile, then this is an easy merge.

If we still have Jenkins slaves running software pinned to 2.11.x under RSpec 2.9.x **then we should fix that**.
