### PR TITLE
(PUP-3247) Remove trigger_string method

### DIFF
--- a/lib/puppet/util/windows/taskscheduler.rb
+++ b/lib/puppet/util/windows/taskscheduler.rb
@@ -555,27 +555,6 @@ module Win32
       count
     end
 
-    # Returns a string that describes the current trigger at the specified
-    # index for the active task.
-    #
-    # Example: "At 7:14 AM every day, starting 4/11/2009"
-    #
-    def trigger_string(index)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
-      raise TypeError unless index.is_a?(Numeric)
-
-      FFI::MemoryPointer.new(:pointer) do |ptr|
-        @pITask.GetTriggerString(index, ptr)
-
-        ptr.read_com_memory_pointer do |str_ptr|
-          trigger = str_ptr.read_arbitrary_wide_string_up_to(256)
-        end
-      end
-
-      trigger
-    end
-
     # Deletes the trigger at the specified index.
     #
     def delete_trigger(index)


### PR DESCRIPTION
Previously, our vendored task scheduler code defined a method that if
called would never work. This is because it would try to return the
`trigger` local variable, but it was never defined, and so would call
the `#trigger` method instead, and that requires one argument for the
index.

This commit just removes the method since it's never used in puppet.
