### PR TITLE
(PUP-3082) When PUPPET_VERSION="~> x.x.x" bundler breaks

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/Gemfile
+++ b/lib/puppet/module_tool/skeleton/templates/generator/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.3']
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'


### PR DESCRIPTION
Without this change, bundler breaks if PUPPET_VERSION is specified with a curvy arrow syntax for example export PUPPET_VERSION="~> 3.6.0".

Without this change the puppet gem declaration after processing would look like 'gem "puppet", "= ~> 3.6.0"' that isn't valid syntax.

