### PR TITLE
(maint) Make it possible to capture logs of test runs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,3 +57,15 @@ The tests can be run with the following rake task:
 To run a single file's worth of tests (much faster!), give the filename:
 
     bundle exec rake spec TEST=spec/unit/ssl/host_spec.rb
+
+When tests fail, it is often useful to capture Puppet's log of a test
+run. The test harness pays attention to two environment variables that can
+be used to send logs to a file, and to adjust the log level:
+
+* `PUPPET_TEST_LOG`: when set, must be an absolute path to a file. Puppet's
+  log messages will be sent to that file. Note that the log file will
+  contain lots of spurious warnings `Unable to set ownership of log file`
+  - you can safely ignore them.
+* `PUPPET_TEST_LOG_LEVEL`: change the log level to adjust how much detail
+  is captured. It defaults to `notice`; useful values include `info` and
+  `debug`.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,7 @@ RSpec.configure do |config|
     Puppet::Test::TestHelper.after_all_tests()
   end
 
-  config.before :each do
+  config.before :each do |test|
     # Disabling garbage collection inside each test, and only running it at
     # the end of each block, gives us an ~ 15 percent speedup, and more on
     # some platforms *cough* windows *cough* that are a little slower.
@@ -121,6 +121,14 @@ RSpec.configure do |config|
     # redirecting logging away from console, because otherwise the test output will be
     #  obscured by all of the log output
     @logs = []
+    if ENV["PUPPET_TEST_LOG_LEVEL"]
+      Puppet::Util::Log.level = ENV["PUPPET_TEST_LOG_LEVEL"].intern
+    end
+    if ENV["PUPPET_TEST_LOG"]
+      Puppet::Util::Log.newdestination(ENV["PUPPET_TEST_LOG"])
+      m = test.metadata
+      Puppet.notice("*** BEGIN TEST #{m[:file_path]}:#{m[:line_number]}")
+    end
     Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
 
     @log_level = Puppet::Util::Log.level


### PR DESCRIPTION
When tests are failing, it is often useful to capture Puppet's logs of the
test run. This change makes it possible to send the log to a file, and to
adjust Puppet's log level.

Thanks to Josh Cooper for pointing out how to do this