### PR TITLE
(PUP-3186) Skip creation of symlinked default directory env

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1137,11 +1137,13 @@ Generated on #{Time.now}.
     configured_environment = self[:environment]
     if configured_environment == "production" && envdir && Puppet::FileSystem.exist?(envdir)
       configured_environment_path = File.join(envdir, configured_environment)
-      catalog.add_resource(
-        Puppet::Resource.new(:file,
-                             configured_environment_path,
-                             :parameters => { :ensure => 'directory' })
-      )
+      if !Puppet::FileSystem.symlink?(configured_environment_path)
+        catalog.add_resource(
+          Puppet::Resource.new(:file,
+                               configured_environment_path,
+                               :parameters => { :ensure => 'directory' })
+        )
+      end
     end
   end
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1408,6 +1408,13 @@ describe Puppet::Settings do
         catalog = @settings.to_catalog
         expect(catalog.resource_keys).to include(["File", "#{default_path}/production"])
       end
+
+      it "does not add if the path to the default directory environment exists as a symlink" do
+        Dir.mkdir(default_path)
+        Puppet::FileSystem.symlink("#{tmpenv}/nowhere", File.join(default_path, 'production'))
+        catalog = @settings.to_catalog
+        expect(catalog.resource_keys).to_not include(["File", "#{default_path}/production"])
+      end
     end
 
     describe "when adding users and groups to the catalog" do


### PR DESCRIPTION
Rebased onto stable, and changed to skip attempting to ensure anything about the production directory environment if there is a symlink, since that is an indication that the user has already made some configuration.  Also added a spec, @hlindberg.
