### PR TITLE
(PUP-3091) Add test coverage for heredoc support

### DIFF
--- a/spec/unit/pops/parser/parse_heredoc_spec.rb
+++ b/spec/unit/pops/parser/parse_heredoc_spec.rb
@@ -71,6 +71,36 @@ describe "egrammar parsing heredoc" do
     ].join("\n")
   end
 
+  it "parses with escaped newlines without preceding whitespace" do
+    src = <<-CODE
+    @(END/L)
+    First Line\\
+     Second Line
+    |- END
+    CODE
+    parse(src)
+    dump(parse(src)).should == [
+      "(@()",
+      "  (sublocated 'First Line Second Line')",
+      ")"
+    ].join("\n")
+  end
+
+  it "parses with escaped newlines with proper margin" do
+    src = <<-CODE
+    @(END/L)
+     First Line\\
+      Second Line
+    |- END
+    CODE
+    parse(src)
+    dump(parse(src)).should == [
+      "(@()",
+      "  (sublocated ' First Line  Second Line')",
+      ")"
+    ].join("\n")
+  end
+
   it "parses interpolated heredoc expression with false start on $" do
     src = <<-CODE
     @("END")


### PR DESCRIPTION
Before this commit the spec tests for heredoc support in Puppet did not
include tests to make sure that escaping new lines used the correct
margin on the preceding lines.

This commit adds in tests to ensure that we do not regress on this in
the future.
