### PR TITLE
(PUP-4032) Fix exitcodes on puppet device

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -115,9 +115,10 @@ parameter, so you can specify '--server <servername>' as an argument.
 
 * --detailed-exitcodes:
   Provide transaction information via exit codes. If this is enabled, an exit
-  code of '2' means there were changes, an exit code of '4' means there were
-  failures during the transaction, and an exit code of '6' means there were both
-  changes and failures.
+  code of '1' means at least one device had a compile failure, an exit code of
+  '2' means at least one device had resource changes, and an exit code of '4'
+  means at least one device had resource failures. Exit codes of '3', '5', '6',
+  or '7' means that a bitwise combination of the preceeding exit codes happened.
 
 * --help:
   Print this help message
@@ -167,7 +168,7 @@ Licensed under the Apache 2.0 License
       Puppet.err "No device found in #{Puppet[:deviceconfig]}"
       exit(1)
     end
-    devices.each_value do |device|
+    returns = devices.collect do |devicename,device|
       begin
         Puppet.info "starting applying configuration to #{device.name} at #{device.url}"
 
@@ -192,12 +193,24 @@ Licensed under the Apache 2.0 License
         configurer.run(:network_device => true, :pluginsync => Puppet[:pluginsync])
       rescue => detail
         Puppet.log_exception(detail)
+        # If we rescued an error, then we return 1 as the exit code
+        1
       ensure
         Puppet[:vardir] = vardir
         Puppet[:confdir] = confdir
         Puppet[:certname] = certname
         Puppet::SSL::Host.reset
       end
+    end
+    if ! returns or returns.compact.empty?
+      exit(1)
+    elsif options[:detailed_exitcodes]
+      # Bitwise OR the return codes together, puppet style
+      exit(returns.compact.reduce(:|))
+    elsif returns.include? 1
+      exit(1)
+    else
+      exit(0)
     end
   end
 

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -271,6 +271,7 @@ describe Puppet::Application::Device do
     before :each do
       @device.options.stubs(:[]).with(:fingerprint).returns(false)
       Puppet.stubs(:notice)
+      @device.options.stubs(:[]).with(:detailed_exitcodes).returns(false)
       @device.options.stubs(:[]).with(:client)
       Puppet::Util::NetworkDevice::Config.stubs(:devices).returns({})
     end
@@ -283,7 +284,7 @@ describe Puppet::Application::Device do
     it "should get the device list" do
       device_hash = stub_everything 'device hash'
       Puppet::Util::NetworkDevice::Config.expects(:devices).returns(device_hash)
-      @device.main
+      expect { @device.main }.to exit_with 1
     end
 
     it "should exit if the device list is empty" do
@@ -310,38 +311,70 @@ describe Puppet::Application::Device do
 
       it "should set vardir to the device vardir" do
         Puppet.expects(:[]=).with(:vardir, make_absolute("/dummy/devices/device1"))
-        @device.main
+        expect { @device.main }.to exit_with 1
       end
 
       it "should set confdir to the device confdir" do
         Puppet.expects(:[]=).with(:confdir, make_absolute("/dummy/devices/device1"))
-        @device.main
+        expect { @device.main }.to exit_with 1
       end
 
       it "should set certname to the device certname" do
         Puppet.expects(:[]=).with(:certname, "device1")
         Puppet.expects(:[]=).with(:certname, "device2")
-        @device.main
+        expect { @device.main }.to exit_with 1
       end
 
       it "should make sure all the required folders and files are created" do
         Puppet.settings.expects(:use).with(:main, :agent, :ssl).twice
-        @device.main
+        expect { @device.main }.to exit_with 1
       end
 
       it "should initialize the device singleton" do
         Puppet::Util::NetworkDevice.expects(:init).with(@device_hash["device1"]).then.with(@device_hash["device2"])
-        @device.main
+        expect { @device.main }.to exit_with 1
       end
 
       it "should setup the SSL context" do
         @device.expects(:setup_host).twice
-        @device.main
+        expect { @device.main }.to exit_with 1
       end
 
       it "should launch a configurer for this device" do
         @configurer.expects(:run).twice
-        @device.main
+        expect { @device.main }.to exit_with 1
+      end
+
+      it "exits 1 when configurer raises error" do
+        @configurer.stubs(:run).raises(Puppet::Error).then.returns(0)
+        expect { @device.main }.to exit_with 1
+      end
+
+      it "exits 0 when run happens without puppet errors but with failed run" do
+        @configurer.stubs(:run).returns(6,2)
+        expect { @device.main }.to exit_with 0
+      end
+
+      it "exits 2 when --detailed-exitcodes and successful runs" do
+        @device.options.stubs(:[]).with(:detailed_exitcodes).returns(true)
+        @configurer.stubs(:run).returns(0,2)
+        expect { @device.main }.to exit_with 2
+      end
+
+      it "exits 1 when --detailed-exitcodes and failed parse" do
+        @configurer = stub_everything 'configurer'
+        Puppet::Configurer.stubs(:new).returns(@configurer)
+        @device.options.stubs(:[]).with(:detailed_exitcodes).returns(true)
+        @configurer.stubs(:run).returns(6,1)
+        expect { @device.main }.to exit_with 7
+      end
+
+      it "exits 6 when --detailed-exitcodes and failed run" do
+        @configurer = stub_everything 'configurer'
+        Puppet::Configurer.stubs(:new).returns(@configurer)
+        @device.options.stubs(:[]).with(:detailed_exitcodes).returns(true)
+        @configurer.stubs(:run).returns(6,2)
+        expect { @device.main }.to exit_with 6
       end
 
       [:vardir, :confdir].each do |setting|
@@ -369,7 +402,7 @@ describe Puppet::Application::Device do
           end
 
 
-          @device.main
+          expect { @device.main }.to exit_with 1
 
           expect(found_devices).to eq(all_devices)
         end
@@ -399,7 +432,7 @@ describe Puppet::Application::Device do
         end
 
 
-        @device.main
+        expect { @device.main }.to exit_with 1
 
         # make sure that we were called with each of the defined devices
         expect(found_devices).to eq(all_devices)
@@ -408,7 +441,7 @@ describe Puppet::Application::Device do
       it "should expire all cached attributes" do
         Puppet::SSL::Host.expects(:reset).twice
 
-        @device.main
+        expect { @device.main }.to exit_with 1
       end
     end
   end


### PR DESCRIPTION
Puppet device does one catalog run per device in device.conf, however it
was then throwing away the return codes of the catalog compile and
apply. The man page says that puppet device supports
--detailed-exitcodes, so this fixes it.

Since there are multiple catalog runs in one command, exitcode masking
is unavoidable, so I selected to take the path of returning the single
most important exit code, in decending order with the exception of exit
1 taking precedence.