### PR TITLE
(PUP-3281) Remove latest_info methods from yum provider

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -222,18 +222,6 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     return rpmvercmp(s1, s2)
   end
 
-  # @deprecated
-  def latest_info
-    Puppet.deprecation_warning("#{self.class}##{__method__} is deprecated and is no longer used.")
-    @latest_info
-  end
-
-  # @deprecated
-  def latest_info=(latest)
-    Puppet.deprecation_warning("#{self.class}##{__method__} is deprecated and is no longer used.")
-    @latest_info = latest
-  end
-
   private
 
   def enablerepo


### PR DESCRIPTION
This commit removes the deprecated #latest_info and #latest_info=
methods from the yum provider.

This commit is part of the Puppet 4 code removal effort.
