### PR TITLE
(PUP-3276) Remove deprecated methods from Puppet::Util::Windows::*

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -85,12 +85,6 @@ module Puppet::Util::Windows::ADSI
       wmi_connection.execquery(query)
     end
 
-    def sid_for_account(name)
-      Puppet.deprecation_warning "Puppet::Util::Windows::ADSI.sid_for_account is deprecated and will be removed in 3.0, use Puppet::Util::Windows::SID.name_to_sid instead."
-
-      Puppet::Util::Windows::SID.name_to_sid(name)
-    end
-
     ffi_convention :stdcall
 
     # http://msdn.microsoft.com/en-us/library/windows/desktop/ms724295(v=vs.85).aspx
@@ -345,20 +339,6 @@ module Puppet::Util::Windows::ADSI
 
       Hash[ sids ]
     end
-
-    def add_members(*names)
-      Puppet.deprecation_warning('Puppet::Util::Windows::ADSI::Group#add_members is deprecated; please use Puppet::Util::Windows::ADSI::Group#add_member_sids')
-      sids = self.class.name_sid_hash(names)
-      add_member_sids(*sids.values)
-    end
-    alias add_member add_members
-
-    def remove_members(*names)
-      Puppet.deprecation_warning('Puppet::Util::Windows::ADSI::Group#remove_members is deprecated; please use Puppet::Util::Windows::ADSI::Group#remove_member_sids')
-      sids = self.class.name_sid_hash(names)
-      remove_member_sids(*sids.values)
-    end
-    alias remove_member remove_members
 
     def add_member_sids(*sids)
       sids.each do |sid|

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -91,12 +91,6 @@ module Puppet::Util::Windows::File
 
   INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF #define INVALID_FILE_ATTRIBUTES (DWORD (-1))
 
-  def get_file_attributes(file_name)
-    Puppet.deprecation_warning('Puppet::Util::Windows::File.get_file_attributes is deprecated; please use Puppet::Util::Windows::File.get_attributes')
-    get_attributes(file_name)
-  end
-  module_function :get_file_attributes
-
   def get_attributes(file_name)
     result = GetFileAttributesW(wide_string(file_name.to_s))
     return result unless result == INVALID_FILE_ATTRIBUTES

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -180,26 +180,6 @@ module Puppet::Util::Windows::Security
     supported
   end
 
