### PR TITLE
(CODEMGMT-69) Update Acceptance Test

### DIFF
--- a/acceptance/tests/modules/build/build_basic.rb
+++ b/acceptance/tests/modules/build/build_basic.rb
@@ -1,47 +1,70 @@
-begin test_name "puppet module build (basic)"
+test_name 'CODEMGMT-69 - Build a Module Using "metadata.json" Only'
 
-step 'Setup'
-on master, "mkdir -p #{master['distmoduledir']}"
-on master, "mkdir -p #{master['sitemoduledir']}"
-apply_manifest_on master, <<-PP
-file {
-  [
-    '#{master['distmoduledir']}/nginx',
-  ]: ensure => directory;
-  '#{master['distmoduledir']}/nginx/Modulefile':
-    content => 'name "puppetlabs-nginx"
-version "0.0.1"
-source "git://github.com/puppetlabs/puppetlabs-nginx.git"
-author "Puppet Labs"
-license "Apache Version 2.0"
-summary "Nginx Module"
-description "Nginx"
-project_page "http://github.com/puppetlabs/puppetlabs-ntp"
-dependency "puppetlabs/stdlub", ">= 1.0.0"
-';
+#Init
+temp_module_path = '/tmp/nginx'
+metadata_json_file_path = File.join(temp_module_path, 'metadata.json')
+
+#In-line File
+metadata_json_file = <<-FILE
+{
+  "name": "puppetlabs-nginx",
+  "version": "0.0.1",
+  "author": "Puppet Labs",
+  "summary": "Nginx Module",
+  "license": "Apache Version 2.0",
+  "source": "git://github.com/puppetlabs/puppetlabs-nginx.git",
+  "project_page": "http://github.com/puppetlabs/puppetlabs-nginx",
+  "issues_url": "http://github.com/puppetlabs/puppetlabs-nginx",
+  "dependencies": [
+    {"name":"puppetlabs-stdlub","version_requirement":">= 1.0.0"}
+  ]
 }
-PP
+FILE
 
-step "Try to build a module with an absolute path"
-on master, puppet("module build #{master['distmoduledir']}/nginx") do
-  assert_equal <<-OUTPUT, stdout
-\e[mNotice: Building #{master['distmoduledir']}/nginx for release\e[0m
-Module built: #{master['distmoduledir']}/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz
-  OUTPUT
-end
-on master, "[ -d #{master['distmoduledir']}/nginx/pkg/puppetlabs-nginx-0.0.1 ]"
-on master, "[ -f #{master['distmoduledir']}/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz ]"
+#Verification
+build_message_1_regex = /Notice: Building #{temp_module_path} for release/
+build_message_2_regex = /Module built: #{temp_module_path}\/pkg\/puppetlabs-nginx-0.0.1.tar.gz/
 
-step "Try to build a module without providing a path"
-on master, ("cd #{master['distmoduledir']}/nginx && puppet module build") do
-  assert_equal <<-OUTPUT, stdout
-\e[mNotice: Building #{master['distmoduledir']}/nginx for release\e[0m
-Module built: #{master['distmoduledir']}/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz
-  OUTPUT
-end
-on master, "[ -d #{master['distmoduledir']}/nginx/pkg/puppetlabs-nginx-0.0.1 ]"
-on master, "[ -f #{master['distmoduledir']}/nginx/pkg/puppetlabs-nginx-0.0.1.tar.gz ]"
+verify_pkg_dir_command = "[ -d #{temp_module_path}/pkg/puppetlabs-nginx-0.0.1 ]"
+verify_tarball_command = "[ -f #{temp_module_path}/pkg/puppetlabs-nginx-0.0.1.tar.gz ]"
 
-ensure step "Teardown"
-  apply_manifest_on master, "file { '#{master['distmoduledir']}/nginx': ensure => absent, force => true }"
+#Teardown
+teardown do
+  step 'Teardown Test Artifacts'
+  on(master, "rm -rf #{temp_module_path}")
 end
+
+#Setup
+step 'Create Temporary Path for Module'
+on(master, "mkdir #{temp_module_path}")
+
+step 'Create "metadata.json" for Temporary Module'
+create_remote_file(master, metadata_json_file_path, metadata_json_file)
+
+#Tests
+step 'Build Module with Absolute Path'
+on(master, puppet("module build #{temp_module_path}")) do |result|
+  assert_no_match(/Error:/, result.output, 'Unexpected error was detected!')
+  assert_no_match(/Warning:/, result.output, 'Unexpected warning was detected!')
+  assert_match(build_message_1_regex, result.stdout, 'Expected message not found!')
+  assert_match(build_message_2_regex, result.stdout, 'Expected message not found!')
+end
+
+step 'Verify Build Artifacts'
+on(master, verify_pkg_dir_command)
+on(master, verify_tarball_command)
+
+step 'Clean-up Artifacts'
+on(master, "rm -rf #{temp_module_path}/pkg")
+
+step "Build Module with Relative Path"
+on(master, ("cd #{temp_module_path} && puppet module build")) do |result|
+  assert_no_match(/Error:/, result.output, 'Unexpected error was detected!')
+  assert_no_match(/Warning:/, result.output, 'Unexpected warning was detected!')
+  assert_match(build_message_1_regex, result.stdout, 'Expected message not found!')
+  assert_match(build_message_2_regex, result.stdout, 'Expected message not found!')
+end
+
+step 'Verify Build Artifacts'
+on(master, verify_pkg_dir_command)
+on(master, verify_tarball_command)


### PR DESCRIPTION
PMT is no longer using the Modulefile and the acceptance test needed to be
updated to use a "metadata.json" file instead. Also, the test has been
updated with current Beaker syntax in increase readability.