### PR TITLE
(MODULES-1188) DRY up generated modules

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/README.md.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/README.md.erb
@@ -63,6 +63,16 @@ This section should include all of the under-the-hood workings of your module so
 people know what the module is touching on their system but don't need to mess
 with things. (We are working on automating this section!)
 
+### Class foo
+
+#### Params
+
+example_param
+-------------
+Boolean to do something awesome.
+
+- *Default*: true
+
 ## Limitations
 
 This is where you list OS compatibility, version compatibility, etc.

--- a/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
@@ -2,35 +2,6 @@
 #
 # Full description of class <%= metadata.name %> here.
 #
-# === Parameters
-#
-# Document parameters here.
-#
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
-#
-# === Variables
-#
-# Here you should define a list of variables that this module would require.
-#
-# [*sample_variable*]
-#   Explanation of how this variable affects the funtion of this class and if
-#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should be avoided in favor of class parameters as
-#   of Puppet 2.6.)
-#
-# === Examples
-#
-#  class { '<%= metadata.name %>':
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
-#  }
-#
-# === Authors
-#
-# Author Name <author@domain.com>
-#
 # === Copyright
 #
 # Copyright <%= Time.now.year %> Your name here, unless otherwise noted.


### PR DESCRIPTION
Without this patch, you repeat yourself in the code and the README,
which violates DRY (Don't Repeat Yourself) and leads to inconsistencies.
