### PR TITLE
(PUP-777) Remove 'versionRequirement' for dependencies

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -124,12 +124,9 @@ class Puppet::Module
         end
       end
 
-      # NOTICE: The fallback to `versionRequirement` is something we'd like to
-      # not have to support, but we have a reasonable number of releases that
-      # don't use `version_requirement`. When we can deprecate this, we should.
       if attr == :dependencies
         value.each do |dep|
-          dep['version_requirement'] ||= dep['versionRequirement'] || '>= 0.0.0'
+          dep['version_requirement'] ||= '>= 0.0.0'
         end
       end
 

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -168,7 +168,7 @@ module Puppet
     #         unparsed range expression.
     def self.parse_module_dependency(where, dep)
       dep_name = dep['name'].tr('/', '-')
-      range = dep['version_requirement'] || dep['versionRequirement'] || '>= 0.0.0'
+      range = dep['version_requirement'] || '>= 0.0.0'
 
       begin
         parsed_range = Semantic::VersionRange.parse(range)

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -611,40 +611,6 @@ describe Puppet::Module do
       @module.load_metadata
       expect(@module.puppetversion).to eq(@data[:puppetversion])
     end
-
-    context "when versionRequirement is used for dependency version info" do
-      before do
-        @data = {
-          :license       => "GPL2",
-          :author        => "luke",
-          :version       => "1.0",
-          :source        => "http://foo/",
-          :puppetversion => "0.25",
-          :dependencies  => [
-            {
-              "versionRequirement" => "0.0.1",
-              "name" => "pmtacceptance/stdlib"
-            },
-            {
-              "versionRequirement" => "0.1.0",
-              "name" => "pmtacceptance/apache"
-            }
-          ]
-        }
-        @module = a_module_with_metadata(@data)
-      end
-
-      it "should set the dependency version_requirement key" do
-        @module.load_metadata
-        expect(@module.dependencies[0]['version_requirement']).to eq("0.0.1")
-      end
-
-      it "should set the version_requirement key for all dependencies" do
-        @module.load_metadata
-        expect(@module.dependencies[0]['version_requirement']).to eq("0.0.1")
-        expect(@module.dependencies[1]['version_requirement']).to eq("0.1.0")
-      end
-    end
   end
 
   it "should be able to tell if there are local changes" do

--- a/spec/unit/module_tool_spec.rb
+++ b/spec/unit/module_tool_spec.rb
@@ -310,13 +310,6 @@ TREE
       expect(expr).to eql('1.2.x')
     end
 
-    it 'parses a dependency with a version range expression in the (deprecated) versionRange key' do
-      name, range, expr = subject.parse_module_dependency('source', 'name' => 'foo-bar', 'versionRequirement' => '1.2.x')
-      expect(name).to eql('foo-bar')
-      expect(range).to eql(Semantic::VersionRange.parse('1.2.x'))
-      expect(expr).to eql('1.2.x')
-    end
-
     it 'does not raise an error on invalid version range expressions' do
       name, range, expr = subject.parse_module_dependency('source', 'name' => 'foo-bar', 'version_requirement' => 'nope')
       expect(name).to eql('foo-bar')


### PR DESCRIPTION
Prior to this commit, we had undocumented support for
'versionRequirement' instead of 'version_requirement' for a dependency
in the metadata.json. This support was created because an old version
of Gepetto inadvertently gave this as the field key. With this commit,
we remove the support for that undocumented field.