### PR TITLE
(PUP-3553) Remove support for OSX versions <= 10.6

### DIFF
--- a/lib/puppet/provider/macauthorization/macauthorization.rb
+++ b/lib/puppet/provider/macauthorization/macauthorization.rb
@@ -10,20 +10,8 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
   "
 
   commands :security => "/usr/bin/security"
-  commands :sw_vers => "/usr/bin/sw_vers"
 
   confine :operatingsystem => :darwin
-
-  # This should be confined based on macosx_productversion
-  # but puppet resource doesn't make the facts available and
-  # that interface is heavily used with this provider.
-  if Puppet::FileSystem.exist?("/usr/bin/sw_vers")
-    product_version = sw_vers "-productVersion"
-
-    confine :true => unless /^10\.[0-4]/.match(product_version)
-      true
-    end
-  end
 
   defaultfor :operatingsystem => :darwin
 

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -11,7 +11,6 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     #  e.g. Puppet::Type.type(:user).provide :directoryservice, :ds_path => "Users"
     #  This is referenced in the get_ds_path class method
     attr_writer :ds_path
-    attr_writer :macosx_version_major
   end
 
   initvars
@@ -87,20 +86,6 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     @resource_type.name.to_s.capitalize + "s"
   end
 
-  def self.get_macosx_version_major
-    return @macosx_version_major if defined?(@macosx_version_major)
-    begin
-      product_version_major = Facter.value(:macosx_productversion_major)
-
-      fail("#{product_version_major} is not supported by the directoryservice provider") if %w{10.0 10.1 10.2 10.3 10.4}.include?(product_version_major)
-      @macosx_version_major = product_version_major
-      return @macosx_version_major
-    rescue Puppet::ExecutionFailure => detail
-      fail("Could not determine OS X version: #{detail}")
-    end
-  end
-
-
   def self.list_all_present
     # JJM: List all objects of this Puppet::Type already present on the system.
     begin
@@ -167,17 +152,9 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       fail("Could not get report.  command execution failed.")
     end
 
-    # (#11593) Remove support for OS X 10.4 and earlier
-    fail_if_wrong_version
     dscl_plist = self.parse_dscl_plist_data(dscl_output)
 
     self.generate_attribute_hash(dscl_plist, *type_properties)
-  end
-
-  def self.fail_if_wrong_version
-    if (Puppet::Util::Package.versioncmp(self.get_macosx_version_major, '10.5') == -1)
-      fail("Puppet does not support OS X versions < 10.5")
-    end
   end
 
   def self.get_exec_preamble(ds_action, resource_name = nil)
@@ -188,8 +165,6 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     #     This method spits out proper DSCL commands for us.
     #     We EXPECT name to be @resource[:name] when called from an instance object.
 
-    # (#11593) Remove support for OS X 10.4 and earlier
-    fail_if_wrong_version
     command_vector = [ command(:dscl), "-plist", "." ]
 
     # JJM: The actual action to perform.  See "man dscl"
@@ -208,120 +183,71 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
   end
 
   def self.set_password(resource_name, guid, password_hash)
