### PR TITLE
(PUP-3548) Allow 4x functions to call 3x functions

### DIFF
--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -96,6 +96,7 @@ module Puppet
 
     module Evaluator
       require 'puppet/pops/evaluator/callable_signature'
+      require 'puppet/pops/evaluator/runtime3_converter'
       require 'puppet/pops/evaluator/runtime3_support'
       require 'puppet/pops/evaluator/evaluator_impl'
       require 'puppet/pops/evaluator/epp_evaluator'

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -53,9 +53,6 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
 
     @@compare_operator     ||= Puppet::Pops::Evaluator::CompareOperator.new()
     @@relationship_operator ||= Puppet::Pops::Evaluator::RelationshipOperator.new()
-
-    # Initialize the runtime module
-    Puppet::Pops::Evaluator::Runtime3Support.instance_method(:initialize).bind(self).call()
   end
 
   # @api private

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -1,0 +1,175 @@
+module Puppet::Pops::Evaluator
+# Converts nested 4x supported values to 3x values. This is required because
+# resources and other objects do not know about the new type system, and does not support
+# regular expressions. Unfortunately this has to be done for array and hash as well.
+# A complication is that catalog types needs to be resolved against the scope.
+#
+# Users should not create instances of this class. Instead the class methods {Runtime3Converter.convert},
+# {Runtime3Converter.convert_args}, or {Runtime3Converter.instance} should be used
+class Runtime3Converter
+  # Converts 4x supported values to a 3x values using the singleton instance.
+  #
+  # @param args [Array] Array of values to convert
+  # @param scope [Puppet::Parser::Scope] The scope to use when converting
+  # @param undef_value [Object] The value that nil is converted to
+  # @return [Array] The converted values
+  #
+  def self.convert_args(args, scope, undef_value)
+    @@instance.convert_args(args, scope, undef_value)
+  end
+
+  # Converts a 4x supported value to a 3x value using the singleton instance.
+  #
+  # @param o [Object]The value to convert
+  # @param scope [Puppet::Parser::Scope] The scope to use when converting
+  # @param undef_value [Object] The value that nil is converted to
+  # @return [Object] The converted value
+  #
+  def self.convert(o, scope, undef_value)
+    @@instance.convert(o, scope, undef_value)
+  end
+
+  # Returns the singleton instance of this class.
+  # @return [Runtime3Converter] The singleton instance
+  def self.instance
+    @@instance
+  end
+
+  # Converts 4x supported values to a 3x values.
+  #
+  # @param args [Array] Array of values to convert
+  # @param scope [Puppet::Parser::Scope] The scope to use when converting
+  # @param undef_value [Object] The value that nil is converted to
+  # @return [Array] The converted values
+  #
+  def convert_args(args, scope, undef_value)
+    args.map {|a| convert(a, scope, undef_value) }
+  end
+
+  # Converts a 4x supported value to a 3x value.
+  #
+  # @param o [Object]The value to convert
+  # @param scope [Puppet::Parser::Scope] The scope to use when converting
+  # @param undef_value [Object] The value that nil is converted to
+  # @return [Object] The converted value
+  #
+  def convert(o, scope, undef_value)
+    @convert_visitor.visit_this_2(self, o, scope, undef_value)
+  end
+
+  def convert_NilClass(o, scope, undef_value)
+    undef_value
+  end
+
+  def convert2_NilClass(o, scope, undef_value)
+    :undef
+  end
+
+  def convert_String(o, scope, undef_value)
+    # although wasteful, needed because user code may mutate these strings in Resources
+    o.frozen? ? o.dup : o
+  end
+  alias convert2_String :convert_String
+
+  def convert_Object(o, scope, undef_value)
+    o
+  end
+  alias :convert2_Object :convert_Object
+
+  def convert_Array(o, scope, undef_value)
+    o.map {|x| convert2(x, scope, undef_value) }
+  end
+  alias :convert2_Array :convert_Array
+
+  def convert_Hash(o, scope, undef_value)
+    result = {}
+    o.each {|k,v| result[convert2(k, scope, undef_value)] = convert2(v, scope, undef_value) }
+    result
+  end
+  alias :convert2_Hash :convert_Hash
+
+  def convert_Regexp(o, scope, undef_value)
+    # Puppet 3x cannot handle parameter values that are reqular expressions. Turn into regexp string in
+    # source form
+    o.inspect
+  end
+  alias :convert2_Regexp :convert_Regexp
+
+  def convert_Symbol(o, scope, undef_value)
+    case o
+      # Support :undef since it may come from a 3x structure
+      when :undef
+        undef_value  # 3x wants undef as either empty string or :undef
+      else
+        o   # :default, and all others are verbatim since they are new in future evaluator
+    end
+  end
+
+  # The :undef symbol should not be converted when nested in arrays or hashes
+  def convert2_Symbol(o, scope, undef_value)
+    o
+  end
+
+  def convert_PAnyType(o, scope, undef_value)
+    o
+  end
+  alias :convert2_PAnyType :convert_PAnyType
+
+  def convert_PCatalogEntryType(o, scope, undef_value)
+    # Since 4x does not support dynamic scoping, all names are absolute and can be
+    # used as is (with some check/transformation/mangling between absolute/relative form
+    # due to Puppet::Resource's idiosyncratic behavior where some references must be
+    # absolute and others cannot be.
+    # Thus there is no need to call scope.resolve_type_and_titles to do dynamic lookup.
+
+    Puppet::Resource.new(*catalog_type_to_split_type_title(o))
+  end
+  alias :convert2_PCatalogEntryType :convert_PCatalogEntryType
+
+  # Produces an array with [type, title] from a PCatalogEntryType
+  # This method is used to produce the arguments for creation of reference resource instances
+  # (used when 3x is operating on a resource).
+  # Ensures that resources are *not* absolute.
+  #
+  def catalog_type_to_split_type_title(catalog_type)
+    split_type = catalog_type.is_a?(Puppet::Pops::Types::PType) ? catalog_type.type : catalog_type
+    case split_type
+      when Puppet::Pops::Types::PHostClassType
+        class_name = split_type.class_name
+        ['class', class_name.nil? ? nil : class_name.sub(/^::/, '')]
+      when Puppet::Pops::Types::PResourceType
+        type_name = split_type.type_name
+        title = split_type.title
+        if type_name =~ /^(::)?[Cc]lass/
+          ['class', title.nil? ? nil : title.sub(/^::/, '')]
+        else
+          # Ensure that title is '' if nil
+          # Resources with absolute name always results in error because tagging does not support leading ::
+          [type_name.nil? ? nil : type_name.sub(/^::/, ''), title.nil? ? '' : title]
+        end
+      else
+        raise ArgumentError, "Cannot split the type #{catalog_type.class}, it represents neither a PHostClassType, nor a PResourceType."
+    end
+  end
+
+  private
+
+  def initialize
+    @convert_visitor  = Puppet::Pops::Visitor.new(self, 'convert', 2, 2)
+    @convert2_visitor = Puppet::Pops::Visitor.new(self, 'convert2', 2, 2)
+  end
+
+  @@instance = self.new
+
+  # Converts a nested 4x supported value to a 3x value.
+  #
+  # @param o [Object]The value to convert
+  # @param scope [Puppet::Parser::Scope] The scope to use when converting
+  # @param undef_value [Object] The value that nil is converted to
+  # @return [Object] The converted value
+  #
+  def convert2(o, scope, undef_value)
+    @convert2_visitor.visit_this_2(self, o, scope, undef_value)
+  end
+end
+end

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -199,7 +199,7 @@ module Puppet::Pops::Evaluator::Runtime3Support
       source_resource = source
     else
       # transform into the wonderful String representation in 3x
