### PR TITLE
(PUP-3127) LDAP - Introduce LDAP-Certificate Directory

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1573,6 +1573,14 @@ EOT
         Defaults to false because SSL usually requires certificates
         to be set up on the client side.",
     },
+    :ldapcrtdir => {
+      :default => false,
+      :desc    => "Path to cerificate directories.
+        Defaults to 'false'.
+        Normally SSL based LDAP connections should work without explicit setting
+        the `ldapcrtdir`. On e.g. Solaris based systems set this to `/var/ldap`
+        or any other Directory that contains the certificates.",
+    },
     :ldaptls => {
       :default  => false,
       :type     => :boolean,

--- a/spec/unit/util/ldap/connection_spec.rb
+++ b/spec/unit/util/ldap/connection_spec.rb
@@ -158,4 +158,28 @@ describe Puppet::Util::Ldap::Connection do
       Puppet::Util::Ldap::Connection.instance
     end
   end
+  
+  describe "when creating a connection with ldapcrtdir" do
+    it "should support specifing a ldapcrtdir" do
+      expect { Puppet::Util::Ldap::Connection.new("myhost", "myport", :crtdir => "/var/ldap") }.to_not raise_error
+    end
+    
+    it "should set the ldapcrtdir if it is used and will also use ssl" do
+      Puppet[:ldapcrtdir] = "/var/ldap"
+      Puppet[:ldapssl] = true
+      Puppet::Util::Ldap::Connection.expects(:new).with { |host, port, options| options[:crtdir] == "/var/ldap" and options[:ssl] == true }
+      Puppet::Util::Ldap::Connection.instance
+    end
+    
+    it "should not use the ldapcrtdir if it is false" do
+      Puppet[:ldapcrtdir] = false
+      Puppet::Util::Ldap::Connection.expects(:new).with { |host, port, options| options[:crtdir] == false }
+      Puppet::Util::Ldap::Connection.instance
+    end
+    
+    it "should not use the ldapcrtdir if it is not set (default)" do
+      Puppet::Util::Ldap::Connection.expects(:new).with { |host, port, options| options[:crtdir] == false }
+      Puppet::Util::Ldap::Connection.instance
+    end
+  end
 end


### PR DESCRIPTION
This is a rebase of @aschuste's [PR-3045](https://github.com/puppetlabs/puppet/pull/3045) with an rspec fix and commit message cleanup.

Add ldapcrtdir settings to enable ssl-based ldap connections on Solaris
based Puppet-Master. Without this implementation, it is not possible to
create ssl encrypted ldap connections on a Solaris system. If the
'ldapcrtdir' parameter is not set or set to false (=> default), the
connection is etablished as before.