-    # Use Puppet::Util::Package.versioncmp() to catch the scenario where a
-    # version '10.10' would be < '10.7' with simple string comparison. This
-    # if-statement only executes if the current version is less-than 10.7
-    if (Puppet::Util::Package.versioncmp(get_macosx_version_major, '10.7') == -1)
-      password_hash_file = "#{password_hash_dir}/#{guid}"
-      begin
-        File.open(password_hash_file, 'w') { |f| f.write(password_hash)}
-      rescue Errno::EACCES => detail
-        fail("Could not write to password hash file: #{detail}")
+    # 10.7 uses salted SHA512 password hashes which are 128 characters plus
+    # an 8 character salt. Previous versions used a SHA1 hash padded with
+    # zeroes. If someone attempts to use a password hash that worked with
+    # a previous version of OX X, we will fail early and warn them.
+    if password_hash.length != 136
+      fail("OS X 10.7 requires a Salted SHA512 hash password of 136 characters. \
+           Please check your password and try again.")
+    end
+
+    if Puppet::FileSystem.exist?("#{users_plist_dir}/#{resource_name}.plist")
+      # If a plist already exists in /var/db/dslocal/nodes/Default/users, then
+      # we will need to extract the binary plist from the 'ShadowHashData'
+      # key, log the new password into the resultant plist's 'SALTED-SHA512'
+      # key, and then save the entire structure back.
+      users_plist = Plist::parse_xml(plutil( '-convert', 'xml1', '-o', '/dev/stdout', \
+                                     "#{users_plist_dir}/#{resource_name}.plist"))
+
+      # users_plist['ShadowHashData'][0].string is actually a binary plist
+      # that's nested INSIDE the user's plist (which itself is a binary
+      # plist). If we encounter a user plist that DOESN'T have a
+      # ShadowHashData field, create one.
+      if users_plist['ShadowHashData']
+        password_hash_plist = users_plist['ShadowHashData'][0].string
+        converted_hash_plist = convert_binary_to_xml(password_hash_plist)
+      else
+        users_plist['ShadowHashData'] = [StringIO.new]
+        converted_hash_plist = {'SALTED-SHA512' => StringIO.new}
       end
 
-      # NBK: For shadow hashes, the user AuthenticationAuthority must contain a value of
-      # ";ShadowHash;". The LKDC in 10.5 makes this more interesting though as it
-      # will dynamically generate ;Kerberosv5;;username@LKDC:SHA1 attributes if
-      # missing. Thus we make sure we only set ;ShadowHash; if it is missing, and
-      # we can do this with the merge command. This allows people to continue to
-      # use other custom AuthenticationAuthority attributes without stomping on them.
-      #
-      # There is a potential problem here in that we're only doing this when setting
-      # the password, and the attribute could get modified at other times while the
-      # hash doesn't change and so this doesn't get called at all... but
-      # without switching all the other attributes to merge instead of create I can't
-      # see a simple enough solution for this that doesn't modify the user record
-      # every single time. This should be a rather rare edge case. (famous last words)
+      # converted_hash_plist['SALTED-SHA512'].string expects a Base64 encoded
+      # string. The password_hash provided as a resource attribute is a
+      # hex value. We need to convert the provided hex value to a Base64
+      # encoded string to nest it in the converted hash plist.
+      converted_hash_plist['SALTED-SHA512'].string = \
+        password_hash.unpack('a2'*(password_hash.size/2)).collect { |i| i.hex.chr }.join
 
