### PR TITLE
(PUP-2628) Add members to groups instead of full list for Windows

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -22,7 +22,14 @@ Puppet::Type.type(:group).provide :windows_adsi do
     return false if current.empty? != should_empty
 
     # dupes automatically weeded out when hashes built
-    Puppet::Util::Windows::ADSI::Group.name_sid_hash(current) == Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
+    current_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
+    specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
+
+    if @resource[:auth_membership]
+      current_users == specified_users
+    else
+      (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
+    end
   end
 
   def members_to_s(users)
@@ -49,7 +56,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
   end
 
   def members=(members)
-    group.set_members(members)
+    group.set_members(members, @resource[:auth_membership])
   end
 
   def create

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -107,7 +107,7 @@ module Puppet
       alias :should_to_s :is_to_s
     end
 
-    newparam(:auth_membership) do
+    newparam(:auth_membership, :boolean => true, :parent => Puppet::Parameter::Boolean) do
       desc "whether the provider is authoritative for group membership."
       defaultto true
     end

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -367,7 +367,7 @@ module Puppet::Util::Windows::ADSI
       sids
     end
 
-    def set_members(desired_members)
+    def set_members(desired_members, inclusive = true)
       return if desired_members.nil? or desired_members.empty?
 
       current_hash = Hash[ self.member_sids.map { |sid| [sid.to_s, sid] } ]
@@ -379,7 +379,8 @@ module Puppet::Util::Windows::ADSI
 
       # Then we remove all extra members
       members_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
-      remove_member_sids(*members_to_remove)
+
+      remove_member_sids(*members_to_remove) if inclusive
     end
 
     def self.create(name)


### PR DESCRIPTION
Previously, if you wanted to use the group resource you needed to specify the
entire list of members as the windows provider ignored the auth_membership
setting and was always the authoritative list. This ensures that the windows
provider respects the auth_membership setting.
