### PR TITLE
(maint) Remove extra agent from the debian init script

### DIFF
--- a/ext/debian/puppet.init
+++ b/ext/debian/puppet.init
@@ -10,8 +10,8 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/bin/puppet
-DAEMON_OPTS="agent"
-NAME=agent
+DAEMON_OPTS=""
+NAME="agent"
 DESC="puppet agent"
 PIDFILE="/var/run/puppet/${NAME}.pid"
 


### PR DESCRIPTION
Previously when the debian puppet service was started, it would have
an extra agent in the name because we set both daemon_opts and name to
agent and pass both to the starting exec. This commit addresses that by
setting daemon_opts to be empty, it can be overridden in the defaults
file.
