### PR TITLE
(PUP-3678) Correct and unify module name validation

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -33,6 +33,25 @@ class Puppet::Module
     env.module(modname)
   end
 
+  def self.is_module_directory?(name, path)
+    # it must be a directory
+    fullpath = File.join(path, name)
+    return false unless Puppet::FileSystem.directory?(fullpath)
+    return is_module_directory_name?(name)
+  end
+
+  def self.is_module_directory_name?(name)
+    # it must match an installed module name according to forge validator
+    return true if name =~ /^[a-z][a-z0-9_]*$/
+    return false
+  end
+
+  def self.is_module_namespaced_name?(name)
+    # it must match the full module name according to forge validator
+    return true if name =~ /^[a-zA-Z0-9]+[-][a-z][a-z0-9_]*$/   
+    return false
+  end
+
   attr_reader :name, :environment, :path, :metadata
   attr_writer :environment
 
@@ -320,6 +339,8 @@ class Puppet::Module
   end
 
   def assert_validity
-    raise InvalidName, "Invalid module name #{name}; module names must be alphanumeric (plus '-'), not '#{name}'" unless name =~ /^[-\w]+$/
+    if !Puppet::Module.is_module_directory_name?(@name) && !Puppet::Module.is_module_namespaced_name?(@name)
+      raise InvalidName, "Invalid module name #{@name}; module names must be alphanumeric (plus '-'), not '#{@name}'"
+    end
   end
 end

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -271,7 +271,7 @@ class Puppet::Node::Environment
       seen_modules = {}
       modulepath.each do |path|
         Dir.entries(path).each do |name|
-          next if name == "." || name == ".."
+          next unless Puppet::Module.is_module_directory?(name, path)
           warn_about_mistaken_path(path, name)
           if not seen_modules[name]
             module_references << {:name => name, :path => File.join(path, name)}
@@ -319,8 +319,8 @@ class Puppet::Node::Environment
     modules_by_path = {}
     modulepath.each do |path|
       Dir.chdir(path) do
-        module_names = Dir.glob('*').select do |d|
-          FileTest.directory?(d) && (File.basename(d) =~ /\A\w+(-\w+)*\Z/)
+        module_names = Dir.entries(path).select do |name|
+          Puppet::Module.is_module_directory?(name, path)
         end
         modules_by_path[path] = module_names.sort.map do |name|
           Puppet::Module.new(name, File.join(path, name), self)

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -34,6 +34,65 @@ describe Puppet::Module do
     end
   end
 
+  describe "is_module_directory?" do
+    let(:first_modulepath) { tmpdir('firstmodules') }
+    let(:not_a_module) { tmpfile('thereisnomodule', first_modulepath) }
+
+    it "should return false for a non-directory" do
+      expect(Puppet::Module.is_module_directory?('thereisnomodule', first_modulepath)).to be_falsey
+    end
+
+    it "should return true for a well named directories" do
+      PuppetSpec::Modules.generate_files('foo', first_modulepath)
+      PuppetSpec::Modules.generate_files('foo2', first_modulepath)
+      PuppetSpec::Modules.generate_files('foo_bar', first_modulepath)
+      expect(Puppet::Module.is_module_directory?('foo', first_modulepath)).to be_truthy
+      expect(Puppet::Module.is_module_directory?('foo2', first_modulepath)).to be_truthy
+      expect(Puppet::Module.is_module_directory?('foo_bar', first_modulepath)).to be_truthy
+    end
+
+    it "should return false for badly named directories" do
+      PuppetSpec::Modules.generate_files('foo=bar', first_modulepath)
+      expect(Puppet::Module.is_module_directory?('foo=bar', first_modulepath)).to be_falsey
+    end
+  end
+
+  describe "is_module_directory_name?" do
+    it "should return true for a valid directory module name" do
+      expect(Puppet::Module.is_module_directory_name?('foo')).to be_truthy
+      expect(Puppet::Module.is_module_directory_name?('foo2')).to be_truthy
+      expect(Puppet::Module.is_module_directory_name?('foo_bar')).to be_truthy
+    end
+
+    it "should return false for badly formed directory module names" do
+      expect(Puppet::Module.is_module_directory_name?('foo-bar')).to be_falsey
+      expect(Puppet::Module.is_module_directory_name?('foo=bar')).to be_falsey
+      expect(Puppet::Module.is_module_directory_name?('foo bar')).to be_falsey
+      expect(Puppet::Module.is_module_directory_name?('foo.bar')).to be_falsey
+      expect(Puppet::Module.is_module_directory_name?('-foo')).to be_falsey
+      expect(Puppet::Module.is_module_directory_name?('foo-')).to be_falsey
+      expect(Puppet::Module.is_module_directory_name?('foo--bar')).to be_falsey
+    end
+  end
+
+  describe "is_module_namespaced_name?" do
+    it "should return true for a valid namespaced module name" do
+      expect(Puppet::Module.is_module_namespaced_name?('foo-bar')).to be_truthy
+    end
+
+    it "should return false for badly formed namespaced module names" do
+      expect(Puppet::Module.is_module_namespaced_name?('foo')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('foo2')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('foo_bar')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('foo=bar')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('foo bar')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('foo.bar')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('-foo')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('foo-')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('foo--bar')).to be_falsey
+    end
+  end
+
   describe "attributes" do
     it "should support a 'version' attribute" do
       mod.version = 1.09

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -270,7 +270,7 @@ describe Puppet::Node::Environment do
             PuppetSpec::Modules.generate_files('foo-', first_modulepath)
             PuppetSpec::Modules.generate_files('foo--bar', first_modulepath)
 
-            expect(env.modules_by_path[first_modulepath].collect{|mod| mod.name}.sort).to eq(%w{foo foo-bar foo2 foo_bar})
+            expect(env.modules_by_path[first_modulepath].collect{|mod| mod.name}.sort).to eq(%w{foo foo2 foo_bar})
           end
 
         end
@@ -396,7 +396,7 @@ describe Puppet::Node::Environment do
             PuppetSpec::Modules.generate_files('foo=bar', first_modulepath)
             PuppetSpec::Modules.generate_files('foo bar', first_modulepath)
 
-            expect(env.modules.collect{|mod| mod.name}.sort).to eq(%w{foo foo-bar foo2 foo_bar})
+            expect(env.modules.collect{|mod| mod.name}.sort).to eq(%w{foo foo2 foo_bar})
           end
 
           it "creates modules with the correct environment" do


### PR DESCRIPTION
Before this commit, we were checking the validity of a module name in
    multiple places. We were also only excluding . and .. from the list
    of modules to create. This permitted directories in the modulepath like
    .git, .svn, and .DS_store to cause errors and warnings. This commit
    consolidates the module name checking and excludes those types of
    directories. It also enforces a name validity check more in line with the Forge validator.