### PR TITLE
(PUP-3642) Remove environment name from URL path

### DIFF
--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -82,7 +82,7 @@ with_puppet_running_on(master, master_opts, testdir) do
         (
           sleep_for="0.$(( $RANDOM % 49 ))"
           sleep $sleep_for
-          url='https://#{master}:8140/production/catalog/#{agent_cert}'
+          url='https://#{master}:8140/catalog/#{agent_cert}?environment=production'
           echo "Curling: $url"
           curl --tlsv1 -v -# -H 'Accept: text/pson' --cert #{cert_path} --key #{key_path} --cacert #{cacert_path} $url
           echo "$PPID Completed"

--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -34,10 +34,11 @@ class Puppet::FileBucket::Dipper
 
   # Backs up a file to the file bucket
   def backup(file)
+    environment = Puppet.lookup(:current_environment)
     file_handle = Puppet::FileSystem.pathname(file)
     raise(ArgumentError, "File #{file} does not exist") unless Puppet::FileSystem.exist?(file_handle)
     begin
-      file_bucket_file = Puppet::FileBucket::File.new(file_handle, :bucket_path => @local_path)
+      file_bucket_file = Puppet::FileBucket::File.new(environment, file_handle, :bucket_path => @local_path)
       files_original_path = absolutize_path(file)
       dest_path = "#{@rest_path}#{file_bucket_file.name}/#{files_original_path}"
       file_bucket_path = "#{@rest_path}#{file_bucket_file.checksum_type}/#{file_bucket_file.checksum_data}/#{files_original_path}"
@@ -75,7 +76,9 @@ class Puppet::FileBucket::Dipper
     restore = true
     file_handle = Puppet::FileSystem.pathname(file)
     if Puppet::FileSystem.exist?(file_handle)
-      cursum = Puppet::FileBucket::File.new(file_handle).checksum_data()
+      cursum = Puppet::FileBucket::File.new(
+          Puppet.lookup(:current_environment).name,
+          file_handle).checksum_data()
 
       # if the checksum has changed...
       # this might be extra effort

--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -206,7 +206,8 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     else
       Puppet.info "Storing content for source '#{resource[:source]}'"
       content = Puppet::FileServing::Content.indirection.find(resource[:source])
-      file = Puppet::FileBucket::File.new(content.content)
+      environment = Puppet.lookup(:current_environment)
+      file = Puppet::FileBucket::File.new(environment.name, content.content)
       Puppet::FileBucket::File.indirection.save(file)
     end
   end

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -21,7 +21,7 @@ module Puppet::FileBucketFile
           return `diff #{Puppet::FileSystem.path_string(contents_file).inspect} #{Puppet::FileSystem.path_string(other_contents_file).inspect}`
         else
           Puppet.info "FileBucket read #{checksum}"
-          model.new(Puppet::FileSystem.binread(contents_file))
+          model.new(request.environment.name, Puppet::FileSystem.binread(contents_file))
         end
       else
         nil
@@ -45,7 +45,7 @@ module Puppet::FileBucketFile
       save_to_disk(instance, files_original_path, contents_file, paths_file)
 
       # don't echo the request content back to the agent
-      model.new('')
+      model.new(request.environment, '')
     end
 
     def validate_key(request)

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -111,7 +111,7 @@ class Puppet::Indirector::Request
   # Create the query string, if options are present.
   def query_string
     return "" if options.nil? || options.empty?
-    "?" + encode_params(expand_into_parameters(options.to_a))
+    encode_params(expand_into_parameters(options.to_a))
   end
 
   def expand_into_parameters(data)

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -120,7 +120,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
 
   def head(request)
     response = do_request(request) do |request|
-      http_head(request, Puppet::Network::HTTP::API::V1.indirection2uri(request), headers)
+      http_head(request, Puppet::Network::HTTP::API::V1.request_to_uri_with_env(request), headers)
     end
 
     if is_http_200?(response)
@@ -132,7 +132,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
 
   def search(request)
     response = do_request(request) do |request|
-      http_get(request, Puppet::Network::HTTP::API::V1.indirection2uri(request), headers)
+      http_get(request, Puppet::Network::HTTP::API::V1.request_to_uri_with_env(request), headers)
     end
 
     if is_http_200?(response)
@@ -147,7 +147,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     raise ArgumentError, "DELETE does not accept options" unless request.options.empty?
 
     response = do_request(request) do |request|
-      http_delete(request, Puppet::Network::HTTP::API::V1.indirection2uri(request), headers)
+      http_delete(request, Puppet::Network::HTTP::API::V1.request_to_uri_with_env(request), headers)
     end
 
     if is_http_200?(response)

--- a/lib/puppet/network/http/api/v1.rb
+++ b/lib/puppet/network/http/api/v1.rb
@@ -30,13 +30,8 @@ class Puppet::Network::HTTP::API::V1
 
   # handle an HTTP request
   def call(request, response)
-    indirection_name, method, key, params = uri2indirection(request.method, request.path, request.params)
+    indirection, method, key, params = uri2indirection(request)
     certificate = request.client_cert
-
-    check_authorization(method, "/#{indirection_name}/#{key}", params)
-
-    indirection = Puppet::Indirector::Indirection.instance(indirection_name.to_sym)
-    raise ArgumentError, "Could not find indirection '#{indirection_name}'" unless indirection
 
     if !indirection.allow_remote_requests?
       # TODO: should we tell the user we found an indirection but it doesn't
@@ -55,29 +50,58 @@ class Puppet::Network::HTTP::API::V1
     return do_exception(response, e)
   end
 
-  def uri2indirection(http_method, uri, params)
-    environment, indirection, key = uri.split("/", 4)[1..-1] # the first field is always nil because of the leading slash
+  def uri2indirection(request)
+    indirection_name, key = request.path.split("/", 3)[1..-1] # the first field is always nil because of the leading slash
 
-    raise ArgumentError, "The environment must be purely alphanumeric, not '#{environment}'" unless Puppet::Node::Environment.valid_name?(environment)
-    raise ArgumentError, "The indirection name must be purely alphanumeric, not '#{indirection}'" unless indirection =~ /^\w+$/
+    if indirection_name !~ /^\w+$/
+      raise ArgumentError, "The indirection name must be purely alphanumeric, not '#{indirection_name}'"
+    end
 
-    method = indirection_method(http_method, indirection)
+    method = indirection_method(request.method, indirection_name)
+    check_authorization(method, "/#{indirection_name}/#{key}", request.params)
+
+    indirection = Puppet::Indirector::Indirection.instance(indirection_name.to_sym)
+    if !indirection
+      raise ArgumentError, "Could not find indirection '#{indirection_name}'"
+    end
+
+    if method == :save
+      # In the case of a PUT request which maps to a `save` indirection, the HTTP
+      # specification doesn't allow a query string, so we can't put the environment
+      # there.  It needs to go in the request body.  However, since the
+      # indirector hides the deserialization of the body behind the 'model' object
+      # for each different indirection, we need to go ahead and deserialize the
+      # body into the indirector model object and then read the environment from there.
+      model_object = read_body_into_model(indirection.model, request)
+      environment = model_object.environment
+      request.params[:model_object] = model_object
+    else
+      environment = request.params.delete(:environment)
+    end
+
+    if ! Puppet::Node::Environment.valid_name?(environment)
+      raise ArgumentError, "The environment must be purely alphanumeric, not '#{environment}'"
+    end
 
     configured_environment = Puppet.lookup(:environments).get(environment)
     if configured_environment.nil?
-      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("Could not find environment '#{environment}'", Puppet::Network::HTTP::Issues::ENVIRONMENT_NOT_FOUND)
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(
+                "Could not find environment '#{environment}'",
+                Puppet::Network::HTTP::Issues::ENVIRONMENT_NOT_FOUND)
     else
       configured_environment = configured_environment.override_from_commandline(Puppet.settings)
-      params[:environment] = configured_environment
+      request.params[:environment] = configured_environment
     end
 
-    params.delete(:bucket_path)
+    request.params.delete(:bucket_path)
 
-    raise ArgumentError, "No request key specified in #{uri}" if key == "" or key.nil?
+    if key == "" or key.nil?
+      raise ArgumentError, "No request key specified in #{request.path}"
+    end
 
     key = URI.unescape(key)
 
-    [indirection, method, key, params]
+    [indirection, method, key, request.params]
   end
 
   private
@@ -155,9 +179,7 @@ class Puppet::Network::HTTP::API::V1
   # Execute our save.
   def do_save(indirection, key, params, request, response)
     formatter = accepted_response_formatter_or_pson_for(indirection.model, request)
-    sent_object = read_body_into_model(indirection.model, request)
-
-    result = indirection.save(sent_object, key)
+    result = indirection.save(params[:model_object], key)
 
     response.respond_with(200, formatter, formatter.render(result))
   end
@@ -191,12 +213,17 @@ class Puppet::Network::HTTP::API::V1
 
   def self.indirection2uri(request)
     indirection = request.method == :search ? pluralize(request.indirection_name.to_s) : request.indirection_name.to_s
-    "/#{request.environment.to_s}/#{indirection}/#{request.escaped_key}#{request.query_string}"
+    "/#{indirection}/#{request.escaped_key}?#{request.query_string}"
+  end
+
+  def self.request_to_uri_with_env(request)
+    indirection = request.method == :search ? pluralize(request.indirection_name.to_s) : request.indirection_name.to_s
+    "/#{indirection}/#{request.escaped_key}?environment=#{request.environment.to_s}&#{request.query_string}"
   end
 
   def self.request_to_uri_and_body(request)
     indirection = request.method == :search ? pluralize(request.indirection_name.to_s) : request.indirection_name.to_s
-    ["/#{request.environment.to_s}/#{indirection}/#{request.escaped_key}", request.query_string.sub(/^\?/,'')]
+    ["/#{indirection}/#{request.escaped_key}", "environment=#{request.environment.to_s}&#{request.query_string}"]
   end
 
   def self.pluralize(indirection)

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -107,6 +107,12 @@ DOC
     @content
   end
 
+  # The environment isn't really relevant for CSRs, but in order to comply with the
+  # indirector's HTTP magic, we need to expose a getter for the environment here.
+  def environment
+    Puppet.lookup(:current_environment).name
+  end
+
   # Return the set of extensions requested on this CSR, in a form designed to
   # be useful to Ruby: an array of hashes.  Which, not coincidentally, you can pass
   # successfully to the OpenSSL constructor later, if you want.

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -212,7 +212,7 @@ module Puppet
 
       request.do_request(:fileserver) do |req|
         connection = Puppet::Network::HttpPool.http_instance(req.server, req.port)
-        connection.request_get(Puppet::Network::HTTP::API::V1.indirection2uri(req), add_accept_encoding({"Accept" => "raw"}), &block)
+        connection.request_get(Puppet::Network::HTTP::API::V1.request_to_uri_with_env(req), add_accept_encoding({"Accept" => "raw"}), &block)
       end
     end
 

--- a/spec/integration/file_bucket/file_spec.rb
+++ b/spec/integration/file_bucket/file_spec.rb
@@ -46,7 +46,7 @@ describe Puppet::FileBucket::File do
     let(:binary) { "\xD1\xF2\r\n\x81NuSc\x00".force_encoding(Encoding::ASCII_8BIT) }
 
     it "does not error when the same contents are saved twice" do
-      bucket_file = Puppet::FileBucket::File.new(binary)
+      bucket_file = Puppet::FileBucket::File.new("production", binary)
       Puppet::FileBucket::File.indirection.save(bucket_file, bucket_file.name)
       Puppet::FileBucket::File.indirection.save(bucket_file, bucket_file.name)
     end

--- a/spec/lib/puppet/indirector_testing.rb
+++ b/spec/lib/puppet/indirector_testing.rb
@@ -21,6 +21,10 @@ class Puppet::IndirectorTesting
     new(data['value'])
   end
 
+  def environment
+    "fooenv"
+  end
+
   def to_data_hash
     { 'value' => value }
   end

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -16,7 +16,7 @@ shared_examples_for "a restorable file" do
       it "should restore the file" do
         request = nil
 
-        klass.any_instance.expects(:find).with { |r| request = r }.returns(Puppet::FileBucket::File.new(plaintext))
+        klass.any_instance.expects(:find).with { |r| request = r }.returns(Puppet::FileBucket::File.new("production", plaintext))
 
         dipper.restore(dest, checksum).should == checksum
         digest(Puppet::FileSystem.binread(dest)).should == checksum
@@ -34,7 +34,7 @@ shared_examples_for "a restorable file" do
       end
 
       it "should overwrite existing file if it has different checksum" do
-        klass.any_instance.expects(:find).returns(Puppet::FileBucket::File.new(plaintext))
+        klass.any_instance.expects(:find).returns(Puppet::FileBucket::File.new("production", plaintext))
 
         File.open(dest, 'wb') {|f| f.print('other contents') }
 
@@ -102,7 +102,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
 
         request = nil
 
-        Puppet::FileBucketFile::File.any_instance.expects(:find).with{ |r| request = r }.once.returns(Puppet::FileBucket::File.new(plaintext))
+        Puppet::FileBucketFile::File.any_instance.expects(:find).with{ |r| request = r }.once.returns(Puppet::FileBucket::File.new("production", plaintext))
 
         @dipper.getfile(checksum).should == plaintext
 
@@ -139,7 +139,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
 
         request = nil
 
-        Puppet::FileBucketFile::Rest.any_instance.expects(:find).with { |r| request = r }.returns(Puppet::FileBucket::File.new(plaintext))
+        Puppet::FileBucketFile::Rest.any_instance.expects(:find).with { |r| request = r }.returns(Puppet::FileBucket::File.new("production", plaintext))
 
         @dipper.getfile(checksum).should == plaintext
 

--- a/spec/unit/file_bucket/file_spec.rb
+++ b/spec/unit/file_bucket/file_spec.rb
@@ -9,37 +9,38 @@ describe Puppet::FileBucket::File, :uses_checksums => true do
   # this is the default from spec_helper, but it keeps getting reset at odd times
   let(:bucketdir) { Puppet[:bucketdir] = tmpdir('bucket') }
 
-  it "defaults to serializing to `:s`" do
-    expect(Puppet::FileBucket::File.default_format).to eq(:s)
+  it "defaults to serializing to `:pson`" do
+    expect(Puppet::FileBucket::File.default_format).to eq(:pson)
   end
 
-  it "accepts s" do
-    expect(Puppet::FileBucket::File.supported_formats).to include(:s)
+  it "accepts pson" do
+    expect(Puppet::FileBucket::File.supported_formats).to include(:pson)
   end
 
   describe "making round trips through network formats" do
     with_digest_algorithms do
-      it "can make a round trip through `s`" do
-        file = Puppet::FileBucket::File.new(plaintext)
-        tripped = Puppet::FileBucket::File.convert_from(:s, file.render)
+      it "can make a round trip through `pson`" do
+        environment = Puppet::Node::Environment.create(:production, [])
+        file = Puppet::FileBucket::File.new(environment, plaintext)
+        tripped = Puppet::FileBucket::File.convert_from(:pson, file.render)
         expect(tripped.contents).to eq(plaintext)
       end
     end
   end
 
   it "should require contents to be a string" do
-    expect { Puppet::FileBucket::File.new(5) }.to raise_error(ArgumentError, /contents must be a String or Pathname, got a Fixnum$/)
+    expect { Puppet::FileBucket::File.new("production", 5) }.to raise_error(ArgumentError, /contents must be a String or Pathname, got a Fixnum$/)
   end
 
   it "should complain about options other than :bucket_path" do
     expect {
-      Puppet::FileBucket::File.new('5', :crazy_option => 'should not be passed')
+      Puppet::FileBucket::File.new("production", '5', :crazy_option => 'should not be passed')
     }.to raise_error(ArgumentError, /Unknown option\(s\): crazy_option/)
   end
 
   with_digest_algorithms do
     it "it uses #{metadata[:digest_algorithm]} as the configured digest algorithm" do
-      file = Puppet::FileBucket::File.new(plaintext)
+      file = Puppet::FileBucket::File.new("production", plaintext)
 
       file.contents.should == plaintext
       file.checksum_type.should == digest_algorithm

--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -11,20 +11,20 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
     include PuppetSpec::Files
 
     def save_bucket_file(contents, path = "/who_cares")
-      bucket_file = Puppet::FileBucket::File.new(contents)
+      bucket_file = Puppet::FileBucket::File.new('environment', contents)
       Puppet::FileBucket::File.indirection.save(bucket_file, "#{bucket_file.name}#{path}")
       bucket_file.checksum_data
     end
 
     describe "when servicing a save request" do
       it "should return a result whose content is empty" do
-        bucket_file = Puppet::FileBucket::File.new('stuff')
+        bucket_file = Puppet::FileBucket::File.new('environment', 'stuff')
         result = Puppet::FileBucket::File.indirection.save(bucket_file, "md5/c13d88cb4cb02003daedb8a84e5d272a")
         result.contents.should be_empty
       end
 
       it "deals with multiple processes saving at the same time", :unless => Puppet::Util::Platform.windows? do
-        bucket_file = Puppet::FileBucket::File.new("contents")
+        bucket_file = Puppet::FileBucket::File.new('environment',"contents")
 
         children = []
         5.times do |count|
@@ -271,7 +271,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
                   key += "//path/to/file"
                 end
 
-                file_instance = Puppet::FileBucket::File.new(plaintext, options)
+                file_instance = Puppet::FileBucket::File.new('environment', plaintext, options)
                 request = Puppet::Indirector::Request.new(:indirection_name, :save, key, file_instance)
 
                 @store.save(request)

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -277,12 +277,6 @@ describe Puppet::Indirector::Request do
       request.query_string.should == ""
     end
 
-    it "should prefix the query string with '?'" do
-      request = a_request_with_options(:one => "two")
-
-      request.query_string.should =~ /^\?/
-    end
-
     it "should include all options in the query string, separated by '&'" do
       request = a_request_with_options(:one => "two", :three => "four")
 

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -241,7 +241,7 @@ describe Puppet::Indirector::REST do
         request = find_request('whoa', params)
 
         connection.expects(:post).with do |uri, body|
-          body.split("&").sort == params.map {|key,value| "#{key}=#{value}"}.sort
+          body.split("&").sort == params.merge({:environment => "production"}).map {|key,value| "#{key}=#{value}"}.sort
         end.returns(mock_response(200, 'body'))
 
         terminus.find(request)
@@ -252,7 +252,7 @@ describe Puppet::Indirector::REST do
       it "calls get on the connection" do
         request = find_request('foo bar')
 
-        connection.expects(:get).with('/production/test_model/foo%20bar?', anything).returns(mock_response('200', 'response body'))
+        connection.expects(:get).with('/test_model/foo%20bar?environment=production&', anything).returns(mock_response('200', 'response body'))
 
         terminus.find(request).should == model.new('foo bar', 'response body')
       end
@@ -283,7 +283,7 @@ describe Puppet::Indirector::REST do
           terminus.find(request)
         end.to raise_error(
           Puppet::Error,
-          'Find /production/test_model/foo?fail_on_404=true resulted in 404 with the message: this is the notfound you are looking for')
+          'Find /test_model/foo?environment=production&fail_on_404=true resulted in 404 with the message: this is the notfound you are looking for')
       end
 
       it 'truncates the URI when it is very long' do
