### PR TITLE
(PUP-2563) Gracefully exit on ruby 187

### DIFF
--- a/bin/puppet
+++ b/bin/puppet
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
 
-require 'puppet/util/command_line'
-Puppet::Util::CommandLine.new.execute
+begin
+  require 'puppet/util/command_line'
+  Puppet::Util::CommandLine.new.execute
+rescue LoadError => e
+  $stderr.puts e.message
+end

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,5 +1,9 @@
 require 'puppet/version'
 
+if RUBY_VERSION < "1.9.3"
+  raise LoadError, "Puppet #{Puppet.version} requires ruby 1.9.3 or greater."
+end
+
 # see the bottom of the file for further inclusions
 # Also see the new Vendor support - towards the end
 #


### PR DESCRIPTION
Previously, running puppet on ruby 187 would fail in an unhelpful way:

```
in `const_defined?': wrong number of arguments (2 for 1) (ArgumentError)
```

Since users have historically installed puppet using whatever ruby
version happens to be installed, we want to ensure puppet displays a
useful error message that ruby 1.9.3 or greater is required, and exits
gracefully.

This commit puts the check in lib/puppet.rb, which handles the various
puppet entry points: when executing the `puppet` command, when using
puppet as a library, e.g. `require 'puppet'`, and via passenger's
config.ru.
