### PR TITLE
(PUP-3229) Remove deprecate methods in BaseSetting class

### DIFF
--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -2,32 +2,17 @@ require 'puppet/settings/errors'
 
 # The base setting type
 class Puppet::Settings::BaseSetting
-  attr_accessor :name, :desc, :section, :default, :call_on_define, :call_hook
+  attr_accessor :name, :desc, :section, :default, :call_hook
   attr_reader :short, :deprecated
 
   def self.available_call_hook_values
     [:on_define_and_write, :on_initialize_and_write, :on_write_only]
   end
 
-  def call_on_define
-    Puppet.deprecation_warning "call_on_define has been deprecated.  Please use call_hook_on_define?"
-    call_hook_on_define?
-  end
-
-  def call_on_define=(value)
-    if value
-      Puppet.deprecation_warning ":call_on_define has been changed to :call_hook => :on_define_and_write. Please change #{name}."
-      @call_hook = :on_define_and_write
-    else
-      Puppet.deprecation_warning ":call_on_define => :false has been changed to :call_hook => :on_write_only. Please change #{name}."
-      @call_hook = :on_write_only
-    end
-  end
-
   def call_hook=(value)
     if value.nil?
       Puppet.warning "Setting :#{name} :call_hook is nil, defaulting to :on_write_only"
-      value ||= :on_write_only
+      value = :on_write_only
     end
     raise ArgumentError, "Invalid option #{value} for call_hook" unless self.class.available_call_hook_values.include? value
     @call_hook = value
@@ -39,19 +24,6 @@ class Puppet::Settings::BaseSetting
 
   def call_hook_on_initialize?
     call_hook == :on_initialize_and_write
-  end
-
-  #added as a proper method, only to generate a deprecation warning
-  #and return value from
-  def setbycli
-    Puppet.deprecation_warning "Puppet.settings.setting(#{name}).setbycli is deprecated. Use Puppet.settings.set_by_cli?(#{name}) instead."
-    @settings.set_by_cli?(name)
-  end
-
-  def setbycli=(value)
-    Puppet.deprecation_warning "Puppet.settings.setting(#{name}).setbycli= is deprecated. You should not manually set that values were specified on the command line."
-    @settings.set_value(name, @settings[name], :cli) if value
-    raise ArgumentError, "Cannot unset setbycli" unless value
   end
 
   # get the arguments in getopt format

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -258,24 +258,6 @@ describe Puppet::Settings do
       @settings.set_by_cli?(:myval).should be_false
     end
 
-    describe "setbycli" do
-      it "should generate a deprecation warning" do
-        Puppet.expects(:deprecation_warning).at_least(1)
-        @settings.setting(:myval).setbycli = true
-      end
-      it "should set the value" do
-        @settings[:myval] = "blah"
-        @settings.setting(:myval).setbycli = true
-        @settings.set_by_cli?(:myval).should be_true
-      end
-      it "should raise error if trying to unset value" do
-        @settings.handlearg("--myval", "blah")
-        expect do
-          @settings.setting(:myval).setbycli = nil
-        end.to raise_error(ArgumentError, /unset/)
-      end
-    end
-
     it "should clear the cache when setting getopt-specific values" do
       @settings.define_settings :mysection,
           :one => { :default => "whah", :desc => "yay" },
@@ -390,27 +372,6 @@ describe Puppet::Settings do
       end
     end
 
-    describe "call_on_define" do
-      [true, false].each do |val|
-        describe "to #{val}" do
-          it "should generate a deprecation warning" do
-            Puppet.expects(:deprecation_warning)
-            values = []
-            @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_on_define => val, :hook => lambda { |v| values << v }})
-          end
-
-          it "should should set call_hook" do
-            values = []
-            name = "hooker_#{val}".to_sym
-            @settings.define_settings(:section, name => {:default => "yay", :desc => "boo", :call_on_define => val, :hook => lambda { |v| values << v }})
-
-            @settings.setting(name).call_hook.should == :on_define_and_write if val
-            @settings.setting(name).call_hook.should == :on_write_only unless val
-          end
-        end
-      end
-    end
-
     it "should call passed blocks when values are set" do
       values = []
       @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| values << v }})
@@ -486,22 +447,6 @@ describe Puppet::Settings do
       Puppet::FileSystem.stubs(:exist?).returns true
     end
 
-    describe "call_on_define" do
-      it "should generate a deprecation warning" do
-        Puppet.expects(:deprecation_warning)
-        @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
-        @settings.setting(:hooker).call_on_define
-      end
-
-      Puppet::Settings::StringSetting.available_call_hook_values.each do |val|
-        it "should match value for call_hook => :#{val}" do
-          hook_values = []
-          @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => val, :hook => lambda { |v| hook_values << v  }})
-          @settings.setting(:hooker).call_on_define.should == @settings.setting(:hooker).call_hook_on_define?
-        end
-      end
-    end
-
     it "should provide a mechanism for returning set values" do
       @settings[:one] = "other"
       @settings[:one].should == "other"
@@ -572,18 +517,6 @@ describe Puppet::Settings do
           :trip_wire => { :type => :boolean, :default => false, :desc => "a trip wire" },
           :tripping => { :default => '$trip_wire', :desc => "once tripped if interpolated was false" })
       @settings[:tripping].should == "false"
-    end
-
-    describe "setbycli" do
-      it "should generate a deprecation warning" do
-        @settings.handlearg("--one", "blah")
-        Puppet.expects(:deprecation_warning)
-        @settings.setting(:one).setbycli
-      end
-      it "should be true" do
-        @settings.handlearg("--one", "blah")
-        @settings.setting(:one).setbycli.should be_true
-      end
     end
   end
 


### PR DESCRIPTION
In Puppet::Settings::BaseSetting, the following 4 methods were deprecated
long ago. This commit removes them:
call_on_define
call_on_define=
setbycli
setbycli=

This commit also makes a one-line change in call_hook= to remove an
unneeded conditional assignment (value can't have been assigned since
the value.nil? check two lines above).
