### PR TITLE
(maint) Remove 'create' key for masterhttplog setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1003,7 +1003,6 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0660",
-      :create => true,
       :desc => "Where the puppet master web server saves its access log. This is
         only used when running a WEBrick puppet master. When puppet master is
         running under a Rack server like Passenger, that web server will have


### PR DESCRIPTION
This is the only setting that uses this key, and yet the
webrick setup_logger step already creates the file if needed.
So removing this will allow for some code cleanup in
FileSetting and derived classes.