### PR TITLE
(PUP-2781) Generate correct dependency expressions for new modules.

### DIFF
--- a/lib/puppet/face/module/generate.rb
+++ b/lib/puppet/face/module/generate.rb
@@ -54,7 +54,7 @@ Puppet::Face.define(:module, '1.0.0') do
         "dependencies": [
           {
             "name": "puppetlabs-stdlib",
-            "version_range": ">= 1.0.0"
+            "version_requirement": ">= 1.0.0"
           }
         ]
       }
@@ -114,7 +114,7 @@ Puppet::Face.define(:module, '1.0.0') do
           'name' => name,
           'version' => '0.1.0',
           'dependencies' => [
-            { :name => 'puppetlabs-stdlib', :version_range => '>= 1.0.0' }
+            { :name => 'puppetlabs-stdlib', :version_requirement => '>= 1.0.0' }
           ]
         )
       rescue ArgumentError


### PR DESCRIPTION
Since Puppet 3.6.0, `puppet module generate` has automatically created a `metadata.json` file for users, with a sample dependency on `puppetlabs-stdlib` to help demonstrate the syntax for expressing dependencies.  Unfortunately, the generated sample used an incorrect key name (`version_range` vs `version_requirement`), which is less useful and was introducing other problems with (e.g.) publishing to the Forge.

This change repairs that mistake.
