### PR TITLE
(PUP-2757) Check for env change before updating Configurer context

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -188,7 +188,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       configured_environment.override_with(:manifest => manifest) :
       configured_environment
 
-    Puppet.override(:current_environment => apply_environment) do
+    Puppet.override({:current_environment => apply_environment}, "For puppet apply") do
       # Find our Node
       unless node = Puppet::Node.indirection.find(Puppet[:node_name_value])
         raise "Could not find node #{Puppet[:node_name_value]}"

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -169,11 +169,16 @@ class Puppet::Configurer
       end
 
       current_environment = Puppet.lookup(:current_environment)
-      Puppet.push_context(:current_environment =>
-                          Puppet::Node::Environment.create(@environment,
-                                                           current_environment.modulepath,
-                                                           current_environment.manifest,
-                                                           current_environment.config_version))
+      local_node_environment =
+      if current_environment.name == @environment.intern
+        current_environment
+      else
+        Puppet::Node::Environment.create(@environment,
+                                         current_environment.modulepath,
+                                         current_environment.manifest,
+                                         current_environment.config_version)
+      end
+      Puppet.push_context({:current_environment => local_node_environment}, "Local node environment for configurer transaction")
 
       query_options = get_facts(options) unless query_options
 


### PR DESCRIPTION
Previous work on PUP-2757 ensured that resource references would use the
current environment and that agent runs would use a correctly
initialized 'remote' reference environment, but, ironically, Charlie
Sharpsteen found that the fixes for agent runs re-introduced the
duplication of initial environment import in the Puppet apply case.
Removing that duplication of effort was the reason for the initial
change.

This commit tests whether the environment has changed, which it should
only do in the agent case, and, if not, pushes the original env onto the
context stack.  We push regardless, so that we don't have to guard the
corresponding pop.
