### PR TITLE
(PUP-586) Deprecate Instrumentation System

### DIFF
--- a/lib/puppet/face/instrumentation_data.rb
+++ b/lib/puppet/face/instrumentation_data.rb
@@ -5,9 +5,10 @@ Puppet::Indirector::Face.define(:instrumentation_data, '0.0.1') do
   copyright "Puppet Labs", 2011
   license   "Apache 2 license; see COPYING"
 
-  summary "Manage instrumentation listener accumulated data."
+  summary "Manage instrumentation listener accumulated data. DEPRECATED."
   description <<-EOT
     This subcommand allows to retrieve the various listener data.
+    (DEPRECATED) This subcommand will be removed in Puppet 4.0.
   EOT
 
   get_action(:destroy).summary "Invalid for this subcommand."

--- a/lib/puppet/face/instrumentation_listener.rb
+++ b/lib/puppet/face/instrumentation_listener.rb
@@ -5,9 +5,10 @@ Puppet::Indirector::Face.define(:instrumentation_listener, '0.0.1') do
   copyright "Puppet Labs", 2011
   license   "Apache 2 license; see COPYING"
 
-  summary "Manage instrumentation listeners."
+  summary "Manage instrumentation listeners. DEPRECATED."
   description <<-EOT
     This subcommand enables/disables or list instrumentation listeners.
+    (DEPRECATED) This subcommand will be removed in Puppet 4.0.
   EOT
 
   get_action(:destroy).summary "Invalid for this subcommand."

--- a/lib/puppet/face/instrumentation_probe.rb
+++ b/lib/puppet/face/instrumentation_probe.rb
@@ -5,9 +5,10 @@ Puppet::Indirector::Face.define(:instrumentation_probe, '0.0.1') do
   copyright "Puppet Labs", 2011
   license   "Apache 2 license; see COPYING"
 
-  summary "Manage instrumentation probes."
+  summary "Manage instrumentation probes. Deprecated"
   description <<-EOT
     This subcommand enables/disables or list instrumentation listeners.
+    (DEPRECATED) This subcommand will be removed in Puppet 4.0.
   EOT
 
   get_action(:find).summary "Invalid for this subcommand."


### PR DESCRIPTION
The instrumentation system is being removed in Puppet 4.0.

This commit is for adding a deprecation message on the subcommands for
users to migrate off of it before it is finally deleted.
