### PR TITLE
(DOC) Clarify resource_type api GET may be for a class, type or nodename

### DIFF
--- a/api/docs/http_resource_type.md
+++ b/api/docs/http_resource_type.md
@@ -25,7 +25,7 @@ Find
 Get info about a specific class, defined type, or node, by name. Returns a
 single resource_type response object (see "Schema" below).
 
-    GET /:environment/resource_type/:nodename
+    GET /:environment/resource_type/:class_type_or_node_name
 
 > **Note:** Although no two classes or defined types may have the same name,
 > it's possible for a node definition to have the same name as a class or


### PR DESCRIPTION
A GET resource_type may request a class, defined type or node by name.
The doc example was just :nodename, which led me briefly astray when I
was querying this endpoint; so I changed it to read
:class_type_or_node_name to make it a little clearer.
