### PR TITLE
(PUP-3019) Make PMT check for string status codes when downloading

### DIFF
--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -188,7 +188,7 @@ class Puppet::Forge < Semantic::Dependency::Source
     def download(uri, destination)
       response = @source.make_http_request(uri, destination)
       destination.flush and destination.close
-      unless response.code == 200
+      unless response.code == '200'
         raise Puppet::Forge::Errors::ResponseError.new(:uri => uri, :response => response)
       end
     end

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -58,15 +58,14 @@ describe Puppet::Forge::ModuleRelease do
     describe '#download' do
       it 'should call make_http_request with correct params' do
         # valid URI comes from file_uri in JSON blob above
-        ssl_repository.expects(:make_http_request).with("/#{api_version}/files/#{module_full_name_versioned}.tar.gz", mock_file).returns(stub(:body => '{}', :code => 200))
+        ssl_repository.expects(:make_http_request).with("/#{api_version}/files/#{module_full_name_versioned}.tar.gz", mock_file).returns(stub(:body => '{}', :code => '200'))
 
         release.send(:download, "/#{api_version}/files/#{module_full_name_versioned}.tar.gz", mock_file)
       end
 
       it 'should raise a response error when it receives an error from forge' do
-        ssl_repository.stubs(:make_http_request).returns(stub(:body => '{"errors": ["error"]}', :code => 500, :message => 'server error'))
+        ssl_repository.stubs(:make_http_request).returns(stub(:body => '{"errors": ["error"]}', :code => '500', :message => 'server error'))
         expect { release.send(:download, "/some/path", mock_file)}. to raise_error Puppet::Forge::Errors::ResponseError
-
       end
     end
 


### PR DESCRIPTION
Previously PMT was checking for integer status codes when downloading
modules. This results in all module downloads failing. After this PMT
will check for string status codes when downloading modules.
