### PR TITLE
(PUP-2563) Exit with 1 on pre-1.9.3 ruby

### DIFF
--- a/bin/puppet
+++ b/bin/puppet
@@ -5,4 +5,5 @@ begin
   Puppet::Util::CommandLine.new.execute
 rescue LoadError => e
   $stderr.puts e.message
+  exit(1)
 end


### PR DESCRIPTION
Exit with 1 when running on versions of ruby before 1.9.3.
