### PR TITLE
Revert "(PUP-659) Optimize qualified variables"

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -339,7 +339,7 @@ module Puppet::Environments
     def entry(env)
       @cache_expiration_service.created(env)
       ttl = (conf = get_conf(env.name)) ? conf.environment_timeout : Puppet.settings.value(:environment_timeout)
-      Puppet.debug {"Caching environment '#{env.name}' (cache ttl: #{ttl})"}
+      Puppet.debug("Caching environment '#{env.name}' (cache ttl: #{ttl})")
       case ttl
       when 0
         NotCachedEntry.new(env)     # Entry that is always expired (avoids syscall to get time)
@@ -354,7 +354,7 @@ module Puppet::Environments
     # Also clears caches in Settings that may prevent the entry from being updated
     def evict_if_expired(name)
       if (result = @cache[name]) && (result.expired? || @cache_expiration_service.expired?(name))
-      Puppet.debug {"Evicting cache entry for environment '#{name}'"}
+        Puppet.debug("Evicting cache entry for environment '#{name}'")
         @cache.delete(name)
         @cache_expiration_service.evicted(name)
 

--- a/lib/puppet/face/node/clean.rb
+++ b/lib/puppet/face/node/clean.rb
@@ -88,7 +88,7 @@ Puppet::Face.define(:node, '0.0.1') do
     if (type = Puppet::Type.type(resource.restype)) && type.validattr?(:ensure)
       return true
     else
-      type = environment.known_resource_types.find_definition(resource.restype)
+      type = environment.known_resource_types.find_definition('', resource.restype)
       return true if type && type.arguments.keys.include?('ensure')
     end
     return false

--- a/lib/puppet/indirector/resource_type/parser.rb
+++ b/lib/puppet/indirector/resource_type/parser.rb
@@ -31,7 +31,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
         # We have to us 'find_<type>' here because it will
         # load any missing types from disk, whereas the plain
         # '<type>' method only returns from memory.
-        if r = krt.send("find_#{type}", request.key)
+        if r = krt.send("find_#{type}", [""], request.key)
           return r
         end
       end

--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -144,7 +144,7 @@ class Puppet::Parser::AST::PopsBridge
         # when running tests that run a partial setup.
         # This is bad if the logic is trying to compile, but a warning can not be issues since it is a normal
         # use case that there is no scope when requesting the type in order to just get the parameters.
-        Puppet.debug {"Instantiating Resource with type checked parameters - scope is missing, skipping type checking."}
+        Puppet.debug("Instantiating Resource with type checked parameters - scope is missing, skipping type checking.")
         nil
       end
       scope

--- a/lib/puppet/parser/ast/resource.rb
+++ b/lib/puppet/parser/ast/resource.rb
@@ -52,7 +52,7 @@ class Puppet::Parser::AST::Resource < Puppet::Parser::AST::Branch
             resource.resource_type.instantiate_resource(scope, resource)
           end
           scope.compiler.add_resource(scope, resource)
-          scope.compiler.evaluate_classes([resource_title], scope, false) if fully_qualified_type == 'class'
+          scope.compiler.evaluate_classes([resource_title], scope, false, true) if fully_qualified_type == 'class'
           resource
         end
       end

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -180,12 +180,18 @@ class Puppet::Parser::Compiler
     evaluate_classes(classes_without_params, @node_scope || topscope)
   end
 
-  # Evaluates each specified class in turn. If there are any classes that 
-  # can't be found, an error is raised. This method really just creates resource objects
+  # Evaluate each specified class in turn.  If there are any classes we can't
+  # find, raise an error.  This method really just creates resource objects
   # that point back to the classes, and then the resources are themselves
   # evaluated later in the process.
   #
-  def evaluate_classes(classes, scope, lazy_evaluate = true)
+  # Sometimes we evaluate classes with a fully qualified name already, in which
+  # case, we tell scope.find_hostclass we've pre-qualified the name so it
+  # doesn't need to search its namespaces again.  This gets around a weird
+  # edge case of duplicate class names, one at top scope and one nested in our
+  # namespace and the wrong one (or both!) getting selected. See ticket #13349
+  # for more detail.  --jeffweiss 26 apr 2012
+  def evaluate_classes(classes, scope, lazy_evaluate = true, fqname = false)
     raise Puppet::DevError, "No source for scope passed to evaluate_classes" unless scope.source
     class_parameters = nil
     # if we are a param class, save the classes hash
@@ -196,7 +202,7 @@ class Puppet::Parser::Compiler
     end
 
     hostclasses = classes.collect do |name|
