### PR TITLE
(PUP-3645) Add support for configurable url prefix

### DIFF
--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -14,15 +14,15 @@ node_names.uniq!
 authfile = "#{testdir}/auth.conf"
 authconf = node_names.map do |node_name|
   %Q[
-path /v3/catalog/#{node_name}
+path /puppet/v3/catalog/#{node_name}
 auth yes
 allow *
 
-path /v3/node/#{node_name}
+path /puppet/v3/node/#{node_name}
 auth yes
 allow *
 
-path /v3/report/#{node_name}
+path /puppet/v3/report/#{node_name}
 auth yes
 allow *
 ]

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -5,15 +5,15 @@ in_testdir = master.tmpdir('nodenamevalue')
 
 authfile = "#{in_testdir}/auth.conf"
 authconf = <<-AUTHCONF
-path /v3/catalog/specified_node_name
+path /puppet/v3/catalog/specified_node_name
 auth yes
 allow *
 
-path /v3/node/specified_node_name
+path /puppet/v3/node/specified_node_name
 auth yes
 allow *
 
-path /v3/report/specified_node_name
+path /puppet/v3/report/specified_node_name
 auth yes
 allow *
 AUTHCONF

--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -82,7 +82,7 @@ with_puppet_running_on(master, master_opts, testdir) do
         (
           sleep_for="0.$(( $RANDOM % 49 ))"
           sleep $sleep_for
-          url='https://#{master}:8140/v3/catalog/#{agent_cert}?environment=production'
+          url='https://#{master}:8140/puppet/v3/catalog/#{agent_cert}?environment=production'
           echo "Curling: $url"
           curl --tlsv1 -v -# -H 'Accept: text/pson' --cert #{cert_path} --key #{key_path} --cacert #{cacert_path} $url
           echo "$PPID Completed"

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -54,13 +54,13 @@ end
 with_puppet_running_on(master, master_opts) do
   agents.each do |agent|
     step "Ensure that an unauthenticated client cannot access the environments list" do
-      on agent, "curl --tlsv1 -ksv https://#{master}:#{master_port(agent)}/v2.0/environments", :acceptable_exit_codes => [0,7] do
+      on agent, "curl --tlsv1 -ksv https://#{master}:#{master_port(agent)}/puppet/v3/environments", :acceptable_exit_codes => [0,7] do
         assert_match(/< HTTP\/1\.\d 403/, stderr)
       end
     end
 
     step "Ensure that an authenticated client can retrieve the list of environments" do
-      curl_master_from(agent, '/v2.0/environments') do
+      curl_master_from(agent, '/puppet/v3/environments') do
         data = JSON.parse(stdout)
         assert_equal(["env1", "env2", "production"], data["environments"].keys.sort)
       end

--- a/acceptance/tests/external_ca_support/fixtures/auth.conf
+++ b/acceptance/tests/external_ca_support/fixtures/auth.conf
@@ -2,24 +2,24 @@
 # external ca testing.
 
 # allow nodes to retrieve their own catalog
-path ~ ^/v3/catalog/([^/]+)$
+path ~ ^/puppet/v3/catalog/([^/]+)$
 method find
 allow *.example.org
 allow $1
 
 # allow nodes to retrieve their own node definition
-path ~ ^/v3/node/([^/]+)$
+path ~ ^/puppet/v3/node/([^/]+)$
 method find
 allow *.example.org
 allow $1
 
 # allow all nodes to access the certificates services
-path /v3/certificate_revocation_list/ca
+path /puppet/v3/certificate_revocation_list/ca
 method find
 allow *
 
 # allow all nodes to store their own reports
-path ~ ^/v3/report/([^/]+)$
+path ~ ^/puppet/v3/report/([^/]+)$
 method save
 allow *.example.org
 allow $1
@@ -29,7 +29,7 @@ allow $1
 # mount points (see fileserver.conf). Note that the `/file` prefix matches
 # requests to both the file_metadata and file_content paths. See "Examples"
 # above if you need more granular access control for custom mount points.
-path /v3/file
+path /puppet/v3/file
 allow *
 
 ### Unauthenticated ACLs, for clients without valid certificates; authenticated
@@ -37,19 +37,19 @@ allow *
 
 # allow access to the CA certificate; unauthenticated nodes need this
 # in order to validate the puppet master's certificate
-path /v3/certificate/ca
+path /puppet/v3/certificate/ca
 auth any
 method find
 allow *
 
 # allow nodes to retrieve the certificate they requested earlier
-path /v3/certificate/
+path /puppet/v3/certificate/
 auth any
 method find
 allow *
 
 # allow nodes to request a new certificate
-path /v3/certificate_request
+path /puppet/v3/certificate_request
 auth any
 method find, save
 allow *

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -7,15 +7,15 @@ test_name "ticket #16753 node data should be cached in yaml to allow it to be qu
 
 node_name = "woy_node_#{SecureRandom.hex}"
 auth_contents = <<AUTHCONF
-path /v3/catalog/#{node_name}
+path /puppet/v3/catalog/#{node_name}
 auth yes
 allow *
 
-path /v3/node/#{node_name}
+path /puppet/v3/node/#{node_name}
 auth yes
 allow *
 
-path /v3/report/#{node_name}
+path /puppet/v3/report/#{node_name}
 auth yes
 allow *
 AUTHCONF

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -12,7 +12,8 @@ test_name "CVE 2013-1652 Improper query parameter validation" do
 
       certname = on(agent, puppet('agent', "--configprint certname")).stdout.chomp
 
-      payload = "https://#{master}:8140/v3/catalog/#{certname}?environment=production&use_node=" +
+      payload = "https://#{master}:8140/puppet/v3/catalog/#{certname}" +
+                "?environment=production&use_node=" +
                 "---%20!ruby/object:Puppet::Node%0A%20%20" +
                 "name:%20#{master}%0A%20%20classes:%20\[\]%0A%20%20" +
                 "parameters:%20%7B%7D%0A%20%20facts:%20%7B%7D"

--- a/acceptance/tests/security/cve-2013-2275_report_acl.rb
+++ b/acceptance/tests/security/cve-2013-2275_report_acl.rb
@@ -20,7 +20,7 @@ with_puppet_running_on(master, {}) do
     "--key \"$(puppet master --configprint hostprivkey)\"",
     "-H 'Content-Type: text/yaml'",
     "-d '#{fake_report}'",
-    "\"https://#{master}:8140/v3/report/mccune?environment=production\"",
+    "\"https://#{master}:8140/puppet/v3/report/mccune?environment=production\"",
   ].join(" ")
 
   on master, submit_fake_report_cmd, :acceptable_exit_codes => [0] do

