### PR TITLE
(maint) Require forwardable in puppet/settings.rb

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -2,6 +2,7 @@ require 'puppet'
 require 'getoptlong'
 require 'puppet/util/watched_file'
 require 'puppet/util/command_line/puppet_option_parser'
+require 'forwardable'
 
 # The class for handling configuration files.
 class Puppet::Settings


### PR DESCRIPTION
Commit a8e9aa6 extended Puppet::Settings with Forwardable, but did not
require it.  This passed specs, but failed in acceptance when run with
system rubies (locally with rvm/rbenv, we're not seeing a problem).
Requiring forwardable, as we do in other files seems to fix the issue.
