### PR TITLE
(PUP-3978) Pass block using Ruby semantics, not as normal parameter

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -314,12 +314,8 @@ module Puppet::Functions
       if @block_type.nil?
         @block_type = type
         @block_name = name
-
-        # mark what should be picked for this position when dispatching. This is the size of
-        # the @names array since the block is required to appear last
-        @weaving << @names.size()
       else
-        raise ArgumentError, "Attempt to redefine block"
+        raise ArgumentError, 'Attempt to redefine block'
       end
     end
 
@@ -334,7 +330,7 @@ module Puppet::Functions
       @block_type = Puppet::Pops::Types::TypeFactory.optional(@block_type)
     end
 
-    # Specifies the min and max occurance of arguments (of the specified types)
+    # Specifies the min and max occurrence of arguments (of the specified types)
     # if something other than the exact count from the number of specified
     # types). The max value may be specified as :default if an infinite number of
     # arguments are supported. When max is > than the number of specified
@@ -347,11 +343,12 @@ module Puppet::Functions
       unless min_occurs.is_a?(Integer) && min_occurs >= 0
         raise ArgumentError, "min arg_count of function parameter must be an Integer >=0, got #{min_occurs.class} '#{min_occurs}'"
       end
-      unless max_occurs == :default || (max_occurs.is_a?(Integer) && max_occurs >= 0)
-        raise ArgumentError, "max arg_count of function parameter must be an Integer >= 0, or :default, got #{max_occurs.class} '#{max_occurs}'"
-      end
-      unless max_occurs == :default || (max_occurs.is_a?(Integer) && max_occurs >= min_occurs)
-        raise ArgumentError, "max arg_count must be :default (infinite) or >= min arg_count, got min: '#{min_occurs}, max: '#{max_occurs}'"
+      if max_occurs == :default
+        @last_captures = true
+      else
+        unless max_occurs.is_a?(Integer) && max_occurs >= min_occurs
+          raise ArgumentError, "max arg_count of function parameter must be :default (infinite) or an Integer >= min arg_count, got min: '#{min_occurs}, max: '#{max_occurs}'"
+        end
       end
     end
 

--- a/lib/puppet/functions/assert_type.rb
+++ b/lib/puppet/functions/assert_type.rb
@@ -30,14 +30,14 @@ Puppet::Functions.create_function(:assert_type) do
   # @param type [Type] the type the value must be an instance of
   # @param value [Object] the value to assert
   #
-  def assert_type(type, value, block=nil)
+  def assert_type(type, value)
     unless Puppet::Pops::Types::TypeCalculator.instance?(type,value)
       inferred_type = Puppet::Pops::Types::TypeCalculator.infer(value)
-      if block
+      if block_given?
         # Give the inferred type to allow richer comparisson in the given block (if generalized
         # information is lost).
         #
-        value = block.call(nil, type, inferred_type)
+        value = yield(type, inferred_type)
       else
         # Do not give all the details - i.e. format as Integer, instead of Integer[n, n] for exact value, which
         # is just confusing. (OTOH: may need to revisit, or provide a better "type diff" output.
@@ -52,8 +52,8 @@ Puppet::Functions.create_function(:assert_type) do
   # @param type_string [String] the type the value must be an instance of given in String form
   # @param value [Object] the value to assert
   #
-  def assert_type_s(type_string, value)
+  def assert_type_s(type_string, value, &proc)
     t = Puppet::Pops::Types::TypeParser.new.parse(type_string)
-    assert_type(t, value)
+    block_given? ? assert_type(t, value, &proc) : assert_type(t, value)
   end
 end

--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -59,40 +59,40 @@ Puppet::Functions.create_function(:each) do
     required_block_param 'Callable[1,1]', :block
   end
 
-  def foreach_Hash_1(hash, pblock)
+  def foreach_Hash_1(hash)
     enumerator = hash.each_pair
     hash.size.times do
-      pblock.call(enumerator.next)
+      yield(enumerator.next)
     end
     # produces the receiver
     hash
   end
 
-  def foreach_Hash_2(hash, pblock)
+  def foreach_Hash_2(hash)
     enumerator = hash.each_pair
     hash.size.times do
-      pblock.call(*enumerator.next)
+      yield(*enumerator.next)
     end
     # produces the receiver
     hash
   end
 
-  def foreach_Enumerable_1(enumerable, pblock)
+  def foreach_Enumerable_1(enumerable)
     enum = asserted_enumerable(enumerable)
       begin
