### PR TITLE
PUP-3492: enabled Upstart as a service provider for linux Mint

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -14,7 +14,8 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   confine :any => [
     Facter.value(:operatingsystem) == 'Ubuntu',
     (Facter.value(:osfamily) == 'RedHat' and Facter.value(:operatingsystemrelease) =~ /^6\./),
-    Facter.value(:operatingsystem) == 'Amazon'
+    Facter.value(:operatingsystem) == 'Amazon',
+    Facter.value(:operatingsystem) == 'LinuxMint',
   ]
 
   defaultfor :operatingsystem => :ubuntu


### PR DESCRIPTION
Change-Id: I3df5054e3cc125718f5f6e99a8ad73a962df8501
