### PR TITLE
(PUP-3936) Ensure that weaving logic is aware of block

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -270,6 +270,7 @@ module Puppet::Functions
     #
     # @api public
     def param(type, name)
+      raise ArgumentError, 'Parameters cannot be added after a block_param' unless @block_type.nil?
       if type.is_a?(String)
         @types << type
         @names << name
@@ -313,6 +314,10 @@ module Puppet::Functions
       if @block_type.nil?
         @block_type = type
         @block_name = name
+
+        # mark what should be picked for this position when dispatching. This is the size of
+        # the @names array since the block is required to appear last
+        @weaving << @names.size()
       else
         raise ArgumentError, "Attempt to redefine block"
       end

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -306,6 +306,13 @@ actual:
         the_function = create_function_with_optional_block_all_defaults().new(:closure_scope, :loader)
         expect(the_function.call({}, 10)).to be_nil
       end
+
+      it 'such that, a scope can be injected and a block can be used' do
+        # use a Function as callable
+        the_callable = create_min_function_class().new(:closure_scope, :loader)
+        the_function = create_function_with_scope_required_block_all_defaults().new(:closure_scope, :loader)
+        expect(the_function.call({}, 10, the_callable)).to be(the_callable)
+      end
     end
 
     context 'provides signature information' do
@@ -605,6 +612,21 @@ actual:
         required_block_param
       end
       def test(x, block)
+        # returns the block to make it easy to test what it got when called
+        block
+      end
+    end
+  end
+
+  def create_function_with_scope_required_block_all_defaults
+    f = Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
+      dispatch :test do
+        scope_param
+        param 'Integer', 'x'
+        # use defaults, any callable, name is 'block'
+        required_block_param
+      end
+      def test(scope, x, block)
         # returns the block to make it easy to test what it got when called
         block
       end


### PR DESCRIPTION
Previously, a block parameter was not added to the weaving array
which resulted in it being omitted by the weaving logic. This
commit ensures two things.

1. No parameters can be added after a block parameter.
2. The index of the block parameter (size of the names array)
   is added to the weaving array.

A test is also added that tests combining injection with a required block
parameter.