### PR TITLE
(QENG-1592) undefined method `assertions' in Beaker 2.0.0

### DIFF
--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -23,7 +23,10 @@ agents.each do |agent|
   step "  install module '#{module_author}-#{module_name}'"
 
   opts ||= Hash.new
-  opts['ENV']=Command::DEFAULT_GIT_ENV
+  #backwards compatability with beaker 1.x
+  if defined? Command::DEFAULT_GIT_ENV
+    opts['ENV']=Command::DEFAULT_GIT_ENV
+  end
   command = agent['platform'] =~ /windows/ ?
     Command.new("'puppet module install --version \"<#{module_version}\" #{module_author}-#{module_name}'", [], opts) :
     puppet("module install --version \"<#{module_version}\" #{module_author}-#{module_name}")

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -1,9 +1,7 @@
 test_name "file resource: symbolic modes"
 
-require 'test/unit/assertions'
-
 module FileModeAssertions
-  include Test::Unit::Assertions
+  include Beaker::DSL::Assertions
 
   def assert_create(agent, manifest, path, expected_mode)
     testcase.apply_manifest_on(agent, manifest) do


### PR DESCRIPTION
- update to work with beaker 2.0, maintain 1.x backwards compatability
