### PR TITLE
(PUP-3702) fix zone type on solaris10

### DIFF
--- a/acceptance/tests/resource/zone/statemachine.rb
+++ b/acceptance/tests/resource/zone/statemachine.rb
@@ -18,7 +18,7 @@ agents.each do |agent|
   step "Zone: statemachine - create zone and make it running"
   step "progress would be logged to agent:/var/log/zones/zoneadm.<date>.<zonename>.install"
   step "install log would be at agent:/system/volatile/install.<id>/install_log"
-  apply_manifest_on(agent, "zone {tstzone : ensure=>running, iptype=>shared, path=>'/tstzones/mnt' }") do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>running, iptype=>shared, path=>"/tstzones/mnt" }') do
     assert_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
 

--- a/acceptance/tests/resource/zone/stepstates.rb
+++ b/acceptance/tests/resource/zone/stepstates.rb
@@ -16,7 +16,7 @@ agents.each do |agent|
   step "Zone: steps - setup"
   setup agent
   step "Zone: steps - create"
-  apply_manifest_on(agent, "zone {tstzone : ensure=>configured, iptype=>shared, path=>'/tstzones/mnt' }" ) do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, iptype=>shared, path=>"/tstzones/mnt" }' ) do
     assert_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
   step "Zone: steps - verify (create)"

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -242,6 +242,7 @@ end
     desc "The list of directories that the zone inherits from the global
       zone.  All directories must be fully qualified."
 
+    defaultto "/sbin"
     def should
       @should
     end


### PR DESCRIPTION
Solaris10 does not inherit /sbin from the global zone by default.
This makes the zone un-bootable (ensure => running fails).
Add inherit => "/sbin" as a default to make solaris10 operate like
solaris11.
fixup the quotes on some tests to make them more consistent
