### PR TITLE
(PUP-3750) Support :include: in mailalias type

### DIFF
--- a/lib/puppet/provider/mailalias/aliases.rb
+++ b/lib/puppet/provider/mailalias/aliases.rb
@@ -11,28 +11,39 @@ Puppet::Type.type(:mailalias).provide(
 
   record_line :aliases, :fields => %w{name recipient}, :separator => /\s*:\s*/, :block_eval => :instance do
     def post_parse(record)
-      record[:recipient] = record[:recipient].split(/\s*,\s*/).collect { |d| d.gsub(/^['"]|['"]$/, '') }
+      if record[:recipient]
+	record[:recipient] = record[:recipient].split(/\s*,\s*/).collect { |d| d.gsub(/^['"]|['"]$/, '') }
+      end
       record
     end
 
     def process(line)
       ret = {}
-      records = line.split(':',2)
+      records = line.split(':',4)
       ret[:name] = records[0].strip
-      ret[:recipient] = records[1].strip
+      if records.length == 4 and records[2].strip == 'include'
+	ret[:file] = records[3].strip
+      else
+	records = line.split(':',2)
+	ret[:recipient] = records[1].strip
+      end
       ret
     end
 
     def to_line(record)
-      dest = record[:recipient].collect do |d|
-        # Quote aliases that have non-alpha chars
-        if d =~ /[^-\w@.]/
-          '"%s"' % d
-        else
-          d
-        end
-      end.join(",")
-      "#{record[:name]}: #{dest}"
+      if record[:recipient]
+	dest = record[:recipient].collect do |d|
+	  # Quote aliases that have non-alpha chars
+	  if d =~ /[^-\w@.]/
+	    '"%s"' % d
+	  else
+	    d
+	  end
+	end.join(",")
+	"#{record[:name]}: #{dest}"
+      elsif record[:file]
+	"#{record[:name]}: :include: #{record[:file]}"
+      end
     end
   end
 end

--- a/lib/puppet/type/mailalias.rb
+++ b/lib/puppet/type/mailalias.rb
@@ -10,7 +10,8 @@ module Puppet
 
     newproperty(:recipient, :array_matching => :all) do
       desc "Where email should be sent.  Multiple values
-        should be specified as an array."
+        should be specified as an array.  The file and the
+        recipient entries are mutually exclusive."
 
       def is_to_s(value)
         if value.include?(:absent)
@@ -20,16 +21,23 @@ module Puppet
         end
       end
 
-      def should
-        @should
-      end
-
       def should_to_s(value)
         if value.include?(:absent)
           super
         else
           value.join(",")
         end
+      end
+    end
+
+    newproperty(:file) do
+      desc "A file containing the alias's contents.  The file and the
+        recipient entries are mutually exclusive."
+
+      validate do |value|
+	unless Puppet::Util.absolute_path?(value)
+	  fail Puppet::Error, "File paths must be fully qualified, not '#{value}'"
+	end
       end
     end
 
@@ -43,6 +51,12 @@ module Puppet
           nil
         end
       }
+    end
+
+    validate do
+      if self[:recipient] && self[:file]
+	self.fail "You cannot specify both a recipient and a file"
+      end
     end
   end
 end

--- a/spec/fixtures/integration/provider/mailalias/aliases/test1
+++ b/spec/fixtures/integration/provider/mailalias/aliases/test1
@@ -26,3 +26,6 @@ decode:     root
 # Other tests
 anothertest: "|/path/to/rt-mailgate --queue 'another test' --action correspond --url http://my.com/"
 test: "|/path/to/rt-mailgate --queue 'test' --action correspond --url http://my.com/"
+
+# Included file
+incfile: :include: /tmp/somefile

--- a/spec/unit/type/mailalias_spec.rb
+++ b/spec/unit/type/mailalias_spec.rb
@@ -5,17 +5,44 @@ describe Puppet::Type.type(:mailalias) do
   include PuppetSpec::Files
 
   let :target do tmpfile('mailalias') end
-  let :resource do
+  let :recipient_resource do
     described_class.new(:name => "luke", :recipient => "yay", :target => target)
   end
 
-  it "should be initially absent" do
-    resource.retrieve_resource[:recipient].should == :absent
+  let :file_resource do
+    described_class.new(:name => "lukefile", :file => "/tmp/afile", :target => target)
+  end
+
+  it "should be initially absent as a recipient" do
+    recipient_resource.retrieve_resource[:recipient].should == :absent
+  end
+
+  it "should be initially absent as an included file" do
+    file_resource.retrieve_resource[:file].should == :absent
   end
 
   it "should try and set the recipient when it does the sync" do
-    resource.retrieve_resource[:recipient].should == :absent
-    resource.property(:recipient).expects(:set).with(["yay"])
-    resource.property(:recipient).sync
+    recipient_resource.retrieve_resource[:recipient].should == :absent
+    recipient_resource.property(:recipient).expects(:set).with(["yay"])
+    recipient_resource.property(:recipient).sync
+  end
+
+  it "should try and set the included file when it does the sync" do
+    file_resource.retrieve_resource[:file].should == :absent
+    file_resource.property(:file).expects(:set).with("/tmp/afile")
+    file_resource.property(:file).sync
+  end
+
+  it "should fail when file is not an absolute path" do
+    expect {
+      Puppet::Type.type(:mailalias).new(:name => 'x', :file => 'afile')
+    }.to raise_error Puppet::Error, /File paths must be fully qualified/
+  end
+
+  it "should fail when both file and recipient are specified" do
+    expect {
+      Puppet::Type.type(:mailalias).new(:name => 'x', :file => '/tmp/afile',
+					:recipient => 'foo@example.com')
+    }.to raise_error Puppet::Error, /cannot specify both a recipient and a file/
   end
 end


### PR DESCRIPTION
The mailalias type does not allow the specification of included files,
which contain an alias's elements. Such alias entries are commonly
specified in the an MTA's aliases file through the following syntax.

aliasname: :include: /path/to/file

Specifying the rest of an ":include:" line as a recipient does not
work, because the existing mailalias type will quote the entry.

This change adds a new parameter named "file" to the mailalias type,
which allows the indirect specification of a file containing the
recipients.  The parameter parses and generates ":include:" alias entries.

Also, as recommended by @joshcooper, remove legacy unneeded "should" from
recipient property implementation.  This fixes a gratuitous difference
between the new file property implementation and the recipient property
one.