--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -61,22 +61,22 @@
 ### has a valid certificate and is thus authenticated
 
 # allow nodes to retrieve their own catalog
-path ~ ^/v3/catalog/([^/]+)$
+path ~ ^/puppet/v3/catalog/([^/]+)$
 method find
 allow $1
 
 # allow nodes to retrieve their own node definition
-path ~ ^/v3/node/([^/]+)$
+path ~ ^/puppet/v3/node/([^/]+)$
 method find
 allow $1
 
 # allow all nodes to access the certificates services
-path /v3/certificate_revocation_list/ca
+path /puppet/v3/certificate_revocation_list/ca
 method find
 allow *
 
 # allow all nodes to store their own reports
-path ~ ^/v3/report/([^/]+)$
+path ~ ^/puppet/v3/report/([^/]+)$
 method save
 allow $1
 
@@ -85,7 +85,7 @@ allow $1
 # mount points (see fileserver.conf). Note that the `/file` prefix matches
 # requests to both the file_metadata and file_content paths. See "Examples"
 # above if you need more granular access control for custom mount points.
-path /v3/file
+path /puppet/v3/file
 allow *
 
 ### Unauthenticated ACLs, for clients without valid certificates; authenticated
@@ -93,28 +93,28 @@ allow *
 
 # allow access to the CA certificate; unauthenticated nodes need this
 # in order to validate the puppet master's certificate
