### PR TITLE
(PUP-3308) Remove deprecation warning about cron purge change

### DIFF
--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -134,13 +134,6 @@ Puppet::Type.newtype(:resources) do
     @resource_type
   end
 
-  def self.deprecate_params(title,params)
-    return unless params
-    if title == 'cron' and ! params.select { |param| param.name.intern == :purge and param.value == true }.empty?
-      Puppet.deprecation_warning("Change notice: purging cron entries will be more aggressive in future versions, take care when updating your agents. See http://links.puppetlabs.com/puppet-aggressive-cron-purge")
-    end
-  end
-
   # Make sure we don't purge users with specific uids
   def user_check(resource)
     return true unless self[:name] == "user"


### PR DESCRIPTION
This commit removes deprecation warnings for the :purge attribute
of the cron resource. Previously, when 'purge' was set to true
for unmanaged cron resources, Puppet would fire off a warning
about the 'purge' option becoming more aggressive in future versions.

This update is part of the code removal effort for Puppet 4.
