### PR TITLE
(PUP-2825) Refactor Ruby[type_name] type to Runtime[ruby, type_name]

### DIFF
--- a/lib/puppet/pops/binder/bindings_factory.rb
+++ b/lib/puppet/pops/binder/bindings_factory.rb
@@ -318,7 +318,7 @@ module Puppet::Pops::Binder::BindingsFactory
     # @overload instance_of(c)
     #   @param c [Class] the Class to base the type on.
     #   Sets the type based on the given ruby class. The result is one of the specific puppet types
-    #   if the class can be represented by a specific type, or the open ended PRubyType otherwise.
+    #   if the class can be represented by a specific type, or the open ended PRuntimeType otherwise.
     # @overload instance_of(s)
     #   The same as using a class, but instead of giving a class instance, the class is expressed using its fully
     #   qualified name. This method of specifying the type allows late binding (the class does not have to be loaded

--- a/lib/puppet/pops/binder/injector.rb
+++ b/lib/puppet/pops/binder/injector.rb
@@ -562,7 +562,7 @@ module Private
     #
     def assistable_injected_class(key)
       kt = key_factory.get_type(key)
-      return nil unless kt.is_a?(Puppet::Pops::Types::PRubyType) && !key_factory.is_named?(key)
+      return nil unless kt.is_a?(Puppet::Pops::Types::PRuntimeType) && kt.runtime == :ruby && !key_factory.is_named?(key)
       type_calculator.injectable_class(kt)
     end
 

--- a/lib/puppet/pops/binder/key_factory.rb
+++ b/lib/puppet/pops/binder/key_factory.rb
@@ -54,7 +54,7 @@ class Puppet::Pops::Binder::KeyFactory
 
   # @api public
   def is_ruby?(key)
-    return key.is_a?(Array) && key[0].is_a?(Puppet::Pops::Types::PRubyType)
+    key.is_a?(Array) && key[0].is_a?(Puppet::Pops::Types::PRuntimeType) && key[0].runtime == :ruby
   end
 
   # Returns the type of the key

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -289,11 +289,11 @@ class Puppet::Pops::Evaluator::AccessOperator
     end
   end
 
-  def access_PRubyType(o, scope, keys)
+  def access_PRuntimeType(o, scope, keys)
     keys.flatten!
-    assert_keys(keys, o, 1, 1, String)
-    # create ruby type based on name of class, not inference of key's type
-    Puppet::Pops::Types::TypeFactory.ruby_type(keys[0])
+    assert_keys(keys, o, 2, 2, String, String)
+    # create runtime type based on runtime and name of class, (not inference of key's type)
+    Puppet::Pops::Types::TypeFactory.runtime(*keys)
   end
 
   def access_PIntegerType(o, scope, keys)

--- a/lib/puppet/pops/types/class_loader.rb
+++ b/lib/puppet/pops/types/class_loader.rb
@@ -36,27 +36,38 @@ class Puppet::Pops::Types::ClassLoader
 
   def self.provide_from_type(type)
     case type
-    when Puppet::Pops::Types::PRubyType
-      provide_from_string(type.ruby_class)
+    when Puppet::Pops::Types::PRuntimeType
+      raise ArgumentError.new("Only Runtime type 'ruby' is supported, got #{type.runtime}") unless type.runtime == :ruby
+      provide_from_string(type.runtime_type_name)
 
     when Puppet::Pops::Types::PBooleanType
       # There is no other thing to load except this Enum meta type
       RGen::MetamodelBuilder::MMBase::Boolean
 
     when Puppet::Pops::Types::PType
-      # TODO: PType should have a type argument (a PAnyType)
+      # TODO: PType should has a type argument (a PAnyType) so the Class' class could be returned
+      #       (but this only matters in special circumstances when meta programming has been used).
       Class
