### PR TITLE
(PUP-2857) Add a type for default expression called Default.

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -397,7 +397,7 @@ class Puppet::Pops::Types::TypeCalculator
 
   def instance_of_Object(t, o)
     # Undef is Undef and Any, but nothing else when checking instance?
-    return false if (o.nil? || o == :undef) && t.class != Types::PAnyType
+    return false if (o.nil?) && t.class != Types::PAnyType
     assignable?(t, infer(o))
   end
 
@@ -451,11 +451,11 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   def instance_of_PNilType(t, o)
-    return o.nil? || o == :undef
+    return o.nil?
   end
 
   def instance_of_POptionalType(t, o)
-    return true if (o.nil? || o == :undef)
+    return true if (o.nil?)
     instance_of(t.optional_type, o)
   end
 
@@ -778,10 +778,16 @@ class Puppet::Pops::Types::TypeCalculator
     Types::PNilType.new()
   end
 
-  # Inference of :undef as PNilType, all other are Ruby[Symbol]
+  # Inference of :default as PDefaultType, and all other are Ruby[Symbol]
   # @api private
   def infer_Symbol(o)
-    o == :undef ? infer_NilClass(o) : infer_Object(o)
+    case o
+    when :default
+      Types::PDefaultType.new()
+
+    else
+      infer_Object(o)
+    end
   end
 
   # @api private
@@ -909,6 +915,12 @@ class Puppet::Pops::Types::TypeCalculator
   # @api private
   def assignable_PUnitType(t, t2)
     true
+  end
+
+  # @api private
+  def assignable_PDefaultType(t, t2)
+    # Only default is assignable to default type
+    t2.is_a?(Types::PDefaultType)
   end
 
   # @api private
@@ -1418,17 +1430,19 @@ class Puppet::Pops::Types::TypeCalculator
   # @api private
   def string_Symbol(t)       ; t.to_s    ; end
 
-  # @api private
-  def string_PAnyType(t)  ; "Any"  ; end
+  def string_PAnyType(t)     ; "Any"     ; end
 
   # @api private
   def string_PNilType(t)     ; 'Undef'   ; end
 
   # @api private
+  def string_PDefaultType(t) ; 'Default' ; end
+
+  # @api private
   def string_PBooleanType(t) ; "Boolean" ; end
 
   # @api private
-  def string_PScalarType(t) ; "Scalar" ; end
+  def string_PScalarType(t)  ; "Scalar"  ; end
 
   # @api private
   def string_PDataType(t)    ; "Data"    ; end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -265,6 +265,12 @@ module Puppet::Pops::Types::TypeFactory
     Types::PNilType.new()
   end
 
+  # Creates an instance of the Default type
+  # @api public
+  def self.default()
+    Types::PDefaultType.new()
+  end
+
   # Produces an instance of the abstract type PCatalogEntryType
   def self.catalog_entry()
     Types::PCatalogEntryType.new()

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -161,8 +161,10 @@ class Puppet::Pops::Types::TypeParser
       TYPES.catalog_entry()
 
     when "undef"
-      # Should not be interpreted as Resource type
       TYPES.undef()
+
+    when "default"
+      TYPES.default()
 
     when "any"
       TYPES.any()
@@ -404,7 +406,7 @@ class Puppet::Pops::Types::TypeParser
       assert_type(parameters[0])
       TYPES.optional(parameters[0])
 
-    when "any", "data", "catalogentry", "boolean", "scalar", "undef", "numeric"
+    when "any", "data", "catalogentry", "boolean", "scalar", "undef", "numeric", "default"
       raise_unparameterized_type_error(parameterized_ast.left_expr)
 
     when "type"

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -71,9 +71,14 @@ module Puppet::Pops::Types
   class PNilType < PAnyType
   end
 
+
   # A type private to the type system that describes "ignored type" - i.e. "I am what you are"
   # @api private
   class  PUnitType < PAnyType
+  end
+
+  # @api public
+  class PDefaultType < PAnyType
   end
 
   # A flexible data type, being assignable to its subtypes as well as PArrayType and PHashType with element type assignable to PDataType.

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -67,6 +67,10 @@ describe 'The type factory' do
       Puppet::Pops::Types::TypeFactory.undef().class().should == Puppet::Pops::Types::PNilType
     end
 
+    it 'default() returns PDefaultType' do
+      Puppet::Pops::Types::TypeFactory.default().class().should == Puppet::Pops::Types::PDefaultType
+    end
+
     it 'range(to, from) returns PIntegerType' do
       t = Puppet::Pops::Types::TypeFactory.range(1,2)
       t.class().should == Puppet::Pops::Types::PIntegerType

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Pops::Types::TypeParser do
   end
 
   [
-    'Any', 'Data', 'CatalogEntry', 'Boolean', 'Scalar', 'Undef', 'Numeric',
+    'Any', 'Data', 'CatalogEntry', 'Boolean', 'Scalar', 'Undef', 'Numeric', 'Default'
   ].each do |name|
     it "does not support parameterizing unparameterized type <#{name}>" do
       expect { parser.parse("#{name}[Integer]") }.to raise_unparameterized_error_for(name)
@@ -51,6 +51,7 @@ describe Puppet::Pops::Types::TypeParser do
     expect(the_type_parsed_from(types.tuple)).to be_the_type(types.tuple)
     expect(the_type_parsed_from(types.struct)).to be_the_type(types.struct)
     expect(the_type_parsed_from(types.optional)).to be_the_type(types.optional)
+    expect(the_type_parsed_from(types.default)).to be_the_type(types.default)
   end
 
   it "interprets an unparameterized Array as an Array of Data" do


### PR DESCRIPTION
Before this change, the special value produced by a default expression
was treated as a Ruby['Symbol'](later changed to Runtime['ruby',
'Symbol']). This commit changes this to produce an instance of a
new type called Default.

The Default type is an Any, but is not assignable to anything else.

This commit also includes improvements to the testing of undef.
