### PR TITLE
(PUP-2752) Fix for invalid semvers

### DIFF
--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -58,7 +58,12 @@ module Puppet::ModuleTool
         @mod = mod
         @metadata = mod.metadata
         name = mod.forge_name.tr('/', '-')
-        version = Semantic::Version.parse(mod.version)
+        begin
+          version = Semantic::Version.parse(mod.version)
+        rescue Semantic::Version::ValidationFailure => e
+          Puppet.warning "#{mod.name} (#{mod.path}) has an invalid version number (#{mod.version}). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org)."
+          version = Semantic::Version.parse("0.0.0")
+        end
         release = "#{name}@#{version}"
 
         super(source, name, version, {})

--- a/spec/unit/module_tool/installed_modules_spec.rb
+++ b/spec/unit/module_tool/installed_modules_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'puppet/module_tool/installed_modules'
+require 'puppet_spec/modules'
+
+describe Puppet::ModuleTool::InstalledModules do
+  include PuppetSpec::Files
+
+  around do |example|
+    dir = tmpdir("deep_path")
+
+    FileUtils.mkdir_p(@modpath = File.join(dir, "modpath"))
+
+    @env = Puppet::Node::Environment.create(:env, [@modpath])
+    Puppet.override(:current_environment => @env) do
+      example.run
+    end
+  end
+
+  it 'works when given a semantic version' do
+    mod = PuppetSpec::Modules.create('goodsemver', @modpath, :metadata => {:version => '1.2.3'})
+    installed = described_class.new(@env)
+    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(Semantic::Version.parse('1.2.3'))
+  end
+
+  it 'defaults when not given a semantic version' do
+    mod = PuppetSpec::Modules.create('badsemver', @modpath, :metadata => {:version => 'banana'})
+    Puppet.expects(:warning).with(regexp_matches(/Semantic Version/))
+    installed = described_class.new(@env)
+    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(Semantic::Version.parse('0.0.0'))
+  end
+
+  it 'defaults when not given a full semantic version' do
+    mod = PuppetSpec::Modules.create('badsemver', @modpath, :metadata => {:version => '1.2'})
+    Puppet.expects(:warning).with(regexp_matches(/Semantic Version/))
+    installed = described_class.new(@env)
+    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(Semantic::Version.parse('0.0.0'))
+  end
+
+  it 'still works if there is an invalid version in one of the modules' do
+    mod1 = PuppetSpec::Modules.create('badsemver', @modpath, :metadata => {:version => 'banana'})
+    mod2 = PuppetSpec::Modules.create('goodsemver', @modpath, :metadata => {:version => '1.2.3'})
+    mod3 = PuppetSpec::Modules.create('notquitesemver', @modpath, :metadata => {:version => '1.2'})
+    Puppet.expects(:warning).with(regexp_matches(/Semantic Version/)).twice
+    installed = described_class.new(@env)
+    expect(installed.modules["puppetlabs-#{mod1.name}"].version).to eq(Semantic::Version.parse('0.0.0'))
+    expect(installed.modules["puppetlabs-#{mod2.name}"].version).to eq(Semantic::Version.parse('1.2.3'))
+    expect(installed.modules["puppetlabs-#{mod3.name}"].version).to eq(Semantic::Version.parse('0.0.0'))
+  end
+end


### PR DESCRIPTION
Prior to this commit the module tool would fail to perform any actions if any module found in the modulepath had an invalid semver.

This commit warns about invalid semvers in installed modules, sets the version to 0.0.0, and moves on. This allows the module tool to continue to work, even with the invalid semver found in the path. This commit also adds some rudimentary tests for the Puppet::ModuleTool::InstalledModules class.
