### PR TITLE
(PUP-2531) add epp validate and render face

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 bundler_args: --without development
 script:
   - "bundle exec rake $CHECK"

--- a/lib/puppet/application/epp.rb
+++ b/lib/puppet/application/epp.rb
@@ -1,0 +1,5 @@
+require 'puppet/application/face_base'
+require 'puppet/face'
+
+class Puppet::Application::Epp < Puppet::Application::FaceBase
+end

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -412,7 +412,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       output << Puppet::Pops::Evaluator::EppEvaluator.epp(compiler.topscope, epp_template_name, compiler.environment, template_args)
     rescue Puppet::ParseError => detail
       if show_filename
-        Puppet.err("#{file_nbr == 1 ? "" : "\n"}--- #{epp_template_name}")
+        Puppet.err("--- #{epp_template_name}")
       end
       Puppet.err(detail.message)
       ""

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -77,7 +77,6 @@ Puppet::Face.define(:epp, '0.0.1') do
       end
       if !missing_files.empty?
         raise Puppet::Error, "One or more file(s) specified did not exist:\n" + missing_files.map { |f| "   #{f}" }.join("\n")
-        exit(1)
       else
         # Exit with 1 if there were errors
         exit(1) unless status

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -1,0 +1,439 @@
+require 'puppet/face'
+require 'puppet/pops'
+require 'puppet/parser/files'
+
+Puppet::Face.define(:epp, '0.0.1') do
+  copyright "Puppet Labs", 2014
+  license   "Apache 2 license; see COPYING"
+
+  summary "Interact directly with the EPP template parser/renderer."
+
+  action(:validate) do
+    summary "Validate the syntax of one or more EPP templates."
+    arguments "[<template>] [<template> ...]"
+    returns "Nothing, or encountered syntax errors."
+    description <<-'EOT'
+      This action validates EPP syntax without producing any output.
+
+      When validating, multiple issues per file are reported up
+      to the settings of max_error, and max_warnings. The processing
+      stops after having reported issues for the first encountered file with errors
+      unless the option --continue_on_error is given.
+
+      Exits with 0 if there were no validation errors.
+    EOT
+
+    option("--[no-]continue_on_error") do
+      summary "Whether or not to continue after errors are reported for a template."
+    end
+
+    examples <<-'EOT'
+      Validate the template 'template.epp' in module 'mymodule':
+
+          $ puppet epp validate mymodule/template.epp
+
+      Validate two arbitrary template files:
+
+          $ puppet parser validate mymodule/template1.epp yourmodule/something.epp
+
+        Validate a template somewhere in the file system:
+
+            $ puppet parser validate /tmp/testing/template1.epp
+
+      Validate from STDIN:
+
+          $ cat template.epp | puppet epp validate
+
+      Continue on error to see errors for all templates:
+
+          $ puppet epp validate mymodule/template1.epp mymodule/template2.epp --continue_on_error
+    EOT
+    when_invoked do |*args|
+      options = args.pop
+      compiler = create_compiler(options)
+
+      status = true # no validation error yet
+      files = args
+      if files.empty?
+        if not STDIN.tty?
+          tmp = validate_template_string(STDIN.read)
+          status &&= tmp
+        else
+          Puppet.notice "No template specified. No action taken"
+        end
+      end
+
+      missing_files = []
+      files.each do |file|
+        break if !status && !options[:continue_on_error]
+
+        template_file = Puppet::Parser::Files.find_template(file, compiler.environment)
+        if template_file
+          tmp = validate_template(template_file)
+          status &&= tmp
+        else
+          missing_files << file
+        end
+      end
+      if !missing_files.empty?
+        raise Puppet::Error, "One or more file(s) specified did not exist:\n" + missing_files.map { |f| "   #{f}" }.join("\n")
+        exit(1)
+      else
+        # Exit with 1 if there were errors
+        exit(1) unless status
+        nil
+      end
+    end
+  end
+
+
+  action (:dump) do
+    summary "Outputs a dump of the internal template parse tree for debugging"
+    arguments "-e <source> | [<templates> ...] "
+    returns "A dump of the resulting AST model unless there are syntax or validation errors."
+    description <<-'EOT'
+      The dump action parses and validates the EPP syntax and dumps the resulting AST model
+      in a human readable (but not necessarily an easy to understand) format.
+      The output format of the dumped tree is intended for epp parser debugging purposes
+      and is not API, and may thus change between versions without deprecation warnings.
+
+      The command accepts one or more templates (.epp) files, or an -e followed by the template
+      source text. The given templates can be absolute paths to template files, or references
+      to templates in modules when given on the form <modulename>/<template-name>.epp.
+      If no arguments are given, the stdin is read (unless it is attached to a terminal)
+
+      If multiple templates are given, they are separated with a header indicating the
+      name of the template. This can be surpressed with the option --no-header.
+      The option --[no-]header has no effect whe a single template is dumped.
+
+      When debugging the epp parser itself, it may be useful to surpress the valiation
+      step with the `--no-validate` option to observe what the parser produced from the
+      given source.
+
+      This command ignores the --render-as setting/option.
+    EOT
+
+    option("--e <source>") do
+      default_to { nil }
+      summary "Dump one epp source expression given on the command line."
+    end
+
+    option("--[no-]validate") do
+      summary "Whether or not to validate the parsed result, if no-validate only syntax errors are reported."
+    end
+
+    option("--[no-]header") do
+      summary "Whether or not to show a file name header between files."
+    end
+
+    when_invoked do |*args|
+      require 'puppet/pops'
+      options = args.pop
+      options[:header] = options[:header].nil? ? true : options[:header]
+      options[:validate] = options[:validate].nil? ? true : options[:validate]
+
+      compiler = create_compiler(options)
+
+      if options[:e]
+        dump_parse(options[:e], 'command-line-string', options, false)
+      elsif args.empty?
+        if ! STDIN.tty?
+          dump_parse(STDIN.read, 'stdin', options, false)
+        else
+          raise Puppet::Error, "No input to parse given on command line or stdin"
+        end
+      else
+        templates, missing_files = args.reduce([[],[]]) do |memo, file|
+          template_file = Puppet::Parser::Files.find_template(file, compiler.environment)
+          if template_file.nil?
+            memo[1] << file
+          else
+            memo[0] << template_file
+          end
+          memo
+        end
+
+        show_filename = templates.count > 1
+        dumps = templates.map do |file|
+          dump_parse(File.read(file), file, options, show_filename)
+        end.join("")
+
+        if missing_files.empty?
+          dumps
+        else
+          dumps + "\nOne or more file(s) specified did not exist:\n" + missing_files.collect { |f| "   #{f}" }.join("\n")
+        end
+      end
+    end
+  end
+
+  action (:render) do
+    summary "Renders an epp template as text"
+    arguments "-e <source> | [<templates> ...] "
+    returns "A rendered result of one or more given templates."
+    description <<-'EOT'
+      This action renders one or more EPP templates.
+
+      The command accepts one or more templates (.epp files), given the same way as templates
+      are given to the puppet `epp` function (a full path, or a relative reference
+      on the form '<modulename>/<template-name>.epp').
+
+      An inline_epp equivalent can also be performed by giving the template after
+      an -e, or by piping the EPP source text to the command.
+
+      Values to the template can be defined using the Puppet Language on the command
+      line with `--values` or in a .pp or .yaml file referenced with `--values_file`. If
+      specifying both the result is merged with --values having higher precedence.
+
+      The --values option allows a Puppet Language sequence of expressions to be defined on the
+      command line the same way as it may be given in a .pp file referenced with `--values_file`.
+      It may set variable values (that become available in the template), and must produce
+      either `undef` or a `Hash` of values (the hash may be empty). Producing `undef` simulates
+      that the template is called without an arguments hash and thus only references
+      variables in its outer scope. When a hash is given, a template is limited to seeing
+      only the global scope. It is thus possible to simulate the different types of
+      calls to the `epp` and `inline_epp` functions, with or without a given hash. Note that if
+      variables are given, they are always available in this simulation - to test that the
+      template only references variables given as arguments, produce a hash in --values or
+      the --values_file, do not specify any variables that are not global, and
+      turn on --strict_variables setting.
+
+      If multiple templates are given, the same set of values are given to each template.
+      If both --values and --value_file are used, the --values are merged on top of those given
+      in the file.
+
+      When multiple templates are rendered, a separating header is output between the templates
+      showing the name of the template before the output. The header output can be turned off with
+      `--no-header`. This also concatenates the template results without any added newline separators.
+
+      Facts for the simulated node can be feed to the rendering process by referencing a .yaml file
+      with facts using the --facts option. (Values can be obtained in yaml format directly from
+      `facter`, or from puppet for a given node). Note that it is not possible to simulate the
+      reserved variable name `$facts` in any other way.
+
+      Note that it is not possible to set variables using the Puppet Language that have the same
+      names as facts as this result in an error; "attempt to redefine a variable" since facts
+      are set first.
+
+      Exits with 0 if there were no validation errors. On errors, no rendered output is produced.
+
+      When designing EPP templates, it is strongly recommended to define all template arguments
+      in the template, and to give them in a hash when calling `epp` or `inline_epp` and to use
+      as few global variables as possible, preferrably only the $facts hash. This makes templates
+      more free standing and are easier to reuse, and to test.
+    EOT
+
+    examples <<-'EOT'
+      Render the template in module 'mymodule' called 'mytemplate.epp', and give it two arguments
+      `a` and `b`:
+
+          $ puppet epp render mymodule/mytemplate.epp --values '{a => 10, b => 20}'
+
+      Render a template using an absolute path:
+
+          $ puppet epp render /tmp/testing/mytemplate.epp --values '{a => 10, b => 20}'
+
+      Render a template with data from a .pp file:
+
+          $ puppet epp render /tmp/testing/mytemplate.epp --values_file mydata.pp
+
+      Render a template with data from a .pp file and override one value on the command line:
+
+          $ puppet epp render /tmp/testing/mytemplate.epp --values_file mydata.pp --values '{a=>10}'
+
+      Render from STDIN:
+
+          $ cat template.epp | puppet epp render --values '{a => 10, b => 20}'
+
+      Set variables in a .pp file and render a template that uses variable references:
+
+          # data.pp file
+          $greeted = 'a global var'
+          undef
+
+          $ puppet epp render -e 'hello <%= $greeted %>' --values_file data.pp
+
+      Render a template that outputs a fact:
+
+          $ facter --yaml > data.yaml
+          $ puppet epp render -e '<% $facts[osfamily] %>' --facts data.yaml
+    EOT
+
+    option "--e <source>" do
+      default_to { nil }
+      summary "Render one inline epp template given on the command line."
+    end
+
+    option("--values <values_hash>") do
+      summary "A Hash in Puppet DSL form given as arguments to the template being rendered."
+    end
+
+    option("--values_file <pp_or_yaml_file>") do
+      summary "A .pp or .yaml file that is processed to produce a hash of values for the template."
+    end
+
+    option("--facts <yaml_file>") do
+      summary "A .yaml file containing a hash of facts made available in $facts"
+    end
+
+    option("--[no-]header") do
+      summary "Whether or not to show a file name header between rendered results."
+    end
+
+    when_invoked do |*args|
+      options = args.pop
+      options[:header] = options[:header].nil? ? true : options[:header]
+
+      compiler = create_compiler(options)
+
+      if options[:e]
+        render_inline(options[:e], compiler, options)
+      elsif args.empty?
+        if ! STDIN.tty?
+          render_inline(STDIN.read, compiler, options)
+        else
+          raise Puppet::Error, "No input to process given on command line or stdin"
+        end
+      else
+        show_filename = args.count > 1
+        file_nbr = 0
+        results = args.map do |file|
+          render_file(file, compiler, options, show_filename, file_nbr += 1)
+        end.join("")
+
+        results
+      end
+    end
+  end
+
+  def dump_parse(source, filename, options, show_filename = true)
+    output = ""
+    dumper = Puppet::Pops::Model::ModelTreeDumper.new
+    evaluating_parser = Puppet::Pops::Parser::EvaluatingParser::EvaluatingEppParser.new
+    begin
+      if options[:validate]
+        parse_result = evaluating_parser.parse_string(source, filename)
+      else
+        # side step the assert_and_report step
+        parse_result = evaluating_parser.parser.parse_string(source)
+      end
+      if show_filename && options[:header]
+        output << "--- #{filename}\n"
+      end
+      output << dumper.dump(parse_result) << "\n"
+    rescue Puppet::ParseError => detail
+      if show_filename
+        Puppet.err("--- #{filename}")
+      end
+      Puppet.err(detail.message)
+      ""
+    end
+  end
+
+  def get_values(compiler, options)
+    template_values = nil
+    if values_file = options[:values_file]
+      begin
+        if values_file =~ /\.yaml$/
+          template_values = YAML.load_file(values_file)
+        elsif values_file =~ /\.pp$/
+          evaluating_parser = Puppet::Pops::Parser::EvaluatingParser.new
+          template_values = evaluating_parser.evaluate_file(compiler.topscope, values_file)
+        else
+          Puppet.err("Only .yaml or .pp can be used as a --values_file")
+        end
+      rescue => e
+        Puppet.err("Could not load --values_file.args #{e.message}")
+      end
+      if !(template_values.nil? || template_values.is_a?(Hash))
+        Puppet.err("--values_file option must evaluate to a Hash or undef/nil, got: '#{template_values.class}'")
+      end
+    end
+
+    if values = options[:values]
+      evaluating_parser = Puppet::Pops::Parser::EvaluatingParser.new
+      result = evaluating_parser.evaluate_string(compiler.topscope, values, 'values-hash')
+      if !(result.nil? || result.is_a?(Hash))
+        Puppet.err("--values option must evaluate to a Hash or undef, got '#{result.class}'")
+      end
+      if template_values.nil?
+        result
+      elsif result.nil?
+        template_values
+      else
+        template_values.merge(result)
+      end
+    else
+      template_values
+    end
+  end
+
+  def render_inline(epp_source, compiler, options)
+    template_args = get_values(compiler, options)
+    begin
+      Puppet::Pops::Evaluator::EppEvaluator.inline_epp(compiler.topscope, epp_source, template_args)
+    rescue Puppet::ParseError => detail
+      Puppet.err(detail.message)
+      ""
+    end
+  end
+
+  def render_file(epp_template_name, compiler, options, show_filename, file_nbr)
+    template_args = get_values(compiler, options)
+    output = ""
+    begin
+      if show_filename && options[:header]
+        output << "\n" unless file_nbr == 1
+        output << "--- #{epp_template_name}\n"
+      end
+      output << Puppet::Pops::Evaluator::EppEvaluator.epp(compiler.topscope, epp_template_name, compiler.environment, template_args)
+    rescue Puppet::ParseError => detail
+      if show_filename
+        Puppet.err("#{file_nbr == 1 ? "" : "\n"}--- #{epp_template_name}")
+      end
+      Puppet.err(detail.message)
+      ""
+    end
+  end
+
+  # @api private
+  def validate_template(template)
+    parser = Puppet::Pops::Parser::EvaluatingParser::EvaluatingEppParser.new()
+    parser.parse_file(template)
+    true
+  rescue => detail
+    Puppet.log_exception(detail)
+    false
+  end
+
+  # @api private
+  def validate_template_string(source)
+    parser = Puppet::Pops::Parser::EvaluatingParser::EvaluatingEppParser.new()
+    parser.parse_string(source, '<stdin>')
+    true
+  rescue => detail
+    Puppet.log_exception(detail)
+    false
+  end
+
+  # @api private
+  def create_compiler(options)
+    fact_values = options[:facts] ? YAML.load_file(options[:facts]) : {}
+    node = Puppet::Node.new("testnode", :facts => Puppet::Node::Facts.new("facts", fact_values))
+    compiler = Puppet::Parser::Compiler.new(node)
+    # configure compiler with facts and node related data
+    # Set all global variables from facts
+    fact_values.each {|param, value| compiler.topscope[param] = value }
+    # Configured trusted data (even if there are none)
+    compiler.topscope.set_trusted(node.trusted_data)
+    # Set the facts hash
+    compiler.topscope.set_facts(fact_values)
+
+    # pretend that the main class (named '') has been evaluated
+    # since it is otherwise not possible to resolve top scope variables
+    # using '::' when rendering. (There is no harm doing this for the other actions)
+    #
+    compiler.topscope.class_set('', compiler.topscope)
+    compiler
+  end
+end

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -195,7 +195,9 @@ Puppet::Face.define(:epp, '0.0.1') do
 
       The command accepts one or more templates (.epp files), given the same way as templates
       are given to the puppet `epp` function (a full path, or a relative reference
-      on the form '<modulename>/<template-name>.epp').
+      on the form '<modulename>/<template-name>.epp'), or as a relative path.args In case
+      the given path matches both a modulename/template and a file, the template from
+      the module is used.
 
       An inline_epp equivalent can also be performed by giving the template after
       an -e, or by piping the EPP source text to the command.
