### PR TITLE
(docs) Quote file modes as recommended

### DIFF
--- a/lib/puppet/reference/type.rb
+++ b/lib/puppet/reference/type.rb
@@ -20,9 +20,9 @@ Puppet::Util::Reference.newreference :type, :doc => "All Puppet resource types a
   In the following code:
 
       file { "/etc/passwd":
-        owner => root,
-        group => root,
-        mode  => 644
+        owner => "root",
+        group => "root",
+        mode  => "0644"
       }
 
   `/etc/passwd` is considered the title of the file object (used for things like

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1379,7 +1379,7 @@ class Type
           }
 
           File['sshdconfig'] {
-            mode => 644,
+            mode => '0644',
           }
 
       There's no way here for the Puppet parser to know that these two stanzas
@@ -1417,7 +1417,7 @@ class Type
           file {'/etc/hosts':
             ensure => file,
             source => 'puppet:///modules/site/hosts',
-            mode   => 0644,
+            mode   => '0644',
             tag    => ['bootstrap', 'minimumrun', 'mediumrun'],
           }
 


### PR DESCRIPTION
Add some quotes around strings that occur in block comments.  These
block comments are converted into HTML documentation that is published
on the official Puppet documentation Web pages at Puppetlabs.  It is
important that the examples be correct, because Puppet users are very
likely to uses these examples as a reference.

I noticed this because my colleagues started putting quotes around file
modes (e.g. mode => '0644').  From looking at the examples, I thought
the correct way to write these were as numbers.  But when I looked up
the documentation on the "mode" attribute of the "file" resource type,
it clearly says:

> This value should be specified as a quoted string; do not use
> un-quoted numbers to represent file modes.

So my colleagues seem to be right, but the examples are wrong.  This is
what the commit is trying to fix.

I also noticed that in one of the examples, the string values of the
"owner" and "group" attributes weren't quoted.  This seems to be an
error as well, so I fixed that too.

Another small change to the examples is that the numeric file modes are
written with four digits, i.e. with leading zeroes.
