### PR TITLE
(PUP-3526) Add configurable prefix for CA routes

### DIFF
--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -30,7 +30,7 @@ master_opts = {
 step 'run master; ensure production environment created'
 with_puppet_running_on(master, master_opts, testdir) do
   if master.is_using_passenger?
-    on(master, "curl -k --cert #{cert_path} --key #{key_path} --cacert #{cacert_path} https://localhost:8140/v2.0/environments")
+    on(master, "curl -k --cert #{cert_path} --key #{key_path} --cacert #{cacert_path} https://localhost:8140/puppet/v2.0/environments")
   end
   on(master, "test -d '#{testdir}/environments/production'")
 

--- a/acceptance/tests/external_ca_support/fixtures/auth.conf
+++ b/acceptance/tests/external_ca_support/fixtures/auth.conf
@@ -14,7 +14,7 @@ allow *.example.org
 allow $1
 
 # allow all nodes to access the certificates services
-path /ca/v1/certificate_revocation_list/ca
+path /puppet-ca/v1/certificate_revocation_list/ca
 method find
 allow *
 
@@ -37,19 +37,19 @@ allow *
 
 # allow access to the CA certificate; unauthenticated nodes need this
 # in order to validate the puppet master's certificate
-path /ca/v1/certificate/ca
+path /puppet-ca/v1/certificate/ca
 auth any
 method find
 allow *
 
 # allow nodes to retrieve the certificate they requested earlier
-path /ca/v1/certificate/
+path /puppet-ca/v1/certificate/
 auth any
 method find
 allow *
 
 # allow nodes to request a new certificate
-path /ca/v1/certificate_request
+path /puppet-ca/v1/certificate_request
 auth any
 method find, save
 allow *

--- a/acceptance/tests/external_ca_support/fixtures/auth.conf
+++ b/acceptance/tests/external_ca_support/fixtures/auth.conf
@@ -1,4 +1,4 @@
-# Puppet 3.1.1 auth.conf, modified to allow requests from example.org for
+# Puppet 4.0.0 auth.conf, modified to allow requests from example.org for
 # external ca testing.
 
 # allow nodes to retrieve their own catalog
@@ -14,7 +14,7 @@ allow *.example.org
 allow $1
 
 # allow all nodes to access the certificates services
-path /puppet/v3/certificate_revocation_list/ca
+path /ca/v1/certificate_revocation_list/ca
 method find
 allow *
 
@@ -37,19 +37,19 @@ allow *
 
 # allow access to the CA certificate; unauthenticated nodes need this
 # in order to validate the puppet master's certificate
-path /puppet/v3/certificate/ca
+path /ca/v1/certificate/ca
 auth any
 method find
 allow *
 
 # allow nodes to retrieve the certificate they requested earlier
-path /puppet/v3/certificate/
+path /ca/v1/certificate/
 auth any
 method find
 allow *
 
 # allow nodes to request a new certificate
-path /puppet/v3/certificate_request
+path /ca/v1/certificate_request
 auth any
 method find, save
 allow *

--- a/acceptance/tests/external_ca_support/fixtures/certchain.sh
+++ b/acceptance/tests/external_ca_support/fixtures/certchain.sh
@@ -455,7 +455,7 @@ check_puppetmaster() {
             --header 'Accept: yaml' \
             --cert "${B}/leaves/client2a.example.org.crt" \
             --key "${B}/leaves/client2a.example.org.key" \
-        "https://127.0.0.1:${HTTPS_PORT}/production/catalog/client2a.example.org" >/dev/null
+        "https://127.0.0.1:${HTTPS_PORT}/puppet/v3/catalog/client2a.example.org?environment=production" >/dev/null
     echo
 }
 

--- a/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
+++ b/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
@@ -25,8 +25,8 @@ test_name "CVE 2013-1652 Poison node cache" do
       exploited = "#{yamldir}/node/you.lose.yaml"
       on master, "rm -rf #{exploited}"
       on master, "rm -rf #{yamldir}/node/*"
-      payload2 = "https://#{master}:8140/production/node/#{certname}?instance=" +
-                 "---+%21ruby%2Fobject%3APuppet%3A%3ANode%0A+classes" +
+      payload2 = "https://#{master}:8140/puppet/v3/node/#{certname}?environment=production" +
+                 "&instance=---+%21ruby%2Fobject%3APuppet%3A%3ANode%0A+classes" +
                  "%3A%0A+-+foo%0A+name%3A+you.lose%0A+parameters" +
                  "%3A+%7B%7D%0A+time%3A+2013-02-28+15%3A12%3A30.367008+-08%3A00"
 

--- a/acceptance/tests/security/cve-2013-4761_resource_type.rb
+++ b/acceptance/tests/security/cve-2013-4761_resource_type.rb
@@ -42,7 +42,7 @@ allow *
 
       step "Request a type that maps to the exploit file" do
         type_name = "::..::..::..::..::..::tmp::exploit"
-        payload = "https://#{master}:8140/production/resource_type/#{type_name}"
+        payload = "https://#{master}:8140/puppet/v3/resource_type/#{type_name}?environment=production"
         cert_path = on(agent, puppet("agent", "--configprint hostcert")).stdout.chomp
         key_path = on(agent, puppet("agent", "--configprint hostprivkey")).stdout.chomp
         curl_base = "curl --tlsv1 -g --cert \"#{cert_path}\" --key \"#{key_path}\" -k -H 'Accept: pson'"

--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -71,7 +71,7 @@ method find
 allow $1
 
 # allow all nodes to access the certificates services
-path /ca/v1/certificate_revocation_list/ca
+path /puppet-ca/v1/certificate_revocation_list/ca
 method find
 allow *
 
@@ -93,19 +93,19 @@ allow *
 
 # allow access to the CA certificate; unauthenticated nodes need this
 # in order to validate the puppet master's certificate
-path /ca/v1/certificate/ca
+path /puppet-ca/v1/certificate/ca
 auth any
 method find
 allow *
 
 # allow nodes to retrieve the certificate they requested earlier
-path /ca/v1/certificate/
+path /puppet-ca/v1/certificate/
 auth any
 method find
 allow *
 
 # allow nodes to request a new certificate
-path /ca/v1/certificate_request
+path /puppet-ca/v1/certificate_request
 auth any
 method find, save
 allow *

--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -71,7 +71,7 @@ method find
 allow $1
 
 # allow all nodes to access the certificates services
-path /puppet/v3/certificate_revocation_list/ca
+path /ca/v1/certificate_revocation_list/ca
 method find
 allow *
 
@@ -93,19 +93,19 @@ allow *
 
 # allow access to the CA certificate; unauthenticated nodes need this
 # in order to validate the puppet master's certificate
-path /puppet/v3/certificate/ca
+path /ca/v1/certificate/ca
 auth any
 method find
 allow *
 
 # allow nodes to retrieve the certificate they requested earlier
-path /puppet/v3/certificate/
+path /ca/v1/certificate/
 auth any
 method find
 allow *
 
 # allow nodes to request a new certificate
-path /puppet/v3/certificate_request
+path /ca/v1/certificate_request
 auth any
 method find, save
 allow *

--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -37,18 +37,18 @@
 #
 # Examples:
 #
-# path ~ ^/path/to/resource    # Equivalent to `path /path/to/resource`.
-# allow *                      # Allow all authenticated nodes (since auth
-#                              # defaults to `yes`).
+# path ~ ^/puppet/v3/path/to/resource    # Equivalent to `path /puppet/v3/path/to/resource`.
+# allow *                                # Allow all authenticated nodes (since auth
+#                                        # defaults to `yes`).
 #
-# path ~ ^/catalog/([^/]+)$    # Permit nodes to access their own catalog (by
-# allow $1                     # certname), but not any other node's catalog.
+# path ~ ^/puppet/v3/catalog/([^/]+)$    # Permit nodes to access their own catalog (by
+# allow $1                               # certname), but not any other node's catalog.
 #
-# path ~ ^/file_(metadata|content)/extra_files/  # Only allow certain nodes to
-# auth yes                                       # access the "extra_files"
-# allow /^(.+)\.example\.com$/                   # mount point; note this must
-# allow_ip 192.168.100.0/24                      # go ABOVE the "/file" rule,
-#                                                # since it is more specific.
+# path ~ ^/puppet/v3/file_(metadata|content)/extra_files/  # Only allow certain nodes to
+# auth yes                                                 # access the "extra_files"
+# allow /^(.+)\.example\.com$/                             # mount point; note this must
+# allow_ip 192.168.100.0/24                                # go ABOVE the "/file" rule,
+#                                                          # since it is more specific.
 #
 # environment:: restrict an ACL to a comma-separated list of environments
 # method:: restrict an ACL to a comma-separated list of HTTP methods
@@ -60,6 +60,14 @@
 ### Authenticated ACLs - these rules apply only when the client
 ### has a valid certificate and is thus authenticated
 
+path /puppet/v2.0/environments
+method find
+allow *
+
+path /puppet/v3/environments
+method find
+allow *
+
 # allow nodes to retrieve their own catalog
 path ~ ^/puppet/v3/catalog/([^/]+)$
 method find
@@ -69,11 +77,6 @@ allow $1
 path ~ ^/puppet/v3/node/([^/]+)$
 method find
 allow $1
-
-# allow all nodes to access the certificates services
-path /puppet-ca/v1/certificate_revocation_list/ca
-method find
-allow *
 
 # allow all nodes to store their own reports
 path ~ ^/puppet/v3/report/([^/]+)$
@@ -86,6 +89,15 @@ allow $1
 # requests to both the file_metadata and file_content paths. See "Examples"
 # above if you need more granular access control for custom mount points.
 path /puppet/v3/file
+allow *
+
+path /puppet/v3/status
+method find
+allow *
+
+# allow all nodes to access the certificates services
+path /puppet-ca/v1/certificate_revocation_list/ca
+method find
 allow *
 
 ### Unauthenticated ACLs, for clients without valid certificates; authenticated
@@ -108,14 +120,6 @@ allow *
 path /puppet-ca/v1/certificate_request
 auth any
 method find, save
-allow *
-
-path /puppet/v2.0/environments
-method find
-allow *
-
-path /puppet/v3/environments
-method find
 allow *
 
 # deny everything else; this ACL is not strictly necessary, but

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -2,14 +2,13 @@ require 'net/http'
 require 'uri'
 
 require 'puppet/network/http'
-require 'puppet/network/http/api/v3/indirected_routes'
 require 'puppet/network/http_pool'
 
 # Access objects via REST
 class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   include Puppet::Network::HTTP::Compression.module
 
-  IndirectedRoutes = Puppet::Network::HTTP::API::V3::IndirectedRoutes
+  IndirectedRoutes = Puppet::Network::HTTP::API::IndirectedRoutes
 
   class << self
     attr_reader :server_setting, :port_setting

--- a/lib/puppet/network/authconfig.rb
+++ b/lib/puppet/network/authconfig.rb
@@ -1,34 +1,39 @@
 require 'puppet/network/rights'
+require 'puppet/network/http'
 
 module Puppet
   class ConfigurationError < Puppet::Error; end
   class Network::AuthConfig
     attr_accessor :rights
 
-    def self.url_prefix
-      Puppet[:master_url_prefix]
+    def self.master_url_prefix
+      Puppet::Network::HTTP::MASTER_URL_PREFIX
+    end
+
+    def self.ca_url_prefix
+      Puppet::Network::HTTP::CA_URL_PREFIX
     end
 
     def self.default_acl
       [
       # API V2.0
-      { :acl => "#{url_prefix}/v2.0/environments", :method => :find, :allow => '*', :authenticated => true },
+      { :acl => "#{master_url_prefix}/v2.0/environments", :method => :find, :allow => '*', :authenticated => true },
 
       # API V3
-      { :acl => "~ ^#{url_prefix}\/v3\/catalog\/([^\/]+)$", :method => :find, :allow => '$1', :authenticated => true },
-      { :acl => "~ ^#{url_prefix}\/v3\/node\/([^\/]+)$", :method => :find, :allow => '$1', :authenticated => true },
+      { :acl => "~ ^#{master_url_prefix}\/v3\/catalog\/([^\/]+)$", :method => :find, :allow => '$1', :authenticated => true },
+      { :acl => "~ ^#{master_url_prefix}\/v3\/node\/([^\/]+)$", :method => :find, :allow => '$1', :authenticated => true },
       # this one will allow all file access, and thus delegate
       # to fileserver.conf
-      { :acl => "#{url_prefix}/v3/file" },
-      { :acl => "#{url_prefix}/v3/certificate_revocation_list/ca", :method => :find, :authenticated => true },
-      { :acl => "~ ^#{url_prefix}\/v3\/report\/([^\/]+)$", :method => :save, :allow => '$1', :authenticated => true },
+      { :acl => "#{master_url_prefix}/v3/file" },
+      { :acl => "#{ca_url_prefix}/v1/certificate_revocation_list/ca", :method => :find, :authenticated => true },
+      { :acl => "~ ^#{master_url_prefix}\/v3\/report\/([^\/]+)$", :method => :save, :allow => '$1', :authenticated => true },
       # These allow `auth any`, because if you can do them anonymously you
       # should probably also be able to do them when trusted.
-      { :acl => "#{url_prefix}/v3/certificate/ca", :method => :find, :authenticated => :any },
-      { :acl => "#{url_prefix}/v3/certificate/", :method => :find, :authenticated => :any },
-      { :acl => "#{url_prefix}/v3/certificate_request", :method => [:find, :save], :authenticated => :any },
-      { :acl => "#{url_prefix}/v3/status", :method => [:find], :authenticated => true },
-      { :acl => "#{url_prefix}/v3/environments", :method => :find, :allow => '*', :authenticated => true },
+      { :acl => "#{ca_url_prefix}/v1/certificate/ca", :method => :find, :authenticated => :any },
+      { :acl => "#{ca_url_prefix}/v1/certificate/", :method => :find, :authenticated => :any },
+      { :acl => "#{ca_url_prefix}/v1/certificate_request", :method => [:find, :save], :authenticated => :any },
+      { :acl => "#{master_url_prefix}/v3/status", :method => [:find], :authenticated => true },
+      { :acl => "#{master_url_prefix}/v3/environments", :method => :find, :allow => '*', :authenticated => true },
       ]
       end
 

--- a/lib/puppet/network/authconfig.rb
+++ b/lib/puppet/network/authconfig.rb
@@ -16,24 +16,30 @@ module Puppet
 
     def self.default_acl
       [
-      # API V2.0
+      # Master API V2.0
       { :acl => "#{master_url_prefix}/v2.0/environments", :method => :find, :allow => '*', :authenticated => true },
 
-      # API V3
+      # Master API V3
+      { :acl => "#{master_url_prefix}/v3/environments", :method => :find, :allow => '*', :authenticated => true },
+
       { :acl => "~ ^#{master_url_prefix}\/v3\/catalog\/([^\/]+)$", :method => :find, :allow => '$1', :authenticated => true },
       { :acl => "~ ^#{master_url_prefix}\/v3\/node\/([^\/]+)$", :method => :find, :allow => '$1', :authenticated => true },
+      { :acl => "~ ^#{master_url_prefix}\/v3\/report\/([^\/]+)$", :method => :save, :allow => '$1', :authenticated => true },
+
       # this one will allow all file access, and thus delegate
       # to fileserver.conf
       { :acl => "#{master_url_prefix}/v3/file" },
+
+      { :acl => "#{master_url_prefix}/v3/status", :method => [:find], :authenticated => true },
+
+      # CA API V1
       { :acl => "#{ca_url_prefix}/v1/certificate_revocation_list/ca", :method => :find, :authenticated => true },
-      { :acl => "~ ^#{master_url_prefix}\/v3\/report\/([^\/]+)$", :method => :save, :allow => '$1', :authenticated => true },
+
       # These allow `auth any`, because if you can do them anonymously you
       # should probably also be able to do them when trusted.
       { :acl => "#{ca_url_prefix}/v1/certificate/ca", :method => :find, :authenticated => :any },
       { :acl => "#{ca_url_prefix}/v1/certificate/", :method => :find, :authenticated => :any },
       { :acl => "#{ca_url_prefix}/v1/certificate_request", :method => [:find, :save], :authenticated => :any },
-      { :acl => "#{master_url_prefix}/v3/status", :method => [:find], :authenticated => true },
-      { :acl => "#{master_url_prefix}/v3/environments", :method => :find, :allow => '*', :authenticated => true },
       ]
       end
 

--- a/lib/puppet/network/http.rb
+++ b/lib/puppet/network/http.rb
@@ -3,7 +3,7 @@ module Puppet::Network::HTTP
   HEADER_PUPPET_VERSION = "X-Puppet-Version"
 
   MASTER_URL_PREFIX = "/puppet"
-  CA_URL_PREFIX = "/ca"
+  CA_URL_PREFIX = "/puppet-ca"
 
   require 'puppet/network/authorization'
   require 'puppet/network/http/issues'

--- a/lib/puppet/network/http.rb
+++ b/lib/puppet/network/http.rb
@@ -2,13 +2,19 @@ module Puppet::Network::HTTP
   HEADER_ENABLE_PROFILING = "X-Puppet-Profiling"
   HEADER_PUPPET_VERSION = "X-Puppet-Version"
 
+  MASTER_URL_PREFIX = "/puppet"
+  CA_URL_PREFIX = "/ca"
+
   require 'puppet/network/authorization'
   require 'puppet/network/http/issues'
   require 'puppet/network/http/error'
   require 'puppet/network/http/route'
   require 'puppet/network/http/api'
-  require 'puppet/network/http/api/v2'
-  require 'puppet/network/http/api/v3'
+  require 'puppet/network/http/api/ca'
+  require 'puppet/network/http/api/ca/v1'
+  require 'puppet/network/http/api/master'
+  require 'puppet/network/http/api/master/v2'
+  require 'puppet/network/http/api/master/v3'
   require 'puppet/network/http/handler'
   require 'puppet/network/http/response'
   require 'puppet/network/http/request'

--- a/lib/puppet/network/http/api.rb
+++ b/lib/puppet/network/http/api.rb
@@ -8,7 +8,7 @@ class Puppet::Network::HTTP::API
   end
 
   def self.master_routes
-    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}")
+    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/")
     Puppet::Network::HTTP::Route.path(master_prefix).
       any.
       chain(Puppet::Network::HTTP::API::Master::V3.routes,
@@ -17,7 +17,7 @@ class Puppet::Network::HTTP::API
   end
 
   def self.ca_routes
-    ca_prefix = Regexp.new("^#{Puppet::Network::HTTP::CA_URL_PREFIX}")
+    ca_prefix = Regexp.new("^#{Puppet::Network::HTTP::CA_URL_PREFIX}/")
     Puppet::Network::HTTP::Route.path(ca_prefix).
       any.
       chain(Puppet::Network::HTTP::API::CA::V1.routes,

--- a/lib/puppet/network/http/api.rb
+++ b/lib/puppet/network/http/api.rb
@@ -6,4 +6,21 @@ class Puppet::Network::HTTP::API
         raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{req.method} #{req.path}", Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
       end)
   end
+
+  def self.master_routes
+    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}")
+    Puppet::Network::HTTP::Route.path(master_prefix).
+      any.
+      chain(Puppet::Network::HTTP::API::Master::V3.routes,
+            Puppet::Network::HTTP::API::Master::V2.routes,
+            Puppet::Network::HTTP::API.not_found)
+  end
+
+  def self.ca_routes
+    ca_prefix = Regexp.new("^#{Puppet::Network::HTTP::CA_URL_PREFIX}")
+    Puppet::Network::HTTP::Route.path(ca_prefix).
+      any.
+      chain(Puppet::Network::HTTP::API::CA::V1.routes,
+            Puppet::Network::HTTP::API.not_found)
+  end
 end

