### PR TITLE
PUP-4046 correct require in hiera_include

### DIFF
--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -1,4 +1,4 @@
-require 'hiera_puppet'
+require 'hiera/puppet_function'
 
 # @see lib/puppet/parser/functions/hiera_include.rb for documentation
 # TODO: Move docs here when the format has been determined.


### PR DESCRIPTION
Here we correct the include of hiera_puppet to one of hiera/puppet_function,
allowing Hiera::PuppetFunction to be resolved.