### PR TITLE
File mode

### DIFF
--- a/lib/puppet/provider/file/posix.rb
+++ b/lib/puppet/provider/file/posix.rb
@@ -118,7 +118,7 @@ Puppet::Type.type(:file).provide :posix do
 
   def mode
     if stat = resource.stat
-      return (stat.mode & 007777).to_s(8)
+      return (stat.mode & 007777).to_s(8).rjust(4, '0')
     else
       return :absent
     end

--- a/spec/unit/provider/file/posix_spec.rb
+++ b/spec/unit/provider/file/posix_spec.rb
@@ -14,7 +14,7 @@ describe Puppet::Type.type(:file).provider(:posix), :if => Puppet.features.posix
       FileUtils.touch(path)
       File.chmod(0644, path)
 
-      provider.mode.should == '644'
+      provider.mode.should == '0644'
     end
 
     it "should return absent if the file doesn't exist" do
@@ -29,12 +29,12 @@ describe Puppet::Type.type(:file).provider(:posix), :if => Puppet.features.posix
 
       provider.mode = '0755'
 
-      provider.mode.should == '755'
+      provider.mode.should == '0755'
     end
 
     it "should pass along any errors encountered" do
       expect do
-        provider.mode = '644'
+        provider.mode = '0644'
       end.to raise_error(Puppet::Error, /failed to set mode/)
     end
   end


### PR DESCRIPTION
(PUP-3787) Add leading '0' for four-digit octal notation of file modes.
