### PR TITLE
(PUP-2882) Fix single available upgrade

### DIFF
--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -124,10 +124,12 @@ module Puppet::ModuleTool
 
           # Ensure that there is at least one candidate release available
           # for the target package.
-          if graph.dependencies[name].empty? || graph.dependencies[name] == SortedSet.new([ installed_modules[name] ])
+          if graph.dependencies[name].empty?
             if results[:requested_version] == :latest || !Semantic::VersionRange.parse(results[:requested_version]).include?(results[:installed_version])
               raise NoCandidateReleasesError, results.merge(:module_name => name, :source => module_repository.host)
             end
+          elsif graph.dependencies[name] == SortedSet.new([installed_modules[name]])
+            raise VersionAlreadyInstalledError, results.merge(:module_name => name, :newer_versions => [])
           end
 
           begin

--- a/spec/lib/puppet_spec/module_tool/stub_source.rb
+++ b/spec/lib/puppet_spec/module_tool/stub_source.rb
@@ -100,6 +100,9 @@ module PuppetSpec
             "0.0.2" => { "pmtacceptance/stdlib" => ">= 2.2.0", "pmtacceptance/mysql" => ">= 0.0.1" },
             "0.0.1" => { "pmtacceptance/stdlib" => ">= 2.2.0" },
           },
+          'puppetlabs-oneversion' => {
+            "0.0.1" => {}
+          }
         }
 
         @available_releases.each do |name, versions|

--- a/spec/unit/module_tool/applications/upgrader_spec.rb
+++ b/spec/unit/module_tool/applications/upgrader_spec.rb
@@ -52,6 +52,16 @@ describe Puppet::ModuleTool::Applications::Upgrader do
     end
 
     context 'for an installed module' do
+      context 'with only one version' do
+        before { preinstall('puppetlabs-oneversion', '0.0.1') }
+        let(:module) { 'puppetlabs-oneversion' }
+
+        it 'declines to upgrade' do
+          subject.should include :result => :noop
+          subject[:error][:multiline].should =~ /already the latest version/
+        end
+      end
+
       context 'without dependencies' do
         before { preinstall('pmtacceptance-stdlib', '1.0.0') }
 
@@ -90,6 +100,7 @@ describe Puppet::ModuleTool::Applications::Upgrader do
               context 'without options' do
                 it 'declines to upgrade' do
                   subject.should include :result => :noop
+                  subject[:error][:multiline].should =~ /already the latest version/
                 end
               end
 


### PR DESCRIPTION
Prior to this commit `puppet module upgrade` would fail with an error message
about not being able to satisfy the upgrade when there is only one published
release of the module.
This commit changes the error message to say that there is no version to upgrade
to. This should reduce some user confusion.
