### PR TITLE
(maint) Dup frozen File content strings

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -432,6 +432,11 @@ module Puppet::Pops::Evaluator::Runtime3Support
     undef_value
   end
 
+  def convert_String(o, scope, undef_value)
+    # although wasteful, needed because user code may mutate these strings in Resources
+    o.frozen? ? o.dup : o
+  end
+
   def convert_Object(o, scope, undef_value)
     o
   end


### PR DESCRIPTION
Commit 2a9e996 froze all string tokens in the lexer as a performance
tweak. This caused a regression in file content behavior where

file { '/tmp/foo': content => stuff } would fail with a 'Error: Could not
set content on file: can't modify frozen String' when using the future
parser on Ruby 1.9.3 and up.  The Ruby version requirement was because
we force_encoding to ASCII_8BIT on platforms (1.9.3 and up) which allow
this, but you can't do that to a frozen string.  This was failing in the
lib/puppet/type/file/content.rb should= method, where the string was
cloned, but a clone() clones the frozen state.

Changed to a dup() which provides an unfrozen copy, and added a spec.
