### PR TITLE
(maint) Remove unused property 'munger' attribute

### DIFF
--- a/lib/puppet/parameter.rb
+++ b/lib/puppet/parameter.rb
@@ -29,12 +29,6 @@ class Puppet::Parameter
   class << self
     include Puppet::Util
     include Puppet::Util::Docs
-    # Unused?
-    # @todo The term "munger" only appears in this location in the Puppet code base. There is munge and unmunge
-    #  and they seem to work perfectly fine without this attribute declaration.
-    # @api private
-    #
-    attr_reader :munger
 
     # @return [Symbol] The parameter name as given when it was created.
     attr_reader :name


### PR DESCRIPTION
The munger attribute was added to Puppet::Property in 1d739731 the code
that would have used it was always commented out and later removed
entirely. Since this attribute isn't respected we can remove it.
