### PR TITLE
PUP-3336 split $libdir when updating $LOAD_PATH

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -230,9 +230,16 @@ module Puppet
           is in Ruby's search path\n",
       :call_hook => :on_initialize_and_write,
       :hook             => proc do |value|
-        $LOAD_PATH.delete(@oldlibdir) if defined?(@oldlibdir) and $LOAD_PATH.include?(@oldlibdir)
+        if defined?(@oldlibdir)
+          @oldlibdir.split(File::PATH_SEPARATOR).each do |path|
+            $LOAD_PATH.delete(path)
+          end
+        end
+
         @oldlibdir = value
-        $LOAD_PATH << value
+        value.split(File::PATH_SEPARATOR).each do |path|
+          $LOAD_PATH << path
+        end
       end
     },
     :ignoreimport => {

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -25,6 +25,15 @@ describe Puppet do
     ENV["PATH"].should == newpath
   end
 
+  it 'should set $LOAD_PATH with the split version of :libdir' do
+    one = tmpdir('load-path-one')
+    two = tmpdir('load-path-two')
+
+    Puppet[:libdir] = [ one, two ].join(File::PATH_SEPARATOR)
+    $LOAD_PATH.should include one
+    $LOAD_PATH.should include two
+  end
+
   it "should change $LOAD_PATH when :libdir changes" do
     one = tmpdir('load-path-one')
     two = tmpdir('load-path-two')


### PR DESCRIPTION
As reported, $libdir can (but typically won't) take a multi-part
libdir.  This was being used wholesale in updating $LOAD_PATH, but
ruby have any special treatment, so would just have an invalid path in
$LOAD_PATH.

With this commit we split libdir when updating $LOAD_PATH, to ensure
we're updating each component correctly.