-      type, title = catalog_type_to_split_type_title(source)
+      type, title = Puppet::Pops::Evaluator::Runtime3Converter.instance.catalog_type_to_split_type_title(source)
       source_resource = Puppet::Resource.new(type, title)
     end
     if target.is_a?(Puppet::Parser::Collector) || target.is_a?(Puppet::Pops::Evaluator::Collectors::AbstractCollector)
@@ -207,7 +207,7 @@ module Puppet::Pops::Evaluator::Runtime3Support
       target_resource = target
     else
       # transform into the wonderful String representation in 3x
-      type, title = catalog_type_to_split_type_title(target)
+      type, title = Puppet::Pops::Evaluator::Runtime3Converter.instance.catalog_type_to_split_type_title(target)
       target_resource = Puppet::Resource.new(type, title)
     end
     # Add the relationship to the compiler for later evaluation.
@@ -244,7 +244,7 @@ module Puppet::Pops::Evaluator::Runtime3Support
 
     # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.
     # NOTE: Passing an empty string last converts nil/:undef to empty string
-    mapped_args = args.map {|a| convert(a, scope, '') }
+    mapped_args = Puppet::Pops::Evaluator::Runtime3Converter.convert_args(args, scope, '')
     result = scope.send("function_#{name}", mapped_args)
     # Prevent non r-value functions from leaking their result (they are not written to care about this)
     Puppet::Parser::Functions.rvalue?(name) ? result : nil
