### PR TITLE
(PUP-3191) Use FileSystem.readlink in unpacker

### DIFF
--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -46,7 +46,7 @@ module Puppet::ModuleTool
         tmpdirpath = Pathname.new tmpdir
 
         symlinks.each do |s|
-          Puppet.warning "Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from tmpdirpath}->#{File.readlink(s)}."
+          Puppet.warning "Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from tmpdirpath}->#{Puppet::FileSystem.readlink(s)}."
         end
       end
 


### PR DESCRIPTION
Prior to this commit we were using File.readlink, which does not work properly
on Windows platforms, to tell the user about symlinks found when unpacking.
This commit changes that behavior to instead use the Puppet::Filesystem.readlink
function, which should work on all platforms that support symlinks.
