### PR TITLE
(PUP-2889) Eventlog specs pending Windows 2003

### DIFF
--- a/spec/integration/agent/logging_spec.rb
+++ b/spec/integration/agent/logging_spec.rb
@@ -88,6 +88,10 @@ describe 'agent logging' do
     else
 
       it "when evoked with #{argv}, logs to #{expected[:loggers].inspect} at level #{expected[:level]}" do
+        if Facter.value(:kernelmajversion).to_f < 6.0
+          pending("requires win32-eventlog gem upgrade to 0.6.2 on Windows 2003")
+        end
+
         # This logger is created by the Puppet::Settings object which creates and
         # applies a catalog to ensure that configuration files and users are in
         # place.

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Util::Log.desttypes[:file] do
 
   before do
     File.stubs(:open)           # prevent actually creating the file
-    File.stubs(:chown)          # prevent chown on non existing file from failing 
+    File.stubs(:chown)          # prevent chown on non existing file from failing
     @class = Puppet::Util::Log.desttypes[:file]
   end
 
@@ -184,6 +184,12 @@ end
 
 
 describe ":eventlog", :if => Puppet::Util::Platform.windows? do
+  before do
+    if Facter.value(:kernelmajversion).to_f < 6.0
+      pending("requires win32-eventlog gem upgrade to 0.6.2 on Windows 2003")
+    end
+  end
+
   let(:klass) { Puppet::Util::Log.desttypes[:eventlog] }
 
   def expects_message_with_type(klass, level, eventlog_type, eventlog_id)


### PR DESCRIPTION
- win32-eventlog gem upgraded from 0.5.3 to 0.6.1 as part of
  https://github.com/puppetlabs/puppet/commit/ac8d4e257f69beaf87489b2e2a57f8aaab512edc
- win32-eventlog gem 0.6.1 doesn't yet include the patch necessary to
  properly load it on 2003 from:
  https://github.com/djberg96/win32-eventlog/commit/4692e2a67ae8dc794981928d6e6488b775a6689a
- Therefore, mark these eventlog tests as pending on 2003 until the
  0.6.2 gem ships and the Gemfile can be updated
- These guards will be removed as part of PUP-3061
