### PR TITLE
(PUP-3396) Make it possible to add a module to Loaders

### DIFF
--- a/lib/puppet/pops/loader/dependency_loader.rb
+++ b/lib/puppet/pops/loader/dependency_loader.rb
@@ -48,6 +48,13 @@ class Puppet::Pops::Loader::DependencyLoader < Puppet::Pops::Loader::BaseLoader
     end
   end
 
+  # Adds a dependency loader to the set of already configured loaders.
+  # @api private - this method is private to the loaders subsystem
+  #
+  def add_loader(loader)
+    @dependency_loaders << loader
+  end
+
   def to_s()
     "(DependencyLoader '#{@loader_name}' [" + @dependency_loaders.map {|loader| loader.to_s }.join(' ,') + "])"
   end


### PR DESCRIPTION
This makes it possible to add a module after the Loaders have been
initialized with modules from a module path. To add a module
call Loaders.add_module(Puppet::Module.new(name, path)). This should be
done after the Compiler has created the Loaders, and preferrably before
any code loading has started to take place.
