### PR TITLE
(PUP-2807) Add output of containing scope for log functions

### DIFF
--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -56,7 +56,17 @@ class Puppet::Pops::Loader::StaticLoader < Puppet::Pops::Loader::Loader
           # New implementation uses the evaluator to get proper formatting per type
           # TODO: uses a fake scope (nil) - fix when :scopes are available via settings
           mapped = vals.map {|v| Puppet::Pops::Evaluator::EvaluatorImpl.new.string(v, nil) }
-          Puppet.send(level, mapped.join(" "))
+
+          # Bypass Puppet.<level> call since it picks up source from "self" which is not applicable in the 4x
+          # Function API.
+          # TODO: When a function can obtain the file, line, pos of the call merge those in (3x supports
+          #       options :file, :line. (These were never output when calling the 3x logging functions since
+          #       3x scope does not know about the calling location at that detailed level, nor do they
+          #       appear in a report to stdout/error when included). Now, the output simply uses scope (like 3x)
+          #       as this is good enough, but does not reflect the true call-stack, but is a rough estimate
+          #       of where the logging call originates from).
+          #
+          Puppet::Util::Log.create({:level => level, :source => scope, :message => mapped.join(" ")})
         end
       end
 

--- a/spec/unit/pops/loaders/static_loader_spec.rb
+++ b/spec/unit/pops/loaders/static_loader_spec.rb
@@ -37,6 +37,12 @@ describe 'the static loader' do
       it "uses the evaluator to format output" do
         expect(loader.load(:function, level).call({}, ['yay', 'surprise']).to_s).to eql('[yay, surprise]')
       end
+
+      it 'outputs name of source (scope) by passing it to the Log utility' do
+        the_scope = {}
+        Puppet::Util::Log.any_instance.expects(:source=).with(the_scope)
+        loader.load(:function, level).call(the_scope, 'x')
+      end
     end
   end
 


### PR DESCRIPTION
The log functions in 3x outputs th name of the containing scope
(for notice etc.). The reimplemented methods for the 4x function API
did not include this behavior.

Now, the calling scope is passed to the Logging utility to be output
the same way as for 3x.
