### PR TITLE
(PUP-2787) Rename Object Type to Any

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -80,7 +80,7 @@
 #
 # If nothing is specified, the number of arguments given to the function must
 # be the same as the number of parameters, and all of the parameters are of
-# type 'Object'.
+# type 'Any'.
 #
 # To express that the last parameter captures the rest, the method
 # `last_captures_rest` can be called. This indicates that the last parameter is
@@ -179,7 +179,7 @@ module Puppet::Functions
     unless the_class.method_defined?(func_name)
       raise ArgumentError, "Function Creation Error, cannot create a default dispatcher for function '#{func_name}', no method with this name found"
     end
-    object_signature(*min_max_param(the_class.instance_method(func_name)))
+    any_signature(*min_max_param(the_class.instance_method(func_name)))
   end
 
   # @api private
@@ -211,11 +211,11 @@ module Puppet::Functions
   # (there is only one type entry).
   #
   # @api private
-  def self.object_signature(from, to, names)
+  def self.any_signature(from, to, names)
     # Construct the type for the signature
     # Tuple[Object, from, to]
     factory = Puppet::Pops::Types::TypeFactory
-    [factory.callable(factory.object, from, to), names]
+    [factory.callable(factory.any, from, to), names]
   end
 
   # Function

--- a/lib/puppet/functions/assert_type.rb
+++ b/lib/puppet/functions/assert_type.rb
@@ -17,14 +17,14 @@
 Puppet::Functions.create_function(:assert_type) do
   dispatch :assert_type do
     param 'Type', 'type'
-    param 'Object', 'value'
-    optional_block_param 'Callable[Object, Object]', 'block'
+    param 'Any', 'value'
+    optional_block_param 'Callable[Any, Any]', 'block'
   end
 
   dispatch :assert_type_s do
     param 'String', 'type_string'
-    param 'Object', 'value'
-    optional_block_param 'Callable[Object, Object]', 'block'
+    param 'Any', 'value'
+    optional_block_param 'Callable[Any, Any]', 'block'
   end
 
   # @param type [Type] the type the value must be an instance of

--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -40,12 +40,12 @@
 #
 Puppet::Functions.create_function(:each) do
   dispatch :foreach_Hash do
-    param 'Hash[Object, Object]', :hash
+    param 'Hash[Any, Any]', :hash
     required_block_param
   end
 
   dispatch :foreach_Enumerable do
-    param 'Object', :enumerable
+    param 'Any', :enumerable
     required_block_param
   end
 

--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -37,12 +37,12 @@
 #
 Puppet::Functions.create_function(:filter) do
   dispatch :filter_Hash do
-    param 'Hash[Object, Object]', :hash
+    param 'Hash[Any, Any]', :hash
     required_block_param
   end
 
   dispatch :filter_Enumerable do
-    param 'Object', :enumerable
+    param 'Any', :enumerable
     required_block_param
   end
 

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -35,12 +35,12 @@
 #
 Puppet::Functions.create_function(:map) do
   dispatch :map_Hash do
-    param 'Hash[Object, Object]', :hash
+    param 'Hash[Any, Any]', :hash
     required_block_param
   end
 
   dispatch :map_Enumerable do
-    param 'Object', :enumerable
+    param 'Any', :enumerable
     required_block_param
   end
 

--- a/lib/puppet/functions/match.rb
+++ b/lib/puppet/functions/match.rb
@@ -19,12 +19,12 @@
 Puppet::Functions.create_function(:match) do
   dispatch :match do
     param 'String', 'string'
-    param 'Variant[Object, Type]', 'pattern'
+    param 'Variant[Any, Type]', 'pattern'
   end
 
   dispatch :enumerable_match do
     param 'Array[String]', 'string'
-    param 'Variant[Object, Type]', 'pattern'
+    param 'Variant[Any, Type]', 'pattern'
   end
 
   def initialize(closure_scope, loader)

--- a/lib/puppet/functions/reduce.rb
+++ b/lib/puppet/functions/reduce.rb
@@ -64,13 +64,13 @@
 Puppet::Functions.create_function(:reduce) do
 
   dispatch :reduce_without_memo do
-    param 'Object', :enumerable
+    param 'Any', :enumerable
     required_block_param
   end
 
   dispatch :reduce_with_memo do
-    param 'Object', :enumerable
-    param 'Object', :memo
+    param 'Any', :enumerable
+    param 'Any', :memo
     required_block_param
   end
 

--- a/lib/puppet/functions/slice.rb
+++ b/lib/puppet/functions/slice.rb
@@ -40,13 +40,13 @@
 #
 Puppet::Functions.create_function(:slice) do
   dispatch :slice_Hash do
-    param 'Hash[Object, Object]', :hash
+    param 'Hash[Any, Any]', :hash
     param 'Integer[1, default]', :slize_size
     optional_block_param
   end
 
   dispatch :slice_Enumerable do
