### PR TITLE
(PUP-2991) Restore ability to manage shells on solaris

### DIFF
--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
     value !~ /\s/
   end
 
-  has_features :manages_homedir, :allows_duplicates, :manages_solaris_rbac, :manages_passwords, :manages_password_age
+  has_features :manages_homedir, :allows_duplicates, :manages_solaris_rbac, :manages_passwords, :manages_password_age, :manages_shell
 
   #must override this to hand the keyvalue pairs
   def add_properties


### PR DESCRIPTION
Background: for PUP-1448 commit 73b0c2b0 added a new feature
for user providers `manage_shells`. The intent of that commit
was to add this feature to all existing user providers which
had that feature, and several were covered, but Solaris was
missed.

This commit simply adds the `manage_shells` feature to the
Solaris user provider, following up on the intent in PUP-1448.
