### PR TITLE
(PUP-3274) Change Closure.call to not take scope as parameter

### DIFF
--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -62,7 +62,7 @@ Puppet::Functions.create_function(:each) do
   def foreach_Hash_1(hash, pblock)
     enumerator = hash.each_pair
     hash.size.times do
-      pblock.call(nil, enumerator.next)
+      pblock.call(enumerator.next)
     end
     # produces the receiver
     hash
@@ -71,7 +71,7 @@ Puppet::Functions.create_function(:each) do
   def foreach_Hash_2(hash, pblock)
     enumerator = hash.each_pair
     hash.size.times do
-      pblock.call(nil, *enumerator.next)
+      pblock.call(*enumerator.next)
     end
     # produces the receiver
     hash
@@ -80,7 +80,7 @@ Puppet::Functions.create_function(:each) do
   def foreach_Enumerable_1(enumerable, pblock)
     enum = asserted_enumerable(enumerable)
       begin
-        loop { pblock.call(nil, enum.next) }
+        loop { pblock.call(enum.next) }
       rescue StopIteration
       end
     # produces the receiver
@@ -92,7 +92,7 @@ Puppet::Functions.create_function(:each) do
     index = 0
     begin
       loop do
-        pblock.call(nil, index, enum.next)
+        pblock.call(index, enum.next)
         index += 1
       end
     rescue StopIteration

--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -57,14 +57,14 @@ Puppet::Functions.create_function(:filter) do
   end
 
   def filter_Hash_1(hash, pblock)
-    result = hash.select {|x, y| pblock.call(self, [x, y]) }
+    result = hash.select {|x, y| pblock.call([x, y]) }
     # Ruby 1.8.7 returns Array
     result = Hash[result] unless result.is_a? Hash
     result
   end
 
   def filter_Hash_2(hash, pblock)
-    result = hash.select {|x, y| pblock.call(self, x, y) }
+    result = hash.select {|x, y| pblock.call(x, y) }
     # Ruby 1.8.7 returns Array
     result = Hash[result] unless result.is_a? Hash
     result
@@ -77,7 +77,7 @@ Puppet::Functions.create_function(:filter) do
     begin
       loop do
         it = enum.next
-        if pblock.call(nil, it) == true
+        if pblock.call(it) == true
           result << it
         end
       end
@@ -93,7 +93,7 @@ Puppet::Functions.create_function(:filter) do
     begin
       loop do
         it = enum.next
-        if pblock.call(nil, index, it) == true
+        if pblock.call(index, it) == true
           result << it
         end
         index += 1

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -55,11 +55,11 @@ Puppet::Functions.create_function(:map) do
   end
 
   def map_Hash_1(hash, pblock)
-    hash.map {|x, y| pblock.call(nil, [x, y]) }
+    hash.map {|x, y| pblock.call([x, y]) }
   end
 
   def map_Hash_2(hash, pblock)
-      hash.map {|x, y| pblock.call(nil, x, y) }
+      hash.map {|x, y| pblock.call(x, y) }
   end
 
   def map_Enumerable_1(enumerable, pblock)
@@ -67,7 +67,7 @@ Puppet::Functions.create_function(:map) do
     index = 0
     enum = asserted_enumerable(enumerable)
     begin
-      loop { result << pblock.call(nil, enum.next) }
+      loop { result << pblock.call(enum.next) }
     rescue StopIteration
     end
     result
@@ -79,7 +79,7 @@ Puppet::Functions.create_function(:map) do
     enum = asserted_enumerable(enumerable)
     begin
       loop do
-        result << pblock.call(nil, index, enum.next)
+        result << pblock.call(index, enum.next)
         index = index +1
       end
     rescue StopIteration

--- a/lib/puppet/functions/reduce.rb
+++ b/lib/puppet/functions/reduce.rb
@@ -76,12 +76,12 @@ Puppet::Functions.create_function(:reduce) do
 
   def reduce_without_memo(enumerable, pblock)
     enum = asserted_enumerable(enumerable)
-    enum.reduce {|memo, x| pblock.call(nil, memo, x) }
+    enum.reduce {|memo, x| pblock.call(memo, x) }
   end
 
   def reduce_with_memo(enumerable, given_memo, pblock)
     enum = asserted_enumerable(enumerable)
-    enum.reduce(given_memo) {|memo, x| pblock.call(nil, memo, x) }
+    enum.reduce(given_memo) {|memo, x| pblock.call(memo, x) }
   end
 
   def asserted_enumerable(obj)

--- a/lib/puppet/functions/scanf.rb
+++ b/lib/puppet/functions/scanf.rb
@@ -39,7 +39,7 @@ Puppet::Functions.create_function(:scanf) do
   def scanf(data, format, block=nil)
     result = data.scanf(format)
     if !block.nil?