+
+    when Puppet::Pops::Type::POptionalType
+      # cannot make a distinction between optional and its type
+      provide_from_type(type.optional_type)
 
     # Although not expected to be the first choice for getting a concrete class for these
     # types, these are of value if the calling logic just has a reference to type.
     #
-    when Puppet::Pops::Types::PArrayType   ; Array
-    when Puppet::Pops::Types::PHashType    ; Hash
-    when Puppet::Pops::Types::PRegexpType  ; Regexp
-    when Puppet::Pops::Types::PIntegerType ; Integer
-    when Puppet::Pops::Types::PStringType  ; String
-    when Puppet::Pops::Types::PFloatType   ; Float
-    when Puppet::Pops::Types::PNilType     ; NilClass
+    when Puppet::Pops::Types::PArrayType    ; Array
+    when Puppet::Pops::Types::PTupleType    ; Array
+    when Puppet::Pops::Types::PHashType     ; Hash
+    when Puppet::Pops::Types::PStructType   ; Hash
+    when Puppet::Pops::Types::PRegexpType   ; Regexp
+    when Puppet::Pops::Types::PIntegerType  ; Integer
+    when Puppet::Pops::Types::PStringType   ; String
+    when Puppet::Pops::Types::PPatternType  ; String
+    when Puppet::Pops::Types::PEnumType     ; String
+    when Puppet::Pops::Types::PFloatType    ; Float
+    when Puppet::Pops::Types::PNilType      ; NilClass
+    when Puppet::Pops::Types::PCallableType ; Proc
     else
       nil
     end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -67,16 +67,20 @@
 # type by looking at the Ruby class of the types this is considered an implementation detail, and such checks should in general
 # be performed by the type_calculator which implements the type system semantics.
 #
-# The PRubyType
+# The PRuntimeType
 # -------------
-# The PRubyType corresponds to a Ruby Class, except for the puppet types that are specialized (i.e. PRubyType should not be
-# used for Integer, String, etc. since there are specialized types for those).
-# When the type calculator deals with PRubyTypes and checks for assignability, it determines the "common ancestor class" of two classes.
-# This check is made based on the superclasses of the two classes being compared. In order to perform this, the classes must be present
-# (i.e. they are resolved from the string form in the PRubyType to a loaded, instantiated Ruby Class). In general this is not a problem,
-# since the question to produce the common super type for two objects means that the classes must be present or there would have been
-# no instances present in the first place. If however the classes are not present, the type calculator will fall back and state that
-# the two types at least have Object in common.
+# The PRuntimeType corresponds to a type in the runtime system (currently only supported runtime is 'ruby'). The
+# type has a runtime_type_name that corresponds to a Ruby Class name.
+# A Runtime[ruby] type can be used to describe any ruby class except for the puppet types that are specialized
+# (i.e. PRuntimeType should not be used for Integer, String, etc. since there are specialized types for those).
+# When the type calculator deals with PRuntimeTypes and checks for assignability, it determines the
+# "common ancestor class" of two classes.
+# This check is made based on the superclasses of the two classes being compared. In order to perform this, the
+# classes must be present (i.e. they are resolved from the string form in the PRuntimeType to a
+# loaded, instantiated Ruby Class). In general this is not a problem, since the question to produce the common
+# super type for two objects means that the classes must be present or there would have been
+# no instances present in the first place. If however the classes are not present, the type
+# calculator will fall back and state that the two types at least have Any in common.
 #
 # @see Puppet::Pops::Types::TypeFactory TypeFactory for how to create instances of types
 # @see Puppet::Pops::Types::TypeParser TypeParser how to construct a type instance from a String
@@ -86,7 +90,7 @@
 # -----
 # The type calculator can be directly used via its class methods. If doing time critical work and doing many
 # calls to the type calculator, it is more performant to create an instance and invoke the corresponding
-# instance methods. Note that inference is an expensive operation, rather than infering the same thing
+# instance methods. Note that inference is an expensive operation, rather than inferring the same thing
 # several times, it is in general better to infer once and then copy the result if mutation to a more generic form is
 # required.
 #
