### PR TITLE
(maint) Fix unit of profile output

### DIFF
--- a/lib/puppet/util/profiler/aggregate.rb
+++ b/lib/puppet/util/profiler/aggregate.rb
@@ -43,7 +43,7 @@ class Puppet::Util::Profiler::Aggregate < Puppet::Util::Profiler::WallClock
 
   def print_metrics(metrics_hash, prefix)
     metrics_hash.sort_by {|k,v| v.time }.reverse.each do |k,v|
-      @logger.call("#{prefix}#{k}: #{v.time} ms (#{v.count} calls)")
+      @logger.call("#{prefix}#{k}: #{v.time} s (#{v.count} calls)")
       print_metrics(metrics_hash[k], "#{prefix}#{k} -> ")
     end
   end


### PR DESCRIPTION
The profile aggregation stated that the times were in milliseconds (ms), but
they are actually in seconds (s).