-        loop { pblock.call(enum.next) }
+        loop { yield(enum.next) }
       rescue StopIteration
       end
     # produces the receiver
     enumerable
   end
 
-  def foreach_Enumerable_2(enumerable, pblock)
+  def foreach_Enumerable_2(enumerable)
     enum = asserted_enumerable(enumerable)
     index = 0
     begin
       loop do
-        pblock.call(index, enum.next)
+        yield(index, enum.next)
         index += 1
       end
     rescue StopIteration

--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -56,28 +56,28 @@ Puppet::Functions.create_function(:filter) do
     required_block_param 'Callable[1,1]', :block
   end
 
-  def filter_Hash_1(hash, pblock)
-    result = hash.select {|x, y| pblock.call([x, y]) }
+  def filter_Hash_1(hash)
+    result = hash.select {|x, y| yield([x, y]) }
     # Ruby 1.8.7 returns Array
     result = Hash[result] unless result.is_a? Hash
     result
   end
 
-  def filter_Hash_2(hash, pblock)
-    result = hash.select {|x, y| pblock.call(x, y) }
+  def filter_Hash_2(hash)
+    result = hash.select {|x, y| yield(x, y) }
     # Ruby 1.8.7 returns Array
     result = Hash[result] unless result.is_a? Hash
     result
   end
 
-  def filter_Enumerable_1(enumerable, pblock)
+  def filter_Enumerable_1(enumerable)
     result = []
     index = 0
     enum = asserted_enumerable(enumerable)
     begin
       loop do
         it = enum.next
-        if pblock.call(it) == true
+        if yield(it) == true
           result << it
         end
       end
@@ -86,14 +86,14 @@ Puppet::Functions.create_function(:filter) do
     result
   end
 
-  def filter_Enumerable_2(enumerable, pblock)
+  def filter_Enumerable_2(enumerable)
     result = []
     index = 0
     enum = asserted_enumerable(enumerable)
     begin
       loop do
         it = enum.next
-        if pblock.call(index, it) == true
+        if yield(index, it) == true
           result << it
         end
         index += 1

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -54,32 +54,32 @@ Puppet::Functions.create_function(:map) do
     required_block_param 'Callable[1,1]', :block
   end
 
-  def map_Hash_1(hash, pblock)
-    hash.map {|x, y| pblock.call([x, y]) }
+  def map_Hash_1(hash)
+    hash.map {|x, y| yield([x, y]) }
   end
 
-  def map_Hash_2(hash, pblock)
-      hash.map {|x, y| pblock.call(x, y) }
+  def map_Hash_2(hash)
+      hash.map {|x, y| yield(x, y) }
   end
 
-  def map_Enumerable_1(enumerable, pblock)
+  def map_Enumerable_1(enumerable)
     result = []
     index = 0
     enum = asserted_enumerable(enumerable)
     begin
-      loop { result << pblock.call(enum.next) }
+      loop { result << yield(enum.next) }
     rescue StopIteration
     end
     result
   end
 
-  def map_Enumerable_2(enumerable, pblock)
+  def map_Enumerable_2(enumerable)
     result = []
     index = 0
     enum = asserted_enumerable(enumerable)
     begin
       loop do
-        result << pblock.call(index, enum.next)
+        result << yield(index, enum.next)
         index = index +1
       end
     rescue StopIteration

--- a/lib/puppet/functions/reduce.rb
+++ b/lib/puppet/functions/reduce.rb
@@ -74,14 +74,14 @@ Puppet::Functions.create_function(:reduce) do
     required_block_param 'Callable[2,2]', :block
   end
 
-  def reduce_without_memo(enumerable, pblock)
+  def reduce_without_memo(enumerable)
     enum = asserted_enumerable(enumerable)
-    enum.reduce {|memo, x| pblock.call(memo, x) }
+    enum.reduce {|memo, x| yield(memo, x) }
   end
 
-  def reduce_with_memo(enumerable, given_memo, pblock)
+  def reduce_with_memo(enumerable, given_memo)
     enum = asserted_enumerable(enumerable)
-    enum.reduce(given_memo) {|memo, x| pblock.call(memo, x) }
+    enum.reduce(given_memo) {|memo, x| yield(memo, x) }
   end
 
   def asserted_enumerable(obj)

--- a/lib/puppet/functions/scanf.rb
+++ b/lib/puppet/functions/scanf.rb
@@ -36,10 +36,10 @@ Puppet::Functions.create_function(:scanf) do
     optional_block_param
   end
 
-  def scanf(data, format, block=nil)
+  def scanf(data, format)
     result = data.scanf(format)
