### PR TITLE
(PUP-3679) Drop use of facter's 'ps' fact.

### DIFF
--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -11,15 +11,28 @@ Puppet::Type.type(:service).provide :base, :parent => :service do
 
   commands :kill => "kill"
 
+  # get the proper 'ps' invocation for the platform
+  # ported from the facter 2.x implementation, since facter 3.x
+  # is dropping the fact (for which this was the only use)
+  def getps
+    case Facter.value(:operatingsystem)
+    when 'OpenWrt'
+      'ps www'
+    when 'FreeBSD', 'NetBSD', 'OpenBSD', 'Darwin', 'DragonFly'
+      'ps auxwww'
+    else
+      'ps -ef'
+     end
+  end
+  private :getps
+
   # Get the process ID for a running process. Requires the 'pattern'
   # parameter.
   def getpid
     @resource.fail "Either stop/status commands or a pattern must be specified" unless @resource[:pattern]
-    ps = Facter.value :ps
-    @resource.fail "You must upgrade Facter to a version that includes 'ps'" unless ps and ps != ""
     regex = Regexp.new(@resource[:pattern])
     self.debug "Executing '#{ps}'"
-    IO.popen(ps) { |table|
+    IO.popen(getps) { |table|
       table.each_line { |line|
         if regex.match(line)
           self.debug "Process matched: #{line}"
@@ -31,6 +44,7 @@ Puppet::Type.type(:service).provide :base, :parent => :service do
 
     nil
   end
+  private :getpid
 
   # Check if the process is running.  Prefer the 'status' parameter,
   # then 'statuscmd' method, then look in the process table.  We give


### PR DESCRIPTION
Facter 3 is planning to drop the 'ps' fact (which is only used here
as far as anyone can tell), so this commit simply moves that logic
for different ps versions into the one provider that relies on it.