### PR TITLE
(PUP-2706) Change adduser to useradd in postinst

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -11,7 +11,7 @@ Homepage: http://projects.puppetlabs.com/projects/puppet
 
 Package: puppet-common
 Architecture: all
-Depends: ${misc:Depends}, ruby | ruby-interpreter, libopenssl-ruby | libopenssl-ruby1.9.1 | libruby (>= 1:1.9.3.4), ruby-shadow | libshadow-ruby1.8, libaugeas-ruby | libaugeas-ruby1.9.1 | libaugeas-ruby1.8, adduser, lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0), facter (>= 1.7.0), libjson-ruby | ruby-json
+Depends: ${misc:Depends}, ruby | ruby-interpreter, libopenssl-ruby | libopenssl-ruby1.9.1 | libruby (>= 1:1.9.3.4), ruby-shadow | libshadow-ruby1.8, libaugeas-ruby | libaugeas-ruby1.9.1 | libaugeas-ruby1.8, lsb-base, sysv-rc (>= 2.86) | file-rc, hiera (>= 1.0.0), facter (>= 1.7.0), libjson-ruby | ruby-json
 Recommends: lsb-release, debconf-utils
 Suggests: ruby-selinux | libselinux-ruby1.8, librrd-ruby1.9.1 | librrd-ruby1.8
 Breaks: puppet (<< 2.6.0~rc2-1), puppetmaster (<< 0.25.4-1)

--- a/ext/debian/puppet-common.postinst
+++ b/ext/debian/puppet-common.postinst
@@ -6,9 +6,9 @@ if [ "$1" = "configure" ]; then
 
 	# Create the "puppet" user
 	if ! getent passwd puppet > /dev/null; then
-		adduser --quiet --system --group --home /var/lib/puppet  \
-			--no-create-home                                 \
-			--gecos "Puppet configuration management daemon" \
+		useradd --system --user-group --home-dir /var/lib/puppet \
+			--no-create-home --shell /bin/false \
+			--comment "Puppet configuration management daemon" \
 			puppet
 	fi
 


### PR DESCRIPTION
There has been an intermittent error where the installation of
puppet-common is failing on Ubtuntu 14.04. This error is

```
chage: the shadow password file is not present
/usr/bin/chage failed with return code 15, shadow not enabled, password aging cannot be set. Continuing.
chfn: PAM: Authentication failure
adduser: `/usr/bin/chfn -f Puppet configuration management daemon puppet' returned error code 1. Exiting.
```

Though `chage` is complaining about the fact that shadow is not enabled,
it looks like the installation is failing sure to the `adduser` call.
The thought is that `adduser` does some things under the hood that
require PAM to be configured in the build environment, which it isn't.
If we change the call from `adduser` to `useradd`, hopefully we will not
run into this issue. Note: it is difficult to test this due to the
intermittent nature of the issue.

Also, since we're removing the use of `adduser`, we no longer need to
ensure that package is available on the system.
