### PR TITLE
(PUP-3126) upgrade win32-service to 0.8.6

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -33,7 +33,7 @@ gem_platform_dependencies:
       win32-eventlog: '~> 0.6.1'
       win32-process: '~> 0.7.4'
       win32-security: '~> 0.2.5'
-      win32-service: '~> 0.8.4'
+      win32-service: '~> 0.8.6'
       win32console:  '1.3.2'
       minitar: '~> 0.5.4'
   x64-mingw32:
@@ -43,7 +43,7 @@ gem_platform_dependencies:
       win32-eventlog: '~> 0.6.1'
       win32-process: '~> 0.7.4'
       win32-security: '~> 0.2.5'
-      win32-service: '~> 0.8.4'
+      win32-service: '~> 0.8.6'
       minitar: '~> 0.5.4'
 bundle_platforms:
   x86-mingw32: mingw


### PR DESCRIPTION
This upgrades the win32-service gem to at least 0.8.6 to take advantage
of the fixes to the service gem. This change includes only the fixes that
we have already applied patches to in puppet-win32-ruby.
