### PR TITLE
PUP-3128: enabled pacman as default provider for manjarolinux

### DIFF
--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -9,8 +9,8 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
   # Yaourt is a common AUR helper which, if installed, we can use to query the AUR
   commands :yaourt => "/usr/bin/yaourt" if Puppet::FileSystem.exist? '/usr/bin/yaourt'
 
-  confine     :operatingsystem => :archlinux
-  defaultfor  :operatingsystem => :archlinux
+  confine     :operatingsystem => [:archlinux, :manjarolinux]
+  defaultfor  :operatingsystem => [:archlinux, :manjarolinux]
   has_feature :install_options
   has_feature :uninstall_options
   has_feature :upgradeable


### PR DESCRIPTION
Change-Id: I4205d3e524e1bb37ac7337e18266910daaa603ed
