### PR TITLE
(PUP-3313) Remove marker method puppet_lambda

### DIFF
--- a/lib/puppet/pops/binder/lookup.rb
+++ b/lib/puppet/pops/binder/lookup.rb
@@ -5,9 +5,7 @@ class Puppet::Pops::Binder::Lookup
 
   def self.parse_lookup_args(args)
     options = {}
-    pblock = if args[-1].respond_to?(:puppet_lambda)
-      args.pop
-    end
+    pblock = args.pop if Puppet::Pops::Types::TypeCalculator.infer(args[-1]).is_a?(Puppet::Pops::Types::PCallableType)
 
     case args.size
     when 1

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -22,13 +22,6 @@ class Puppet::Pops::Evaluator::Closure < Puppet::Pops::Evaluator::CallableSignat
     @enclosing_scope = scope
   end
 
-  # marker method checked with respond_to :puppet_lambda
-  # @api private
-  # @deprecated Use the type system to query if an object is of Callable type, then use its signatures method for info
-  def puppet_lambda()
-    true
-  end
-
   # Evaluates a closure in its enclosing scope after having matched given arguments with parameters (from left to right)
   # @api public
   def call(*args)


### PR DESCRIPTION
Now when the 3x AST implementation has been removed the marker
method :puppet_lambda is no longer needed. This commit replaces
the check if an argument is callable by using the type calculator
instead of checking the marker method.

The marker method was only used by the lookup function. All other such
calls have already been cleaned up.