### PR TITLE
Issue/pup 909/type inference benchmark

### DIFF
--- a/benchmarks/type_inference/benchmarker.rb
+++ b/benchmarks/type_inference/benchmarker.rb
@@ -1,0 +1,54 @@
+require 'erb'
+require 'ostruct'
+require 'fileutils'
+require 'json'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size
+  end
+
+  def setup
+  end
+
+  def run(args=nil)
+    unless @initialized
+      require 'puppet'
+      config = File.join(@target, 'puppet.conf')
+      Puppet.initialize_settings(['--config', config])
+      @initialized = true
+    end
+    env = Puppet.lookup(:environments).get('benchmarking')
+    node = Puppet::Node.new("testing", :environment => env)
+    # Mimic what apply does (or the benchmark will in part run for the *root* environment)
+    Puppet.push_context({:current_environment => env},'current env for benchmark')
+    Puppet::Resource::Catalog.indirection.find("testing", :use_node => node)
+  end
+
+  def generate
+    environment = File.join(@target, 'environments', 'benchmarking')
+    templates = File.join('benchmarks', 'type_inference')
+
+    mkdir_p(File.join(environment, 'modules'))
+    mkdir_p(File.join(environment, 'manifests'))
+
+    render(
+        File.join(templates, 'site.pp.erb'),
+        File.join(environment, 'manifests', 'site.pp'),
+        :size => @size)
+
+    render(File.join(templates, 'puppet.conf.erb'),
+           File.join(@target, 'puppet.conf'),
+           :location => @target)
+  end
+
+  def render(erb_file, output_file, bindings)
+    site = ERB.new(File.read(erb_file))
+    File.open(output_file, 'w') do |fh|
+      fh.write(site.result(OpenStruct.new(bindings).instance_eval { binding }))
+    end
+  end
+end

--- a/benchmarks/type_inference/description
+++ b/benchmarks/type_inference/description
@@ -1,0 +1,4 @@
+Benchmark scenario: a resource is defined with typed arguments
+Benchmark target: type inference overhead
+Parser: Future
+

--- a/benchmarks/type_inference/puppet.conf.erb
+++ b/benchmarks/type_inference/puppet.conf.erb
@@ -1,0 +1,4 @@
+confdir = <%= location %>
+vardir = <%= location %>
+environmentpath = <%= File.join(location, 'environments') %>
+environment_timeout = '0'

--- a/benchmarks/type_inference/site.pp.erb
+++ b/benchmarks/type_inference/site.pp.erb
@@ -1,0 +1,10 @@
+$vr = { 'mode' => 'read', 'path' => ['foo', 'fee' ] }
+$vw = { 'mode' => 'write', 'path' => ['biz', 'baz' ] }
+$v1 = { 'key' => 'a', 'value' => $vr }
+$v2 = { 'key' => 3, 'value' => $vw }
+$val = [ $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2 ]
+
+<% size.times do |i| %>
+each($val) | Struct[{key=>Variant[Integer[1,3],Enum[a,b,c]], value=>Struct[{mode=>Enum[read,write,update],path=>Array[String]}]}] $v | {  }
+# each($val) | $v | {  }
+<% end %>


### PR DESCRIPTION
This PR adds two commits. One with a type_inference performance test and another with a performance
optimization that makes the test run almost twice as fast. The optimization replaces the ```copy``` method of
the ```PAnyType::ClassModule``` so that it performs a regular recursive deep copy instead of the more
expensive ```Marshal dump/load```.

Before optimization:

                     user     system      total        real
    Run 1        1.750000   0.020000   1.770000 (  1.785820)
    Run 2        1.200000   0.000000   1.200000 (  1.200219)
    Run 3        1.140000   0.010000   1.150000 (  1.149083)
    Run 4        1.150000   0.000000   1.150000 (  1.147719)
    Run 5        1.140000   0.000000   1.140000 (  1.148519)
    Run 6        1.150000   0.000000   1.150000 (  1.149797)
    Run 7        1.110000   0.010000   1.120000 (  1.120035)
    Run 8        1.140000   0.000000   1.140000 (  1.139771)
    Run 9        1.120000   0.010000   1.130000 (  1.133738)
    Run 10       1.140000   0.000000   1.140000 (  1.140323)
    > total:    12.040000   0.050000  12.090000 ( 12.115024)
    > avg:       1.204000   0.005000   1.209000 (  1.211502)

After optimization:

                     user     system      total        real
    Run 1        1.090000   0.040000   1.130000 (  1.135578)
    Run 2        0.630000   0.000000   0.630000 (  0.638859)
    Run 3        0.620000   0.000000   0.620000 (  0.620085)
    Run 4        0.560000   0.010000   0.570000 (  0.563677)
    Run 5        0.560000   0.000000   0.560000 (  0.564784)
    Run 6        0.560000   0.000000   0.560000 (  0.564206)
    Run 7        0.570000   0.000000   0.570000 (  0.567278)
    Run 8        0.570000   0.000000   0.570000 (  0.567765)
    Run 9        0.550000   0.010000   0.560000 (  0.557852)
    Run 10       0.560000   0.000000   0.560000 (  0.556824)
    > total:     6.270000   0.060000   6.330000 (  6.336907)
    > avg:       0.627000   0.006000   0.633000 (  0.633691)
