### PR TITLE
(doc) Fixes simple typo in 'parser' section

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1947,7 +1947,7 @@ EOT
         language/'.pp' files). Available choices are `current` (the default)
         and `future`.
 
-        The `curent` parser means that the released version of the parser should
+        The `current` parser means that the released version of the parser should
         be used.
 
         The `future` parser is a "time travel to the future" allowing early


### PR DESCRIPTION
Corrects a doc typo.

Also present in https://github.com/puppetlabs/puppet-docs repo. Pull Request https://github.com/puppetlabs/puppet-docs/pull/345 submitted.