-      scope.find_hostclass(name) or raise Puppet::Error, "Could not find class #{name} for #{node.name}"
+      scope.find_hostclass(name, :assume_fqname => fqname) or raise Puppet::Error, "Could not find class #{name} for #{node.name}"
     end
 
     if class_parameters
@@ -391,7 +397,7 @@ class Puppet::Parser::Compiler
 
   # Find and evaluate our main object, if possible.
   def evaluate_main
-    @main = known_resource_types.find_hostclass("") || known_resource_types.add(Puppet::Resource::Type.new(:hostclass, ""))
+    @main = known_resource_types.find_hostclass([""], "") || known_resource_types.add(Puppet::Resource::Type.new(:hostclass, ""))
     @topscope.source = @main
     @main_resource = Puppet::Parser::Resource.new("class", :main, :scope => @topscope, :source => @main)
     @topscope.resource = @main_resource

--- a/lib/puppet/parser/relationship.rb
+++ b/lib/puppet/parser/relationship.rb
@@ -45,7 +45,7 @@ class Puppet::Parser::Relationship
     unless catalog.resource(target)
       raise ArgumentError, "Could not find resource '#{target}' for relationship from '#{source}'"
     end
-    Puppet.debug {"Adding relationship from #{source} to #{target} with '#{param_name}'"}
+    Puppet.debug "Adding relationship from #{source} to #{target} with '#{param_name}'"
     if source_resource[param_name].class != Array
       source_resource[param_name] = [source_resource[param_name]].compact
     end

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -224,12 +224,22 @@ class Puppet::Parser::Scope
     end
   end
 
-  def find_hostclass(name)
-    known_resource_types.find_hostclass(name)
+  # Add to our list of namespaces.
+  def add_namespace(ns)
+    return false if @namespaces.include?(ns)
+    if @namespaces == [""]
+      @namespaces = [ns]
+    else
+      @namespaces << ns
+    end
+  end
+
+  def find_hostclass(name, options = {})
+    known_resource_types.find_hostclass(namespaces, name, options)
   end
 
   def find_definition(name)
-    known_resource_types.find_definition(name)
+    known_resource_types.find_definition(namespaces, name)
   end
 
   def find_global_scope()
@@ -260,9 +270,9 @@ class Puppet::Parser::Scope
     end
 
     if n = options.delete(:namespace)
-      @namespaces = [n.freeze].freeze
+      @namespaces = [n]
     else
-      @namespaces = ["".freeze].freeze
+      @namespaces = [""]
     end
 
     raise Puppet::DevError, "compiler passed in options" if options.include? :compiler
@@ -342,8 +352,7 @@ class Puppet::Parser::Scope
 
   # Look up a defined type.
   def lookuptype(name)
-    # This happens a lot, avoid making a call to make a call
-    known_resource_types.find_definition(name) || known_resource_types.find_hostclass(name)
+    find_definition(name) || find_hostclass(name)
   end
 
   def undef_as(x,v)
@@ -528,7 +537,7 @@ class Puppet::Parser::Scope
   end
 
   def namespaces
-    @namespaces
+    @namespaces.dup
   end
 
   # Create a new scope and set these options.
@@ -750,7 +759,7 @@ class Puppet::Parser::Scope
   end
 
   def find_defined_resource_type(type)
-    known_resource_types.find_definition(type.to_s.downcase)
+    known_resource_types.find_definition(namespaces, type.to_s.downcase)
   end
 
 

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -299,7 +299,7 @@ module Puppet::Pops::Evaluator::Runtime3Support
           resource.resource_type.instantiate_resource(scope, resource)
         end
         scope.compiler.add_resource(scope, resource)
-        scope.compiler.evaluate_classes([resource_title], scope, false) if fully_qualified_type == CLASS_STRING
+        scope.compiler.evaluate_classes([resource_title], scope, false, true) if fully_qualified_type == CLASS_STRING
         # Turn the resource into a PType (a reference to a resource type)
         # weed out nil's
         resource_to_ptype(resource)

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -220,7 +220,7 @@ class Puppet::Pops::Loaders
     private
 
     def create_loader_with_all_modules_visible(from_module_data)
-      Puppet.debug{"ModuleLoader: module '#{from_module_data.name}' has unknown dependencies - it will have all other modules visible"}
+      Puppet.debug("ModuleLoader: module '#{from_module_data.name}' has unknown dependencies - it will have all other modules visible")
 
       Puppet::Pops::Loader::DependencyLoader.new(from_module_data.public_loader, from_module_data.name, all_module_loaders())
     end

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -235,11 +235,34 @@ class Puppet::Resource::Type
     end
   end
 
