### PR TITLE
(PUP-3853) Add cfacter to the msi build

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -22,6 +22,11 @@ build_msi:
   facter:
     ref: 'refs/tags/2.3.0'
     repo: 'git://github.com/puppetlabs/facter.git'
+  cfacter:
+    archive:
+      x86: 'cfacter-0.3.0-x86.zip'
+      x64: 'cfacter-0.3.0-x64.zip'
+    path: 'http://builds.puppetlabs.lan/cfacter/0.3.0/artifacts/windows'
   hiera:
     ref: 'refs/tags/1.3.4'
     repo: 'git://github.com/puppetlabs/hiera.git'


### PR DESCRIPTION
This commit will allow us to include a specific cfacter build in the
puppet-agent msi package. This update is dependent on updates to the
automation in puppet_for_the_win to be able to encorporate this
addition.