### PR TITLE
(PUP-3168) Change minitar permissions to match

### DIFF
--- a/acceptance/lib/puppet/acceptance/module_utils.rb
+++ b/acceptance/lib/puppet/acceptance/module_utils.rb
@@ -197,7 +197,7 @@ module Puppet
         end
 
         # A module's files should have:
-        #     * a mode of 444 (755, if they're a directory)
+        #     * a mode of 644 (755, if they're a directory)
         #     * owner == owner of moduledir
         #     * group == group of moduledir
         on host, %Q{ls -alR "#{moduledir}/#{module_name}"} do

--- a/lib/puppet/module_tool/tar/mini.rb
+++ b/lib/puppet/module_tool/tar/mini.rb
@@ -4,7 +4,7 @@ class Puppet::ModuleTool::Tar::Mini
       Archive::Tar::Minitar.unpack(reader, destdir, find_valid_files(reader)) do |action, name, stats|
         case action
         when :file_done
-          File.chmod(0444, "#{destdir}/#{name}")
+          File.chmod(0644, "#{destdir}/#{name}")
         when :dir, :file_start
           validate_entry(destdir, name)
           Puppet.debug("Extracting: #{destdir}/#{name}")


### PR DESCRIPTION
Changes minitar file permissions to 0644 to match new gnu tar
permissions. Fixes acceptance failures in PMT install.