### PR TITLE
(PUP-1299) Stop stripping arrays in future parser

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -418,15 +418,23 @@ class Puppet::Resource
         end
       end
 
-      # If the value is an array with only one value, then
-      # convert it to a single value.  This is largely so that
-      # the database interaction doesn't have to worry about
-      # whether it returns an array or a string.
-      result[p] = if v.is_a?(Array) and v.length == 1
-                    v[0]
-                  else
-                    v
-                  end
+      if Puppet[:parser] == 'current'
+        # If the value is an array with only one value, then
+        # convert it to a single value.  This is largely so that
+        # the database interaction doesn't have to worry about
+        # whether it returns an array or a string.
+        #
+        # This behavior is not done in the future parser, but we can't issue a
+        # deprecation warning either since there isn't anything that a user can
+        # do about it.
+        result[p] = if v.is_a?(Array) and v.length == 1
+                      v[0]
+                    else
+                      v
+                    end
+      else
+        result[p] = v
+      end
     end
 
     result

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -654,7 +654,16 @@ describe "Two step scoping for variables" do
     describe "using plussignment to change in a new scope" do
 
       it "does not change an array in the parent scope" do
-        expect_the_message_to_be('top_msg') do <<-MANIFEST
+        # Under the future parser single element arrays are no longer converted
+        # into the first element of the array. This causes the message to be
+        # different in the two versions.
+        if Puppet[:parser] == 'future'
+          expected = ['top_msg']
+        else
+          expected = 'top_msg'
+        end
+
+        expect_the_message_to_be(expected) do <<-MANIFEST
             $var = ["top_msg"]
             class override {
               $var += ["override"]


### PR DESCRIPTION
Resource values that were arrays used to be converted to a single value iff
the array only had one element. This created a lot of confusion for type and
provider authors when the value they would set in a manifest would not be the
value they would get in the type. The conversion causes large amounts of code
that would check for values that aren't arrays and convert them to arrays in
various places. There were also often tests that would be written directly
against providers that would then not catch errors in real use because the
author was unaware, or just forgot, that the array conversion would happen.

Under the future parser this is no longer done. The old behavior, however,
won't issue a deprecation warning because there isn't anything that can be
done about it from a user's perspective. The most likely outcome from this
change is that some manifests may stop working because a value just happened
to be a single-valued array that was on a parameter that is not supposed to
take an array. In such cases the error would have been masked previously, but
now will be uncovered.
