### PR TITLE
(PUP-3887) Fix checksum and source_permissions option in file servers

### DIFF
--- a/lib/puppet/file_serving/content.rb
+++ b/lib/puppet/file_serving/content.rb
@@ -21,11 +21,9 @@ class Puppet::FileServing::Content < Puppet::FileServing::Base
     instance
   end
 
-  # BF: we used to fetch the file content here, but this is counter-productive
-  # for puppetmaster streaming of file content. So collect just returns itself
+  # This is no longer used, but is still called by the file server implementations when interacting
+  # with their model abstraction.
   def collect(source_permissions = nil)
-    return if stat.ftype == "directory"
-    self
   end
 
   # Read the content of our file in.

--- a/lib/puppet/file_serving/terminus_helper.rb
+++ b/lib/puppet/file_serving/terminus_helper.rb
@@ -3,6 +3,21 @@ require 'puppet/file_serving/fileset'
 
 # Define some common methods for FileServing termini.
 module Puppet::FileServing::TerminusHelper
+  # Create model instance for a file in a file server.
+  def path2instance(request, path, options = {})
+    result = model.new(path, :relative_path => options[:relative_path])
+    result.checksum_type = request.options[:checksum_type] if request.options[:checksum_type]
+    result.links = request.options[:links] if request.options[:links]
+
+    # :ignore_source_permissions is here pending investigation in PUP-3906.
+    if options[:ignore_source_permissions]
+      result.collect
+    else
+      result.collect(request.options[:source_permissions])
+    end
+    result
+  end
+
   # Create model instances for all files in a fileset.
   def path2instances(request, *paths)
     filesets = paths.collect do |path|
@@ -11,11 +26,7 @@ module Puppet::FileServing::TerminusHelper
     end
 
     Puppet::FileServing::Fileset.merge(*filesets).collect do |file, base_path|
-      inst = model.new(base_path, :relative_path => file)
-      inst.checksum_type = request.options[:checksum_type] if request.options[:checksum_type]
-      inst.links = request.options[:links] if request.options[:links]
-      inst.collect
-      inst
+      path2instance(request, base_path, :ignore_source_permissions => true, :relative_path => file)
     end
   end
 end

--- a/lib/puppet/indirector/direct_file_server.rb
+++ b/lib/puppet/indirector/direct_file_server.rb
@@ -7,9 +7,7 @@ class Puppet::Indirector::DirectFileServer < Puppet::Indirector::Terminus
 
   def find(request)
     return nil unless Puppet::FileSystem.exist?(request.key)
-    instance = model.new(request.key)
-    instance.links = request.options[:links] if request.options[:links]
-    instance
+    path2instance(request, request.key)
   end
 
   def search(request)

--- a/lib/puppet/indirector/file_metadata/file.rb
+++ b/lib/puppet/indirector/file_metadata/file.rb
@@ -4,19 +4,4 @@ require 'puppet/indirector/direct_file_server'
 
 class Puppet::Indirector::FileMetadata::File < Puppet::Indirector::DirectFileServer
   desc "Retrieve file metadata directly from the local filesystem."
-
-  def find(request)
-    return unless data = super
-    data.collect(request.options[:source_permissions])
-
-    data
-  end
-
-  def search(request)
-    return unless result = super
-
-    result.each { |instance| instance.collect }
-
-    result
-  end
 end

--- a/lib/puppet/indirector/file_server.rb
+++ b/lib/puppet/indirector/file_server.rb
@@ -27,10 +27,7 @@ class Puppet::Indirector::FileServer < Puppet::Indirector::Terminus
     # The mount checks to see if the file exists, and returns nil
     # if not.
     return nil unless path = mount.find(relative_path, request)
-    result = model.new(path)
-    result.links = request.options[:links] if request.options[:links]
-    result.collect(request.options[:source_permissions])
-    result
+    path2instance(request, path)
   end
 
   # Search for files.  This returns an array rather than a single
