### PR TITLE
(maint) Guard preserve_configuration in acceptance

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -71,9 +71,9 @@ module HarnessOptions
 end
 
 def beaker_test(mode = :packages, options = {})
-  delete_options = options[:__delete_options__] || []
-  final_options = HarnessOptions.options(mode,
-                                         options.reject { |k,v| k == :__delete_options__ })
+  delete_options = options.delete(:__delete_options__) || []
+  final_options = HarnessOptions.options(mode, options)
+  preserve_config = final_options.delete(:__preserve_config__)
 
   if mode == :git
     # Build up project git urls based on git server and fork env variables or defaults
@@ -113,7 +113,7 @@ EOS
   begin
     sh("beaker", *args)
   ensure
-    preserve_configuration(final_options, options_file)
+    preserve_configuration(final_options, options_file) if preserve_config
   end
 end
 
@@ -128,28 +128,48 @@ end
 def generate_config_for_latest_hosts
   preserved_config_hash = { 'HOSTS' => {} }
 
-  config_hash = YAML.load_file('log/latest/config.yml').to_hash
-  nodes = config_hash['HOSTS'].map do |node_label,hash|
-    { :node_label => node_label, :platform => hash['platform'] }
-  end
+  puts "\nPreserving configuration so that any preserved nodes can be tested again locally..."
 
-  pre_suite_log = File.read('log/latest/pre_suite-run.log')
-  nodes.each do |node_info|
-    hostname = /^(\w+) \(#{node_info[:node_label]}\)/.match(pre_suite_log)[1]
-    fqdn = "#{hostname}.delivery.puppetlabs.net"
-    preserved_config_hash['HOSTS'][fqdn] = {
-      'roles' => [ 'agent'],
-      'platform' => node_info[:platform],
-    }
-    preserved_config_hash['HOSTS'][fqdn]['roles'].unshift('master') if node_info[:node_label] =~ /master/
-  end
-  pp preserved_config_hash
+  config_hash = YAML.load_file('log/latest/config.yml')
+  if !config_hash || !config_hash.include?('HOSTS')
+    puts "Warning: No HOSTS configuration found in log/latest/config.yml"
+    return
+  else
+    nodes = config_hash['HOSTS'].map do |node_label,hash|
+      {
+        :node_label => node_label,
+        :roles => hash['roles'],
+        :platform => hash['platform']
+      }
+    end
 
-  File.open('log/latest/preserved_config.yaml', 'w') do |config_file|
-    YAML.dump(preserved_config_hash, config_file)
+    pre_suite_log = File.read('log/latest/pre_suite-run.log')
+    nodes.each do |node_info|
+      host_regex = /^([\w.]+) \(#{node_info[:node_label]}\)/
+      if matched = host_regex.match(pre_suite_log)
+        hostname = matched[1]
+        fqdn = "#{hostname}.delivery.puppetlabs.net"
+      elsif /^#{node_info[:node_label]} /.match(pre_suite_log)
+        fqdn = "#{node_info[:node_label]}"
+        puts "* Couldn't find any log lines for #{host_regex}, assuming #{fqdn} is the fqdn"
+      end
+      if fqdn
+        preserved_config_hash['HOSTS'][fqdn] = {
+          'roles' => node_info[:roles],
+          'platform' => node_info[:platform],
+        }
+      else
+        puts "* Couldn't match #{node_info[:node_label]} in pre_suite-run.log"
+      end
+    end
+    pp preserved_config_hash
+
+    File.open('log/latest/preserved_config.yaml', 'w') do |config_file|
+      YAML.dump(preserved_config_hash, config_file)
+    end
   end
 rescue Errno::ENOENT => e
-  puts "Couldn't generate log #{e}"
+  puts "Warning: Couldn't generate preserved_config.yaml #{e}"
 end
 
 def list_preserved_configurations(secs_ago = ONE_DAY_IN_SECS)
@@ -270,7 +290,7 @@ Defaults to a packages run, but you can set it to 'git' with TYPE='git'.
 #{USAGE}
   EOS
   task :test_and_preserve_hosts => 'ci:check_env'  do
-    beaker_test(beaker_run_type, :preserve_hosts => 'always')
+    beaker_test(beaker_run_type, :preserve_hosts => 'always', :__preserve_config__ => true)
   end
 
   desc "List acceptance runs from the past day which had hosts preserved."

--- a/docs/acceptance_tests.md
+++ b/docs/acceptance_tests.md
@@ -123,6 +123,8 @@ Then you can log into the hosts, or rerun tests against them by:
 
 This will use the existing hosts.
 
+NOTE: If you want configuration information to be preserved for all runs (potentially allowing you to run ci:test_against_preserved_hosts for any previous run that failed, and who's hosts were preserved, regardless of whether you initiated with a ci:test_and_preserve_hosts call) then you should add a ':__preserve_config__ => true' to your local_options.rb.
+
 ### Cleaning Up Preserved Hosts
 
 If you run a number of jobs with --preserve_hosts or vi ci:test_and_preserve_hosts, you may eventually generate a large number of stale vms.  They should be reaped automatically by qa infrastructure within a day or so, but you may also run:


### PR DESCRIPTION
It is only useful to attempt to generate a local preserved_config.yml if
you are manually testing and may need to re-run.  Automated tools such
as Jenkins have tripped over this step if the logs or layout are
different, and there is no reason to abort a test run for this step.

This commit changes the behavior of the acceptance harness so that it
only preserves the configuration if you are running the manual
'test_and_preserve_hosts' task, or if you have specified you want this
behavior in your local_options.rb.  It is also a little more resilient
for failures when preserving the configuration.
