### PR TITLE
(maint) Always use a remote env in the configurer

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -156,7 +156,9 @@ class Puppet::Configurer
       unless options[:catalog]
         begin
           if node = Puppet::Node.indirection.find(Puppet[:node_name_value],
-              :environment => @environment, :ignore_cache => true, :transaction_uuid => @transaction_uuid,
+              :environment => Puppet::Node::Environment.remote(@environment),
+              :ignore_cache => true,
+              :transaction_uuid => @transaction_uuid,
               :fail_on_404 => true)
 
             # If we have deserialized a node from a rest call, we want to set
@@ -242,7 +244,7 @@ class Puppet::Configurer
   def send_report(report)
     puts report.summary if Puppet[:summarize]
     save_last_run_summary(report)
-    Puppet::Transaction::Report.indirection.save(report, nil, :environment => @environment) if Puppet[:report]
+    Puppet::Transaction::Report.indirection.save(report, nil, :environment => Puppet::Node::Environment.remote(@environment)) if Puppet[:report]
   rescue => detail
     Puppet.log_exception(detail, "Could not send report: #{detail}")
   end
@@ -274,7 +276,7 @@ class Puppet::Configurer
     result = nil
     @duration = thinmark do
       result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value],
-        query_options.merge(:ignore_terminus => true, :environment => @environment))
+        query_options.merge(:ignore_terminus => true, :environment => Puppet::Node::Environment.remote(@environment)))
     end
     Puppet.notice "Using cached catalog"
     result
@@ -287,7 +289,7 @@ class Puppet::Configurer
     result = nil
     @duration = thinmark do
       result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value],
-        query_options.merge(:ignore_cache => true, :environment => @environment, :fail_on_404 => true))
+        query_options.merge(:ignore_cache => true, :environment => Puppet::Node::Environment.remote(@environment), :fail_on_404 => true))
     end
     result
   rescue SystemExit,NoMemoryError


### PR DESCRIPTION
Before this commit the configurer would track the appropriate environment to
request from the master in the `@environment` variable. This contained simply
the name of the remote environment. The value was passed through to various
indirection requests as the `:environment` parameter. However, as part of
PUP-3244, something changed that caused the configurer to begin failing when
- The requested environment did not exist remotely
- There was a cached catalog locally
- The cached catalog referenced an environment that did not exist
  locally This situation caused the indirector requests to contain an
  environment name that the Puppet::Indirector::Request code would then try to
  expand into a full environment instance by calling
  `Puppet.lookup(:environments).get!(env)`. However, since the environment 
  didn't exist locally the `get!` method raised an error.

This commit changes it so that the configurer always converts the
`@environment`, which is always the environment from the server for the 
current run, to `Puppet::Node::Environment.remote`. This stops
`Puppet::Indirector::Request` from trying to load the environment locally.

I don't know how this ever worked...
