### PR TITLE
(PUP-3167) Prevent regex node names from colliding

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -216,8 +216,11 @@ class Puppet::Resource::Type
   end
 
   def name
-    return @name unless @name.is_a?(Regexp)
-    @name.source.downcase.gsub(/[^-\w:.]/,'').sub(/^\.+/,'')
+    if type == :node && name_is_regex?
+      "__node_regexp__#{@name.source.downcase.gsub(/[^-\w:.]/,'').sub(/^\.+/,'')}"
+    else
+      @name
+    end
   end
 
   def name_is_regex?

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -128,11 +128,11 @@ describe Puppet::Resource::Type do
       end
 
       it "should return the regex converted to a string when asked for its name" do
-        expect(Puppet::Resource::Type.new(:node, /ww/).name).to eq("ww")
+        expect(Puppet::Resource::Type.new(:node, /ww/).name).to eq("__node_regexp__ww")
       end
 
       it "should downcase the regex when returning the name as a string" do
-        expect(Puppet::Resource::Type.new(:node, /W/).name).to eq("w")
+        expect(Puppet::Resource::Type.new(:node, /W/).name).to eq("__node_regexp__w")
       end
 
       it "should remove non-alpha characters when returning the name as a string" do


### PR DESCRIPTION
Prior to this commit, it was possible for a node resource to have
a name that collided with another resource. This is due to the fact
that when a resource is created for a node, if the node has a regex
name the regular expression will be munged and altered into a regular
string.

If the munged node name matched the name of another resource, the
two would collide and the collision would go undetected but potentially
case small errors.

In order to prevent this from happening, prepend "__node_regexp__"
to front of resource names that represent nodes which are specified
by a regex in order to prevent a possible collision.