### PR TITLE
(PUP-3094) - Support for dynamic SELinux domain transition

### DIFF
--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -15,6 +15,7 @@ require "puppet/util/plugins"
 require "puppet/util/rubygems"
 require "puppet/util/limits"
 require 'puppet/util/colors'
+require 'puppet/util/selinux'
 
 module Puppet
   module Util
@@ -23,6 +24,7 @@ module Puppet
     # begins.
     class CommandLine
       include Puppet::Util::Limits
+      include Puppet::Util::SELinux
 
       OPTION_OR_MANIFEST_FILE = /^-|\.pp$|\.rb$/
 
@@ -83,6 +85,17 @@ module Puppet
       #
       # @return [void]
       def execute
+        # Before we load configuration do SELinux domain switch. This operation does not throw
+        # any errors or exceptions when SELinux is turned off or policy does not allow this
+        # kind of transition.
+        if selinux_support? && ! ENV['NO_PUPPET_SELINUX_DTRANS']
+          if subcommand_name == 'master' then
+            set_selinux_domain(SELINUX_DOMAIN_PUPPET_MASTER)
+          elsif subcommand_name == 'ca' then
+            set_selinux_domain(SELINUX_DOMAIN_PUPPET_CA)
+          end
+        end
+
         Puppet::Util.exit_on_fail("initialize global default settings") do
           Puppet.initialize_settings(args)
         end

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -13,6 +13,10 @@ require 'pathname'
 
 module Puppet::Util::SELinux
 
+  # Domains for dynamic transition which can be overriden by downstream Linux distributions.
+  SELINUX_DOMAIN_PUPPET_MASTER = ENV['PUPPET_SELINUX_MASTER_DOMAIN'] || 'puppetmaster_t'
+  SELINUX_DOMAIN_PUPPET_CA = ENV['PUPPET_SELINUX_CA_DOMAIN'] || 'puppetca_t'
+
   def selinux_support?
     return false unless defined?(Selinux)
     if Selinux.is_selinux_enabled == 1
@@ -135,6 +139,18 @@ module Puppet::Util::SELinux
       return new_context
     end
     nil
+  end
+
+  # Sets process domain and returns true on success.
+  def set_selinux_domain(domain_type)
+    return nil unless selinux_support?
+    context = Selinux.getcon[1].split(':')
+    context[2] = domain_type
+    if Selinux.setcon(context.join(':')) == 0
+      true
+    else
+      false
+    end
   end
 
   ########################################################################


### PR DESCRIPTION
Do not merge, this is for initial discussion.

Here is what we think is the best approach to allow dynamic transition into
target SELinux domains required for hardening master and ca processes as
discussed in

https://groups.google.com/forum/#!topic/puppet-dev/VTb2o-Nuxkw

This replaces wrappers which were proposed in

https://github.com/puppetlabs/puppet/pull/2997

Let me know if you like this approach in comments and I will go ahead and test
this (this is a draft really). Thanks. @domcleal