-    param 'Object', :enumerable
+    param 'Any', :enumerable
     param 'Integer[1, default]', :slize_size
     optional_block_param
   end

--- a/lib/puppet/functions/with.rb
+++ b/lib/puppet/functions/with.rb
@@ -12,7 +12,7 @@
 #
 Puppet::Functions.create_function(:with) do
   dispatch :with do
-    param 'Object', 'arg'
+    param 'Any', 'arg'
     arg_count(0, :default)
     required_block_param
   end

--- a/lib/puppet/pops/binder/bindings_checker.rb
+++ b/lib/puppet/pops/binder/bindings_checker.rb
@@ -38,7 +38,7 @@ class Puppet::Pops::Binder::BindingsChecker
   # @api private
   def check_Binding(b)
     # Must have a type
-    acceptor.accept(Issues::MISSING_TYPE, b) unless b.type.is_a?(Types::PObjectType)
+    acceptor.accept(Issues::MISSING_TYPE, b) unless b.type.is_a?(Types::PAnyType)
 
     # Must have a producer
     acceptor.accept(Issues::MISSING_PRODUCER, b) unless b.producer.is_a?(Bindings::ProducerDescriptor)
@@ -167,7 +167,7 @@ class Puppet::Pops::Binder::BindingsChecker
   end
 
   # @api private
-  def check_PObjectType(t)
+  def check_PAnyType(t)
     # Do nothing
   end
 

--- a/lib/puppet/pops/binder/bindings_factory.rb
+++ b/lib/puppet/pops/binder/bindings_factory.rb
@@ -219,7 +219,7 @@ module Puppet::Pops::Binder::BindingsFactory
     # @example creating a Hash with Integer key and Array[Integer] element type
     #     tc = type_factory
     #     type(tc.hash(tc.array_of(tc.integer), tc.integer)
-    # @param type [Puppet::Pops::Types::PObjectType] the type to set for the binding
+    # @param type [Puppet::Pops::Types::PAnyType] the type to set for the binding
     # @api public
     #
     def type(type)
@@ -284,7 +284,7 @@ module Puppet::Pops::Binder::BindingsFactory
     end
 
     # Sets the type of the binding to Array[T], where T is given.
-    # @param t [Puppet::Pops::Types::PObjectType] the type of the elements of the array
+    # @param t [Puppet::Pops::Types::PAnyType] the type of the elements of the array
     # @return [Puppet::Pops::Types::PArrayType] the type
     # @api public
     def array_of(t)
@@ -310,7 +310,7 @@ module Puppet::Pops::Binder::BindingsFactory
     # Sets the type of the binding based on the given argument.
     # @overload instance_of(t)
     #   The same as calling {#type} with `t`.
-    #   @param t [Puppet::Pops::Types::PObjectType] the type
+    #   @param t [Puppet::Pops::Types::PAnyType] the type
     # @overload instance_of(o)
     #   Infers the type from the given Ruby object and sets that as the type - i.e. "set the type
     #   of the binding to be that of the given data object".
@@ -695,7 +695,7 @@ module Puppet::Pops::Binder::BindingsFactory
   end
 
   # Creates a Producer that looks up a value.
-  # @param type [Puppet::Pops::Types::PObjectType] the type to lookup
+  # @param type [Puppet::Pops::Types::PAnyType] the type to lookup
   # @param name [String] the name to lookup
   # @return [Puppet::Pops::Binder::Bindings::ProducerDescriptor] a producer description
   # @api public
@@ -709,7 +709,7 @@ module Puppet::Pops::Binder::BindingsFactory
   # Creates a Hash lookup producer that looks up a hash value, and then a key in the hash.
   #
   # @return [Puppet::Pops::Binder::Bindings::ProducerDescriptor] a producer description
-  # @param type [Puppet::Pops::Types::PObjectType] the type to lookup (i.e. a Hash of some key/value type).
+  # @param type [Puppet::Pops::Types::PAnyType] the type to lookup (i.e. a Hash of some key/value type).
   # @param name [String] the name to lookup
   # @param key [Object] the key to lookup in the looked up hash (type should comply with given key type).
   # @api public

--- a/lib/puppet/pops/binder/bindings_label_provider.rb
+++ b/lib/puppet/pops/binder/bindings_label_provider.rb
@@ -13,7 +13,7 @@ class Puppet::Pops::Binder::BindingsLabelProvider < Puppet::Pops::LabelProvider
    @@label_visitor.visit(o)
   end
 
-  def label_PObjectType o                       ; "#{Puppet::Pops::Types::TypeFactory.label(o)}" end
+  def label_PAnyType o                          ; "#{Puppet::Pops::Types::TypeFactory.label(o)}" end
   def label_ProducerDescriptor o                ; "Producer"                                     end
   def label_NonCachingProducerDescriptor o      ; "Non Caching Producer"                         end
   def label_ConstantProducerDescriptor o        ; "Producer['#{o.value}']"                       end

