### PR TITLE
(maint) Reword debug message

### DIFF
--- a/lib/puppet/graph/relationship_graph.rb
+++ b/lib/puppet/graph/relationship_graph.rb
@@ -173,7 +173,7 @@ class Puppet::Graph::RelationshipGraph < Puppet::Graph::SimpleGraph
           if edge?(edge.target, edge.source)
             vertex.debug "Skipping automatic relationship with #{edge.source}"
           else
-            vertex.debug "Forming automation relationship of type #{rel_type} with #{edge.source}"
+            vertex.debug "Adding auto#{rel_type} relationship with #{edge.source}"
             if rel_type == :require
               edge.event = :NONE
             else
@@ -193,7 +193,7 @@ class Puppet::Graph::RelationshipGraph < Puppet::Graph::SimpleGraph
           if edge?(edge.source, edge.target)
             vertex.debug "Skipping automatic relationship with #{edge.target}"
           else
-            vertex.debug "Forming automation relationship of type #{rel_type} with #{edge.target}"
+            vertex.debug "Adding auto#{rel_type} relationship with #{edge.target}"
             if rel_type == :before
               edge.event = :NONE
             else


### PR DESCRIPTION
When puppet autorequired a resource, its debug message used to say:

```
Autorequiring File[/Users/josh/.puppet]
```

Commit b864bfbcd for PUP-3331 added the ability to define autobefore,
autonotify, and autosubscribe relationships, similar to autorequire. In
the process the debug message changed to support these other types of
relationships:

```
Forming automation relationship of type <type> with File[/Users/josh/.puppet]
```

This commit changes the message to be more concise:

```
Adding auto<type> relationship with File[/Users/josh/.puppet]
```
