### PR TITLE
(PUP-4012) Dont merge lines with uppercase Q

### DIFF
--- a/lib/puppet/util/fileparsing.rb
+++ b/lib/puppet/util/fileparsing.rb
@@ -214,8 +214,9 @@ module Puppet::Util::FileParsing
 
   # Split text into separate lines using the record separator.
   def lines(text)
-    # Remove any trailing separators, and then split based on them
-    text.sub(/#{self.line_separator}\Q/,'').split(self.line_separator)
+    # NOTE: We do not have to remove trailing separators because split will ignore
+    # them by default (unless you pass -1 as a second parameter)
+    text.split(self.line_separator)
   end
 
   # Split a bunch of text into lines and then parse them individually.

--- a/spec/fixtures/unit/provider/parsedfile/simple.txt
+++ b/spec/fixtures/unit/provider/parsedfile/simple.txt
@@ -2,3 +2,6 @@
 # HEADER As added by software from a third party.
 # Another inconspicuous comment.
 A generic content line with: a value.
+A_second_line_with_no_spaces
+Qexample for bug PUP-4012
+Another line


### PR DESCRIPTION
If the fileparsing parses a file that includes a line that starts with
an uppercase Q, this line is merged with the previous line, so

    foo
    Quest
    bar

becomes

    foouest
    bar

this can have some serious and unexpected sideeffects. The problem lies
in the way how trailing line seperators are removed. The current regex
"\n\Q" (given the fact that line seperator is \n is most cases) looks
like some perlish regex. But in fact `\Q` does not have a special
meaning here and is translated to a literal `Q` instead. As a result the
newline and the `Q` from the following line are just removed.

However the split method does ignore trailing delimiter by default

    irb(main):003:0> "foo\nbar\n\n".split("\n")
    => ["foo", "bar"]

so I am not sure of the original intention. The fact that this caused no
issue so far is because most files (cron, /etc/hosts) that currently
make use of the provider do not use words at the start (at least not in
uppercase). The issue was found in the `oratab` provider
(https://forge.puppetlabs.com/stschulte/oracle) that parses database
names in `/etc/oratab` which are all uppercase. If you install a
database that starts with the letter `Q` you are screwed :-)