--- a/lib/puppet/pops/binder/bindings_loader.rb
+++ b/lib/puppet/pops/binder/bindings_loader.rb
@@ -10,8 +10,8 @@ class Puppet::Pops::Binder::BindingsLoader
 
   # Returns a XXXXX given a fully qualified class name.
   # Lookup of class is never relative to the calling namespace.
-  # @param name [String, Array<String>, Array<Symbol>, Puppet::Pops::Types::PObjectType] A fully qualified
-  #   class name String (e.g. '::Foo::Bar', 'Foo::Bar'), a PObjectType, or a fully qualified name in Array form where each part
+  # @param name [String, Array<String>, Array<Symbol>, Puppet::Pops::Types::PAnyType] A fully qualified
+  #   class name String (e.g. '::Foo::Bar', 'Foo::Bar'), a PAnyType, or a fully qualified name in Array form where each part
   #   is either a String or a Symbol, e.g. `%w{Puppetx Puppetlabs SomeExtension}`.
   # @return [Class, nil] the looked up class or nil if no such class is loaded
   # @raise ArgumentError If the given argument has the wrong type

--- a/lib/puppet/pops/binder/bindings_model.rb
+++ b/lib/puppet/pops/binder/bindings_model.rb
@@ -81,7 +81,7 @@ module Puppet::Pops::Binder::Bindings
   # @api public
   #
   class LookupProducerDescriptor < ProducerDescriptor
-    contains_one_uni 'type', Puppet::Pops::Types::PObjectType
+    contains_one_uni 'type', Puppet::Pops::Types::PAnyType
     has_attr 'name', String
   end
 
@@ -134,7 +134,7 @@ module Puppet::Pops::Binder::Bindings
   #
   # @api public
   class Binding < AbstractBinding
-    contains_one_uni 'type', Puppet::Pops::Types::PObjectType
+    contains_one_uni 'type', Puppet::Pops::Types::PAnyType
     has_attr 'name', String
     has_attr 'override', Boolean
     has_attr 'abstract', Boolean

--- a/lib/puppet/pops/binder/bindings_model_dumper.rb
+++ b/lib/puppet/pops/binder/bindings_model_dumper.rb
@@ -109,7 +109,7 @@ class Puppet::Pops::Binder::BindingsModelDumper < Puppet::Pops::Model::TreeDumpe
     ['lookup', do_dump(o.type), o.name]
   end
 
-  def dump_PObjectType o
+  def dump_PAnyType o
     type_calculator.string(o)
   end
 

--- a/lib/puppet/pops/binder/injector.rb
+++ b/lib/puppet/pops/binder/injector.rb
@@ -205,7 +205,7 @@ class Puppet::Pops::Binder::Injector
   # @overload lookup(scope, type, name = '')
   #   (see #lookup_type)
   #   @param scope [Puppet::Parser::Scope] the scope to use for evaluation
-  #   @param type [Puppet::Pops::Types::PObjectType] the type of what to lookup
+  #   @param type [Puppet::Pops::Types::PAnyType] the type of what to lookup
   #   @param name [String] the name to use, defaults to empty string (for unnamed)
   #
   # @overload lookup(scope, name)
@@ -231,7 +231,7 @@ class Puppet::Pops::Binder::Injector
   # Creates a key for the type/name combination using a KeyFactory. Specialization of the Data type are transformed
   # to a Data key, and the result is type checked to conform with the given key.
   #
-  # @param type [Puppet::Pops::Types::PObjectType] the type to lookup as defined by Puppet::Pops::Types::TypeFactory
+  # @param type [Puppet::Pops::Types::PAnyType] the type to lookup as defined by Puppet::Pops::Types::TypeFactory
   # @param name [String] the (optional for non `Data` types) name of the entry to lookup.
   #   The name may be an empty String (the default), but not nil. The name is required for lookup for subtypes of
   #   `Data`.
@@ -275,7 +275,7 @@ class Puppet::Pops::Binder::Injector
   # @overload lookup_producer(scope, type, name = '')
   #   (see #lookup_type)
   #   @param scope [Puppet::Parser::Scope] the scope to use for evaluation
-  #   @param type [Puppet::Pops::Types::PObjectType], the type of what to lookup
+  #   @param type [Puppet::Pops::Types::PAnyType], the type of what to lookup
   #   @param name [String], the name to use, defaults to empty string (for unnamed)
   #
   # @overload lookup_producer(scope, name)
@@ -441,7 +441,7 @@ module Private
 
       val = case args[ 0 ]
 
-      when Puppet::Pops::Types::PObjectType
+      when Puppet::Pops::Types::PAnyType
         lookup_type(scope, *args)
 
       when String
