### PR TITLE
(PUP-2929) Optimize the TypedName for use as hash key

### DIFF
--- a/lib/puppet/pops/loader/dependency_loader.rb
+++ b/lib/puppet/pops/loader/dependency_loader.rb
@@ -26,7 +26,7 @@ class Puppet::Pops::Loader::DependencyLoader < Puppet::Pops::Loader::BaseLoader
   # Finds name in a loader this loader depends on / can see
   #
   def find(typed_name)
-    if typed_name.qualified
+    if typed_name.qualified?
       if l = index()[typed_name.name_parts[0]]
         l.load_typed(typed_name)
       else

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -137,43 +137,49 @@ class Puppet::Pops::Loader::Loader
   # A name/type combination that can be used as a compound hash key
   #
   class TypedName
+    attr_reader :hash
     attr_reader :type
     attr_reader :name
     attr_reader :name_parts
-
-    # True if name is qualified (more than a single segment)
-    attr_reader :qualified
+    attr_reader :compound_name
 
     def initialize(type, name)
       @type = type
       # relativize the name (get rid of leading ::), and make the split string available
-      @name_parts = name.to_s.split(/::/)
-      @name_parts.shift if name_parts[0].empty?
-      @name = name_parts.join('::')
-      @qualified = name_parts.size > 1
-      # precompute hash - the name is frozen, so this is safe to do
-      @hash = [self.class, type, @name].hash
+      parts = name.to_s.split('::')
+      if parts[0].empty?
+        parts.shift
+        @name = name[2..-1]
+      else
+        @name = name
+      end
+      @name_parts = parts
 
-      # Not allowed to have numeric names - 0, 010, 0x10, 1.2 etc
-      if Puppet::Pops::Utils.is_numeric?(@name)
+      # Not allowed to have numeric names - 0, 010, 0x10, 1.2 etc.
+      # At this point it is known that @name is a relativized string so it's
+      # safe to do a direct regexp match
+      unless Puppet::Pops::Patterns::NUMERIC.match(@name).nil?
         raise ArgumentError, "Illegal attempt to use a numeric name '#{name}' at #{origin_label(origin)}."
       end
 
-      freeze()
-    end
-
-    def hash
-      @hash
+      # Use a frozen compound key for the hash and comparison
+      @compound_name = "#{type}/#{name}".freeze
+      @hash = @compound_name.hash
+      freeze
     end
 
     def ==(o)
-      o.class == self.class && type == o.type && name == o.name
+      o.class == self.class && o.compound_name == @compound_name
     end
 
     alias eql? ==
 
+    def qualified?
+      @name_parts.size > 1
+    end
+
     def to_s
-      "#{type}/#{name}"
+      @compound_name
     end
   end
 end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -19,7 +19,7 @@ describe 'loader helper classes' do
     expect(tn.type).to eq(:function)
     expect(tn.name_parts).to eq(['foo', 'bar'])
     expect(tn.name).to eq('foo::bar')
-    expect(tn.qualified).to be_truthy
+    expect(tn.qualified?).to be_truthy
   end
 end
 


### PR DESCRIPTION
This commit will optimize the TypedName in two ways.

1. The initialize method now executes more than twice as fast. The
optimization consists of three improvements:
 - Use a string instead of a regexp when splitting the name
 - Never join the parts together. Instead use name or substring of name
 - Use direct match with NUMERIC. Avoids redundant relativization

2. A compound frozen name is created when the instance is initialized.
This instance is then used when comparing and when doing to_s.

The cached @qualified attribute and associated attr_reader was
replaced with an 'qualified?' method because there's almost no
noticable gain by caching it (it's extremely fast with or without a
cache). Also, 'qualified?' (with a questionmark) is a better name.

The commit does not contain the actual performance tests since a) I
wasn't sure where to put them and b) Not sure how useful they will be
once this commit has been merged. The number are:

Benchmark using old TypeName
```
                        user     system      total        real
Create              6.850000   0.000000   6.850000 (  6.859569)
Create ::global     6.800000   0.000000   6.800000 (  6.802436)
Hash lookup         0.590000   0.000000   0.590000 (  0.586534)
qualified           0.050000   0.000000   0.050000 (  0.052163)
to_s                0.380000   0.000000   0.380000 (  0.386374)
```
Benchmark using new TypeName
```
                        user     system      total        real
Create              2.400000   0.000000   2.400000 (  2.393237)
Create ::global     2.940000   0.000000   2.940000 (  2.947483)
Hash lookup         0.430000   0.000000   0.430000 (  0.427165)
qualified?          0.070000   0.000000   0.070000 (  0.067695)
to_s                0.060000   0.000000   0.060000 (  0.062700)
```
