### PR TITLE
(maint) Revert "(maint) Skip certificate_extensions test for AIO"

### DIFF
--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -5,7 +5,6 @@ extend Puppet::Acceptance::TempFileUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
-skip_test '(PUP-4005) Skip test for the AIO pipeline'
 disable_pe_enterprise_mcollective_agent_classes
 
 initialize_temp_dirs


### PR DESCRIPTION
This reverts commit df7306b39da0d53cd657161ce5368ea5a43addcd
and un-skips the certificate_extensions test which was previously
failing in the AIO pipeline due to a needed update to puppet-server.