### PR TITLE
(PUP-3621) Add search_paths and list to Cached environment loader

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -338,6 +338,17 @@ module Puppet::Environments
       @cache_expiration_service = Puppet::Environments::Cached.cache_expiration_service
     end
 
+    # @!macro loader_list
+    def list
+      @loader.list
+    end
+
+    # @!macro loader_search_paths
+    def search_paths
+      @loader.search_paths
+    end
+
+    # @!macro loader_get
     def get(name)
       evict_if_expired(name)
       if result = @cache[name]
@@ -360,10 +371,14 @@ module Puppet::Environments
       @cache = {}
     end
 
-    # This implementation evicts the cache, and always gets the current configuration of the environment
-    # TODO: While this is wasteful since it needs to go on a search for the conf, it is too disruptive to optimize
+    # This implementation evicts the cache, and always gets the current
+    # configuration of the environment
+    #
+    # TODO: While this is wasteful since it
+    # needs to go on a search for the conf, it is too disruptive to optimize
     # this.
     #
+    # @!macro loader_get_conf
     def get_conf(name)
       evict_if_expired(name)
       @loader.get_conf(name)

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -41,7 +41,7 @@ class Puppet::Settings::EnvironmentConf
     Static.new(environment, environment_timeout)
   end
 
-  attr_reader :section
+  attr_reader :section, :path_to_env, :global_modulepath
 
   # Create through EnvironmentConf.load_from()
   def initialize(path_to_env, section, global_module_path)


### PR DESCRIPTION
Recent changes to the Puppet::Environments::Cached loader changed its
construction so that it was no longer a subclass of Combined. This
meant that it no longer had search_path or list functions, which are
needed by the v2 environments to list known directory environments. We
were lacking spec coverage for this and it was caught by the
can_enumerate_environments system test.

In this commit, the Cached loader now delegates search_paths and list
calls to its @loader. Specs have been added for search_paths/list calls,
for the Combined loader in general, and for get_conf in Cached.
Accessors were added to EnvironmentConf for some of its internal
attributes so that it can more easily be tested.
