### PR TITLE
(PUP-1343) Use chkconfig --add to ensure K-symlinks get installed

### DIFF
--- a/acceptance/tests/resource/service/ticket_1343_should_add_and_remove_symlinks.rb
+++ b/acceptance/tests/resource/service/ticket_1343_should_add_and_remove_symlinks.rb
@@ -1,5 +1,7 @@
 test_name 'RedHat Service Symlink Validation'
 
+confine :to, :platform => 'el-5' 
+
 manifest_httpd_setup = %Q{
   package { 'httpd':
     ensure => present,

--- a/acceptance/tests/resource/service/ticket_1343_should_add_and_remove_symlinks.rb
+++ b/acceptance/tests/resource/service/ticket_1343_should_add_and_remove_symlinks.rb
@@ -1,0 +1,54 @@
+test_name 'RedHat Service Symlink Validation'
+
+manifest_httpd_setup = %Q{
+  package { 'httpd':
+    ensure => present,
+  }
+}
+
+manifest_httpd_enabled = %Q{
+  package { 'httpd':
+    ensure => present,
+  }
+  service { 'httpd':
+    enable => true,
+  }
+}
+
+manifest_httpd_disabled = %Q{
+  package { 'httpd':
+    ensure => present,
+  }
+  service { 'httpd':
+    enable => false,
+  }
+}
+
+init_script = "/etc/init.d/httpd"
+start_symlink = "S85httpd"
+kill_symlink = "K15httpd"
+
+start_runlevels = ["2", "3", "4", "5"]
+kill_runlevels = ["0", "1", "6"]
+
+agents.each do |agent|
+  step "setting up test preconditions"
+  apply_manifest_on(agent, manifest_httpd_setup, :catch_failures => true) do
+    # chkconfig --del will remove all rc.d symlinks for this service
+    on agent, "chkconfig --del httpd"
+  end
+
+  step "ensure enabling httpd creates the S-symlinks"
+  apply_manifest_on(agent, manifest_httpd_enabled, :catch_failures => true) do
+    start_runlevels.each do |runlevel|
+      on agent, "test -L /etc/rc.d/rc#{runlevel}.d/#{start_symlink} && test -f #{init_script}"
+    end
+  end
+
+  step "ensure enabling httpd creates the K-symlinks"
+  apply_manifest_on(agent, manifest_httpd_enabled, :catch_failures => true) do
+    kill_runlevels.each do |runlevel|
+      on agent, "test -L /etc/rc.d/rc#{runlevel}.d/#{kill_symlink} && test -f #{init_script}"
+    end
+  end
+end

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -55,7 +55,8 @@ describe provider_class, :as_platform => :posix do
     end
   end
 
-  it "(#15797) should use 'on' when calling enable" do
+  it "should use '--add' and 'on' when calling enable" do
+    provider_class.expects(:chkconfig).with("--add", @resource[:name])
     provider_class.expects(:chkconfig).with(@resource[:name], :on)
     @provider.enable
   end


### PR DESCRIPTION
On RHEL/CentOS 5 systems, the use of chkconfig on to enable a service
does not create the K-symlinks in /etc/rc.d to shut down the service.
Running chkconfig --add before chkconfig on fixes this issue, and
should be harmless on the unaffected OS versions.

The rspec unit test has been updated, and a new acceptance test
included to validate the bugfix.