### PR TITLE
(PUP-3090) Update puppetmaster rack config for new paths

### DIFF
--- a/ext/rack/config.ru
+++ b/ext/rack/config.ru
@@ -11,11 +11,18 @@ $0 = "master"
 
 ARGV << "--rack"
 
-# Rack applications typically don't start as root.  Set --confdir and --vardir
-# to prevent reading configuration from ~puppet/.puppet/puppet.conf and writing
-# to ~puppet/.puppet
-ARGV << "--confdir" << "/etc/puppet"
-ARGV << "--vardir"  << "/var/lib/puppet"
+# Rack applications typically don't start as root.  Set --confdir, --vardir,
+# --logdir, --rundir to prevent reading configuration from
+# ~/ based pathing.
+ARGV << "--confdir" << "/etc/puppetlabs/puppet"
+ARGV << "--vardir"  << "/opt/puppetlabs/server/data/puppetmaster"
+ARGV << "--logdir"  << "/var/log/puppetlabs/puppetmaster"
+ARGV << "--rundir"  << "/var/run/puppetlabs/puppetmaster"
+
+# always_cache_features is a performance improvement and safe for a master to
+# apply. This is intended to allow agents to recognize new features that may be
+# delivered during catalog compilation.
+ARGV << "--always_cache_features"
 
 # NOTE: it's unfortunate that we have to use the "CommandLine" class
 #  here to launch the app, but it contains some initialization logic


### PR DESCRIPTION
With PUP-4074, the master section was removed from the puppet.conf being
laid down by puppet during installation. Those settings are still
required by a master running under passenger, so this commit adds these
settings to the example config.ru in ext/rack. always_cache_features is
also included as a performance improvement for the master.