### PR TITLE
(PUP-3096) Remove deprecated trusted_node_data and immutable_node_data options

### DIFF
--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -30,7 +30,6 @@ test_name "certificate extensions available as trusted data" do
     'master' => {
       'autosign' => '/bin/true',
       'dns_alt_names' => "puppet,#{hostname},#{fqdn}",
-      'trusted_node_data' => true,
     }
   }
 

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -240,7 +240,7 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
     else
       Puppet::SSL::Host.ca_location = :none
     end
-    Puppet::SSL::Oids.load_custom_oid_file(Puppet[:trusted_oid_mapping_file]) if Puppet[:trusted_node_data]
+    Puppet::SSL::Oids.load_custom_oid_file(Puppet[:trusted_oid_mapping_file])
   end
 
   # Sets up a special node cache "write only yaml" that collects and stores node data in yaml

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -488,17 +488,6 @@ module Puppet
         :desc     => "Freezes the 'main' class, disallowing any code to be added to it.  This
           essentially means that you can't have any code outside of a node,
           class, or definition other than in the site manifest.",
-    },
-    :trusted_node_data => {
-      :default => false,
-      :type    => :boolean,
-      :desc    => "Stores trusted node data in a hash called $trusted.
-        When true also prevents $trusted from being overridden in any scope.",
-    },
-    :immutable_node_data => {
-      :default => '$trusted_node_data',
-      :type    => :boolean,
-      :desc    => "When true, also prevents $trusted and $facts from being overridden in any scope",
     }
   )
   Puppet.define_settings(:module_tool,

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -574,13 +574,9 @@ class Puppet::Parser::Compiler
     # These might be nil.
     catalog.client_version = node.parameters["clientversion"]
     catalog.server_version = node.parameters["serverversion"]
-    if Puppet[:trusted_node_data]
-      @topscope.set_trusted(node.trusted_data)
-    end
-    if(Puppet[:immutable_node_data])
-      facts_hash = node.facts.nil? ? {} : node.facts.values
-      @topscope.set_facts(facts_hash)
-    end
+    @topscope.set_trusted(node.trusted_data)
+    facts_hash = node.facts.nil? ? {} : node.facts.values
+    @topscope.set_facts(facts_hash)
   end
 
   def create_settings_scope

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -296,8 +296,6 @@ class Puppet::Parser::Scope
     # The table for storing class singletons.  This will only actually
     # be used by top scopes and node scopes.
     @class_scopes = {}
-
-    @enable_immutable_data = Puppet[:immutable_node_data]
   end
 
   # Store the fact that we've evaluated a class, and store a reference to
@@ -625,7 +623,7 @@ class Puppet::Parser::Scope
     end
 
     # Check for reserved variable names
-    if @enable_immutable_data && !options[:privileged] && RESERVED_VARIABLE_NAMES.include?(name)
+    if !options[:privileged] && RESERVED_VARIABLE_NAMES.include?(name)
       raise Puppet::ParseError, "Attempt to assign to a reserved variable name: '#{name}'"
     end
 

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -916,14 +916,6 @@ Boolean; whether puppet agent should ignore schedules\. This is useful for initi
 .
 .IP "" 0
 .
-.SS "immutable_node_data"
-When true, also prevents $trusted and $facts from being overridden in any scope
-.
-.IP "\(bu" 4
-\fIDefault\fR: $trusted_node_data
-.
-.IP "" 0
-.
 .SS "keylength"
 The bit length of keys\.
 .
@@ -1808,14 +1800,6 @@ Boolean; whether Puppet should store only facts and exported resources in the st
 .
 .SS "trace"
 Whether to print stack traces on some errors
-.
-.IP "\(bu" 4
-\fIDefault\fR: false
-.
-.IP "" 0
-.
-.SS "trusted_node_data"
-Stores trusted node data in a hash called $trusted\. When true also prevents $trusted from being overridden in any scope\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: false

--- a/spec/integration/parser/future_compiler_spec.rb
+++ b/spec/integration/parser/future_compiler_spec.rb
@@ -375,59 +375,28 @@ describe "Puppet::Parser::Compiler" do
     end
 
     context 'when working with the trusted data hash' do
-      context 'and have opted in to hashed_node_data' do
-        before :each do
-          Puppet[:trusted_node_data] = true
-        end
 
-        it 'should make $trusted available' do
-          node = Puppet::Node.new("testing")
-          node.trusted_data = { "data" => "value" }
+      it 'should make $trusted available' do
+        node = Puppet::Node.new("testing")
+        node.trusted_data = { "data" => "value" }
 
-          catalog = compile_to_catalog(<<-MANIFEST, node)
-            notify { 'test': message => $trusted[data] }
-          MANIFEST
+        catalog = compile_to_catalog(<<-MANIFEST, node)
+          notify { 'test': message => $trusted[data] }
+        MANIFEST
 
-          expect(catalog).to have_resource("Notify[test]").with_parameter(:message, "value")
-        end
-
-        it 'should not allow assignment to $trusted' do
-          node = Puppet::Node.new("testing")
-          node.trusted_data = { "data" => "value" }
-
-          expect do
-            compile_to_catalog(<<-MANIFEST, node)
-              $trusted = 'changed'
-              notify { 'test': message => $trusted == 'changed' }
-            MANIFEST
-          end.to raise_error(Puppet::Error, /Attempt to assign to a reserved variable name: 'trusted'/)
-        end
+        expect(catalog).to have_resource("Notify[test]").with_parameter(:message, "value")
       end
 
-      context 'and have not opted in to hashed_node_data' do
-        before :each do
-          Puppet[:trusted_node_data] = false
-        end
+      it 'should not allow assignment to $trusted' do
+        node = Puppet::Node.new("testing")
+        node.trusted_data = { "data" => "value" }
 
-        it 'should not make $trusted available' do
-          node = Puppet::Node.new("testing")
-          node.trusted_data = { "data" => "value" }
-
-          catalog = compile_to_catalog(<<-MANIFEST, node)
-            notify { 'test': message => ($trusted == undef) }
-          MANIFEST
-
-          expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
-        end
-
-        it 'should allow assignment to $trusted' do
-          catalog = compile_to_catalog(<<-MANIFEST)
+        expect do
+          compile_to_catalog(<<-MANIFEST, node)
             $trusted = 'changed'
             notify { 'test': message => $trusted == 'changed' }
           MANIFEST
-
-          expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
-        end
+        end.to raise_error(Puppet::Error, /Attempt to assign to a reserved variable name: 'trusted'/)
       end
     end
 


### PR DESCRIPTION
This commit removes the deprecated trusted_node_data and
immutable_node_data options from puppet/defaults. This ensures
that $facts and $trusted are always available so that we can
start phasing out facts as top-scope variables.

This commit is part of the Puppet 4 code removal effort.
