### PR TITLE
(PUP-3812) Change file_bucket content type to application/octet-stream

### DIFF
--- a/api/docs/http_file_content.md
+++ b/api/docs/http_file_content.md
@@ -38,7 +38,7 @@ None
     Accept: raw
 
     HTTP/1.1 200 OK
-    Content-Type: application/x-raw
+    Content-Type: application/octet-stream
     Content-Length: 16
 
     this is my file

--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -14,16 +14,11 @@ class Puppet::FileBucket::File
   attr :bucket_path
 
   def self.supported_formats
-    [:s]
+    [:binary]
   end
 
   def self.default_format
-    # This should really be :raw, like is done for Puppet::FileServing::Content
-    # but this class hasn't historically supported `from_raw`, so switching
-    # would break compatibility between newer 3.x agents talking to older 3.x
-    # masters. However, to/from_s has been supported and achieves the desired
-    # result without breaking compatibility.
-    :s
+    :binary
   end
 
   def initialize(contents, options = {})
@@ -67,6 +62,10 @@ class Puppet::FileBucket::File
     @contents.to_s
   end
 
+  def to_binary
+    @contents.to_s
+  end
+
   def contents
     to_s
   end
@@ -76,6 +75,10 @@ class Puppet::FileBucket::File
   end
 
   def self.from_s(contents)
+    self.new(contents)
+  end
+
+  def self.from_binary(contents)
     self.new(contents)
   end
 

--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -59,23 +59,19 @@ class Puppet::FileBucket::File
   end
 
   def to_s
-    @contents.to_s
+    to_binary
   end
 
   def to_binary
-    @contents.to_s
+    @contents.to_binary
   end
 
   def contents
-    to_s
+    to_binary
   end
 
   def name
     "#{checksum_type}/#{checksum_data}"
-  end
-
-  def self.from_s(contents)
-    self.new(contents)
   end
 
   def self.from_binary(contents)
@@ -84,7 +80,7 @@ class Puppet::FileBucket::File
 
   def to_data_hash
     # Note that this serializes the entire data to a string and places it in a hash.
-    { "contents" => contents.to_s }
+    { "contents" => contents.to_binary }
   end
 
   def self.from_data_hash(data)
@@ -116,7 +112,7 @@ class Puppet::FileBucket::File
       Puppet::Util::Checksums.method(base_method).call(@contents)
     end
 
-    def to_s
+    def to_binary
       # This is not so horrible as for FileContent, but still possible to mutate the content that the
       # checksum is based on... so semi horrible...
       return @contents;
@@ -141,7 +137,7 @@ class Puppet::FileBucket::File
       Puppet::Util::Checksums.method(:"#{base_method}_file").call(@path)
     end
 
-    def to_s
+    def to_binary
       Puppet::FileSystem::binread(@path)
     end
   end

--- a/lib/puppet/file_serving/content.rb
+++ b/lib/puppet/file_serving/content.rb
@@ -12,10 +12,10 @@ class Puppet::FileServing::Content < Puppet::FileServing::Base
   attr_writer :content
 
   def self.supported_formats
-    [:raw]
+    [:binary]
   end
 
-  def self.from_raw(content)
+  def self.from_binary(content)
     instance = new("/this/is/a/fake/path")
     instance.content = content
     instance
@@ -37,7 +37,7 @@ class Puppet::FileServing::Content < Puppet::FileServing::Base
     @content
   end
 
-  def to_raw
+  def to_binary
     File.new(full_path, "rb")
   end
 end

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -64,10 +64,7 @@ end
 
 Puppet::Network::FormatHandler.create(:s, :mime => "text/plain", :extension => "txt")
 
-Puppet::Network::FormatHandler.create(:binary, :mime => "application/octet-stream")
-
-# A very low-weight format so it'll never get chosen automatically.
-Puppet::Network::FormatHandler.create(:raw, :mime => "application/x-raw", :weight => 1) do
+Puppet::Network::FormatHandler.create(:binary, :mime => "application/octet-stream", :weight => 1) do
   def intern_multiple(klass, text)
     raise NotImplementedError
   end

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -64,6 +64,8 @@ end
 
 Puppet::Network::FormatHandler.create(:s, :mime => "text/plain", :extension => "txt")
 
+Puppet::Network::FormatHandler.create(:binary, :mime => "application/octet-stream")
+
 # A very low-weight format so it'll never get chosen automatically.
 Puppet::Network::FormatHandler.create(:raw, :mime => "application/x-raw", :weight => 1) do
   def intern_multiple(klass, text)

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -213,7 +213,7 @@ module Puppet
 
       request.do_request(:fileserver) do |req|
         connection = Puppet::Network::HttpPool.http_instance(req.server, req.port)
-        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => "raw"}), &block)
+        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => "binary"}), &block)
       end
     end
 

--- a/spec/lib/puppet/indirector_testing.rb
+++ b/spec/lib/puppet/indirector_testing.rb
@@ -13,7 +13,7 @@ class Puppet::IndirectorTesting
     self.value = value
   end
 
-  def self.from_raw(raw)
+  def self.from_binary(raw)
     new(raw)
   end
 

--- a/spec/unit/file_bucket/file_spec.rb
+++ b/spec/unit/file_bucket/file_spec.rb
@@ -9,19 +9,19 @@ describe Puppet::FileBucket::File, :uses_checksums => true do
   # this is the default from spec_helper, but it keeps getting reset at odd times
   let(:bucketdir) { Puppet[:bucketdir] = tmpdir('bucket') }
 
