### PR TITLE
(PUP-3960) Fix installed rpm package helper

### DIFF
--- a/acceptance/lib/puppet/acceptance/rpm_util.rb
+++ b/acceptance/lib/puppet/acceptance/rpm_util.rb
@@ -7,7 +7,7 @@ module Puppet
       def setup(agent)
         required_packages = ['createrepo', 'rpm-build']
         required_packages.each do |pkg|
-          unless ((on agent, "#{pkg} --version", :acceptable_exit_codes => (0..255)).exit_code == 0) then
+          unless ((on agent, "yum list installed #{pkg}", :acceptable_exit_codes => (0..255)).exit_code == 0) then
             on agent, "yum install -y #{pkg}"
           end
         end


### PR DESCRIPTION
This commit changes the validation of an rpm package install to
use yum to perform the query.

Prior to this commit, the helper assumed that the package installed
a binary of the same name.