### PR TITLE
PUP-1235 Add systemd service masking support

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def self.instances
     i = []
     output = systemctl('list-unit-files', '--type', 'service', '--full', '--all',  '--no-pager')
-    output.scan(/^(\S+)\s+(disabled|enabled)\s*$/i).each do |m|
+    output.scan(/^(\S+)\s+(disabled|enabled|masked)\s*$/i).each do |m|
       i << new(:name => m[0])
     end
     return i
@@ -30,6 +30,20 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     begin
       systemctl("is-enabled", @resource[:name])
     rescue Puppet::ExecutionFailure
+      # The masked state is equivalent to the disabled state in terms of
+      # comparison so we only care to check if it is masked if we want to keep
+      # it masked.
+      if @resource[:enable] == :mask
+        begin
+          output = systemctl('show', @resource[:name], '--property', 'LoadState', '--no-pager')
+          if output and (output.split('=').last[0,4] == 'mask')
+            return :mask
+          end
+        rescue Puppet::ExecutionFailure
+          # Don't worry about this failing, just return :false if it does.
+        end
+      end
+
       return :false
     end
 
@@ -46,9 +60,18 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def enable
+    output = systemctl("unmask", @resource[:name])
     output = systemctl("enable", @resource[:name])
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not enable #{self.name}: #{output}", $!.backtrace
+  end
+
+  def mask
+    begin
+      output = systemctl("mask", @resource[:name])
+    rescue Puppet::ExecutionFailure
+      raise Puppet::Error, "Could not mask #{self.name}: #{output}", $!.backtrace
+    end
   end
 
   def restartcmd

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -60,6 +60,16 @@ module Puppet
         provider.manual_start
       end
 
+      # This only makes sense on systemd systems. Otherwise, it just defaults
+      # to disable.
+      newvalue(:mask, :event => :service_disabled) do
+        if provider.respond_to?(:mask)
+          provider.mask
+        else
+          provider.disable
+        end
+      end
+
       def retrieve
         provider.enabled?
       end

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -63,6 +63,11 @@ describe Puppet::Type.type(:service), "when validating attribute values" do
       srv.should(:enable).should == :false
     end
 
+    it "should support :mask as a value" do
+      srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :mask)
+      srv.should(:enable).should == :mask
+    end
+
     it "should support :manual as a value on Windows" do
       Puppet.features.stubs(:microsoft_windows?).returns true
 


### PR DESCRIPTION
This updated the systemd service type to add support for masking. If a
service is masked, it is deemed to also be disabled. If a service is
masked and changed to enabled, it will first be unmasked since the
standard 'systemctl enable' command does not properly unmask the command
first.
