### PR TITLE
(PUP-3322) Add debugging to appdmg provider

### DIFF
--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -73,13 +73,16 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
             entity['mount-point']
           }.select { |mountloc|; mountloc }
           begin
+            found_app = false
             mounts.each do |fspath|
               Dir.entries(fspath).select { |f|
                 f =~ /\.app$/i
               }.each do |pkg|
+                found_app = true
                 installapp("#{fspath}/#{pkg}", name, source)
               end
             end
+            Puppet.debug "Unable to find .app in .appdmg. #{name} will not be installed." if !found_app
           ensure
             hdiutil "eject", mounts[0]
           end


### PR DESCRIPTION
I was trying to install Scratch[1] using boxen[2]. The appdmg isn’t in
the expected format, so this failed. I had to poke around a bit to
understand why that was happening. This change captures that knowledge.

[1] http://scratch.mit.edu/scratch_1.4/
[2] https://boxen.github.com/
