### PR TITLE
(PUP-3296) Remove :before and :after for parameters

### DIFF
--- a/lib/puppet/parameter/value.rb
+++ b/lib/puppet/parameter/value.rb
@@ -7,7 +7,7 @@ require 'puppet/parameter/value_collection'
 #
 class Puppet::Parameter::Value
   attr_reader :name, :options, :event
-  attr_accessor :block, :call, :method, :required_features, :invalidate_refreshes
+  attr_accessor :block, :method, :required_features, :invalidate_refreshes
 
   # Adds an alias for this value.
   # Makes the given _name_ be an alias for this acceptable value.
@@ -47,8 +47,6 @@ class Puppet::Parameter::Value
     end
 
     @aliases = []
-
-    @call = :instead
   end
 
   # Checks if the given value matches the acceptance rules (literal value, regular expression, or one

--- a/spec/unit/parameter/value_collection_spec.rb
+++ b/spec/unit/parameter/value_collection_spec.rb
@@ -35,11 +35,6 @@ describe Puppet::Parameter::ValueCollection do
     expect(@collection.match?('')).to equal(value)
   end
 
-  it "should set :call to :none when adding a value with no block" do
-    value = @collection.newvalue(:foo)
-    expect(value.call).to eq(:none)
-  end
-
   describe "when adding a value with a block" do
     it "should set the method name to 'set_' plus the value name" do
       value = @collection.newvalue(:myval) { raise "testing" }
@@ -48,8 +43,8 @@ describe Puppet::Parameter::ValueCollection do
   end
 
   it "should be able to add an individual value with options" do
-    value = @collection.newvalue(:foo, :call => :bar)
-    expect(value.call).to eq(:bar)
+    value = @collection.newvalue(:foo, :method => 'set_myval')
+    expect(value.method).to eq('set_myval')
   end
 
   it "should have a method for validating a value" do

--- a/spec/unit/parameter/value_spec.rb
+++ b/spec/unit/parameter/value_spec.rb
@@ -36,16 +36,12 @@ describe Puppet::Parameter::Value do
     expect(value.aliases).to eq([:bar, :baz])
   end
 
-  [:block, :call, :method, :event, :required_features].each do |attr|
+  [:block, :method, :event, :required_features].each do |attr|
     it "should support a #{attr} attribute" do
       value = Puppet::Parameter::Value.new("foo")
       expect(value).to respond_to(attr.to_s + "=")
       expect(value).to respond_to(attr)
     end
-  end
-
-  it "should default to :instead for :call if a block is provided" do
-    expect(Puppet::Parameter::Value.new("foo").call).to eq(:instead)
   end
 
   it "should always return events as symbols" do

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -368,6 +368,12 @@ describe Puppet::Property do
         resource.provider.expects(:foo=).with :bar
         property.set(:bar)
       end
+
+       it "should generate setter named from :method argument and propagate call to the provider" do
+        subclass.newvalue(:bar, :method => 'set_vv')
+        resource.provider.expects(:foo=).with :bar
+        property.set_vv(:bar)
+      end
     end
 
     describe "that was defined with a block" do


### PR DESCRIPTION
This commit effectively removes the `:call` option from the
`Puppet::Resource::Value` since it becomes meaningless when the only
valid settings are `:none`and `:instead`. The option is still
recognized and validated for backwards compatibility but will trigger
a deprecation warning.

The value of the `:call` option is no longer used. Instead, a check is
made if either a method or block has been given. If so, it is called.
If not, the providers setter is called.

This commit also removes a couple of @TODO's related to the `:method`
option and ensures that a given method always exists. If a block is
given, then a method is defined using that block and the name given
by the `:method` option. If not, then the name becomes an alias for
a call to the providers setter method.