### PR TITLE
(PUP-3609) Always pass exec's user parameter to Execution.execute

### DIFF
--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -47,21 +47,12 @@ class Puppet::Provider::Exec < Puppet::Provider
           end
         end
 
-        if Puppet.features.microsoft_windows?
-          exec_user = resource[:user]
-        # Etc.getpwuid() returns nil on Windows
-        elsif resource.current_username == resource[:user]
-          exec_user = nil
-        else
-          exec_user = resource[:user]
-        end
-
         Timeout::timeout(resource[:timeout]) do
           # note that we are passing "false" for the "override_locale" parameter, which ensures that the user's
           # default/system locale will be respected.  Callers may override this behavior by setting locale-related
           # environment variables (LANG, LC_ALL, etc.) in their 'environment' configuration.
           output = Puppet::Util::Execution.execute(command, :failonfail => false, :combine => true,
-                                  :uid => exec_user, :gid => resource[:group],
+                                  :uid => resource[:user], :gid => resource[:group],
                                   :override_locale => false,
                                   :custom_environment => environment)
         end

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -115,8 +115,10 @@ module Puppet::Util::Execution
   # @param options [Hash] a Hash of options
   # @option options [Boolean]  :failonfail if this value is set to true, then this method will raise an error if the
   #   command is not executed successfully.
-  # @option options [Integer, String] :uid (nil) the user id of the user that the process should be run as
-  # @option options [Integer, String] :gid (nil) the group id of the group that the process should be run as
+  # @option options [Integer, String] :uid (nil) the user id of the user that the process should be run as. Will be ignored if the
+  #   user id matches the effective user id of the current process.
+  # @option options [Integer, String] :gid (nil) the group id of the group that the process should be run as. Will be ignored if the
+  #   group id matches the effective group id of the current process.
   # @option options [Boolean] :combine sets whether or not to combine stdout/stderr in the output
   # @option options [String] :stdinfile (nil) sets a file that can be used for stdin. Passing a string for stdin is not currently
   #   supported.

--- a/spec/unit/provider/exec/posix_spec.rb
+++ b/spec/unit/provider/exec/posix_spec.rb
@@ -90,16 +90,6 @@ describe Puppet::Type.type(:exec).provider(:posix), :if => Puppet.features.posix
       expect { provider.run("cd ..") }.to raise_error(ArgumentError, "Could not find command 'cd'")
     end
 
-    it "does not override the user when it is already the requested user" do
-      Etc.stubs(:getpwuid).returns(Struct::Passwd.new('testing'))
-      provider.resource[:user] = 'testing'
-      command = make_exe
-
-      Puppet::Util::Execution.expects(:execute).with(anything(), has_entry(:uid, nil)).returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
-
-      provider.run(command)
-    end
-
     it "should execute the command if the command given includes arguments or subcommands" do
       provider.resource[:path] = ['/bogus/bin']
       command = make_exe

--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -143,6 +143,7 @@ describe Puppet::Util::SUIDManager do
         xids[:egid].should == 42
         xids[:gid].should == 42
       end
+
       it "should not change_privilege when gid already matches" do
         Process::GID.expects(:change_privilege).with do |gid|
           Process.gid = 42


### PR DESCRIPTION
Previously, the base `exec` provider would check to see if the
resource's `user` parameter matched the current Process' effective uid.
If they matched, it would call `Puppet::Util::Execution.execute` with a
nil uid, since there's no point in switching uids.

However, it didn't handle the case when the resource's `group` parameter
matched the current Process' effective gid, nor when
`Puppet::Util::Execution.execute` is called from other places.

The previous behavior was added in PUP-2732 (commit 9c7cb196cb).
Since then PUP-3457 (commit 84ff1526e) was implemented so that
SUIDManager.change_XXX is a noop when the current effective uid matches
the desired uid, and same for gid.

This commit partially reverts commit 9c7cb196cb, so that we always call
`Puppet::Util::Execution.execute` with the `exec` resource's `user`
parameter. If it is the same as the current euid, then it will not be
changed (due to PUP-3457).

It preserves the behavior that puppet will raise an error if an `exec`
resource specifies a `user`, and puppet is running on Windows, or is not
running as root and the user doesn't match the current user name.