@@ -259,6 +259,10 @@ module Puppet::Pops::Evaluator::Runtime3Support
       :source => scope.source, :line => line, :file => file,
       :add    => operator == :'+>'
     )
+  end
+
+  def convert(value, scope, undef_value)
+    Puppet::Pops::Evaluator::Runtime3Converter.convert(value, scope, undef_value)
   end
 
   CLASS_STRING = 'class'.freeze
@@ -421,127 +425,6 @@ module Puppet::Pops::Evaluator::Runtime3Support
   # @param x [Object] the object to test if it is instance of TrueClass or FalseClass
   def is_boolean? x
     x.is_a?(TrueClass) || x.is_a?(FalseClass)
-  end
-
-  def initialize
-    @@convert_visitor   ||= Puppet::Pops::Visitor.new(self, "convert", 2, 2)
-    @@convert2_visitor   ||= Puppet::Pops::Visitor.new(self, "convert2", 2, 2)
-  end
-
-  # Converts 4x supported values to 3x values. This is required because
-  # resources and other objects do not know about the new type system, and does not support
-  # regular expressions. Unfortunately this has to be done for array and hash as well.
-  # A complication is that catalog types needs to be resolved against the scope.
-  #
-  def convert(o, scope, undef_value)
-    @@convert_visitor.visit_this_2(self, o, scope, undef_value)
-  end
-
-  # Converts nested 4x supported values to 3x values. This is required because
-  # resources and other objects do not know about the new type system, and does not support
-  # regular expressions. Unfortunately this has to be done for array and hash as well.
-  # A complication is that catalog types needs to be resolved against the scope.
-  #
-  def convert2(o, scope, undef_value)
-    @@convert2_visitor.visit_this_2(self, o, scope, undef_value)
-  end
-
-
-  def convert_NilClass(o, scope, undef_value)
-    undef_value
-  end
-
-  def convert2_NilClass(o, scope, undef_value)
-    :undef
-  end
-
-  def convert_String(o, scope, undef_value)
-    # although wasteful, needed because user code may mutate these strings in Resources
-    o.frozen? ? o.dup : o
-  end
-  alias convert2_String :convert_String
-
-  def convert_Object(o, scope, undef_value)
-    o
-  end
-  alias :convert2_Object :convert_Object
-
-  def convert_Array(o, scope, undef_value)
-    o.map {|x| convert2(x, scope, undef_value) }
-  end
-  alias :convert2_Array :convert_Array
-
-  def convert_Hash(o, scope, undef_value)
-    result = {}
-    o.each {|k,v| result[convert2(k, scope, undef_value)] = convert2(v, scope, undef_value) }
-    result
-  end
-  alias :convert2_Hash :convert_Hash
-
-  def convert_Regexp(o, scope, undef_value)
-    # Puppet 3x cannot handle parameter values that are reqular expressions. Turn into regexp string in
-    # source form
-    o.inspect
-  end
-  alias :convert2_Regexp :convert_Regexp
-
-  def convert_Symbol(o, scope, undef_value)
-    case o
-    # Support :undef since it may come from a 3x structure
-    when :undef
-      undef_value  # 3x wants undef as either empty string or :undef
-    else
-      o   # :default, and all others are verbatim since they are new in future evaluator
-    end
-  end
-
-  # The :undef symbol should not be converted when nested in arrays or hashes
-  def convert2_Symbol(o, scope, undef_value)
-    o
-  end
-
-  def convert_PAnyType(o, scope, undef_value)
-    o
-  end
-  alias :convert2_PAnyType :convert_PAnyType
-
-  def convert_PCatalogEntryType(o, scope, undef_value)
-    # Since 4x does not support dynamic scoping, all names are absolute and can be
-    # used as is (with some check/transformation/mangling between absolute/relative form
-    # due to Puppet::Resource's idiosyncratic behavior where some references must be
-    # absolute and others cannot be.
-    # Thus there is no need to call scope.resolve_type_and_titles to do dynamic lookup.
-
-    Puppet::Resource.new(*catalog_type_to_split_type_title(o))
-  end
-  alias :convert2_PCatalogEntryType :convert_PCatalogEntryType
-
-  private
-
-  # Produces an array with [type, title] from a PCatalogEntryType
-  # This method is used to produce the arguments for creation of reference resource instances
-  # (used when 3x is operating on a resource).
-  # Ensures that resources are *not* absolute.
-  #
-  def catalog_type_to_split_type_title(catalog_type)
-    split_type = catalog_type.is_a?(Puppet::Pops::Types::PType) ? catalog_type.type : catalog_type
-    case split_type
-    when Puppet::Pops::Types::PHostClassType
-      class_name = split_type.class_name
-      ['class', class_name.nil? ? nil : class_name.sub(/^::/, '')]
-    when Puppet::Pops::Types::PResourceType
-      type_name = split_type.type_name
-      title = split_type.title
-      if type_name =~ /^(::)?[Cc]lass/
-        ['class', title.nil? ? nil : title.sub(/^::/, '')]
-      else
-        # Ensure that title is '' if nil
-        # Resources with absolute name always results in error because tagging does not support leading ::
-        [type_name.nil? ? nil : type_name.sub(/^::/, ''), title.nil? ? '' : title]
-      end
-    else
-      raise ArgumentError, "Cannot split the type #{catalog_type.class}, it represents neither a PHostClassType, nor a PResourceType."
-    end
   end
 
   def extract_file_line(o)

