### PR TITLE
FOR REVIEW: (PUP-3642) Remove environment name from URL path

### DIFF
--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -109,7 +109,7 @@ class Puppet::Indirector::Request
   # Create the query string, if options are present.
   def query_string
     return "" if options.nil? || options.empty?
-    "?" + encode_params(expand_into_parameters(options.to_a))
+    encode_params(expand_into_parameters(options.to_a))
   end
 
   def expand_into_parameters(data)

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -120,7 +120,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
 
   def head(request)
     response = do_request(request) do |request|
-      http_head(request, Puppet::Network::HTTP::API::V1.indirection2uri(request), headers)
+      http_head(request, Puppet::Network::HTTP::API::V1.request_to_uri_with_env(request), headers)
     end
 
     if is_http_200?(response)
@@ -132,7 +132,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
 
   def search(request)
     response = do_request(request) do |request|
-      http_get(request, Puppet::Network::HTTP::API::V1.indirection2uri(request), headers)
+      http_get(request, Puppet::Network::HTTP::API::V1.request_to_uri_with_env(request), headers)
     end
 
     if is_http_200?(response)
@@ -147,7 +147,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     raise ArgumentError, "DELETE does not accept options" unless request.options.empty?
 
     response = do_request(request) do |request|
-      http_delete(request, Puppet::Network::HTTP::API::V1.indirection2uri(request), headers)
+      http_delete(request, Puppet::Network::HTTP::API::V1.request_to_uri_with_env(request), headers)
     end
 
     if is_http_200?(response)

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -262,12 +262,6 @@ describe Puppet::Indirector::Request do
       request.query_string.should == ""
     end
 
-    it "should prefix the query string with '?'" do
-      request = a_request_with_options(:one => "two")
-
-      request.query_string.should =~ /^\?/
-    end
-
     it "should include all options in the query string, separated by '&'" do
       request = a_request_with_options(:one => "two", :three => "four")
 

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -239,7 +239,7 @@ describe Puppet::Indirector::REST do
         request = find_request('whoa', params)
 
         connection.expects(:post).with do |uri, body|
-          body.split("&").sort == params.map {|key,value| "#{key}=#{value}"}.sort
+          body.split("&").sort == params.merge({:environment => "production"}).map {|key,value| "#{key}=#{value}"}.sort
         end.returns(mock_response(200, 'body'))
 
         terminus.find(request)
@@ -250,7 +250,7 @@ describe Puppet::Indirector::REST do
       it "calls get on the connection" do
         request = find_request('foo bar')
 
-        connection.expects(:get).with('/production/test_model/foo%20bar?', anything).returns(mock_response('200', 'response body'))
+        connection.expects(:get).with('/test_model/foo%20bar?environment=production&', anything).returns(mock_response('200', 'response body'))
 
         terminus.find(request).should == model.new('foo bar', 'response body')
       end
@@ -281,7 +281,7 @@ describe Puppet::Indirector::REST do
           terminus.find(request)
         end.to raise_error(
           Puppet::Error,
-          'Find /production/test_model/foo?fail_on_404=true resulted in 404 with the message: this is the notfound you are looking for')
+          'Find /test_model/foo?environment=production&fail_on_404=true resulted in 404 with the message: this is the notfound you are looking for')
       end
 
       it 'truncates the URI when it is very long' do
@@ -293,7 +293,7 @@ describe Puppet::Indirector::REST do
           terminus.find(request)
         end.to raise_error(
           Puppet::Error,
-          /\/production\/test_model\/foo.*long_param=A+\.\.\..*resulted in 404 with the message/)
+          /\/test_model\/foo.*\?environment=production&.*long_param=A+\.\.\..*resulted in 404 with the message/)
       end
 
       it 'does not truncate the URI when logging debug information' do
@@ -306,7 +306,7 @@ describe Puppet::Indirector::REST do
           terminus.find(request)
         end.to raise_error(
           Puppet::Error,
-          /\/production\/test_model\/foo.*long_param=A+B.*resulted in 404 with the message/)
+          /\/test_model\/foo.*\?environment=production&.*long_param=A+B.*resulted in 404 with the message/)
       end
     end
 
@@ -407,7 +407,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a deserializing terminus method', :search
 
     it "should call the GET http method on a network connection" do
-      connection.expects(:get).with('/production/test_models/foo', has_key('Accept')).returns mock_response(200, 'data3, data4')
+      connection.expects(:get).with('/test_models/foo?environment=production&', has_key('Accept')).returns mock_response(200, 'data3, data4')
 
       terminus.search(request)
     end
@@ -452,7 +452,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a deserializing terminus method', :destroy
 
     it "should call the DELETE http method on a network connection" do
-      connection.expects(:delete).with('/production/test_model/foo', has_key('Accept')).returns(response)
+      connection.expects(:delete).with('/test_model/foo?environment=production&', has_key('Accept')).returns(response)
 
       terminus.destroy(request)
     end
