### PR TITLE
(PUP-1103) Faces should respond to --help

### DIFF
--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -16,6 +16,17 @@ class Puppet::Application::FaceBase < Puppet::Application
     self.render_as = format.to_sym
   end
 
+  option("--help", "-h") do |arg|
+    if action && !@is_default_action
+      # Only invoke help on the action if it was specified, not if
+      # it was the default action.
+      puts Puppet::Face[:help, :current].help(face.name, action.name)
+    else
+      puts Puppet::Face[:help, :current].help(face.name)
+    end
+    exit
+  end
+
   attr_accessor :face, :action, :type, :arguments, :render_as
 
   def render_as=(format)
@@ -108,6 +119,14 @@ class Puppet::Application::FaceBase < Puppet::Application
       if @action = @face.get_default_action() then
         @is_default_action = true
       else
+        # First try to handle global command line options
+        # But ignoring invalid options as this is a invalid action, and
+        # we want the error message for that instead.
+        begin
+          super
+        rescue OptionParser::InvalidOption
+        end
+
         face   = @face.name
         action = action_name.nil? ? 'default' : "'#{action_name}'"
         msg = "'#{face}' has no #{action} action.  See `puppet help #{face}`."

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -420,4 +420,18 @@ EOT
       }.to have_printed(/you invoked the 's' rendering hook/)
     end
   end
+
+  describe "#help" do
+    it "should generate help for --help" do
+      app.command_line.stubs(:args).returns %w{--help}
+      Puppet::Face[:help, :current].expects(:help)
+      expect { app.run }.to exit_with(0)
+    end
+
+    it "should generate help for -h" do
+      app.command_line.stubs(:args).returns %w{-h}
+      Puppet::Face[:help, :current].expects(:help)
+      expect { app.run }.to exit_with(0)
+    end
+  end
 end


### PR DESCRIPTION
This makes puppet <face> --help into an alias for puppet help <face>.
And puppet <face> <action> --help into an alias for puppet help <face>
<action>.