### PR TITLE
(PUP-3446) Sign certificates used in testing

### DIFF
--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -25,14 +25,17 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
     end
 
     let(:minimal_certificate) do
-        cert = OpenSSL::X509::Certificate.new
-        cert.version = 2
-        cert.serial = 0
-        cert.not_before = Time.now
-        cert.not_after = Time.now + 3600
-        cert.public_key = OpenSSL::PKey::RSA.new(512)
-        cert.subject = OpenSSL::X509::Name.parse("/CN=testing")
-        cert
+      key = OpenSSL::PKey::RSA.new(512)
+      signer = Puppet::SSL::CertificateSigner.new
+      cert = OpenSSL::X509::Certificate.new
+      cert.version = 2
+      cert.serial = 0
+      cert.not_before = Time.now
+      cert.not_after = Time.now + 3600
+      cert.public_key = key
+      cert.subject = OpenSSL::X509::Name.parse("/CN=testing")
+      signer.sign(cert, key)
+      cert
     end
 
     describe "#headers" do


### PR DESCRIPTION
On versions of OpenSSL around version 0.9.8y, it was possible to decode certificates
that had not been signed. However OpenSSL 1.0.1i cannot decode unsigned
certificates. Given the following PEM encoded cert:

```
-----BEGIN CERTIFICATE-----
MIGqMIGgoAMCAQICAQAwAgYAMAAwHhcNMTQxMDAxMTgzNTQ5WhcNMTQxMDAxMTkz
NTQ5WjASMRAwDgYDVQQDDAd0ZXN0aW5nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJB
ALiOQvoQaSIRDogCJwLKmM11vObOnBm93AdGkezbpdHI/TFebvvZYT2J6ukPmyVD
bGa0ZEpg5gc2yJ+sgJTwbSsCAwEAATACBgADAQA=
-----END CERTIFICATE-----
```

When printed to text this results in the following:

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 0 (0x0)
    Signature Algorithm: NULL
        Issuer:
        Validity
            Not Before: Oct  1 18:35:49 2014 GMT
            Not After : Oct  1 19:35:49 2014 GMT
        Subject: CN=testing
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (512 bit)
                Modulus:
                    00:b8:8e:42:fa:10:69:22:11:0e:88:02:27:02:ca:
                    98:cd:75:bc:e6:ce:9c:19:bd:dc:07:46:91:ec:db:
                    a5:d1:c8:fd:31:5e:6e:fb:d9:61:3d:89:ea:e9:0f:
                    9b:25:43:6c:66:b4:64:4a:60:e6:07:36:c8:9f:ac:
                    80:94:f0:6d:2b
                Exponent: 65537 (0x10001)
    Signature Algorithm: NULL
```

OpenSSL 1.0.1i can convert the certificate to PEM and DER, but it cannot
decode it. Decoding the PEM encoded text directly as a cert results in
the following error:

```
OpenSSL::X509::Certificate.new(minimal_certificate.to_pem)
OpenSSL::X509::CertificateError: nested asn1 error
```

Decoding the DER encoded cert as raw ASN1 results in the following:

```
OpenSSL::ASN1.decode(minimal_certificate.to_der)
OpenSSL::ASN1::ASN1Error: invalid object encoding
```

So OpenSSL is convinced that we have a mangled certificate.

The solution to this to self-sign the certificate, so that the
certificate can be properly encoded and decoded.