-    if !block.nil?
-      result = block.call(result)
+    if block_given?
+      result = yield(result)
     end
     result
   end

--- a/lib/puppet/functions/slice.rb
+++ b/lib/puppet/functions/slice.rb
@@ -51,15 +51,15 @@ Puppet::Functions.create_function(:slice) do
     optional_block_param
   end
 
-  def slice_Hash(hash, slice_size, pblock = nil)
-    result = slice_Common(hash, slice_size, [], pblock)
-    pblock ? hash : result
+  def slice_Hash(hash, slice_size, &pblock)
+    result = slice_Common(hash, slice_size, [], block_given? ? pblock : nil)
+    block_given? ? hash : result
   end
 
-  def slice_Enumerable(enumerable, slice_size, pblock = nil)
+  def slice_Enumerable(enumerable, slice_size, &pblock)
     enum = asserted_enumerable(enumerable)
-    result = slice_Common(enum, slice_size, nil, pblock)
-    pblock ? enumerable : result
+    result = slice_Common(enum, slice_size, nil, block_given? ? pblock : nil)
+    block_given? ? enumerable : result
   end
 
   def slice_Common(o, slice_size, filler, pblock)
@@ -101,7 +101,8 @@ Puppet::Functions.create_function(:slice) do
 
   def asserted_slice_serving_size(pblock, slice_size)
     if pblock
-      serving_size = pblock.last_captures_rest? ? slice_size : pblock.parameter_count
+      arity = pblock.arity
+      serving_size = arity < 0 ? slice_size : arity
     else
       serving_size = 1
     end

--- a/lib/puppet/functions/with.rb
+++ b/lib/puppet/functions/with.rb
@@ -18,6 +18,6 @@ Puppet::Functions.create_function(:with) do
   end
 
   def with(*args)
-    args[-1].call(*args[0..-2])
+    yield(*args)
   end
 end

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -102,6 +102,7 @@ module Puppet
       require 'puppet/pops/evaluator/epp_evaluator'
       require 'puppet/pops/evaluator/callable_mismatch_describer'
       require 'puppet/pops/evaluator/collector_transformer'
+      require 'puppet/pops/evaluator/puppet_proc'
       module Collectors
         require 'puppet/pops/evaluator/collectors/abstract_collector'
         require 'puppet/pops/evaluator/collectors/fixed_set_collector'

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -783,10 +783,74 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       call_function(name, evaluated_arguments, o, scope)
     else
       closure = Puppet::Pops::Evaluator::Closure.new(self, o.lambda, scope)
-      call_function(name, evaluated_arguments, o, scope, &Puppet::Pops::Evaluator::PuppetProc.new(closure) { |*args| closure.call(*args) })
+      call_function(name, evaluated_arguments, o, scope, &proc_from_closure(closure))
     end
   end
   private :call_function_with_block
+
+  # Creates a Proc with an arity count that matches the parameters of the given closure. The arity will
+  # be correct up to 10 parameters and then default to varargs (-1)
+  #
+  def proc_from_closure(closure)
+    return Puppet::Pops::Evaluator::PuppetProc.new(closure) { |*args| closure.call(*args) } unless RUBY_VERSION[0,3] == '1.8'
+
+    # This code is required since a Proc isn't propagated by reference in Ruby 1.8.x. It produces a standard
+    # Proc that has correct arity as a replacement for the otherwise used PuppetProc
+    # TODO: Remove when Ruby 1.8.x support is dropped
+    arity = closure.parameters.reduce(0) do |memo, param|
+      count = memo + 1
+      break -count if param.captures_rest || !param.value.nil?
+      count
+    end
+
+    case arity
+    when 0
+      proc { || closure.call }
+    when 1
+      proc { |a| closure.call(a) }
+    when 2
+      proc { |a, b| closure.call(a, b) }
+    when 3
+      proc { |a, b, c| closure.call(a, b, c) }
+    when 4
+      proc { |a, b, c, d| closure.call(a, b, c, d) }
+    when 5
+      proc { |a, b, c, d, e| closure.call(a, b, c, d, e) }
+    when 6
+      proc { |a, b, c, d, e, f| closure.call(a, b, c, d, e, f) }
+    when 7
+      proc { |a, b, c, d, e, f, g| closure.call(a, b, c, d, e, f, g) }
+    when 8
+      proc { |a, b, c, d, e, f, g, h| closure.call(a, b, c, d, e, f, g, h) }
+    when 9
+      proc { |a, b, c, d, e, f, g, h, i| closure.call(a, b, c, d, e, f, g, h, i) }
+    when 10
+      proc { |a, b, c, d, e, f, g, h, i, j| closure.call(a, b, c, d, e, f, g, h, i, j) }
+    when -1
+      proc { |*v| closure.call(*v) }
+    when -2
+      proc { |a, *v| closure.call(a, *v) }
+    when -3
+      proc { |a, b, *v| closure.call(a, b, *v) }
+    when -4
+      proc { |a, b, c, *v| closure.call(a, b, c, *v) }
+    when -5
+      proc { |a, b, c, d, *v| closure.call(a, b, c, d, *v) }
+    when -6
+      proc { |a, b, c, d, e, *v| closure.call(a, b, c, d, e, *v) }
+    when -7
+      proc { |a, b, c, d, e, f, *v| closure.call(a, b, c, d, e, f, *v) }
+    when -8
+      proc { |a, b, c, d, e, f, g, *v| closure.call(a, b, c, d, e, f, g, *v) }
+    when -9
+      proc { |a, b, c, d, e, f, g, h, *v| closure.call(a, b, c, d, e, f,g, h, *v) }
+    when -10
+      proc { |a, b, c, d, e, f, g, h, i, *v| closure.call(a, b, c, d, e, f,g, h, i, *v) }
+    else
+      proc { |*a| closure.call(*a) }
+    end
+  end
+  private :proc_from_closure
 
   # @example
   #   $x ? { 10 => true, 20 => false, default => 0 }

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -760,7 +760,7 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       fail(Issues::ILLEGAL_EXPRESSION, o.functor_expr, {:feature=>'function name', :container => o})
     end
     name = o.functor_expr.value
