### PR TITLE
(PUP-4017) Make parser an environment specific setting

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -258,6 +258,18 @@ module Puppet
 
   # The single instance used for normal operation
   @context = Puppet::Context.new(bootstrap_context)
+
+  def self.future_parser?
+    env = Puppet.lookup(:current_environment) { return Puppet[:parser] == 'future' }
+    env_conf = Puppet.lookup(:environments).get_conf(env.name)
+
+    if env_conf.nil?
+      # Case for non-directory environments
+      Puppet[:parser] == 'future'
+    else
+      env_conf.parser == 'future'
+    end
+  end
 end
 
 # This feels weird to me; I would really like for us to get to a state where there is never a "require" statement

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -107,7 +107,7 @@ module Puppet::Environments
     def get_conf(name)
       env = get(name)
       if env
-        Puppet::Settings::EnvironmentConf.static_for(env)
+        Puppet::Settings::EnvironmentConf.static_for(env, Puppet[:parser])
       else
         nil
       end

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -550,7 +550,7 @@ class Puppet::Node::Environment
       if file == NO_MANIFEST
         Puppet::Parser::AST::Hostclass.new('')
       elsif File.directory?(file)
-        if Puppet[:parser] == 'future'
+        if Puppet.future_parser?
           parse_results = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**/*.pp')).glob.sort.map do | file_to_parse |
             parser.file = file_to_parse
             parser.parse

--- a/lib/puppet/parser/ast/arithmetic_operator.rb
+++ b/lib/puppet/parser/ast/arithmetic_operator.rb
@@ -70,7 +70,7 @@ class Puppet::Parser::AST
     end
 
     def assert_concatenation_supported
-      return if Puppet[:parser] == 'future'
+      return if Puppet.future_parser?
       raise ParseError.new("Unsupported Operation: Array concatenation available with '--parser future' setting only.")
     end
 

--- a/lib/puppet/parser/ast/collexpr.rb
+++ b/lib/puppet/parser/ast/collexpr.rb
@@ -9,7 +9,7 @@ class CollExpr < AST::Branch
   attr_accessor :test1, :test2, :oper, :form, :type, :parens
 
   def evaluate(scope)
-    if Puppet[:parser] == 'future'
+    if Puppet.future_parser?
       evaluate4x(scope)
     else
       evaluate3x(scope)

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -150,7 +150,7 @@ class Puppet::Parser::Compiler
 
   # Constructs the overrides for the context
   def context_overrides()
-    if Puppet[:parser] == 'future'
+    if Puppet.future_parser?
       require 'puppet/loaders'
       {
         :current_environment => environment,
@@ -294,7 +294,7 @@ class Puppet::Parser::Compiler
   # Answers if Puppet Binder should be active or not, and if it should and is not active, then it is activated.
   # @return [Boolean] true if the Puppet Binder should be activated
   def is_binder_active?
-    should_be_active = Puppet[:binder] || Puppet[:parser] == 'future'
+    should_be_active = Puppet[:binder] || Puppet.future_parser?
     if should_be_active
       # TODO: this should be in a central place, not just for ParserFactory anymore...
       Puppet::Parser::ParserFactory.assert_rgen_installed()
@@ -447,7 +447,7 @@ class Puppet::Parser::Compiler
   # look for resources, because we want to consider those to be
   # parse errors.
   def fail_on_unevaluated_resource_collections
-    if Puppet[:parser] == 'future'
+    if Puppet.future_parser?
       remaining = @collections.collect(&:unresolved_resources).flatten.compact
     else
       remaining = @collections.collect(&:resources).flatten.compact

--- a/lib/puppet/parser/functions/defined.rb
+++ b/lib/puppet/parser/functions/defined.rb
@@ -52,7 +52,7 @@ Puppet::Parser::Functions::newfunction(:defined, :type => :rvalue, :arity => -2,
       when Puppet::Resource
         compiler.findresource(val.type, val.title)
       else
-        if Puppet[:parser] == 'future'
+        if Puppet.future_parser?
           case val
           when Puppet::Pops::Types::PResourceType
             raise ArgumentError, "The given resource type is a reference to all kind of types" if val.type_name.nil?

--- a/lib/puppet/parser/functions/lookup.rb
+++ b/lib/puppet/parser/functions/lookup.rb
@@ -137,7 +137,7 @@ If you want to make lookup return undef when no value was found instead of raisi
 
 ENDHEREDOC
 
-  unless Puppet[:binder] || Puppet[:parser] == 'future'
+  unless Puppet[:binder] || Puppet.future_parser?
     raise Puppet::ParseError, "The lookup function is only available with settings --binder true, or --parser future"
   end
   Puppet::Pops::Binder::Lookup.lookup(self, args)

--- a/lib/puppet/parser/functions/realize.rb
+++ b/lib/puppet/parser/functions/realize.rb
@@ -8,7 +8,7 @@ Puppet::Parser::Functions::newfunction(:realize, :arity => -2, :doc => "Make a v
     reference; e.g.: `realize User[luke]`." ) do |vals|
 
     vals = [vals] unless vals.is_a?(Array)
-    if Puppet[:parser] == 'future'
+    if Puppet.future_parser?
       coll = Puppet::Pops::Evaluator::Collectors::FixedSetCollector.new(self, vals.flatten)
     else
       coll = Puppet::Parser::Collector.new(self, :nomatter, nil, nil, :virtual)

--- a/lib/puppet/parser/parser_factory.rb
+++ b/lib/puppet/parser/parser_factory.rb
@@ -9,7 +9,7 @@ module Puppet::Parser
   class ParserFactory
     # Produces a parser instance for the given environment
     def self.parser(environment)
-      if Puppet[:parser] == 'future'
+      if Puppet.future_parser?
         evaluating_parser(environment)
       else
         classic_parser(environment)
@@ -66,7 +66,7 @@ module Puppet::Parser
     end
 
     def self.code_merger
-      if Puppet[:parser] == 'future'
+      if Puppet.future_parser?
         Puppet::Pops::Parser::CodeMerger.new
       else
         Puppet::Parser::CodeMerger.new

--- a/lib/puppet/parser/relationship.rb
+++ b/lib/puppet/parser/relationship.rb
@@ -7,7 +7,7 @@ class Puppet::Parser::Relationship
     # This if statement is needed because the 3x parser cannot load
     # Puppet::Pops. This logic can be removed for 4.0 when the 3x AST
     # is removed (when Pops is always used).
-    if !(Puppet[:parser] == 'future')
+    if !(Puppet.future_parser?)
       case resources
       when Puppet::Parser::Collector
         resources.collected.values

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -401,7 +401,7 @@ class Puppet::Parser::Scope
 
   def variable_not_found(name, reason=nil)
     if Puppet[:strict_variables]
-      if Puppet[:parser] == 'future'
+      if Puppet.future_parser?
         throw :undefined_variable
       else
         reason_msg = reason.nil? ? '' : "; #{reason}"
@@ -534,8 +534,8 @@ class Puppet::Parser::Scope
   #
   # @see to_hash_legacy
   def to_hash(recursive = true)
-    @parser ||= Puppet[:parser]
-    if @parser == 'future'
+    @future_parser ||= Puppet.future_parser?
+    if @future_parser
       to_hash_future(recursive)
     else
       to_hash_legacy(recursive)
@@ -847,7 +847,7 @@ class Puppet::Parser::Scope
   # lookup in the compiler.
   #
   # Makes names passed in the names array absolute if they are relative
-  # Names are now made absolute if Puppet[:parser] == 'future', this will
+  # Names are now made absolute if Puppet.future_parser? is true, this will
   # be the default behavior in Puppet 4.0
   #
   # Transforms Class[] and Resource[] type referenes to class name
@@ -860,7 +860,7 @@ class Puppet::Parser::Scope
   # @return [Array<String>] names after transformation
   #
   def transform_and_assert_classnames(names)
-    if Puppet[:parser] == 'future'
+    if Puppet.future_parser?
       names.map do |name|
         case name
         when String

--- a/lib/puppet/pops/binder/lookup.rb
+++ b/lib/puppet/pops/binder/lookup.rb
@@ -210,7 +210,7 @@ class Puppet::Pops::Binder::Lookup
       # way, and should instead be turned into :undef.
       # TODO PUPPET4: Simply return the result
       #
-      Puppet[:parser] == 'future' ? result : nil_as_undef(result)
+      Puppet.future_parser? ? result : nil_as_undef(result)
     end
   end
 end

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -442,7 +442,7 @@ class Puppet::Resource
         end
       end
 
-      if Puppet[:parser] == 'current'
+      if !Puppet.future_parser?
         # If the value is an array with only one value, then
         # convert it to a single value.  This is largely so that
         # the database interaction doesn't have to worry about
@@ -481,7 +481,7 @@ class Puppet::Resource
     end
 
     # Perform optional type checking
-    if Puppet[:parser] == 'future'
+    if Puppet.future_parser?
       # Perform type checking
       arg_types = resource_type.argument_types
       # Parameters is a map from name, to parameter, and the parameter again has name and value

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -341,7 +341,7 @@ class Puppet::Resource::Type
     @argument_types = {}
     # Stop here if not running under future parser, the rest requires pops to be initialized
     # and that the type system is available
-    return unless Puppet[:parser] == 'future' && name_to_type_hash
+    return unless Puppet.future_parser? && name_to_type_hash
     name_to_type_hash.each do |name, t|
       # catch internal errors
       unless @arguments.include?(name)

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -1,7 +1,7 @@
 # Configuration settings for a single directory Environment.
 # @api private
 class Puppet::Settings::EnvironmentConf
-  VALID_SETTINGS = [:modulepath, :manifest, :config_version, :environment_timeout].freeze
+  VALID_SETTINGS = [:modulepath, :manifest, :config_version, :environment_timeout, :parser].freeze
 
   # Given a path to a directory environment, attempts to load and parse an
   # environment.conf in ini format, and return an EnvironmentConf instance.
@@ -37,8 +37,8 @@ class Puppet::Settings::EnvironmentConf
   # Configuration values are exactly those returned by the environment object,
   # without interpolation.  This is a special case for the default configured
   # environment returned by the Puppet::Environments::StaticPrivate loader.
-  def self.static_for(environment, environment_timeout = 0)
-    Static.new(environment, environment_timeout)
+  def self.static_for(environment, parser, environment_timeout = 0)
+    Static.new(environment, environment_timeout, parser)
   end
 
   attr_reader :section, :path_to_env, :global_modulepath
@@ -100,6 +100,12 @@ class Puppet::Settings::EnvironmentConf
     end
   end
 
+  def parser
+    get_setting(:parser, Puppet.settings.value(:parser)) do |value|
+      value
+    end
+  end
+
   def config_version
     get_setting(:config_version) do |config_version|
       absolute(config_version)
@@ -152,10 +158,12 @@ class Puppet::Settings::EnvironmentConf
   # @api private
   class Static
     attr_reader :environment_timeout
+    attr_reader :parser
 
-    def initialize(environment, environment_timeout)
+    def initialize(environment, environment_timeout, parser)
       @environment = environment
       @environment_timeout = environment_timeout
+      @parser = parser
     end
 
     def manifest

--- a/lib/puppetx.rb
+++ b/lib/puppetx.rb
@@ -31,7 +31,7 @@ module Puppetx
   # @api public
   module Puppet
 
-    if ::Puppet[:binder] || ::Puppet[:parser] == 'future'
+    if ::Puppet[:binder] || ::Puppet.future_parser?
         # Extension-points are registered here:
         # - If in a Ruby submodule it is best to create it here
         # - The class does not have to be required; it will be auto required when the binder
@@ -68,7 +68,7 @@ module Puppetx
 
     # @api public
     module SyntaxCheckers
-      if ::Puppet[:binder] || ::Puppet[:parser] == 'future'
+      if ::Puppet[:binder] || ::Puppet.future_parser?
 
         # Classes in this name-space are lazily loaded as they may be overridden and/or never used
         # (Lazy loading is done by binding to the name of a class instead of a Class instance).

--- a/spec/integration/parser/environment_spec.rb
+++ b/spec/integration/parser/environment_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe "A parser environment setting" do
+
+  let(:confdir) { Puppet[:confdir] }
+  let(:environmentpath) { File.expand_path("envdir", confdir) }
+  let(:testingdir) { File.join(environmentpath, "testing") }
+
+  before(:each) do
+    FileUtils.mkdir_p(testingdir)
+  end
+
+  it "selects the given parser when compiling" do
+    manifestsdir = File.expand_path("manifests", confdir)
+    FileUtils.mkdir_p(manifestsdir)
+
+    File.open(File.join(testingdir, "environment.conf"), "w") do |f|
+      f.puts(<<-ENVCONF)
+        parser='future'
+        manifest =#{manifestsdir}
+      ENVCONF
+    end
+
+    File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+      f.puts(<<-EOF)
+          environmentpath=#{environmentpath}
+      EOF
+    end
+
+    File.open(File.join(manifestsdir, "site.pp"), "w") do |f|
+      f.puts("notice( [1,2,3].map |$x| { $x*10 })")
+    end
+
+    expect { a_catalog_compiled_for_environment('testing') }.to_not raise_error
+  end
+
+  def a_catalog_compiled_for_environment(envname)
+    Puppet.initialize_settings
+    expect(Puppet[:environmentpath]).to eq(environmentpath)
+    node = Puppet::Node.new('testnode', :environment => 'testing')
+    expect(node.environment).to eq(Puppet.lookup(:environments).get('testing'))
+    Puppet.override(:current_environment => Puppet.lookup(:environments).get('testing')) do
+      Puppet::Parser::Compiler.compile(node)
+    end
+  end
+end

--- a/spec/integration/parser/environment_spec.rb
+++ b/spec/integration/parser/environment_spec.rb
@@ -24,6 +24,7 @@ describe "A parser environment setting" do
     File.open(File.join(confdir, "puppet.conf"), "w") do |f|
       f.puts(<<-EOF)
           environmentpath=#{environmentpath}
+          parser='current'
       EOF
     end
 

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -515,7 +515,7 @@ config_version=$vardir/random/scripts
         env = Puppet::Node::Environment.create(:cached, [])
         mocked_loader = mock('loader')
         mocked_loader.expects(:get).with(:cached).returns(env).once
-        mocked_loader.expects(:get_conf).with(:cached).returns(Puppet::Settings::EnvironmentConf.static_for(env,'currentt', 20)).once
+        mocked_loader.expects(:get_conf).with(:cached).returns(Puppet::Settings::EnvironmentConf.static_for(env,'current', 20)).once
 
         cached = Puppet::Environments::Cached.new(mocked_loader)
 

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -489,7 +489,7 @@ config_version=$vardir/random/scripts
         env = Puppet::Node::Environment.create(:cached, [])
         mocked_loader = mock('loader')
         mocked_loader.expects(:get).with(:cached).returns(env).once
-        mocked_loader.expects(:get_conf).with(:cached).returns(Puppet::Settings::EnvironmentConf.static_for(env, 20)).once
+        mocked_loader.expects(:get_conf).with(:cached).returns(Puppet::Settings::EnvironmentConf.static_for(env,'current', 20)).once
 
         cached = Puppet::Environments::Cached.new(mocked_loader)
 
@@ -515,7 +515,7 @@ config_version=$vardir/random/scripts
         env = Puppet::Node::Environment.create(:cached, [])
         mocked_loader = mock('loader')
         mocked_loader.expects(:get).with(:cached).returns(env).once
-        mocked_loader.expects(:get_conf).with(:cached).returns(Puppet::Settings::EnvironmentConf.static_for(env, 20)).once
+        mocked_loader.expects(:get_conf).with(:cached).returns(Puppet::Settings::EnvironmentConf.static_for(env,'currentt', 20)).once
 
         cached = Puppet::Environments::Cached.new(mocked_loader)
 

--- a/spec/unit/settings/environment_conf_spec.rb
+++ b/spec/unit/settings/environment_conf_spec.rb
@@ -33,10 +33,16 @@ describe Puppet::Settings::EnvironmentConf do
       expect(envconf.config_version).to eq(File.expand_path('/some/version.sh'))
     end
 
-    it "read an environment_timeout from config" do
+    it "reads an environment_timeout from config" do
       setup_environment_conf(config, :environment_timeout => '3m')
 
       expect(envconf.environment_timeout).to eq(180)
+    end
+
+    it "reads a parser from config" do
+      setup_environment_conf(config, :parser => 'future')
+
+      expect(envconf.parser).to eq('future')
     end
 
     it "can retrieve raw settings" do
@@ -66,6 +72,11 @@ describe Puppet::Settings::EnvironmentConf do
 
     it "returns a defult of 0 for environment_timeout when config has none" do
       expect(envconf.environment_timeout).to eq(0)
+    end
+
+    it "returns what is configured for all environments if parser is not specified" do
+      Puppet[:parser] = 'future'
+      expect(envconf.parser).to eq('future')
     end
 
     it "can still retrieve raw setting" do


### PR DESCRIPTION
Prior to this pull request, the 'parser' setting was not environment
specific. In order to make it easier for users to migrate to using
the future parser, make 'parser' environment specific.

The environment parameter is optional, and if missing will use
what is configured for all environments.

This mechanism can only be used with directory environments.