### PR TITLE
(maint) Update ruby sha used to build

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -26,8 +26,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/hiera.git'
   sys:
     ref:
-      x86: 'cbe94f4cafb0f78d587e8addcf723bc671af7cca'
-      x64: '417378f607340d211fbfef89a96e6639bef1bfb1'
+      x86: '0813124a1e06f0c98987b8e543d8c13b305a5ca0'
+      x64: '531319f5c121e98990772e018eb9781bf7dc6316'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
We've updated the certs included in ruby to access rubygems.org.
Since the website has updated their certs, we were behind, and
installing gems using the provided package of rubygems would fail. This
commit updates the sha of puppet-win32-ruby we are pulling in to include
in the msi build. This will provide the additional certs for use, and
allow people to access rubygems.org via the provided rubygem package.
