### PR TITLE
(PUP-3153) Guard against nil when closing Uniquefiles

### DIFF
--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -19,7 +19,9 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
     f = new(identifier)
     yield f
   ensure
-    f.close!
+    if f
+      f.close!
+    end
   end
 
   def initialize(basename, *rest)

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -463,7 +463,9 @@ module Util
     ensure
       # in case an error occurred before we renamed the temp file, make sure it
       # gets deleted
-      tempfile.close!
+      if tempfile
+        tempfile.close!
+      end
     end
 
 

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -203,7 +203,7 @@ module Puppet::Util::Execution
         raise Puppet::ExecutionFailure, "Execution of '#{str}' returned #{exit_status}: #{output.strip}"
       end
     ensure
-      if !options[:squelch]
+      if !options[:squelch] && stdout
         # if we opened a temp file for stdout, we need to clean it up.
         stdout.close!
       end


### PR DESCRIPTION
In a recent commit we introduced `Uniquefile` to use in place
of `Tempfile` for certain code paths.  Because `Uniquefile` does
not automatically delete files for you, it is necessary to call
`close!` explicitly if you wish to make sure that they get
removed.

In the original commit I did this in a few places in an `ensure`
block.  However, I did not guard against the possibility that
an error might occur when attempting to instantiate the `Uniquefile`
object (e.g., file permissions error), and thus the calls to `close!`
in the `ensure` blocks may result in a NilClass exception (and also
mask the real error).

This commit adds guards to ensure that we only try to call `close!`
if the `Uniquefile` object was actually instantiated.
