### PR TITLE
(PUP-3512) Remove the old Profiler profile API

### DIFF
--- a/lib/puppet/util/profiler.rb
+++ b/lib/puppet/util/profiler.rb
@@ -47,7 +47,7 @@ module Puppet::Util::Profiler
   # @param metric_id [Array] A list of strings making up the ID of a metric to profile
   # @param block [Block] The segment of code to profile
   # @api public
-  def self.profile(message, metric_id = nil, &block)
+  def self.profile(message, metric_id, &block)
     @profiler.profile(message, metric_id, &block)
   end
 end

--- a/lib/puppet/util/profiler/around_profiler.rb
+++ b/lib/puppet/util/profiler/around_profiler.rb
@@ -47,7 +47,7 @@ class Puppet::Util::Profiler::AroundProfiler
   # @param metric_id [Array] A list of strings making up the ID of a metric to profile
   # @param block [Block] The segment of code to profile
   # @api private
-  def profile(message, metric_id = nil)
+  def profile(message, metric_id)
     retval = nil
     contexts = {}
     @profilers.each do |profiler|

--- a/spec/unit/util/profiler/aggregate_spec.rb
+++ b/spec/unit/util/profiler/aggregate_spec.rb
@@ -37,10 +37,6 @@ describe Puppet::Util::Profiler::Aggregate do
     logger.output.should =~ /compiler: .*\(2 calls\)\ncompiler ->.*\(1 calls\)/
   end
 
-  it "tolerates calls to `profile` that don't include a metric id" do
-    profiler_mgr.profile("yo") {}
-  end
-
   it "supports both symbols and strings as components of a metric id" do
     profiler_mgr.profile("yo", [:foo, "bar"]) {}
   end

--- a/spec/unit/util/profiler_spec.rb
+++ b/spec/unit/util/profiler_spec.rb
@@ -29,14 +29,6 @@ describe Puppet::Util::Profiler do
     profiler.description.should == "hi"
   end
 
-  it "supports profiling without a metric id" do
-    subject.add_profiler(profiler)
-    subject.profile("hi") {}
-    profiler.context[:metric_id].should == nil
-    profiler.context[:description].should == "hi"
-    profiler.description.should == "hi"
-  end
-
   class TestProfiler
     attr_accessor :context, :metric, :description
 


### PR DESCRIPTION
Remove the old Profiler profile API, which supported calls to
profile without a metric ID. Remove tests that ensured the
old API worked.
