### PR TITLE
(PUP-3306) Remove deprecated Puppet::SSL::Inventory#serial method

### DIFF
--- a/lib/puppet/ssl/inventory.rb
+++ b/lib/puppet/ssl/inventory.rb
@@ -35,13 +35,6 @@ class Puppet::SSL::Inventory
     end
   end
 
-  # Find the serial number for a given certificate.
-  def serial(name)
-    Puppet.deprecation_warning 'Inventory#serial is deprecated, use Inventory#serials instead.'
-    return nil unless Puppet::FileSystem.exist?(@path)
-    serials(name).first
-  end
-
   # Find all serial numbers for a given certificate. If none can be found, returns
   # an empty array.
   def serials(name)

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -111,31 +111,8 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
       end
     end
 
-    it "should be able to find a given host's serial number" do
-      @inventory.should respond_to(:serial)
-    end
-
-    describe "and finding a serial number" do
-      it "should return nil if the inventory file is missing" do
-        Puppet::FileSystem.expects(:exist?).with(cert_inventory).returns false
-        @inventory.serial(:whatever).should be_nil
-      end
-
-      it "should return the serial number from the line matching the provided name" do
-        File.expects(:readlines).with(cert_inventory).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n"]
-
-        @inventory.serial("me").should == 15
-      end
-
-      it "should return the number as an integer" do
-        File.expects(:readlines).with(cert_inventory).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n"]
-
-        @inventory.serial("me").should == 15
-      end
-    end
-
-    describe "and finding all serial numbers" do
-      it "should return nil if the inventory file is missing" do
+    describe "and finding serial numbers" do
+      it "should return an empty array if the inventory file is missing" do
         Puppet::FileSystem.expects(:exist?).with(cert_inventory).returns false
         @inventory.serials(:whatever).should be_empty
       end


### PR DESCRIPTION
This commit removes the deprecated `serial` method from the 
Puppet::SSL::Inventory class. It is replaced by Puppet::SSL::Inventory#serials.

This commit is part of the Puppet 4 code removal effort.
