### PR TITLE
(PUP-4070) Fix TypeAsserter to use infer_set instead of infer

### DIFF
--- a/lib/puppet/pops/types/type_asserter.rb
+++ b/lib/puppet/pops/types/type_asserter.rb
@@ -26,7 +26,7 @@ module Puppet::Pops::Types::TypeAsserter
   def self.assert_instance_of(subject, expected_type, value, nil_ok = false)
     if !(value.nil? && nil_ok)
       tc = Puppet::Pops::Types::TypeCalculator.singleton
-      check_assignability(tc, subject, expected_type, tc.infer(value), true)
+      check_assignability(tc, subject, expected_type, tc.infer_set(value), true)
     end
     value
   end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -113,8 +113,18 @@ describe "when performing lookup" do
       expect(resources).to include('global_e1_module_e2_env_e3')
     end
 
-    it "can pass merge parameter in the form of a hash with a 'strategy'" do
+    it "can pass merge parameter in the form of a hash with a 'strategy=>unique'" do
+      resources = assemble_and_compile('${r[0]}_${r[1]}', "'c'", 'Array[String]', "{strategy => 'unique'}")
+      expect(resources).to include('env_c_module_c')
+    end
+
+    it "can pass merge parameter in the form of a hash with 'strategy=>hash'" do
       resources = assemble_and_compile('${r[k1]}_${r[k2]}_${r[k3]}', "'e'", 'Hash[String,String]', "{strategy => 'hash'}")
+      expect(resources).to include('env_e1_module_e2_env_e3')
+    end
+
+    it "can pass merge parameter in the form of a hash with a 'strategy=>deep'" do
+      resources = assemble_and_compile('${r[k1]}_${r[k2]}_${r[k3]}', "'e'", 'Hash[String,String]', "{strategy => 'deep'}")
       expect(resources).to include('env_e1_module_e2_env_e3')
     end
 


### PR DESCRIPTION
The TypeAsserter.assert_instance_of incorrectly used infer() to
determine the type of the given instance. This commit changes it
to use infer_set().

A couple of tests for the new lookup function are also added since
it was impacted by this bug.