@@ -402,6 +404,10 @@ Puppet::Face.define(:epp, '0.0.1') do
       if show_filename && options[:header]
         output << "\n" unless file_nbr == 1
         output << "--- #{epp_template_name}\n"
+      end
+      template_file = Puppet::Parser::Files.find_template(epp_template_name, compiler.environment)
+      if template_file.nil? && Puppet::FileSystem.exist?(epp_template_name)
+        epp_template_name = File.expand_path(epp_template_name)
       end
       output << Puppet::Pops::Evaluator::EppEvaluator.epp(compiler.topscope, epp_template_name, compiler.environment, template_args)
     rescue Puppet::ParseError => detail

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -112,7 +112,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       and is not API, and may thus change between versions without deprecation warnings.
 
       The command accepts one or more templates (.epp) files, or an -e followed by the template
-      source text. The given templates can be absolute paths to template files, or references
+      source text. The given templates can be paths to template files, or references
       to templates in modules when given on the form <modulename>/<template-name>.epp.
       If no arguments are given, the stdin is read (unless it is attached to a terminal)
 
@@ -159,6 +159,9 @@ Puppet::Face.define(:epp, '0.0.1') do
       else
         templates, missing_files = args.reduce([[],[]]) do |memo, file|
           template_file = Puppet::Parser::Files.find_template(file, compiler.environment)
