### PR TITLE
(PUP-3174) Make settings catalog skip manifestdir if environmentpath

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -887,8 +887,8 @@ class Puppet::Settings
     sections = nil if sections.empty?
 
     catalog = Puppet::Resource::Catalog.new("Settings", Puppet::Node::Environment::NONE)
-
     @config.keys.find_all { |key| @config[key].is_a?(FileSetting) }.each do |key|
+      next if (key == :manifestdir && should_skip_manifestdir?())
       file = @config[key]
       next unless (sections.nil? or sections.include?(file.section))
       next unless resource = file.to_resource
@@ -904,6 +904,13 @@ class Puppet::Settings
 
     catalog
   end
+
+  def should_skip_manifestdir?()
+    setting = @config[:environmentpath]
+    !(setting.nil? || setting.value.nil? || setting.value.empty?)
+  end
+
+  private :should_skip_manifestdir?
 
   # Convert our list of config settings into a configuration file.
   def to_config

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1338,6 +1338,14 @@ describe Puppet::Settings do
       @settings.to_catalog
     end
 
+    it "should ignore manifestdir if environmentpath is set" do
+      @settings.define_settings :main,
+        :manifestdir => { :type => :directory, :default => @prefix+"/manifestdir", :desc => "a" },
+        :environmentpath => { :type => :path, :default => @prefix+"/envs", :desc => "a" }
+        catalog = @settings.to_catalog(:main)
+        catalog.resource(:file, @prefix+"/manifestdir").should be_nil
+    end
+
     describe "on Microsoft Windows" do
       before :each do
         Puppet.features.stubs(:root?).returns true


### PR DESCRIPTION
This makes the settings catalog skip managment of manifestdir if
environmentpath is set.
