### PR TITLE
(doc) Remove outdated notice concerning rdoc and ruby > 1.8.7

### DIFF
--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -59,8 +59,6 @@ SYNOPSIS
 Generates a reference for all Puppet types. Largely meant for internal
 Puppet Labs use.
 
-WARNING: RDoc support is only available under Ruby 1.8.7 and earlier.
-
 
 USAGE
 -----
@@ -83,11 +81,6 @@ can be changed with the 'outputdir' option.
 
 If the command is run with the name of a manifest file as an argument,
 puppet doc will output a single manifest's documentation on stdout.
-
-WARNING: RDoc support is only available under Ruby 1.8.7 and earlier.
-The internal API used to support manifest documentation has changed
-radically in newer versions, and support is not yet available for
-using those versions of RDoc.
 
 
 OPTIONS


### PR DESCRIPTION
This note is deprecated by the following pull requests:

https://github.com/puppetlabs/puppet/pull/2009
https://github.com/puppetlabs/puppet/pull/2187

Relevant redmine ticket;

https://projects.puppetlabs.com/issues/22180
