### PR TITLE
(PUP-2350) Disallow non-string file modes

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -66,8 +66,7 @@ module Puppet
 
     validate do |value|
       if !value.is_a?(String)
-        Puppet.deprecation_warning("Non-string values for the file mode property are deprecated. It must be a string, " \
-          "either a symbolic mode like 'o+w,a+r' or an octal representation like '0644' or '755'.")
+        raise Puppet::Error, "The file mode specification must be a string, not '#{value.class.name}'"
       end
       unless value.nil? or valid_symbolic_mode?(value)
         raise Puppet::Error, "The file mode specification is invalid: #{value.inspect}"

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -145,7 +145,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
         let(:target) { tmpdir('dir_mode') }
 
         it "should set executable bits for newly created directories" do
-          catalog.add_resource described_class.new(:path => target, :ensure => :directory, :mode => 0600)
+          catalog.add_resource described_class.new(:path => target, :ensure => :directory, :mode => '0600')
 
           catalog.apply
 
@@ -163,7 +163,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
         it "should not set executable bits for unreadable directories" do
           begin
-            catalog.add_resource described_class.new(:path => target, :ensure => :directory, :mode => 0300)
+            catalog.add_resource described_class.new(:path => target, :ensure => :directory, :mode => '0300')
 
             catalog.apply
 
@@ -175,7 +175,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
         end
 
         it "should set user, group, and other executable bits" do
-          catalog.add_resource described_class.new(:path => target, :ensure => :directory, :mode => 0664)
+          catalog.add_resource described_class.new(:path => target, :ensure => :directory, :mode => '0664')
 
           catalog.apply
 
@@ -186,7 +186,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           target_path = tmpfile_with_contents('executable', '')
           set_mode(0444, target_path)
 
-          catalog.add_resource described_class.new(:path => target_path, :ensure => :directory, :mode => 0666, :backup => false)
+          catalog.add_resource described_class.new(:path => target_path, :ensure => :directory, :mode => '0666', :backup => false)
           catalog.apply
 
           (get_mode(target_path) & 07777).should == 0777
@@ -196,7 +196,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
       describe "for files" do
         it "should not set executable bits" do
-          catalog.add_resource described_class.new(:path => path, :ensure => :file, :mode => 0666)
+          catalog.add_resource described_class.new(:path => path, :ensure => :file, :mode => '0666')
           catalog.apply
 
           (get_mode(path) & 07777).should == 0666
@@ -229,7 +229,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           end
 
           it "should not set the executable bit on the link nor the target" do
-            catalog.add_resource described_class.new(:path => link, :ensure => :link, :mode => 0666, :target => link_target, :links => :manage)
+            catalog.add_resource described_class.new(:path => link, :ensure => :link, :mode => '0666', :target => link_target, :links => :manage)
 
             catalog.apply
 
@@ -240,7 +240,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           it "should ignore dangling symlinks (#6856)" do
             File.delete(link_target)
 
-            catalog.add_resource described_class.new(:path => link, :ensure => :link, :mode => 0666, :target => link_target, :links => :manage)
+            catalog.add_resource described_class.new(:path => link, :ensure => :link, :mode => '0666', :target => link_target, :links => :manage)
             catalog.apply
 
             Puppet::FileSystem.exist?(link).should be_false
@@ -265,7 +265,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
             Puppet::FileSystem.symlink(target, link)
             File.delete(target)
 
-            catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0600, :links => :follow)
+            catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0600', :links => :follow)
             catalog.apply
           end
 
@@ -284,7 +284,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
             describe "that is readable" do
               it "should set the executable bits when creating the destination (#10315)" do
-                catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0666, :links => :follow)
+                catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0666', :links => :follow)
                 catalog.apply
 
                 File.should be_directory(path)
@@ -294,7 +294,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               it "should set the executable bits when overwriting the destination (#10315)" do
                 FileUtils.touch(path)
 
-                catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0666, :links => :follow, :backup => false)
+                catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0666', :links => :follow, :backup => false)
                 catalog.apply
 
                 File.should be_directory(path)
@@ -313,7 +313,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               end
 
               it "should set executable bits when creating the destination (#10315)" do
-                catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0666, :links => :follow)
+                catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0666', :links => :follow)
                 catalog.apply
 
                 File.should be_directory(path)
@@ -323,7 +323,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               it "should set executable bits when overwriting the destination" do
                 FileUtils.touch(path)
 
-                catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0666, :links => :follow, :backup => false)
+                catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0666', :links => :follow, :backup => false)
                 catalog.apply
 
                 File.should be_directory(path)
@@ -342,7 +342,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
             end
 
             it "should create the file, not a symlink (#2817, #10315)" do
-              catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0600, :links => :follow)
+              catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0600', :links => :follow)
               catalog.apply
 
               File.should be_file(path)
@@ -352,7 +352,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
             it "should overwrite the file" do
               FileUtils.touch(path)
 
-              catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0600, :links => :follow)
+              catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0600', :links => :follow)
               catalog.apply
 
               File.should be_file(path)
