### PR TITLE
(PUP-3706) Render console output using PSON

### DIFF
--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -151,7 +151,7 @@ Puppet::Network::FormatHandler.create(:console,
     end
 
     # ...or pretty-print the inspect outcome.
-    return JSON.pretty_generate(datum)
+    return PSON.pretty_generate(datum)
   end
 
   def render_multiple(data)

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -325,9 +325,9 @@ describe Puppet::Application::FaceBase do
         end
       end
 
-      it "should render a non-trivially-keyed Hash with using pretty printed JSON" do
+      it "should render a non-trivially-keyed Hash with using pretty printed PSON" do
         hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
-        expect(app.render(hash, {})).to eq(JSON.pretty_generate(hash).chomp)
+        expect(app.render(hash, {})).to eq(PSON.pretty_generate(hash).chomp)
       end
 
       it "should render a {String,Numeric}-keyed Hash into a table" do

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -279,6 +279,12 @@ describe "Puppet Network Format" do
       end
     end
 
+    [true, false, nil, Object.new].each do |input|
+      it "renders #{input.class} using PSON" do
+        expect(subject.render(input)).to eq(input.to_pson)
+      end
+    end
+
     [[1, 2], ["one"], [{ 1 => 1 }]].each do |input|
       it "should render #{input.inspect} as one item per line" do
         expect(subject.render(input)).to eq(input.collect { |item| item.to_s + "\n" }.join(''))
@@ -289,9 +295,9 @@ describe "Puppet Network Format" do
       expect(subject.render({})).to eq('')
     end
 
-    it "should render a non-trivially-keyed Hash as pretty printed JSON" do
+    it "should render a non-trivially-keyed Hash as pretty printed PSON" do
       hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
-      expect(subject.render(hash)).to eq(JSON.pretty_generate(hash).chomp)
+      expect(subject.render(hash)).to eq(PSON.pretty_generate(hash).chomp)
     end
 
     it "should render a {String,Numeric}-keyed Hash into a table" do


### PR DESCRIPTION
Previously, rendering console output would fail if `datum` was true,
false, nil, or Object. This regressed in commit ac56d115ac9, which
switched from `json.render(datum)` to `JSON.pretty_generate(datum)`. It
turns out that the latter will render values that are not valid JSON,
e.g. `json.render(true) => 'true'`, while the latter raises an
exception.

This commit modifies the console formatter to use
`PSON.pretty_generate(datum)`. This preserves the old behavior of
accepting non-JSON values, while adding the pretty printing we need for
nested datum values.

We will be switching everything from PSON to JSON in PUP-3524