### PR TITLE
(PUP-3624) Don't modify application-level options

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -366,10 +366,11 @@ class Application
     Puppet::Util::Log.setup_default unless options[:setdest]
   end
 
-  def set_log_level
-    if options[:debug]
+  def set_log_level(opts = nil)
+    opts ||= options
+    if opts[:debug]
       Puppet::Util::Log.level = :debug
-    elsif options[:verbose] && !Puppet::Util::Log.sendlevel?(:info)
+    elsif opts[:verbose] && !Puppet::Util::Log.sendlevel?(:info)
       Puppet::Util::Log.level = :info
     end
   end

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -5,13 +5,11 @@ require 'pp'
 
 class Puppet::Application::FaceBase < Puppet::Application
   option("--debug", "-d") do |arg|
-    options[:debug] = true
-    set_log_level
+    set_log_level(:debug => true)
   end
 
   option("--verbose", "-v") do |_|
-    options[:verbose] = true
-    set_log_level
+    set_log_level(:verbose => true)
   end
 
   option("--render-as FORMAT") do |format|

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -176,6 +176,22 @@ describe Puppet::Application::FaceBase do
       app.options.should == {}
     end
 
+    it "should not add :debug to the application-level options" do
+      app.command_line.stubs(:args).returns %w{--confdir /tmp/puppet foo --debug}
+      app.preinit
+      app.parse_options
+      app.action.name.should == :foo
+      app.options.should == {}
+    end
+
+    it "should not add :verbose to the application-level options" do
+      app.command_line.stubs(:args).returns %w{--confdir /tmp/puppet foo --verbose}
+      app.preinit
+      app.parse_options
+      app.action.name.should == :foo
+      app.options.should == {}
+    end
+
     { "boolean options before" => %w{--trace foo},
       "boolean options after"  => %w{foo --trace}
     }.each do |name, args|

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -416,6 +416,11 @@ describe Puppet::Application do
       Puppet::Util::Log.level.should == :debug
     end
 
+    it "allows the loglevel to be specified as an argument" do
+      @app.set_log_level(:debug => true)
+
+      Puppet::Util::Log.level.should == :debug
+    end
   end
 
   describe "when configuring routes" do


### PR DESCRIPTION
The previous fix modified `face_base` so that if --debug/--verbose were
specified, it set the corresponding application-level options, like we
do for other types of applications, and called Application#set_log_level
to do the right thing.

However, faces will automatically take any application-level option and
dispatch it to the face application. And since --debug and --verbose are
global options, the face framework would report it as an unknown option:

   puppet module install foo-bar --debug
   Unknown options passed: debug

This commit modifies the base Application#set_log_level method to take
an optional set of options. This way face_base can specify the desired
log level without needing to modify the application-level options.
Non-face application continue to work as before.
