### PR TITLE
(PUP-2843) Fix constants on Windows x64

### DIFF
--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -130,7 +130,8 @@ module Puppet::Util::Windows::File
   end
   module_function :set_attributes
 
-  INVALID_HANDLE_VALUE = -1 #define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)
+  #define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)
+  INVALID_HANDLE_VALUE = FFI::Pointer.new(-1).address
   def self.create_file(file_name, desired_access, share_mode, security_attributes,
     creation_disposition, flags_and_attributes, template_file_handle)
 

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -474,8 +474,6 @@ module Puppet::Util::Windows::Security
     dacl
   end
 
-  INVALID_HANDLE_VALUE = FFI::Pointer.new(-1).address
-
   # Open an existing file with the specified access mode, and execute a
   # block with the opened file HANDLE.
   def open_file(path, access, &block)
@@ -488,7 +486,10 @@ module Puppet::Util::Windows::Security
              FILE::FILE_FLAG_OPEN_REPARSE_POINT | FILE::FILE_FLAG_BACKUP_SEMANTICS,
              FFI::Pointer::NULL_HANDLE) # template
 
-    raise Puppet::Util::Windows::Error.new("Failed to open '#{path}'") if handle == INVALID_HANDLE_VALUE
+    if handle == Puppet::Util::Windows::File::INVALID_HANDLE_VALUE
+      raise Puppet::Util::Windows::Error.new("Failed to open '#{path}'")
+    end
+
     begin
       yield handle
     ensure


### PR DESCRIPTION
- Previous definition in Puppet::Util::Windows::File would work on x86
  but not x64.  Adjust the constant, and share the constant with
  Puppet::Util::Windows::Security.