--- a/lib/puppet/network/http/api/ca.rb
+++ b/lib/puppet/network/http/api/ca.rb
@@ -1,0 +1,2 @@
+module Puppet::Network::HTTP::API::CA
+end

--- a/lib/puppet/network/http/api/ca/v1.rb
+++ b/lib/puppet/network/http/api/ca/v1.rb
@@ -6,6 +6,6 @@ class Puppet::Network::HTTP::API::CA::V1
     any(Puppet::Network::HTTP::API::IndirectedRoutes.new)
 
   def self.routes
-    Puppet::Network::HTTP::Route.path(%r{/v1}).any.chain(INDIRECTED)
+    Puppet::Network::HTTP::Route.path(%r{v1}).any.chain(INDIRECTED)
   end
 end

--- a/lib/puppet/network/http/api/ca/v1.rb
+++ b/lib/puppet/network/http/api/ca/v1.rb
@@ -1,0 +1,11 @@
+require 'puppet/network/http/api/indirected_routes'
+class Puppet::Network::HTTP::API::CA::V1
+
+  INDIRECTED = Puppet::Network::HTTP::Route.
+    path(/.*/).
+    any(Puppet::Network::HTTP::API::IndirectedRoutes.new)
+
+  def self.routes
+    Puppet::Network::HTTP::Route.path(%r{/v1}).any.chain(INDIRECTED)
+  end
+end

