### PR TITLE
(PUP-2882) Correct acceptance test for single version module upgrade

### DIFF
--- a/acceptance/tests/modules/upgrade/to_installed_version.rb
+++ b/acceptance/tests/modules/upgrade/to_installed_version.rb
@@ -30,7 +30,7 @@ on master, puppet("module upgrade pmtacceptance-java --version 1.6.x --force") d
   assert_match(/#{master['distmoduledir']}/, stdout,
     'Error that distmoduledir was not displayed')
 
-  assert_match(/pmtacceptance-java \(.*v1\.6\.0.*\)/, stdout,
+  assert_match(/\'pmtacceptance-java\' \(.*v1\.6\.0.*\)/, stdout,
     'Error that package name and version were not displayed')
 end
 


### PR DESCRIPTION
Before this commit, the acceptance test for upgrading a module which
only has one version was expecting old error messages. This commit
corrects the acceptance test to expect the new error message.
