### PR TITLE
(PUP-3057) ensure acceptance tests run on sol10

### DIFF
--- a/acceptance/config/nodes/solaris10.yaml
+++ b/acceptance/config/nodes/solaris10.yaml
@@ -3,9 +3,9 @@ HOSTS:
     roles:
       - master
       - agent
-    platform: solaris-10-x86_64
+    platform: ubuntu-trusty-x86_64
     hypervisor: vcloud
-    template: Delivery/Quality Assurance/Templates/vCloud/solaris-10-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
   agent:
     roles:
       - agent

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -9,7 +9,8 @@ module Puppet
         :redhat        => /fedora|el|centos/,
         :debian        => /debian|ubuntu/,
         :debian_ruby18 => /debian|ubuntu-lucid|ubuntu-precise/,
-        :solaris       => /solaris/,
+        :solaris_10    => /solaris-10/,
+        :solaris_11    => /solaris-11/,
         :windows       => /windows/,
       }.freeze
 

--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -22,16 +22,38 @@ PACKAGES = {
   :debian_ruby18 => [
     'libjson-ruby',
   ],
-  :solaris => [
+  :solaris_11 => [
     ['git', 'developer/versioning/git'],
     ['ruby', 'runtime/ruby-18'],
     # there isn't a package for json, so it is installed later via gems
+  ],
+  :solaris_10 => [
+    'coreutils',
+    'curl', # update curl to fix "CURLOPT_SSL_VERIFYHOST no longer supports 1 as value!" issue
+    'git',
+    'ruby18',
+    'ruby18_dev',
+    'gcc4core',
+    'ruby18_gcc4',
   ],
   :windows => [
     'git',
     # there isn't a need for json on windows because it is bundled in ruby 1.9
   ],
 }
+
+hosts.each do |host|
+  case host['platform']
+  when  /solaris-10/
+    on host, 'mkdir -p /var/lib'
+    on host, 'ln -sf /opt/csw/bin/pkgutil /usr/bin/pkgutil'
+    on host, 'ln -sf /opt/csw/bin/gem18 /usr/bin/gem'
+    on host, 'ln -sf /opt/csw/bin/git /usr/bin/git'
+    on host, 'ln -sf /opt/csw/bin/ruby18 /usr/bin/ruby'
+    on host, 'ln -sf /opt/csw/bin/gstat /usr/bin/stat'
+    on host, 'ln -sf /opt/csw/bin/greadlink /usr/bin/readlink'
+  end
+end
 
 install_packages_on(hosts, PACKAGES, :check_if_exists => true)
 
@@ -60,7 +82,10 @@ hosts.each do |host|
     on host, 'cd /; icacls bin /reset /T'
     on host, 'ruby --version'
     on host, 'cmd /c gem list'
-  when /solaris/
+  when /solaris-10/
+    step "#{host} Install json from rubygems"
+    on host, 'gem install json_pure'
+  when /solaris-11/
     step "#{host} Install json from rubygems"
     on host, 'gem install json'
   end

--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -1,5 +1,5 @@
 test_name "Package:IPS basic tests"
-confine :to, :platform => 'solaris'
+confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_holdable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_holdable.rb
@@ -1,5 +1,5 @@
 test_name "Package:IPS versionable"
-confine :to, :platform => 'solaris'
+confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_idempotent.rb
+++ b/acceptance/tests/resource/package/ips/should_be_idempotent.rb
@@ -1,5 +1,5 @@
 test_name "Package:IPS idempotency"
-confine :to, :platform => 'solaris'
+confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_updatable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_updatable.rb
@@ -1,5 +1,5 @@
 test_name "Package:IPS test for updatable (update, latest)"
-confine :to, :platform => 'solaris'
+confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_versionable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_versionable.rb
@@ -1,5 +1,5 @@
 test_name "Package:IPS versionable"
-confine :to, :platform => 'solaris'
+confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -1,5 +1,5 @@
 test_name "Package:IPS basic tests"
-confine :to, :platform => 'solaris'
+confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_query.rb
+++ b/acceptance/tests/resource/package/ips/should_query.rb
@@ -1,5 +1,5 @@
 test_name "Package:IPS query"
-confine :to, :platform => 'solaris'
+confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_remove.rb
+++ b/acceptance/tests/resource/package/ips/should_remove.rb
@@ -1,5 +1,5 @@
 test_name "Package:IPS basic tests"
-confine :to, :platform => 'solaris'
+confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/user/should_query_all.rb
+++ b/acceptance/tests/resource/user/should_query_all.rb
@@ -1,6 +1,8 @@
 test_name "should query all users"
 
 agents.each do |agent|
+  next if agent == master
+
   step "query natively"
   users = agent.user_list
 

--- a/acceptance/tests/resource/zpool/basic_tests.rb
+++ b/acceptance/tests/resource/zpool/basic_tests.rb
@@ -1,5 +1,6 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
+skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils

--- a/acceptance/tests/resource/zpool/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zpool/should_be_idempotent.rb
@@ -1,5 +1,6 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
+skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils

--- a/acceptance/tests/resource/zpool/should_create.rb
+++ b/acceptance/tests/resource/zpool/should_create.rb
@@ -1,5 +1,6 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
+skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils

--- a/acceptance/tests/resource/zpool/should_query.rb
+++ b/acceptance/tests/resource/zpool/should_query.rb
@@ -1,5 +1,6 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
+skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils

--- a/acceptance/tests/resource/zpool/should_remove.rb
+++ b/acceptance/tests/resource/zpool/should_remove.rb
@@ -1,5 +1,6 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
+skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils

--- a/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
+++ b/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
@@ -26,5 +26,5 @@ agents.each do |agent|
   on agent, "test -f #{scratch}/ssl/certs/#{target}.pem"
 
   step "verify the private key for #{target} exists"
-  on agent, "grep -q 'BEGIN RSA PRIVATE KEY' #{scratch}/ssl/private_keys/#{target}.pem"
+  on agent, "grep 'BEGIN RSA PRIVATE KEY' #{scratch}/ssl/private_keys/#{target}.pem > /dev/null 2>&1"
 end


### PR DESCRIPTION
- fixup solaris10 config file
- add forge_host to options file so tests can run outside rake
- confine IPS tests to solaris11
- skip zone tests as there is not enough drive space on our solaris10
  machines (QENG-1351)
- remove grep -q option for cross-platform sanity