@@ -42,18 +39,7 @@ class Puppet::Indirector::FileServer < Puppet::Indirector::Terminus
       Puppet.info "Could not find filesystem info for file '#{request.key}' in environment #{request.environment}"
       return nil
     end
-
-    filesets = paths.collect do |path|
-      # Filesets support indirector requests as an options collection
-      Puppet::FileServing::Fileset.new(path, request)
-    end
-
-    Puppet::FileServing::Fileset.merge(*filesets).collect do |file, base_path|
-      inst = model.new(base_path, :relative_path => file)
-      inst.links = request.options[:links] if request.options[:links]
-      inst.collect
-      inst
-    end
+    path2instances(request, *paths)
   end
 
   private

--- a/spec/integration/indirector/direct_file_server_spec.rb
+++ b/spec/integration/indirector/direct_file_server_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'matchers/include'
 
 require 'puppet/indirector/file_content/file'
+require 'puppet/indirector/file_metadata/file'
 
 describe Puppet::Indirector::DirectFileServer, " when interacting with the filesystem and the model" do
   include PuppetSpec::Files
@@ -9,30 +10,21 @@ describe Puppet::Indirector::DirectFileServer, " when interacting with the files
   before do
     # We just test a subclass, since it's close enough.
     @terminus = Puppet::Indirector::FileContent::File.new
-
-    @filepath = make_absolute("/path/to/my/file")
   end
 
   it "should return an instance of the model" do
-    if Puppet.features.microsoft_windows?
-      skip("porting to Windows")
-    else
-      Puppet::FileSystem.expects(:exist?).with(@filepath).returns(true)
+    filepath = make_absolute("/path/to/my/file")
+    Puppet::FileSystem.expects(:exist?).with(filepath).returns(true)
 
-      expect(@terminus.find(@terminus.indirection.request(:find, "file://host#{@filepath}", nil))).to be_instance_of(Puppet::FileServing::Content)
-    end
+    expect(@terminus.find(@terminus.indirection.request(:find, Puppet::Util.path_to_uri(filepath).to_s, nil))).to be_instance_of(Puppet::FileServing::Content)
   end
 
   it "should return an instance capable of returning its content" do
-    if Puppet.features.microsoft_windows?
-      skip("porting to Windows")
-    else
-      filename = file_containing("testfile", "my content")
+    filename = file_containing("testfile", "my content")
 
-      instance = @terminus.find(@terminus.indirection.request(:find, "file://host#{filename}", nil))
+    instance = @terminus.find(@terminus.indirection.request(:find, Puppet::Util.path_to_uri(filename).to_s, nil))
 
-      expect(instance.content).to eq("my content")
-    end
+    expect(instance.content).to eq("my content")
   end
 end
 
@@ -58,11 +50,43 @@ describe Puppet::Indirector::DirectFileServer, " when interacting with FileServi
     File.open(File.join(path, "two"), "w") { |f| f.print "two content" }
 
     terminus = Puppet::Indirector::FileContent::File.new
-    request = terminus.indirection.request(:search, "file:///#{path}", nil, :recurse => true)
+    request = terminus.indirection.request(:search, Puppet::Util.path_to_uri(path).to_s, nil, :recurse => true)
 
     expect(terminus.search(request)).to include_in_any_order(
       file_with_content(File.join(path, "one"), "one content"),
       file_with_content(File.join(path, "two"), "two content"),
       directory_named(path))
