### PR TITLE
(PUP-4014) Add PKINIT support to Puppet CA

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -74,6 +74,14 @@ class Puppet::Application::Cert < Puppet::Application
     options[:allow_dns_alt_names] = value
   end
 
+  option("--[no-]allow-pkinit-kdc") do |value|
+    options[:allow_pkinit_kdc] = value
+  end
+
+  option("--[no-]allow-pkinit-client") do |value|
+    options[:allow_pkinit_client] = value
+  end
+
   option("--verbose", "-v") do |arg|
     options[:verbose] = true
     set_log_level
@@ -246,6 +254,9 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       if Puppet.settings.set_by_cli?(:dns_alt_names)
         options[:dns_alt_names] = Puppet[:dns_alt_names]
       end
+      options[:request_pkinit_client] ||= Puppet[:request_pkinit_client]
+      options[:request_pkinit_kdc] ||= Puppet[:request_pkinit_kdc]
+      options[:kerberos_realm] ||= Puppet[:kerberos_realm]
     end
 
     begin

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -550,6 +550,21 @@ have a pool of multiple load balanced masters, or for the same master to
 respond on two physically separate networks under different names.
 EOT
     },
+    :request_pkinit_client => {
+      :default => false,
+      :type => :boolean,
+      :desc => "Add a PKINIT Client subjectAltName extension to certificate requests.",
+    },
+    :request_pkinit_kdc => {
+      :default => false,
+      :type => :boolean,
+      :desc => "Add a PKINIT KDC subjectAltName extension to certificate requests.",
+    },
+    :kerberos_realm => {
+      :default => nil,
+      :type => :string,
+      :desc => "The Kerberos realm to use in PKINIT extesions.",
+    },
     :csr_attributes => {
       :default => "$confdir/csr_attributes.yaml",
       :type => :file,

--- a/lib/puppet/face/ca.rb
+++ b/lib/puppet/face/ca.rb
@@ -178,7 +178,7 @@ Puppet::Face.define(:ca, '0.1.0') do
       Puppet::SSL::Host.ca_location = :only
 
       begin
-        ca.sign(host, options[:allow_dns_alt_names])
+        ca.sign(host, options)
       rescue ArgumentError => e
         if e.to_s =~ /Could not find certificate request/
           e.to_s

--- a/lib/puppet/face/certificate.rb
+++ b/lib/puppet/face/certificate.rb
@@ -129,7 +129,7 @@ Puppet::Indirector::Face.define(:certificate, '0.0.1') do
           raise ArgumentError, "This process is not configured as a certificate authority"
         end
 
-        ca.sign(name, options[:allow_dns_alt_names])
+        ca.sign(name, options)
       end
     end
   end

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -161,7 +161,7 @@ module Puppet
           list = subjects == :all ? ca.waiting? : subjects
           raise InterfaceError, "No waiting certificate requests to sign" if list.empty?
           list.each do |host|
-            ca.sign(host, options[:allow_dns_alt_names])
+            ca.sign(host, options)
           end
         end
 

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -172,6 +172,15 @@ DOC
       elsif Puppet::SSL::CertificateAuthority.ca? and fqdn = Facter.value(:fqdn) and domain = Facter.value(:domain)
         options[:dns_alt_names] = "puppet, #{fqdn}, puppet.#{domain}"
       end
+      if Puppet[:request_pkinit_client]
+        options[:request_pkinit_client] ||= Puppet[:request_pkinit_client]
+      end
+      if Puppet[:request_pkinit_kdc]
+        options[:request_pkinit_kdc] ||= Puppet[:request_pkinit_kdc]
+      end
+      if Puppet[:kerberos_realm]
+        options[:kerberos_realm] ||= Puppet[:kerberos_realm]
+      end
     end
 
     csr_attributes = Puppet::SSL::CertificateRequestAttributes.new(Puppet[:csr_attributes])
@@ -233,7 +242,7 @@ ERROR_STRING
     # should use it to sign our request; else, just try to read
     # the cert.
     if ! certificate and ca = Puppet::SSL::CertificateAuthority.instance
-      ca.sign(self.name, true)
+      ca.sign(self.name, { :allow_dns_alt_names => true } )
     end
   end
 

--- a/spec/integration/ssl/autosign_spec.rb
+++ b/spec/integration/ssl/autosign_spec.rb
@@ -106,9 +106,9 @@ describe "autosigning" do
       it "pulls extension attributes from the csr_attributes file into the certificate" do
         csr = Puppet::SSL::CertificateRequest.indirection.find(host.name)
         expect(csr.request_extensions).to have(3).items
-        expect(csr.request_extensions).to include('oid' => 'pp_uuid', 'value' => 'abcdef')
-        expect(csr.request_extensions).to include('oid' => 'pp_instance_id', 'value' => '1234')
-        expect(csr.request_extensions).to include('oid' => '1.3.6.1.4.1.34380.1.2.1', 'value' => 'some-value')
+        expect(csr.request_extensions).to include('oid' => 'pp_uuid', 'value' => 'abcdef', 'raw' => "\f\x06abcdef")
+        expect(csr.request_extensions).to include('oid' => 'pp_instance_id', 'value' => '1234', 'raw' => "\f\x041234")
+        expect(csr.request_extensions).to include('oid' => '1.3.6.1.4.1.34380.1.2.1', 'value' => 'some-value', 'raw' => "\f\nsome-value")
       end
 
       it "copies extension requests to certificate" do

--- a/spec/unit/ssl/certificate_authority/interface_spec.rb
+++ b/spec/unit/ssl/certificate_authority/interface_spec.rb
@@ -162,8 +162,8 @@ describe Puppet::SSL::CertificateAuthority::Interface do
         it "should sign the specified waiting certificate requests" do
           @options = {:allow_dns_alt_names => false}
 
-          @ca.expects(:sign).with("host1", false)
-          @ca.expects(:sign).with("host2", false)
+          @ca.expects(:sign).with("host1", {:allow_dns_alt_names => false})
+          @ca.expects(:sign).with("host2", {:allow_dns_alt_names => false})
 
           applier.apply(@ca)
         end
@@ -171,8 +171,8 @@ describe Puppet::SSL::CertificateAuthority::Interface do
         it "should sign the certificate requests with alt names if specified" do
           @options = {:allow_dns_alt_names => true}
 
-          @ca.expects(:sign).with("host1", true)
-          @ca.expects(:sign).with("host2", true)
+          @ca.expects(:sign).with("host1", {:allow_dns_alt_names => true})
+          @ca.expects(:sign).with("host2", {:allow_dns_alt_names => true})
 
           applier.apply(@ca)
         end
@@ -182,8 +182,8 @@ describe Puppet::SSL::CertificateAuthority::Interface do
         it "should sign all waiting certificate requests" do
           @ca.stubs(:waiting?).returns(%w{cert1 cert2})
 
-          @ca.expects(:sign).with("cert1", nil)
-          @ca.expects(:sign).with("cert2", nil)
+          @ca.expects(:sign).with("cert1", {}, nil)
+          @ca.expects(:sign).with("cert2", {}, nil)
 
           @applier = @class.new(:sign, :to => :all)
           @applier.apply(@ca)

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -248,8 +248,8 @@ describe Puppet::SSL::CertificateRequest do
 
         exts = request.request_extensions
 
-        expect(exts).to include('oid' => '1.3.6.1.4.1.34380.1.1.31415', 'value' => 'pi')
-        expect(exts).to include('oid' => '1.3.6.1.4.1.34380.1.1.2718', 'value' => 'e')
+        expect(exts).to include('oid' => '1.3.6.1.4.1.34380.1.1.31415', 'value' => 'pi', "raw" => "\f\x02pi")
+        expect(exts).to include('oid' => '1.3.6.1.4.1.34380.1.1.2718', 'value' => 'e', "raw" => "\f\x01e")
       end
 
       it "defines the extensions as non-critical" do
@@ -276,9 +276,10 @@ describe Puppet::SSL::CertificateRequest do
                          :extension_requests => extension_data)
         exts = request.request_extensions
 
