### PR TITLE
(maint) Clarify docs for certificate_status

### DIFF
--- a/api/docs/http_certificate_status.md
+++ b/api/docs/http_certificate_status.md
@@ -39,9 +39,8 @@ certificate signing request; similar to `puppet cert --sign`) and
 `{"desired_state":"revoked"}` (for revoking a certificate; similar to
 `puppet cert --revoke`).
 
-When revoking certificates, you may wish to use a DELETE request
-instead, which will also clean up other info about the host.
-
+Note that revoking a certificate will not clean up other info about the
+host - see the DELETE request for more information.
 
 Delete
 -----


### PR DESCRIPTION
Prior to this commit, the SAVE and DELETE sections of the
certificate_status HTTP API docs were conflicting.
This commit corrects the documentation of the SAVE section
to match the actual Puppet behavior and be consistent with
the DELETE section.
