### PR TITLE
(maint) Allow non-root users to traverse tmpdir

### DIFF
--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -17,14 +17,8 @@ test_name "autosign command and csr attributes behavior (#7243,#7244)" do
   step "Generate tmp dirs on all hosts" do
     hosts.each do |host|
       testdirs[host] = host.tmpdir('autosign_command')
-      apply_manifest_on(host, <<-MANIFEST, :catch_failures => true)
-        file { '#{testdirs[host]}':
-          ensure => directory,
-          owner => #{host.puppet['user']},
-          mode => "0770",
-        }
-      MANIFEST
-    end 
+      on(host, "chmod 755 #{testdirs[host]}")
+    end
   end
 
   teardown do


### PR DESCRIPTION
This test creates a tmpdir, initially owned by root:root and mode 0700,
and executes `puppet agent` with an ssldir contained within the tmpdir:

```
puppet agent --ssldir /tmp/autosign_command.XXXX/ssldir-autosign
```

Puppet will manage the owner/group/mode of the ssldir (but not its
parent) by temporarily switching uid/gid to the `puppet` user & group,
create the directory, etc, and then switch back. If the parent
directory has mode 0700, then the `puppet` user is not allowed to create
a directory within the parent.

Previously, the test used puppet apply to switch the owner and mode of
the parent directory. This works by accident on some platforms, e.g.
Windows, because there is a setup step that will create the `puppet`
user and group.

But in PE, that is not the case, so this test would fail in PE on
Windows with the error:

```
Could not write /tmp/autosign_command.jwi1dW/ssldir-autosign/\
  private_keys/hj6ml6atya3wuiz.delivery.puppetlabs.net-autosign.pem \
  to privatekeydir: Permission denied
```

This commit modifies the test to allow `group` and `other` read and
traverse permissions on the parent directory, and doesn't require the
existence of the `puppet` user.
