### PR TITLE
(PUP-417) Make use of QENG-188 to restart puppet

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 1.11.0"
+gem "beaker", "~> 1.17"
 gem 'rake', "~> 10.1.0"
 
 group(:test) do

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -26,7 +26,8 @@ module HarnessOptions
     :repo_proxy => true,
     :add_el_extras => true,
     :preserve_hosts => 'onfail',
-    :forge_host => 'forge-aio01-petest.puppetlabs.com'
+    :forge_host => 'forge-aio01-petest.puppetlabs.com',
+    :'master-start-curl-retries' => 30,
   }
 
   class Aggregator
@@ -324,13 +325,24 @@ Defaults to a packages run, but you can set it to 'git' with TYPE='git'.
     preserved = list_preserved_configurations
     print_preserved(preserved)
     config_path = preserved[config_number][0]
+
     puts "Using ##{config_number}: #{config_path}"
-    beaker_test(beaker_run_type,
+
+    options = {
       :hosts_file => "#{config_path}/preserved_config.yaml",
       :no_provision => true,
       :preserve_hosts => 'always',
-      :__delete_options__ => [:pre_suite]
-    )
+    }
+    run_type = beaker_run_type
+    if run_type == :packages
+      options.merge!(:pre_suite => [
+        'setup/packages/pre-suite/015_PackageHostsPresets.rb',
+        'setup/packages/pre-suite/045_EnsureMasterStartedOnPassenger.rb',
+      ])
+    else
+      options.merge!(:__delete_options__ => [:pre_suite])
+    end
+    beaker_test(beaker_run_type, options)
   end
 end
 

--- a/acceptance/config/packages/options.rb
+++ b/acceptance/config/packages/options.rb
@@ -1,8 +1,11 @@
 {
+  :type => 'foss-packages',
   :pre_suite => [
     'setup/packages/pre-suite/010_Install.rb',
+    'setup/packages/pre-suite/015_PackageHostsPresets.rb',
     'setup/common/pre-suite/025_StopFirewall.rb',
     'setup/common/pre-suite/040_ValidateSignCert.rb',
+    'setup/packages/pre-suite/045_EnsureMasterStartedOnPassenger.rb',
     'setup/common/pre-suite/100_SetParser.rb',
   ],
 }

--- a/acceptance/setup/packages/pre-suite/010_Install.rb
+++ b/acceptance/setup/packages/pre-suite/010_Install.rb
@@ -20,7 +20,7 @@ MASTER_PACKAGES = {
     'puppet-server',
   ],
   :debian => [
-    'puppetmaster',
+    'puppetmaster-passenger',
   ],
 #  :solaris => [
 #    'puppet-server',
@@ -46,7 +46,4 @@ AGENT_PACKAGES = {
 }
 
 install_packages_on(master, MASTER_PACKAGES)
-if master['platform'] =~ /debian|ubuntu/
-  on(master, '/etc/init.d/puppetmaster stop')
-end
 install_packages_on(agents, AGENT_PACKAGES)

--- a/acceptance/setup/packages/pre-suite/015_PackageHostsPresets.rb
+++ b/acceptance/setup/packages/pre-suite/015_PackageHostsPresets.rb
@@ -1,0 +1,5 @@
+if master['platform'] =~ /debian|ubuntu/
+  master.uses_passenger!
+elsif master['platform'] =~ /redhat|el|centos|scientific/
+  master['use-service'] = true
+end

--- a/acceptance/setup/packages/pre-suite/045_EnsureMasterStartedOnPassenger.rb
+++ b/acceptance/setup/packages/pre-suite/045_EnsureMasterStartedOnPassenger.rb
@@ -1,0 +1,3 @@
+if master.graceful_restarts?
+  on(master, puppet('resource', 'service', master['puppetservice'], "ensure=running"))
+end

--- a/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
+++ b/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
@@ -12,6 +12,16 @@ confine :except, :platform => 'solaris'
 # pe setup includes ownership of external directories such as the passenger
 # document root, which puppet itself knows nothing about
 confine :except, :type => 'pe'
+# same issue for a foss passenger run
+if master.is_using_passenger?
+  skip_test 'Cannot test with passenger.'
+end
+
+if master.use_service_scripts?
+  # Beaker defaults to leaving puppet running when using service scripts,
+  # Need to shut it down so we can modify user/group and test startup failure
+  on(master, puppet('resource', 'service', master['puppetservice'], 'ensure=stopped'))
+end
 
 step "Clear out yaml directory because of a bug in the indirector/yaml. (See #21145)"
 on master, 'rm -rf $(puppet master --configprint yamldir)'
@@ -62,7 +72,6 @@ end
 
 step "Ensure master starts when making users after having previously failed startup" do
   with_puppet_running_on(master,
-                         :__commandline_args__ => '--debug --trace',
                          :master => { :mkusers => true }) do
     agents.each do |agent|
       on agent, puppet('agent', '-t', '--server', master)

--- a/acceptance/tests/environment/cmdline_overrides_environment.rb
+++ b/acceptance/tests/environment/cmdline_overrides_environment.rb
@@ -110,18 +110,39 @@ file { "#{cmdline_manifest}":
 }
 MANIFEST
 
+def shutdown_puppet_if_running_as_a_service
+  if master.use_service_scripts?
+    # Beaker defaults to leaving puppet running when using service scripts,
+    # Need to shut it down so we can start up with commandline options
+    on(master, puppet('resource', 'service', master['puppetservice'], 'ensure=stopped'))
+  end
+end
+
+teardown do
+  if master.use_service_scripts?
+    # Beaker defaults to leaving puppet running when using service scripts,
+    on(master, puppet('resource', 'service', master['puppetservice'], 'ensure=running'))
+  end
+end
+
 # Note: this is the semantics seen with legacy environments if commandline
 # manifest/modulepath are set.
 step "CASE 1: puppet master with --manifest and --modulepath overrides set production directory environment" do
