### PR TITLE
(PUP-3656) Prefetch only rescue LoadError or MissingCommand

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -59,4 +59,8 @@ module Puppet
   class DevError < Puppet::Error
     include ExternalFileError
   end
+
+  class MissingCommand < Puppet::Error
+  end
+
 end

--- a/lib/puppet/provider/command.rb
+++ b/lib/puppet/provider/command.rb
@@ -19,7 +19,7 @@ class Puppet::Provider::Command
   # @param args [Array<String>] Any command line arguments to pass to the executable
   # @return The output from the command
   def execute(*args)
-    resolved_executable = @resolver.which(@executable) or raise Puppet::Error, "Command #{@name} is missing"
+    resolved_executable = @resolver.which(@executable) or raise Puppet::MissingCommand, "Command #{@name} is missing"
     @executor.execute([resolved_executable] + args, @options)
   end
 end

--- a/lib/puppet/provider/network_device.rb
+++ b/lib/puppet/provider/network_device.rb
@@ -20,6 +20,9 @@ class Puppet::Provider::NetworkDevice < Puppet::Provider
         resource.provider = new(device, :ensure => :absent)
       end
     end
+  rescue => detail
+    # Preserving behavior introduced in #6907
+    Puppet.log_exception(detail, "Could not perform network device prefetch: #{detail}")
   end
 
   def exists?

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -305,7 +305,7 @@ class Puppet::Transaction
     Puppet.debug "Prefetching #{provider_class.name} resources for #{type_name}"
     begin
       provider_class.prefetch(resources)
-    rescue => detail
+    rescue LoadError, Puppet::MissingCommand => detail
       Puppet.log_exception(detail, "Could not prefetch #{type_name} provider '#{provider_class.name}': #{detail}")
     end
     @prefetched_providers[type_name][provider_class.name] = true


### PR DESCRIPTION
Currently prefetch rescue all StandardError, and this results in puppet
creating resources unecessarily when prefetch fails. This patch limits
the exception handling to only rescue LoadError for rubygems, and
Puppet::MissingCommand when software packages have not been installed
yet.