### PR TITLE
PUP-2040/PE-3113 Remove symlink-ignore tests for symlinkless OSes

### DIFF
--- a/spec/unit/module_tool/applications/builder_spec.rb
+++ b/spec/unit/module_tool/applications/builder_spec.rb
@@ -311,7 +311,7 @@ symlinkfile
       it_behaves_like "pmtignored files are not present"
     end
 
-    context "with unignored symlinks" do
+    context "with unignored symlinks", :if => Puppet.features.manages_symlinks? do
       before :each do
         create_regular_files
         create_symlinks
@@ -323,7 +323,7 @@ symlinkfile
       end
     end
 
-    context "with .gitignore file and ignored symlinks" do
+    context "with .gitignore file and ignored symlinks", :if => Puppet.features.manages_symlinks? do
       before :each do
         create_regular_files
         create_symlinks


### PR DESCRIPTION
Before this commit, the spec tests checked for symlink-ignore behavior on all
OSes. After this commit, the spec tests only check symlink-ignore
behavior on OSes that have symlinks.
