### PR TITLE
(maint) Add deep_merge gem install to git and packages pre-suite

### DIFF
--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -120,5 +120,15 @@ hosts.each do |host|
   when /solaris/
     step "#{host} Install json from rubygems"
     on host, 'gem install json_pure'
+
+    step "#{host} Install deep_merge from rubygems"
+    on host, 'gem install deep_merge'
+
+  when /windows/
+    # skip deep_merge gem on windows
+
+  else
+    step "#{host} Install deep_merge from rubygems"
+    on host, 'gem install deep_merge'
   end
 end

--- a/acceptance/setup/packages/pre-suite/010_Install.rb
+++ b/acceptance/setup/packages/pre-suite/010_Install.rb
@@ -50,3 +50,14 @@ install_packages_on(agents, AGENT_PACKAGES)
 
 configure_gem_mirror(hosts)
 
+hosts.each do |host|
+  case host['platform']
+  when /windows/
+    # skip deep_merge gem on windows
+
+  else
+    step "#{host} Install deep_merge from rubygems"
+    on host, 'gem install deep_merge'
+  end
+end
+


### PR DESCRIPTION
Puppet 4.0 requires the deep_merge gem. It needs to be available
when running the acceptance suite on git or packages (it is included
in aio).

This adds a 'gem install deep_merge' on all hosts (for the sake of
simplicity) except windows hosts (where it is not needed).