### PR TITLE
(PUP-4054) Remove unhelpful unwrapping of errors in create_resources

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -70,13 +70,5 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
     resource.virtual = true
   end
 
-  begin
-    resource.safeevaluate(self)
-  rescue Puppet::ParseError => internal_error
-    if internal_error.original.nil?
-      raise internal_error
-    else
-      raise internal_error.original
-    end
-  end
+  resource.safeevaluate(self)
 end

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -63,7 +63,7 @@ describe 'function for dynamically creating resources' do
     it 'should fail to add non-existing type' do
       expect do
         @scope.function_create_resources(['create-resource-foo', { 'foo' => {} }])
-      end.to raise_error(ArgumentError, /Invalid resource type create-resource-foo/)
+      end.to raise_error(/Invalid resource type create-resource-foo/)
     end
 
     it 'should be able to add edges' do
@@ -169,7 +169,7 @@ describe 'function for dynamically creating resources' do
         compile_to_catalog(<<-MANIFEST)
           create_resources('class', {'blah'=>{'one'=>'two'}})
         MANIFEST
-      end.to raise_error(Puppet::Error, 'Could not find declared class blah at line 1 on node foonode')
+      end.to raise_error(/Could not find declared class blah at line 1 on node foonode/)
     end
 
     it 'should be able to add edges' do


### PR DESCRIPTION
Before this fix, if Puppet::ParseError was raised with a causing
(original) error associated with it, the original error was unwrapped
and passed on. This led to valuable information being lost as the
original error would typically be a lower level ArgumentError that has
no information about file and line.
This in turn means that the error is reported against the call to
create_resources as opposed to the actual location in puppet source that
invoked the logic that in turn triggered the ArgumentError.

This can be observed by having create_resource create a defined resource
that attempts to add two strings.

The fix is simply to remove the unwrapping and not catching the error at
all. With this implementation the error is as detailed as it can get,
albeit slightly oddly formatted in some cases since the original error
is also presented with a 'wrapped exception' label.

Note that 3x is notoriously bad in associating the error with the
correct line number - it reports the error on the line after the actual
position in many cases (or at end of file, end of block). This fix does
not attempt to correct that (instead, use the future parser where
this works).