### PR TITLE
Maint/mount doc wording

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -214,8 +214,6 @@ module Puppet
         newvalue(%r{(0|1)})
       end
 
-      newvalue(%r{(0|1)})
-
       defaultto {
         0 if @resource.managed?
       }


### PR DESCRIPTION
The [docs](http://docs.puppetlabs.com/references/3.6.0/type.html#mount-attribute-dump) read funny. Slight fixes to the relevant property code. Not really tested, though.

Note how 38984362 apparently introduced duplicate code. This was probably a result of James applying a not-quite-fitting [patch](https://projects.puppetlabs.com/issues/2405) to his tree.
