### PR TITLE
(PUP-406) Deprecate stringify_ facts option

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -537,7 +537,7 @@ module Puppet
       :default => true,
       :type    => :boolean,
       :desc    => "Flatten fact values to strings using #to_s. Means you can't have arrays or
-        hashes as fact values.",
+        hashes as fact values. (DEPRECATED) This option will be removed in Puppet 4.0.",
     },
     :trusted_node_data => {
       :default => false,


### PR DESCRIPTION
The `stringify_facts` option is going to be removed in Puppet 4.0 and we
need to let users know about deprecated features.

This commit adds in a deprecation message in the stringify_facts
description.
