### PR TITLE
(PUP-3605) use correct usermod flag on OpenBSD for group management

### DIFF
--- a/lib/puppet/provider/user/openbsd.rb
+++ b/lib/puppet/provider/user/openbsd.rb
@@ -1,0 +1,61 @@
+require 'puppet/error'
+
+Puppet::Type.type(:user).provide :openbsd, :parent => :useradd do
+  desc "User management via `useradd` and its ilk for OpenBSD. Note that you
+    will need to install Ruby's shadow password library (package known as
+    `ruby-shadow`) if you wish to manage user passwords."
+
+  commands :add      => "useradd",
+           :delete   => "userdel",
+           :modify   => "usermod",
+           :password => "passwd"
+
+  defaultfor :operatingsystem => :openbsd
+
+  options :home, :flag => "-d", :method => :dir
+  options :comment, :method => :gecos
+  options :groups, :flag => "-G"
+  options :password, :method => :sp_pwdp
+  options :expiry, :method => :sp_expire,
+    :munge => proc { |value|
+      if value == :absent
+        ''
+      else
+        # OpenBSD uses a format like "january 1 1970"
+        Time.parse(value).strftime('%B %d %Y')
+      end
+    },
+    :unmunge => proc { |value|
+      if value == -1
+        :absent
+      else
+        # Expiry is days after 1970-01-01
+        (Date.new(1970,1,1) + value).strftime('%Y-%m-%d')
+      end
+    }
+
+  [:expiry, :password].each do |shadow_property|
+    define_method(shadow_property) do
+      if Puppet.features.libshadow?
+        if ent = Shadow::Passwd.getspnam(@resource.name)
+          method = self.class.option(shadow_property, :method)
+          return unmunge(shadow_property, ent.send(method))
+        end
+      end
+      :absent
+    end
+  end
+
+  has_features :manages_homedir, :manages_expiry, :system_users
+  has_features :manages_passwords if Puppet.features.libshadow?
+  has_features :manages_shell
+
+  def modifycmd(param, value)
+    cmd = super
+    if param == :groups
+      idx = cmd.index('-G')
+      cmd[idx] = '-S'
+    end
+    cmd
+  end
+end

--- a/spec/unit/provider/user/openbsd_spec.rb
+++ b/spec/unit/provider/user/openbsd_spec.rb
@@ -1,0 +1,44 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:user).provider(:openbsd) do
+
+  before :each do
+    described_class.stubs(:command).with(:password).returns '/usr/sbin/passwd'
+    described_class.stubs(:command).with(:add).returns '/usr/sbin/useradd'
+    described_class.stubs(:command).with(:modify).returns '/usr/sbin/usermod'
+    described_class.stubs(:command).with(:delete).returns '/usr/sbin/userdel'
+  end
+
+  let(:resource) do
+    Puppet::Type.type(:user).new(
+      :name       => 'myuser',
+      :managehome => :false,
+      :system     => :false,
+      :provider   => provider
+    )
+  end
+
+  let(:provider) { described_class.new(:name => 'myuser') }
+
+  describe "#expiry=" do
+    it "should pass expiry to usermod as MM/DD/YY" do
+      resource[:expiry] = '2014-11-05'
+      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', 'November 05 2014', 'myuser'])
+      provider.expiry = '2014-11-05'
+    end
+
+    it "should use -e with an empty string when the expiry property is removed" do
+      resource[:expiry] = :absent
+      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '', 'myuser'])
+      provider.expiry = :absent
+    end
+  end
+
+  describe "#addcmd" do
+    it "should return an array with the full command and expiry as MM/DD/YY" do
+      resource[:expiry] = "1997-06-01"
+      provider.addcmd.must == ['/usr/sbin/useradd', '-e', 'June 01 1997', 'myuser']
+    end
+  end
+end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -50,6 +50,13 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       provider.create
     end
 
+    it "should use -G to set groups" do
+      resource[:ensure] = :present
+      resource[:groups] = ['group1', 'group2']
+      provider.expects(:execute).with(['/usr/sbin/useradd', '-G', 'group1,group2', 'myuser'], kind_of(Hash))
+      provider.create
+    end
+
     it "should add -o when allowdupe is enabled and the user is being created" do
       resource[:allowdupe] = true
       provider.expects(:execute).with(includes('-o'), kind_of(Hash))


### PR DESCRIPTION
this allows 'membership => inclusive' to remove groups if needed as
'-G' only appends on OpenBSD and doesn't set.

The spec test is slightly unrelated in that it ensures the creation still uses `-G`, but currently there are no tests available for `objectadd.rb` (should be added, but it's out of scope for this PR).
