### PR TITLE
(PUP-3702) roll-back previous fix, which broke solaris11 zone acceptance

### DIFF
--- a/acceptance/tests/resource/zone/should_be_created_and_removed.rb
+++ b/acceptance/tests/resource/zone/should_be_created_and_removed.rb
@@ -12,8 +12,11 @@ teardown do
   end
 end
 
-
+config_inherit_string = ""
 agents.each do |agent|
+  #inherit /sbin on solaris10 until PUP-3722
+  config_inherit_string = "inherit=>'/sbin'" if agent['platform'] =~ /solaris-10/
+  
   step "Zone: setup"
   setup agent
   #-----------------------------------
@@ -21,7 +24,7 @@ agents.each do |agent|
   step "progress would be logged to agent:/var/log/zones/zoneadm.<date>.<zonename>.install"
   step "install log would be at agent:/system/volatile/install.<id>/install_log"
 
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>running, path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, "zone {tstzone : ensure=>running, path=>'/tstzones/mnt', #{config_inherit_string} }") do
     assert_match( /created/, result.stdout, "err: #{agent}")
   end
   on(agent, "zoneadm list -cp") do

--- a/acceptance/tests/resource/zone/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zone/should_be_idempotent.rb
@@ -12,17 +12,20 @@ teardown do
   end
 end
 
-
+config_inherit_string = ""
 agents.each do |agent|
+  #inherit /sbin on solaris10 until PUP-3722
+  config_inherit_string = "inherit=>'/sbin'" if agent['platform'] =~ /solaris-10/
+
   step "Zone: idempotency - setup"
   setup agent
   #-----------------------------------
   step "Zone: idempotency - make it configured"
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, "zone {tstzone : ensure=>configured, path=>'/tstzones/mnt', #{config_inherit_string} }") do
     assert_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
   step "Zone: idempotency, should not create again."
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, "zone {tstzone : ensure=>configured, path=>'/tstzones/mnt', #{config_inherit_string} }") do
     assert_no_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
   step "Zone: idempotency - make it installed"

--- a/acceptance/tests/resource/zone/statemachine.rb
+++ b/acceptance/tests/resource/zone/statemachine.rb
@@ -11,14 +11,18 @@ teardown do
   end
 end
 
+config_inherit_string = ""
 agents.each do |agent|
+  #inherit /sbin on solaris10 until PUP-3722
+  config_inherit_string = "inherit=>'/sbin'" if agent['platform'] =~ /solaris-10/
+
   step "Zone: statemachine - setup"
   setup agent
 
   step "Zone: statemachine - create zone and make it running"
   step "progress would be logged to agent:/var/log/zones/zoneadm.<date>.<zonename>.install"
   step "install log would be at agent:/system/volatile/install.<id>/install_log"
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>running, iptype=>shared, path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, "zone {tstzone : ensure=>running, iptype=>shared, path=>'/tstzones/mnt', #{config_inherit_string} }") do
     assert_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
 

--- a/acceptance/tests/resource/zone/stepstates.rb
+++ b/acceptance/tests/resource/zone/stepstates.rb
@@ -1,6 +1,5 @@
 test_name "Zone:statemachine single states"
 confine :to, :platform => 'solaris'
-
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 
@@ -11,12 +10,15 @@ teardown do
   end
 end
 
-
+config_inherit_string = ""
 agents.each do |agent|
+  #inherit /sbin on solaris10 until PUP-3722
+  config_inherit_string = "inherit=>'/sbin'" if agent['platform'] =~ /solaris-10/
+
   step "Zone: steps - setup"
   setup agent
   step "Zone: steps - create"
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, iptype=>shared, path=>"/tstzones/mnt" }' ) do
+  apply_manifest_on(agent, "zone {tstzone : ensure=>configured, iptype=>shared, path=>'/tstzones/mnt', #{config_inherit_string} }" ) do
     assert_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
   step "Zone: steps - verify (create)"

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -242,7 +242,6 @@ end
     desc "The list of directories that the zone inherits from the global
       zone.  All directories must be fully qualified."
 
-    defaultto "/sbin"
     def should
       @should
     end


### PR DESCRIPTION
Inherit /sbin in the zone acceptance tests on solaris10 until PUP-3722.
Solaris10 zone provider needs to add /sbin to it's pkg-dir inheritance
otherwise the zones cannot boot.  solaris11 zones can not be configured
with inherit-pkg-dir because of IPS.  this is covered by PUP-3722.
