### PR TITLE
(PUP-3332) Add a value? method for auto insync?

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -289,7 +289,8 @@ class Puppet::Property < Puppet::Parameter
     # We call this if someone has added on their own method. If they haven't
     # done this, we just fall through to {#insync?} as per usual.
     method = self.class.name.to_s + "?"
-    if provider.respond_to? method
+
+    if self.class.name and provider.respond_to? method
       provider.send(method, is)
     else
       # Otherwise delegate to the (possibly derived) insync? method.

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -217,7 +217,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       check_valid_shell
     end
      super
-     if @resource.forcelocal? and self.groups?
+     if @resource.forcelocal? and self.has_groups?
        set(:groups, @resource[:groups])
      end
      if @resource.forcelocal? and @resource[:expiry]
@@ -225,7 +225,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
      end
   end
 
-  def groups?
+  def has_groups?
     !!@resource[:groups]
   end
 end


### PR DESCRIPTION
This patch adds the ability to use value? in your provider instead of
needing to add the insync? method to your type.

The group provider needed to be modified since it already defined a
groups? method for one of its properties.

Example:

<pre>
def value?(is)
  &lt;some logic here&gt;
  return &lt;logical value&gt;
end
</pre>