### PR TITLE
(maint) Pin rubocop version to ~> 0.26.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group(:development, :test) do
   gem "multi_json", "1.7.7", :require => false, :platforms => [:ruby, :jruby]
   gem "json-schema", "2.1.1", :require => false, :platforms => [:ruby, :jruby]
 
-  gem "rubocop", :platforms => [:ruby] unless RUBY_VERSION =~ /^1.8/
+  gem "rubocop", "~> 0.26.1", :platforms => [:ruby] unless RUBY_VERSION =~ /^1.8/
 end
 
 group(:development) do


### PR DESCRIPTION
Commit 13f6d7c updated the rubocop configuration to use the Rubocop 0.26.1
metrics namespace; this commit updates the Gemfile to require that
version or greater.
