### PR TITLE
(PUP-2948) enable rubocop for travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 bundler_args: --without development
-script: "bundle exec rake \"parallel:spec[2]\""
+script:
+  - "bundle exec rake $CHECK"
 notifications:
   email: false
 rvm:
@@ -8,3 +9,16 @@ rvm:
   - 2.0.0
   - 1.9.3
   - 1.8.7-p374
+
+env:
+  - "CHECK=parallel:spec\\[2\\]"
+  - "CHECK=rubocop"
+
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      env: "CHECK=rubocop"
+    - rvm: 1.9.3
+      env: "CHECK=rubocop"
+    - rvm: 1.8.7-p374
+      env: "CHECK=rubocop"

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ platforms :ruby do
   gem 'yard', :group => :development
   gem 'redcarpet', '~> 2.0', :group => :development
   gem "racc", "1.4.9", :group => :development
-  gem "rubocop", :group => :development unless RUBY_VERSION =~ /^1.8/
 
   # To enable the augeas feature, use this gem.
   # Note that it is a native gem, so the augeas headers/libs
@@ -44,6 +43,8 @@ group(:development, :test) do
   # json-schema uses multi_json, but chokes with multi_json 1.7.9, so prefer 1.7.7
   gem "multi_json", "1.7.7", :require => false, :platforms => [:ruby, :jruby]
   gem "json-schema", "2.1.1", :require => false, :platforms => [:ruby, :jruby]
+
+  gem "rubocop" unless RUBY_VERSION =~ /^1.8/
 end
 
 group(:development) do

--- a/Rakefile
+++ b/Rakefile
@@ -69,8 +69,12 @@ end
 
 desc 'run static analysis with rubocop'
 task(:rubocop) do
-  require 'rubocop'
-  cli = RuboCop::CLI.new
-  cli.run(%w(-D))
+  if RUBY_VERSION !~ /1.8/
+    require 'rubocop'
+    cli = RuboCop::CLI.new
+    cli.run(%w(-D -f s))
+  else
+    puts "Rubocop is disabled in ruby 1.8"
+  end
 end
 


### PR DESCRIPTION
- Add rubocop step in travis CI
- Ensure rubocop is present in test group
- Ensure rubocop is not added for ruby 1.8
