### PR TITLE
(PUP-3945) Fix checksum recursing directories

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -656,10 +656,6 @@ Puppet::Type.newtype(:file) do
       end
       children[meta.relative_path] ||= newchild(meta.relative_path)
       children[meta.relative_path][:source] = meta.source
-      if meta.ftype == "file"
-        children[meta.relative_path][:checksum] = Puppet[:digest_algorithm].to_sym
-      end
-
       children[meta.relative_path].parameter(:source).metadata = meta
     end
 


### PR DESCRIPTION
When copying a directory from a source with recurse enabled, any files
copied this way would be forced to the configured default. That meant
they're copied every time you initialize the resource, even if already
present.

This fix lets the files be managed by the checksum property on the
resource. It also updates a prior spec test that confirmed the previous
hack that was required to work around checksums failing to be copied
across the indirector.