-      dscl_vector = self.get_exec_preamble("-merge", resource_name)
-      dscl_vector << "AuthenticationAuthority" << ";ShadowHash;"
-      begin
-        execute(dscl_vector)
-      rescue Puppet::ExecutionFailure => detail
-        fail("Could not set AuthenticationAuthority.")
-      end
-    else
-      # 10.7 uses salted SHA512 password hashes which are 128 characters plus
-      # an 8 character salt. Previous versions used a SHA1 hash padded with
-      # zeroes. If someone attempts to use a password hash that worked with
-      # a previous version of OX X, we will fail early and warn them.
-      if password_hash.length != 136
-        fail("OS X 10.7 requires a Salted SHA512 hash password of 136 characters. \
-             Please check your password and try again.")
-      end
-
-      if Puppet::FileSystem.exist?("#{users_plist_dir}/#{resource_name}.plist")
-        # If a plist already exists in /var/db/dslocal/nodes/Default/users, then
-        # we will need to extract the binary plist from the 'ShadowHashData'
-        # key, log the new password into the resultant plist's 'SALTED-SHA512'
-        # key, and then save the entire structure back.
-        users_plist = Plist::parse_xml(plutil( '-convert', 'xml1', '-o', '/dev/stdout', \
-                                       "#{users_plist_dir}/#{resource_name}.plist"))
-
-        # users_plist['ShadowHashData'][0].string is actually a binary plist
-        # that's nested INSIDE the user's plist (which itself is a binary
-        # plist). If we encounter a user plist that DOESN'T have a
-        # ShadowHashData field, create one.
-        if users_plist['ShadowHashData']
-          password_hash_plist = users_plist['ShadowHashData'][0].string
-          converted_hash_plist = convert_binary_to_xml(password_hash_plist)
-        else
-          users_plist['ShadowHashData'] = [StringIO.new]
-          converted_hash_plist = {'SALTED-SHA512' => StringIO.new}
-        end
-
-        # converted_hash_plist['SALTED-SHA512'].string expects a Base64 encoded
-        # string. The password_hash provided as a resource attribute is a
-        # hex value. We need to convert the provided hex value to a Base64
-        # encoded string to nest it in the converted hash plist.
-        converted_hash_plist['SALTED-SHA512'].string = \
-          password_hash.unpack('a2'*(password_hash.size/2)).collect { |i| i.hex.chr }.join
-
-        # Finally, we can convert the nested plist back to binary, embed it
-        # into the user's plist, and convert the resultant plist back to
-        # a binary plist.
-        changed_plist = convert_xml_to_binary(converted_hash_plist)
-        users_plist['ShadowHashData'][0].string = changed_plist
-        Plist::Emit.save_plist(users_plist, "#{users_plist_dir}/#{resource_name}.plist")
-        plutil('-convert', 'binary1', "#{users_plist_dir}/#{resource_name}.plist")
-      end
+      # Finally, we can convert the nested plist back to binary, embed it
+      # into the user's plist, and convert the resultant plist back to
+      # a binary plist.
+      changed_plist = convert_xml_to_binary(converted_hash_plist)
+      users_plist['ShadowHashData'][0].string = changed_plist
+      Plist::Emit.save_plist(users_plist, "#{users_plist_dir}/#{resource_name}.plist")
+      plutil('-convert', 'binary1', "#{users_plist_dir}/#{resource_name}.plist")
     end
   end
 
   def self.get_password(guid, username)
-    # Use Puppet::Util::Package.versioncmp() to catch the scenario where a
-    # version '10.10' would be < '10.7' with simple string comparison. This
-    # if-statement only executes if the current version is less-than 10.7
-    if (Puppet::Util::Package.versioncmp(get_macosx_version_major, '10.7') == -1)
-      password_hash = nil
-      password_hash_file = "#{password_hash_dir}/#{guid}"
-      if Puppet::FileSystem.exist?(password_hash_file) and File.file?(password_hash_file)
-        fail("Could not read password hash file at #{password_hash_file}") if not File.readable?(password_hash_file)
-        f = File.new(password_hash_file)
-        password_hash = f.read
-        f.close
-      end
-      password_hash
-    else
-      if Puppet::FileSystem.exist?("#{users_plist_dir}/#{username}.plist")
-        # If a plist exists in /var/db/dslocal/nodes/Default/users, we will
-        # extract the binary plist from the 'ShadowHashData' key, decode the
-        # salted-SHA512 password hash, and then return it.
-        users_plist = Plist::parse_xml(plutil('-convert', 'xml1', '-o', '/dev/stdout', "#{users_plist_dir}/#{username}.plist"))
-        if users_plist['ShadowHashData']
-          # users_plist['ShadowHashData'][0].string is actually a binary plist
-          # that's nested INSIDE the user's plist (which itself is a binary
-          # plist).
-          password_hash_plist = users_plist['ShadowHashData'][0].string
-          converted_hash_plist = convert_binary_to_xml(password_hash_plist)
+    if Puppet::FileSystem.exist?("#{users_plist_dir}/#{username}.plist")
+      # If a plist exists in /var/db/dslocal/nodes/Default/users, we will
+      # extract the binary plist from the 'ShadowHashData' key, decode the
+      # salted-SHA512 password hash, and then return it.
+      users_plist = Plist::parse_xml(plutil('-convert', 'xml1', '-o', '/dev/stdout', "#{users_plist_dir}/#{username}.plist"))
+      if users_plist['ShadowHashData']
+        # users_plist['ShadowHashData'][0].string is actually a binary plist
+        # that's nested INSIDE the user's plist (which itself is a binary
+        # plist).
+        password_hash_plist = users_plist['ShadowHashData'][0].string
+        converted_hash_plist = convert_binary_to_xml(password_hash_plist)
 
