### PR TITLE
(PUP-1244) Fix yum/rpm version comparison to work the way RPM actually does

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -165,6 +165,115 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
     join_options(resource[:uninstall_options])
   end
 
+  # This is an attempt at implementing RPM's
+  # lib/rpmvercmp.c rpmvercmp(a, b) in Ruby.
+  #
+  # Some of the things in here look REALLY
+  # UGLY and/or arbitrary. Our goal is to
+  # match how RPM compares versions, quirks
+  # and all.
+  #
+  # I've kept a lot of C-like string processing
+  # in an effort to keep this as identical to RPM
+  # as possible.
+  #
+  # returns 1 if str1 is newer than str2,
+  #         0 if they are identical
+  #        -1 if str1 is older than str2
+  def rpmvercmp(str1, str2)
+    return 0 if str1 == str2
+    
+    front_strip_re = /^[^A-Za-z0-9~]+/
+    segment_re = /^[A-Za-z0-9]/
+    # these represent RPM rpmio/rpmstring.c functions
+    risalnum = /[A-Za-z0-9]/
+    risdigit = /^[0-9]+/
+    risalpha = /[A-Za-z]/
+    
+    while str1.length > 0 or str2.length > 0
+      # trim anything that's !risalnum() and != '~' off the beginning of each string
+      str1 = str1.gsub(front_strip_re, '')
+      str2 = str2.gsub(front_strip_re, '')
+      
+      # "handle the tilde separator, it sorts before everything else"
+      if /^~/.match(str1) and /^~/.match(str2)
+	# if they both have ~, strip it
+	str1 = str1[1..-1]
+	str2 = str2[1..-1]
+      elsif /^~/.match(str1)
+	return -1
+      elsif /^~/.match(str2)
+	return 1
+      end
+      
+      break if str1.length == 0 or str2.length == 0
+      
+      # "grab first completely alpha or completely numeric segment"
+      isnum = false
+      # if the first char of str1 is a digit, grab the chunk of continuous digits from each string
+      if risdigit.match(str1)
+	if str1 =~ /^[0-9]+/
+	  segment1 = $~.to_s
+	  str1 = $~.post_match
+	else
+	  segment1 = ''
+	end
+	if str2 =~ /^[0-9]+/
+	  segment2 = $~.to_s
+	  str2 = $~.post_match
+	else
+	  segment2 = ''
+	end
+	isnum = true
+      # else grab the chunk of continuous alphas from each string (which may be '')
+      else
+	if str1 =~ /^[A-Za-z]+/
+	  segment1 = $~.to_s
+	  str1 = $~.post_match
+	else
+	  segment1 = ''
+	end
+	if str2 =~ /^[A-Za-z]+/
+	  segment2 = $~.to_s
+	  str2 = $~.post_match
+	else
+	  segment2 = ''
+	end
+      end
+      
+      # if the segments we just grabbed from the strings are different types (i.e. one numeric one alpha),
+      # where alpha also includes ''; "numeric segments are always newer than alpha segments"
+      if segment2.length == 0
+        return 1 if isnum
+        return -1
+      end
+      
+      if isnum
+	# "throw away any leading zeros - it's a number, right?"
+	segment1 = segment1.gsub(/^0+/, '')
+	segment2 = segment2.gsub(/^0+/, '')
+	# "whichever number has more digits wins"
+	return 1 if segment1.length > segment2.length
+	return -1 if segment1.length < segment2.length
+      end
+      
+      # "strcmp will return which one is greater - even if the two segments are alpha
+      # or if they are numeric. don't return if they are equal because there might
+      # be more segments to compare"
+      rc = segment1 <=> segment2
+      return rc if rc != 0
+    end #end while loop
+
+    # if we haven't returned anything yet, "whichever version still has characters left over wins"
+    if str1.length > str2.length
+      return 1
+    elsif str1.length < str2.length
+      return -1
+    else
+      return 0
+    end
+  end
+
   private
   # @param line [String] one line of rpm package query information
   # @return [Hash] of NEVRA_FIELDS strings parsed from package info

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -1,5 +1,3 @@
-require 'puppet/util/package'
-
 Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   desc "Support via `yum`.
 
@@ -112,7 +110,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       # Add the package version
       wanted += "-#{should}"
       is = self.query
-      if is && Puppet::Util::Package.versioncmp(should, is[:ensure]) < 0
+      if is && yum_compareEVR(yum_parse_evr(should), yum_parse_evr(is[:ensure])) < 0
         self.debug "Downgrading package #{@resource[:name]} from version #{is[:ensure]} to #{should}"
         operation = :downgrade
       end
@@ -129,7 +127,8 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
       # FIXME: Should we raise an exception even if should == :latest
       # and yum updated us to a version other than @param_hash[:ensure] ?
