### PR TITLE
(PUP-1343) Include additional platforms in ticket_1343 acceptance test

### DIFF
--- a/acceptance/tests/resource/service/ticket_1343_should_add_and_remove_symlinks.rb
+++ b/acceptance/tests/resource/service/ticket_1343_should_add_and_remove_symlinks.rb
@@ -1,6 +1,7 @@
 test_name 'RedHat Service Symlink Validation'
 
-confine :to, :platform => 'el-5' 
+# RedHat v7 uses systemd, so confine this test to v5 and v6 only
+confine :to, :platform => /el\-5|el\-6|centos\-5|centos\-6/
 
 manifest_httpd_setup = %Q{
   package { 'httpd':


### PR DESCRIPTION
Adding RHEL 6 and CentOS 5 and 6.

I'll note that currently these tests won't get run due to puppet master requiring ruby 1.9. But I've been told we're only a week or so away from AIO integration, at which point the ruby dependency will get satisifed and these tests can kick in. 