### PR TITLE
(PUP-3902) Remove duplicate key from main settings

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -463,10 +463,6 @@ module Puppet
       :default    => "stomp",
       :desc       => "Which type of queue to use for asynchronous processing.",
     },
-    :queue_type => {
-      :default    => "stomp",
-      :desc       => "Which type of queue to use for asynchronous processing.",
-    },
     :queue_source => {
       :default    => "stomp://localhost:61613/",
       :desc       => "Which type of queue to use for asynchronous processing.  If your stomp server requires


### PR DESCRIPTION
Redundant stanza causes warning under ruby 2.2.0:

    # puppet
    /opt/puppet/lib/puppet/defaults.rb:465: warning: duplicated key at line 466 ignored: :queue_type