### PR TITLE
(PUP-2777) Fix Gemfile test for x64 platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ end
 require 'yaml'
 data = YAML.load_file(File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml'))
 bundle_platforms = data['bundle_platforms']
-x64_platform = Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
+x64_platform = Gem::Platform.local.cpu == 'x64'
 data['gem_platform_dependencies'].each_pair do |gem_platform, info|
   next if gem_platform == 'x86-mingw32' && x64_platform
   next if gem_platform == 'x64-mingw32' && !x64_platform


### PR DESCRIPTION
- Previously it was assumed that the :x64_mingw platform was only
  defined in the Bundler DSL as a valid platform on a x64 Ruby.
  However, this is not actually the case.  Due to a coincidence, during
  testing, Bundler 1.3.5 was used on Ruby 1.9.3 x86 and that old
  Bundler version didn't have a :x64_mingw platform.  Upon upgrading
  to Bundler 1.6.3, :x64_mingw became defined on Ruby 1.9.3 x86.
  So the check was adjusted to what Bundler uses internally to
  determine if the current platform is running on x64.
