### PR TITLE
(PUP-2613) Fix unstable tests when ignoring source

### DIFF
--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -970,6 +970,23 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       (get_mode(path) & 07777).should == expected_mode
     end
 
+    it "should not override existing target metadata" do
+      FileUtils.touch(path)
+      set_mode(0766, path)
+
+      file = described_class.new(
+        :path   => path,
+        :ensure => :file,
+        :source => source,
+        :backup => false
+      )
+
+      catalog.add_resource file
+      catalog.apply
+
+      (get_mode(path) & 07777).should == 0766
+    end
+
     it "should override the default metadata values" do
       set_mode(0770, source)
 


### PR DESCRIPTION
Ignoring source permissions sets permissions based on the running user and
group; checking that the value is valid should be sufficient. The other test
is checking explicitly set source permissions, and doesn't make a lot of
sense for source_permissions => ignore.
