### PR TITLE
(PUP-3930) Optimize `failed_dependencies?`

### DIFF
--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -83,13 +83,13 @@ module Puppet
       #     while evaluating `@real_resource`.
       attr_reader :events
 
-      # @!attribute [rw] dependency_failed
-      #   @return [Boolean] A cache of whether some dependency of this
-      #     resource is known to have failed.
-      attr_accessor :dependency_failed
+      # @!attribute [rw] failed_dependencies
+      #   @return [Array<Puppet::Resource>] A cache of all
+      #   dependencies of this resource that failed to apply.
+      attr_accessor :failed_dependencies
 
       def dependency_failed?
-        dependency_failed
+        failed_dependencies && !failed_dependencies.empty?
       end
 
       # A list of instance variables that should be serialized with this object

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -83,6 +83,15 @@ module Puppet
       #     while evaluating `@real_resource`.
       attr_reader :events
 
+      # @!attribute [rw] dependency_failed
+      #   @return [Boolean] A cache of whether some dependency of this
+      #     resource is known to have failed.
+      attr_accessor :dependency_failed
+
+      def dependency_failed?
+        dependency_failed
+      end
+
       # A list of instance variables that should be serialized with this object
       # when converted to YAML.
       YAML_ATTRIBUTES = %w{@resource @file @line @evaluation_time @change_count

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -352,10 +352,16 @@ describe Puppet::Transaction do
     )
 
     catalog = mk_catalog(exec, file1, file2)
-    catalog.apply
+    transaction = catalog.apply
 
     expect(Puppet::FileSystem.exist?(file1[:path])).to be_falsey
     expect(Puppet::FileSystem.exist?(file2[:path])).to be_falsey
+
+    expect(transaction.resource_status(file1).skipped).to be_truthy
+    expect(transaction.resource_status(file2).skipped).to be_truthy
+
+    expect(transaction.resource_status(file1).failed_dependencies).to eq([exec])
+    expect(transaction.resource_status(file2).failed_dependencies).to eq([exec])
   end
 
   it "on failure, skips dynamically-generated dependents" do


### PR DESCRIPTION
I profiled `puppet agent --test` on one of my servers using stackprof
[1] on Ruby 2.1.

Something like 30% or more of the time was spent in
`Puppet::Graph::SimpleGraph#upstream_from_vertex`, called from
`Puppet::Transaction#failed_dependencies?`

It turns out that, while evaluating the resource graph, when considering
a resource, we look at *the complete set of transitive dependencies* to
evaluate whether any of them have failed. This is hugely expensive, and
moreover, is wasted work in the success case where no resources fail.

Instead of all that work, this patch pushes the work to the *failed*
nodes; When a node fails, we transitively walk the dependents of that
node, and mark them as having failed dependencies, and then check that
flag directly when considering whether to skip a node later.

On my test system, this patch drops `puppet agent --test` runtime from
about 40s to about 23s.

[1] https://github.com/tmm1/stackprof