### PR TITLE
(PUP-3066) Services are started before flags are set

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -80,6 +80,9 @@ module Puppet
       end
 
       newvalue(:running, :event => :service_started, :invalidate_refreshes => true) do
+        # Ensure flags are written out before starting the service as it may
+        # need to read it's flags from the filesystem.
+        @resource.flush if @resource.provider.flaggable?
         provider.start
       end
 


### PR DESCRIPTION
This patch ensures the flags are flushed out, and written into `/etc/rc.conf.local`  before the service is actually started.