@@ -295,7 +295,7 @@ describe Puppet::Indirector::REST do
           terminus.find(request)
         end.to raise_error(
           Puppet::Error,
-          /\/production\/test_model\/foo.*long_param=A+\.\.\..*resulted in 404 with the message/)
+          /\/test_model\/foo.*\?environment=production&.*long_param=A+\.\.\..*resulted in 404 with the message/)
       end
 
       it 'does not truncate the URI when logging debug information' do
@@ -308,7 +308,7 @@ describe Puppet::Indirector::REST do
           terminus.find(request)
         end.to raise_error(
           Puppet::Error,
-          /\/production\/test_model\/foo.*long_param=A+B.*resulted in 404 with the message/)
+          /\/test_model\/foo.*\?environment=production&.*long_param=A+B.*resulted in 404 with the message/)
       end
     end
 
@@ -409,7 +409,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a deserializing terminus method', :search
 
     it "should call the GET http method on a network connection" do
-      connection.expects(:get).with('/production/test_models/foo', has_key('Accept')).returns mock_response(200, 'data3, data4')
+      connection.expects(:get).with('/test_models/foo?environment=production&', has_key('Accept')).returns mock_response(200, 'data3, data4')
 
       terminus.search(request)
     end
@@ -454,7 +454,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a deserializing terminus method', :destroy
 
     it "should call the DELETE http method on a network connection" do
