### PR TITLE
(WIP - DO NOT MERGE) (PUP-3848) MSI Dependencies for Ruby 2.1.5 / Puppet 4.0.0 - ROUND 2

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -31,7 +31,7 @@ build_msi:
     ref: 'refs/tags/1.3.4'
     repo: 'git://github.com/puppetlabs/hiera.git'
   mcollective:
-    ref: 'refs/tags/2.7.0'
+    ref: 'refs/tags/2.8.0'
     repo: 'git://github.com/puppetlabs/marionette-collective.git'
   sys:
     ref:


### PR DESCRIPTION
Depends on #3564

Update MSI dependencies for PUP 4.0.0 - round 2

- [x] MCO 2.8.0
- [ ] Hiera 2.0.0