--- a/lib/puppet/network/http/api/indirection_type.rb
+++ b/lib/puppet/network/http/api/indirection_type.rb
@@ -1,0 +1,32 @@
+class Puppet::Network::HTTP::API::IndirectionType
+
+  INDIRECTION_TYPE_MAP = {
+    "certificate" => :ca,
+    "certificate_request" => :ca,
+    "certificate_revocation_list" => :ca,
+    "certificate_status" => :ca
+  }
+
+  def self.master_url_prefix
+    "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3"
+  end
+
+  def self.ca_url_prefix
+    "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v1"
+  end
+
+  def self.type_for(indirection)
+    INDIRECTION_TYPE_MAP[indirection] || :master
+  end
+
+  def self.url_prefix_for(indirection_name)
+    case type_for(indirection_name)
+    when :ca
+      ca_url_prefix
+    when :master
+      master_url_prefix
+    else
+      raise ArgumentError, "Not a valid indirection type"
+    end
+  end
+end

--- a/lib/puppet/network/http/api/master.rb
+++ b/lib/puppet/network/http/api/master.rb
@@ -1,0 +1,2 @@
+module Puppet::Network::HTTP::API::Master
+end

--- a/lib/puppet/network/http/api/master/v2.rb
+++ b/lib/puppet/network/http/api/master/v2.rb
@@ -3,7 +3,7 @@ module Puppet::Network::HTTP::API::Master::V2
   require 'puppet/network/http/api/master/v2/authorization'
 
   def self.routes
