### PR TITLE
(PUP-3890) Fix mtime/ctime checksum type

### DIFF
--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'tempfile'
+require 'date'
 
 require 'puppet/util/checksums'
 require 'puppet/network/http'
@@ -73,19 +74,6 @@ module Puppet
       end
     end
 
-    def checksum_type
-      if source = resource.parameter(:source)
-        result = source.checksum
-      else
-        result = resource[:checksum]
-      end
-      if result =~ /^\{(\w+)\}.+/
-        return $1.to_sym
-      else
-        return result
-      end
-    end
-
     def length
       (actual_content and actual_content.length) || 0
     end
@@ -117,6 +105,21 @@ module Puppet
         end
       end
       result
+    end
+
+    def property_matches?(current, desired)
+      basic = super
+      # The inherited equality is always accepted, so use it if valid.
+      time_types = [:mtime, :ctime]
+      checksum_type = resource.parameter(:checksum).value
+      return basic if basic || !time_types.include?(checksum_type)
+      return false unless current && desired
+      begin
+        raise if !time_types.include?(sumtype(current).to_sym) || !time_types.include?(sumtype(desired).to_sym)
+        DateTime.parse(sumdata(current)) >= DateTime.parse(sumdata(desired))
+      rescue => detail
+        self.fail Puppet::Error, "Resource with checksum_type #{checksum_type} didn't contain a date in #{current} or #{desired}", detail.backtrace
+      end
     end
 
     def retrieve

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -686,8 +686,10 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
     describe "when recursing remote directories" do
       describe "for the 2nd time" do
         with_checksum_types "one", "x" do
-          it "should not update the target directory" do
-            options = {
+          let(:target_file) { File.join(path, 'x') }
+          let(:second_catalog) { Puppet::Resource::Catalog.new }
+          before(:each) do
+            @options = {
               :path => path,
               :ensure => :directory,
               :backup => false,
@@ -695,21 +697,44 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               :checksum => checksum_type,
               :source => env_path
             }
-            target_file = File.join(path, 'x')
+          end
 
-            first_catalog = Puppet::Resource::Catalog.new
-            first_catalog.add_resource Puppet::Type.send(:newfile, options)
-            first_catalog.apply
+          it "should not update the target directory" do
+            # Ensure the test believes the source file was written in the past.
+            FileUtils.touch checksum_file, :mtime => Time.now - 20
+            catalog.add_resource Puppet::Type.send(:newfile, @options)
+            catalog.apply
             expect(File).to be_directory(path)
             expect(Puppet::FileSystem.exist?(target_file)).to be_truthy
 
             # The 2nd time the resource should not change.
-            second_catalog = Puppet::Resource::Catalog.new
-            second_catalog.add_resource Puppet::Type.send(:newfile, options)
+            second_catalog.add_resource Puppet::Type.send(:newfile, @options)
             result = second_catalog.apply
             status = result.report.resource_statuses["File[#{target_file}]"]
             expect(status).not_to be_failed
             expect(status).not_to be_changed
+          end
+
+          it "should update the target directory if contents change" do
+            pending "a way to appropriately mock ctime checks for a particular file" if checksum_type == 'ctime'
+
+            catalog.add_resource Puppet::Type.send(:newfile, @options)
+            catalog.apply
+            expect(File).to be_directory(path)
+            expect(Puppet::FileSystem.exist?(target_file)).to be_truthy
+
+            # Change the source file.
+            File.open(checksum_file, "wb") { |f| f.write "some content" }
+            File::Stat.any_instance.unstub(:mtime)
+            File::Stat.any_instance.unstub(:ctime)
+            FileUtils.touch target_file, :mtime => Time.now - 20
+
+            # The 2nd time should update the resource.
+            second_catalog.add_resource Puppet::Type.send(:newfile, @options)
+            result = second_catalog.apply
+            status = result.report.resource_statuses["File[#{target_file}]"]
+            expect(status).not_to be_failed
+            expect(status).to be_changed
           end
         end
       end

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -725,8 +725,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
             # Change the source file.
             File.open(checksum_file, "wb") { |f| f.write "some content" }
-            File::Stat.any_instance.unstub(:mtime)
-            File::Stat.any_instance.unstub(:ctime)
             FileUtils.touch target_file, :mtime => Time.now - 20
 
             # The 2nd time should update the resource.

--- a/spec/shared_contexts/checksum.rb
+++ b/spec/shared_contexts/checksum.rb
@@ -26,7 +26,13 @@ shared_context('with supported checksum types') do
       expect(meta).to_not be_nil
       expect(meta).to be_instance_of(type)
       expect(meta.checksum_type).to eq(checksum_type)
-      expect(meta.checksum).to eq("{#{checksum_type}}#{checksum}")
+
+      case checksum_type
+      when 'mtime', 'ctime'
+        expect(DateTime.parse(meta.checksum)).to be >= DateTime.parse(checksum)
+      else
+        expect(meta.checksum).to eq("{#{checksum_type}}#{checksum}")
+      end
     end
 
     (CHECKSUM_TYPES_TO_TRY + TIME_TYPES_TO_TRY).each do |checksum_type, checksum|
@@ -44,8 +50,6 @@ shared_context('with supported checksum types') do
         before(:each) do
           FileUtils.mkdir_p(File.dirname(checksum_file))
           File.open(checksum_file, "wb") { |f| f.write plaintext }
-          File::Stat.any_instance.stubs(:ctime).returns(CHECKSUM_STAT_TIME)
-          File::Stat.any_instance.stubs(:mtime).returns(CHECKSUM_STAT_TIME)
         end
 
         instance_eval(&block)


### PR DESCRIPTION
Makes file contents that use mtime or ctime for checksum_type
compare to ensure the target mtime/ctime is newer than the source.