### PR TITLE
(PUP-3479) (PUP-3737) Update Windows ffi ~> 1.9.5

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -28,7 +28,7 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       # Pinning versions that require native extensions
-      ffi: '1.9.3'
+      ffi: '~> 1.9.5'
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.1'
       win32-process: '~> 0.7.4'
@@ -38,7 +38,7 @@ gem_platform_dependencies:
       minitar: '~> 0.5.4'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: '1.9.3'
+      ffi: '~> 1.9.5'
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.1'
       win32-process: '~> 0.7.4'


### PR DESCRIPTION
Ruby 2.1.3 on Windows requires ffi 1.9.5. Update our Windows dependencies
to allow 1.9.5+ to be selected.

This commit was originally merged to the master branch targeted at 4.x,
when it should have been targeted first at the stable branch to affect
the 3.7.x release and keep it in sync with Facter 2.3.0, which now
requires ffi ~> 1.9.5

Gem installation of Puppet on Windows is thus currently broken until
Puppet 3.7.4 ships or a workaround is employed, where Facter 2.2.0 is
installed by gem prior to installing Puppet.
