### PR TITLE
(PUP-398) Windows package provider source munging and test

### DIFF
--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -98,7 +98,7 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
     end
   end
 
-  # This only get's called if there is a value to validate, but not if it's absent
+  # This only gets called if there is a value to validate, but not if it's absent
   def validate_source(value)
     fail("The source parameter cannot be empty when using the Windows provider.") if value.empty?
   end

--- a/lib/puppet/provider/package/windows/exe_package.rb
+++ b/lib/puppet/provider/package/windows/exe_package.rb
@@ -41,7 +41,7 @@ class Puppet::Provider::Package::Windows
     end
 
     def self.install_command(resource)
-      ['cmd.exe', '/c', 'start', '"puppet-install"', '/w', quote(resource[:source])]
+      ['cmd.exe', '/c', 'start', '"puppet-install"', '/w', munge(resource[:source])]
     end
 
     def uninstall_command

--- a/lib/puppet/provider/package/windows/msi_package.rb
+++ b/lib/puppet/provider/package/windows/msi_package.rb
@@ -52,7 +52,7 @@ class Puppet::Provider::Package::Windows
     end
 
     def self.install_command(resource)
-      ['msiexec.exe', '/qn', '/norestart', '/i', quote(resource[:source])]
+      ['msiexec.exe', '/qn', '/norestart', '/i', munge(resource[:source])]
     end
 
     def uninstall_command

--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -65,6 +65,18 @@ class Puppet::Provider::Package::Windows
       end
     end
 
+    def self.munge(value)
+      quote(replace_forward_slashes(value))
+    end
+
+    def self.replace_forward_slashes(value)
+      if value.include?('/')
+        value.gsub!('/', "\\") 
+        Puppet.debug('Package source parameter contained /s - replaced with \\s')
+      end
+      value
+    end
+
     def self.quote(value)
       value.include?(' ') ? %Q["#{value.gsub(/"/, '\"')}"] : value
     end

--- a/spec/unit/provider/package/windows/package_spec.rb
+++ b/spec/unit/provider/package/windows/package_spec.rb
@@ -103,6 +103,21 @@ describe Puppet::Provider::Package::Windows::Package do
     end
   end
 
+  context '::munge' do
+    it 'should shell quote strings with spaces and fix forward slashes' do
+      subject.munge('c:/windows/the thing').should == '"c:\windows\the thing"'
+    end
+    it 'should leave properly formatted paths alone' do
+      subject.munge('c:\windows\thething').should == 'c:\windows\thething'
+    end
+  end
+
+  context '::replace_forward_slashes' do
+    it 'should replace forward with back slashes' do
+      subject.replace_forward_slashes('c:/windows/thing/stuff').should == 'c:\windows\thing\stuff'
+    end
+  end
+
   context '::quote' do
     it 'should shell quote strings with spaces' do
       subject.quote('foo bar').should == '"foo bar"'


### PR DESCRIPTION
Package installation/upgrade in Windows will probably fail if the source attribute path contains /

Not sure of all the ins and outs here, but I think warning is sufficient - it the path ends up really not existing to msiexec etc then the resource will fail, and the debug will give a hint as to the cause.
