### PR TITLE
(maint) Change puppetserver conf.d

### DIFF
--- a/acceptance/config/nodes/rhel7.yaml
+++ b/acceptance/config/nodes/rhel7.yaml
@@ -10,7 +10,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetserver/conf.d/
+    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/rhel7.yaml
+++ b/acceptance/config/nodes/rhel7.yaml
@@ -10,6 +10,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
+    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
@@ -24,6 +25,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
+    puppetpath: /etc/puppetlabs/puppet
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/trusty.yaml
+++ b/acceptance/config/nodes/trusty.yaml
@@ -10,7 +10,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetserver/conf.d/
+    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/trusty.yaml
+++ b/acceptance/config/nodes/trusty.yaml
@@ -10,6 +10,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
+    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
@@ -24,6 +25,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
+    puppetpath: /etc/puppetlabs/puppet
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/wheezy.yaml
+++ b/acceptance/config/nodes/wheezy.yaml
@@ -10,7 +10,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetserver/conf.d/
+    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/wheezy.yaml
+++ b/acceptance/config/nodes/wheezy.yaml
@@ -10,6 +10,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
+    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
@@ -24,6 +25,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
+    puppetpath: /etc/puppetlabs/puppet
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/win2012r2-rubyx64.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx64.yaml
@@ -9,6 +9,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
+    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache

--- a/acceptance/config/nodes/win2012r2-rubyx64.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx64.yaml
@@ -9,7 +9,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetserver/conf.d/
+    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/win2012r2-rubyx86.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
+    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache

--- a/acceptance/config/nodes/win2012r2-rubyx86.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx86.yaml
@@ -9,7 +9,7 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetserver/conf.d/
+    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
+++ b/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
@@ -36,9 +36,3 @@ end
 step "(SERVER-347) Set required codedir setting on puppetserver"
 on master, puppet("config set codedir /etc/puppetlabs/code --section master")
 
-step "(SERVER-370) overwrite ruby-load-path"
-create_remote_file(master, '/etc/puppetserver/conf.d/os-settings.conf', <<-EOF)
-os-settings: {
-    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
-}
-EOF

--- a/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
+++ b/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
@@ -1,7 +1,3 @@
-step "(PUP-4001) Work around packaging issue"
-on master, "mkdir -p #{master['distmoduledir']}"
-on master, "mkdir -p #{master['sitemoduledir']}"
-
 step "(PUP-4004) Set permissions on puppetserver directories that currently live in the agent cache dir"
 %w[reports server_data yaml bucket].each do |dir|
   on master, "install --directory /opt/puppetlabs/puppet/cache/#{dir}"

--- a/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
+++ b/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
@@ -21,14 +21,3 @@ test_name '(PUP-3997) Puppet User and Group on agents only' do
     end
   end
 end
-
-# The codedir setting should be passed into the puppetserver
-# initialization method, like is done for other required settings
-# confdir & vardir. For some reason, puppetserver gets confused
-# if this is not done, and tries to manage a directory:
-# /opt/puppetlabs/agent/cache/.puppet/code, which is a combination
-# of the default master-var-dir in puppetserver, and the user
-# based codedir.
-step "(SERVER-347) Set required codedir setting on puppetserver"
-on master, puppet("config set codedir /etc/puppetlabs/code --section master")
-


### PR DESCRIPTION
Previously, we had to override the puppetserver conf.d to refer to the
old location and override ruby-load-path to point to where the
puppet-agent installed puppet, facter, etc ruby code.

A recent build of puppetserver fixes the ruby-load-path issue, so that
workaround step is no longer required. Also puppetserver moved the
location of conf.d from /etc/puppetserver/conf.d to the correct location
/etc/puppetlabs/puppetserver/conf.d, so this commit updates the node
definitions to refer to the new locations.