### PR TITLE
(maint) Update CI Setup for AIO Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ puppet-acceptance/
 .idea/
 .ruby-version
 .ruby-gemset
+acceptance/junit
+acceptance/log
+acceptance/.bundle

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -2,7 +2,7 @@
 # to ensure a similar environment on acceptance hosts.
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-gem (ENV['BEAKER_GEM'] || "beaker"), "~> 1.17"
+gem (ENV['BEAKER_GEM'] || "beaker"), "~> 2.2"
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -273,6 +273,14 @@ EOS
     end
 
     desc <<-EOS
+Run the acceptance tests through Beaker and install packages as part of the AIO puppet-agent installation.
+#{USAGE}
+EOS
+    task :aio => 'ci:check_env' do
+      beaker_test(:aio)
+    end
+
+    desc <<-EOS
 Run the acceptance tests through Beaker and install from git on the configuration targets.
 #{USAGE}
 EOS

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,0 +1,12 @@
+{
+  :type => 'aio',
+  :pre_suite => [
+    'setup/common/pre-suite/001_PkgBuildSetup.rb',
+    'setup/aio/pre-suite/010_Install.rb',
+    'setup/aio/pre-suite/015_PackageHostsPresets.rb',
+    'setup/common/pre-suite/025_StopFirewall.rb',
+    'setup/common/pre-suite/040_ValidateSignCert.rb',
+    'setup/aio/pre-suite/045_EnsureMasterStartedOnPassenger.rb',
+    'setup/common/pre-suite/070_InstallCACerts.rb',
+  ],
+}

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -115,7 +115,7 @@ module Puppet
         end
       end
 
-      def install_repos_on(host, sha, repo_configs_dir)
+      def install_repos_on(host, project, sha, repo_configs_dir)
         platform = host['platform'].with_version_codename
         platform_configs_dir = File.join(repo_configs_dir,platform)
 
@@ -132,8 +132,9 @@ module Puppet
               platform_configs_dir
             )
 
-            pattern = "pl-puppet-%s-%s-%s%s-%s.repo"
+            pattern = "pl-%s-%s-%s-%s%s-%s.repo"
             repo_filename = pattern % [
+              project,
               sha,
               variant,
               fedora_prefix,
@@ -141,14 +142,28 @@ module Puppet
               arch
             ]
             repo = fetch(
-              "http://builds.puppetlabs.lan/puppet/%s/repo_configs/rpm/" % sha,
+              "http://builds.puppetlabs.lan/%s/%s/repo_configs/rpm/" % [project, sha],
               repo_filename,
               platform_configs_dir
             )
 
-            link = "http://builds.puppetlabs.lan/puppet/%s/repos/%s/%s%s/products/%s/" % [sha, variant, fedora_prefix, version, arch]
+            link = "http://builds.puppetlabs.lan/%s/%s/repos/%s/%s%s/products/%s/" % [
+              project,
+              sha,
+              variant,
+              fedora_prefix,
+              version,
+              arch
+            ]
             if not link_exists?(link)
-              link = "http://builds.puppetlabs.lan/puppet/%s/repos/%s/%s%s/devel/%s/" % [sha, variant, fedora_prefix, version, arch]
+              link = "http://builds.puppetlabs.lan/%s/%s/repos/%s/%s%s/devel/%s/" % [
+                project,
+                sha,
+                variant,
+                fedora_prefix,
+                version,
+                arch
+              ]
             end
             if not link_exists?(link)
               raise "Unable to reach a repo directory at #{link}"
@@ -177,12 +192,12 @@ module Puppet
             )
 
             list = fetch(
-              "http://builds.puppetlabs.lan/puppet/%s/repo_configs/deb/" % sha,
-              "pl-puppet-%s-%s.list" % [sha, version],
+              "http://builds.puppetlabs.lan/%s/%s/repo_configs/deb/" % [project, sha],
+              "pl-%s-%s-%s.list" % [project, sha, version],
               platform_configs_dir
             )
 
-            repo_dir = fetch_remote_dir("http://builds.puppetlabs.lan/puppet/%s/repos/apt/%s" % [sha, version], platform_configs_dir)
+            repo_dir = fetch_remote_dir("http://builds.puppetlabs.lan/%s/%s/repos/apt/%s" % [project, sha, version], platform_configs_dir)
 
             on host, "rm -rf /root/*.list; rm -rf /root/*.deb; rm -rf /root/#{version}"
 

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -10,7 +10,7 @@ step "Install repositories on target machines..." do
   repo_configs_dir = 'repo-configs'
 
   hosts.each do |host|
-    install_repos_on(host, 'puppet', sha, repo_configs_dir)
+    install_repos_on(host, 'puppet-agent', sha, repo_configs_dir)
   end
 end
 
@@ -32,10 +32,10 @@ MASTER_PACKAGES = {
 
 AGENT_PACKAGES = {
   :redhat => [
-    'puppet',
+    'puppet-agent',
   ],
   :debian => [
-    'puppet',
+    'puppet-agent',
   ],
 #  :solaris => [
 #    'puppet',

--- a/acceptance/setup/aio/pre-suite/015_PackageHostsPresets.rb
+++ b/acceptance/setup/aio/pre-suite/015_PackageHostsPresets.rb
@@ -1,0 +1,5 @@
+if master['platform'] =~ /debian|ubuntu/
+  master.uses_passenger!
+elsif master['platform'] =~ /redhat|el|centos|scientific|fedora/
+  master['use-service'] = true
+end

--- a/acceptance/setup/aio/pre-suite/045_EnsureMasterStartedOnPassenger.rb
+++ b/acceptance/setup/aio/pre-suite/045_EnsureMasterStartedOnPassenger.rb
@@ -1,0 +1,3 @@
+if master.graceful_restarts?
+  on(master, puppet('resource', 'service', master['puppetservice'], "ensure=running"))
+end


### PR DESCRIPTION
This implements a new pre-suite that installs the puppet-agent (all in
one) package and add a new Rake task "ci:test:aio" to utilize the new
pre-suite.

note: there are currently failures in the pre-suite for AIO because of
issues between the AIO package and the puppet server. These are expected
to be ironed out with the dev release of puppet-server 2.0

You can see the current CI pipeline against this commit [here](https://jenkins.puppetlabs.com/view/z-temp-view-for-aio/view/puppet/job/experimental-Puppet-Package-Acceptance-master/3/)*

You can see the current AIO pipeline failing (with legit failures, but still accurately running the tests) [here](http://10.32.77.180/view/job%20development/view/All%20in%20One%20Agent/view/Integrated%20Acceptance/job/platform_puppet-agent_intn-sys_master/13/SLAVE_LABEL=beaker,TEST_TARGET=centos5/console).


* fedora failed from a network error? Succeeded on a [re-run](https://jenkins.puppetlabs.com/view/z-temp-view-for-aio/view/puppet/job/experimental-Puppet-Package-Acceptance-master/4/)