### PR TITLE
(RE-3997) Update vendored Windows Ruby to latest.

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -35,8 +35,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/marionette-collective.git'
   sys:
     ref:
-      x86: '93d40ef690dbf888f1f584a79212b2278ed4a063'
-      x64: 'b313f5b5baa2cabb59a1903651533bc9d6c7e685'
+      x86: 'aac9e790c9c3e59175e9d528f8aa517bb6caed76'
+      x64: '9e70b6ac8474678487f4330fecc2179158ae62f3'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
This commit updates the refs for vendored Windows Ruby to
the latest SHAs in the 2.1.x-x86 and 2.1.x-x64 branches.