### PR TITLE
(PUP-3275) Remove deprecated `from_pson` method

### DIFF
--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -139,9 +139,4 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
     new(data.delete('path'), data)
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
 end

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -26,11 +26,6 @@ class Puppet::Node
     node
   end
 
-  def self.from_pson(pson)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(pson)
-  end
-
   def to_data_hash
     result = {
       'name' => name,

--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -75,11 +75,6 @@ class Puppet::Node::Facts
     new_facts
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
   def to_data_hash
     result = {
       'name' => name,

--- a/lib/puppet/relationship.rb
+++ b/lib/puppet/relationship.rb
@@ -28,11 +28,6 @@ class Puppet::Relationship
     new(source, target, args)
   end
 
-  def self.from_pson(pson)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(pson)
-  end
-
   def event=(event)
     raise ArgumentError, "You must pass a callback for non-NONE events" if event != :NONE and ! callback
     @event = event

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -42,11 +42,6 @@ class Puppet::Resource
     resource
   end
 
-  def self.from_pson(pson)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(pson)
-  end
-
   def inspect
     "#{@type}[#{@title}]#{to_hash.inspect}"
   end

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -368,11 +368,6 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     result
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
   def to_data_hash
     {
       'tags'      => tags,

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -96,11 +96,6 @@ module Puppet
         obj
       end
 
-      def self.from_pson(data)
-        Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-        self.from_data_hash(data)
-      end
-
       # Provide a boolean method for each of the states.
       STATES.each do |attr|
         define_method("#{attr}?") do

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -67,11 +67,6 @@ class Puppet::Resource::Type
     new(type, name, data)
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
   def to_data_hash
     data = [:doc, :line, :file, :parent].inject({}) do |hash, param|
       next hash unless (value = self.send(param)) and (value != "")

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -126,11 +126,6 @@ DOC
     instance
   end
 
-  def self.from_pson(pson)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(pson)
-  end
-
   # Puppet::SSL::Host is actually indirected now so the original implementation
   # has been moved into the certificate_status indirector.  This method does not
   # appear to be in use in `puppet cert -l`.

--- a/lib/puppet/status.rb
+++ b/lib/puppet/status.rb
@@ -22,11 +22,6 @@ class Puppet::Status
     end
   end
 
-  def self.from_pson(pson)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(pson)
-  end
-
   def name
     "status"
   end

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -25,11 +25,6 @@ class Puppet::Transaction::Event
     obj
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
   def initialize(options = {})
     @audited = false
 

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -103,11 +103,6 @@ class Puppet::Transaction::Report
     obj
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
   def as_logging_destination(&block)
     Puppet::Util::Log.with_destination(self, &block)
   end

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -239,11 +239,6 @@ class Puppet::Util::Log
     obj
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
   attr_accessor :time, :remote, :file, :line, :source
   attr_reader :level, :message
 

--- a/lib/puppet/util/metric.rb
+++ b/lib/puppet/util/metric.rb
@@ -15,11 +15,6 @@ class Puppet::Util::Metric
     metric
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
   def to_data_hash
     {
       'name' => @name,

--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -16,11 +16,6 @@ class Puppet::Util::TagSet < Set
     self.new(data)
   end
 
-  def self.from_pson(data)
-    Puppet.deprecation_warning("from_pson is being removed in favour of from_data_hash.")
-    self.from_data_hash(data)
-  end
-
   def to_data_hash
     to_a
   end


### PR DESCRIPTION
This commit removes the misnamed and deprecated `from_pson` method.
It is replaced by the `from_data_hash` method.

This commit is part of the Puppet 4 code removal effort.
