### PR TITLE
(PUP-3934) Propagate environment to Resource initializer

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -211,6 +211,7 @@ class Puppet::Resource
   # @api public
   def initialize(type, title = nil, attributes = {})
     @parameters = {}
+    environment = attributes[:environment]
     if type.is_a?(Class) && type < Puppet::Type
       # Set the resource type to avoid an expensive `known_resource_types`
       # lookup.

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -296,13 +296,14 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
   def resource(type, title = nil)
     # Always create a resource reference, so that it always
     # canonicalizes how we are referring to them.
+    attributes = { :environment => environment_instance }
     if title
-      res = Puppet::Resource.new(type, title)
+      res = Puppet::Resource.new(type, title, attributes)
     else
       # If they didn't provide a title, then we expect the first
       # argument to be of the form 'Class[name]', which our
       # Reference class canonicalizes for us.
-      res = Puppet::Resource.new(nil, type)
+      res = Puppet::Resource.new(nil, type, attributes)
     end
     res.catalog = self
     title_key      = [res.type, res.title.to_s]


### PR DESCRIPTION
Prior to this commit, if a Resource was created as 'Bar[instance]',
it would fail an attemt to fetch the resource type from its
environment. The environment would not be set and thus fallback
to whatever the :current_environment referred to. This made
the test spec/integration/parser/ruby_manifest_spec.rb fail.

Here, the environment is passed from the catalog to the Resource
initialize methdo in the attributes hash and properly assigned
before used.