### PR TITLE
(PUP-1253) Add systemd service masking support

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -42,6 +42,9 @@ module Puppet
 
     feature :flaggable, "The provider can pass flags to the service."
 
+    feature :maskable, "The provider can 'mask' the service.",
+      :methods => [:mask]
+
     newproperty(:enable, :required_features => :enableable) do
       desc "Whether a service should be enabled to start at boot.
         This property behaves quite differently depending on the platform;
@@ -58,6 +61,12 @@ module Puppet
 
       newvalue(:manual, :event => :service_manual_start) do
         provider.manual_start
+      end
+
+      # This only makes sense on systemd systems. Otherwise, it just defaults
+      # to disable.
+      newvalue(:mask, :event => :service_disabled, :required_features => :maskable) do
+        provider.mask
       end
 
       def retrieve

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -108,20 +108,57 @@ describe Puppet::Type.type(:service).provider(:systemd) do
   describe "#enabled?" do
     it "should return :true if the service is enabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      provider.expects(:systemctl).with('is-enabled', 'sshd.service').returns 'enabled'
+      provider.expects(:systemctl).with(
+        'show',
+        'sshd.service',
+        '--property', 'LoadState',
+        '--property', 'UnitFileState',
+        '--no-pager'
+      ).returns "LoadState=loaded\nUnitFileState=enabled\n"
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :false if the service is disabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      provider.expects(:systemctl).with('is-enabled', 'sshd.service').raises Puppet::ExecutionFailure, "Execution of '/bin/systemctl is-enabled sshd.service' returned 1: disabled"
+      provider.expects(:systemctl).with(
+        'show',
+        'sshd.service',
+        '--property', 'LoadState',
+        '--property', 'UnitFileState',
+        '--no-pager'
+      ).returns "LoadState=loaded\nUnitFileState=disabled\n"
       expect(provider.enabled?).to eq(:false)
+    end
+
+    it "should return :false if the service is masked and the resource is attempting to be disabled" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
+      provider.expects(:systemctl).with(
+        'show',
+        'sshd.service',
+        '--property', 'LoadState',
+        '--property', 'UnitFileState',
+        '--no-pager'
+      ).returns "LoadState=masked\nUnitFileState=\n"
+      expect(provider.enabled?).to eq(:false)
+    end
+
+    it "should return :mask if the service is masked and the resource is attempting to be masked" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => 'mask'))
+      provider.expects(:systemctl).with(
+        'show',
+        'sshd.service',
+        '--property', 'LoadState',
+        '--property', 'UnitFileState',
+        '--no-pager'
+      ).returns "LoadState=masked\nUnitFileState=\n"
+      expect(provider.enabled?).to eq(:mask)
     end
   end
 
   describe "#enable" do
     it "should run systemctl enable to enable a service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('unmask', 'sshd.service')
       provider.expects(:systemctl).with('enable', 'sshd.service')
       provider.enable
     end
@@ -132,6 +169,18 @@ describe Puppet::Type.type(:service).provider(:systemd) do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       provider.expects(:systemctl).with(:disable, 'sshd.service')
       provider.disable
+    end
+  end
+  
+  describe "#mask" do
+    it "should run systemctl to disable and mask a service" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      # :disable is the only call in the provider that uses a symbol instead of
+      # a string.
+      # This should be made consistent in the future and all tests updated.
+      provider.expects(:systemctl).with(:disable, 'sshd.service')
+      provider.expects(:systemctl).with('mask', 'sshd.service')
+      provider.mask
     end
   end
 

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -63,6 +63,11 @@ describe Puppet::Type.type(:service), "when validating attribute values" do
       expect(srv.should(:enable)).to eq(:false)
     end
 
+    it "should support :mask as a value" do
+      srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :mask)
+      expect(srv.should(:enable)).to eq(:mask)
+    end
+
     it "should support :manual as a value on Windows" do
       Puppet.features.stubs(:microsoft_windows?).returns true
 


### PR DESCRIPTION
This updates the systemd service type to add support for masking. If a
service is masked, it is deemed to also be disabled. If a service is
masked and changed to enabled, it will first be unmasked since the
standard 'systemctl enable' command does not properly unmask the command
first.