### PR TITLE
Confine test ticket_1343 to el-5

### DIFF
--- a/acceptance/tests/resource/service/ticket_1343_should_add_and_remove_symlinks.rb
+++ b/acceptance/tests/resource/service/ticket_1343_should_add_and_remove_symlinks.rb
@@ -1,5 +1,7 @@
 test_name 'RedHat Service Symlink Validation'
 
+confine :to, :platform => 'el-5' 
+
 manifest_httpd_setup = %Q{
   package { 'httpd':
     ensure => present,


### PR DESCRIPTION
This fixes the acceptance test failures happening for all the
platforms this test wasn't intended for.