### PR TITLE
(PUP-3806) Add missing support for interpolation in collection

### DIFF
--- a/lib/puppet/pops/evaluator/collector_transformer.rb
+++ b/lib/puppet/pops/evaluator/collector_transformer.rb
@@ -126,6 +126,10 @@ protected
     @@evaluator.evaluate(o, scope)
   end
 
+  def query_ConcatenatedString(o, scope)
+    @@evaluator.evaluate(o, scope)
+  end
+
   def query_LiteralNumber(o, scope)
     @@evaluator.evaluate(o, scope)
   end
@@ -169,6 +173,10 @@ protected
   end
 
   def match_LiteralString(o, scope)
+    @@evaluator.evaluate(o, scope)
+  end
+
+  def match_ConcatenatedString(o, scope)
     @@evaluator.evaluate(o, scope)
   end
 

--- a/spec/integration/parser/collector_spec.rb
+++ b/spec/integration/parser/collector_spec.rb
@@ -68,6 +68,35 @@ describe Puppet::Parser::Collector do
       MANIFEST
     end
 
+    it "matches with bare word" do
+      expect_the_message_to_be(["wanted"], <<-MANIFEST)
+        @notify { "testing": tag => ["one"], message => "wanted" }
+        Notify <| tag == one |>
+      MANIFEST
+    end
+
+    it "matches with single quoted string" do
+      expect_the_message_to_be(["wanted"], <<-MANIFEST)
+        @notify { "testing": tag => ["one"], message => "wanted" }
+        Notify <| tag == 'one' |>
+      MANIFEST
+    end
+
+    it "matches with double quoted string" do
+      expect_the_message_to_be(["wanted"], <<-MANIFEST)
+        @notify { "testing": tag => ["one"], message => "wanted" }
+        Notify <| tag == "one" |>
+      MANIFEST
+    end
+
+    it "matches with double quoted string with interpolated expression" do
+      expect_the_message_to_be(["wanted"], <<-MANIFEST)
+        @notify { "testing": tag => ["one"], message => "wanted" }
+        $x = 'one'
+        Notify <| tag == "$x" |>
+      MANIFEST
+    end
+
     it "allows criteria to be combined with 'and'" do
       expect_the_message_to_be(["the message"], <<-MANIFEST)
         @notify { "testing": message => "the message" }


### PR DESCRIPTION
The support for double quoted (interpolated) strings were
missing in the new implementation of collectors introduced in
PUP-2906.This was not detected since there is a parser optimization
that treats double quoted strings that does not require
interpolation as literal strings and there were no tests
that included double quited strings with interpolation of an expression.

This commit adds support for concatenated string (i.e. interpolation).