### PR TITLE
(PUP-4057) Don't rely on puppetpath beaker option

### DIFF
--- a/acceptance/config/nodes/rhel7.yaml
+++ b/acceptance/config/nodes/rhel7.yaml
@@ -10,7 +10,6 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
@@ -25,7 +24,6 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetpath: /etc/puppetlabs/puppet
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/trusty.yaml
+++ b/acceptance/config/nodes/trusty.yaml
@@ -10,7 +10,6 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
@@ -25,7 +24,6 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetpath: /etc/puppetlabs/puppet
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/wheezy.yaml
+++ b/acceptance/config/nodes/wheezy.yaml
@@ -10,7 +10,6 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
@@ -25,7 +24,6 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetpath: /etc/puppetlabs/puppet
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache
     sitemoduledir: /opt/puppetlabs/puppet/modules

--- a/acceptance/config/nodes/win2012r2-rubyx64.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx64.yaml
@@ -9,7 +9,6 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache

--- a/acceptance/config/nodes/win2012r2-rubyx86.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx86.yaml
@@ -9,7 +9,6 @@ HOSTS:
     distmoduledir: /etc/puppetlabs/code/modules
     hieraconf:     /etc/puppetlabs/code/hiera.yaml
     puppetconfdir: /etc/puppetlabs/puppet
-    puppetpath: /etc/puppetlabs/puppet
     puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
     puppetbindir:  /opt/puppetlabs/puppet/bin
     puppetvardir:  /opt/puppetlabs/puppet/cache

--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -227,7 +227,7 @@ module Puppet
         master_puppet_conf = master_opts.dup # shallow clone
 
         results = {}
-        safely_shadow_directory_contents_and_yield(master, master['puppetpath'], envdir) do
+        safely_shadow_directory_contents_and_yield(master, master.puppet('master')['codedir'], envdir) do
 
           config_print = options[:config_print]
           directory_environments = options[:directory_environments]

--- a/acceptance/setup/git/pre-suite/010_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/010_TestSetup.rb
@@ -45,8 +45,9 @@ test_name "Install packages and repositories on target machines..." do
 
   step "Hosts: create basic puppet.conf" do
     hosts.each do |host|
-      on host, "mkdir -p #{host['puppetpath']}"
-      puppetconf = File.join(host['puppetpath'], 'puppet.conf')
+      confdir = host.puppet['confdir']
+      on host, "mkdir -p #{confdir}"
+      puppetconf = File.join(confdir, 'puppet.conf')
 
       if host['roles'].include?('agent')
         on host, "echo '[agent]' > #{puppetconf} && " +

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -23,7 +23,7 @@ master_opts = {
 }
 general = [ master_opts, testdir, puppet_conf_backup_dir, { :directory_environments => true } ]
 env = 'doesnotexist'
-path = master['puppetpath']
+path = master.puppet('master')['codedir']
 
 results = use_an_environment("testing", "bad environmentpath", master_opts, testdir, puppet_conf_backup_dir, :directory_environments => true)
 

--- a/acceptance/tests/environment/environment_scenario-default.rb
+++ b/acceptance/tests/environment/environment_scenario-default.rb
@@ -10,18 +10,19 @@ step "setup environments"
 
 stub_forge_on(master)
 
-testdir = create_tmpdir_for_user master, "confdir"
-puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
+codedir = master.puppet('master')['codedir']
+testdir = create_tmpdir_for_user master, "codedir"
+puppet_code_backup_dir = create_tmpdir_for_user(master, "puppet-code-backup-dir")
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
 step  "Test"
 master_opts = {
   'main' => {
-    'environmentpath' => '$confdir/environments',
+    'environmentpath' => '$codedir/environments',
   }
 }
-general = [ master_opts, testdir, puppet_conf_backup_dir, { :directory_environments => true } ]
+general = [ master_opts, testdir, puppet_code_backup_dir, { :directory_environments => true } ]
 env = nil
 
 results = use_an_environment(env, "default environment", *general)