-      connection.expects(:delete).with('/production/test_model/foo', has_key('Accept')).returns(response)
+      connection.expects(:delete).with('/test_model/foo?environment=production&', has_key('Accept')).returns(response)
 
       terminus.destroy(request)
     end
@@ -501,7 +501,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a REST terminus method', :save
 
     it "should call the PUT http method on a network connection" do
-      connection.expects(:put).with('/production/test_model/the%20thing', anything, has_key("Content-Type")).returns response
+       connection.expects(:put).with('/test_model/the%20thing?', anything, has_key("Content-Type")).returns response
 
       terminus.save(request)
     end

--- a/spec/unit/network/http/api/v1_spec.rb
+++ b/spec/unit/network/http/api/v1_spec.rb
@@ -13,6 +13,7 @@ describe Puppet::Network::HTTP::API::V1 do
   let(:indirection) { Puppet::IndirectorTesting.indirection }
   let(:handler) { Puppet::Network::HTTP::API::V1.new }
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+  let(:params) { { :environment => "production" } }
 
   def a_request_that_heads(data, request = {})
     Puppet::Network::HTTP::Request.from_hash({
@@ -20,8 +21,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "HEAD",
-      :path => "/production/#{indirection.name}/#{data.value}",
-      :params => {},
+      :path => "/#{indirection.name}/#{data.value}",
+      :params => params,
     })
   end
 
