### PR TITLE
(PUP-2971) Fix yum package provider missing install_options for list.

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -97,7 +97,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     wanted = @resource[:name]
     # If not allowing virtual packages, do a query to ensure a real package exists
     unless @resource.allow_virtual?
-      yum '-d', '0', '-e', '0', '-y', :list, wanted
+      yum *['-d', '0', '-e', '0', '-y', install_options, :list, wanted].compact
     end
 
     should = @resource.should(:ensure)

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -81,6 +81,7 @@ describe provider_class do
       resource[:ensure] = :installed
       resource[:install_options] = ['-t', {'-x' => 'expackage'}]
 
+      provider.expects(:yum).with('-d', '0', '-e', '0', '-y', ['-t', '-x=expackage'], :list, name)
       provider.expects(:yum).with('-d', '0', '-e', '0', '-y', ['-t', '-x=expackage'], :install, name)
       provider.install
     end


### PR DESCRIPTION
When executing the list command to filter virtual packages (when
allow_virtual is false or nil), the yum package provider was not passing
down the install options to the list command.  For users passing options
like --enablerepo, this prevents the packages from being discovered and
the list command fails.

The fix is to properly pass down the install options when executing the
list command.
