### PR TITLE
(PUP-2728) Remove rug package provider as default

### DIFF
--- a/lib/puppet/provider/package/rug.rb
+++ b/lib/puppet/provider/package/rug.rb
@@ -5,7 +5,6 @@ Puppet::Type.type(:package).provide :rug, :parent => :rpm do
 
   commands :rug => "/usr/bin/rug"
   commands :rpm => "rpm"
-  defaultfor :operatingsystem => [:suse, :sles]
   confine    :operatingsystem => [:suse, :sles]
 
   # Install a package using 'rug'.


### PR DESCRIPTION
We only support SLES 10.4 which uses zypper, and when zypper is present
we should always use it over rug. This commit removes rug as a default
provider; if zypper is not present then rug should be used as a fallback
due to the number of confine statements.