-      raise Puppet::Error, "Failed to update to version #{should}, got version #{is[:ensure]} instead" if should != is[:ensure]
+      vercmp_result = yum_compareEVR(yum_parse_evr(should), yum_parse_evr(is[:ensure]))
+      raise Puppet::Error, "Failed to update to version #{should}, got version #{is[:ensure]} instead" if vercmp_result != 0
     end
   end
 
@@ -155,6 +154,75 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
   def purge
     yum "-y", :erase, @resource[:name]
+  end
+
+  # parse a yum "version" specification
+  # this re-implements yum's
+  # rpmUtils.miscutils.stringToVersion() in ruby
+  def yum_parse_evr(s)
+    ei = s.index(':')
+    if ei
+      e = s[0,ei]
+      s = s[ei+1,s.length]
+    else
+      e = nil
+    end
+    e = String(Bignum(e)) rescue '0'
+    ri = s.index('-')
+    if ri
+      v = s[0,ri]
+      r = s[ri+1,s.length]
+    else
+      v = s
+      r = nil
+    end
+    return { :epoch => e, :version => v, :release => r }
+  end
+
+  # how yum compares two package versions:
+  # rpmUtils.miscutils.compareEVR(), which massages data types and then calls
+  # rpm.labelCompare(), found in rpm.git/python/header-py.c, which
+  # sets epoch to 0 if null, then compares epoch, then ver, then rel
+  # using compare_values() and returns the first non-0 result, else 0.
+  # This function combines the logic of compareEVR() and labelCompare().
+  # 
+  #
+  # TODO: this is the place to hook in PUP-1365 (globbing)
+  #
+  # "version_should" can be v, v-r, or e:v-r.
+  # "version_is" will always be at least v-r, can be e:v-r
+  def yum_compareEVR(should_hash, is_hash)
+    # pass on to rpm labelCompare
+    rc = compare_values(should_hash[:epoch], is_hash[:epoch])
+    return rc unless rc == 0
+    rc = compare_values(should_hash[:version], is_hash[:version])
+    return rc unless rc == 0
+
+    # here is our special case, PUP-1244.
+    # if should_hash[:release] is nil (not specified by the user),
+    # and comparisons up to here are equal, return equal. We need to
+    # evaluate to whatever level of detail the user specified, so we
+    # don't end up upgrading or *downgrading* when not intended.
+    #
+    # This should NOT be triggered if we're trying to ensure latest.
+    return 0 if should_hash[:release].nil?
+
+    rc = compare_values(should_hash[:release], is_hash[:release])
+    return rc
+  end
+
+  # this method is a native implementation of the
+  # compare_values function in rpm's python bindings,
+  # found in python/header-py.c, as used by yum.
+  def compare_values(s1, s2)
+    if s1.nil? and s2.nil?
+      return 0
+    elsif ( not s1.nil? ) and s2.nil?
+      return 1
+    elsif s1.nil? and (not s2.nil?)
+      return -1
+    end
+    return rpmvercmp(s1, s2)
   end
 
   # @deprecated

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -387,4 +387,85 @@ describe provider_class do
       end
     end
   end
