### PR TITLE
(PUP-3177) Remove magic handling of square brackets in resource title

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -551,10 +551,12 @@ class Puppet::Resource
   end
 
   def extract_type_and_title(argtype, argtitle)
-    if    (argtitle || argtype) =~ /^([^\[\]]+)\[(.+)\]$/m then [ $1,                 $2            ]
-    elsif argtitle                                         then [ argtype,            argtitle      ]
-    elsif argtype.is_a?(Puppet::Type)                      then [ argtype.class.name, argtype.title ]
-    elsif argtype.is_a?(Hash)                              then
+    if    (argtype.nil? || argtype == :component || argtype == :whit) &&
+           argtitle =~ /^([^\[\]]+)\[(.+)\]$/m                 then [ $1,                 $2            ]
+    elsif argtitle.nil? && argtype =~ /^([^\[\]]+)\[(.+)\]$/m  then [ $1,                 $2            ]
+    elsif argtitle                                             then [ argtype,            argtitle      ]
+    elsif argtype.is_a?(Puppet::Type)                          then [ argtype.class.name, argtype.title ]
+    elsif argtype.is_a?(Hash)                                  then
       raise ArgumentError, "Puppet::Resource.new does not take a hash as the first argument. "+
         "Did you mean (#{(argtype[:type] || argtype["type"]).inspect}, #{(argtype[:title] || argtype["title"]).inspect }) ?"
     else raise ArgumentError, "No title provided and #{argtype.inspect} is not a valid resource reference"

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -85,6 +85,12 @@ describe Puppet::Resource do
     ref.title.should =="baz"
   end
 
+  it "should not interpret the title as a reference if the type is a non component or whit reference" do
+    ref = Puppet::Resource.new("Notify", "foo::bar[baz]")
+    ref.type.should == "Notify"
+    ref.title.should =="foo::bar[baz]"
+  end
+
   it "should be able to extract its information from a Puppet::Type instance" do
     ral = Puppet::Type.type(:file).new :path => basepath+"/foo"
     ref = Puppet::Resource.new(ral)


### PR DESCRIPTION
The Resource handles square brackets in a resource title as
if it is a complete resource reference. This behavior is there
to support the component resource type, and whits. The implementation
however did not check if a regular type was also given.

This means that any resource with square brackets in its title either
leads to an error, or to the creation of an instance of different
type/title than what was intended.

This commit fixes this by only doing the munging of the title if the
type is nil, component or a whit.
