### PR TITLE
(PUP-2967) Remove the deprecated recurse => inf

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -149,20 +149,18 @@ Puppet::Type.newtype(:file) do
         The `source` attribute is not mandatory when using `recurse => true`, so you
         can enable purging in directories where all files are managed individually.
 
-        (Note: `inf` is a deprecated synonym for `true`.)
-
       By default, setting recurse to `remote` or `true` will manage _all_
       subdirectories. You can use the `recurselimit` attribute to limit the
       recursion depth.
     "
 
-    newvalues(:true, :false, :inf, :remote)
+    newvalues(:true, :false, :remote)
 
     validate { |arg| }
     munge do |value|
       newval = super(value)
       case newval
-      when :true, :inf; true
+      when :true; true
       when :false; false
       when :remote; :remote
       else

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -137,7 +137,7 @@ describe Puppet::Type.type(:file) do
       file[:recurse].should be_false
     end
 
-    [true, "true", "inf", "remote"].each do |value|
+    [true, "true", "remote"].each do |value|
       it "should consider #{value} to enable recursion" do
         file[:recurse] = value
         file[:recurse].should be_true


### PR DESCRIPTION
The use of 'inf' as a synonym for 'true' made sense when the 'recurse'
parameter could take integer values, instead of using 'recurselimit'.
But integer values for 'recurse' are no longer valid, so 'inf' makes
no sense.
