### PR TITLE
(PUP-2833) Make all types inherit PAnyType

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -55,7 +55,7 @@ module Puppet::Pops::Types
   # The type of types.
   # @api public
   class PType < PAnyType
-    contains_one_uni 'type', PAbstractType
+    contains_one_uni 'type', PAnyType
     module ClassModule
       def hash
         [self.class, type].hash
@@ -86,7 +86,7 @@ module Puppet::Pops::Types
   # A flexible type describing an any? of other types
   # @api public
   class PVariantType < PAnyType
-    contains_many_uni 'types', PAbstractType, :lowerBound => 1
+    contains_many_uni 'types', PAnyType, :lowerBound => 1
 
     module ClassModule
 
@@ -254,7 +254,7 @@ module Puppet::Pops::Types
 
   # @api public
   class PCollectionType < PAnyType
-    contains_one_uni 'element_type', PAbstractType
+    contains_one_uni 'element_type', PAnyType
     contains_one_uni 'size_type', PIntegerType
 
     module ClassModule
@@ -282,7 +282,7 @@ module Puppet::Pops::Types
 
   class PStructElement < Puppet::Pops::Model::PopsObject
     has_attr 'name', String, :lowerBound => 1
-    contains_one_uni 'type', PAbstractType
+    contains_one_uni 'type', PAnyType
 
     module ClassModule
       def hash
@@ -322,7 +322,7 @@ module Puppet::Pops::Types
 
   # @api public
   class PTupleType < PAnyType
-    contains_many_uni 'types', PAbstractType, :lowerBound => 1
+    contains_many_uni 'types', PAnyType, :lowerBound => 1
     # If set, describes min and max required of the given types - if max > size of
     # types, the last type entry repeats
     #
@@ -367,7 +367,7 @@ module Puppet::Pops::Types
     # Although being an abstract type reference, only PAbstractCallable, and Optional[Callable] are supported
     # If not set, the meaning is that block is not supported.
     #
-    contains_one_uni 'block_type', PAbstractType, :lowerBound => 0
+    contains_one_uni 'block_type', PAnyType, :lowerBound => 0
 
     module ClassModule
       # Returns the number of accepted arguments [min, max]
@@ -419,7 +419,7 @@ module Puppet::Pops::Types
 
   # @api public
   class PHashType < PCollectionType
-    contains_one_uni 'key_type', PAbstractType
+    contains_one_uni 'key_type', PAnyType
     module ClassModule
       def hash
         [self.class, key_type, self.element_type, self.size_type].hash
@@ -489,7 +489,7 @@ module Puppet::Pops::Types
   # Represents a type that accept PNilType instead of the type parameter
   # required_type - is a short hand for Variant[T, Undef]
   #
-  class POptionalType < PAbstractType
+  class POptionalType < PAnyType
     contains_one_uni 'optional_type', PAbstractType
     module ClassModule
       def hash

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -112,6 +112,7 @@ describe 'The type calculator' do
         Puppet::Pops::Types::PTupleType,
         Puppet::Pops::Types::PCallableType,
         Puppet::Pops::Types::PType,
+        Puppet::Pops::Types::POptionalType,
       ]
     end
 
@@ -989,16 +990,25 @@ describe 'The type calculator' do
   context 'when testing if x is instance of type t' do
     include_context "types_setup"
 
-    it 'should consider undef to be instance of Object and NilType' do
+    it 'should consider undef to be instance of Any, NilType, and optional' do
       calculator.instance?(Puppet::Pops::Types::PNilType.new(), nil).should    == true
       calculator.instance?(Puppet::Pops::Types::PAnyType.new(), nil).should == true
+      calculator.instance?(Puppet::Pops::Types::POptionalType.new(), nil).should == true
+    end
+
+    it 'all types should be (ruby) instance of PAnyType' do
+      all_types.each do |t|
+        t.new.is_a?(Puppet::Pops::Types::PAnyType).should == true
+      end
     end
 
     it 'should not consider undef to be an instance of any other type than Object and NilType and Data' do
       types_to_test = all_types - [ 
         Puppet::Pops::Types::PAnyType,
         Puppet::Pops::Types::PNilType,
-        Puppet::Pops::Types::PDataType]
+        Puppet::Pops::Types::PDataType,
+        Puppet::Pops::Types::POptionalType,
+        ]
 
       types_to_test.each {|t| calculator.instance?(t.new, nil).should == false }
       types_to_test.each {|t| calculator.instance?(t.new, :undef).should == false }


### PR DESCRIPTION
Some types inherited PAbstractType (to indicate they where not
concrete). This just causes confusion when using the Ruby API
to check if a Type is PAnyType.

This makes all types inherit from PAnyType (which is the only
type inheriting from PAbstractType).
