### PR TITLE
(PUP-3558) Fix offset error of '[' lexing when multibyte chars are used

### DIFF
--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -329,7 +329,7 @@ class Puppet::Pops::Parser::Lexer2
       emit(TOKEN_COMMA, before)
 
     when '['
-      if (before == 0 || scn.string[before-1,1] =~ /[[:blank:]\r\n]+/)
+      if (before == 0 || scn.string[locator.char_offset(before)-1,1] =~ /[[:blank:]\r\n]+/)
         emit(TOKEN_LISTSTART, before)
       else
         emit(TOKEN_LBRACK, before)


### PR DESCRIPTION
If there were multibyte characters anywhere before a '[' and the '['
should have been lexed as a LBRACK the difference in byte position and
char position could result in looking at the wrong position for the
character preceding the '['. If that character (wrong position) was
a whitespace, the lexer would emit a LISTSTART token instead of LBRACK.

The correct way to translate byte offset to char offset is to
use the locator.char_offset(byte_offset) method (since the method varies
depending on Ruby version).

If jupiter aligned with mars the result could be a syntax error on the
'[' because a literal list was not accepted in that position, or worse,
an access expression (x[y]), could be broken apart into two expressions;
a value followed by a literal list. The latter could go unnoticed except
for not producing the wanted answer.

This commit changes the method to get the char offset to use the locator
instead of using the byte offset as a char index when looking at the
preceding character of a '['.
