### PR TITLE
(PUP-2766) Make newer environment tests run in PE env

### DIFF
--- a/acceptance/lib/puppet/acceptance/environment_utils_spec.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils_spec.rb
@@ -1,0 +1,144 @@
+require File.join(File.dirname(__FILE__),'../../acceptance_spec_helper.rb')
+require 'puppet/acceptance/environment_utils'
+
+module EnvironmentUtilsSpec
+describe 'EnvironmentUtils' do
+  class ATestCase
+    include Puppet::Acceptance::EnvironmentUtils
+
+    def step(str)
+      yield
+    end
+
+    def on(host, command, options = nil)
+      stdout = host.do(command, options)
+      yield TestResult.new(stdout) if block_given?
+    end
+  end
+
+  class TestResult
+    attr_accessor :stdout
+
+    def initialize(stdout)
+      self.stdout = stdout
+    end
+  end
+
+  class TestHost
+    attr_accessor :did, :directories, :attributes
+
+    def initialize(directories, attributes = {})
+      self.directories = directories
+      self.did = []
+      self.attributes = attributes
+    end
+
+    def do(command, options)
+      did << (options.nil? ? command : [command, options])
+      case command
+      when /^ls (.*)/ then directories[$1]
+      end
+    end
+
+    def [](param)
+      attributes[param]
+    end
+  end
+
+  let(:testcase) { ATestCase.new }
+  let(:host) { TestHost.new(directory_contents, 'user' => 'root', 'group' => 'puppet') }
+  let(:directory_contents) do
+    {
+      '/etc/puppet' => 'foo bar baz widget',
+      '/tmp/dir'    => 'foo dingo bar thing',
+    }
+  end
+
+  it "runs the block of code" do
+    ran_code = false
+    testcase.safely_shadow_directory_contents_and_yield(host, '/etc/puppet', '/tmp/dir') do
+      ran_code = true
+    end
+    expect(ran_code).to be_true
+    expect(host.did).to eq([
+      "ls /etc/puppet",
+      "ls /tmp/dir",
+      "mv /etc/puppet/foo /etc/puppet/foo.bak",
+      "mv /etc/puppet/bar /etc/puppet/bar.bak",
+      "cp -R /tmp/dir/foo /etc/puppet/foo",
+      "cp -R /tmp/dir/dingo /etc/puppet/dingo",
+      "cp -R /tmp/dir/bar /etc/puppet/bar",
+      "cp -R /tmp/dir/thing /etc/puppet/thing",
+      "chown -R root:puppet /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+      "chmod -R 770 /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+      "rm -rf /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+      "mv /etc/puppet/foo.bak /etc/puppet/foo",
+      "mv /etc/puppet/bar.bak /etc/puppet/bar"
+    ])
+  end
+
+  it "backs up the original items that are shadowed by tmp items" do
+    testcase.safely_shadow_directory_contents_and_yield(host, '/etc/puppet', '/tmp/dir') {}
+    expect(host.did.grep(%r{mv /etc/puppet/\w+ })).to eq([
+      "mv /etc/puppet/foo /etc/puppet/foo.bak",
+      "mv /etc/puppet/bar /etc/puppet/bar.bak",
+    ])
+  end
+
+  it "copies in all the tmp items into the working dir" do
+    testcase.safely_shadow_directory_contents_and_yield(host, '/etc/puppet', '/tmp/dir') {}
+    expect(host.did.grep(%r{cp})).to eq([
+      "cp -R /tmp/dir/foo /etc/puppet/foo",
+      "cp -R /tmp/dir/dingo /etc/puppet/dingo",
+      "cp -R /tmp/dir/bar /etc/puppet/bar",
+      "cp -R /tmp/dir/thing /etc/puppet/thing",
+    ])
+  end
+
+  it "opens the permissions on all copied files to 770 and sets ownership based on host settings" do
+    testcase.safely_shadow_directory_contents_and_yield(host, '/etc/puppet', '/tmp/dir') {}
+    expect(host.did.grep(%r{ch(mod|own)})).to eq([
+      "chown -R root:puppet /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+      "chmod -R 770 /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+    ])
+  end
+
+  it "deletes all the tmp items from the working dir" do
+    testcase.safely_shadow_directory_contents_and_yield(host, '/etc/puppet', '/tmp/dir') {}
+    expect(host.did.grep(%r{rm})).to eq([
+      "rm -rf /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+    ])
+  end
+
+  it "replaces the original items that had been shadowed into the working dir" do
+    testcase.safely_shadow_directory_contents_and_yield(host, '/etc/puppet', '/tmp/dir') {}
+    expect(host.did.grep(%r{mv /etc/puppet/\w+\.bak})).to eq([
+      "mv /etc/puppet/foo.bak /etc/puppet/foo",
+      "mv /etc/puppet/bar.bak /etc/puppet/bar"
+    ])
+  end
+
+  it "always cleans up, even if the code we yield to raises an error" do
+    expect do
+      testcase.safely_shadow_directory_contents_and_yield(host, '/etc/puppet', '/tmp/dir') do
+        raise 'oops'
+      end
+    end.to raise_error('oops')
+    expect(host.did).to eq([
+      "ls /etc/puppet",
+      "ls /tmp/dir",
+      "mv /etc/puppet/foo /etc/puppet/foo.bak",
+      "mv /etc/puppet/bar /etc/puppet/bar.bak",
+      "cp -R /tmp/dir/foo /etc/puppet/foo",
+      "cp -R /tmp/dir/dingo /etc/puppet/dingo",
+      "cp -R /tmp/dir/bar /etc/puppet/bar",
+      "cp -R /tmp/dir/thing /etc/puppet/thing",
+      "chown -R root:puppet /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+      "chmod -R 770 /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+      "rm -rf /etc/puppet/foo /etc/puppet/dingo /etc/puppet/bar /etc/puppet/thing",
+      "mv /etc/puppet/foo.bak /etc/puppet/foo",
+      "mv /etc/puppet/bar.bak /etc/puppet/bar"
+    ])
+  end
+end
+end

--- a/acceptance/lib/puppet/acceptance/install_utils_spec.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils_spec.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__),'../../acceptance_spec_helper.rb')
 require 'puppet/acceptance/install_utils'
 
