### PR TITLE
(PUP-2521) Remove windows-pr gem

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -30,7 +30,6 @@ gem_platform_dependencies:
     gem_runtime_dependencies:
       # Pinning versions that require native extensions
       ffi: '1.9.3'
-      win32-api: '1.4.8'
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.1'
       win32-process: '~> 0.7.4'
@@ -38,8 +37,6 @@ gem_platform_dependencies:
       win32-service: '~> 0.8.4'
       win32-taskscheduler: '~> 0.2.2'
       win32console:  '1.3.2'
-      windows-api: '~> 0.4.2'
-      windows-pr: '~> 1.2.2'
       minitar: '~> 0.5.4'
   x64-mingw32:
     gem_runtime_dependencies:

--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -42,7 +42,7 @@ class Puppet::Provider::Package::Windows
               end
             end
           rescue Puppet::Util::Windows::Error => e
-            raise e unless e.code == Windows::Error::ERROR_FILE_NOT_FOUND
+            raise e unless e.code == Puppet::Util::Windows::Error::ERROR_FILE_NOT_FOUND
           end
         end
       end

--- a/spec/unit/provider/package/windows/package_spec.rb
+++ b/spec/unit/provider/package/windows/package_spec.rb
@@ -61,7 +61,7 @@ describe Puppet::Provider::Package::Windows::Package do
 
       expect {
         subject.with_key{ |key, values| }
-      }.to raise_error(Puppet::Error, /Access is denied/)
+      }.to raise_error(Puppet::Util::Windows::Error, /Access is denied/)
     end
   end
 


### PR DESCRIPTION
- Windows::Error no longer exists and the ERROR_FILE_NOT_FOUND
  constant is part of the Puppet codebase now.
- Catch appropriate error in package specs
- Remove windows-pr, win32-api and windows-api from gemspec
