### PR TITLE
(PUP-3899) Testing for checksum type on file resource

### DIFF
--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -8,11 +8,27 @@ agents.each do |agent|
 
   step "Content Attribute: using raw content"
 
+  checksums = ['md5', 'md5lite', 'sha256', 'sha256lite']
   manifest = "file { '#{target}': content => 'This is the test file content', ensure => present }"
-  apply_manifest_on agent, manifest
+  manifest += checksums.collect {|checksum_type|
+    "file { '#{target+checksum_type}': content => 'This is the test file content', ensure => present, checksum => #{checksum_type} }"
+  }.join("\n")
+  apply_manifest_on agent, manifest do
+    checksums.each do |checksum_type|
+      assert_no_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote #{target+checksum_type}")
+    end
+  end
 
   on agent, "cat #{target}" do
     assert_match(/This is the test file content/, stdout, "File content not matched on #{agent}")
+  end
+
+  step "Content Attribute: illegal timesteps"
+  ['mtime', 'ctime'].each do |checksum_type|
+    manifest = "file { '#{target+checksum_type}': content => 'This is the test file content', ensure => present, checksum => #{checksum_type} }"
+    apply_manifest_on agent, manifest, :acceptable_exit_codes => [1] do
+      assert_match(/Error: Validation of File\[#{target+checksum_type}\] failed: You cannot specify content when using checksum '#{checksum_type}'/, stderr, "#{agent}: expected failure")
+    end
   end
 
   step "Ensure the test environment is clean"

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -2,15 +2,24 @@ test_name "The source attribute"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-target_file_on_windows = 'C:/windows/temp/source_attr_test'
-target_file_on_nix     = '/tmp/source_attr_test'
+@target_file_on_windows = 'C:/windows/temp/source_attr_test'
+@target_file_on_nix     = '/tmp/source_attr_test'
+@target_dir_on_windows  = 'C:/windows/temp/source_attr_test_dir'
+@target_dir_on_nix      = '/tmp/source_attr_test_dir'
+
+checksums = [nil, 'md5', 'md5lite', 'sha256', 'sha256lite', 'ctime', 'mtime']
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)
   hosts.each do |host|
-    file_to_rm = host['platform'] =~ /windows/ ? target_file_on_windows : target_file_on_nix
-    on(host, "rm #{file_to_rm}", :acceptable_exit_codes => [0,1])
+    file_to_rm = host['platform'] =~ /windows/ ? @target_file_on_windows : @target_file_on_nix
+    dir_to_rm = host['platform'] =~ /windows/ ? @target_dir_on_windows : @target_dir_on_nix
+
+    checksums.each do |checksum_type|
+      on(host, "rm #{file_to_rm}#{checksum_type}", :acceptable_exit_codes => [0,1])
+      on(host, "rm -r #{file_to_rm}#{checksum_type}", :acceptable_exit_codes => [0,1])
+    end
   end
 end
 
@@ -27,20 +36,43 @@ test_module_manifests_dir = "#{test_module_dir}/manifests"
 test_module_files_dir = "#{test_module_dir}/files"
 mod_manifest_file = "#{test_module_manifests_dir}/init.pp"
 mod_source_file = "#{test_module_files_dir}/source_file"
+mod_source_dir = "#{test_module_files_dir}/source_dir"
+mod_source_dir_file = "#{mod_source_dir}/source_dir_file"
 
 mod_source = ' the content is present'
 
-mod_manifest = <<EOF
-class source_test_module {
-  $target_file = $::kernel ? {
-    \\'windows\\' => \\'#{target_file_on_windows}\\',
-    default   => \\'#{target_file_on_nix}\\'
+def mod_manifest_entry(checksum_type = nil)
+  checksum = if checksum_type then "checksum => #{checksum_type}," else "" end
+  manifest = <<EOF
+  $target_file#{checksum_type} = $::kernel ? {
+    \\'windows\\' => \\'#{@target_file_on_windows}#{checksum_type}\\',
+    default   => \\'#{@target_file_on_nix}#{checksum_type}\\'
   }
 
-  file { $target_file:
+  file { $target_file#{checksum_type}:
     source => \\'puppet:///modules/source_test_module/source_file\\',
+    #{checksum}
     ensure => present
   }
+
+  $target_dir#{checksum_type} = $::kernel ? {
+    \\'windows\\' => \\'#{@target_dir_on_windows}#{checksum_type}\\',
+    default   => \\'#{@target_dir_on_nix}#{checksum_type}\\'
+  }
+
+  file { $target_dir#{checksum_type}:
+    source => \\'puppet:///modules/source_test_module/source_dir\\',
+    #{checksum}
+    ensure => directory,
+    recurse => true
+  }
+EOF
+  manifest
+end
+
+mod_manifest = <<EOF
+class source_test_module {
+#{checksums.collect { |checksum_type| mod_manifest_entry(checksum_type) }.join("\n")}
 }
 EOF
 
@@ -79,7 +111,19 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
     mode => '0644',
     content => '#{mod_manifest}',
   }
+
   file { '#{mod_source_file}':
+    ensure => file,
+    mode => '0644',
+    content => '#{mod_source}',
+  }
+
+  file { '#{mod_source_dir}':
+    ensure => directory,
+    mode => '0755'
+  }
+
+  file { '#{mod_source_dir_file}':
     ensure => file,
     mode => '0644',
     content => '#{mod_source}',
@@ -100,15 +144,56 @@ master_opts = {
 }
 with_puppet_running_on(master, master_opts, testdir) do
   agents.each do |agent|
-    # accept an exit code of 2 which is returned if thre are changes
+    # accept an exit code of 2 which is returned if there are changes
+    step "create file the first run"
     on(agent, puppet('agent', "--test --server #{master}"), :acceptable_exit_codes => [0,2]) do
-      file_to_check = agent['platform'] =~ /windows/ ? target_file_on_windows : target_file_on_nix
-      on agent, "cat #{file_to_check}" do
-        assert_match(/the content is present/, stdout, "Result file not created")
+      file_to_check = agent['platform'] =~ /windows/ ? @target_file_on_windows : @target_file_on_nix
+      dir_to_check = agent['platform'] =~ /windows/ ? @target_dir_on_windows : @target_dir_on_nix
+
+      checksums.each do |checksum_type|
+        on agent, "cat #{file_to_check}#{checksum_type}" do
+          assert_match(/the content is present/, stdout, "Result file not created")
+        end
+
+        on agent, "cat #{dir_to_check}#{checksum_type}/source_dir_file" do
+          assert_match(/the content is present/, stdout, "Result file not created")
+        end
+      end
+    end
+
+    step "second run should not update file"
+    on(agent, puppet('agent', "--test --server #{master}")) do
+      assert_no_match(/content changed/, stdout, "Shouldn't have overwrote any files")
+    end
+  end
+
+  step "touch files and verify they're updated with ctime/mtime"
+  sleep(1)
+  on master, "touch #{mod_source_file} #{mod_source_dir_file}"
+  agents.each do |agent|
+    on(agent, puppet('agent', "--test --server #{master}"), :acceptable_exit_codes => [0,2]) do
+      file_to_check = agent['platform'] =~ /windows/ ? @target_file_on_windows : @target_file_on_nix
+      dir_to_check = agent['platform'] =~ /windows/ ? @target_dir_on_windows : @target_dir_on_nix
+      ['ctime', 'mtime'].each do |time_type|
+        assert_match(/File\[#{file_to_check}#{time_type}\]\/content: content changed/, stdout, "Should have updated files")
+        assert_match(/File\[#{dir_to_check}#{time_type}\/source_dir_file\]\/content: content changed/, stdout, "Should have updated files")
       end
     end
   end
 end
+
+new_mod_manifest = <<EOF
+class source_test_module {
+#{mod_manifest_entry}
+}
+EOF
+apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+  file { '#{mod_manifest_file}':
+    ensure => file,
+    mode => '0644',
+    content => '#{new_mod_manifest}',
+  }
+MANIFEST
 
 # TODO: Add tests for puppet:// URIs with multi-master/agent setups.
 step "when using a puppet://$server/ URI with a master/agent setup"

--- a/spec/integration/network/http/api/indirected_routes_spec.rb
+++ b/spec/integration/network/http/api/indirected_routes_spec.rb
@@ -1,0 +1,56 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/network/http'
+require 'puppet/network/http/api/indirected_routes'
+require 'puppet/indirector_proxy'
+require 'puppet_spec/files'
+require 'puppet_spec/network'
+require 'json'
+
+describe Puppet::Network::HTTP::API::IndirectedRoutes do
+  include PuppetSpec::Files
+  include PuppetSpec::Network
+  include_context 'with supported checksum types'
+
+  describe "when running the master application" do
+    before :each do
+      Puppet::Application[:master].setup_terminuses
+    end
+
+    describe "using Puppet API to request file metadata" do
+      let(:handler) { Puppet::Network::HTTP::API::IndirectedRoutes.new }
+      let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+
+      with_checksum_types 'file_content', 'lib/files/file.rb' do
+        before :each do
+          Puppet.settings[:modulepath] = env_path
+        end
+
+        it "should find the file metadata with expected checksum" do
+          request = a_request_that_finds(Puppet::IndirectorProxy.new("modules/lib/file.rb", "file_metadata"),
+                                         {:accept_header => 'unknown, text/pson'},
+                                         {:environment => 'production', :checksum_type => checksum_type})
+          handler.call(request, response)
+          resp = JSON.parse(response.body)
+
+          expect(resp['checksum']['type']).to eq(checksum_type)
+          expect(checksum_valid(checksum_type, checksum, resp['checksum']['value'])).to be_truthy
+        end
+
+        it "should search for the file metadata with expected checksum" do
+          request = a_request_that_searches(Puppet::IndirectorProxy.new("modules/lib", "file_metadata"),
+                                            {:accept_header => 'unknown, text/pson'},
+                                            {:environment => 'production', :checksum_type => checksum_type, :recurse => 'yes'})
+          handler.call(request, response)
+          resp = JSON.parse(response.body)
+
+          expect(resp.length).to eq(2)
+          file = resp.find {|x| x['relative_path'] == 'file.rb'}
+
+          expect(file['checksum']['type']).to eq(checksum_type)
+          expect(checksum_valid(checksum_type, checksum, file['checksum']['value'])).to be_truthy
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/puppet/indirector_proxy.rb
+++ b/spec/lib/puppet/indirector_proxy.rb
@@ -1,0 +1,34 @@
+class Puppet::IndirectorProxy
+  class ProxyId
+    attr_accessor :name
+    def initialize(name)
+      self.name = name
+    end
+  end
+
+  # We should have some way to identify if we got a valid object back with the
+  # current values, no?
+  attr_accessor :value, :proxyname
+  alias_method :name, :value
+  alias_method :name=, :value=
+  def initialize(value, proxyname)
+    self.value = value
+    self.proxyname = proxyname
+  end
+
+  def self.indirection
+    ProxyId.new("file_metadata")
+  end
+
+  def self.from_binary(raw)
+    new(raw)
+  end
+
+  def self.from_data_hash(data)
+    new(data['value'])
+  end
+
+  def to_data_hash
+    { 'value' => value }
+  end
+end

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+require 'puppet/network/http'
+require 'puppet/network/http/api/indirected_routes'
+require 'puppet/indirector_testing'
+
+module PuppetSpec::Network
+  def not_found_code
+    Puppet::Network::HTTP::Error::HTTPNotFoundError::CODE
+  end
+
+  def not_acceptable_code
+    Puppet::Network::HTTP::Error::HTTPNotAcceptableError::CODE
+  end
+
+  def bad_request_code
+    Puppet::Network::HTTP::Error::HTTPBadRequestError::CODE
+  end
+
+  def not_authorized_code
+    Puppet::Network::HTTP::Error::HTTPNotAuthorizedError::CODE
+  end
+
+  def params
+    { :environment => "production" }
+  end
+
+  def master_url_prefix
+    "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3"
+  end
+
+  def ca_url_prefix
+    "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v1"
+  end
+
+  def a_request_that_heads(data, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => "text/pson"
+      },
+      :method => "HEAD",
+      :path => "#{master_url_prefix}/#{data.class.indirection.name}/#{data.value}",
+      :params => params,
+    })
+  end
+
+  def a_request_that_submits(data, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => request[:content_type_header] || "text/pson"
+      },
+      :method => "PUT",
+      :path => "#{master_url_prefix}/#{data.class.indirection.name}/#{data.value}",
+      :params => params,
+      :body => request[:body].nil? ? data.render("pson") : request[:body]
+    })
+  end
+
+  def a_request_that_destroys(data, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => "text/pson"
+      },
+      :method => "DELETE",
+      :path => "#{master_url_prefix}/#{data.class.indirection.name}/#{data.value}",
+      :params => params,
+      :body => ''
+    })
+  end
+
+  def a_request_that_finds(data, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => "text/pson"
+      },
+      :method => "GET",
+      :path => "#{master_url_prefix}/#{data.class.indirection.name}/#{data.value}",
+      :params => params,
+      :body => ''
+    })
+  end
+
+  def a_request_that_searches(data, request = {})
+    Puppet::Network::HTTP::Request.from_hash({
+      :headers => {
+        'accept' => request[:accept_header],
+        'content-type' => "text/pson"
+      },
+      :method => "GET",
+      :path => "#{master_url_prefix}/#{data.class.indirection.name}s/#{data.name}",
+      :params => params,
+      :body => ''
+    })
+  end
+
+end
+

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -33,7 +33,7 @@ module PuppetSpec::Network
     "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v1"
   end
 
