### PR TITLE
(PUP-1281) Don't use win32console if ruby v2

### DIFF
--- a/lib/puppet/util/colors.rb
+++ b/lib/puppet/util/colors.rb
@@ -79,8 +79,9 @@ module Puppet::Util::Colors
   # We define console_has_color? at load time since it's checking the
   # underlying platform which will not change, and we don't want to perform
   # the check every time we use logging
-  if Puppet::Util::Platform.windows?
-    # We're on windows, need win32console for color to work
+  if Puppet::Util::Platform.windows? && RUBY_VERSION =~ /^1\./
+    # We're on windows and using ruby less than v2
+    # so we need win32console for color to work
     begin
       require 'ffi'
       require 'win32console'

--- a/spec/unit/util/colors_spec.rb
+++ b/spec/unit/util/colors_spec.rb
@@ -66,4 +66,16 @@ describe Puppet::Util::Colors do
       end
     end
   end
+
+  context "on Windows in Ruby 1.x", :if => Puppet.features.microsoft_windows? && RUBY_VERSION =~ /^1./ do
+    it "should load win32console" do
+      Gem.loaded_specs["win32console"].should_not be_nil
+    end
+  end
+
+  context "on Windows in Ruby 2.x", :if => Puppet.features.microsoft_windows? && RUBY_VERSION =~ /^2./ do
+    it "should not load win32console" do
+      Gem.loaded_specs["win32console"].should be_nil
+    end
+  end
 end


### PR DESCRIPTION
Some of this work was done with PUP-2777 (support bundler workflow - see https://github.com/puppetlabs/puppet/pull/2822). That limits
win32console down to being installed/depended upon only for ruby 1.x. This builds
on top of that to only setup functions for colorizing output when using Ruby 1.x
on Windows.
