### PR TITLE
(PUP-3201) Treat :undef as PNilType

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -453,12 +453,11 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   def instance_of_PNilType(t, o)
-    return o.nil?
+    o.nil? || o == :undef
   end
 
   def instance_of_POptionalType(t, o)
-    return true if (o.nil?)
-    instance_of(t.optional_type, o)
+    instance_of_PNilType(t, o) || instance_of(t.optional_type, o)
   end
 
   def instance_of_PVariantType(t, o)
@@ -786,7 +785,6 @@ class Puppet::Pops::Types::TypeCalculator
     case o
     when :default
       Types::PDefaultType.new()
-
     else
       infer_Object(o)
     end

--- a/spec/integration/parser/future_compiler_spec.rb
+++ b/spec/integration/parser/future_compiler_spec.rb
@@ -440,6 +440,16 @@ describe "Puppet::Parser::Compiler" do
         expect(catalog).to have_resource("Foo[test]").with_parameter(:x, 'say friend')
       end
 
+      it 'accepts undef as the default for an Optional argument' do
+        catalog = compile_to_catalog(<<-MANIFEST)
+          define foo(Optional[String] $x = undef) {
+            notify { "expected": message => $x == undef }
+          }
+          foo { 'test': }
+        MANIFEST
+        expect(catalog).to have_resource("Notify[expected]").with_parameter(:message, true)
+      end
+
       it 'accepts anything when parameters are untyped' do
         expect do
           catalog = compile_to_catalog(<<-MANIFEST)
@@ -487,6 +497,16 @@ describe "Puppet::Parser::Compiler" do
           class { 'foo': x =>'say friend' }
         MANIFEST
         expect(catalog).to have_resource("Class[Foo]").with_parameter(:x, 'say friend')
+      end
+
+      it 'accepts undef as the default for an Optional argument' do
+        catalog = compile_to_catalog(<<-MANIFEST)
+          class foo(Optional[String] $x = undef) {
+            notify { "expected": message => $x == undef }
+          }
+          class { 'foo': }
+        MANIFEST
+        expect(catalog).to have_resource("Notify[expected]").with_parameter(:message, true)
       end
 
       it 'accepts anything when parameters are untyped' do

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1088,6 +1088,10 @@ describe 'The type calculator' do
       calculator.instance?(Puppet::Pops::Types::PRuntimeType.new(:runtime => :ruby, :runtime_type_name => 'Symbol'), :undef).should == true
     end
 
+    it "should consider :undef to be instance of an Optional type" do
+      calculator.instance?(Puppet::Pops::Types::POptionalType.new(), :undef).should == true
+    end
+
     it 'should not consider undef to be an instance of any other type than Any, NilType and Data' do
       types_to_test = all_types - [
         Puppet::Pops::Types::PAnyType,


### PR DESCRIPTION
For PUP-2857 :undef was changed from being a PNilType to a PRuntimeType. This
stopped the undef literal in the language from being able to be assigned to
Optional parameters. However, this only happened when the undef was the
default expression for the parameter.