--- a/lib/puppet/pops/functions/function.rb
+++ b/lib/puppet/pops/functions/function.rb
@@ -47,18 +47,46 @@ class Puppet::Pops::Functions::Function
   # Allows the implementation of a function to call other functions by name. The callable functions
   # are those visible to the same loader that loaded this function (the calling function).
   #
+  # @param function_name [String] The name of the function
+  # @param args [Any] splat of arguments
+  # @return [Any] The result returned by the called function
+  #
   # @api public
   def call_function(function_name, *args)
-    if the_loader = loader
-      func = the_loader.load(:function, function_name)
-      if func
-        return func.call(closure_scope, *args)
-      end
-    end
-    # Raise a generic error to allow upper layers to fill in the details about where in a puppet manifest this
-    # error originates. (Such information is not available here).
-    #
-    raise ArgumentError, "Function #{self.class.name}(): cannot call function '#{function_name}' - not found"
+    call_function_with_scope(closure_scope, function_name, *args)
+  end
+
+  # Allows the implementation of a function to call other functions by name and pass the caller
+  # scope. The callable functions are those visible to the same loader that loaded this function
+  # (the calling function).
+  #
+  # @param scope [Puppet::Parser::Scope] The caller scope
+  # @param function_name [String] The name of the function
+  # @param args [Any] splat of arguments
+  # @return [Any] The result returned by the called function
+  #
+  # @api public
+  def call_function_with_scope(scope, function_name, *args)
+
+    the_loader = loader
+    raise ArgumentError, "Function #{self.class.name}(): cannot call function '#{function_name}' - no loader specified" unless the_loader
+
+    func = the_loader.load(:function, function_name)
+    return func.call(scope, *args) if func
+
+    # Check if a 3x function is present. Raise a generic error if it's not to allow upper layers to fill in the details
+    # about where in a puppet manifest this error originates. (Such information is not available here).
+    loader_scope = closure_scope
+    func_3x = Puppet::Parser::Functions.function(function_name, loader_scope.environment) if loader_scope.is_a?(Puppet::Parser::Scope)
+    raise ArgumentError, "Function #{self.class.name}(): cannot call function '#{function_name}' - not found" unless func_3x
+
+    # Call via 3x API
+    # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.
+    # NOTE: Passing an empty string last converts nil/:undef to empty string
+    result = scope.send(func_3x, Puppet::Pops::Evaluator::Runtime3Converter.convert_args(args, loader_scope, ''))
+
+    # Prevent non r-value functions from leaking their result (they are not written to care about this)
+    Puppet::Parser::Functions.rvalue?(function_name) ? result : nil
   end
 
   # The dispatcher for the function

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/callee.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/callee.rb
@@ -1,0 +1,8 @@
+module Puppet::Parser::Functions
+  newfunction(:callee, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    "usee::callee() got '#{arguments[0]}'"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/callee_ws.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/callee_ws.rb
@@ -1,0 +1,8 @@
+module Puppet::Parser::Functions
+  newfunction(:callee_ws, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    "usee::callee_ws() got '#{self['passed_in_scope']}'"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/metadata.json
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-usee",
+  "author": "test",
+  "description": "",
+  "license": "",
+  "source": "",
+  "version": "1.0.0",
+  "dependencies": []
+}

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/user/lib/puppet/functions/user/caller.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/user/lib/puppet/functions/user/caller.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:'user::caller') do
+  def caller()
+    call_function('callee', 'first') + ' - ' + call_function('callee', 'second')
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/user/lib/puppet/functions/user/caller_ws.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/user/lib/puppet/functions/user/caller_ws.rb
@@ -1,0 +1,12 @@
+Puppet::Functions.create_function(:'user::caller_ws', Puppet::Functions::InternalFunction) do
+  dispatch :caller_ws do
+    scope_param
+    param 'String', 'value'
+  end
+
+  def caller_ws(scope, value)
+    scope = scope.compiler.newscope(scope)
+    scope['passed_in_scope'] = value
+    call_function_with_scope(scope, 'callee_ws')
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/user/metadata.json
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/user/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-user",
+  "author": "test",
+  "description": "",
+  "license": "",
+  "source": "",
+  "version": "1.0.0",
+  "dependencies": [{ "name": "test/usee" }]
+}

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -27,6 +27,7 @@ describe 'loaders' do
   include PuppetSpec::Files
 
   let(:module_without_metadata) { File.join(config_dir('wo_metadata_module'), 'modules') }
