### PR TITLE
(PUP-3389) Do not list all directories when getting an environment

### DIFF
--- a/benchmarks/many_environments/benchmarker.rb
+++ b/benchmarks/many_environments/benchmarker.rb
@@ -1,0 +1,38 @@
+require 'fileutils'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size > 1000 ? size : 1000
+  end
+
+  def setup
+    require 'puppet'
+    @config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', @config])
+  end
+
+  def run(args=nil)
+    Puppet.settings.clear
+    environment_loaders = Puppet.lookup(:environments)
+    environment_loaders.clear_all
+    environment_loaders.get!("anenv#{@size/2}")
+  end
+
+  def generate
+    environments = File.join(@target, 'environments')
+    puppet_conf = File.join(@target, 'puppet.conf')
+
+    File.open(puppet_conf, 'w') do |f|
+      f.puts(<<-EOF)
+        environmentpath=#{environments}
+      EOF
+    end
+
+    @size.times do |i|
+      mkdir_p(File.join(environments, "anenv#{i}"))
+    end
+  end
+end

--- a/benchmarks/many_environments/description
+++ b/benchmarks/many_environments/description
@@ -1,0 +1,2 @@
+Benchmark scenario: many directory environments.
+Benchmark target: environment lookup.

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -26,6 +26,7 @@ describe Puppet::Environments do
       FS::MemoryFile.a_directory("another_environment", [
         FS::MemoryFile.a_missing_file("environment.conf"),
       ]),
+      FS::MemoryFile.a_missing_file("doesnotexist"),
     ])
   end
 
@@ -87,7 +88,7 @@ describe Puppet::Environments do
       loader_from(:filesystem => [directory_tree],
                   :directory => directory_tree) do |loader|
         expect do
-          loader.get!("does_not_exist")
+          loader.get!("doesnotexist")
         end.to raise_error(Puppet::Environments::EnvironmentNotFound)
       end
     end
@@ -95,7 +96,7 @@ describe Puppet::Environments do
     it "returns nil if an environment can't be found" do
       loader_from(:filesystem => [directory_tree],
                   :directory => directory_tree) do |loader|
-        expect(loader.get("env_not_in_this_list")).to be_nil
+        expect(loader.get("doesnotexist")).to be_nil
       end
     end
 
@@ -412,6 +413,8 @@ config_version=$vardir/random/scripts
           FS::MemoryFile.a_directory("modules"),
           FS::MemoryFile.a_directory("manifests"),
         ]),
+        FS::MemoryFile.a_missing_file("env_does_not_exist"),
+        FS::MemoryFile.a_missing_file("static2"),
       ])
     end
 
@@ -572,7 +575,7 @@ config_version=$vardir/random/scripts
     end
 
     failure_message_for_should do |env|
-      "expected <#{env.name}: modulepath = [#{env.modulepath.join(', ')}], manifest = #{env.manifest}, config_version = #{env.config_version}> to be #{description}"
+      "expected <#{env.name}: modulepath = [#{env.full_modulepath.join(', ')}], manifest = #{env.manifest}, config_version = #{env.config_version}> to be #{description}"
     end
   end
 


### PR DESCRIPTION
The Puppet::Environment::Directories loader had a stable but naive
implementation for obtaining a valid directory env.  It relied on its
list function to provide the set of all valid directory environments in
its root directory, and then returned the one that matched.  This worked
fine for small numbers of directory environments, but became costly for
hundred or thousands of environments.  The impact was exacerbated by the
need to lookup the environment.conf for each directory environment, in
the context of a Puppet::Settings values object that could interpolate
the settings in the environment.conf.  Each such lookup relied on yet
another pass through the list of all directory environments, causing
num_of_direnvs^2 calls for each initial lookup of a new environment.

This commit fixes that, separating validation of a directory environment
entry and creation of a new environment from the act of listing all
valid directory environments.

A benchmark is added as well, testing the time it takes to look up one
environment out of a thousand available environments after base settings
initialization.

Prior to this patch, 10 passes of the benchmark test took ~100s on a
4 core Intel 2.9Ghz machine with 8GB.  After the patch, it's down to
about 0.01s, so about a 10^4 boost...which is probably the best
performance boost I've ever managed out of fairly minor patch :)
