### PR TITLE
(PUP-3682) Disable HTTP keepalive in webrick on 1.8.7

### DIFF
--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -79,6 +79,9 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
       response.body = result
       response["content-length"] = result.stat.size if result.is_a?(File)
     end
+    if RUBY_VERSION[0,3] == "1.8"
+      response["connection"] = 'close'
+    end
   end
 
   # Retrieve node/cert/ip information from the request object.


### PR DESCRIPTION
Previously, webrick would attempt to support HTTP keepalive so that HTTP
clients could send multiple HTTP messages on the same TCP (SSL)
connection. However, we found in practice that RHEL6 with system ruby
1.8.7-p352 with openssl 1.0.1e-fips does not reliably handle keepalive.
Most commonly the webrick server fails to read the agent's report, or
sometimes fails when handling the agent's catalog request:

```
Server Error: SSL_read:: internal error
```

This commit causes the webrick rest handler to always include the HTTP
header `Connection: close` in the HTTP response. This indicates to the
HTTP client that the webrick server does not want to keep the connection
alive, and that the client should make a new connection the next time it
connects.

This change does not affect webrick running under 1.9 or later, nor does
it affect puppet masters running under passenger or puppet-server. As
these do reliably handle HTTP keepalive, and we want the performance
benefit that persistent http connections provide.

Note 1.8.7 support will be going away in Puppet 4, so this is a
short-term fix to the 3.7.x series.
