### PR TITLE
(DO NOT MERGE)(QENG-1800) Use SUITE_VERSION to identify packages

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -54,7 +54,7 @@ agents.each do |agent|
   if agent['platform'] =~ /windows/
     arch = agent[:ruby_arch] || 'x86'
     base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{ENV['SHA']}/artifacts/windows"
-    filename = ENV['MSI_FILENAME'] || "puppet-agent-#{ENV['VERSION']}-#{arch}.msi"
+    filename = ENV['MSI_FILENAME'] || "puppet-agent-#{ENV['SUITE_VERSION']}-#{arch}.msi"
 
     install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
   end


### PR DESCRIPTION
 - On other platforms, repo configs are used to find actual package
   names that include a .x.y.z.XX-<SHA> type version.  The previous
   assumption was that there would be an ENV['VERSION'] passed through
   the pipeline, but that assumption proved incorrect as it's not
   necessary for other platforms.  In the existing pipelines, <SHA> is
   the only thing necessary to identify a package.

   So a new parameter called SUITE_VERSION was added to the environment
   to address this.