### PR TITLE
(PUP-3654) Deprecate Puppet.newtype

### DIFF
--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -36,7 +36,7 @@ agent_module_type_file = "#{agent_lib_dir}/puppet/type/#{module_name}.rb"
 master_module_type_file = "#{master_module_dir}/#{module_name}/lib/puppet/type/#{module_name}.rb"
 master_module_type_content = <<HERE
 module Puppet
-  newtype(:#{module_name}) do
+  Type.newtype(:#{module_name}) do
     newparam(:name) do
       isnamevar
     end

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -136,6 +136,7 @@ module Puppet
   # code was deprecated in 2008, but this is still in heavy use.  I suppose
   # this can count as a soft deprecation for the next dev. --daniel 2011-04-12
   def self.newtype(name, options = {}, &block)
+    Puppet.deprecation_warning("Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.")
     Puppet::Type.newtype(name, options, &block)
   end
 

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:exec) do
+  Type.newtype(:exec) do
     include Puppet::Util::Execution
     require 'timeout'
 

--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -1,7 +1,7 @@
 module Puppet
   require 'puppet/file_bucket/dipper'
 
-  newtype(:filebucket) do
+  Type.newtype(:filebucket) do
     @doc = <<-EOT
       A repository for storing and retrieving file content by MD5 checksum. Can
       be local to each agent node, or centralized on a puppet master server. All

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -4,7 +4,7 @@ require 'puppet/property/keyvalue'
 require 'puppet/parameter/boolean'
 
 module Puppet
-  newtype(:group) do
+  Type.newtype(:group) do
     @doc = "Manage groups. On most platforms this can only create groups.
       Group membership must be managed on individual users.
 

--- a/lib/puppet/type/host.rb
+++ b/lib/puppet/type/host.rb
@@ -1,7 +1,7 @@
 require 'puppet/property/ordered_list'
 
 module Puppet
-  newtype(:host) do
+  Type.newtype(:host) do
     ensurable
 
     newproperty(:ip) do

--- a/lib/puppet/type/mailalias.rb
+++ b/lib/puppet/type/mailalias.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:mailalias) do
+  Type.newtype(:mailalias) do
     @doc = "Creates an email alias in the local alias database."
 
     ensurable

--- a/lib/puppet/type/maillist.rb
+++ b/lib/puppet/type/maillist.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:maillist) do
+  Type.newtype(:maillist) do
     @doc = "Manage email lists.  This resource type can only create
       and remove lists; it cannot currently reconfigure them."
 

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -2,7 +2,7 @@ require 'puppet/property/boolean'
 
 module Puppet
   # We want the mount to refresh when it changes.
-  newtype(:mount, :self_refresh => true) do
+  Type.newtype(:mount, :self_refresh => true) do
     @doc = "Manages mounted filesystems, including putting mount
       information into the mount table. The actual behavior depends
       on the value of the 'ensure' parameter.

--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -3,7 +3,7 @@
 
 
 module Puppet
-  newtype(:notify) do
+  Type.newtype(:notify) do
     @doc = "Sends an arbitrary message to the agent run-time log."
 
     newproperty(:message) do

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -7,7 +7,7 @@ require 'puppet/parameter/package_options'
 require 'puppet/parameter/boolean'
 
 module Puppet
-  newtype(:package) do
+  Type.newtype(:package) do
     @doc = "Manage packages.  There is a basic dichotomy in package
       support right now:  Some package types (e.g., yum and apt) can
       retrieve their own package files, while others (e.g., rpm and sun)

--- a/lib/puppet/type/router.rb
+++ b/lib/puppet/type/router.rb
@@ -3,7 +3,7 @@
 
 
 module Puppet
-  newtype(:router) do
+  Type.newtype(:router) do
     @doc = "Manages connected router."
 
     newparam(:url) do

