### PR TITLE
(PUP-3935) Fix pluginsync errors when dealing with symlinks

### DIFF
--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -1,0 +1,44 @@
+test_name "pluginsync should not error when modulepath is a symlink and no modules have plugin directories"
+
+step "Create a modulepath directory which is a symlink and includes a module without facts.d or lib directories"
+basedir = master.tmpdir("symlink_modulepath")
+
+target           =  "#{basedir}/target_dir"
+test_module_dir  =  "#{target}/module1"
+link_dest        =  "#{basedir}/link_dest"
+modulepath       =  "#{link_dest}"
+modulepath << "#{master['sitemoduledir']}" if master.is_pe?
+
+apply_manifest_on(master, <<MANIFEST, :catch_failures => true)
+File {
+  ensure => directory,
+  mode   => "0750",
+  owner  => #{master.puppet['user']},
+  group  => #{master.puppet['group']},
+}
+
+file {
+  '#{basedir}':;
+  '#{target}':;
+  '#{test_module_dir}':;
+}
+
+file { '#{link_dest}':
+  ensure => link,
+  target => '#{target}',
+}
+MANIFEST
+
+master_opts = {
+  'main' => {
+    'basemodulepath' => "#{modulepath}"
+  }
+}
+
+with_puppet_running_on master, master_opts, basedir do
+  agents.each do |agent|
+    on(agent, puppet('agent', "-t --server #{master}"))
+      assert_no_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/pluginfacts/, stderr)
+      assert_no_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/plugins/, stderr)
+  end
+end

--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -45,6 +45,7 @@ class Puppet::Configurer::Downloader
     defargs = {
       :path => path,
       :recurse => true,
+      :links => :follow,
       :source => source,
       :source_permissions => @source_permissions,
       :tag => name,

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -58,6 +58,12 @@ describe Puppet::Configurer::Downloader do
       expect(file[:recurse]).to be_truthy
     end
 
+    it "should follow links by default" do
+      file = generate_file_resource
+
+      expect(file[:links]).to eq(:follow)
+    end
+
     it "should always purge" do
       file = generate_file_resource
 


### PR DESCRIPTION
Currently, Puppet produces one of two pluginsync errors during an
agent run if the root of a modulepath directory is a symlink
and no modules contain a facts.d or lib directory.

In the normal case, when the base module path is a directory
and none if its modules include facts.d or lib directories,
pluginsync returns the path to the module path directory itself,
at which point the file type disables recursion in its
`recurse_remote` method and stops the agent from attempting to
download plugins.

However, if the base module path is not a directory (in this case
a link), `recurse_remote` returns early, causing the agent-side
facts.d or lib directory to not have its 'source' metadata set,
leading to a failing query back to the master.

This commit forces pluginsync to follow symlinks rather than
manage them. To do this, the :links attribute is set to :follow
in the #default_arguments method of the
Puppet::Configurer::Downloader class, which is only used
for pluginsync. Doing this ensures that what pluginsync
returns will be a directory rather than a link, allowing the
resource to have its source metadata correctly set.

Paired with Peter Huene <peter.huene@puppetlabs.com>