### PR TITLE
(PUP-4072) Make defined function work for variables with initial ::

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -194,10 +194,15 @@ class Puppet::Parser::Scope
       return true if class_name == '' && BUILT_IN_VARS.include?(variable_name)
 
       # lookup class, but do not care if it is not evaluated since that will result
-      # in it not existing anyway. (Tests may run with just scopes and no evaluated classes).
+      # in it not existing anyway. (Tests may run with just scopes and no evaluated classes which
+      # will result in class_scope for "" not returning topscope).
       klass = find_hostclass(class_name)
       other_scope = klass.nil? ? nil : class_scope(klass)
-      other_scope && other_scope.exist?(variable_name)
+      if other_scope.nil?
+        class_name == '' ? compiler.topscope.exist?(variable_name) : false
+      else
+        other_scope.exist?(variable_name)
+      end
     else
       next_scope = inherited_scope || enclosing_scope
       effective_symtable(true).include?(name) || next_scope && next_scope.exist?(name) || BUILT_IN_VARS.include?(name)

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -184,9 +184,24 @@ class Puppet::Parser::Scope
 
   # Returns true if the variable of the given name is set to any value (including nil)
   #
+  # @return [Boolean] if variable exists or not
+  #
   def exist?(name)
-    next_scope = inherited_scope || enclosing_scope
-    effective_symtable(true).include?(name) || next_scope && next_scope.exist?(name) || BUILT_IN_VARS.include?(name)
+    # Note !! ensure the answer is boolean
+    !! if name =~ /^(.*)::(.+)$/
+      class_name = $1
+      variable_name = $2
+      return true if class_name == '' && BUILT_IN_VARS.include?(variable_name)
+
+      # lookup class, but do not care if it is not evaluated since that will result
+      # in it not existing anyway. (Tests may run with just scopes and no evaluated classes).
+      klass = find_hostclass(class_name)
+      other_scope = klass.nil? ? nil : class_scope(klass)
+      other_scope && other_scope.exist?(variable_name)
+    else
+      next_scope = inherited_scope || enclosing_scope
+      effective_symtable(true).include?(name) || next_scope && next_scope.exist?(name) || BUILT_IN_VARS.include?(name)
+    end
   end
 
   # Returns true if the given name is bound in the current (most nested) scope for assignments.

--- a/spec/unit/parser/functions/defined_spec.rb
+++ b/spec/unit/parser/functions/defined_spec.rb
@@ -55,6 +55,11 @@ describe "the 'defined' function" do
       expect(@scope.function_defined(['$x'])).to be_true
     end
 
+    it "is true when ::variable exists in scope" do
+      @compiler.topscope['x'] = 'something'
+      expect(@scope.function_defined(['$::x'])).to be_true
+    end
+
     it "is true when at least one variable exists in scope" do
       @scope['x'] = 'something'
       expect(@scope.function_defined(['$y', '$x', '$z'])).to be_true


### PR DESCRIPTION
This fixes the problem of checking if an absolute variable is defined or not.

The fix is a back port of the fix on master with extra support added for a corner case that occurs only
when running tests (the class "" is not mapped to a scope in partially set up tests).