### PR TITLE
(PUP-1044) Ensure file bucket streams are closed at all times after use

### DIFF
--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -94,11 +94,8 @@ class Puppet::FileBucket::Dipper
         end
         ::File.open(file, ::File::WRONLY|::File::TRUNC|::File::CREAT) { |of|
           of.binmode
-          begin
-            source_stream = newcontents.stream
+          source_stream = newcontents.stream do |source_stream|
             FileUtils.copy_stream(source_stream, of)
-          ensure
-            source_stream.close()
           end
           #of.print(newcontents)
         }

--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -47,8 +47,8 @@ class Puppet::FileBucket::File
   end
 
   # @return [IO] A stream that reads the contents
-  def stream
-    @contents.stream()
+  def stream(&block)
+    @contents.stream(&block)
   end
 
   def checksum_type
@@ -107,8 +107,13 @@ class Puppet::FileBucket::File
       @contents = content;
     end
 
-    def stream
-      StringIO.new(@contents)
+    def stream(&block)
+      s = StringIO.new(@contents)
+      begin
+        block.call(s)
+      ensure
+        s.close
+      end
     end
 
     def size
@@ -132,9 +137,8 @@ class Puppet::FileBucket::File
       @path = path
     end
 
-    # Caller *must* close the stream
-    def stream()
-      Puppet::FileSystem.open(@path, nil, 'rb')
+    def stream(&block)
+      Puppet::FileSystem.open(@path, nil, 'rb', &block)
     end
 
     def size

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -88,9 +88,9 @@ module Puppet::FileBucketFile
           else
             Puppet::FileSystem.open(contents_file, 0440, 'wb') do |of|
               # PUP-1044 writes all of the contents
-              src = bucket_file.stream;
-              FileUtils.copy_stream(src, of)
-              src.close
+              bucket_file.stream() do |src|
+                FileUtils.copy_stream(src, of)
+              end
             end
           end
 
@@ -128,7 +128,7 @@ module Puppet::FileBucketFile
     # @param bucket_file [IO]
     def verify_identical_file!(contents_file, bucket_file)
       if bucket_file.size == Puppet::FileSystem.size(contents_file)
-        if Puppet::FileSystem.compare_stream(contents_file, bucket_file.stream)
+        if bucket_file.stream() {|s| Puppet::FileSystem.compare_stream(contents_file, s) }
           Puppet.info "FileBucket got a duplicate file #{bucket_file.checksum}"
           return
         end


### PR DESCRIPTION
This makes the stream() method on file bucket file take a block
to ensure that the processing of the stream always ends up closing it.