-  def a_request_that_heads(data, request = {})
+  def a_request_that_heads(data, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
@@ -45,7 +45,7 @@ module PuppetSpec::Network
     })
   end
 
-  def a_request_that_submits(data, request = {})
+  def a_request_that_submits(data, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
@@ -58,7 +58,7 @@ module PuppetSpec::Network
     })
   end
 
-  def a_request_that_destroys(data, request = {})
+  def a_request_that_destroys(data, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
@@ -71,7 +71,7 @@ module PuppetSpec::Network
     })
   end
 
-  def a_request_that_finds(data, request = {})
+  def a_request_that_finds(data, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
@@ -84,7 +84,7 @@ module PuppetSpec::Network
     })
   end
 
-  def a_request_that_searches(data, request = {})
+  def a_request_that_searches(data, request = {}, params = params())
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],

--- a/spec/shared_contexts/checksum.rb
+++ b/spec/shared_contexts/checksum.rb
@@ -22,17 +22,20 @@ TIME_TYPES_TO_TRY = [
 
 shared_context('with supported checksum types') do
   def self.with_checksum_types(path, file, &block)
+    def checksum_valid(checksum_type, expected_checksum, actual_checksum_signature)
+      case checksum_type
+      when 'mtime', 'ctime'
+        expect(DateTime.parse(actual_checksum_signature)).to be >= DateTime.parse(expected_checksum)
+      else
+        expect(actual_checksum_signature).to eq("{#{checksum_type}}#{expected_checksum}")
+      end
+    end
+
     def expect_correct_checksum(meta, checksum_type, checksum, type)
       expect(meta).to_not be_nil
       expect(meta).to be_instance_of(type)
       expect(meta.checksum_type).to eq(checksum_type)
-
-      case checksum_type
-      when 'mtime', 'ctime'
-        expect(DateTime.parse(meta.checksum)).to be >= DateTime.parse(checksum)
-      else
-        expect(meta.checksum).to eq("{#{checksum_type}}#{checksum}")
-      end
+      expect(checksum_valid(checksum_type, checksum, meta.checksum)).to be_truthy
     end
 
     (CHECKSUM_TYPES_TO_TRY + TIME_TYPES_TO_TRY).each do |checksum_type, checksum|


### PR DESCRIPTION
Add integration and acceptance tests for specifying the checksum on a file. Covers puppet apply, querying the server via the HTTP API, and puppet agent runs.