### PR TITLE
(PUP-4066) Make built in variables exist at all times

### DIFF
--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -281,6 +281,11 @@ describe Puppet::Parser::Scope do
       it "should raise an error when unknown qualified variable is looked up" do
         expect { @scope['nowhere::john_doe'] }.to raise_error(/Undefined variable/)
       end
+
+      it "should not raise an error when built in variable is looked up" do
+        expect { @scope['caller_module_name'] }.to_not raise_error
+        expect { @scope['module_name'] }.to_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Before this commit, it was problematic to use the built in variables
$caller_module_name, and $module_name when testing a module since
and using the --strict_variables option since these built in variables
are not set by the test harness.

This commit makes the two built in variables always exist. They have
undef value unless set by the runtime.