### PR TITLE
(DO NOT MERGE) (QENG-1800) VERSION is not available ENV var

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -54,7 +54,14 @@ agents.each do |agent|
   if agent['platform'] =~ /windows/
     arch = agent[:ruby_arch] || 'x86'
     base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{ENV['SHA']}/artifacts/windows"
-    filename = ENV['MSI_FILENAME'] || "puppet-agent-#{ENV['VERSION']}-#{arch}.msi"
+
+    filename = ENV['MSI_FILENAME']
+    if !filename
+      Dir.mktmpdir do |tmp_dir|
+        latest = fetch(base_url, "LATEST-#{ARCH}", tmp_dir)
+        filename = File.read(latest).strip
+      end
+    end
 
     install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
   end


### PR DESCRIPTION
 - Previously, the Windows package installation assumed that a
   VERSION environment variable is available during the Jenkins pipeline
   However, other platforms use only a SHA + repo configs to identify
   the actual package names.

   Therefore, the Windows packaging jobs are using a rough equivalent to
   repo configs by creating a LATEST-x64 and LATEST-x86 in
   builds.puppetlabs.lan/puppet-agent/<SHA>/artifacts/windows

   With this approach, the file is read for the actual version string
   in the x.y.z.XX.g<SHA> format and injected into the MSI package name