### PR TITLE
(FOR REVIEW) (SERVER-299) Craft custom 404 error message

### DIFF
--- a/lib/puppet/network/http.rb
+++ b/lib/puppet/network/http.rb
@@ -5,6 +5,10 @@ module Puppet::Network::HTTP
   MASTER_URL_PREFIX = "/puppet"
   CA_URL_PREFIX = "/puppet-ca"
 
+  NOT_FOUND_ERROR_MESSAGE = 'This master is running Puppet 4, and the URL format has changed. ' +
+      'This request was likely made with a Puppet 3 Agent, as it used an invalid ' +
+      'URL format. Please upgrade your agents to Puppet 4 and try again.'
+
   require 'puppet/network/authorization'
   require 'puppet/network/http/issues'
   require 'puppet/network/http/error'

--- a/lib/puppet/network/http/api.rb
+++ b/lib/puppet/network/http/api.rb
@@ -1,9 +1,11 @@
 class Puppet::Network::HTTP::API
+
   def self.not_found
     Puppet::Network::HTTP::Route.
       path(/.*/).
       any(lambda do |req, res|
-        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{req.method} #{req.path}", Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
+        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{req.method} #{req.path} #{Puppet::Network::HTTP::NOT_FOUND_ERROR_MESSAGE}",
+                                                                  Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
       end)
   end
 

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -59,7 +59,8 @@ module Puppet::Network::HTTP::Handler
       if route = @routes.find { |r| r.matches?(new_request) }
         route.process(new_request, new_response)
       else
-        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{new_request.method} #{new_request.path}", HANDLER_NOT_FOUND)
+        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{new_request.method} #{new_request.path} #{Puppet::Network::HTTP::NOT_FOUND_ERROR_MESSAGE}",
+                                                                  HANDLER_NOT_FOUND)
       end
     end
 

--- a/spec/unit/network/http/api_spec.rb
+++ b/spec/unit/network/http/api_spec.rb
@@ -47,7 +47,9 @@ describe Puppet::Network::HTTP::API do
       req = Puppet::Network::HTTP::Request.from_hash(:path => "/unknown")
       res = {}
       handler.process(req, res)
+      res_body = JSON(res[:body])
       expect(res[:status]).to eq(404)
+      expect(res_body["message"]).to include(Puppet::Network::HTTP::NOT_FOUND_ERROR_MESSAGE)
     end
 
     describe "when processing master routes" do
@@ -78,7 +80,9 @@ describe Puppet::Network::HTTP::API do
         req = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_prefix}/unknown")
         res = {}
         handler.process(req, res)
+        res_body = JSON(res[:body])
         expect(res[:status]).to eq(404)
+        expect(res_body["message"]).to include(Puppet::Network::HTTP::NOT_FOUND_ERROR_MESSAGE)
       end
     end
 
@@ -98,7 +102,9 @@ describe Puppet::Network::HTTP::API do
         req = Puppet::Network::HTTP::Request.from_hash(:path => "#{ca_prefix}/unknown")
         res = {}
         handler.process(req, res)
+        res_body = JSON(res[:body])
         expect(res[:status]).to eq(404)
+        expect(res_body["message"]).to include(Puppet::Network::HTTP::NOT_FOUND_ERROR_MESSAGE)
       end
     end
   end

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -70,7 +70,7 @@ describe Puppet::Network::HTTP::Handler do
 
       expect(res[:content_type_header]).to eq("application/json")
       expect(res_body["issue_kind"]).to eq("HANDLER_NOT_FOUND")
-      expect(res_body["message"]).to eq("Not Found: No route for GET /vtest/foo")
+      expect(res_body["message"]).to eq("Not Found: No route for GET /vtest/foo #{Puppet::Network::HTTP::NOT_FOUND_ERROR_MESSAGE}")
       expect(res[:status]).to eq(404)
     end
 


### PR DESCRIPTION
Craft a custom 404 error message indicating to the user that
the request has failed, and stating that this may be because they
are running a Puppet 3 agent and if so they should upgrade to
Puppet 4.

This change corresponds to the change made to Puppet Server in https://github.com/puppetlabs/puppet-server/pull/371. As in that PR, there is going to need to be some discussion as to what the new 404 message should actually say.