### PR TITLE
(PUP-4083) Add sample environment.conf to conf/

### DIFF
--- a/conf/environment.conf
+++ b/conf/environment.conf
@@ -1,0 +1,16 @@
+# Each environment can have an environment.conf file. Its settings will only
+# affect its own environment. See docs for more info:
+# https://docs.puppetlabs.com/puppet/latest/reference/config_file_environment.html
+
+# Any unspecified settings use default values; some of those defaults are based
+# on puppet.conf settings.
+
+# If these settings include relative file paths, they'll be resolved relative to
+# this environment's directory.
+
+# Allowed settings and default values:
+
+# modulepath = ./modules:$basemodulepath
+# manifest = (default_manifest from puppet.conf; defaults to ./manifests)
+# config_version = (no script; Puppet will use the time the catalog was compiled)
+# environment_timeout = (environment_timeout from puppet.conf; defaults to unlimited)


### PR DESCRIPTION
The file is all comments, so we can include it in a default production
environment. It includes a link to docs, a brief explanation, and a list of
allowed settings with default values.