### PR TITLE
(PUP-1276) Normalize tidy paths

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -20,6 +20,9 @@ Puppet::Type.newtype(:tidy) do
     desc "The path to the file or directory to manage.  Must be fully
       qualified."
     isnamevar
+    munge do |value|
+      File.expand_path(value)
+    end
   end
 
   newparam(:recurse) do

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -12,6 +12,13 @@ describe tidy do
     Puppet.settings.stubs(:use)
   end
 
+  context "when normalizing 'path' on windows", :if => Puppet.features.microsoft_windows? do
+    it "replaces backslashes with forward slashes" do
+      resource = tidy.new(:path => 'c:\directory')
+      expect(resource[:path]).to eq('c:/directory')
+    end
+  end
+
   it "should use :lstat when stating a file" do
     path = '/foo/bar'
     stat = mock 'stat'


### PR DESCRIPTION
Previously, a tidy resource could create a duplicate file resource due to a
mismatch between back and forward slashes on Windows.

This commit munges the tidy path parameter using File.expand_path, so on
Windows, `C:\dir` becomes `C:/dir`. When that is File.join'ed with a file
needing to be tidy'ed, the resulting path contains only forward slashes,
which is consistent with the path parameter for the file type.