### PR TITLE
(PUP-2867) Support ~ in file paths, allows to deploy to ~<user> directories

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -51,7 +51,7 @@ Puppet::Type.newtype(:file) do
     isnamevar
 
     validate do |value|
-      unless Puppet::Util.absolute_path?(value)
+      unless Puppet::Util.absolute_expanded_path?(value)
         fail Puppet::Error, "File paths must be fully qualified, not '#{value}'"
       end
     end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -241,6 +241,15 @@ module Util
   end
   module_function :absolute_path?
 
+  def absolute_expanded_path?(path, platform=nil)
+    begin
+      absolute_path?(File.expand_path(path), platform)
+    rescue ArgumentError
+      false
+    end
+  end
+  module_function :absolute_expanded_path?
+
   # Convert a path to a file URI
   def path_to_uri(path)
     return unless path

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -99,6 +99,10 @@ describe Puppet::Configurer::Downloader do
     end
 
     describe "on Windows", :as_platform => :windows do
+      before :each do
+        Puppet::Util.expects(:absolute_expanded_path?).with('C:/path').returns(true)
+      end
+
       it "should omit the owner" do
         file = generate_file_resource(:path => 'C:/path')
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -112,6 +112,26 @@ describe Puppet::Util do
     end
   end
 
+  describe "#absolute_expanded_path?" do
+    describe "when file is expanded to absolute path" do
+      it "should return true" do
+        # Catch all previous calls
+        File.stubs(:expand_path)
+        File.expects(:expand_path).with("~foo/.bar").returns("/home/foo/.bar")
+        Puppet::Util.should be_absolute_expanded_path("~foo/.bar", :posix)
+      end
+    end
+
+    describe "when expanding path raises an exception" do
+      it "should return false" do
+        # Catch all previous calls
+        File.stubs(:expand_path)
+        File.expects(:expand_path).with("~foo/.bar").raises(ArgumentError, "user foo doesn't exist")
+        Puppet::Util.should_not be_absolute_expanded_path("~foo/.bar", :posix)
+      end
+    end
+  end
+
   describe "#path_to_uri" do
     %w[. .. foo foo/bar foo/../bar].each do |path|
       it "should reject relative path: #{path}" do


### PR DESCRIPTION
  Note: validation will let ~ pass, but munging will fail if the user
    does not exist since it calls File#expand_path
