### PR TITLE
(maint) log uid and gid for Puppet::Util::Execution.execute if specified as non-default

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -163,10 +163,21 @@ module Puppet::Util::Execution
       str = command
     end
 
+    user_log_s = ''
+    if options[:uid]
+      user_log_s << " uid=#{options[:uid]}"
+    end
+    if options[:gid]
+      user_log_s << " gid=#{options[:gid]}"
+    end
+    if user_log_s != ''
+      user_log_s.prepend(' with')
+    end
+
     if respond_to? :debug
-      debug "Executing '#{str}'"
+      debug "Executing#{user_log_s}: '#{str}'"
     else
-      Puppet.debug "Executing '#{str}'"
+      Puppet.debug "Executing#{user_log_s}: '#{str}'"
     end
 
     null_file = Puppet.features.microsoft_windows? ? 'NUL' : '/dev/null'

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -469,6 +469,41 @@ describe Puppet::Util::Execution do
       end
     end
 
+    describe "#execute (debug logging)" do
+      it "should log if no uid or gid specified" do
+        Puppet::Util::Execution.expects(:debug).with("Executing: 'echo hello'")
+        Puppet::Util::Execution.execute('echo hello')
+      end
+      it "should log numeric uid if specified" do
+        Puppet::Util::Execution.expects(:debug).with("Executing with uid=100: 'echo hello'")
+        Puppet::Util::Execution.execute('echo hello', {:uid => 100})
+      end
+      it "should log numeric gid if specified" do
+        Puppet::Util::Execution.expects(:debug).with("Executing with gid=500: 'echo hello'")
+        Puppet::Util::Execution.execute('echo hello', {:gid => 500})
+      end
+      it "should log numeric uid and gid if specified" do
+        Puppet::Util::Execution.expects(:debug).with("Executing with uid=100 gid=500: 'echo hello'")
+        Puppet::Util::Execution.execute('echo hello', {:uid => 100, :gid => 500})
+      end
+      it "should log string uid if specified" do
+        Puppet::Util::Execution.expects(:debug).with("Executing with uid=myuser: 'echo hello'")
+        Puppet::Util::Execution.execute('echo hello', {:uid => 'myuser'})
+      end
+      it "should log string gid if specified" do
+        Puppet::Util::Execution.expects(:debug).with("Executing with gid=mygroup: 'echo hello'")
+        Puppet::Util::Execution.execute('echo hello', {:gid => 'mygroup'})
+      end
+      it "should log string uid and gid if specified" do
+        Puppet::Util::Execution.expects(:debug).with("Executing with uid=myuser gid=mygroup: 'echo hello'")
+        Puppet::Util::Execution.execute('echo hello', {:uid => 'myuser', :gid => 'mygroup'})
+      end
+      it "should log numeric uid and string gid if specified" do
+        Puppet::Util::Execution.expects(:debug).with("Executing with uid=100 gid=mygroup: 'echo hello'")
+        Puppet::Util::Execution.execute('echo hello', {:uid => 100, :gid => 'mygroup'})
+      end
+    end
+
     describe "after execution" do
       before :each do
         stub_process_wait(0)


### PR DESCRIPTION
This might be able to use a little bit of cleanup, I guess it depends on how nicely you want the output formatted. But I was debugging a custom provider that uses Puppet::Util::Execution.execute and seemed to be executing as root instead of the specified user... and found that the debugging output didn't really help me find the problem.