### PR TITLE
(PUP-3090) Set always_cache_features to true for masters

### DIFF
--- a/conf/puppet.conf
+++ b/conf/puppet.conf
@@ -7,3 +7,7 @@
 
     # Where Puppet PID files are kept.
     rundir=/var/run/puppetlabs
+
+    # Masters won't get new features while compiling catalogs for agents, so it
+    # is safe to set this to true
+    always_cache_features=true


### PR DESCRIPTION
While for agents caching features would not be good as they can have new
features delivered during the course of a run, for masters this poses no
problems and decreases overhead during catalog compilation. Without
this, masters will reset and reinterrogate features during the course of
operation which is expensive.