### PR TITLE
(do not merge) (PUP-3012) Accept. tests - 3.7 PMT updates upgrade

### DIFF
--- a/acceptance/tests/modules/upgrade/upgrade_should_succeed_with_warning_when_symlink.rb
+++ b/acceptance/tests/modules/upgrade/upgrade_should_succeed_with_warning_when_symlink.rb
@@ -1,0 +1,40 @@
+test_name "puppet module upgrade should succeed with warning when module contains symlink"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+hosts.each do |host|
+  pending_test "pending requiring forge certs on solaris and PE-5766" if host['platform'] =~ /solaris/
+end
+
+module_author = "pmtacceptance"
+module_name   = "containssymlink"
+module_version   = "1.0.0"
+
+orig_installed_modules = get_installed_modules_for_hosts(hosts)
+teardown do
+  rm_installed_modules_from_hosts(orig_installed_modules, get_installed_modules_for_hosts(hosts))
+end
+
+agents.each do |agent|
+  step 'ensure moduledir exists'
+  on(agent, "mkdir -p #{agent['distmoduledir']}")
+
+  step 'Install module containing symlink' do
+    stub_forge_on(agent)
+    tmpdir = agent.tmpdir(module_name)
+    download = "#{tmpdir}/#{module_name}.tar.gz"
+    curl_on(agent, "-o #{download} https://forgeapi.puppetlabs.com/v3/files/#{module_author}-#{module_name}-#{module_version}.tar.gz")
+    on(agent, "cd #{tmpdir}; tar -vxzf #{module_name}.tar.gz; mv #{module_author}-#{module_name}-#{module_version} #{agent['distmoduledir']}/#{module_name}")
+  end
+
+  step 'Upgrade module containing symlink' do
+    on(agent, puppet("module upgrade --ignore-changes #{module_author}-#{module_name}")) do |res|
+      if agent['platform'] =~ /windows/
+        fail_test('Proper warning displayed! Fix this test after pup-3789.') if res.stderr.include? 'Symlinks in modules are unsupported'
+        pending_test "Pending partial test on windows until pup-3789"
+      else
+        fail_test('Proper failure message not displayed') unless res.stderr.include? 'Symlinks in modules are unsupported'
+      end
+    end
+  end
+end