-    call_function_or_method(name, unfold([], o.arguments, scope), o, scope)
+    call_function_with_block(name, unfold([], o.arguments, scope), o, scope)
   end
 
   # Evaluation of CallMethodExpression handles a NamedAccessExpression functor (receiver.function_name)
@@ -775,10 +775,10 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       fail(Issues::ILLEGAL_EXPRESSION, o.functor_expr, {:feature=>'function name', :container => o})
     end 
     name = name.value # the string function name
-    call_function_or_method(name, unfold([receiver], o.arguments || [], scope), o, scope)
+    call_function_with_block(name, unfold([receiver], o.arguments || [], scope), o, scope)
   end
 
-  def call_function_or_method(name, evaluated_arguments, o, scope)
+  def call_function_with_block(name, evaluated_arguments, o, scope)
     if o.lambda.nil?
       call_function(name, evaluated_arguments, o, scope)
     else
@@ -786,7 +786,7 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       call_function(name, evaluated_arguments, o, scope, &Puppet::Pops::Evaluator::PuppetProc.new(closure) { |*args| closure.call(*args) })
     end
   end
-  private :call_function_or_method
+  private :call_function_with_block
 
   # @example
   #   $x ? { 10 => true, 20 => false, default => 0 }

--- a/lib/puppet/pops/evaluator/puppet_proc.rb
+++ b/lib/puppet/pops/evaluator/puppet_proc.rb
@@ -1,16 +1,48 @@
+# Complies with Proc API by mapping a Puppet::Pops::Evaluator::Closure to a ruby Proc.
+# Creating and passing an instance of this class instead of just a plain block makes
+# it possible to inherit the parameter info and arity from the closure. Advanced users
+# may also access the closure itself. The Puppet::Pops::Functions::Dispatcher uses this
+# when it needs to get the Callable type of the closure.
+#
+# The class is part of the Puppet Function API for Ruby and thus public API but a user
+# should never create an instance of this class.
+#
+# @api public
 class Puppet::Pops::Evaluator::PuppetProc < Proc
+  # Creates a new instance from a closure and a block that will dispatch
+  # all parameters to the closure. The block must be similar to:
+  #
+  #   { |*args| closure.call(*args) }
+  #
+  # @param closure [Puppet::Pops::Evaluator::Closure] The closure to map
+  # @param &block [Block] The varargs block that invokes the closure.call method
+  #
+  # @api private
   def self.new(closure, &block)
     proc = super(&block)
     proc.instance_variable_set(:@closure, closure)
     proc
   end
 
+  # @return  [Puppet::Pops::Evaluator::Closure] the mapped closure
+  # @api public
   attr_reader :closure
 
+  # @overrides Block.lambda?
+  # @return [Boolean] always false since this proc doesn't do the Ruby lambda magic
+  # @api public
   def lambda?
     false
   end
 