+  # MQR TODO:
+  #
+  # The change(s) introduced by the fix for #4270 are mostly silly & should be
+  # removed, though we didn't realize it at the time.  If it can be established/
+  # ensured that nodes never call parent_type and that resource_types are always
+  # (as they should be) members of exactly one resource_type_collection the
+  # following method could / should be replaced with:
+  #
+  # def parent_type
+  #   @parent_type ||= parent && (
+  #     resource_type_collection.find_or_load([name],parent,type.to_sym) ||
+  #     fail Puppet::ParseError, "Could not find parent resource type '#{parent}' of type #{type} in #{resource_type_collection.environment}"
+  #   )
+  # end
+  #
+  # ...and then the rest of the changes around passing in scope reverted.
+  #
   def parent_type(scope = nil)
     return nil unless parent
 
-    @parent_type ||= scope.environment.known_resource_types.send("find_#{type}", parent) ||
-      fail(Puppet::ParseError, "Could not find parent resource type '#{parent}' of type #{type} in #{scope.environment}")
+    unless @parent_type
+      raise "Must pass scope to parent_type when called first time" unless scope
+      unless @parent_type = scope.environment.known_resource_types.send("find_#{type}", [name], parent)
+        fail Puppet::ParseError, "Could not find parent resource type '#{parent}' of type #{type} in #{scope.environment}"
+      end
+    end
+
+    @parent_type
   end
 
   # Set any arguments passed by the resource as variables in the scope.

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -932,7 +932,7 @@ class Puppet::Settings
       next unless resource = file.to_resource
       next if catalog.resource(resource.ref)
 
-      Puppet.debug {"Using settings: adding file resource '#{key}': '#{resource.inspect}'"}
+      Puppet.debug("Using settings: adding file resource '#{key}': '#{resource.inspect}'")
 
       catalog.add_resource(resource)
     end

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -11,30 +11,9 @@ module Puppet::Util::Logging
 
   # Create a method for each log level.
   Puppet::Util::Log.eachlevel do |level|
-    # handle debug a special way for performance reasons
-    next if level == :debug
     define_method(level) do |args|
       args = args.join(" ") if args.is_a?(Array)
       send_log(level, args)
-    end
-  end
-
-  # Output a debug log message if debugging is on (but only then)
-  # If the output is anything except a static string, give the debug
-  # a block - it will be called with all other arguments, and is expected
-  # to return the single string result.
-  #
-  # Use a block at all times for increased performance.
-  #
-  # @example This takes 40% of the time compared to not using a block
-  #  Puppet.debug { "This is a string that interpolated #{x} and #{y} }"
-  #
-  def debug(*args)
-    return nil unless Puppet::Util::Log.level == :debug
-    if block_given?
-      send_log(:debug, yield(*args))
-    else
-      send_log(:debug, args.join(" "))
     end
   end
 

--- a/lib/puppet/util/warnings.rb
+++ b/lib/puppet/util/warnings.rb
@@ -7,7 +7,6 @@ module Puppet::Util::Warnings
   end
 
   def debug_once(msg)
-    return nil unless Puppet[:debug]
     Puppet::Util::Warnings.maybe_log(msg, self.class) { Puppet.debug msg }
   end
 

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -240,7 +240,7 @@ describe Puppet::Parser::Compiler do
     it "should create a new, empty 'main' if no main class exists" do
       compile_stub(:evaluate_main)
       @compiler.compile
-      @known_resource_types.find_hostclass("").should be_instance_of(Puppet::Resource::Type)
+      @known_resource_types.find_hostclass([""], "").should be_instance_of(Puppet::Resource::Type)
     end
 
     it "should add an edge between the main stage and main class" do
@@ -553,14 +553,14 @@ describe Puppet::Parser::Compiler do
     end
 
     it "should raise an error if a class is not found" do
-      @scope.expects(:find_hostclass).with("notfound").returns(nil)
+      @scope.expects(:find_hostclass).with("notfound", {:assume_fqname => false}).returns(nil)
       lambda{ @compiler.evaluate_classes(%w{notfound}, @scope) }.should raise_error(Puppet::Error, /Could not find class/)
     end
 
     it "should raise an error when it can't find class" do
       klasses = {'foo'=>nil}
       @node.classes = klasses
-      @compiler.topscope.expects(:find_hostclass).with('foo').returns(nil)
+      @compiler.topscope.expects(:find_hostclass).with('foo', {:assume_fqname => false}).returns(nil)
       lambda{ @compiler.compile }.should raise_error(Puppet::Error, /Could not find class foo for testnode/)
     end
   end
