### PR TITLE
(PUP-3801) Fixed issue with HP-UX Trusted Computing where password

### DIFF
--- a/lib/puppet/provider/user/hpux.rb
+++ b/lib/puppet/provider/user/hpux.rb
@@ -3,7 +3,7 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
     switch to HP-UX's special `usermod` binary to work around the fact that
     its standard `usermod` cannot make changes while the user is logged in.
     New functionality provides for changing trusted computing passwords and 
-    resetting password exipirations under trusted computing"
+    resetting password expirations under trusted computing"
 
   defaultfor :operatingsystem => "hp-ux"
   confine :operatingsystem => "hp-ux"

--- a/lib/puppet/provider/user/hpux.rb
+++ b/lib/puppet/provider/user/hpux.rb
@@ -2,11 +2,7 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
   desc "User management for HP-UX. This provider uses the undocumented `-F`
     switch to HP-UX's special `usermod` binary to work around the fact that
     its standard `usermod` cannot make changes while the user is logged in.
-<<<<<<< HEAD
     New functionality provides for changing trusted computing passwords and
-=======
-    New functionality provides for changing trusted computing passwords and 
->>>>>>> refs/remotes/import/fix/master/PUP-3801-HP-UX-User-Provider
     resetting password expirations under trusted computing"
 
   defaultfor :operatingsystem => "hp-ux"

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'spec_helper'
 require 'etc'
+require 'pp'
 
 provider_class = Puppet::Type.type(:user).provider(:hpuxuseradd)
 
@@ -13,7 +14,6 @@ describe provider_class do
     )
   end
   let(:provider) { resource.provider }
-
   it "should add -F when modifying a user" do
     resource.stubs(:allowdupe?).returns true
     provider.expects(:execute).with { |args| args.include?("-F") }
@@ -49,4 +49,54 @@ describe provider_class do
       provider.password.must == "foopassword"
     end
   end
+
+  context "managing passwords 2" do
+    let :pwent do
+      Struct::Passwd.new("root", "bazpassword")
+    end
+    before :each do
+      Etc.stubs(:getpwent).returns(pwent)
+      Etc.stubs(:getpwnam).returns(pwent)
+    end
+
+     it "Should have feature manages_password_age" do
+        provider_class.should be_manages_password_age
+     end
+
+     it "Should have feature manages_expiry" do
+        provider_class.should be_manages_expiry
+     end
+
+
+     it "should return modprpw for password aging on trusted systems" do
+        if provider.trusted == "Trusted"
+           provider_class.command(:password).should == "/usr/lbin/modprpw"
+        end
+     end
+
+    it "Should be able to test for trusted computing" do
+      #provider.trusted.should be ("Trusted").or("NotTrusted")
+      provider.trusted.should_not be_nil
+    end
+
+    it "Should return min age for user if trusted system" do
+       if provider.trusted == "Trusted"
+          provider.password_min_age.should_not be_nil
+       end
+    end
+
+    it "Should return max age for user if trusted system" do
+       if provider.trusted == "Trusted"
+          provider.password_max_age.should_not be_nil
+       end
+    end
+
+  it "should add /usr/lbin/modprpw -v -l when modifying user if trusted" do
+    if provider.trust2
+       resource.stubs(:allowdupe?).returns true
+       provider.expects(:execute).with() { |args|  args.include?('/usr/lbin/modprpw') and args.include?("-v") and args.include?("-l") }
+       provider.uid = 1000
+    end
+  end
+ end
 end


### PR DESCRIPTION
expirations were not being updated.

When I modified the HP-UX Password Provider in 2013, the issue was not
found until months later when the accounts used for testing exceeded the
system defined 90 day password expiration. The password hash for the new
password was getting pushed. When logging in with the new password,
HP-UX Trusted Computing was showing a successful password change, but it
was not resetting the password age back to 0 days. 

This fix corrects that behavior.