### PR TITLE
(PUP-3505) Fix problem with passing explicit undef res parameter

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -357,8 +357,8 @@ class Puppet::Resource
 
   def missing_arguments
     resource_type.arguments.select do |param, default|
-      param = param.to_sym
-      parameters[param].nil? || parameters[param].value == :undef
+      the_param = parameters[param.to_sym]
+      the_param.nil? || the_param.value.nil? || the_param.value == :undef
     end
   end
   private :missing_arguments

--- a/spec/integration/parser/resource_expressions_spec.rb
+++ b/spec/integration/parser/resource_expressions_spec.rb
@@ -206,6 +206,19 @@ describe "Puppet resource expressions" do
         "@@notify { example: } realize(Notify[example])" => "defined(Notify[example])",
         "@@notify { exported: message => set } notify { real: message => Notify[exported][message] }" => "Notify[real][message] == 'set'")
     end
+
+    context "explicit undefs" do
+      # PUP-3505
+      produces("
+        $x = 10
+        define foo($x = undef) {
+          notify { example:
+            message => \"'$x'\"
+          }
+        }
+        foo {'blah': x => undef }
+      " => "Notify[example][message] == \"''\"")
+    end
   end
 
   describe "current parser" do


### PR DESCRIPTION
With the future parser in effect and a resource attribute is undef the
logic that checks for missing arguments did not report the parameter.
This in turn led to that the logic that either fails the operation, or
assigns the default value to completely skip that parameter/argument.
Subsequently a reference of that parameter ended up picking the same
variable from an outer context.

The fix is to equate a nil value (4x) with an :undef value (for 3x) when
computing the missing arguments.

A test is added that tests the functionality.
