### PR TITLE
(PUP-3231) Don't check suitability if resource is missing tags.

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -105,6 +105,7 @@ class Puppet::Transaction
     overly_deferred_resource_handler = lambda do |resource|
       # We don't automatically assign unsuitable providers, so if there
       # is one, it must have been selected by the user.
+      return if missing_tags?(resource)
       if resource.provider
         resource.err "Provider #{resource.provider.class.name} is not functional on this host"
       else


### PR DESCRIPTION
A transaction applying resources has to lazily determine suitability of
resources, since changes being made during the application of the
catalog can alter whether the system is now in a state to apply a
resource. Specifically in the case of providers, a provider may become
suitable because of package installation performed during the
application. However if tags are being used, and a resource has not been
tagged, then it should not matter whether or not the specified provider
has been found for the resource.

Prior to this patch, unsuitable, untagged resources would halt the
transaction. With this patch, we check whether the deferred resource is
missing_tags? before issuing an error. With that change, a tagged run
will no longer halt if an untagged resource's provider is not available.
