### PR TITLE
(maint) Include deep_merge in .gemspec

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -44,12 +44,15 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<facter>, [">= 1.7", "< 3"])
       s.add_runtime_dependency(%q<hiera>, ["~> 1.0"])
+      s.add_runtime_dependency(%q<deep_merge>, ["~> 1.0"])
     else
       s.add_dependency(%q<facter>, [">= 1.7", "< 3"])
       s.add_dependency(%q<hiera>, ["~> 1.0"])
+      s.add_dependency(%q<deep_merge>, ["~> 1.0"])
     end
   else
     s.add_dependency(%q<facter>, [">= 1.7", "< 3"])
     s.add_dependency(%q<hiera>, ["~> 1.0"])
+    s.add_dependency(%q<deep_merge>, ["~> 1.0"])
   end
 end


### PR DESCRIPTION
PuppetDB uses the gem version of Puppet to test its terminus. Recently a new
hard dependency was added for Puppet::Pops::MergeStrategy to work, this patch
ensures the gem 'deep_merge' is included in the gem dependencies.

Signed-off-by: Ken Barber <ken@bob.sh>