### PR TITLE
(PUP-1270) Fix Solaris ips acceptance tests for version changes.

### DIFF
--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -35,7 +35,7 @@ agents.each do |agent|
 
   step "IPS: check it was created"
   on agent, "puppet resource package mypkg" do
-    assert_match( /ensure => '0.0.1'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure => '0\.0\.1,.*'/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: do not upgrade until latest is mentioned"
@@ -46,7 +46,7 @@ agents.each do |agent|
 
   step "IPS: verify it was not upgraded"
   on agent, "puppet resource package mypkg" do
-    assert_match( /ensure => '0.0.1'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure => '0\.0\.1,.*'/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: ask to be latest"
@@ -54,7 +54,7 @@ agents.each do |agent|
 
   step "IPS: ensure it was upgraded"
   on agent, "puppet resource package mypkg" do
-    assert_match( /ensure => '0.0.2'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure => '0\.0\.2,.*'/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: when there are more than one option, choose latest."
@@ -62,7 +62,7 @@ agents.each do |agent|
   send_pkg agent,:pkg => 'mypkg@0.0.4'
   apply_manifest_on(agent, 'package {mypkg : ensure=>latest}')
   on agent, "puppet resource package mypkg" do
-    assert_match( /ensure => '0.0.4'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure => '0\.0\.4,.*'/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: ensure removed."

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -26,7 +26,7 @@ agents.each do |agent|
   end
   step "IPS: check it was created"
   on agent, "puppet resource package mypkg" do
-    assert_match( /ensure => '0.0.1'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure => '0\.0\.1,.*'/, result.stdout, "err: #{agent}")
   end
   on agent, "pkg list -v mypkg" do
     assert_match( /mypkg@0.0.1/, result.stdout, "err: #{agent}")


### PR DESCRIPTION
The pkg package provider now reports the timestamp for the ensure, even
if packages are given only by version number in the manifest.

This fixes the regexes used in the acceptance tests to verify packages
are correctly installed by the provider.