@@ -570,7 +570,7 @@ describe Puppet::Parser::Compiler do
     before do
       Puppet.settings[:data_binding_terminus] = "none"
       @class = stub 'class', :name => "my::class"
-      @scope.stubs(:find_hostclass).with("myclass").returns(@class)
+      @scope.stubs(:find_hostclass).with("myclass", {:assume_fqname => false}).returns(@class)
 
       @resource = stub 'resource', :ref => "Class[myclass]", :type => "file"
     end
@@ -711,7 +711,7 @@ describe Puppet::Parser::Compiler do
 
     it "should skip classes previously evaluated with different capitalization" do
       @compiler.catalog.stubs(:tag)
-      @scope.stubs(:find_hostclass).with("MyClass").returns(@class)
+      @scope.stubs(:find_hostclass).with("MyClass",{:assume_fqname => false}).returns(@class)
       @scope.stubs(:class_scope).with(@class).returns(@scope)
       @compiler.expects(:add_resource).never
       @resource.expects(:evaluate).never

--- a/spec/integration/resource/type_collection_spec.rb
+++ b/spec/integration/resource/type_collection_spec.rb
@@ -40,40 +40,55 @@ describe Puppet::Resource::TypeCollection do
     end
 
     it "should return nil when a class can't be found or loaded" do
-      @code.find_hostclass('nosuchclass').should be_nil
+      @code.find_hostclass('', 'nosuchclass').should be_nil
     end
 
     it "should load the module's init file first" do
       name = "simple"
       mk_module(name, :init => [name])
-      @code.find_hostclass(name).name.should == name
+
+      @code.find_hostclass("", name).name.should == name
+    end
+
+    it "should load the module's init file even when searching from a different namespace" do
+      name = "simple"
+      mk_module(name, :init => [name])
+
+      @code.find_hostclass("other::ns", name).name.should == name
     end
 
     it "should be able to load definitions from the module base file" do
       name = "simpdef"
       mk_module(name, :define => true, :init => [name])
-      @code.find_definition(name).name.should == name
+      @code.find_definition("", name).name.should == name
     end
 
     it "should be able to load qualified classes from the module base file" do
-      mk_module('both', :init => %w{both both::sub})
-      @code.find_hostclass("both::sub").name.should == "both::sub"
+      modname = "both"
+      name = "sub"
+      mk_module(modname, :init => %w{both both::sub})
+
+      @code.find_hostclass("both", name).name.should == "both::sub"
     end
 
     it "should be able load classes from a separate file" do
-      mk_module('separate', :init => %w{separate}, :sub => %w{separate::sub})
-      @code.find_hostclass("separate::sub").name.should == "separate::sub"
+      modname = "separate"
+      name = "sub"
+      mk_module(modname, :init => %w{separate}, :sub => %w{separate::sub})
+      @code.find_hostclass("separate", name).name.should == "separate::sub"
     end
 
     it "should not fail when loading from a separate file if there is no module file" do
-      mk_module('alone', :sub => %w{alone::sub})
-      lambda { @code.find_hostclass("alone::sub") }.should_not raise_error
+      modname = "alone"
+      name = "sub"
+      mk_module(modname, :sub => %w{alone::sub})
+      lambda { @code.find_hostclass("alone", name) }.should_not raise_error
     end
 
     it "should be able to load definitions from their own file" do
       name = "mymod"
       mk_module(name, :define => true, :mydefine => ["mymod::mydefine"])
-      @code.find_definition("mymod::mydefine").name.should == "mymod::mydefine"
+      @code.find_definition("", "mymod::mydefine").name.should == "mymod::mydefine"
     end
   end
 end

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -346,7 +346,7 @@ describe Puppet::Node::Environment do
             mod = PuppetSpec::Modules.create(
               'baz',
               first_modulepath,
-              module_options
+              module_options,
             )
             expect(env.module_by_forge_name('puppetlabs/baz')).to eq(mod)
           end
@@ -429,7 +429,7 @@ describe Puppet::Node::Environment do
       it "loads from Puppet[:code]" do
         Puppet[:code] = "define foo {}"
         krt = env.known_resource_types
-        expect(krt.find_definition('foo')).to be_kind_of(Puppet::Resource::Type)
+        expect(krt.find_definition('', 'foo')).to be_kind_of(Puppet::Resource::Type)
       end
 
       it "parses from the the environment's manifests if Puppet[:code] is not set" do
