### PR TITLE
(maint) Use $vardir for ssldir, like factpath.

### DIFF
--- a/ext/debian/puppet.conf
+++ b/ext/debian/puppet.conf
@@ -1,7 +1,7 @@
 [main]
 logdir=/var/log/puppet
 vardir=/var/lib/puppet
-ssldir=/var/lib/puppet/ssl
+ssldir=$vardir/ssl
 rundir=/var/run/puppet
 factpath=$vardir/lib/facter
 templatedir=$confdir/templates
@@ -9,6 +9,6 @@ templatedir=$confdir/templates
 [master]
 # These are needed when the puppetmaster is run by passenger
 # and can safely be removed if webrick is used.
-ssl_client_header = SSL_CLIENT_S_DN 
+ssl_client_header = SSL_CLIENT_S_DN
 ssl_client_verify_header = SSL_CLIENT_VERIFY
 


### PR DESCRIPTION
We might as well use `$vardir` when setting `ssldir` just like we do for `factpath`.