@@ -378,7 +378,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
             describe "when following all links" do
               it "should create the destination and apply executable bits (#10315)" do
-                catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0600, :links => :follow)
+                catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0600', :links => :follow)
                 catalog.apply
 
                 File.should be_directory(path)
@@ -388,7 +388,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               it "should overwrite the destination and apply executable bits" do
                 FileUtils.mkdir(path)
 
-                catalog.add_resource described_class.new(:path => path, :source => link, :mode => 0600, :links => :follow)
+                catalog.add_resource described_class.new(:path => path, :source => link, :mode => '0600', :links => :follow)
                 catalog.apply
 
                 File.should be_directory(path)
@@ -536,7 +536,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
     it "should be able to recurse over a nonexistent file" do
       @file = described_class.new(
         :name    => path,
-        :mode    => 0644,
+        :mode    => '0644',
         :recurse => true,
         :backup  => false
       )
@@ -553,7 +553,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
       file = described_class.new(
         :name    => path,
-        :mode    => 0644,
+        :mode    => '0644',
         :recurse => true,
         :backup  => false
       )
@@ -648,18 +648,17 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
     it "should recursively manage files even if there is an explicit file whose name is a prefix of the managed file" do
       managed      = File.join(path, "file")
       generated    = File.join(path, "file_with_a_name_starting_with_the_word_file")
-      managed_mode = 0700
 
       FileUtils.mkdir_p(path)
       FileUtils.touch(managed)
       FileUtils.touch(generated)
 
-      catalog.add_resource described_class.new(:name => path,    :recurse => true, :backup => false, :mode => managed_mode)
+      catalog.add_resource described_class.new(:name => path,    :recurse => true, :backup => false, :mode => '0700')
       catalog.add_resource described_class.new(:name => managed, :recurse => true, :backup => false, :mode => "644")
 
       catalog.apply
 
-      (get_mode(generated) & 007777).should == managed_mode
+      (get_mode(generated) & 007777).should == 0700
     end
 
     describe "when recursing remote directories" do
@@ -981,7 +980,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
          :ensure => :file,
          :source => source,
          :backup => false,
-         :mode => 0440
+         :mode => '0440'
        )
 
       catalog.add_resource file

--- a/spec/unit/provider/file/posix_spec.rb
+++ b/spec/unit/provider/file/posix_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:file).provider(:posix), :if => Puppet.features.posix
   include PuppetSpec::Files
 
   let(:path) { tmpfile('posix_file_spec') }
-  let(:resource) { Puppet::Type.type(:file).new :path => path, :mode => 0777, :provider => described_class.name }
+  let(:resource) { Puppet::Type.type(:file).new :path => path, :mode => '0777', :provider => described_class.name }
   let(:provider) { resource.provider }
 
   describe "#mode" do

--- a/spec/unit/type/file/ensure_spec.rb
+++ b/spec/unit/type/file/ensure_spec.rb
@@ -88,7 +88,7 @@ describe Puppet::Type::File::Ensure do
       end
 
       it "should accept octal mode as fixnum" do
-        resource[:mode] = 0700
+        resource[:mode] = '0700'
         resource.expects(:property_fix)
         Dir.expects(:mkdir).with(path, 0700)
 

--- a/spec/unit/type/file/mode_spec.rb
+++ b/spec/unit/type/file/mode_spec.rb
@@ -10,8 +10,10 @@ describe Puppet::Type.type(:file).attrclass(:mode) do
   let(:mode) { resource.property(:mode) }
 
   describe "#validate" do
-    it "should accept values specified as integers" do
-      expect { mode.value = 0755 }.not_to raise_error
+    it "should reject non-string values" do
+      expect {
+        mode.value = 0755
+      }.to raise_error(Puppet::Error, /The file mode specification must be a string, not 'Fixnum'/)
     end
 
     it "should accept values specified as octal numbers in strings" do

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -249,14 +249,14 @@ describe Puppet::Type.type(:file).attrclass(:source) do
       it "should not copy the metadata's owner, group, checksum and mode to the resource if they are already set" do
         @resource[:owner] = 1
         @resource[:group] = 2
-        @resource[:mode] = 3
+        @resource[:mode] = '173'
         @resource[:content] = "foobar"
 
         @source.copy_source_values
 
         @resource[:owner].must == 1
         @resource[:group].must == 2
-        @resource[:mode].must == "3"
+        @resource[:mode].must == '173'
         @resource[:content].should_not == @metadata.checksum
       end
 

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1219,7 +1219,7 @@ describe Puppet::Type.type(:file) do
 
   describe "#property_fix" do
     {
-      :mode     => 0777,
+      :mode     => '0777',
       :owner    => 'joeuser',
       :group    => 'joeusers',
       :seluser  => 'seluser',


### PR DESCRIPTION
In Puppet 4.0 integers will be parsed more strictly, which means that
file modes like `644` will be octal 1204. The alternative to this is to
force file modes to be strings where they cannot be interpreted
incorrectly. PUP-2349 deprecated non-string modes; this commit removes
support for them entirely.
