### PR TITLE
(PUP-3514) Fix broken errors from future parser

### DIFF
--- a/lib/puppet/pops/parser/parser_support.rb
+++ b/lib/puppet/pops/parser/parser_support.rb
@@ -49,7 +49,7 @@ class Puppet::Pops::Parser::Parser
   # Raises a Parse error with location information. Information about file is always obtained from the
   # lexer. Line and position is produced if the given semantic is a Positioned object and have been given an offset.
   #
-  def error(semantic, message, options = {})
+  def error(semantic, message)
     semantic = semantic.current() if semantic.is_a?(Puppet::Pops::Model::Factory)
     # Adapt the model so it is possible to get location information.
     # The model may not have been added to the source tree, so give it the lexer's locator

--- a/spec/unit/pops/parser/parser_spec.rb
+++ b/spec/unit/pops/parser/parser_spec.rb
@@ -39,9 +39,9 @@ describe Puppet::Pops::Parser::Parser do
     rescue Puppet::ParseError => e
       the_error = e
     end
-    the_error.is_a?(Puppet::ParseError).should == true
-    the_error.file.should == 'fakefile.pp'
-    the_error.line.should == 1
-    the_error.pos.should == 6
+    expect(the_error).to be_a(Puppet::ParseError)
+    expect(the_error.file).to eq('fakefile.pp')
+    expect(the_error.line).to eq(1)
+    expect(the_error.pos).to eq(6)
   end
 end


### PR DESCRIPTION
When the future parser called the error method from within the parser
(the few remaining cases handled by the parser directly), that resulted
in the Factory being called to produce new expressions and these were
subsequently turned into strings - showing a series of (slice ...)
s-expression.

The error method was simply doing the wrong thing (copied from the 3x
parser). This commit fixes the problem by picking up as much as possible
of the known location and passing that along in the exception that is
raised.

One test is included to ensure we do not have regressions on this
behavior. The remaining error cases are still untested, but the
intention is for those to be moved out from the grammar and into
validation to improve the ability to give better error messages.

This commit only fixes the immediate problem of getting garbage output
instead of file, line and position in these cases.