-path /v3/certificate/ca
+path /puppet/v3/certificate/ca
 auth any
 method find
 allow *
 
 # allow nodes to retrieve the certificate they requested earlier
-path /v3/certificate/
+path /puppet/v3/certificate/
 auth any
 method find
 allow *
 
 # allow nodes to request a new certificate
-path /v3/certificate_request
+path /puppet/v3/certificate_request
 auth any
 method find, save
 allow *
 
-path /v2.0/environments
+path /puppet/v2.0/environments
 method find
 allow *
 
-path /v3/environments
+path /puppet/v3/environments
 method find
 allow *
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1001,6 +1001,15 @@ EOT
       this is the port to listen on; for puppet agent, this is the port
       to make requests on. Both applications use this setting to get the port.",
     },
+    :master_url_prefix => {
+        :default => "/puppet",
+        :desc    => "The prefix at which the puppet master API is mounted.",
+        :hook    => proc do |value|
+          if !value.start_with?("/")
+            Puppet[:master_url_prefix] = "/#{value}"
+          end
+        end
+    },
     :node_name => {
       :default    => "cert",
       :desc       => "How the puppet master determines the client's identity

--- a/lib/puppet/network/http/api.rb
+++ b/lib/puppet/network/http/api.rb
@@ -1,2 +1,9 @@
 class Puppet::Network::HTTP::API
+  def self.not_found
+    Puppet::Network::HTTP::Route.
+      path(/.*/).
+      any(lambda do |req, res|
+        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{req.method} #{req.path}", Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
+      end)
+  end
 end

--- a/lib/puppet/network/http/api/v2.rb
+++ b/lib/puppet/network/http/api/v2.rb
@@ -5,7 +5,7 @@ module Puppet::Network::HTTP::API::V2
   def self.routes
     path(%r{^/v2\.0}).
       get(Authorization.new).
-      chain(ENVIRONMENTS, NOT_FOUND)
+      chain(ENVIRONMENTS, Puppet::Network::HTTP::API.not_found)
   end
 
   private
@@ -19,12 +19,6 @@ module Puppet::Network::HTTP::API::V2
       block.call.call(request, response)
     end
   end
-
-  NOT_FOUND = Puppet::Network::HTTP::Route.
-    path(/.*/).
-    any(lambda do |req, res|
-      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(req.path, Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
-    end)
 
   ENVIRONMENTS = path(%r{^/environments$}).get(provide do
     Environments.new(Puppet.lookup(:environments))

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -28,8 +28,11 @@ class Puppet::Network::HTTP::RackREST
 
   def initialize(args={})
     super()
-    register([Puppet::Network::HTTP::API::V3.routes,
-              Puppet::Network::HTTP::API::V2.routes])
+    prefix = Regexp.new("^#{Puppet[:master_url_prefix]}")
+    register([Puppet::Network::HTTP::Route.path(prefix).
+                  any.
+                  chain(Puppet::Network::HTTP::API::V3.routes,
+                        Puppet::Network::HTTP::API::V2.routes)])
   end
 
   def set_content_type(response, format)

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -32,7 +32,8 @@ class Puppet::Network::HTTP::RackREST
     register([Puppet::Network::HTTP::Route.path(prefix).
                   any.
                   chain(Puppet::Network::HTTP::API::V3.routes,
-                        Puppet::Network::HTTP::API::V2.routes)])
+                        Puppet::Network::HTTP::API::V2.routes,
+                        Puppet::Network::HTTP::API.not_found)])
   end
 
   def set_content_type(response, format)

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -15,8 +15,11 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
 
   def initialize(server)
     raise ArgumentError, "server is required" unless server
