### PR TITLE
(PUP-2777) Bundler Windows x64 workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,10 @@ end
 require 'yaml'
 data = YAML.load_file(File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml'))
 bundle_platforms = data['bundle_platforms']
+x64_platform = Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 data['gem_platform_dependencies'].each_pair do |gem_platform, info|
+  next if gem_platform == 'x86-mingw32' && x64_platform
+  next if gem_platform == 'x64-mingw32' && !x64_platform
   if bundle_deps = info['gem_runtime_dependencies']
     bundle_platform = bundle_platforms[gem_platform] or raise "Missing bundle_platform"
     platform(bundle_platform.intern) do

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -29,7 +29,7 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       # Pinning versions that require native extensions
-      ffi: '1.9.0'
+      ffi: '1.9.3'
       win32-api: '1.4.8'
       win32-dir: '~> 0.4.3'
       win32-eventlog: '~> 0.5.3'
@@ -41,5 +41,16 @@ gem_platform_dependencies:
       windows-api: '~> 0.4.2'
       windows-pr: '~> 1.2.2'
       minitar: '~> 0.5.4'
+  x64-mingw32:
+    gem_runtime_dependencies:
+      ffi: '1.9.3'
+      win32-dir: '~> 0.4.8'
+      win32-eventlog: '~> 0.6.1'
+      win32-process: '~> 0.7.4'
+      win32-security: '~> 0.2.5'
+      win32-service: '0.8.4'
+      win32-taskscheduler: '~> 0.3.0'
+      minitar: '~> 0.5.4'
 bundle_platforms:
   x86-mingw32: mingw
+  x64-mingw32: x64_mingw


### PR DESCRIPTION
- Ensure that Bundler loads proper gemset whether on x86 or x64, based
  on what is defined in project_data.yaml
- Note that latest FFI compatible gems have been added to x64 out of
  necessity, but the code fails tests, and is not yet compatible with
  Ruby 2 changes / gem updates.
- Gem versions for Ruby 1.9.x were kept the same, and will be upgraded
  as part of verifying gem compatibility when updating 1.9.x branch
  to use latest FFI compatible gems.
