### PR TITLE
(PUP-3024) Add deltarpm_percentage and deltarpm_metadata_percentage

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -368,4 +368,22 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(YUM_BOOLEAN, :absent)
   end
+
+  newproperty(:deltarpm_percentage) do
+    desc "Percentage value that determines when to use deltas for this repo.
+      When the delta is larger than this percentage value of the package, the
+      delta is not used.
+      #{ABSENT_DOC}"
+
+    newvalues(/^\d+$/, :absent)
+  end
+
+  newproperty(:deltarpm_metadata_percentage) do
+    desc "Percentage value that determines when to download deltarpm metadata.
+      When the deltarpm metadata is larger than this percentage value of the
+      package, deltarpm metadata is not downloaded.
+      #{ABSENT_DOC}"
+
+    newvalues(/^\d+$/, :absent)
+  end
 end

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -388,5 +388,15 @@ describe Puppet::Type.type(:yumrepo) do
       it_behaves_like "a yumrepo parameter that can be absent", :mirrorlist_expire
       it_behaves_like "a yumrepo parameter that expects a natural value", :mirrorlist_expire
     end
+
+    describe "deltarpm_percentage" do
+      it_behaves_like "a yumrepo parameter that can be absent", :deltarpm_percentage
+      it_behaves_like "a yumrepo parameter that expects a natural value", :deltarpm_percentage
+    end
+
+    describe "deltarpm_metadata_percentage" do
+      it_behaves_like "a yumrepo parameter that can be absent", :deltarpm_metadata_percentage
+      it_behaves_like "a yumrepo parameter that expects a natural value", :deltarpm_metadata_percentage
+    end
   end
 end


### PR DESCRIPTION
This patch adds deltarpm_percentage and deltarpm_metadata_percentage to the yumrepo type.
These yum repo configuration options are only available with newer versions of Fedora and CentOS 7, which have DeltaRPM support (Presto).

Earlier versions of yum appear to ignore options which aren't recognised, loading the repo file successfully.
- Does there need to be added logic which rejects this parameter for earlier OS versions? (This could be quite a bit of work and other modules such as the puppetlabs-apt one are not doing something similar currently)
- Should I also create some kind of (doc) tracking ticket for this as well?
