### PR TITLE
(PUP-3615) Remove string to number auto convert for compare and equals

### DIFF
--- a/lib/puppet/pops/evaluator/compare_operator.rb
+++ b/lib/puppet/pops/evaluator/compare_operator.rb
@@ -39,47 +39,27 @@ class Puppet::Pops::Evaluator::CompareOperator
   protected
 
   def cmp_String(a, b)
-    # if both are numerics in string form, compare as number
-    n1 = Puppet::Pops::Utils.to_n(a)
-    n2 = Puppet::Pops::Utils.to_n(b)
-
-    # Numeric is always lexically smaller than a string, even if the string is empty.
-    return n1 <=> n2    if n1 && n2
-    return -1           if n1 && b.is_a?(String)
-    return 1            if n2
     return a.casecmp(b) if b.is_a?(String)
-
-    raise ArgumentError.new("A String is not comparable to a non String or Number")
+    raise ArgumentError.new("A String is not comparable to a non String")
   end
 
   # Equality is case independent.
   def equals_String(a, b)
-    if n1 = Puppet::Pops::Utils.to_n(a)
-      if n2 = Puppet::Pops::Utils.to_n(b)
-        n1 == n2
-      else
-        false
-      end
-    else
-      return false unless b.is_a?(String)
-      a.casecmp(b) == 0
-    end
+    return false unless b.is_a?(String)
+    a.casecmp(b) == 0
   end
 
   def cmp_Numeric(a, b)
-    if n2 = Puppet::Pops::Utils.to_n(b)
-      a <=> n2
-    elsif b.kind_of?(String)
-      # Numeric is always lexiographically smaller than a string, even if the string is empty.
-      -1
+    if b.is_a?(Numeric)
+      a <=> b
     else
-      raise ArgumentError.new("A Numeric is not comparable to non Numeric or String")
+      raise ArgumentError.new("A Numeric is not comparable to non Numeric")
     end
   end
 
   def equals_Numeric(a, b)
-    if n2 = Puppet::Pops::Utils.to_n(b)
-      a == n2
+    if b.is_a?(Numeric)
+      a == b
     else
       false
     end

--- a/spec/unit/pops/evaluator/comparison_ops_spec.rb
+++ b/spec/unit/pops/evaluator/comparison_ops_spec.rb
@@ -71,15 +71,21 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     context "of mixed value types" do
       it "1 == 1.0  == true"   do; evaluate(literal(1)     == literal(1.0)).should == true   ; end
       it "1 < 1.1   == true"   do; evaluate(literal(1)     <  literal(1.1)).should == true   ; end
-      it "'1' < 1.1 == true"   do; evaluate(literal('1')   <  literal(1.1)).should == true   ; end
       it "1.0 == 1  == true"   do; evaluate(literal(1.0)   == literal(1)).should == true     ; end
       it "1.0 < 2   == true"   do; evaluate(literal(1.0)   <  literal(2)).should == true     ; end
-      it "'1.0' < 1.1 == true" do; evaluate(literal('1.0') <  literal(1.1)).should == true   ; end
-
       it "'1.0' < 'a' == true" do; evaluate(literal('1.0') <  literal('a')).should == true   ; end
-      it "'1.0' < ''  == true" do; evaluate(literal('1.0') <  literal('')).should == true    ; end
-      it "'1.0' < ' ' == true" do; evaluate(literal('1.0') <  literal(' ')).should == true   ; end
+      it "'1.0' < ''  == true" do; evaluate(literal('1.0') <  literal('')).should == false   ; end
+      it "'1.0' < ' ' == true" do; evaluate(literal('1.0') <  literal(' ')).should == false   ; end
       it "'a' > '1.0' == true" do; evaluate(literal('a')   >  literal('1.0')).should == true ; end
+    end
+
+    context "of unsupported mixed value types" do
+      it "'1' < 1.1 == true"   do
+        expect{ evaluate(literal('1') <  literal(1.1))}.to raise_error(/String < Float/)
+      end
+      it "'1.0' < 1.1 == true" do
+        expect{evaluate(literal('1.0') <  literal(1.1))}.to raise_error(/String < Float/)
+      end
     end
 
     context "of regular expressions" do
@@ -235,9 +241,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       evaluate(literal(15).in(literal([1,0xf,2]))).should == true
     end
 
-    it "should find numbers as strings" do
-      evaluate(literal(15).in(literal([1, '0xf',2]))).should == true
-      evaluate(literal('15').in(literal([1, 0xf,2]))).should == true
+    it "should not find numbers as strings" do
+      evaluate(literal(15).in(literal([1, '0xf',2]))).should == false
+      evaluate(literal('15').in(literal([1, 0xf,2]))).should == false
     end
 
     it "should not find numbers embedded in strings, nor digits in numbers" do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -190,14 +190,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "2 >= 1"         => true,
       "1 == 1.0 "      => true,
       "1 < 1.1  "      => true,
-      "'1' < 1.1"      => true,
       "1.0 == 1 "      => true,
       "1.0 < 2  "      => true,
-      "1.0 < 'a'"      => true,
-      "'1.0' < 1.1"    => true,
       "'1.0' < 'a'"    => true,
-      "'1.0' < '' "    => true,
-      "'1.0' < ' '"    => true,
+      "'1.0' < '' "    => false,
+      "'1.0' < ' '"    => false,
       "'a' > '1.0'"    => true,
       "/.*/ == /.*/ "  => true,
       "/.*/ != /a.*/"  => true,
@@ -209,6 +206,21 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
           parser.evaluate_string(scope, source, __FILE__).should == result
         end
       end
+
+   {
+     "a > 1" => /String > Integer/,
+     "a >= 1" => /String >= Integer/,
+     "a < 1" => /String < Integer/,
+     "a <= 1" => /String <= Integer/,
+     "1 > a" => /Integer > String/,
+     "1 >= a" => /Integer >= String/,
+     "1 < a" => /Integer < String/,
+     "1 <= a" => /Integer <= String/,
+   }.each do | source, error|
+     it "should not allow comparison of String and Number '#{source}'" do
+       expect { parser.evaluate_string(scope, source, __FILE__)}.to raise_error(error)
+     end
+   end
 
    {
       "'a' =~ /.*/"                     => true,
@@ -271,8 +283,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "/xxx/ in {'aaaxxxbbb'=>1}"     => true,
       "/yyy/ in {'aaaxxxbbb'=>1}"     => false,
       "15 in [1, 0xf]"                => true,
-      "15 in [1, '0xf']"              => true,
-      "'15' in [1, 0xf]"              => true,
+      "15 in [1, '0xf']"              => false,
+      "'15' in [1, 0xf]"              => false,
       "15 in [1, 115]"                => false,
       "1 in [11, '111']"              => false,
       "'1' in [11, '111']"            => false,


### PR DESCRIPTION
This removes the problematic auto convert from String to Number for
comparisson operations.
