### PR TITLE
(maint) Stop the windows service

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -251,6 +251,9 @@ module Puppet
         # `start /w` blocks until installation is complete, but needs to be wrapped in `cmd.exe /c`
         on host, "cmd.exe /c start /w msiexec /qn /i #{opts[:url]} /L*V C:\\\\Windows\\\\Temp\\\\Puppet-Install.log"
 
+        # make sure the background service isn't running while the test executes
+        on host, "net stop puppet"
+
         # make sure install is sane, beaker has already added puppet and ruby
         # to PATH in ~/.ssh/environment
         on host, puppet('--version')


### PR DESCRIPTION
Previously, when puppet is installed on windows, it creates and executes
a service that runs in the background. This can interfere with tests
that try to execute the agent, resulting in:

    Notice: Run of Puppet configuration client already in progress;
    skipping (C:/ProgramData/PuppetLabs/puppet/var/state/agent_catalog_run.lock
    exists)

This commit stop the service after installing the MSI.

Another approach would have been to specify
PUPPET_AGENT_STARTUP_MODE=Manual, but cygwin keeps quoting the argument
and msiexec hangs because it thinks it's a single argument as opposed to
a key=value.

```
$ cmd.exe /c start /w msiexec /qn /i http://builds.puppetlabs.lan/puppet-agent/7f9eb57786e5862ead966f71415ebc0ed21c1ee4/artifacts/windows/puppet-agent-x64.msi /L*V C:\\Windows\\Temp\\Puppet-Install.log
Created ssh connection to h6q6h41jod84w93.delivery.puppetlabs.net, user: Administrator, opts: 
{:config=>false, :paranoid=>false,
:timeout=>300, :auth_methods=>["publickey"], :port=>22,
:forward_agent=>true, :keys=>["id_rsa_acceptance",
"/Users/josh/.ssh/id_rsa-acceptance"],
:user_known_hosts_file=>"/Users/josh/.ssh/known_hosts",
:user=>"Administrator"}

h6q6h41jod84w93.delivery.puppetlabs.net (agent-2012r2-x86_64-rubyx64) executed in 33.75 seconds
h6q6h41jod84w93.delivery.puppetlabs.net (agent-2012r2-x86_64-rubyx64) 15:26:06$ net stop puppet
The Puppet Agent service is stopping.
The Puppet Agent service was stopped successfully.
```