-    register([Puppet::Network::HTTP::API::V3.routes,
-              Puppet::Network::HTTP::API::V2.routes])
+    prefix = Regexp.new("^#{Puppet[:master_url_prefix]}")
+    register([Puppet::Network::HTTP::Route.path(prefix).
+                  any.
+                  chain(Puppet::Network::HTTP::API::V3.routes,
+                        Puppet::Network::HTTP::API::V2.routes)])
     super(server)
   end
 

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -19,7 +19,8 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
     register([Puppet::Network::HTTP::Route.path(prefix).
                   any.
                   chain(Puppet::Network::HTTP::API::V3.routes,
-                        Puppet::Network::HTTP::API::V2.routes)])
+                        Puppet::Network::HTTP::API::V2.routes,
+                        Puppet::Network::HTTP::API.not_found)])
     super(server)
   end
 

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -118,6 +118,7 @@ describe Puppet::Indirector::REST do
   let(:terminus) { Puppet::TestModel.indirection.terminus(:rest) }
   let(:indirection) { Puppet::TestModel.indirection }
   let(:model) { Puppet::TestModel }
+  let(:url_prefix) { "#{Puppet[:master_url_prefix]}/v3"}
 
   around(:each) do |example|
     Puppet.override(:current_environment => Puppet::Node::Environment.create(:production, [])) do
@@ -254,7 +255,7 @@ describe Puppet::Indirector::REST do
       it "calls get on the connection" do
         request = find_request('foo bar')
 
-        connection.expects(:get).with('/v3/test_model/foo%20bar?environment=production&', anything).returns(mock_response('200', 'response body'))
+        connection.expects(:get).with("#{url_prefix}/test_model/foo%20bar?environment=production&", anything).returns(mock_response('200', 'response body'))
 
         terminus.find(request).should == model.new('foo bar', 'response body')
       end
@@ -284,7 +285,7 @@ describe Puppet::Indirector::REST do
           terminus.find(request)
         end.to raise_error(
           Puppet::Error,
-          'Find /v3/test_model/foo?environment=production&fail_on_404=true resulted in 404 with the message: this is the notfound you are looking for')
+          "Find #{url_prefix}/test_model/foo?environment=production&fail_on_404=true resulted in 404 with the message: this is the notfound you are looking for")
       end
 
       it 'truncates the URI when it is very long' do
@@ -410,7 +411,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a deserializing terminus method', :search
 
     it "should call the GET http method on a network connection" do
-      connection.expects(:get).with('/v3/test_models/foo?environment=production&', has_key('Accept')).returns mock_response(200, 'data3, data4')
+      connection.expects(:get).with("#{url_prefix}/test_models/foo?environment=production&", has_key('Accept')).returns mock_response(200, 'data3, data4')
 
       terminus.search(request)
     end
@@ -455,7 +456,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a deserializing terminus method', :destroy
 
     it "should call the DELETE http method on a network connection" do
-      connection.expects(:delete).with('/v3/test_model/foo?environment=production&', has_key('Accept')).returns(response)
+      connection.expects(:delete).with("#{url_prefix}/test_model/foo?environment=production&", has_key('Accept')).returns(response)
 
       terminus.destroy(request)
     end
@@ -502,7 +503,7 @@ describe Puppet::Indirector::REST do
     it_behaves_like 'a REST terminus method', :save
 
     it "should call the PUT http method on a network connection" do
-      connection.expects(:put).with('/v3/test_model/the%20thing?environment=production&', anything, has_key("Content-Type")).returns response
+      connection.expects(:put).with("#{url_prefix}/test_model/the%20thing?environment=production&", anything, has_key("Content-Type")).returns response
 
       terminus.save(request)
     end

--- a/spec/unit/network/authconfig_spec.rb
+++ b/spec/unit/network/authconfig_spec.rb
@@ -58,7 +58,7 @@ describe Puppet::Network::AuthConfig do
       Puppet::Network::AuthConfig.any_instance.unstub(:insert_default_acl)
     end
 
