### PR TITLE
(PUP-3166) Debian provider handles 101 status

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -38,7 +38,8 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
     # See x-man-page://invoke-rc.d
     if [104, 106].include?($CHILD_STATUS.exitstatus)
       return :true
-    elsif [105].include?($CHILD_STATUS.exitstatus)
+    elsif [101, 105].include?($CHILD_STATUS.exitstatus)
+      # 101 is action not allowed, which means we have to do the check manually.
       # 105 is unknown, which generally means the iniscript does not support query
       # The debian policy states that the initscript should support methods of query
       # For those that do not, peform the checks manually

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -88,19 +88,27 @@ describe provider_class do
       expect(@provider.enabled?).to eq(:true)
     end
 
-    context "when invoke-rc.d exits with 105 status" do
+    shared_examples "manually queries service status" do |status|
       it "links count is 4" do
         @provider.stubs(:system)
-        $CHILD_STATUS.stubs(:exitstatus).returns(105)
+        $CHILD_STATUS.stubs(:exitstatus).returns(status)
         @provider.stubs(:get_start_link_count).returns(4)
         expect(@provider.enabled?).to eq(:true)
       end
       it "links count is less than 4" do
         @provider.stubs(:system)
-        $CHILD_STATUS.stubs(:exitstatus).returns(105)
+        $CHILD_STATUS.stubs(:exitstatus).returns(status)
         @provider.stubs(:get_start_link_count).returns(3)
         expect(@provider.enabled?).to eq(:false)
       end
+    end
+
+    context "when invoke-rc.d exits with 101 status" do
+      it_should_behave_like "manually queries service status", 101
+    end
+
+    context "when invoke-rc.d exits with 105 status" do
+      it_should_behave_like "manually queries service status", 105
     end
 
     # pick a range of non-[104.106] numbers, strings and booleans to test with.


### PR DESCRIPTION
Check for enabled debian service manually on 101 status. 101 is action
not allowed, meaning we have to manually check the service status
similar to when we get a status 105 (unknown).