### PR TITLE
(PUP-2948) enable rubocop for travisCI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group(:development, :test) do
   gem "multi_json", "1.7.7", :require => false, :platforms => [:ruby, :jruby]
   gem "json-schema", "2.1.1", :require => false, :platforms => [:ruby, :jruby]
 
-  gem "rubocop" unless RUBY_VERSION =~ /^1.8/
+  gem "rubocop", :platforms => [:ruby] unless RUBY_VERSION =~ /^1.8/
 end
 
 group(:development) do


### PR DESCRIPTION
Previously, the Rubocop gem was added to development and testing groups without
any further constraints. However, this caused failures in windows platform, due
to its dependency on json. Since we are using only multi-json, we do not want
to have this dependency added. So this commit restricts rubocop to
non-windows native rubies.

An issue requesting for multi-json dependency in rubycop is logged [here](https://github.com/bbatsov/rubocop/issues/1228)