@@ -31,8 +32,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => request[:content_type_header] || "text/pson", },
       :method => "PUT",
-      :path => "/production/#{indirection.name}/#{data.value}",
-      :params => {},
+      :path => "/#{indirection.name}/#{data.value}",
+      :params => params,
       :body => request[:body].nil? ? data.render("pson") : request[:body]
     })
   end
@@ -43,8 +44,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "DELETE",
-      :path => "/production/#{indirection.name}/#{data.value}",
-      :params => {},
+      :path => "/#{indirection.name}/#{data.value}",
+      :params => params,
       :body => ''
     })
   end
@@ -55,8 +56,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "GET",
-      :path => "/production/#{indirection.name}/#{data.value}",
-      :params => {},
+      :path => "/#{indirection.name}/#{data.value}",
+      :params => params,
       :body => ''
     })
   end
@@ -67,8 +68,8 @@ describe Puppet::Network::HTTP::API::V1 do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "GET",
-      :path => "/production/#{indirection.name}s/#{key}",
-      :params => {},
+      :path => "/#{indirection.name}s/#{key}",
+      :params => params,
       :body => ''
     })
   end
@@ -84,6 +85,7 @@ describe Puppet::Network::HTTP::API::V1 do
   describe "when converting a URI into a request" do
     let(:environment) { Puppet::Node::Environment.create(:env, []) }
     let(:env_loaders) { Puppet::Environments::Static.new(environment) }