-      result = block.call({}, result)
+      result = block.call(result)
     end
     result
   end

--- a/lib/puppet/functions/slice.rb
+++ b/lib/puppet/functions/slice.rb
@@ -71,7 +71,7 @@ Puppet::Functions.create_function(:slice) do
       begin
         if pblock
           loop do
-            pblock.call(nil, enumerator.next)
+            pblock.call(enumerator.next)
           end
         else
           loop do
@@ -87,7 +87,7 @@ Puppet::Functions.create_function(:slice) do
           if a.size < serving_size
             a = a.dup.fill(filler, a.length...serving_size)
           end
-          pblock.call(nil, *a)
+          pblock.call(*a)
         end
       rescue StopIteration
       end

--- a/lib/puppet/functions/with.rb
+++ b/lib/puppet/functions/with.rb
@@ -18,6 +18,6 @@ Puppet::Functions.create_function(:with) do
   end
 
   def with(*args)
-    args[-1].call({}, *args[0..-2])
+    args[-1].call(*args[0..-2])
   end
 end

--- a/lib/puppet/pops/binder/lookup.rb
+++ b/lib/puppet/pops/binder/lookup.rb
@@ -166,11 +166,11 @@ class Puppet::Pops::Binder::Lookup
     result = if pblock = options[:pblock]
       result2 = case pblock.parameter_count
       when 1
-        pblock.call(scope, undef_as_nil(result))
+        pblock.call(undef_as_nil(result))
       when 2
-        pblock.call(scope, result_with_name[ 0 ], undef_as_nil(result))
+        pblock.call(result_with_name[ 0 ], undef_as_nil(result))
       else
-        pblock.call(scope, result_with_name[ 0 ], undef_as_nil(result), undef_as_nil(options[ :default ]))
+        pblock.call(result_with_name[ 0 ], undef_as_nil(result), undef_as_nil(options[ :default ]))
       end
 
       # if the given result was returned, there is no need to type-check it again

--- a/lib/puppet/pops/binder/producers.rb
+++ b/lib/puppet/pops/binder/producers.rb
@@ -57,7 +57,7 @@ module Puppet::Pops::Binder::Producers
     def initialize(injector, binding, scope, options)
       if transformer_lambda = options[:transformer]
         if transformer_lambda.is_a?(Proc)
-          raise ArgumentError, "Transformer Proc must take two arguments; scope, value." unless transformer_lambda.arity == 2
+          raise ArgumentError, "Transformer Proc must take one argument; value." unless transformer_lambda.arity == 1
           @transformer = transformer_lambda
         else
           raise ArgumentError, "Transformer must be a LambdaExpression" unless transformer_lambda.is_a?(Puppet::Pops::Model::LambdaExpression)
@@ -110,7 +110,7 @@ module Puppet::Pops::Binder::Producers
     #
     def do_transformation(scope, produced_value)
       return produced_value unless transformer
-      transformer.call(scope, produced_value)
+      transformer.call(produced_value)
     end
   end
 

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -29,7 +29,7 @@ class Puppet::Pops::Evaluator::Closure < Puppet::Pops::Evaluator::CallableSignat
 
   # compatible with 3x AST::Lambda
   # @api public
-  def call(scope, *args)
+  def call(*args)
     variable_bindings = combine_values_with_parameters(args)
 
     tc = Puppet::Pops::Types::TypeCalculator

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -464,7 +464,7 @@ actual:
           end
           def test(x, block)
             # call the block with x
-            block.call(closure_scope, x)
+            block.call(x)
           end
         end
         # add the function to the loader (as if it had been loaded from somewhere)

--- a/spec/unit/pops/binder/injector_spec.rb
+++ b/spec/unit/pops/binder/injector_spec.rb
@@ -752,7 +752,7 @@ describe 'Injector' do
       end
 
       it "should be possible to post process lookup with a ruby proc" do
-        transformer = lambda {|scope, value| value + 1 }
+        transformer = lambda {|value| value + 1 }
         bindings.bind.name('an_int').to(42).producer_options( :transformer => transformer)
         injector(lbinder).lookup(scope, 'an_int').should == 43
       end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -921,7 +921,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
           required_block_param
         end
         def test(count, block)
-          block.call({}, *[].fill(10, 0, count))
+          block.call(*[].fill(10, 0, count))
         end
       end
       the_func = fc.new({}, env_loader)
@@ -938,7 +938,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
           required_block_param
         end
         def test(lambda_arg, block)
-          block.call({}, lambda_arg)
+          block.call(lambda_arg)
         end
       end
       the_func = fc.new({}, env_loader)


### PR DESCRIPTION
This commit was merged to master 3 months ago. It is also needed on stable since it changes the way blocks are called from puppet functions written in Ruby.