### PR TITLE
(PUP-4076) Remove 'allow_virtual' deprecation warning in the 3.x series

### DIFF
--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -438,11 +438,8 @@ module Puppet
     newparam(:allow_virtual, :boolean => true, :parent => Puppet::Parameter::Boolean, :required_features => :virtual_packages) do
       desc 'Specifies if virtual package names are allowed for install and uninstall.'
 
-      # In a future release, this should be defaulted to true and the below deprecation warning removed
-      defaultto do
-        Puppet.deprecation_warning('The package type\'s allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.') unless value
-        false
-      end
+      # In a future release, this should be defaulted to true
+      defaultto false
     end
 
     autorequire(:file) do

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -118,26 +118,6 @@ describe Puppet::Type.type(:package) do
         Puppet::Type.type(:package).new(:name => ["error"])
       end.to raise_error(Puppet::ResourceError, /Name must be a String/)
     end
-
-    it "should issue deprecation warning for default allow_virtual for a provider that supports virtual packages" do
-      Puppet.expects(:deprecation_warning).with('The package type\'s allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.')
-      Puppet::Type.type(:package).new(:name => 'yay', :provider => :yum)
-    end
-
-    it "should not issue deprecation warning for allow_virtual set to false for a provider that supports virtual packages" do
-      Puppet.expects(:deprecation_warning).never
-      Puppet::Type.type(:package).new(:name => 'yay', :provider => :yum, :allow_virtual => false)
-    end
-
-    it "should not issue deprecation warning for allow_virtual set to true for a provider that supports virtual packages" do
-      Puppet.expects(:deprecation_warning).never
-      Puppet::Type.type(:package).new(:name => 'yay', :provider => :yum, :allow_virtual => true)
-    end
-
-    it "should not issue deprecation warning for default allow_virtual for a provider that does not support virtual packages" do
-      Puppet.expects(:deprecation_warning).never
-      Puppet::Type.type(:package).new(:name => 'yay', :provider => :apt)
-    end
   end
 
   module PackageEvaluationTesting


### PR DESCRIPTION
In Puppet 4, the package type's allow_virtual setting will be true by
default. In commit 3f6d7cad, this change was made and the deprecation
warning for allow_virtual was removed in master. However, many have
found the deprecation warning to be disruptive in the 3.x series, so
this commit removes it. We will deprecate in docs instead.