### PR TITLE
(PUP-2828) puppet-win32-ruby acceptance ver config

### DIFF
--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -38,11 +38,31 @@ install_packages_on(hosts, PACKAGES, :check_if_exists => true)
 hosts.each do |host|
   case host['platform']
   when /windows/
-    step "#{host} Install ruby from git"
+    arch = lookup_in_env('WIN32_RUBY_ARCH', 'puppet-win32-ruby', 'x86')
+    step "#{host} Selected architecture #{arch}"
+
+    step "#{host} Loading git commit-ish to use for Windows Ruby"
+    version_defs_file = '../../../../ext/windows/versions.yaml'
+    raise "Unable to find yaml config at #{version_defs_file}:" if ! File.exist?(version_defs_file)
+
+    begin
+      require 'yaml'
+      @version_defs ||= YAML.load_file(version_defs_file)
+    rescue Exception => e
+      STDERR.puts "Unable to load yaml from #{version_defs_file}:"
+      STDERR.puts e
+      raise
+    end
+
+    revision = @version_defs['git_dependencies'][arch]['puppet_win32_ruby_sha']
+    raise "Could not find #{arch} architecture git revision for puppet-win32-ruby in #{version_defs_file}" if revision.nil?
+
+    step "#{host} Install ruby from git - revision #{revision}"
     # TODO remove this step once we are installing puppet from msi packages
     install_from_git(host, "/opt/puppet-git-repos",
                      :name => 'puppet-win32-ruby',
-                     :path => build_giturl('puppet-win32-ruby'))
+                     :path => build_giturl('puppet-win32-ruby'),
+                     :rev => revision)
     on host, 'cd /opt/puppet-git-repos/puppet-win32-ruby; cp -r ruby/* /'
     on host, 'cd /lib; icacls ruby /grant "Everyone:(OI)(CI)(RX)"'
     on host, 'cd /lib; icacls ruby /reset /T'

--- a/ext/windows/versions.yaml
+++ b/ext/windows/versions.yaml
@@ -1,0 +1,7 @@
+# pin to specific versions of puppet-win32-ruby repository
+# these vendored bits are used by packaging and acceptance tests
+git_dependencies:
+  x86:
+    puppet_win32_ruby_sha: '1.9.3-p484.3'
+  x64:
+    puppet_win32_ruby_sha: '2.0.0-x64'


### PR DESCRIPTION
- Previously, Jenkins acceptance jobs on Windows would clone Windows
  source for puppet-win32-ruby, the vendored Ruby that we ship as part
  of Windows MSI builds.  This comes from an internal git mirror.
- At present, a simple checkout is performed against whatever is the
  'default' branch (typically the 1.9.3 branch).  Unfortunately, this
  will not work for any acceptance jobs that intend to use 2.0, and it
  currently doesn't work for jobs that need new versions of gems.
- Rather than take a 'clone the repo and hope it works' approach, make
  use of Beaker's :rev option when calling install_from_git.
  https://github.com/puppetlabs/beaker/blob/beaker1.11.2/lib/beaker/dsl/install_utils.rb#L106
- Using :rev allows us to pin the repo version by using an environment
  variable that can be setup in the Jenkins job.  Track the relevant
  SHAs with the modified code so that dependent versions are tracked
  in the source tree, rather than through transient Jenkins jobs.
- To allow the jobs to build a particular architecture, introduce a
  new environment variable called WIN32_RUBY_ARCH that can be used to
  select either 'x86' or 'x64'.  If an arch is not specified, fall
  back to 'x86', but if the appropriate :rev is not specified, kill
  the setup step.
