### PR TITLE
(PUP-3921) Add 404 error suggesting an upgrade

### DIFF
--- a/lib/puppet/network/http.rb
+++ b/lib/puppet/network/http.rb
@@ -3,10 +3,10 @@ module Puppet::Network::HTTP
   HEADER_PUPPET_VERSION = "X-Puppet-Version"
 
   MASTER_URL_PREFIX = "/puppet"
-  CA_URL_PREFIX = "/puppet-ca"
+  MASTER_URL_VERSIONS = "v3"
 
-  PUPPET_API_VERSIONS = "v3"
-  PUPPET_CA_API_VERSIONS = "v1"
+  CA_URL_PREFIX = "/puppet-ca"
+  CA_URL_VERSIONS = "v1"
 
   require 'puppet/network/authorization'
   require 'puppet/network/http/issues'

--- a/lib/puppet/network/http.rb
+++ b/lib/puppet/network/http.rb
@@ -5,6 +5,9 @@ module Puppet::Network::HTTP
   MASTER_URL_PREFIX = "/puppet"
   CA_URL_PREFIX = "/puppet-ca"
 
+  PUPPET_API_VERSIONS = "v3"
+  PUPPET_CA_API_VERSIONS = "v1"
+
   require 'puppet/network/authorization'
   require 'puppet/network/http/issues'
   require 'puppet/network/http/error'

--- a/lib/puppet/network/http/api.rb
+++ b/lib/puppet/network/http/api.rb
@@ -1,9 +1,28 @@
 class Puppet::Network::HTTP::API
+  require 'puppet/version'
+
   def self.not_found
     Puppet::Network::HTTP::Route.
       path(/.*/).
       any(lambda do |req, res|
         raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{req.method} #{req.path}", Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
+      end)
+  end
+
+  def self.not_found_upgrade
+    Puppet::Network::HTTP::Route.
+      path(/.*/).
+      any(lambda do |req, res|
+        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("Error: Invalid URL - Puppet expects requests that conform to the " +
+                                                                      "/puppet and /puppet-ca APIs.\n\n" +
+                                                                      "Note that Puppet 3 agents aren't compatible with this version; if you're " +
+                                                                      "running Puppet 3, you must either upgrade your agents to match the server " +
+                                                                      "or point them to a server running Puppet 3.\n\n" +
+                                                                      "Master Info:\n" +
+                                                                      "  Puppet version: #{Puppet.version}\n" +
+                                                                      "  Supported /puppet API versions: #{Puppet::Network::HTTP::PUPPET_API_VERSIONS}\n" +
+                                                                      "  Supported /puppet-ca API versions: #{Puppet::Network::HTTP::PUPPET_CA_API_VERSIONS}",
+                                                                  Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
       end)
   end
 

--- a/lib/puppet/network/http/api.rb
+++ b/lib/puppet/network/http/api.rb
@@ -20,8 +20,8 @@ class Puppet::Network::HTTP::API
                                                                       "or point them to a server running Puppet 3.\n\n" +
                                                                       "Master Info:\n" +
                                                                       "  Puppet version: #{Puppet.version}\n" +
-                                                                      "  Supported /puppet API versions: #{Puppet::Network::HTTP::PUPPET_API_VERSIONS}\n" +
-                                                                      "  Supported /puppet-ca API versions: #{Puppet::Network::HTTP::PUPPET_CA_API_VERSIONS}",
+                                                                      "  Supported /puppet API versions: #{Puppet::Network::HTTP::MASTER_URL_VERSIONS}\n" +
+                                                                      "  Supported /puppet-ca API versions: #{Puppet::Network::HTTP::CA_URL_VERSIONS}",
                                                                   Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
       end)
   end

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -29,7 +29,8 @@ class Puppet::Network::HTTP::RackREST
   def initialize(args={})
     super()
     register([Puppet::Network::HTTP::API.master_routes,
-              Puppet::Network::HTTP::API.ca_routes])
+              Puppet::Network::HTTP::API.ca_routes,
+              Puppet::Network::HTTP::API.not_found_upgrade])
   end
 
   def set_content_type(response, format)

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -15,7 +15,8 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
   def initialize(server)
     raise ArgumentError, "server is required" unless server
     register([Puppet::Network::HTTP::API.master_routes,
-              Puppet::Network::HTTP::API.ca_routes])
+              Puppet::Network::HTTP::API.ca_routes,
+              Puppet::Network::HTTP::API.not_found_upgrade])
     super(server)
   end
 

--- a/spec/unit/network/http/api_spec.rb
+++ b/spec/unit/network/http/api_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'puppet_spec/handler'
 require 'puppet/network/http'
+require 'puppet/version'
 
 describe Puppet::Network::HTTP::API do
   def respond(text)
@@ -38,16 +39,40 @@ describe Puppet::Network::HTTP::API do
 
   describe "Puppet API" do
     let(:handler) { PuppetSpec::Handler.new(Puppet::Network::HTTP::API.master_routes,
-                                            Puppet::Network::HTTP::API.ca_routes) }
+                                            Puppet::Network::HTTP::API.ca_routes,
+                                            Puppet::Network::HTTP::API.not_found_upgrade) }
 
     let(:master_prefix) { Puppet::Network::HTTP::MASTER_URL_PREFIX }
     let(:ca_prefix) { Puppet::Network::HTTP::CA_URL_PREFIX }
 
