### PR TITLE
(PUP-3351) Evaluate ENC classes in the correct order

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -187,9 +187,10 @@ class Puppet::Parser::Compiler
       classes_without_params = @node.classes
     end
 
-    evaluate_classes(classes_without_params, @node_scope || topscope)
-
+    # (PUP-3351) Avoid "Duplicate declaration" errors by evaluating classes
+    # with params prior to classes without params.
     evaluate_classes(classes_with_params, @node_scope || topscope)
+    evaluate_classes(classes_without_params, @node_scope || topscope)
   end
 
   # Evaluate each specified class in turn.  If there are any classes we can't


### PR DESCRIPTION
Without this patch classes declared from an ENC are evaluated in the wrong
order.  This is a problem because classes declared without parameters are
evaluated prior to classes with parameters which causes an Error: Duplicate
declaration when the classes with parameters are evaluated.  According to the
code comments for the `evaluate_node_classes` method, the expected behavior is
that classes with an empty set of parameters will not conflict with classes
that have declared parameters.

Note: This should be included as a bug fix in the 3.7.x series because the
actual behavior does not match the expected behavior in 3.7.1.
