### PR TITLE
(PUP-4056) Pin beaker

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.2')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || 'git://github.com/puppetlabs/beaker#31bc7aa4405ac4fa0a2896be1c644dee34a0ea3e')
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false


### PR DESCRIPTION
This commit pins beaker to the last known SHA prior to
https://github.com/puppetlabs/beaker/commit/c6a15c8f6df09a, which
changes the semantics around `puppetbindir`.

This is a temporary measure until PUP-4056 is implemented.