### PR TITLE
(PUP-2613) Default source_permissions to ignore

### DIFF
--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -253,7 +253,7 @@ module Puppet
         running as.
     EOT
 
-    defaultto :use
+    defaultto :ignore
     newvalues(:use, :use_when_creating, :ignore)
   end
 end


### PR DESCRIPTION
Copying permissions from the source by default leads to surprising
results. Change the default to ignore source permissions.
