### PR TITLE
(PUP-2798) Remove warnings for reserved words in 3x regular.

### DIFF
--- a/lib/puppet/parser/lexer.rb
+++ b/lib/puppet/parser/lexer.rb
@@ -221,8 +221,6 @@ class Puppet::Parser::Lexer
         value = eval(value)
         string_token = TOKENS[:BOOLEAN]
       end
-    else
-      lexer.warn_if_reserved(value)
     end
     [string_token, value]
   end
@@ -605,14 +603,6 @@ class Puppet::Parser::Lexer
   def warn_if_variable_has_hyphen(var_name)
     if var_name.include?('-')
       Puppet.deprecation_warning("Using `-` in variable names is deprecated at #{file || '<string>'}:#{line}. See http://links.puppetlabs.com/puppet-hyphenated-variable-deprecation")
-    end
-  end
-
-  def warn_if_reserved(name)
-    case name
-    when 'private', 'function', 'attr', 'type'
-      msg = "Future reserved word: #{name}. Either choose a different name or quote the string, if possible. In #{file || '<string>'}:#{line}. See http://links.puppetlabs.com/reserved-words-4"
-      Puppet.deprecation_warning(msg, name)
     end
   end
 end

--- a/spec/unit/parser/lexer_spec.rb
+++ b/spec/unit/parser/lexer_spec.rb
@@ -280,7 +280,6 @@ describe Puppet::Parser::Lexer::TOKENS[:NAME] do
   it "should return itself and the value if the matched term is not a keyword" do
     Puppet::Parser::Lexer::KEYWORDS.expects(:lookup).returns(nil)
     lexer = stub("lexer")
-    lexer.expects(:warn_if_reserved).returns(nil)
     @token.convert(lexer, "myval").should == [Puppet::Parser::Lexer::TOKENS[:NAME], "myval"]
   end
 
@@ -849,8 +848,7 @@ end
 
 describe 'Puppet::Parser::Lexer handles reserved words' do
     ['function', 'private', 'attr', 'type'].each do |reserved_bare_word|
-      it "by warning if '#{reserved_bare_word}' is used as bare word" do
-        Puppet.expects(:deprecation_warning).once
+      it "by delivering '#{reserved_bare_word}' as a bare word" do
         expect(tokens_scanned_from(reserved_bare_word)).to eq([[:NAME, {:value=>reserved_bare_word, :line => 1}]])
       end
     end


### PR DESCRIPTION
We are issuing too many deprecation warnings for people to keep up.
The migration paths is to use the future parser/evaluator to "future
proof" manifests.

This only changes the warnings for 3x regular. And is basically a
reversal of part of PUP-1027 where these warnings were added).
