### PR TITLE
(PUP-2966) Remove deprecated stringify_facts option

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -489,12 +489,6 @@ module Puppet
           essentially means that you can't have any code outside of a node,
           class, or definition other than in the site manifest.",
     },
-    :stringify_facts => {
-      :default => true,
-      :type    => :boolean,
-      :desc    => "Flatten fact values to strings using #to_s. Means you can't have arrays or
-        hashes as fact values. (DEPRECATED) This option will be removed in Puppet 4.0.",
-    },
     :trusted_node_data => {
       :default => false,
       :type    => :boolean,

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -26,7 +26,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
 
     result = Puppet::Node::Facts.new(request.key, Facter.to_hash)
     result.add_local_facts
-    Puppet[:stringify_facts] ? result.stringify : result.sanitize
+    result.sanitize
     result
   end
 

--- a/lib/puppet/indirector/facts/network_device.rb
+++ b/lib/puppet/indirector/facts/network_device.rb
@@ -13,8 +13,7 @@ class Puppet::Node::Facts::NetworkDevice < Puppet::Indirector::Code
     result = Puppet::Node::Facts.new(request.key, Puppet::Util::NetworkDevice.current.facts)
 
     result.add_local_facts
-    Puppet[:stringify_facts] ? result.stringify : result.sanitize
-
+    result.sanitize
     result
   end
 

--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -56,13 +56,6 @@ class Puppet::Node::Facts
     end
   end
 
-  # Convert all fact values into strings.
-  def stringify
-    values.each do |fact, value|
-      values[fact] = value.to_s
-    end
-  end
-
   # Sanitize fact values by converting everything not a string, boolean
   # numeric, array or hash into strings.
   def sanitize

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -1860,14 +1860,6 @@ Makes the parser raise errors when referencing unknown variables\. (This does no
 .
 .IP "" 0
 .
-.SS "stringify_facts"
-Flatten fact values to strings using #to_s\. Means you can\'t have arrays or hashes as fact values\. (DEPRECATED) This option will be removed in Puppet 4\.0\.
-.
-.IP "\(bu" 4
-\fIDefault\fR: true
-.
-.IP "" 0
-.
 .SS "summarize"
 Whether to print a transaction summary\.
 .

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -16,7 +16,6 @@ describe Puppet::Application::Facts do
   end
 
   it "should return facts if a key is given to find" do
-    Puppet[:stringify_facts] = false
     Puppet::Node::Facts.indirection.reset_terminus_class
     Puppet::Node::Facts.indirection.expects(:find).returns(Puppet::Node::Facts.new('whatever', {}))
     subject.command_line.stubs(:args).returns %w{find whatever --render-as yaml}

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -82,17 +82,7 @@ describe Puppet::Node::Facts::Facter do
       @facter.find(@request)
     end
 
-    it "should convert facts into strings when stringify_facts is true" do
-      Puppet[:stringify_facts] = true
-      facts = Puppet::Node::Facts.new("foo")
-      Puppet::Node::Facts.expects(:new).returns facts
-      facts.expects(:stringify)
-
-      @facter.find(@request)
-    end
-
-    it "should sanitize facts when stringify_facts is false" do
-      Puppet[:stringify_facts] = false
+    it "should sanitize facts" do
       facts = Puppet::Node::Facts.new("foo")
       Puppet::Node::Facts.expects(:new).returns facts
       facts.expects(:sanitize)

--- a/spec/unit/indirector/facts/network_device_spec.rb
+++ b/spec/unit/indirector/facts/network_device_spec.rb
@@ -55,17 +55,7 @@ describe Puppet::Node::Facts::NetworkDevice do
       @device.find(@request)
     end
 
-    it "should convert facts into strings when stringify_facts is true" do
-      Puppet[:stringify_facts] = true
-      facts = Puppet::Node::Facts.new("foo")
-      Puppet::Node::Facts.expects(:new).returns facts
-      facts.expects(:stringify)
-
-      @device.find(@request)
-    end
-
-    it "should sanitizer facts when stringify_facts is false" do
-      Puppet[:stringify_facts] = false
+    it "should sanitize facts" do
       facts = Puppet::Node::Facts.new("foo")
       Puppet::Node::Facts.expects(:new).returns facts
       facts.expects(:sanitize)

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -10,12 +10,6 @@ describe Puppet::Node::Facts, "when indirecting" do
     @facts = Puppet::Node::Facts.new("me")
   end
 
-  it "should be able to convert all fact values to strings" do
-    @facts.values["one"] = 1
-    @facts.stringify
-    @facts.values["one"].should == "1"
-  end
-
   describe "adding local facts" do
     it "should add the node's certificate name as the 'clientcert' fact" do
       @facts.add_local_facts


### PR DESCRIPTION
This commit removes the option to stringify facts (convert
non-string facts into strings).

This commit is part of the code removal effort for Puppet 4.