-        expect(exts).to include('oid' => '1.3.6.1.4.1.34380.1.1.31415', 'value' => 'pi')
-        expect(exts).to include('oid' => '1.3.6.1.4.1.34380.1.1.2718', 'value' => 'e')
-        expect(exts).to include('oid' => 'subjectAltName', 'value' => 'DNS:first.tld, DNS:myname, DNS:second.tld')
+        expect(exts).to include('oid' => '1.3.6.1.4.1.34380.1.1.31415', 'value' => 'pi', "raw"=>"\f\x02pi")
+        expect(exts).to include('oid' => '1.3.6.1.4.1.34380.1.1.2718', 'value' => 'e', "raw" => "\f\x01e")
+        expect(exts).to include('oid' => 'subjectAltName', 'value' => 'DNS:first.tld, DNS:myname, DNS:second.tld',
+                                'raw' => ["301f820966697273742e746c6482066d796e616d65820a7365636f6e642e746c64"].pack("H*"))
 
         expect(request.subject_alt_names).to eq ['DNS:first.tld', 'DNS:myname', 'DNS:second.tld']
       end

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -649,7 +649,7 @@ describe Puppet::SSL::Host do
       it "should use the CA to sign its certificate request if it does not have a certificate" do
         @host.expects(:certificate).returns nil
 