@@ -29,23 +30,23 @@ results = use_an_environment(env, "default environment", *general)
 expectations = {
   :puppet_config => {
     :exit_code => 0,
-    :matches => [%r{manifest.*#{master['puppetpath']}/environments/#{env}/manifests$},
-                 %r{modulepath.*#{master['puppetpath']}/environments/#{env}/modules:.+},
+    :matches => [%r{manifest.*#{codedir}/environments/#{env}/manifests$},
+                 %r{modulepath.*#{codedir}/environments/#{env}/modules:.+},
                  %r{config_version = $}]
   },
   :puppet_module_install => {
     :exit_code => 0,
-    :matches => [%r{Preparing to install into #{master['puppetpath']}/environments/#{env}/modules},
+    :matches => [%r{Preparing to install into #{codedir}/environments/#{env}/modules},
                  %r{pmtacceptance-nginx}],
   },
   :puppet_module_uninstall => {
     :exit_code => 0,
-    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{master['puppetpath']}/environments/#{env}/modules}],
+    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{codedir}/environments/#{env}/modules}],
   },
   :puppet_apply => {
     :exit_code => 0,
     :matches => [%r{include default environment testing_mod}],
-    :notes => "The production directory environment is empty, but the inclusion of basemodulepath in the directory environment modulepath picks up the default testing_mod class in $confdir/modules"
+    :notes => "The production directory environment is empty, but the inclusion of basemodulepath in the directory environment modulepath picks up the default testing_mod class in $codedir/modules"
   },
   :puppet_agent => {
     :exit_code => 0,

--- a/acceptance/tests/environment/environment_scenario-existing.rb
+++ b/acceptance/tests/environment/environment_scenario-existing.rb
@@ -10,8 +10,9 @@ step "setup environments"
 
 stub_forge_on(master)
 
-testdir = create_tmpdir_for_user master, "confdir"
-puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
+codedir = master.puppet('master')['codedir']
+testdir = create_tmpdir_for_user master, "codedir"
+puppet_code_backup_dir = create_tmpdir_for_user(master, "puppet-code-backup-dir")
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
@@ -19,10 +20,10 @@ step "Test"
 
 master_opts = {
   'main' => {
-    'environmentpath' => '$confdir/environments',
+    'environmentpath' => '$codedir/environments',
   }
 }
-general = [ master_opts, testdir, puppet_conf_backup_dir, { :directory_environments => true } ]
+general = [ master_opts, testdir, puppet_code_backup_dir, { :directory_environments => true } ]
 
 env = 'testing'
 
@@ -30,18 +31,18 @@ results = use_an_environment(env, "directory testing", *general)
 expectations = {
   :puppet_config => {
     :exit_code => 0,
-    :matches => [%r{manifest.*#{master['puppetpath']}/environments/#{env}/manifests$},
-                 %r{modulepath.*#{master['puppetpath']}/environments/#{env}/modules:.+},
+    :matches => [%r{manifest.*#{codedir}/environments/#{env}/manifests$},
+                 %r{modulepath.*#{codedir}/environments/#{env}/modules:.+},
                  %r{config_version = $}]
   },
   :puppet_module_install => {
     :exit_code => 0,
-    :matches => [%r{Preparing to install into #{master['puppetpath']}/environments/#{env}/modules},
+    :matches => [%r{Preparing to install into #{codedir}/environments/#{env}/modules},
                  %r{pmtacceptance-nginx}],
   },
   :puppet_module_uninstall => {
     :exit_code => 0,
-    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{master['puppetpath']}/environments/#{env}/modules}],
+    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{codedir}/environments/#{env}/modules}],
   },
   :puppet_apply => {
     :exit_code => 0,

--- a/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
+++ b/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
@@ -10,38 +10,39 @@ step "setup environments"
 
 stub_forge_on(master)
 
-testdir = create_tmpdir_for_user master, "confdir"
-puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
+codedir = master.puppet('master')['codedir']
+testdir = create_tmpdir_for_user master, "codedir"
+puppet_code_backup_dir = create_tmpdir_for_user(master, "puppet-code-backup-dir")
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
 step  "Test"
 master_opts = {
   'master' => {
-    'environmentpath' => '$confdir/environments',
+    'environmentpath' => '$codedir/environments',
   }
 }
 env = 'testing'
 
-results = use_an_environment("testing", "master environmentpath", master_opts, testdir, puppet_conf_backup_dir, :directory_environments => true, :config_print => '--section=master')
+results = use_an_environment("testing", "master environmentpath", master_opts, testdir, puppet_code_backup_dir, :directory_environments => true, :config_print => '--section=master')
 
 expectations = {
   :puppet_config => {
     :exit_code => 0,
-    :matches => [%r{manifest.*#{master['puppetpath']}/environments/#{env}/manifests$},
-                 %r{modulepath.*#{master['puppetpath']}/environments/#{env}/modules:.+},
+    :matches => [%r{manifest.*#{codedir}/environments/#{env}/manifests$},
+                 %r{modulepath.*#{codedir}/environments/#{env}/modules:.+},
                  %r{config_version = $}]
   },
   :puppet_module_install => {
     :exit_code => 0,
-    :matches => [%r{Preparing to install into #{master['puppetpath']}/modules},
+    :matches => [%r{Preparing to install into #{codedir}/modules},
                  %r{pmtacceptance-nginx}],
     :expect_failure => true,
     :notes => "Runs in user mode and doesn't see the master environmenetpath setting.",
   },
   :puppet_module_uninstall => {
     :exit_code => 0,
-    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{master['puppetpath']}/modules}],
+    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{codedir}/modules}],
     :expect_failure => true,
     :notes => "Runs in user mode and doesn't see the master environmenetpath setting.",
   },

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -10,20 +10,20 @@ step "setup environments"
 
 stub_forge_on(master)
 
-testdir = create_tmpdir_for_user master, "confdir"
-puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
+testdir = create_tmpdir_for_user master, "codedir"
+puppet_code_backup_dir = create_tmpdir_for_user(master, "puppet-code-backup-dir")
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
 step "Test"
 master_opts = {
   'main' => {
-    'environmentpath' => '$confdir/environments',
+    'environmentpath' => '$codedir/environments',
   }
 }
-general = [ master_opts, testdir, puppet_conf_backup_dir, { :directory_environments => true } ]
+general = [ master_opts, testdir, puppet_code_backup_dir, { :directory_environments => true } ]
 env = 'doesnotexist'
-path = master['puppetpath']
+path = master.puppet('master')['codedir']
 
 results = use_an_environment(env, "non existent environment", *general)
 

--- a/acceptance/tests/environment/environment_scenario-with_explicit_environment_conf.rb
+++ b/acceptance/tests/environment/environment_scenario-with_explicit_environment_conf.rb
@@ -10,36 +10,37 @@ step "setup environments"
 
 stub_forge_on(master)
 
-testdir = create_tmpdir_for_user master, "confdir"
-puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
+codedir = master.puppet('master')['codedir']
+testdir = create_tmpdir_for_user master, "codedir"
+puppet_code_backup_dir = create_tmpdir_for_user(master, "puppet-code-backup-dir")
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
 step  "Test"
 master_opts = {
   'main' => {
-    'environmentpath' => '$confdir/environments',
+    'environmentpath' => '$codedir/environments',
   }
 }
-general = [ master_opts, testdir, puppet_conf_backup_dir, { :directory_environments => true } ]
+general = [ master_opts, testdir, puppet_code_backup_dir, { :directory_environments => true } ]
 
 results = use_an_environment("testing_environment_conf", "directory with environment.conf testing", *general)
 
 expectations = {
   :puppet_config => {
     :exit_code => 0,
-    :matches => [%r{manifest.*#{master['puppetpath']}/environments/testing_environment_conf/nonstandard-manifests$},
-                 %r{modulepath.*#{master['puppetpath']}/environments/testing_environment_conf/nonstandard-modules:.+},
-                 %r{config_version = #{master['puppetpath']}/environments/testing_environment_conf/local-version.sh$}]
+    :matches => [%r{manifest.*#{codedir}/environments/testing_environment_conf/nonstandard-manifests$},
+                 %r{modulepath.*#{codedir}/environments/testing_environment_conf/nonstandard-modules:.+},
+                 %r{config_version = #{codedir}/environments/testing_environment_conf/local-version.sh$}]
   },
   :puppet_module_install => {
     :exit_code => 0,
-    :matches => [%r{Preparing to install into #{master['puppetpath']}/environments/testing_environment_conf/nonstandard-modules},
+    :matches => [%r{Preparing to install into #{codedir}/environments/testing_environment_conf/nonstandard-modules},
                  %r{pmtacceptance-nginx}],
   },
   :puppet_module_uninstall => {
     :exit_code => 0,
-    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{master['puppetpath']}/environments/testing_environment_conf/nonstandard-modules}],
+    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{codedir}/environments/testing_environment_conf/nonstandard-modules}],
   },
   :puppet_apply => {
     :exit_code => 0,

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -8,6 +8,7 @@ hosts.each do |host|
   skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
 end
 
+codedir = master.puppet('master')['codedir']
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []
@@ -16,28 +17,28 @@ orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)
   # TODO: make helper take modulepath
-  on master, "rm -rf #{master['puppetpath']}/modules2"
+  on master, "rm -rf #{codedir}/modules2"
 end
 
 step 'Setup'
 
 stub_forge_on(master)
 
-on master, "mkdir -p #{master['puppetpath']}/modules2"
+on master, "mkdir -p #{codedir}/modules2"
 
 step "Install a module with relative modulepath"
-on master, "cd #{master['puppetpath']}/modules2 && puppet module install #{module_author}-#{module_name} --modulepath=." do
+on master, "cd #{codedir}/modules2 && puppet module install #{module_author}-#{module_name} --modulepath=." do
   assert_module_installed_ui(stdout, module_author, module_name)
-  assert_match(/#{master['puppetpath']}\/modules2/, stdout,
+  assert_match(/#{codedir}\/modules2/, stdout,
         "Notice of non default install path was not displayed")
 end
-assert_module_installed_on_disk(master, module_name, "#{master['puppetpath']}/modules2")
+assert_module_installed_on_disk(master, module_name, "#{codedir}/modules2")
 
 step "Install a module with absolute modulepath"
-on master, "test -d #{master['puppetpath']}/modules2/#{module_name} && rm -rf #{master['puppetpath']}/modules2/#{module_name}"
-on master, puppet("module install #{module_author}-#{module_name} --modulepath=#{master['puppetpath']}/modules2") do
+on master, "test -d #{codedir}/modules2/#{module_name} && rm -rf #{codedir}/modules2/#{module_name}"
+on master, puppet("module install #{module_author}-#{module_name} --modulepath=#{codedir}/modules2") do
   assert_module_installed_ui(stdout, module_author, module_name)
-  assert_match(/#{master['puppetpath']}\/modules2/, stdout,
+  assert_match(/#{codedir}\/modules2/, stdout,
         "Notice of non default install path was not displayed")
 end
-assert_module_installed_on_disk(master, module_name, "#{master['puppetpath']}/modules2")
+assert_module_installed_on_disk(master, module_name, "#{codedir}/modules2")

--- a/acceptance/tests/modules/list/with_modulepath.rb
+++ b/acceptance/tests/modules/list/with_modulepath.rb
@@ -1,18 +1,20 @@
 test_name "puppet module list (with modulepath)"
 
+codedir = master.puppet('master')['codedir']
+
 step "Setup"
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['puppetpath']}/modules2',
-    '#{master['puppetpath']}/modules2/crakorn',
-    '#{master['puppetpath']}/modules2/appleseed',
-    '#{master['puppetpath']}/modules2/thelock',
+    '#{codedir}/modules2',
+    '#{codedir}/modules2/crakorn',
+    '#{codedir}/modules2/appleseed',
+    '#{codedir}/modules2/thelock',
   ]: ensure => directory,
      recurse => true,
      purge => true,
      force => true;
-  '#{master['puppetpath']}/modules2/crakorn/metadata.json':
+  '#{codedir}/modules2/crakorn/metadata.json':
     content => '{
       "name": "jimmy/crakorn",
       "version": "0.4.0",
@@ -21,7 +23,7 @@ file {
       "license": "MIT",
       "dependencies": []
     }';
-  '#{master['puppetpath']}/modules2/appleseed/metadata.json':
+  '#{codedir}/modules2/appleseed/metadata.json':
     content => '{
       "name": "jimmy/appleseed",
       "version": "1.1.0",
@@ -32,7 +34,7 @@ file {
         { "name": "jimmy/crakorn", "version_requirement": "0.4.0" }
       ]
     }';
-  '#{master['puppetpath']}/modules2/thelock/metadata.json':
+  '#{codedir}/modules2/thelock/metadata.json':
     content => '{
       "name": "jimmy/thelock",
       "version": "1.0.0",
@@ -47,17 +49,17 @@ file {
 PP
 
 teardown do
-  on master, "rm -rf #{master['puppetpath']}/modules2"
+  on master, "rm -rf #{codedir}/modules2"
 end
 
-on master, "[ -d #{master['puppetpath']}/modules2/crakorn ]"
-on master, "[ -d #{master['puppetpath']}/modules2/appleseed ]"
-on master, "[ -d #{master['puppetpath']}/modules2/thelock ]"
+on master, "[ -d #{codedir}/modules2/crakorn ]"
+on master, "[ -d #{codedir}/modules2/appleseed ]"
+on master, "[ -d #{codedir}/modules2/thelock ]"
 
 step "List the installed modules with relative modulepath"
-on master, "cd #{master['puppetpath']}/modules2 && puppet module list --modulepath=." do
+on master, "cd #{codedir}/modules2 && puppet module list --modulepath=." do
   assert_equal <<-STDOUT, stdout
-#{master['puppetpath']}/modules2
+#{codedir}/modules2
 ├── jimmy-appleseed (\e[0;36mv1.1.0\e[0m)
 ├── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
 └── jimmy-thelock (\e[0;36mv1.0.0\e[0m)
@@ -65,9 +67,9 @@ STDOUT
 end
 
 step "List the installed modules with absolute modulepath"
-on master, puppet("module list --modulepath=#{master['puppetpath']}/modules2") do
+on master, puppet("module list --modulepath=#{codedir}/modules2") do
   assert_equal <<-STDOUT, stdout
-#{master['puppetpath']}/modules2
+#{codedir}/modules2
 ├── jimmy-appleseed (\e[0;36mv1.1.0\e[0m)
 ├── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
 └── jimmy-thelock (\e[0;36mv1.0.0\e[0m)

--- a/acceptance/tests/modules/uninstall/with_modulepath.rb
+++ b/acceptance/tests/modules/uninstall/with_modulepath.rb
@@ -1,18 +1,20 @@
 test_name "puppet module uninstall (with modulepath)"
 
+codedir = master.puppet('master')['codedir']
+
 teardown do
-  on master, "rm -rf #{master['puppetpath']}/modules2"
+  on master, "rm -rf #{codedir}/modules2"
 end
 
 step "Setup"
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['puppetpath']}/modules2',
-    '#{master['puppetpath']}/modules2/crakorn',
-    '#{master['puppetpath']}/modules2/absolute',
+    '#{codedir}/modules2',
+    '#{codedir}/modules2/crakorn',
+    '#{codedir}/modules2/absolute',
   ]: ensure => directory;
-  '#{master['puppetpath']}/modules2/crakorn/metadata.json':
+  '#{codedir}/modules2/crakorn/metadata.json':
     content => '{
       "name": "jimmy/crakorn",
       "version": "0.4.0",
@@ -21,7 +23,7 @@ file {
       "license": "MIT",
       "dependencies": []
     }';
-  '#{master['puppetpath']}/modules2/absolute/metadata.json':
+  '#{codedir}/modules2/absolute/metadata.json':
     content => '{
       "name": "jimmy/absolute",
       "version": "0.4.0",
@@ -33,24 +35,24 @@ file {
 }
 PP
 
-on master, "[ -d #{master['puppetpath']}/modules2/crakorn ]"
-on master, "[ -d #{master['puppetpath']}/modules2/absolute ]"
+on master, "[ -d #{codedir}/modules2/crakorn ]"
+on master, "[ -d #{codedir}/modules2/absolute ]"
 
 step "Try to uninstall the module jimmy-crakorn using relative modulepath"
-on master, "cd #{master['puppetpath']}/modules2 && puppet module uninstall jimmy-crakorn --modulepath=." do
+on master, "cd #{codedir}/modules2 && puppet module uninstall jimmy-crakorn --modulepath=." do
   assert_equal <<-OUTPUT, stdout
 \e[mNotice: Preparing to uninstall 'jimmy-crakorn' ...\e[0m
-Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from #{master['puppetpath']}/modules2
+Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from #{codedir}/modules2
   OUTPUT
 end
 
-on master, "[ ! -d #{master['puppetpath']}/modules2/crakorn ]"
+on master, "[ ! -d #{codedir}/modules2/crakorn ]"
 
 step "Try to uninstall the module jimmy-absolute using an absolute modulepath"
-on master, "cd #{master['puppetpath']}/modules2 && puppet module uninstall jimmy-absolute --modulepath=#{master['puppetpath']}/modules2" do
+on master, "cd #{codedir}/modules2 && puppet module uninstall jimmy-absolute --modulepath=#{codedir}/modules2" do
   assert_equal <<-OUTPUT, stdout
 \e[mNotice: Preparing to uninstall 'jimmy-absolute' ...\e[0m
-Removed 'jimmy-absolute' (\e[0;36mv0.4.0\e[0m) from #{master['puppetpath']}/modules2
+Removed 'jimmy-absolute' (\e[0;36mv0.4.0\e[0m) from #{codedir}/modules2
   OUTPUT
 end
-on master, "[ ! -d #{master['puppetpath']}/modules2/absolute ]"
+on master, "[ ! -d #{codedir}/modules2/absolute ]"


### PR DESCRIPTION
Previously, several acceptance tests relied on the `puppetpath` beaker
setting, which beaker currently defaults to `/etc/puppetlabs/agent` and
will be deprecated.

This commit updates the acceptance tests to use either `codedir` or
`confdir` as appropriate, and to query the host for the method, rather
than relying on beaker.