### PR TITLE
(PUP-3728) Fix off by one error in cron month names

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -290,7 +290,11 @@ Puppet::Type.newtype(:cron) do
 
   newproperty(:month, :parent => CronParam) do
     def alpha
-      %w{january february march april may june july
+      # The ___placeholder accounts for the fact that month is unique among
+      # "nameable" crontab entries in that it does not use 0-based indexing.
+      # Padding the array with a placeholder introduces the appropriate shift
+      # in indices.
+      %w{___placeholder january february march april may june july
         august september october november december}
     end
     self.boundaries = [1, 12]

--- a/spec/unit/type/cron_spec.rb
+++ b/spec/unit/type/cron_spec.rb
@@ -307,33 +307,33 @@ describe Puppet::Type.type(:cron), :unless => Puppet.features.microsoft_windows?
       end
 
       it "should support valid months as words" do
-        expect { described_class.new(:name => 'foo', :month => 'January') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'February') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'March') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'April') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'May') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'June') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'July') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'August') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'September') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'October') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'November') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'December') }.to_not raise_error
+        expect( described_class.new(:name => 'foo', :month => 'January')[:month]   ).to eq(['1'])
+        expect( described_class.new(:name => 'foo', :month => 'February')[:month]  ).to eq(['2'])
+        expect( described_class.new(:name => 'foo', :month => 'March')[:month]     ).to eq(['3'])
+        expect( described_class.new(:name => 'foo', :month => 'April')[:month]     ).to eq(['4'])
+        expect( described_class.new(:name => 'foo', :month => 'May')[:month]       ).to eq(['5'])
+        expect( described_class.new(:name => 'foo', :month => 'June')[:month]      ).to eq(['6'])
+        expect( described_class.new(:name => 'foo', :month => 'July')[:month]      ).to eq(['7'])
+        expect( described_class.new(:name => 'foo', :month => 'August')[:month]    ).to eq(['8'])
+        expect( described_class.new(:name => 'foo', :month => 'September')[:month] ).to eq(['9'])
+        expect( described_class.new(:name => 'foo', :month => 'October')[:month]   ).to eq(['10'])
+        expect( described_class.new(:name => 'foo', :month => 'November')[:month]  ).to eq(['11'])
+        expect( described_class.new(:name => 'foo', :month => 'December')[:month]  ).to eq(['12'])
       end
 
       it "should support valid months as words (3 character short version)" do
-        expect { described_class.new(:name => 'foo', :month => 'Jan') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Feb') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Mar') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Apr') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'May') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Jun') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Jul') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Aug') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Sep') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Oct') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Nov') }.to_not raise_error
-        expect { described_class.new(:name => 'foo', :month => 'Dec') }.to_not raise_error
+        expect( described_class.new(:name => 'foo', :month => 'Jan')[:month] ).to eq(['1'])
+        expect( described_class.new(:name => 'foo', :month => 'Feb')[:month] ).to eq(['2'])
+        expect( described_class.new(:name => 'foo', :month => 'Mar')[:month] ).to eq(['3'])
+        expect( described_class.new(:name => 'foo', :month => 'Apr')[:month] ).to eq(['4'])
+        expect( described_class.new(:name => 'foo', :month => 'May')[:month] ).to eq(['5'])
+        expect( described_class.new(:name => 'foo', :month => 'Jun')[:month] ).to eq(['6'])
+        expect( described_class.new(:name => 'foo', :month => 'Jul')[:month] ).to eq(['7'])
+        expect( described_class.new(:name => 'foo', :month => 'Aug')[:month] ).to eq(['8'])
+        expect( described_class.new(:name => 'foo', :month => 'Sep')[:month] ).to eq(['9'])
+        expect( described_class.new(:name => 'foo', :month => 'Oct')[:month] ).to eq(['10'])
+        expect( described_class.new(:name => 'foo', :month => 'Nov')[:month] ).to eq(['11'])
+        expect( described_class.new(:name => 'foo', :month => 'Dec')[:month] ).to eq(['12'])
       end
 
       it "should not support numeric values out of range" do


### PR DESCRIPTION
When a name, such as "January", is used to specify a month in the Cron type,
the resulting numeric value would be off by one (i.e. "0"). This is because
month is unique among "namable" crotab entries in that it does not use 0-based
indexing. This patch updates the spec tests to enforce this expectation and
fixes the issue by padding out the list of acceptable month names so that
indices start at 1.
