### PR TITLE
(PUP-3998) Fix interpolation of "${0[...]}"

### DIFF
--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -45,7 +45,7 @@ class Puppet::Pops::Model::ModelLabelProvider < Puppet::Pops::LabelProvider
   def label_LiteralRegularExpression o    ; "Regular Expression"                end
   def label_Nop o                         ; "Nop Expression"                    end
   def label_NamedAccessExpression o       ; "'.' expression"                    end
-  def label_NilClass o                    ; "Nil Object"                        end
+  def label_NilClass o                    ; "Undef Value"                       end
   def label_NotExpression o               ; "'not' expression"                  end
   def label_VariableExpression o          ; "Variable"                          end
   def label_TextExpression o              ; "Expression in Interpolated String" end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -478,11 +478,13 @@ class Puppet::Pops::Validation::Checker4_0
 
   # Checks that variable is either strictly 0, or a non 0 starting decimal number, or a valid VAR_NAME
   def check_VariableExpression(o)
-    # The expression must be a qualified name
-    if !o.expr.is_a?(Model::QualifiedName)
+    # The expression must be a qualified name or an integer
+    name_expr = o.expr
+    return if name_expr.is_a?(Model::LiteralInteger)
+    if !name_expr.is_a?(Model::QualifiedName)
       acceptor.accept(Issues::ILLEGAL_EXPRESSION, o, :feature => 'name', :container => o)
     else
-      # name must be either a decimal value, or a valid NAME
+      # name must be either a decimal string value, or a valid NAME
       name = o.expr.value
       if name[0,1] =~ /[0-9]/
         unless name =~ Puppet::Pops::Patterns::NUMERIC_VAR_NAME

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1050,6 +1050,26 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       expect(parser.evaluate_string(scope, source, __FILE__)).to eql('10')
     end
 
+    it 'should accept a numeric variable expressed as $n' do
+      source = '$x = "abc123def" =~ /(abc)(123)(def)/; "${$2}"'
+      expect(parser.evaluate_string(scope, source, __FILE__)).to eql('123')
+    end
+
+    it 'should accept a numeric variable expressed as just an integer' do
+      source = '$x = "abc123def" =~ /(abc)(123)(def)/; "${2}"'
+      expect(parser.evaluate_string(scope, source, __FILE__)).to eql('123')
+    end
+
+    it 'should accept a numeric variable expressed as $n in an access operation' do
+      source = '$x = "abc123def" =~ /(abc)(123)(def)/; "${$0[4,3]}"'
+      expect(parser.evaluate_string(scope, source, __FILE__)).to eql('23d')
+    end
+
+    it 'should accept a numeric variable expressed as just an integer in an access operation' do
+      source = '$x = "abc123def" =~ /(abc)(123)(def)/; "${0[4,3]}"'
+      expect(parser.evaluate_string(scope, source, __FILE__)).to eql('23d')
+    end
+
     {
       '"value is ${a*2} yo"'  => :error,
     }.each do |source, result|


### PR DESCRIPTION
When interpolating a short form numeric variable name (e.g. ${0}) and
continuing with an access operation (to take a substring e.g.
${0[2,4]}) this failed because the validation of a Variable expected the
name of the variable to always be a NAME, not an integer).

This fixes the validation logic, and adds tests.

Also fixed is the label provider which now provides the label "Undef
Value" instead of "Nil Object".