-  def get_attributes(path)
-    Puppet.deprecation_warning('Puppet::Util::Windows::Security.get_attributes is deprecated; please use Puppet::Util::Windows::File.get_attributes')
-    FILE.get_attributes(file_name)
-  end
-
-  def add_attributes(path, flags)
-    Puppet.deprecation_warning('Puppet::Util::Windows::Security.add_attributes is deprecated; please use Puppet::Util::Windows::File.add_attributes')
-    FILE.add_attributes(path, flags)
-  end
-
-  def remove_attributes(path, flags)
-    Puppet.deprecation_warning('Puppet::Util::Windows::Security.remove_attributes is deprecated; please use Puppet::Util::Windows::File.remove_attributes')
-    FILE.remove_attributes(path, flags)
-  end
-
-  def set_attributes(path, flags)
-    Puppet.deprecation_warning('Puppet::Util::Windows::Security.set_attributes is deprecated; please use Puppet::Util::Windows::File.set_attributes')
-    FILE.set_attributes(path, flags)
-  end
-
   MASK_TO_MODE = {
     FILE::FILE_GENERIC_READ => S_IROTH,
     FILE::FILE_GENERIC_WRITE => S_IWOTH,
@@ -546,15 +526,6 @@ module Puppet::Util::Windows::Security
     true
   end
 
-  def with_process_token(access, &block)
-    Puppet.deprecation_warning('Puppet::Util::Windows::Security.with_process_token is deprecated; please use Puppet::Util::Windows::Process.with_process_token')
-    Puppet::Util::Windows::Process.with_process_token(access) do |token|
-      yield token
-    end
-
-    nil
-  end
-
   def get_security_descriptor(path)
     sd = nil
 
@@ -664,41 +635,6 @@ module Puppet::Util::Windows::Security
           end
         end
       end
-    end
-
-    def name_to_sid(name)
-      Puppet.deprecation_warning('Puppet::Util::Windows::Security.name_to_sid is deprecated; please use Puppet::Util::Windows::SID.name_to_sid')
-      Puppet::Util::Windows::SID.name_to_sid(name)
-    end
-
-    def name_to_sid_object(name)
-      Puppet.deprecation_warning('Puppet::Util::Windows::Security.name_to_sid_object is deprecated; please use Puppet::Util::Windows::SID.name_to_sid_object')
-      Puppet::Util::Windows::SID.name_to_sid_object(name)
-    end
-
-    def octet_string_to_sid_object(bytes)
-      Puppet.deprecation_warning('Puppet::Util::Windows::Security.octet_string_to_sid_object is deprecated; please use Puppet::Util::Windows::SID.octet_string_to_sid_object')
-      Puppet::Util::Windows::SID.octet_string_to_sid_object(bytes)
-    end
-
-    def sid_to_name(value)
-      Puppet.deprecation_warning('Puppet::Util::Windows::Security.sid_to_name is deprecated; please use Puppet::Util::Windows::SID.sid_to_name')
-      Puppet::Util::Windows::SID.sid_to_name(value)
-    end
-
-    def sid_ptr_to_string(psid)
-      Puppet.deprecation_warning('Puppet::Util::Windows::Security.sid_ptr_to_string is deprecated; please use Puppet::Util::Windows::SID.sid_ptr_to_string')
-      Puppet::Util::Windows::SID.sid_ptr_to_string(psid)
-    end
-
-    def string_to_sid_ptr(string_sid, &block)
-      Puppet.deprecation_warning('Puppet::Util::Windows::Security.string_to_sid_ptr is deprecated; please use Puppet::Util::Windows::SID.string_to_sid_ptr')
-      Puppet::Util::Windows::SID.string_to_sid_ptr(string_sid, &block)
-    end
-
-    def valid_sid?(string_sid)
-      Puppet.deprecation_warning('Puppet::Util::Windows::Security.valid_sid? is deprecated; please use Puppet::Util::Windows::SID.valid_sid?')
-      Puppet::Util::Windows::SID.valid_sid?(string_sid)
     end
   end
 

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -60,6 +60,16 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
       subject.name_to_sid('SYSTEM').should == sid
     end
 
+    it "should return a SID for a passed user or group name" do
+      subject.expects(:name_to_sid_object).with('testers').returns 'S-1-5-32-547'
+      subject.name_to_sid('testers').should == 'S-1-5-32-547'
+    end
+
+    it "should return a SID for a passed fully-qualified user or group name" do
+      subject.expects(:name_to_sid_object).with('MACHINE\testers').returns 'S-1-5-32-547'
+      subject.name_to_sid('MACHINE\testers').should == 'S-1-5-32-547'
+    end
+
     it "should be case-insensitive" do
       subject.name_to_sid('SYSTEM').should == subject.name_to_sid('system')
     end


### PR DESCRIPTION
This commit removes deprecated methods from several Windows utility
modules. Removed methods include:
- `Puppet::Util::Windows::ADSI.sid_for_account`
- `Puppet::Util::Windows::ADSI::Group#add_members`
- `Puppet::Util::Windows::ADSI::Group#remove_members`
- `Puppet::Util::Windows::File.get_file_attributes`
- `Puppet::Util::Windows::Security.get_attributes`
- `Puppet::Util::Windows::Security.add_attributes`
- `Puppet::Util::Windows::Security.remove_attributes`
- `Puppet::Util::Windows::Security.set_attributes`
- `Puppet::Util::Windows::Security.with_process_token`
- `Puppet::Util::Windows::Security.name_to_sid`
- `Puppet::Util::Windows::Security.name_to_sid_object`
- `Puppet::Util::Windows::Security.octet_string_to_sid_object`
- `Puppet::Util::Windows::Security.sid_to_name`
- `Puppet::Util::Windows::Security.sid_ptr_to_string`
- `Puppet::Util::Windows::Security.string_to_sid_ptr`
- `Puppet::Util::Windows::Security.valid_sid?`

This commit is part of the code removal effort for Puppet 4.
