### PR TITLE
(PUP-3923) Fix lexer problem seeing regexp for div after var or word

### DIFF
--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -685,7 +685,7 @@ class Puppet::Pops::Parser::Lexer2
       true
 
     # Operands (that can be followed by DIV (even if illegal in grammar)
-    when :NAME, :CLASSREF, :NUMBER, :STRING, :BOOLEAN, :DQPRE, :DQMID, :DQPOST, :HEREDOC, :REGEX
+    when :NAME, :CLASSREF, :NUMBER, :STRING, :BOOLEAN, :DQPRE, :DQMID, :DQPOST, :HEREDOC, :REGEX, :VARIABLE, :WORD
       false
 
     else

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -301,6 +301,8 @@ describe 'Lexer2' do
     "]"     => ["] /./",       [:RBRACK, :DIV, :DOT, :DIV]],
     "|>"     => ["|> /./",     [:RCOLLECT, :DIV, :DOT, :DIV]],
     "|>>"    => ["|>> /./",    [:RRCOLLECT, :DIV, :DOT, :DIV]],
+    "$x"     => ["$x /1/",     [:VARIABLE, :DIV, :NUMBER, :DIV]],
+    "a-b"    => ["a-b /1/",    [:WORD, :DIV, :NUMBER, :DIV]],
     '"a$a"'  => ['"a$a" /./',  [:DQPRE, :VARIABLE, :DQPOST, :DIV, :DOT, :DIV]],
   }.each do |token, entry|
     it "should not lex regexp after '#{token}'" do


### PR DESCRIPTION
The lexer treated a div after a variable or bare word as a potential
literal regular expression.

e.g.

$foo / 2 / 2 
abc-def / 2 / 2

This was caused by two entries (:VARIABLE, and :WORD) missing from the
list of tokens that do not allow a following literal regexp.