### PR TITLE
(PUP-3665) Fix resource overrides for 4x collector

### DIFF
--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -24,7 +24,8 @@ class Puppet::Parser::AST::PopsBridge
     end
 
     def evaluate(scope)
-      @@evaluator.evaluate(scope, @value)
+      object = @@evaluator.evaluate(scope, @value)
+      @@evaluator.convert_to_3x(object, scope)
     end
 
     # Adapts to 3x where top level constructs needs to have each to iterate over children. Short circuit this

--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -60,6 +60,10 @@ class Puppet::Pops::Parser::EvaluatingParser
     @@evaluator
   end
 
+  def convert_to_3x(object, scope)
+    val = @@evaluator.convert(object, scope, nil)
+  end
+
   def validate(parse_result)
     resulting_acceptor = acceptor()
     validator(resulting_acceptor).validate(parse_result)


### PR DESCRIPTION
Prior to this commit, the new implementation of collections caused
overrides to fail if the given attribute was a Resource. This was
because 3x required an instance of Resource rather than PResource
Type. In order to fix this issue, transform the override attribute
into the appropriate format for the 3x compiler.
