### PR TITLE
(PUP-3821) Don't check Windows admin? with Facter

### DIFF
--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -8,11 +8,10 @@ module Puppet::Util::Windows::User
   extend FFI::Library
 
   def admin?
-    majversion = Facter.value(:kernelmajversion)
-    return false unless majversion
+    elevated_supported = Puppet::Util::Windows::Process.supports_elevated_security?
 
     # if Vista or later, check for unrestricted process token
-    return Puppet::Util::Windows::Process.elevated_security? unless majversion.to_f < 6.0
+    return Puppet::Util::Windows::Process.elevated_security? if elevated_supported
 
     # otherwise 2003 or less
     check_token_membership

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows? do
   describe "2003 without UAC" do
     before :each do
-      Facter.stubs(:value).with(:kernelmajversion).returns("5.2")
+      Puppet::Util::Windows::Process.stubs(:windows_major_version).returns(5)
     end
 
     it "should be an admin if user's token contains the Administrators SID" do
@@ -32,7 +32,7 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
 
   describe "2008 with UAC" do
     before :each do
-      Facter.stubs(:value).with(:kernelmajversion).returns("6.0")
+      Puppet::Util::Windows::Process.stubs(:windows_major_version).returns(6)
     end
 
     it "should be an admin if user is running with elevated privileges" do


### PR DESCRIPTION
 - The previous method for checking whether a user is an admin? on
   Windows can cause issues loading Puppet when the --cfacter switch is
   applied.  The error message is:

   Error: Could not initialize global default settings: facter has
   already evaluated facts.

   Detect that the Windows major version is at least 6 (Vista+) as a
   shortcut to whether or not TokenElevation is available on the current
   operating system.

   An alternative approach would rewrite supports_elevated_security to
   execute similarly to elevated_security?, but watch only for
   ERROR_NO_SUCH_PRIVILEGE.  This would be less code, but several
   additional API calls to clone the current process token and
   call GetTokenInformation against it.