### PR TITLE
Don't allow insecure SSL connections w/curl

### DIFF
--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
       if %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ cached_source
         cached_source = File.join(tmpdir, name)
         begin
-          curl "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--url", source
+          curl "-o", cached_source, "-C", "-", "-L", "-s", "--url", source
           Puppet.debug "Success: curl transfered [#{name}]"
         rescue Puppet::ExecutionFailure
           Puppet.debug "curl did not transfer [#{name}].  Falling back to slower open-uri transfer methods."

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -81,7 +81,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
     begin
       if %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ cached_source
         cached_source = File.join(tmpdir, "#{name}#{ext}")
-        args = [ "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--fail", "--url", source ]
+        args = [ "-o", cached_source, "-C", "-", "-L", "-s", "--fail", "--url", source ]
         if http_proxy_host and http_proxy_port
           args << "--proxy" << "#{http_proxy_host}:#{http_proxy_port}"
         elsif http_proxy_host and not http_proxy_port


### PR DESCRIPTION
The `appdmg` and `pkgdmg` providers were calling `curl` with `-k` which allows curl'ing over insecure HTTPS connections. I can't see why this would ever be desired, and many connections will often fail when attempting establish a connection.

This PR removes the insecure option.