+    let(:params) { { :environment => "env" } }
 
     before do
       handler.stubs(:handler).returns "foo"
@@ -95,103 +97,112 @@ describe Puppet::Network::HTTP::API::V1 do
       end
     end
 
-    it "should require the http method, the URI, and the query parameters" do
-      # Not a terribly useful test, but an important statement for the spec
-      lambda { handler.uri2indirection("/foo") }.should raise_error(ArgumentError)
-    end
-
-    it "should use the first field of the URI as the environment" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[3][:environment].to_s.should == "env"
+    it "should get the environment from a query parameter" do
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/node/bar")
+      handler.uri2indirection(request)[3][:environment].to_s.should == "env"
     end
 
     it "should fail if the environment is not alphanumeric" do
-      lambda { handler.uri2indirection("GET", "/env ness/foo/bar", {}) }.should raise_error(ArgumentError)
-    end
-
-    it "should use the environment from the URI even if one is specified in the parameters" do
-      handler.uri2indirection("GET", "/env/foo/bar", {:environment => "otherenv"})[3][:environment].to_s.should == "env"
+      request = Puppet::Network::HTTP::Request.new({},
+                                                   {:environment => "env ness"},
+                                                   "GET", "/node/bar")
+      lambda { handler.uri2indirection(request) }.should raise_error(ArgumentError)
     end
 
     it "should not pass a buck_path parameter through (See Bugs #13553, #13518, #13511)" do
