### PR TITLE
remove --include-dependencies as it is deprecated and no longer availabl...

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -72,8 +72,6 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
   def install(useversion = true)
     command = [command(:gemcmd), "install"]
     command << "-v" << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion
-    # Always include dependencies
-    command << "--include-dependencies"
 
     if source = resource[:source]
       begin

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -29,10 +29,6 @@ describe provider_class do
       provider.install
     end
 
-    it "should specify that dependencies should be included" do
-      provider.expects(:execute).with { |args| args[2] == "--include-dependencies" }.returns ""
-      provider.install
-    end
 
     it "should specify that documentation should not be included" do
       provider.expects(:execute).with { |args| args[3] == "--no-rdoc" }.returns ""


### PR DESCRIPTION
Issue: https://tickets.puppetlabs.com/browse/PUP-3202

This is breaking the gem provider for us, and this has been deprecated since 2007. --include-dependencies is the default behaviour so there should not be a problem.