-    path(%r{^/v2\.0}).
+    path(%r{^v2\.0}).
       get(Authorization.new).
       chain(ENVIRONMENTS, Puppet::Network::HTTP::API.not_found)
   end

--- a/lib/puppet/network/http/api/master/v2.rb
+++ b/lib/puppet/network/http/api/master/v2.rb
@@ -1,6 +1,6 @@
-module Puppet::Network::HTTP::API::V2
-  require 'puppet/network/http/api/v2/environments'
-  require 'puppet/network/http/api/v2/authorization'
+module Puppet::Network::HTTP::API::Master::V2
+  require 'puppet/network/http/api/master/v2/environments'
+  require 'puppet/network/http/api/master/v2/authorization'
 
   def self.routes
     path(%r{^/v2\.0}).

--- a/lib/puppet/network/http/api/master/v2/authorization.rb
+++ b/lib/puppet/network/http/api/master/v2/authorization.rb
@@ -1,4 +1,4 @@
-class Puppet::Network::HTTP::API::V2::Authorization
+class Puppet::Network::HTTP::API::Master::V2::Authorization
   include Puppet::Network::Authorization
 
   def call(request, response)

--- a/lib/puppet/network/http/api/master/v2/environments.rb
+++ b/lib/puppet/network/http/api/master/v2/environments.rb
@@ -1,6 +1,6 @@
 require 'json'
 
-class Puppet::Network::HTTP::API::V2::Environments
+class Puppet::Network::HTTP::API::Master::V2::Environments
   def initialize(env_loader)
     @env_loader = env_loader
   end

--- a/lib/puppet/network/http/api/master/v3.rb
+++ b/lib/puppet/network/http/api/master/v3.rb
@@ -15,7 +15,7 @@ class Puppet::Network::HTTP::API::Master::V3
   end)
 
   def self.routes
-    Puppet::Network::HTTP::Route.path(%r{/v3}).
+    Puppet::Network::HTTP::Route.path(%r{v3}).
         any.
         chain(ENVIRONMENTS, INDIRECTED)
   end

--- a/lib/puppet/network/http/api/master/v3.rb
+++ b/lib/puppet/network/http/api/master/v3.rb
@@ -1,13 +1,13 @@
-class Puppet::Network::HTTP::API::V3
-  require 'puppet/network/http/api/v3/authorization'
-  require 'puppet/network/http/api/v3/environments'
-  require 'puppet/network/http/api/v3/indirected_routes'
+class Puppet::Network::HTTP::API::Master::V3
+  require 'puppet/network/http/api/master/v3/authorization'
+  require 'puppet/network/http/api/master/v3/environments'
+  require 'puppet/network/http/api/indirected_routes'
 
   AUTHZ = Authorization.new
 
   INDIRECTED = Puppet::Network::HTTP::Route.
       path(/.*/).
