### PR TITLE
(PUP-3969) Use Beaker puppet method for host 'user' and 'group'

### DIFF
--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -65,8 +65,8 @@ module Puppet
         manifest = <<-MANIFEST
           File {
             ensure => directory,
-            owner => #{master['user']},
-            group => #{master['group']},
+            owner => #{master.puppet['user']},
+            group => #{master.puppet['group']},
             mode => "0750",
           }
 

--- a/acceptance/lib/puppet/acceptance/temp_file_utils.rb
+++ b/acceptance/lib/puppet/acceptance/temp_file_utils.rb
@@ -17,8 +17,8 @@ module Puppet
 
         # set default options
         options[:mkdirs] ||= false
-        options[:owner] ||= host['user']
-        options[:group] ||= host['group']
+        options[:owner] ||= host.puppet['user']
+        options[:group] ||= host.puppet['group']
         options[:mode] ||= "755"
 
         file_path = get_test_file_path(host, file_rel_path)

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -7,8 +7,8 @@ environment = 'debug'
 manifest = <<-MANIFEST
   File {
     ensure => directory,
-    owner => #{master['user']},
-    group => #{master['group']},
+    owner => #{master.puppet['user']},
+    group => #{master.puppet['group']},
     mode => "0750",
   }
 

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -31,7 +31,7 @@ apply_manifest_on(master, <<-MANIFEST)
 File {
   ensure => directory,
   owner => #{master_user},
-  group => #{master['group']},
+  group => #{master.puppet['group']},
   mode => "0770",
 }
 

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -11,7 +11,7 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
   owner => #{master_user},
-  group => #{master['group']},
+  group => #{master.puppet['group']},
   mode => '0640',
 }
 

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -72,7 +72,7 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
   owner => #{master_user},
-  group => #{master['group']},
+  group => #{master.puppet['group']},
   mode => "0770",
 }
 

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -46,7 +46,7 @@ apply_manifest_on(master, <<-MANIFEST , :catch_failures => true)
     ]:
 
     ensure => directory,
-    owner => #{master['user']},
+    owner => #{master.puppet['user']},
   }
 MANIFEST
 

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -78,8 +78,8 @@ class ModifiesModeTest < ActionModeTest
 
     @start_mode = start_mode
 
-    user = agent['user']
-    group = agent['group'] || user
+    user = agent.puppet['user']
+    group = agent.puppet['group'] || user
 
     testcase.on(agent, "touch #{@file} && chown #{user}:#{group} #{@file} && chmod #{start_mode.to_s(8)} #{@file}")
     testcase.on(agent, "mkdir -p #{@dir} && chown #{user}:#{group} #{@dir} && chmod #{start_mode.to_s(8)} #{@dir}")

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -2,7 +2,7 @@ test_name "tests that user resource will not add users that already exist."
 
 step "verify that we don't try to create a user account that already exists"
 agents.each do |agent|
-  on(agent, puppet_resource('user', agent['user'], 'ensure=present')) do
-    fail_test "tried to create '#{agent['user']}' user" if stdout.include? 'created'
+  on(agent, puppet_resource('user', agent.puppet['user'], 'ensure=present')) do
+    fail_test "tried to create '#{agent.puppet['user']}' user" if stdout.include? 'created'
   end
 end

--- a/acceptance/tests/ticket_4110_puppet_apply_should_not_create_a_user_that_already_exists.rb
+++ b/acceptance/tests/ticket_4110_puppet_apply_should_not_create_a_user_that_already_exists.rb
@@ -1,7 +1,7 @@
 test_name "#4110: puppet apply should not create a user that already exists"
 
 agents.each do |host|
-  user = host['user']
+  user = host.puppet['user']
   apply_manifest_on(host, "user { '#{user}': ensure => 'present' }") do
     assert_no_match(/created/, stdout, "we tried to create #{user} on #{host}")
   end


### PR DESCRIPTION
This commit updates puppet acceptance tests and their helper methods to use
the Beaker `host.puppet['user']` and `host.puppet['group']` method in order to
introspect the proper puppet user and group.

Previously, these tests and helpers were relying on the `host` hash as defined
by Beaker to determine these values. This method is no longer proper procedure
for determining these values and was resulting in test failures in the
acceptance testing of puppet against the All In One agent as well as
failures in the acceptance testing of Beaker.