### PR TITLE
(do not merge) (PUP-3014) Accept. tests - 3.7 PMT updates generate

### DIFF
--- a/acceptance/tests/modules/generate/basic_generate.rb
+++ b/acceptance/tests/modules/generate/basic_generate.rb
@@ -6,19 +6,16 @@ module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []
 
-orig_installed_modules = get_installed_modules_for_hosts hosts
-teardown do
-  rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)
-end
-
 agents.each do |agent|
+
+  teardown do
+    on agent,"rm -fr '#{module_author}-#{module_name}'", :acceptable_exit_codes => (0..254)
+  end
 
   step "Generate #{module_author}-#{module_name} module"
   on agent, puppet("module generate #{module_author}-#{module_name} --skip-interview")
 
-  step "Check for #{module_author}-#{module_name} scaffolding"
+  step "Check for #{module_name} scaffolding"
   on agent,"test -f #{module_author}-#{module_name}/manifests/init.pp"
 
-  step "Clean up"
-  on agent,"rm -fr #{module_author}-#{module_name}"
 end

--- a/acceptance/tests/modules/generate/dependencies_metadata_should_use_version_requirement.rb
+++ b/acceptance/tests/modules/generate/dependencies_metadata_should_use_version_requirement.rb
@@ -1,0 +1,29 @@
+test_name "puppet module generate - dependencies in metadata.json should use 'version_requirement' NOT 'version_range'"
+require 'json'
+
+module_author = "foo"
+module_name   = "bar"
+module_dependencies = []
+
+agents.each do |agent|
+
+  teardown do
+    on agent,"rm -fr #{module_author}-#{module_name}"
+  end
+
+  step "Generate #{module_author}-#{module_name} module" do
+    on agent, puppet("module generate #{module_author}-#{module_name} --skip-interview")
+  end
+
+  step "Check for 'version_requirement' in metadata.json" do
+    on agent,"test -f #{module_author}-#{module_name}/metadata.json"
+
+    on agent,"cat #{module_author}-#{module_name}/metadata.json" do |res|
+      metadata = res.stdout.chomp
+      m = JSON.parse(metadata)
+      fail_test('version_requirement not in dependencies keys') unless m['dependencies'][0].keys.include? 'version_requirement'
+      fail_test('version_range in dependencies keys') if m['dependencies'][0].keys.include? 'version_range'
+    end
+  end
+
+end

--- a/acceptance/tests/modules/generate/erb_template_support.rb
+++ b/acceptance/tests/modules/generate/erb_template_support.rb
@@ -1,0 +1,67 @@
+test_name "puppet module generate should support erb templates in skeleton"
+
+module_author = "foo"
+module_name   = "bar"
+
+agents.each do |agent|
+
+  teardown do
+    apply_manifest_on(agent, "user { '#{module_author}': ensure => absent, managehome => true, }", :catch_failures => true)
+  end
+
+  step "Create non-privileged user" do
+    # The use of skeleton data is not supported for privileged user
+
+    home_prop = nil
+    case agent['platform']
+    when /windows/
+      home_prop = "home='#{profile_base(agent)}\\#{module_author}'"
+    when /solaris/
+      pending_test("managehome needs work on solaris")
+    end
+      on agent, puppet_resource('user', module_author, ["ensure=present", "managehome=true", home_prop].compact)
+  end
+
+  step "Add skeleton .fixtures.yml.erb file" do
+    home_dir = nil
+    on agent, puppet_resource('user', module_author) do |result|
+      home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
+    end
+    pp = "file { [ '#{home_dir}/.puppet',
+                   '#{home_dir}/.puppet/var',
+                   '#{home_dir}/.puppet/var/puppet-module',
+                   '#{home_dir}/.puppet/var/puppet-module/skeleton' ]:
+         ensure   => 'directory',
+         owner    => '#{module_author}',
+         }"
+    apply_manifest_on(agent, pp, :catch_failures => true)
+    pp = 'file { "home_dir/.puppet/var/puppet-module/skeleton/.fixtures.yml.erb":
+         ensure   => present,
+         content  => "fixtures:
+           repositories:
+             stdlib: \"git://github.com/puppetlabs/puppetlabs-stdlib.git\"
+           symlinks:
+             <%= metadata.name %>: \"#{source_dir}\"",
+         }'
+     pp = pp.sub('home_dir', home_dir)
+     apply_manifest_on(agent, pp, :catch_failures => true)
+  end
+
+  step "Generate #{module_author}-#{module_name} module as #{module_author}" do
+    on agent, "su #{module_author} - -c 'cd ~ ; puppet module generate #{module_author}-#{module_name} --skip-interview'"
+  end
+
+  step "Check for template in #{module_author}-#{module_name}" do
+    expected = 'fixtures:
+           repositories:
+             stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+           symlinks:
+             bar: "#{source_dir}"'
+
+    on agent,"test -f /home/#{module_author}/#{module_author}-#{module_name}/.fixtures.yml"
+    on agent,"cat /home/#{module_author}/#{module_author}-#{module_name}/.fixtures.yml" do |res|
+      assert_equal(expected, res.stdout)
+    end
+  end
+
+end

