### PR TITLE
(PUP-2411) Make Program/Locator contain byte vs char offset encoding

### DIFF
--- a/lib/puppet/pops/model/model.rb
+++ b/lib/puppet/pops/model/model.rb
@@ -102,7 +102,7 @@ module Puppet::Pops
       module ClassModule
         def locator
           unless result = getLocator
-            setLocator(result = Puppet::Pops::Parser::Locator.locator(source_text, source_ref(), line_offsets))
+            setLocator(result = Puppet::Pops::Parser::Locator.locator(source_text, source_ref(), line_offsets, char_offsets))
           end
           result
         end

--- a/lib/puppet/pops/model/model_meta.rb
+++ b/lib/puppet/pops/model/model_meta.rb
@@ -563,14 +563,20 @@ module Puppet::Pops::Model
 
   # A Program is the top level construct returned by the parser
   # it contains the parsed result in the body, and has a reference to the full source text,
-  # and its origin. The line_offset's is an array with the start offset of each line.
+  # and its origin. The line_offset's is an array with the start offset of each line measured
+  # in bytes or characters (as given by the attribute char_offsets). The `char_offsets` setting
+  # applies to all offsets recorded in the mode (not just the line_offsets).
   #
+  # A model that will be shared across different platforms should use char_offsets true as the byte
+  # offsets are platform and encoding dependent.
+  # 
   class Program < PopsObject
     contains_one_uni 'body', Expression
     has_many 'definitions', Definition
     has_attr 'source_text', String
     has_attr 'source_ref', String
     has_many_attr 'line_offsets', Integer
+    has_attr 'char_offsets', Boolean, :defaultValueLiteral => 'false'
     has_attr 'locator', Object, :lowerBound => 1, :transient => true
   end
 end

--- a/lib/puppet/pops/parser/locator.rb
+++ b/lib/puppet/pops/parser/locator.rb
@@ -27,12 +27,16 @@ class Puppet::Pops::Parser::Locator
   # Creates, or recreates a Locator. A Locator is created if index is not given (a scan is then
   # performed of the given source string.
   #
-  def self.locator(string, file, index = nil)
-    case LOCATOR_VERSION
-    when :ruby20, :ruby19
-      Locator19.new(string, file, index)
+  def self.locator(string, file, index = nil, char_offsets = false)
+    if(char_offsets)
+      LocatorForChars.new(string, file, index);
     else
-      Locator18.new(string, file, index)
+      case LOCATOR_VERSION
+      when :ruby20, :ruby19
+        Locator19.new(string, file, index)
+      else
+        LocatorForChars.new(string, file, index)
+      end
     end
   end
 
@@ -162,7 +166,7 @@ class Puppet::Pops::Parser::Locator
       @prev_offset = nil
       @prev_line = nil
       @line_index = index
-      compute_line_index unless !index.nil?
+      compute_line_index if index.nil?
     end
 
     # Returns the position on line (first position on a line is 1)
@@ -247,7 +251,7 @@ class Puppet::Pops::Parser::Locator
     end
   end
 
-  class Locator18 < AbstractLocator
+  class LocatorForChars < AbstractLocator
 
     def offset_on_line(offset)
       line_offset = line_index[ line_for_offset(offset)-1 ]


### PR DESCRIPTION
As discussed in the ticket. Ruby before 1.8.7 has no way to efficiently
scan a string by character (it is done per byte). In Ruby 2.0.0 the
StringScanner can respond with character positions instead of byte
positions. It is however slower than using the byte positions.

To make 1.8.7 or 1.9.3 encode strings in chars would be prohibitively
slow (a string has to be constructed to be able to know its length for
every token). In Ruby 2.0.0 it is more or less a wash (they byte way of
calculating this is however still faster (when last measured).

This fix makes it possible to record the information in the model if the
offsets in the model are byte or char based. Currently, there is no
implementation that uses char based, so this is preparation for the
future and making the AST model's API more stable.

As a comparison on other platforms (JVM) it is far easier and more
efficient to get the char positions than the byte positions).