-  if master.is_pe?
+  if master.is_using_passenger?
     step "Skipping for Passenger (PE) setup; since the equivalent of a commandline override would be adding the setting to config.ru, which seems like a very odd thing to do."
   else
+
+    shutdown_puppet_if_running_as_a_service
+
     master_opts = {
       'master' => {
         'environmentpath' => environmentpath,
         'manifest' => sitepp,
         'modulepath' => modulepath,
-      }
+      },
+      :__service_args__ => {
+        :bypass_service_script => true,
+      },
     }
 
     master_opts_with_cmdline = master_opts.merge(:__commandline_args__ => "--manifest=#{cmdline_manifest} --modulepath=#{other_modulepath}")
@@ -201,11 +222,17 @@ end
 
 step "CASE 4: puppet master with default manifest, modulepath, environment, environmentpath and an existing '#{environmentpath}/production' directory environment that has not been set" do
 
-  if master.is_pe?
+  if master.is_using_passenger?
     step "Skipping for PE because PE requires most of the existing puppet.conf and /etc/puppetlabs/puppet configuration, and we cannot simply point to a new conf directory."
   else
+
+    shutdown_puppet_if_running_as_a_service
+
     ssldir = on(master, puppet("master --configprint ssldir")).stdout.chomp
     master_opts = {
+      :__service_args__ => {
+        :bypass_service_script => true,
+      },
       :__commandline_args__ => "--confdir=#{testdir} --ssldir=#{ssldir}"
     }
 

--- a/acceptance/tests/external_ca_support/apache_external_root_ca.rb
+++ b/acceptance/tests/external_ca_support/apache_external_root_ca.rb
@@ -9,6 +9,17 @@ end
 confine :to, :platform => 'el-6'
 confine :except, :type => 'pe'
 
+if master.use_service_scripts?
+  # Beaker defaults to leaving puppet running when using service scripts,
+  # Need to shut it down so we can start up our apache instance
+  on(master, puppet('resource', 'service', master['puppetservice'], 'ensure=stopped'))
+
+  teardown do
+    # And ensure that it is up again after everything is done
+    on(master, puppet('resource', 'service', master['puppetservice'], 'ensure=running'))
+  end
+end
+
 # Verify that a trivial manifest can be run to completion.
 # Supported Setup: Single, Root CA
 #  - Agent and Master SSL cert issued by the Root CA

--- a/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
+++ b/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
@@ -1,6 +1,6 @@
 test_name "generate a helpful error message when hostname doesn't match server certificate"
 
-skip_test( 'Changing certnames of the master will break PE' )if master.is_pe?
+skip_test( 'Changing certnames of the master will break PE/Passenger installations' ) if master.is_using_passenger?
 
 # Start the master with a certname not matching its hostname
 master_opts = {

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -38,6 +38,7 @@ if master.is_pe?
 else
 
   testdir = master.tmpdir('report_submission')
+  on(master, "chown puppet:puppet #{testdir}")
 
   teardown do
     on master, "rm -rf #{testdir}"

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -12,6 +12,13 @@ EOF
 target_file_on_windows = 'C:/windows/temp/source_attr_test'
 target_file_on_nix     = '/tmp/source_attr_test'
 
+teardown do
+  hosts.each do |host|
+    file_to_rm = host['platform'] =~ /windows/ ? target_file_on_windows : target_file_on_nix
+    on(host, "rm #{file_to_rm}", :acceptable_exit_codes => [0,1])
+  end
+end
+
 mod_manifest = "#{testdir}/modules/source_test_module/manifests/init.pp"
 on master, "mkdir -p #{File.dirname(mod_manifest)}"
 create_remote_file master, mod_manifest, <<EOF

--- a/acceptance/tests/security/cve-2013-3567_yaml_deserialization_again.rb
+++ b/acceptance/tests/security/cve-2013-3567_yaml_deserialization_again.rb
@@ -21,6 +21,15 @@ master_opts = {
   }
 }
 
+# In PE, the master is running as non-root. We need to set the
+# reportdir permissions correctly for it.
+on master, "chmod 750 #{reportdir}"
+if options.is_pe?
+  on master, "chown pe-puppet:pe-puppet #{reportdir}"
+elsif master.is_using_passenger?
+  on master, "chown puppet:puppet #{reportdir}"
+end
+
 with_puppet_running_on(master, master_opts) do
   on master, submit_bad_yaml
   on master, "cat #{reportdir}/$(puppet master --configprint certname)/*" do

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -114,7 +114,6 @@ custom_attributes:
         'autosign' => autosign_inspect_csr_path,
         'dns_alt_names' => "puppet,#{hostname},#{fqdn}",
       },
-      :__commandline_args__ => '--debug --trace',
     }
     with_puppet_running_on(master, master_opts) do
       agents.each do |agent|


### PR DESCRIPTION
This PR changes Puppet acceptance to setup properly so that Beaker can take advantage of using service scripts for package installations of puppet, or for using apache graceful restarts for package installation with passenger.  It updates tests to in account some changes related specifically to Passenger.  In the case of the newer environment tests, this applies to PE as well.

This should not be merged until QENG-188 (https://github.com/puppetlabs/beaker/pull/359) gets merged, and a new Beaker is released.  At that point, we will need to check the Beaker version change in this PR (it's currently set to 1.16.0, as Beaker is currently 1.15.0...) to see if it needs updating before merging.

There's also the question of whether this should be targeted to stable.  I don't think it needs to be, since this should not require a change to the Jenkin's jobs, and I don't believe we are planning another z release on the current stable branch?
