### PR TITLE
(QENG-1800) Use symlink convention to find MSIs

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -54,7 +54,7 @@ agents.each do |agent|
   if agent['platform'] =~ /windows/
     arch = agent[:ruby_arch] || 'x86'
     base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{ENV['SHA']}/artifacts/windows"
-    filename = ENV['MSI_FILENAME'] || "puppet-agent-#{ENV['VERSION']}-#{arch}.msi"
+    filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
 
     install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
   end


### PR DESCRIPTION
 - Previously, the ability to find MSIs for an acceptance run required
   3 pieces of information:

   - Long SHA of puppet-agent repository
   - ARCH as either x86 or x64
   - The `git describe` of the puppet-agent repository, typically in the
     x.y.z.XX.g<SHA> format

  Unfortunately, the `git describe` was not made available anywhere to
  the job, and thus acceptance runs would need to have a change made to
  make it easier to find the correct MSI.  On platforms other than
  Windows, the `git describe` is actually not necessary as the SHA is
  enough to find a repo config, which then contains the information
  necessary to resolve packages with the specific version.  So Windows
  needs a solution (as will other platforms not using repo configs like
  Solaris and AIX).

  Options discussed:

  - Pass the `git describe` through the pipeline as SUITE_VERSION.  This
    is the least intrusive option, but adds an additional burden to
    consumers of the MSI that are not part of the pipeline, since that
    information may not be readily available.
  - Write a LATEST-<ARCH> file that would need to be retrieved that
    contains the `git describe` that would be produced during packaging.
    This carries a burden of a multi-step retrieve / string munging.
  - Use a standard convention in the file structure to symlink to the
    "real" versioned MSI from a filename that does not include the
    version.  This ends up making package consumption quite a bit
    simpler for all consumers (not just Jenkins), since the SHA from
    puppet-agent is enough to be able to resolve a package now.  This
    third option is what was decided on.  So in a real example, the
    following would occur:

    puppet-agent/<SHA>/artifacts/windows/puppet-agent-x64.msi

    points to

    puppet-agent/<SHA>/artifacts/windows/puppet-agent-0.3.2.30.g22a154b-x64.msi