### PR TITLE
(PUP-3446) Self-sign REST interface test x509 certificate

### DIFF
--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -26,12 +26,14 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
 
     let(:minimal_certificate) do
         cert = OpenSSL::X509::Certificate.new
+        key = OpenSSL::PKey::RSA.new(512)
         cert.version = 2
         cert.serial = 0
         cert.not_before = Time.now
         cert.not_after = Time.now + 3600
-        cert.public_key = OpenSSL::PKey::RSA.new(512)
+        cert.public_key = key.public_key
         cert.subject = OpenSSL::X509::Name.parse("/CN=testing")
+        cert.sign(key, OpenSSL::Digest::SHA256.new)
         cert
     end
 


### PR DESCRIPTION
Not calling OpenSSL::X509::Certificate#sign on a new certificate
produces invalid ASN.1 output, as the signing algorithm fields are left
empty. Versions of OpenSSL prior to 1.0.1i accepted this invalid ASN.1,
which is why this problem went unnoticed. Without this patch, this test
fails on any system with OpenSSL 1.0.1i or newer.

This fix signs the certificate with the private key used to generate
it, producing a self-signed certificate with valid ASN.1. This allows
all tests to pass with OpenSSL 1.0.1i.