@@ -570,7 +570,7 @@ module Private
       raise ArgumentError, "lookup_producer should be called with two or three arguments, got: #{args.size()+1}" unless args.size <= 2
 
       p = case args[ 0 ]
-      when Puppet::Pops::Types::PObjectType
+      when Puppet::Pops::Types::PAnyType
         lookup_producer_type(scope, *args)
 
       when String

--- a/lib/puppet/pops/binder/key_factory.rb
+++ b/lib/puppet/pops/binder/key_factory.rb
@@ -48,7 +48,7 @@ class Puppet::Pops::Binder::KeyFactory
 
   # @api public
   def is_data?(key)
-    return false unless key.is_a?(Array) && key[0].is_a?(Puppet::Pops::Types::PObjectType)
+    return false unless key.is_a?(Array) && key[0].is_a?(Puppet::Pops::Types::PAnyType)
     type_calculator.assignable?(type_calculator.data(), key[0])
   end
 

--- a/lib/puppet/pops/binder/producers.rb
+++ b/lib/puppet/pops/binder/producers.rb
@@ -323,7 +323,7 @@ module Puppet::Pops::Binder::Producers
     # @param binder [Puppet::Pops::Binder::Bindings::Binding, nil] The binding using this producer
     # @param scope [Puppet::Parser::Scope] The scope to use for evaluation
     # @option options [Puppet::Pops::Model::LambdaExpression] :transformer (nil) a transformer of produced value
-    # @option options [Puppet::Pops::Types::PObjectType] :type The type to lookup
+    # @option options [Puppet::Pops::Types::PAnyType] :type The type to lookup
     # @option options [String] :name ('') The name to lookup
     # @api public
     #
@@ -352,9 +352,9 @@ module Puppet::Pops::Binder::Producers
     # @param binder [Puppet::Pops::Binder::Bindings::Binding, nil] The binding using this producer
     # @param scope [Puppet::Parser::Scope] The scope to use for evaluation
     # @option options [Puppet::Pops::Model::LambdaExpression] :transformer (nil) a transformer of produced value
-    # @option options [Puppet::Pops::Types::PObjectType] :type The type to lookup
+    # @option options [Puppet::Pops::Types::PAnyType] :type The type to lookup
     # @option options [String] :name ('') The name to lookup
-    # @option options [Puppet::Pops::Types::PObjectType] :key The key to lookup in the hash
+    # @option options [Puppet::Pops::Types::PAnyType] :key The key to lookup in the hash
     # @api public
     #
     def initialize(injector, binder, scope, options)
@@ -527,8 +527,8 @@ module Puppet::Pops::Binder::Producers
       @contributions_key = injector.key_factory.multibind_contributions(binding.id)
     end
 
-    # @param expected [Array<Puppet::Pops::Types::PObjectType>, Puppet::Pops::Types::PObjectType] expected type or types
-    # @param actual [Object, Puppet::Pops::Types::PObjectType> the actual value (or its type)
+    # @param expected [Array<Puppet::Pops::Types::PAnyType>, Puppet::Pops::Types::PAnyType] expected type or types
+    # @param actual [Object, Puppet::Pops::Types::PAnyType> the actual value (or its type)
     # @return [String] a formatted string for inclusion as detail in an error message
     # @api private
     #

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -167,7 +167,7 @@ class Puppet::Pops::Evaluator::Closure < Puppet::Pops::Evaluator::CallableSignat
       type = if param.type_expr
                @evaluator.evaluate(param.type_expr, @enclosing_scope)
              else
-               Puppet::Pops::Types::TypeFactory.object()
+               Puppet::Pops::Types::TypeFactory.any()
              end
 
       if param.captures_rest && type.is_a?(Puppet::Pops::Types::PArrayType)

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -636,7 +636,7 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
     evaluate(o.body, scope)
   end
 
-  # Produces Array[PObjectType], an array of resource references
+  # Produces Array[PAnyType], an array of resource references
   #
   def eval_ResourceExpression(o, scope)
     exported = o.exported

--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -98,7 +98,7 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
       # Define a dispatch that performs argument type/count checking
       #
       dispatch :__relay__call__ do
-        param 'Object', 'args'
+        param 'Any', 'args'
         # Specify arg count (transformed from 3x function arity specification).
         arg_count(min_arg_count, max_arg_count)
       end

--- a/lib/puppet/pops/types/class_loader.rb
+++ b/lib/puppet/pops/types/class_loader.rb
@@ -9,8 +9,8 @@ class Puppet::Pops::Types::ClassLoader
 
   # Returns a Class given a fully qualified class name.
   # Lookup of class is never relative to the calling namespace.