+          if template_file.nil? && Puppet::FileSystem.exist?(file)
+            template_file = file
+          end
           if template_file.nil?
             memo[1] << file
           else
@@ -175,7 +178,9 @@ Puppet::Face.define(:epp, '0.0.1') do
         if missing_files.empty?
           dumps
         else
-          dumps + "\nOne or more file(s) specified did not exist:\n" + missing_files.collect { |f| "   #{f}" }.join("\n")
+          puts dumps
+          STDERR.puts "One or more file(s) specified did not exist:\n" + missing_files.collect { |f| "   #{f}" }.join("\n")
+          exit(1)
         end
       end
     end

--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -37,8 +37,8 @@ class Puppet::Pops::Parser::EvaluatingParser
     evaluate(scope, parse_string(s, file_source))
   end
 
-  def evaluate_file(file)
-    evaluate(parse_file(file))
+  def evaluate_file(scope, file)
+    evaluate(scope, parse_file(file))
   end
 
   def clear()

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -1,0 +1,303 @@
+require 'spec_helper'
+require 'puppet_spec/files'
+
+require 'puppet/face'
+
+describe Puppet::Face[:epp, :current] do
+  include PuppetSpec::Files
+
+  let(:eppface) { Puppet::Face[:epp, :current] }
+
+  context "validate" do
+    context "from an interactive terminal" do
+      before :each do
+        from_an_interactive_terminal
+      end
+
+      it "validates the template referenced as an absolute file" do
+        template_name = 'template1.epp'
+        dir = dir_containing('templates', { template_name => "<%= |$a $b |%>" })
+        template = File.join(dir, template_name)
+        expect { eppface.validate(template) }.to exit_with(1)
+      end
+
+      it "runs error free when there are no validation errors from an absolute file" do
+        template_name = 'template1.epp'
+        dir = dir_containing('templates', { template_name => "just text" })
+        template = File.join(dir, template_name)
+        expect { eppface.validate(template) }.to_not exit_with(1)
+      end
+
+      it "reports missing files" do
+        expect do
+          eppface.validate("missing.epp")
+        end.to raise_error(Puppet::Error, /One or more file\(s\) specified did not exist.*missing\.epp/m)
+      end
+
+      context "in an environment with templates" do
+        let(:dir) do
+          dir_containing('environments', { 'production' => { 'modules' => {
+            'm1' => { 'templates' => {
+              'greetings.epp' => "<% |$subject = world| %>hello <%= $subject -%>",
+              'broken.epp'    => "<% | $a $b | %> I am broken",
+              'broken2.epp'   => "<% | $a $b | %> I am broken too"
+            }},
+            'm2' => { 'templates' => {
+              'goodbye.epp'   => "<% | $subject = world |%>goodbye <%= $subject -%>",
+              'broken3.epp'   => "<% | $a $b | %> I am broken too"
+            }}
+          }}})
+
+        end
+
+        around(:each) do |example|
+          Puppet.settings.initialize_global_settings
+          loader = Puppet::Environments::Directories.new(dir, [])
+          Puppet.override(:environments => loader) do
+            example.run
+          end
+        end
+
+        it "parses supplied template files in different modules of a directory environment" do
+          expect(eppface.validate('m1/greetings.epp')).to be_nil
+          expect(eppface.validate('m2/goodbye.epp')).to be_nil
+        end
+
+        it "finds errors in supplied template file in the context of a directory environment" do
+          expect { eppface.validate('m1/broken.epp') }.to exit_with(1)
+          expect(@logs.join).to match(/Syntax error at 'b'/)
+        end
+
+        it "stops on first error by default" do
+          expect { eppface.validate('m1/broken.epp', 'm1/broken2.epp') }.to exit_with(1)
+          expect(@logs.join).to match(/Syntax error at 'b'.*broken\.epp/)
+          expect(@logs.join).to_not match(/Syntax error at 'b'.*broken2\.epp/)
+        end
+
+        it "continues after error when --continue_on_error is given" do
+          expect { eppface.validate('m1/broken.epp', 'm1/broken2.epp', :continue_on_error => true) }.to exit_with(1)
+          expect(@logs.join).to match(/Syntax error at 'b'.*broken\.epp/)
+          expect(@logs.join).to match(/Syntax error at 'b'.*broken2\.epp/)
+        end
+
+        it "validates all templates in the environment" do
+          pending "NOT IMPLEMENTED YET"
+          expect { eppface.validate(:continue_on_error => true) }.to exit_with(1)
+          expect(@logs.join).to match(/Syntax error at 'b'.*broken\.epp/)
+          expect(@logs.join).to match(/Syntax error at 'b'.*broken2\.epp/)
+          expect(@logs.join).to match(/Syntax error at 'b'.*broken3\.epp/)
+        end
+      end
+    end
+
+    it "validates the contents of STDIN when no files given and STDIN is not a tty" do
+      from_a_piped_input_of("<% | $a $oh_no | %> I am broken")
+      expect { eppface.validate() }.to exit_with(1)
+      expect(@logs.join).to match(/Syntax error at 'oh_no'/)
+    end
+
+    it "validates error free contents of STDIN when no files given and STDIN is not a tty" do
+      from_a_piped_input_of("look, just text")
+      expect(eppface.validate()).to be_nil
+    end
+  end
+
+  context "render" do
+
+  end
+
+  context "dump" do
+    it "prints the AST of a template given with the -e option" do
+      expect(eppface.dump({ :e => 'hello world' })).to eq("(lambda (epp (block\n  (render-s 'hello world')\n)))\n")
+    end
+
+    it "prints the AST of a template given as an absolute file" do
+      template_name = 'template1.epp'
+      dir = dir_containing('templates', { template_name => "hello world" })
+      template = File.join(dir, template_name)
+      expect(eppface.dump(template)).to eq("(lambda (epp (block\n  (render-s 'hello world')\n)))\n")
+    end
+
+    it "adds a header between dumps by default" do
+      template_name1 = 'template1.epp'
+      template_name2 = 'template2.epp'
+      dir = dir_containing('templates', { template_name1 => "hello world", template_name2 => "hello again"} )
+      template1 = File.join(dir, template_name1)
+      template2 = File.join(dir, template_name2)
+
+      # Do not move the text block, the left margin and indentation matters
+      expect(eppface.dump(template1, template2)).to eq( <<-"EOT" )
+--- #{template1}
+(lambda (epp (block
+  (render-s 'hello world')
+)))
+--- #{template2}
+(lambda (epp (block
+  (render-s 'hello again')
+)))
+      EOT
+    end
+
+    it "dumps non validated content when given --no-validate" do
+      template_name = 'template1.epp'
+      dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
+      template = File.join(dir, template_name)
+      expect(eppface.dump(template, :validate => false)).to eq("(lambda (epp (block\n  1\n  2\n  3\n)))\n")
+    end
+
+    it "validated content when given --validate" do
+      template_name = 'template1.epp'
+      dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
+      template = File.join(dir, template_name)
+      expect(eppface.dump(template, :validate => true)).to eq("")
+      expect(@logs.join).to match(/This Literal Integer is not productive.* line 1:4/)
+    end
+
+    it "validated content by default" do
+      template_name = 'template1.epp'
+      dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
+      template = File.join(dir, template_name)
+      expect(eppface.dump(template)).to eq("")
+      expect(@logs.join).to match(/This Literal Integer is not productive.* line 1:4/)
+    end
+
+    it "informs the user of files that don't exist" do
+      result = eppface.dump('does_not_exist_here.epp')
+      expect(result).to match(/One or more file\(s\) specified did not exist:\n\s*does_not_exist_here\.epp/m)
+    end
+
+    it "dumps the AST of STDIN when no files given and STDIN is not a tty" do
+      from_a_piped_input_of("hello world")
+      expect(eppface.dump()).to eq("(lambda (epp (block\n  (render-s 'hello world')\n)))\n")
+    end
+
+    it "logs an error if the input cannot be parsed even if validation is off" do
+      from_a_piped_input_of("<% |$a  $b| %> oh no")
+      expect(eppface.dump(:validate => false)).to eq("")
+      expect(@logs[0].message).to match(/Syntax error at 'b'/)
+      expect(@logs[0].level).to eq(:err)
+    end
+  end
+
+  context "render" do
+    it "renders input from stdin" do
+      from_a_piped_input_of("hello world")
+      expect(eppface.render()).to eq("hello world")
+    end
+
+    it "renders input from command line" do
+      expect(eppface.render(:e => 'hello world')).to eq("hello world")
+    end
+
+    it "renders input from an absolute file" do
+      template_name = 'template1.epp'
+      dir = dir_containing('templates', { template_name => "absolute world" })
+      template = File.join(dir, template_name)
+      expect(eppface.render(template)).to eq("absolute world")
+    end
+
+    it "renders expressions" do
+      expect(eppface.render(:e => '<% $x = "mr X"%>hello <%= $x %>')).to eq("hello mr X")
+    end
+
+    it "adds values given in a puppet hash given on command line with --values" do
+      expect(eppface.render(:e => 'hello <%= $x %>', :values => '{x => "mr X"}')).to eq("hello mr X")
+    end
+
+    it "adds values given in a puppet hash given on command line with --values" do
+      expect(eppface.render(:e => 'hello <%= $x %>', :values => '{x => "mr X"}')).to eq("hello mr X")
+    end
+
+    it "adds values given in a puppet hash produced by a .pp file given with --values_file" do
+      file_name = 'values.pp'
+      dir = dir_containing('values', { file_name => '{x => "mr X"}' })
+      values_file = File.join(dir, file_name)
+      expect(eppface.render(:e => 'hello <%= $x %>', :values_file => values_file)).to eq("hello mr X")
+    end
+
+    it "adds values given in a yaml hash given with --values_file" do
+      file_name = 'values.yaml'
+      dir = dir_containing('values', { file_name => "---\n x: 'mr X'" })
+      values_file = File.join(dir, file_name)
+      expect(eppface.render(:e => 'hello <%= $x %>', :values_file => values_file)).to eq("hello mr X")
+    end
+
+    it "merges values from values file and command line with command line having higher precedence" do
+      file_name = 'values.yaml'
+      dir = dir_containing('values', { file_name => "---\n x: 'mr X'\n word: 'goodbye'" })
+      values_file = File.join(dir, file_name)
+      expect(eppface.render(:e => '<%= $word %> <%= $x %>',
+        :values_file => values_file,
+        :values => '{x => "mr Y"}')
+        ).to eq("goodbye mr Y")
+    end
+
+    context "in an environment with templates" do
+      let(:dir) do
+        dir_containing('environments', { 'production' => { 'modules' => {
+          'm1' => { 'templates' => {
+            'greetings.epp' => "<% |$subject = world| %>hello <%= $subject -%>",
+            'factshash.epp' => "fact = <%= $facts[the_fact] -%>",
+            'fact.epp'      => "fact = <%= $the_fact -%>",
+          }},
+          'm2' => { 'templates' => {
+            'goodbye.epp'   => "<% | $subject = world |%>goodbye <%= $subject -%>",
+          }}
+        },
+          'extra' => {
+            'facts.yaml' => "---\n the_fact: 42"
+          }
+        }})
+
+      end
+
+      around(:each) do |example|
+        Puppet.settings.initialize_global_settings
+        loader = Puppet::Environments::Directories.new(dir, [])
+        Puppet.override(:environments => loader) do
+          example.run
+        end
+      end
+
+      it "renders supplied template files in different modules of a directory environment" do
+        expect(eppface.render('m1/greetings.epp')).to eq("hello world")
+        expect(eppface.render('m2/goodbye.epp')).to eq("goodbye world")
+      end
+
+      it "makes facts available in $facts" do
+        facts_file = File.join(dir, 'production', 'extra', 'facts.yaml')
+        expect(eppface.render('m1/factshash.epp', :facts => facts_file)).to eq("fact = 42")
+      end
+
+      it "makes facts available individually" do
+        facts_file = File.join(dir, 'production', 'extra', 'facts.yaml')
+        expect(eppface.render('m1/fact.epp', :facts => facts_file)).to eq("fact = 42")
+      end
+
+      it "renders multiple files separated by headers by default" do
+        modules_dir = File.join(dir, 'environments', 'production', 'modules')
+        # chomp the last newline, it is put there by heredoc
+        expect(eppface.render('m1/greetings.epp', 'm2/goodbye.epp')).to eq(<<-EOT.chomp)
+--- m1/greetings.epp
+hello world
+--- m2/goodbye.epp
+goodbye world
+        EOT
+      end
+
+      it "outputs multiple files verbatim when --no-headers is given" do
+        modules_dir = File.join(dir, 'environments', 'production', 'modules')
+        expect(eppface.render('m1/greetings.epp', 'm2/goodbye.epp', :header => false)).to eq("hello worldgoodbye world")
+      end
+    end
+  end
+
+  def from_an_interactive_terminal
+    STDIN.stubs(:tty?).returns(true)
+  end
+
+  def from_a_piped_input_of(contents)
+    STDIN.stubs(:tty?).returns(false)
+    STDIN.stubs(:read).returns(contents)
+  end
+end

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -18,14 +18,14 @@ describe Puppet::Face[:epp, :current] do
         template_name = 'template1.epp'
         dir = dir_containing('templates', { template_name => "<%= |$a $b |%>" })
         template = File.join(dir, template_name)
