### PR TITLE
(PUP-3829) Allow pip provider to work when osfamily is 'RedHat'

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -36,12 +36,7 @@ Puppet::Type.type(:package).provide :pip,
   end
 
   def self.cmd
-    case Facter.value(:osfamily)
-      when "RedHat"
-        "pip-python"
-      else
-        "pip"
-    end
+    'pip'
   end
 
   # Return structured information about a particular package or `nil` if

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:package).provider(:pip)
-osfamilies = { 'RedHat' => 'pip-python', 'Not RedHat' => 'pip' }
+osfamilies = { 'Everything' => 'pip' }
 
 describe provider_class do
 
@@ -32,9 +32,9 @@ describe provider_class do
   end
 
   describe "cmd" do
-    it "should return pip-python on RedHat systems" do
+    it "should return pip on RedHat systems" do
       Facter.stubs(:value).with(:osfamily).returns("RedHat")
-      provider_class.cmd.should == 'pip-python'
+      provider_class.cmd.should == 'pip'
     end
 
     it "should return pip by default" do


### PR DESCRIPTION
Without this patch, the pip package provider is broken on EL systems.