### PR TITLE
(PUP-3793) Check for agent's process owner instead of master's one for user property validation in exec type

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -204,7 +204,7 @@ module Puppet
       validate do |user|
         if Puppet.features.microsoft_windows?
           self.fail "Unable to execute commands as other users on Windows"
-        elsif !Puppet.features.root? && resource.current_username() != user
+        elsif Facter.value(:id) != 'root' && Facter.value(:id) != user
           self.fail "Only root can execute commands as other users"
         end
       end
@@ -583,10 +583,6 @@ module Puppet
           self.property(:returns).sync
         end
       end
-    end
-
-    def current_username
-      Etc.getpwuid(Process.uid).name
     end
   end
 end

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -198,15 +198,14 @@ describe Puppet::Type.type(:exec) do
   describe "when setting user" do
     describe "on POSIX systems", :as_platform => :posix do
       it "should fail if we are not root" do
-        Puppet.features.stubs(:root?).returns(false)
+        Facter.fact(:id).stubs(:value).returns('foo')
         expect {
           Puppet::Type.type(:exec).new(:name => '/bin/true whatever', :user => 'input')
         }.to raise_error Puppet::Error, /Parameter user failed/
       end
 
       it "accepts the current user" do
-        Puppet.features.stubs(:root?).returns(false)
-        Etc.stubs(:getpwuid).returns(Struct::Passwd.new('input'))
+        Facter.fact(:id).stubs(:value).returns('input')
 
         type = Puppet::Type.type(:exec).new(:name => '/bin/true whatever', :user => 'input')
 
@@ -215,7 +214,7 @@ describe Puppet::Type.type(:exec) do
 
       ['one', 2, 'root', 4294967295, 4294967296].each do |value|
         it "should accept '#{value}' as user if we are root" do
-          Puppet.features.stubs(:root?).returns(true)
+          Facter.fact(:id).stubs(:value).returns(value)
           type = Puppet::Type.type(:exec).new(:name => '/bin/true whatever', :user => value)
           type[:user].should == value
         end


### PR DESCRIPTION
Should fix that kind of stuffs : https://github.com/puppetlabs/puppetlabs-postgresql/pull/394