### PR TITLE
(PUP-2946) File2 with #compare_stream from 1.9.3

### DIFF
--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -12,9 +12,12 @@ module Puppet::FileSystem
          elsif Puppet::Util::Platform.windows?
            require 'puppet/file_system/file19windows'
            Puppet::FileSystem::File19Windows
-         else
+         elsif RUBY_VERSION =~ /^1\.9/
            require 'puppet/file_system/file19'
            Puppet::FileSystem::File19
+         else
+           require 'puppet/file_system/file2'
+           Puppet::FileSystem::File2
          end.new()
 
   # Allows overriding the filesystem for the duration of the given block.

--- a/lib/puppet/file_system/file2.rb
+++ b/lib/puppet/file_system/file2.rb
@@ -1,0 +1,21 @@
+require 'puppet/file_system/file19'
+
+class Puppet::FileSystem::File2 < Puppet::FileSystem::File19
+  def compare_stream(path, stream)
+    open(path, 0, 'rb') do |a|
+      # use FileUtils 1.9 implementation because of problems with encodings
+      bsize = FileUtils.send :fu_stream_blksize, a, stream
+      sa = sb = nil
+      while sa == sb
+        sa = a.read(bsize)
+        sb = stream.read(bsize)
+        unless sa and sb
+          if sa.nil? and sb.nil?
+            return true
+          end
+        end
+      end
+      false
+    end
+  end
+end

--- a/spec/integration/file_bucket/file_spec.rb
+++ b/spec/integration/file_bucket/file_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 require 'puppet/file_bucket/file'
+require 'tempfile'
 
 describe Puppet::FileBucket::File do
   describe "#indirection" do
@@ -38,6 +39,31 @@ describe Puppet::FileBucket::File do
 
           described_class.indirection.find(key)
         end
+      end
+    end
+  end
+
+  if RUBY_VERSION > "2"
+    describe "#verify_identical_file!" do
+      subject { Puppet::FileBucketFile::File.new }
+      let(:binary) { "\xD1\xF2\r\n\x81NuSc\x00".force_encoding(Encoding::ASCII_8BIT) }
+
+      let(:contents_file) do
+        tf = Tempfile.new("hello")
+        tf.write(binary)
+        tf.close
+        tf.path
+      end
+
+      let(:bucket_file) do
+        stub(
+          :stream   => StringIO.new(binary),
+          :contents => binary,
+          :checksum => nil)
+      end
+
+      it "must be identical for binary files" do
+        subject.send :verify_identical_file!, contents_file, bucket_file
       end
     end
   end


### PR DESCRIPTION
FileUtils.compare_stream in Ruby 2 is broken when comparing
binary file stream with StringIO stream of different encoding.

This change reverts FileUtils.compare_stream to stdlib v1.9.3
implementation.

(followup to #2881)
