### PR TITLE
(PUP-2882) Verify available versions

### DIFF
--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -89,6 +89,11 @@ module Puppet::ModuleTool
           available_versions = module_repository.fetch(name)
           if available_versions.empty?
             raise NoCandidateReleasesError, results.merge(:module_name => name, :source => module_repository.host)
+          elsif results[:requested_version] != :latest
+            requested = Semantic::VersionRange.parse(results[:requested_version])
+            unless available_versions.any? {|m| requested.include? m.version}
+              raise NoCandidateReleasesError, results.merge(:module_name => name, :source => module_repository.host)
+            end
           end
 
           Puppet.notice "Downloading from #{module_repository.host} ..."


### PR DESCRIPTION
Prior to this commit we didn't check up front to make sure there is a version
matching what is requested by the --version flag. This changed the error given,
which made acceptance tests fail.

This commit adds a check before even attempting to build a graph to ensure that
there is a compatible version.