+  # Maps the closure parameters to standard Block parameter info where each
+  # parameter is represented as a two element Array where the first
+  # element is :req, :opt, or :rest and the second element is the name
+  # of the parameter.
+  #
+  # @return [Array<Array<Symbol>>] array of parameter info pairs
+  # @overrides Block.parameters
+  # @api public
   def parameters
     @closure.parameters.map do |param|
       sym = param.name.to_sym
@@ -24,6 +56,9 @@ class Puppet::Pops::Evaluator::PuppetProc < Proc
     end
   end
 
+  # @return [Fixnum] the arity of the block
+  # @overrides Block.arity
+  # @api public
   def arity
     parameters.reduce(0) do |memo, param|
       count = memo + 1

--- a/lib/puppet/pops/evaluator/puppet_proc.rb
+++ b/lib/puppet/pops/evaluator/puppet_proc.rb
@@ -1,0 +1,34 @@
+class Puppet::Pops::Evaluator::PuppetProc < Proc
+  def self.new(closure, &block)
+    proc = super(&block)
+    proc.instance_variable_set(:@closure, closure)
+    proc
+  end
+
+  attr_reader :closure
+
+  def lambda?
+    false
+  end
+
+  def parameters
+    @closure.parameters.map do |param|
+      sym = param.name.to_sym
+      if param.captures_rest
+        [ :rest, sym ]
+      elsif param.value
+        [ :opt, sym ]
+      else
+        [ :req, sym ]
+      end
+    end
+  end
+
+  def arity
+    parameters.reduce(0) do |memo, param|
+      count = memo + 1
+      break -count unless param[0] == :req
+      count
+    end
+  end
+end

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -229,14 +229,14 @@ module Puppet::Pops::Evaluator::Runtime3Support
     n
   end
 
-  def call_function(name, args, o, scope)
+  def call_function(name, args, o, scope, &block)
     # Call via 4x API if the function exists there
     loaders = scope.compiler.loaders
     # find the loader that loaded the code, or use the private_environment_loader (sees env + all modules)
     adapter = Puppet::Pops::Utils.find_adapter(o, Puppet::Pops::Adapters::LoaderAdapter)
     loader = adapter.nil? ? loaders.private_environment_loader : adapter.loader
     if loader && func = loader.load(:function, name)
-      return func.call(scope, *args)
+      return func.call(scope, *args, &block)
     end
 
     # Call via 3x API if function exists there
@@ -245,7 +245,7 @@ module Puppet::Pops::Evaluator::Runtime3Support
     # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.
     # NOTE: Passing an empty string last converts nil/:undef to empty string
     mapped_args = Puppet::Pops::Evaluator::Runtime3Converter.map_args(args, scope, '')
-    result = scope.send("function_#{name}", mapped_args)
+    result = scope.send("function_#{name}", mapped_args, &block)
     # Prevent non r-value functions from leaking their result (they are not written to care about this)
     Puppet::Parser::Functions.rvalue?(name) ? result : nil
   end

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -41,21 +41,22 @@ class Puppet::Pops::Functions::Dispatch < Puppet::Pops::Evaluator::CallableSigna
   end
 
   # @api private
-  def invoke(instance, calling_scope, args)
-    instance.send(@method_name, *weave(calling_scope, args))
+  def invoke(instance, calling_scope, args, &block)
+    instance.send(@method_name, *weave(calling_scope, args), &block)
   end
 
   # @api private
   def weave(scope, args)
     # no need to weave if there are no injections
-    if injections.empty?
+    if @injections.empty?
       args
     else
       injector = nil # lazy lookup of injector Puppet.lookup(:injector)
-      weaving.map do |knit|
+      new_args = []
+      @weaving.each do |knit|
         if knit.is_a?(Array)
           injection_data = @injections[knit[0]]
-          case injection_data[3]
+          new_args << case injection_data[3]
           when :dispatcher_internal
             # currently only supports :scope injection
             scope
@@ -67,10 +68,12 @@ class Puppet::Pops::Functions::Dispatch < Puppet::Pops::Evaluator::CallableSigna
             injector.lookup(scope, injection_data[0], injection_data[2])
           end
         else
-          # pick that argument (injection of static value)
-          args[knit]
+          # Careful so no new nil arguments are added since they would override default
+          # parameter values in the received
+          new_args << args[knit] if knit < args.size
         end
       end
+      new_args
     end
   end
 end

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -56,17 +56,18 @@ class Puppet::Pops::Functions::Dispatch < Puppet::Pops::Evaluator::CallableSigna
       @weaving.each do |knit|
         if knit.is_a?(Array)
           injection_data = @injections[knit[0]]
