### PR TITLE
(PUP-2953) Remove masterlog option

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1014,16 +1014,6 @@ EOT
       by `puppet`, and should only be set if you're writing your own Puppet
       executable.",
     },
-    :masterlog => {
-      :default => "$logdir/puppetmaster.log",
-      :type => :file,
-      :owner => "service",
-      :group => "service",
-      :mode => 0660,
-      :desc => "This file is literally never used, although Puppet may create it
-        as an empty file. For more context, see the `puppetdlog` setting and
-        puppet master's `--logdest` command line option."
-    },
     :masterhttplog => {
       :default => "$logdir/masterhttp.log",
       :type => :file,


### PR DESCRIPTION
Pull the `masterlog` configuration option as it is unused and causes confusion.

This is #1686 re-submitted for Puppet 4.