-        expect { eppface.validate(template) }.to exit_with(1)
+        expect { eppface.validate(template) }.to raise_exception(Puppet::Error, /Errors while validating epp/)
       end
 
       it "runs error free when there are no validation errors from an absolute file" do
         template_name = 'template1.epp'
         dir = dir_containing('templates', { template_name => "just text" })
         template = File.join(dir, template_name)
-        expect { eppface.validate(template) }.to_not exit_with(1)
+        expect { eppface.validate(template) }.to_not raise_exception()
       end
 
       it "reports missing files" do
@@ -64,25 +64,25 @@ describe Puppet::Face[:epp, :current] do
         end
 
         it "finds errors in supplied template file in the context of a directory environment" do
-          expect { eppface.validate('m1/broken.epp') }.to exit_with(1)
+          expect { eppface.validate('m1/broken.epp') }.to raise_exception(Puppet::Error, /Errors while validating epp/)
           expect(@logs.join).to match(/Syntax error at 'b'/)
         end
 
         it "stops on first error by default" do
-          expect { eppface.validate('m1/broken.epp', 'm1/broken2.epp') }.to exit_with(1)
+          expect { eppface.validate('m1/broken.epp', 'm1/broken2.epp') }.to raise_exception(Puppet::Error, /Errors while validating epp/)
           expect(@logs.join).to match(/Syntax error at 'b'.*broken\.epp/)
           expect(@logs.join).to_not match(/Syntax error at 'b'.*broken2\.epp/)
         end
 
         it "continues after error when --continue_on_error is given" do
