### PR TITLE
(PUP-3282) Remove support for method access to variables in ERB templ.

### DIFF
--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -58,30 +58,6 @@ class Puppet::Parser::TemplateWrapper
     scope.catalog.tags
   end
 
-  # Ruby treats variables like methods, so we used to expose variables
-  # within scope to the ERB code via method_missing.  As per RedMine #1427,
-  # though, this means that conflicts between methods in our inheritance
-  # tree (Kernel#fork) and variable names (fork => "yes/no") could arise.
-  #
-  # Worse, /new/ conflicts could pop up when a new kernel or object method
-  # was added to Ruby, causing templates to suddenly fail mysteriously when
-  # Ruby was upgraded.
-  #
-  # To ensure that legacy templates using unqualified names work we retain
-  # the missing_method definition here until we declare the syntax finally
-  # dead.
-  def method_missing(name, *args)
-    line_number = script_line
-    if scope.include?(name.to_s)
-      Puppet.deprecation_warning("Variable access via '#{name}' is deprecated. Use '@#{name}' instead. #{to_s}:#{line_number}")
-      return scope[name.to_s, { :file => @__file__, :line => line_number }]
-    else
-      # Just throw an error immediately, instead of searching for
-      # other missingmethod things or whatever.
-      raise Puppet::ParseError.new("Could not find value for '#{name}'", @__file__, line_number)
-    end
-  end
-
   # @api private
   def file=(filename)
     unless @__file__ = Puppet::Parser::Files.find_template(filename, scope.compiler.environment)

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -36,12 +36,12 @@ describe "the template function" do
     it "raises an error when accessing an undefined variable" do
       expect {
         eval_template("template <%= deprecated %>")
-      }.to raise_error(Puppet::ParseError, /Could not find value for 'deprecated'/)
+      }.to raise_error(Puppet::ParseError, /undefined local variable or method `deprecated'/)
     end
 
     it "looks up the value from the scope" do
       scope["deprecated"] = "deprecated value"
-      eval_template("template <%= deprecated %>").should == "template deprecated value"
+      expect { eval_template("template <%= deprecated %>")}.to raise_error(/undefined local variable or method `deprecated'/)
     end
 
     it "still has access to Kernel methods" do
@@ -78,7 +78,7 @@ describe "the template function" do
   it "does not have direct access to Scope#lookupvar" do
     expect {
       eval_template("<%= lookupvar('myvar') %>")
-    }.to raise_error(Puppet::ParseError, /Could not find value for 'lookupvar'/)
+    }.to raise_error(Puppet::ParseError, /undefined method `lookupvar'/)
   end
 
   def eval_template(content)

--- a/spec/unit/parser/templatewrapper_spec.rb
+++ b/spec/unit/parser/templatewrapper_spec.rb
@@ -70,19 +70,9 @@ describe Puppet::Parser::TemplateWrapper do
     tw.tags.should == ["tag1","tag2"]
   end
 
-  it "warns about deprecated access to in-scope variables via method calls" do
-    Puppet.expects(:deprecation_warning).with("Variable access via 'in_scope_variable' is deprecated. Use '@in_scope_variable' instead. template[inline]:1")
+  it "raises error on access to removed in-scope variables via method calls" do
     scope["in_scope_variable"] = "is good"
-    tw.result("<%= in_scope_variable %>")
-  end
-
-  it "provides access to in-scope variables via method calls" do
-    scope["in_scope_variable"] = "is good"
-    tw.result("<%= in_scope_variable %>").should == "is good"
-  end
-
-  it "errors if accessing via method call a variable that does not exist" do
-    expect { tw.result("<%= does_not_exist %>") }.to raise_error(Puppet::ParseError)
+    expect { tw.result("<%= in_scope_variable %>") }.to raise_error(/undefined local variable or method `in_scope_variable'/ )
   end
 
   it "reports that variable is available when it is in scope" do


### PR DESCRIPTION
This removes the deprecated support to produce lookup of variable
names when a missing method was invoked having the same name as
the variable.

This is now an error, just like calling any other missing method.