-      any(Puppet::Network::HTTP::API::V3::IndirectedRoutes.new)
+      any(Puppet::Network::HTTP::API::IndirectedRoutes.new)
 
   ENVIRONMENTS = Puppet::Network::HTTP::Route.
       path(%r{^/environments$}).get(AUTHZ.wrap do

--- a/lib/puppet/network/http/api/master/v3/authorization.rb
+++ b/lib/puppet/network/http/api/master/v3/authorization.rb
@@ -1,6 +1,6 @@
 require 'puppet/network/authorization'
 
-class Puppet::Network::HTTP::API::V3::Authorization
+class Puppet::Network::HTTP::API::Master::V3::Authorization
   include Puppet::Network::Authorization
 
   def wrap(&block)

--- a/lib/puppet/network/http/api/master/v3/environments.rb
+++ b/lib/puppet/network/http/api/master/v3/environments.rb
@@ -1,6 +1,6 @@
 require 'json'
 
-class Puppet::Network::HTTP::API::V3::Environments
+class Puppet::Network::HTTP::API::Master::V3::Environments
   def initialize(env_loader)
     @env_loader = env_loader
   end

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -28,11 +28,16 @@ class Puppet::Network::HTTP::RackREST
 
   def initialize(args={})
     super()
-    prefix = Regexp.new("^#{Puppet[:master_url_prefix]}")
-    register([Puppet::Network::HTTP::Route.path(prefix).
+    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}")
+    ca_prefix = Regexp.new("^#{Puppet::Network::HTTP::CA_URL_PREFIX}")
+    register([Puppet::Network::HTTP::Route.path(master_prefix).
                   any.
-                  chain(Puppet::Network::HTTP::API::V3.routes,
-                        Puppet::Network::HTTP::API::V2.routes,
+                  chain(Puppet::Network::HTTP::API::Master::V3.routes,
+                        Puppet::Network::HTTP::API::Master::V2.routes,
+                        Puppet::Network::HTTP::API.not_found),
+              Puppet::Network::HTTP::Route.path(ca_prefix).
+                  any.
+                  chain(Puppet::Network::HTTP::API::CA::V1.routes,
                         Puppet::Network::HTTP::API.not_found)])
   end
 

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -28,17 +28,8 @@ class Puppet::Network::HTTP::RackREST
 
   def initialize(args={})
     super()
-    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}")
-    ca_prefix = Regexp.new("^#{Puppet::Network::HTTP::CA_URL_PREFIX}")
-    register([Puppet::Network::HTTP::Route.path(master_prefix).
-                  any.
-                  chain(Puppet::Network::HTTP::API::Master::V3.routes,
-                        Puppet::Network::HTTP::API::Master::V2.routes,
-                        Puppet::Network::HTTP::API.not_found),
-              Puppet::Network::HTTP::Route.path(ca_prefix).
-                  any.
-                  chain(Puppet::Network::HTTP::API::CA::V1.routes,
-                        Puppet::Network::HTTP::API.not_found)])
+    register([Puppet::Network::HTTP::API.master_routes,
+              Puppet::Network::HTTP::API.ca_routes])
   end
 
   def set_content_type(response, format)

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -1,5 +1,4 @@
 require 'puppet/network/http/handler'
-require 'puppet/network/http/api/v3'
 require 'resolv'
 require 'webrick'
 require 'webrick/httputils'
@@ -15,11 +14,16 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
 
   def initialize(server)
     raise ArgumentError, "server is required" unless server
-    prefix = Regexp.new("^#{Puppet[:master_url_prefix]}")
-    register([Puppet::Network::HTTP::Route.path(prefix).
+    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}")
+    ca_prefix = Regexp.new("^#{Puppet::Network::HTTP::CA_URL_PREFIX}")
+    register([Puppet::Network::HTTP::Route.path(master_prefix).
                   any.
-                  chain(Puppet::Network::HTTP::API::V3.routes,
-                        Puppet::Network::HTTP::API::V2.routes,
+                  chain(Puppet::Network::HTTP::API::Master::V3.routes,
+                        Puppet::Network::HTTP::API::Master::V2.routes,
+                        Puppet::Network::HTTP::API.not_found),
+              Puppet::Network::HTTP::Route.path(ca_prefix).
+                  any.
+                  chain(Puppet::Network::HTTP::API::CA::V1.routes,
                         Puppet::Network::HTTP::API.not_found)])
     super(server)
   end

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -14,17 +14,8 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
 
   def initialize(server)
     raise ArgumentError, "server is required" unless server
-    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}")
-    ca_prefix = Regexp.new("^#{Puppet::Network::HTTP::CA_URL_PREFIX}")
-    register([Puppet::Network::HTTP::Route.path(master_prefix).
-                  any.
-                  chain(Puppet::Network::HTTP::API::Master::V3.routes,
-                        Puppet::Network::HTTP::API::Master::V2.routes,
-                        Puppet::Network::HTTP::API.not_found),
-              Puppet::Network::HTTP::Route.path(ca_prefix).
-                  any.
-                  chain(Puppet::Network::HTTP::API::CA::V1.routes,
-                        Puppet::Network::HTTP::API.not_found)])
+    register([Puppet::Network::HTTP::API.master_routes,
+              Puppet::Network::HTTP::API.ca_routes])
     super(server)
   end
 

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -4,7 +4,7 @@ require 'tempfile'
 
 require 'puppet/util/checksums'
 require 'puppet/network/http'
-require 'puppet/network/http/api/v3/indirected_routes'
+require 'puppet/network/http/api/indirected_routes'
 require 'puppet/network/http/compression'
 
 module Puppet
@@ -213,7 +213,7 @@ module Puppet
 
       request.do_request(:fileserver) do |req|
         connection = Puppet::Network::HttpPool.http_instance(req.server, req.port)
-        connection.request_get(Puppet::Network::HTTP::API::V3::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => "raw"}), &block)
+        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => "raw"}), &block)
       end
     end
 

--- a/spec/lib/puppet_spec/handler.rb
+++ b/spec/lib/puppet_spec/handler.rb
@@ -1,0 +1,53 @@
+require 'puppet/network/http/handler'
+
+class PuppetSpec::Handler
+  include Puppet::Network::HTTP::Handler
+
+  def initialize(* routes)
+    register(routes)
+  end
+
+  def set_content_type(response, format)
+    response[:content_type_header] = format
+  end
+
+  def set_response(response, body, status = 200)
+    response[:body] = body
+    response[:status] = status
+  end
+
+  def http_method(request)
+    request[:method]
+  end
+
+  def path(request)
+    request[:path]
+  end
+
+  def params(request)
+    request[:params]
+  end
+
+  def client_cert(request)
+    request[:client_cert]
+  end
+
+  def body(request)
+    request[:body]
+  end
+
+  def headers(request)
+    request[:headers] || {}
+  end
+end
+
+class PuppetSpec::HandlerProfiler
+  def start(metric, description)
+  end
+
+  def finish(context, metric, description)
+  end
+
+  def shutdown()
+  end
+end

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -118,7 +118,7 @@ describe Puppet::Indirector::REST do
   let(:terminus) { Puppet::TestModel.indirection.terminus(:rest) }
   let(:indirection) { Puppet::TestModel.indirection }
   let(:model) { Puppet::TestModel }
