### PR TITLE
(PUP-2920) Make PMT authenticate with forge and request extra modules.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -533,6 +533,14 @@ module Puppet
     :module_skeleton_dir => {
         :default  => '$module_working_dir/skeleton',
         :desc     => "The directory which the skeleton for module tool generate is stored.",
+    },
+    :forge_authorization => {
+        :default  => nil,
+        :desc     => "The authorization key to connect to the Puppet Forge. Leave blank for unauthorized or license based connections",
+    },
+    :module_groups => {
+        :default  => nil,
+        :desc     => "Extra module groups to request from the Puppet Forge",
     }
   )
 

--- a/lib/puppet/feature/pe_license.rb
+++ b/lib/puppet/feature/pe_license.rb
@@ -1,0 +1,4 @@
+require 'puppet/util/feature'
+
+#Is the pe license library installed providing the ability to read licenses.
+Puppet.features.add(:pe_license, :libs => %{pe_license})

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -54,6 +54,9 @@ class Puppet::Forge < Semantic::Dependency::Source
   def search(term)
     matches = []
     uri = "/v3/modules?query=#{URI.escape(term)}"
+    if Puppet[:module_groups]
+      uri += "&module_groups=#{Puppet[:module_groups]}"
+    end
 
     while uri
       response = make_http_request(uri)
@@ -86,6 +89,9 @@ class Puppet::Forge < Semantic::Dependency::Source
   def fetch(input)
     name = input.tr('/', '-')
     uri = "/v3/releases?module=#{name}"
+    if Puppet[:module_groups]
+      uri += "&module_groups=#{Puppet[:module_groups]}"
+    end
     releases = []
 
     while uri

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -52,6 +52,14 @@ class Puppet::Forge
       return read_response(request, io)
     end
 
+    def forge_authorization
+      if Puppet[:forge_authorization]
+        Puppet[:forge_authorization]
+      elsif Puppet.features.pe_license?
+        PELicense.load_license_key.authorization_token
+      end
+    end
+
     def get_request_object(path)
       headers = {
         "User-Agent" => user_agent,
@@ -63,9 +71,13 @@ class Puppet::Forge
         })
       end
 
+      if forge_authorization
+        headers = headers.merge({"Authorization" => forge_authorization})
+      end
+
       request = Net::HTTP::Get.new(URI.escape(path), headers)
 
-      unless @uri.user.nil? || @uri.password.nil?
+      unless @uri.user.nil? || @uri.password.nil? || forge_authorization
         request.basic_auth(@uri.user, @uri.password)
       end
 

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -80,6 +80,20 @@ describe Puppet::Forge::Repository do
       request['User-Agent'].should =~ /\bRuby\b/
     end
 
+    it "Does not set Authorization header by default" do
+      Puppet.features.stubs(:pe_license?).returns(false)
+      Puppet[:forge_authorization] = nil
+      request = repository.get_request_object("the_path")
+      request['Authorization'].should == nil
+    end
+
+    it "Sets Authorization header from config" do
+      token = 'bearer some token'
+      Puppet[:forge_authorization] = token
+      request = repository.get_request_object("the_path")
+      request['Authorization'].should == token
+    end
+
     it "escapes the received URI" do
       unescaped_uri = "héllo world !! ç à"
       performs_an_http_request do |http|

--- a/spec/unit/forge_spec.rb
+++ b/spec/unit/forge_spec.rb
@@ -110,6 +110,27 @@ describe Puppet::Forge do
     forge.search('bacula').should == search_results
   end
 
+  context "when module_groups are defined" do
+    let(:release_response) do
+      releases = JSON.parse(http_response)
+      releases['results'] = []
+      JSON.dump(releases)
+    end
+
+    before :each do
+      repository_responds_with(stub(:body => release_response, :code => '200')).with {|uri| uri =~ /module_groups=foo/}
+      Puppet[:module_groups] = "foo"
+    end
+
+    it "passes module_groups with search" do
+      forge.search('bacula')
+    end
+
+    it "passes module_groups with fetch" do
+      forge.fetch('puppetlabs-bacula')
+    end
+  end
+
   context "when the connection to the forge fails" do
     before :each do
       repository_responds_with(stub(:body => '{}', :code => '404', :message => "not found"))


### PR DESCRIPTION
Before this PMT only supported basic authentication which the Puppet Forge
does not. This adds the ability to configure other authentication
methods and request that forge include extra module groups in responses.
