### PR TITLE
(PUP-4074) Remove master section from puppet.conf

### DIFF
--- a/conf/puppet.conf
+++ b/conf/puppet.conf
@@ -1,9 +1,6 @@
-[master]
-    # Where Puppet stores dynamic and growing data.
-    vardir=/opt/puppetlabs/puppet/cache
-
-    # The Puppet log directory.
-    logdir=/var/log/puppetlabs
-
-    # Where Puppet PID files are kept.
-    rundir=/var/run/puppetlabs
+# This file can be used to override the default puppet settings.
+# See the following links for more details on what settings are available:
+# - https://docs.puppetlabs.com/puppet/latest/reference/config_important_settings.html
+# - https://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+# - https://docs.puppetlabs.com/puppet/latest/reference/config_file_main.html
+# - https://docs.puppetlabs.com/references/latest/configuration.html


### PR DESCRIPTION
This PR removes the master section from puppet.conf, as it will be
specified by puppetserver or puppetmaster as needed. It is replaced with
comments so that users can easily find the documentation on which
settings are available and how to use them.