### PR TITLE
(PUP-3756) Only chown log file when running as root

### DIFF
--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -77,10 +77,12 @@ Puppet::Util::Log.newdesttype :file do
     file = File.open(path, File::WRONLY|File::CREAT|File::APPEND)
 
     # Give ownership to the user and group puppet will run as
-    begin
-      FileUtils.chown(Puppet[:user], Puppet[:group], path) unless Puppet::Util::Platform.windows?
-    rescue ArgumentError, Errno::EPERM
-      Puppet.err "Unable to set ownership to #{Puppet[:user]}:#{Puppet[:group]} for log file: #{path}"
+    if Puppet.features.root? && !Puppet::Util::Platform.windows?
+      begin
+        FileUtils.chown(Puppet[:user], Puppet[:group], path)
+      rescue ArgumentError, Errno::EPERM
+        Puppet.err "Unable to set ownership to #{Puppet[:user]}:#{Puppet[:group]} for log file: #{path}"
+      end
     end
 
     @file = file

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -56,7 +56,15 @@ describe Puppet::Util::Log.desttypes[:file] do
 
       it "logs an error if it can't chown the file owner & group" do
         FileUtils.expects(:chown).with(Puppet[:user], Puppet[:group], abspath).raises(Errno::EPERM)
+        Puppet.features.expects(:root?).returns(true)
         Puppet.expects(:err).with("Unable to set ownership to #{Puppet[:user]}:#{Puppet[:group]} for log file: #{abspath}")
+
+        @class.new(abspath)
+      end
+
+      it "doesn't attempt to chown when running as non-root" do
+        FileUtils.expects(:chown).with(Puppet[:user], Puppet[:group], abspath).never
+        Puppet.features.expects(:root?).returns(false)
 
         @class.new(abspath)
       end


### PR DESCRIPTION
Previously, if you specified a log file destination on non-windows
platforms, puppet would attempt to chown the file to the `Puppet[:user]`
and `Puppet[:group]`. However, this will only work if puppet is running
as root.

This commit change the log file destination to only chown when running
as root. It continues to skip the operation on Windows.
