### PR TITLE
(maint) Enable rubocop checking for shadowed variables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,9 +37,8 @@ Lint/HandleExceptions:
 Lint/LiteralInCondition:
   Enabled: false
 
-# MAYBE useful - but too many instances
 Lint/ShadowingOuterLocalVariable:
-  Enabled: false
+  Enabled: true
 
 # Can catch complicated strings.
 Lint/LiteralInInterpolation:

--- a/ext/nagios/check_puppet.rb
+++ b/ext/nagios/check_puppet.rb
@@ -16,7 +16,7 @@ class CheckPuppet
     :interval  => 30,
   }
 
-  o = OptionParser.new do |o|
+  OptionParser.new do |o|
     o.set_summary_indent('  ')
     o.banner =    "Usage: #{script_name} [OPTIONS]"
     o.define_head "The check_puppet Nagios plug-in checks that specified Puppet process is running and the state file is no older than specified interval."

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -121,9 +121,9 @@ class Puppet::Application::FaceBase < Puppet::Application
 
     # Now we can interact with the default option code to build behaviour
     # around the full set of options we now know we support.
-    @action.options.each do |option|
-      option = @action.get_option(option) # make it the object.
-      self.class.option(*option.optparse) # ...and make the CLI parse it.
+    @action.options.each do |o|
+      o = @action.get_option(o) # make it the object.
+      self.class.option(*o.optparse) # ...and make the CLI parse it.
     end
 
     # ...and invoke our parent to parse all the command line options.

--- a/lib/puppet/external/nagios/base.rb
+++ b/lib/puppet/external/nagios/base.rb
@@ -283,8 +283,8 @@ class Nagios::Base
     oc.sub!(/Nagios/,'nagios')
     oc.sub!(/::/,'')
     ocs.push oc
