### PR TITLE
(PUP-3299) Remove deprecated Puppet::Util::CommandLine methods

### DIFF
--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -59,24 +59,6 @@ module Puppet
         end
       end
 
-      # @api private
-      # @deprecated
-      def self.available_subcommands
-        Puppet.deprecation_warning('Puppet::Util::CommandLine.available_subcommands is deprecated; please use Puppet::Application.available_application_names instead.')
-        Puppet::Application.available_application_names
-      end
-
-      # available_subcommands was previously an instance method, not a class
-      # method, and we have an unknown number of user-implemented applications
-      # that depend on that behaviour.  Forwarding allows us to preserve a
-      # backward compatible API. --daniel 2011-04-11
-      # @api private
-      # @deprecated
-      def available_subcommands
-        Puppet.deprecation_warning('Puppet::Util::CommandLine#available_subcommands is deprecated; please use Puppet::Application.available_application_names instead.')
-        Puppet::Application.available_application_names
-      end
-
       # Run the puppet subcommand. If the subcommand is determined to be an
       # external executable, this method will never return and the current
       # process will be replaced via {Kernel#exec}.

--- a/spec/unit/util/command_line_spec.rb
+++ b/spec/unit/util/command_line_spec.rb
@@ -124,23 +124,6 @@ describe Puppet::Util::CommandLine do
       end
     end
 
-    describe 'when loading commands' do
-      it "should deprecate the available_subcommands instance method" do
-        Puppet::Application.expects(:available_application_names)
-        Puppet.expects(:deprecation_warning).with("Puppet::Util::CommandLine#available_subcommands is deprecated; please use Puppet::Application.available_application_names instead.")
-
-        command_line = Puppet::Util::CommandLine.new("foo", %w{ client --help whatever.pp })
-        command_line.available_subcommands
-      end
-
-      it "should deprecate the available_subcommands class method" do
-        Puppet::Application.expects(:available_application_names)
-        Puppet.expects(:deprecation_warning).with("Puppet::Util::CommandLine.available_subcommands is deprecated; please use Puppet::Application.available_application_names instead.")
-
-        Puppet::Util::CommandLine.available_subcommands
-      end
-    end
-
     describe 'when setting process priority' do
       let(:command_line) do
         Puppet::Util::CommandLine.new("puppet", %w{ agent })


### PR DESCRIPTION
This commit removes the deprecated class and instance methods
`available_subcommands` from the Puppet::Util::CommandLine class.
They are replaced by `Puppet::Application.available_application_names`.

This commit is part of the code removal effort for Puppet 4.
