### PR TITLE
(PUP-3839) Use PL Gem mirror in acceptance tests

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,21 +1,11 @@
-gem_source = ENV['GEM_SOURCE']
-if gem_source.nil? || gem_source.empty?
-  default = ENV['OUTSIDE_PUPPETLABS'] ?
-    'https://rubygems.org' :
-    'http://rubygems.delivery.puppetlabs.net'
-  gem_source = default
-end
-source gem_source
+# Specifies a gem mirror; duplicated in acceptance setup
+# to ensure a similar environment on acceptance hosts.
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gem (ENV['BEAKER_GEM'] || "beaker"), "~> 1.17"
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false
-
-# qa utils that live only in our testing environment.
-if !ENV['OUTSIDE_PUPPETLABS']
-  gem 'sqa-utils'
-end
 
 group(:test) do
   gem "rspec", "~> 2.14.0", :require => false

--- a/acceptance/bin/ci-pe-puppet.sh
+++ b/acceptance/bin/ci-pe-puppet.sh
@@ -15,6 +15,8 @@ if [[ -z "$BEAKER_GEM" || -z "$tests" || -z "$platform" || -z "$layout" || -z "$
     'layout'      (to '64mcda' or '32mcda' or '32m-32d-32c-32a' or '64mdc-32a' for various cpu & master/database/console node combinations)
     'tests'       (to the comma separated list of tests or directory of tests to execute)
     'BEAKER_GEM'  (to either 'beaker' or 'pe-beaker' which is holding some temporary puppetserver related changes)
+    The gem 'sqa-utils' is also required, but not part of the Gemfile as it's internal to Puppet Labs.
+    The script will add sqa-utils to Gemfile.local.
 "
   exit 1
 fi
@@ -23,11 +25,17 @@ cd acceptance
 
 rm -f Gemfile.lock
 
+if ! grep -qs sqa-utils Gemfile.local; then
+  echo "gem 'sqa-utils'" >> Gemfile.local
+fi
+
 bundle install --path=./.bundle/gems
 
 #export pe_version=${pe_version_override:-$pe_version}
 #export pe_family=3.4
-bundle exec genconfig ${platform}-${layout} > hosts.cfg
+if bundle exec genconfig ${platform}-${layout} > hosts.cfg
+then; else echo "Usage: ensure Gemfile.local exists requiring sqa-utils"
+fi
 
 export forge_host=api-forge-aio01-petest.puppetlabs.com
 

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -198,6 +198,18 @@ module Puppet
             host.logger.notify("No repository installation step for #{platform} yet...")
         end
       end
+
+      # Configures gem sources on hosts to use a mirror, if specified
+      # This is a duplicate of the Gemfile logic.
+      def configure_gem_mirror(hosts)
+        hosts = [hosts] unless hosts.kind_of?(Array)
+        gem_source = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+        hosts.each do |host|
+          on host, 'gem source --clear-all'
+          on host, "gem source --add #{gem_source}"
+        end
+      end
     end
   end
 end

--- a/acceptance/setup/packages/pre-suite/010_Install.rb
+++ b/acceptance/setup/packages/pre-suite/010_Install.rb
@@ -47,3 +47,6 @@ AGENT_PACKAGES = {
 
 install_packages_on(master, MASTER_PACKAGES)
 install_packages_on(agents, AGENT_PACKAGES)
+
+configure_gem_mirror(hosts)
+


### PR DESCRIPTION
The testing infrastucture should be resilient to network issues. For
acceptance tests that exercise the Gem provider and setup that installs
Gems, there hasn't been a clean way to specify that the internal mirror
should be used. This follows the Gemfile pattern and selects the
internal mirror if it's available.