### PR TITLE
(PUP-3056) Restore Windows constants from mixins

### DIFF
--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -196,6 +196,9 @@ module Puppet::Util::Windows::File
   module_function :symlink?
 
   GENERIC_READ                  = 0x80000000
+  GENERIC_WRITE                 = 0x40000000
+  GENERIC_EXECUTE               = 0x20000000
+  GENERIC_ALL                   = 0x10000000
   FILE_SHARE_READ               = 1
   FILE_SHARE_WRITE              = 2
   OPEN_EXISTING                 = 3

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -101,6 +101,7 @@ module Puppet::Util::Windows::Security
   SE_BACKUP_NAME              = 'SeBackupPrivilege'
   SE_RESTORE_NAME             = 'SeRestorePrivilege'
 
+  DELETE                      = 0x00010000
   READ_CONTROL                = 0x20000
   WRITE_DAC                   = 0x40000
   WRITE_OWNER                 = 0x80000


### PR DESCRIPTION
- Previously these constants were defined by using mixins from
  windows-pr.  As it turns out, while Puppet core does not need them,
  they are consumed by the ACL module.