-  let(:url_prefix) { "#{Puppet[:master_url_prefix]}/v3"}
+  let(:url_prefix) { "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3"}
 
   around(:each) do |example|
     Puppet.override(:current_environment => Puppet::Node::Environment.create(:production, [])) do

--- a/spec/unit/network/authconfig_spec.rb
+++ b/spec/unit/network/authconfig_spec.rb
@@ -81,7 +81,7 @@ describe Puppet::Network::AuthConfig do
 
     it '(CVE-2013-2275) allows report submission only for the node matching the certname by default' do
       acl = {
-        :acl => "~ ^#{Puppet[:master_url_prefix]}\/v3\/report\/([^\/]+)$",
+        :acl => "~ ^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}\/v3\/report\/([^\/]+)$",
         :method => :save,
         :allow => '$1',
         :authenticated => true

--- a/spec/unit/network/http/api/ca/v1_spec.rb
+++ b/spec/unit/network/http/api/ca/v1_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Network::HTTP::API::CA::V1 do
 
   let(:ca_routes) {
     Puppet::Network::HTTP::Route.
-      path(Regexp.new("#{Puppet::Network::HTTP::CA_URL_PREFIX}")).
+      path(Regexp.new("#{Puppet::Network::HTTP::CA_URL_PREFIX}/")).
       any.
       chain(Puppet::Network::HTTP::API::CA::V1.routes)
   }

--- a/spec/unit/network/http/api/ca/v1_spec.rb
+++ b/spec/unit/network/http/api/ca/v1_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+require 'puppet/network/http'
+
+describe Puppet::Network::HTTP::API::CA::V1 do
+  let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+  let(:ca_url_prefix) { "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v1"}
+
+  let(:ca_routes) {
+    Puppet::Network::HTTP::Route.
+      path(Regexp.new("#{Puppet::Network::HTTP::CA_URL_PREFIX}")).
+      any.
+      chain(Puppet::Network::HTTP::API::CA::V1.routes)
+  }
+
+  it "mounts ca routes" do
+    Puppet::SSL::Certificate.indirection.stubs(:find).returns "foo"
+    request = Puppet::Network::HTTP::Request.
+        from_hash(:path => "#{ca_url_prefix}/certificate/foo",
+                  :params => {:environment => "production"},
+                  :headers => {"accept" => "s"})
+    ca_routes.process(request, response)
+
+    expect(response.code).to eq(200)
+  end
+end

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -111,6 +111,14 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {:environment => "env ness"}) }.should raise_error(ArgumentError)
     end
 
+    it "should fail if the indirection does not match the prefix" do
+      lambda { handler.uri2indirection("GET", "#{master_url_prefix}/certificate/foo", params) }.should raise_error(ArgumentError)
+    end
+
+    it "should fail if the indirection does not have the correct version" do
+      lambda { handler.uri2indirection("GET", "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v3/certificate/foo", params) }.should raise_error(ArgumentError)
+    end
+
     it "should not pass a buck_path parameter through (See Bugs #13553, #13518, #13511)" do
       handler.uri2indirection("GET", "#{master_url_prefix}/node/bar",
                               { :environment => "env",

--- a/spec/unit/network/http/api/master/v2/authorization_spec.rb
+++ b/spec/unit/network/http/api/master/v2/authorization_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 require 'puppet/network/http'
 
-describe Puppet::Network::HTTP::API::V2::Authorization do
+describe Puppet::Network::HTTP::API::Master::V2::Authorization do
   HTTP = Puppet::Network::HTTP
 
   let(:response) { HTTP::MemoryResponse.new }
-  let(:authz) { HTTP::API::V2::Authorization.new }
+  let(:authz) { HTTP::API::Master::V2::Authorization.new }
 
   it "only authorizes GET requests" do
     request = HTTP::Request.from_hash({

--- a/spec/unit/network/http/api/master/v2/environments_spec.rb
+++ b/spec/unit/network/http/api/master/v2/environments_spec.rb
@@ -4,13 +4,13 @@ require 'puppet/node/environment'
 require 'puppet/network/http'
 require 'matchers/json'
 
-describe Puppet::Network::HTTP::API::V3::Environments do
+describe Puppet::Network::HTTP::API::Master::V2::Environments do
   include JSONMatchers
 
   it "responds with all of the available environments" do
     environment = Puppet::Node::Environment.create(:production, ["/first", "/second"], '/manifests')
     loader = Puppet::Environments::Static.new(environment)
-    handler = Puppet::Network::HTTP::API::V3::Environments.new(loader)
+    handler = Puppet::Network::HTTP::API::Master::V2::Environments.new(loader)
     response = Puppet::Network::HTTP::MemoryResponse.new
 
     handler.call(Puppet::Network::HTTP::Request.from_hash(:headers => { 'accept' => 'application/json' }), response)
@@ -38,7 +38,7 @@ describe Puppet::Network::HTTP::API::V3::Environments do
     environment = Puppet::Node::Environment.create(:production, [])
     env_loader = Puppet::Environments::Static.new(environment)
     env_loader.expects(:get_conf).with(:production).returns(conf_stub)
-    handler = Puppet::Network::HTTP::API::V3::Environments.new(env_loader)
+    handler = Puppet::Network::HTTP::API::Master::V2::Environments.new(env_loader)
     response = Puppet::Network::HTTP::MemoryResponse.new
 
     handler.call(Puppet::Network::HTTP::Request.from_hash(:headers => { 'accept' => 'application/json' }), response)
@@ -52,7 +52,7 @@ describe Puppet::Network::HTTP::API::V3::Environments do
     environment = Puppet::Node::Environment.create(:production, [])
     env_loader = Puppet::Environments::Static.new(environment)
     env_loader.expects(:get_conf).with(:production).returns(conf_stub)
-    handler = Puppet::Network::HTTP::API::V3::Environments.new(env_loader)
+    handler = Puppet::Network::HTTP::API::Master::V2::Environments.new(env_loader)
     response = Puppet::Network::HTTP::MemoryResponse.new
 
     handler.call(Puppet::Network::HTTP::Request.from_hash(:headers => { 'accept' => 'application/json' }), response)

--- a/spec/unit/network/http/api/master/v2_spec.rb
+++ b/spec/unit/network/http/api/master/v2_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 require 'puppet/network/http'
 
-describe Puppet::Network::HTTP::API::V2 do
+describe Puppet::Network::HTTP::API::Master::V2 do
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
 
   it "mounts the environments endpoint" do
     request = Puppet::Network::HTTP::Request.from_hash(:path => "/v2.0/environments")
-    Puppet::Network::HTTP::API::V2.routes.process(request, response)
+    Puppet::Network::HTTP::API::Master::V2.routes.process(request, response)
 
     expect(response.code).to eq(200)
   end
@@ -16,7 +16,7 @@ describe Puppet::Network::HTTP::API::V2 do
     request = Puppet::Network::HTTP::Request.from_hash(:path => "/v2.0/unknown")
 
     expect do
-      Puppet::Network::HTTP::API::V2.routes.process(request, response)
+      Puppet::Network::HTTP::API::Master::V2.routes.process(request, response)
     end.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError)
   end
 end

--- a/spec/unit/network/http/api/master/v2_spec.rb
+++ b/spec/unit/network/http/api/master/v2_spec.rb
@@ -4,19 +4,22 @@ require 'puppet/network/http'
 
 describe Puppet::Network::HTTP::API::Master::V2 do
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+  let(:routes) { Puppet::Network::HTTP::Route.path(Regexp.new("/puppet/")).
+                  any.
+                  chain(Puppet::Network::HTTP::API::Master::V2.routes) }
 
   it "mounts the environments endpoint" do
-    request = Puppet::Network::HTTP::Request.from_hash(:path => "/v2.0/environments")
-    Puppet::Network::HTTP::API::Master::V2.routes.process(request, response)
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "/puppet/v2.0/environments")
+    routes.process(request, response)
 
     expect(response.code).to eq(200)
   end
 
   it "responds to unknown paths with a 404" do
-    request = Puppet::Network::HTTP::Request.from_hash(:path => "/v2.0/unknown")
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "/puppet/v2.0/unknown")
 
     expect do
-      Puppet::Network::HTTP::API::Master::V2.routes.process(request, response)
+      routes.process(request, response)
     end.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError)
   end
 end

