### PR TITLE
(PUP-3469) fix zpool tests on solaris10

### DIFF
--- a/acceptance/tests/resource/zpool/basic_tests.rb
+++ b/acceptance/tests/resource/zpool/basic_tests.rb
@@ -13,7 +13,6 @@ end
 
 
 agents.each do |agent|
-  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zpool/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zpool/should_be_idempotent.rb
@@ -13,7 +13,6 @@ end
 
 
 agents.each do |agent|
-  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zpool/should_create.rb
+++ b/acceptance/tests/resource/zpool/should_create.rb
@@ -13,7 +13,6 @@ end
 
 
 agents.each do |agent|
-  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zpool/should_query.rb
+++ b/acceptance/tests/resource/zpool/should_query.rb
@@ -13,7 +13,6 @@ end
 
 
 agents.each do |agent|
-  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zpool/should_remove.rb
+++ b/acceptance/tests/resource/zpool/should_remove.rb
@@ -13,7 +13,6 @@ end
 
 
 agents.each do |agent|
-  skip_test "not enough drive space on our solaris10 machines" if agent['platform'] =~ /solaris-10/
   step "ZPool: setup"
   setup agent
   #-----------------------------------


### PR DESCRIPTION
These would previously run out of drive space.
They work again; remove skip_tests for solaris10.
