### PR TITLE
(PUP-3863) Move 3x hiera functions to 4x API

### DIFF
--- a/lib/puppet/functions/hiera.rb
+++ b/lib/puppet/functions/hiera.rb
@@ -1,0 +1,26 @@
+require 'puppet/functions/hiera_function'
+
+# Performs a standard priority lookup and returns the most specific value for a given key.
+# The returned value can be data of any type (strings, arrays, or hashes).
+#
+# The function can be called in one of three ways:
+# 1. Using 1 to 3 arguments where the arguments are:
+#    'key'      [String] Required
+#          The key to lookup.
+#    'default`  [Any] Optional
+#          A value to return when there's no match for `key`. Optional
+#    `override` [Any] Optional
+#          An argument in the third position, providing a data source
+#          to consult for matching values, even if it would not ordinarily be
+#          part of the matched hierarchy. If Hiera doesn't find a matching key
+#          in the named override data source, it will continue to search through the
+#          rest of the hierarchy.
+#
+# 2. Using a 'key' and an optional 'override' parameter like in #1 but with a block to
+#    provide the default value.
+#
+# 3. Like #1 but with all arguments passed in an array.
+#
+#  More thorough examples of `hiera` are available at:
+#  <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
+Puppet::Functions.create_function(:hiera, Puppet::Functions::InternalFunction, &Puppet::Functions::HieraFunction.common_layout)

--- a/lib/puppet/functions/hiera_array.rb
+++ b/lib/puppet/functions/hiera_array.rb
@@ -1,0 +1,3 @@
+require 'puppet/functions/hiera_function.rb'
+
+Puppet::Functions.create_function(:hiera_array, Puppet::Functions::InternalFunction, &Puppet::Functions::HieraFunction.common_layout)

--- a/lib/puppet/functions/hiera_function.rb
+++ b/lib/puppet/functions/hiera_function.rb
@@ -1,0 +1,58 @@
+require 'hiera_puppet'
+
+# Provides the block that defines the hiera, hiera_array, and hiera_hash functions. The only difference
+# between those functions is the merge type (:priority, :array, or :hash) passed to the Hiera lookup. The
+# definition contained here derives the merge type from the name of the function.
+#
+class Puppet::Functions::HieraFunction
+  def self.common_layout
+    proc do
+      dispatch :hiera_array_param do
+        scope_param
+        param 'Tuple[String, Any, Any, 1, 3]', :args
+      end
+
+      dispatch :hiera_params do
+        scope_param
+        param 'String',:key
+        param 'Any',   :default
+        param 'Any',   :override
+        arg_count(1,3)
+      end
+
+      dispatch :hiera_block_default do
+        scope_param
+        param 'String',        :key
+        param 'Optional[Any]', :override
+        required_block_param 'Callable[1,1]', :block
+        arg_count(1,2)
+      end
+
+      def hiera_array_param(scope, args)
+        hiera_params(scope, *args)
+      end
+
+      def hiera_params(scope, key, default = nil, override = nil)
+        lookup(scope, key, default, override)
+      end
+
+      def hiera_block_default(scope, key, override = nil, block)
+        undefined = (@@undefined_value ||= Object.new)
+        result = lookup(scope, key, undefined, override)
+        result.equal?(undefined) ? block.call(scope, key) : result
+      end
+
+      def lookup(scope, key, default, override)
+        case self.class.name
+        when 'hiera_hash'
+          merge_type = :hash
+        when 'hiera_array'
+          merge_type = :array
+        else
+          merge_type = :priority
+        end
+        HieraPuppet.lookup(key, default,scope, override, merge_type)
+      end
+    end
+  end
+end

--- a/lib/puppet/functions/hiera_hash.rb
+++ b/lib/puppet/functions/hiera_hash.rb
@@ -1,0 +1,3 @@
+require 'puppet/functions/hiera_function'
+
+Puppet::Functions.create_function(:hiera_hash, Puppet::Functions::InternalFunction, &Puppet::Functions::HieraFunction.common_layout)

