### PR TITLE
(pup-3338) Make systemd the default service provider for OpenSuSE >= 12 and SLES 12

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -7,6 +7,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => "7"
+  defaultfor :osfamily => :suse, :operatingsystemmajrelease => ["12", "13"]
 
   def self.instances
     i = []

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -36,6 +36,24 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     described_class.default?.should_not be_true
   end
 
+  it "should be the default provider on sles12" do
+    Facter.expects(:value).with(:osfamily).at_least_once.returns(:suse)
+    Facter.expects(:value).with(:operatingsystemmajrelease).returns("12")
+    described_class.default?.should be_true
+  end
+
+  it "should be the default provider on opensuse13" do
+    Facter.expects(:value).with(:osfamily).at_least_once.returns(:suse)
+    Facter.expects(:value).with(:operatingsystemmajrelease).returns("13")
+    described_class.default?.should be_true
+  end
+
+  it "should not be the default provider on sles11" do
+    Facter.expects(:value).with(:osfamily).at_least_once.returns(:suse)
+    Facter.expects(:value).with(:operatingsystemmajrelease).returns("11")
+    described_class.default?.should_not be_true
+  end
+
   [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|
     it "should have a #{method} method" do
       provider.should respond_to(method)


### PR DESCRIPTION
OpenSuSE >= 12 and SLES 12 use systemd as the default service management framework. This updates puppet to use the systemd provider by default on OpenSuSE 12 and 13 and SLES 12
