### PR TITLE
(DO NOT MERGE)(QENG-1800) Install MSI during package acceptance

### DIFF
--- a/acceptance/config/nodes/win2012r2-rubyx64.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx64.yaml
@@ -5,6 +5,15 @@ HOSTS:
     platform: el-7-x86_64
     hypervisor: vcloud
     template: redhat-7-x86_64
+    systembindir: /opt/puppetlabs/agent/bin
+    puppetconfdir: /etc/puppetlabs/agent
+    puppetcodedir: /etc/puppetlabs/agent
+    puppetvardir: /opt/puppetlabs/agent/cache
+    distmoduledir: /etc/puppetlabs/agent/modules
+    # puppet-agent 0.3.1 package on the master still uses /usr/share
+    sitemoduledir: /usr/share/puppet/modules
+    hieraconf: /etc/puppetlabs/puppet/hiera.yaml
+    puppetserver-confdir: /etc/puppetserver/conf.d/
   agent-2012r2-x86_64-rubyx64:
     roles:
       - agent
@@ -12,6 +21,13 @@ HOSTS:
     ruby_arch: x64
     hypervisor: vcloud
     template: win-2012r2-x86_64
+    puppetconfdir: C:/ProgramData/PuppetLabs/puppet/etc
+    puppetcodedir: C:/ProgramData/PuppetLabs/puppet/etc
+    puppetvardir: C:/ProgramData/PuppetLabs/puppet/var
+    distmoduledir: C:/ProgramData/PuppetLabs/puppet/etc/modules
+    # puppet-agent 0.3.1 package on the master still uses /usr/share
+    sitemoduledir: C:/usr/share/puppet/modules
+    hieraconf: C:/ProgramData/PuppetLabs/puppet/etc/hiera.yaml
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -242,6 +242,20 @@ module Puppet
           on host, "#{gem} source --add #{gem_source}"
         end
       end
+
+      def install_puppet_from_msi( host, opts )
+        if not link_exists?(opts[:url])
+          raise "Puppet does not exist at #{opts[:url]}!"
+        end
+
+        # `start /w` blocks until installation is complete, but needs to be wrapped in `cmd.exe /c`
+        on host, "cmd.exe /c start /w msiexec /qn /i #{opts[:url]} /L*V C:\\Windows\\Temp\\Puppet-Install.log"
+
+        # make sure install is sane, beaker has already added puppet and ruby
+        # to PATH in ~/.ssh/environment
+        on host, puppet('--version')
+        on host, 'ruby --version'
+      end
     end
   end
 end

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -54,4 +54,14 @@ AGENT_PACKAGES = {
 install_packages_on(master, MASTER_PACKAGES)
 install_packages_on(agents, AGENT_PACKAGES)
 
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    arch = agent[:ruby_arch] || 'x86'
+    base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{ENV['SHA']}/artifacts/windows"
+    filename = ENV['MSI_FILENAME'] || "puppet-agent-#{ENV['VERSION']}-#{arch}.msi"
+
+    install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
+  end
+end
+
 configure_gem_mirror(hosts)

--- a/acceptance/setup/packages/pre-suite/010_Install.rb
+++ b/acceptance/setup/packages/pre-suite/010_Install.rb
@@ -48,5 +48,15 @@ AGENT_PACKAGES = {
 install_packages_on(master, MASTER_PACKAGES)
 install_packages_on(agents, AGENT_PACKAGES)
 
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    arch = agent[:ruby_arch] || 'x86'
+    base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet/#{ENV['SHA']}/artifacts/windows"
+    filename = ENV['MSI_FILENAME'] || "puppet-agent-#{ENV['VERSION']}-#{arch}.msi"
+
+    install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
+  end
+end
+
 configure_gem_mirror(hosts)
 


### PR DESCRIPTION
Previously it was not possible to run Windows acceptance against FOSS
MSI packages. This commit adds a step to both the package and aio
rake tasks that can install the puppet-agent MSI.
It depends on https://github.com/puppetlabs/beaker/pull/674

With this commit you can do:

    $ bundle exec rake ci:test:packages \
        CONFIG=config/nodes/win2008r2-rubyx64.yaml \
        SHA=<SHA> VERSION=3.7.4-1303

    $ bundle exec rake ci:test:aio \
        CONFIG=config/nodes/win2012r2-rubyx64.yaml \
        SHA=<SHA> VERSION=1.0.0-o-ga354e25 \
        MSI_BASE_URL=http://int-resources.corp.puppetlabs.net/aio

Note the VERSION string must match the filename of the MSI which
includes the output from `git describe`. The host definition file needs
to specify which `ruby_arch` it wants to install, either x86 or x64.

Given one off builds may wish to be tested that are not products
of the build pipeline, the MSI url and filename may be overridden
completely with two environment variables:

* MSI_BASE_URL may optionally override the URL that Puppet can be
retrieved from, which normally defaults to:

`http://builds.puppetlabs.lan/puppet(-agent)/<SHA>/artifacts/windows`

* MSI_FILENAME may optionally override the filename that Puppet pulls
the MSI from, which normally defaults to:

`puppet-agent-<VERSION>-<arch>.msi`