### PR TITLE
PUP-3155 Improve spec tests around the PE puppet version

### DIFF
--- a/spec/unit/util/command_line_spec.rb
+++ b/spec/unit/util/command_line_spec.rb
@@ -70,7 +70,7 @@ describe Puppet::Util::CommandLine do
       it "should print the version and exit if #{arg} is given" do
         expect do
           described_class.new("puppet", [arg]).execute
-        end.to have_printed(/^#{Puppet.version}$/)
+        end.to have_printed(/^#{Regexp.escape(Puppet.version)}$/)
       end
     end
   end
@@ -125,7 +125,7 @@ describe Puppet::Util::CommandLine do
 
             expect {
               commandline.execute
-            }.to have_printed(/^#{Puppet.version}$/).and_exit_with(1)
+            }.to have_printed(%r[^#{Regexp.escape(Puppet.version)}$]).and_exit_with(1)
           end
         end
       end


### PR DESCRIPTION
Before this commit, when checking the puppet version on a PE build,
several characters; '(', ')' and '.'; caused problems with the regex.
This commit Regexp.escape-s them.
