### PR TITLE
(maint) Add Equifax cert for pmt acceptance

### DIFF
--- a/acceptance/setup/git/pre-suite/070_InstalCACerts.rb
+++ b/acceptance/setup/git/pre-suite/070_InstalCACerts.rb
@@ -53,6 +53,28 @@ KqMiDP+JJn1fIytH1xUdqWqeUQ0qUZ6B+dQ7XnASfxAynB67nfhmqA==
 -----END CERTIFICATE-----
 EOM
 
+EQUIFAX_CA = <<-EOM
+-----BEGIN CERTIFICATE-----
+MIIDIDCCAomgAwIBAgIENd70zzANBgkqhkiG9w0BAQUFADBOMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRXF1aWZheDEtMCsGA1UECxMkRXF1aWZheCBTZWN1cmUgQ2Vy
+dGlmaWNhdGUgQXV0aG9yaXR5MB4XDTk4MDgyMjE2NDE1MVoXDTE4MDgyMjE2NDE1
+MVowTjELMAkGA1UEBhMCVVMxEDAOBgNVBAoTB0VxdWlmYXgxLTArBgNVBAsTJEVx
+dWlmYXggU2VjdXJlIENlcnRpZmljYXRlIEF1dGhvcml0eTCBnzANBgkqhkiG9w0B
+AQEFAAOBjQAwgYkCgYEAwV2xWGcIYu6gmi0fCG2RFGiYCh7+2gRvE4RiIcPRfM6f
+BeC4AfBONOziipUEZKzxa1NfBbPLZ4C/QgKO/t0BCezhABRP/PvwDN1Dulsr4R+A
+cJkVV5MW8Q+XarfCaCMczE1ZMKxRHjuvK9buY0V7xdlfUNLjUA86iOe/FP3gx7kC
+AwEAAaOCAQkwggEFMHAGA1UdHwRpMGcwZaBjoGGkXzBdMQswCQYDVQQGEwJVUzEQ
+MA4GA1UEChMHRXF1aWZheDEtMCsGA1UECxMkRXF1aWZheCBTZWN1cmUgQ2VydGlm
+aWNhdGUgQXV0aG9yaXR5MQ0wCwYDVQQDEwRDUkwxMBoGA1UdEAQTMBGBDzIwMTgw
+ODIyMTY0MTUxWjALBgNVHQ8EBAMCAQYwHwYDVR0jBBgwFoAUSOZo+SvSspXXR9gj
+IBBPM5iQn9QwHQYDVR0OBBYEFEjmaPkr0rKV10fYIyAQTzOYkJ/UMAwGA1UdEwQF
+MAMBAf8wGgYJKoZIhvZ9B0EABA0wCxsFVjMuMGMDAgbAMA0GCSqGSIb3DQEBBQUA
+A4GBAFjOKer89961zgK5F7WF0bnj4JXMJTENAKaSbn+2kmOeUJXRmm/kEd5jhW6Y
+7qj/WsjTVbJmcVfewCHrPSqnI0kBBIZCe/zuf6IWUrVnZ9NA2zsmWLIodz2uFHdh
+1voqZiegDfqnc1zqcPGUIWVEX/r87yloqaKHee9570+sB3c4
+-----END CERTIFICATE-----
+EOM
+
 hosts.each do |host|
   step "Installing Geotrust CA cert"
   create_remote_file(host, "geotrustglobal.pem", GEOTRUST_GLOBAL_CA)
@@ -63,4 +85,9 @@ hosts.each do |host|
   create_remote_file(host, "usertrust-network.pem", USERTRUST_NETWORK_CA)
   on host, "chmod 644 usertrust-network.pem"
   on host, "cmd /c certutil -v -addstore Root `cygpath -w usertrust-network.pem`"
+
+  step "Installing Equifax CA cert"
+  create_remote_file(host, "equifax.pem", EQUIFAX_CA)
+  on host, "chmod 644 equifax.pem"
+  on host, "cmd /c certutil -v -addstore Root `cygpath -w equifax.pem`"
 end


### PR DESCRIPTION
The forge SSL certificates are being updated to use SHA-256, and that's
introduced a new certificate dependency that's not present on Windows.
Add it as part of acceptance testing. This is a stop-gap until the PMT
is fixed to come with its own certs.
