### PR TITLE
(PUP-3009) Add error handling to PMT module downloads

### DIFF
--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -66,7 +66,7 @@ class Puppet::Forge < Semantic::Dependency::Source
         uri = result['pagination']['next']
         matches.concat result['results']
       else
-        raise ResponseError.new(:uri => URI.parse(@host).merge(uri) , :input => term, :response => response)
+        raise ResponseError.new(:uri => URI.parse(@host).merge(uri), :response => response)
       end
     end
 
@@ -100,7 +100,7 @@ class Puppet::Forge < Semantic::Dependency::Source
       if response.code == '200'
         response = JSON.parse(response.body)
       else
-        raise ResponseError.new(:uri => URI.parse(@host).merge(uri), :input => input, :response => response)
+        raise ResponseError.new(:uri => URI.parse(@host).merge(uri), :response => response)
       end
 
       releases.concat(process(response['results']))
@@ -186,8 +186,11 @@ class Puppet::Forge < Semantic::Dependency::Source
     end
 
     def download(uri, destination)
-      @source.make_http_request(uri, destination)
+      response = @source.make_http_request(uri, destination)
       destination.flush and destination.close
+      unless response.code == 200
+        raise Puppet::Forge::Errors::ResponseError.new(:uri => uri, :response => response)
+      end
     end
 
     def validate_checksum(file, checksum)

--- a/lib/puppet/forge/errors.rb
+++ b/lib/puppet/forge/errors.rb
@@ -77,7 +77,6 @@ Could not connect to #{@uri}
     # @option options [Net::HTTPResponse] :response The original HTTP response
     def initialize(options)
       @uri     = options[:uri]
-      @input   = options[:input]
       @message = options[:message]
       response = options[:response]
       @response = "#{response.code} #{response.message.strip}"
@@ -90,7 +89,7 @@ Could not connect to #{@uri}
       rescue JSON::ParserError
       end
 
-      message = "Could not execute operation for '#{@input}'. Detail: "
+      message = "Request to Puppet Forge failed. Detail: "
       message << @message << " / " if @message
       message << @response << "."
       super(message, original)
@@ -100,13 +99,13 @@ Could not connect to #{@uri}
     #
     # @return [String] the multiline version of the error message
     def multiline
-      message = <<-EOS
-Could not execute operation for '#{@input}'
+      message = <<-EOS.chomp
+Request to Puppet Forge failed.
   The server being queried was #{@uri}
   The HTTP response we received was '#{@response}'
       EOS
-      message << "  The message we received said '#{@message}'\n" if @message
-      message << "    Check the author and module names are correct."
+      message << "\n  The message we received said '#{@message}'" if @message
+      message
     end
   end
 

--- a/spec/unit/forge/errors_spec.rb
+++ b/spec/unit/forge/errors_spec.rb
@@ -47,15 +47,14 @@ Could not connect to http://fake.com:1111
       let(:exception) { subject.new(:uri => 'http://fake.com:1111', :response => response, :input => 'user/module') }
 
       it 'should return a valid single line error' do
-        exception.message.should == 'Could not execute operation for \'user/module\'. Detail: 404 not found.'
+        exception.message.should == 'Request to Puppet Forge failed. Detail: 404 not found.'
       end
 
       it 'should return a valid multiline error' do
         exception.multiline.should == <<-eos.chomp
-Could not execute operation for 'user/module'
+Request to Puppet Forge failed.
   The server being queried was http://fake.com:1111
   The HTTP response we received was '404 not found'
-    Check the author and module names are correct.
         eos
       end
     end
@@ -64,16 +63,15 @@ Could not execute operation for 'user/module'
       let(:exception) { subject.new(:uri => 'http://fake.com:1111', :response => response, :input => 'user/module', :message => 'no such module') }
 
       it 'should return a valid single line error' do
-        exception.message.should == 'Could not execute operation for \'user/module\'. Detail: no such module / 404 not found.'
+        exception.message.should == 'Request to Puppet Forge failed. Detail: no such module / 404 not found.'
       end
 
       it 'should return a valid multiline error' do
         exception.multiline.should == <<-eos.chomp
-Could not execute operation for 'user/module'
+Request to Puppet Forge failed.
   The server being queried was http://fake.com:1111
   The HTTP response we received was '404 not found'
   The message we received said 'no such module'
-    Check the author and module names are correct.
         eos
       end
     end

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -58,9 +58,15 @@ describe Puppet::Forge::ModuleRelease do
     describe '#download' do
       it 'should call make_http_request with correct params' do
         # valid URI comes from file_uri in JSON blob above
-        ssl_repository.expects(:make_http_request).with("/#{api_version}/files/#{module_full_name_versioned}.tar.gz", mock_file).returns(mock_file)
+        ssl_repository.expects(:make_http_request).with("/#{api_version}/files/#{module_full_name_versioned}.tar.gz", mock_file).returns(stub(:body => '{}', :code => 200))
 
         release.send(:download, "/#{api_version}/files/#{module_full_name_versioned}.tar.gz", mock_file)
+      end
+
+      it 'should raise a response error when it receives an error from forge' do
+        ssl_repository.stubs(:make_http_request).returns(stub(:body => '{"errors": ["error"]}', :code => 500, :message => 'server error'))
+        expect { release.send(:download, "/some/path", mock_file)}. to raise_error Puppet::Forge::Errors::ResponseError
+
       end
     end
 

--- a/spec/unit/forge_spec.rb
+++ b/spec/unit/forge_spec.rb
@@ -137,11 +137,11 @@ describe Puppet::Forge do
     end
 
     it "raises an error for search" do
-      expect { forge.search('bacula') }.to raise_error Puppet::Forge::Errors::ResponseError, "Could not execute operation for 'bacula'. Detail: 404 not found."
+      expect { forge.search('bacula') }.to raise_error Puppet::Forge::Errors::ResponseError, "Request to Puppet Forge failed. Detail: 404 not found."
     end
 
     it "raises an error for fetch" do
-      expect { forge.fetch('puppetlabs/bacula') }.to raise_error Puppet::Forge::Errors::ResponseError, "Could not execute operation for 'puppetlabs/bacula'. Detail: 404 not found."
+      expect { forge.fetch('puppetlabs/bacula') }.to raise_error Puppet::Forge::Errors::ResponseError, "Request to Puppet Forge failed. Detail: 404 not found."
     end
   end
 
@@ -151,7 +151,7 @@ describe Puppet::Forge do
     end
 
     it "raises an error for fetch" do
-      expect { forge.fetch('puppetlabs/bacula') }.to raise_error Puppet::Forge::Errors::ResponseError, "Could not execute operation for 'puppetlabs/bacula'. Detail: 410 Gone."
+      expect { forge.fetch('puppetlabs/bacula') }.to raise_error Puppet::Forge::Errors::ResponseError, "Request to Puppet Forge failed. Detail: 410 Gone."
     end
   end
 end


### PR DESCRIPTION
Before this PMT would not check if the module download request
succeeded before trying install the module. This causes informative
errors from forge to be hidden by an error about the checksum of the
download not matching. After this PMT will only move forward with module
installation if a 200 is received from forge otherwise it will display
the error returned by forge.
