### PR TITLE
(PUP-1413) Add 'touch' command to Augeas provider

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -39,6 +39,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     "rm" => [ :path ],
     "clear" => [ :path ],
     "clearm" => [ :path, :string ],
+    "touch" => [ :path ],
     "mv" => [ :path, :path ],
     "insert" => [ :string, :string, :path ],
     "get" => [ :path, :comparator, :string ],
@@ -472,6 +473,12 @@ Puppet::Type.type(:augeas).provide(:augeas) do
               fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (!rv)
             else
               fail("command '#{command}' not supported in installed version of ruby-augeas")
+            end
+          when "touch"
+            debug("sending command '#{command}' (match, set) with params #{cmd_array.inspect}")
+            if aug.match(cmd_array[0]).empty?
+              rv = aug.clear(cmd_array[0])
+              fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (!rv)
             end
           when "insert", "ins"
             label = cmd_array[0]

--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -104,6 +104,7 @@ Puppet::Type.newtype(:augeas) do
     * `remove <PATH>` --- Synonym for `rm`
     * `clear <PATH>` --- Sets the node at `PATH` to `NULL`, creating it if needed
     * `clearm <PATH> <SUB>` --- Sets multiple nodes (matching `SUB` relative to `PATH`) to `NULL`
+    * `touch <PATH>` --- Creates `PATH` with the value `NULL` if it does not exist
     * `ins <LABEL> (before|after) <PATH>` --- Inserts an empty node `LABEL` either before or after `PATH`.
     * `insert <LABEL> <WHERE> <PATH>` --- Synonym for `ins`
     * `mv <PATH> <OTHER PATH>` --- Moves a node at `PATH` to the new location `OTHER PATH`

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -596,6 +596,28 @@ describe provider_class do
       @provider.execute_changes.should == :executed
     end
 
+    describe "touch command" do
+      it "should clear missing path" do
+        @resource[:changes] = "touch Jar/Jar"
+        @resource[:context] = "/foo/"
+        @augeas.expects(:match).with("/foo/Jar/Jar").returns([])
+        @augeas.expects(:clear).with("/foo/Jar/Jar").returns(true)
+        @augeas.expects(:save).returns(true)
+        @augeas.expects(:close)
+        @provider.execute_changes.should == :executed
+      end
+
+      it "should not change on existing path" do
+        @resource[:changes] = "touch Jar/Jar"
+        @resource[:context] = "/foo/"
+        @augeas.expects(:match).with("/foo/Jar/Jar").returns(["/foo/Jar/Jar"])
+        @augeas.expects(:clear).never
+        @augeas.expects(:save).returns(true)
+        @augeas.expects(:close)
+        @provider.execute_changes.should == :executed
+      end
+    end
+
     it "should handle ins commands with before" do
       @resource[:changes] = "ins Binks before Jar/Jar"
       @resource[:context] = "/foo"


### PR DESCRIPTION
The touch command works like its POSIX namesake, only creating the node in
the Augeas tree when it doesn't already exist, and creating it with a NULL
value.  The behaviour is copied from augtool (augrun).
