### PR TITLE
(PUP-2879) Add two nfsd-related upstart services to the blacklist

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -50,9 +50,11 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     # Prevent puppet failing to get status of these services, which need parameters
     # passed in (see https://bugs.launchpad.net/ubuntu/+source/puppet/+bug/1276766).
     excludes += %w{idmapd-mounting startpar-bridge}
-    # Prevent puppet failing to get status of cryptdisks-udev, another upstart
+    # Prevent puppet failing to get status of these services, additional upstart
     # service with instances
     excludes += %w{cryptdisks-udev}
+    excludes += %w{statd-mounting}
+    excludes += %w{gssd-mounting}
   end
 
   # List all services of this type.

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -60,6 +60,8 @@ describe Puppet::Type.type(:service).provider(:upstart) do
       processes += "\nidmapd-mounting stop/waiting"
       processes += "\nstartpar-bridge start/running"
       processes += "\ncryptdisks-udev stop/waiting"
+      processes += "\nstatd-mounting stop/waiting"
+      processes += "\ngssd-mounting stop/waiting"
       provider_class.stubs(:execpipe).yields(processes)
       provider_class.instances.should be_empty
     end


### PR DESCRIPTION
In testing these two services were installed on the https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm vm, so worthwhile adding them to the blacklist.
