### PR TITLE
(PUP-2738) Ensure block in user.password_is?

### DIFF
--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -53,7 +53,7 @@ module Puppet::Util::Windows::User
   module_function :check_token_membership
 
   def password_is?(name, password)
-    logon_user(name, password)
+    logon_user(name, password) { |token| }
   rescue Puppet::Util::Windows::Error
     false
   end

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -66,6 +66,7 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
       it "should raise an error when provided with an incorrect username and password" do
         lambda { Puppet::Util::Windows::User.load_profile(username, bad_password) }.should raise_error(Puppet::Util::Windows::Error, logon_fail_msg)
       end
+
       it "should raise an error when provided with an incorrect username and nil password" do
         lambda { Puppet::Util::Windows::User.load_profile(username, nil) }.should raise_error(Puppet::Util::Windows::Error, logon_fail_msg)
       end
@@ -75,6 +76,7 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
       it "should raise an error when provided with an incorrect username and password" do
         lambda { Puppet::Util::Windows::User.logon_user(username, bad_password) }.should raise_error(Puppet::Util::Windows::Error, logon_fail_msg)
       end
+
       it "should raise an error when provided with an incorrect username and nil password" do
         lambda { Puppet::Util::Windows::User.logon_user(username, nil) }.should raise_error(Puppet::Util::Windows::Error, logon_fail_msg)
       end
@@ -84,8 +86,13 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
       it "should return false given an incorrect username and password" do
         Puppet::Util::Windows::User.password_is?(username, bad_password).should be_false
       end
+
       it "should return false given an incorrect username and nil password" do
         Puppet::Util::Windows::User.password_is?(username, nil).should be_false
+      end
+
+      it "should return false given a nil username and an incorrect password" do
+        Puppet::Util::Windows::User.password_is?(nil, bad_password).should be_false
       end
     end
 


### PR DESCRIPTION
This ensures that a block is given by password_is? when calling
logon_user even though it doesn't need to do anything with it. We went this
route because it made more sense to require a block for this call versus
checking if a block was given in the logon_user method. If you call
logon_user without passing a block you cannot take the next step to later do
something as that user. So it would be a misleading if we allowed it without
requiring a block.
