### PR TITLE
remove commented out code (self.to_s)

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -493,17 +493,6 @@ class Puppet::Provider
     !!satisfies?(*features)
   end
 
-#    def self.to_s
-#        unless defined?(@str)
-#            if self.resource_type
-#                @str = "#{resource_type.name} provider #{self.name}"
-#            else
-#                @str = "unattached provider #{self.name}"
-#            end
-#        end
-#        @str
-#    end
-
   dochook(:defaults) do
     if @defaults.length > 0
       return @defaults.collect do |d|


### PR DESCRIPTION
to_s is implemented properly hundred lines down this file.
this code has been commented out for quite some time.

should we need it back, we have version control.
