### PR TITLE
(PUP-3844) Rename the MSI

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -14,6 +14,7 @@ yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: TRUE
 build_dmg: TRUE
+msi_name: 'puppet-agent'
 build_msi:
   puppet_for_the_win:
     ref: '2476cd007b1b52fb1b9f22202b56218629626b5c'


### PR DESCRIPTION
This change is necessary because we are renaming the puppet installer
on windows. Since we want to maintain the ability to build older
versions of the puppet installer with the old name, this new var will
allow us to know when we expect the new name, and when we expect the old
name.