### PR TITLE
(PUP-2902) Change error message when attempting to collect classes.

### DIFF
--- a/lib/puppet/parser/ast/collection.rb
+++ b/lib/puppet/parser/ast/collection.rb
@@ -15,6 +15,10 @@ class Puppet::Parser::AST
     def evaluate(scope)
       match, code = query && query.safeevaluate(scope)
 
+      if @type == 'class'
+        fail "Classes cannot be collected"
+      end
+
       resource_type = scope.find_resource_type(@type)
       fail "Resource type #{@type} doesn't exist" unless resource_type
       newcoll = Puppet::Parser::Collector.new(scope, resource_type.name, match, code, self.form)

--- a/spec/integration/parser/collector_spec.rb
+++ b/spec/integration/parser/collector_spec.rb
@@ -151,7 +151,7 @@ describe Puppet::Parser::Collector do
           }
           Class <|  |>
         MANIFEST
-      end.to raise_error()
+      end.to raise_error(/Classes cannot be collected/)
     end
 
     context "overrides" do


### PR DESCRIPTION
An attempt to collect classes led to an error message that said
that 'class' is not a known resource type (in a way that can be
misinterpreted).

This commit make the error message specific, and clear.
