### PR TITLE
(PUP-2816) Default forge override in Rakefile

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -25,7 +25,8 @@ module HarnessOptions
     :timesync => true,
     :repo_proxy => true,
     :add_el_extras => false,
-    :preserve_hosts => 'onfail'
+    :preserve_hosts => 'onfail',
+    :forge_host => 'forge-aio01-petest.puppetlabs.com'
   }
 
   class Aggregator

--- a/acceptance/bin/ci-bootstrap-from-artifacts.sh
+++ b/acceptance/bin/ci-bootstrap-from-artifacts.sh
@@ -42,7 +42,6 @@ cat > local_options.rb <<-EOF
   :ssh => {
     :keys => ["${HOME}/.ssh/id_rsa-old.private"],
   },
-  :forge_host => 'forge-aio01-petest.puppetlabs.com',
 ${repo_proxy}
 }
 EOF


### PR DESCRIPTION
The override for the fake forge to use only showed up in the 
ci-bootstrap-from-artifacts.sh, but that only affects how the jenkins jobs
handle the pipeline. When you run the tests on your own machine, you aren't
going to use that script, which would mean that it would use the wrong fake
forge. This moves the override to the Rakefile so that it will always take
effect.
