### PR TITLE
(PUP-2912) Puppet FS symlinks in build/unpack

### DIFF
--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'json'
+require 'puppet/file_system'
 
 module Puppet::ModuleTool
   module Applications
@@ -68,7 +69,7 @@ module Puppet::ModuleTool
       end
 
       def sanity_check
-        symlinks = Dir.glob("#{@path}/**/*", File::FNM_DOTMATCH).map { |f| Pathname.new(f) }.select(&:symlink?)
+        symlinks = Dir.glob("#{@path}/**/*", File::FNM_DOTMATCH).map { |f| Pathname.new(f) }.select {|p| Puppet::FileSystem.symlink? p}
         dirpath = Pathname.new @path
 
         unless symlinks.empty?

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -1,6 +1,7 @@
 require 'pathname'
 require 'tmpdir'
 require 'json'
+require 'puppet/file_system'
 
 module Puppet::ModuleTool
   module Applications
@@ -41,7 +42,7 @@ module Puppet::ModuleTool
       # @api private
       # Error on symlinks and other junk
       def sanity_check
-        symlinks = Dir.glob("#{tmpdir}/**/*", File::FNM_DOTMATCH).map { |f| Pathname.new(f) }.select(&:symlink?)
+        symlinks = Dir.glob("#{tmpdir}/**/*", File::FNM_DOTMATCH).map { |f| Pathname.new(f) }.select {|p| Puppet::FileSystem.symlink? p}
         tmpdirpath = Pathname.new tmpdir
 
         symlinks.each do |s|

--- a/spec/unit/module_tool/applications/builder_spec.rb
+++ b/spec/unit/module_tool/applications/builder_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'puppet/file_system'
 require 'puppet/module_tool/applications'
 require 'puppet_spec/modules'
 
@@ -50,7 +51,7 @@ describe Puppet::ModuleTool::Applications::Builder do
 
     it "does not package with a symlink", :if => Puppet.features.manages_symlinks? do
       FileUtils.touch(File.join(path, 'tempfile'))
-      File.symlink(File.join(path, 'tempfile'), File.join(path, 'tempfile2'))
+      Puppet::FileSystem.symlink(File.join(path, 'tempfile'), File.join(path, 'tempfile2'))
 
       expect {
         builder.run
@@ -60,7 +61,7 @@ describe Puppet::ModuleTool::Applications::Builder do
     it "does not package with a symlink in a subdir", :if => Puppet.features.manages_symlinks? do
       FileUtils.mkdir(File.join(path, 'manifests'))
       FileUtils.touch(File.join(path, 'manifests/tempfile.pp'))
-      File.symlink(File.join(path, 'manifests/tempfile.pp'), File.join(path, 'manifests/tempfile2.pp'))
+      Puppet::FileSystem.symlink(File.join(path, 'manifests/tempfile.pp'), File.join(path, 'manifests/tempfile2.pp'))
 
       expect {
         builder.run

--- a/spec/unit/module_tool/applications/unpacker_spec.rb
+++ b/spec/unit/module_tool/applications/unpacker_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'json'
 
 require 'puppet/module_tool/applications'
+require 'puppet/file_system'
 require 'puppet_spec/modules'
 
 describe Puppet::ModuleTool::Applications::Unpacker do
@@ -40,7 +41,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
         file.puts JSON.generate('name' => module_name, 'version' => '1.0.0')
       end
       FileUtils.touch(File.join(dest, 'extractedmodule/tempfile'))
-      File.symlink(File.join(dest, 'extractedmodule/tempfile'), File.join(dest, 'extractedmodule/tempfile2'))
+      Puppet::FileSystem.symlink(File.join(dest, 'extractedmodule/tempfile'), File.join(dest, 'extractedmodule/tempfile2'))
       true
     end
 
@@ -60,7 +61,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
       end
       FileUtils.mkdir(File.join(dest, 'extractedmodule/manifests'))
       FileUtils.touch(File.join(dest, 'extractedmodule/manifests/tempfile'))
-      File.symlink(File.join(dest, 'extractedmodule/manifests/tempfile'), File.join(dest, 'extractedmodule/manifests/tempfile2'))
+      Puppet::FileSystem.symlink(File.join(dest, 'extractedmodule/manifests/tempfile'), File.join(dest, 'extractedmodule/manifests/tempfile2'))
       true
     end
 


### PR DESCRIPTION
Prior to this commit build/unpack were trying to use the Ruby stdlib symlink to
deal with symlinks. This fails on platforms (Windows) that Puppet says supports
symlinks because it does not duck punch Ruby stdlib.

This commit switches the specs and code for build/unpack to use Puppet FS lib's
symlink functions. This should allow it to function correctly on Windows hosts that Puppet
supports symlinks.

This is correcting the incomplete fix from my previous PR https://github.com/puppetlabs/puppet/pull/2927
