### PR TITLE
(maint) Fixed debug and error output for Solaris zones

### DIFF
--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -234,10 +234,10 @@ Puppet::Type.type(:zone).provide(:solaris) do
           end
           current[$1.intern] = $2
         else
-          err "Ignoring '#{line}'"
+          Puppet.err "Ignoring '#{line}'"
         end
       else
-        debug "Ignoring zone output '#{line}'"
+        Puppet.debug "Ignoring zone output '#{line}'"
       end
     end
 


### PR DESCRIPTION
Every time we did set up a zone we crashed at the debug line. Now it works
