### PR TITLE
Remove trusted facts from indirector

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -96,6 +96,7 @@ class Puppet::Node
   # Merge the node facts with parameters from the node source.
   def fact_merge
     if @facts = Puppet::Node::Facts.indirection.find(name, :environment => environment)
+      @facts.delete_trusted_facts
       @facts.sanitize
       merge(@facts.values)
     end

--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -67,6 +67,10 @@ class Puppet::Node::Facts
     end
   end
 
+  def delete_trusted_facts
+    values.delete(:trusted)
+  end
+
   def ==(other)
     return false unless self.name == other.name
     values == other.values


### PR DESCRIPTION
Data coming from PuppetDB will include trusted facts as a structured
fact under the name "trusted". Puppet expects that it is the source of
trusted facts and so seeing these trusted facts included in results from
the indirector causes Puppet runs to fail. Previously this only happened
when there was some issue reading facts from cache (hence going to
PuppetDB to get the most recent copy). Current behavior is no longer
going to cache and is always going to PuppetDB, which always fails since
PuppetDB will include trusted facts.

This commit removes trusted facts from indirector responses.