-      handler.uri2indirection("GET", "/env/foo/bar", { :bucket_path => "/malicious/path" })[3].should_not include({ :bucket_path => "/malicious/path" })
+      request = Puppet::Network::HTTP::Request.new({},
+                                                   {:environment => "env",
+                                                    :bucket_path => "/malicious/path" },
+                                                   "GET", "/node/bar")
+      handler.uri2indirection(request)[3].should_not include({ :bucket_path => "/malicious/path" })
     end
 
     it "should pass allowed parameters through" do
-      handler.uri2indirection("GET", "/env/foo/bar", { :allowed_param => "value" })[3].should include({ :allowed_param => "value" })
+      request = Puppet::Network::HTTP::Request.new({},
+                                                   {:environment => "env",
+                                                    :allowed_param => "value" },
+                                                   "GET", "/node/bar")
+      handler.uri2indirection(request)[3].should include({ :allowed_param => "value" })
     end
 
     it "should return the environment as a Puppet::Node::Environment" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[3][:environment].should be_a(Puppet::Node::Environment)
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/node/bar")
+      handler.uri2indirection(request)[3][:environment].should be_a(Puppet::Node::Environment)
     end
 
-    it "should not pass a buck_path parameter through (See Bugs #13553, #13518, #13511)" do
-      handler.uri2indirection("GET", "/env/foo/bar", { :bucket_path => "/malicious/path" })[3].should_not include({ :bucket_path => "/malicious/path" })
-    end
-
-    it "should pass allowed parameters through" do
-      handler.uri2indirection("GET", "/env/foo/bar", { :allowed_param => "value" })[3].should include({ :allowed_param => "value" })
-    end
-
-    it "should use the second field of the URI as the indirection name" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[0].should == "foo"
+    it "should use the first field of the URI as the indirection name" do
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/node/bar")
+      handler.uri2indirection(request)[0].name.should == :node
     end
 
     it "should fail if the indirection name is not alphanumeric" do
-      lambda { handler.uri2indirection("GET", "/env/foo ness/bar", {}) }.should raise_error(ArgumentError)
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/foo ness/bar")
+      lambda { handler.uri2indirection(request) }.should raise_error(ArgumentError)
     end
 
     it "should use the remainder of the URI as the indirection key" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[2].should == "bar"
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/node/bar")
+      handler.uri2indirection(request)[2].should == "bar"
     end
 
     it "should support the indirection key being a /-separated file path" do
-      handler.uri2indirection("GET", "/env/foo/bee/baz/bomb", {})[2].should == "bee/baz/bomb"
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/node/bee/baz/bomb")
+      handler.uri2indirection(request)[2].should == "bee/baz/bomb"
     end
 
     it "should fail if no indirection key is specified" do
