### PR TITLE
(maint) allow puppet server installs from version

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -7,13 +7,14 @@ test_name "Install Packages"
 step "Install repositories on target machines..." do
 
   sha = ENV['SHA']
+  server_version = ENV['SERVER_VERSION'] ||= 'nightly'
   repo_configs_dir = 'repo-configs'
 
   hosts.each do |host|
     install_repos_on(host, 'puppet-agent', sha, repo_configs_dir)
   end
 
-  install_repos_on(master, 'puppetserver', 'nightly', repo_configs_dir)
+  install_repos_on(master, 'puppetserver', server_version, repo_configs_dir)
 end
 
 
@@ -61,4 +62,3 @@ agents.each do |agent|
 end
 
 configure_gem_mirror(hosts)
-


### PR DESCRIPTION
    Without this change the pre-suite installs puppet-server from
    nightlies/puppetserver-latest which can sometimes be an older version.
    this fix allows one to specify SERVER_VERSION environment variable to
    pull a specific build.
    This change also adds puppetserver-confdir to the aio options file.