### PR TITLE
(maint) Set Travis CI to run two spec runner processes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 bundler_args: --without development
-script: "bundle exec rake \"parallel:spec[1]\""
+script: "bundle exec rake \"parallel:spec[2]\""
 notifications:
   email: false
 rvm:


### PR DESCRIPTION
Setting Travis CI to use two concurrent processes for running specs.
This should hopefully speed up running specs for pull request CI.