@@ -499,7 +499,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a REST terminus method', :save
 
     it "should call the PUT http method on a network connection" do
-      connection.expects(:put).with('/production/test_model/the%20thing', anything, has_key("Content-Type")).returns response
+       connection.expects(:put).with('/test_model/the%20thing?', anything, has_key("Content-Type")).returns response
 
       terminus.save(request)
     end

--- a/spec/unit/network/http/api/v1_spec.rb
+++ b/spec/unit/network/http/api/v1_spec.rb
@@ -13,6 +13,7 @@ describe Puppet::Network::HTTP::API::V1 do
   let(:indirection) { Puppet::IndirectorTesting.indirection }
   let(:handler) { Puppet::Network::HTTP::API::V1.new }
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+  let(:params) { { :environment => "production" } }
 
   def a_request_that_heads(data, request = {})
     Puppet::Network::HTTP::Request.from_hash({
@@ -20,8 +21,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "HEAD",
-      :path => "/production/#{indirection.name}/#{data.value}",
-      :params => {},
+      :path => "/#{indirection.name}/#{data.value}",
+      :params => params,
     })
   end
 
@@ -31,8 +32,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => request[:content_type_header] || "text/pson", },
       :method => "PUT",
-      :path => "/production/#{indirection.name}/#{data.value}",
-      :params => {},
+      :path => "/#{indirection.name}/#{data.value}",
+      :params => params,
       :body => request[:body].nil? ? data.render("pson") : request[:body]
     })
   end
@@ -43,8 +44,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "DELETE",
-      :path => "/production/#{indirection.name}/#{data.value}",
-      :params => {},
+      :path => "/#{indirection.name}/#{data.value}",
+      :params => params,
       :body => ''
     })
   end
@@ -55,8 +56,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "GET",
-      :path => "/production/#{indirection.name}/#{data.value}",
-      :params => {},
+      :path => "/#{indirection.name}/#{data.value}",
+      :params => params,
       :body => ''
     })
   end
@@ -67,8 +68,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "GET",
-      :path => "/production/#{indirection.name}s/#{key}",
-      :params => {},
+      :path => "/#{indirection.name}s/#{key}",
+      :params => params,
       :body => ''
     })
   end
@@ -82,6 +83,7 @@ describe Puppet::Network::HTTP::API::V1 do
   end
 
   describe "when converting a URI into a request" do
+    let(:params) { { :environment => "env" } }
     before do
       handler.stubs(:handler).returns "foo"
     end
@@ -91,98 +93,93 @@ describe Puppet::Network::HTTP::API::V1 do
       lambda { handler.uri2indirection("/foo") }.should raise_error(ArgumentError)
     end
 
-    it "should use the first field of the URI as the environment" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[3][:environment].to_s.should == "env"
+    it "should get the environment from a query parameter" do
+      handler.uri2indirection("GET", "/foo/bar", params)[3][:environment].to_s.should == "env"
     end
 
     it "should fail if the environment is not alphanumeric" do
-      lambda { handler.uri2indirection("GET", "/env ness/foo/bar", {}) }.should raise_error(ArgumentError)
-    end
-
-    it "should use the environment from the URI even if one is specified in the parameters" do
-      handler.uri2indirection("GET", "/env/foo/bar", {:environment => "otherenv"})[3][:environment].to_s.should == "env"
+      lambda { handler.uri2indirection("GET", "/foo/bar", {:environment => "env ness"}) }.should raise_error(ArgumentError)
     end
 
     it "should not pass a buck_path parameter through (See Bugs #13553, #13518, #13511)" do
-      handler.uri2indirection("GET", "/env/foo/bar", { :bucket_path => "/malicious/path" })[3].should_not include({ :bucket_path => "/malicious/path" })
+      handler.uri2indirection("GET", "/foo/bar", { :environment => "env", :bucket_path => "/malicious/path" })[3].should_not include({ :bucket_path => "/malicious/path" })
     end
 
     it "should pass allowed parameters through" do
-      handler.uri2indirection("GET", "/env/foo/bar", { :allowed_param => "value" })[3].should include({ :allowed_param => "value" })
+      handler.uri2indirection("GET", "/foo/bar", { :environment => "env", :allowed_param => "value" })[3].should include({ :allowed_param => "value" })
     end
 
     it "should return the environment as a Puppet::Node::Environment" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[3][:environment].should be_a(Puppet::Node::Environment)
-    end
-
-    it "should not pass a buck_path parameter through (See Bugs #13553, #13518, #13511)" do
-      handler.uri2indirection("GET", "/env/foo/bar", { :bucket_path => "/malicious/path" })[3].should_not include({ :bucket_path => "/malicious/path" })
+      handler.uri2indirection("GET", "/foo/bar", params)[3][:environment].should be_a(Puppet::Node::Environment)
     end
 
     it "should pass allowed parameters through" do
