### PR TITLE
(PUP-3755) Use catalog's environment when filtering it

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -416,7 +416,18 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
   # If the block result is false, the resource will
   # be kept otherwise it will be skipped
   def filter(&block)
-    to_catalog :to_resource, &block
+    # to_catalog must take place in a context where current_environment is set to the same env as the
+    # environment set in the catalog (if it is set)
+    # See PUP-3755
+    if environment_instance
+      Puppet.override({:current_environment => environment_instance}) do
+        to_catalog :to_resource, &block
+      end
+    else
+      # If catalog has no environment_instance, hope that the caller has made sure the context has the
+      # correct current_environment
+      to_catalog :to_resource, &block
+    end
   end
 
   # Store the classes in the classfile.


### PR DESCRIPTION
When a catalog is produced, it is at one point filtered for
exported resources. The code path leading to this have lost the
knowledge of in which the environment the catalog was produced
and when it calls Catalog.filter, this takes place in the default
environment.

During the filtering, new resources are created. These resources do not
know why they are being created, if they will end up in a catalog or
not. Unless they are associated with a catalog, they have to lookup the
current_environment from the context.

Then, when a resource is being processed, it may need the Type, and if
so, and it is not already loaded a full import of the
current_environment will take place.

Since the call to filter the catalog took place from logic where the
environment is not know, the operatoin will fail if the default loaded
environment has errors. It may also produce the wrong result since it
may get information that is incompatible with the environment used to
compile the catalog.

The fix is to pick up the `environment_instance` set in the produced
catalog and to make the call to filter the catalog in a context where
this environment is set as the `current_environment`