### PR TITLE
(PUP-3470) Fix Ruby 1.8.7 syntax error in test suite

### DIFF
--- a/spec/unit/external/pson_spec.rb
+++ b/spec/unit/external/pson_spec.rb
@@ -56,7 +56,7 @@ describe PSON do
   it 'ignores "document_type" during parsing' do
     text = '{"data":{},"document_type":"Node"}'
 
-    expect(PSON.parse(text))
+    expect(PSON.parse(text)) \
       .to eq({"data" => {}, "document_type" => "Node"})
   end
 end


### PR DESCRIPTION
Rubies older than 1.8.7-p352 (at least) don't understand that this is
a single line of code, and need an explicit escape on the newline.
Without this patch, the test suite can't run on older Rubies at all.
