### PR TITLE
(PUP-3307) Remove 'rmdeps' param from Puppet::Type#remove

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -930,13 +930,8 @@ class Type
 
   # Removes this object (FROM WHERE?)
   # @todo removes if from where?
-  # @overload remove(rmdeps)
-  #   @deprecated Use remove()
-  #   @param rmdeps [Boolean] intended to indicate that all subscriptions should also be removed, ignored.
-  # @overload remove()
   # @return [void]
-  #
-  def remove(rmdeps = true)
+  def remove()
     # This is hackish (mmm, cut and paste), but it works for now, and it's
     # better than warnings.
     @parameters.each do |name, obj|


### PR DESCRIPTION
This commit removes the deprecated 'rmdeps' parameter from
the Puppet::Type#remove method.

This commit is part of the Puppet 4 code removal effort.