-    ocs.each { |oc|
-      str += "objectclass: #{oc}\n"
+    ocs.each { |objclass|
+      str += "objectclass: #{objclass}\n"
     }
     @parameters.each { |name,value|
       next if self.class.suppress.include?(name)

--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -94,10 +94,9 @@ class Puppet::FileBucket::Dipper
         end
         ::File.open(file, ::File::WRONLY|::File::TRUNC|::File::CREAT) { |of|
           of.binmode
-          source_stream = newcontents.stream do |source_stream|
+          newcontents.stream do |source_stream|
             FileUtils.copy_stream(source_stream, of)
           end
-          #of.print(newcontents)
         }
         ::File.chmod(changed, file) if changed
       else

--- a/lib/puppet/file_serving/mount/pluginfacts.rb
+++ b/lib/puppet/file_serving/mount/pluginfacts.rb
@@ -6,7 +6,7 @@ require 'puppet/file_serving/mount'
 class Puppet::FileServing::Mount::PluginFacts < Puppet::FileServing::Mount
   # Return an instance of the appropriate class.
   def find(relative_path, request)
-    return nil unless mod = request.environment.modules.find { |mod|  mod.pluginfact(relative_path) }
+    return nil unless mod = request.environment.modules.find { |m|  m.pluginfact(relative_path) }
 
     path = mod.pluginfact(relative_path)
 

--- a/lib/puppet/file_serving/mount/plugins.rb
+++ b/lib/puppet/file_serving/mount/plugins.rb
@@ -6,7 +6,7 @@ require 'puppet/file_serving/mount'
 class Puppet::FileServing::Mount::Plugins < Puppet::FileServing::Mount
   # Return an instance of the appropriate class.
   def find(relative_path, request)
-    return nil unless mod = request.environment.modules.find { |mod|  mod.plugin(relative_path) }
+    return nil unless mod = request.environment.modules.find { |m|  m.plugin(relative_path) }
 
     path = mod.plugin(relative_path)
 

--- a/lib/puppet/graph/relationship_graph.rb
+++ b/lib/puppet/graph/relationship_graph.rb
@@ -126,9 +126,9 @@ class Puppet::Graph::RelationshipGraph < Puppet::Graph::SimpleGraph
         if made_progress
           enqueue(*deferred_resources)
         else
-          deferred_resources.each do |resource|
-            overly_deferred_resource_handler.call(resource)
-            finish(resource)
+          deferred_resources.each do |res|
+            overly_deferred_resource_handler.call(res)
+            finish(res)
           end
         end
 

--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -140,10 +140,10 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     source = resource[:source]
 
     # This is largely a copy of recurse_remote in File
-    total = file[:source].collect do |source|
-      next unless result = file.perform_recursion(source)
+    total = file[:source].collect do |src|
+      next unless result = file.perform_recursion(src)
       return if top = result.find { |r| r.relative_path == "." } and top.ftype != "directory"
-      result.each { |data| data.source = "#{source}/#{data.relative_path}" }
+      result.each { |data| data.source = "#{src}/#{data.relative_path}" }
       break result if result and ! result.empty? and sourceselect == :first
       result
     end.flatten.compact

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -85,13 +85,13 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     uri, body = Puppet::Network::HTTP::API::V1.request_to_uri_and_body(request)
     uri_with_query_string = "#{uri}?#{body}"
 
-    response = do_request(request) do |request|
+    response = do_request(request) do |req|
       # WEBrick in Ruby 1.9.1 only supports up to 1024 character lines in an HTTP request
       # http://redmine.ruby-lang.org/issues/show/3991
       if "GET #{uri_with_query_string} HTTP/1.1\r\n".length > 1024
-        http_post(request, uri, body, headers)
+        http_post(req, uri, body, headers)
       else
-        http_get(request, uri_with_query_string, headers)
+        http_get(req, uri_with_query_string, headers)
       end
     end
 
@@ -119,8 +119,8 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   end
 
   def head(request)
-    response = do_request(request) do |request|
-      http_head(request, Puppet::Network::HTTP::API::V1.request_to_uri(request), headers)
+    response = do_request(request) do |req|
+      http_head(req, Puppet::Network::HTTP::API::V1.request_to_uri(req), headers)
     end
 
     if is_http_200?(response)
@@ -131,8 +131,8 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   end
 
   def search(request)
-    response = do_request(request) do |request|
-      http_get(request, Puppet::Network::HTTP::API::V1.request_to_uri(request), headers)
+    response = do_request(request) do |req|
+      http_get(req, Puppet::Network::HTTP::API::V1.request_to_uri(req), headers)
     end
 
     if is_http_200?(response)
@@ -146,8 +146,8 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   def destroy(request)
     raise ArgumentError, "DELETE does not accept options" unless request.options.empty?
 
-    response = do_request(request) do |request|
-      http_delete(request, Puppet::Network::HTTP::API::V1.request_to_uri(request), headers)
+    response = do_request(request) do |req|
+      http_delete(req, Puppet::Network::HTTP::API::V1.request_to_uri(req), headers)
     end
 
     if is_http_200?(response)
@@ -161,8 +161,8 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   def save(request)
     raise ArgumentError, "PUT does not accept options" unless request.options.empty?
 
-    response = do_request(request) do |request|
-      http_put(request, Puppet::Network::HTTP::API::V1.request_to_uri(request), request.instance.render, headers.merge({ "Content-Type" => request.instance.mime }))
+    response = do_request(request) do |req|
+      http_put(req, Puppet::Network::HTTP::API::V1.request_to_uri(req), req.instance.render, headers.merge({ "Content-Type" => req.instance.mime }))
     end
 
     if is_http_200?(response)
@@ -180,7 +180,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   # to request.do_request from here, thus if we change what we pass or how we
   # get it, we only need to change it here.
   def do_request(request)
-    request.do_request(self.class.srv_service, self.class.server, self.class.port) { |request| yield(request) }
+    request.do_request(self.class.srv_service, self.class.server, self.class.port) { |req| yield(req) }
   end
 
   def validate_key(request)

--- a/lib/puppet/interface/face_collection.rb
+++ b/lib/puppet/interface/face_collection.rb
@@ -27,8 +27,8 @@ module Puppet::Interface::FaceCollection
       # ...we need to search for it bound to an o{lder,ther} version.  Since
       # we load all actions when the face is first references, this will be in
       # memory in the known set of versions of the face.
-      (@faces[name].keys - [ :current ]).sort.reverse.each do |version|
-        break if action = @faces[name][version].get_action(action_name)
+      (@faces[name].keys - [ :current ]).sort.reverse.each do |vers|
+        break if action = @faces[name][vers].get_action(action_name)
       end
     end
 

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -57,11 +57,11 @@ module Puppet::ModuleTool
         results = { :action => :install, :module_name => name, :module_version => version }
 
         begin
-          if mod = installed_modules[name]
+          if installed_module = installed_modules[name]
             unless forced?
-              if Semantic::VersionRange.parse(version).include? mod.version
+              if Semantic::VersionRange.parse(version).include? installed_module.version
                 results[:result] = :noop
-                results[:version] = mod.version
+                results[:version] = installed_module.version
                 return results
               else
                 changes = Checksummer.run(installed_modules[name].mod.path) rescue []
@@ -135,8 +135,8 @@ module Puppet::ModuleTool
           unless forced?
             # Check for module name conflicts.
             releases.each do |rel|
-              if mod = installed_modules_source.by_name[rel.name.split('-').last]
-                next if mod.has_metadata? && mod.forge_name.tr('/', '-') == rel.name
+              if installed_module = installed_modules_source.by_name[rel.name.split('-').last]
+                next if installed_module.has_metadata? && installed_module.forge_name.tr('/', '-') == rel.name
 
                 if rel.name != name
                   dependency = {
@@ -149,8 +149,8 @@ module Puppet::ModuleTool
                   :requested_module  => name,
                   :requested_version => options[:version] || 'latest',
                   :dependency        => dependency,
-                  :directory         => mod.path,
-                  :metadata          => mod.metadata
+                  :directory         => installed_module.path,
+                  :metadata          => installed_module.metadata
               end
             end
           end

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -107,9 +107,9 @@ module Puppet::ModuleTool
             add_module_name_constraints_to_graph(graph)
           end
 
-          installed_modules.each do |mod, release|
-            mod = mod.tr('/', '-')
-            next if mod == name
+          installed_modules.each do |installed_module, release|
+            installed_module = installed_module.tr('/', '-')
+            next if installed_module == name
 
             version = release.version
 
@@ -118,7 +118,7 @@ module Puppet::ModuleTool
               # we'll place constraints on the graph for each installed
               # module, locking it to upgrades within the same major version.
               ">=#{version} #{version.major}.x".tap do |range|
-                graph.add_constraint('installed', mod, range) do |node|
+                graph.add_constraint('installed', installed_module, range) do |node|
                   Semantic::VersionRange.parse(range).include? node.version
                 end
               end
@@ -127,7 +127,7 @@ module Puppet::ModuleTool
                 dep_name = dep['name'].tr('/', '-')
 
                 dep['version_requirement'].tap do |range|
-                  graph.add_constraint("#{mod} constraint", dep_name, range) do |node|
+                  graph.add_constraint("#{installed_module} constraint", dep_name, range) do |node|
                     Semantic::VersionRange.parse(range).include? node.version
                   end
                 end

--- a/lib/puppet/module_tool/contents_description.rb
+++ b/lib/puppet/module_tool/contents_description.rb
@@ -42,9 +42,9 @@ module Puppet::ModuleTool
           end
         end
 
-        type_names.each do |type_name|
-          if type = Puppet::Type.type(type_name.to_sym)
-            type_hash = {:name => type_name, :doc => type.doc}
+        type_names.each do |name|
+          if type = Puppet::Type.type(name.to_sym)
+            type_hash = {:name => name, :doc => type.doc}
             type_hash[:properties] = attr_doc(type, :property)
             type_hash[:parameters] = attr_doc(type, :param)
             if type.providers.size > 0
@@ -52,7 +52,7 @@ module Puppet::ModuleTool
             end
             @data << type_hash
           else
-            Puppet.warning "Could not find/load type: #{type_name}"
+            Puppet.warning "Could not find/load type: #{name}"
           end
         end
       end

--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -69,11 +69,11 @@ module Puppet::ModuleTool
         super(source, name, version, {})
 
         if mod.dependencies
-          mod.dependencies.each do |dep|
-            results = Puppet::ModuleTool.parse_module_dependency(release, dep)
+          mod.dependencies.each do |dependency|
+            results = Puppet::ModuleTool.parse_module_dependency(release, dependency)
             dep_name, parsed_range, range = results
 
-            dep.tap do |dep|
+            dependency.tap do |dep|
               add_constraint('initialize', dep_name, range.to_s) do |node|
                 parsed_range === node.version
               end

--- a/lib/puppet/network/auth_config_parser.rb
+++ b/lib/puppet/network/auth_config_parser.rb
@@ -40,8 +40,8 @@ class AuthConfigParser
     # Verify each of the rights are valid.
     # We let the check raise an error, so that it can raise an error
     # pointing to the specific problem.
-    rights.each { |name, right|
-      right.valid?
+    rights.each { |name, r|
+      r.valid?
     }
     rights
   end

--- a/lib/puppet/network/format_handler.rb
+++ b/lib/puppet/network/format_handler.rb
@@ -77,16 +77,16 @@ module Puppet::Network::FormatHandler
   # @return [Puppet::Network::Format, nil] the most suitable format
   # @api private
   def self.most_suitable_format_for(accepted, supported)
-    format_name = accepted.collect do |accepted|
-      accepted.to_s.sub(/;q=.*$/, '')
-    end.collect do |accepted|
-      if accepted == ALL_MEDIA_TYPES
+    format_name = accepted.collect do |format|
+      format.to_s.sub(/;q=.*$/, '')
+    end.collect do |format|
+      if format == ALL_MEDIA_TYPES
         supported.first
       else
-        format_to_canonical_name_or_nil(accepted)
+        format_to_canonical_name_or_nil(format)
       end
-    end.find do |accepted|
-      supported.include?(accepted)
+    end.find do |format|
+      supported.include?(format)
     end
 
     if format_name

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -57,7 +57,7 @@ module Puppet::Network::HTTP::Handler
     profiler = configure_profiler(request_headers, request_params)
 
     Puppet::Util::Profiler.profile("Processed request #{request_method} #{request_path}", [:http, request_method, request_path]) do
-      if route = @routes.find { |route| route.matches?(new_request) }
+      if route = @routes.find { |r| r.matches?(new_request) }
         route.process(new_request, new_response)
       else
         raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{new_request.method} #{new_request.path}", HANDLER_NOT_FOUND)

--- a/lib/puppet/network/resolver.rb
+++ b/lib/puppet/network/resolver.rb
@@ -31,8 +31,8 @@ module Puppet::Network::Resolver
       # for the specific service.
       each_srv_record(domain, :puppet, &block)
     else
-      each_priority(records) do |priority, records|
-        while next_rr = records.delete(find_weighted_server(records))
+      each_priority(records) do |priority, recs|
+        while next_rr = recs.delete(find_weighted_server(recs))
           Puppet.debug "Yielding next server of #{next_rr.target.to_s}:#{next_rr.port}"
           yield next_rr.target.to_s, next_rr.port
         end

--- a/lib/puppet/network/rights.rb
+++ b/lib/puppet/network/rights.rb
@@ -20,8 +20,8 @@ class Rights
                        else
                          [method]
                        end
-    authorization_failure_exceptions = methods_to_check.map do |method|
-      is_forbidden_and_why?(path, params.merge({:method => method}))
+    authorization_failure_exceptions = methods_to_check.map do |m|
+      is_forbidden_and_why?(path, params.merge({:method => m}))
     end
     if authorization_failure_exceptions.include? nil
       # One of the methods we checked is ok, therefore this request is ok.

--- a/lib/puppet/parameter.rb
+++ b/lib/puppet/parameter.rb
@@ -108,8 +108,8 @@ class Puppet::Parameter
           @doc << "\n\n#{vals}"
         end
 
-        if f = self.required_features
-          @doc << "\n\nRequires features #{f.flatten.collect { |f| f.to_s }.join(" ")}."
+        if features = self.required_features
+          @doc << "\n\nRequires features #{features.flatten.collect { |f| f.to_s }.join(" ")}."
         end
         @addeddocvals = true
       end
@@ -542,7 +542,7 @@ class Puppet::Parameter
   #
   def self.format_value_for_display(value)
     if value.is_a? Array
-      formatted_values = value.collect {|value| format_value_for_display(value)}.join(', ')
+      formatted_values = value.collect {|v| format_value_for_display(v)}.join(', ')
       "[#{formatted_values}]"
     elsif value.is_a? Hash
       # Sorting the hash keys for display is largely for having stable

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -89,11 +89,11 @@ class Puppet::Pops::Evaluator::AccessOperator
     when 0
       fail(Puppet::Pops::Issues::BAD_ARRAY_SLICE_ARITY, @semantic.left_expr, {:actual => keys.size})
     when 1
-      k = coerce_numeric(keys[0], @semantic.keys[0], scope)
-      unless k.is_a?(Integer)
-        bad_access_key_type(o, 0, k, Integer)
+      key = coerce_numeric(keys[0], @semantic.keys[0], scope)
+      unless key.is_a?(Integer)
+        bad_access_key_type(o, 0, key, Integer)
       end
-      o[k]
+      o[key]
     when 2
       # A slice [from, to] with support for -1 to mean start, or end respectively.
       k1 = coerce_numeric(keys[0], @semantic.keys[0], scope)

--- a/lib/puppet/pops/evaluator/callable_mismatch_describer.rb
+++ b/lib/puppet/pops/evaluator/callable_mismatch_describer.rb
@@ -17,9 +17,9 @@ module Puppet::Pops::Evaluator::CallableMismatchDescriber
       result << "expected:\n  #{name}(#{signature_string(signature)}) - #{arg_count_string(signature.type)}"
     else
       result << "expected one of:\n"
-      result << supported_signatures.map do |signature|
-        params_type = signature.type.param_types
-        "  #{name}(#{signature_string(signature)}) - #{arg_count_string(signature.type)}"
+      result << supported_signatures.map do |sig|
+        params_type = sig.type.param_types
+        "  #{name}(#{signature_string(sig)}) - #{arg_count_string(sig.type)}"
       end.join("\n")
     end
 

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -35,11 +35,11 @@ class Puppet::Pops::Evaluator::Closure < Puppet::Pops::Evaluator::CallableSignat
     variable_bindings = combine_values_with_parameters(args)
 
     tc = Puppet::Pops::Types::TypeCalculator
-    final_args = tc.infer_set(parameters.inject([]) do |final_args, param|
+    final_args = tc.infer_set(parameters.inject([]) do |tmp_args, param|
       if param.captures_rest
-        final_args.concat(variable_bindings[param.name])
+        tmp_args.concat(variable_bindings[param.name])
       else
-        final_args << variable_bindings[param.name]
+        tmp_args << variable_bindings[param.name]
       end
     end)
 

--- a/lib/puppet/pops/evaluator/relationship_operator.rb
+++ b/lib/puppet/pops/evaluator/relationship_operator.rb
@@ -134,7 +134,7 @@ class Puppet::Pops::Evaluator::RelationshipOperator
       # into an array, and thus the resulting left and right must be flattened individually
       # Once flattened, the operands should be sets (to remove duplicate entries)
       #
-      real = left_right_evaluated.collect {|x| [x].flatten.collect {|x| transform(x, scope) }}
+      real = left_right_evaluated.collect {|x| [x].flatten.collect {|y| transform(y, scope) }}
       real[0].flatten!
       real[1].flatten!
       real[0].uniq!

--- a/lib/puppet/pops/loader/dependency_loader.rb
+++ b/lib/puppet/pops/loader/dependency_loader.rb
@@ -27,8 +27,8 @@ class Puppet::Pops::Loader::DependencyLoader < Puppet::Pops::Loader::BaseLoader
   #
   def find(typed_name)
     if typed_name.qualified
-      if loader = index()[typed_name.name_parts[0]]
-        loader.load_typed(typed_name)
+      if l = index()[typed_name.name_parts[0]]
+        l.load_typed(typed_name)
       else
         # no module entered as dependency with name matching first segment of wanted name
         nil

--- a/lib/puppet/provider/group/aix.rb
+++ b/lib/puppet/provider/group/aix.rb
@@ -111,7 +111,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
         |k,v| !self.class.attribute_mapping_from.include?(k) and
                 !self.class.attribute_ignore.include?(k)
       }.inject({}) {
-        |hash, array| hash[array[0]] = array[1]; hash
+        |h, array| h[array[0]] = array[1]; h
       }
   end
 

--- a/lib/puppet/provider/package/pkgin.rb
+++ b/lib/puppet/provider/package/pkgin.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:package).provide :pkgin, :parent => Puppet::Provider::Package
   end
 
   def latest
-    package = parse_pkgsearch_line.detect{ |package| package[:status] == '<' }
+    package = parse_pkgsearch_line.detect{ |p| p[:status] == '<' }
     return properties[:ensure] if not package
     return package[:ensure]
   end

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -354,8 +354,8 @@ private
   end
 
   def write_script_to(file, text)
-    Puppet::Util.replace_file(file, 0644) do |file|
-      file.write(text)
+    Puppet::Util.replace_file(file, 0644) do |f|
+      f.write(text)
     end
   end
 end

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -294,7 +294,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     results = hash.select {
         |k,v| should_include?(k, managed_keys)
       }.inject({}) {
-        |hash, array| hash[array[0]] = array[1]; hash
+        |h, array| h[array[0]] = array[1]; h
       }
     results
   end

--- a/lib/puppet/reference/type.rb
+++ b/lib/puppet/reference/type.rb
@@ -94,19 +94,18 @@ Puppet::Util::Reference.newreference :type, :doc => "All Puppet resource types a
     str << markdown_header("Parameters", 4) + "\n"
     type.parameters.sort { |a,b|
       a.to_s <=> b.to_s
-    }.each { |name,param|
-      #docs[name] = indent(scrub(type.paramdoc(name)), $tab)
-      docs[name] = scrub(type.paramdoc(name))
+    }.each { |type_name, param|
+      docs[type_name] = scrub(type.paramdoc(type_name))
     }
 
     additional_key_attributes = type.key_attributes - [:name]
     docs.sort { |a, b|
       a[0].to_s <=> b[0].to_s
-    }.each { |name, doc|
-      if additional_key_attributes.include?(name)
+    }.each { |type_name, doc|
+      if additional_key_attributes.include?(type_name)
         doc = "(**Namevar:** If omitted, this parameter's value defaults to the resource's title.)\n\n" + doc
       end
-      str << markdown_definitionlist(name, doc)
+      str << markdown_definitionlist(type_name, doc)
     }
     str << "\n"
   }

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -83,9 +83,9 @@ class Puppet::Resource::TypeCollection
       return node
     end
 
-    @node_list.each do |node|
-      next unless node.name_is_regex?
-      return node if node.match(name)
+    @node_list.each do |n|
+      next unless n.name_is_regex?
+      return n if n.match(name)
     end
     nil
   end

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -446,8 +446,8 @@ class Puppet::Settings
         val = val.inspect if val == ""
         hash[name] = val
       end
-      hash.sort { |a,b| a[0].to_s <=> b[0].to_s }.each do |name, val|
-        puts "#{name} = #{val}"
+      hash.sort { |a,b| a[0].to_s <=> b[0].to_s }.each do |name, v|
+        puts "#{name} = #{v}"
       end
     else
       val.split(/\s*,\s*/).sort.each do |v|
@@ -1106,7 +1106,7 @@ Generated on #{Time.now}.
 
   DEPRECATION_REFS = {
     # intentionally empty. This could be repopulated if we deprecate more settings
-    # and have reference links to associate with them 
+    # and have reference links to associate with them
   }.freeze
 
   def screen_non_puppet_conf_settings(puppet_conf)
@@ -1281,8 +1281,8 @@ Generated on #{Time.now}.
     # @return [Object] The configuration setting value or nil if the setting is not known
     # @api public
     def lookup(name)
-      set = @value_sets.find do |set|
-        set.include?(name)
+      set = @value_sets.find do |value_set|
+        value_set.include?(name)
       end
       if set
         value = set.lookup(name)

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -284,7 +284,7 @@ class Puppet::Transaction
 
   def resources_by_provider(type_name, provider_name)
     unless @resources_by_provider
-      @resources_by_provider = Hash.new { |h, k| h[k] = Hash.new { |h, k| h[k] = {} } }
+      @resources_by_provider = Hash.new { |h, k| h[k] = Hash.new { |h1, k1| h1[k1] = {} } }
 
       @catalog.vertices.each do |resource|
         if resource.class.attrclass(:provider)

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -122,8 +122,8 @@ class Puppet::Transaction::Report
   def add_metric(name, hash)
     metric = Puppet::Util::Metric.new(name)
 
-    hash.each do |name, value|
-      metric.newvalue(name, value)
+    hash.each do |metric_name, value|
+      metric.newvalue(metric_name, value)
     end
 
     @metrics[metric.name] = metric
@@ -281,8 +281,8 @@ class Puppet::Transaction::Report
     @metrics.each do |name, metric|
       key = metric.name.to_s
       report[key] = {}
-      metric.values.each do |name, label, value|
-        report[key][name.to_s] = value
+      metric.values.each do |metric_name, label, value|
+        report[key][metric_name.to_s] = value
       end
       report[key]["total"] = 0 unless key == "time" or report[key].include?("total")
     end

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1006,15 +1006,15 @@ class Type
       end
     end
 
-    properties.each { |property|
-      unless is.include? property
+    properties.each { |prop|
+      unless is.include? prop
         raise Puppet::DevError,
-          "The is value is not in the is array for '#{property.name}'"
+          "The is value is not in the is array for '#{prop.name}'"
       end
 
-      propis = is[property]
-      unless property.safe_insync?(propis)
-        property.debug("Not in sync: #{propis.inspect} vs #{property.should.inspect}")
+      propis = is[prop]
+      unless prop.safe_insync?(propis)
+        prop.debug("Not in sync: #{propis.inspect} vs #{prop.should.inspect}")
         insync = false
       #else
       #    property.debug("In sync")

--- a/lib/puppet/util/network_device/cisco/interface.rb
+++ b/lib/puppet/util/network_device/cisco/interface.rb
@@ -68,8 +68,8 @@ class Puppet::Util::NetworkDevice::Cisco::Interface
       command(prefix + COMMANDS[property][1] % value)
     when Proc
       value = [value] unless value.is_a?(Array)
-      value.each do |value|
-        command(prefix + COMMANDS[property][1].call(*value))
+      value.each do |v|
+        command(prefix + COMMANDS[property][1].call(*v))
       end
     end
   end

--- a/lib/puppet/util/network_device/transport/ssh.rb
+++ b/lib/puppet/util/network_device/transport/ssh.rb
@@ -49,8 +49,8 @@ class Puppet::Util::NetworkDevice::Transport::Ssh < Puppet::Util::NetworkDevice:
       channel.send_channel_request("shell") do |ch, success|
         raise "failed to open ssh shell channel" unless success
 
-        ch.on_data { |ch,data| @buf << data }
-        ch.on_extended_data { |ch,type,data|  @buf << data if type == 1 }
+        ch.on_data { |_,data| @buf << data }
+        ch.on_extended_data { |_,type,data|  @buf << data if type == 1 }
         ch.on_close { @eof = true }
 
         @channel = ch

--- a/lib/puppet/util/rdoc/code_objects.rb
+++ b/lib/puppet/util/rdoc/code_objects.rb
@@ -151,10 +151,10 @@ module RDoc
           if result
             last_name = ""
             previous = nil
-            modules.each do |module_name|
+            modules.each do |mod|
               previous = result
-              last_name = module_name
-              result = result.find_module_named(module_name)
+              last_name = mod
+              result = result.find_module_named(mod)
               break unless result
             end
             unless result

--- a/lib/puppet/util/rdoc/generators/puppet_generator.rb
+++ b/lib/puppet/util/rdoc/generators/puppet_generator.rb
@@ -416,7 +416,7 @@ module Generators
       @values["resources"] = rl unless rl.empty?
 
       @context.sections.each do |section|
-        secdata = @values["sections"].select { |secdata| secdata["secsequence"] == section.sequence }
+        secdata = @values["sections"].select { |s| s["secsequence"] == section.sequence }
         if secdata.size == 1
           secdata = secdata[0]
 

--- a/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
+++ b/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
@@ -52,10 +52,10 @@ module RDoc::PuppetParserCore
     names = name.split('::')
 
     final_name = names.pop
-    names.each do |name|
+    names.each do |n|
       prev_container = container
-      container = find_object_named(container, name)
-      container ||= prev_container.add_class(RDoc::PuppetClass, name, nil)
+      container = find_object_named(container, n)
+      container ||= prev_container.add_class(RDoc::PuppetClass, n, nil)
     end
     [container, final_name]
   end


### PR DESCRIPTION
Previously, we allowed variables to be shadowed by variables
of the same name at local scope. This can make for confusing
reading to someone new to the code (and can potentially indicate
logic errors).

So this commit enables rubocop checking for shadow variables. It
also fixes (by renaming) all extant shadowed variables. Naming
is hard, but a best effort was made.
