### PR TITLE
(PUP-3031) Move certification expiration check up

### DIFF
--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -57,7 +57,6 @@ module Puppet::Network::HTTP::Handler
     response[Puppet::Network::HTTP::HEADER_PUPPET_VERSION] = Puppet.version
 
     profiler = configure_profiler(request_headers, request_params)
-    warn_if_near_expiration(new_request.client_cert)
 
     Puppet::Util::Profiler.profile("Processed request #{request_method} #{request_path}", [:http, request_method, request_path]) do
       if route = @routes.find { |route| route.matches?(new_request) }

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -94,7 +94,9 @@ class Puppet::Network::HTTP::RackREST
     if cert.nil? || cert.empty?
       nil
     else
-      Puppet::SSL::Certificate.from_instance(OpenSSL::X509::Certificate.new(cert))
+      cert = Puppet::SSL::Certificate.from_instance(OpenSSL::X509::Certificate.new(cert))
+      warn_if_near_expiration(cert)
+      cert
     end
   end
 

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -60,7 +60,9 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
 
   def client_cert(request)
     if cert = request.client_cert
-      Puppet::SSL::Certificate.from_instance(cert)
+      cert = Puppet::SSL::Certificate.from_instance(cert)
+      warn_if_near_expiration(cert)
+      cert
     else
       nil
     end

--- a/spec/unit/network/authentication_spec.rb
+++ b/spec/unit/network/authentication_spec.rb
@@ -81,6 +81,10 @@ describe Puppet::Network::Authentication do
         cert.stubs(:unmunged_name).returns('foo')
       end
 
+      after(:all) do
+        reload_module
+      end
+
       it "should log a warning if a certificate's expiration is near" do
         logger.expects(:warning)
         subject.warn_if_near_expiration(cert)

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -103,15 +103,6 @@ describe Puppet::Network::HTTP::Handler do
       handler.stubs(:warn_if_near_expiration)
     end
 
-    it "should check the client certificate for upcoming expiration" do
-      request = a_request
-      cert = mock 'cert'
-      handler.expects(:client_cert).returns(cert).with(request)
-      handler.expects(:warn_if_near_expiration).with(cert)
-
-      handler.process(request, response)
-    end
-
     it "should setup a profiler when the puppet-profiling header exists" do
       request = a_request
       request[:headers][Puppet::Network::HTTP::HEADER_ENABLE_PROFILING.downcase] = "true"

--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -12,11 +12,11 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
     before :all do
       @model_class = stub('indirected model class')
       Puppet::Indirector::Indirection.stubs(:model).with(:foo).returns(@model_class)
-      @handler = Puppet::Network::HTTP::RackREST.new(:handler => :foo)
     end
 
     before :each do
       @response = Rack::Response.new
+      @handler = Puppet::Network::HTTP::RackREST.new(:handler => :foo)
     end
 
     def mk_req(uri, opts = {})


### PR DESCRIPTION
The http handler code contains a check to see if the expiration
date of the client certificate is within a certain window, so
that we can log a warning message if it will expire soon.

However, the mechanisms for handling this kind of check can
really vary depending on what web server you're running in, so
it doesn't make sense for this check to occur in a code path
that is common to all of the different web servers.

This commit simply moves the logic up into the code for
the individual web servers so that they will have the
ability to adjust the behavior according to their own
needs.
