### PR TITLE
(PUP-3899) Fix source_attribute acceptance on Solaris

### DIFF
--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -18,7 +18,7 @@ teardown do
 
     checksums.each do |checksum_type|
       on(host, "rm #{file_to_rm}#{checksum_type}", :acceptable_exit_codes => [0,1])
-      on(host, "rm -r #{file_to_rm}#{checksum_type}", :acceptable_exit_codes => [0,1])
+      on(host, "rm -r #{dir_to_rm}#{checksum_type}", :acceptable_exit_codes => [0,1])
     end
   end
 end


### PR DESCRIPTION
Fix mistype in removing directories. For some reason that only failed on
Solaris, but it impacts the environment of every platform.