### PR TITLE
(PUP-2924) Set resource_type when retrieving state

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1040,6 +1040,15 @@ class Type
     fail "Provider #{provider.class.name} is not functional on this host" if self.provider.is_a?(Puppet::Provider) and ! provider.class.suitable?
 
     result = Puppet::Resource.new(type, title)
+    # Normally, a Puppet::Resource instance will follow a very expensive code
+    # path that involves hitting the type loader to determine the Type class
+    # for `resource_type`. Since we're constructing this Resource inside a Type
+    # instance, we have the class information readily available and can save
+    # a lot of time by setting it directly.
+    #
+    # TODO: Puppet::Resource.new(type, ...) should handle this case during
+    # initialization.
+    result.resource_type = self.class
 
     # Provide the name, so we know we'll always refer to a real thing
     result[:name] = self[:name] unless self[:name] == title


### PR DESCRIPTION
Instances of `Puppet::Resource` will follow a very expensive code path when
asked to retrieve their `resource_type`. In the case of whits, this results in
an exhaustive search as Whit types have unique per-instance names that never
map to an on-disk implementation as Ruby code.

This patch avoids some of this work by having the `Puppet::Type#retrieve`
method set `resource_type` to `self.class` after creating a Resource instance.
