### PR TITLE
WIP (PUP-3899) Add tests for file checksum

### DIFF
--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -15,6 +15,19 @@ agents.each do |agent|
     assert_match(/This is the test file content/, stdout, "File content not matched on #{agent}")
   end
 
+  step "Expect the test environment contains the file"
+  ['md5', 'md5lite', 'sha256', 'sha256lite'].each do |checksum_type|
+    step "Content Attribute: using #{checksum_type}"
+    manifest = "file { '#{target}': content => 'This is the test file content', ensure => present, checksum => #{checksum_type} }"
+    apply_manifest_on agent, manifest do
+      assert_no_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
+    end
+
+    on agent, "cat #{target}" do
+      assert_match(/This is the test file content/, stdout, "File content not matched on #{agent}")
+    end
+  end
+
   step "Ensure the test environment is clean"
   on agent, "rm -f #{target}"
 

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -28,6 +28,14 @@ agents.each do |agent|
     end
   end
 
+  ['mtime', 'ctime'].each do |checksum_type|
+    step "Content Attribute: using #{checksum_type}"
+    manifest = "file { '#{target}': content => 'This is the test file content', ensure => present, checksum => #{checksum_type} }"
+    apply_manifest_on agent, manifest, :acceptable_exit_codes => [1] do
+      assert_match(/Error: Validation of File\[#{target}\] failed: You cannot specify content when using checksum '#{checksum_type}'/, stderr, "#{agent}: expected failure")
+    end
+  end
+
   step "Ensure the test environment is clean"
   on agent, "rm -f #{target}"
 

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -379,6 +379,11 @@ Puppet::Type.newtype(:file) do
 
     self.warning "Possible error: recurselimit is set but not recurse, no recursion will happen" if !self[:recurse] and self[:recurselimit]
 
+    if @parameters[:content] and @parameters[:content].actual_content
+      # Now that we know the checksum, update content (in case it was created before checksum was known).
+      @parameters[:content].value = @parameters[:checksum].sum(@parameters[:content].actual_content)
+    end
+
     provider.validate if provider.respond_to?(:validate)
   end
 

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -33,7 +33,7 @@ module PuppetSpec::Network
     "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v1"
   end
 
-  def a_request_that_heads(data, name, request = {})
+  def a_request_that_heads(data, name, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
@@ -45,7 +45,7 @@ module PuppetSpec::Network
     })
   end
 
-  def a_request_that_submits(data, name, request = {})
+  def a_request_that_submits(data, name, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
@@ -58,7 +58,7 @@ module PuppetSpec::Network
     })
   end
 
-  def a_request_that_destroys(data, name, request = {})
+  def a_request_that_destroys(data, name, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
@@ -71,7 +71,7 @@ module PuppetSpec::Network
     })
   end
 
-  def a_request_that_finds(data, name, request = {})
+  def a_request_that_finds(data, name, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
@@ -84,7 +84,7 @@ module PuppetSpec::Network
     })
   end
 
-  def a_request_that_searches(key, name, request = {})
+  def a_request_that_searches(key, name, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+require 'puppet/network/http'
+require 'puppet/network/http/api/indirected_routes'
+require 'puppet/indirector_testing'
+
+module PuppetSpec::Network
+  def not_found_code
+    Puppet::Network::HTTP::Error::HTTPNotFoundError::CODE
+  end
+
+  def not_acceptable_code
+    Puppet::Network::HTTP::Error::HTTPNotAcceptableError::CODE
+  end
+
+  def bad_request_code
+    Puppet::Network::HTTP::Error::HTTPBadRequestError::CODE
+  end
+
+  def not_authorized_code
+    Puppet::Network::HTTP::Error::HTTPNotAuthorizedError::CODE
+  end
+
+  def params
+    { :environment => "production" }
+  end
+
+  def master_url_prefix
+    "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3"
+  end
+
+  def ca_url_prefix
+    "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v1"
+  end
+
+  def a_request_that_heads(data, name, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => "text/pson"
+      },
+      :method => "HEAD",
+      :path => "#{master_url_prefix}/#{name}/#{data.value}",
+      :params => params,
+    })
+  end
+
+  def a_request_that_submits(data, name, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => request[:content_type_header] || "text/pson"
+      },
+      :method => "PUT",
+      :path => "#{master_url_prefix}/#{name}/#{data.value}",
+      :params => params,
+      :body => request[:body].nil? ? data.render("pson") : request[:body]
+    })
+  end
+
+  def a_request_that_destroys(data, name, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => "text/pson"
+      },
+      :method => "DELETE",
+      :path => "#{master_url_prefix}/#{name}/#{data.value}",
+      :params => params,
+      :body => ''
+    })
+  end
+
+  def a_request_that_finds(data, name, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => "text/pson"
+      },
+      :method => "GET",
+      :path => "#{master_url_prefix}/#{name}/#{data.value}",
+      :params => params,
+      :body => ''
+    })
+  end
+
+  def a_request_that_searches(key, name, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => "text/pson"
+      },
+      :method => "GET",
+      :path => "#{master_url_prefix}/#{name}s/#{key}",
+      :params => params,
+      :body => ''
+    })
+  end
+
+end
+

--- a/spec/shared_contexts/checksum.rb
+++ b/spec/shared_contexts/checksum.rb
@@ -6,13 +6,15 @@
 # create a new example group for each types and will run the given block
 # in each example group.
 
-CHECKSUM_STAT_TIME = Time.now
+CHECKSUM_PLAINTEXT = "1\r\n"*4000
 CHECKSUM_TYPES_TO_TRY = [
   ['md5', 'a7a169ac84bb863b30484d0aa03139c1'],
   ['md5lite', '22b4182363e81b326e98231fde616782'],
   ['sha256', '47fcae62967db2fb5cba2fc0d9cf3e6767035d763d825ecda535a7b1928b9746'],
-  ['sha256lite', 'fd50217a2b0286ba25121bf2297bbe6c197933992de67e4e568f19861444ecf8'],
+  ['sha256lite', 'fd50217a2b0286ba25121bf2297bbe6c197933992de67e4e568f19861444ecf8']
 ]
+
+CHECKSUM_STAT_TIME = Time.now
 TIME_TYPES_TO_TRY = [
   ['ctime', "#{CHECKSUM_STAT_TIME}"],
   ['mtime', "#{CHECKSUM_STAT_TIME}"]
@@ -30,7 +32,7 @@ shared_context('with supported checksum types') do
     (CHECKSUM_TYPES_TO_TRY + TIME_TYPES_TO_TRY).each do |checksum_type, checksum|
       describe("when checksum_type is #{checksum_type}") do
         let(:checksum_type) { checksum_type }
-        let(:plaintext) { "1\r\n"*4000 }
+        let(:plaintext) { CHECKSUM_PLAINTEXT }
         let(:checksum) { checksum }
         let(:env_path) { tmpfile(path) }
         let(:checksum_file) { File.join(env_path, file) }


### PR DESCRIPTION
Add integration and acceptance tests for specifying the checksum on a file. Covers puppet apply, querying the server via the HTTP API, and puppet agent runs.