### PR TITLE
(PUP-2750) Fix aggregate profiler spec tests on windows

### DIFF
--- a/spec/unit/util/profiler/aggregate_spec.rb
+++ b/spec/unit/util/profiler/aggregate_spec.rb
@@ -13,9 +13,9 @@ describe Puppet::Util::Profiler::Aggregate do
   end
 
   it "tracks the aggregate counts and time for the hierarchy of metrics" do
-    profiler_mgr.profile("Looking up hiera data in production environment", ["function", "hiera_lookup", "production"]) {}
+    profiler_mgr.profile("Looking up hiera data in production environment", ["function", "hiera_lookup", "production"]) { sleep 0.01 }
     profiler_mgr.profile("Looking up hiera data in test environment", ["function", "hiera_lookup", "test"]) {}
-    profiler_mgr.profile("looking up stuff for compilation", ["compiler", "lookup"]) {}
+    profiler_mgr.profile("looking up stuff for compilation", ["compiler", "lookup"]) { sleep 0.01 }
     profiler_mgr.profile("COMPILING ALL OF THE THINGS!", ["compiler", "compiling"]) {}
 
     profiler.values["function"].count.should == 2
@@ -23,7 +23,7 @@ describe Puppet::Util::Profiler::Aggregate do
     profiler.values["function"]["hiera_lookup"].count.should == 2
     profiler.values["function"]["hiera_lookup"]["production"].count.should == 1
     profiler.values["function"]["hiera_lookup"]["test"].count.should == 1
-    profiler.values["function"].time.should be >= profiler.values["function"]["hiera_lookup"].time
+    profiler.values["function"].time.should be >= profiler.values["function"]["hiera_lookup"]["test"].time
 
     profiler.values["compiler"].count.should == 2
     profiler.values["compiler"].time.should be > 0


### PR DESCRIPTION
It appears that on Windows, the precision of the Time object is
not fine enough to guarantee that we'd get a non-zero value
for the empty code blocks that we were timing in our tests.

This commit simply adds a 10ms sleep to the tests to ensure that
that enough time will have passed for us to be able to make
an assertion that the elapsed time was greater than zero.
