### PR TITLE
(PUP-2991) Add test case for user shell management

### DIFF
--- a/acceptance/tests/resource/user/should_manage_shell.rb
+++ b/acceptance/tests/resource/user/should_manage_shell.rb
@@ -1,0 +1,33 @@
+test_name "should manage user shell"
+
+name = "pl#{rand(999999).to_i}"
+
+confine :except, :platform => 'windows'
+
+agents.each do |agent|
+  step "ensure the user and group do not exist"
+  agent.user_absent(name)
+  agent.group_absent(name)
+
+  step "create the user with shell"
+  shell = '/bin/sh'
+  on agent, puppet_resource('user', name, ["ensure=present", "shell=#{shell}"])
+
+  step "verify the user shell matches the managed shell"
+  agent.user_get(name) do |result|
+    fail_test "didn't set the user shell for #{name}" unless result.stdout.include? shell
+  end
+
+  step "modify the user with shell"
+  shell = '/bin/bash'
+  on agent, puppet_resource('user', name, ["ensure=present", "shell=#{shell}"])
+
+  step "verify the user shell matches the managed shell"
+  agent.user_get(name) do |result|
+    fail_test "didn't set the user shell for #{name}" unless result.stdout.include? shell
+  end
+
+  step "delete the user, and group, if any"
+  agent.user_absent(name)
+  agent.group_absent(name)
+end


### PR DESCRIPTION
This commit adds a test case to validate the shell attribute of
the puppet user resource is being managed by the manifest.

This test validates that the set shell on creation is part of the
user profile. It also tests that the shell is updated when the
shell defined in the manifest changes.
