### PR TITLE
Issue/pup 3665/make tagged case insensitive

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -189,15 +189,21 @@ class Puppet::Parser::Resource < Puppet::Resource
     copy_as_resource.to_ral
   end
 
-  # Is the receiver tagged with the given tags?
+  # Faster variant of the tagged method that does no conversion of its
+  # arguments. Instead it's assumed that the arguments already are
+  # downcased strings.
+  #
   # This match takes into account the tags that a resource will inherit from its container
   # but have not been set yet.
   # It does *not* take tags set via resource defaults as these will *never* be set on
   # the resource itself since all resources always have tags that are automatically
   # assigned.
   #
-  def tagged?(*tags)
-    super || ((scope_resource = scope.resource) && scope_resource != self && scope_resource.tagged?(tags))
+  # @param tag_array [Array[String]] list tags to look for
+  # @return [Boolean] true if this instance is tagged with at least one of the provided tags
+  #
+  def raw_tagged?(tag_array)
+    super || ((scope_resource = scope.resource) && !scope_resource.equal?(self) && scope_resource.raw_tagged?(tag_array))
   end
 
   private

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -189,11 +189,12 @@ class Puppet::Parser::Resource < Puppet::Resource
     copy_as_resource.to_ral
   end
 
-  # Faster variant of the tagged method that does no conversion of its
-  # arguments. Instead it's assumed that the arguments already are
-  # downcased strings.
+  # Answers if this resource is tagged with at least one of the tags given in downcased string form.
   #
-  # This match takes into account the tags that a resource will inherit from its container
+  # The method is a faster variant of the tagged? method that does no conversion of its
+  # arguments.
+  #
+  # The match takes into account the tags that a resource will inherit from its container
   # but have not been set yet.
   # It does *not* take tags set via resource defaults as these will *never* be set on
   # the resource itself since all resources always have tags that are automatically

--- a/lib/puppet/pops/evaluator/collector_transformer.rb
+++ b/lib/puppet/pops/evaluator/collector_transformer.rb
@@ -95,8 +95,19 @@ protected
     case o.operator
     when :'=='
       if left_code == "tag"
+        # Ensure that to_s and downcase is done once, i.e. outside the proc block and
+        # then use raw_tagged? instead of tagged?
+        if right_code.is_a?(Array)
+          tags = right_code
+        else
+          tags = [ right_code ]
+        end
+        tags = tags.collect do |t|
+          raise ArgumentError, 'Cannot transform a number to a tag' if t.is_a?(Numeric)
+          t.to_s.downcase
+        end
         proc do |resource|
-          resource.tagged?(right_code)
+          resource.raw_tagged?(tags)
         end
       else
         proc do |resource|

--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -23,7 +23,9 @@ module Puppet::Util::Tagging
     end
   end
 
-  # Is the receiver tagged with at least one of the given tags?
+  # Answers if this resource is tagged with at least one of the given tags.
+  #
+  # The given tags are converted to downcased strings before the match is performed.
   #
   # @param *tags [String] splat of tags to look for
   # @return [Boolean] true if this instance is tagged with at least one of the provided tags
@@ -32,16 +34,17 @@ module Puppet::Util::Tagging
     raw_tagged?(tags.collect {|t| t.to_s.downcase})
   end
 
-  # Faster variant of the tagged method that does no conversion of its
-  # arguments. Instead it's assumed that the arguments already are
-  # downcased strings.
+  # Answers if this resource is tagged with at least one of the tags given in downcased string form.
   #
-  # @param tag_array [Array] array of tags to look for
+  # The method is a faster variant of the tagged? method that does no conversion of its
+  # arguments.
+  #
+  # @param tag_array [Array[String]] array of tags to look for
   # @return [Boolean] true if this instance is tagged with at least one of the provided tags
   #
   def raw_tagged?(tag_array)
     my_tags = self.tags
-    not tag_array.index { |t| my_tags.include?(t) }.nil?
+    !tag_array.index { |t| my_tags.include?(t) }.nil?
   end
 
   # Return a copy of the tag list, so someone can't ask for our tags

--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -23,9 +23,25 @@ module Puppet::Util::Tagging
     end
   end
 
-  # Is the receiver tagged with the given tags?
+  # Is the receiver tagged with at least one of the given tags?
+  #
+  # @param *tags [String] splat of tags to look for
+  # @return [Boolean] true if this instance is tagged with at least one of the provided tags
+  #
   def tagged?(*tags)
-    not ( self.tags & tags.flatten.collect { |t| t.to_s } ).empty?
+    raw_tagged?(tags.collect {|t| t.to_s.downcase})
+  end
+
+  # Faster variant of the tagged method that does no conversion of its
+  # arguments. Instead it's assumed that the arguments already are
+  # downcased strings.
+  #
+  # @param tag_array [Array] array of tags to look for
+  # @return [Boolean] true if this instance is tagged with at least one of the provided tags
+  #
+  def raw_tagged?(tag_array)
+    my_tags = self.tags
+    not tag_array.index { |t| my_tags.include?(t) }.nil?
   end
 
   # Return a copy of the tag list, so someone can't ask for our tags

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -88,6 +88,13 @@ describe Puppet::Util::Tagging do
       expect(tagger).to be_tagged("goodbye")
     end
 
+    it "downcases tag arguments" do
+      tagger.tag("hello")
+      tagger.tag("goodbye")
+      expect(tagger).to be_tagged(:HEllO)
+      expect(tagger).to be_tagged("GooDByE")
+    end
+
     it "accepts hyphenated tags" do
       tagger.tag("my-tag")
       expect(tagger).to be_tagged("my-tag")


### PR DESCRIPTION
(PUP-3665) Make tagging arguments case insensitive
Tags are stored internally as downcased strings. All objects passed
as tags to the tagged? method where converted to strings prior to
comparison but they were not downcased. As a result, a query for
tags containing uppercase letters would always fail.

This commit adds the needed downcasing of the tags parameter. It
also introduces a new raw_tagged? method that assumes that whatever
tags that are passed to it already have been converted to strings
and downcased. This to allow the CollectorTransformer to do this
conversion once and then ask multiple resources if they are tagged.