### PR TITLE
(HI-328) Test against Hiera 2.x source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,8 @@ end
 
 gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 1.6', '< 3'])
-gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
+# gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
+gem "hiera", :path => "#{File.dirname(File.dirname(__FILE__))}/hiera", :require => false
 gem "rake", "10.1.1", :require => false
 
 group(:development, :test) do

--- a/lib/hiera/backend/puppet_backend.rb
+++ b/lib/hiera/backend/puppet_backend.rb
@@ -43,7 +43,7 @@ class Hiera
         hierarchy
       end
 
-      def lookup(key, scope, order_override, resolution_type)
+      def lookup(key, scope, order_override, resolution_type, recursive_guard)
         answer = nil
 
         Hiera.debug("Looking up #{key} in Puppet backend")
@@ -84,12 +84,12 @@ class Hiera
             case resolution_type
             when :array
               answer ||= []
-              answer << Backend.parse_answer(temp_answer, scope)
+              answer << Backend.parse_answer(temp_answer, scope, recursive_guard)
             when :hash
               answer ||= {}
-              answer = Backend.parse_answer(temp_answer, scope).merge answer
+              answer = Backend.parse_answer(temp_answer, scope, recursive_guard).merge answer
             else
-              answer = Backend.parse_answer(temp_answer, scope)
+              answer = Backend.parse_answer(temp_answer, scope, recursive_guard)
               break
             end
           end

--- a/spec/unit/hiera/backend/puppet_backend_spec.rb
+++ b/spec/unit/hiera/backend/puppet_backend_spec.rb
@@ -59,7 +59,7 @@ describe Hiera::Backend::Puppet_backend do
       @mockscope.expects(:function_include).with(["rspec::rspec"])
       @mockscope.expects(:lookupvar).with("rspec::rspec::key").returns("rspec")
 
-      expect(@backend.lookup("key", @scope, nil, nil)).to eq("rspec")
+      expect(@backend.lookup("key", @scope, nil, nil, nil)).to eq("rspec")
     end
 
     it "should not load loaded classes" do
@@ -72,7 +72,7 @@ describe Hiera::Backend::Puppet_backend do
       @mockscope.expects(:function_include).never
       @mockscope.expects(:lookupvar).with("rspec::rspec::key").returns("rspec")
 
-      expect(@backend.lookup("key", @scope, nil, nil)).to eq("rspec")
+      expect(@backend.lookup("key", @scope, nil, nil, nil)).to eq("rspec")
     end
 
     it "should return the first found data" do
@@ -86,7 +86,7 @@ describe Hiera::Backend::Puppet_backend do
       @mockscope.expects(:lookupvar).with("rspec::override::key").returns("rspec")
       @mockscope.expects(:lookupvar).with("rspec::rspec::key").never
 
-      expect(@backend.lookup("key", @scope, "override", nil)).to eq("rspec")
+      expect(@backend.lookup("key", @scope, "override", nil, nil)).to eq("rspec")
     end
 
     it "should consider a value of false to be a real value" do
@@ -100,7 +100,7 @@ describe Hiera::Backend::Puppet_backend do
       @mockscope.expects(:lookupvar).with("rspec::override::key").returns(expected_answer)
       @mockscope.expects(:lookupvar).with("rspec::rspec::key").never
 
-      expect(@backend.lookup("key", @scope, "override", nil)).to eq(expected_answer)
+      expect(@backend.lookup("key", @scope, "override", nil, nil)).to eq(expected_answer)
     end
 
     it "should return an array of found data for array searches" do
@@ -112,7 +112,7 @@ describe Hiera::Backend::Puppet_backend do
       @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
 
       @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
-      expect(@backend.lookup("key", @scope, nil, :array)).to eq(["rspec::key", "test::key"])
+      expect(@backend.lookup("key", @scope, nil, :array, nil)).to eq(["rspec::key", "test::key"])
     end
 
     it "should return a hash of found data for hash searches" do
@@ -124,7 +124,7 @@ describe Hiera::Backend::Puppet_backend do
       @mockscope.expects(:lookupvar).with("test::key").returns({'test'=>'key'})
 
       @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
-      expect(@backend.lookup("key", @scope, nil, :hash)).to eq({'rspec'=>'key', 'test'=>'key'})
+      expect(@backend.lookup("key", @scope, nil, :hash, nil)).to eq({'rspec'=>'key', 'test'=>'key'})
     end
 
     it "should return a merged hash of found data for hash searches" do
@@ -136,7 +136,7 @@ describe Hiera::Backend::Puppet_backend do
       @mockscope.expects(:lookupvar).with("test::key").returns({'test'=>'key', 'common'=>'rspec'})
 
       @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
-      expect(@backend.lookup("key", @scope, nil, :hash)).to eq({'rspec'=>'key', 'common'=>'rspec', 'test'=>'key'})
+      expect(@backend.lookup("key", @scope, nil, :hash, nil)).to eq({'rspec'=>'key', 'common'=>'rspec', 'test'=>'key'})
     end
   end
 


### PR DESCRIPTION
Tests that the additonal recurse_guard argument added to the
Hiera backend lookup mehtod by HI-328 is propagated correctly.

This commit assumes that 2x hiera source is clone adjacent
to the puppet clone (Gemfile appoints ../hiera)