### PR TITLE
(PUP-3363) Make transformation of unparenthesized calls handle errors

### DIFF
--- a/lib/puppet/pops/parser/egrammar.ra
+++ b/lib/puppet/pops/parser/egrammar.ra
@@ -86,7 +86,7 @@ syntactic_statements
 #
 syntactic_statement
   : assignment                             =LOW { result = val[0] }
-  | syntactic_statement COMMA assignment   =LOW { result = aryfy(val[0]).push val[2] }
+  | syntactic_statement COMMA assignment   =LOW { result = aryfy(val[0]).push(val[1]).push(val[2]) }
 
 # Assignment (is right recursive since assignment is right associative)
 assignment

--- a/lib/puppet/pops/parser/eparser.rb
+++ b/lib/puppet/pops/parser/eparser.rb
@@ -1296,7 +1296,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 87)
 
 module_eval(<<'.,.,', 'egrammar.ra', 88)
   def _reduce_9(val, _values, result)
-     result = aryfy(val[0]).push val[2] 
+     result = aryfy(val[0]).push(val[1]).push(val[2]) 
     result
   end
 .,.,

--- a/spec/unit/pops/parser/parse_calls_spec.rb
+++ b/spec/unit/pops/parser/parse_calls_spec.rb
@@ -59,11 +59,6 @@ describe "egrammar parsing function calls" do
       dump(parse("$a = foo()")).should == "(= $a (call foo))"
     end
 
-    #    # For regular grammar where a bare word can not be a "statement"
-    #    it "$a = foo bar # illegal, must have parentheses" do
-    #      expect { dump(parse("$a = foo bar"))}.to raise_error(Puppet::ParseError)
-    #    end
-
     # For egrammar where a bare word can be a "statement"
     it "$a = foo bar # illegal, must have parentheses" do
       dump(parse("$a = foo bar")).should == "(block\n  (= $a foo)\n  bar\n)"
@@ -99,6 +94,26 @@ describe "egrammar parsing function calls" do
         "  (= $b $x)",
         ")))"
         ].join("\n")
+    end
+  end
+
+  context "When parsing an illegal argument list" do
+    it "raises an error if argument list is not for a call" do
+      expect do
+        parse("$a  = 10, 3")
+      end.to raise_error(/illegal comma/)
+    end
+
+    it "raises an error if argument list is for a potential call not allowed without parentheses" do
+      expect do
+        parse("foo 10, 3")
+      end.to raise_error(/attempt to pass argument list to the function 'foo' which cannot be called without parentheses/)
+    end
+
+    it "does no raise an error for an argument list to an allowed call" do
+      expect do
+        parse("notice 10, 3")
+      end.to_not raise_error()
     end
   end
 end


### PR DESCRIPTION
This fixes problems when a user enters commas where they are not
supposed to be. As a result, an expression will be parsed as being an
argument list for an unparenthesized function call. The transformation
logic for such calls did not take one case into account; a non call
followed by an argument list. e.g:

$a = 1,10

Which resulted in a strange AST model (a literal list with an assignment
and a 10).

This commit adds error checking and raising of an exception in the
transformation which is caught by parser_support and formatted into an
error - either about an illegal comma (when the LHS cannot possibly be
a call at all (as in the above exampel), or a more elaborate
message about that what could be a function call requires parentheses.

In order to enable positioning of the error message on the first comma
in the argumet list, the comma tokens were required in the expression
list fed to the transformer. Subsequently these tokens must be filtered
out by the transformation, and passed on in the raised exception (since
the receiver would otherwise not know which token that caused the
problem (it is nested inside the stucture it passes on to be
transformed).

Unparenthesized function calls are a very bad idea...
