### PR TITLE
(maint) Remove the agent role from the master node on Solaris 11

### DIFF
--- a/acceptance/config/nodes/solaris11.yaml
+++ b/acceptance/config/nodes/solaris11.yaml
@@ -2,7 +2,6 @@ HOSTS:
   master:
     roles:
       - master
-      - agent
     platform: solaris-11-x86_64
     hypervisor: vcloud
     template: Delivery/Quality Assurance/Templates/vCloud/solaris-11-x86_64


### PR DESCRIPTION
Background: the Solaris 11 acceptance tests take a long time. One reason
is that the agent role is executed on both the agent and master node,
doubling the time taken for agent testing. This isn't giving us more
coverage and it increases the test feedback loop.

So this commit drops the agent role from the master node.
