### PR TITLE
(PUP-3488) Stop overwriting agent's facts timestamp

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -31,8 +31,6 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
         raise Puppet::Error, "Catalog for #{request.key.inspect} was requested with fact definition for the wrong node (#{facts.name.inspect})."
       end
 
-      facts.add_timestamp
-
       options = {
         :environment => request.environment,
         :transaction_uuid => request.options[:transaction_uuid],

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -150,15 +150,12 @@ describe Puppet::Resource::Catalog::Compiler do
       @compiler.extract_facts_from_request(request).should be_nil
     end
 
-    it "deserializes the facts and timestamps them" do
-      @facts.timestamp = Time.parse('2010-11-01')
+    it "should deserialize the facts without changing the timestamp" do
+      time = Time.now
+      @facts.timestamp = time
       request = a_request_that_contains(@facts)
-      now = Time.parse('2010-11-02')
-      Time.stubs(:now).returns(now)
-
       facts = @compiler.extract_facts_from_request(request)
-
-      facts.timestamp.should == now
+      expect(facts.timestamp).to eq(time)
     end
 
     it "should convert the facts into a fact instance and save it" do


### PR DESCRIPTION
This commit undoes a change made in commit fb5f859cf4 that
causes the master to alter the agent's facts timestamp when
they are received by the catalog compiler.

With this change, the facts timestamp is always based on the
agent's time.