### PR TITLE
(maint) Remove GC bug workaround for Ruby < 1.8.7

### DIFF
--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -244,7 +244,7 @@ HELP
     options[:references] << :type if options[:references].empty?
   end
 
-  def setup_rdoc(dummy_argument=:work_arround_for_ruby_GC_bug)
+  def setup_rdoc
     # consume the unknown options
     # and feed them as settings
     if @unknown_args.size > 0

--- a/lib/puppet/file_serving/base.rb
+++ b/lib/puppet/file_serving/base.rb
@@ -20,7 +20,7 @@ class Puppet::FileServing::Base
   end
 
   # Return the full path to our file.  Fails if there's no path set.
-  def full_path(dummy_argument=:work_arround_for_ruby_GC_bug)
+  def full_path
     if relative_path.nil? or relative_path == "" or relative_path == "."
        full_path = path
      else

--- a/lib/puppet/indirector/node/ldap.rb
+++ b/lib/puppet/indirector/node/ldap.rb
@@ -75,7 +75,7 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
 
   # The attributes that Puppet will stack as array over the full
   # hierarchy.
-  def stacked_attributes(dummy_argument=:work_arround_for_ruby_GC_bug)
+  def stacked_attributes
     Puppet[:ldapstackedattrs].split(/\s*,\s*/)
   end
 

--- a/lib/puppet/provider/service/daemontools.rb
+++ b/lib/puppet/provider/service/daemontools.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:service).provide :daemontools, :parent => :base do
     attr_writer :defpath
 
     # Determine the daemon path.
-    def defpath(dummy_argument=:work_arround_for_ruby_GC_bug)
+    def defpath
       unless @defpath
         ["/var/lib/service", "/etc"].each do |path|
           if Puppet::FileSystem.exist?(path)

--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
   class << self
     # this is necessary to autodetect a valid resource
     # default path, since there is no standard for such directory.
-    def defpath(dummy_argument=:work_arround_for_ruby_GC_bug)
+    def defpath
       unless @defpath
         ["/etc/sv", "/var/lib/service"].each do |path|
           if Puppet::FileSystem.exist?(path)

--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -159,7 +159,7 @@ Puppet::Type.type(:zone).provide(:solaris) do
     end
   end
 
-  def install(dummy_argument=:work_arround_for_ruby_GC_bug)
+  def install
     if @resource[:clone] # TODO: add support for "-s snapshot"
       zoneadm :clone, @resource[:clone]
     elsif @resource[:install_args]

--- a/lib/puppet/rails/resource.rb
+++ b/lib/puppet/rails/resource.rb
@@ -183,7 +183,7 @@ class Puppet::Rails::Resource < ActiveRecord::Base
     end
   end
 
-  def ref(dummy_argument=:work_arround_for_ruby_GC_bug)
+  def ref
     "#{self[:restype].split("::").collect { |s| s.capitalize }.join("::")}[#{self.title}]"
   end
 

--- a/lib/puppet/type/k5login.rb
+++ b/lib/puppet/type/k5login.rb
@@ -55,7 +55,7 @@ Puppet::Type.newtype(:k5login) do
     end
 
     # Return the principals
-    def principals(dummy_argument=:work_arround_for_ruby_GC_bug)
+    def principals
       if Puppet::FileSystem.exist?(@resource[:name])
         File.readlines(@resource[:name]).collect { |line| line.chomp }
       else


### PR DESCRIPTION
Commit bd5dc649 added a workaround for a Ruby GC bug that was present in
1.8.5, 1.8.6, and partially fixed but still residual in 1.8.7. Since
we're dropping Ruby 1.8 support entirely we can now remove the
workarounds.
