### PR TITLE
(WIP DO NOT MERGE)(PUP-3837) Ensure Ruby 2.1.5 on Windows

### DIFF
--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -32,15 +32,20 @@ module Puppet::Util::Windows
 
     def values(subkey)
       values = {}
-      subkey.each_value do |name, type, data|
-        case type
-        when Win32::Registry::REG_MULTI_SZ
-          data.each { |str| force_encoding(str) }
-        when Win32::Registry::REG_SZ, Win32::Registry::REG_EXPAND_SZ
-          force_encoding(data)
+      begin
+        subkey.each_value do |name, type, data|
+          case type
+            when Win32::Registry::REG_MULTI_SZ
+              data.each { |str| force_encoding(str) }
+            when Win32::Registry::REG_SZ, Win32::Registry::REG_EXPAND_SZ
+              force_encoding(data)
+          end
+          values[name] = data
         end
-        values[name] = data
+      rescue Encoding::UndefinedConversionError => error
+        raise Puppet::Error.new("Failed to get registry key values for '#{subkey.name}'.\n  #{error.to_s}")
       end
+
       values
     end
 

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -4,7 +4,7 @@ require 'etc'
 
 provider_class = Puppet::Type.type(:user).provider(:hpuxuseradd)
 
-describe provider_class do
+describe provider_class, :unless => Puppet.features.microsoft_windows? do
   let :resource do
     Puppet::Type.type(:user).new(
       :title => 'testuser',


### PR DESCRIPTION
This provides the necessary changes so that Puppet will run with Ruby 2.1.5 on Windows.

* Confined Hpux.password spec not to run on Windows. See commit for specifics.