### PR TITLE
(maint) Add error message if GitURI is nil

### DIFF
--- a/acceptance/setup/git/pre-suite/010_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/010_TestSetup.rb
@@ -11,6 +11,7 @@ test_name "Install packages and repositories on target machines..." do
 
   tmp_repositories = []
   options[:install].each do |uri|
+    raise(ArgumentError, "Missing GitURI argument. URI is nil.") if uri.nil?
     raise(ArgumentError, "#{uri} is not recognized.") unless(uri =~ GitURI)
     tmp_repositories << extract_repo_info_from(uri)
   end


### PR DESCRIPTION
Prior to this commit, if the options param was left out from the
ci:test:git rake task, it would only tell the user that nil was an
unrecognized task i.e.

`#<ArgumentError:  is not recognized.>`

This was not helpful in the case where that uri variable was nil.

This commit changes that by adding a ArgumentError check to see if that
git uri is nil.

I'm not entirely convinced this is the greatest error message either, so if anyone has a better suggestion please let me know.
