### PR TITLE
(PUP-3839) Fix calling gem on Windows

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -206,8 +206,15 @@ module Puppet
         gem_source = ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
         hosts.each do |host|
-          on host, 'gem source --clear-all'
-          on host, "gem source --add #{gem_source}"
+          case host['platform']
+          when /windows/
+            gem = 'cmd /c gem'
+          else
+            gem = 'gem'
+          end
+
+          on host, "#{gem} source --clear-all"
+          on host, "#{gem} source --add #{gem_source}"
         end
       end
     end

--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -84,8 +84,6 @@ end
 
 install_packages_on(hosts, PACKAGES, :check_if_exists => true)
 
-configure_gem_mirror(hosts)
-
 hosts.each do |host|
   case host['platform']
   when /windows/
@@ -111,6 +109,14 @@ hosts.each do |host|
     on host, 'cd /; icacls bin /reset /T'
     on host, 'ruby --version'
     on host, 'cmd /c gem list'
+  end
+end
+
+# Only configure gem mirror after Ruby has been installed, but before any gems are installed.
+configure_gem_mirror(hosts)
+
+hosts.each do |host|
+  case host['platform']
   when /solaris/
     step "#{host} Install json from rubygems"
     on host, 'gem install json_pure'


### PR DESCRIPTION
Fixes calling the gem command on Windows, which requires that Ruby is
installed first and that it be called via cmd /c.