### PR TITLE
(PUP-1281) Ensure don't override stdout/stderr (windows/ruby2)

### DIFF
--- a/spec/unit/util/colors_spec.rb
+++ b/spec/unit/util/colors_spec.rb
@@ -69,13 +69,29 @@ describe Puppet::Util::Colors do
 
   context "on Windows in Ruby 1.x", :if => Puppet.features.microsoft_windows? && RUBY_VERSION =~ /^1./ do
     it "should load win32console" do
-      Gem.loaded_specs["win32console"].should_not be_nil
+      Gem.loaded_specs["win32console"].must_not be_nil
+    end
+
+    it "should wrap $stdout with Puppet::Util::Colors::WideIO" do
+      $stdout.must be_an_instance_of Puppet::Util::Colors::WideIO
+    end
+
+    it "should wrap $stderr with Puppet::Util::Colors::WideIO" do
+      $stderr.must be_an_instance_of Puppet::Util::Colors::WideIO
     end
   end
 
   context "on Windows in Ruby 2.x", :if => Puppet.features.microsoft_windows? && RUBY_VERSION =~ /^2./ do
-    it "should not load win32console" do
-      Gem.loaded_specs["win32console"].should be_nil
+    it "should not have attempted to extend IO with Puppet::Util::Colors::WideIO" do
+      defined?(Puppet::Util::Colors::WideIO).must be_false
+    end
+
+    it "should not attempt to wrap $stdout" do
+      $stdout.must be_an_instance_of IO
+    end
+
+    it "should not attempt to wrap $stderr" do
+      $stderr.must be_an_instance_of IO
     end
   end
 end


### PR DESCRIPTION
This provides a more deterministic set of specs that determine whether we have
wrapped $stderr/$stdout or not based on ruby version.
