### PR TITLE
(FOR REVIEW) (PUP-3521) Fix Puppet's exception swallowing

### DIFF
--- a/ext/regexp_nodes/regexp_nodes.rb
+++ b/ext/regexp_nodes/regexp_nodes.rb
@@ -152,7 +152,7 @@ class ExternalNode
         patternlist <<  pattern
         log("appending [#{pattern}] to patternlist for [#{filepath}]")
       }
-    rescue Exception
+    rescue StandardError
       log("Problem reading #{filepath}: #{$!}",:err)
       exit(1)
     end

--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -45,9 +45,7 @@ class Puppet::Agent
           begin
             client_args = client_options.merge(:pluginsync => Puppet[:pluginsync])
             lock { client.run(client_args) }
-          rescue SystemExit,NoMemoryError
-            raise
-          rescue Exception => detail
+          rescue StandardError => detail
             Puppet.log_exception(detail, "Could not run #{client_class}: #{detail}")
           end
         end
@@ -108,9 +106,7 @@ class Puppet::Agent
   def with_client
     begin
       @client = client_class.new
-    rescue SystemExit,NoMemoryError
-      raise
-    rescue Exception => detail
+    rescue StandardError => detail
       Puppet.log_exception(detail, "Could not create instance of #{client_class}: #{detail}")
       return
     end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -176,9 +176,7 @@ class Puppet::Configurer
               query_options = nil
             end
           end
-        rescue SystemExit,NoMemoryError
-          raise
-        rescue Exception => detail
+        rescue StandardError => detail
           Puppet.warning("Unable to fetch my node definition, but the agent run will continue:")
           Puppet.warning(detail)
         end
@@ -295,9 +293,7 @@ class Puppet::Configurer
         query_options.merge(:ignore_cache => true, :environment => Puppet::Node::Environment.remote(@environment), :fail_on_404 => true))
     end
     result
-  rescue SystemExit,NoMemoryError
-    raise
-  rescue Exception => detail
+  rescue StandardError => detail
     Puppet.log_exception(detail, "Could not retrieve catalog from remote server: #{detail}")
     return nil
   end

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -162,9 +162,8 @@ Detail: "#{detail.message}"
           return md[1]
         end
       end
-    rescue Exception
-      # Damn, but I hate this: we just ignore errors here, no matter what
-      # class they are.  Meh.
+    rescue StandardError
+      result << [ "! #{appname}", "! Subcommand unavailable due to error. Check error logs." ]
     end
     return ''
   end

--- a/lib/puppet/network/http/api/v1.rb
+++ b/lib/puppet/network/http/api/v1.rb
@@ -51,7 +51,7 @@ class Puppet::Network::HTTP::API::V1
     end
   rescue Puppet::Network::HTTP::Error::HTTPError => e
     return do_http_control_exception(response, e)
-  rescue Exception => e
+  rescue StandardError => e
     return do_exception(response, e)
   end
 

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -67,7 +67,7 @@ module Puppet::Network::HTTP::Handler
   rescue Puppet::Network::HTTP::Error::HTTPError => e
     Puppet.info(e.message)
     new_response.respond_with(e.status, "application/json", e.to_json)
-  rescue Exception => e
+  rescue StandardError => e
     http_e = Puppet::Network::HTTP::Error::HTTPServerError.new(e)
     Puppet.err(http_e.message)
     new_response.respond_with(http_e.status, "application/json", http_e.to_json)

--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -367,9 +367,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           when "get"; return_value = process_get(cmd_array)
           when "match"; return_value = process_match(cmd_array)
           end
-        rescue SystemExit,NoMemoryError
-          raise
-        rescue Exception => e
+        rescue StandardError => e
           fail("Error sending command '#{command}' with params #{cmd_array[1..-1].inspect}/#{e.message}")
         end
       end
@@ -499,9 +497,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (rv == -1)
           else fail("Command '#{command}' is not supported")
         end
-      rescue SystemExit,NoMemoryError
-        raise
-      rescue Exception => e
+      rescue StandardError => e
         fail("Error sending command '#{command}' with params #{cmd_array.inspect}/#{e.message}")
       end
     end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -321,9 +321,7 @@ ERROR_STRING
       return if certificate
       generate
       return if certificate
-    rescue SystemExit,NoMemoryError
-      raise
-    rescue Exception => detail
+    rescue StandardError => detail
       Puppet.log_exception(detail, "Could not request certificate: #{detail.message}")
       if time < 1
         puts "Exiting; failed to retrieve certificate and waitforcert is disabled"

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -17,7 +17,7 @@ class Puppet::Util::Feature
     if block_given?
       begin
         result = yield
-      rescue Exception => detail
+      rescue StandardError,ScriptError => detail
         warn "Failed to load feature test for #{name}: #{detail}"
         result = false
       end
@@ -86,9 +86,7 @@ class Puppet::Util::Feature
 
     begin
       require lib
-    rescue SystemExit,NoMemoryError
-      raise
-    rescue Exception
+    rescue ScriptError
       Puppet.debug "Failed to load library '#{lib}' for feature '#{name}'"
       return false
     end

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -3,7 +3,7 @@ end
 
 begin
   Process.maxgroups = 1024
-rescue Exception
+rescue NotImplementedError
   # Actually, I just want to ignore it, since various platforms - JRuby,
   # Windows, and so forth - don't support it, but only because it isn't a
   # meaningful or implementable concept there.

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -73,7 +73,7 @@ describe Puppet::Network::HTTP::Handler do
 
     it "returns a structured error response with a stacktrace when the server encounters an internal error" do
       handler = TestingHandler.new(
-        Puppet::Network::HTTP::Route.path(/.*/).get(lambda { |_, _| raise Exception.new("the sky is falling!")}))
+        Puppet::Network::HTTP::Route.path(/.*/).get(lambda { |_, _| raise StandardError.new("the sky is falling!")}))
 
       req = a_request("GET", "/vtest/foo")
       res = {}

--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -129,7 +129,7 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
         req = mk_req('/production/report/foo')
         req.body.expects(:read).with(1)
 
-        @handler.stubs(:headers).raises(Exception)
+        @handler.stubs(:headers).raises(StandardError)
 
         @handler.process(req, @response)
       end


### PR DESCRIPTION
# FOR REVIEW

This PR attempts to fix Puppet's exception swallowing. It does this by changing places where Puppet rescues and swallows an exception to have a more granular `rescue` clause. 

This PR is going to need some review to ensure these changes are sane.