@@ -233,18 +237,18 @@ class Puppet::Pops::Types::TypeCalculator
   # A class is injectable if it has a special *assisted inject* class method called `inject` taking
   # an injector and a scope as argument, or if it has a zero args `initialize` method.
   #
-  # @param klazz [Class, PRubyType] the class/type to check if it is injectable
+  # @param klazz [Class, PRuntimeType] the class/type to check if it is injectable
   # @return [Class, nil] the injectable Class, or nil if not injectable
   # @api public
   #
   def injectable_class(klazz)
     # Handle case when we get a PType instead of a class
-    if klazz.is_a?(Types::PRubyType)
+    if klazz.is_a?(Types::PRuntimeType)
       klazz = Puppet::Pops::Types::ClassLoader.provide(klazz)
     end
 
-    # data types can not be injected (check again, it is not safe to assume that given RubyType klazz arg was ok)
-    return false unless type(klazz).is_a?(Types::PRubyType)
+    # data types can not be injected (check again, it is not safe to assume that given RubyRuntime klazz arg was ok)
+    return false unless type(klazz).is_a?(Types::PRuntimeType)
     if (klazz.respond_to?(:inject) && klazz.method(:inject).arity() == -4) || klazz.instance_method(:initialize).arity() == 0
       klazz
     else
@@ -326,8 +330,7 @@ class Puppet::Pops::Types::TypeCalculator
       type.key_type = Types::PScalarType.new()
       type.element_type = Types::PDataType.new()
     else
-      type = Types::PRubyType.new()
-      type.ruby_class = c.name
+      type = Types::PRuntimeType.new(:runtime => :ruby, :runtime_type_name => c.name)
     end
     type
   end
@@ -616,11 +619,13 @@ class Puppet::Pops::Types::TypeCalculator
       return type
     end
 
-    if t1.is_a?(Types::PRubyType) && t2.is_a?(Types::PRubyType)
-      if t1.ruby_class == t2.ruby_class
+    # If both are Runtime types
+    if t1.is_a?(Types::PRuntimeType) && t2.is_a?(Types::PRuntimeType)
+      if t1.runtime == t2.runtime && t1.runtime_type_name == t2.runtime_type_name
         return t1
       end
       # finding the common super class requires that names are resolved to class
+      # NOTE: This only supports runtime type of :ruby
       c1 = Types::ClassLoader.provide_from_type(t1)
       c2 = Types::ClassLoader.provide_from_type(t2)
       if c1 && c2
@@ -628,17 +633,15 @@ class Puppet::Pops::Types::TypeCalculator
         superclasses(c1).each do|c1_super|
           c2_superclasses.each do |c2_super|
             if c1_super == c2_super
-              result = Types::PRubyType.new()
-              result.ruby_class = c1_super.name
-              return result
+              return Types::PRuntimeType.new(:runtime => :ruby, :runtime_type_name => c1_super.name)
             end
           end
         end
       end
     end
-    # If both are RubyObjects
 
-    if common_pobject?(t1, t2)
+    # They better both be Any type, or the wrong thing was asked and nil is returned
+    if t1.is_a?(Types::PAnyType) && t2.is_a?(Types::PAnyType)
       return Types::PAnyType.new()
     end
   end
@@ -701,9 +704,7 @@ class Puppet::Pops::Types::TypeCalculator
 
   # @api private
   def infer_Object(o)
-    type = Types::PRubyType.new()
-    type.ruby_class = o.class.name
-    type
+    Types::PRuntimeType.new(:runtime => :ruby, :runtime_type_name => o.class.name)
   end
 
   # The type of all types is PType
@@ -1315,14 +1316,18 @@ class Puppet::Pops::Types::TypeCalculator
     t2.is_a?(Types::PDataType) || assignable?(@data_variant_t, t2)
   end
 
