### PR TITLE
(PUP-2912) Build/unpack spec tests w/o symlinks

### DIFF
--- a/spec/unit/module_tool/applications/builder_spec.rb
+++ b/spec/unit/module_tool/applications/builder_spec.rb
@@ -48,7 +48,7 @@ describe Puppet::ModuleTool::Applications::Builder do
 
     it_behaves_like "a packagable module"
 
-    it "does not package with a symlink" do
+    it "does not package with a symlink", :if => Puppet.features.manages_symlinks? do
       FileUtils.touch(File.join(path, 'tempfile'))
       File.symlink(File.join(path, 'tempfile'), File.join(path, 'tempfile2'))
 
@@ -57,7 +57,7 @@ describe Puppet::ModuleTool::Applications::Builder do
       }.to raise_error Puppet::ModuleTool::Errors::ModuleToolError, /symlinks/i
     end
 
-    it "does not package with a symlink in a subdir" do
+    it "does not package with a symlink in a subdir", :if => Puppet.features.manages_symlinks? do
       FileUtils.mkdir(File.join(path, 'manifests'))
       FileUtils.touch(File.join(path, 'manifests/tempfile.pp'))
       File.symlink(File.join(path, 'manifests/tempfile.pp'), File.join(path, 'manifests/tempfile2.pp'))

--- a/spec/unit/module_tool/applications/unpacker_spec.rb
+++ b/spec/unit/module_tool/applications/unpacker_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
     File.should be_directory(File.join(target, 'mytarball'))
   end
 
-  it "should warn about symlinks" do
+  it "should warn about symlinks", :if => Puppet.features.manages_symlinks? do
     untar = mock('Tar')
     untar.expects(:unpack).with(filename, anything()) do |src, dest, _|
       FileUtils.mkdir(File.join(dest, 'extractedmodule'))
@@ -51,7 +51,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
     File.should be_directory(File.join(target, 'mytarball'))
   end
 
-  it "should warn about symlinks in subdirectories" do
+  it "should warn about symlinks in subdirectories", :if => Puppet.features.manages_symlinks? do
     untar = mock('Tar')
     untar.expects(:unpack).with(filename, anything()) do |src, dest, _|
       FileUtils.mkdir(File.join(dest, 'extractedmodule'))


### PR DESCRIPTION
Prior to this commit we would try to use symlinks in the tests on platforms that
do not support symlinking.
This commit uses the Puppet feature checker to conditionally try the tests if
Puppet thinks the platform supports symlinks (Unixes, Linuxes, Win 2k8+).
