### PR TITLE
(PUP-3894) Update license in PMT generate example to match SPDX string

### DIFF
--- a/lib/puppet/face/module/generate.rb
+++ b/lib/puppet/face/module/generate.rb
@@ -26,7 +26,7 @@ Puppet::Face.define(:module, '1.0.0') do
       Who wrote this module?  [puppetlabs]
       -->
 
-      What license does this module code fall under?  [Apache 2.0]
+      What license does this module code fall under?  [Apache-2.0]
       -->
 
       How would you describe this module in a single sentence?
@@ -47,7 +47,7 @@ Puppet::Face.define(:module, '1.0.0') do
         "version": "0.1.0",
         "author": "puppetlabs",
         "summary": null,
-        "license": "Apache 2.0",
+        "license": "Apache-2.0",
         "source": "",
         "project_page": null,
         "issues_url": null,


### PR DESCRIPTION
Before this commit, the "examples" string in the generate face still
    read "Apache 2.0". After this commit, it reads "Apache-2.0" to be in
    line with the behavior of puppet module generate.