-        @ca.expects(:sign).with(@host.name, true)
+        @ca.expects(:sign).with(@host.name, {:allow_dns_alt_names => true})
 
         @host.generate
       end


### PR DESCRIPTION
Hi,

I've written up this patch to enable the Puppet CA to deal with Kerberos-PKINIT-enabled certificate requests and allow the clients to request those extensions.

Those certificates can be used on the client to obtain Kerberos tickets using just the certificate and private key and no password or keytab:

```
root@client:~# fqdn=`hostname -f`
root@client:~# pupssl=/var/lib/puppet/ssl
root@client:~# kinit -X "X509_user_identity=FILE:$pupssl/certs/${fqdn}.pem,$pupssl/private_keys/${fqdn}.pem" $fqdn
root@client:~# klist
Ticket cache: FILE:/tmp/krb5cc_0
Default principal: client.example.org@EXAMPLE.ORG

Valid starting       Expires              Service principal
02/15/2015 12:56:21  02/15/2015 22:56:21  krbtgt/EXAMPLE.ORG@EXAMPLE.ORG
        renew until 02/16/2015 12:56:21
```

This can easily be made into a cron job so the machine always has a TGT floating around for accessing kerberised services!

I am also using this in an environment where I run Kerberos-enabled services and want to allow them to auto-enroll with the KDC and create their principals and keytabs. Using PKINIT with the Puppet machine certificates and making the machine principal a very limited Kerberos administrator for it's own principal namespace (*/$fqdn@$realm) allows for this very elegantly, securely and without any additional password storage and passing.

With the KDC extension it is also possible to run a PKINIT-enabled KDC with just the Puppet client certificate and key.

Since the whole PKINIT certificate extension thing is IMO highly inaccessible to people with non-ASN.1-capable brains (i.e. everyone) I think it would be a killer feature for Puppet to support this with just a few command line options out of the box.

Usage:
```
root@freshlybootstrappedbox # puppet agent -t --request_pkinit_client
(or option in puppet.conf)
```

```
root@puppetmaster:~# puppet cert sign freshlybootstrappedbox.example.org
Error: CSR 'freshlybootstrappedbox.example.org' contains subject alternative names (PKINIT-Client:freshlybootstrappedbox.example.org@EXAMPLE.ORG), which are disallowed. Use `puppet cert --allow-dns-alt-names sign freshlybootstrappedbox.example.org` to sign this request.
root@puppetmaster:~# puppet cert sign freshlybootstrappedbox.example.org --allow-dns-alt-names
Error: CSR 'freshlybootstrappedbox.example.org' contains a PKINIT extension for Kerberos clients (PKINIT-Client:freshlybootstrappedbox.example.org@EXAMPLE.ORG), which is disallowed. Use `puppet cert --allow-pkinit-client sign freshlybootstrappedbox.example.org` to sign this request.
root@puppetmaster:~# puppet cert sign freshlybootstrappedbox.example.org --allow-dns-alt-names --allow-pkinit-kdc --allow-pkinit-client
Notice: Signed certificate request for freshlybootstrappedbox.example.org
Notice: Removing file Puppet::SSL::CertificateRequest freshlybootstrappedbox.example.org at '/var/lib/puppet/ssl/ca/requests/freshlybootstrappedbox.example.org.pem'
```
(This doubled acceptance procedure is intentional and IMO a nice opportunity for the admin to realise what he's doing.)

I've developed this with Puppet 3.7.2 on Debian jessie and adjusted slightly for current master HEAD.

Extend agent to allow requesting of Kerberos PKINIT certificate
extensions for a configurable realm. Extend CA to check certificate
requests for those extensions, vet them and present the user with
instructions how to sign them.

This allows to distribute Kerberos PKINIT-ready certificates to Puppet
clients, enabling easy bootstrapping of PKINIT-enabled KDCs as well as
using PKINIT from the Kerberos clients. Instructions on how to do so can
be found here:
http://web.mit.edu/kerberos/krb5-devel/doc/admin/pkinit.html. A puppet
module that does so fully automatically is available here:
https://github.com/michaelweiser/puppet-module-kerberos.