### PR TITLE
(PUP-2998): Make log_level settable in puppet.conf

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -144,7 +144,6 @@ module Puppet
     Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(run_mode))
     Puppet.push_context(Puppet.base_context(Puppet.settings), "Initial context after settings initialization")
     Puppet::Parser::Functions.reset
-    Puppet::Util::Log.level = Puppet[:log_level]
   end
   private_class_method :do_initialize_settings_for_run_mode
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -83,6 +83,8 @@ module Puppet
         * emerg
         * crit
         ",
+      :hook => proc {|value| Puppet::Util::Log.level = value },
+      :call_hook => :on_initialize_and_write,
     },
     :disable_warnings => {
       :default => [],


### PR DESCRIPTION
Added a call hook to the `log_level` setting so that this setting can be
defined in `puppet.conf` in addtion to being passed as a command line flag.
