### PR TITLE
(PUP-2647) Report when password is changed

### DIFF
--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -71,7 +71,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
   end
 
   def password
-    user.password_is?( @resource[:password] ) ? @resource[:password] : :absent
+    user.password_is?( @resource[:password] ) ? @resource[:password] : nil
   end
 
   def password=(value)

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -111,7 +111,7 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       resource[:password] = 'plaintext'
       provider.user.expects(:password_is?).with('plaintext').returns false
 
-      provider.password.should == :absent
+      provider.password.should be_nil
     end
 
     it 'should not create a user if a group by the same name exists' do


### PR DESCRIPTION
Previously, if Puppet changed the user's password, it would always
report that the password was created, instead of changed. This was because
the provider's `password` getter method returned :absent when the current
password didn't match the desired value.

This commit changes the windows user provider to return nil if the
passwords don't match. This will cause puppet to sync the passwords
and correctly report that the password was changed.
