### PR TITLE
(PUP-3786) Correct text length calculation of [] and {}

### DIFF
--- a/lib/puppet/pops/parser/egrammar.ra
+++ b/lib/puppet/pops/parser/egrammar.ra
@@ -635,14 +635,14 @@ reserved_word
 
 array
   : LISTSTART assignments endcomma  RBRACK { result = Factory.LIST(val[1]); loc result, val[0], val[3] }
-  | LISTSTART                       RBRACK { result = Factory.literal([]) ; loc result, val[0] }
+  | LISTSTART                       RBRACK { result = Factory.literal([]) ; loc result, val[0], val[1] }
   | LBRACK    assignments endcomma  RBRACK { result = Factory.LIST(val[1]); loc result, val[0], val[3] }
-  | LBRACK                          RBRACK { result = Factory.literal([]) ; loc result, val[0] }
+  | LBRACK                          RBRACK { result = Factory.literal([]) ; loc result, val[0], val[1] }
 
 hash
   : LBRACE hashpairs RBRACE       { result = Factory.HASH(val[1]); loc result, val[0], val[2] }
   | LBRACE hashpairs COMMA RBRACE { result = Factory.HASH(val[1]); loc result, val[0], val[3] }
-  | LBRACE RBRACE                 { result = Factory.literal({}) ; loc result, val[0], val[3] }
+  | LBRACE RBRACE                 { result = Factory.literal({}) ; loc result, val[0], val[1] }
 
   hashpairs
     : hashpair                 { result = [val[0]] }

--- a/lib/puppet/pops/parser/eparser.rb
+++ b/lib/puppet/pops/parser/eparser.rb
@@ -2360,7 +2360,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 636)
 
 module_eval(<<'.,.,', 'egrammar.ra', 637)
   def _reduce_180(val, _values, result)
-     result = Factory.literal([]) ; loc result, val[0] 
+     result = Factory.literal([]) ; loc result, val[0], val[1] 
     result
   end
 .,.,
@@ -2374,7 +2374,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 638)
 
 module_eval(<<'.,.,', 'egrammar.ra', 639)
   def _reduce_182(val, _values, result)
-     result = Factory.literal([]) ; loc result, val[0] 
+     result = Factory.literal([]) ; loc result, val[0], val[1] 
     result
   end
 .,.,
@@ -2395,7 +2395,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 643)
 
 module_eval(<<'.,.,', 'egrammar.ra', 644)
   def _reduce_185(val, _values, result)
-     result = Factory.literal({}) ; loc result, val[0], val[3] 
+     result = Factory.literal({}) ; loc result, val[0], val[1] 
     result
   end
 .,.,

--- a/spec/unit/pops/parser/parse_basic_expressions_spec.rb
+++ b/spec/unit/pops/parser/parse_basic_expressions_spec.rb
@@ -163,6 +163,11 @@ describe "egrammar parsing basic expressions" do
     it "$a [1,2,3] == [1,2,3]" do
       dump(parse("$a = [1,2,3] == [1,2,3]")).should == "(= $a (== ([] 1 2 3) ([] 1 2 3)))"
     end
+
+    it "calculates the text length of an empty array" do
+      expect(parse("[]").current.body.length).to eq(2)
+      expect(parse("[ ]").current.body.length).to eq(3)
+    end
   end
 
   context "When parsing indexed access" do
@@ -220,6 +225,11 @@ describe "egrammar parsing basic expressions" do
 
     it "$a = {'a'=> 1, 'b'=>2} != {'x'=> 1, 'y'=>3}" do
       dump(parse("$a = {'a'=>1,'b'=>2} != {'a'=>1,'b'=>2}")).should == "(= $a (!= ({} ('a' 1) ('b' 2)) ({} ('a' 1) ('b' 2))))"
+    end
+
+    it "calculates the text length of an empty hash" do
+      expect(parse("{}").current.body.length).to eq(2)
+      expect(parse("{ }").current.body.length).to eq(3)
     end
   end
 


### PR DESCRIPTION
The length of the source text associated with model elements is
important for error reporting and for the Puppet Strings documentation
tool. The grammar did not correctly produce the length of empty array
and hash expresses (they were always recorded with a length of 1).

This was caused by rules either referencing a non existant token, or by
only including the starting token in the calculation (which always leads
to a length of 1).

This commit changes the grammar's calls to associate length for the
erronous cases. Tests are also added.