### PR TITLE
(PUP-2310) Treat a CRL as expired if it's past next_update

### DIFF
--- a/lib/puppet/ssl/certificate_revocation_list.rb
+++ b/lib/puppet/ssl/certificate_revocation_list.rb
@@ -57,6 +57,11 @@ DOC
     Puppet::SSL::CertificateRevocationList.indirection.save(self)
   end
 
+  def expiration
+    return nil unless @content
+    @content.next_update
+  end
+
 private
 
   def create_crl_issued_by(cert)

--- a/spec/unit/ssl/certificate_revocation_list_spec.rb
+++ b/spec/unit/ssl/certificate_revocation_list_spec.rb
@@ -118,6 +118,10 @@ describe Puppet::SSL::CertificateRevocationList do
       expects_time_close_to_five_years(nextUpdate)
     end
 
+    it "has an expiration corresponding to its next update time" do
+      @crl.generate(@cert, @key).next_update.should == @crl.expiration
+    end
+
     it "should verify using the CA public_key" do
       @crl.generate(@cert, @key).verify(@key.public_key).should be_true
     end


### PR DESCRIPTION
Without CertificateRevocationList#expiration defined,
Puppet::Indirector::Indirection#find_in_cache considers a cached CRL to
always be valid. This is a problem because the Puppet agent fails to
establish an SSL connection to the master when it tries to make use of
the expired CRL.

By treating a CRL as expired if it's past its next_update timestamp,
the Puppet agent will invalidate and refresh its CRL from the master
before proceeding with its run.