-  # @param name [String, Array<String>, Array<Symbol>, Puppet::Pops::Types::PObjectType] A fully qualified
-  #   class name String (e.g. '::Foo::Bar', 'Foo::Bar'), a PObjectType, or a fully qualified name in Array form where each part
+  # @param name [String, Array<String>, Array<Symbol>, Puppet::Pops::Types::PAnyType] A fully qualified
+  #   class name String (e.g. '::Foo::Bar', 'Foo::Bar'), a PAnyType, or a fully qualified name in Array form where each part
   #   is either a String or a Symbol, e.g. `%w{Puppetx Puppetlabs SomeExtension}`.
   # @return [Class, nil] the looked up class or nil if no such class is loaded
   # @raise ArgumentError If the given argument has the wrong type
@@ -24,7 +24,7 @@ class Puppet::Pops::Types::ClassLoader
     when Array
       provide_from_name_path(name.join('::'), name)
 
-    when Puppet::Pops::Types::PObjectType, Puppet::Pops::Types::PType
+    when Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::PType
       provide_from_type(name)
 
     else
@@ -44,7 +44,7 @@ class Puppet::Pops::Types::ClassLoader
       RGen::MetamodelBuilder::MMBase::Boolean
 
     when Puppet::Pops::Types::PType
-      # TODO: PType should have a type argument (a PObjectType)
+      # TODO: PType should have a type argument (a PAnyType)
       Class
 
     # Although not expected to be the first choice for getting a concrete class for these
@@ -52,7 +52,7 @@ class Puppet::Pops::Types::ClassLoader
     #
     when Puppet::Pops::Types::PArrayType   ; Array
     when Puppet::Pops::Types::PHashType    ; Hash
-    when Puppet::Pops::Types::PRegexpType ; Regexp
+    when Puppet::Pops::Types::PRegexpType  ; Regexp
     when Puppet::Pops::Types::PIntegerType ; Integer
     when Puppet::Pops::Types::PStringType  ; String
     when Puppet::Pops::Types::PFloatType   ; Float

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -178,7 +178,7 @@ class Puppet::Pops::Types::TypeCalculator
     @data_t = Types::PDataType.new()
     @scalar_t = Types::PScalarType.new()
     @numeric_t = Types::PNumericType.new()
-    @t = Types::PObjectType.new()
+    @t = Types::PAnyType.new()
 
     # Data accepts a Tuple that has 0-infinity Data compatible entries (e.g. a Tuple equivalent to Array).
     data_tuple = Types::PTupleType.new()
@@ -391,8 +391,8 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   def instance_of_Object(t, o)
-    # Undef is Undef and Object, but nothing else when checking instance?
-    return false if (o.nil? || o == :undef) && t.class != Types::PObjectType
+    # Undef is Undef and Any, but nothing else when checking instance?
+    return false if (o.nil? || o == :undef) && t.class != Types::PAnyType
     assignable?(t, infer(o))
   end
 
@@ -639,7 +639,7 @@ class Puppet::Pops::Types::TypeCalculator
     # If both are RubyObjects
 
     if common_pobject?(t1, t2)
-      return Types::PObjectType.new()
+      return Types::PAnyType.new()
     end
   end
 
@@ -870,6 +870,7 @@ class Puppet::Pops::Types::TypeCalculator
       possible_variant
     end
   end
+
   # False in general type calculator
   # @api private
   def assignable_Object(t, t2)
@@ -877,8 +878,8 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   # @api private
-  def assignable_PObjectType(t, t2)
-    t2.is_a?(Types::PObjectType)
+  def assignable_PAnyType(t, t2)
+    t2.is_a?(Types::PAnyType)
   end
 
   # @api private
@@ -1347,7 +1348,7 @@ class Puppet::Pops::Types::TypeCalculator
   def string_String(t)       ; t         ; end
 
   # @api private
-  def string_PObjectType(t)  ; "Object"  ; end
+  def string_PAnyType(t)  ; "Any"  ; end
 
   # @api private
   def string_PNilType(t)     ; 'Undef'   ; end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -119,11 +119,11 @@ module Puppet::Pops::Types::TypeFactory
     Types::PBooleanType.new()
   end
 
-  # Produces the Object type
+  # Produces the Any type
   # @api public
   #
-  def self.object()
-    Types::PObjectType.new()
+  def self.any()
+    Types::PAnyType.new()
   end
 
   # Produces the Regexp type

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -24,7 +24,7 @@ class Puppet::Pops::Types::TypeParser
   #
   # @param string [String] a string with the type expressed in stringified form as produced by the 
   #   {Puppet::Pops::Types::TypeCalculator#string TypeCalculator#string} method.
-  # @return [Puppet::Pops::Types::PObjectType] a specialization of the PObjectType representing the type.
+  # @return [Puppet::Pops::Types::PAnyType] a specialization of the PAnyType representing the type.
   #
   # @api public
   #
@@ -164,8 +164,8 @@ class Puppet::Pops::Types::TypeParser
       # Should not be interpreted as Resource type
       TYPES.undef()
 