+  end
+end
+
+describe Puppet::Indirector::DirectFileServer, " when interacting with filesystem metadata" do
+  include PuppetSpec::Files
+  include_context 'with supported checksum types'
+
+  before do
+    @terminus = Puppet::Indirector::FileMetadata::File.new
+  end
+
+  with_checksum_types("file_metadata", "testfile") do
+    it "should return the correct metadata" do
+      request = @terminus.indirection.request(:find, Puppet::Util.path_to_uri(checksum_file).to_s, nil, :checksum_type => checksum_type)
+      result = @terminus.find(request)
+      expect_correct_checksum(result, checksum_type, checksum, Puppet::FileServing::Metadata)
+    end
+  end
+
+  with_checksum_types("direct_file_server_testing", "testfile") do
+    it "search of FileServing::Fileset should return the correct metadata" do
+      request = @terminus.indirection.request(:search, Puppet::Util.path_to_uri(env_path).to_s, nil, :recurse => true, :checksum_type => checksum_type)
+      result = @terminus.search(request)
+
+      expect(result).to_not be_nil
+      expect(result.length).to eq(2)
+      file, dir = result.partition {|x| x.relative_path == 'testfile'}
+      expect(file.length).to eq(1)
+      expect(dir.length).to eq(1)
+      expect_correct_checksum(dir[0], 'ctime', "#{CHECKSUM_STAT_TIME}", Puppet::FileServing::Metadata)
+      expect_correct_checksum(file[0], checksum_type, checksum, Puppet::FileServing::Metadata)
+    end
   end
 end

--- a/spec/integration/indirector/file_metadata/file_server_spec.rb
+++ b/spec/integration/indirector/file_metadata/file_server_spec.rb
@@ -4,11 +4,88 @@ require 'spec_helper'
 require 'puppet/indirector/file_metadata/file_server'
 require 'shared_behaviours/file_server_terminus'
 
+require 'puppet_spec/files'
+
 describe Puppet::Indirector::FileMetadata::FileServer, " when finding files" do
   it_should_behave_like "Puppet::Indirector::FileServerTerminus"
+  include PuppetSpec::Files
 
   before do
     @terminus = Puppet::Indirector::FileMetadata::FileServer.new
     @test_class = Puppet::FileServing::Metadata
+    Puppet::FileServing::Configuration.instance_variable_set(:@configuration, nil)
+  end
+
+  it "should find plugin file content in the environment specified in the request" do
+    path = tmpfile("file_content_with_env")
+
+    Dir.mkdir(path)
+
+    modpath = File.join(path, "mod")
+    FileUtils.mkdir_p(File.join(modpath, "lib"))
+    file = File.join(modpath, "lib", "file.rb")
+    File.open(file, "wb") { |f| f.write "1\r\n" }
+
+    Puppet.settings[:modulepath] = "/no/such/file"
+
+    env = Puppet::Node::Environment.create(:foo, [path])
+
+    result = Puppet::FileServing::Metadata.indirection.search("plugins", :environment => env, :recurse => true)
+
+    result.should_not be_nil
+    result.length.should == 2
+    result.map {|x| x.should be_instance_of(Puppet::FileServing::Metadata) }
+    result.find {|x| x.relative_path == 'file.rb' }.checksum.should == "{md5}a5ea0ad9260b1550a14cc58d2c39b03d"
+  end
+
+  it "should find file metadata in modules" do
+    path = tmpfile("file_content")
+
+    Dir.mkdir(path)
+
+    modpath = File.join(path, "mymod")
+    FileUtils.mkdir_p(File.join(modpath, "files"))
+    file = File.join(modpath, "files", "myfile")
+    File.open(file, "wb") { |f| f.write "1\r\n" }
+
+    env = Puppet::Node::Environment.create(:foo, [path])
+
+    result = Puppet::FileServing::Metadata.indirection.find("modules/mymod/myfile", :environment => env)
+
+    result.should_not be_nil
+    result.should be_instance_of(Puppet::FileServing::Metadata)
+    result.checksum.should == "{md5}a5ea0ad9260b1550a14cc58d2c39b03d"
+  end
+
+  it "should find file content in files when node name expansions are used" do
+    Puppet::FileSystem.stubs(:exist?).returns true
+    Puppet::FileSystem.stubs(:exist?).with(Puppet[:fileserverconfig]).returns(true)
+
+    path = tmpfile("file_server_testing")
+
+    Dir.mkdir(path)
+    subdir = File.join(path, "mynode")
+    Dir.mkdir(subdir)
+    File.open(File.join(subdir, "myfile"), "wb") { |f| f.write "1\r\n" }
+
+    # Use a real mount, so the integration is a bit deeper.
+    mount1 = Puppet::FileServing::Configuration::Mount::File.new("one")
+    mount1.stubs(:allowed?).returns true
+    mount1.path = File.join(path, "%h")
+
+    parser = stub 'parser', :changed? => false
+    parser.stubs(:parse).returns("one" => mount1)
+
+    Puppet::FileServing::Configuration::Parser.stubs(:new).returns(parser)
+
+    path = File.join(path, "myfile")
+
+    env = Puppet::Node::Environment.create(:foo, [])
+
+    result = Puppet::FileServing::Metadata.indirection.find("one/myfile", :environment => env, :node => "mynode")
+
+    result.should_not be_nil
+    result.should be_instance_of(Puppet::FileServing::Metadata)
+    result.checksum.should == "{md5}a5ea0ad9260b1550a14cc58d2c39b03d"
   end
 end

