### PR TITLE
(maint) Rename PNilType to PUndefType

### DIFF
--- a/lib/puppet/pops/types/class_loader.rb
+++ b/lib/puppet/pops/types/class_loader.rb
@@ -66,7 +66,7 @@ class Puppet::Pops::Types::ClassLoader
     when Puppet::Pops::Types::PPatternType  ; String
     when Puppet::Pops::Types::PEnumType     ; String
     when Puppet::Pops::Types::PFloatType    ; Float
-    when Puppet::Pops::Types::PNilType      ; NilClass
+    when Puppet::Pops::Types::PUndefType      ; NilClass
     when Puppet::Pops::Types::PCallableType ; Proc
     else
       nil

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -197,7 +197,7 @@ class Puppet::Pops::Types::TypeCalculator
     data_variant.addTypes(@data_hash.copy)
     data_variant.addTypes(@data_array.copy)
     data_variant.addTypes(Types::PScalarType.new)
-    data_variant.addTypes(Types::PNilType.new)
+    data_variant.addTypes(Types::PUndefType.new)
     data_variant.addTypes(@data_tuple_t.copy)
     @data_variant_t = data_variant
 
@@ -212,7 +212,7 @@ class Puppet::Pops::Types::TypeCalculator
     non_empty_string.size_type.to = nil # infinity
     @non_empty_string_t = non_empty_string
 
-    @nil_t = Types::PNilType.new
+    @nil_t = Types::PUndefType.new
   end
 
   # Convenience method to get a data type for comparisons
@@ -322,7 +322,7 @@ class Puppet::Pops::Types::TypeCalculator
     when c == Regexp
       type = Types::PRegexpType.new()
     when c == NilClass
-      type = Types::PNilType.new()
+      type = Types::PUndefType.new()
     when c == FalseClass, c == TrueClass
       type = Types::PBooleanType.new()
     when c == Class
@@ -471,12 +471,12 @@ class Puppet::Pops::Types::TypeCalculator
     instance_of(@data_variant_t, o)
   end
 
-  def instance_of_PNilType(t, o)
+  def instance_of_PUndefType(t, o)
     o.nil? || o == :undef
   end
 
   def instance_of_POptionalType(t, o)
-    instance_of_PNilType(t, o) || instance_of(t.optional_type, o)
+    instance_of_PUndefType(t, o) || instance_of(t.optional_type, o)
   end
 
   def instance_of_PVariantType(t, o)
@@ -505,11 +505,11 @@ class Puppet::Pops::Types::TypeCalculator
     return t.is_a?(Types::PAnyType)
   end
 
-  # Answers if t represents the puppet type PNilType
+  # Answers if t represents the puppet type PUndefType
   # @api public
   #
   def is_pnil?(t)
-    return t.nil? || t.is_a?(Types::PNilType)
+    return t.nil? || t.is_a?(Types::PUndefType)
   end
 
   # Answers, 'What is the common type of t1 and t2?'
@@ -795,7 +795,7 @@ class Puppet::Pops::Types::TypeCalculator
 
   # @api private
   def infer_NilClass(o)
-    Types::PNilType.new()
+    Types::PUndefType.new()
   end
 
   # @api private
@@ -882,7 +882,7 @@ class Puppet::Pops::Types::TypeCalculator
     type = Types::PArrayType.new()
     type.element_type =
     if o.empty?
-      Types::PNilType.new()
+      Types::PUndefType.new()
     else
       infer_and_reduce_type(o)
     end
@@ -894,8 +894,8 @@ class Puppet::Pops::Types::TypeCalculator
   def infer_Hash(o)
     type = Types::PHashType.new()
     if o.empty?
-      ktype = Types::PNilType.new()
-      etype = Types::PNilType.new()
+      ktype = Types::PUndefType.new()
+      etype = Types::PUndefType.new()
     else
       ktype = infer_and_reduce_type(o.keys())
       etype = infer_and_reduce_type(o.values())
@@ -922,7 +922,7 @@ class Puppet::Pops::Types::TypeCalculator
   def infer_set_Array(o)
     if o.empty?
       type = Types::PArrayType.new()
-      type.element_type = Types::PNilType.new()
+      type.element_type = Types::PUndefType.new()
       type.size_type = size_as_type(o)
     else
       type = Types::PTupleType.new()
@@ -934,8 +934,8 @@ class Puppet::Pops::Types::TypeCalculator
   def infer_set_Hash(o)
     if o.empty?
       type = Types::PHashType.new
-      type.key_type = Types::PNilType.new
-      type.element_type = Types::PNilType.new
+      type.key_type = Types::PUndefType.new
+      type.element_type = Types::PUndefType.new
       type.size_type = size_as_type(o)
     else
       if o.keys.find {|k| !instance_of_PStringType(@non_empty_string_t, k) }
