### PR TITLE
(PUP-3601) Adjust Facter dependency for Windows

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -19,7 +19,7 @@ build_msi:
     ref: '4eb71b5b063f611eb447d561d51481831a66b5dd'
     repo: 'git://github.com/puppetlabs/puppet_for_the_win.git'
   facter:
-    ref: 'refs/tags/2.2.0'
+    ref: 'refs/tags/2.3.0'
     repo: 'git://github.com/puppetlabs/facter.git'
   hiera:
     ref: 'refs/tags/1.3.4'


### PR DESCRIPTION
This moves the Facter dependency to 2.3.0 since it was just released and should
be released with the next version of the Puppet MSI that we ship (3.7.3).
