### PR TITLE
(PUP-2631) Elide long URIs for 404 message

### DIFF
--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -114,7 +114,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       # that makes a user aware of the reason for the failure.
       #
       content_type, body = parse_response(response)
-      msg = "Find #{uri_with_query_string} resulted in 404 with the message: #{body}"
+      msg = "Find #{elide(uri_with_query_string, 100)} resulted in 404 with the message: #{body}"
       raise Puppet::Error, msg
     else
       nil
@@ -255,5 +255,13 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
 
   def deserialize_save(content_type, body)
     nil
+  end
+
+  def elide(string, length)
+    if Puppet::Util::Log.level == :debug || string.length <= length
+      string
+    else
+      string[0, length - 3] + "..."
+    end
   end
 end

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -291,17 +291,41 @@ describe Puppet::Indirector::REST do
     end
 
     context 'when fail_on_404 is used in request' do
-      let(:request) { find_request('foo', :fail_on_404 => true) }
-
       it 'raises an error for a 404 when asked to do so' do
+        request = find_request('foo', :fail_on_404 => true)
         response = mock_response('404', 'this is the notfound you are looking for')
         connection.expects(:get).returns(response)
-        expected_message = [
-          'Find /production/test_model/foo?fail_on_404=true',
-          'resulted in 404 with the message: this is the notfound you are looking for'].join( ' ')
+
         expect do
           terminus.find(request)
-        end.to raise_error(Puppet::Error, expected_message)
+        end.to raise_error(
+          Puppet::Error,
+          'Find /production/test_model/foo?fail_on_404=true resulted in 404 with the message: this is the notfound you are looking for')
+      end
+
+      it 'truncates the URI when it is very long' do
+        request = find_request('foo', :fail_on_404 => true, :long_param => ('A' * 100) + 'B')
+        response = mock_response('404', 'this is the notfound you are looking for')
+        connection.expects(:get).returns(response)
+
+        expect do
+          terminus.find(request)
+        end.to raise_error(
+          Puppet::Error,
+          /\/production\/test_model\/foo.*long_param=A+\.\.\. resulted in 404 with the message/)
+      end
+
+      it 'does not truncate the URI when logging debug information' do
+        Puppet.debug = true
+        request = find_request('foo', :fail_on_404 => true, :long_param => ('A' * 100) + 'B')
+        response = mock_response('404', 'this is the notfound you are looking for')
+        connection.expects(:get).returns(response)
+
+        expect do
+          terminus.find(request)
+        end.to raise_error(
+          Puppet::Error,
+          /\/production\/test_model\/foo.*long_param=A+B resulted in 404 with the message/)
       end
     end
 


### PR DESCRIPTION
When the agent encounters a 404 response from the master and it has been told
to fail on 404, it previously output the entire path plus query string that
it requested. However, the most common case where this occurs is when
requesting a catalog, which can have a very long query string if the request
was done with a GET. This does not always occur because even longer query
strings will result in the agent using a POST instead of a GET, which causes
the long query string output problem to go away.

In order to fix this the query string is now elided to 100 characters
(97 characters of the original text plus 3 periods).  In order to still be
able to debug any problems that might result from the query, however, the
query string is _not_ elided if the log level is `debug`.
