### PR TITLE
(PUP-4064) Fix bogus error from 3x lookup function parameter validator

### DIFF
--- a/lib/puppet/pops/binder/lookup.rb
+++ b/lib/puppet/pops/binder/lookup.rb
@@ -78,7 +78,7 @@ class Puppet::Pops::Binder::Lookup
 
     t = type_calculator.infer(options[:name])
     if ! type_calculator.assignable?(name_type, t)
-      fail("given 'name' argument, #{type_mismatch(type_calculator, options[:name], t)}")
+      fail("given 'name' argument, #{type_mismatch(type_calculator, name_type, t)}")
     end
 
     # unless a type is already given (future case), parse the type (or default 'Data'), fails if invalid type is given

--- a/spec/unit/parser/functions/lookup_spec.rb
+++ b/spec/unit/parser/functions/lookup_spec.rb
@@ -17,6 +17,10 @@ describe "lookup function" do
     expect do
       scope.function_lookup([])
     end.to raise_error(ArgumentError, /Wrong number of arguments/)
+
+    expect do
+      scope.function_lookup([1,2])
+    end.to raise_error(Puppet::ParseError, /given 'name' argument, has wrong type/)
   end
 
   it "looks up a value that exists" do


### PR DESCRIPTION
Type parameter validator, when encountering a name that was not a
string, passed the value instead of the value type to the
TypeCalculator.string method responsible for producing a string
representation of the type to include in the validation error message.
This resulted in an internal error.

This commit fixes so that the type of the value is used instead.