### PR TITLE
(PUP-1635) Make daemon.rb signals Ruby 2.x safe

### DIFF
--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -53,8 +53,6 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
 
         Puppet.expects(:notice)
 
-        daemon.expects(method)
-
         daemon.set_signal_traps
       end
     end


### PR DESCRIPTION
Ruby 2.x changes the way signals work to mean you can't do certain things from the 'trap context'. This means that SIGUSR1 and the like no longer work.

This change makes it so that we, instead of processing methods in the 'trap context', just store them on a list and pop them out the other side in another job called signal_loop.

This is modelled on the way other Ruby Daemon-like projects have fixed this issue.