### PR TITLE
(maint) fix production-created acceptnace for passenger systems

### DIFF
--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -4,31 +4,34 @@ testdir = create_tmpdir_for_user master, 'prod-env-created'
 
 step 'make environmentpath'
 master_user = on(master, puppet("master --configprint user")).stdout.strip
+cert_path   = on(master, puppet('config', 'print', 'hostcert')).stdout.strip
+key_path    = on(master, puppet('config', 'print', 'hostprivkey')).stdout.strip
+cacert_path = on(master, puppet('config', 'print', 'localcacert')).stdout.strip
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
   owner => #{master_user},
   group => #{master['group']},
-  mode => '0770',
+  mode => '0640',
 }
 
 file {
   "#{testdir}":;
-  "#{testdir}/environments":
-    ensure => directory,
-    mode => '0640',
-  ;
+  "#{testdir}/environments":;
 }
 MANIFEST
 
 master_opts = {
-  'master' => {
+  'main' => {
     'environmentpath' => "#{testdir}/environments",
   }
 }
 
 step 'run master; ensure production environment created'
 with_puppet_running_on(master, master_opts, testdir) do
+  if master.is_using_passenger?
+    on(master, "curl -k --cert #{cert_path} --key #{key_path} --cacert #{cacert_path} https://localhost:8140/v2.0/environments")
+  end
   on(master, "test -d '#{testdir}/environments/production'")
 
   step 'ensure catalog returned from production env with no changes'
@@ -36,7 +39,6 @@ with_puppet_running_on(master, master_opts, testdir) do
     on(agent, puppet("agent -t --server #{master} --environment production --detailed-exitcodes")) do
       # detailed-exitcodes produces a 0 when no changes are made.
       assert_equal(0, exit_code)
-      assert_match(/Applied catalog/, stdout)
     end
   end
 end


### PR DESCRIPTION
Passenger doesn't start up a master process until it's required.
Issue a curl to an endpoint to force passenger to startup the master
before testing if the production directory has been created.
