### PR TITLE
(PUP-3462) Hiera scope: add the key 'calling_class_path' 

### DIFF
--- a/lib/hiera/scope.rb
+++ b/lib/hiera/scope.rb
@@ -1,6 +1,7 @@
 class Hiera
   class Scope
     CALLING_CLASS = "calling_class"
+    CALLING_CLASS_PATH = "calling_class_path"
     CALLING_MODULE = "calling_module"
     MODULE_NAME = "module_name"
 
@@ -13,6 +14,8 @@ class Hiera
     def [](key)
       if key == CALLING_CLASS
         ans = find_hostclass(@real)
+      elsif key == CALLING_CLASS_PATH
+        ans = find_hostclass(@real).gsub(/::/, '/')
       elsif key == CALLING_MODULE
         ans = @real.lookupvar(MODULE_NAME)
       else
@@ -27,7 +30,7 @@ class Hiera
     end
 
     def include?(key)
-      if key == CALLING_CLASS or key == CALLING_MODULE
+      if [CALLING_CLASS, CALLING_CLASS_PATH, CALLING_MODULE].include? key
         true
       else
         @real.lookupvar(key) != ""

--- a/spec/integration/data_binding.rb
+++ b/spec/integration/data_binding.rb
@@ -17,13 +17,16 @@ describe "Data binding" do
     configure_hiera_for({
       "testing::binding::value" => "the value",
       "testing::binding::calling_class" => "%{calling_class}",
+      "testing::binding::calling_class_path" => "%{calling_class_path}",
       "testing::binding::calling_module" => "%{calling_module}"
+     
     })
 
     create_manifest_in_module("testing", "binding.pp",
                               <<-MANIFEST)
     class testing::binding($value,
                            $calling_class,
+                           $calling_class_path,
                            $calling_module) {}
     MANIFEST
 
@@ -32,6 +35,7 @@ describe "Data binding" do
 
     expect(resource[:value]).to eq("the value")
     expect(resource[:calling_class]).to eq("testing::binding")
+    expect(resource[:calling_class_path]).to eq("testing/binding")
     expect(resource[:calling_module]).to eq("testing")
   end
 

--- a/spec/unit/hiera/scope_spec.rb
+++ b/spec/unit/hiera/scope_spec.rb
@@ -83,6 +83,7 @@ describe Hiera::Scope do
 
     it "should always return true for calling_class and calling_module" do
       scope.include?("calling_class").should == true
+      scope.include?("calling_class_path").should == true
       scope.include?("calling_module").should == true
     end
   end


### PR DESCRIPTION
calling_class_path is calling_class with :: replaced by a /

This enables to have the class hiera yaml files in directories and enables to have class based hiera data on windows which does not allow ":" in path names.
