### PR TITLE
Revert "(PUP-392) update win32-eventlog"

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -32,7 +32,7 @@ gem_platform_dependencies:
       ffi: '1.9.3'
       win32-api: '1.4.8'
       win32-dir: '~> 0.4.9'
-      win32-eventlog: '~> 0.6.1'
+      win32-eventlog: '~> 0.5.3'
       win32-process: '~> 0.7.4'
       win32-security: '~> 0.2.5'
       win32-service: '~> 0.8.4'

--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -126,15 +126,15 @@ class WindowsDaemon < Win32::Daemon
 
       case level
         when :debug
-          report_windows_event(Win32::EventLog::INFO_TYPE,0x01,msg.to_s)
+          report_windows_event(Win32::EventLog::INFO,0x01,msg.to_s)
         when :info
-          report_windows_event(Win32::EventLog::INFO_TYPE,0x01,msg.to_s)
+          report_windows_event(Win32::EventLog::INFO,0x01,msg.to_s)
         when :notice
-          report_windows_event(Win32::EventLog::INFO_TYPE,0x01,msg.to_s)
+          report_windows_event(Win32::EventLog::INFO,0x01,msg.to_s)
         when :err
-          report_windows_event(Win32::EventLog::ERROR_TYPE,0x03,msg.to_s)
+          report_windows_event(Win32::EventLog::ERR,0x03,msg.to_s)
         else
-          report_windows_event(Win32::EventLog::WARN_TYPE,0x02,msg.to_s)
+          report_windows_event(Win32::EventLog::WARN,0x02,msg.to_s)
       end
     end
   end
@@ -145,7 +145,7 @@ class WindowsDaemon < Win32::Daemon
       eventlog = Win32::EventLog.open("Application")
       eventlog.report_event(
         :source      => "Puppet",
-        :event_type  => type,   # Win32::EventLog::INFO_TYPE, WARN_TYPE or ERROR_TYPE
+        :event_type  => type,   # Win32::EventLog::INFO or WARN, ERROR
         :event_id    => id,     # 0x01 or 0x02, 0x03 etc.
         :data        => message # "the message"
       )

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -200,11 +200,11 @@ Puppet::Util::Log.newdesttype :eventlog do
   def to_native(level)
     case level
     when :debug,:info,:notice
-      [Win32::EventLog::INFO_TYPE, 0x01]
+      [Win32::EventLog::INFO, 0x01]
     when :warning
-      [Win32::EventLog::WARN_TYPE, 0x02]
+      [Win32::EventLog::WARN, 0x02]
     when :err,:alert,:emerg,:crit
-      [Win32::EventLog::ERROR_TYPE, 0x03]
+      [Win32::EventLog::ERROR, 0x03]
     end
   end
 


### PR DESCRIPTION
This reverts commit cffa48679b20362b3a50403a7460c1400524d790.

We need to revert win32-eventlog updates for now since it now has
dependencies on a library that doesn't exist in Windows 2003.
