### PR TITLE
(maint) No longer necessary to gem install rgen

### DIFF
--- a/acceptance/setup/common/pre-suite/100_SetParser.rb
+++ b/acceptance/setup/common/pre-suite/100_SetParser.rb
@@ -12,12 +12,6 @@ test_name "add parser=#{ENV['PARSER']} to all puppet.conf (only if $PARSER is se
         }
       }
       lay_down_new_puppet_conf(host, opts, temp)
-
-      if !options[:install].empty? and parser == 'future'
-        # We are installing from source rather than packages and need the following:
-        win_cmd_prefix = 'cmd /c ' if host['platform'] =~ /windows/
-        on(host, "#{win_cmd_prefix}gem install rgen")
-      end
     end
   end
 end


### PR DESCRIPTION
Puppet used to express gem dependencies on rgen in its Gemfile, packaging,
etc, but in PUP-2914 the rgen code was vendored into puppet, and the
dependencies removed.

However, the future parser setup step still tried to install the rgen
gem, but only when testing against git checkouts (effectively Solaris
and Windows).

Since rgen is vendored in puppet, it is not necessary to install the gem
during future parser testing.