--- a/spec/shared_contexts/checksum.rb
+++ b/spec/shared_contexts/checksum.rb
@@ -1,0 +1,48 @@
+# Shared contexts for testing against all supported checksum types.
+#
+# These helpers define nested rspec example groups to test code against all our
+# supported checksum types. Example groups that need to be run against all
+# types should use the `with_checksum_types` helper which will
+# create a new example group for each types and will run the given block
+# in each example group.
+
+CHECKSUM_STAT_TIME = Time.now
+CHECKSUM_TYPES_TO_TRY = [
+  ['md5', 'a7a169ac84bb863b30484d0aa03139c1'],
+  ['md5lite', '22b4182363e81b326e98231fde616782'],
+  ['sha256', '47fcae62967db2fb5cba2fc0d9cf3e6767035d763d825ecda535a7b1928b9746'],
+  ['sha256lite', 'fd50217a2b0286ba25121bf2297bbe6c197933992de67e4e568f19861444ecf8'],
+  ['ctime', "#{CHECKSUM_STAT_TIME}"],
+  ['mtime', "#{CHECKSUM_STAT_TIME}"]
+]
+
+shared_context('with supported checksum types') do
+
+  def self.with_checksum_types(path, file, &block)
+    def expect_correct_checksum(meta, checksum_type, checksum, type)
+      expect(meta).to_not be_nil
+      expect(meta).to be_instance_of(type)
+      expect(meta.checksum_type).to eq(checksum_type)
+      expect(meta.checksum).to eq("{#{checksum_type}}#{checksum}")
+    end
+
+    CHECKSUM_TYPES_TO_TRY.each do |checksum_type, checksum|
+      describe("when checksum_type is #{checksum_type}") do
+        let(:checksum_type) { checksum_type }
+        let(:plaintext) { "1\r\n"*4000 }
+        let(:checksum) { checksum }
+        let(:env_path) { tmpfile(path) }
+        let(:checksum_file) { File.join(env_path, file) }
+
+        before do
+          FileUtils.mkdir_p(File.dirname(checksum_file))
+          File.open(checksum_file, "wb") { |f| f.write plaintext }
+          Puppet::FileSystem.stubs(:stat).returns(stub('stat', :ctime => CHECKSUM_STAT_TIME, :mtime => CHECKSUM_STAT_TIME))
+        end
+
+        instance_eval(&block)
+      end
+    end
+  end
+end
+

--- a/spec/shared_contexts/digests.rb
+++ b/spec/shared_contexts/digests.rb
@@ -2,14 +2,14 @@
 #
 # These helpers define nested rspec example groups to test code against all our
 # supported digest algorithms. Example groups that need to be run against all
