### PR TITLE
(PUP-1283) win32-security gem raises a different exception

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -35,7 +35,7 @@ gem_platform_dependencies:
       win32-dir: '~> 0.4.3'
       win32-eventlog: '~> 0.5.3'
       win32-process: '~> 0.6.5'
-      win32-security: '~> 0.1.4'
+      win32-security: '~> 0.2.5'
       win32-service: '0.7.2'
       win32-taskscheduler: '~> 0.2.2'
       win32console:  '1.3.2'

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -63,8 +63,8 @@ module Puppet::Util::Windows::ADSI
       begin
         sid = Win32::Security::SID.new(Win32::Security::SID.string_to_sid(sid))
         sid_uri(sid)
-      rescue Win32::Security::SID::Error
-        return nil
+      rescue
+        nil
       end
     end
 

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -47,7 +47,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
       expect {
         invalid_octet = [1]
         subject.octet_string_to_sid_object(invalid_octet)
-      }.to raise_error(Win32::Security::SID::Error, /No mapping between account names and security IDs was done./)
+      }.to raise_error(SystemCallError, /No mapping between account names and security IDs was done./)
     end
   end
 


### PR DESCRIPTION
Previously, puppet relied on win32-security version 0.1.4, which raises
Win32::Security::SID::Error when it fails to resolve a name into a SID.

However, FFI versions of win32-security raise SystemCallError instead,
which is a StandardError subclass. When trying to run the puppet agent
against newer versions of the library, puppet reports:

```
Uninitialized constant Win32::Security::SID::Error
```

This commit changes the rescue to capture standard errors instead.
