### PR TITLE
(PUP-3739) Don't require master to have agent role

### DIFF
--- a/acceptance/setup/git/pre-suite/010_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/010_TestSetup.rb
@@ -42,12 +42,17 @@ test_name "Install packages and repositories on target machines..." do
     end
   end
 
-  step "Agents: create basic puppet.conf" do
-    agents.each do |agent|
-      puppetconf = File.join(agent['puppetpath'], 'puppet.conf')
+  step "Hosts: create basic puppet.conf" do
+    hosts.each do |host|
+      on host, "mkdir -p #{host['puppetpath']}"
+      puppetconf = File.join(host['puppetpath'], 'puppet.conf')
 
-      on agent, "echo '[agent]' > #{puppetconf} && " +
-                "echo server=#{master} >> #{puppetconf}"
+      if host['roles'].include?('agent')
+        on host, "echo '[agent]' > #{puppetconf} && " +
+                 "echo server=#{master} >> #{puppetconf}"
+      else
+        on host, "touch #{puppetconf}"
+      end
     end
   end
 end

--- a/acceptance/tests/security/cve-2013-1654_sslv2_downgrade_master.rb
+++ b/acceptance/tests/security/cve-2013-1654_sslv2_downgrade_master.rb
@@ -15,6 +15,9 @@ END
   end
 
   suitable_agent = agents.select {|agent| suitable_agent?( agent ) }.first
+  if suitable_agent.nil?
+    skip_test "No agents are suitable to test the master"
+  end
 
   if suitable?( master )
     with_puppet_running_on( master, {} ) do

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -4,14 +4,9 @@ agent_hostnames = agents.map {|a| a.to_s}
 
 with_puppet_running_on master, {'master' => {'allow_duplicate_certs' => true}} do
   agents.each do |agent|
-    if agent['platform'].include?('windows')
-      Log.warn("Pending: Windows does not support facter fqdn")
-      next
-    end
-
     step "Generate a certificate request for the agent"
     fqdn = on(agent, facter("fqdn")).stdout.strip
-    on agent, "puppet certificate generate #{fqdn} --ca-location remote --server #{master}"
+    on agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}")
   end
 
   step "Collect the original certs"
@@ -27,14 +22,9 @@ with_puppet_running_on master, {'master' => {'allow_duplicate_certs' => true}} d
   end
 
   agents.each do |agent|
-    if agent['platform'].include?('windows')
-      Log.warn("Pending: Windows does not support facter fqdn")
-      next
-    end
-
     fqdn = on(agent, facter("fqdn")).stdout.strip
     step "Make another request with the same certname"
-    on agent, "puppet certificate generate #{fqdn} --ca-location remote --server #{master}"
+    on agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}")
   end
 
   step "Collect the new certs"


### PR DESCRIPTION
Previously, when executing acceptance tests from a git checkout, the
master host also needed to have the agent role. This is because the
010_TestSetup step only created `/etc/puppet/puppet.conf` for agents.

If you tried to run against a master host that didn't have the agent
role, then puppet.conf was never created. So later when trying to start
the master via `with_puppet_running_on`, beaker would try to back up the
old `puppet.conf`, warn that it didn't exist:

```
Warning: Could not backup file '/etc/puppet/puppet.conf': no such file
```

Then it would try to read in the old `puppet.conf`, to apply the new
settings on top, but that failed with:

```
cat: /etc/puppet/puppet.conf: No such file or directory
```

This commit updates the setup step to ensure the parent directory and
puppet.conf both exist.

The sslv2_downgrade_master test had to be updated to handle the case
where there are no suitable agents, e.g. windows agent doesn't have
openssl in its PATH, and the master doesn't have an agent.

The ticket_3360_allow_duplicate_csr_with_option_set test required at
least one non-Windows agent. It was last updated a long time ago when
facter on windows didn't support the fqdn fact. The test also wasn't
using the `puppet` helper method that prefixes the command with
`cmd.exe /c`.
