### PR TITLE
(PUP-3500) Avoid cacheing environment values when handling setting hooks

### DIFF
--- a/spec/integration/environments/setting_hooks_spec.rb
+++ b/spec/integration/environments/setting_hooks_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe "setting hooks" do
+  let(:confdir) { Puppet[:confdir] }
+  let(:environmentpath) { File.expand_path("envdir", confdir) }
+
+  describe "reproducing PUP-3500" do
+    let(:productiondir) { File.join(environmentpath, "production") }
+
+    before(:each) do
+      FileUtils.mkdir_p(productiondir)
+    end
+
+    it "accesses correct directory environment settings after intializing a setting with an on_write hook" do
+      expect(Puppet.settings.setting(:certname).call_hook).to eq(:on_write_only) 
+
+      File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+        f.puts("environmentpath=#{environmentpath}")
+        f.puts("certname=something")
+      end
+
+      Puppet.initialize_settings
+      production_env = Puppet.lookup(:environments).get(:production)
+      expect(Puppet.settings.value(:manifest, production_env)).to eq("#{productiondir}/manifests")
+    end
+  end
+end


### PR DESCRIPTION
Environment in parse_config is being used to ensure that settings in the
current run_mode's environment are checked for hooks, and to handle
hooks that are simply on_write.  In this latter case, the code looks up
the value of the setting from all available elements of the setting's
search_path including the current environment layer.

But if directory environments are in use, their environment settings
cannot be looked up at this early point in settings initialization (we
have no environment loaders), and the consequence is that we end up with
a ChainedValues instance cached in the Settings @values[:env][:runmode]
that does not have a section for :env.  This then blocks resolution of
the real environment settings at a later date.

The fix in this patch is to construct a temporary ChainedValues instance
for the lookup rather than invoking value(), thus avoiding the cacheing.

Since none of the documented environment settings has a hook, we were
very tempted to yank out the environment handling entirely, but this
would leave us with yet more odd behavior if a hook was added to an
environment setting in the 3.7.x series for some unknowable reason, and
it was then set in a legacy environment block.
- the question of how to handle Setting hooks for directory environment
  settings is open in PUP-3507

Paired-with: Britt Gresham britt@puppetlabs.com