@@ -439,7 +439,7 @@ describe Puppet::Node::Environment do
         end
         env = Puppet::Node::Environment.create(:testing, [], filename)
         krt = env.known_resource_types
-        expect(krt.find_definition('from_manifest')).to be_kind_of(Puppet::Resource::Type)
+        expect(krt.find_definition('', 'from_manifest')).to be_kind_of(Puppet::Resource::Type)
       end
 
       it "prefers Puppet[:code] over manifest files" do
@@ -450,7 +450,7 @@ describe Puppet::Node::Environment do
         end
         env = Puppet::Node::Environment.create(:testing, [], filename)
         krt = env.known_resource_types
-        expect(krt.find_definition('from_code_setting')).to be_kind_of(Puppet::Resource::Type)
+        expect(krt.find_definition('', 'from_code_setting')).to be_kind_of(Puppet::Resource::Type)
       end
 
       it "initial import proceeds even if manifest file does not exist on disk" do

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -240,7 +240,7 @@ describe Puppet::Parser::Compiler do
     it "should create a new, empty 'main' if no main class exists" do
       compile_stub(:evaluate_main)
       @compiler.compile
-      @known_resource_types.find_hostclass("").should be_instance_of(Puppet::Resource::Type)
+      @known_resource_types.find_hostclass([""], "").should be_instance_of(Puppet::Resource::Type)
     end
 
     it "should add an edge between the main stage and main class" do
@@ -553,14 +553,14 @@ describe Puppet::Parser::Compiler do
     end
 
     it "should raise an error if a class is not found" do
-      @scope.expects(:find_hostclass).with("notfound").returns(nil)
+      @scope.expects(:find_hostclass).with("notfound", {:assume_fqname => false}).returns(nil)
       lambda{ @compiler.evaluate_classes(%w{notfound}, @scope) }.should raise_error(Puppet::Error, /Could not find class/)
     end
 
     it "should raise an error when it can't find class" do
       klasses = {'foo'=>nil}
       @node.classes = klasses
-      @compiler.topscope.expects(:find_hostclass).with('foo').returns(nil)
+      @compiler.topscope.expects(:find_hostclass).with('foo', {:assume_fqname => false}).returns(nil)
       lambda{ @compiler.compile }.should raise_error(Puppet::Error, /Could not find class foo for testnode/)
     end
   end
@@ -570,7 +570,7 @@ describe Puppet::Parser::Compiler do
     before do
       Puppet.settings[:data_binding_terminus] = "none"
       @class = stub 'class', :name => "my::class"
-      @scope.stubs(:find_hostclass).with("myclass").returns(@class)
+      @scope.stubs(:find_hostclass).with("myclass", {:assume_fqname => false}).returns(@class)
 
       @resource = stub 'resource', :ref => "Class[myclass]", :type => "file"
     end
@@ -711,7 +711,7 @@ describe Puppet::Parser::Compiler do
 
     it "should skip classes previously evaluated with different capitalization" do
       @compiler.catalog.stubs(:tag)
-      @scope.stubs(:find_hostclass).with("MyClass").returns(@class)
+      @scope.stubs(:find_hostclass).with("MyClass",{:assume_fqname => false}).returns(@class)
       @scope.stubs(:class_scope).with(@class).returns(@scope)
       @compiler.expects(:add_resource).never
       @resource.expects(:evaluate).never

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -553,6 +553,18 @@ describe Puppet::Parser::Scope do
     end
   end
 
+  it "should use its namespaces to find hostclasses" do
+    klass = @scope.known_resource_types.add Puppet::Resource::Type.new(:hostclass, "a::b::c")
+    @scope.add_namespace "a::b"
+    @scope.find_hostclass("c").should equal(klass)
+  end
+
+  it "should use its namespaces to find definitions" do
+    define = @scope.known_resource_types.add Puppet::Resource::Type.new(:definition, "a::b::c")
+    @scope.add_namespace "a::b"
+    @scope.find_definition("c").should equal(define)
+  end
+
   describe "when managing defaults" do
     it "should be able to set and lookup defaults" do
       param = Puppet::Parser::Resource::Param.new(:name => :myparam, :value => "myvalue", :source => stub("source"))

--- a/spec/unit/parser/type_loader_spec.rb
+++ b/spec/unit/parser/type_loader_spec.rb
@@ -71,7 +71,7 @@ describe Puppet::Parser::TypeLoader do
 
     it "should fail if no files are found" do
       Puppet::Parser::Files.expects(:find_manifests_in_modules).returns [nil, []]