-    Puppet::Network::AuthConfig::DEFAULT_ACL.each do |acl|
+    Puppet::Network::AuthConfig::default_acl.each do |acl|
       it "should create a default right for #{acl[:acl]}" do
         @authconfig.stubs(:mk_acl)
         @authconfig.expects(:mk_acl).with(acl)
@@ -81,7 +81,7 @@ describe Puppet::Network::AuthConfig do
 
     it '(CVE-2013-2275) allows report submission only for the node matching the certname by default' do
       acl = {
-        :acl => "~ ^\/v3\/report\/([^\/]+)$",
+        :acl => "~ ^#{Puppet[:master_url_prefix]}\/v3\/report\/([^\/]+)$",
         :method => :save,
         :allow => '$1',
         :authenticated => true

--- a/spec/unit/network/http/api/v2_spec.rb
+++ b/spec/unit/network/http/api/v2_spec.rb
@@ -3,8 +3,16 @@ require 'spec_helper'
 require 'puppet/network/http'
 
 describe Puppet::Network::HTTP::API::V2 do
+  let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+
+  it "mounts the environments endpoint" do
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "/v2.0/environments")
+    Puppet::Network::HTTP::API::V2.routes.process(request, response)
+
+    expect(response.code).to eq(200)
+  end
+
   it "responds to unknown paths with a 404" do
-    response = Puppet::Network::HTTP::MemoryResponse.new
     request = Puppet::Network::HTTP::Request.from_hash(:path => "/v2.0/unknown")
 
     expect do

--- a/spec/unit/network/http/api/v3/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/v3/indirected_routes_spec.rb
@@ -15,6 +15,7 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
   let(:handler) { Puppet::Network::HTTP::API::V3::IndirectedRoutes.new }
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
   let(:params) { { :environment => "production" } }
+  let(:url_prefix) { "#{Puppet[:master_url_prefix]}/v3"}
 
   def a_request_that_heads(data, request = {})
     Puppet::Network::HTTP::Request.from_hash({
@@ -22,7 +23,7 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "HEAD",
-      :path => "/v3/#{indirection.name}/#{data.value}",
+      :path => "#{url_prefix}/#{indirection.name}/#{data.value}",
       :params => params,
     })
   end
@@ -33,7 +34,7 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
         'accept' => request[:accept_header],
         'content-type' => request[:content_type_header] || "text/pson", },
       :method => "PUT",
-      :path => "/v3/#{indirection.name}/#{data.value}",
+      :path => "#{url_prefix}/#{indirection.name}/#{data.value}",
       :params => params,
       :body => request[:body].nil? ? data.render("pson") : request[:body]
     })
@@ -45,7 +46,7 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "DELETE",
-      :path => "/v3/#{indirection.name}/#{data.value}",
+      :path => "#{url_prefix}/#{indirection.name}/#{data.value}",
       :params => params,
       :body => ''
     })
@@ -57,7 +58,7 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "GET",
-      :path => "/v3/#{indirection.name}/#{data.value}",
+      :path => "#{url_prefix}/#{indirection.name}/#{data.value}",
       :params => params,
       :body => ''
     })
@@ -69,7 +70,7 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
         'accept' => request[:accept_header],
         'content-type' => "text/pson", },
       :method => "GET",
-      :path => "/v3/#{indirection.name}s/#{key}",
+      :path => "#{url_prefix}/#{indirection.name}s/#{key}",
       :params => params,
       :body => ''
     })
@@ -98,90 +99,92 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
     end
 
     it "should get the environment from a query parameter" do
-      handler.uri2indirection("GET", "/v3/node/bar", params)[3][:environment].to_s.should == "env"
+      handler.uri2indirection("GET", "#{url_prefix}/node/bar", params)[3][:environment].to_s.should == "env"
     end
 
     it "should fail if there is no environment specified" do
-      lambda { handler.uri2indirection("GET", "/v3/node/bar", {}) }.should raise_error(ArgumentError)
+      lambda { handler.uri2indirection("GET", "#{url_prefix}/node/bar", {}) }.should raise_error(ArgumentError)
     end
 
     it "should fail if the environment is not alphanumeric" do
