### PR TITLE
(PUP-2918) Clarify missing Modulefile error

### DIFF
--- a/lib/puppet/face/module/build.rb
+++ b/lib/puppet/face/module/build.rb
@@ -43,11 +43,11 @@ Puppet::Face.define(:module, '1.0.0') do
         pwd = Dir.pwd
         module_path = Puppet::ModuleTool.find_module_root(pwd)
         if module_path.nil?
-          raise "Unable to find module root at #{pwd} or parent directories"
+          raise "Unable to find metadata.json or Modulefile in module root #{pwd} or parent directories. See <http://links.puppetlabs.com/modulefile> for required file format."
         end
       else
         unless Puppet::ModuleTool.is_module_root?(module_path)
-          raise "Unable to find module root at #{module_path}"
+          raise "Unable to find metadata.json or Modulefile in module root #{module_path}. See <http://links.puppetlabs.com/modulefile> for required file format."
         end
       end
 

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -40,6 +40,10 @@ module Puppet::ModuleTool
           raise ArgumentError, "Could not determine module path"
         end
 
+        if require_metadata && !Puppet::ModuleTool.is_module_root?(@path)
+          raise ArgumentError, "Unable to find metadata.json or Modulefile in module root at #{@path} See http://links.puppetlabs.com/modulefile for required file format."
+        end
+
         modulefile_path = File.join(@path, 'Modulefile')
         metadata_path   = File.join(@path, 'metadata.json')
 
@@ -61,11 +65,6 @@ module Puppet::ModuleTool
           end
 
           Puppet::ModuleTool::ModulefileReader.evaluate(@metadata, modulefile_path)
-        end
-
-        has_metadata = File.file?(modulefile_path) || File.file?(metadata_path)
-        if !has_metadata && require_metadata
-          raise ArgumentError, "No metadata found for module #{@path}"
         end
 
         return @metadata

--- a/spec/unit/face/module/build_spec.rb
+++ b/spec/unit/face/module/build_spec.rb
@@ -25,7 +25,7 @@ describe "puppet module build" do
     it "if current directory or parents contain no module root, should return exception" do
       Dir.expects(:pwd).returns('/a/b/c')
       Puppet::ModuleTool.expects(:find_module_root).returns(nil)
-      expect { subject.build }.to raise_error RuntimeError, "Unable to find module root at /a/b/c or parent directories"
+      expect { subject.build }.to raise_error RuntimeError, "Unable to find metadata.json or Modulefile in module root /a/b/c or parent directories. See <http://links.puppetlabs.com/modulefile> for required file format."
     end
   end
 
@@ -39,7 +39,7 @@ describe "puppet module build" do
 
     it "if path is not a module root should raise exception" do
       Puppet::ModuleTool.expects(:is_module_root?).with('/a/b/c').returns(false)
-      expect { subject.build('/a/b/c') }.to raise_error RuntimeError, "Unable to find module root at /a/b/c"
+      expect { subject.build('/a/b/c') }.to raise_error RuntimeError, "Unable to find metadata.json or Modulefile in module root /a/b/c. See <http://links.puppetlabs.com/modulefile> for required file format."
     end
   end
 


### PR DESCRIPTION
Prior to this commit, when building a module without a Modulefile or metadata.json,
the builder would blow up with a cryptic 'Unable to find module root at DIRECTORY'
It's not entirely clear what that means to an end user.
This commit clarifies that metadata.json or a Modulefile are what need to be found
at the module root. Also removes some duplicated logic for checking module root.
