### PR TITLE
(PUP-900) Don't refresh resources that have `noop => true`

### DIFF
--- a/lib/puppet/transaction/event_manager.rb
+++ b/lib/puppet/transaction/event_manager.rb
@@ -120,7 +120,7 @@ class Puppet::Transaction::EventManager
   #   associated with this callback and resource.
   # @return [true, false] Whether the callback should be run.
   def process_callback?(resource, events)
-    !events.all? { |e| e.status == "noop" }
+    !(events.all? { |e| e.status == "noop" } || resource.noop?)
   end
 
   # Processes callbacks for a given resource.

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -193,6 +193,26 @@ describe Puppet::Transaction do
     Puppet::FileSystem.exist?(file2).should be_true
   end
 
+  it "does not refresh resources that have 'noop => true'" do
+    path = tmpfile("path")
+
+    notify = Puppet::Type.type(:notify).new(
+      :name    => "trigger",
+      :notify  => Puppet::Resource.new(:exec, "noop exec")
+    )
+
+    noop_exec = Puppet::Type.type(:exec).new(
+      :name    => "noop exec",
+      :path    => ENV["PATH"],
+      :command => touch(path),
+      :noop    => true
+    )
+
+    catalog = mk_catalog(notify, noop_exec)
+    catalog.apply
+    Puppet::FileSystem.exist?(path).should be_false
+  end
+
   it "should apply no resources whatsoever if a pre_run_check fails" do
     path = tmpfile("path")
     file = Puppet::Type.type(:file).new(


### PR DESCRIPTION
This pull request prevents resources that have `noop => true` from running callbacks due to events.

Note that this preserves the same behavior as where a noop'd resource refreshes another resource in that it sends a `noop` event; does this make sense?
