### PR TITLE
(PUP-3013) Accept. tests - 3.7 PMT updates build

### DIFF
--- a/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
+++ b/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
@@ -1,0 +1,33 @@
+test_name "puppet module build should verify there are no symlinks in module"
+
+confine :except, :platform => 'windows'
+
+modauthor = 'foo'
+modname = 'bar'
+defaultversion = '0.1.0'
+buildpath = "#{modname}/pkg/#{modname}-#{defaultversion}"
+
+agents.each do |agent|
+  tmpdir = agent.tmpdir('pmtbuildsymlink')
+
+  teardown do
+    on(agent, "rm -rf #{modname}")
+    on(agent, "rm -rf #{tmpdir}")
+  end
+
+  step 'Generate module' do
+    on(agent, puppet("module generate #{modauthor}-#{modname} --skip-interview"))
+  end
+
+  step 'Add symlink to module' do
+    on(agent, "touch #{tmpdir}/hello")
+    on(agent, "ln -s #{tmpdir}/hello #{modname}/tests/symlink")
+  end
+
+  step 'Build module should fail with message about needing symlinks removed' do
+    on(agent, puppet("module build #{modname}"), :acceptable_exit_codes => [1]) do |res|
+      fail_test('Proper failure message not displayed') unless res.stderr.include? 'Symlinks in modules are unsupported'
+    end
+  end
+
+end

--- a/acceptance/tests/modules/build/build_should_not_create_changes.rb
+++ b/acceptance/tests/modules/build/build_should_not_create_changes.rb
@@ -1,0 +1,27 @@
+test_name "puppet module build should not result in changed files"
+
+modauthor = 'foo'
+modname = 'bar'
+defaultversion = '0.1.0'
+buildpath = "#{modname}/pkg/#{modauthor}-#{modname}-#{defaultversion}"
+
+agents.each do |agent|
+  teardown do
+    on(agent, "rm -rf #{modname}")
+  end
+
+  step 'Generate module' do
+    on(agent, puppet("module generate #{modauthor}-#{modname} --skip-interview"))
+  end
+
+  step 'Build module' do
+    on(agent, puppet("module build #{modname}"))
+    on(agent, "test -d #{buildpath}")
+  end
+
+  step 'Verify fresh build has no changes' do
+    on(agent, puppet("module changes #{buildpath}")) do |res|
+      fail_test('Changed files found') if res.stderr.include? 'modified'
+    end
+  end
+end


### PR DESCRIPTION
This commit adds additional acceptance test coverage for updates
the puppet module build command. These tests validate the
following:

```
* enforcement of metadata.json file
* ignoring checksum data in metadata.json
* detection of symlinks in module
* detection of file changes created by build process
* use of .pmtignore and .gitignore to suppress file inclusion
  during build
* metadata.json field validation of name
* metadata.json field validation of semantic version
* metadata.json field validation of version range
  incompatibility when duplicate dependencies are found
```
