### PR TITLE
(PUP-3203) Windows scheduled task triggers can't be updated

### DIFF
--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -274,9 +274,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   def translate_hash_to_trigger(puppet_trigger)
     trigger = dummy_time_trigger
 
-    puppet_trigger.delete('index')
-
-    if puppet_trigger.delete('enabled') == false
+    if puppet_trigger['enabled'] == false
       trigger['flags'] |= Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED
     else
       trigger['flags'] &= ~Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED

--- a/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -635,6 +635,16 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
   describe '#triggers_same?' do
     let(:provider) { described_class.new(:name => 'foobar', :command => 'C:\Windows\System32\notepad.exe') }
 
+    it "should not mutate triggers" do
+      current = {'schedule' => 'daily', 'start_date' => '2011-09-12', 'start_time' => '15:30', 'every' => 3}
+      current.freeze
+
+      desired = {'schedule' => 'daily', 'start_date' => '2011-09-12', 'start_time' => '15:30'}
+      desired.freeze
+
+      expect(provider).to be_triggers_same(current, desired)
+    end
+
     it "ignores 'index' in current trigger" do
       current = {'index' => 0, 'schedule' => 'daily', 'start_date' => '2011-09-12', 'start_time' => '15:30', 'every' => 3}
       desired = {'schedule' => 'daily', 'start_date' => '2011-09-12', 'start_time' => '15:30', 'every' => 3}


### PR DESCRIPTION
This builds on PR #3158

Previously, if the Windows scheduled task provider needed to update a trigger, it would try to remove the current trigger, and add the new trigger in its place. However, along the way, the provider deleted the 'index' of the current trigger, leading to the error:

```
 no implicit conversion from nil to integer
```

This commit ensures we don't mutate the current trigger, so that we can delete it later if necessary.
