### PR TITLE
PUP-2289 Fix host type and provider. 

### DIFF
--- a/lib/puppet/provider/host/parsed.rb
+++ b/lib/puppet/provider/host/parsed.rb
@@ -17,10 +17,10 @@ Puppet::Type.type(:host).provide(:parsed,:parent => Puppet::Provider::ParsedFile
 
   text_line :comment, :match => /^#/
   text_line :blank, :match => /^\s*$/
-
+  hosts_pattern = '^([0-9a-f:]\S+)\s+([^#\s+]\S+)\s*(.*?)?(?:\s*#\s*(.*))?$'
   record_line :parsed, :fields => %w{ip name host_aliases comment},
     :optional => %w{host_aliases comment},
-    :match    => /^(\S+)\s+(\S+)\s*(.*?)?(?:\s*#\s*(.*))?$/,
+    :match    => /#{hosts_pattern}/,
     :post_parse => proc { |hash|
       # An absent comment should match "comment => ''"
       hash[:comment] = '' if hash[:comment].nil? or hash[:comment] == :absent
@@ -41,4 +41,6 @@ Puppet::Type.type(:host).provide(:parsed,:parent => Puppet::Provider::ParsedFile
       end
       str
     }
+
+  text_line :incomplete, :match => /(?! (#{hosts_pattern}))/
 end

--- a/lib/puppet/type/host.rb
+++ b/lib/puppet/type/host.rb
@@ -22,9 +22,13 @@ module Puppet
 
         return false
       end
+      def valid_newline?(addr)
+        return false if (addr =~ /\n/ || addr =~ /\r/)
+        return true
+      end
 
       validate do |value|
-        return true if valid_v4?(value) or valid_v6?(value)
+        return true if ((valid_v4?(value) || valid_v6?(value)) && (valid_newline?(value)))
         raise Puppet::Error, "Invalid IP address #{value.inspect}"
       end
     end
@@ -43,14 +47,18 @@ module Puppet
       end
 
       validate do |value|
+        # This regex already includes newline check.
         raise Puppet::Error, "Host aliases cannot include whitespace" if value =~ /\s/
-        raise Puppet::Error, "Host alias cannot be an empty string. Use an empty array to delete all host_aliases " if value =~ /^\s*$/
+        raise Puppet::Error, "Host aliases cannot be an empty string. Use an empty array to delete all host_aliases " if value =~ /^\s*$/
       end
 
     end
 
     newproperty(:comment) do
       desc "A comment that will be attached to the line with a # character."
+      validate do |value|
+        raise Puppet::Error, "Comment cannot include newline" if (value =~ /\n/ || value =~ /\r/)
+      end
     end
 
     newproperty(:target) do
@@ -76,6 +84,7 @@ module Puppet
             raise Puppet::Error, "Invalid host name"
           end
         end
+        raise Puppet::Error, "Hostname cannot include newline" if (value =~ /\n/ || value =~ /\r/)
       end
     end
 

--- a/spec/unit/provider/host/parsed_spec.rb
+++ b/spec/unit/provider/host/parsed_spec.rb
@@ -44,6 +44,33 @@ describe provider_class do
     host.flush
     @provider.target_object(@hostfile).read
   end
+  describe "when parsing on incomplete line" do
+    it "should work for only ip" do
+      @provider.parse_line("127.0.0.1")[:line].should ==  "127.0.0.1"
+    end
+    it "should work for only hostname" do
+      @provider.parse_line("www.example.com")[:line].should == "www.example.com"
+    end
+    it "should work for ip and space" do
+      @provider.parse_line("127.0.0.1 ")[:line].should ==  "127.0.0.1 "
+    end
+    it "should work for hostname and space" do
+      @provider.parse_line("www.example.com ")[:line].should == "www.example.com "
+    end
+    it "should work for hostname and host_aliases" do
+      @provider.parse_line("www.example.com  www xyz")[:line].should == "www.example.com  www xyz"
+    end
+    it "should work for ip and comment" do
+      @provider.parse_line("127.0.0.1  #www xyz")[:line].should == "127.0.0.1  #www xyz"
+    end
+    it "should work for hostname and comment" do
+      @provider.parse_line("xyz  #www test123")[:line].should == "xyz  #www test123"
+    end
+
+    it "should work for crazy incomplet lines" do
+      @provider.parse_line("%th1s is a\t cr$zy    !incompl1t line")[:line].should == "%th1s is a\t cr$zy    !incompl1t line"
+    end
+  end
 
   describe "when parsing a line with ip and hostname" do
 

--- a/spec/unit/type/host_spec.rb
+++ b/spec/unit/type/host_spec.rb
@@ -602,16 +602,32 @@ describe host do
       end
     end
 
+    it "should not accept newlines in resourcename" do
+      expect { @class.new(:name => "fo\no", :ip => '127.0.0.1' ) }.to  raise_error(Puppet::ResourceError, /Hostname cannot include newline/)
+    end
+
+    it "should not accept newlines in ipaddress" do
+      expect { @class.new(:name => "foo", :ip => "127.0.0.1\n") }.to raise_error(Puppet::ResourceError, /Invalid IP address/)
+    end
+
+    it "should not accept newlines in host_aliases" do
+      expect { @class.new(:name => "foo", :ip => '127.0.0.1', :host_aliases => [ 'well_formed', "thisalias\nhavenewline" ] ) }.to raise_error(Puppet::ResourceError, /Host aliases cannot include whitespace/)
+    end
+
+    it "should not accept newlines in comment" do
+      expect { @class.new(:name => "foo", :ip => '127.0.0.1', :comment => "Test of comment blah blah \n test 123" ) }.to raise_error(Puppet::ResourceError, /Comment cannot include newline/)
+    end
+
     it "should not accept spaces in resourcename" do
-      proc { @class.new(:name => "foo bar") }.should raise_error
+      expect { @class.new(:name => "foo bar") }.to raise_error(Puppet::ResourceError, /Invalid host name/)
     end
 
     it "should not accept host_aliases with spaces" do
-      proc { @class.new(:name => "foo", :host_aliases => [ 'well_formed', 'not wellformed' ]) }.should raise_error
+      expect { @class.new(:name => "foo", :host_aliases => [ 'well_formed', 'not wellformed' ]) }.to raise_error(Puppet::ResourceError, /Host aliases cannot include whitespace/)
     end
 
     it "should not accept empty host_aliases" do
-      proc { @class.new(:name => "foo", :host_aliases => ['alias1','']) }.should raise_error
+      expect { @class.new(:name => "foo", :host_aliases => ['alias1','']) }.to raise_error(Puppet::ResourceError, /Host aliases cannot be an empty string/)
     end
   end
 


### PR DESCRIPTION
This commit fix the first bug reported on PUP-2289.
This is done by implementing validation of newlines
on ip, hostname, comments and host_aliases, making
sure we don't have any \n or \r.

Bellow is the problem description:

If the ip address or hostname or host_aliases
use double quoting and have \n, Puppet Will:

1 - Write the wrong entry on /etc/hosts with the linebreak.
This leads to a corrupted /etc/hosts, with some lines
that could not be parsed by the host resource provider
parsed.

This leads to second bug on the second puppet run,
where it will have error after failing to parse the file,
but wipes out the /etc/hosts file, writing only the information
on that file that is managed by puppet.

How to reproduce it:
1- backup /etc/hosts
cp /etc/hosts /etc/hosts.orig
2 - Create the script to reproduce the bug 01
cat <<EOF > /tmp/hostsbug.pp
host {'hostsbug': ip => "10.10.12.1\n" }
EOF
The same apply if you have newline on hostname, hostaliases or comment.
3 - Run the script the first time to reproduce bug 01.
puppet apply /tmp/hostsbug.pp
4 - Check /etc/hosts
cat /etc/hosts

Leonardo Rodrigues de Mello
