### PR TITLE
(PUP-3136) Fix upstart acceptance test on lucid

### DIFF
--- a/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
+++ b/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
@@ -11,7 +11,11 @@ def manage_service_for(pkg, state, agent)
   return_code = 0
 
   if pkg == 'rabbitmq-server' && state == 'stopped'
-    return_code = 3
+    if agent['platform'].codename == 'lucid'
+      return_code = 1
+    else
+      return_code = 3
+    end
   end
 
   manifest = <<-MANIFEST
@@ -25,18 +29,26 @@ def manage_service_for(pkg, state, agent)
     }
   MANIFEST
 
+  # Since these acceptance tests rely on the output of `service rabbitmq-server status`,
+  # they're likely to break when rabbitmq is updated and the output changes (this is why
+  # exit codes and regexes are different for lucid; it has a much older version of rabbitmq).
   apply_manifest_on(agent, manifest, :catch_failures => true) do
     if pkg == 'rabbitmq-server'
       if state == 'running'
-        assert_match(/Status of node/m, stdout, "Could not start #{pkg}.")
-      elsif
-        assert_match(/unable to connect to node/m, stdout, "Could not stop #{pkg}.")
+        # With the .* wildcard this regex will work on lucid, precise, and trusty
+        assert_match(/Status of.*node/m, stdout, "Could not start #{pkg}.")
+      else
+        if agent['platform'].codename == 'lucid'
+          assert_match(/no_nodes_running/, stdout, "Could not stop #{pkg}.")
+        else
+          assert_match(/unable to connect to node/, stdout, "Could not stop #{pkg}.")
+        end
       end
     else
       if state == 'running'
-        assert_match(/start/m, stdout, "Could not start #{pkg}.")
-      elsif
-        assert_match(/stop/m, stdout, "Could not stop #{pkg}.")
+        assert_match(/start/, stdout, "Could not start #{pkg}.")
+      else
+        assert_match(/stop/, stdout, "Could not stop #{pkg}.")
       end
     end
   end


### PR DESCRIPTION
Due to the fact that this acceptance test depends on the output
of `service rabbitmq-server status`, it was failing on lucid.
This was due to the fact that lucid has an older version of rabbitmq
and therefor a different output than trusty and precise.

Update the regexes and exit codes so that they support lucid. It's
worth noting that since these tests are based on the text output
of `service rabbitmq-server status`, they are fragile and may break
if rabbitmq changes the output of its init.d script. Additionally, if
rabbitmq switches from init.d to upstart we will need to find another
package.

Paired with Will Hopper whopper@puppetlabs.com
