### PR TITLE
(maint) Ensure that default data providers throws :no_such_key

### DIFF
--- a/lib/puppet/plugins/data_providers.rb
+++ b/lib/puppet/plugins/data_providers.rb
@@ -78,13 +78,13 @@ class Puppet::Plugins::DataProviders
 
   class ModuleDataProvider
     def lookup(name, scope, merge)
-      nil
+      throw :no_such_key
     end
   end
 
   class EnvironmentDataProvider
     def lookup(name, scope, merge)
-      nil
+      throw :no_such_key
     end
   end
 end


### PR DESCRIPTION
The default data provider that is used when no environment has been
setup or when no module provider is found returned nil on lookup.
This commit changes this so that they instead throw :no_such_key to
indicate that no value was found (as opposed to finding nil).