### PR TITLE
(PUP-3312) Remove deprecated methods from the Puppet module

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -109,13 +109,6 @@ module Puppet
   # Load all of the settings.
   require 'puppet/defaults'
 
-  # Parse the config file for this process.
-  # @deprecated Use {initialize_settings}
-  def self.parse_config()
-    Puppet.deprecation_warning("Puppet.parse_config is deprecated; please use Faces API (which will handle settings and state management for you), or (less desirable) call Puppet.initialize_settings")
-    Puppet.initialize_settings
-  end
-
   # Initialize puppet's settings. This is intended only for use by external tools that are not
   #  built off of the Faces API or the Puppet::Util::Application class. It may also be used
   #  to initialize state so that a Face may be used programatically, rather than as a stand-alone
@@ -126,14 +119,6 @@ module Puppet
   # @return [void]
   def self.initialize_settings(args = [])
     do_initialize_settings_for_run_mode(:user, args)
-  end
-
-  # Initialize puppet's settings for a specified run_mode.
-  #
-  # @deprecated Use {initialize_settings}
-  def self.initialize_settings_for_run_mode(run_mode)
-    Puppet.deprecation_warning("initialize_settings_for_run_mode may be removed in a future release, as may run_mode itself")
-    do_initialize_settings_for_run_mode(run_mode, [])
   end
 
   # private helper method to provide the implementation details of initializing for a run mode,


### PR DESCRIPTION
This commit removes the `parse_config` and
`initialize_settings_for_run_mode` class methods from the Puppet
module. This commit is part of the code removal effort for Puppet 4.
