### PR TITLE
(maint) Add rdoc dependency in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ group(:development, :test) do
   gem "json-schema", "2.1.1", :require => false, :platforms => [:ruby, :jruby]
 
   gem "rubocop", "~> 0.26.1", :platforms => [:ruby] unless RUBY_VERSION =~ /^1.8/
+
+  gem 'rdoc', "~> 4.1", :platforms => [:ruby] unless RUBY_VERSION =~ /^1.8/
 end
 
 group(:development) do


### PR DESCRIPTION
Without this patch the Puppet spec tests fail to run using the system
ruby included with Enterprise Linux 7.  This is a problem because EL7 is
a supported platform and it is helpful to use the system packages to run
the Puppet spec tests.

The specific issue is the following from a jenkins job that simply runs
`bundle install --path .bundle/gems` and then `bundle exec rspec spec`.

```
+ bundle exec rspec spec -fd
/var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require': cannot load such file -- rdoc/rdoc (LoadError)
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `block in require'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:236:in `load_dependency'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
        from /var/lib/jenkins/jobs/puppet/workspace/spec/unit/util/rdoc_spec.rb:5:in `<top (required)>'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `each'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load_spec_files'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:22:in `run'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:80:in `run'
        from /var/lib/jenkins/jobs/puppet/workspace/.bundle/gems/ruby/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:17:in `block in autorun'
```

This patch addresses the problem by adding 'rdoc' to the set of
dependencies managed by bundler as a pre-requisite step prior to running
the spec tests.