+
+  describe 'version comparison' do
+
+    # test cases munged directly from rpm's own
+    # tests/rpmvercmp.at
+    it { provider.rpmvercmp("1.0", "1.0").should == 0 }
+    it { provider.rpmvercmp("1.0", "2.0").should == -1 }
+    it { provider.rpmvercmp("2.0", "1.0").should == 1 }
+    it { provider.rpmvercmp("2.0.1", "2.0.1").should == 0 }
+    it { provider.rpmvercmp("2.0", "2.0.1").should == -1 }
+    it { provider.rpmvercmp("2.0.1", "2.0").should == 1 }
+    it { provider.rpmvercmp("2.0.1a", "2.0.1a").should == 0 }
+    it { provider.rpmvercmp("2.0.1a", "2.0.1").should == 1 }
+    it { provider.rpmvercmp("2.0.1", "2.0.1a").should == -1 }
+    it { provider.rpmvercmp("5.5p1", "5.5p1").should == 0 }
+    it { provider.rpmvercmp("5.5p1", "5.5p2").should == -1 }
+    it { provider.rpmvercmp("5.5p2", "5.5p1").should == 1 }
+    it { provider.rpmvercmp("5.5p10", "5.5p10").should == 0 }
+    it { provider.rpmvercmp("5.5p1", "5.5p10").should == -1 }
+    it { provider.rpmvercmp("5.5p10", "5.5p1").should == 1 }
+    it { provider.rpmvercmp("10xyz", "10.1xyz").should == -1 }
+    it { provider.rpmvercmp("10.1xyz", "10xyz").should == 1 }
+    it { provider.rpmvercmp("xyz10", "xyz10").should == 0 }
+    it { provider.rpmvercmp("xyz10", "xyz10.1").should == -1 }
+    it { provider.rpmvercmp("xyz10.1", "xyz10").should == 1 }
+    it { provider.rpmvercmp("xyz.4", "xyz.4").should == 0 }
+    it { provider.rpmvercmp("xyz.4", "8").should == -1 }
+    it { provider.rpmvercmp("8", "xyz.4").should == 1 }
+    it { provider.rpmvercmp("xyz.4", "2").should == -1 }
+    it { provider.rpmvercmp("2", "xyz.4").should == 1 }
+    it { provider.rpmvercmp("5.5p2", "5.6p1").should == -1 }
+    it { provider.rpmvercmp("5.6p1", "5.5p2").should == 1 }
+    it { provider.rpmvercmp("5.6p1", "6.5p1").should == -1 }
+    it { provider.rpmvercmp("6.5p1", "5.6p1").should == 1 }
+    it { provider.rpmvercmp("6.0.rc1", "6.0").should == 1 }
+    it { provider.rpmvercmp("6.0", "6.0.rc1").should == -1 }
+    it { provider.rpmvercmp("10b2", "10a1").should == 1 }
+    it { provider.rpmvercmp("10a2", "10b2").should == -1 }
+    it { provider.rpmvercmp("1.0aa", "1.0aa").should == 0 }
+    it { provider.rpmvercmp("1.0a", "1.0aa").should == -1 }
+    it { provider.rpmvercmp("1.0aa", "1.0a").should == 1 }
+    it { provider.rpmvercmp("10.0001", "10.0001").should == 0 }
+    it { provider.rpmvercmp("10.0001", "10.1").should == 0 }
+    it { provider.rpmvercmp("10.1", "10.0001").should == 0 }
+    it { provider.rpmvercmp("10.0001", "10.0039").should == -1 }
+    it { provider.rpmvercmp("10.0039", "10.0001").should == 1 }
+    it { provider.rpmvercmp("4.999.9", "5.0").should == -1 }
+    it { provider.rpmvercmp("5.0", "4.999.9").should == 1 }
+    it { provider.rpmvercmp("20101121", "20101121").should == 0 }
+    it { provider.rpmvercmp("20101121", "20101122").should == -1 }
+    it { provider.rpmvercmp("20101122", "20101121").should == 1 }
+    it { provider.rpmvercmp("2_0", "2_0").should == 0 }
+    it { provider.rpmvercmp("2.0", "2_0").should == 0 }
+    it { provider.rpmvercmp("2_0", "2.0").should == 0 }
+    it { provider.rpmvercmp("a", "a").should == 0 }
+    it { provider.rpmvercmp("a+", "a+").should == 0 }
+    it { provider.rpmvercmp("a+", "a_").should == 0 }
+    it { provider.rpmvercmp("a_", "a+").should == 0 }
+    it { provider.rpmvercmp("+a", "+a").should == 0 }
+    it { provider.rpmvercmp("+a", "_a").should == 0 }
+    it { provider.rpmvercmp("_a", "+a").should == 0 }
+    it { provider.rpmvercmp("+_", "+_").should == 0 }
+    it { provider.rpmvercmp("_+", "+_").should == 0 }
+    it { provider.rpmvercmp("_+", "_+").should == 0 }
+    it { provider.rpmvercmp("+", "_").should == 0 }
+    it { provider.rpmvercmp("_", "+").should == 0 }
+    it { provider.rpmvercmp("1.0~rc1", "1.0~rc1").should == 0 }
+    it { provider.rpmvercmp("1.0~rc1", "1.0").should == -1 }
+    it { provider.rpmvercmp("1.0", "1.0~rc1").should == 1 }
+    it { provider.rpmvercmp("1.0~rc1", "1.0~rc2").should == -1 }
+    it { provider.rpmvercmp("1.0~rc2", "1.0~rc1").should == 1 }
+    it { provider.rpmvercmp("1.0~rc1~git123", "1.0~rc1~git123").should == 0 }
+    it { provider.rpmvercmp("1.0~rc1~git123", "1.0~rc1").should == -1 }
+    it { provider.rpmvercmp("1.0~rc1", "1.0~rc1~git123").should == 1 }
+    it { provider.rpmvercmp("1.0~rc1", "1.0arc1").should == -1 }
+
+    # non-upstream test cases
+    it { provider.rpmvercmp("405", "406").should == -1 }
+    it { provider.rpmvercmp("1", "0").should == 1 }
+  end
+
 end


### PR DESCRIPTION
As requested, this is a rebase of my earlier PR, https://github.com/puppetlabs/puppet/pull/2262, on the puppet-4 branch. So far I've only run specs locally.

Description of the original PR, for reference:

Puppet uses one vercmp method for all package types by default. Unfortunately that method assumes the packages use semver, which RPM and Yum do not.

This is an almost line-for-line port of the version comparison algorithms in Yum (Python) and RPM (C) to Puppet. The comments I left in show how insane the actual version comparison algorithm is. It's essentially a bunch of special cases that might eventually fall through to strcmp().

I've also brought over all of RPM's upstream test cases and included them in rpm_spec.rb as a reference/sanity check.
