### PR TITLE
(maint) skip acceptance tests requiring forge certs on solaris and aix

### DIFF
--- a/acceptance/tests/environment/dynamic.rb
+++ b/acceptance/tests/environment/dynamic.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/static.rb
+++ b/acceptance/tests/environment/static.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,5 +1,9 @@
 test_name 'puppet module changes (on a module with a modified file)'
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,5 +1,9 @@
 test_name 'puppet module changes (on a module with a removed file)'
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,5 +1,9 @@
 test_name 'puppet module changes (on an unmodified module)'
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/install/already_installed.rb
+++ b/acceptance/tests/modules/install/already_installed.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (already installed)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (already installed elsewhere)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (already installed with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (agent)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/force_ignores_dependencies.rb
+++ b/acceptance/tests/modules/install/force_ignores_dependencies.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (force ignores dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "git"
 module_dependencies   = ["apache"]

--- a/acceptance/tests/modules/install/ignoring_dependencies.rb
+++ b/acceptance/tests/modules/install/ignoring_dependencies.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (ignoring dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (nonexistent directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (nonexistent module)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nonexistent"
 module_dependencies  = []

--- a/acceptance/tests/modules/install/with_debug.rb
+++ b/acceptance/tests/modules/install/with_debug.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with debug)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_dependencies.rb
+++ b/acceptance/tests/modules/install/with_dependencies.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -2,6 +2,10 @@ test_name 'puppet module install (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 tmpdir = master.tmpdir('environmentpath')
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with existing module directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -4,6 +4,10 @@ test_name "puppet module install (with modulepath)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with necessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with no dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with unnecessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with unsatisfied constraints)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name   = "git"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_author = "pmtacceptance"
 module_name = "java"
 module_version = "1.7.0"

--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -2,6 +2,10 @@ test_name 'puppet module list (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 tmpdir = master.tmpdir('environmentpath')
 
 step 'Setup'

--- a/acceptance/tests/modules/search/formatting.rb
+++ b/acceptance/tests/modules/search/formatting.rb
@@ -1,5 +1,9 @@
 test_name 'puppet module search output should be well structured'
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 step 'Setup'
 stub_forge_on(master)
 

--- a/acceptance/tests/modules/search/no_results.rb
+++ b/acceptance/tests/modules/search/no_results.rb
@@ -1,5 +1,9 @@
 test_name 'puppet module search should print a reasonable message for no results'
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 module_name   = "module_not_appearing_in_this_forge"
 
 step 'Setup'

--- a/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
@@ -1,5 +1,9 @@
 test_name "puppet module uninstall (with multiple modules installed)"
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 if master.is_pe?
   skip_test
 end

--- a/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
+++ b/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (in a secondary directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (introducing new dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/not_upgradable.rb
+++ b/acceptance/tests/modules/upgrade/not_upgradable.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (not upgradable)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/to_a_specific_version.rb
+++ b/acceptance/tests/modules/upgrade/to_a_specific_version.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (to a specific version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/to_installed_version.rb
+++ b/acceptance/tests/modules/upgrade/to_installed_version.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (to installed version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (with constraints on it)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (with constraints on its dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_environment.rb
+++ b/acceptance/tests/modules/upgrade/with_environment.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (with environment)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 tmpdir = master.tmpdir('environmentpath')
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/upgrade/with_local_changes.rb
+++ b/acceptance/tests/modules/upgrade/with_local_changes.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_update_available.rb
+++ b/acceptance/tests/modules/upgrade/with_update_available.rb
@@ -2,6 +2,10 @@ test_name "puppet module upgrade (with update available)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+hosts.each do |host|
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+end
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)


### PR DESCRIPTION
the forge certificate was changed.  solaris does not yet have the new
certificates installed.  aix can not install the certs.
Users on these platforms have no good way of installing the
certificates.
skip these tests until we can test and/or the users have a method for
using the forge on these platforms.
Also, skip the legacy environment tests on these platforms prior to
legacy env removal.
