### PR TITLE
(PUP-4004) Remove puppet-server cachedir acceptance workaround for AIO

### DIFF
--- a/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
+++ b/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
@@ -1,10 +1,3 @@
-step "(PUP-4004) Set permissions on puppetserver directories that currently live in the agent cache dir"
-%w[reports server_data yaml bucket].each do |dir|
-  on master, "install --directory /opt/puppetlabs/puppet/cache/#{dir}"
-end
-on master, "chown -R puppet:puppet /opt/puppetlabs/puppet/cache"
-on master, "chmod -R 750 /opt/puppetlabs/puppet/cache"
-
 # The AIO puppet-agent package does not create the puppet user or group, but
 # puppet-server does. However, some puppet acceptance tests assume the user
 # is present. This is a temporary setup step to create the puppet user and


### PR DESCRIPTION
This commit removes an acceptance workaround for AIO that
created the puppet-server cache and related directories.

With the resolution of SERVER-357, we can remove this workaround.