### PR TITLE
(PUP-3339) Confine failed test off of Fedora 19

### DIFF
--- a/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
+++ b/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
@@ -5,6 +5,8 @@
 # expect that after correcting their actions, puppet will work correctly.
 test_name "Puppet manages its own configuration in a robust manner"
 
+confine :except, :platform => 'fedora-19'
+
 skip_test "JVM Puppet cannot change its user while running." if @options[:is_puppetserver]
 
 # when owner/group works on windows for settings, this confine should be removed.


### PR DESCRIPTION
There seems to be a bug in `usermod` on Fedora 19 which is causing
this acceptance test to fail. The bug does not appear to be present
in Fedora 20. Since Fedora 19 will likely each end of life soon,
just confine the acceptance test off the platform rather than try
to find a work around in puppet.
