### PR TITLE
(PUP-2613) Fix Windows specs

### DIFF
--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1029,7 +1029,8 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           :path   => path,
           :ensure => :file,
           :source => source,
-          :backup => false
+          :backup => false,
+          :source_permissions => :use
         )
 
         catalog.add_resource file
@@ -1065,10 +1066,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           end
 
           describe "when source permissions are ignored" do
-            before :each do
-              @file[:source_permissions] = :ignore
-            end
-
             it "preserves the inherited SYSTEM ACE" do
               catalog.apply
 
@@ -1097,6 +1094,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
             before :each do
               @file[:owner] = 'None'
               @file[:group] = 'None'
+              @file[:source_permissions] = :use
             end
 
             it "replaces inherited SYSTEM ACEs with an uninherited one for an existing file" do
@@ -1182,10 +1180,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           end
 
           describe "when source permissions are ignored" do
-            before :each do
-              @directory[:source_permissions] = :ignore
-            end
-
             it "preserves the inherited SYSTEM ACE" do
               catalog.apply
 

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -188,6 +188,7 @@ describe Puppet::Type.type(:file).attrclass(:source) do
 
     it "should not issue a deprecation warning if the source mode value is a Numeric" do
       @metadata.stubs(:mode).returns 0173
+      @resource[:source_permissions] = :use
       if Puppet::Util::Platform.windows?
         Puppet.expects(:deprecation_warning).with(regexp_matches(/Copying owner\/mode\/group from the source file on Windows is deprecated/)).at_least_once
       else
@@ -199,6 +200,7 @@ describe Puppet::Type.type(:file).attrclass(:source) do
 
     it "should not issue a deprecation warning if the source mode value is a String" do
       @metadata.stubs(:mode).returns "173"
+      @resource[:source_permissions] = :use
       if Puppet::Util::Platform.windows?
         Puppet.expects(:deprecation_warning).with(regexp_matches(/Copying owner\/mode\/group from the source file on Windows is deprecated/)).at_least_once
       else


### PR DESCRIPTION
Changes tests for copying permissions to explicitly use source_permissions
=> :use.
