### PR TITLE
(PUP-3236) Support PUPPET_LOADED env var in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,9 @@ platforms :ruby do
   #gem 'ruby-augeas', :group => :development
 end
 
-gem "puppet", :path => File.dirname(__FILE__), :require => false
+if !ENV['PUPPET_LOADED']
+  gem "puppet", :path => File.dirname(__FILE__), :require => false
+end
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 1.6', '< 3'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
 gem "rake", "10.1.1", :require => false


### PR DESCRIPTION
This commit adds support for an environment variable, PUPPET_LOADED,
to be set during bundle installation.  If set, the variable will
prevent the puppet gem from being loaded; the use case is for test
environments where you already have puppet available on the load path.