-      lambda { handler.uri2indirection("GET", "/v3/node/bar", {:environment => "env ness"}) }.should raise_error(ArgumentError)
+      lambda { handler.uri2indirection("GET", "#{url_prefix}/node/bar", {:environment => "env ness"}) }.should raise_error(ArgumentError)
     end
 
     it "should not pass a buck_path parameter through (See Bugs #13553, #13518, #13511)" do
-      handler.uri2indirection("GET", "/v3/node/bar", { :environment => "env",
-                                                       :bucket_path => "/malicious/path" })[3].should_not include({ :bucket_path => "/malicious/path" })
+      handler.uri2indirection("GET", "#{url_prefix}/node/bar",
+                              { :environment => "env",
+                                :bucket_path => "/malicious/path" })[3].should_not include({ :bucket_path => "/malicious/path" })
     end
 
     it "should pass allowed parameters through" do
-      handler.uri2indirection("GET", "/v3/node/bar", { :environment => "env",
-                                                       :allowed_param => "value" })[3].should include({ :allowed_param => "value" })
+      handler.uri2indirection("GET", "#{url_prefix}/node/bar",
+                              { :environment => "env",
+                                :allowed_param => "value" })[3].should include({ :allowed_param => "value" })
     end
 
     it "should return the environment as a Puppet::Node::Environment" do
-      handler.uri2indirection("GET", "/v3/node/bar", params)[3][:environment].should be_a(Puppet::Node::Environment)
+      handler.uri2indirection("GET", "#{url_prefix}/node/bar", params)[3][:environment].should be_a(Puppet::Node::Environment)
     end
 
     it "should use the first field of the URI as the indirection name" do
-      handler.uri2indirection("GET", "/v3/node/bar", params)[0].name.should == :node
+      handler.uri2indirection("GET", "#{url_prefix}/node/bar", params)[0].name.should == :node
     end
 
     it "should fail if the indirection name is not alphanumeric" do
-      lambda { handler.uri2indirection("GET", "/v3/foo ness/bar", params) }.should raise_error(ArgumentError)
+      lambda { handler.uri2indirection("GET", "#{url_prefix}/foo ness/bar", params) }.should raise_error(ArgumentError)
     end
 
     it "should use the remainder of the URI as the indirection key" do
-      handler.uri2indirection("GET", "/v3/node/bar", params)[2].should == "bar"
+      handler.uri2indirection("GET", "#{url_prefix}/node/bar", params)[2].should == "bar"
     end
 
     it "should support the indirection key being a /-separated file path" do
-      handler.uri2indirection("GET", "/v3/node/bee/baz/bomb", params)[2].should == "bee/baz/bomb"
+      handler.uri2indirection("GET", "#{url_prefix}/node/bee/baz/bomb", params)[2].should == "bee/baz/bomb"
     end
 
     it "should fail if no indirection key is specified" do
-      lambda { handler.uri2indirection("GET", "/v3/node", params) }.should raise_error(ArgumentError)
+      lambda { handler.uri2indirection("GET", "#{url_prefix}/node", params) }.should raise_error(ArgumentError)
     end
 
     it "should choose 'find' as the indirection method if the http method is a GET and the indirection name is singular" do
-      handler.uri2indirection("GET", "/v3/node/bar", params)[1].should == :find
+      handler.uri2indirection("GET", "#{url_prefix}/node/bar", params)[1].should == :find
     end
 
     it "should choose 'find' as the indirection method if the http method is a POST and the indirection name is singular" do
-      handler.uri2indirection("POST", "/v3/node/bar", params)[1].should == :find
+      handler.uri2indirection("POST", "#{url_prefix}/node/bar", params)[1].should == :find
     end
 
     it "should choose 'head' as the indirection method if the http method is a HEAD and the indirection name is singular" do
