### PR TITLE
(PUP-3753) Improve performance of zfs checks.

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -30,9 +30,10 @@ Puppet::Type.type(:zfs).provide(:zfs) do
   end
 
   def exists?
-    if zfs(:list).split("\n").detect { |line| line.split("\s")[0] == @resource[:name] }
+    begin
+      zfs(:list, @resource[:name])
       true
-    else
+    rescue Puppet::ExecutionFailure
       false
     end
   end

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -71,13 +71,13 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
   context "#exists?" do
     it "should return true if the resource exists" do
       #return stuff because we have to slice and dice it
-      provider.expects(:zfs).with(:list).returns("NAME USED AVAIL REFER MOUNTPOINT\nmyzfs 100K 27.4M /myzfs")
+      provider.expects(:zfs).with(:list, name)
 
       provider.should be_exists
     end
 
     it "should return false if returned values don't match the name" do
-      provider.expects(:zfs).with(:list).returns("no soup for you")
+      provider.expects(:zfs).with(:list, name).raises(Puppet::ExecutionFailure, "Failed")
 
       provider.should_not be_exists
     end


### PR DESCRIPTION
We run machines on ZFS with relatively slow hard drives and relatively many filesystems (couple of hundred). When we want to manage ZFSes with Puppet, this is very slow. Investigation shows that for every Zfs resource the provider does a `zfs list` and then parses the output to see if a particular ZFS shows up. At least on our systems, this takes forever. I think I came up with a far more effective way of checking whether a ZFS exists or not.
Tested by ensuring a ZFS, running puppet a couple of times seeing that it only creates it once, and when ensuring the resource to be absent, the ZFS was removed.
