### PR TITLE
(PUP-3567) Remove current_environment check in Puppet::Indirector::Reque...

### DIFF
--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -36,8 +36,6 @@ class Puppet::Indirector::Request
     @environment =
     if env.is_a?(Puppet::Node::Environment)
       env
-    elsif (current_environment = Puppet.lookup(:current_environment)).name == env
-      current_environment
     else
       Puppet.lookup(:environments).get!(env)
     end


### PR DESCRIPTION
...st#environment=

Prior to this commit, there was an environment setter that allowed an
environment to be set if it existed in `Puppet.lookup(:current_environment)`. This commit changes that by only
allowing environments to be set from what exists within Puppet.lookup(:environments).