### PR TITLE
(PUP-3121) Lookup dependencies by forge name

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -242,7 +242,8 @@ class Puppet::Module
     return unmet_dependencies unless dependencies
 
     dependencies.each do |dependency|
-      forge_name = dependency['name']
+      name = dependency['name']
+      forge_name = name.tr('-', '/')
       version_string = dependency['version_requirement'] || '>= 0.0.0'
 
       dep_mod = begin
@@ -252,7 +253,7 @@ class Puppet::Module
       end
 
       error_details = {
-        :name => forge_name,
+        :name => name,
         :version_constraint => version_string.gsub(/^(?=\d)/, "v"),
         :parent => {
           :name => self.forge_name,

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -95,6 +95,33 @@ describe Puppet::Module do
       Puppet.settings[:modulepath] = @modpath
     end
 
+    it "should resolve module dependencies using forge names" do
+      parent = PuppetSpec::Modules.create(
+        'parent',
+        @modpath,
+        :metadata => {
+          :author => 'foo',
+          :dependencies => [{
+            "name" => "foo/child"
+          }]
+        },
+        :environment => env
+      )
+      child = PuppetSpec::Modules.create(
+        'child',
+        @modpath,
+        :metadata => {
+          :author => 'foo',
+          :dependencies => []
+        },
+        :environment => env
+      )
+
+      env.expects(:module_by_forge_name).with('foo/child').returns(child)
+
+      expect(parent.unmet_dependencies).to eq([])
+    end
+
     it "should list modules that are missing" do
       metadata_file = "#{@modpath}/needy/metadata.json"
       Puppet::FileSystem.expects(:exist?).with(metadata_file).returns true

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -133,8 +133,12 @@ describe Puppet::Module do
             "version_requirement" => ">= 2.2.0",
             "name" => "baz/foobar"
           }]
-        }
+        },
+        :environment => env
       )
+
+      env.expects(:module_by_forge_name).with('baz/foobar').returns(nil)
+
       expect(mod.unmet_dependencies).to eq([{
         :reason => :missing,
         :name   => "baz/foobar",
@@ -155,8 +159,12 @@ describe Puppet::Module do
             "version_requirement" => ">= 2.2.0",
             "name" => "baz/foobar=bar"
           }]
-        }
+        },
+        :environment => env
       )
+
+      env.expects(:module_by_forge_name).with('baz/foobar=bar').returns(nil)
+
       expect(mod.unmet_dependencies).to eq([{
         :reason => :missing,
         :name   => "baz/foobar=bar",


### PR DESCRIPTION
Previously, if a module had a dependency named "puppetlabs-stdlib", it
would call `Environment.module_by_forge_name` with that name, but that
method expects names to be of the form `author/name`.

This commit translates the name prior to making the call.