### PR TITLE
DO NOT MERGE (QENG-1800) Install MSI during package acceptance

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -232,6 +232,20 @@ module Puppet
           on host, "#{gem} source --add #{gem_source}"
         end
       end
+
+      def install_puppet_from_msi( host, opts )
+        if not link_exists?(opts[:url])
+          raise "Puppet does not exist at #{opts[:url]}!"
+        end
+
+        # `start /w` blocks until installation is complete, but needs to be wrapped in `cmd.exe /c`
+        on host, "cmd.exe /c start /w msiexec /qn /i #{opts[:url]}"
+
+        # make sure install is sane, beaker has already added puppet and ruby
+        # to PATH in ~/.ssh/environment
+        on host, puppet('--version')
+        on host, 'ruby --version'
+      end
     end
   end
 end

--- a/acceptance/setup/packages/pre-suite/010_Install.rb
+++ b/acceptance/setup/packages/pre-suite/010_Install.rb
@@ -48,5 +48,15 @@ AGENT_PACKAGES = {
 install_packages_on(master, MASTER_PACKAGES)
 install_packages_on(agents, AGENT_PACKAGES)
 
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    arch = agent[:ruby_arch] || 'x86'
+    base_url = "http://builds.puppetlabs.lan/puppet/#{ENV['SHA']}/artifacts/windows"
+    filename = "puppet-agent-#{ENV['VERSION']}-#{arch}.msi"
+
+    install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
+  end
+end
+
 configure_gem_mirror(hosts)
 


### PR DESCRIPTION
Previously it was not possible to run windows acceptance against FOSS
MSI packages. This commit adds a step to install the puppet-agent MSI. It
depends on https://github.com/puppetlabs/beaker/pull/674

With this commit you can do:

    $ bundle exec rake ci:test:packages \
        CONFIG=config/nodes/win2008r2-rubyx64.yaml \
        SHA=<SHA> VERSION=3.7.4-1303

Note the VERSION string must match the filename of the MSI which
includes the output from `git describe`. The host definition file needs
to specify which `ruby_arch` it wants to install, either x86 or x64.