-    it "raises a not-found error for non-CA or master routes" do
+    it "raises a not-found error for non-CA or master routes and suggests an upgrade" do
       req = Puppet::Network::HTTP::Request.from_hash(:path => "/unknown")
       res = {}
       handler.process(req, res)
       expect(res[:status]).to eq(404)
+      expect(res[:body]).to include("Puppet version: #{Puppet.version}")
+    end
+
+    describe "when processing Puppet 3 routes" do
+      it "gives an upgrade message for master routes" do
+        req = Puppet::Network::HTTP::Request.from_hash(:path => "/production/node/foo")
+        res = {}
+        handler.process(req, res)
+        expect(res[:status]).to eq(404)
+        expect(res[:body]).to include("Puppet version: #{Puppet.version}")
+        expect(res[:body]).to include("Supported /puppet API versions: #{Puppet::Network::HTTP::PUPPET_API_VERSIONS}")
+        expect(res[:body]).to include("Supported /puppet-ca API versions: #{Puppet::Network::HTTP::PUPPET_CA_API_VERSIONS}")
+      end
+
+      it "gives an upgrade message for CA routes" do
+        req = Puppet::Network::HTTP::Request.from_hash(:path => "/production/certificate/foo")
+        res = {}
+        handler.process(req, res)
+        expect(res[:status]).to eq(404)
+        expect(res[:body]).to include("Puppet version: #{Puppet.version}")
+        expect(res[:body]).to include("Supported /puppet API versions: #{Puppet::Network::HTTP::PUPPET_API_VERSIONS}")
+        expect(res[:body]).to include("Supported /puppet-ca API versions: #{Puppet::Network::HTTP::PUPPET_CA_API_VERSIONS}")
+      end
     end
 
     describe "when processing master routes" do
@@ -67,11 +92,13 @@ describe Puppet::Network::HTTP::API do
         expect(res[:status]).to eq(200)
       end
 
-      it "responds with a not found error to non-v3 requests" do
+      it "responds with a not found error to non-v3 requests and does not suggest an upgrade" do
         req = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_prefix}/unknown")
         res = {}
         handler.process(req, res)
         expect(res[:status]).to eq(404)
+        expect(res[:body]).to include("No route for GET #{master_prefix}/unknown")
+        expect(res[:body]).not_to include("Puppet version: #{Puppet.version}")
       end
     end
 
@@ -87,11 +114,13 @@ describe Puppet::Network::HTTP::API do
         expect(res[:status]).to eq(200)
       end
 
-      it "responds with a not found error to non-v1 requests" do
+      it "responds with a not found error to non-v1 requests and does not suggest an upgrade" do
         req = Puppet::Network::HTTP::Request.from_hash(:path => "#{ca_prefix}/unknown")
         res = {}
         handler.process(req, res)
         expect(res[:status]).to eq(404)
+        expect(res[:body]).to include("No route for GET #{ca_prefix}/unknown")
+        expect(res[:body]).not_to include("Puppet version: #{Puppet.version}")
       end
     end
   end

--- a/spec/unit/network/http/api_spec.rb
+++ b/spec/unit/network/http/api_spec.rb
@@ -60,8 +60,8 @@ describe Puppet::Network::HTTP::API do
         handler.process(req, res)
         expect(res[:status]).to eq(404)
         expect(res[:body]).to include("Puppet version: #{Puppet.version}")
-        expect(res[:body]).to include("Supported /puppet API versions: #{Puppet::Network::HTTP::PUPPET_API_VERSIONS}")
-        expect(res[:body]).to include("Supported /puppet-ca API versions: #{Puppet::Network::HTTP::PUPPET_CA_API_VERSIONS}")
+        expect(res[:body]).to include("Supported /puppet API versions: #{Puppet::Network::HTTP::MASTER_URL_VERSIONS}")
+        expect(res[:body]).to include("Supported /puppet-ca API versions: #{Puppet::Network::HTTP::CA_URL_VERSIONS}")
       end
 
       it "gives an upgrade message for CA routes" do
@@ -70,8 +70,8 @@ describe Puppet::Network::HTTP::API do
         handler.process(req, res)
         expect(res[:status]).to eq(404)
         expect(res[:body]).to include("Puppet version: #{Puppet.version}")
-        expect(res[:body]).to include("Supported /puppet API versions: #{Puppet::Network::HTTP::PUPPET_API_VERSIONS}")
-        expect(res[:body]).to include("Supported /puppet-ca API versions: #{Puppet::Network::HTTP::PUPPET_CA_API_VERSIONS}")
+        expect(res[:body]).to include("Supported /puppet API versions: #{Puppet::Network::HTTP::MASTER_URL_VERSIONS}")
+        expect(res[:body]).to include("Supported /puppet-ca API versions: #{Puppet::Network::HTTP::CA_URL_VERSIONS}")
       end
     end
 


### PR DESCRIPTION
Add a 404 error that is triggered when requests are made to
routes without the /puppet or /puppet-ca prefixes to indicate
to the user that they may need to upgrade Puppet on their
agents.

This is a new PR addressing the same ticket as https://github.com/puppetlabs/puppet/pull/3532, which I am closing in favor of this one.  