-    when "object"
-      TYPES.object()
+    when "any"
+      TYPES.any()
 
     when "variant"
       TYPES.variant()
@@ -404,7 +404,7 @@ class Puppet::Pops::Types::TypeParser
       assert_type(parameters[0])
       TYPES.optional(parameters[0])
 
-    when "object", "data", "catalogentry", "boolean", "scalar", "undef", "numeric"
+    when "any", "data", "catalogentry", "boolean", "scalar", "undef", "numeric"
       raise_unparameterized_type_error(parameterized_ast.left_expr)
 
     when "type"
@@ -431,7 +431,7 @@ class Puppet::Pops::Types::TypeParser
   private
 
   def assert_type(t)
-    raise_invalid_type_specification_error unless t.is_a?(Puppet::Pops::Types::PObjectType)
+    raise_invalid_type_specification_error unless t.is_a?(Puppet::Pops::Types::PAnyType)
     true
   end
 

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -45,7 +45,7 @@ module Puppet::Pops::Types
 
   # Base type for all types except {Puppet::Pops::Types::PType PType}, the type of types.
   # @api public
-  class PObjectType < PAbstractType
+  class PAnyType < PAbstractType
 
     module ClassModule
     end
@@ -54,7 +54,7 @@ module Puppet::Pops::Types
 
   # The type of types.
   # @api public
-  class PType < PObjectType
+  class PType < PAnyType
     contains_one_uni 'type', PAbstractType
     module ClassModule
       def hash
@@ -68,13 +68,13 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PNilType < PObjectType
+  class PNilType < PAnyType
   end
 
   # A flexible data type, being assignable to its subtypes as well as PArrayType and PHashType with element type assignable to PDataType.
   #
   # @api public
-  class PDataType < PObjectType
+  class PDataType < PAnyType
     module ClassModule
       def ==(o)
         self.class == o.class ||
@@ -85,7 +85,7 @@ module Puppet::Pops::Types
 
   # A flexible type describing an any? of other types
   # @api public
-  class PVariantType < PObjectType
+  class PVariantType < PAnyType
     contains_many_uni 'types', PAbstractType, :lowerBound => 1
 
     module ClassModule
@@ -103,7 +103,7 @@ module Puppet::Pops::Types
 
   # Type that is PDataType compatible, but is not a PCollectionType.
   # @api public
-  class PScalarType < PObjectType
+  class PScalarType < PAnyType
   end
 
   # A string type describing the set of strings having one of the given values
@@ -253,7 +253,7 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PCollectionType < PObjectType
+  class PCollectionType < PAnyType
     contains_one_uni 'element_type', PAbstractType
     contains_one_uni 'size_type', PIntegerType
 
@@ -296,7 +296,7 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PStructType < PObjectType
+  class PStructType < PAnyType
     contains_many_uni 'elements', PStructElement, :lowerBound => 1
     has_attr 'hashed_elements', Object, :derived => true
 
@@ -321,7 +321,7 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PTupleType < PObjectType
+  class PTupleType < PAnyType
     contains_many_uni 'types', PAbstractType, :lowerBound => 1
     # If set, describes min and max required of the given types - if max > size of
     # types, the last type entry repeats
@@ -360,7 +360,7 @@ module Puppet::Pops::Types
     end
   end
 
-  class PCallableType < PObjectType
+  class PCallableType < PAnyType
     # Types of parameters and required/optional count
     contains_one_uni 'param_types', PTupleType, :lowerBound => 1
 
@@ -435,7 +435,7 @@ module Puppet::Pops::Types
   end
 
   # @api public
-  class PRubyType < PObjectType
+  class PRubyType < PAnyType
     has_attr 'ruby_class', String
     module ClassModule
       def hash
@@ -451,7 +451,7 @@ module Puppet::Pops::Types
   # Abstract representation of a type that can be placed in a Catalog.
   # @api public
   #
-  class PCatalogEntryType < PObjectType
+  class PCatalogEntryType < PAnyType
   end
 
   # Represents a (host-) class in the Puppet Language.

--- a/spec/integration/parser/future_compiler_spec.rb
+++ b/spec/integration/parser/future_compiler_spec.rb
@@ -563,7 +563,7 @@ describe "Puppet::Parser::Compiler" do
           compile_to_catalog(<<-MANIFEST)
             with(1) |$x, String $defaulted = 1| { notify { "${$x + $defaulted}": }}
           MANIFEST