-          new_args << case injection_data[3]
-          when :dispatcher_internal
-            # currently only supports :scope injection
-            scope
-          when :producer
-            injector ||= Puppet.lookup(:injector)
-            injector.lookup_producer(scope, injection_data[0], injection_data[2])
-          else
-            injector ||= Puppet.lookup(:injector)
-            injector.lookup(scope, injection_data[0], injection_data[2])
-          end
+          new_args <<
+            case injection_data[3]
+            when :dispatcher_internal
+              # currently only supports :scope injection
+              scope
+            when :producer
+              injector ||= Puppet.lookup(:injector)
+              injector.lookup_producer(scope, injection_data[0], injection_data[2])
+            else
+              injector ||= Puppet.lookup(:injector)
+              injector.lookup(scope, injection_data[0], injection_data[2])
+            end
         else
           # Careful so no new nil arguments are added since they would override default
           # parameter values in the received

--- a/lib/puppet/pops/functions/dispatcher.rb
+++ b/lib/puppet/pops/functions/dispatcher.rb
@@ -27,12 +27,12 @@ class Puppet::Pops::Functions::Dispatcher
   # @return [Object] - what the called function produced
   #
   # @api private
-  def dispatch(instance, calling_scope, args)
+  def dispatch(instance, calling_scope, args, &block)
     tc = Puppet::Pops::Types::TypeCalculator
-    actual = tc.infer_set(args)
+    actual = tc.infer_set(block_given? ? args + [block] : args)
     found = @dispatchers.find { |d| tc.callable?(d.type, actual) }
     if found
-      found.invoke(instance, calling_scope, args)
+      found.invoke(instance, calling_scope, args, &block)
     else
       raise ArgumentError, "function '#{instance.class.name}' called with mis-matched arguments\n#{Puppet::Pops::Evaluator::CallableMismatchDescriber.diff_string(instance.class.name, actual, @dispatchers)}"
     end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -798,6 +798,32 @@ class Puppet::Pops::Types::TypeCalculator
     Types::PNilType.new()
   end
 
+  # @api private
+  # @param o [Proc]
+  def infer_Proc(o)
+    min = 0
+    max = 0
+    mapped_types = o.parameters.map do |p|
+      case p[0]
+      when :rest
+        max = :default
+        break @t
+      when :req
+        min += 1
+      end
+      max += 1
+      @t
+    end
+    mapped_types << min
+    mapped_types << max
+    Types::TypeFactory.callable(*mapped_types)
+  end
+
+  # @api private
+  def infer_PuppetProc(o)
+    infer_Closure(o.closure)
+  end
+
   # Inference of :default as PDefaultType, and all other are Ruby[Symbol]
   # @api private
   def infer_Symbol(o)

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -803,19 +803,36 @@ class Puppet::Pops::Types::TypeCalculator
   def infer_Proc(o)
     min = 0
     max = 0
-    mapped_types = o.parameters.map do |p|
-      case p[0]
-      when :rest
-        max = :default
-        break @t
-      when :req
-        min += 1
+    if o.respond_to?(:parameters)
+      mapped_types = o.parameters.map do |p|
+        param_t = Types::PAnyType.new
+        case p[0]
+        when :rest
+          max = :default
+          break param_t
+        when :req
+          min += 1
+        end
+        max += 1
+      	param_t
       end
-      max += 1
-      @t
+    else
+      # Cannot correctly compute the signature in Ruby 1.8.7 because arity for
+      # optional values is screwed up (there is no way to get the upper limit),
+      # an optional looks the same as a varargs.
+      arity = o.arity
+      if arity < 0
+        min = -arity - 1
+        max = :default # i.e. infinite (which is wrong when there are optional - flaw in 1.8.7)
+      else
+        min = max = arity
+      end
+      mapped_types = Array.new(min) { Types::PAnyType.new }
     end
-    mapped_types << min
-    mapped_types << max
+    if min == 0 || min != max
+      mapped_types << min
+      mapped_types << max
+    end
     Types::TypeFactory.callable(*mapped_types)
   end
 

--- a/spec/integration/parser/future_compiler_spec.rb
+++ b/spec/integration/parser/future_compiler_spec.rb
@@ -600,12 +600,17 @@ describe "Puppet::Parser::Compiler" do
         expect(catalog).to have_resource("Notify[value second]")
       end
 
