### PR TITLE
(PUP-3719) Group resource non-authoritative by default

### DIFF
--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -109,7 +109,7 @@ module Puppet
 
     newparam(:auth_membership, :boolean => true, :parent => Puppet::Parameter::Boolean) do
       desc "whether the provider is authoritative for group membership."
-      defaultto true
+      defaultto false
     end
 
     newparam(:name) do

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -329,7 +329,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def self.name_sid_hash(names)
-      return [] if names.nil? or names.empty?
+      return {} if names.nil? or names.empty?
 
       sids = names.map do |name|
         sid = Puppet::Util::Windows::SID.name_to_sid_object(name)

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -51,12 +51,6 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         provider.members_insync?(['user1'], nil).should be_false
       end
 
-      it "should return false for differing lists of members" do
-        provider.members_insync?(['user1'], ['user2']).should be_false
-        provider.members_insync?(['user1'], []).should be_false
-        provider.members_insync?([], ['user2']).should be_false
-      end
-
       it "should return true for same lists of members" do
         provider.members_insync?(['user1', 'user2'], ['user1', 'user2']).should be_true
       end
@@ -71,8 +65,19 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
       context "when auth_membership => true" do
         before :each do
-          # this is also the default
           resource[:auth_membership] = true
+        end
+
+        it "should return false when current contains different users than should" do
+          provider.members_insync?(['user1'], ['user2']).should be_false
+        end
+
+        it "should return false when current contains members and should is empty" do
+          provider.members_insync?(['user1'], []).should be_false
+        end
+
+        it "should return false when current is empty and should contains members" do
+          provider.members_insync?([], ['user2']).should be_false
         end
 
         it "should return false when should user(s) are not the only items in the current" do
@@ -82,7 +87,20 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
       context "when auth_membership => false" do
         before :each do
+          # this is also the default
           resource[:auth_membership] = false
+        end
+
+        it "should return false when current contains different users than should" do
+          provider.members_insync?(['user1'], ['user2']).should be_false
+        end
+
+        it "should return true when current contains members and should is empty" do
+          provider.members_insync?(['user1'], []).should be_true
+        end
+
+        it "should return false when current is empty and should contains members" do
+          provider.members_insync?([], ['user2']).should be_false
         end
 
         it "should return true when current user(s) contains at least the should list" do
@@ -115,6 +133,10 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
   end
 
   describe "when managing members" do
+    before :each do
+      resource[:auth_membership] = true
+    end
+
     it "should be able to provide a list of members" do
       provider.group.stubs(:members).returns ['user1', 'user2', 'user3']
 
@@ -151,7 +173,8 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
       create = sequence('create')
       group.expects(:commit).in_sequence(create)
-      group.expects(:set_members).with(['user1', 'user2'], true).in_sequence(create)
+      # it seems a bit strange that defaultto false returns nil
+      group.expects(:set_members).with(['user1', 'user2'], nil).in_sequence(create)
 
       provider.create
     end


### PR DESCRIPTION
The `auth_membership` group parameter controls whether puppet ensures the
group contains _exactly_ the members specified, and no more, or contains _at
least_ the members specified. By default, the group parameter defaults to the
former, which is opposite to the `auth_membership` user parameter. This makes
the group parameter difficult to use in practice, because you need to know what
the complete set of group members should be. For example, on Windows the local
`Administrators` group may contain a combination of local and domain
user/group accounts, and that may vary across different types of machines.

This switches the default to false to correct the confusion and needing to 
know/specify every member of a group.
