### PR TITLE
(maint) Add qualified variable lookup benchmark

### DIFF
--- a/benchmarks/fq_var_lookup/benchmarker.rb
+++ b/benchmarks/fq_var_lookup/benchmarker.rb
@@ -1,0 +1,77 @@
+require 'erb'
+require 'ostruct'
+require 'fileutils'
+require 'json'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size
+  end
+
+  def setup
+    require 'puppet'
+    config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', config])
+  end
+
+  def run(args=nil)
+    env = Puppet.lookup(:environments).get('benchmarking')
+    node = Puppet::Node.new("testing", :environment => env)
+    Puppet::Resource::Catalog.indirection.find("testing", :use_node => node)
+  end
+
+  def generate
+    environment = File.join(@target, 'environments', 'benchmarking')
+    templates = File.join('benchmarks', 'fq_var_lookup')
+
+    mkdir_p(File.join(environment, 'modules'))
+    mkdir_p(File.join(environment, 'manifests'))
+
+    render(File.join(templates, 'site.pp.erb'),
+           File.join(environment, 'manifests', 'site.pp'),
+           :size => @size)
+
+
+    module_name = "tst_generate"
+    module_base = File.join(environment, 'modules', module_name)
+    manifests = File.join(module_base, 'manifests')
+
+    mkdir_p(manifests)
+
+    File.open(File.join(module_base, 'metadata.json'), 'w') do |f|
+      JSON.dump({
+        "types" => [],
+        "source" => "",
+        "author" => "tst_generate Benchmark",
+        "license" => "Apache 2.0",
+        "version" => "1.0.0",
+        "description" => "Qualified variable lookup benchmark module 1",
+        "summary" => "Just this benchmark module, you know?",
+        "dependencies" => [],
+      }, f)
+
+    render(File.join(templates, 'module', 'params.pp.erb'),
+           File.join(manifests, 'params.pp'),
+           :name => module_name)
+
+    render(File.join(templates, 'module', 'badclass.pp.erb'),
+           File.join(manifests, 'badclass.pp'),
+           :size => @size)
+
+    end
+
+    render(File.join(templates, 'puppet.conf.erb'),
+           File.join(@target, 'puppet.conf'),
+           :location => @target)
+  end
+
+  def render(erb_file, output_file, bindings)
+    site = ERB.new(File.read(erb_file))
+    File.open(output_file, 'w') do |fh|
+      fh.write(site.result(OpenStruct.new(bindings).instance_eval { binding }))
+    end
+  end
+end

--- a/benchmarks/fq_var_lookup/description
+++ b/benchmarks/fq_var_lookup/description
@@ -1,0 +1,3 @@
+Benchmark scenario: many qualified variable lookups without leading ::.
+Benchmark target: catalog compilation.
+

--- a/benchmarks/fq_var_lookup/module/badclass.pp.erb
+++ b/benchmarks/fq_var_lookup/module/badclass.pp.erb
@@ -1,0 +1,29 @@
+class tst_generate::badclass {
+  include tst_generate::params
+
+  group { "${tst_generate::params::ugroup}":
+    ensure => present,
+  }
+
+  user { "${tst_generate::params::user}":
+    ensure => present,
+    gid    => $tst_generate::params::ugroup,
+  }
+
+  file { "${tst_generate::params::basedir}":
+    ensure  => directory,
+    owner   => $tst_generate::params::user,
+    group   => $tst_generate::params::ugroup,
+  }
+
+<% (1..500).to_a.each do |i| %>
+  file{ "${tst_generate::params::basedir}/file_<%= i %>":
+    ensure  => file,
+    content => "This is a test file.\n",
+    owner   => $tst_generate::params::user,
+    group   => $tst_generate::params::ugroup,
+    require => File["${tst_generate::params::basedir}"],
+  }
+
+<% end %>
+}

--- a/benchmarks/fq_var_lookup/module/params.pp.erb
+++ b/benchmarks/fq_var_lookup/module/params.pp.erb
@@ -1,0 +1,5 @@
+class tst_generate::params {
+  $basedir = '/tmp/type_collection_tst'
+  $user = 'tstusr'
+  $ugroup = 'tstugroup'
+}

--- a/benchmarks/fq_var_lookup/puppet.conf.erb
+++ b/benchmarks/fq_var_lookup/puppet.conf.erb
@@ -1,0 +1,3 @@
+confdir = <%= location %>
+vardir = <%= location %>
+environmentpath = <%= File.join(location, 'environments') %>

--- a/benchmarks/fq_var_lookup/site.pp.erb
+++ b/benchmarks/fq_var_lookup/site.pp.erb
@@ -1,0 +1,1 @@
+include tst_generate::badclass


### PR DESCRIPTION
This commit adds a benchmark to test the compilation of many qualified
variable lookups in a manifest.