+  let(:mix_4x_and_3x_functions) { config_dir('mix_4x_and_3x_functions') }
   let(:module_with_metadata) { File.join(config_dir('single_module'), 'modules') }
   let(:dependent_modules_with_metadata) { config_dir('dependent_modules_with_metadata') }
   let(:empty_test_env) { environment_for() }
@@ -99,6 +100,26 @@ describe 'loaders' do
     expect(function.call({})).to eql("usee::callee() was told 'passed value' + I am user::caller()")
   end
 
+  context 'with scope' do
+    let(:env) { environment_for(mix_4x_and_3x_functions) }
+    let(:scope) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)).newscope(nil) }
+    let(:loader) { Puppet::Pops::Loaders.new(env).private_loader_for_module('user') }
+
+    it 'can call 3x function in dependent module from a 4x function' do
+      Puppet.override({ :current_environment => scope.environment, :global_scope => scope }) do
+        function = loader.load_typed(typed_name(:function, 'user::caller')).value
+        expect(function.call(scope)).to eql("usee::callee() got 'first' - usee::callee() got 'second'")
+      end
+    end
+
+    it 'can call 3x function and propagate caller scope from a 4x function' do
+      Puppet.override({ :current_environment => scope.environment, :global_scope => scope }) do
+        function = loader.load_typed(typed_name(:function, 'user::caller_ws')).value
+        expect(function.call(scope, 'passed in scope')).to eql("usee::callee_ws() got 'passed in scope'")
+      end
+    end
+  end
+
   it 'can load a function more than once from modules' do
     env = environment_for(dependent_modules_with_metadata)
     loaders = Puppet::Pops::Loaders.new(env)
@@ -112,7 +133,7 @@ describe 'loaders' do
   end
 
   def environment_for(*module_paths)
-    Puppet::Node::Environment.create(:'*test*', module_paths, '')
+    Puppet::Node::Environment.create(:'*test*', module_paths)
   end
 
   def typed_name(type, name)


### PR DESCRIPTION
The call_function() method of the Puppet::Pops::Functions::Function
class did not make any attempt to find functions that had been
declared using the 3x function API. This commit adds the following:

Proper load and execute:
The call_function() method will now consult the 3x Functions class
to find (and optionally load) the function from there when it fails
to find it using the 4x loader.

Other improvements:
The initialize method in Puppet::Pops::Evaluator::Runtime3Support
was removed in favor of accessors that creates the needed visitors.
This was done to get rid of code in the EvaluatorImpl initializer
that otherwize would need to be copied into the ArgsConverter class
as well.