### PR TITLE
Issue/stable/pup 3244 acceptance enc needs hashbang

### DIFF
--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -1,28 +1,30 @@
 test_name "Master should produce error if enc specifies a nonexistent environment"
 testdir = create_tmpdir_for_user master, 'nonexistent_env'
 
-apply_manifest_on master, <<-MANIFEST
-file {
-  [  "#{testdir}/environments", "#{testdir}/environments/production" ]:
+apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+File {
   ensure => directory,
+  owner => #{master.puppet['user']},
+  group => #{master.puppet['group']},
+  mode => 0770,
 }
 
-file { "#{testdir}/environments/production/environment.conf":
+file {
+  "#{testdir}":;
+  "#{testdir}/environments":;
+  "#{testdir}/environments/production":;
+  "#{testdir}/environments/production/manifests":;
+  "#{testdir}/environments/production/manifests/site.pp":
     ensure  => file,
-    content => '
-      manifest=./production.pp
-    ',
-}
+    mode => '0644',
+    content => 'notify { "In the production environment": }';
 
-file { "#{testdir}/environments/production/production.pp":
-  ensure  => file,
-  content => 'notify { "In the production environment": }',
-}
-
-file { "#{testdir}/enc.rb":
-  ensure  => file,
-  mode    => '0775',
-  content => 'echo "environment: doesnotexist"',
+  "#{testdir}/enc.rb":
+    ensure  => file,
+    mode    => '0775',
+    content => '#!#{master['puppetbindir']}/ruby
+      puts "environment: doesnotexist"
+    ';
 }
 MANIFEST
 
@@ -38,6 +40,7 @@ with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
     on agent, "puppet agent --no-daemonize --onetime --server #{master} --verbose", :acceptable_exit_codes => [0] do
       assert_match(/Could not find a directory environment named 'doesnotexist'/, stderr, "Errors when nonexistant environment is specified")
+      assert_not_match(/In the production environment/, stdout, "Executed manifest from production environment")
     end
   end
 end


### PR DESCRIPTION
I think the remaining question, though, is whether the case where it ends up executing a cached catalog is correct:

a3m9lej0pifviyl.delivery.puppetlabs.net 10:56:53$  puppet agent --no-daemonize --onetime --server a3m9lej0pifviyl.delivery.puppetlabs.net --verbose  
Warning: Unable to fetch my node definition, but the agent run will continue:
Warning: Could not find a directory environment named 'doesnotexist' anywhere in the path: /tmp/nonexistent_env.LZUfeD/environments. Does the directory exist?
Info: Retrieving pluginfacts
Notice: /File[/var/lib/puppet/facts.d]/mode: mode changed '0750' to '0755'
Info: Retrieving plugin
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed when searching for node a3m9lej0pifviyl.delivery.puppetlabs.net: Could not find a directory environment named 'doesnotexist' anywhere in the path: /tmp/nonexistent_env.LZUfeD/environments. Does the directory exist?
Notice: Using cached catalog
Warning: Local environment: "production" doesn't match server specified environment "testing", restarting agent run with environment "testing"
Error: Could not retrieve catalog from remote server: Find /testing/catalog/a3m9lej0pifviyl.delivery.puppetlabs.net?facts=%257B%2522values%2522%253A%257B%25... resulted in 404 with the message: Not Found: Could not find environment 'testing'
Notice: Using cached catalog
Info: Applying configuration version '1413309407'
Notice: testing-site.pp
Notice: /Stage[main]/Main/Notify[testing-site.pp]/message: defined 'message' as 'testing-site.pp'
Notice: foo-testing
Notice: /Stage[main]/Main/Notify[hiera]/message: defined 'message' as 'foo-testing'
Notice: testing-amod
Notice: /Stage[main]/Amod/Notify[testing-amod]/message: defined 'message' as 'testing-amod'
Notice: Finished catalog run in 0.06 seconds

The cached catalog was prepared in an environment that no longer exists on the master, should we be executing it.  This is perhaps a different issue/ticket though.
