### PR TITLE
(PUP-2987) Windows service hangs

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -12,6 +12,7 @@ class WindowsDaemon < Win32::Daemon
   EVENTLOG_WARNING_TYPE       = 0x0002
   EVENTLOG_INFORMATION_TYPE   = 0x0004
 
+  @run_thread = nil
   @LOG_TO_FILE = false
   LOG_FILE =  File.expand_path(File.join(Dir::COMMON_APPDATA, 'PuppetLabs', 'puppet', 'var', 'log', 'windows.log'))
   LEVELS = [:debug, :info, :notice, :err]
@@ -61,30 +62,38 @@ class WindowsDaemon < Win32::Daemon
 
     log_notice('Service started')
 
-    while running? do
-      runinterval = parse_runinterval(puppet)
+    service = self
+    @run_thread = Thread.new do
+      begin
+        while service.running? do
+          runinterval = service.parse_runinterval(puppet)
+          if service.state == RUNNING or service.state == IDLE
+            service.log_notice("Executing agent with arguments: #{args}")
+            pid = Process.create(:command_line => "\"#{puppet}\" agent --onetime #{args}", :creation_flags => CREATE_NEW_CONSOLE).process_id
+            service.log_debug("Process created: #{pid}")
+          else
+            service.log_debug("Service is paused.  Not invoking Puppet agent")
+          end
 
-      if state == RUNNING or state == IDLE
-        log_notice("Executing agent with arguments: #{args}")
-        pid = Process.create(:command_line => "\"#{puppet}\" agent --onetime #{args}", :creation_flags => CREATE_NEW_CONSOLE).process_id
-        log_debug("Process created: #{pid}")
-      else
-        log_debug("Service is paused.  Not invoking Puppet agent")
+          service.log_debug("Service worker thread waiting for #{runinterval} seconds")
+          sleep(runinterval)
+          service.log_debug('Service worker thread woken up')
+        end
+      rescue Exception => e
+        service.log_exception(e)
       end
-
-      log_debug("Service waiting for #{runinterval} seconds")
-      sleep(runinterval)
-      log_debug('Service woken up')
     end
+    @run_thread.join
 
-    log_notice('Service stopped')
   rescue Exception => e
     log_exception(e)
+  ensure
+    log_notice('Service stopped')
   end
 
   def service_stop
-    log_notice('Service stopping')
-    Thread.main.wakeup
+    log_notice('Service stopping / killing worker thread')
+    @run_thread.kill if @run_thread
   end
 
   def service_pause


### PR DESCRIPTION
In conjunction with changes made in several other PRs, this at least prevents the service code from deadlocking in a `STOP_PENDING` state.  When in this state, the service code needs to be forcefully have its process terminated before the service can become responsive.  In practice, this issue appeared to be more reproducible in Ruby 2.0.0 x64.

Note that the changes to the win32-gem are a workaround until it can be discovered where the race exists in the code, and why `Service_Main` of the win32-service gems `daemon.rb` will sometimes prematurely exit.  It was this premature exit that caused `SetTheServiceStatus.call(SERVICE_STOPPED, NO_ERROR, 0, 0)` to never be called, which never signaled the SCM that it can return from [StartServiceCtrlDispatcher](http://msdn.microsoft.com/en-us/library/windows/desktop/ms686324%28v=vs.85%29.aspx).  Effectively this blocks the call infinitely and deadlocks the process.

Related PRs:
https://github.com/djberg96/win32-service/pull/21
https://github.com/puppetlabs/puppet-win32-ruby/pull/51
https://github.com/puppetlabs/puppet-win32-ruby/pull/52
