### PR TITLE
(PUP-2869) Puppet should support HTTP proxy authentication

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -366,11 +366,26 @@ module Puppet
     :http_proxy_host => {
       :default    => "none",
       :desc       => "The HTTP proxy host to use for outgoing connections.  Note: You
-      may need to use a FQDN for the server hostname when using a proxy.",
+      may need to use a FQDN for the server hostname when using a proxy. Environment variable
+      http_proxy or HTTP_PROXY will override this value",
     },
     :http_proxy_port => {
       :default    => 3128,
       :desc       => "The HTTP proxy port to use for outgoing connections",
+    },
+    :http_proxy_user => {
+      :default    => "none",
+      :desc       => "The user name for an authenticated HTTP proxy. Requires http_proxy_host.",
+    },
+    :http_proxy_password =>{
+      :default    => "none",
+      :hook       => proc do |value|
+        if Puppet.settings[:http_proxy_password] =~ /[@!# \/]/
+          raise "Special characters in passwords must be URL compliant, we received #{value}"
+        end
+      end,
+      :desc       => "The password for the user of an authenticated HTTP proxy. Requires http_proxy_user.
+      NOTE: Special characters must be escaped or encoded for URL compliance",
     },
     :filetimeout => {
       :default    => "15s",

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -121,7 +121,7 @@ class Puppet::Forge
     #
     # @return [Net::HTTP::Proxy] object constructed from repo settings
     def get_http_object
-      proxy_class = Net::HTTP::Proxy(Puppet::Util::HttpProxy.http_proxy_host, Puppet::Util::HttpProxy.http_proxy_port)
+      proxy_class = Net::HTTP::Proxy(Puppet::Util::HttpProxy.http_proxy_host, Puppet::Util::HttpProxy.http_proxy_port, Puppet::Util::HttpProxy.http_proxy_user, Puppet::Util::HttpProxy.http_proxy_password)
       proxy = proxy_class.new(@uri.host, @uri.port)
 
       if @uri.scheme == 'https'

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -14,7 +14,7 @@ module Puppet::Util::HttpProxy
   def self.http_proxy_host
     env = self.http_proxy_env
 
-    if env and env.host then
+    if env and env.host
       return env.host
     end
 
@@ -28,11 +28,38 @@ module Puppet::Util::HttpProxy
   def self.http_proxy_port
     env = self.http_proxy_env
 
-    if env and env.port then
+    if env and env.port
       return env.port
     end
 
     return Puppet.settings[:http_proxy_port]
   end
 
+  def self.http_proxy_user
+    env = self.http_proxy_env
+
+    if env and env.user
+      return env.user
+    end
+
+    if Puppet.settings[:http_proxy_user] == 'none'
+      return nil
+    end
+
+    return Puppet.settings[:http_proxy_user]
+  end
+
+  def self.http_proxy_password
+    env = self.http_proxy_env
+
+    if env and env.password
+      return env.password
+    end
+
+    if Puppet.settings[:http_proxy_user] == 'none' or Puppet.settings[:http_proxy_password] == 'none'
+      return nil
+    end
+
+    return Puppet.settings[:http_proxy_password]
+  end
 end

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -97,7 +97,7 @@ describe Puppet::Forge::Repository do
       proxy = mock("http proxy")
       proxy_class.expects(:new).with("fake.com", 80).returns(proxy)
       proxy.expects(:start).yields(http).returns(result)
-      Net::HTTP.expects(:Proxy).with("proxy", 1234).returns(proxy_class)
+      Net::HTTP.expects(:Proxy).with("proxy", 1234, nil, nil).returns(proxy_class)
     end
 
     def performs_an_https_request(result = nil, &block)
@@ -111,12 +111,106 @@ describe Puppet::Forge::Repository do
       proxy.expects(:use_ssl=).with(true)
       proxy.expects(:cert_store=)
       proxy.expects(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
-      Net::HTTP.expects(:Proxy).with("proxy", 1234).returns(proxy_class)
+      Net::HTTP.expects(:Proxy).with("proxy", 1234, nil, nil).returns(proxy_class)
+    end
+  end
+
+  describe "making a request against an authentiated proxy" do
+    before :each do
+      authenticated_proxy_settings_of("proxy", 1234, 'user1', 'password')
+    end
+
+    it "returns the result object from the request" do
+      result = "#{Object.new}"
+
+      performs_an_authenticated_http_request result do |http|
+        http.expects(:request).with(responds_with(:path, "the_path"))
+      end
+
+      repository.make_http_request("the_path").should == result
+    end
+
+    it 'returns the result object from a request with ssl' do
+      result = "#{Object.new}"
+      performs_an_authenticated_https_request result do |http|
+        http.expects(:request).with(responds_with(:path, "the_path"))
+      end
+
+      ssl_repository.make_http_request("the_path").should == result
+    end
+
+    it 'return a valid exception when there is an SSL verification problem' do
+      performs_an_authenticated_https_request "#{Object.new}" do |http|
+        http.expects(:request).with(responds_with(:path, "the_path")).raises OpenSSL::SSL::SSLError.new("certificate verify failed")
+      end
+
+      expect { ssl_repository.make_http_request("the_path") }.to raise_error Puppet::Forge::Errors::SSLVerifyError, 'Unable to verify the SSL certificate at https://fake.com'
+    end
+
+    it 'return a valid exception when there is a communication problem' do
+      performs_an_authenticated_http_request "#{Object.new}" do |http|
+        http.expects(:request).with(responds_with(:path, "the_path")).raises SocketError
+      end
+
+      expect { repository.make_http_request("the_path") }.
+        to raise_error Puppet::Forge::Errors::CommunicationError,
+        'Unable to connect to the server at http://fake.com. Detail: SocketError.'
+    end
+
+    it "sets the user agent for the request" do
+      path = 'the_path'
+
+      request = repository.get_request_object(path)
+
+      request['User-Agent'].should =~ /\b#{agent}\b/
+      request['User-Agent'].should =~ /\bPuppet\b/
+      request['User-Agent'].should =~ /\bRuby\b/
+    end
+
+    it "escapes the received URI" do
+      unescaped_uri = "héllo world !! ç à"
+      performs_an_authenticated_http_request do |http|
+        http.expects(:request).with(responds_with(:path, URI.escape(unescaped_uri)))
+      end
+
+      repository.make_http_request(unescaped_uri)
+    end
+
+    def performs_an_authenticated_http_request(result = nil, &block)
+      http = mock("http client")
+      yield http
+
+      proxy_class = mock("http proxy class")
+      proxy = mock("http proxy")
+      proxy_class.expects(:new).with("fake.com", 80).returns(proxy)
+      proxy.expects(:start).yields(http).returns(result)
+      Net::HTTP.expects(:Proxy).with("proxy", 1234, "user1", "password").returns(proxy_class)
+    end
+
+    def performs_an_authenticated_https_request(result = nil, &block)
+      http = mock("http client")
+      yield http
+
+      proxy_class = mock("http proxy class")
+      proxy = mock("http proxy")
+      proxy_class.expects(:new).with("fake.com", 443).returns(proxy)
+      proxy.expects(:start).yields(http).returns(result)
+      proxy.expects(:use_ssl=).with(true)
+      proxy.expects(:cert_store=)
+      proxy.expects(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+      Net::HTTP.expects(:Proxy).with("proxy", 1234, "user1", "password").returns(proxy_class)
     end
   end
 
   def proxy_settings_of(host, port)
     Puppet[:http_proxy_host] = host
     Puppet[:http_proxy_port] = port
+  end
+
+  def authenticated_proxy_settings_of(host, port, user, password)
+    Puppet[:http_proxy_host] = host
+    Puppet[:http_proxy_port] = port
+    Puppet[:http_proxy_user] = user
+    Puppet[:http_proxy_password] = password
   end
 end

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -4,7 +4,7 @@ require 'puppet/util/http_proxy'
 
 describe Puppet::Util::HttpProxy do
 
-  host, port = 'some.host', 1234
+  host, port, user, password = 'some.host', 1234, 'user1', 'pAssw0rd'
 
   describe ".http_proxy_env" do
     it "should return nil if no environment variables" do
@@ -80,4 +80,46 @@ describe Puppet::Util::HttpProxy do
 
   end
 
+  describe ".http_proxy_user" do
+    it "should return a proxy user if set in environment" do
+      Puppet::Util.withenv('HTTP_PROXY' => "http://#{user}:#{password}@#{host}:#{port}") do
+        subject.http_proxy_user.should == user
+      end
+    end
+
+    it "should return a proxy user if set in config" do
+      Puppet.settings[:http_proxy_user] = user
+      subject.http_proxy_user.should == user
+    end
+
+    it "should use environment variable before puppet settings" do
+      Puppet::Util.withenv('HTTP_PROXY' => "http://#{user}:#{password}@#{host}:#{port}") do
+        Puppet.settings[:http_proxy_user] = 'clownpants'
+        subject.http_proxy_user.should == user
+      end
+    end
+
+  end
+
+  describe ".http_proxy_password" do
+    it "should return a proxy password if set in environment" do
+      Puppet::Util.withenv('HTTP_PROXY' => "http://#{user}:#{password}@#{host}:#{port}") do
+        subject.http_proxy_password.should == password
+      end
+    end
+
+    it "should return a proxy password if set in config" do
+      Puppet.settings[:http_proxy_user] = user
+      Puppet.settings[:http_proxy_password] = password
+      subject.http_proxy_password.should == password
+    end
+
+    it "should use environment variable before puppet settings" do
+      Puppet::Util.withenv('HTTP_PROXY' => "http://#{user}:#{password}@#{host}:#{port}") do
+        Puppet.settings[:http_proxy_password] = 'clownpants'
+        subject.http_proxy_password.should == password
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
Without this patch it is not possible to use the Puppet Module
Tool (PMT) with an authenticated proxy.
Many enterprises utilise the services of authenticated proxies for
Internet access. Current code is able to utilise a proxy, but does
not consider credentials for authenticated proxies.
This patch uses the credentials from either the environment settings
for HTTP_PROXY or http_proxy, or the corresponding values in the
puppet.conf file.  The patch allows for http_proxy_user and
http_proxy_password to supplement the current http_proxy_host and
http_proxy_port variables within the puppet.conf.