-  # Assignable if t2's ruby class is same or subclass of t1's ruby class
+  # Assignable if t2's has the same runtime and the runtime name resolves to
+  # a class that is the same or subclass of t1's resolved runtime type name
   # @api private
-  def assignable_PRubyType(t1, t2)
-    return false unless t2.is_a?(Types::PRubyType)
-    return true if t1.ruby_class.nil?   # t1 is wider
-    return false if t2.ruby_class.nil?  # t1 not nil, so t2 can not be wider
-    c1 = class_from_string(t1.ruby_class)
-    c2 = class_from_string(t2.ruby_class)
+  def assignable_PRuntimeType(t1, t2)
+    return false unless t2.is_a?(Types::PRuntimeType)
+    return false unless t1.runtime == t2.runtime
+    return true if t1.runtime_type_name.nil?   # t1 is wider
+    return false if t2.runtime_type_name.nil?  # t1 not nil, so t2 can not be wider
+
+    # NOTE: This only supports Ruby, must change when/if the set of runtimes is expanded
+    c1 = class_from_string(t1.runtime_type_name)
+    c2 = class_from_string(t2.runtime_type_name)
     return false unless c1.is_a?(Class) && c2.is_a?(Class)
     !!(c2 <= c1)
   end
@@ -1346,6 +1351,9 @@ class Puppet::Pops::Types::TypeCalculator
 
   # @api private
   def string_String(t)       ; t         ; end
+
+  # @api private
+  def string_Symbol(t)       ; t.to_s    ; end
 
   # @api private
   def string_PAnyType(t)  ; "Any"  ; end
@@ -1495,7 +1503,7 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   # @api private
-  def string_PRubyType(t)   ; "Ruby[#{string(t.ruby_class)}]"  ; end
+  def string_PRuntimeType(t)   ; "Runtime[#{string(t.runtime)}, #{string(t.runtime_type_name)}]"  ; end
 
   # @api private
   def string_PArrayType(t)
@@ -1596,7 +1604,4 @@ class Puppet::Pops::Types::TypeCalculator
     assignable?(@numeric_t, t1) && assignable?(@numeric_t, t2)
   end
 
-  def common_pobject?(t1, t2)
-    assignable?(@t, t1) && assignable?(@t, t2)
-  end
 end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -347,9 +347,7 @@ module Puppet::Pops::Types::TypeFactory
     elsif o.is_a?(Types::PAbstractType)
       o
     elsif o.is_a?(String)
-      type = Types::PRubyType.new()
-      type.ruby_class = o
-      type
+      Types::PRuntimeType.new(:runtime => :ruby, :runtime_type_name => o)
     else
       @type_calculator.infer_generic(o)
     end
@@ -370,9 +368,7 @@ module Puppet::Pops::Types::TypeFactory
     if o.is_a?(Class)
       @type_calculator.type(o)
     else
-      type = Types::PRubyType.new()
-      type.ruby_class = o.class.name
-      type
+      Types::PRuntimeType.new(:runtime => :ruby, :runtime_type_name => o.class.name)
     end
   end
 
@@ -380,9 +376,15 @@ module Puppet::Pops::Types::TypeFactory
   # Also see ruby(o) which performs inference, or mapps a Ruby Class to its name.
   #
   def self.ruby_type(class_name = nil)
-    type = Types::PRubyType.new()
-    type.ruby_class = class_name
-    type
+    Types::PRuntimeType.new(:runtime => :ruby, :runtime_type_name => class_name)
+  end
+
+  # Generic creator of a RuntimeType - allows creating the type with nil or String runtime_type_name.
+  # Also see ruby_type(o) and ruby(o).
+  #
+  def self.runtime(runtime=nil, runtime_type_name = nil)
+    runtime = runtime.to_sym if runtime.is_a?(String)
+    Types::PRuntimeType.new(:runtime => runtime, :runtime_type_name => runtime_type_name)
   end
 
   # Sets the accepted size range of a collection if something other than the default 0 to Infinity

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -173,8 +173,8 @@ class Puppet::Pops::Types::TypeParser
     when "optional"
       TYPES.optional()
 