-# algorithms should use the `using_checksums_describe` helper which will
+# algorithms should use the `with_digest_algorithms` helper which will
 # create a new example group for each algorithm and will run the given block
 # in each example group.
 #
 # For each algorithm a shared context is defined for the given algorithm that
 # has precomputed checksum values and paths. These contexts are included
 # automatically based on the rspec metadata selected with
-# `using_checksums_describe`.
+# `with_digest_algorithms`.
 
 DIGEST_ALGORITHMS_TO_TRY = ['md5', 'sha256']
 

--- a/spec/unit/file_serving/content_spec.rb
+++ b/spec/unit/file_serving/content_spec.rb
@@ -22,22 +22,10 @@ describe Puppet::FileServing::Content do
     expect(Puppet::FileServing::Content.new(path)).to respond_to(:collect)
   end
 
-  it "should not retrieve and store its contents when its attributes are collected if the file is a normal file" do
+  it "should not retrieve and store its contents when its attributes are collected" do
     content = Puppet::FileServing::Content.new(path)
 
     result = "foo"
-    Puppet::FileSystem.expects(:lstat).with(path).returns stub('stat', :ftype => "file")
-    File.expects(:read).with(path).never
-    content.collect
-
-    expect(content.instance_variable_get("@content")).to be_nil
-  end
-
-  it "should not attempt to retrieve its contents if the file is a directory" do
-    content = Puppet::FileServing::Content.new(path)
-
-    result = "foo"
-    Puppet::FileSystem.expects(:lstat).with(path).returns stub('stat', :ftype => "directory")
     File.expects(:read).with(path).never
     content.collect
 

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -93,6 +93,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
     describe "when collecting attributes" do
       describe "when managing files" do
         let(:path) { tmpfile('file_serving_metadata') }
+        let(:time) { Time.now }
 
         before :each do
           FileUtils.touch(path)
@@ -108,13 +109,26 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
               expect(metadata.checksum).to eq("{#{digest_algorithm}}#{checksum}")
             end
 
-            it "should give a mtime checksum when checksum_type is set" do
-              time = Time.now
-              metadata.checksum_type = "mtime"
-              metadata.expects(:mtime_file).returns(@time)
+            it "should give a #{Puppet[:digest_algorithm]} when checksum_type is set" do
+              Puppet[:digest_algorithm] = nil
+              metadata.checksum_type = digest_algorithm
               metadata.collect
-              expect(metadata.checksum).to eq("{mtime}#{@time}")
+              expect(metadata.checksum).to eq("{#{digest_algorithm}}#{checksum}")
             end
+          end
+
+          it "should give a mtime checksum when checksum_type is set" do
+            metadata.checksum_type = "mtime"
+            metadata.expects(:mtime_file).returns(time)
+            metadata.collect
+            expect(metadata.checksum).to eq("{mtime}#{time}")
+          end
+
+          it "should give a ctime checksum when checksum_type is set" do
+            metadata.checksum_type = "ctime"
+            metadata.expects(:ctime_file).returns(time)
+            metadata.collect
+            expect(metadata.checksum).to eq("{ctime}#{time}")
           end
         end
 

--- a/spec/unit/indirector/direct_file_server_spec.rb
+++ b/spec/unit/indirector/direct_file_server_spec.rb
@@ -32,8 +32,10 @@ describe Puppet::Indirector::DirectFileServer do
 
     it "should return a Content instance created with the full path to the file if the file exists" do
       Puppet::FileSystem.expects(:exist?).with(@path).returns true
-      @model.expects(:new).returns(:mycontent)
-      expect(@server.find(@request)).to eq(:mycontent)
+      mycontent = stub 'content', :collect => nil
+      mycontent.expects(:collect)
+      @model.expects(:new).returns(mycontent)
+      expect(@server.find(@request)).to eq(mycontent)
     end
   end
 
