### PR TITLE
Check package presence before yum erase. fixes PUP-1295

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -188,7 +188,11 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   end
 
   def purge
-    yum "-y", :erase, @resource[:name]
+    wanted = @resource[:name]
+    args = ["-q", wanted].compact
+    if :rpm *args
+      yum "-y", :erase, @resource[:name]
+    end
   end
 
   # parse a yum "version" specification


### PR DESCRIPTION
This PR ensures yum provider will check a package is installed (with rpm -q) before it tries to erase it.
It should remove noise from packages resources ensured absent on RedHat systems.
