### PR TITLE
(PUP-3168) Fix all file permissions on puppet module install

### DIFF
--- a/lib/puppet/module_tool/tar/gnu.rb
+++ b/lib/puppet/module_tool/tar/gnu.rb
@@ -8,7 +8,7 @@ class Puppet::ModuleTool::Tar::Gnu
     Dir.chdir(destdir) do
       Puppet::Util::Execution.execute("gzip -dc #{Shellwords.shellescape(sourcefile)} | tar xof -")
       Puppet::Util::Execution.execute("find . -type d -exec chmod 755 {} +")
-      Puppet::Util::Execution.execute("find . -type f -exec chmod a-wst {} +")
+      Puppet::Util::Execution.execute("find . -type f -exec chmod 644 {} +")
       Puppet::Util::Execution.execute("chown -R #{owner} .")
     end
   end

--- a/spec/unit/module_tool/tar/gnu_spec.rb
+++ b/spec/unit/module_tool/tar/gnu_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::ModuleTool::Tar::Gnu do
     Dir.expects(:chdir).with(File.expand_path(destdir)).yields(mock)
     Puppet::Util::Execution.expects(:execute).with("gzip -dc #{Shellwords.shellescape(File.expand_path(sourcefile))} | tar xof -")
     Puppet::Util::Execution.expects(:execute).with("find . -type d -exec chmod 755 {} +")
-    Puppet::Util::Execution.expects(:execute).with("find . -type f -exec chmod a-wst {} +")
+    Puppet::Util::Execution.expects(:execute).with("find . -type f -exec chmod 644 {} +")
     Puppet::Util::Execution.expects(:execute).with("chown -R <owner:group> .")
     subject.unpack(sourcefile, destdir, '<owner:group>')
   end


### PR DESCRIPTION
If directory permissions are fixed to 755, file permissions
should be fixed in same way. Otherwise module files with 600
permissions (e.g. ceritsc-psacct) aren't available to real
Puppet user (pe-apache?) different from current user.

See
https://tickets.puppetlabs.com/browse/PUP-3168
https://github.com/CERIT-SC/puppet-psacct/issues/1