### PR TITLE
(PUP-2307) acceptance tests should use puppet helper

### DIFF
--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -25,7 +25,7 @@ def curl_master_from(agent, path, headers = '', &block)
   on agent, "#{curl_base} '#{url}'", &block
 end
 
-master_user = on(master, "puppet master --configprint user").stdout.strip
+master_user = on(master, puppet("master --configprint user")).stdout.strip
 environments_dir = create_tmpdir_for_user master, "environments"
 apply_manifest_on(master, <<-MANIFEST)
 File {

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -67,7 +67,7 @@ def generate_site_manifest(path_to_manifest, *modules_to_include)
   EOS
 end
 
-master_user = on(master, "puppet master --configprint user").stdout.strip
+master_user = on(master, puppet("master --configprint user")).stdout.strip
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -23,7 +23,7 @@ stub_forge_on(master)
 puppet_conf = generate_base_directory_environments(tmpdir)
 
 check_module_install_in = lambda do |environment_path, module_install_args|
-  on master, "puppet module install #{module_author}-#{module_name} --config=#{puppet_conf} #{module_install_args}" do
+  on(master, puppet("module install #{module_author}-#{module_name} --config=#{puppet_conf} #{module_install_args}")) do
     assert_module_installed_ui(stdout, module_author, module_name)
     assert_match(/#{environment_path}/, stdout,
           "Notice of non default install path was not displayed")
@@ -55,7 +55,7 @@ step "Install a module into --modulepath #{modulepath_dir} despite the implicit 
 end
 
 step "Uninstall so we can try a different scenario" do
-  on master, "puppet module uninstall #{module_author}-#{module_name} --config=#{puppet_conf} --modulepath=#{modulepath_dir}"
+  on(master, puppet("module uninstall #{module_author}-#{module_name} --config=#{puppet_conf} --modulepath=#{modulepath_dir}"))
 end
 
 step "Install a module into --modulepath #{modulepath_dir} with a directory env specified" do

--- a/acceptance/tests/modules/uninstall/with_environment.rb
+++ b/acceptance/tests/modules/uninstall/with_environment.rb
@@ -38,7 +38,7 @@ apply_manifest_on master, %Q{
 
 step 'Uninstall a module from a non default directory environment' do
   environment_path = "#{tmpdir}/environments/direnv/modules"
-  on master, "puppet module uninstall jimmy-crakorn --config=#{puppet_conf} --environment=direnv" do
+  on(master, puppet("module uninstall jimmy-crakorn --config=#{puppet_conf} --environment=direnv")) do
     assert_equal <<-OUTPUT, stdout
 \e[mNotice: Preparing to uninstall 'jimmy-crakorn' ...\e[0m
 Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from #{environment_path}

--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -34,7 +34,7 @@ agents.each do |agent|
   end
 
   step "IPS: check it was created"
-  on agent, "puppet resource package mypkg" do
+  on(agent, puppet("resource package mypkg")) do
     assert_match( /ensure => '0\.0\.1,.*'/, result.stdout, "err: #{agent}")
   end
 
@@ -45,7 +45,7 @@ agents.each do |agent|
   end
 
   step "IPS: verify it was not upgraded"
-  on agent, "puppet resource package mypkg" do
+  on(agent, puppet("resource package mypkg")) do
     assert_match( /ensure => '0\.0\.1,.*'/, result.stdout, "err: #{agent}")
   end
 
@@ -53,7 +53,7 @@ agents.each do |agent|
   apply_manifest_on(agent, 'package {mypkg : ensure=>latest}')
 
   step "IPS: ensure it was upgraded"
-  on agent, "puppet resource package mypkg" do
+  on(agent, puppet("resource package mypkg")) do
     assert_match( /ensure => '0\.0\.2,.*'/, result.stdout, "err: #{agent}")
   end
 
@@ -61,7 +61,7 @@ agents.each do |agent|
   send_pkg agent,:pkg => 'mypkg@0.0.3'
   send_pkg agent,:pkg => 'mypkg@0.0.4'
   apply_manifest_on(agent, 'package {mypkg : ensure=>latest}')
-  on agent, "puppet resource package mypkg" do
+  on(agent, puppet("resource package mypkg")) do
     assert_match( /ensure => '0\.0\.4,.*'/, result.stdout, "err: #{agent}")
   end
 

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -25,7 +25,7 @@ agents.each do |agent|
     assert_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
   step "IPS: check it was created"
-  on agent, "puppet resource package mypkg" do
+  on(agent, puppet("resource package mypkg")) do
     assert_match( /ensure => '0\.0\.1,.*'/, result.stdout, "err: #{agent}")
   end
   on agent, "pkg list -v mypkg" do

--- a/acceptance/tests/resource/package/ips/should_query.rb
+++ b/acceptance/tests/resource/package/ips/should_query.rb
@@ -23,11 +23,11 @@ agents.each do |agent|
     assert_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
 
-  on agent, "puppet resource package mypkg" do
+  on(agent, puppet("resource package mypkg")) do
     assert_match( /0.0.1/, result.stdout, "err: #{agent}")
   end
 
-  on agent, "puppet resource package" do
+  on(agent, puppet("resource package")) do
     assert_match( /0.0.1/, result.stdout, "err: #{agent}")
   end
 end

--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -25,7 +25,7 @@ agents.each do |agent|
     assert_match( / ensure changed 'stopped'.* to 'running'/, result.stdout, "err: #{agent}")
   end
   step "SMF: verify it with puppet"
-  on agent, "puppet resource service tstapp" do
+  on(agent, puppet("resource service tstapp")) do
     assert_match( /ensure => 'running'/, result.stdout, "err: #{agent}")
   end
 

--- a/acceptance/tests/resource/service/smf_should_query.rb
+++ b/acceptance/tests/resource/service/smf_should_query.rb
@@ -19,11 +19,11 @@ agents.each do |agent|
     assert_match( / ensure changed 'stopped'.* to 'running'/, result.stdout, "err: #{agent}")
   end
   step "SMF: query the resource"
-  on agent, "puppet resource service tstapp" do
+  on(agent, puppet("resource service tstapp")) do
     assert_match( /ensure => 'running'/, result.stdout, "err: #{agent}")
   end
   step "SMF: query all the instances"
-  on agent, "puppet resource service" do
+  on(agent, puppet("resource service")) do
     assert_match( /tstapp/, result.stdout, "err: #{agent}")
   end
 end

--- a/acceptance/tests/resource/zpool/basic_tests.rb
+++ b/acceptance/tests/resource/zpool/basic_tests.rb
@@ -42,7 +42,7 @@ agents.each do |agent|
   end
 
   step "ZPool: verify puppet resource reports on the disk array"
-  on agent, "puppet resource zpool tstpool" do
+  on(agent, puppet("resource zpool tstpool")) do
     assert_match(/ensure => 'present'/, result.stdout, "err: #{agent}")
     assert_match(/disk +=> .'.+dsk1 .+dsk2'./, result.stdout, "err: #{agent}")
   end
@@ -69,7 +69,7 @@ agents.each do |agent|
   end
 
   step "ZPool: verify puppet resource reports on the mirror"
-  on agent, "puppet resource zpool tstpool" do
+  on(agent, puppet("resource zpool tstpool")) do
     assert_match(/ensure => 'present'/, result.stdout, "err: #{agent}")
     assert_match(/mirror => \['\/ztstpool\/dsk1 \/ztstpool\/dsk2 \/ztstpool\/dsk3'\]/, result.stdout, "err: #{agent}")
   end
@@ -98,7 +98,7 @@ agents.each do |agent|
   end
 
   step "ZPool: verify puppet resource reports on both mirrors"
-  on agent, "puppet resource zpool tstpool" do
+  on(agent, puppet("resource zpool tstpool")) do
     assert_match(/ensure => 'present'/, result.stdout, "err: #{agent}")
     assert_match(/mirror => \['\/ztstpool\/dsk1 \/ztstpool\/dsk2', '\/ztstpool\/dsk3 \/ztstpool\/dsk5'\]/, result.stdout, "err: #{agent}")
   end
@@ -125,7 +125,7 @@ agents.each do |agent|
   end
 
   step "ZPool: verify puppet reports on the raidz pool"
-  on agent, "puppet resource zpool tstpool" do
+  on(agent, puppet("resource zpool tstpool")) do
     assert_match(/ensure => 'present'/, result.stdout, "err: #{agent}")
     assert_match(/raidz  => \['\/ztstpool\/dsk1 \/ztstpool\/dsk2 \/ztstpool\/dsk3'\]/, result.stdout, "err: #{agent}")
   end
@@ -154,7 +154,7 @@ agents.each do |agent|
   end
 
   step "ZPool: verify puppet resource reports on both raidz"
-  on agent, "puppet resource zpool tstpool" do
+  on(agent, puppet("resource zpool tstpool")) do
     assert_match(/ensure => 'present'/, result.stdout, "err: #{agent}")
     assert_match(/raidz  => \['\/ztstpool\/dsk1 \/ztstpool\/dsk2', '\/ztstpool\/dsk3 \/ztstpool\/dsk5'\]/, result.stdout, "err: #{agent}")
   end

--- a/acceptance/tests/resource/zpool/should_query.rb
+++ b/acceptance/tests/resource/zpool/should_query.rb
@@ -22,12 +22,12 @@ agents.each do |agent|
   end
 
   step "ZPool: query one"
-  on agent, "puppet resource zpool tstpool" do
+  on(agent, puppet("resource zpool tstpool")) do
     assert_match(/ensure *=> *'present'/, result.stdout, "err: #{agent}")
   end
 
   step "ZPool: query all"
-  on agent, "puppet resource zpool" do
+  on(agent, puppet("resource zpool tstpool")) do
     assert_match(/tstpool'/, result.stdout, "err: #{agent}")
   end
 end

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -2,16 +2,16 @@ test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 
 agent_hostnames = agents.map {|a| a.to_s}
 
-with_puppet_running_on master, {'master' => {'allow_duplicate_certs' => true}} do
+with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true}}) do
   agents.each do |agent|
     step "Generate a certificate request for the agent"
     fqdn = on(agent, facter("fqdn")).stdout.strip
-    on agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}")
+    on(agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}"))
   end
 
   step "Collect the original certs"
-  on master, puppet_cert("--sign --all")
-  original_certs = on master, puppet_cert("--list --all")
+  on(master, puppet_cert("--sign --all"))
+  original_certs = on(master, puppet_cert("--list --all"))
 
   old_certs = {}
   original_certs.stdout.each_line do |line|
@@ -24,12 +24,12 @@ with_puppet_running_on master, {'master' => {'allow_duplicate_certs' => true}} d
   agents.each do |agent|
     fqdn = on(agent, facter("fqdn")).stdout.strip
     step "Make another request with the same certname"
-    on agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}")
+    on(agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}"))
   end
 
   step "Collect the new certs"
-  on master, puppet_cert("--sign --all")
-  new_cert_list = on master, puppet_cert("--list --all")
+  on(master, puppet_cert("--sign --all"))
+  new_cert_list = on(master, puppet_cert("--list --all"))
 
   new_certs = {}
   new_cert_list.stdout.each_line do |line|


### PR DESCRIPTION
Clean up tests that assume puppet executable is on the path.
Without this change some tests will error when puppet can not be found.
The puppet helper should always know how to run puppet properly.
