### PR TITLE
(PUP-3094) - Adding separate binaries for SELinux

### DIFF
--- a/bin/puppetagent
+++ b/bin/puppetagent
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+#
+# This starter is used for SELinux initial domain transition
+#
+require 'puppet/application/agent'
+Puppet::Application[:agent].run

--- a/bin/puppetca
+++ b/bin/puppetca
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+#
+# This starter is used for SELinux initial domain transition
+#
+require 'puppet/application/cert'
+Puppet::Application[:cert].run

--- a/bin/puppetmaster
+++ b/bin/puppetmaster
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+#
+# This starter is used for SELinux initial domain transition
+#
+require 'puppet/application/master'
+Puppet::Application[:master].run


### PR DESCRIPTION
Downstream SELinux-aware distributions need to add shell wrappers for
"puppet master" and "puppet ca" command to be able set puppet_exec_t file 
context for successful domain transition. Without this, it is not possible to
start master or ca process in the correct (secured) domain.

Puppet Enterprise customers who would like to use SELinux in their 
environments need to create and set contexts for these wrappers manually. 
Having this upstream would allow to support SELinux out-of-box.

The third binary "puppetagent" is for the same purpose. In rare cases, 
customers may want to tighten security around running agents and this binary 
allows to do the domain transition.
