### PR TITLE
(PUP-2944) Use osfamily to choose yum as a default

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       end
   end
 
-  defaultfor :operatingsystem => [:fedora, :centos, :redhat]
+  defaultfor :osfamily => :redhat
 
   def self.prefetch(packages)
     raise Puppet::Error, "The yum provider can only be used as root" if Process.euid != 0


### PR DESCRIPTION
This is a re-submission of PR #1360. Using `operatingsystem` instead of `osfamily` means that some Red Hat derivatives, notable Oracle Linux and Scientific Linux, don't actually receive a default package provider. Yum just happens to win because it is suitable and has a high "specificity" score. However, if some other suitable provider happens to be installed that matches (or exceeds) Yum in specificity, an alphabetical sort will be used as a tie-breaker and Yum will loose.

Chaos ensues.
