### PR TITLE
(PUP-3140) Include faulty number in Illegal Number Parser Error

### DIFF
--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -141,6 +141,7 @@ class Puppet::Pops::Parser::Lexer2
   KEYWORD_NAMES.freeze
 
   PATTERN_WS        = %r{[[:blank:]\r]+}
+  PATTERN_NON_WS    = %r{\w+\b?}
 
   # The single line comment includes the line ending.
   PATTERN_COMMENT   = %r{#.*\r?}
@@ -574,8 +575,9 @@ class Puppet::Pops::Parser::Lexer2
         emit_completed([:NUMBER, value.freeze, length], before)
       else
         # move to faulty position ([0-9] was ok)
-        scn.pos = scn.pos + 1
-        lex_error("Illegal number")
+        invalid_number = scn.scan_until(PATTERN_NON_WS)
+        scn.pos = before + 1
+        lex_error("Illegal number '#{invalid_number}'")
       end
 
     when 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',

--- a/spec/integration/parser/node_spec.rb
+++ b/spec/integration/parser/node_spec.rb
@@ -124,7 +124,7 @@ describe 'node statements' do
     it 'is unable to parse a name that is an invalid number' do
       expect do
         compile_to_catalog('node 5name {} ')
-      end.to raise_error(Puppet::Error, /Illegal number/)
+      end.to raise_error(Puppet::Error, /Illegal number '5name'/)
     end
 
     it 'parses a node name that is dotted numbers' do


### PR DESCRIPTION
Before this commit whenever an invalid number was found in a manifest
the lexer would raise an "Invalid Number" error without any context as
to what number was invalid. This commit changes the behavior to show
what number was an issue.
