### PR TITLE
(PUP-2889) Ensure project_data.yaml eventlog 0.6.1

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -31,7 +31,7 @@ gem_platform_dependencies:
       # Pinning versions that require native extensions
       ffi: '1.9.3'
       win32-dir: '~> 0.4.9'
-      win32-eventlog: '~> 0.5.3'
+      win32-eventlog: '~> 0.6.1'
       win32-process: '~> 0.7.4'
       win32-security: '~> 0.2.5'
       win32-service: '~> 0.8.4'


### PR DESCRIPTION
Fixes a missed dependency upgrade for eventlog. This ensures that both
the 32 bit and 64 bit versions of Puppet on Windows are using the
same dependencies.

The change that caused this was https://github.com/puppetlabs/puppet/commit/35b1abc1, which reverted a previous upgrade. It doesn't appear that we went back and added this back in.
