### PR TITLE
(PUP-3227) Address man page ownship conflicts

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -60,6 +60,7 @@ Architecture: all
 Depends: ${misc:Depends}, ruby | ruby-interpreter, puppet-common (= ${binary:Version}), facter (>= 1.7.0), lsb-base
 Breaks: puppet (<< 0.24.7-1), puppetmaster (<< 2.6.1~rc2-1)
 Replaces: puppetmaster (<< 2.6.1~rc2-1)
+Conflicts: puppet-common (<< 3.3.0-1puppetlabs1)
 Suggests: apache2 | nginx, puppet-el, vim-puppet, stompserver, ruby-stomp | libstomp-ruby1.8,
  rdoc, ruby-ldap | libldap-ruby1.8, puppetdb-terminus
 Description: Puppet master common scripts
@@ -81,6 +82,7 @@ Package: puppetmaster
 Architecture: all
 Depends: ${misc:Depends}, ruby | ruby-interpreter, puppetmaster-common (= ${source:Version}), facter (>= 1.7.0), lsb-base
 Breaks: puppet (<< 0.24.7-1)
+Conflicts: puppet (<< 3.3.0-1puppetlabs1)
 Suggests: apache2 | nginx, puppet-el, vim-puppet, stompserver, ruby-stomp | libstomp-ruby1.8,
  rdoc, ruby-ldap | libldap-ruby1.8, puppetdb-terminus
 Description: Centralized configuration management - master startup and compatibility scripts


### PR DESCRIPTION
Prior to this commit, upgrading from puppet=2.7.23-1~deb7u3 and
puppetmaster=2.7.23-1~deb7u3 to puppet=3.7.0.29-1puppetlabs1 and
puppetmaster=3.7.0.29-1puppetlabs1 fails. I believe this problem is due
to how Debian chose to package puppet-common, which owns
`/usr/share/man/man8/puppet-master.8.gz`.

This commit adds in a `Conflicts:` to the puppetmaster and
puppetmaster-common packages to make sure that we can successfully
upgrade from these older package versions. However, if a user has
puppetmaster and puppet older than 3.3.0 installed on a machine, and
only upgrades puppetmaster, this will uninstall the puppet package from
the system.
