### PR TITLE
(PUP-3601) - Upgrade win32-eventlog to 0.6.2

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -30,7 +30,7 @@ gem_platform_dependencies:
       # Pinning versions that require native extensions
       ffi: '~> 1.9.5'
       win32-dir: '~> 0.4.9'
-      win32-eventlog: '~> 0.6.1'
+      win32-eventlog: '~> 0.6.2'
       win32-process: '~> 0.7.4'
       win32-security: '~> 0.2.5'
       win32-service: '~> 0.8.6'
@@ -40,7 +40,7 @@ gem_platform_dependencies:
     gem_runtime_dependencies:
       ffi: '~> 1.9.5'
       win32-dir: '~> 0.4.9'
-      win32-eventlog: '~> 0.6.1'
+      win32-eventlog: '~> 0.6.2'
       win32-process: '~> 0.7.4'
       win32-security: '~> 0.2.5'
       win32-service: '~> 0.8.6'

--- a/spec/integration/agent/logging_spec.rb
+++ b/spec/integration/agent/logging_spec.rb
@@ -88,10 +88,6 @@ describe 'agent logging' do
     else
 
       it "when evoked with #{argv}, logs to #{expected[:loggers].inspect} at level #{expected[:level]}" do
-        if Facter.value(:kernelmajversion).to_f < 6.0
-          pending("requires win32-eventlog gem upgrade to 0.6.2 on Windows 2003")
-        end
-
         # This logger is created by the Puppet::Settings object which creates and
         # applies a catalog to ensure that configuration files and users are in
         # place.

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -199,12 +199,6 @@ end
 
 
 describe ":eventlog", :if => Puppet::Util::Platform.windows? do
-  before do
-    if Facter.value(:kernelmajversion).to_f < 6.0
-      pending("requires win32-eventlog gem upgrade to 0.6.2 on Windows 2003")
-    end
-  end
-
   let(:klass) { Puppet::Util::Log.desttypes[:eventlog] }
 
   def expects_message_with_type(klass, level, eventlog_type, eventlog_id)


### PR DESCRIPTION
 - Previously win32-eventlog 0.6.1 was referenced for the sake of
   source development on Windows.  However, as part of the MSI
   distribution, 0.6.1 + a critical patch for Windows 2003 is shipped.
   This commit ensures that test execution is restored on Windows 2003
   and that 0.6.2, which incorporates the critical fix, is used for
   development from source on Windows.

   The original test changes were introduced as part of PUP-2889 and
   merged in as 6fdea01544f6025abf84d68d1ba9a222c87ea488