### PR TITLE
(PUP-3121) Address default metadata.json template issue with puppetlabs/...

### DIFF
--- a/lib/puppet/face/module/generate.rb
+++ b/lib/puppet/face/module/generate.rb
@@ -53,7 +53,7 @@ Puppet::Face.define(:module, '1.0.0') do
         "issues_url": null,
         "dependencies": [
           {
-            "name": "puppetlabs-stdlib",
+            "name": "puppetlabs/stdlib",
             "version_requirement": ">= 1.0.0"
           }
         ]
@@ -114,7 +114,7 @@ Puppet::Face.define(:module, '1.0.0') do
           'name' => name,
           'version' => '0.1.0',
           'dependencies' => [
-            { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 1.0.0' }
+            { 'name' => 'puppetlabs/stdlib', 'version_requirement' => '>= 1.0.0' }
           ]
         )
       rescue ArgumentError


### PR DESCRIPTION
Replaced the incorrect dependency format of author-module with
author/module in the metadata.json created by 'puppet module generate'.
Updated example text as well.

See https://tickets.puppetlabs.com/browse/PUP-3121
