### PR TITLE
(PUP-3706) console format should pretty print nested structures

### DIFF
--- a/lib/puppet/network/format_support.rb
+++ b/lib/puppet/network/format_support.rb
@@ -92,6 +92,10 @@ module Puppet::Network::FormatSupport
     to_data_hash.to_pson(*args)
   end
 
+  def to_json(*args)
+    to_data_hash.to_json(*args)
+  end
+
   def render(format = nil)
     format ||= self.class.default_format
 

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -151,7 +151,7 @@ Puppet::Network::FormatHandler.create(:console,
     end
 
     # ...or pretty-print the inspect outcome.
-    return json.render(datum)
+    return JSON.pretty_generate(datum)
   end
 
   def render_multiple(data)

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -325,9 +325,9 @@ describe Puppet::Application::FaceBase do
         end
       end
 
-      it "should render a non-trivially-keyed Hash with using JSON" do
+      it "should render a non-trivially-keyed Hash with using pretty printed JSON" do
         hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
-        expect(app.render(hash, {})).to eq(hash.to_pson.chomp)
+        expect(app.render(hash, {})).to eq(JSON.pretty_generate(hash).chomp)
       end
 
       it "should render a {String,Numeric}-keyed Hash into a table" do

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -289,9 +289,9 @@ describe "Puppet Network Format" do
       expect(subject.render({})).to eq('')
     end
 
-    it "should render a non-trivially-keyed Hash as JSON" do
+    it "should render a non-trivially-keyed Hash as pretty printed JSON" do
       hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
-      expect(subject.render(hash)).to eq(json.render(hash).chomp)
+      expect(subject.render(hash)).to eq(JSON.pretty_generate(hash).chomp)
     end
 
     it "should render a {String,Numeric}-keyed Hash into a table" do


### PR DESCRIPTION
This is a rebase and trivial rspec update to @dalen's [PR-3348](https://github.com/puppetlabs/puppet/pull/3348):

This makes the console format actually pretty print nested structures.
It already said it would, but didn't in fact.