### PR TITLE
(PUP-3282) Fix acceptance test to reflect removal

### DIFF
--- a/acceptance/tests/ticket_7101_template_compile.rb
+++ b/acceptance/tests/ticket_7101_template_compile.rb
@@ -4,15 +4,15 @@ agents.each do |agent|
   template = agent.tmpfile('template_7101.erb')
   target = agent.tmpfile('file_7101.erb')
 
-  manifest = %Q{
-$bar = 'test 7101'
-file { '#{target}':
-  content => template("#{template}")
-}
-}
+  manifest = <<-EOF
+  $bar = 'test 7101'
+  file { '#{target}':
+    content => template("#{template}")
+  }
+  EOF
 
   step "Agents: Create template file"
-  create_remote_file(agent, template, %w{<%= bar %>} )
+  create_remote_file(agent, template, "<%= @bar %>" )
 
   step "Run manifest referencing template file"
   apply_manifest_on(agent, manifest)


### PR DESCRIPTION
Since the support for method access of variables in templates has been removed,
update the related acceptance test so that it no longer relies on this functionality.
