### PR TITLE
(PUP-4082) Make unfold of undef produce nothing

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -235,6 +235,8 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
   def eval_UnfoldExpression(o, scope)
     candidate = evaluate(o.expr, scope)
     case candidate
+    when nil
+      []
     when Array
       candidate
     when Hash

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -508,8 +508,14 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
          Type[Integer] : { yes } }"                          => 'yes',
       # supports unfold
       "case ringo {
-         *[paul, john, ringo, george] : { 'beatle' } }"       => 'beatle',
+         *[paul, john, ringo, george] : { 'beatle' } }"      => 'beatle',
 
+      "case undef {
+         undef : { 'yes' } }"                                => 'yes',
+
+      "case undef {
+         *undef : { 'no' }
+         default :{ 'yes' }}"                                => 'yes',
     }.each do |source, result|
         it "should parse and evaluate the expression '#{source}' to #{result}" do
           parser.evaluate_string(scope, source, __FILE__).should == result
@@ -526,6 +532,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "'banana' ? { /.*(ana).*/  => $1 }"                 => 'ana',
       "[2] ? { Array[String] => yes, Array => yes}"       => 'yes',
       "ringo ? *[paul, john, ringo, george] => 'beatle'"  => 'beatle',
+      "undef ? undef => 'yes'"                            => 'yes',
+      "undef ? {*undef => 'no', default => 'yes'}"        => 'yes',
     }.each do |source, result|
         it "should parse and evaluate the expression '#{source}' to #{result}" do
           parser.evaluate_string(scope, source, __FILE__).should == result


### PR DESCRIPTION
Before this commit, an unfold of undef would be treated like unfold of
any other value - i.e. wrapping it in an array, and then depending on
context unfold the result into that context.

It is more natural that an unfold of undef leads to nothing - i.e that
undef is turned into an empty array, that when unfolded in context adds
nothing.

Thus *undef and [] has the same result.
In options for case and selector expressions, if a *undef is used as an
option, that option will not match any value, not even undef or an empty
array.