### PR TITLE
(PUP-2891) Treat override of class as an error.

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -327,6 +327,9 @@ module Puppet::Pops::Evaluator::Runtime3Support
     file, line = extract_file_line(o)
 
     evaluated_resources.each do |r|
+      unless r.is_a?(Puppet::Pops::Types::PResourceType) && r.type_name != 'class'
+        fail(Puppet::Pops::Issues::ILLEGAL_OVERRIDEN_TYPE, o, {:actual => r} )
+      end
       resource = Puppet::Parser::Resource.new(
       r.type_name, r.title,
         :parameters => evaluated_parameters,

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -502,4 +502,8 @@ module Puppet::Pops::Issues
   ILLEGAL_NODE_INHERITANCE = issue :ILLEGAL_NODE_INHERITANCE do
     "Node inheritance is not supported in Puppet >= 4.0.0. See http://links.puppetlabs.com/puppet-node-inheritance-deprecation"
   end
+
+  ILLEGAL_OVERRIDEN_TYPE = issue :ILLEGAL_OVERRIDEN_TYPE, :actual do
+    "Resource Override can only operate on resources, got: #{label.label(actual)}"
+  end
 end

--- a/spec/integration/parser/future_compiler_spec.rb
+++ b/spec/integration/parser/future_compiler_spec.rb
@@ -112,6 +112,14 @@ describe "Puppet::Parser::Compiler" do
       expect(catalog).to have_resource("Notify[bye_test]").with_parameter(:message, "defaulted")
     end
 
+    it 'does not allow override of class parameters using a resource override expression' do
+      expect do
+        compile_to_catalog(<<-CODE)
+          Class[a] { x => 2}
+        CODE
+      end.to raise_error(/Resource Override can only.*got: Class\[a\].*/)
+    end
+
     describe "when resolving class references" do
       it "should not favor local scope (with class included in topscope)" do
         catalog = compile_to_catalog(<<-PP)


### PR DESCRIPTION
This makes an attempt to override a class parameter issue an
error from the runtime layer rather than expecting the underlying
3x implementation to do it when the left expression does not
result in a resource, or a resource that has 'class' as resource type.
