### PR TITLE
(PUP-4050) Windows changes to codedir / vardir

### DIFF
--- a/acceptance/config/nodes/win2012r2-rubyx64.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx64.yaml
@@ -21,11 +21,11 @@ HOSTS:
     hypervisor: vcloud
     template: win-2012r2-x86_64
     puppetconfdir: C:/ProgramData/PuppetLabs/puppet/etc
-    puppetcodedir: C:/ProgramData/PuppetLabs/puppet/code
-    puppetvardir: C:/ProgramData/PuppetLabs/puppet/var
-    distmoduledir: C:/ProgramData/PuppetLabs/puppet/code/modules
+    puppetcodedir: C:/ProgramData/PuppetLabs/code
+    puppetvardir: C:/ProgramData/PuppetLabs/puppet/cache
+    distmoduledir: C:/ProgramData/PuppetLabs/code/modules
     sitemoduledir: C:/opt/puppetlabs/puppet/modules
-    hieraconf: C:/ProgramData/PuppetLabs/puppet/code/hiera.yaml
+    hieraconf: C:/ProgramData/PuppetLabs/code/hiera.yaml
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/config/nodes/win2012r2-rubyx86.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx86.yaml
@@ -21,11 +21,11 @@ HOSTS:
     hypervisor: vcloud
     template: win-2012r2-x86_64
     puppetconfdir: C:/ProgramData/PuppetLabs/puppet/etc
-    puppetcodedir: C:/ProgramData/PuppetLabs/puppet/code
-    puppetvardir: C:/ProgramData/PuppetLabs/puppet/var
-    distmoduledir: C:/ProgramData/PuppetLabs/puppet/code/modules
+    puppetcodedir: C:/ProgramData/PuppetLabs/code
+    puppetvardir: C:/ProgramData/PuppetLabs/puppet/cache
+    distmoduledir: C:/ProgramData/PuppetLabs/code/modules
     sitemoduledir: C:/opt/puppetlabs/puppet/modules
-    hieraconf: C:/ProgramData/PuppetLabs/puppet/code/hiera.yaml
+    hieraconf: C:/ProgramData/PuppetLabs/code/hiera.yaml
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/install.rb
+++ b/install.rb
@@ -273,7 +273,7 @@ def prepare_installation
   if not InstallOptions.codedir.nil?
     codedir = InstallOptions.codedir
   elsif $operatingsystem == "windows"
-    codedir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "code")
+    codedir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "code")
   else
     codedir = "/etc/puppetlabs/code"
   end
@@ -281,7 +281,7 @@ def prepare_installation
   if not InstallOptions.vardir.nil?
     vardir = InstallOptions.vardir
   elsif $operatingsystem == "windows"
-    vardir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "var")
+    vardir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "cache")
   else
     vardir = "/opt/puppetlabs/puppet/cache"
   end


### PR DESCRIPTION
 - In previous commits, Windows was aligned to other platform
   file system layout for both

   - codedir, which changed from PuppetLabs/puppet/code to
     Puppetlabs/code
   - vardir, which changed from PuppetLabs/puppet/var to
     PuppetLabs/puppet/cache

   These changes were made to run_mode:

   codedir introduced in 423f9b3aa8a987b7e4e25a8131eaad9754c4131a
   codedir was moved in c3757f734e9b5ec6979c43c07c671c482590ae66

   vardir was moved in c3757f734e9b5ec6979c43c07c671c482590ae66

 - Unfortunately, there were some additional changes that should
   have been made that affect install.rb, where those
   default values are duplicated.  This commit addresses those
   omissions.

 - Further, since the defaults changed, acceptance node definitions
   were also invalidated for the AIO platform we're currently
   supporting - namely win2012r2.  Update those as well.