### PR TITLE
(PUP-3081) Indicate catalog benchmark is for application

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -114,7 +114,7 @@ class Puppet::Configurer
     report = options[:report]
     report.configuration_version = catalog.version
 
-    benchmark(:notice, "Finished catalog run") do
+    benchmark(:notice, "Applied catalog") do
       catalog.apply(options)
     end
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -185,7 +185,7 @@ describe Puppet::Configurer do
     end
 
     it "should benchmark how long it takes to apply the catalog" do
-      @agent.expects(:benchmark).with(:notice, "Finished catalog run")
+      @agent.expects(:benchmark).with(:notice, instance_of(String))
 
       @agent.expects(:retrieve_catalog).returns @catalog
 


### PR DESCRIPTION
The message "Finished catalog run in $x seconds" may mislead users into
believing that the operation being benchmarked includes both catalog
catalog compilation, downloading, and application. The actual operation
being timed is the catalog application. We should give more indication
of this when reporting the benchmarked time.
