### PR TITLE
(PUP-3191) Fix symlink checking

### DIFF
--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -46,7 +46,7 @@ module Puppet::ModuleTool
         tmpdirpath = Pathname.new tmpdir
 
         symlinks.each do |s|
-          Puppet.warning "Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from tmpdirpath}->#{s.realpath.relative_path_from tmpdirpath}."
+          Puppet.warning "Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from tmpdirpath}->#{File.readlink(s)}."
         end
       end
 


### PR DESCRIPTION
Prior to this commit we were trying to use Pathname.realpath to find where a
symlink points to. This throws a file not found when the symlink doesn't point
at anything valid in the filesystem.
This commit fixes that problem by only using File.readlink and not attempting
to find the symlinked file relative to the module unpacking directory.