-    when "ruby"
-      TYPES.ruby_type()
+    when "runtime"
+      TYPES.runtime()
 
     when "type"
       TYPES.type_type()
@@ -414,9 +414,9 @@ class Puppet::Pops::Types::TypeParser
       assert_type(parameters[0])
       TYPES.type_type(parameters[0])
 
-    when "ruby"
-      raise_invalid_parameters_error("Ruby", "1", parameters.size) unless parameters.size == 1
-      TYPES.ruby_type(parameters[0])
+    when "runtime"
+      raise_invalid_parameters_error("Runtime", "2", parameters.size) unless parameters.size == 2
+      TYPES.runtime(*parameters)
 
     else
       # It is a resource such a File['/tmp/foo']

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -434,16 +434,20 @@ module Puppet::Pops::Types
     end
   end
 
+  RuntimeEnum = RGen::MetamodelBuilder::DataTypes::Enum.new([:'ruby', ])
+
   # @api public
-  class PRubyType < PAnyType
-    has_attr 'ruby_class', String
+  class PRuntimeType < PAnyType
+    has_attr 'runtime', RuntimeEnum, :lowerBound => 1
+    has_attr 'runtime_type_name', String
+
     module ClassModule
       def hash
-        [self.class, ruby_class].hash
+        [self.class, runtime, runtime_type_name].hash
       end
 
       def ==(o)
-        self.class == o.class && ruby_class == o.ruby_class
+        self.class == o.class && runtime == o.runtime && runtime_type_name == o.runtime_type_name 
       end
     end
   end

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -415,12 +415,12 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
     # Ruby Type
     #
     it 'creates a Ruby Type instance when applied to a Ruby Type' do
-      type_expr = fqr('Ruby')['String']
+      type_expr = fqr('Runtime')['ruby','String']
       tf = Puppet::Pops::Types::TypeFactory
       expect(evaluate(type_expr)).to eql(tf.ruby_type('String'))
 
       # arguments are flattened
-      type_expr = fqr('Ruby')[['String']]
+      type_expr = fqr('Runtime')[['ruby', 'String']]
       expect(evaluate(type_expr)).to eql(tf.ruby_type('String'))
     end
 

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -102,7 +102,7 @@ describe 'The type calculator' do
         Puppet::Pops::Types::PCollectionType,
         Puppet::Pops::Types::PArrayType,
         Puppet::Pops::Types::PHashType,
-        Puppet::Pops::Types::PRubyType,
+        Puppet::Pops::Types::PRuntimeType,
         Puppet::Pops::Types::PHostClassType,
         Puppet::Pops::Types::PResourceType,
         Puppet::Pops::Types::PPatternType,
@@ -220,13 +220,14 @@ describe 'The type calculator' do
       calculator.infer(:undef).class.should == Puppet::Pops::Types::PNilType
     end
 
-    it 'an instance of class Foo translates to PRubyType[Foo]' do
+    it 'an instance of class Foo translates to PRuntimeType[ruby, Foo]' do
       class Foo
       end
 
       t = calculator.infer(Foo.new)
-      t.class.should == Puppet::Pops::Types::PRubyType
-      t.ruby_class.should == 'Foo'
+      t.class.should == Puppet::Pops::Types::PRuntimeType
+      t.runtime.should == :ruby
+      t.runtime_type_name.should == 'Foo'
     end
 
     context 'array' do
@@ -329,17 +330,18 @@ describe 'The type calculator' do
         calculator.infer({:first => 1, :second => 2}).class.should == Puppet::Pops::Types::PHashType
       end
 
