### PR TITLE
(PUP-3842,PUP-3844,PUP-3842) Updates for building the puppet windows installer

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -24,6 +24,9 @@ build_msi:
   hiera:
     ref: 'refs/tags/1.3.4'
     repo: 'git://github.com/puppetlabs/hiera.git'
+  mcollective:
+    ref: 'refs/tags/2.7.0'
+    repo: 'git://github.com/puppetlabs/marionette-collective.git'
   sys:
     ref:
       x86: '57068e7b7c87288c51ff39d96c80cfb509a42091'

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -14,6 +14,7 @@ yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: TRUE
 build_dmg: TRUE
+msi_name: 'puppet-agent'
 build_msi:
   puppet_for_the_win:
     ref: '2476cd007b1b52fb1b9f22202b56218629626b5c'

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -17,7 +17,7 @@ build_dmg: TRUE
 msi_name: 'puppet-agent'
 build_msi:
   puppet_for_the_win:
-    ref: '2476cd007b1b52fb1b9f22202b56218629626b5c'
+    ref: '59031fc0783c70706d1faa774ce4c9cfd74e2965'
     repo: 'git://github.com/puppetlabs/puppet_for_the_win.git'
   facter:
     ref: 'refs/tags/2.3.0'


### PR DESCRIPTION
This PR adds updates to what is pulled in and defined for building the puppet MSI. We're changing the name of the installer, adding in mcollective, and using new automation to deal with these changes. These are all targeted at Puppet 4.