### PR TITLE
(PUP-3680) Remove confusing convenience Hash[value-type]

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -330,11 +330,6 @@ class Puppet::Pops::Evaluator::AccessOperator
       end
     end
     case keys.size
-    when 1
-      result = Puppet::Pops::Types::PHashType.new()
-      result.key_type = o.key_type.copy
-      result.element_type = keys[0]
-      result
     when 2
       result = Puppet::Pops::Types::PHashType.new()
       result.key_type = keys[0]
@@ -354,7 +349,7 @@ class Puppet::Pops::Evaluator::AccessOperator
       result
     else
       fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, @semantic, {
-        :base_type => 'Hash-Type', :min => 1, :max => 4, :actual => keys.size
+        :base_type => 'Hash-Type', :min => 2, :max => 4, :actual => keys.size
       })
     end
     result.size_type = size_t if size_t

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -230,9 +230,6 @@ class Puppet::Pops::Types::TypeParser
 
     when "hash"
       result = case parameters.size
-      when 1
-        assert_type(parameters[0])
-        TYPES.hash_of(parameters[0])
       when 2
         assert_type(parameters[0])
         assert_type(parameters[1])
@@ -256,7 +253,7 @@ class Puppet::Pops::Types::TypeParser
         assert_type(parameters[1])
         TYPES.hash_of(parameters[1], parameters[0])
       else
-        raise_invalid_parameters_error("Hash", "1 to 4", parameters.size)
+        raise_invalid_parameters_error("Hash", "2 to 4", parameters.size)
       end
       result.size_type = size_type if size_type
       result

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -166,23 +166,23 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
 
     # Hash Type
     #
-    it 'produces a Hash[Scalar,String] from the expression Hash[String]' do
-      expr = fqr('Hash')[fqr('String')]
+    it 'produces a Hash[Scalar,String] from the expression Hash[Scalar, String]' do
+      expr = fqr('Hash')[fqr('Scalar'), fqr('String')]
       expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.scalar))
 
       # arguments are flattened
-      expr = fqr('Hash')[[fqr('String')]]
+      expr = fqr('Hash')[[fqr('Scalar'), fqr('String')]]
       expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.scalar))
     end
 
-    it 'produces a Hash[String,String] from the expression Hash[String, String]' do
-      expr = fqr('Hash')[fqr('String'), fqr('String')]
-      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.string))
+    it 'gives an error if only one type is specified ' do
+      expr = fqr('Hash')[fqr('String')]
+      expect {evaluate(expr)}.to raise_error(/accepts 2 to 4 arguments/)
     end
 
-    it 'produces a Hash[Scalar,String] from the expression Hash[Integer][String]' do
-      expr = fqr('Hash')[fqr('Integer')][fqr('String')]
-      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.scalar))
+    it 'produces a Hash[Scalar,String] from the expression Hash[Integer, Array][Integer, String]' do
+      expr = fqr('Hash')[fqr('Integer'), fqr('Array')][fqr('Integer'), fqr('String')]
+      expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.integer))
     end
 
     it "gives an error if parameter is not a type" do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -688,7 +688,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "Hash[Integer, 0]"            => 'Hash-Type[] arguments must be types. Got Fixnum',
       "Array[Integer,1,2,3]"        => 'Array-Type[] accepts 1 to 3 arguments. Got 4',
       "Array[Integer,String]"       => "A Type's size constraint arguments must be a single Integer type, or 1-2 integers (or default). Got a String-Type",
-      "Hash[Integer,String, 1,2,3]" => 'Hash-Type[] accepts 1 to 4 arguments. Got 5',
+      "Hash[Integer,String, 1,2,3]" => 'Hash-Type[] accepts 2 to 4 arguments. Got 5',
       "'abc'[x]"                    => "The value 'x' cannot be converted to Numeric",
       "'abc'[1.0]"                  => "A String[] cannot use Float where Integer is expected",
       "'abc'[1,2,3]"                => "String supports [] with one or two arguments. Got 3",

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::Pops::Types::TypeParser do
   end
 
   it "interprets a parameterized Hash[t] as a Hash of Scalar to t" do
-    expect(parser.parse("Hash[Integer]")).to be_the_type(types.hash_of(types.integer))
+    expect(parser.parse("Hash[Scalar, Integer]")).to be_the_type(types.hash_of(types.integer))
   end
 
   it "parses a parameterized type into the type object" do
@@ -129,7 +129,7 @@ describe Puppet::Pops::Types::TypeParser do
 
   it "rejects an collection spec with the wrong number of parameters" do
     expect { parser.parse("Array[Integer, 1,2,3]") }.to raise_the_parameter_error("Array", "1 to 3", 4)
-    expect { parser.parse("Hash[Integer, Integer, 1,2,3]") }.to raise_the_parameter_error("Hash", "1 to 4", 5)
+    expect { parser.parse("Hash[Integer, Integer, 1,2,3]") }.to raise_the_parameter_error("Hash", "2 to 4", 5)
   end
 
   it "interprets anything that is not a built in type to be a resource type" do


### PR DESCRIPTION
In an attempt to be helpful, the type system offers a convenience
that if a Hash type is specified with one key, then this is taken
as being the type of the value (and the key type defaults to
Scalar).

In practice this proved to be confusing as it raises the question
about if it is the key type or the value type that is being
specified. Some users thought it was they key type, as that is
what they wanted control over, others thought it was the value type.

From a consistency standpoint (a Hash is a Collection), it could
be viewed as being a collection of Tuple[Key, Value], but implementing
that is not very helpful (it is just more to type). The best solution is
therefore to simply remove the convenience and require both Key and
Value type as a minimum. (This also removes the confusion over the error
if wanting to specify Hash[Value, 2,5](which fails because 2 is not a
type). Now users have to specify the full type: Hash[Key, Value, 2, 5]
if they want to add min and max entries.
