### PR TITLE
(PUP-3293) Remove deprecated and unused pson and rubygems features

### DIFF
--- a/lib/puppet/feature/pson.rb
+++ b/lib/puppet/feature/pson.rb
@@ -1,4 +1,0 @@
-Puppet.features.add(:pson) do
-  Puppet.deprecation_warning "There is no need to check for pson support. It is always available."
-  true
-end

--- a/lib/puppet/feature/rubygems.rb
+++ b/lib/puppet/feature/rubygems.rb
@@ -1,7 +1,0 @@
-require 'puppet/util/feature'
-
-Puppet.features.add(:rubygems) do
-  Puppet.deprecation_warning "Puppet.features.rubygems? is deprecated. Require rubygems in your application's entry point if you need it."
-
-  require 'rubygems'
-end


### PR DESCRIPTION
This commit removes the deprecated `features.pson?` and `features.rubygems?`
features.
