### PR TITLE
(PUP-3016) use puppet helper in acceptance tests

### DIFF
--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -9,7 +9,6 @@ end
 module_author = "pmtacceptance"
 module_name = "java"
 module_version = "1.7.0"
-module_dependencies   = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
@@ -20,19 +19,10 @@ agents.each do |agent|
   step 'setup'
   stub_forge_on(agent)
 
-  step "  install module '#{module_author}-#{module_name}'"
-
-  opts ||= Hash.new
-  #backwards compatability with beaker 1.x
-  if defined? Command::DEFAULT_GIT_ENV
-    opts['ENV']=Command::DEFAULT_GIT_ENV
-  end
-  command = agent['platform'] =~ /windows/ ?
-    Command.new("'puppet module install --version \"<#{module_version}\" #{module_author}-#{module_name}'", [], opts) :
-    puppet("module install --version \"<#{module_version}\" #{module_author}-#{module_name}")
-
-  on(agent, command) do
+  step "install module '< #{module_version}' #{module_author}-#{module_name}"
+  on(agent, puppet("module install --version '< #{module_version}' #{module_author}-#{module_name}")) do
     assert_module_installed_ui(stdout, module_author, module_name, module_version, '<')
+    assert_module_installed_on_disk(agent, module_name)
   end
-  assert_module_installed_on_disk(agent, module_name)
 end
+


### PR DESCRIPTION
Use the puppet() helper function instead of assuming puppet is in the
path. After installing puppet on a Windows system in particular, it's
path is not reflected in the shell environment. Using puppet() lets
Beaker figure out how to execute the puppet binary.
Retain less-than argument for version of module installed.

Get around having to quote the whole command by inserting a space
after the version operator.  sigh.

In our current windows-cygwin overloaded ENV one has to single quote the entire
'puppet module #args <options>' command, which is not currently possible
with the helper (thus the use of Command in the previous version of this test).

The only other way i could get it to work is by quoting the version
string, but this requires a space after the operator. Otherwise
windows/cygwin says "file not found".

closes #3342 