--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:schedule) do
+  Type.newtype(:schedule) do
     @doc = <<-'EOT'
       Define schedules for Puppet. Resources can be limited to a schedule by using the
       [`schedule`](http://docs.puppetlabs.com/references/latest/metaparameter.html#schedule)

--- a/lib/puppet/type/selboolean.rb
+++ b/lib/puppet/type/selboolean.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:selboolean) do
+  Type.newtype(:selboolean) do
     @doc = "Manages SELinux booleans on systems with SELinux support.  The supported booleans
       are any of the ones found in `/selinux/booleans/`."
 

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -7,7 +7,7 @@
 
 module Puppet
 
-  newtype(:service) do
+  Type.newtype(:service) do
     @doc = "Manage running services.  Service support unfortunately varies
       widely by platform --- some platforms have very little if any concept of a
       running service, and some have a very codified and powerful concept.

--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:ssh_authorized_key) do
+  Type.newtype(:ssh_authorized_key) do
     @doc = "Manages SSH authorized keys. Currently only type 2 keys are supported.
 
       In their native habitat, SSH keys usually appear as a single long line. This

--- a/lib/puppet/type/sshkey.rb
+++ b/lib/puppet/type/sshkey.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:sshkey) do
+  Type.newtype(:sshkey) do
     @doc = "Installs and manages ssh host keys.  At this point, this type
       only knows how to install keys into `/etc/ssh/ssh_known_hosts`.  See
       the `ssh_authorized_key` type to manage authorized keys."

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -6,7 +6,7 @@ require 'puppet/property/ordered_list'
 require 'puppet/property/keyvalue'
 
 module Puppet
-  newtype(:user) do
+  Type.newtype(:user) do
     @doc = "Manage users.  This type is mostly built to manage system
       users, so it is lacking some features useful for managing normal
       users.

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:zfs) do
+  Type.newtype(:zfs) do
     @doc = "Manage zfs. Create destroy and set properties on zfs instances.
 
 **Autorequires:** If Puppet is managing the zpool at the root of this zfs

--- a/lib/puppet/type/zpool.rb
+++ b/lib/puppet/type/zpool.rb
@@ -29,7 +29,7 @@ module Puppet
     end
   end
 
-  newtype(:zpool) do
+  Type.newtype(:zpool) do
     @doc = "Manage zpools. Create and delete zpools. The provider WILL NOT SYNC, only report differences.
 
       Supports vdevs with mirrors, raidz, logs and spares."

--- a/spec/unit/parameter/path_spec.rb
+++ b/spec/unit/parameter/path_spec.rb
@@ -9,7 +9,7 @@ require 'puppet/parameter/path'
       # The new type allows us a test that is guaranteed to go direct to our
       # validation code, without passing through any "real type" overrides or
       # whatever on the way.
-      Puppet::newtype(:test_puppet_parameter_path) do
+      Puppet::Type.newtype(:test_puppet_parameter_path) do
         newparam(:path, :parent => Puppet::Parameter::Path, :arrays => arrays) do
           isnamevar
           accept_arrays arrays

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -38,4 +38,11 @@ describe Puppet do
     $LOAD_PATH.should_not include one
     $LOAD_PATH.should include two
   end
+
+  context "newtype" do
+    it "should issue a deprecation warning" do
+      subject.expects(:deprecation_warning).with("Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.")
+      subject.newtype("sometype")
+    end
+  end
 end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -952,7 +952,7 @@ describe Puppet::Resource do
 
   describe "#prune_parameters" do
     before do
-      Puppet.newtype('blond') do
+      Puppet::Type.newtype('blond') do
         newproperty(:ensure)
         newproperty(:height)
         newproperty(:weight)


### PR DESCRIPTION
The `newtype` class method of the Puppet module includes a comment from
2011 stating that the method should be deprecated, but was under heavy
use at the time.

This commit adds a deprecation warning to this method to indicate that
it will be removed in a future release. Types using the old method have
also been updated to use `Puppet::Type.newtype`.