@@ -55,6 +57,14 @@ describe Puppet::Indirector::DirectFileServer do
       @data.expects(:links=).with(:manage)
 
       @request.stubs(:options).returns(:links => :manage)
+      @server.find(@request)
+    end
+
+    it "should set 'checksum_type' on the instances if it is set in the request options" do
+      @model.expects(:new).returns(@data)
+      @data.expects(:checksum_type=).with :checksum
+
+      @request.stubs(:options).returns(:checksum_type => :checksum)
       @server.find(@request)
     end
   end

--- a/spec/unit/indirector/file_metadata/file_spec.rb
+++ b/spec/unit/indirector/file_metadata/file_spec.rb
@@ -43,8 +43,16 @@ describe Puppet::Indirector::FileMetadata::File do
 
     it "should collect the attributes of the instances returned" do
       Puppet::FileSystem.expects(:exist?).with(@path).returns true
-      @metadata.expects(:path2instances).returns( [mock("one", :collect => nil), mock("two", :collect => nil)] )
-      @metadata.search(@request)
+      Puppet::FileServing::Fileset.expects(:new).with(@path, @request).returns mock("fileset")
+      Puppet::FileServing::Fileset.expects(:merge).returns [["one", @path], ["two", @path]]
+
+      one = mock("one", :collect => nil)
+      Puppet::FileServing::Metadata.expects(:new).with(@path, {:relative_path => "one"}).returns one
+
+      two = mock("two", :collect => nil)
+      Puppet::FileServing::Metadata.expects(:new).with(@path, {:relative_path => "two"}).returns two
+
+      expect(@metadata.search(@request)).to eq([one, two])
     end
   end
 end

--- a/spec/unit/indirector/file_server_spec.rb
+++ b/spec/unit/indirector/file_server_spec.rb
@@ -75,7 +75,7 @@ describe Puppet::Indirector::FileServer do
 
       @mount.expects(:find).with { |key, request| key == "rel/path" }.returns "/my/file"
 
-      @model.expects(:new).with("/my/file").returns @instance
+      @model.expects(:new).with("/my/file", {:relative_path => nil}).returns @instance
 
       expect(@file_server.find(@request)).to equal(@instance)
     end
@@ -86,7 +86,7 @@ describe Puppet::Indirector::FileServer do
 
       @mount.expects(:find).with { |key, request| key == "rel/path" }.returns "/my/file"
 
-      @model.expects(:new).with("/my/file").returns @instance
+      @model.expects(:new).with("/my/file", {:relative_path => nil}).returns @instance
 
       @instance.expects(:links=).with(true)
 
@@ -99,7 +99,7 @@ describe Puppet::Indirector::FileServer do
 
       @mount.expects(:find).with { |key, request| key == "rel/path" }.returns "/my/file"
 
-      @model.expects(:new).with("/my/file").returns @instance
+      @model.expects(:new).with("/my/file", {:relative_path => nil}).returns @instance
 
       @instance.expects(:collect)
 
@@ -202,6 +202,24 @@ describe Puppet::Indirector::FileServer do
       one.expects(:links=).with true
 
       @request.options[:links] = true
+
+      @file_server.search(@request)
+    end
+
+    it "should set 'checksum_type' on the instances if it is set in the request options" do
+      @configuration.expects(:split_path).with(@request).returns([@mount, "rel/path"])
+
+      @mount.expects(:search).with { |key, request| key == "rel/path" }.returns []
+
+      Puppet::FileSystem.stubs(:exist?).returns true
+
+      Puppet::FileServing::Fileset.expects(:merge).returns("one" => "/one")
+
+      one = stub 'one', :collect => nil
+      @model.expects(:new).with("/one", :relative_path => "one").returns one
+
+      one.expects(:checksum_type=).with :checksum
+      @request.options[:checksum_type] = :checksum
 
       @file_server.search(@request)
     end


### PR DESCRIPTION
The file_server uses the requested checksum_type to calculate a
file checksum, rather than always defaulting to md5.