--- a/spec/unit/network/http/api/master/v3/authorization_spec.rb
+++ b/spec/unit/network/http/api/master/v3/authorization_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 require 'puppet/network/http'
 
-describe Puppet::Network::HTTP::API::V3::Authorization do
+describe Puppet::Network::HTTP::API::Master::V3::Authorization do
   HTTP = Puppet::Network::HTTP
 
   let(:response) { HTTP::MemoryResponse.new }
-  let(:authz) { HTTP::API::V3::Authorization.new }
+  let(:authz) { HTTP::API::Master::V3::Authorization.new }
   let(:noop_handler) {
     lambda do |request, response|
     end

--- a/spec/unit/network/http/api/master/v3/environments_spec.rb
+++ b/spec/unit/network/http/api/master/v3/environments_spec.rb
@@ -4,13 +4,13 @@ require 'puppet/node/environment'
 require 'puppet/network/http'
 require 'matchers/json'
 
-describe Puppet::Network::HTTP::API::V2::Environments do
+describe Puppet::Network::HTTP::API::Master::V3::Environments do
   include JSONMatchers
 
   it "responds with all of the available environments" do
     environment = Puppet::Node::Environment.create(:production, ["/first", "/second"], '/manifests')
     loader = Puppet::Environments::Static.new(environment)
-    handler = Puppet::Network::HTTP::API::V2::Environments.new(loader)
+    handler = Puppet::Network::HTTP::API::Master::V3::Environments.new(loader)
     response = Puppet::Network::HTTP::MemoryResponse.new
 
     handler.call(Puppet::Network::HTTP::Request.from_hash(:headers => { 'accept' => 'application/json' }), response)
@@ -38,7 +38,7 @@ describe Puppet::Network::HTTP::API::V2::Environments do
     environment = Puppet::Node::Environment.create(:production, [])
     env_loader = Puppet::Environments::Static.new(environment)
     env_loader.expects(:get_conf).with(:production).returns(conf_stub)
-    handler = Puppet::Network::HTTP::API::V2::Environments.new(env_loader)
+    handler = Puppet::Network::HTTP::API::Master::V3::Environments.new(env_loader)
     response = Puppet::Network::HTTP::MemoryResponse.new
 
     handler.call(Puppet::Network::HTTP::Request.from_hash(:headers => { 'accept' => 'application/json' }), response)
@@ -52,7 +52,7 @@ describe Puppet::Network::HTTP::API::V2::Environments do
     environment = Puppet::Node::Environment.create(:production, [])
     env_loader = Puppet::Environments::Static.new(environment)
     env_loader.expects(:get_conf).with(:production).returns(conf_stub)
-    handler = Puppet::Network::HTTP::API::V2::Environments.new(env_loader)
+    handler = Puppet::Network::HTTP::API::Master::V3::Environments.new(env_loader)
     response = Puppet::Network::HTTP::MemoryResponse.new
 
     handler.call(Puppet::Network::HTTP::Request.from_hash(:headers => { 'accept' => 'application/json' }), response)

--- a/spec/unit/network/http/api/master/v3_spec.rb
+++ b/spec/unit/network/http/api/master/v3_spec.rb
@@ -2,36 +2,36 @@ require 'spec_helper'
 
 require 'puppet/network/http'
 
-describe Puppet::Network::HTTP::API::V3 do
+describe Puppet::Network::HTTP::API::Master::V3 do
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
-  let(:url_prefix) { "#{Puppet[:master_url_prefix]}/v3"}
-  let(:routes) {
+  let(:master_url_prefix) { "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3" }
+  let(:master_routes) {
     Puppet::Network::HTTP::Route.
-        path(Regexp.new(Puppet[:master_url_prefix])).
+        path(Regexp.new("#{Puppet::Network::HTTP::MASTER_URL_PREFIX}")).
         any.
-        chain(Puppet::Network::HTTP::API::V3.routes)
+        chain(Puppet::Network::HTTP::API::Master::V3.routes)
   }
 
   it "mounts the environments endpoint" do
-    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{url_prefix}/environments")
-    routes.process(request, response)
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_url_prefix}/environments")
+    master_routes.process(request, response)
 
     expect(response.code).to eq(200)
   end
 
   it "mounts indirected routes" do
     request = Puppet::Network::HTTP::Request.
-        from_hash(:path => "#{url_prefix}/node/foo",
+        from_hash(:path => "#{master_url_prefix}/node/foo",
                   :params => {:environment => "production"},
                   :headers => {"accept" => "text/pson"})
-    routes.process(request, response)
+    master_routes.process(request, response)
 
     expect(response.code).to eq(200)
   end
 
   it "responds to unknown paths with a 404" do
-    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{url_prefix}/unknown")
-    routes.process(request, response)
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_url_prefix}/unknown")
+    master_routes.process(request, response)
 
     expect(response.code).to eq(404)
     expect(response.body).to match("Not Found: Could not find indirection 'unknown'")

--- a/spec/unit/network/http/api/master/v3_spec.rb
+++ b/spec/unit/network/http/api/master/v3_spec.rb
@@ -7,7 +7,7 @@ describe Puppet::Network::HTTP::API::Master::V3 do
   let(:master_url_prefix) { "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3" }
   let(:master_routes) {
     Puppet::Network::HTTP::Route.
-        path(Regexp.new("#{Puppet::Network::HTTP::MASTER_URL_PREFIX}")).
+        path(Regexp.new("#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/")).
         any.
         chain(Puppet::Network::HTTP::API::Master::V3.routes)
   }

--- a/spec/unit/network/http/api_spec.rb
+++ b/spec/unit/network/http/api_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 
 require 'spec_helper'
+require 'puppet_spec/handler'
 require 'puppet/network/http'
 
 describe Puppet::Network::HTTP::API do
@@ -8,30 +9,97 @@ describe Puppet::Network::HTTP::API do
     lambda { |req, res| res.respond_with(200, "text/plain", text) }
   end
 
-  let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+  describe "#not_found" do
+    let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
 
-  let(:routes) {
-    Puppet::Network::HTTP::Route.path(Regexp.new("foo")).
-    any.
-    chain(Puppet::Network::HTTP::Route.path(%r{^/bar$}).get(respond("bar")),
-          Puppet::Network::HTTP::API.not_found)
-  }
+    let(:routes) {
+      Puppet::Network::HTTP::Route.path(Regexp.new("foo")).
+      any.
+      chain(Puppet::Network::HTTP::Route.path(%r{^/bar$}).get(respond("bar")),
+            Puppet::Network::HTTP::API.not_found)
+    }
 
-  it "mounts the bar endpoint" do
-    request = Puppet::Network::HTTP::Request.from_hash(:path => "foo/bar")
-    routes.process(request, response)
+    it "mounts the chained routes" do
+      request = Puppet::Network::HTTP::Request.from_hash(:path => "foo/bar")
+      routes.process(request, response)
 
-    expect(response.code).to eq(200)
-    expect(response.body).to eq("bar")
+      expect(response.code).to eq(200)
+      expect(response.body).to eq("bar")
+    end
+
+    it "responds to unknown paths with a 404" do
+      request = Puppet::Network::HTTP::Request.from_hash(:path => "foo/unknown")
+
+      expect do
+        routes.process(request, response)
+      end.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError)
+    end
   end
 
