### PR TITLE
(PUP-3848) MSI Dependencies for Ruby 2.1.5 / Puppet 4.0.0

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -35,8 +35,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/marionette-collective.git'
   sys:
     ref:
-      x86: '57068e7b7c87288c51ff39d96c80cfb509a42091'
-      x64: '531319f5c121e98990772e018eb9781bf7dc6316'
+      x86: '93d40ef690dbf888f1f584a79212b2278ed4a063'
+      x64: 'b313f5b5baa2cabb59a1903651533bc9d6c7e685'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -20,7 +20,7 @@ build_msi:
     ref: '52e81967253924428bb0b1e7e1a11e8678d68378'
     repo: 'git://github.com/puppetlabs/puppet_for_the_win.git'
   facter:
-    ref: 'refs/tags/2.3.0'
+    ref: 'refs/tags/2.4.0'
     repo: 'git://github.com/puppetlabs/facter.git'
   cfacter:
     archive:


### PR DESCRIPTION
Update MSI dependencies for PUP 4.0.0

This may or may not cover the following (depending on whether we need to split this to multiple PRs as those other components are released):

- [x] Facter 2.4.0
- [x] Ruby 2.1.5

Followup to address the rest at https://github.com/puppetlabs/puppet/pull/3583
