### PR TITLE
(PUP-3114) Added an enforcement for FIPS

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -970,8 +970,9 @@ EOT
       :desc       => "The bit length of the certificates.",
     },
     :keylength => {
-      :default    => 4096,
-      :desc       => "The bit length of keys.",
+      :default    => Facter.value('fips_enabled') == 'true' ? 2048 : 4096,
+      :desc       => "The bit length of keys. In FIPS mode, this must not be set
+        above 2048 until the standard changes.",
     },
     :cert_inventory => {
       :default => "$cadir/inventory.txt",

--- a/lib/puppet/ssl/key.rb
+++ b/lib/puppet/ssl/key.rb
@@ -22,7 +22,14 @@ DOC
   # Knows how to create keys with our system defaults.
   def generate
     Puppet.info "Creating a new SSL key for #{name}"
-    @content = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
+    keylength = Puppet[:keylength].to_i
+    if Facter.value('fips_enabled') == 'true'
+      if keylength > 2048
+        Puppet.info "Forcing keylength to 2048 due to FIPS being enabled."
+        keylength = 2048
+      end
+    end
+    @content = OpenSSL::PKey::RSA.new(keylength)
   end
 
   def initialize(name)


### PR DESCRIPTION
FIPS mode requires that the keylength be restricted to 2048 bits instead
of the new standard 4096.

This patch provides that proper enforcement.
