### PR TITLE
(PUP-4030) Support no_proxy env variable

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -130,8 +130,7 @@ class Puppet::Forge
     #
     # @return [Net::HTTP::Proxy] object constructed from repo settings
     def get_http_object
-      proxy_class = Net::HTTP::Proxy(Puppet::Util::HttpProxy.http_proxy_host, Puppet::Util::HttpProxy.http_proxy_port, Puppet::Util::HttpProxy.http_proxy_user, Puppet::Util::HttpProxy.http_proxy_password)
-      proxy = proxy_class.new(@uri.host, @uri.port)
+      proxy = Puppet::Util::HttpProxy.proxy(@uri)
 
       if @uri.scheme == 'https'
         cert_store = OpenSSL::X509::Store.new

--- a/lib/puppet/network/http/factory.rb
+++ b/lib/puppet/network/http/factory.rb
@@ -23,10 +23,13 @@ class Puppet::Network::HTTP::Factory
     Puppet.debug("Creating new connection for #{site}")
 
     args = [site.host, site.port]
-    if Puppet[:http_proxy_host] == "none"
-      args << nil << nil
-    else
-      args << Puppet[:http_proxy_host] << Puppet[:http_proxy_port]
+
+    unless Puppet::Util::HttpProxy.no_proxy?(site)
+      if Puppet[:http_proxy_host] == "none"
+        args << nil << nil
+      else
+        args << Puppet[:http_proxy_host] << Puppet[:http_proxy_port]
+      end
     end
 
     http = Net::HTTP.new(*args)

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -68,8 +68,10 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
   end
 
   def self.installpkgdmg(source, name)
-    http_proxy_host = Puppet::Util::HttpProxy.http_proxy_host
-    http_proxy_port = Puppet::Util::HttpProxy.http_proxy_port
+    unless Puppet::Util::HttpProxy.no_proxy?(source)
+      http_proxy_host = Puppet::Util::HttpProxy.http_proxy_host
+      http_proxy_port = Puppet::Util::HttpProxy.http_proxy_port
+    end
 
     unless source =~ /\.dmg$/i || source =~ /\.pkg$/i
       raise Puppet::Error.new("Mac OS X PKG DMG's must specify a source string ending in .dmg or flat .pkg file")

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -1,4 +1,13 @@
 module Puppet::Util::HttpProxy
+  def self.proxy(uri)
+    if self.no_proxy?(uri)
+      proxy_class = Net::HTTP::Proxy(nil)
+    else
+      proxy_class = Net::HTTP::Proxy(self.http_proxy_host, self.http_proxy_port, self.http_proxy_user, self.http_proxy_password)
+    end
+
+    return proxy_class.new(uri.host, uri.port)
+  end
 
   def self.http_proxy_env
     # Returns a URI object if proxy is set, or nil
@@ -9,6 +18,57 @@ module Puppet::Util::HttpProxy
       return nil
     end
     return nil
+  end
+
+  # The documentation around the format of the no_proxy variable seems
+  # inconsistent.  Some suggests the use of the * as a way of matching any
+  # hosts under a domain, e.g.:
+  #   *.example.com
+  # Other documentation suggests that just a leading '.' indicates a domain
+  # level exclusion, e.g.:
+  #   .example.com
+  # We'll accomodate both here.
+  def self.no_proxy?(dest)
+    unless no_proxy_env = ENV["no_proxy"] || ENV["NO_PROXY"]
+      return false
+    end
+
+    unless dest.is_a? URI
+      begin
+        dest = URI.parse(dest)
+      rescue URI::InvalidURIError
+        return false
+      end
+    end
+
+    no_proxy_env.split(/\s*,\s*/).each do |d|
+      host, port = d.split(':')
+      host = Regexp.escape(host).gsub('\*', '.*')
+
+      #If the host of this no_proxy value starts with '.', this entry is
+      #a domain level entry. Don't pin the regex to the beginning of the entry.
+      #If it does not start with a '.' then it is a host specific entry and
+      #should be matched to the destination starting at the beginning.
+      unless host =~ /^\\\./
+        host = "^#{host}"
+      end
+
+      #If this no_proxy entry specifies a port, we want to match it against
+      #the destination port.  Otherwise just match hosts.
+      if port
+        no_proxy_regex  = %r(#{host}:#{port}$)
+        dest_string     = "#{dest.host}:#{dest.port}"
+      else
+        no_proxy_regex  = %r(#{host}$)
+        dest_string     = "#{dest.host}"
+      end
+
+      if no_proxy_regex.match(dest_string)
+        return true
+      end
+    end
+
+    return false
   end
 
   def self.http_proxy_host


### PR DESCRIPTION
Implement support for the no_proxy variable in various places where http_proxy was taken into consideration such as accessing the forge.