### PR TITLE
(PUP-3951) Default Windows API strings to UTF_8

### DIFF
--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -53,7 +53,7 @@ module Puppet::Util::Windows::APITypes
     alias_method :read_wchar, :read_uint16
     alias_method :read_word,  :read_uint16
 
-    def read_wide_string(char_length, dst_encoding = Encoding.default_external)
+    def read_wide_string(char_length, dst_encoding = Encoding::UTF_8)
       # char_length is number of wide chars (typically excluding NULLs), *not* bytes
       str = get_bytes(0, char_length * 2).force_encoding('UTF-16LE')
       str.encode(dst_encoding)

--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -109,7 +109,7 @@ module Puppet::Util::Windows
 
             filetime = FFI::WIN32::FILETIME.new(filetime_ptr)
             subkey_length = subkey_length_ptr.read_dword
-            subkey = subkey_ptr.read_wide_string(subkey_length, Encoding::UTF_8)
+            subkey = subkey_ptr.read_wide_string(subkey_length)
           end
         end
       end
@@ -139,7 +139,7 @@ module Puppet::Util::Windows
           end
 
           subkey_length = subkey_length_ptr.read_dword
-          subkey = subkey_ptr.read_wide_string(subkey_length, Encoding::UTF_8)
+          subkey = subkey_ptr.read_wide_string(subkey_length)
 
           type, data = read(key, subkey_ptr)
         end
@@ -209,9 +209,9 @@ module Puppet::Util::Windows
 
         case type
         when Win32::Registry::REG_SZ, Win32::Registry::REG_EXPAND_SZ
-          result = [ type, data_ptr.read_wide_string(string_length, Encoding::UTF_8) ]
+          result = [ type, data_ptr.read_wide_string(string_length) ]
         when Win32::Registry::REG_MULTI_SZ
-          result = [ type, data_ptr.read_wide_string(string_length, Encoding::UTF_8).split(/\0/) ]
+          result = [ type, data_ptr.read_wide_string(string_length).split(/\0/) ]
         when Win32::Registry::REG_BINARY
           result = [ type, data.read_bytes(0, byte_length) ]
         when Win32::Registry::REG_DWORD

--- a/spec/unit/util/windows/api_types_spec.rb
+++ b/spec/unit/util/windows/api_types_spec.rb
@@ -16,13 +16,13 @@ describe "FFI::MemoryPointer", :if => Puppet.features.microsoft_windows? do
       expect(read_string).to eq(string)
     end
 
-    it "should return a given string in the default encoding" do
+    it "should return a given string in UTF-8" do
       read_string = nil
       FFI::MemoryPointer.from_string_to_wide_string(string) do |ptr|
         read_string = ptr.read_wide_string(string.length)
       end
 
-      expect(read_string.encoding).to eq(Encoding.default_external)
+      expect(read_string.encoding).to eq(Encoding::UTF_8)
     end
   end
 end


### PR DESCRIPTION
 - Previously, only Windows API calls that were Registry related had
   the Encoding set to UTF_8 at their individual callsites.  Change the
   default from Encoding.default_external (which matched previous
   Puppet 3.7 and below behavior) to now favor UTF_8 instead.  Though
   this commit doesn't see those changes, the calls that will
   automatically pick up this new string encoding are:

   Puppet::Util::Windows::ADSI.computer_name
   Puppet::Util::Windows::ADSI::User.current_user_name
   Puppet::Util::Windows::Error.format_error_code
   Puppet::Util::Windows::File.resolve_symlink