### PR TITLE
(maint) Add validation tests for top-level constructs in conditionals

### DIFF
--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -178,6 +178,29 @@ describe "validating 4x" do
     end
   end
 
+  context 'top level constructs in conditionals' do
+    ['class', 'define', 'node'].each do |word|
+      it "produces an error when $#{word} is nested in an if expression" do
+        source = "if true { #{word} x {} }"
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::NOT_TOP_LEVEL)
+      end
+    end
+
+    ['class', 'define', 'node'].each do |word|
+      it "produces an error when $#{word} is nested in an if-else expression" do
+        source = "if false {} else { #{word} x {} }"
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::NOT_TOP_LEVEL)
+      end
+    end
+
+    ['class', 'define', 'node'].each do |word|
+      it "produces an error when $#{word} is nested in an unless expression" do
+        source = "unless false { #{word} x {} }"
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::NOT_TOP_LEVEL)
+      end
+    end
+  end
+
   def parse(source)
     Puppet::Pops::Parser::Parser.new().parse_string(source)
   end


### PR DESCRIPTION
In PUP-3274 some tests ended up "missing" (or at least hard to see
where certain behavior was asserted). This brings back three such
tests for testing that top-level constructs class, define and node
can not be defined inside of a conditional expression.

The tests are added to the validator_spec since it is responsible for
flagging these as errors.