--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -1,0 +1,83 @@
+require 'hiera_puppet'
+
+# Assigns classes to a node using an array merge lookup that retrieves the value for
+# a user-specified key from a Hiera data source.
+#
+# To use `hiera_include`, the following configuration is required:
+# - A key name to use for classes, e.g. `classes`.
+# - A line in the puppet `sites.pp` file (e.g. `/etc/puppet/manifests/sites.pp`)
+#   reading `hiera_include('classes')`. Note that this line must be outside any node
+#   definition and below any top-scope variables in use for Hiera lookups.
+# - Class keys in the appropriate data sources. In a data source keyed to a node's role,
+#   one might have:
+#
+#       ---
+#        classes:
+#          - apache
+#          - apache::passenger
+#
+# The function can be called in one of three ways:
+# 1. Using 1 to 3 arguments where the arguments are:
+#    'key'      [String] Required
+#          The key to lookup.
+#    'default`  [Any] Optional
+#          A value to return when there's no match for `key`. Optional
+#    `override` [Any] Optional
+#          An argument in the third position, providing a data source
+#          to consult for matching values, even if it would not ordinarily be
+#          part of the matched hierarchy. If Hiera doesn't find a matching key
+#          in the named override data source, it will continue to search through the
+#          rest of the hierarchy.
+#
+# 2. Using a 'key' and an optional 'override' parameter like in #1 but with a block to
+#    provide the default value.
+#
+# 3. Like #1 but with all arguments passed in an array.
+#
+#  More thorough examples of `hiera` are available at:
+#  <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
+Puppet::Functions.create_function(:hiera_include, Puppet::Functions::InternalFunction) do
+  dispatch :hiera_include_splat do
+    scope_param
+    param 'Tuple[String, Any, Any, 1, 3]', :args
+  end
+
+  dispatch :hiera_include do
+    scope_param
+    param 'String',:key
+    param 'Any',   :default
+    param 'Any',   :override
+    arg_count(1,3)
+  end
+
+  dispatch :hiera_include_block do
+    scope_param
+    param 'String',        :key
+    param 'Optional[Any]', :override
+    required_block_param 'Callable[1,1]', :block
+    arg_count(1,2)
+  end
+
+  def hiera_include_splat(scope, args)
+    hiera_include(scope, *args)
+  end
+
+  def hiera_include(scope, key, default = nil, override = nil)
+    do_include(key, lookup(scope, key, default, override))
+  end
+
+  def hiera_include_block(scope, key, override = nil, block)
+    undefined = (@@undefined_value ||= Object.new)
+    result = lookup(scope, key, undefined, override)
+    do_include(key, result.equal?(undefined) ? block.call(scope, key) : result)
+  end
+
+  def lookup(scope, key, default, override)
+    HieraPuppet.lookup(key, default,scope, override, :array)
+  end
+
+  def do_include(key, value)
+    raise Puppet::ParseError, "Could not find data item #{key}" if value.nil?
+    call_function('include', value) unless value.empty?
+  end
+end

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -19,8 +19,7 @@ module Puppet::Parser::Functions
   More thorough examples of `hiera` are available at:  
   <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
   ") do |*args|
-    key, default, override = HieraPuppet.parse_args(args)
-    HieraPuppet.lookup(key, default, self, override, :priority)
+    function_fail(["hiera() has been converted to 4x API"])
   end
 end
 

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -20,8 +20,7 @@ module Puppet::Parser::Functions
   More thorough examples of `hiera` are available at:  
   <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
   ") do |*args|
-    key, default, override = HieraPuppet.parse_args(args)
-    HieraPuppet.lookup(key, default, self, override, :array)
+    function_fail(["hiera_array() has been converted to 4x API"])
   end
 end
 

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -22,8 +22,7 @@ module Puppet::Parser::Functions
   More thorough examples of `hiera_hash` are available at:  
   <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
   ") do |*args|
-    key, default, override = HieraPuppet.parse_args(args)
-    HieraPuppet.lookup(key, default, self, override, :hash)
+    function_fail(["hiera_hash() has been converted to 4x API"])
   end
 end
 

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -32,13 +32,7 @@ module Puppet::Parser::Functions
   More thorough examples of `hiera_include` are available at:
   <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
   ") do |*args|
