### PR TITLE
(PUP-877) Deprecate masterlog setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1022,7 +1022,10 @@ EOT
       :mode => 0660,
       :desc => "This file is literally never used, although Puppet may create it
         as an empty file. For more context, see the `puppetdlog` setting and
-        puppet master's `--logdest` command line option."
+        puppet master's `--logdest` command line option.
+
+        This setting is deprecated and will be removed in a future version of Puppet.",
+      :deprecated => :completely
     },
     :masterhttplog => {
       :default => "$logdir/masterhttp.log",


### PR DESCRIPTION
The `masterlog` setting is dead code, not used anywhere and has been removed in
Puppet 4.
