### PR TITLE
(PUP-3750) Use tmpfile to generate temporary path

### DIFF
--- a/spec/unit/type/mailalias_spec.rb
+++ b/spec/unit/type/mailalias_spec.rb
@@ -4,12 +4,7 @@ require 'spec_helper'
 describe Puppet::Type.type(:mailalias) do
   include PuppetSpec::Files
 
-  if Puppet.features.microsoft_windows?
-    tmpfile_path = 'C:\\afile'
-  else
-    tmpfile_path = '/tmp/afile'
-  end
-
+  let :tmpfile_path do tmpfile('afile') end
   let :target do tmpfile('mailalias') end
   let :recipient_resource do
     described_class.new(:name => "luke", :recipient => "yay", :target => target)


### PR DESCRIPTION
Use tmpfile to generate a cross-platform temporary file path for
verifying mailalias file include.