### PR TITLE
(PUP-3373) (doc) Clarify options parameter docs for mount

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -168,11 +168,12 @@ module Puppet
     end
 
     newproperty(:options) do
-      desc "Mount options for the mounts, as they would
-        appear in the fstab."
+      desc "A single string containing options for the mount, as they would
+        appear in fstab. For many platforms this is a comma delimited string.
+        Consult the fstab(5) man page for system-specific details."
 
       validate do |value|
-        raise Puppet::Error, "option must not contain whitespace: #{value}" if value =~ /\s/
+        raise Puppet::Error, "options must not contain whitespace: #{value}" if value =~ /\s/
       end
     end
 


### PR DESCRIPTION
The docstring for the `options` parameter of the mount Type did not clarify
that the parameter value should be a single string. Also noted that many
operating systems use a comma-delimited list.
