### PR TITLE
(PUP-3589) Only treat 'ensure' specially if it is a property

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -76,9 +76,9 @@ class Puppet::Transaction::ResourceHarness
       cache(resource, param, context.current_values[param])
     end
 
-    ensure_param = resource.parameter(:ensure)
-    if ensure_param && ensure_param.should
-      ensure_event = sync_if_needed(ensure_param, context)
+    ensure_prop = resource.property(:ensure)
+    if ensure_prop && ensure_prop.should
+      ensure_event = sync_if_needed(ensure_prop, context)
     else
       ensure_event = NO_ACTION
     end

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1039,7 +1039,7 @@ class Type
     # Provide the name, so we know we'll always refer to a real thing
     result[:name] = self[:name] unless self[:name] == title
 
-    if ensure_prop = property(:ensure) or (self.class.validattr?(:ensure) and ensure_prop = newattr(:ensure))
+    if ensure_prop = property(:ensure) or (self.class.validattr?(:ensure) and ensure_prop = newattr(:ensure) and ensure_prop.is_a?(Puppet::Property))
       result[:ensure] = ensure_state = ensure_prop.retrieve
     else
       ensure_state = nil

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -159,6 +159,73 @@ describe Puppet::Transaction::ResourceHarness do
     stubProvider
   end
 
+  describe "when ensure is a parameter" do
+    before :each do
+      stub_type = Class.new(Puppet::Type)
+      stub_type.instance_eval do
+        initvars
+
+        newparam(:name) do
+          desc "Name"
+          isnamevar
+        end
+
+        newparam(:ensure) do
+          desc "ensure parameter"
+          newvalues :present, :absent
+          defaultto :present
+        end
+      end
+
+      @resource = stub_type.new(:name => "test")
+    end
+
+    it "does not try to call ensure#should" do
+      @resource.parameter(:ensure).expects(:should).never
+      @harness.evaluate(@resource)
+    end
+
+    it "does not try to call ensure#retrieve" do
+      @resource.parameter(:ensure).expects(:retrieve).never
+      @harness.evaluate(@resource)
+    end
+  end
+
+  describe "when ensure is a property" do
+    before :each do
+      stub_type = Class.new(Puppet::Type)
+      stub_type.instance_eval do
+        initvars
+
+        newparam(:name) do
+          desc "Name"
+          isnamevar
+        end
+
+        newproperty(:ensure) do
+          desc "ensure property"
+          newvalues :present, :absent
+          defaultto :present
+
+          def retrieve
+            :absent
+          end
+        end
+      end
+
+      @resource = stub_type.new(:name => "test")
+    end
+
+    it "calls ensure#should" do
+      @resource.property(:ensure).expects(:should).once
+      @harness.evaluate(@resource)
+    end
+
+    it "calls ensure#retrieve" do
+      @resource.property(:ensure).expects(:retrieve).once
+      @harness.evaluate(@resource)
+    end
+  end
 
   context "interaction of ensure with other properties" do
     def an_ensurable_resource_reacting_as(behaviors)


### PR DESCRIPTION
Without this patch, any 'ensure' parameter in a type is treated as if
it were a property that needs to be synced. Since "syncing" only makes
sense for a property (which is a special type of parameter), and not a
parameter in general, this causes Ruby to throw undefined method
exceptions if 'ensure' is not a property.

This patch only treats 'ensure' as syncable if it is a property,
allowing native types to use that name for a bare parameter. This is
particularly useful for custom types that exist only to generate
additional resources on the agent, without having any properties of
their own, but which pass on their parameter values to properties of
the generated resources.
