### PR TITLE
(PUP-2994) Make validation of storeconfigs a runtime concern.

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -679,6 +679,13 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       end
     end
 
+    # This is a runtime check - the model is valid, but will have runtime issues when evaluated
+    # and storeconfigs is not set.
+    #if acceptor.will_accept?(Issues::RT_NO_STORECONFIGS) && o.exported
+    if(o.exported)
+      optionally_fail(Puppet::Pops::Issues::RT_NO_STORECONFIGS_EXPORT, o);
+    end
+
     titles_to_body = {}
     body_to_titles = {}
     body_to_params = {}

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -541,6 +541,10 @@ module Puppet::Pops::Evaluator::Runtime3Support
       else
         p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
       end
+
+      # Store config issues, ignore or warning
+      p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning
+      p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
     end
   end
 

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -425,11 +425,6 @@ class Puppet::Pops::Validation::Checker4_0
     #  acceptor.accept(Issues::ILLEGAL_EXPRESSION, o.type_name, :feature => 'resource type', :container => o)
     #end
 
-    # This is a runtime check - the model is valid, but will have runtime issues when evaluated
-    # and storeconfigs is not set.
-    if acceptor.will_accept?(Issues::RT_NO_STORECONFIGS) && o.exported
-      acceptor.accept(Issues::RT_NO_STORECONFIGS_EXPORT, o)
-    end
   end
 
   def check_ResourceDefaultsExpression(o)


### PR DESCRIPTION
The validation of store configs where previously done statically (on parsed code) in the future parser. (The 3x version does this in the parser itself). The change in future parser is not enough, it should not be considered a validation problem as store configs is a runtime concern.

This PR moves the warning from validation to runtime.
