### PR TITLE
(PUP-3927) Ensure Fedora uses the systemd service provider

### DIFF
--- a/acceptance/tests/resource/service/ticket_3927_redhat_systemd_vs_service_provider.rb
+++ b/acceptance/tests/resource/service/ticket_3927_redhat_systemd_vs_service_provider.rb
@@ -1,0 +1,46 @@
+test_name 'RedHat Service vs. Systemd Provider Validation'
+
+# A simple acceptance test to ensure basic usage of the service
+# provider works for a mix of sysV and systemd RedHat Linux platforms
+confine :to, :platform => /el|centos|fedora/
+
+manifest_install_httpd = %Q{
+  package { 'httpd':
+    ensure => present,
+  }
+}
+
+manifest_httpd_enabled = %Q{
+  service { 'httpd':
+    enable => true,
+  }
+}
+
+manifest_httpd_disabled = %Q{
+  service { 'httpd':
+    enable => false,
+  }
+}
+
+agents.each do |agent|
+  distro = on(agent, facter('operatingsystem')).stdout.chomp
+  if distro == 'fedora'
+    majrelease = on(agent, facter('operatingsystemmajrelease')).stdout.chomp.to_i
+    if majrelease < 17
+      skip_test "Test not applicable to Fedora #{majrelease}"
+    elsif majrelease > 21
+      # This is a reminder so we update the provider's defaultfor when new
+      # versions of Fedora are released (then update this test)
+      fail_test "Provider needs manual update to support Fedora #{majrelease}"
+    end
+  end
+
+  step "installing httpd"
+  apply_manifest_on(agent, manifest_install_httpd, :catch_failures => true)
+
+  step "enabling httpd"
+  apply_manifest_on(agent, manifest_httpd_enabled, :catch_failures => true)
+
+  step "disabling httpd"
+  apply_manifest_on(agent, manifest_httpd_disabled, :catch_failures => true)
+end

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -7,6 +7,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => "7"
+  defaultfor :osfamily => :redhat, :operatingsystem => :fedora, :operatingsystemmajrelease => ["17", "18", "19", "20", "21"]
 
   def self.instances
     i = []

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -30,10 +30,22 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     described_class.default?.should be_true
   end
 
-  it "should not be the default provider on rhel6" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:redhat)
-    Facter.expects(:value).with(:operatingsystemmajrelease).returns("6")
-    described_class.default?.should_not be_true
+  [ 4, 5, 6 ].each do |ver|
+    it "should not be the default provider on rhel#{ver}" do
+      Facter.expects(:value).with(:osfamily).at_least_once.returns(:redhat)
+      Facter.expects(:value).with(:operatingsystem).returns(:redhat)
+      Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("#{ver}")
+      described_class.default?.should_not be_true
+    end
+  end
+
+  [ 17, 18, 19, 20, 21 ].each do |ver|
+    it "should be the default provider on fedora#{ver}" do
+      Facter.expects(:value).with(:osfamily).at_least_once.returns(:redhat)
+      Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:fedora)
+      Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("#{ver}")
+      described_class.default?.should be_true
+    end
   end
 
   [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|


### PR DESCRIPTION
Recent changes to the redhat (chkconfig) service provider requires
features that the chkconfig shim doesn't support (specifically, --add).
Besides, the systemd provider should be the default for Fedora anyway.