-      handler.uri2indirection("GET", "/env/foo/bar", { :allowed_param => "value" })[3].should include({ :allowed_param => "value" })
+      handler.uri2indirection("GET", "/foo/bar", { :environment => "env", :allowed_param => "value" })[3].should include({ :allowed_param => "value" })
     end
 
-    it "should use the second field of the URI as the indirection name" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[0].should == "foo"
+    it "should use the first field of the URI as the indirection name" do
+      handler.uri2indirection("GET", "/foo/bar", params)[0].should == "foo"
     end
 
     it "should fail if the indirection name is not alphanumeric" do
-      lambda { handler.uri2indirection("GET", "/env/foo ness/bar", {}) }.should raise_error(ArgumentError)
+      lambda { handler.uri2indirection("GET", "/foo ness/bar", params) }.should raise_error(ArgumentError)
     end
 
     it "should use the remainder of the URI as the indirection key" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[2].should == "bar"
+      handler.uri2indirection("GET", "/foo/bar", params)[2].should == "bar"
     end
 
     it "should support the indirection key being a /-separated file path" do
-      handler.uri2indirection("GET", "/env/foo/bee/baz/bomb", {})[2].should == "bee/baz/bomb"
+      handler.uri2indirection("GET", "/foo/bee/baz/bomb", params)[2].should == "bee/baz/bomb"
     end
 
     it "should fail if no indirection key is specified" do
-      lambda { handler.uri2indirection("GET", "/env/foo/", {}) }.should raise_error(ArgumentError)
-      lambda { handler.uri2indirection("GET", "/env/foo", {}) }.should raise_error(ArgumentError)
+      lambda { handler.uri2indirection("GET", "/foo/", params) }.should raise_error(ArgumentError)
+    end
+
+    it "should fail if no indirection key is specified" do
+      lambda { handler.uri2indirection("GET", "/foo", params) }.should raise_error(ArgumentError)
     end
 
     it "should choose 'find' as the indirection method if the http method is a GET and the indirection name is singular" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[1].should == :find
+      handler.uri2indirection("GET", "/foo/bar", params)[1].should == :find
     end
 
     it "should choose 'find' as the indirection method if the http method is a POST and the indirection name is singular" do
-      handler.uri2indirection("POST", "/env/foo/bar", {})[1].should == :find
+      handler.uri2indirection("POST", "/foo/bar", params)[1].should == :find
     end
 
     it "should choose 'head' as the indirection method if the http method is a HEAD and the indirection name is singular" do
-      handler.uri2indirection("HEAD", "/env/foo/bar", {})[1].should == :head
+      handler.uri2indirection("HEAD", "/foo/bar", params)[1].should == :head
     end
 
     it "should choose 'search' as the indirection method if the http method is a GET and the indirection name is plural" do
-      handler.uri2indirection("GET", "/env/foos/bar", {})[1].should == :search
+      handler.uri2indirection("GET", "/foos/bar", params)[1].should == :search
     end
 
     it "should change indirection name to 'status' if the http method is a GET and the indirection name is statuses" do
-      handler.uri2indirection("GET", "/env/statuses/bar", {})[0].should == 'status'
+      handler.uri2indirection("GET", "/statuses/bar", params)[0].should == 'status'
     end
 
     it "should change indirection name to 'probe' if the http method is a GET and the indirection name is probes" do
-      handler.uri2indirection("GET", "/env/probes/bar", {})[0].should == 'probe'
+      handler.uri2indirection("GET", "/probes/bar", params)[0].should == 'probe'
     end
 
     it "should choose 'delete' as the indirection method if the http method is a DELETE and the indirection name is singular" do
-      handler.uri2indirection("DELETE", "/env/foo/bar", {})[1].should == :destroy
+      handler.uri2indirection("DELETE", "/foo/bar", params)[1].should == :destroy
     end
 
     it "should choose 'save' as the indirection method if the http method is a PUT and the indirection name is singular" do
-      handler.uri2indirection("PUT", "/env/foo/bar", {})[1].should == :save
+      handler.uri2indirection("PUT", "/foo/bar", params)[1].should == :save
     end
 
     it "should fail if an indirection method cannot be picked" do
-      lambda { handler.uri2indirection("UPDATE", "/env/foo/bar", {}) }.should raise_error(ArgumentError)
+      lambda { handler.uri2indirection("UPDATE", "/foo/bar", params) }.should raise_error(ArgumentError)
     end
 
     it "should URI unescape the indirection key" do
       escaped = URI.escape("foo bar")
-      indirection_name, method, key, params = handler.uri2indirection("GET", "/env/foo/#{escaped}", {})
+      indirection_name, method, key, final_params = handler.uri2indirection("GET", "/foo/#{escaped}", params)
       key.should == "foo bar"
     end
   end
