### PR TITLE
(PUP-2654) Capitalize each segment of a resource type "label"

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -1527,9 +1527,9 @@ class Puppet::Pops::Types::TypeCalculator
   def string_PResourceType(t)
     if t.type_name
       if t.title
-        "#{t.type_name.capitalize}['#{t.title}']"
+        "#{capitalize_segments(t.type_name)}['#{t.title}']"
       else
-        "#{t.type_name.capitalize}"
+        capitalize_segments(t.type_name)
       end
     else
       "Resource"
@@ -1573,6 +1573,10 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   private
+
+  def capitalize_segments(s)
+    s.split(/::/).map(&:capitalize).join('::')
+  end
 
   def class_from_string(str)
     begin

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1489,6 +1489,10 @@ describe 'The type calculator' do
       calculator.string(calculator.infer(Puppet::Pops::Types::PTupleType.new()     )).should == "Type[Tuple]"
       calculator.string(calculator.infer(Puppet::Pops::Types::POptionalType.new()  )).should == "Type[Optional]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PCallableType.new()  )).should == "Type[Callable]"
+
+      calculator.infer(Puppet::Pops::Types::PResourceType.new(:type_name => 'foo::fee::fum')).to_s.should == "Type[Foo::Fee::Fum]"
+      calculator.string(calculator.infer(Puppet::Pops::Types::PResourceType.new(:type_name => 'foo::fee::fum'))).should == "Type[Foo::Fee::Fum]"
+      calculator.infer(Puppet::Pops::Types::PResourceType.new(:type_name => 'Foo::Fee::Fum')).to_s.should == "Type[Foo::Fee::Fum]"
     end
 
     it "computes the common type of PType's type parameter" do


### PR DESCRIPTION
When a Resource type is stringified it selects the short notation
(e.g. Fee::Foo) over the longer (e.g. Resource[Fee::Foo]), and
when doing so it should output each segment of the FQN with a
capital letter. The current implementation only capitalizes
the initial letter (e.g. Fee::foo::fum).

This fixes the implementation of
TypeCalculator.string_PResourceExpression to capitalize all segments.
