### PR TITLE
(PUP-1283) Upgrade win32-service gem

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -35,7 +35,7 @@ gem_platform_dependencies:
       win32-eventlog: '~> 0.5.3'
       win32-process: '~> 0.6.5'
       win32-security: '~> 0.2.5'
-      win32-service: '0.7.2'
+      win32-service: '0.8.4'
       win32-taskscheduler: '~> 0.2.2'
       win32console:  '1.3.2'
       windows-api: '~> 0.4.2'


### PR DESCRIPTION
This upgrades win32-service from 0.7.2 (native compiled gem) to
0.8.4 (FFI-ed gem), which is a step in getting puppet to run on x64
ruby.