-    key, default, override = HieraPuppet.parse_args(args)
-    if answer = HieraPuppet.lookup(key, default, self, override, :array)
-      method = Puppet::Parser::Functions.function(:include)
-      send(method, [answer])
-    else
-      raise Puppet::ParseError, "Could not find data item #{key}"
-    end
+    function_fail(["hiera_include() has been converted to 4x API"])
   end
 end
 

--- a/lib/puppet/pops/binder/lookup.rb
+++ b/lib/puppet/pops/binder/lookup.rb
@@ -128,7 +128,7 @@ class Puppet::Pops::Binder::Lookup
     elsif !(result = scope.compiler.injector.lookup(scope, type, name)).nil?
       result
    else
-     result = scope.function_hiera([name, PrivateNotFoundMarker])
+     result = call_function(scope, :hiera, name, PrivateNotFoundMarker)
      if !result.nil? && result != PrivateNotFoundMarker
        result
      else
@@ -137,7 +137,14 @@ class Puppet::Pops::Binder::Lookup
    end
   end
 
-  # This is the method called from the puppet/parser/functions/lookup.rb
+  def self.call_function(scope, name, *args)
+    loader = scope.compiler.loaders.private_environment_loader
+    func = loader.load(:function, name) unless loader.nil?
+    raise Error, "Function not found: #{name}" if func.nil?
+    func.call(scope, *args)
+  end
+
+    # This is the method called from the puppet/parser/functions/lookup.rb
   # @param args [Array] array following the puppet function call conventions
   def self.lookup(scope, args)
     type_calculator = Puppet::Pops::Types::TypeCalculator.new

--- a/spec/unit/functions/hiera_spec.rb
+++ b/spec/unit/functions/hiera_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+require 'puppet_spec/scope'
+require 'puppet/pops'
+require 'puppet/loaders'
+
+describe 'when calling' do
+  include PuppetSpec::Scope
+
+  let(:scope) { create_test_scope_for_node('foo') }
+  let(:loaders) { Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, [])) }
+  let(:loader) { loaders.puppet_system_loader }
+
+  context 'hiera' do
+    let(:hiera) { loader.load(:function, 'hiera') }
+
+    it 'should require a key argument' do
+      expect { hiera.call(scope, []) }.to raise_error(ArgumentError)
+    end
+
+    it 'should raise a useful error when nil is returned' do
+      expect { hiera.call(scope, 'badkey') }.to raise_error(Puppet::ParseError, /Could not find data item badkey/)
+    end
+
+    it 'should use the priority resolution_type' do
+      Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be(:priority) }.returns('foo_result')
+      expect(hiera.call(scope, 'key', {'key' => 'foo_result'})).to eql('foo_result')
+    end
+
+    it 'should use default block' do
+      expect(hiera.call(scope, 'foo', lambda_1(scope, loader) { |k| "default for key '#{k}'" })).to eql("default for key 'foo'")
+    end
+  end
+
+  context 'hiera_array' do
+    let(:hiera_array) { loader.load(:function, 'hiera_array') }
+
+    it 'should require a key argument' do
+      expect { hiera_array.call(scope, []) }.to raise_error(ArgumentError)
+    end
+
+    it 'should raise a useful error when nil is returned' do
+      expect { hiera_array.call(scope, 'badkey') }.to raise_error(Puppet::ParseError, /Could not find data item badkey/)
+    end
+
+    it 'should use the array resolution_type' do
+      Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be(:array) }.returns(%w[foo bar baz])
+      expect(hiera_array.call(scope, 'key', {'key' => 'foo_result'})).to eql(%w[foo bar baz])
+    end
+
+    it 'should use default block' do
+      expect(hiera_array.call(scope, 'foo', lambda_1(scope, loader) { |k| ['key', k] })).to eql(%w[key foo])
+    end
+  end
+
+  context 'hiera_hash' do
+    let(:hiera_hash) { loader.load(:function, 'hiera_hash') }
+
+    it 'should require a key argument' do
+      expect { hiera_hash.call(scope, []) }.to raise_error(ArgumentError)
+    end
+
+    it 'should raise a useful error when nil is returned' do
+      expect { hiera_hash.call(scope, 'badkey') }.to raise_error(Puppet::ParseError, /Could not find data item badkey/)
+    end
+
+    it 'should use the hash resolution_type' do
+      Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be(:hash) }.returns({'foo' => 'result'})
+      expect(hiera_hash.call(scope, 'key', {'key' => 'foo_result'})).to eql({'foo' => 'result'})
+    end
+
+    it 'should use default block' do
+      expect(hiera_hash.call(scope, 'foo', lambda_1(scope, loader) { |k| {'key' => k} })).to eql({'key' => 'foo'})
+    end
+  end
+
+  context 'hiera_include' do
+    let(:hiera_include) { loader.load(:function, 'hiera_include') }
+
+    it 'should require a key argument' do
+      expect { hiera_include.call(scope, []) }.to raise_error(ArgumentError)
+    end
+
+    it 'should raise a useful error when nil is returned' do
+      expect { hiera_include.call(scope, 'badkey') }.to raise_error(Puppet::ParseError, /Could not find data item badkey/)
+    end
+
+    it 'should use the array resolution_type' do
+      Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be(:array) }.returns(%w[foo bar baz])
+      hiera_include.expects(:call_function).with('include', %w[foo bar baz])
+      hiera_include.call(scope, 'key', {'key' => 'foo_result'})
+    end
+
+    it 'should not raise an error if the resulting hiera lookup returns an empty array' do
+      Hiera.any_instance.expects(:lookup).returns []
+      expect { hiera_include.call(scope, 'key') }.to_not raise_error
+    end
+
+    it 'should use default block' do
+      hiera_include.expects(:call_function).with('include', %w[key foo])
+      hiera_include.call(scope, 'foo', lambda_1(scope, loader) { |k| ['key', k] })
+    end
+  end
+
+  # Creates the correspondence to a lambda block in puppet DSL
+  def lambda_1(scope, loader, &block)
+    Puppet::Functions.create_function('do_it') do
+      def initialize(scope, loader, block)
+        super(scope, loader)
+        @my_block = block
+      end
+
+      def do_it(x)
+        @my_block.call(x)
+      end
+    end.new(scope, loader, block)
+  end
+end