-  it "responds to unknown paths with a 404" do
-    request = Puppet::Network::HTTP::Request.from_hash(:path => "foo/unknown")
+  describe "Puppet API" do
+    let(:handler) { PuppetSpec::Handler.new(Puppet::Network::HTTP::API.master_routes,
+                                            Puppet::Network::HTTP::API.ca_routes) }
 
-    expect do
-      routes.process(request, response)
-    end.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError)
+    let(:master_prefix) { Puppet::Network::HTTP::MASTER_URL_PREFIX }
+    let(:ca_prefix) { Puppet::Network::HTTP::CA_URL_PREFIX }
+
+    it "raises a not-found error for non-CA or master routes" do
+      req = Puppet::Network::HTTP::Request.from_hash(:path => "/unknown")
+      res = {}
+      handler.process(req, res)
+      expect(res[:status]).to eq(404)
+    end
+
+    describe "when processing master routes" do
+      it "responds to v3 indirector requests" do
+        req = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_prefix}/v3/node/foo",
+                                                       :params => {:environment => "production"},
+                                                       :headers => {'accept' => "pson"})
+        res = {}
+        handler.process(req, res)
+        expect(res[:status]).to eq(200)
+      end
+
+      it "responds to v3 environments requests" do
+        req = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_prefix}/v3/environments")
+        res = {}
+        handler.process(req, res)
+        expect(res[:status]).to eq(200)
+      end
+
+      it "responds to v2.0 environments requests" do
+        req = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_prefix}/v2.0/environments")
+        res = {}
+        handler.process(req, res)
+        expect(res[:status]).to eq(200)
+      end
+
+      it "responds with a not found error to non-v3/2.0 requests" do
+        req = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_prefix}/unknown")
+        res = {}
+        handler.process(req, res)
+        expect(res[:status]).to eq(404)
+      end
+    end
+
+    describe "when processing CA routes" do
+      it "responds to v1 indirector requests" do
+        Puppet::SSL::Certificate.indirection.stubs(:find).returns "foo"
+        req = Puppet::Network::HTTP::Request.from_hash(:path => "#{ca_prefix}/v1/certificate/foo",
+                                                       :params => {:environment => "production"},
+                                                       :headers => {'accept' => "s"})
+        res = {}
+        handler.process(req, res)
+        expect(res[:body]).to eq("foo")
+        expect(res[:status]).to eq(200)
+      end
+
+      it "responds with a not found error to non-v1 requests" do
+        req = Puppet::Network::HTTP::Request.from_hash(:path => "#{ca_prefix}/unknown")
+        res = {}
+        handler.process(req, res)
+        expect(res[:status]).to eq(404)
+      end
+    end
   end
 end
-
-

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -405,7 +405,7 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
         source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
 
         conn.unstub(:request_get)
-        conn.expects(:request_get).with("#{Puppet[:master_url_prefix]}/v3/file_content/test/foo%20bar?environment=testing&", anything).yields(response)
+        conn.expects(:request_get).with("#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3/file_content/test/foo%20bar?environment=testing&", anything).yields(response)
 
         resource.write(source)
       end


### PR DESCRIPTION
Restructure the CA endpoints to allow for a configurable url prefix, separate from the master url prefix. 