### PR TITLE
(PUP-1527) After upgrade from 3.3.2-1 to 3.4.2-1 naginator fails to crea...

### DIFF
--- a/lib/puppet/external/nagios/base.rb
+++ b/lib/puppet/external/nagios/base.rb
@@ -303,7 +303,7 @@ class Nagios::Base
         if value.is_a? Array
           value.join(",").sub(';', '\;')
         else
-          value.sub(';', '\;')
+          value.to_s.sub(';', '\;')
         end
         ]
     }

--- a/spec/unit/type/nagios_spec.rb
+++ b/spec/unit/type/nagios_spec.rb
@@ -217,6 +217,15 @@ describe "Nagios generator" do
     results = parser.parse(nagios_type.to_s)
     results[0].command_line.should eql(param)
   end
+
+  it "should accept FixNum params and convert to string" do
+    param = 1
+    nagios_type = Nagios::Base.create(:serviceescalation)
+    nagios_type.first_notification = param
+    parser =  Nagios::Parser.new
+    results = parser.parse(nagios_type.to_s)
+    results[0].first_notification.should eql(param.to_s)
+  end
 end
 
 describe "Nagios resource types" do


### PR DESCRIPTION
After upgrade from 3.3.2-1 to 3.4.2-1 naginator fails to create config from exported resources taken from hiera

Some changes introduced in hiera around 3.4 resulted in type coercion from strings
to FixNums when creating exported resources that were partially built from hiera data.

This patch ensures that any non-array parameter passed through the Nagios::Base.to_s 
method is a string before trying to run the .sub method on it.
