### PR TITLE
(PUP-4008) Consider empty hash assignable to any Hash with size 0

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -1429,7 +1429,8 @@ class Puppet::Pops::Types::TypeCalculator
   # @api private
   def assignable_PHashType(t, t2)
     case t2
-    when Types::PHashType
+      when Types::PHashType
+      return true if (t.size_type.nil? || t.size_type.from == 0) && t2.is_the_empty_hash?
       return false unless assignable?(t.key_type, t2.key_type) && assignable?(t.element_type, t2.element_type)
       assignable_PCollectionType(t, t2)
     when Types::PStructType

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -344,9 +344,12 @@ module Puppet::Pops
           self.element_type == o.element_type  &&
           self.size_type    == o.size_type
         end
+
+        def is_the_empty_hash?
+          size_type.is_a?(PIntegerType) && size_type.from == 0 && size_type.to == 0 && key_type.is_a?(PNilType) && element_type.is_a?(PNilType)
+        end
       end
     end
-
 
     class PRuntimeType < PAnyType
       module ClassModule

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -364,6 +364,19 @@ describe 'The type calculator' do
         calculator.infer({:first => 1, :second => 2}).element_type.class.should == Puppet::Pops::Types::PIntegerType
       end
 
+      it 'when empty infers a type that answers true to is_the_empty_hash?' do
+        expect(calculator.infer({}).is_the_empty_hash?).to be_true
+        expect(calculator.infer_set({}).is_the_empty_hash?).to be_true
+      end
+
+      it 'when empty is assignable to any PHashType' do
+        expect(calculator.assignable?(hash_t(string_t, string_t), calculator.infer({}))).to be_true
+      end
+
+      it 'when empty is not assignable to a PHashType with from size > 0' do
+        expect(calculator.assignable?(constrained_t(hash_t(string_t,string_t), 1, 1), calculator.infer({}))).to be_false
+      end
+
       context 'using infer_set' do
         it "with 'first' and 'second' keys translates to PStructType[{first=>value,second=>value}]" do
           t = calculator.infer_set({'first' => 1, 'second' => 2})


### PR DESCRIPTION
This commit adds the method 'is_the_empty_hash?' to the PHashType.
It responds true when both the key and value types are PNilType and
the size_type is 0,0. This method is then called by the
TypeCalculator.assignable_PHashType when the first parameter accepts
a hash type of size zero.