### PR TITLE
(CPR-37)(PUP-2956) vendor json_pure in OSX package

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -49,3 +49,5 @@ gem_platform_dependencies:
 bundle_platforms:
   x86-mingw32: mingw
   x64-mingw32: x64_mingw
+pre_tasks:
+  'package:apple': 'vendorjson'

--- a/tasks/vendorjson.rake
+++ b/tasks/vendorjson.rake
@@ -1,0 +1,18 @@
+task 'vendorjson' do
+  if defined? Pkg::Config and Pkg::Config.project_root
+    json_version = "1.8.1"
+    libdir = File.join(Pkg::Config.project_root, "lib")
+    source = "https://github.com/flori/json/archive/v#{json_version}.tar.gz"
+    target_dir = Pkg::Util::File.mktemp
+    target = File.join(target_dir, "json")
+    Pkg::Util::Net.fetch_uri(source, target)
+    Pkg::Util::File.untar_into(target, target_dir, "--strip-components 1")
+    unless Dir.glob("#{File.join(target_dir, "lib", "json*")}").empty?
+      rm_rf(Dir.glob("#{File.join(target_dir, "lib", "json*")}"))
+    end
+    mv(Dir.glob("#{File.join(target_dir, "lib")}/json*"), libdir)
+    mv(Dir.glob("#{target_dir}/{COPYING,GPL,VERSION}"), File.join(libdir, "json"))
+  else
+    warn "It looks like the packaging tasks have not been loaded. You'll need to `rake package:bootstrap` before using this task"
+  end
+end


### PR DESCRIPTION
Per CPR-37, prior to this commit the dmg/pkg of puppet we shipped did not work
out of the box in OSX < 10.9 because of a dependency on json that is not
satisfied by system ruby. In OSX 10.9 system ruby is 2.0...prior to this it was
1.8.7 or less. This commit introduces a pre-automation task that retrieves the
json_pure 1.8.1 release from github and vendors it within the lib. This is the
approach we took with facter 2 and cfpropertylist for FACT-332 in aa9ee28b of
facter. This commit will drop json.rb and its lib dir in /Library/Ruby/Site
alongside puppet.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
