### PR TITLE
(PUP-3787) Add leading '0' to ensure four-digit octal notation of file modes in Windows

### DIFF
--- a/lib/puppet/provider/file/windows.rb
+++ b/lib/puppet/provider/file/windows.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:file).provide :windows do
   def mode
     if resource.stat
       mode = get_mode(resource[:path])
-      mode ? mode.to_s(8) : :absent
+      mode ? mode.to_s(8).rjust(4, '0') : :absent
     else
       :absent
     end

--- a/spec/unit/provider/file/windows_spec.rb
+++ b/spec/unit/provider/file/windows_spec.rb
@@ -18,11 +18,11 @@ describe Puppet::Type.type(:file).provider(:windows), :if => Puppet.features.mic
   let(:account)  { 'quinn' }
 
   describe "#mode" do
-    it "should return a string with the higher-order bits stripped away" do
+    it "should return a string representing the mode in 4-digit octal notation" do
       FileUtils.touch(path)
       WindowsSecurity.set_mode(0644, path)
 
-      provider.mode.should == '644'
+      provider.mode.should == '0644'
     end
 
     it "should return absent if the file doesn't exist" do
@@ -37,12 +37,12 @@ describe Puppet::Type.type(:file).provider(:windows), :if => Puppet.features.mic
 
       provider.mode = '0755'
 
-      provider.mode.should == '755'
+      provider.mode.should == '0755'
     end
 
     it "should pass along any errors encountered" do
       expect do
-        provider.mode = '644'
+        provider.mode = '0644'
       end.to raise_error(Puppet::Error, /failed to set mode/)
     end
   end


### PR DESCRIPTION
This change is a followup to commit 54f6159102, which added leading '0's
to ensure four-digit octal notation on file modes in the POSIX file
provider. This commit does the same for the Windows file provider.