### PR TITLE
PUP-1253 Add systemd service masking support

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def self.instances
     i = []
     output = systemctl('list-unit-files', '--type', 'service', '--full', '--all',  '--no-pager')
-    output.scan(/^(\S+)\s+(disabled|enabled)\s*$/i).each do |m|
+    output.scan(/^(\S+)\s+(disabled|enabled|masked)\s*$/i).each do |m|
       i << new(:name => m[0])
     end
     return i
@@ -28,12 +28,33 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   def enabled?
     begin
-      systemctl("is-enabled", @resource[:name])
+      systemctl_info = systemctl(
+         'show',
+         @resource[:name],
+         '--property', 'LoadState',
+         '--property', 'UnitFileState',
+         '--no-pager'
+      )
+
+      svc_info = Hash.new
+      systemctl_info.split.map{|svc|
+        entry_pair = svc.split('=')
+        svc_info[entry_pair.first.to_sym] = entry_pair.last
+      }
+
+      # The masked state is equivalent to the disabled state in terms of
+      # comparison so we only care to check if it is masked if we want to keep
+      # it masked.
+      #
+      # We only return :mask if we're trying to mask the service. This prevents
+      # flapping when simply trying to disable a masked service.
+      return :mask if (@resource[:enable] == :mask) && (svc_info[:LoadState] == 'masked')
+      return :true if svc_info[:UnitFileState] == 'enabled'
     rescue Puppet::ExecutionFailure
-      return :false
+      # Don't worry about this failing, just return :false if it does.
     end
 
-    :true
+    return :false
   end
 
   def status
@@ -46,9 +67,18 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def enable
+    output = systemctl("unmask", @resource[:name])
     output = systemctl("enable", @resource[:name])
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not enable #{self.name}: #{output}", $!.backtrace
+  end
+
+  def mask
+    begin
+      output = systemctl("mask", @resource[:name])
+    rescue Puppet::ExecutionFailure
+      raise Puppet::Error, "Could not mask #{self.name}: #{output}", $!.backtrace
+    end
   end
 
   def restartcmd

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -60,6 +60,16 @@ module Puppet
         provider.manual_start
       end
 
+      # This only makes sense on systemd systems. Otherwise, it just defaults
+      # to disable.
+      newvalue(:mask, :event => :service_disabled) do
+        if provider.respond_to?(:mask)
+          provider.mask
+        else
+          provider.disable
+        end
+      end
+
       def retrieve
         provider.enabled?
       end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -108,20 +108,57 @@ describe Puppet::Type.type(:service).provider(:systemd) do
   describe "#enabled?" do
     it "should return :true if the service is enabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      provider.expects(:systemctl).with('is-enabled', 'sshd.service').returns 'enabled'
+      provider.expects(:systemctl).with(
+        'show',
+        'sshd.service',
+        '--property', 'LoadState',
+        '--property', 'UnitFileState',
+        '--no-pager'
+      ).returns "LoadState=loaded\nUnitFileState=enabled\n"
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :false if the service is disabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      provider.expects(:systemctl).with('is-enabled', 'sshd.service').raises Puppet::ExecutionFailure, "Execution of '/bin/systemctl is-enabled sshd.service' returned 1: disabled"
+      provider.expects(:systemctl).with(
+        'show',
+        'sshd.service',
+        '--property', 'LoadState',
+        '--property', 'UnitFileState',
+        '--no-pager'
+      ).returns "LoadState=loaded\nUnitFileState=disabled\n"
       expect(provider.enabled?).to eq(:false)
+    end
+
+    it "should return :false if the service is masked and the resource is attempting to be disabled" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
+      provider.expects(:systemctl).with(
+        'show',
+        'sshd.service',
+        '--property', 'LoadState',
+        '--property', 'UnitFileState',
+        '--no-pager'
+      ).returns "LoadState=masked\nUnitFileState=\n"
+      expect(provider.enabled?).to eq(:false)
+    end
+
+    it "should return :mask if the service is masked and the resource is attempting to be masked" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => 'mask'))
+      provider.expects(:systemctl).with(
+        'show',
+        'sshd.service',
+        '--property', 'LoadState',
+        '--property', 'UnitFileState',
+        '--no-pager'
+      ).returns "LoadState=masked\nUnitFileState=\n"
+      expect(provider.enabled?).to eq(:mask)
     end
   end
 
   describe "#enable" do
     it "should run systemctl enable to enable a service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('unmask', 'sshd.service')
       provider.expects(:systemctl).with('enable', 'sshd.service')
       provider.enable
     end
@@ -132,6 +169,14 @@ describe Puppet::Type.type(:service).provider(:systemd) do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       provider.expects(:systemctl).with(:disable, 'sshd.service')
       provider.disable
+    end
+  end
+  
+  describe "#mask" do
+    it "should run systemctl mask to mask a service" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('mask', 'sshd.service')
+      provider.mask
     end
   end
 

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -63,6 +63,11 @@ describe Puppet::Type.type(:service), "when validating attribute values" do
       expect(srv.should(:enable)).to eq(:false)
     end
 
+    it "should support :mask as a value" do
+      srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :mask)
+      srv.should(:enable).should == :mask
+    end
+
     it "should support :manual as a value on Windows" do
       Puppet.features.stubs(:microsoft_windows?).returns true
 


### PR DESCRIPTION
This updated the systemd service type to add support for masking. If a
service is masked, it is deemed to also be disabled. If a service is
masked and changed to enabled, it will first be unmasked since the
standard 'systemctl enable' command does not properly unmask the command
first.