-      lambda { handler.uri2indirection("GET", "/env/foo/", {}) }.should raise_error(ArgumentError)
-      lambda { handler.uri2indirection("GET", "/env/foo", {}) }.should raise_error(ArgumentError)
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/node/")
+      lambda { handler.uri2indirection(request) }.should raise_error(ArgumentError)
+    end
+
+    it "should fail if no indirection key is specified" do
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/node")
+      lambda { handler.uri2indirection(request) }.should raise_error(ArgumentError)
     end
 
     it "should choose 'find' as the indirection method if the http method is a GET and the indirection name is singular" do
-      handler.uri2indirection("GET", "/env/foo/bar", {})[1].should == :find
+      handler.send(:indirection_method, "GET", "foo").should == :find
     end
 
     it "should choose 'find' as the indirection method if the http method is a POST and the indirection name is singular" do
-      handler.uri2indirection("POST", "/env/foo/bar", {})[1].should == :find
+      handler.send(:indirection_method, "POST", "foo").should == :find
     end
 
     it "should choose 'head' as the indirection method if the http method is a HEAD and the indirection name is singular" do
-      handler.uri2indirection("HEAD", "/env/foo/bar", {})[1].should == :head
+      handler.send(:indirection_method, "HEAD", "foo").should == :head
     end
 
     it "should choose 'search' as the indirection method if the http method is a GET and the indirection name is plural" do
-      handler.uri2indirection("GET", "/env/foos/bar", {})[1].should == :search
+      handler.send(:indirection_method, "GET", "foos").should == :search
     end
 
     it "should change indirection name to 'status' if the http method is a GET and the indirection name is statuses" do
-      handler.uri2indirection("GET", "/env/statuses/bar", {})[0].should == 'status'
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/statuses/bar")
+      handler.uri2indirection(request)[0].name.should == :status
     end
 
-    it "should change indirection name to 'probe' if the http method is a GET and the indirection name is probes" do
-      handler.uri2indirection("GET", "/env/probes/bar", {})[0].should == 'probe'
+    it "should change indirection name to 'node' if the http method is a GET and the indirection name is nodes" do
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/nodes/bar")
+      handler.uri2indirection(request)[0].name.should == :node
     end
 
     it "should choose 'delete' as the indirection method if the http method is a DELETE and the indirection name is singular" do
-      handler.uri2indirection("DELETE", "/env/foo/bar", {})[1].should == :destroy
+      handler.send(:indirection_method, "DELETE", "foo").should == :destroy
     end
 
     it "should choose 'save' as the indirection method if the http method is a PUT and the indirection name is singular" do
-      handler.uri2indirection("PUT", "/env/foo/bar", {})[1].should == :save
+      handler.send(:indirection_method, "PUT", "foo").should == :save
     end
 
     it "should fail if an indirection method cannot be picked" do
-      lambda { handler.uri2indirection("UPDATE", "/env/foo/bar", {}) }.should raise_error(ArgumentError)
+      request = Puppet::Network::HTTP::Request.new({}, params, "UPDATE", "/node/bar")
+      lambda { handler.uri2indirection(request) }.should raise_error(ArgumentError)
     end
 
     it "should URI unescape the indirection key" do
       escaped = URI.escape("foo bar")
-      indirection_name, method, key, params = handler.uri2indirection("GET", "/env/foo/#{escaped}", {})
+      request = Puppet::Network::HTTP::Request.new({}, params, "GET", "/node/#{escaped}")
+      indirection, method, key, final_params = handler.uri2indirection(request)
       key.should == "foo bar"
     end
   end
@@ -204,27 +215,18 @@ describe Puppet::Network::HTTP::API::V1 do
       handler.stubs(:handler).returns "foo"
     end
 
-    it "should use the environment as the first field of the URI" do
-      handler.class.indirection2uri(request).split("/")[1].should == "myenv"
-    end
-
-    it "should use the indirection as the second field of the URI" do
-      handler.class.indirection2uri(request).split("/")[2].should == "foo"
+    it "should include the environment in the query string of the URI" do
+      handler.class.request_to_uri_with_env(request).should == "/foo/with%20spaces?environment=myenv&foo=bar"
     end
 
     it "should pluralize the indirection name if the method is 'search'" do
       request.stubs(:method).returns :search
-      handler.class.indirection2uri(request).split("/")[2].should == "foos"
-    end
-
-    it "should use the escaped key as the remainder of the URI" do
-      escaped = URI.escape("with spaces")
-      handler.class.indirection2uri(request).split("/")[3].sub(/\?.+/, '').should == escaped
+      handler.class.request_to_uri_with_env(request).split("/")[1].should == "foos"
     end
 
     it "should add the query string to the URI" do
-      request.expects(:query_string).returns "?query"
-      handler.class.indirection2uri(request).should =~ /\?query$/
+      request.expects(:query_string).returns "query"
+      handler.class.request_to_uri_with_env(request).should =~ /\&query$/
     end
   end
 