-        end.to raise_error(/expected.*Object.*String.*actual.*Integer.*Integer/m)
+        end.to raise_error(/expected.*Any.*String.*actual.*Integer.*Integer/m)
       end
 
       it 'raises an error when a default argument value is an incorrect type and there are no arguments passed' do

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -37,8 +37,8 @@ describe 'the assert_type function' do
     end.to raise_error(ArgumentError, Regexp.new(Regexp.escape(
 "function 'assert_type' called with mis-matched arguments
 expected one of:
-  assert_type(Type type, Object value, Callable[Object, Object] block {0,1}) - arg count {2,3}
-  assert_type(String type_string, Object value, Callable[Object, Object] block {0,1}) - arg count {2,3}
+  assert_type(Type type, Any value, Callable[Any, Any] block {0,1}) - arg count {2,3}
+  assert_type(String type_string, Any value, Callable[Any, Any] block {0,1}) - arg count {2,3}
 actual:
   assert_type(Integer, Integer) - arg count {2}")))
   end

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -83,9 +83,9 @@ actual:
     func = f.new(:closure_scope, :loader)
     expect(func.is_a?(Puppet::Functions::Function)).to be_true
     signature = if RUBY_VERSION =~ /^1\.8/
-      'Object{2}'
+      'Any{2}'
     else
-      'Object x, Object y'
+      'Any x, Any y'
     end
     expect do
       func.call({}, 10)
@@ -102,9 +102,9 @@ actual:
     func = f.new(:closure_scope, :loader)
     expect(func.is_a?(Puppet::Functions::Function)).to be_true
     signature = if RUBY_VERSION =~ /^1\.8/
-      'Object{2}'
+      'Any{2}'
     else
-      'Object x, Object y'
+      'Any x, Any y'
     end
     expect do
       func.call({}, 10, 10, 10)
@@ -162,9 +162,9 @@ actual:
       func = f.new(:closure_scope, :loader)
       expect(func.is_a?(Puppet::Functions::Function)).to be_true
       signature = if RUBY_VERSION =~ /^1\.8/
-        'Object{2,}'
+        'Any{2,}'
       else
-        'Object x, Object y, Object a?, Object b?, Object c{0,}'
+        'Any x, Any y, Any a?, Any b?, Any c{0,}'
       end
       expect do
         func.call({}, 10)

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -292,7 +292,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     {
-      'Object'  => ['Data', 'Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Collection',
+      'Any'  => ['Data', 'Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Collection',
                     'Array', 'Hash', 'CatalogEntry', 'Resource', 'Class', 'Undef', 'File', 'NotYetKnownResourceType'],
 
       # Note, Data > Collection is false (so not included)
@@ -900,7 +900,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       env_loader = @compiler.loaders.public_environment_loader
       fc = Puppet::Functions.create_function(:test) do
         dispatch :test do
-          param 'Object', 'lambda_arg'
+          param 'Any', 'lambda_arg'
           required_block_param
         end
         def test(lambda_arg, block)

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -79,7 +79,7 @@ describe 'The type calculator' do
   end
 
   def object_t
-    Puppet::Pops::Types::TypeFactory.object()
+    Puppet::Pops::Types::TypeFactory.any()
   end
 
   def types
@@ -89,7 +89,7 @@ describe 'The type calculator' do
   shared_context "types_setup" do
 
     def all_types
-      [ Puppet::Pops::Types::PObjectType,
+      [ Puppet::Pops::Types::PAnyType,
         Puppet::Pops::Types::PNilType,
         Puppet::Pops::Types::PDataType,
         Puppet::Pops::Types::PScalarType,
@@ -279,8 +279,8 @@ describe 'The type calculator' do
         calculator.infer(['one', /two/]).element_type.class.should == Puppet::Pops::Types::PScalarType
       end
 
-      it 'with string and symbol values translates to PArrayType[PObjectType]' do
-        calculator.infer(['one', :two]).element_type.class.should == Puppet::Pops::Types::PObjectType
+      it 'with string and symbol values translates to PArrayType[PAnyType]' do
+        calculator.infer(['one', :two]).element_type.class.should == Puppet::Pops::Types::PAnyType
       end
 
       it 'with fixnum and nil values translates to PArrayType[PIntegerType]' do
@@ -494,13 +494,13 @@ describe 'The type calculator' do
 
     context "for Object, such that" do
       it 'all types are assignable to Object' do
-        t = Puppet::Pops::Types::PObjectType.new()
+        t = Puppet::Pops::Types::PAnyType.new()
         all_types.each { |t2| t2.new.should be_assignable_to(t) }
       end
 
       it 'Object is not assignable to anything but Object' do
-        tested_types = all_types() - [Puppet::Pops::Types::PObjectType]
-        t = Puppet::Pops::Types::PObjectType.new()
+        tested_types = all_types() - [Puppet::Pops::Types::PAnyType]
+        t = Puppet::Pops::Types::PAnyType.new()
         tested_types.each { |t2| t.should_not be_assignable_to(t2.new) }
       end
     end
@@ -531,7 +531,7 @@ describe 'The type calculator' do
       end
 
       it 'Data is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PObjectType, Puppet::Pops::Types::PDataType] - scalar_types
+        tested_types = all_types - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::PDataType] - scalar_types
         t = Puppet::Pops::Types::PDataType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
@@ -550,7 +550,7 @@ describe 'The type calculator' do
       end
 
       it 'Scalar is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PObjectType, Puppet::Pops::Types::PDataType] - scalar_types
+        tested_types = all_types - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::PDataType] - scalar_types
         t = Puppet::Pops::Types::PScalarType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
@@ -570,7 +570,7 @@ describe 'The type calculator' do
 
       it 'Numeric is not assignable to any disjunct type' do
         tested_types = all_types - [
-          Puppet::Pops::Types::PObjectType,
+          Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::PDataType,
           Puppet::Pops::Types::PScalarType,
           ] - numeric_types
@@ -592,7 +592,7 @@ describe 'The type calculator' do
       end
 
       it 'Collection is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PObjectType] - collection_types
+        tested_types = all_types - [Puppet::Pops::Types::PAnyType] - collection_types
         t = Puppet::Pops::Types::PCollectionType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
@@ -610,7 +610,7 @@ describe 'The type calculator' do
 
       it 'Array is not assignable to any disjunct type' do
         tested_types = all_types - [
-          Puppet::Pops::Types::PObjectType,
+          Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PArrayType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -629,7 +629,7 @@ describe 'The type calculator' do
 
       it 'Hash is not assignable to any disjunct type' do
         tested_types = all_types - [
-          Puppet::Pops::Types::PObjectType,
+          Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PHashType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -648,7 +648,7 @@ describe 'The type calculator' do
 
       it 'Tuple is not assignable to any disjunct type' do
         tested_types = all_types - [
-          Puppet::Pops::Types::PObjectType,
+          Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PTupleType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -667,7 +667,7 @@ describe 'The type calculator' do
 
       it 'Struct is not assignable to any disjunct type' do
         tested_types = all_types - [
-          Puppet::Pops::Types::PObjectType,
+          Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PStructType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -679,7 +679,7 @@ describe 'The type calculator' do
         t = Puppet::Pops::Types::PCallableType.new()
         tested_types = all_types - [
           Puppet::Pops::Types::PCallableType,
-          Puppet::Pops::Types::PObjectType]
+          Puppet::Pops::Types::PAnyType]
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
     end
@@ -991,12 +991,12 @@ describe 'The type calculator' do
 
     it 'should consider undef to be instance of Object and NilType' do
       calculator.instance?(Puppet::Pops::Types::PNilType.new(), nil).should    == true
-      calculator.instance?(Puppet::Pops::Types::PObjectType.new(), nil).should == true
+      calculator.instance?(Puppet::Pops::Types::PAnyType.new(), nil).should == true
     end
 
     it 'should not consider undef to be an instance of any other type than Object and NilType and Data' do
       types_to_test = all_types - [ 
-        Puppet::Pops::Types::PObjectType,
+        Puppet::Pops::Types::PAnyType,
         Puppet::Pops::Types::PNilType,
         Puppet::Pops::Types::PDataType]
 
@@ -1219,8 +1219,8 @@ describe 'The type calculator' do
       calculator.string(Puppet::Pops::Types::PType.new()).should == 'Type'
     end
 
-    it 'should yield \'Object\' for PObjectType' do
-      calculator.string(Puppet::Pops::Types::PObjectType.new()).should == 'Object'
+    it 'should yield \'Object\' for PAnyType' do
+      calculator.string(Puppet::Pops::Types::PAnyType.new()).should == 'Any'
     end
 
     it 'should yield \'Scalar\' for PScalarType' do

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Pops::Types::TypeParser do
   end
 
   [
-    'Object', 'Data', 'CatalogEntry', 'Boolean', 'Scalar', 'Undef', 'Numeric',
+    'Any', 'Data', 'CatalogEntry', 'Boolean', 'Scalar', 'Undef', 'Numeric',
   ].each do |name|
     it "does not support parameterizing unparameterized type <#{name}>" do
       expect { parser.parse("#{name}[Integer]") }.to raise_unparameterized_error_for(name)
@@ -39,7 +39,7 @@ describe Puppet::Pops::Types::TypeParser do
   end
 
   it "parses a simple, unparameterized type into the type object" do
-    expect(the_type_parsed_from(types.object)).to be_the_type(types.object)
+    expect(the_type_parsed_from(types.any)).to be_the_type(types.any)
     expect(the_type_parsed_from(types.integer)).to be_the_type(types.integer)
     expect(the_type_parsed_from(types.float)).to be_the_type(types.float)
     expect(the_type_parsed_from(types.string)).to be_the_type(types.string)


### PR DESCRIPTION
This renames the top most type in the type system to Any from
the name Object. This is done because the word Object carries
connotations of "Object Oriented Programming" that simply adds confusion
about how puppet works.

This commit is basically a rename refactoring.
