### PR TITLE
(maint) Remove redundant methods and refactor.

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -293,10 +293,12 @@ module Puppet::Environments
 
     # @!macro loader_get_or_fail
     def get!(name)
-      if !environment = get(name)
-        raise EnvironmentNotFound, name
+      @loaders.each do |loader|
+        if env = loader.get!(name)
+          return env
+        end
       end
-      environment
+      raise EnvironmentNotFound, name
     end
 
     # @!macro loader_get_conf
@@ -327,14 +329,6 @@ module Puppet::Environments
         @cache[name] = entry(result)
         result
       end
-    end
-
-    # @!macro loader_get_or_fail
-    def get!(name)
-      if !environment = get(name)
-        raise EnvironmentNotFound, name
-      end
-      environment
     end
 
     # Clears the cache of the environment with the given name.

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -97,6 +97,17 @@ describe Puppet::Environments do
       end
     end
 
+    it "raises error when environment not found" do
+      directory_tree = FS::MemoryFile.a_directory(File.expand_path("envdir"), [])
+
+      loader_from(:filesystem => [directory_tree],
+                  :directory => directory_tree) do |loader|
+        expect do
+          loader.get!("does_not_exist")
+        end.to raise_error(Puppet::Environments::EnvironmentNotFound)
+      end
+    end
+
     it "returns nil if an environment can't be found" do
       directory_tree = FS::MemoryFile.a_directory("envdir", [])
 


### PR DESCRIPTION
Before this commit the Puppet::Environments::Cached#get! was not needed
as it was defined in a parent class. Puppet::Environments::Combined#get!
now calls get! in environment objects instead of assuming how get!
should work.

This commit also refactors areas in the code where
Puppet::Environments::EnvironmentNotFound was raised after calling get
in favor of the new get! method.