-      handler.uri2indirection("HEAD", "/v3/node/bar", params)[1].should == :head
+      handler.uri2indirection("HEAD", "#{url_prefix}/node/bar", params)[1].should == :head
     end
 
     it "should choose 'search' as the indirection method if the http method is a GET and the indirection name is plural" do
-      handler.uri2indirection("GET", "/v3/nodes/bar", params)[1].should == :search
+      handler.uri2indirection("GET", "#{url_prefix}/nodes/bar", params)[1].should == :search
     end
 
     it "should change indirection name to 'status' if the http method is a GET and the indirection name is statuses" do
-      handler.uri2indirection("GET", "/v3/statuses/bar", params)[0].name.should == :status
+      handler.uri2indirection("GET", "#{url_prefix}/statuses/bar", params)[0].name.should == :status
     end
 
     it "should change indirection name to 'node' if the http method is a GET and the indirection name is nodes" do
-      handler.uri2indirection("GET", "/v3/nodes/bar", params)[0].name.should == :node
+      handler.uri2indirection("GET", "#{url_prefix}/nodes/bar", params)[0].name.should == :node
     end
 
     it "should choose 'delete' as the indirection method if the http method is a DELETE and the indirection name is singular" do
-      handler.uri2indirection("DELETE", "/v3/node/bar", params)[1].should == :destroy
+      handler.uri2indirection("DELETE", "#{url_prefix}/node/bar", params)[1].should == :destroy
     end
 
     it "should choose 'save' as the indirection method if the http method is a PUT and the indirection name is singular" do
-      handler.uri2indirection("PUT", "/v3/node/bar", params)[1].should == :save
+      handler.uri2indirection("PUT", "#{url_prefix}/node/bar", params)[1].should == :save
     end
 
     it "should fail if an indirection method cannot be picked" do
-      lambda { handler.uri2indirection("UPDATE", "/v3/node/bar", params) }.should raise_error(ArgumentError)
+      lambda { handler.uri2indirection("UPDATE", "#{url_prefix}/node/bar", params) }.should raise_error(ArgumentError)
     end
 
     it "should URI unescape the indirection key" do
       escaped = URI.escape("foo bar")
-      indirection, method, key, final_params = handler.uri2indirection("GET", "/v3/node/#{escaped}", params)
+      indirection, method, key, final_params = handler.uri2indirection("GET", "#{url_prefix}/node/#{escaped}", params)
       key.should == "foo bar"
     end
   end
@@ -195,12 +198,12 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
     end
 
     it "should include the environment in the query string of the URI" do
-      handler.class.request_to_uri(request).should == "/v3/foo/with%20spaces?environment=myenv&foo=bar"
+      handler.class.request_to_uri(request).should == "#{url_prefix}/foo/with%20spaces?environment=myenv&foo=bar"
     end
 
     it "should pluralize the indirection name if the method is 'search'" do
       request.stubs(:method).returns :search
-      handler.class.request_to_uri(request).split("/")[2].should == "foos"
+      handler.class.request_to_uri(request).split("/")[3].should == "foos"
     end
 
     it "should add the query string to the URI" do
@@ -214,16 +217,16 @@ describe Puppet::Network::HTTP::API::V3::IndirectedRoutes do
     let(:request) { Puppet::Indirector::Request.new(:foo, :find, "with spaces", nil, :foo => :bar, :environment => environment) }
 
     it "should use the indirection as the first field of the URI" do
-      handler.class.request_to_uri_and_body(request).first.split("/")[2].should == "foo"
+      handler.class.request_to_uri_and_body(request).first.split("/")[3].should == "foo"
     end
 
     it "should use the escaped key as the remainder of the URI" do
       escaped = URI.escape("with spaces")
-      handler.class.request_to_uri_and_body(request).first.split("/")[3].sub(/\?.+/, '').should == escaped
+      handler.class.request_to_uri_and_body(request).first.split("/")[4].sub(/\?.+/, '').should == escaped
     end
 
     it "should return the URI and body separately" do
