### PR TITLE
(PUP-3779) confine hpux password spec

### DIFF
--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -4,7 +4,7 @@ require 'etc'
 
 provider_class = Puppet::Type.type(:user).provider(:hpuxuseradd)
 
-describe provider_class do
+describe provider_class, :unless => Puppet.features.microsoft_windows? do
   let :resource do
     Puppet::Type.type(:user).new(
       :title => 'testuser',


### PR DESCRIPTION
Ruby 2.1.5 on Windows does not contain Etc::Password.passwd due to not
having HAVE_STRUCT_PASSWD_PW_PASSWD defined when it was compiled -
https://github.com/ruby/ruby/blob/v2_1_5/ext/etc/etc.c#L691-L693.
Ruby 2.0.0 did not have this and passwd was not guarded by an ifdef -
https://github.com/ruby/ruby/blob/v2_0_0_598/ext/etc/etc.c#L682

This goes for both x86 and x64 versions of Ruby. Since Etc is not used
on Windows, it is safe to confine this spec to only run on POSIX
systems.