### PR TITLE
(PUP-3010) Allow Upstart jobs on Amazon Linux

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -14,6 +14,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   confine :any => [
     Facter.value(:operatingsystem) == 'Ubuntu',
     (Facter.value(:osfamily) == 'RedHat' and Facter.value(:operatingsystemrelease) =~ /^6\./),
+    Facter.value(:operatingsystem) == 'Amazon'
   ]
 
   defaultfor :operatingsystem => :ubuntu


### PR DESCRIPTION
Amazon Linux is a RedHat derivative and comes with support for Upstart built in.  The current Upstart requirements assume the RedHat versioning scheme, but Amazon Linux does not use the same versioning scheme.

This change allows the use of Upstart jobs on Amazon linux.