-      handler.class.request_to_uri_and_body(request).should == ["/v3/foo/with%20spaces", "environment=myenv&foo=bar"]
+      handler.class.request_to_uri_and_body(request).should == ["#{url_prefix}/foo/with%20spaces", "environment=myenv&foo=bar"]
     end
   end
 

--- a/spec/unit/network/http/api/v3_spec.rb
+++ b/spec/unit/network/http/api/v3_spec.rb
@@ -4,28 +4,35 @@ require 'puppet/network/http'
 
 describe Puppet::Network::HTTP::API::V3 do
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+  let(:url_prefix) { "#{Puppet[:master_url_prefix]}/v3"}
+  let(:routes) {
+    Puppet::Network::HTTP::Route.
+        path(Regexp.new(Puppet[:master_url_prefix])).
+        any.
+        chain(Puppet::Network::HTTP::API::V3.routes)
+  }
 
   it "mounts the environments endpoint" do
-    request = Puppet::Network::HTTP::Request.from_hash(:path => "/v3/environments")
-    Puppet::Network::HTTP::API::V3.routes.process(request, response)
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{url_prefix}/environments")
+    routes.process(request, response)
 
     expect(response.code).to eq(200)
   end
 
   it "mounts indirected routes" do
     request = Puppet::Network::HTTP::Request.
-        from_hash(:path => "/v3/node/foo",
+        from_hash(:path => "#{url_prefix}/node/foo",
                   :params => {:environment => "production"},
                   :headers => {"accept" => "text/pson"})
-    Puppet::Network::HTTP::API::V3.routes.process(request, response)
+    routes.process(request, response)
 
     expect(response.code).to eq(200)
   end
 
   it "responds to unknown paths with a 404" do
-    request = Puppet::Network::HTTP::Request.from_hash(:path => "/v3/unknown")
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{url_prefix}/unknown")
+    routes.process(request, response)
 
-    Puppet::Network::HTTP::API::V3.routes.process(request, response)
     expect(response.code).to eq(404)
     expect(response.body).to match("Not Found: Could not find indirection 'unknown'")
   end

--- a/spec/unit/network/http/api_spec.rb
+++ b/spec/unit/network/http/api_spec.rb
@@ -1,0 +1,37 @@
+#! /usr/bin/env ruby
+
+require 'spec_helper'
+require 'puppet/network/http'
+
+describe Puppet::Network::HTTP::API do
+  def respond(text)
+    lambda { |req, res| res.respond_with(200, "text/plain", text) }
+  end
+
+  let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+
+  let(:routes) {
+    Puppet::Network::HTTP::Route.path(Regexp.new("foo")).
+    any.
+    chain(Puppet::Network::HTTP::Route.path(%r{^/bar$}).get(respond("bar")),
+          Puppet::Network::HTTP::API.not_found)
+  }
+
+  it "mounts the bar endpoint" do
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "foo/bar")
+    routes.process(request, response)
+
+    expect(response.code).to eq(200)
+    expect(response.body).to eq("bar")
+  end
+
+  it "responds to unknown paths with a 404" do
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "foo/unknown")
+
+    expect do
+      routes.process(request, response)
+    end.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError)
+  end
+end
+
+

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -405,7 +405,7 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
         source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
 
         conn.unstub(:request_get)
-        conn.expects(:request_get).with('/v3/file_content/test/foo%20bar?environment=testing&', anything).yields(response)
+        conn.expects(:request_get).with("#{Puppet[:master_url_prefix]}/v3/file_content/test/foo%20bar?environment=testing&", anything).yields(response)
 
         resource.write(source)
       end


### PR DESCRIPTION
This commit support for a configurable setting `master_url_prefix`, which
defaults to `/puppet`, that the master's http endpoints are mounted at. All
requests generated by the agent honor this prefix. This will allow us to mount
the Puppet HTTP endpoints in a namespaced URL space alongside other apps
running on the same webserver.