### PR TITLE
(PUP-3818) Windows acceptance on Ruby 2.1.5

### DIFF
--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -91,9 +91,9 @@ hosts.each do |host|
     step "#{host} Selected architecture #{arch}"
 
     revision = if arch == 'x64'
-                 '2.0.0-x64'
+                 '2.1.x-x64'
                else
-                 '1.9.3-x86'
+                 '2.1.x-x86'
                end
 
     step "#{host} Install ruby from git using revision #{revision}"


### PR DESCRIPTION
 - Update the pointers to the puppet-win32-ruby to the appropriate
   SHAs so that Windows acceptance tests can run against Ruby 2.1.5