### PR TITLE
(PUP-1362) (PUP-1775) additional cleanup related to the removal of yumhelp.py

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -66,8 +66,8 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   #   found with a list of found versions for each package.
   def self.check_updates(enablerepo, disablerepo)
     args = [command(:yum), 'check-update']
-    args.concat(enablerepo.map { |repo| ['-e', repo] }.flatten)
-    args.concat(disablerepo.map { |repo| ['-d', repo] }.flatten)
+    args.concat(enablerepo.map { |repo| ["--enablerepo=#{repo}"] }.flatten)
+    args.concat(disablerepo.map { |repo| ["--disablerepo=#{repo}"] }.flatten)
 
     output = Puppet::Util::Execution.execute(args, :failonfail => false, :combine => false)
 

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -375,21 +375,21 @@ describe provider_class do
 
     it "passes repos to enable to 'yum check-update'" do
       Puppet::Util::Execution.expects(:execute).with do |args, *rest|
-        expect(args).to eq %w[/usr/bin/yum check-update -e updates -e centosplus]
+        expect(args).to eq %w[/usr/bin/yum check-update --enablerepo=updates --enablerepo=centosplus]
       end.returns(stub(:exitstatus => 0))
       described_class.check_updates(%w[updates centosplus], [])
     end
 
     it "passes repos to disable to 'yum check-update'" do
       Puppet::Util::Execution.expects(:execute).with do |args, *rest|
-        expect(args).to eq %w[/usr/bin/yum check-update -d updates -d centosplus]
+        expect(args).to eq %w[/usr/bin/yum check-update --disablerepo=updates --disablerepo=centosplus]
       end.returns(stub(:exitstatus => 0))
       described_class.check_updates([],%w[updates centosplus])
     end
 
     it "passes a combination of repos to enable and disable to 'yum check-update'" do
       Puppet::Util::Execution.expects(:execute).with do |args, *rest|
-        expect(args).to eq %w[/usr/bin/yum check-update -e os -e contrib -d updates -d centosplus]
+        expect(args).to eq %w[/usr/bin/yum check-update --enablerepo=os --enablerepo=contrib --disablerepo=updates --disablerepo=centosplus]
       end.returns(stub(:exitstatus => 0))
       described_class.check_updates(%w[os contrib], %w[updates centosplus])
     end


### PR DESCRIPTION
The -e & -d flags to yumhelper.py had different semantics than yum's -d & -e flags.  The yum equivalent option flags are --enablerepo & --disablerepo.
