### PR TITLE
(WIP,PUP-3500) Ignore environment when handling setting hooks

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1196,9 +1196,10 @@ Generated on #{Time.now}.
           if section = @configuration_file.sections[name]
             values_from_section = ValuesFromSection.new(name, section)
           end
-        end
-        if values_from_section.nil? && global_defaults_initialized?
-          values_from_section = ValuesFromEnvironmentConf.new(name)
+          if values_from_section.nil?
+            raise(SettingsError, "Cannot obtain environment settings for the '#{name}' directory environment prior to initialization of settings.") if !global_defaults_initialized?
+            values_from_section = ValuesFromEnvironmentConf.new(name)
+          end
         end
         values_from_section
       end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -917,22 +917,6 @@ describe Puppet::Settings do
       values.should == ["setval"]
     end
 
-    it "should pass the environment-specific value to the hook when one is available" do
-      values = []
-      @settings.define_settings :section, :mysetting => {:default => "defval", :desc => "a", :hook => proc { |v| values << v }}
-      @settings.define_settings :section, :environment => { :default => "yay", :desc => "a" }
-      @settings.define_settings :section, :environments => { :default => "yay,foo", :desc => "a" }
-
-      text = "[main]
-      mysetting = setval
-      [yay]
-      mysetting = other
-      "
-      @settings.expects(:read_file).returns(text)
-      @settings.send(:parse_config_files)
-      values.should == ["other"]
-    end
-
     it "should pass the interpolated value to the hook when one is available" do
       values = []
       @settings.define_settings :section, :base => {:default => "yay", :desc => "a", :hook => proc { |v| values << v }}


### PR DESCRIPTION
Env was only being used when handling hooks that were not defered to
after initialization.

This breaks settings_spec "Puppet::Settings when parsing its
configuration should pass the environment-specific value to the hook
when one is available"

Not sure if ths is important (and whether it is relevant only for legacy
settings or also for directory environment settings).