-  it "defaults to serializing to `:s`" do
-    expect(Puppet::FileBucket::File.default_format).to eq(:s)
+  it "defaults to serializing to `:binary`" do
+    expect(Puppet::FileBucket::File.default_format).to eq(:binary)
   end
 
   it "accepts s" do
-    expect(Puppet::FileBucket::File.supported_formats).to include(:s)
+    expect(Puppet::FileBucket::File.supported_formats).to include(:binary)
   end
 
   describe "making round trips through network formats" do
     with_digest_algorithms do
       it "can make a round trip through `s`" do
         file = Puppet::FileBucket::File.new(plaintext)
-        tripped = Puppet::FileBucket::File.convert_from(:s, file.render)
+        tripped = Puppet::FileBucket::File.convert_from(:binary, file.render)
         expect(tripped.contents).to eq(plaintext)
       end
     end

--- a/spec/unit/file_bucket/file_spec.rb
+++ b/spec/unit/file_bucket/file_spec.rb
@@ -13,13 +13,13 @@ describe Puppet::FileBucket::File, :uses_checksums => true do
     expect(Puppet::FileBucket::File.default_format).to eq(:binary)
   end
 
-  it "accepts s" do
+  it "accepts binary" do
     expect(Puppet::FileBucket::File.supported_formats).to include(:binary)
   end
 
   describe "making round trips through network formats" do
     with_digest_algorithms do
-      it "can make a round trip through `s`" do
+      it "can make a round trip through `binary`" do
         file = Puppet::FileBucket::File.new(plaintext)
         tripped = Puppet::FileBucket::File.convert_from(:binary, file.render)
         expect(tripped.contents).to eq(plaintext)

--- a/spec/unit/file_serving/content_spec.rb
+++ b/spec/unit/file_serving/content_spec.rb
@@ -14,8 +14,8 @@ describe Puppet::FileServing::Content do
     expect(Puppet::FileServing::Content.indirection.name).to eq(:file_content)
   end
 
-  it "should only support the raw format" do
-    expect(Puppet::FileServing::Content.supported_formats).to eq([:raw])
+  it "should only support the binary format" do
+    expect(Puppet::FileServing::Content.supported_formats).to eq([:binary])
   end
 
   it "should have a method for collecting its attributes" do
@@ -43,25 +43,25 @@ describe Puppet::FileServing::Content do
     expect(content.content).to eq("foo/bar")
   end
 
-  it "should be able to create a content instance from raw file contents" do
-    expect(Puppet::FileServing::Content).to respond_to(:from_raw)
+  it "should be able to create a content instance from binary file contents" do
+    expect(Puppet::FileServing::Content).to respond_to(:from_binary)
   end
 
-  it "should create an instance with a fake file name and correct content when converting from raw" do
+  it "should create an instance with a fake file name and correct content when converting from binary" do
     instance = mock 'instance'
     Puppet::FileServing::Content.expects(:new).with("/this/is/a/fake/path").returns instance
 
     instance.expects(:content=).with "foo/bar"
 
-    expect(Puppet::FileServing::Content.from_raw("foo/bar")).to equal(instance)
+    expect(Puppet::FileServing::Content.from_binary("foo/bar")).to equal(instance)
   end
 
-  it "should return an opened File when converted to raw" do
+  it "should return an opened File when converted to binary" do
     content = Puppet::FileServing::Content.new(path)
 
     File.expects(:new).with(path, "rb").returns :file
 
-    expect(content.to_raw).to eq(:file)
+    expect(content.to_binary).to eq(:file)
   end
 end
 

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -130,6 +130,16 @@ describe "Puppet Network Format" do
     end
   end
 
+  describe "binary" do
+    before do
+      @binary = Puppet::Network::FormatHandler.format(:binary)
+    end
+
+    it "should have its mimetype set to application/octet-stream" do
+      @binary.mime.should == "application/octet-stream"
+    end
+  end
+
   describe "plaintext" do
     before do
       @text = Puppet::Network::FormatHandler.format(:s)

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -130,16 +130,6 @@ describe "Puppet Network Format" do
     end
   end
 
-  describe "binary" do
-    before do
-      @binary = Puppet::Network::FormatHandler.format(:binary)
-    end
-
-    it "should have its mimetype set to application/octet-stream" do
-      @binary.mime.should == "application/octet-stream"
-    end
-  end
-
   describe "plaintext" do
     before do
       @text = Puppet::Network::FormatHandler.format(:s)
@@ -164,17 +154,17 @@ describe "Puppet Network Format" do
     end
   end
 
-  describe Puppet::Network::FormatHandler.format(:raw) do
+  describe Puppet::Network::FormatHandler.format(:binary) do
     before do
-      @format = Puppet::Network::FormatHandler.format(:raw)
+      @format = Puppet::Network::FormatHandler.format(:binary)
     end
 
     it "should exist" do
       expect(@format).not_to be_nil
     end
 
-    it "should have its mimetype set to application/x-raw" do
-      expect(@format.mime).to eq("application/x-raw")
+    it "should have its mimetype set to application/octet-stream" do
+      expect(@format.mime).to eq("application/octet-stream")
     end
 
     it "should always be supported" do

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -437,7 +437,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
 
       data = Puppet::IndirectorTesting.new("test")
       request = a_request_that_submits(data,
-                                       :content_type_header => "application/x-raw",
+                                       :content_type_header => "application/octet-stream",
                                        :body => '')
 
       handler.call(request, response)


### PR DESCRIPTION
Previously the MIME type that the filebucket endpoints used to transfer
data was `text/plain`. This leads to potential problems transfering
binary data. This commit adds a new format called `:binary` which uses
`application/octet-stream` as the MIME type, which is the correct type
to specify arbitrary binary data.