### PR TITLE
(PUP-3618) Include pkgng provider for FreeBSD

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -1,0 +1,129 @@
+require 'puppet/provider/package'
+
+Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package do
+  desc "A PkgNG provider for FreeBSD and DragonFly."
+
+  commands :pkg => "/usr/local/sbin/pkg"
+
+  confine :operatingsystem => [:freebsd, :dragonfly]
+  confine :pkgng_enabled => :true
+
+  has_feature :versionable
+  has_feature :upgradeable
+
+  def self.get_query
+    pkg(['query', '-a', '%n %v %o'])
+  end
+
+  def self.get_version_list
+    pkg(['version', '-voRL='])
+  end
+
+  def self.get_latest_version(origin)
+    if latest_version = self.get_version_list.lines.find { |l| l =~ /^#{origin} / }
+      latest_version = latest_version.split(' ').last.split(')').first
+      return latest_version
+    end
+    nil
+  end
+
+  def self.instances
+    packages = []
+    begin
+      info = self.get_query
+
+      unless info
+        return packages
+      end
+
+      info.lines.each do |line|
+
+        name, version, origin = line.chomp.split(" ", 3)
+        latest_version  = get_latest_version(origin) || version
+
+        pkg = {
+          :ensure   => version,
+          :name     => name,
+          :provider => self.name,
+          :origin   => origin,
+          :version  => version,
+          :latest   => latest_version
+        }
+        packages << new(pkg)
+      end
+
+      return packages
+    rescue Puppet::ExecutionFailure
+      nil
+    end
+  end
+
+  def self.prefetch(resources)
+    packages = instances
+    resources.keys.each do |name|
+      if provider = packages.find{|p| p.name == name or p.origin == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def repo_tag_from_urn(urn)
+    # extract repo tag from URN: urn:freebsd:repo:<tag>
+    match = /^urn:freebsd:repo:(.+)$/.match(urn)
+    raise ArgumentError urn.inspect unless match
+    match[1]
+  end
+
+  def install
+    source = resource[:source]
+    source = URI(source) unless source.nil?
+
+    # Ensure we handle the version
+    case resource[:ensure]
+    when true, false, Symbol
+      installname = resource[:name]
+    else
+      installname = resource[:name] + '-' + resource[:ensure]
+    end
+
+    if not source # install using default repo logic
+      args = ['install', '-qy', installname]
+    elsif source.scheme == 'urn' # install from repo named in URN
+      tag = repo_tag_from_urn(source.to_s)
+      args = ['install', '-qy', '-r', tag, installname]
+    else # add package located at URL
+      args = ['add', '-q', source.to_s]
+    end
+
+    pkg(args)
+  end
+
+  def uninstall
+    pkg(['remove', '-qy', resource[:name]])
+  end
+
+  def query
+    if @property_hash[:ensure] == nil
+      return nil
+    else
+      version = @property_hash[:version]
+      return { :version => version }
+    end
+  end
+
+  def version
+    @property_hash[:version]
+  end
+
+  # Upgrade to the latest version
+  def update
+    install
+  end
+
+  # Return the latest version of the package
+  def latest
+    debug "returning the latest #{@property_hash[:name].inspect} version #{@property_hash[:latest].inspect}"
+    @property_hash[:latest]
+  end
+
+end

--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -6,7 +6,8 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
   commands :pkg => "/usr/local/sbin/pkg"
 
   confine :operatingsystem => [:freebsd, :dragonfly]
-  confine :pkgng_enabled => :true
+
+  defaultfor :operatingsystem => :freebsd
 
   has_feature :versionable
   has_feature :upgradeable

--- a/lib/puppet/provider/package/ports.rb
+++ b/lib/puppet/provider/package/ports.rb
@@ -8,7 +8,6 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
 
   defaultfor :operatingsystem => :freebsd
 
-  # I hate ports
   %w{INTERACTIVE UNAME}.each do |var|
     ENV.delete(var) if ENV.include?(var)
   end

--- a/lib/puppet/provider/package/ports.rb
+++ b/lib/puppet/provider/package/ports.rb
@@ -6,8 +6,6 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
     :portuninstall => "/usr/local/sbin/pkg_deinstall",
     :portinfo => "/usr/sbin/pkg_info"
 
-  defaultfor :operatingsystem => :freebsd
-
   %w{INTERACTIVE UNAME}.each do |var|
     ENV.delete(var) if ENV.include?(var)
   end

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.info
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.info
@@ -1,0 +1,8 @@
+ca_root_nss 3.15.3.1 security/ca_root_nss
+curl 7.33.0 ftp/curl
+gnupg 2.0.22 security/gnupg
+mcollective 2.2.4 sysutils/mcollective
+nmap 6.40 security/nmap
+pkg 1.2.4_1 ports-mgmt/pkg
+zsh 5.0.2_1 shells/zsh
+tac_plus F4.0.4.27a net/tac_plus4

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.query
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.query
@@ -1,0 +1,1 @@
+zsh-5.0.2                      The Z shell

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.query_absent
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.query_absent
@@ -1,0 +1,1 @@
+pkg: No package(s) matching bash

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.version
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.version
@@ -1,0 +1,3 @@
+shells/bash-completion             <   needs updating (index has 2.1_3)
+ftp/curl                           <   needs updating (index has 7.33.0_2)
+shells/zsh                         <   needs updating (index has 5.0.4)

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -163,4 +163,13 @@ describe provider_class do
       bash_comp_latest_version.should == "2.1_3"
     end
   end
+
+  describe "confine" do
+    context "on FreeBSD" do
+      it "should be the default provider" do
+        Facter.expects(:value).with(:operatingsystem).at_least_once.returns :freebsd
+        expect(provider_class).to be_default
+      end
+    end
+  end
 end

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -1,0 +1,166 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/provider/package/pkgng'
+
+provider_class = Puppet::Type.type(:package).provider(:pkgng)
+
+describe provider_class do
+  let(:name) { 'bash' }
+  let(:pkgng) { 'pkgng' }
+
+  let(:resource) do
+    # When bash is not present
+    Puppet::Type.type(:package).new(:name => name, :provider => pkgng)
+  end
+
+  let(:installed_resource) do
+    # When zsh is present
+    Puppet::Type.type(:package).new(:name => 'zsh', :provider => pkgng)
+  end
+
+  let(:latest_resource) do
+    # When curl is installed but not the latest
+    Puppet::Type.type(:package).new(:name => 'ftp/curl', :provider => pkgng, :ensure => latest)
+  end
+
+  let (:provider) { resource.provider }
+
+  def run_in_catalog(*resources)
+    catalog = Puppet::Resource::Catalog.new
+    catalog.host_config = false
+    resources.each do |resource|
+      #resource.expects(:err).never
+      catalog.add_resource(resource)
+    end
+    catalog.apply
+  end
+
+  before do
+    provider_class.stubs(:command).with(:pkg) { '/usr/local/sbin/pkg' }
+
+    info = File.read(my_fixture('pkg.info'))
+    provider_class.stubs(:get_query).returns(info)
+
+    version_list = File.read(my_fixture('pkg.version'))
+    provider_class.stubs(:get_version_list).returns(version_list)
+  end
+
+  context "#instances" do
+    it "should return the empty set if no packages are listed" do
+      provider_class.stubs(:get_query).returns('')
+      provider_class.stubs(:get_version_list).returns('')
+      provider_class.instances.should be_empty
+    end
+
+    it "should return all packages when invoked" do
+      provider_class.instances.map(&:name).sort.should ==
+        %w{ca_root_nss curl nmap pkg gnupg mcollective zsh tac_plus}.sort
+    end
+
+    it "should set latest to current version when no upgrade available" do
+      nmap = provider_class.instances.find {|i| i.properties[:origin] == 'security/nmap' }
+
+      nmap.properties[:version].should == nmap.properties[:latest]
+    end
+
+    describe "version" do
+      it "should retrieve the correct version of the current package" do
+        zsh = provider_class.instances.find {|i| i.properties[:origin] == 'shells/zsh' }
+        zsh.properties[:version].should == '5.0.2_1'
+      end
+    end
+  end
+
+  context "#install" do
+    it "should call pkg with the specified package version given an origin for package name" do
+      resource = Puppet::Type.type(:package).new(
+        :name     => 'ftp/curl',
+        :provider => :pkgng,
+        :ensure   => '7.33.1'
+      )
+      resource.provider.expects(:pkg) do |arg|
+        arg.should include('curl-7.33.1')
+      end
+      resource.provider.install
+    end
+
+    it "should call pkg with the specified package version" do
+      resource = Puppet::Type.type(:package).new(
+        :name     => 'curl',
+        :provider => :pkgng,
+        :ensure   => '7.33.1'
+      )
+      resource.provider.expects(:pkg) do |arg|
+        arg.should include('curl-7.33.1')
+      end
+      resource.provider.install
+    end
+
+    it "should call pkg with the specified package repo" do
+      resource = Puppet::Type.type(:package).new(
+        :name     => 'curl',
+        :provider => :pkgng,
+        :source   => 'urn:freebsd:repo:FreeBSD'
+      )
+      resource.provider.expects(:pkg) do |arg|
+        arg.should include('FreeBSD')
+      end
+      resource.provider.install
+    end
+  end
+
+  context "#query" do
+    # This is being commented out as I am not sure how to test the code when
+    # using prefetching.  I somehow need to pass a fake resources object into
+    # #prefetch so that it can build the @property_hash, but I am not sure how.
+    #
+    #it "should return the installed version if present" do
+    #  fixture = File.read('spec/fixtures/pkg.query')
+    #  provider_class.stub(:get_resource_info) { fixture }
+    #  resource[:name] = 'zsh'
+    #  expect(provider.query).to eq({:version=>'5.0.2'})
+    #end
+
+    it "should return nil if not present" do
+      fixture = File.read(my_fixture('pkg.query_absent'))
+      provider_class.stubs(:get_resource_info).with('bash').returns(fixture)
+      expect(provider.query).to equal(nil)
+    end
+  end
+
+  describe "latest" do
+    it "should retrieve the correct version of the latest package" do
+      provider.latest.should_not nil
+    end
+
+    it "should set latest to newer package version when available" do
+      instances = provider_class.instances
+      curl = instances.find {|i| i.properties[:origin] == 'ftp/curl' }
+      curl.properties[:latest].should == "7.33.0_2"
+    end
+
+    it "should call update to upgrade the version" do
+      resource = Puppet::Type.type(:package).new(
+        :name     => 'ftp/curl',
+        :provider => pkgng,
+        :ensure   => :latest
+      )
+
+      resource.provider.expects(:update)
+
+      resource.property(:ensure).sync
+    end
+  end
+
+  describe "get_latest_version" do
+    it "should rereturn nil when the current package is the latest" do
+      nmap_latest_version = provider_class.get_latest_version('security/nmap')
+      nmap_latest_version.should be_nil
+    end
+
+    it "should match the package name exactly" do
+      bash_comp_latest_version = provider_class.get_latest_version('shells/bash-completion')
+      bash_comp_latest_version.should == "2.1_3"
+    end
+  end
+end


### PR DESCRIPTION
To improve the default state of Puppet on FreeBSD systems, this work
moves the pkgng provider into core.  Previously, users of the provider
would need to install from the forge module zleslie/pkgng.