### PR TITLE
(PUP-2350) Fixup Windows tests for removal of non-string file mode support

### DIFF
--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1121,7 +1121,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
             before :each do
               @file[:owner] = @sids[:users]
               @file[:group] = @sids[:system]
-              @file[:mode] = 0644
+              @file[:mode] = '0644'
 
               catalog.apply
             end
@@ -1218,7 +1218,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
             before :each do
               @directory[:owner] = 'None'
               @directory[:group] = 'None'
-              @directory[:mode] = 0444
+              @directory[:mode] = '0444'
             end
 
             it "replaces inherited SYSTEM ACEs with an uninherited one for an existing directory" do
@@ -1241,7 +1241,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               before :each do
                 @directory[:owner] = @sids[:users]
                 @directory[:group] = @sids[:system]
-                @directory[:mode] = 0644
+                @directory[:mode] = '0644'
 
                 catalog.apply
               end

--- a/spec/unit/provider/file/windows_spec.rb
+++ b/spec/unit/provider/file/windows_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Type.type(:file).provider(:windows), :if => Puppet.features.mic
   include PuppetSpec::Files
 
   let(:path) { tmpfile('windows_file_spec') }
-  let(:resource) { Puppet::Type.type(:file).new :path => path, :mode => 0777, :provider => described_class.name }
+  let(:resource) { Puppet::Type.type(:file).new :path => path, :mode => '0777', :provider => described_class.name }
   let(:provider) { resource.provider }
   let(:sid)      { 'S-1-1-50' }
   let(:account)  { 'quinn' }
@@ -135,7 +135,7 @@ describe Puppet::Type.type(:file).provider(:windows), :if => Puppet.features.mic
   end
 
   describe "when validating" do
-    {:owner => 'foo', :group => 'foo', :mode => 0777}.each do |k,v|
+    {:owner => 'foo', :group => 'foo', :mode => '0777'}.each do |k,v|
       it "should fail if the filesystem doesn't support ACLs and we're managing #{k}" do
         described_class.any_instance.stubs(:supports_acl?).returns false
 


### PR DESCRIPTION
This commit updates several Windows-only spec tests so that they
adhere to the recent removal of support for non-string file modes.
