### PR TITLE
(maint) fix tests that incorrectly use host['user']

### DIFF
--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -7,8 +7,8 @@ environment = 'debug'
 manifest = <<-MANIFEST
   File {
     ensure => directory,
-    owner => #{master['user']},
-    group => #{master['group']},
+    owner => #{master.puppet['user']},
+    group => #{master.puppet['group']},
     mode => "0750",
   }
 

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -31,7 +31,7 @@ apply_manifest_on(master, <<-MANIFEST)
 File {
   ensure => directory,
   owner => #{master_user},
-  group => #{master['group']},
+  group => #{master.puppet['group']},
   mode => "0770",
 }
 

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -11,7 +11,7 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
   owner => #{master_user},
-  group => #{master['group']},
+  group => #{master.puppet['group']},
   mode => '0640',
 }
 

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -72,7 +72,7 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
   owner => #{master_user},
-  group => #{master['group']},
+  group => #{master.puppet['group']},
   mode => "0770",
 }
 

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -46,7 +46,7 @@ apply_manifest_on(master, <<-MANIFEST , :catch_failures => true)
     ]:
 
     ensure => directory,
-    owner => #{master['user']},
+    owner => #{master.puppet['user']},
   }
 MANIFEST
 


### PR DESCRIPTION
Beaker uses these for user/group on test-runner.  Ensure the tests use
the output of puppet agent/master --configprint so manifests get created
and run correctly using the puppet user/group.
This is required for the AIO pipelines.