### PR TITLE
(maint,QENG-174) Allow installing a new puppet package on top of the PE tar

### DIFF
--- a/acceptance/setup/pe/pre-suite/010_UpdatePkg.rb
+++ b/acceptance/setup/pe/pre-suite/010_UpdatePkg.rb
@@ -1,0 +1,18 @@
+test_name 'Update pe-puppet pkg' do
+
+  repo_path = ENV['PUPPET_REPO_CONFIGS']
+  version = ENV['PUPPET_REF']
+
+  unless repo_path && version
+    skip_test "The puppet version to install isn't specified, using what's in the tarball..."
+  end
+
+  hosts.each do |host|
+    deploy_package_repo(host, repo_path, "pe-puppet", version)
+    host.upgrade_package("pe-puppet")
+  end
+
+  with_puppet_running_on master, {} do
+    # this bounces the puppet master for us
+  end
+end


### PR DESCRIPTION
Currently, when running the puppet acceptance tests against PE, you
can only test the version of puppet that is shipped with the PE
tarball. This adds another step to the PE pre-suite which will install
an arbitrary version of pe-puppet on top of the installed PE tarball.
