### PR TITLE
(PUP-3336) Be consistent about a single libdir

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -242,7 +242,7 @@ module Puppet
           is in Ruby's search path\n",
       :call_hook => :on_initialize_and_write,
       :hook             => proc do |value|
-        $LOAD_PATH.delete(@oldlibdir) if defined?(@oldlibdir) and $LOAD_PATH.include?(@oldlibdir)
+        $LOAD_PATH.delete(@oldlibdir) if defined?(@oldlibdir) && $LOAD_PATH.include?(@oldlibdir)
         @oldlibdir = value
         $LOAD_PATH << value
       end

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -147,7 +147,7 @@ class Puppet::Util::Autoload
       # See the comments in #module_directories above.  Basically, we need to be careful not to try to access the
       # libdir before we know for sure that all of the settings have been initialized (e.g., during bootstrapping).
       if (Puppet.settings.app_defaults_initialized?)
-        Puppet[:libdir].split(File::PATH_SEPARATOR)
+        [Puppet[:libdir]]
       else
         []
       end

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -58,10 +58,16 @@ describe Puppet::Util::Autoload do
     end
 
     it "should include the module directories, the Puppet libdir, and all of the Ruby load directories" do
-      Puppet[:libdir] = %w{/libdir1 /lib/dir/two /third/lib/dir}.join(File::PATH_SEPARATOR)
+      Puppet[:libdir] = '/libdir1'
       @autoload.class.expects(:gem_directories).returns %w{/one /two}
       @autoload.class.expects(:module_directories).returns %w{/three /four}
-      @autoload.class.search_directories(nil).should == %w{/one /two /three /four} + Puppet[:libdir].split(File::PATH_SEPARATOR) + $LOAD_PATH
+      @autoload.class.search_directories(nil).should == %w{/one /two /three /four} + [Puppet[:libdir]] + $LOAD_PATH
+    end
+
+    it "does not split the Puppet[:libdir]" do
+      Puppet[:libdir] = "/libdir1#{File::PATH_SEPARATOR}/libdir2"
+
+      @autoload.class.libdirs.should == [Puppet[:libdir]]
     end
   end
 


### PR DESCRIPTION
Previously, it was possible to set `Puppet[:libdir]` to a list of
directories, so that the autoloader's search path could be expanded.
That behavior was added in f9e05a806.

That said, it only worked when using puppet as a library, most commonly
when executing tests for modules that depend on each other. If you ever
tried to actually run puppet with `:libdir` containing multiple
directories, puppet would try to manage/create the directory,
interpreting it as a single directory, and would fail with:

    $ puppet apply -e "notice 'hi'" --libdir /tmp/a:/tmp/b
    Cannot create /tmp/a:/tmp/b; parent directory /tmp/a:/tmp does not exist

This commit modifies the autoloader so that it no longer splits the
`:libdir` setting, consistent with other parts of puppet that assume
it's a single directory, e.g. the :libdir hook that updates $LOAD_PATH
and loading augeas lenses.

To accomplish the behavior that existed previously, it is better to
update the ruby $LOAD_PATH to include whatever additional directories
are necessary. This way the autoloader can load module specific code as
well as helper code within the module, or in different modules.