### PR TITLE
(SERVER-360) Add deps for "common package name" test

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -40,6 +40,9 @@ end
 
 # Setup repo and package
 hosts_to_test.each do |agent|
+  # (SERVER-360) Install dependencies requires for repository and package setup
+  install_package agent, 'createrepo'
+  install_package agent, 'rpm-build'
   clean_rpm agent, rpm_options
   setup_rpm agent, rpm_options
   send_rpm agent, rpm_options


### PR DESCRIPTION
Without this patch the `common_package_name_in_different_providers` acceptance
test is failing in puppet-server with a `createrepo: command not found` error
and exit code of 127.

This patch addresses the problem by ensuring the necessary dependencies of
createrepo and rpm-utils are installed on the system under test.