### PR TITLE
(trivial) Give notice about invalid modules

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -345,7 +345,6 @@ class Puppet::Node::Environment
       Dir.entries(path).each do |name|
         next if name == "." || name == ".."
         warn_about_mistaken_path(path, name)
-        next if module_references.include?(name)
         if not seen_modules[name]
           module_references << {:name => name, :path => File.join(path, name)}
           seen_modules[name] = true


### PR DESCRIPTION
Give notice when a module on the modulepath is invalid, explaining why.
To do this cleanly, we stop trying to add "." and ".." as modules since
these are always invalid.