-      lambda { loader.import("myfile", "/path") }.should raise_error(/No file\(s\) found for import/)
+      lambda { loader.import("myfile", "/path") }.should raise_error(Puppet::ImportError)
     end
 
     it "should parse each found file" do

--- a/spec/unit/pops/evaluator/evaluator_rspec_helper.rb
+++ b/spec/unit/pops/evaluator/evaluator_rspec_helper.rb
@@ -18,6 +18,9 @@ module EvaluatorRspecHelper
     node = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)
 
+    # Compiler must create the top scope
+#    compiler.send(:evaluate_main)
+
     # compiler creates the top scope if one is not present
     top_scope = compiler.topscope()
     # top_scope = Puppet::Parser::Scope.new(compiler)
@@ -25,7 +28,8 @@ module EvaluatorRspecHelper
     evaluator = Puppet::Pops::Evaluator::EvaluatorImpl.new
     result = evaluator.evaluate(in_top_scope.current, top_scope)
     if in_named_scope
-      other_scope = Puppet::Parser::Scope.new(compiler, :namespace => scopename)
+      other_scope = Puppet::Parser::Scope.new(compiler)
+      other_scope.add_namespace(scopename)
       result = evaluator.evaluate(in_named_scope.current, other_scope)
     end
     if in_top_scope_again

--- a/spec/unit/resource/type_collection_spec.rb
+++ b/spec/unit/resource/type_collection_spec.rb
@@ -88,67 +88,88 @@ describe Puppet::Resource::TypeCollection do
     loader.node("node").should be_nil
   end
 
+  describe "when resolving namespaces" do
+    [ ['',               '::foo', ['foo']],
+      ['a',              '::foo', ['foo']],
+      ['a::b',           '::foo', ['foo']],
+      [['a::b'],         '::foo', ['foo']],
+      [['a::b', 'c'],    '::foo', ['foo']],
+      [['A::B', 'C'],    '::Foo', ['foo']],
+      ['',               '',      ['']],
+      ['a',              '',      ['']],
+      ['a::b',           '',      ['']],
+      [['a::b'],         '',      ['']],
+      [['a::b', 'c'],    '',      ['']],
+      [['A::B', 'C'],    '',      ['']],
+      ['',               'foo',   ['foo']],
+      ['a',              'foo',   ['a::foo', 'foo']],
+      ['a::b',           'foo',   ['a::b::foo', 'a::foo', 'foo']],
+      ['A::B',           'Foo',   ['a::b::foo', 'a::foo', 'foo']],
+      [['a::b'],         'foo',   ['a::b::foo', 'a::foo', 'foo']],
+      [['a', 'b'],       'foo',   ['a::foo', 'foo', 'b::foo']],
+      [['a::b', 'c::d'], 'foo',   ['a::b::foo', 'a::foo', 'foo', 'c::d::foo', 'c::foo']],
+      [['a::b', 'a::c'], 'foo',   ['a::b::foo', 'a::foo', 'foo', 'a::c::foo']],
+    ].each do |namespaces, name, expected_result|
+      it "should resolve #{name.inspect} in namespaces #{namespaces.inspect} correctly" do
+        @code.instance_eval { resolve_namespaces(namespaces, name) }.should == expected_result
+      end
+    end
+  end
+
   describe "when looking up names" do
     before do
       @type = Puppet::Resource::Type.new(:hostclass, "ns::klass")
     end
 
+    it "should support looking up with multiple namespaces" do
+      @code.add @type
+      @code.find_hostclass(%w{boo baz ns}, "klass").should equal(@type)
+    end
+
     it "should not attempt to import anything when the type is already defined" do
       @code.add @type
       @code.loader.expects(:import).never
-      @code.find_hostclass("ns::klass").should equal(@type)
+      @code.find_hostclass(%w{ns}, "klass").should equal(@type)
     end
 
     describe "that need to be loaded" do
       it "should use the loader to load the files" do
-        @code.loader.expects(:try_load_fqname).with(:hostclass, "klass")
-        @code.find_hostclass("klass")
-      end
-      it "should use the loader to load the files" do
         @code.loader.expects(:try_load_fqname).with(:hostclass, "ns::klass")
-        @code.find_hostclass("ns::klass")
+        @code.loader.expects(:try_load_fqname).with(:hostclass, "klass")
+        @code.find_hostclass(["ns"], "klass")
       end
 
       it "should downcase the name and downcase and array-fy the namespaces before passing to the loader" do
         @code.loader.expects(:try_load_fqname).with(:hostclass, "ns::klass")
