### PR TITLE
(PUP-3129) Do not store _timestamp fact in immutable hash

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -655,6 +655,10 @@ class Puppet::Parser::Scope
   end
 
   def set_facts(hash)
+    # Remove _timestamp (it has an illegal datatype). It is not allowed to mutate the given hash
+    # since it contins the facts.
+    hash = hash.dup
+    hash.delete('_timestamp')
     setvar('facts', deep_freeze(hash), :privileged => true)
   end
 


### PR DESCRIPTION
The _timestamp fact causes problems when turning on immutable facts
because it is an unsupported data type (Time) that should not leak into
the puppet language. (The system halts with an error if you try prior to
this fix).