-          expect { eppface.validate('m1/broken.epp', 'm1/broken2.epp', :continue_on_error => true) }.to exit_with(1)
+          expect { eppface.validate('m1/broken.epp', 'm1/broken2.epp', :continue_on_error => true) }.to raise_exception(Puppet::Error, /Errors while validating epp/)
           expect(@logs.join).to match(/Syntax error at 'b'.*broken\.epp/)
           expect(@logs.join).to match(/Syntax error at 'b'.*broken2\.epp/)
         end
 
         it "validates all templates in the environment" do
           pending "NOT IMPLEMENTED YET"
-          expect { eppface.validate(:continue_on_error => true) }.to exit_with(1)
+          expect { eppface.validate(:continue_on_error => true) }.to raise_exception(Puppet::Error, /Errors while validating epp/)
           expect(@logs.join).to match(/Syntax error at 'b'.*broken\.epp/)
           expect(@logs.join).to match(/Syntax error at 'b'.*broken2\.epp/)
           expect(@logs.join).to match(/Syntax error at 'b'.*broken3\.epp/)
@@ -92,7 +92,7 @@ describe Puppet::Face[:epp, :current] do
 
     it "validates the contents of STDIN when no files given and STDIN is not a tty" do
       from_a_piped_input_of("<% | $a $oh_no | %> I am broken")
-      expect { eppface.validate() }.to exit_with(1)
+      expect { eppface.validate() }.to raise_exception(Puppet::Error, /Errors while validating epp/)
       expect(@logs.join).to match(/Syntax error at 'oh_no'/)
     end
 
@@ -162,8 +162,8 @@ describe Puppet::Face[:epp, :current] do
     end
 
     it "informs the user of files that don't exist" do
-      result = eppface.dump('does_not_exist_here.epp')
-      expect(result).to match(/One or more file\(s\) specified did not exist:\n\s*does_not_exist_here\.epp/m)
+      expected_message = /One or more file\(s\) specified did not exist:\n\s*does_not_exist_here\.epp/m
+      expect { eppface.dump('does_not_exist_here.epp') }.to raise_exception(Puppet::Error, expected_message)
     end
 
     it "dumps the AST of STDIN when no files given and STDIN is not a tty" do


### PR DESCRIPTION
This adds a new command called puppet-epp that can validate
one or several epp templates, render them to text with
various options for specifying facts and variables in scope,
giving variables to the template etc.

The command also has a dump action that is useful for debugging
epp parsing. This command is similar to the puppet parser dump
action.

For more details run 'puppet man epp' on this branch.