### PR TITLE
(PUP-1085) Fix handling of package groups in pacman provider.

### DIFF
--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -185,7 +185,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
         return { :ensure => group_version }
       else
         return {
-          :ensure => :purged,
+          :ensure => :absent,
           :status => 'missing',
           :name => @resource[:name],
           :error => 'ok',
@@ -199,7 +199,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
       # report package missing if it is not installed
     else
       return {
-        :ensure => :purged,
+        :ensure => :absent,
         :status => 'missing',
         :name => @resource[:name],
         :error => 'ok',

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     begin
       !pacman("-Sg", name).empty?
     rescue Puppet::ExecutionFailure
-      false
+      fail("Error while determining if '#{@resource[:name]}' is a group")
     end
   end
 
@@ -45,7 +45,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     end
 
     unless self.query
-      raise Puppet::ExecutionFailure.new("Could not find package %s" % self.name)
+      fail("Could not find package '#{@resource[:name]}'")
     end
   end
 
@@ -84,7 +84,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
         end
       end
     rescue Puppet::ExecutionFailure
-      fail "Error getting groupnames of installed packages (pacman -Qg)"
+      fail("Error getting groupnames of installed packages")
     end
 
     instances
@@ -101,7 +101,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
           if match = regex.match(line)
             packages[match.captures[0]] = match.captures[1]
           else
-            warning("Failed to match line %s" % line)
+            warning("Failed to match line '#{line}'")
           end
         end
       end
@@ -135,7 +135,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
       end
       [group_version, fully_installed]
     rescue Puppet::ExecutionFailure
-      [nil, nil]
+      fail("Error while getting virtual group version for '#{@resource[:name]}'")
     end
   end
 
@@ -201,8 +201,8 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     # return the version if the package is installed
     if pkgversion = installed_packages[@resource[:name]]
       return { :ensure => pkgversion }
-      # report package missing if it is not installed
     else
+      # report package missing if it is not installed
       return {
         :ensure => :absent,
         :status => 'missing',

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -9,9 +9,14 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
+  # If yaourt is installed, we can make use of it
+  def self.yaourt?
+    @yaourt ||= Puppet::FileSystem.exist?('/usr/bin/yaourt')
+  end
+
   commands :pacman => "/usr/bin/pacman"
   # Yaourt is a common AUR helper which, if installed, we can use to query the AUR
-  commands :yaourt => "/usr/bin/yaourt" if Puppet::FileSystem.exist? '/usr/bin/yaourt'
+  commands :yaourt => "/usr/bin/yaourt" if yaourt?
 
   confine     :operatingsystem => [:archlinux, :manjarolinux]
   defaultfor  :operatingsystem => [:archlinux, :manjarolinux]
@@ -19,9 +24,13 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
   has_feature :uninstall_options
   has_feature :upgradeable
 
-  # If yaourt is installed, we can make use of it
-  def yaourt?
-    return Puppet::FileSystem.exist?('/usr/bin/yaourt')
+  # Checks if a given name is a group
+  def self.group?(name)
+    begin
+      !pacman("-Sg", name).empty?
+    rescue Puppet::ExecutionFailure
+      false
+    end
   end
 
   # Install a package using 'pacman', or 'yaourt' if available.
@@ -39,20 +48,182 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     end
   end
 
-  def install_from_repo
-    if yaourt?
-      cmd = %w{--noconfirm --needed}
-      cmd += install_options if @resource[:install_options]
-      cmd << "-S" << @resource[:name]
-      yaourt *cmd
-    else
-      cmd = %w{--noconfirm  --needed --noprogressbar}
-      cmd += install_options if @resource[:install_options]
-      cmd << "-Sy" << @resource[:name]
-      pacman *cmd
+  # Fetch the list of packages and package groups that are currently installed on the system.
+  # Only package groups that are fully installed are included. If a group adds packages over time, it will not
+  # be considered as fully installed any more, and we would install the new packages on the next run.
+  # If a group removes packages over time, nothing will happen. This is intended.
+  def self.instances
+    instances = []
+    installed_packages = get_installed_packages
+    installed_packages.sort_by { |k, _| k }.each do |(pkgname, pkgver)|
+      hash = {
+        :name => pkgname,
+        :ensure => pkgver,
+        :provider => self.name,
+      }
+      instances << new(hash)
+    end
+
+    # Get list of groupnames that have at least one package installed and add them to instances
+    begin
+      execpipe([command(:pacman), "-Qg"]) do |process|
+        # pacman -Qg output is 'groupname packagename'
+        # Groups need to be deduplicated
+        group_names = Set[]
+
+        process.each_line do |line|
+          group_names.add(line.split[0])
+        end
+
+        group_names.each do |group|
+          group_version, fully_installed = get_virtual_group_version(group, installed_packages)
+          if fully_installed
+            instances << new({ :name => group, :ensure => group_version, :provider => self.name })
+          end
+        end
+      end
+    rescue Puppet::ExecutionFailure
+      fail "Error getting groupnames of installed packages (pacman -Qg)"
+    end
+
+    instances
+  end
+
+  # returns a hash pkgname => pkgversion of installed packages
+  def self.get_installed_packages
+    begin
+      packages = {}
+      execpipe([command(:pacman), "-Q"]) do |process|
+        # pacman -Q output is 'packagename version-rel'
+        regex = %r{^(\S+)\s(\S+)}
+        process.each_line do |line|
+          if match = regex.match(line)
+            packages[match.captures[0]] = match.captures[1]
+          else
+            warning("Failed to match line %s" % line)
+          end
+        end
+      end
+      packages
+    rescue Puppet::ExecutionFailure
+      fail("Error getting installed packages")
     end
   end
-  private :install_from_repo
+
+  # Generates a virtual version for a group - a line in the format "<pkgname> <pkgversion>" per package.
+  # For missing packages the pkgversion is skipped. This should trigger a group install when this string is compared
+  # to the output of latest (which will have package versions given for all packages).
+  # Needs to be passed a groupname and a hash pkgname => pkgversion of installed packages.
+  # Returns a tuple of the generated version and a boolean indicating if the group is fully installed.
+  def self.get_virtual_group_version group, package_versions
+    begin
+      fully_installed = true
+      group_version = "\n" # the leading newline is just to make Puppet's output look nicer
+      group_pkgs = []
+      execpipe([command(:pacman), "-Sg", group]) do |process|
+        process.each_line do |line|
+          group_pkg = line.split[1]
+          # if a package is missing, the group should be considered to be present
+          fully_installed = false unless package_versions[group_pkg]
+          group_pkgs << group_pkg
+        end
+      end
+      # sort packages by name
+      group_pkgs.sort.each do |group_pkg|
+        group_version += "#{group_pkg} #{package_versions[group_pkg]}\n"
+      end
+      [group_version, fully_installed]
+    rescue Puppet::ExecutionFailure
+      [nil, nil]
+    end
+  end
+
+  # Because Archlinux is a rolling release based distro, installing a package
+  # should always result in the newest release.
+  def update
+    # Install in pacman can be used for update, too
+    self.install
+  end
+
+  # We rescue the main check from Pacman with a check on the AUR using yaourt, if installed
+  def latest
+    pacman "-Sy"
+    # If target is a group, construct the virtual group version
+    if self.class.group?(@resource[:name])
+      output = pacman("-Sp", "--print-format", "%n %v", @resource[:name])
+      return "\n" + output.lines.sort.join
+    end
+    pacman_check = true   # Query the main repos first
+    begin
+      if pacman_check
+        output = pacman "-Sp", "--print-format", "%v", @resource[:name]
+        return output.chomp
+      else
+        output = yaourt "-Qma", @resource[:name]
+        output.split("\n").each do |line|
+          return line.split[1].chomp if line =~ /^aur/
+        end
+      end
+    rescue Puppet::ExecutionFailure
+      if pacman_check and self.class.yaourt?
+        pacman_check = false # now try the AUR
+        retry
+      else
+        raise
+      end
+    end
+  end
+
+  # Querys an installed package for information
+  def query
+    installed_packages = self.class.get_installed_packages
+
+    # generate the virtual group version of the target is a group
+    if self.class.group?(@resource[:name])
+      group_version, fully_installed = self.class.get_virtual_group_version(@resource[:name], installed_packages)
+      if group_version && fully_installed
+        return { :ensure => group_version }
+      else
+        return {
+          :ensure => :purged,
+          :status => 'missing',
+          :name => @resource[:name],
+          :error => 'ok',
+        }
+      end
+    end
+
+    # return the version if the package is installed
+    if pkgversion = installed_packages[@resource[:name]]
+      return { :ensure => pkgversion }
+      # report package missing if it is not installed
+    else
+      return {
+        :ensure => :purged,
+        :status => 'missing',
+        :name => @resource[:name],
+        :error => 'ok',
+      }
+    end
+  end
+
+  # Removes a package from the system.
+  def uninstall
+    cmd = %w{--noconfirm --noprogressbar}
+    cmd += uninstall_options if @resource[:uninstall_options]
+    cmd << "-R" << @resource[:name]
+    pacman *cmd
+  end
+
+  private
+
+  def install_options
+    join_options(@resource[:install_options])
+  end
+
+  def uninstall_options
+    join_options(@resource[:uninstall_options])
+  end
 
   def install_from_file
     source = @resource[:source]
@@ -75,160 +246,19 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     pacman "--noconfirm", "--noprogressbar", "-Sy"
     pacman "--noconfirm", "--noprogressbar", "-U", source
   end
-  private :install_from_file
 
-  def self.listcmd
-    [command(:pacman), "-Q"]
-  end
-
-  # Pacman has a concept of package groups as well.
-  # Package groups have no versions.
-  def self.listgroupcmd
-    [command(:pacman), "-Qg"]
-  end
-
-  # Get installed packages (pacman -Q)
-  def self.installedpkgs
-    packages = []
-    begin
-      execpipe(listcmd()) do |process|
-        # pacman -Q output is 'packagename version-rel'
-        regex = %r{^(\S+)\s(\S+)}
-        fields = [:name, :ensure]
-        hash = {}
-
-        process.each_line { |line|
-          if match = regex.match(line)
-            fields.zip(match.captures) { |field,value|
-              hash[field] = value
-            }
-
-            hash[:provider] = self.name
-
-            packages << new(hash)
-
-            hash = {}
-          else
-            warning("Failed to match line %s" % line)
-          end
-        }
-      end
-    rescue Puppet::ExecutionFailure
-      return nil
-    end
-    packages
-  end
-
-  # Get installed groups (pacman -Qg)
-  def self.installedgroups
-    packages = []
-    begin
-      execpipe(listgroupcmd()) do |process|
-        # pacman -Qg output is 'groupname packagename'
-        # Groups need to be deduplicated
-        groups = Set[]
-
-        process.each_line { |line|
-          groups.add(line.split[0])
-        }
-
-        groups.each { |line|
-          hash = {
-            :name   => line,
-            :ensure => "1", # Groups don't have versions, so ensure => latest
-                            # will still cause a reinstall.
-            :provider => self.name
-          }
-          packages << new(hash)
-        }
-      end
-    rescue Puppet::ExecutionFailure
-      return nil
-    end
-    packages
-  end
-
-  # Fetch the list of packages currently installed on the system.
-  def self.instances
-    packages = self.installedpkgs
-    groups   = self.installedgroups
-    result   = nil
-
-    if (!packages && !groups)
-      nil
-    elsif (packages && groups)
-      packages.concat(groups)
+  def install_from_repo
+    if self.class.yaourt?
+      cmd = %w{--noconfirm --needed}
+      cmd += install_options if @resource[:install_options]
+      cmd << "-S" << @resource[:name]
+      yaourt *cmd
     else
-      packages
+      cmd = %w{--noconfirm  --needed --noprogressbar}
+      cmd += install_options if @resource[:install_options]
+      cmd << "-Sy" << @resource[:name]
+      pacman *cmd
     end
   end
 
-
-  # Because Archlinux is a rolling release based distro, installing a package
-  # should always result in the newest release.
-  def update
-    # Install in pacman can be used for update, too
-    self.install
-  end
-
-  # We rescue the main check from Pacman with a check on the AUR using yaourt, if installed
-  def latest
-    pacman "-Sy"
-    pacman_check = true   # Query the main repos first
-    begin
-      if pacman_check
-        output = pacman "-Sp", "--print-format", "%v", @resource[:name]
-        return output.chomp
-      else
-        output = yaourt "-Qma", @resource[:name]
-        output.split("\n").each do |line|
-          return line.split[1].chomp if line =~ /^aur/
-        end
-      end
-    rescue Puppet::ExecutionFailure
-      if pacman_check and self.yaourt?
-        pacman_check = false # now try the AUR
-        retry
-      else
-        raise
-      end
-    end
-  end
-
-  # Querys the pacman master list for information about the package.
-  def query
-    begin
-      output = pacman("-Qi", @resource[:name])
-
-      if output =~ /Version.*:\s(.+)/
-        return { :ensure => $1 }
-      end
-    rescue Puppet::ExecutionFailure
-      return {
-        :ensure => :purged,
-        :status => 'missing',
-        :name => @resource[:name],
-        :error => 'ok',
-      }
-    end
-    nil
-  end
-
-  # Removes a package from the system.
-  def uninstall
-    cmd = %w{--noconfirm --noprogressbar}
-    cmd += uninstall_options if @resource[:uninstall_options]
-    cmd << "-R" << @resource[:name]
-    pacman *cmd
-  end
-
-  private
-
-  def install_options
-    join_options(@resource[:install_options])
-  end
-
-  def uninstall_options
-    join_options(@resource[:uninstall_options])
-  end
 end

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -41,12 +41,12 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
   def install_from_repo
     if yaourt?
-      cmd = %w{--noconfirm}
+      cmd = %w{--noconfirm --needed}
       cmd += install_options if @resource[:install_options]
       cmd << "-S" << @resource[:name]
       yaourt *cmd
     else
-      cmd = %w{--noconfirm --noprogressbar}
+      cmd = %w{--noconfirm  --needed --noprogressbar}
       cmd += install_options if @resource[:install_options]
       cmd << "-Sy" << @resource[:name]
       pacman *cmd

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -39,16 +39,16 @@ describe Puppet::Type.type(:package).provider(:pacman) do
       provider.install
     end
 
-    it "should raise an ExecutionFailure if the installation failed" do
+    it "should raise an Puppet::Error if the installation failed" do
       executor.stubs(:execute).returns("")
       provider.expects(:query).returns(nil)
 
-      expect { provider.install }.to raise_exception(Puppet::ExecutionFailure)
+      expect { provider.install }.to raise_exception(Puppet::Error)
     end
 
     it "should raise an Puppet::Error when trying to install a group and allow_virtual is false" do
       described_class.stubs(:group?).returns(true)
-      lambda { provider.install }.should raise_error(Puppet::Error)
+      expect { provider.install }.to raise_error(Puppet::Error)
     end
 
     it "should not raise an Puppet::Error when trying to install a group and allow_virtual is true" do
@@ -332,6 +332,11 @@ EOF
       expect { described_class.instances }.to raise_error(RuntimeError)
     end
 
+    it "should warn on invalid input" do
+      described_class.expects(:execpipe).twice.yields(StringIO.new("blah"))
+      described_class.expects(:warning).with("Failed to match line 'blah'")
+      expect(described_class.instances).to eq([])
+    end
   end
 
   describe "when determining the latest version" do

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -182,7 +182,7 @@ EOF
     it "should return a hash indicating that the package is missing" do
       executor.expects(:execpipe).yields("")
       expect(provider.query).to eq({
-        :ensure => :purged,
+        :ensure => :absent,
         :status => 'missing',
         :name => resource[:name],
         :error => 'ok',

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -27,14 +27,14 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
     it "should call pacman to install the right package quietly when yaourt is not installed" do
       provider.stubs(:yaourt?).returns(false)
-      args = ['--noconfirm', '--noprogressbar', '-Sy', resource[:name]]
+      args = ['--noconfirm', '--needed', '--noprogressbar', '-Sy', resource[:name]]
       provider.expects(:pacman).at_least_once.with(*args).returns ''
       provider.install
     end
 
     it "should call yaourt to install the right package quietly when yaourt is installed" do
       provider.stubs(:yaourt?).returns(true)
-      args = ['--noconfirm', '-S', resource[:name]]
+      args = ['--noconfirm', '--needed', '-S', resource[:name]]
       provider.expects(:yaourt).at_least_once.with(*args).returns ''
       provider.install
     end
@@ -53,14 +53,14 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
       it "should call pacman to install the right package quietly when yaourt is not installed" do
         provider.stubs(:yaourt?).returns(false)
-        args = ['--noconfirm', '--noprogressbar', '-x', '--arg=value', '-Sy', resource[:name]]
+        args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-Sy', resource[:name]]
         provider.expects(:pacman).at_least_once.with(*args).returns ''
         provider.install
       end
 
       it "should call yaourt to install the right package quietly when yaourt is installed" do
         provider.stubs(:yaourt?).returns(true)
-        args = ['--noconfirm', '-x', '--arg=value', '-S', resource[:name]]
+        args = ['--noconfirm', '--needed', '-x', '--arg=value', '-S', resource[:name]]
         provider.expects(:yaourt).at_least_once.with(*args).returns ''
         provider.install
       end


### PR DESCRIPTION
These commits fix the pacman package provider's handling of groups.

Previously, the pacman provider would return a version of '1' for package groups if a single package of the group was installed. This meant that groups that were partially installed were considered to be installed.  Additionally, if a package in a group was updated, the group was still considered to be the latest and no action would be taken to update the group.

This fixes the above issue by considering a package group to be installed only if all the packages in the group are installed.  Additionally, package group versions are now a concatenation of all the versions of the packages comprising the groups.  This allows the group to install packages in the group that have been updated.

Also fixed:

* Pass the `--needed` option to pacman to prevent needless reinstallation of packages.
* Return :absent instead of :purged if a package is missing
* Implement the virtual_packages feature to disable handling package groups.
* Improve errors and warnings in the provider.
