### PR TITLE
(PUP-3986) Adds new OID names to Puppet

### DIFF
--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -35,7 +35,20 @@ module Puppet::SSL::Oids
     ["1.3.6.1.4.1.34380.1.1.2", 'pp_instance_id', 'Puppet Node Instance ID'],
     ["1.3.6.1.4.1.34380.1.1.3", 'pp_image_name', 'Puppet Node Image Name'],
     ["1.3.6.1.4.1.34380.1.1.4", 'pp_preshared_key', 'Puppet Node Preshared Key'],
-
+    ["1.3.6.1.4.1.34380.1.1.5", 'pp_cost_center', 'Puppet Node Cost Center Name'],
+    ["1.3.6.1.4.1.34380.1.1.6", 'pp_product', 'Puppet Node Product Name'],
+    ["1.3.6.1.4.1.34380.1.1.7", 'pp_project', 'Puppet Node Project Name'],
+    ["1.3.6.1.4.1.34380.1.1.8", 'pp_application', 'Puppet Node Application Name'],
+    ["1.3.6.1.4.1.34380.1.1.9", 'pp_service', 'Puppet Node Service Name'],
+    ["1.3.6.1.4.1.34380.1.1.10", 'pp_employee', 'Puppet Node Employee Name'],
+    ["1.3.6.1.4.1.34380.1.1.11", 'pp_created_by', 'Puppet Node created_by Tag'],
+    ["1.3.6.1.4.1.34380.1.1.12", 'pp_environment', 'Puppet Node Environment Name'],
+    ["1.3.6.1.4.1.34380.1.1.13", 'pp_role', 'Puppet Node Role Name'],
+    ["1.3.6.1.4.1.34380.1.1.14", 'pp_software_version', 'Puppet Node Software Version'],
+    ["1.3.6.1.4.1.34380.1.1.15", 'pp_department', 'Puppet Node Department Name'],
+    ["1.3.6.1.4.1.34380.1.1.16", 'pp_cluster', 'Puppet Node Cluster Name'],
+    ["1.3.6.1.4.1.34380.1.1.17", 'pp_provisioner', 'Puppet Node Provisioner Name'],
+    
     ["1.3.6.1.4.1.34380.1.2", 'ppPrivCertExt', 'Puppet Private Certificate Extension'],
   ]
 


### PR DESCRIPTION
Introduces 13 new possible named OID references that can be used when
provisioning a node's certificate, allowing for easy reference in the
trusted hash in the Puppet dsl.