### PR TITLE
(PUP-3755) Make compile for a node use compiler's context for transform

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -31,7 +31,7 @@ class Puppet::Parser::Compiler
       raise(Puppet::Error, errmsg.join(' '))
     end
 
-    new(node).compile.to_resource
+    new(node).compile {|resulting_catalog| resulting_catalog.to_resource }
   rescue => detail
     message = "#{detail} on node #{node.name}"
     Puppet.log_exception(detail, message)
@@ -140,7 +140,11 @@ class Puppet::Parser::Compiler
 
       fail_on_unevaluated
 
-      @catalog
+      if block_given?
+        yield @catalog
+      else
+        @catalog
+      end
     end
   end
 

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -522,4 +522,20 @@ describe "Puppet::Parser::Compiler" do
       expect(catalog).to have_resource("Notify[nbr2]").with_parameter(:message, 'overridden')
     end
   end
+
+
+  context "when converting catalog to resource" do
+    it "the same environment is used for compilation as for transformation to resource form" do
+        Puppet[:code] = <<-MANIFEST
+          notify { 'dummy':
+          }
+        MANIFEST
+
+      Puppet::Parser::Resource::Catalog.any_instance.expects(:to_resource).with do |catalog|
+        Puppet.lookup(:current_environment).name == :production
+      end
+
+      Puppet::Parser::Compiler.compile(Puppet::Node.new("mynode"))
+    end
+  end
 end

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -78,17 +78,6 @@ describe Puppet::Parser::Compiler do
     @scope.resource = @scope_resource
   end
 
-  it "should have a class method that compiles, converts, and returns a catalog" do
-    compiler = stub 'compiler'
-    Puppet::Parser::Compiler.expects(:new).with(@node).returns compiler
-    catalog = stub 'catalog'
-    compiler.expects(:compile).returns catalog
-    converted_catalog = stub 'converted_catalog'
-    catalog.expects(:to_resource).returns converted_catalog
-
-    Puppet::Parser::Compiler.compile(@node).should equal(converted_catalog)
-  end
-
   it "should fail intelligently when a class-level compile fails" do
     Puppet::Parser::Compiler.expects(:new).raises ArgumentError
     lambda { Puppet::Parser::Compiler.compile(@node) }.should raise_error(Puppet::Error)
@@ -115,22 +104,6 @@ describe Puppet::Parser::Compiler do
     @compiler.add_class "two"
 
     @compiler.classlist.sort.should == %w{one two}.sort
-  end
-
-  it "should clear the global caches before compile" do
-    compiler = stub 'compiler'
-    Puppet::Parser::Compiler.expects(:new).with(@node).returns compiler
-    catalog = stub 'catalog'
-    compiler.expects(:compile).returns catalog
-    catalog.expects(:to_resource)
-
-    $known_resource_types = "rspec"
-    $env_module_directories = "rspec"
-
-    Puppet::Parser::Compiler.compile(@node)
-
-    $known_resource_types = nil
-    $env_module_directories = nil
   end
 
   describe "when initializing" do


### PR DESCRIPTION
Without this fix, the final step of compiling a catalog for a node will
transform the produced catalog to resource form in a context that is not
configured for the environment used to compule the catalog. This can
lead to a wide variety of problems since there is a high chans that
unrelated code gets loaded and this code may have errors, may cause side
effects and cause the catalog to silently contain a result different
from the intended.

The fix is simple - the compile method now accepts a block that it
yields the produced catalog to if the block is given in a call to
compile. This is then used instead of simply calling to_resource on the
produced result.

As a conseuence of the change mocking tests were failing. As it was
found that these tests were meaningless and testing nothing they were
removed.