### PR TITLE
(maint) Update deep_merge to 1.0.1 on x86

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -26,7 +26,7 @@ build_msi:
     repo: 'git://github.com/puppetlabs/hiera.git'
   sys:
     ref:
-      x86: '0813124a1e06f0c98987b8e543d8c13b305a5ca0'
+      x86: '57068e7b7c87288c51ff39d96c80cfb509a42091'
       x64: '531319f5c121e98990772e018eb9781bf7dc6316'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'


### PR DESCRIPTION
Use the updated puppet-win32-ruby including deep_merge 1.0.1 for x86
builds. x64 builds already used 1.0.1, so this makes the gem versions
consistent.