### PR TITLE
PUP-3366 Fix issues with string/enum type assignable calculations

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -1159,7 +1159,9 @@ class Puppet::Pops::Types::TypeCalculator
     when Types::PVariantType
       t2.types.all? {|variant_t| assignable_PEnumType(t, variant_t) }
     when Types::PEnumType
-      t2.values.all? { |s| t.values.any? {|e| e == s }}
+      # empty means any enum
+      return true if t.values.empty?
+      !t2.values.empty? && t2.values.all? { |s| t.values.any? {|e| e == s }}
     else
       false
     end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -845,6 +845,11 @@ describe 'The type calculator' do
         calculator.assignable?(enum_t('a', 'b'), enum_t('c')).should == false
       end
 
+      it 'non parameterized enum accepts any other enum but not the reverse' do
+        calculator.assignable?(enum_t(), enum_t('a')).should == true
+        calculator.assignable?(enum_t('a'), enum_t()).should == false
+      end
+
       it 'enum should accept a variant where all variants are acceptable' do
         enum = enum_t('a', 'b')
         calculator.assignable?(enum, variant_t(string_t('a'), string_t('b'))).should == true


### PR DESCRIPTION
There were errors in the calculation of string/enum calculation.
Basically Enum == String, if String is size constrained then
Enum < String. This fixes this calculation.

There were no tests for this, they are now added.
