### PR TITLE
(maint) Stub execute when testing debug logging

### DIFF
--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -470,6 +470,16 @@ describe Puppet::Util::Execution do
     end
 
     describe "#execute (debug logging)" do
+      before :each do
+        stub_process_wait(0)
+
+        if Puppet.features.microsoft_windows?
+          Puppet::Util::Execution.stubs(:execute_windows).returns(proc_info_stub)
+        else
+          Puppet::Util::Execution.stubs(:execute_posix).returns(pid)
+        end
+      end
+
       it "should log if no uid or gid specified" do
         Puppet::Util::Execution.expects(:debug).with("Executing: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello')


### PR DESCRIPTION
Execute was trying to call 'echo hello', which is invalid on Windows. Stub
execution subcalls so no process is called, making it platform independent.