### PR TITLE
(PUP-3997) Remove assumed user/group in agent tests

### DIFF
--- a/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
+++ b/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
@@ -9,23 +9,6 @@ end
 on master, "chown -R puppet:puppet /opt/puppetlabs/puppet/cache"
 on master, "chmod -R 750 /opt/puppetlabs/puppet/cache"
 
-# The AIO puppet-agent package does not create the puppet user or group, but
-# puppet-server does. However, some puppet acceptance tests assume the user
-# is present. This is a temporary setup step to create the puppet user and
-# group, but only on nodes that are agents and not the master
-test_name '(PUP-3997) Puppet User and Group on agents only' do
-  agents.each do |agent|
-    if agent == master
-      step "Skipping creating puppet user and group on #{agent}"
-    else
-      step "Ensure puppet user and group added to #{agent}" do
-        on agent, puppet("resource user puppet ensure=present")
-        on agent, puppet("resource group puppet ensure=present")
-      end
-    end
-  end
-end
-
 # The codedir setting should be passed into the puppetserver
 # initialization method, like is done for other required settings
 # confdir & vardir. For some reason, puppetserver gets confused

--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -21,6 +21,23 @@ require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
 initialize_temp_dirs
 
+user = "user#{rand(999999).to_i}"
+group = "group#{rand(999999).to_i}"
+
+teardown do
+  hosts.each do |host|
+    host.user_absent(user)
+    host.group_absent(group)
+  end
+end
+
+step "Setup: Create test user and group" do
+  hosts.each do |host|
+    host.user_present(user)
+    host.group_present(group)
+  end
+end
+
 agents.each do |agent|
   # The modulepath to use in environment 'dev'
   envs_path = get_test_file_path(agent, 'environments')
@@ -30,8 +47,6 @@ agents.each do |agent|
 
   # make sure that we use the modulepath from the dev environment
   puppetconf = get_test_file_path(agent, 'puppet.conf')
-  user = agent.puppet['user']
-  group = agent.puppet['group']
   # Setting user/group ensures that when puppet apply's Configurer use()'s the
   # settings, that it doesn't default to owning them as root, which can have an
   # impact on following tests.

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -78,8 +78,10 @@ class ModifiesModeTest < ActionModeTest
 
     @start_mode = start_mode
 
-    user = agent.puppet['user']
-    group = agent.puppet['group'] || user
+    user = 'symbolictestuser'
+    group = 'symbolictestgroup'
+    agent.user_present(user)
+    agent.group_present(group)
 
     testcase.on(agent, "touch #{@file} && chown #{user}:#{group} #{@file} && chmod #{start_mode.to_s(8)} #{@file}")
     testcase.on(agent, "mkdir -p #{@dir} && chown #{user}:#{group} #{@dir} && chmod #{start_mode.to_s(8)} #{@dir}")

--- a/acceptance/tests/resource/user/should_destroy.rb
+++ b/acceptance/tests/resource/user/should_destroy.rb
@@ -10,5 +10,8 @@ agents.each do |agent|
   on agent, puppet_resource('user', name, 'ensure=absent')
 
   step "verify the user was deleted"
+  fail_test "User #{name} was not deleted" if agent.user_list.include? name
+
+  step "delete the user, if any"
   agent.user_absent(name)
 end

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -1,8 +1,25 @@
 test_name "tests that user resource will not add users that already exist."
 
+user  = "user#{rand(999999).to_i}"
+group = "group#{rand(999999).to_i}"
+
+teardown do
+  hosts.each do |host|
+    host.user_absent(user)
+    host.group_absent(group)
+  end
+end
+
+step "Setup: Create test user and group" do
+  hosts.each do |host|
+    host.user_present(user)
+    host.group_present(group)
+  end
+end
+
 step "verify that we don't try to create a user account that already exists"
 agents.each do |agent|
-  on(agent, puppet_resource('user', agent.puppet['user'], 'ensure=present')) do
-    fail_test "tried to create '#{agent.puppet['user']}' user" if stdout.include? 'created'
+  on(agent, puppet_resource('user', user, 'ensure=present')) do
+    fail_test "tried to create '#{user}' user" if stdout.include? 'created'
   end
 end


### PR DESCRIPTION
This commit removes the usage of `host.puppet['user']`, `host.puppet['group'],
in tests where it is used as an assumed user/group on non-master hosts.

The agent only packaging no longer creates a user and group
corresponding to the `puppet config print user` value. Tests
assuming this user/group exists on agents can no longer do so.

The previous pattern is replaced by the explicit creation of a
user on the host using the beaker `host.user_present('username')`
method.