### PR TITLE
(PUP-3461) Make Variant assignable when contained types are assignable

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -272,7 +272,12 @@ class Puppet::Pops::Types::TypeCalculator
     # Unit can be assigned to anything
     return true if t2.class == Types::PUnitType
 
-    @@assignable_visitor.visit_this_1(self, t, t2)
+    if t2.class == Types::PVariantType
+      # Assignable if all contained types are assignable
+      t2.types.all? { |vt| @@assignable_visitor.visit_this_1(self, t, vt) }
+    else
+      @@assignable_visitor.visit_this_1(self, t, t2)
+    end
  end
 
   # Returns an enumerable if the t represents something that can be iterated
@@ -411,9 +416,18 @@ class Puppet::Pops::Types::TypeCalculator
     return false unless o.is_a?(Array)
     return false unless o.all? {|element| instance_of(t.element_type, element) }
     size_t = t.size_type || @collection_default_size_t
-    size_t2 = size_as_type(o)
     # optimize by calling directly
-    assignable_PIntegerType(size_t, size_t2)
+    return instance_of_PIntegerType(size_t, o.size)
+  end
+
+  # @api private
+  def instance_of_PIntegerType(t, o)
+    return false unless o.is_a?(Integer)
+    x = t.from
+    x = -Float::INFINITY if x.nil? || x == :default
+    y = t.to
+    y = Float::INFINITY if y.nil? || y == :default
+    return x < y ? x <= o && y >= o : y <= o && x >= o
   end
 
   def instance_of_PTupleType(t, o)
@@ -421,9 +435,7 @@ class Puppet::Pops::Types::TypeCalculator
     # compute the tuple's min/max size, and check if that size matches
     size_t = t.size_type || Puppet::Pops::Types::TypeFactory.range(*t.size_range)
 
-    # compute the array's size as type
-    size_t2 = size_as_type(o)
-    return false unless assignable?(size_t, size_t2)
+    return false unless instance_of_PIntegerType(size_t, o.size)
     o.each_with_index do |element, index|
        return false unless instance_of(t.types[index] || t.types[-1], element)
     end
@@ -443,9 +455,8 @@ class Puppet::Pops::Types::TypeCalculator
     element_t = t.element_type
     return false unless o.keys.all? {|key| instance_of(key_t, key) } && o.values.all? {|value| instance_of(element_t, value) }
     size_t = t.size_type || @collection_default_size_t
-    size_t2 = size_as_type(o)
     # optimize by calling directly
-    assignable_PIntegerType(size_t, size_t2)
+    return instance_of_PIntegerType(size_t, o.size)
   end
 
   def instance_of_PDataType(t, o)

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -568,6 +568,24 @@ describe 'The type calculator' do
       end
     end
 
+    context 'for Variant, such that' do
+      it 'it is assignable to a type if all contained types are assignable to that type' do
+        v = variant_t(range_t(10, 12),range_t(14, 20))
+        v.should be_assignable_to(integer_t)
+        v.should be_assignable_to(range_t(10, 20))
+
+        # test that both types are assignable to one of the variants OK
+        v.should be_assignable_to(variant_t(range_t(10, 20), range_t(30, 40)))
+
+        # test where each type is assignable to different types in a variant is OK
+        v.should be_assignable_to(variant_t(range_t(10, 13), range_t(14, 40)))
+
+        # not acceptable
+        v.should_not be_assignable_to(range_t(0, 4))
+        v.should_not be_assignable_to(string_t)
+      end
+    end
+
     context "for Scalar, such that" do
       it "all scalars are assignable to Scalar" do
         t = Puppet::Pops::Types::PScalarType.new()


### PR DESCRIPTION
This commit changes the assignable?(t1, t2) so that A Variant t2 is
assignable to t1 if all types contained in t2 are assignable to t1. A
test is also added to verify this behavior.

The commit also adds the method instance_of_PIntegerType(t, o) as
a performance improvement. There were several places where an integer
instance was checked against an existing PIntegerType. Creating an
interim type for that instance just to perform the check is expensive
and puts an unecessary load on the garbage collector.