-        @code.find_hostclass("ns::klass")
+        @code.loader.expects(:try_load_fqname).with(:hostclass, "klass")
+        @code.find_hostclass("Ns", "Klass")
       end
 
       it "should use the class returned by the loader" do
         @code.loader.expects(:try_load_fqname).returns(:klass)
         @code.expects(:hostclass).with("ns::klass").returns(false)
-        @code.find_hostclass("ns::klass").should == :klass
+        @code.find_hostclass("ns", "klass").should == :klass
       end
 
       it "should return nil if the name isn't found" do
         @code.loader.stubs(:try_load_fqname).returns(nil)
-        @code.find_hostclass("Ns::Klass").should be_nil
+        @code.find_hostclass("Ns", "Klass").should be_nil
       end
 
       it "already-loaded names at broader scopes should not shadow autoloaded names" do
         @code.add Puppet::Resource::Type.new(:hostclass, "bar")
         @code.loader.expects(:try_load_fqname).with(:hostclass, "foo::bar").returns(:foobar)
-        @code.find_hostclass("foo::bar").should == :foobar
+        @code.find_hostclass("foo", "bar").should == :foobar
       end
 
-      context 'when debugging' do
-        # This test requires that debugging is on, it will otherwise not make a call to debug,
-        # which is the easiest way to detect that that a certain path has been taken.
-        before(:each) do
-          Puppet.debug = true
-        end
+      it "should not try to autoload names that we couldn't autoload in a previous step if ignoremissingtypes is enabled" do
+        Puppet[:ignoremissingtypes] = true
+        @code.loader.expects(:try_load_fqname).with(:hostclass, "ns::klass").returns(nil)
+        @code.loader.expects(:try_load_fqname).with(:hostclass, "klass").returns(nil)
+        @code.find_hostclass("Ns", "Klass").should be_nil
 
-        after (:each) do
-          Puppet.debug = false
-        end
-
-        it "should not try to autoload names that we couldn't autoload in a previous step if ignoremissingtypes is enabled" do
-          Puppet[:ignoremissingtypes] = true
-          @code.loader.expects(:try_load_fqname).with(:hostclass, "ns::klass").returns(nil)
-          @code.find_hostclass("ns::klass").should be_nil
-          Puppet.expects(:debug).at_least_once.with {|msg| msg =~ /Not attempting to load hostclass/}
-          @code.find_hostclass("ns::klass").should be_nil
-        end
+        Puppet.expects(:debug).at_least_once.with {|msg| msg =~ /Not attempting to load hostclass/}
+        @code.find_hostclass("Ns", "Klass").should be_nil
       end
     end
   end
@@ -183,33 +204,68 @@ describe Puppet::Resource::TypeCollection do
       loader = Puppet::Resource::TypeCollection.new(environment)
       instance = Puppet::Resource::Type.new(:hostclass, "foo::bar")
       loader.add instance
-      loader.find_hostclass("::foo::bar").should equal(instance)
+      loader.find_hostclass("namespace", "::foo::bar").should equal(instance)
     end
 
     it "should return nil if the instance name is fully qualified and no such instance exists" do
       loader = Puppet::Resource::TypeCollection.new(environment)
-      loader.find_hostclass("::foo::bar").should be_nil
+      loader.find_hostclass("namespace", "::foo::bar").should be_nil
     end
 
     it "should be able to find classes in the base namespace" do
       loader = Puppet::Resource::TypeCollection.new(environment)
       instance = Puppet::Resource::Type.new(:hostclass, "foo")
       loader.add instance
-      loader.find_hostclass("foo").should equal(instance)
+      loader.find_hostclass("", "foo").should equal(instance)
+    end
+
+    it "should return the partially qualified object if it exists in a provided namespace" do
+      loader = Puppet::Resource::TypeCollection.new(environment)
+      instance = Puppet::Resource::Type.new(:hostclass, "foo::bar::baz")
+      loader.add instance
+      loader.find_hostclass("foo", "bar::baz").should equal(instance)
+    end
+
+    it "should be able to find partially qualified objects in any of the provided namespaces" do
+      loader = Puppet::Resource::TypeCollection.new(environment)
+      instance = Puppet::Resource::Type.new(:hostclass, "foo::bar::baz")
+      loader.add instance
+      loader.find_hostclass(["nons", "foo", "otherns"], "bar::baz").should equal(instance)
     end
 
     it "should return the unqualified object if it exists in a provided namespace" do
       loader = Puppet::Resource::TypeCollection.new(environment)
       instance = Puppet::Resource::Type.new(:hostclass, "foo::bar")
       loader.add instance
