### PR TITLE
(PUP-3378) Don't require puppet resource service output to be the same

### DIFF
--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -1,24 +1,22 @@
-test_name "`puppet resource service` should list running services without changing the system"
+test_name "`puppet resource service` should list running services without calling dangerous init scripts"
 
 confine :except, :platform => 'windows'
 confine :except, :platform => 'solaris'
 
+# For each script in /etc/init.d, the init service provider will call
+# the script with the `status` argument, except for blacklisted
+# scripts that are known to be dangerous, e.g. /etc/init.d/reboot.sh
+# The first execution of `puppet resource service` will enumerate
+# all services, and we want to check that puppet enumerates at
+# least one service. We use ssh because our tests run over ssh, so it
+# must be present.
 
 agents.each do |agent|
   step "list running services and make sure ssh reports running"
-
-  on agent, 'puppet resource service'
+  on(agent, puppet('resource service'))
   assert_match /service { 'ssh[^']*':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is not running"
-  expected_output = stdout
 
-  step "make sure nothing on the system was changed and ssh is still running"
-
-  on agent, 'puppet resource service'
-
-  # It's possible that `puppet resource service` changed the system before
-  # printing output the *first* time, so in addition to comparing the output,
-  # we also want to check that a known service is in a good state. We use ssh
-  # because our tests run over ssh, so it must be present.
+  step "list running services again and make sure ssh is still running"
+  on(agent, puppet('resource service'))
   assert_match /service { 'ssh[^']*':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is no longer running"
-  assert_equal expected_output, stdout, "`puppet resource service` changed the state of the system"
 end


### PR DESCRIPTION
Previously, the acceptance test would execute `puppet resource service`
twice, and compare the output to ensure puppet did not change the state
of the system. This was done because in the past the `init` service
provider would invoke the status command on all scripts in /etc/init.d,
including /etc/init.d/reboot.sh, which would unconditionally reboot the
system[1]

However, this test is not reliable as some platforms like fedora 19 &
20 have services that change state between the two puppet runs, e.g.
NetworkManager-dispatcher.service, and this behavior is unrelated to
puppet.

This commit removes the requirement that the `puppet resource service`
command be identical. We continue to execute `puppet resource service`
twice and compare the output of the ssh(d) service. We also have specs
to ensure that the `init` service's instances method excludes dangerous
scripts.

This commit also changes the test to use beaker's `puppet` DSL method,
which is the preferred way of executing puppet in acceptance tests.

[1] http://projects.puppetlabs.com/issues/14615

Paired-with: Eric Thompson &lt;erict@puppetlabs.com&gt;