-          # converted_hash_plist['SALTED-SHA512'].string is a Base64 encoded
-          # string. The password_hash provided as a resource attribute is a
-          # hex value. We need to convert the Base64 encoded string to a
-          # hex value and provide it back to Puppet.
-          password_hash = converted_hash_plist['SALTED-SHA512'].string.unpack("H*")[0]
-          password_hash
-        end
+        # converted_hash_plist['SALTED-SHA512'].string is a Base64 encoded
+        # string. The password_hash provided as a resource attribute is a
+        # hex value. We need to convert the Base64 encoded string to a
+        # hex value and provide it back to Puppet.
+        password_hash = converted_hash_plist['SALTED-SHA512'].string.unpack("H*")[0]
+        password_hash
       end
     end
   end

--- a/spec/unit/provider/nameservice/directoryservice_spec.rb
+++ b/spec/unit/provider/nameservice/directoryservice_spec.rb
@@ -37,16 +37,7 @@ require 'spec_helper'
 end
 
 describe 'DirectoryService.single_report' do
-  it 'should fail on OS X < 10.5' do
-    Puppet::Provider::NameService::DirectoryService.stubs(:get_macosx_version_major).returns("10.4")
-
-    expect {
-      Puppet::Provider::NameService::DirectoryService.single_report('resource_name')
-    }.to raise_error(RuntimeError, "Puppet does not support OS X versions < 10.5")
-  end
-
-  it 'should use plist data on >= 10.5' do
-    Puppet::Provider::NameService::DirectoryService.stubs(:get_macosx_version_major).returns("10.5")
+  it 'should use plist data' do
     Puppet::Provider::NameService::DirectoryService.stubs(:get_ds_path).returns('Users')
     Puppet::Provider::NameService::DirectoryService.stubs(:list_all_present).returns(
       ['root', 'user1', 'user2', 'resource_name']
@@ -60,16 +51,7 @@ describe 'DirectoryService.single_report' do
 end
 
 describe 'DirectoryService.get_exec_preamble' do
-  it 'should fail on OS X < 10.5' do
-    Puppet::Provider::NameService::DirectoryService.stubs(:get_macosx_version_major).returns("10.4")
-
-    expect {
-      Puppet::Provider::NameService::DirectoryService.get_exec_preamble('-list')
-    }.to raise_error(RuntimeError, "Puppet does not support OS X versions < 10.5")
-  end
-
-  it 'should use plist data on >= 10.5' do
-    Puppet::Provider::NameService::DirectoryService.stubs(:get_macosx_version_major).returns("10.5")
+  it 'should use plist data' do
     Puppet::Provider::NameService::DirectoryService.stubs(:get_ds_path).returns('Users')
 
     Puppet::Provider::NameService::DirectoryService.get_exec_preamble('-list').should include("-plist")
@@ -104,11 +86,7 @@ describe 'DirectoryService password behavior' do
     Puppet::Provider::NameService::DirectoryService
   end
 
-  before :each do
-    subject.expects(:get_macosx_version_major).returns("10.7")
-  end
-
-  it 'should execute convert_binary_to_xml once when getting the password on >= 10.7' do
+  it 'should execute convert_binary_to_xml once when getting the password' do
     subject.expects(:convert_binary_to_xml).returns({'SALTED-SHA512' => StringIO.new(pw_string)})
     Puppet::FileSystem.expects(:exist?).with(plist_path).once.returns(true)
     Plist.expects(:parse_xml).returns(shadow_hash_data)
@@ -117,7 +95,7 @@ describe 'DirectoryService password behavior' do
     subject.get_password('uid', 'jeff')
   end
 
-  it 'should fail if a salted-SHA512 password hash is not passed in >= 10.7' do
+  it 'should fail if a salted-SHA512 password hash is not passed in' do
     expect {
       subject.set_password('jeff', 'uid', 'badpassword')
     }.to raise_error(RuntimeError, /OS X 10.7 requires a Salted SHA512 hash password of 136 characters./)

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -37,48 +37,6 @@ describe Puppet::Type.type(:service).provider(:launchd) do
     end
   end
 
-  describe "when checking whether the service is enabled on OS X 10.5" do
-    it "should return true in if the job plist says disabled is false" do
-      subject.expects(:has_macosx_plist_overrides?).returns(false)
-      subject.expects(:plist_from_label).with(joblabel).returns(["foo", {"Disabled" => false}])
-      subject.enabled?.should == :true
-    end
-    it "should return true in if the job plist has no disabled key" do
-      subject.expects(:has_macosx_plist_overrides?).returns(false)
-      subject.expects(:plist_from_label).returns(["foo", {}])
-      subject.enabled?.should == :true
-    end
-    it "should return false in if the job plist says disabled is true" do
-      subject.expects(:has_macosx_plist_overrides?).returns(false)
-      subject.expects(:plist_from_label).returns(["foo", {"Disabled" => true}])
-      subject.enabled?.should == :false
-    end
-  end
-
-  describe "when checking whether the service is enabled on OS X 10.6" do
-    it "should return true if the job plist says disabled is true and the global overrides says disabled is false" do
-      provider.expects(:get_macosx_version_major).returns("10.6")
-      subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => true}])
-      provider.expects(:read_plist).returns({joblabel => {"Disabled" => false}})
-      FileTest.expects(:file?).with(launchd_overrides).returns(true)
-      subject.enabled?.should == :true
-    end
-    it "should return false if the job plist says disabled is false and the global overrides says disabled is true" do
-      provider.expects(:get_macosx_version_major).returns("10.6")
-      subject.expects(:plist_from_label).returns([joblabel, {"Disabled" => false}])
-      provider.expects(:read_plist).returns({joblabel => {"Disabled" => true}})
-      FileTest.expects(:file?).with(launchd_overrides).returns(true)
-      subject.enabled?.should == :false
-    end
-    it "should return true if the job plist and the global overrides have no disabled keys" do
-      provider.expects(:get_macosx_version_major).returns("10.6")
-      subject.expects(:plist_from_label).returns([joblabel, {}])
-      provider.expects(:read_plist).returns({})
-      FileTest.expects(:file?).with(launchd_overrides).returns(true)
-      subject.enabled?.should == :true
-    end
-  end
-
   describe "when starting the service" do
     it "should call any explicit 'start' command" do
       resource[:start] = "/bin/false"
@@ -189,20 +147,18 @@ describe Puppet::Type.type(:service).provider(:launchd) do
     end
   end
 
-  describe "when enabling the service on OS X 10.6" do
+  describe "when enabling the service" do
     it "should write to the global launchd overrides file once" do
       resource[:enable] = true
-      provider.expects(:get_macosx_version_major).returns("10.6")
       provider.expects(:read_plist).returns({})
       Plist::Emit.expects(:save_plist).once
       subject.enable
     end
   end
 
-  describe "when disabling the service on OS X 10.6" do
+  describe "when disabling the service" do
     it "should write to the global launchd overrides file once" do
       resource[:enable] = false
-      provider.stubs(:get_macosx_version_major).returns("10.6")
       provider.stubs(:read_plist).returns({})
       Plist::Emit.expects(:save_plist).once
       subject.enable


### PR DESCRIPTION
This isn't on the removal list, but seems like it could be. I picked 10.6 somewhat arbitrarily. Comments?

If we decide to go for it, we can enter a ticket and I'll reference it here.
