### PR TITLE
(PUP-3222) Rescue StandardError instead of non-existent exception

### DIFF
--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -21,21 +21,21 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
   def enable
     w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_AUTO_START )
     raise Puppet::Error.new("Win32 service enable of #{@resource[:name]} failed" ) if( w32ss.nil? )
-  rescue Win32::Service::Error => detail
+  rescue SystemCallError => detail
     raise Puppet::Error.new("Cannot enable #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def disable
     w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_DISABLED )
     raise Puppet::Error.new("Win32 service disable of #{@resource[:name]} failed" ) if( w32ss.nil? )
-  rescue Win32::Service::Error => detail
+  rescue SystemCallError => detail
     raise Puppet::Error.new("Cannot disable #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def manual_start
     w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_DEMAND_START )
     raise Puppet::Error.new("Win32 service manual enable of #{@resource[:name]} failed" ) if( w32ss.nil? )
-  rescue Win32::Service::Error => detail
+  rescue SystemCallError => detail
     raise Puppet::Error.new("Cannot enable #{@resource[:name]} for manual start, error was: #{detail}", detail )
   end
 
@@ -55,7 +55,7 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
       else
         raise Puppet::Error.new("Unknown start type: #{w32ss.start_type}")
     end
-  rescue Win32::Service::Error => detail
+  rescue SystemCallError => detail
     raise Puppet::Error.new("Cannot get start type for #{@resource[:name]}, error was: #{detail}", detail )
   end
 
@@ -95,7 +95,7 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
     end
     debug("Service #{@resource[:name]} is #{w32ss.current_state}")
     return state
-  rescue Win32::Service::Error => detail
+  rescue SystemCallError => detail
     raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 

--- a/spec/integration/provider/service/windows_spec.rb
+++ b/spec/integration/provider/service/windows_spec.rb
@@ -1,0 +1,48 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:service).provider(:windows), '(integration)',
+  :if => Puppet.features.microsoft_windows? do
+
+  require 'puppet/util/windows'
+
+  before :each do
+    Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
+  end
+
+  context 'should fail querying services that do not exist' do
+    let(:service) do
+      Puppet::Type.type(:service).new(:name => 'foobarservice1234')
+    end
+
+    it "with a Puppet::Error when querying enabled?" do
+      expect { service.provider.enabled? }.to raise_error(Puppet::Error)
+    end
+
+    it "with a Puppet::Error when querying status" do
+      expect { service.provider.status }.to raise_error(Puppet::Error)
+    end
+  end
+
+  context 'should return valid values when querying a service that does exist' do
+    let(:service) do
+      Puppet::Type.type(:service).new(:name => 'lmhosts')
+    end
+
+    it "with a valid boolean when asked if enabled" do
+      expect([:true, :false]).to include(service.provider.enabled?)
+    end
+
+    it "with a valid status when asked about status" do
+      expect([
+        :running,
+        :'continue pending',
+        :'pause pending',
+        :paused,
+        :running,
+        :'start pending',
+        :'stop pending',
+        :stopped]).to include(service.provider.status)
+    end
+  end
+end


### PR DESCRIPTION
Previously, the windows service provider rescued exceptions of type
Win32::Service::Error. However, FFI-based versions of win32-service (v0.8.x)
no longer raise that type of error. Instead they raise SystemCallError.

So previously, if puppet failed to manage a service, e.g. service didn't
exist, puppet would try to rescue the exception specifying a class that
was not defined:

```
puppet resource service foo ensure=stopped
Error: /Service[foo]: Could not evaluate: uninitialized constant Win32::Service::Error
```

This regression was introduced as part of PUP-1283 when we migrated from
win32-service version 0.7.x to 0.8.x.

This commit modifies the various provider methods to more broadly rescue
StandardErrors and updates the spec tests to handle the negative cases.
