### PR TITLE
(PUP-3897) Add acceptance: ensure new environment picked up by agent

### DIFF
--- a/acceptance/tests/environment/environment_scenario-new.rb
+++ b/acceptance/tests/environment/environment_scenario-new.rb
@@ -1,0 +1,53 @@
+test_name "Test a new environment, unknown to agent"
+
+step "setup environments"
+
+testdir = create_tmpdir_for_user master, "confdir"
+manifest = <<-MANIFEST
+  File {
+    ensure => directory,
+    owner => #{master['user']},
+    group => #{master['group']},
+    mode => "0750",
+  }
+
+  file { "#{testdir}":;
+    "#{testdir}/environments":;
+    "#{testdir}/environments/production":;
+    "#{testdir}/environments/production/manifests":;
+    "#{testdir}/environments/production/modules":;
+    "#{testdir}/environments/debug":;
+    "#{testdir}/environments/debug/manifests":;
+    "#{testdir}/environments/debug/modules":;
+  }
+  file { "#{testdir}/environments/production/manifests/site.pp":
+    ensure  => file,
+    content => 'node default{\nnotify{"fail!1!":}\n}'
+  }
+  file { "#{testdir}/environments/debug/manifests/site.pp":
+    ensure  => file,
+    content => 'node default{\nnotify{"you win":}\n}'
+  }
+MANIFEST
+
+apply_manifest_on(master, manifest, :catch_failures => true)
+
+step "run agents, ensure new environment used"
+
+master_opts = {
+  'main' => {
+    'environmentpath' => "#{testdir}/environments",
+  },
+  'agent' => {
+    'environment' => 'debug'
+  }
+}
+
+with_puppet_running_on(master, master_opts, testdir) do
+  agents.each do |agent|
+    on(agent, puppet("agent", "--test"), :acceptable_exit_codes => (0..255) ) do
+      assert_match(/you win/, stdout,
+                   "agent did not pickup newly classified environment." )
+    end
+  end
+end

--- a/acceptance/tests/environment/environment_scenario-new.rb
+++ b/acceptance/tests/environment/environment_scenario-new.rb
@@ -1,8 +1,8 @@
-test_name "Test a new environment, unknown to agent"
+test_name 'Test a new environment, unknown to agent'
 
-step "setup environments"
+step 'setup environments'
 
-testdir = create_tmpdir_for_user master, "confdir"
+testdir = create_tmpdir_for_user master, 'confdir'
 manifest = <<-MANIFEST
   File {
     ensure => directory,
@@ -32,11 +32,11 @@ MANIFEST
 
 apply_manifest_on(master, manifest, :catch_failures => true)
 
-step "run agents, ensure new environment used"
+step 'run agents, ensure new environment used'
 
 master_opts = {
   'main' => {
-    'environmentpath' => "#{testdir}/environments",
+    'environmentpath' => "#{testdir}/environments"
   },
   'agent' => {
     'environment' => 'debug'
@@ -45,9 +45,9 @@ master_opts = {
 
 with_puppet_running_on(master, master_opts, testdir) do
   agents.each do |agent|
-    on(agent, puppet("agent", "--test"), :acceptable_exit_codes => (0..255) ) do
+    on(agent, puppet('agent', "--test --server #{master}"), :acceptable_exit_codes => (0..255) ) do
       assert_match(/you win/, stdout,
-                   "agent did not pickup newly classified environment." )
+                   'agent did not pickup newly classified environment.')
     end
   end
 end


### PR DESCRIPTION
in PUP-3755 there are two scenarios that lead to a newly classified
agent not picking up its new environment.  This test should catch both
of the cases that aren't tested by spec.
This test does not use the environment helpers as they circumvent most
of the functionality in this test such as hard wiring to test
environment and specifying agent environment on commandline.  We need to
classify a node's environment from master.