@@ -190,48 +187,57 @@ describe Puppet::Network::HTTP::API::V1 do
   describe "when converting a request into a URI" do
     let(:request) { Puppet::Indirector::Request.new(:foo, :find, "with spaces", nil, :foo => :bar, :environment => "myenv") }
 
-    it "should use the environment as the first field of the URI" do
-      handler.class.indirection2uri(request).split("/")[1].should == "myenv"
-    end
-
-    it "should use the indirection as the second field of the URI" do
-      handler.class.indirection2uri(request).split("/")[2].should == "foo"
+    it "should include the environment in the query string of the URI" do
+      handler.class.request_to_uri_with_env(request).should == "/foo/with%20spaces?environment=myenv&foo=bar"
     end
 
     it "should pluralize the indirection name if the method is 'search'" do
       request.stubs(:method).returns :search
-      handler.class.indirection2uri(request).split("/")[2].should == "foos"
-    end
-
-    it "should use the escaped key as the remainder of the URI" do
-      escaped = URI.escape("with spaces")
-      handler.class.indirection2uri(request).split("/")[3].sub(/\?.+/, '').should == escaped
+      handler.class.request_to_uri_with_env(request).split("/")[1].should == "foos"
     end
 
     it "should add the query string to the URI" do
-      request.expects(:query_string).returns "?query"
-      handler.class.indirection2uri(request).should =~ /\?query$/
+      request.expects(:query_string).returns "query"
+      handler.class.request_to_uri_with_env(request).should =~ /\&query$/
     end
   end
 
   describe "when converting a request into a URI with body" do
     let(:request) { Puppet::Indirector::Request.new(:foo, :find, "with spaces", nil, :foo => :bar, :environment => "myenv") }
 
-    it "should use the environment as the first field of the URI" do
-      handler.class.request_to_uri_and_body(request).first.split("/")[1].should == "myenv"
+    it "should include the environment in the body" do
+      handler.class.request_to_uri_and_body(request)[1].split("&")[0].should == "environment=myenv"
     end
 
-    it "should use the indirection as the second field of the URI" do
-      handler.class.request_to_uri_and_body(request).first.split("/")[2].should == "foo"
+    it "should use the indirection as the first field of the URI" do
+      handler.class.request_to_uri_and_body(request).first.split("/")[1].should == "foo"
     end
 
     it "should use the escaped key as the remainder of the URI" do
       escaped = URI.escape("with spaces")
-      handler.class.request_to_uri_and_body(request).first.split("/")[3].sub(/\?.+/, '').should == escaped
+      handler.class.request_to_uri_and_body(request).first.split("/")[2].sub(/\?.+/, '').should == escaped
     end
 
     it "should return the URI and body separately" do
-      handler.class.request_to_uri_and_body(request).should == ["/myenv/foo/with%20spaces", "foo=bar"]
+      handler.class.request_to_uri_and_body(request).should == ["/foo/with%20spaces", "environment=myenv&foo=bar"]
+    end
+  end
+
+  describe "when converting a save request into a URI" do
+    let(:request) { Puppet::Indirector::Request.new(:foo, :save, "with spaces", nil, :foo => :bar, :environment => "myenv") }
+
+    it "should use the indirection as the first field of the URI" do
+      handler.class.indirection2uri(request).split("/")[1].should == "foo"
+    end
+
+    it "should use the escaped key as the remainder of the URI" do
+      escaped = URI.escape("with spaces")
+      handler.class.indirection2uri(request).split("/")[2].sub(/\?.+/, '').should == escaped
+    end
+
+    it "should add the query string to the URI" do
+      request.expects(:query_string).returns "query"
+      handler.class.indirection2uri(request).should =~ /\?query$/
     end
   end
 

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -400,7 +400,7 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
         source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
 
         conn.unstub(:request_get)
-        conn.expects(:request_get).with('/none/file_content/test/foo%20bar', anything).yields(response)
+        conn.expects(:request_get).with('/file_content/test/foo%20bar?', anything).yields(response)
 
         resource.write(source)
       end


### PR DESCRIPTION
## FOR REVIEW ONLY

This probably isn't quite ready yet.  I need to talk to @hlindberg , @kylog , or @joshcooper and make sure that what I'm doing here for `save` requests is sane; I might need to go put in a bit more string massaging to prevent putting extra '?' or '&' characters into the URL when they're not needed; and I need to make sure that @ahpook is ready to approve this change for 4.0.

This commit makes some changes to the indirector network layer
such that the environment name is no longer a part of the main
URL path structure.  Instead, the environment becomes a query
parameter for GET requests, or part of the form body for POST
requests.  This will allow us to have a more finite URL space
and run Puppet in the same webserver with other apps, without
worrying about URL collisions.
