### PR TITLE
(PUP-3002) Improve error message for invalid parameter name

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -498,7 +498,7 @@ class Puppet::Resource
   end
 
   def validate_parameter(name)
-    raise ArgumentError, "Invalid parameter #{name}" unless valid_parameter?(name)
+    raise ArgumentError, "Invalid parameter: '#{name}'" unless valid_parameter?(name)
   end
 
   def prune_parameters(options = {})

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -664,7 +664,7 @@ describe Puppet::Parser::Compiler do
       @node.classes = klass
       klass = Puppet::Resource::Type.new(:hostclass, 'foo', :arguments => {})
       @compiler.topscope.known_resource_types.add klass
-      lambda { @compiler.compile }.should raise_error(Puppet::ParseError, "Invalid parameter 3 on Class[Foo]")
+      lambda { @compiler.compile }.should raise_error(Puppet::ParseError, "Invalid parameter: '3' on Class[Foo]")
     end
 
     it "should ensure class is in catalog without params" do

--- a/spec/integration/parser/resource_expressions_spec.rb
+++ b/spec/integration/parser/resource_expressions_spec.rb
@@ -164,15 +164,15 @@ describe "Puppet resource expressions" do
              path => '/somewhere',
              * => $y }"  => "File[$t][mode] == '0666' and File[$t][owner] == 'the_x' and File[$t][path] == '/somewhere'")
 
-    fails("notify { title: unknown => value }" => /Invalid parameter unknown/)
+    fails("notify { title: unknown => value }" => /Invalid parameter: 'unknown'/)
 
     # this really needs to be a better error message.
-    fails("notify { title: * => { hash => value }, message => oops }" => /Invalid parameter hash/)
+    fails("notify { title: * => { hash => value }, message => oops }" => /Invalid parameter: 'hash'/)
 
     # should this be a better error message?
-    fails("notify { title: message => oops, * => { hash => value } }" => /Invalid parameter hash/)
+    fails("notify { title: message => oops, * => { hash => value } }" => /Invalid parameter: 'hash'/)
 
-    fails("notify { title: * => { unknown => value } }" => /Invalid parameter unknown/)
+    fails("notify { title: * => { unknown => value } }" => /Invalid parameter: 'unknown'/)
     fails("
          $x = { mode => '0666' }
          $y = { owner => the_y }

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -664,7 +664,7 @@ describe Puppet::Parser::Compiler do
       @node.classes = klass
       klass = Puppet::Resource::Type.new(:hostclass, 'foo', :arguments => {})
       @compiler.topscope.known_resource_types.add klass
-      lambda { @compiler.compile }.should raise_error(Puppet::ParseError, "Invalid parameter 3 on Class[Foo]")
+      lambda { @compiler.compile }.should raise_error(Puppet::ParseError, "Invalid parameter: '3' on Class[Foo]")
     end
 
     it "should ensure class is in catalog without params" do


### PR DESCRIPTION
The error message emitted when an attribute operation used
an attribute name that was invalid did not read well and caused
confusion since it did not clearly indicate that part of the message was
the name of the parameter - e.g. "invalid parameter hash" which can be
read as an invalid "parameter hash" (confusing when actually setting all
parameters from a hash and having a parameter named 'hash' in the hash).

The message is now changed to say "Invalid parameter: '<name>'". As a
consequence spec tests are updated to match this message.