### PR TITLE
(maint) Don't try to set expectations on $CHILD_STATUS

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -79,14 +79,17 @@ module Puppet::Util::Execution
       end
     end
 
-    if failonfail
-      unless $CHILD_STATUS == 0
-        raise Puppet::ExecutionFailure, output
-      end
+    if failonfail && exitstatus != 0
+      raise Puppet::ExecutionFailure, output
     end
 
     output
   end
+
+  def self.exitstatus
+    $CHILD_STATUS.exitstatus
+  end
+  private_class_method :exitstatus
 
   # Wraps execution of {execute} with mapping of exception to given exception (and output as argument).
   # @raise [exception] under same conditions as {execute}, but raises the given `exception` with the output as argument

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -3,13 +3,6 @@ require 'spec_helper'
 
 describe Puppet::Util::Execution do
   include Puppet::Util::Execution
-  # utility method to help deal with some windows vs. unix differences
-  def process_status(exitstatus)
-    return exitstatus if Puppet.features.microsoft_windows?
-
-    stub('child_status', :exitstatus => exitstatus)
-  end
-
   # utility methods to help us test some private methods without being quite so verbose
   def call_exec_posix(command, arguments, stdin, stdout, stderr)
     Puppet::Util::Execution.send(:execute_posix, command, arguments, stdin, stdout, stderr)
@@ -597,40 +590,39 @@ describe Puppet::Util::Execution do
   describe "#execpipe" do
     it "should execute a string as a string" do
       Puppet::Util::Execution.expects(:open).with('| echo hello 2>&1').returns('hello')
-      $CHILD_STATUS.expects(:==).with(0).returns(true)
+      Puppet::Util::Execution.expects(:exitstatus).returns(0)
       Puppet::Util::Execution.execpipe('echo hello').should == 'hello'
     end
 
     it "should print meaningful debug message for string argument" do
       Puppet::Util::Execution.expects(:debug).with("Executing 'echo hello'")
       Puppet::Util::Execution.expects(:open).with('| echo hello 2>&1').returns('hello')
-      $CHILD_STATUS.expects(:==).with(0).returns(true)
+      Puppet::Util::Execution.expects(:exitstatus).returns(0)
       Puppet::Util::Execution.execpipe('echo hello')
     end
 
     it "should print meaningful debug message for array argument" do
       Puppet::Util::Execution.expects(:debug).with("Executing 'echo hello'")
       Puppet::Util::Execution.expects(:open).with('| echo hello 2>&1').returns('hello')
-      $CHILD_STATUS.expects(:==).with(0).returns(true)
+      Puppet::Util::Execution.expects(:exitstatus).returns(0)
       Puppet::Util::Execution.execpipe(['echo','hello'])
     end
 
     it "should execute an array by pasting together with spaces" do
       Puppet::Util::Execution.expects(:open).with('| echo hello 2>&1').returns('hello')
-      $CHILD_STATUS.expects(:==).with(0).returns(true)
+      Puppet::Util::Execution.expects(:exitstatus).returns(0)
       Puppet::Util::Execution.execpipe(['echo', 'hello']).should == 'hello'
     end
 
     it "should fail if asked to fail, and the child does" do
-      Puppet::Util::Execution.stubs(:open).returns('error message')
-      $CHILD_STATUS.expects(:==).with(0).returns(false)
+      Puppet::Util::Execution.stubs(:open).with('| echo hello 2>&1').returns('error message')
+      Puppet::Util::Execution.expects(:exitstatus).returns(1)
       expect { Puppet::Util::Execution.execpipe('echo hello') }.
         to raise_error Puppet::ExecutionFailure, /error message/
     end
 
     it "should not fail if asked not to fail, and the child does" do
       Puppet::Util::Execution.stubs(:open).returns('error message')
-      $CHILD_STATUS.stubs(:==).with(0).returns(false)
       Puppet::Util::Execution.execpipe('echo hello', false).should == 'error message'
     end
   end


### PR DESCRIPTION
Previously, executing bundle exec rspec spec/unit/util/execution_spec.rb
would fail on windows with an rspec error:

```
unexpected invocation: nil.==(/error message/)
```

The issue first appears in commit f41800a. I believe because before
f41800a, facter would evaluate the certname fact, executing `hostname.exe`
prior to executing the rspec example. As a result $CHILD_STATUS was never
nil when the test executed.

But starting in f41800a, $CHILD_STATUS may be nil as can be seen by the
rspec output:

```
expected exactly once, invoked once: nil.==(0)
```

Since the object we are trying to set an expectation on is global and
sometimes doesn't exist, this commit creates a private method for stubbing
and setting expectations on the $CHILD_STATUS.exitstatus
