### PR TITLE
(PUP-3232) Prevent group duplication when group list created from multiple sources.

### DIFF
--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -258,7 +258,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     # reading of the file.
     Etc.endgrent
 
-    groups.join(",")
+    groups.uniq.join(",")
   end
 
   # Convert the Etc struct into a hash.

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -20,10 +20,11 @@ describe Puppet::Provider::NameService do
     ]
   end
 
-  # These are values getgrent might give you
+  # These are values getgrent might give you, bin is duplicated intentionally
   let :groups do
     [
       Struct::Group.new('root', 'x', 0, %w{root}),
+      Struct::Group.new('bin', 'x', 1, %w{root bin daemon}),
       Struct::Group.new('bin', 'x', 1, %w{root bin daemon}),
       nil
     ]
@@ -129,7 +130,7 @@ describe Puppet::Provider::NameService do
       described_class.listbyname.should == %w{root foo}
     end
 
-    it "should return a list of groups if resource_type is group", :unless => Puppet.features.microsoft_windows? do
+    it "should return a list of groups, with no duplicates, if resource_type is group", :unless => Puppet.features.microsoft_windows? do
       described_class.resource_type = Puppet::Type.type(:group)
       Etc.expects(:setgrent)
       Etc.stubs(:getgrent).returns *groups

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -284,6 +284,12 @@ describe Puppet::Type.type(:user) do
         @instance[:membership] = :inclusive
         @instance[:groups].should == 'a,b,c'
       end
+
+      # it "should deduplicate groups" do
+      #   @instance = described_class.new(:name => 'foo', :groups => [ 'a', 'b', 'c', 'b', 'a' ], :provider => @provider)
+      #   @instance[:membership] = :inclusive
+      #   @instance[:groups].should == 'a,b,c'
+      # end
     end
   end
 


### PR DESCRIPTION
On a Puppet node that has multiple group directories (e.g. `/etc/group` and LDAP) puppet may end up with groups listed multiple times in a user's group list. This leads to a state of constant change where puppet detects the muliple entries and tries to remove them (when nothing is wrong).

This change ensures that a user's group list only contains unique entries and no duplicates.

(We have local groups as a fail-over when LDAP is unavailable as we use groups for sudo authentication)