+module InstallUtilsSpec
 describe 'InstallUtils' do
 
   class ATestCase
@@ -258,4 +259,5 @@ describe 'InstallUtils' do
       testcase.install_repos_on(host, sha, 'repo-configs')
     end
   end
+end
 end

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -31,7 +31,7 @@ File {
   ensure => directory,
   owner => #{master['user']},
   group => #{master['group']},
-  mode => 0750,
+  mode => 0770,
 }
 
 file {

--- a/acceptance/tests/environment/directory_environment_with_environment_conf.rb
+++ b/acceptance/tests/environment/directory_environment_with_environment_conf.rb
@@ -11,7 +11,7 @@ File {
   ensure => directory,
   owner => #{master['user']},
   group => #{master['group']},
-  mode => 0750,
+  mode => 0770,
 }
 
 file {

--- a/acceptance/tests/environment/static.rb
+++ b/acceptance/tests/environment/static.rb
@@ -7,6 +7,7 @@ step "setup environments"
 stub_forge_on(master)
 
 testdir = master.tmpdir("confdir")
+puppet_conf_backup_dir = master.tmpdir("puppet-conf-backup-dir")
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
@@ -25,35 +26,37 @@ master_opts = {
     'config_version' => "$confdir/static-version.sh",
   },
 }
-results[existing_legacy_scenario] = use_an_environment("testing", "legacy testing", master_opts, testdir)
+results[existing_legacy_scenario] = use_an_environment("testing", "legacy testing", master_opts, testdir, puppet_conf_backup_dir)
 
 default_environment_scenario = "Test behavior of default environment"
 step default_environment_scenario
-results[default_environment_scenario] = use_an_environment(nil, "default environment", master_opts, testdir)
+results[default_environment_scenario] = use_an_environment(nil, "default environment", master_opts, testdir, puppet_conf_backup_dir)
 
 non_existent_environment_scenario = "Test for an environment that does not exist"
 step non_existent_environment_scenario
-results[non_existent_environment_scenario] = use_an_environment("doesnotexist", "non existent environment", master_opts, testdir)
+results[non_existent_environment_scenario] = use_an_environment("doesnotexist", "non existent environment", master_opts, testdir, puppet_conf_backup_dir)
 
 ########################################
 step "[ Report on Environment Results ]"
+
+confdir = master.puppet['confdir']
 
 step "Reviewing: #{existing_legacy_scenario}"
 review[existing_legacy_scenario] = review_results(results[existing_legacy_scenario],
   :puppet_config => {
     :exit_code => 0,
-    :matches => [%r{manifest.*/tmp.*/testing-manifests$},
-                 %r{modulepath.*/tmp.*/testing-modules$},
-                 %r{config_version.*/tmp.*/static-version.sh$}]
+    :matches => [%r{manifest.*#{confdir}/testing-manifests$},
+                 %r{modulepath.*#{confdir}/testing-modules$},
+                 %r{config_version.*#{confdir}/static-version.sh$}]
   },
   :puppet_module_install => {
     :exit_code => 0,
-    :matches => [%r{Preparing to install into /tmp.*/testing-modules},
+    :matches => [%r{Preparing to install into #{confdir}/testing-modules},
                  %r{pmtacceptance-nginx}],
   },
   :puppet_module_uninstall => {
     :exit_code => 0,
-    :matches => [%r{Removed.*pmtacceptance-nginx.*from /tmp.*/testing-modules}],
+    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{confdir}/testing-modules}],
   },
   :puppet_apply => {
     :exit_code => 0,
@@ -71,18 +74,18 @@ step "Reviewing: #{default_environment_scenario}"
 default_expectations = {
   :puppet_config => {
     :exit_code => 0,
-    :matches => [%r{manifest.*/tmp.*/manifests/site.pp$},
-                 %r{modulepath.*/tmp.*/modules:.*},
+    :matches => [%r{manifest.*#{confdir}/manifests/site.pp$},
+                 %r{modulepath.*#{confdir}/modules:.*},
                  %r{^config_version\s+=\s*$}]
   },
   :puppet_module_install => {
     :exit_code => 0,
-    :matches => [%r{Preparing to install into /tmp.*/modules},
+    :matches => [%r{Preparing to install into #{confdir}/modules},
                  %r{pmtacceptance-nginx}],
   },
   :puppet_module_uninstall => {
     :exit_code => 0,
-    :matches => [%r{Removed.*pmtacceptance-nginx.*from /tmp.*/modules}],
+    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{confdir}/modules}],
   },
   :puppet_apply => {
     :exit_code => 0,

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -68,7 +68,7 @@ File {
   ensure => directory,
   owner => #{master['user']},
   group => #{master['group']},
-  mode => 0750,
+  mode => 0770,
 }
 
 file {


### PR DESCRIPTION
Newer directory environment tests were relying on setting commandline
parameters for puppet to point to a temporary config directory.  This
doesn't work well for passenger or PE, so added some utility methods to
backup the established confdir files we are shadowing and ensure they
are replaced.  Also some changes to permissions related to Puppet
running with passenger dropping root permissions.
