### PR TITLE
(PUP-3038) Cache typeloader misses

### DIFF
--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -143,29 +143,29 @@ module Manager
   #
   def type(name)
     # Avoid loading if name obviously is not a type name
-    if name.to_s.include?(':')
-      return nil
-    end
+    return nil if name.to_s.include? ':'
 
     @types ||= {}
 
     # We are overwhelmingly symbols here, which usually match, so it is worth
     # having this special-case to return quickly.  Like, 25K symbols vs. 300
     # strings in this method. --daniel 2012-07-17
-    return @types[name] if @types[name]
+    return @types[name] if @types.include? name
 
     # Try mangling the name, if it is a string.
     if name.is_a? String
       name = name.downcase.intern
-      return @types[name] if @types[name]
+      return @types[name] if @types.include? name
     end
     # Try loading the type.
     if typeloader.load(name, Puppet.lookup(:current_environment))
       Puppet.warning "Loaded puppet/type/#{name} but no class was created" unless @types.include? name
+    else
+      @types[name] = nil
     end
 
     # ...and I guess that is that, eh.
-    return @types[name]
+    @types[name]
   end
 
   # Creates a loader for Puppet types.
@@ -181,4 +181,3 @@ module Manager
   end
 end
 end
-


### PR DESCRIPTION
Reference to defined type defined in global scope makes puppet look for builtin type with same name in all known directories which is slow in large repositories.

This change potentially introduces problems for server processes that are never restarted/reloaded - i'm not sure how much of an issue that is. IMHO when one deploys new module, new code, installs new gem, etc - it is ok to require server to reload, this can be easily automated.

This combined with another PR i'm going to created in a moment gives 70-100% performance improvement for both puppet catalog application and server-side catalog generation and none code-staleness issues so far.