@@ -982,9 +982,9 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   # @api private
-  def assignable_PNilType(t, t2)
+  def assignable_PUndefType(t, t2)
     # Only undef/nil is assignable to nil type
-    t2.is_a?(Types::PNilType)
+    t2.is_a?(Types::PUndefType)
   end
 
   # Anything is assignable to a Unit type
@@ -1078,7 +1078,7 @@ class Puppet::Pops::Types::TypeCalculator
     if args_tuple.size_type
       raise ArgumentError, "Callable tuple may not have a size constraint when used as args"
     end
-    # Assume no block was given - i.e. it is nil, and its type is PNilType
+    # Assume no block was given - i.e. it is nil, and its type is PUndefType
     block_t = @nil_t
     if self.class.is_kind_of_callable?(args_tuple.types.last)
       # a split is needed to make it possible to use required, optional, and varargs semantics
@@ -1117,8 +1117,8 @@ class Puppet::Pops::Types::TypeCalculator
     assignable?(callable_t.block_type || @nil_t, @nil_t)
   end
 
-  def callable_PNilType(nil_t, callable_t)
-    # if callable_t is Optional (or indeed PNilType), this means that 'missing callable' is accepted
+  def callable_PUndefType(nil_t, callable_t)
+    # if callable_t is Optional (or indeed PUndefType), this means that 'missing callable' is accepted
     assignable?(callable_t, nil_t)
   end
 
@@ -1216,7 +1216,7 @@ class Puppet::Pops::Types::TypeCalculator
 
   # @api private
   def assignable_POptionalType(t, t2)
-    return true if t2.is_a?(Types::PNilType)
+    return true if t2.is_a?(Types::PUndefType)
     if t2.is_a?(Types::POptionalType)
       assignable?(t.optional_type, t2.optional_type)
     else
@@ -1520,7 +1520,7 @@ class Puppet::Pops::Types::TypeCalculator
   def string_PAnyType(t)     ; "Any"     ; end
 
   # @api private
-  def string_PNilType(t)     ; 'Undef'   ; end
+  def string_PUndefType(t)     ; 'Undef'   ; end
 
   # @api private
   def string_PDefaultType(t) ; 'Default' ; end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -264,7 +264,7 @@ module Puppet::Pops::Types::TypeFactory
   # Creates an instance of the Undef type
   # @api public
   def self.undef()
-    Types::PNilType.new()
+    Types::PUndefType.new()
   end
 
   # Creates an instance of the Default type

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -346,7 +346,7 @@ module Puppet::Pops
         end
 
         def is_the_empty_hash?
-          size_type.is_a?(PIntegerType) && size_type.from == 0 && size_type.to == 0 && key_type.is_a?(PNilType) && element_type.is_a?(PNilType)
+          size_type.is_a?(PIntegerType) && size_type.from == 0 && size_type.to == 0 && key_type.is_a?(PUndefType) && element_type.is_a?(PUndefType)
         end
       end
     end

--- a/lib/puppet/pops/types/types_meta.rb
+++ b/lib/puppet/pops/types/types_meta.rb
@@ -36,7 +36,7 @@ module Puppet::Pops::Types
 
   # @api public
   #
-  class PNilType < PAnyType
+  class PUndefType < PAnyType
   end
 
 
@@ -212,7 +212,7 @@ module Puppet::Pops::Types
     has_attr 'title', String
   end
 
