### PR TITLE
(PUP-1884) Migrate MSI deps into puppet repo

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -14,6 +14,21 @@ yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: TRUE
 build_dmg: TRUE
+build_msi:
+  puppet_for_the_win:
+    ref: '177b224087e384fc91ca0acbc6c160bf20514188'
+    repo: 'git://github.com/puppetlabs/puppet_for_the_win.git'
+  facter:
+    ref: 'refs/tags/2.2.0'
+    repo: 'git://github.com/puppetlabs/facter.git'
+  hiera:
+    ref: 'refs/tags/1.3.4'
+    repo: 'git://github.com/puppetlabs/hiera.git'
+  sys:
+    ref:
+      x86: '890ad47c3b70de4e4956d2699b54d481d5a1b72e'
+      x64: '2820779a3f4281534a6792b0ab20b2cf213647dc'
+    repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
 apt_repo_path: '/opt/repository/incoming'


### PR DESCRIPTION
We have this problem where it is very difficult to know what exactly is
getting into the Puppet MSI when we build it. Previously, all that
information was stored in the Jenkins job used to build the MSI. This
proved difficult because there is no real way to audit changes made to
the jobs, why those changes were made, or who made them. This commit
moves that information into the Puppet Repo itself. This will help us
make sure the correct version of each project is getting into the MSI,
and allow us to build the MSI with the current checkout of the Puppet
Repo. However, this means we have to make sure we do not forget to
update the versions of the dependencies getting pulled into the MSI when
a new release happens.
