### PR TITLE
(PUP-2879) Add cryptdisks-udev to the services blacklist

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -50,6 +50,9 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     # Prevent puppet failing to get status of these services, which need parameters
     # passed in (see https://bugs.launchpad.net/ubuntu/+source/puppet/+bug/1276766).
     excludes += %w{idmapd-mounting startpar-bridge}
+    # Prevent puppet failing to get status of cryptdisks-udev, another upstart
+    # service with instances
+    excludes += %w{cryptdisks-udev}
   end
 
   # List all services of this type.

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -55,7 +55,11 @@ describe Puppet::Type.type(:service).provider(:upstart) do
     end
 
     it "should not find excluded services" do
-      processes = "wait-for-state stop/waiting\nportmap-wait start/running\nidmapd-mounting stop/waiting\nstartpar-bridge start/running"
+      processes = "wait-for-state stop/waiting"
+      processes += "\nportmap-wait start/running"
+      processes += "\nidmapd-mounting stop/waiting"
+      processes += "\nstartpar-bridge start/running"
+      processes += "\ncryptdisks-udev stop/waiting"
       provider_class.stubs(:execpipe).yields(processes)
       provider_class.instances.should be_empty
     end


### PR DESCRIPTION
Also this patch splits out the long line in upstart_spec.rb to be
one line per service, so more diff-friendly.
