### PR TITLE
(PUP-3829) pip package provider : on RHEL7, with latest python-pip >= 1.5 from EPEL...

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -36,11 +36,10 @@ Puppet::Type.type(:package).provide :pip,
   end
 
   def self.cmd
-    case Facter.value(:osfamily)
-      when "RedHat"
-        "pip-python"
-      else
-        "pip"
+    if Facter.value(:osfamily) == "RedHat" and Facter.value(:operatingsystemmajrelease).to_i < 7
+      "pip-python"
+    else
+      "pip"
     end
   end
 


### PR DESCRIPTION
..., 'pip-python' is no more and the command to use is back to 'pip' !

Currently, on an up-to-date RHEL7 or CentOS 7 install, it is not possible anymore to use the pip package provider : it fails with a "Could not locate the pip command." error.

This issue happens since 2014-12-18, when the python-pip package on EPEL has been updated to 1.5.6.