### PR TITLE
(PUP-3520) Refactor Puppet OID registration to be explicit

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -3,6 +3,7 @@ require 'puppet/daemon'
 require 'puppet/util/pidlock'
 require 'puppet/agent'
 require 'puppet/configurer'
+require 'puppet/ssl/oids'
 
 class Puppet::Application::Agent < Puppet::Application
 
@@ -371,6 +372,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     setup_logs
 
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
+
+    Puppet::SSL::Oids.register_puppet_oids
 
     if options[:fqdn]
       Puppet[:certname] = options[:fqdn]

--- a/lib/puppet/application/ca.rb
+++ b/lib/puppet/application/ca.rb
@@ -1,5 +1,10 @@
 require 'puppet/application/face_base'
+require 'puppet/ssl/oids'
 
 class Puppet::Application::Ca < Puppet::Application::FaceBase
   run_mode :master
+
+  def setup
+    Puppet::SSL::Oids.register_puppet_oids
+  end
 end

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -227,6 +227,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     require 'puppet/ssl/certificate_authority'
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
+    Puppet::SSL::Oids.register_puppet_oids
+
     Puppet::Util::Log.newdestination :console
 
     if [:generate, :destroy].include? subcommand

--- a/lib/puppet/application/certificate.rb
+++ b/lib/puppet/application/certificate.rb
@@ -1,7 +1,9 @@
 require 'puppet/application/indirection_base'
+require 'puppet/ssl/oids'
 
 class Puppet::Application::Certificate < Puppet::Application::IndirectionBase
   def setup
+    Puppet::SSL::Oids.register_puppet_oids
     location = Puppet::SSL::Host.ca_location
     if location == :local && !Puppet::SSL::CertificateAuthority.ca?
       # I'd prefer if this could be dealt with differently; ideally, run_mode should be set as

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -240,6 +240,7 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
     else
       Puppet::SSL::Host.ca_location = :none
     end
+    Puppet::SSL::Oids.register_puppet_oids
     Puppet::SSL::Oids.load_custom_oid_file(Puppet[:trusted_oid_mapping_file])
   end
 

--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -39,8 +39,13 @@ module Puppet::SSL::Oids
     ["1.3.6.1.4.1.34380.1.2", 'ppPrivCertExt', 'Puppet Private Certificate Extension'],
   ]
 
-  PUPPET_OIDS.each do |oid_defn|
-    OpenSSL::ASN1::ObjectId.register(*oid_defn)
+  # Register our custom Puppet OIDs with OpenSSL so they can be used as CSR
+  # extensions. Without registering these OIDs, OpenSSL will fail when it
+  # encounters such an extension in a CSR.
+  def self.register_puppet_oids()
+    PUPPET_OIDS.each do |oid_defn|
+      OpenSSL::ASN1::ObjectId.register(*oid_defn)
+    end
   end
 
   # Parse and load custom OID mapping file that enables custom OIDs to be resolved

--- a/spec/integration/ssl/autosign_spec.rb
+++ b/spec/integration/ssl/autosign_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+Puppet::SSL::Oids.register_puppet_oids
+
 describe "autosigning" do
   include PuppetSpec::Files
 

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 
 require 'puppet/ssl/certificate_authority'
 
+Puppet::SSL::Oids.register_puppet_oids
+
 describe Puppet::SSL::CertificateAuthority do
   after do
     Puppet::SSL::CertificateAuthority.instance_variable_set(:@singleton_instance, nil)

--- a/spec/unit/ssl/certificate_factory_spec.rb
+++ b/spec/unit/ssl/certificate_factory_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 
 require 'puppet/ssl/certificate_factory'
 
+Puppet::SSL::Oids.register_puppet_oids
+
 describe Puppet::SSL::CertificateFactory do
   let :serial    do OpenSSL::BN.new('12') end
   let :name      do "example.local" end

--- a/spec/unit/ssl/certificate_spec.rb
+++ b/spec/unit/ssl/certificate_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 
 require 'puppet/ssl/certificate'
 
+Puppet::SSL::Oids.register_puppet_oids
+
 describe Puppet::SSL::Certificate do
   before do
     @class = Puppet::SSL::Certificate

--- a/spec/unit/ssl/oids_spec.rb
+++ b/spec/unit/ssl/oids_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'puppet/ssl/oids'
 
+Puppet::SSL::Oids.register_puppet_oids
+
 describe Puppet::SSL::Oids do
   describe "defining application OIDs" do
 


### PR DESCRIPTION
Prior to this commit, the Puppet::SSL::Oids module would register with
OpenSSL the list of special Puppet OIDs every time it was
loaded (i.e. implicitly during require 'puppet/ssl/oids'). This commit
refactors the registration calls into a module method that is invoked
from the following application faces: agent, master, cert, certificate,
and ca.

The reason for this refactoring is to try and avoid all implicit calls
into OpenSSL so that it is easier to eliminate/avoid the OpenSSL usage
when the Puppet ruby code is loaded into Puppet Server.

The relevant acceptance test that should cover these changes is
puppet/acceptance/tests/ssl/certificate_extensions.rb
