### PR TITLE
(PUP-3243) There's no way the 'bsd' provider will work on OpenBSD

### DIFF
--- a/lib/puppet/provider/service/bsd.rb
+++ b/lib/puppet/provider/service/bsd.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:service).provide :bsd, :parent => :init do
 
   EOT
 
-  confine :operatingsystem => [:freebsd, :netbsd, :openbsd, :dragonfly]
+  confine :operatingsystem => [:freebsd, :netbsd, :dragonfly]
 
   def rcconf_dir
     '/etc/rc.conf.d'


### PR DESCRIPTION
OpenBSD has it's own service provider and the 'bsd' service provider will certainly not work on OpenBSD.