-      it 'denies when missing required arguments' do
-        expect do
-          compile_to_catalog(<<-MANIFEST)
-            with(1) |$x, $y| { }
-          MANIFEST
-        end.to raise_error(/Parameter \$y is required but no value was given/m)
+      # Conditinoally left out for Ruby 1.8.x since the Proc created for the expected number of arguments will accept
+      # a call with fewer arguments and then pass all arguments to the closure. The closure then receives an argument
+      # array of correct size with nil values instead of an array with too few arguments
+      unless RUBY_VERSION[0,3] == '1.8'
+        it 'denies when missing required arguments' do
+          expect do
+            compile_to_catalog(<<-MANIFEST)
+              with(1) |$x, $y| { }
+            MANIFEST
+          end.to raise_error(/Parameter \$y is required but no value was given/m)
+        end
       end
 
       it 'accepts anything when parameters are untyped' do

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -3,19 +3,10 @@ require 'puppet/pops'
 require 'puppet/loaders'
 
 describe 'the assert_type function' do
-
   after(:all) { Puppet::Pops::Loaders.clear }
 
-  around(:each) do |example|
-    loaders = Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, []))
-    Puppet.override({:loaders => loaders}, "test-example") do
-      example.run
-    end
-  end
-
-  let(:func) do
-    Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'assert_type')
-  end
+  let(:loaders) { Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, [])) }
+  let(:func) { loaders.puppet_system_loader.load(:function, 'assert_type') }
 
   it 'asserts compliant type by returning the value' do
     expect(func.call({}, type(String), 'hello world')).to eql('hello world')
@@ -50,9 +41,10 @@ actual:
   end
 
   it 'can be called with a callable that receives a specific type' do
-    expected, actual = func.call({}, optional(String), 1, create_callable_2_args_unit)
+    expected, actual, actual2 = func.call({}, 'Optional[String]', 1) { |expected, actual| [expected, actual, actual] }
     expect(expected.to_s).to eql('Optional[String]')
     expect(actual.to_s).to eql('Integer[1, 1]')
+    expect(actual2.to_s).to eql('Integer[1, 1]')
   end
 
   def optional(type_ref)
@@ -61,18 +53,5 @@ actual:
 
   def type(type_ref)
     Puppet::Pops::Types::TypeFactory.type_of(type_ref)
-  end
-
-  def create_callable_2_args_unit()
-    Puppet::Functions.create_function(:func) do
-      dispatch :func do
-        param 'Type', 'expected'
-        param 'Type', 'actual'
-      end
-
-      def func(expected, actual)
-        [expected, actual]
-      end
-    end.new({}, nil)
   end
 end

--- a/spec/unit/functions/with_spec.rb
+++ b/spec/unit/functions/with_spec.rb
@@ -27,9 +27,14 @@ describe 'the with function' do
     expect(compile_to_catalog('notify { test: message => "data" } with(Notify[test]) |$x| { notify { "${x[message]}": } }')).to have_resource('Notify[data]')
   end
 
-  it 'errors when not given enough arguments for the lambda' do
-    expect do
-      compile_to_catalog('with(1) |$x, $y| { }')
-    end.to raise_error(/Parameter \$y is required but no value was given/m)
+  # Conditinoally left out for Ruby 1.8.x since the Proc created for the expected number of arguments will accept
+  # a call with fewer arguments and then pass all arguments to the closure. The closure then receives an argument
+  # array of correct size with nil values instead of an array with too few arguments
+  unless RUBY_VERSION[0,3] == '1.8'
+    it 'errors when not given enough arguments for the lambda' do
+      expect do
+        compile_to_catalog('with(1) |$x, $y| { }')
+      end.to raise_error(/Parameter \$y is required but no value was given/m)
+    end
   end
 end

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -273,15 +273,12 @@ actual:
 
     context 'supports lambdas' do
       it 'such that, a required block can be defined and given as an argument' do
-        # use a Function as callable
-        the_callable = create_min_function_class().new(:closure_scope, :loader)
         the_function = create_function_with_required_block_all_defaults().new(:closure_scope, :loader)
-        result = the_function.call({}, 10, the_callable)
-        expect(result).to be(the_callable)
+        result = the_function.call({}, 7) { |a,b| a < b ? a : b }
+        expect(result).to eq(7)
       end
 
       it 'such that, a missing required block when called raises an error' do
-        # use a Function as callable
         the_function = create_function_with_required_block_all_defaults().new(:closure_scope, :loader)
         expect do
           the_function.call({}, 10)
@@ -294,24 +291,19 @@ actual:
       end
 
       it 'such that, an optional block can be defined and given as an argument' do
-        # use a Function as callable
-        the_callable = create_min_function_class().new(:closure_scope, :loader)
         the_function = create_function_with_optional_block_all_defaults().new(:closure_scope, :loader)
