### PR TITLE
(PUP-3186) Fix directory enforcement of production directory environment

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1130,6 +1130,9 @@ Generated on #{Time.now}.
     configured_environment = self[:environment]
     if configured_environment == "production" && envdir && Puppet::FileSystem.exist?(envdir)
       configured_environment_path = File.join(envdir, configured_environment)
+      if File.symlink?(configured_environment_path)
+        configured_environment_path = File.realpath(configured_environment_path)
+      end
       catalog.add_resource(
         Puppet::Resource.new(:file,
                              configured_environment_path,


### PR DESCRIPTION
When puppet was checking for the production directory environment to
exist puppet would ensure that the directory environment was a
directory. During the ensure step if the directory environment was a
symlink to a directory puppet would replace the symlink with a directory
called production.

This commit makes it so that puppet will follow the symlink to its
destination and ensure that the destination is a directory instead of
replacing the symlink all together.
