### PR TITLE
(maint) Add Puppet::Indirector::Request#description for better errors

### DIFF
--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -294,7 +294,7 @@ class Puppet::Indirector::Indirection
     return unless terminus.respond_to?(:authorized?)
 
     unless terminus.authorized?(request)
-      msg = "Not authorized to call #{request.method} on #{request}"
+      msg = "Not authorized to call #{request.method} on #{request.description}"
       msg += " with #{request.options.inspect}" unless request.options.empty?
       raise ArgumentError, msg
     end
@@ -305,7 +305,7 @@ class Puppet::Indirector::Indirection
     # Pick our terminus.
     if respond_to?(:select_terminus)
       unless terminus_name = select_terminus(request)
-        raise ArgumentError, "Could not determine appropriate terminus for #{request}"
+        raise ArgumentError, "Could not determine appropriate terminus for #{request.description}"
       end
     else
       terminus_name = terminus_class

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -176,6 +176,10 @@ class Puppet::Indirector::Request
     result
   end
 
+  def description
+    return(uri ? uri : "/#{indirection_name}/#{key}")
+  end
+
   def do_request(srv_service=:puppet, default_server=Puppet.settings[:server], default_port=Puppet.settings[:masterport], &block)
     # We were given a specific server to use, so just use that one.
     # This happens if someone does something like specifying a file

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -207,8 +207,18 @@ describe Puppet::Indirector::Request do
     Puppet::Indirector::Request.new(:myind, :find, :key, nil).should_not be_plural
   end
 
-  it "should use its indirection name and key, if it has no uri, as its string representation" do
-    Puppet::Indirector::Request.new(:myind, :find, "key", nil) == "/myind/key"
+  it "should use its uri, if it has one, as its description" do
+    Puppet.override({
+      :environments => Puppet::Environments::Static.new(
+        Puppet::Node::Environment.create(:baz, [])
+    )},
+      "Static loader for spec") do
+      Puppet::Indirector::Request.new(:myind, :find, "foo://bar/baz", nil).description.should == "foo://bar/baz"
+      end
+  end
+
+  it "should use its indirection name and key, if it has no uri, as its description" do
+    Puppet::Indirector::Request.new(:myind, :find, "key", nil).description.should == "/myind/key"
   end
 
   it "should be able to return the URI-escaped key" do


### PR DESCRIPTION
The `to_s` method on Puppet::Indirector::Request was removed in
fd7c4f912d3f26977863faaec91e010c9bc48abb, without realizing that it was used
to make two error messages more useful. This adds back this functionality,
renamed to `description`.