### PR TITLE
(maint) Remove unused property 'validater' attribute

### DIFF
--- a/lib/puppet/parameter.rb
+++ b/lib/puppet/parameter.rb
@@ -30,13 +30,6 @@ class Puppet::Parameter
     include Puppet::Util
     include Puppet::Util::Docs
     # Unused?
-    # @todo The term "validater" only appears in this location in the Puppet code base. There is `validate`
-    #   which seems to works fine without this attribute declaration.
-    # @api private
-    #
-    attr_reader :validater
-
-    # Unused?
     # @todo The term "munger" only appears in this location in the Puppet code base. There is munge and unmunge
     #  and they seem to work perfectly fine without this attribute declaration.
     # @api private


### PR DESCRIPTION
The validater attribute was added to Puppet::Property in 1d739731, but
the code that would have used it was always commented out and later
removed entirely. Since this attribute isn't respected we can remove it.
