### PR TITLE
(maint) Change spec test to pass on ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script:
 notifications:
   email: false
 rvm:
+  - 2.2.0
   - 2.1.5
   - 2.0.0
   - 1.9.3
@@ -16,6 +17,8 @@ env:
 
 matrix:
   exclude:
+    - rvm: 2.2.0
+      env: "CHECK=rubocop"
     - rvm: 2.0.0
       env: "CHECK=rubocop"
     - rvm: 1.9.3

--- a/spec/unit/reports/store_spec.rb
+++ b/spec/unit/reports/store_spec.rb
@@ -24,7 +24,7 @@ describe processor do
     end
 
     it "should write the report to the file in YAML" do
-      Time.stubs(:now).returns(Time.parse("2011-01-06 12:00:00 UTC"))
+      Time.stubs(:now).returns(Time.utc(2011,01,06,12,00,00))
       @report.process
 
       File.read(File.join(Puppet[:reportdir], @report.host, "201101061200.yaml")).should == @report.to_yaml


### PR DESCRIPTION
Prior to this change, this spec test failed on ruby 2.2.0-rc1 with:

     Failure/Error: Time.stubs(:now).returns(Time.parse("2011-01-06 12:00:00 UTC"))
     NoMethodError:
       undefined method `utc_offset' for nil:NilClass

I didn't track down the root cause of this failure, but just
normalized this stub to use Time.utc, which (along with Time.local)
is the more common way of stubbing Time objects in the codebase.