### PR TITLE
(PUP-2078) Clarify --force behavior

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -84,9 +84,10 @@ Puppet::Face.define(:module, '1.0.0') do
     arguments "<name>"
 
     option "--force", "-f" do
-      summary "Force overwrite of existing module, if any."
+      summary "Force overwrite of existing module, if any. (Implies --ignore-dependencies.)"
       description <<-EOT
         Force overwrite of existing module, if any.
+        Implies --ignore-dependencies.
       EOT
     end
 
@@ -104,9 +105,9 @@ Puppet::Face.define(:module, '1.0.0') do
     end
 
     option "--ignore-dependencies" do
-      summary "Do not attempt to install dependencies"
+      summary "Do not attempt to install dependencies. (Implied by --force.)"
       description <<-EOT
-        Do not attempt to install dependencies.  (Implied by --force.)
+        Do not attempt to install dependencies. Implied by --force.
       EOT
     end
 

--- a/lib/puppet/face/module/upgrade.rb
+++ b/lib/puppet/face/module/upgrade.rb
@@ -32,17 +32,18 @@ Puppet::Face.define(:module, '1.0.0') do
     arguments "<name>"
 
     option "--force", "-f" do
-      summary "Force upgrade of an installed module."
+      summary "Force upgrade of an installed module. (Implies --ignore-dependencies.)"
       description <<-EOT
         Force the upgrade of an installed module even if there are local
         changes or the possibility of causing broken dependencies.
+        Implies --ignore-dependencies.
       EOT
     end
 
     option "--ignore-dependencies" do
-      summary "Do not attempt to install dependencies"
+      summary "Do not attempt to install dependencies. (Implied by --force.)"
       description <<-EOT
-        Do not attempt to install dependencies.  (Implied by --force.)
+        Do not attempt to install dependencies. Implied by --force.
       EOT
     end
 


### PR DESCRIPTION
Prior to this commit it was unclear that --force also implies --ignore-dependencies.
This commit clarifies that --force does also imply --ignore-dependencies.
