### PR TITLE
(PUP-3127) LDAP - introduce LDAP-Certificat Directory

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1870,6 +1870,14 @@ EOT
         Defaults to false because SSL usually requires certificates
         to be set up on the client side.",
     },
+    :ldapcrtdir => {
+      :default => false,
+      :desc    => "Path to cerificate directories.
+        Defaults to 'false'.
+        Normally SSL based LDAP connections should work without explicit setting
+        the `ldapcrtdir`. On e.g. Solaris based systems set this to `/var/ldap`
+        or any other Directory that contains the certificates.",
+    },
     :ldaptls => {
       :default  => false,
       :type     => :boolean,


### PR DESCRIPTION
Introduction of a new config parameter 'ldapcrtdir' to implement ssl based ldap connections on Solaris based Puppet-Master.
Without this implementation it is not possible to create ssl encrypted ldap connections on a Soalris system.
If the 'ldapcrtdir' parameter is not set or set to false (=> default), the connectin is set up as before.
