### PR TITLE
(maint) PUP-3638 clarify puppet-doc manpage re: rdoc on manifests

### DIFF
--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -64,7 +64,7 @@ USAGE
 -----
 puppet doc [-a|--all] [-h|--help] [-l|--list] [-o|--outputdir <rdoc-outputdir>]
   [-m|--mode text|pdf|rdoc] [-r|--reference <reference-name>]
-  [--charset <charset>] [<manifest-file>]
+  [--charset <charset>]
 
 
 DESCRIPTION
@@ -125,10 +125,6 @@ EXAMPLE
 or
 
     $ puppet doc --outputdir /tmp/rdoc --mode rdoc --modulepath /path/to/modules
-
-or
-
-    $ puppet doc /etc/puppet/manifests/site.pp
 
 or
 


### PR DESCRIPTION
remove the manifest examples and related doc
this functionality has been removed in PUP-3638