-  # Represents a type that accept PNilType instead of the type parameter
+  # Represents a type that accept PUndefType instead of the type parameter
   # required_type - is a short hand for Variant[T, Undef]
   # @api public
   #

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -107,7 +107,7 @@ describe 'The type calculator' do
     # Do not include the special type Unit in this list
     def all_types
       [ Puppet::Pops::Types::PAnyType,
-        Puppet::Pops::Types::PNilType,
+        Puppet::Pops::Types::PUndefType,
         Puppet::Pops::Types::PDataType,
         Puppet::Pops::Types::PScalarType,
         Puppet::Pops::Types::PStringType,
@@ -183,7 +183,7 @@ describe 'The type calculator' do
       result << Puppet::Pops::Types::PDataType
       result << array_t(types::PDataType.new)
       result << types::TypeFactory.hash_of_data
-      result << Puppet::Pops::Types::PNilType
+      result << Puppet::Pops::Types::PUndefType
       tmp = tuple_t(types::PDataType.new)
       result << (tmp)
       tmp.size_type = range_t(0, nil)
@@ -231,8 +231,8 @@ describe 'The type calculator' do
       calculator.infer(/^a regular expression$/).class.should == Puppet::Pops::Types::PRegexpType
     end
 
-    it 'nil translates to PNilType' do
-      calculator.infer(nil).class.should == Puppet::Pops::Types::PNilType
+    it 'nil translates to PUndefType' do
+      calculator.infer(nil).class.should == Puppet::Pops::Types::PUndefType
     end
 
     it ':undef translates to PRuntimeType' do
@@ -803,7 +803,7 @@ describe 'The type calculator' do
         Bignum     => Puppet::Pops::Types::PIntegerType.new,
         Float      => Puppet::Pops::Types::PFloatType.new,
         Numeric    => Puppet::Pops::Types::PNumericType.new,
-        NilClass   => Puppet::Pops::Types::PNilType.new,
+        NilClass   => Puppet::Pops::Types::PUndefType.new,
         TrueClass  => Puppet::Pops::Types::PBooleanType.new,
         FalseClass => Puppet::Pops::Types::PBooleanType.new,
         String     => Puppet::Pops::Types::PStringType.new,
@@ -1212,7 +1212,7 @@ describe 'The type calculator' do
     include_context "types_setup"
 
     it 'should consider undef to be instance of Any, NilType, and optional' do
-      calculator.instance?(Puppet::Pops::Types::PNilType.new(), nil).should    == true
+      calculator.instance?(Puppet::Pops::Types::PUndefType.new(), nil).should    == true
       calculator.instance?(Puppet::Pops::Types::PAnyType.new(), nil).should == true
       calculator.instance?(Puppet::Pops::Types::POptionalType.new(), nil).should == true
     end
@@ -1234,7 +1234,7 @@ describe 'The type calculator' do
     it 'should not consider undef to be an instance of any other type than Any, NilType and Data' do
       types_to_test = all_types - [
         Puppet::Pops::Types::PAnyType,
-        Puppet::Pops::Types::PNilType,
+        Puppet::Pops::Types::PUndefType,
         Puppet::Pops::Types::PDataType,
         Puppet::Pops::Types::POptionalType,
         ]
@@ -1465,8 +1465,8 @@ describe 'The type calculator' do
       end
     end
 
-    it 'should yield \'PNilType\' for NilClass' do
-      calculator.type(NilClass).class.should == Puppet::Pops::Types::PNilType
+    it 'should yield \'PUndefType\' for NilClass' do
+      calculator.type(NilClass).class.should == Puppet::Pops::Types::PUndefType
     end
 
     it 'should yield \'PStringType\' for String' do
@@ -1729,7 +1729,7 @@ describe 'The type calculator' do
   context 'when processing meta type' do
     it 'should infer PType as the type of all other types' do
       ptype = Puppet::Pops::Types::PType
-      calculator.infer(Puppet::Pops::Types::PNilType.new()       ).is_a?(ptype).should() == true
+      calculator.infer(Puppet::Pops::Types::PUndefType.new()       ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PDataType.new()      ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PScalarType.new()   ).is_a?(ptype).should() == true
       calculator.infer(Puppet::Pops::Types::PStringType.new()    ).is_a?(ptype).should() == true
@@ -1754,7 +1754,7 @@ describe 'The type calculator' do
 
     it 'should infer PType as the type of all other types' do
       ptype = Puppet::Pops::Types::PType
-      calculator.string(calculator.infer(Puppet::Pops::Types::PNilType.new()       )).should == "Type[Undef]"
+      calculator.string(calculator.infer(Puppet::Pops::Types::PUndefType.new()       )).should == "Type[Undef]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PDataType.new()      )).should == "Type[Data]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PScalarType.new()   )).should == "Type[Scalar]"
       calculator.string(calculator.infer(Puppet::Pops::Types::PStringType.new()    )).should == "Type[String]"
@@ -1897,7 +1897,7 @@ describe 'The type calculator' do
       inferred_type.class.should == Puppet::Pops::Types::PTupleType
       element_types = inferred_type.types
       element_types[0].class.should == Puppet::Pops::Types::PStringType
-      element_types[1].class.should == Puppet::Pops::Types::PNilType
+      element_types[1].class.should == Puppet::Pops::Types::PUndefType
     end
   end
 

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -63,8 +63,8 @@ describe 'The type factory' do
       Puppet::Pops::Types::TypeFactory.tuple().class().should == Puppet::Pops::Types::PTupleType
     end
 
-    it 'undef() returns PNilType' do
-      Puppet::Pops::Types::TypeFactory.undef().class().should == Puppet::Pops::Types::PNilType
+    it 'undef() returns PUndefType' do
+      Puppet::Pops::Types::TypeFactory.undef().class().should == Puppet::Pops::Types::PUndefType
     end
 
     it 'default() returns PDefaultType' do


### PR DESCRIPTION
Before this commit, the type PNilType was used to represent the
Puppet 'undef' value. This was an unessesary mismatch. It is now renamed
to PUndefType.

The PNilType is not exposed to users of the Puppet Language or its APIs
so this is completely an internal refactoring/rename.