### PR TITLE
(PUP-2901/PE-4524) Add module dependency validation

### DIFF
--- a/lib/puppet/module_tool/errors.rb
+++ b/lib/puppet/module_tool/errors.rb
@@ -3,6 +3,7 @@ require 'puppet/module_tool'
 module Puppet::ModuleTool
   module Errors
     require 'puppet/module_tool/errors/base'
+    require 'puppet/module_tool/errors/build'
     require 'puppet/module_tool/errors/installer'
     require 'puppet/module_tool/errors/uninstaller'
     require 'puppet/module_tool/errors/upgrader'

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -52,7 +52,7 @@ module Puppet::ModuleTool
       process_name(data) if data['name']
       process_version(data) if data['version']
       process_source(data) if data['source']
-      merge_dependencies(data) if data['dependencies']
+      process_dependencies(data) if data['dependencies']
 
       @data.merge!(data)
       return self
@@ -65,8 +65,13 @@ module Puppet::ModuleTool
       validate_name(name)
       validate_version_range(version_requirement) if version_requirement
 
-      if dup = @data['dependencies'].find { |d| d.full_module_name == name && d.version_requirement != version_requirement }
-        raise ArgumentError, "Dependency conflict for #{full_module_name}: Dependency #{name} was given conflicting version requirements #{version_requirement} and #{dup.version_requirement}. Verify that there are no duplicates in the metadata.json or the Modulefile."
+      duplicates = @data['dependencies'].select { |d| d.full_module_name == name }
+      unless duplicates.empty?
+        duplicates.each do |dup|
+          if dup.version_requirement != version_requirement
+            raise Puppet::ModuleTool::Errors::DuplicateDependencyError.new(name, :original => dup.version_requirement, :dupe => version_requirement, :source => 'metadata.json')
+          end
+        end
       end
 
       dep = Dependency.new(name, version_requirement, repository)
@@ -111,7 +116,11 @@ module Puppet::ModuleTool
       keys -= demoted_keys
 
       contents = (promoted_keys + keys + demoted_keys).map do |k|
-        value = (JSON.pretty_generate(data[k]) rescue data[k].to_json)
+        if k == 'dependencies'
+          value = @data[k].to_a.to_json
+        else
+          value = (JSON.pretty_generate(@data[k]) rescue @data[k].to_json)
+        end
         "#{k.to_json}: #{value}"
       end
 
@@ -161,7 +170,7 @@ module Puppet::ModuleTool
     end
 
     # Validates and parses the dependencies.
-    def merge_dependencies(data)
+    def process_dependencies(data)
       data['dependencies'].each do |dep|
         add_dependency(dep['name'], dep['version_requirement'], dep['repository'])
       end

--- a/lib/puppet/module_tool/modulefile.rb
+++ b/lib/puppet/module_tool/modulefile.rb
@@ -43,6 +43,8 @@ module Puppet::ModuleTool
     # string). Optional. Can be called multiple times to add many dependencies.
     def dependency(name, version_requirement = nil, repository = nil)
       @metadata.add_dependency(name, version_requirement, repository)
+    rescue Puppet::ModuleTool::Errors::DuplicateDependencyError => e
+      raise Puppet::ModuleTool::Errors::DuplicateDependencyError.new(e.name, :original => e.original, :dupe => e.dupe, :source => "Modulefile")
     end
 
     # Set the source

--- a/spec/unit/module_tool/metadata_spec.rb
+++ b/spec/unit/module_tool/metadata_spec.rb
@@ -207,7 +207,7 @@ describe Puppet::ModuleTool::Metadata do
       }
 
       it "raises an exception" do
-        expect { subject }.to raise_error(ArgumentError)
+        expect { subject }.to raise_error(Puppet::ModuleTool::Errors::DuplicateDependencyError, /puppetlabs-dupmodule/)
       end
     end
 
@@ -216,7 +216,7 @@ describe Puppet::ModuleTool::Metadata do
 
       it "with a different version raises an exception" do
         metadata.add_dependency('puppetlabs-origmodule', '>= 0.0.1')
-        expect { subject }.to raise_error(ArgumentError)
+        expect { subject }.to raise_error(Puppet::ModuleTool::Errors::DuplicateDependencyError, /puppetlabs-origmodule/)
       end
 
       it "with the same version does not add another dependency" do


### PR DESCRIPTION
Prior to this commit there wasn't much verification for module dependencies.
This commit adds verification the module dependencies have sane names and version
ranges. If verification fails, it will raise an argument exception.