-        result = the_function.call({}, 10, the_callable)
-        expect(result).to be(the_callable)
+        result = the_function.call({}, 4) { |a,b| a < b ? a : b }
+        expect(result).to eql(4)
       end
 
       it 'such that, an optional block can be omitted when called and gets the value nil' do
-        # use a Function as callable
         the_function = create_function_with_optional_block_all_defaults().new(:closure_scope, :loader)
-        expect(the_function.call({}, 10)).to be_nil
+        expect(the_function.call({}, 2)).to be_nil
       end
 
       it 'such that, a scope can be injected and a block can be used' do
-        # use a Function as callable
-        the_callable = create_min_function_class().new(:closure_scope, :loader)
         the_function = create_function_with_scope_required_block_all_defaults().new(:closure_scope, :loader)
-        expect(the_function.call({}, 10, the_callable)).to be(the_callable)
+        expect(the_function.call({}, 1) { |a,b| a < b ? a : b }).to eql(1)
       end
     end
 
@@ -462,9 +454,9 @@ actual:
             # block called 'the_block', and using "all_callables"
             required_block_param #(all_callables(), 'the_block')
           end
-          def test(x, block)
+          def test(x)
             # call the block with x
-            block.call(x)
+            yield(x)
           end
         end
         # add the function to the loader (as if it had been loaded from somewhere)
@@ -611,9 +603,8 @@ actual:
         # use defaults, any callable, name is 'block'
         required_block_param
       end
-      def test(x, block)
-        # returns the block to make it easy to test what it got when called
-        block
+      def test(x)
+        yield(8,x)
       end
     end
   end
@@ -626,9 +617,8 @@ actual:
         # use defaults, any callable, name is 'block'
         required_block_param
       end
-      def test(scope, x, block)
-        # returns the block to make it easy to test what it got when called
-        block
+      def test(scope, x)
+        yield(3,x)
       end
     end
   end
@@ -640,9 +630,8 @@ actual:
         # use defaults, any callable, name is 'block'
         required_block_param 'the_block'
       end
-      def test(x, block)
-        # returns the block to make it easy to test what it got when called
-        block
+      def test(x)
+        yield
       end
     end
   end
@@ -653,9 +642,8 @@ actual:
         param 'Integer', 'x'
         required_block_param
       end
-      def test(x, block)
-        # returns the block to make it easy to test what it got when called
-        block
+      def test(x)
+        yield
       end
     end
   end
@@ -667,9 +655,8 @@ actual:
         # use defaults, any callable, name is 'block'
         required_block_param('Callable', 'the_block')
       end
-      def test(x, block)
-        # returns the block to make it easy to test what it got when called
-        block
+      def test(x)
+        yield
       end
     end
   end
@@ -681,10 +668,8 @@ actual:
         # use defaults, any callable, name is 'block'
         optional_block_param
       end
-      def test(x, block=nil)
-        # returns the block to make it easy to test what it got when called
-        # a default of nil must be used or the call will fail with a missing parameter
-        block
+      def test(x)
+        yield(5,x) if block_given?
       end
     end
   end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -920,8 +920,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
           param 'Integer', 'count'
           required_block_param
         end
-        def test(count, block)
-          block.call(*[].fill(10, 0, count))
+        def test(count)
+          yield(*[].fill(10, 0, count))
         end
       end
       the_func = fc.new({}, env_loader)
@@ -937,8 +937,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
           param 'Any', 'lambda_arg'
           required_block_param
         end
-        def test(lambda_arg, block)
-          block.call(lambda_arg)
+        def test(lambda_arg)
+          yield(lambda_arg)
         end
       end
       the_func = fc.new({}, env_loader)


### PR DESCRIPTION
Passing a block as a normal parameter messed up the notion of
optional parameters since the last parameter could be a required
block. It also made the calling convention somewhat unorthodox
from a ruby developers point of view.

This commit introduces a new class 'PuppetProc' derived from the Ruby
'Proc'. It wrapps the normal closure that would otherwise be passed in
a parameter and enables it to instead be passed as a block, thus
making it possible to use standard calls like 'block_given?' and
'yield' to execute a Puppet lambda from Ruby.

The 'TypeCalculator' will infer a 'PuppetProc' to the type of its
closure. It is also capable of inferring a normal ruby 'Proc' using the
information returned by its 'parameters' method so that all parameters
are of type 'Any' and the min/max is controlled by the :req, :opt, and
:rest indicators of the parameter info arrays.