### PR TITLE
(PUP-3962) Test for '.' module directories

### DIFF
--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -53,7 +53,9 @@ describe Puppet::Module do
 
     it "should return false for badly named directories" do
       PuppetSpec::Modules.generate_files('foo=bar', first_modulepath)
+      PuppetSpec::Modules.generate_files('.foo', first_modulepath)
       expect(Puppet::Module.is_module_directory?('foo=bar', first_modulepath)).to be_falsey
+      expect(Puppet::Module.is_module_directory?('.foo', first_modulepath)).to be_falsey
     end
   end
 
@@ -72,6 +74,7 @@ describe Puppet::Module do
       expect(Puppet::Module.is_module_directory_name?('-foo')).to be_falsey
       expect(Puppet::Module.is_module_directory_name?('foo-')).to be_falsey
       expect(Puppet::Module.is_module_directory_name?('foo--bar')).to be_falsey
+      expect(Puppet::Module.is_module_directory_name?('.foo')).to be_falsey
     end
   end
 
@@ -82,6 +85,7 @@ describe Puppet::Module do
 
     it "should return false for badly formed namespaced module names" do
       expect(Puppet::Module.is_module_namespaced_name?('foo')).to be_falsey
+      expect(Puppet::Module.is_module_namespaced_name?('.foo-bar')).to be_falsey
       expect(Puppet::Module.is_module_namespaced_name?('foo2')).to be_falsey
       expect(Puppet::Module.is_module_namespaced_name?('foo_bar')).to be_falsey
       expect(Puppet::Module.is_module_namespaced_name?('foo=bar')).to be_falsey

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -260,6 +260,7 @@ describe Puppet::Node::Environment do
 
           it "ignores modules with invalid names" do
             PuppetSpec::Modules.generate_files('foo', first_modulepath)
+            PuppetSpec::Modules.generate_files('.foo', first_modulepath)
             PuppetSpec::Modules.generate_files('foo2', first_modulepath)
             PuppetSpec::Modules.generate_files('foo-bar', first_modulepath)
             PuppetSpec::Modules.generate_files('foo_bar', first_modulepath)
@@ -390,6 +391,7 @@ describe Puppet::Node::Environment do
 
           it "ignores modules with invalid names" do
             PuppetSpec::Modules.generate_files('foo', first_modulepath)
+            PuppetSpec::Modules.generate_files('.foo', first_modulepath)
             PuppetSpec::Modules.generate_files('foo2', first_modulepath)
             PuppetSpec::Modules.generate_files('foo-bar', first_modulepath)
             PuppetSpec::Modules.generate_files('foo_bar', first_modulepath)


### PR DESCRIPTION
Before this test, the spec tests don't include negative tests for module
directories starting with '.'. After this commit, we test for those
types of directories also. This tests the original intention of
PUP-3678.