### PR TITLE
(PUP-3724) Use ffi 1.9.6

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -28,7 +28,7 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       # Pinning versions that require native extensions
-      ffi: '~> 1.9.5'
+      ffi: '~> 1.9.6'
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.2'
       win32-process: '~> 0.7.4'
@@ -38,7 +38,7 @@ gem_platform_dependencies:
       minitar: '~> 0.5.4'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.5'
+      ffi: '~> 1.9.6'
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.2'
       win32-process: '~> 0.7.4'


### PR DESCRIPTION
Update ffi requirement to use at least 1.9.6 because Ruby 2.1.5
requires it.