### PR TITLE
(maint) Remove pending face specs

### DIFF
--- a/spec/unit/face/certificate_request_spec.rb
+++ b/spec/unit/face/certificate_request_spec.rb
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby
-require 'spec_helper'
-require 'puppet/face'
-
-describe Puppet::Face[:certificate_request, '0.0.1'] do
-  it "should actually have some tests..."
-end

--- a/spec/unit/face/certificate_revocation_list_spec.rb
+++ b/spec/unit/face/certificate_revocation_list_spec.rb
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby
-require 'spec_helper'
-require 'puppet/face'
-
-describe Puppet::Face[:certificate_revocation_list, '0.0.1'] do
-  it "should actually have some tests..."
-end

--- a/spec/unit/face/key_spec.rb
+++ b/spec/unit/face/key_spec.rb
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby
-require 'spec_helper'
-require 'puppet/face'
-
-describe Puppet::Face[:key, '0.0.1'] do
-  it "should actually have some tests..."
-end

--- a/spec/unit/face/report_spec.rb
+++ b/spec/unit/face/report_spec.rb
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby
-require 'spec_helper'
-require 'puppet/face'
-
-describe Puppet::Face[:report, '0.0.1'] do
-  it "should actually have some tests..."
-end

--- a/spec/unit/face/resource_spec.rb
+++ b/spec/unit/face/resource_spec.rb
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby
-require 'spec_helper'
-require 'puppet/face'
-
-describe Puppet::Face[:resource, '0.0.1'] do
-  it "should actually have some tests..."
-end

--- a/spec/unit/face/resource_type_spec.rb
+++ b/spec/unit/face/resource_type_spec.rb
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby
-require 'spec_helper'
-require 'puppet/face'
-
-describe Puppet::Face[:resource_type, '0.0.1'] do
-  it "should actually have some tests..."
-end


### PR DESCRIPTION
The certificate_request, certificate_revocation_list, key, report,
resource, and resource_type faces were added years ago and the tests have
always been pending. Since we've been ignoring those pending tests up to
this point the warnings are clearly not adding value; let's just get rid
of them.