@@ -232,21 +234,47 @@ describe Puppet::Network::HTTP::API::V1 do
     let(:environment) { Puppet::Node::Environment.create(:myenv, []) }
     let(:request) { Puppet::Indirector::Request.new(:foo, :find, "with spaces", nil, :foo => :bar, :environment => environment) }
 
-    it "should use the environment as the first field of the URI" do
-      handler.class.request_to_uri_and_body(request).first.split("/")[1].should == "myenv"
+    it "should include the environment in the body" do
+      handler.class.request_to_uri_and_body(request)[1].split("&")[0].should == "environment=myenv"
     end
 
-    it "should use the indirection as the second field of the URI" do
-      handler.class.request_to_uri_and_body(request).first.split("/")[2].should == "foo"
+    it "should use the indirection as the first field of the URI" do
+      handler.class.request_to_uri_and_body(request).first.split("/")[1].should == "foo"
     end
 
     it "should use the escaped key as the remainder of the URI" do
       escaped = URI.escape("with spaces")
-      handler.class.request_to_uri_and_body(request).first.split("/")[3].sub(/\?.+/, '').should == escaped
+      handler.class.request_to_uri_and_body(request).first.split("/")[2].sub(/\?.+/, '').should == escaped
     end
 
     it "should return the URI and body separately" do
-      handler.class.request_to_uri_and_body(request).should == ["/myenv/foo/with%20spaces", "foo=bar"]
+      handler.class.request_to_uri_and_body(request).should == ["/foo/with%20spaces", "environment=myenv&foo=bar"]
+    end
+  end
+
+  describe "when converting a save request into a URI" do
+    let(:environment) { Puppet::Node::Environment.create(:myenv, []) }
+    let(:env_loaders) { Puppet::Environments::Static.new(environment) }
+    let(:request) { Puppet::Indirector::Request.new(:foo, :save, "with spaces", nil, :foo => :bar, :environment => "myenv") }
+
+    around do |example|
+      Puppet.override(:environments => env_loaders) do
+        example.run
+      end
+    end
+
+    it "should use the indirection as the first field of the URI" do
+      handler.class.indirection2uri(request).split("/")[1].should == "foo"
+    end
+
+    it "should use the escaped key as the remainder of the URI" do
+      escaped = URI.escape("with spaces")
+      handler.class.indirection2uri(request).split("/")[2].sub(/\?.+/, '').should == escaped
+    end
+
+    it "should add the query string to the URI" do
+      request.expects(:query_string).returns "query"
+      handler.class.indirection2uri(request).should =~ /\?query$/
     end
   end
 
@@ -413,7 +441,7 @@ describe Puppet::Network::HTTP::API::V1 do
     it "raises an error and does not destroy when no accepted formats are known" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
-      request = a_request_that_submits(data, :accept_header => "unknown, also/unknown")
+      request = a_request_that_destroys(data, :accept_header => "unknown, also/unknown")
 
       handler.call(request, response)
 
@@ -423,6 +451,15 @@ describe Puppet::Network::HTTP::API::V1 do
   end
 
   describe "when saving a model instance" do
+    let(:environment) { Puppet::Node::Environment.create(:fooenv, []) }
+    let(:env_loaders) { Puppet::Environments::Static.new(environment) }
+
+    around do |example|
+      Puppet.override(:environments => env_loaders) do
+        example.run
+      end
+    end
+
     it "allows an empty body when the format supports it" do
       class Puppet::IndirectorTesting::Nonvalidatingmemory < Puppet::IndirectorTesting::Memory
         def validate_key(_)

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -405,7 +405,7 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
         source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
 
         conn.unstub(:request_get)
-        conn.expects(:request_get).with('/testing/file_content/test/foo%20bar', anything).yields(response)
+        conn.expects(:request_get).with('/file_content/test/foo%20bar?environment=testing&', anything).yields(response)
 
         resource.write(source)
       end


### PR DESCRIPTION
This commit makes some changes to the indirector network layer
such that the environment name is no longer a part of the main
URL path structure.  This will allow us to have a more finite URL space
and run Puppet in the same webserver with other apps, without
worrying about URL collisions.

Instead, the environment becomes a query parameter for GET requests, or part
of the form body for POST requests.

For PUT requests, the HTTP specification doesn't allow a query string, so the
environment must go into the request body, which is deseralized by the
indirector model. The commit changes the logic such that all indirector model
objects that can have `:save` called on them are now expected to provide an
`environment` getter method that returns the environment, presumably
deserialized from the request body.

In order to achieve this, the commit changes the implementation of
the `uri2indirection` method so that, in the case of `:save` requests,
we read the body into the model object a little earlier than we
would have in the old implementation, and we pass it along in the
params map so that it is still accessible when the `do_save` method
is called a little later on.
