### PR TITLE
(PUP-3228) Remove "{}" from PUPPETMASTER_EXTRA_OPTS and PUPPET_EXTRA_OPTS 

### DIFF
--- a/ext/systemd/puppet.service
+++ b/ext/systemd/puppet.service
@@ -6,7 +6,7 @@ After=basic.target network.target puppetmaster.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/puppetagent
 EnvironmentFile=-/etc/sysconfig/puppet
-ExecStart=/usr/bin/puppet agent ${PUPPET_EXTRA_OPTS} --no-daemonize
+ExecStart=/usr/bin/puppet agent $PUPPET_EXTRA_OPTS --no-daemonize
 
 [Install]
 WantedBy=multi-user.target

--- a/ext/systemd/puppetmaster.service
+++ b/ext/systemd/puppetmaster.service
@@ -5,7 +5,7 @@ After=basic.target network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/puppetmaster
-ExecStart=/usr/bin/puppet master ${PUPPETMASTER_EXTRA_OPTS} --no-daemonize
+ExecStart=/usr/bin/puppet master $PUPPETMASTER_EXTRA_OPTS --no-daemonize
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This prevents systemd from failing to interpret values correctly.  Variables enclosed as "${}" are interpreted by systemd literally.
## examples

"${PUPPETMASTER_EXTRA_OPTS}":
[root@c7 vagrant]# systemctl status puppetmaster
puppetmaster.service - Puppet master
   Loaded: loaded (/usr/lib/systemd/system/puppetmaster.service; disabled)
   Active: failed (Result: exit-code) since Mon 2014-08-25 20:25:02 UTC; 40s ago
  Process: 17658 ExecStart=/usr/bin/puppet master ${PUPPETMASTER_EXTRA_OPTS} --no-daemonize (code=exited, status=1/FAILURE)
 Main PID: 17658 (code=exited, status=1/FAILURE)

Aug 25 20:25:02 c7.hubspot.local systemd[1]: Started Puppet master.
Aug 25 20:25:02 c7.hubspot.local puppet[17658]: Error: Could not parse application options: invalid option: --config /etc/puppetmaster/puppet-vagrant.conf --logdest /var/log/puppetmaster.log
Aug 25 20:25:02 c7.hubspot.local systemd[1]: puppetmaster.service: main process exited, code=exited, status=1/FAILURE
Aug 25 20:25:02 c7.hubspot.local systemd[1]: Unit puppetmaster.service entered failed state.

---

"$PUPPETMASTER_EXTRA_OPTS"
[root@c7 vagrant]# systemctl status puppetmaster
puppetmaster.service - Puppet master
   Loaded: loaded (/usr/lib/systemd/system/puppetmaster.service; disabled)
   Active: active (running) since Mon 2014-08-25 20:26:47 UTC; 4s ago
 Main PID: 17873 (puppet)
   CGroup: /system.slice/puppetmaster.service
           └─17873 /usr/bin/ruby /usr/bin/puppet master --config /etc/puppetmaster/puppet-vagrant.conf --logdest /var/log/puppetmaster.log --no-daemonize

Aug 25 20:26:47 c7.hubspot.local systemd[1]: Started Puppet master.
