### PR TITLE
(PUP-2817) Fix zone properties so that nil is not passed through

### DIFF
--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:zone).provide(:solaris) do
 
   def multi_conf(name, should, &action)
     has = properties[name]
-    has = [] if has == :absent
+    has = [] if !has || has == :absent
     rms = has - should
     adds = should - has
     (rms.map{|o| action.call(:rm,o)} + adds.map{|o| action.call(:add,o)}).join("\n")

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -171,8 +171,7 @@ end
 
     # overridden so that we match with self.should
     def insync?(is)
-      return true unless is
-      is = [] if is == :absent
+      is = [] if !is || is == :absent
       is.sort == self.should.sort
     end
   end
@@ -228,8 +227,7 @@ end
 
     # overridden so that we match with self.should
     def insync?(is)
-      return true unless is
-      is = [] if is == :absent
+      is = [] if !is || is == :absent
       is.sort == self.should.sort
     end
 
@@ -250,8 +248,7 @@ end
 
     # overridden so that we match with self.should
     def insync?(is)
-      return true unless is
-      is = [] if is == :absent
+      is = [] if !is || is == :absent
       is.sort == self.should.sort
     end
 

--- a/spec/unit/type/zone_spec.rb
+++ b/spec/unit/type/zone_spec.rb
@@ -2,8 +2,11 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:zone) do
-  let(:zone)     { described_class.new(:name => 'dummy', :path => '/dummy', :provider => :solaris) }
+  let(:zone)     { described_class.new(:name => 'dummy', :path => '/dummy', :provider => :solaris, :ip=>'if:1.2.3.4:2.3.4.5', :inherit=>'/', :dataset=>'tank') }
   let(:provider) { zone.provider }
+  let(:ip)      { zone.property(:ip) }
+  let(:inherit) { zone.property(:inherit) }
+  let(:dataset) { zone.property(:dataset) }
 
   parameters = [:create_args, :install_args, :sysidcfg, :realhostname]
 
@@ -18,6 +21,46 @@ describe Puppet::Type.type(:zone) do
   properties.each do |property|
     it "should have a #{property} property" do
       described_class.attrclass(property).ancestors.should be_include(Puppet::Property)
+    end
+  end
+
+  describe  "when trying to set a property that is empty" do
+    it "should verify that property.insync? of nil or :absent is true" do
+      [inherit, ip, dataset].each do |prop|
+        prop.stubs(:should).returns []
+      end
+      [inherit, ip, dataset].each do |prop|
+        prop.insync?(nil).should be_true
+      end
+      [inherit, ip, dataset].each do |prop|
+        prop.insync?(:absent).should be_true
+      end
+    end
+  end
+  describe  "when trying to set a property that is non empty" do
+    it "should verify that property.insync? of nil or :absent is false" do
+      [inherit, ip, dataset].each do |prop|
+        prop.stubs(:should).returns ['a','b']
+      end
+      [inherit, ip, dataset].each do |prop|
+        prop.insync?(nil).should be_false
+      end
+      [inherit, ip, dataset].each do |prop|
+        prop.insync?(:absent).should be_false
+      end
+    end
+  end
+  describe  "when trying to set a property that is non empty" do
+    it "insync? should return true or false depending on the current value, and new value" do
+      [inherit, ip, dataset].each do |prop|
+        prop.stubs(:should).returns ['a','b']
+      end
+      [inherit, ip, dataset].each do |prop|
+        prop.insync?(['b', 'a']).should be_true
+      end
+      [inherit, ip, dataset].each do |prop|
+        prop.insync?(['a']).should be_false
+      end
     end
   end
 


### PR DESCRIPTION
Before this patch, when `insync?` was called on the zone properties ip,
dataset and inherit with value nil (happens the first time when the properties
are not present), `true` was returned, which resulted in them not being set
until the values were actually queried, which happened after the installation
of zone. Unfortunately, the inherit property can only be set before
installation.

This patch removes the spurious check for `nil`, which always returned `true`,
and instead handles it similar to when `:absent` is used.
