### PR TITLE
DO NOT MERGE (PUP-3449) Skip merging node parameters reserved in top scope

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -566,7 +566,11 @@ class Puppet::Parser::Compiler
   # Set the node's parameters into the top-scope as variables.
   def set_node_parameters
     node.parameters.each do |param, value|
-      @topscope[param.to_s] = value
+      if Puppet[:immutable_node_data] && Puppet::Parser::Scope::RESERVED_VARIABLE_NAMES.include?(param)
+        Puppet.debug("Node '#{node.name}' has a parameter '#{param}', but this is a reserved variable name and will not be included in the evaluation top scope.")
+      else
+        @topscope[param.to_s] = value
+      end
     end
     # These might be nil.
     catalog.client_version = node.parameters["clientversion"]


### PR DESCRIPTION
So I think I've come full circle on this issue and am no longer convinced we should be preventing the scope from raising an error if it is presented with 'trusted' or 'facts' in the node parameters.  But this potentially conflicts with how PuppetDB is storing 'trusted'.  If you setup your master to work with PuppetDB and do not set a separate cache, you will stop compiling.  Perhaps this is seen as an invalid configuration, but it seems odd to me.
