### PR TITLE
(PUP-3848) Bump Facter/Hiera dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ platforms :ruby do
 end
 
 gem "puppet", :path => File.dirname(__FILE__), :require => false
-gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 1.6', '< 3'])
-gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
+gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
+gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['> 1.0', '< 3'])
 gem "rake", "10.1.1", :require => false
 
 group(:development, :test) do

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -15,8 +15,8 @@ gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_forge_project: 'puppet'
 gem_runtime_dependencies:
-  facter: ['> 1.6', '< 3']
-  hiera: '~> 1.0'
+  facter: ['> 2.0', '< 4']
+  hiera: ['> 1.0', '< 3']
   json_pure:
 gem_rdoc_options:
   - --title


### PR DESCRIPTION
Bump Facter up to at least 2.0 but less than 4 to allow for Facter
3, which is expected to be out during Puppet 4.x series. Bump Hiera
to allow it to take a dependency from 1.0 but less than 3. Without
this change Facter 3.x and Hiera 2.x will not be able to be
resolved as dependencies.