### PR TITLE
(maint) Remove templatedir from Debian packaging

### DIFF
--- a/ext/debian/puppet.conf
+++ b/ext/debian/puppet.conf
@@ -4,7 +4,6 @@ vardir=/var/lib/puppet
 ssldir=/var/lib/puppet/ssl
 rundir=/var/run/puppet
 factpath=$vardir/lib/facter
-templatedir=$confdir/templates
 
 [master]
 # These are needed when the puppetmaster is run by passenger


### PR DESCRIPTION
The `templatedir` setting has been deprecated since Puppet 3.6.2 and isn't even
set in RedHat packages. Remove this setting from the `puppet.conf` used by
Debian packaging scripts.