--- a/acceptance/tests/modules/upgrade/upgrade_should_work_with_invalid_semver_in_diff_module.rb
+++ b/acceptance/tests/modules/upgrade/upgrade_should_work_with_invalid_semver_in_diff_module.rb
@@ -1,0 +1,57 @@
+test_name "puppet module upgrade should succeed if a different installed module has an invalid semver"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+require 'json'
+
+hosts.each do |host|
+  pending_test "pending requiring forge certs on solaris and PE-5766" if host['platform'] =~ /solaris/
+end
+
+module_author = "pmtacceptance"
+module_name   = "java"
+module_dependencies = ["stdlub"]
+module_version = "1.6.0"
+
+other_module_name   = "nginx"
+
+orig_installed_modules = get_installed_modules_for_hosts(hosts)
+teardown do
+  rm_installed_modules_from_hosts(orig_installed_modules, get_installed_modules_for_hosts(hosts))
+end
+
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    p = on(agent, 'cygpath -uF 35').stdout.chomp
+    agent['distmoduledir'] = agent['distmoduledir'].sub('`cygpath -smF 35`', p)
+  end
+
+  step "Install older version of module" do
+    stub_forge_on(agent)
+    on(agent, puppet("module install #{module_author}-#{module_name} --version #{module_version}"))
+  end
+
+  step "Install a different module" do
+    stub_forge_on(agent)
+    on(agent, puppet("module install #{module_author}-#{other_module_name}"))
+  end
+
+  step "Change 'version' to invalid value in metadata.json of the different module" do
+    metafile = "#{agent['distmoduledir']}/#{other_module_name}/metadata.json"
+    if on(agent, "test -f #{metafile}", :acceptable_exit_codes => [0,1]).exit_code == 1
+      metafile = "#{agent['distmoduledir']}/#{other_module_name}/Modulefile"
+      on(agent, "test -f #{metafile}")
+    end
+    puts metafile
+    metadata = on(agent, "cat #{metafile}").stdout
+    m = JSON.parse(metadata)
+    m['version'] = 'hello.world'
+    on(agent, "rm -f #{agent['distmoduledir']}/#{other_module_name}/metadata.json")
+    create_remote_file(agent, "#{agent['distmoduledir']}/#{other_module_name}/metadata.json", JSON.dump(m))
+  end
+
+  step "Upgrade module should succeed and warn that the version is invalid" do
+    on(agent, puppet("module upgrade #{module_author}-#{module_name}")) do |res|
+      assert_match(/Warning: #{other_module_name} .* has an invalid version number/, res.stderr, "Proper warning not displayed")
+    end
+  end
+end

--- a/acceptance/tests/modules/upgrade/upgrade_should_work_with_invalid_semver_installed.rb
+++ b/acceptance/tests/modules/upgrade/upgrade_should_work_with_invalid_semver_installed.rb
@@ -1,0 +1,52 @@
+test_name "puppet module upgrade should succeed if installed version is an invalid semver"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+require 'json'
+
+pending_test "Pending until PUP-3093 is resolved"
+
+hosts.each do |host|
+  pending_test "pending requiring forge certs on solaris and PE-5766" if host['platform'] =~ /solaris/
+end
+
+module_author = "pmtacceptance"
+module_name   = "java"
+module_dependencies = ["stdlub"]
+module_version = "1.6.0"
+
+orig_installed_modules = get_installed_modules_for_hosts(hosts)
+teardown do
+  rm_installed_modules_from_hosts(orig_installed_modules, get_installed_modules_for_hosts(hosts))
+end
+
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    p = on(agent, 'cygpath -uF 35').stdout.chomp
+    agent['distmoduledir'] = agent['distmoduledir'].sub('`cygpath -smF 35`', p)
+  end
+
+  step "Install older version of module" do
+    stub_forge_on(agent)
+    on(agent, puppet("module install #{module_author}-#{module_name} --version #{module_version}"))
+  end
+
+  step "Change 'version' to invalid value in metadata.json" do
+    metafile = "#{agent['distmoduledir']}/#{module_name}/metadata.json"
+    if on(agent, "test -f #{metafile}", :acceptable_exit_codes => [0,1]).exit_code == 1
+      metafile = "#{agent['distmoduledir']}/#{module_name}/Modulefile"
+      on(agent, "test -f #{metafile}")
+    end
+    puts metafile
+    metadata = on(agent, "cat #{metafile}").stdout
+    m = JSON.parse(metadata)
+    m['version'] = 'hello.world'
+    on(agent, "rm -f #{agent['distmoduledir']}/#{other_module_name}/metadata.json")
+    create_remote_file(agent, "#{agent['distmoduledir']}/#{module_name}/metadata.json", JSON.dump(m))
+  end
+
+  step "Upgrade module should succeed and warn that the version is invalid" do
+    on(agent, puppet("module upgrade #{module_author}-#{module_name}")) do |res|
+      assert_match(/Warning: #{module_name} .* has an invalid version number/, res.stderr, "Proper warning not displayed")
+    end
+  end
+end

--- a/acceptance/tests/modules/upgrade/upgrade_with_latest_installed_should_suceed_with_notice.rb
+++ b/acceptance/tests/modules/upgrade/upgrade_with_latest_installed_should_suceed_with_notice.rb
@@ -1,0 +1,29 @@
+test_name "puppet module upgrade with lastest version already installed should succeed with notice"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+hosts.each do |host|
+  pending_test "pending requiring forge certs on solaris and PE-5766" if host['platform'] =~ /solaris/
+end
+
+module_author = "pmtacceptance"
+module_name   = "java"
+module_dependencies = ["stdlub"]
+
+orig_installed_modules = get_installed_modules_for_hosts(hosts)
+teardown do
+  rm_installed_modules_from_hosts(orig_installed_modules, get_installed_modules_for_hosts(hosts))
+end
+
+agents.each do |agent|
+  step "Install module" do
+    stub_forge_on(agent)
+    on(agent, puppet("module install #{module_author}-#{module_name}"))
+  end
+
+  step "Upgrade module should succeed with notice that the lastest is already installed" do
+    on(agent, puppet("module upgrade #{module_author}-#{module_name}")) do |res|
+      assert_match(/version is already the latest version/, res.stdout, "Proper notice not displayed")
+    end
+  end
+end

--- a/acceptance/tests/modules/upgrade/upgrade_with_only_one_version_should_suceed_with_notice.rb
+++ b/acceptance/tests/modules/upgrade/upgrade_with_only_one_version_should_suceed_with_notice.rb
@@ -1,0 +1,28 @@
+test_name "puppet module upgrade with module installed when only one version exists should succeed with notice"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+hosts.each do |host|
+  pending_test "pending requiring forge certs on solaris and PE-5766" if host['platform'] =~ /solaris/
+end
+
+module_author = "pmtacceptance"
+module_name   = "oneversion"
+
+orig_installed_modules = get_installed_modules_for_hosts(hosts)
+teardown do
+  rm_installed_modules_from_hosts(orig_installed_modules, get_installed_modules_for_hosts(hosts))
+end
+
+agents.each do |agent|
+  step "Install module" do
+    stub_forge_on(agent)
+    on(agent, puppet("module install #{module_author}-#{module_name}"))
+  end
+
+  step "Upgrade module should succeed with notice that the lastest is already installed" do
+    on(agent, puppet("module upgrade #{module_author}-#{module_name}")) do |res|
+      assert_match(/version is already the latest version/, res.stdout, "Proper notice not displayed")
+    end
+  end
+end


### PR DESCRIPTION
from John:
This commit adds additional acceptance test coverage for updates
to the puppet module upgrade command. These tests validate the
following:

* detection of symlinks in installed module
* detection of latest version already installed
* allow upgrade when invalid semver in installed modules

from Eric:
fixup John's PR for changes to upstream
pending_test more gracefully while waiting on fixes
pending tests on solaris until the forge cert issue is sorted
fix the symlink test so it works more uniformly on windows with cygwin
weirdness
  prior to this change, tar would fail on windows across the C:\
  boundary? we also ensure the moduledir exists (not always true on git
  installs)

closing https://github.com/puppetlabs/puppet/pull/3019