### PR TITLE
(maint) PUP-3057 fix sol10 acceptance for sol11

### DIFF
--- a/acceptance/tests/resource/zpool/basic_tests.rb
+++ b/acceptance/tests/resource/zpool/basic_tests.rb
@@ -1,6 +1,5 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
-skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
@@ -14,6 +13,7 @@ end
 
 
 agents.each do |agent|
+  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zpool/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zpool/should_be_idempotent.rb
@@ -1,6 +1,5 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
-skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
@@ -14,6 +13,7 @@ end
 
 
 agents.each do |agent|
+  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zpool/should_create.rb
+++ b/acceptance/tests/resource/zpool/should_create.rb
@@ -1,6 +1,5 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
-skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
@@ -14,6 +13,7 @@ end
 
 
 agents.each do |agent|
+  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zpool/should_query.rb
+++ b/acceptance/tests/resource/zpool/should_query.rb
@@ -1,6 +1,5 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
-skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
@@ -14,6 +13,7 @@ end
 
 
 agents.each do |agent|
+  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zpool/should_remove.rb
+++ b/acceptance/tests/resource/zpool/should_remove.rb
@@ -1,6 +1,5 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
-skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
@@ -14,6 +13,7 @@ end
 
 
 agents.each do |agent|
+  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------


### PR DESCRIPTION
move skip_test to inside of agents loop so the tests will run on solaris
setups with multiple agents. Previous changes to ensure acceptance would
run on solaris10 broke solaris11 acceptance for some tests.
