### PR TITLE
(maint) use grep for ssh_authorized_key test

### DIFF
--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -28,8 +28,6 @@ agents.each do |agent|
   on(agent, puppet_resource('ssh_authorized_key', "#{name}", args))
 
   step "verify entry deleted from #{auth_keys}"
-  on(agent, "cat #{auth_keys}")  do |res|
-    fail_test "found the ssh_authorized_key for #{name}" if stdout.include? "#{name}"
-  end
+  on(agent, "grep #{name}  #{auth_keys}", :acceptable_exit_codes => [1])
 
 end


### PR DESCRIPTION
In the CI runs of acceptance/tests/resource/ssh_authorized_key/destroy.rb,
the length of the ~/.ssh/authorized_keys file can be large enough
to cause the step to not complete correctly.

This commit changes the validation to a grep command verifying that
the exit code is 1 indicating that the name no longer is contained
in the file.