--- a/spec/unit/parser/functions/hiera_array_spec.rb
+++ b/spec/unit/parser/functions/hiera_array_spec.rb
@@ -4,23 +4,9 @@ require 'puppet_spec/scope'
 describe 'Puppet::Parser::Functions#hiera_array' do
   include PuppetSpec::Scope
 
-  before :each do
-    Puppet[:hiera_config] = PuppetSpec::Files.tmpfile('hiera_config')
-  end
-
   let :scope do create_test_scope_for_node('foo') end
 
-  it 'should require a key argument' do
-    expect { scope.function_hiera_array([]) }.to raise_error(ArgumentError)
-  end
-
-  it 'should raise a useful error when nil is returned' do
-    Hiera.any_instance.expects(:lookup).returns(nil)
-    expect { scope.function_hiera_array(["badkey"]) }.to raise_error(Puppet::ParseError, /Could not find data item badkey/ )
-  end
-
-  it 'should use the array resolution_type' do
-    Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be(:array) }.returns([])
-    scope.function_hiera_array(['key'])
+  it 'should raise an error since this function is converted to 4x API)' do
+    expect { scope.function_hiera_array(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
   end
 end

--- a/spec/unit/parser/functions/hiera_hash_spec.rb
+++ b/spec/unit/parser/functions/hiera_hash_spec.rb
@@ -6,17 +6,7 @@ describe 'Puppet::Parser::Functions#hiera_hash' do
 
   let :scope do create_test_scope_for_node('foo') end
 
-  it 'should require a key argument' do
-    expect { scope.function_hiera_hash([]) }.to raise_error(ArgumentError)
-  end
-
-  it 'should raise a useful error when nil is returned' do
-    Hiera.any_instance.expects(:lookup).returns(nil)
-    expect { scope.function_hiera_hash(["badkey"]) }.to raise_error(Puppet::ParseError, /Could not find data item badkey/ )
-  end
-
-  it 'should use the hash resolution_type' do
-    Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be :hash }.returns({})
-    scope.function_hiera_hash(['key'])
+  it 'should raise an error since this function is converted to 4x API)' do
+    expect { scope.function_hiera_hash(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
   end
 end

--- a/spec/unit/parser/functions/hiera_include_spec.rb
+++ b/spec/unit/parser/functions/hiera_include_spec.rb
@@ -6,34 +6,7 @@ describe 'Puppet::Parser::Functions#hiera_include' do
 
   let :scope do create_test_scope_for_node('foo') end
 
-  before :each do
-    Puppet[:hiera_config] = PuppetSpec::Files.tmpfile('hiera_config')
-  end
-
-  it 'should require a key argument' do
-    expect { scope.function_hiera_include([]) }.to raise_error(ArgumentError)
-  end
-
-  it 'should raise a useful error when nil is returned' do
-    HieraPuppet.expects(:lookup).returns(nil)
-    expect { scope.function_hiera_include(["badkey"]) }.
-      to raise_error(Puppet::ParseError, /Could not find data item badkey/ )
-  end
-
-  it 'should use the array resolution_type' do
-    HieraPuppet.expects(:lookup).with() { |*args| args[4].should be(:array) }.returns(['someclass'])
-    expect { scope.function_hiera_include(['key']) }.to raise_error(Puppet::Error, /Could not find class someclass/)
-  end
-
-  it 'should call the `include` function with the classes' do
-    HieraPuppet.expects(:lookup).returns %w[foo bar baz]
-
-    scope.expects(:function_include).with([%w[foo bar baz]])
-    scope.function_hiera_include(['key'])
-  end
-
-  it 'should not raise an error if the resulting hiera lookup returns an empty array' do
-    HieraPuppet.expects(:lookup).returns []
-    expect { scope.function_hiera_include(['key']) }.to_not raise_error
+  it 'should raise an error since this function is converted to 4x API)' do
+    expect { scope.function_hiera_include(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
   end
 end

--- a/spec/unit/parser/functions/hiera_spec.rb
+++ b/spec/unit/parser/functions/hiera_spec.rb
@@ -6,17 +6,7 @@ describe 'Puppet::Parser::Functions#hiera' do
 
   let :scope do create_test_scope_for_node('foo') end
 
-  it 'should require a key argument' do
-    expect { scope.function_hiera([]) }.to raise_error(ArgumentError)
-  end
-
-  it 'should raise a useful error when nil is returned' do
-    Hiera.any_instance.expects(:lookup).returns(nil)
-    expect { scope.function_hiera(["badkey"]) }.to raise_error(Puppet::ParseError, /Could not find data item badkey/ )
-  end
-
-  it 'should use the priority resolution_type' do
-    Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be(:priority) }.returns('foo_result')
-    scope.function_hiera(['key']).should == 'foo_result'
+  it 'should raise an error since this function is converted to 4x API)' do
+    expect { scope.function_hiera(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
   end
 end

--- a/spec/unit/parser/functions/lookup_spec.rb
+++ b/spec/unit/parser/functions/lookup_spec.rb
@@ -42,7 +42,7 @@ describe "lookup function" do
   end
 
   it "hiera is called to lookup if value is not bound" do
-    Puppet::Parser::Scope.any_instance.stubs(:function_hiera).returns('from_hiera')
+    Hiera.any_instance.stubs(:lookup).returns('from_hiera')
     scope = scope_with_injections_from(bound(bind_single("another_value", "something")))
     expect(scope.function_lookup(['a_value'])).to eq('from_hiera')
   end


### PR DESCRIPTION
This commit moves all four hiera functions from 3x to 4x. It also moves the
parameter validation from the HieraPuppet class into the 4x function dispatch.

Tests are added to verify the validity of the new functions (and invalidity of
the old).

Since three functions are identical in all aspects except the merge type
argument sent to hiera, and since the merge type can be derived from the name
of the function, an approach was taken where these three functions share the
same class definition block. The hiera_include is separate though, since its
logic differs.