### PR TITLE
Maint/minor pmt cleanup

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -128,10 +128,8 @@ class Puppet::Module
       # not have to support, but we have a reasonable number of releases that
       # don't use `version_requirement`. When we can deprecate this, we should.
       if attr == :dependencies
-        value.tap do |dependencies|
-          dependencies.each do |dep|
-            dep['version_requirement'] ||= dep['versionRequirement'] || '>= 0.0.0'
-          end
+        value.each do |dep|
+          dep['version_requirement'] ||= dep['versionRequirement'] || '>= 0.0.0'
         end
       end
 

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -101,19 +101,17 @@ module Puppet::ModuleTool
               # Since upgrading already installed modules can be troublesome,
               # we'll place constraints on the graph for each installed module,
               # locking it to upgrades within the same major version.
-              ">=#{version} #{version.major}.x".tap do |range|
-                graph.add_constraint('installed', mod, range) do |node|
-                  Semantic::VersionRange.parse(range).include? node.version
-                end
+              installed_range = ">=#{version} #{version.major}.x"
+              graph.add_constraint('installed', mod, installed_range) do |node|
+                Semantic::VersionRange.parse(installed_range).include? node.version
               end
 
               release.mod.dependencies.each do |dep|
                 dep_name = dep['name'].tr('/', '-')
 
-                dep['version_requirement'].tap do |range|
-                  graph.add_constraint("#{mod} constraint", dep_name, range) do |node|
-                    Semantic::VersionRange.parse(range).include? node.version
-                  end
+                range = dep['version_requirement']
+                graph.add_constraint("#{mod} constraint", dep_name, range) do |node|
+                  Semantic::VersionRange.parse(range).include? node.version
                 end
               end
             end

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -117,19 +117,17 @@ module Puppet::ModuleTool
               # Since upgrading already installed modules can be troublesome,
               # we'll place constraints on the graph for each installed
               # module, locking it to upgrades within the same major version.
-              ">=#{version} #{version.major}.x".tap do |range|
-                graph.add_constraint('installed', installed_module, range) do |node|
-                  Semantic::VersionRange.parse(range).include? node.version
-                end
+              installed_range = ">=#{version} #{version.major}.x"
+              graph.add_constraint('installed', installed_module, installed_range) do |node|
+                Semantic::VersionRange.parse(installed_range).include? node.version
               end
 
               release.mod.dependencies.each do |dep|
                 dep_name = dep['name'].tr('/', '-')
 
-                dep['version_requirement'].tap do |range|
-                  graph.add_constraint("#{installed_module} constraint", dep_name, range) do |node|
-                    Semantic::VersionRange.parse(range).include? node.version
-                  end
+                range = dep['version_requirement']
+                graph.add_constraint("#{installed_module} constraint", dep_name, range) do |node|
+                  Semantic::VersionRange.parse(range).include? node.version
                 end
               end
             end

--- a/lib/puppet/module_tool/contents_description.rb
+++ b/lib/puppet/module_tool/contents_description.rb
@@ -62,23 +62,27 @@ module Puppet::ModuleTool
     # Return an array of hashes representing this +type+'s attrs of +kind+
     # (e.g. :param or :property), each containing :name and :doc.
     def attr_doc(type, kind)
-      [].tap do |attrs|
-        type.allattrs.each do |name|
-          if type.attrtype(name) == kind && name != :provider
-            attrs.push(:name => name, :doc => type.attrclass(name).doc)
-          end
+      attrs = []
+
+      type.allattrs.each do |name|
+        if type.attrtype(name) == kind && name != :provider
+          attrs.push(:name => name, :doc => type.attrclass(name).doc)
         end
       end
+
+      attrs
     end
 
     # Return an array of hashes representing this +type+'s providers, each
     # containing :name and :doc.
     def provider_doc(type)
-      [].tap do |providers|
-        type.providers.sort.each do |prov|
-          providers.push(:name => prov, :doc => type.provider(prov).doc)
-        end
+      providers = []
+
+      type.providers.sort.each do |prov|
+        providers.push(:name => prov, :doc => type.provider(prov).doc)
       end
+
+      providers
     end
   end
 end

--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -73,10 +73,8 @@ module Puppet::ModuleTool
             results = Puppet::ModuleTool.parse_module_dependency(release, dependency)
             dep_name, parsed_range, range = results
 
-            dependency.tap do |dep|
-              add_constraint('initialize', dep_name, range.to_s) do |node|
-                parsed_range === node.version
-              end
+            add_constraint('initialize', dep_name, range.to_s) do |node|
+              parsed_range === node.version
             end
           end
         end


### PR DESCRIPTION
This removes some uses of `tap` in the PMT code. There should be no functional change, but the commits either remove dead code or make the code more readable (to my eyes).

This came out of some observations @joshcooper made when reviewing #3427.

/cc @andersonmills 