### PR TITLE
(PUP-3855) Restore ability for auth.conf to restrict on environment

### DIFF
--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -87,14 +87,16 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     end
 
     configured_environment = Puppet.lookup(:environments).get(environment)
-    if configured_environment.nil?
-      raise ArgumentError, "Could not find environment '#{environment}'"
-    else
+    unless configured_environment.nil?
       configured_environment = configured_environment.override_from_commandline(Puppet.settings)
       params[:environment] = configured_environment
     end
 
     check_authorization(method, "#{url_prefix}/#{indirection_name}/#{key}", params)
+
+    if configured_environment.nil?
+      raise ArgumentError, "Could not find environment '#{environment}'"
+    end
 
     params.delete(:bucket_path)
 

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -72,8 +72,6 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       raise ArgumentError, "Indirection '#{indirection_name}' does not match url prefix '#{url_prefix}'"
     end
 
-    check_authorization(method, "#{url_prefix}/#{indirection_name}/#{key}", params)
-
     indirection = Puppet::Indirector::Indirection.instance(indirection_name.to_sym)
     if !indirection
       raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(
@@ -95,6 +93,8 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       configured_environment = configured_environment.override_from_commandline(Puppet.settings)
       params[:environment] = configured_environment
     end
+
+    check_authorization(method, "#{url_prefix}/#{indirection_name}/#{key}", params)
 
     params.delete(:bucket_path)
 

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -208,6 +208,15 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
                                                                            :env))))
       handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", params)
     end
+
+    it "should not pass through an environment to check_authorization and fail if the environment is unknown" do
+      handler.expects(:check_authorization).with(anything,
+                                                 anything,
+                                                 Not(has_entry(:environment)))
+      expect(lambda { handler.uri2indirection("GET",
+                                              "#{master_url_prefix}/node/bar",
+                                              {:environment => 'bogus'}) }).to raise_error(ArgumentError)
+    end
   end
 
   describe "when converting a request into a URI" do

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -196,6 +196,18 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       indirection, method, key, final_params = handler.uri2indirection("GET", "#{master_url_prefix}/node/#{escaped}", params)
       expect(key).to eq("foo bar")
     end
+
+    it "should pass through a proper environment param in a call to check_authorization" do
+      handler.expects(:check_authorization).with(anything,
+                                                 anything,
+                                                 all_of(
+                                                   has_entry(:environment,
+                                                             is_a(Puppet::Node::Environment)),
+                                                   has_entry(:environment,
+                                                             responds_with(:name,
+                                                                           :env))))
+      handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", params)
+    end
   end
 
   describe "when converting a request into a URI" do


### PR DESCRIPTION
The PR for PUP-3644 moved the `check_authorization` call for
indirected routes to a spot before the environment for a request is
translated into a `Puppet::Node::Environment` instance in the request
params.  This caused any restrictions on environment made in an
auth.conf file to inappropriately reject all requests matching the
rule path, even ones that should have been allowed.

This PR moves the `check_authorization` call back to a spot in the
code after the translation to an `Puppet::Node:::Environment` instance
occurs.  This change restores the ability for an environment value in
the auth.conf to appropriately allow/deny access for requests.