### PR TITLE
(PUP-2389) puppet-win32-ruby acceptance ver config

### DIFF
--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -42,7 +42,8 @@ hosts.each do |host|
     # TODO remove this step once we are installing puppet from msi packages
     install_from_git(host, "/opt/puppet-git-repos",
                      :name => 'puppet-win32-ruby',
-                     :path => build_giturl('puppet-win32-ruby'))
+                     :path => build_giturl('puppet-win32-ruby'),
+                     :rev => lookup_in_env('WIN32_RUBY_SHA', 'puppet-win32-ruby', ''))
     on host, 'cd /opt/puppet-git-repos/puppet-win32-ruby; cp -r ruby/* /'
     on host, 'cd /lib; icacls ruby /grant "Everyone:(OI)(CI)(RX)"'
     on host, 'cd /lib; icacls ruby /reset /T'


### PR DESCRIPTION
- Previously, Jenkins acceptance jobs on Windows would clone Windows
  source for puppet-win32-ruby, the vendored Ruby that we ship as part
  of Windows MSI builds.  This comes from an internal git mirror.
- At present, a simple checkout is performed against whatever is the
  'default' branch (typically the 1.9.3 branch).  Unfortunately, this
  will not work for any acceptance jobs that intend to use 2.0, and it
  currently doesn't work for jobs that need new versions of gems.
- Rather than take a clone the repo and hope it works approach, make
  use of Beaker's 'rev' option when calling install_from_git.
  https://github.com/puppetlabs/beaker/blob/beaker1.11.2/lib/beaker/dsl/install_utils.rb#L106
- Using :rev allows us to pin the repo version by using an environment
  variable that can be setup in the Jenkins job.  This variable is
  called WIN32_RUBY_SHA, but realistically can use a git commit-ish as
  specified in the git documentation for checkout -f
  https://www.kernel.org/pub/software/scm/git/docs/git-checkout.html
  It will accept a branch, tag, SHA, etc
- The default :rev is set to '' so that prior behavior is preserved