-      loader.find_hostclass("foo::bar").should equal(instance)
+      loader.find_hostclass("foo", "bar").should equal(instance)
+    end
+
+    it "should return the unqualified object if it exists in the parent namespace" do
+      loader = Puppet::Resource::TypeCollection.new(environment)
+      instance = Puppet::Resource::Type.new(:hostclass, "foo::bar")
+      loader.add instance
+      loader.find_hostclass("foo::bar::baz", "bar").should equal(instance)
+    end
+
+    it "should should return the partially qualified object if it exists in the parent namespace" do
+      loader = Puppet::Resource::TypeCollection.new(environment)
+      instance = Puppet::Resource::Type.new(:hostclass, "foo::bar::baz")
+      loader.add instance
+      loader.find_hostclass("foo::bar", "bar::baz").should equal(instance)
+    end
+
+    it "should return the qualified object if it exists in the root namespace" do
+      loader = Puppet::Resource::TypeCollection.new(environment)
+      instance = Puppet::Resource::Type.new(:hostclass, "foo::bar::baz")
+      loader.add instance
+      loader.find_hostclass("foo::bar", "foo::bar::baz").should equal(instance)
     end
 
     it "should return nil if the object cannot be found" do
       loader = Puppet::Resource::TypeCollection.new(environment)
       instance = Puppet::Resource::Type.new(:hostclass, "foo::bar::baz")
       loader.add instance
-      loader.find_hostclass("foo::bar::eh").should be_nil
+      loader.find_hostclass("foo::bar", "eh").should be_nil
     end
 
     describe "when topscope has a class that has the same name as a local class" do
@@ -220,11 +276,16 @@ describe Puppet::Resource::TypeCollection do
         end
       end
 
-      it "looks up the given name, no more, no less" do
-        @loader.find_hostclass("bar").name.should == 'bar'
-        @loader.find_hostclass("::bar").name.should == 'bar'
-        @loader.find_hostclass("foo::bar").name.should == 'foo::bar'
-        @loader.find_hostclass("::foo::bar").name.should == 'foo::bar'
+      it "should favor the local class, if the name is unqualified" do
+        @loader.find_hostclass("foo", "bar").name.should == 'foo::bar'
+      end
+
+      it "should only look in the topclass, if the name is qualified" do
+        @loader.find_hostclass("foo", "::bar").name.should == 'bar'
+      end
+
+      it "should only look in the topclass, if we assume the name is fully qualified" do
+        @loader.find_hostclass("foo", "bar", :assume_fqname => true).name.should == 'bar'
       end
     end
 
@@ -232,7 +293,7 @@ describe Puppet::Resource::TypeCollection do
         @loader = Puppet::Resource::TypeCollection.new(environment)
         @loader.add Puppet::Resource::Type.new(:hostclass, "foo::bar")
 
-        @loader.find_hostclass("::bar").should == nil
+        @loader.find_hostclass("foo", "::bar").should == nil
     end
 
   end
@@ -241,7 +302,7 @@ describe Puppet::Resource::TypeCollection do
     node = Puppet::Resource::Type.new(:node, "bar")
     loader = Puppet::Resource::TypeCollection.new(environment)
     loader.add(node)
-    loader.find_node("bar").should == node
+    loader.find_node(stub("ignored"), "bar").should == node
   end
 
   it "should indicate whether any nodes are defined" do

--- a/spec/unit/util/warnings_spec.rb
+++ b/spec/unit/util/warnings_spec.rb
@@ -7,14 +7,6 @@ describe Puppet::Util::Warnings do
     @msg2 = "more booness"
   end
 
-  before(:each) do
-    Puppet.debug = true
-  end
-
-  after (:each) do
-    Puppet.debug = false
-  end
-
   {:notice => "notice_once", :warning => "warnonce", :debug => "debug_once"}.each do |log, method|
     describe "when registring '#{log}' messages" do
       it "should always return nil" do


### PR DESCRIPTION
Reverts puppetlabs/puppet#3359. This pull request was causing two
acceptance failures: `tests.ticket_4293_define_and_use_a_define_within_a_class.rb`
and `tests/parser_functions/hiera_array.lookup_data.rb`. These tests
were both failing with an `Invalid resource type` error. 

This seems to be happening because we not longer have the fully qualified 
named for the defined type when the resource is created (i.e. `do_notify` 
rather than `foo::do_notify`). It's not clear whether this is the intended behavior 
or a bug, and what should be changed in order to fix the issue. Thus, it is 
being reverted until the original author can make the necessary changes.
