### PR TITLE
(PUP-3154) Create and manage the mode of $statedir on redhat

### DIFF
--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -119,6 +119,7 @@ install -d -m0755 %{buildroot}%{_sysconfdir}/puppet/environments/example_env/mod
 install -d -m0755 %{buildroot}%{_sysconfdir}/puppet/manifests
 install -d -m0755 %{buildroot}%{_datadir}/%{name}/modules
 install -d -m0755 %{buildroot}%{_localstatedir}/lib/puppet
+install -d -m0755 %{buildroot}%{_localstatedir}/lib/puppet/state
 install -d -m0755 %{buildroot}%{_localstatedir}/run/puppet
 
 # As per redhat bz #495096
@@ -259,6 +260,7 @@ cp -pr ext/puppet-nm-dispatcher \
 %defattr(-, puppet, puppet, 0750)
 %{_localstatedir}/log/puppet
 %{_localstatedir}/lib/puppet
+%{_localstatedir}/lib/puppet/state
 # Return the default attributes to 0755 to
 # prevent incorrect permission assignment on EL6
 %defattr(-, root, root, 0755)


### PR DESCRIPTION
In debian, we create and manage the $statedir in the postinst of the
puppet-common package. In redhat, $statedir would be created on
service start, and owned by root. This means that other applications,
even those in the puppet group, could not write to this directory. This
commit adds $statedir to the directories created in the redhat package
and sets the user and group ownership to puppet:puppet. This will ensure
a more consistent experience for users of our packages.
