### PR TITLE
(PUP-3163) Create and manage the mode of $reportsdir

### DIFF
--- a/ext/debian/puppet-common.postinst
+++ b/ext/debian/puppet-common.postinst
@@ -23,6 +23,8 @@ if [ "$1" = "configure" ]; then
 	# to be owned by the "puppet" user
 	install --owner puppet --group puppet --directory \
 		/var/lib/puppet/state
+	install --owner puppet --group puppet --directory \
+		/var/lib/puppet/reports
 	
 	# Handle 
 	if [ -d /etc/puppet/ssl ] && [ ! -e /var/lib/puppet/ssl ] && grep -q 'ssldir=/var/lib/puppet/ssl' /etc/puppet/puppet.conf; then

--- a/ext/debian/puppet-common.postrm
+++ b/ext/debian/puppet-common.postrm
@@ -6,9 +6,10 @@ case "$1" in
 		rm -f /etc/puppet/puppetd.conf
 
 		# Remove puppet state directory created by the postinst script.
-		# This directory can be removed without causing harm 
+		# This directory can be removed without causing harm
 		# according to upstream documentation.
 		rm -rf /var/lib/puppet/state
+		rm -rf /var/lib/puppet/reports
 		if [ -d /var/lib/puppet ]; then
 			rmdir --ignore-fail-on-non-empty /var/lib/puppet
 		fi

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -120,6 +120,7 @@ install -d -m0755 %{buildroot}%{_sysconfdir}/puppet/manifests
 install -d -m0755 %{buildroot}%{_datadir}/%{name}/modules
 install -d -m0755 %{buildroot}%{_localstatedir}/lib/puppet
 install -d -m0755 %{buildroot}%{_localstatedir}/lib/puppet/state
+install -d -m0755 %{buildroot}%{_localstatedir}/lib/puppet/reports
 install -d -m0755 %{buildroot}%{_localstatedir}/run/puppet
 
 # As per redhat bz #495096
@@ -261,6 +262,7 @@ cp -pr ext/puppet-nm-dispatcher \
 %{_localstatedir}/log/puppet
 %{_localstatedir}/lib/puppet
 %{_localstatedir}/lib/puppet/state
+%{_localstatedir}/lib/puppet/reports
 # Return the default attributes to 0755 to
 # prevent incorrect permission assignment on EL6
 %defattr(-, root, root, 0755)


### PR DESCRIPTION
For redhat and debian, we create and manage a $statedir with ownership
set to puppet:puppet. Unfortuntely, we also create a $reportsdir that is
owned by root. This means that other applications, even those in the
puppet group, could not write to this directory. This commits adds the
$reportsdir to both debian and redhat packaging to ensure it is created
with the correct permissions (just at the $statedir is), to ensure a
more consistent experience for users of our packages.
