### PR TITLE
(PUP-1186) Ignore PAX header in tar unpacking

### DIFF
--- a/lib/puppet/module_tool/tar/mini.rb
+++ b/lib/puppet/module_tool/tar/mini.rb
@@ -1,13 +1,13 @@
 class Puppet::ModuleTool::Tar::Mini
   def unpack(sourcefile, destdir, _)
     Zlib::GzipReader.open(sourcefile) do |reader|
-      Archive::Tar::Minitar.unpack(reader, destdir) do |action, name, stats|
+      Archive::Tar::Minitar.unpack(reader, destdir, find_valid_files(reader)) do |action, name, stats|
         case action
         when :file_done
           File.chmod(0444, "#{destdir}/#{name}")
         when :dir, :file_start
           validate_entry(destdir, name)
-          Puppet.debug("extracting #{destdir}/#{name}")
+          Puppet.debug("Extracting: #{destdir}/#{name}")
         end
       end
     end
@@ -20,6 +20,24 @@ class Puppet::ModuleTool::Tar::Mini
   end
 
   private
+
+  # Find all the valid files in tarfile.
+  #
+  # This check was mainly added to ignore 'x' and 'g' flags from the PAX
+  # standard but will also ignore any other non-standard tar flags.
+  # tar format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Ftaf.htm
+  # pax format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Fpxarchfm.htm
+  def find_valid_files(tarfile)
+    Archive::Tar::Minitar.open(tarfile).collect do |entry|
+      flag = entry.typeflag
+      if flag.nil? || flag =~ /[[:digit:]]/ && (0..7).include?(flag.to_i)
+        entry.name
+      else
+        Puppet.debug "Invalid tar flag '#{flag}' will not be extracted: #{entry.name}"
+        next
+      end
+    end
+  end
 
   def validate_entry(destdir, path)
     if Pathname.new(path).absolute?

--- a/spec/unit/module_tool/tar/mini_spec.rb
+++ b/spec/unit/module_tool/tar/mini_spec.rb
@@ -54,6 +54,7 @@ describe Puppet::ModuleTool::Tar::Mini, :if => (Puppet.features.minitar? and Pup
     reader = mock('GzipReader')
 
     Zlib::GzipReader.expects(:open).with(sourcefile).yields(reader)
-    Archive::Tar::Minitar.expects(:unpack).with(reader, destdir).yields(type, name, nil)
+    minitar.expects(:find_valid_files).with(reader).returns([name])
+    Archive::Tar::Minitar.expects(:unpack).with(reader, destdir, [name]).yields(type, name, nil)
   end
 end


### PR DESCRIPTION
Prior to this commit if you installed a puppet module built on a platform with
a tar implementation that adds PAX headers and your platform didn't have a native
tar implementation (Windows), the module would contain junk PaxHeader directories.

This is due to the default POSIX behavior programmed in to minitar (the ruby tar
implementation used for platforms with out native tar) for an unknown typeflag,
such as those used in PAX headers, is to treat it as a regular file and extract it.

This commit adds a pre-scan step to our use of minitar for unpacking that finds
all the files with standard typeflags (0-7) and then only unpacks those, thus ignoring
any Pax typeflags like 'x' or 'g'.