-      it 'with symbolic keys translates to PHashType[PRubyType[Symbol],value]' do
+      it 'with symbolic keys translates to PHashType[PRuntimeType[ruby, Symbol], value]' do
         k = calculator.infer({:first => 1, :second => 2}).key_type
-        k.class.should == Puppet::Pops::Types::PRubyType
-        k.ruby_class.should == 'Symbol'
+        k.class.should == Puppet::Pops::Types::PRuntimeType
+        k.runtime.should == :ruby
+        k.runtime_type_name.should == 'Symbol'
       end
 
-      it 'with string keys translates to PHashType[PStringType,value]' do
+      it 'with string keys translates to PHashType[PStringType, value]' do
         calculator.infer({'first' => 1, 'second' => 2}).key_type.class.should == Puppet::Pops::Types::PStringType
       end
 
-      it 'with fixnum values translates to PHashType[key,PIntegerType]' do
+      it 'with fixnum values translates to PHashType[key, PIntegerType]' do
         calculator.infer({:first => 1, :second => 2}).element_type.class.should == Puppet::Pops::Types::PIntegerType
       end
     end
@@ -1455,7 +1457,7 @@ describe 'The type calculator' do
       calculator.infer(Puppet::Pops::Types::PCollectionType.new()).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PArrayType.new()     ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PHashType.new()      ).is_a?(ptype).should() == true
-      calculator.infer(Puppet::Pops::Types::PRubyType.new()      ).is_a?(ptype).should() == true
+      calculator.infer(Puppet::Pops::Types::PRuntimeType.new()   ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PHostClassType.new() ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PResourceType.new()  ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PEnumType.new()      ).is_a?(ptype).should() == true
@@ -1480,7 +1482,7 @@ describe 'The type calculator' do
       calculator.string(calculator.infer(Puppet::Pops::Types::PCollectionType.new())).should == "Type[Collection]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PArrayType.new()     )).should == "Type[Array[?]]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PHashType.new()      )).should == "Type[Hash[?, ?]]"
-      calculator.string(calculator.infer(Puppet::Pops::Types::PRubyType.new()      )).should == "Type[Ruby[?]]"
+      calculator.string(calculator.infer(Puppet::Pops::Types::PRuntimeType.new()   )).should == "Type[Runtime[?, ?]]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PHostClassType.new() )).should == "Type[Class]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PResourceType.new()  )).should == "Type[Resource]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PEnumType.new()      )).should == "Type[Enum]"

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -150,10 +150,11 @@ describe 'The type factory' do
       ht.element_type.class.should == Puppet::Pops::Types::PDataType
     end
 
-    it 'ruby(1) returns PRubyType[\'Fixnum\']' do
+    it 'ruby(1) returns PRuntimeType[ruby, \'Fixnum\']' do
       ht = Puppet::Pops::Types::TypeFactory.ruby(1)
-      ht.class().should == Puppet::Pops::Types::PRubyType
-      ht.ruby_class.should == 'Fixnum'
+      ht.class().should == Puppet::Pops::Types::PRuntimeType
+      ht.runtime.should == :ruby
+      ht.runtime_type_name.should == 'Fixnum'
     end
 
     it 'a size constrained collection can be created from array' do

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -172,7 +172,7 @@ describe Puppet::Pops::Types::TypeParser do
   end
 
   it 'parses a ruby type' do
-    expect(parser.parse("Ruby['Integer']")).to be_the_type(types.ruby_type('Integer'))
+    expect(parser.parse("Runtime[ruby, 'Integer']")).to be_the_type(types.ruby_type('Integer'))
   end
 
   it 'parses a callable type' do


### PR DESCRIPTION
This changes the type Ruby[class_name] to the more generic
Runtime[ruby, runtime_type_name] to avoid squatting on open
set of names for potential runtimes which may clash with managment
of the same runtime via a Puppet class or define.

After this change, all references in .pp logic to `Ruby[name]` should be replaced
with `Runtime['ruby',name]`. (This only affects those that have played with the advanced features
of the binder).