--- a/acceptance/tests/modules/generate/erb_template_support.rb
+++ b/acceptance/tests/modules/generate/erb_template_support.rb
@@ -1,4 +1,8 @@
 test_name "puppet module generate should support erb templates in skeleton"
+require 'puppet/acceptance/windows_utils'
+extend Puppet::Acceptance::WindowsUtils
+
+confine :except, :platform => 'windows'
 
 module_author = "foo"
 module_name   = "bar"
@@ -19,7 +23,8 @@ agents.each do |agent|
     when /solaris/
       pending_test("managehome needs work on solaris")
     end
-      on agent, puppet_resource('user', module_author, ["ensure=present", "managehome=true", home_prop].compact)
+
+    on agent, puppet_resource('user', module_author, ["ensure=present", "managehome=true", "password='Puppet11'", home_prop].compact)
   end
 
   step "Add skeleton .fixtures.yml.erb file" do

--- a/acceptance/tests/modules/generate/metadata_erb_with_description.rb
+++ b/acceptance/tests/modules/generate/metadata_erb_with_description.rb
@@ -1,4 +1,8 @@
 test_name "puppet module generate should succeed when metadata erb template contains deprecated field 'description'"
+require 'puppet/acceptance/windows_utils'
+extend Puppet::Acceptance::WindowsUtils
+
+confine :except, :platform => 'windows'
 
 module_author = "foo"
 module_name   = "bar"
@@ -22,7 +26,7 @@ agents.each do |agent|
       pending_test("managehome needs work on solaris")
     end
 
-    on agent, puppet_resource('user', module_author, ["ensure=present", "managehome=true", home_prop].compact)
+    on agent, puppet_resource('user', module_author, ["ensure=present", "managehome=true", "password='Puppet11'", home_prop].compact)
   end
 
   step "Add skeleton .fixtures.yml.erb file" do

--- a/acceptance/tests/modules/generate/metadata_erb_with_description.rb
+++ b/acceptance/tests/modules/generate/metadata_erb_with_description.rb
@@ -1,0 +1,61 @@
+test_name "puppet module generate should succeed when metadata erb template contains deprecated field 'description'"
+
+module_author = "foo"
+module_name   = "bar"
+
+agents.each do |agent|
+
+  home_dir = nil
+
+  teardown do
+    apply_manifest_on(agent, "user { '#{module_author}': ensure => absent, managehome => true, }", :catch_failures => true)
+  end
+
+  step "Create non-privileged user" do
+    # The use of skeleton data is not supported for privileged user
+
+    home_prop = nil
+    case agent['platform']
+    when /windows/
+      home_prop = "home='#{profile_base(agent)}\\#{module_author}'"
+    when /solaris/
+      pending_test("managehome needs work on solaris")
+    end
+
+    on agent, puppet_resource('user', module_author, ["ensure=present", "managehome=true", home_prop].compact)
+  end
+
+  step "Add skeleton .fixtures.yml.erb file" do
+    on agent, puppet_resource('user', module_author) do |result|
+      home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
+    end
+    pp = "file { [ '#{home_dir}/.puppet',
+                   '#{home_dir}/.puppet/var',
+                   '#{home_dir}/.puppet/var/puppet-module',
+                   '#{home_dir}/.puppet/var/puppet-module/skeleton' ]:
+         ensure   => 'directory',
+         owner    => '#{module_author}',
+         }"
+    apply_manifest_on(agent, pp, :catch_failures => true)
+    pp = 'file { "home_dir/.puppet/var/puppet-module/skeleton/metadata.json.erb":
+         ensure   => present,
+         content  => "
+           {
+             \"name\": \"<%= metadata.full_module_name %>\",
+             \"version\": \"0.1.0\",
+             \"description\": \"<%= defined?(metadata.description) ? metadata.description : metadata.summary %>\",
+           }"
+         }'
+
+     pp = pp.sub('home_dir', home_dir)
+     apply_manifest_on(agent, pp, :catch_failures => true)
+  end
+
+  step "Generate #{module_author}-#{module_name} module as #{module_author}" do
+    on agent, "su #{module_author} - -c 'cd ~ ; puppet module generate #{module_author}-#{module_name} --skip-interview'"
+    on agent, "su #{module_author} - -c 'cd ~ ; cat #{home_dir}/#{module_author}-#{module_name}/metadata.json'" do |res|
+      assert_match(/description/, res.stdout, "Template not correctly used")
+    end
+  end
+
+end


### PR DESCRIPTION
This commit adds additional acceptance test coverage for updates
to the puppet module generate command. These tests validate the
following:

* (PUP-2781) Generated requirements should use the version_requirement field
* (PUP-2691) Generate should succeed when skeletons use the 'description'
  metadata property.
* (PUP-2079) Generate should support erb skeleton templates"