### PR TITLE
(PUP-3894) Update default license in metadata so that it matches string from http:/...

### DIFF
--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -19,7 +19,7 @@ module Puppet::ModuleTool
       'version'      => nil,
       'author'       => nil,
       'summary'      => nil,
-      'license'      => 'Apache 2.0',
+      'license'      => 'Apache-2.0',
       'source'       => '',
       'project_page' => nil,
       'issues_url'   => nil,

--- a/spec/unit/module_tool/metadata_spec.rb
+++ b/spec/unit/module_tool/metadata_spec.rb
@@ -276,7 +276,7 @@ describe Puppet::ModuleTool::Metadata do
 
     describe "['license']" do
       it "defaults to Apache 2" do
-        subject['license'].should == "Apache 2.0"
+        subject['license'].should == "Apache-2.0"
       end
     end
 


### PR DESCRIPTION
Module metadata default for license is still 'Apache 2.0'. Default should be in line with http://spdx.org/licenses/.
https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file