### PR TITLE
(PUP-4046) Fix missing requirement and system private loaders

### DIFF
--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -1,4 +1,4 @@
-require 'hiera_puppet'
+require 'hiera/puppet_function'
 
 # @see lib/puppet/parser/functions/hiera_include.rb for documentation
 # TODO: Move docs here when the format has been determined.

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -175,7 +175,9 @@ module Puppet::Pops::Loader::ModuleLoaders
     # Produces the private loader for the module. If this module is not already resolved, this will trigger resolution
     #
     def private_loader
-      @private_loader ||= @loaders.private_loader_for_module(module_name)
+      # The system loader has a nil module_name and it does not have a private_loader as there are no functions
+      # that can only by called by puppet runtime - if so, it acts as the privuate loader directly.
+      @private_loader ||= ((module_name.nil? && self) || @loaders.private_loader_for_module(module_name))
     end
   end
 

--- a/spec/unit/pops/loaders/module_loaders_spec.rb
+++ b/spec/unit/pops/loaders/module_loaders_spec.rb
@@ -57,6 +57,11 @@ describe 'FileBased module loader' do
     expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
   end
 
+  it 'system loader has itself as private loader' do
+    module_loader = Puppet::Pops::Loader::ModuleLoaders.system_loader_from(static_loader, loaders)
+    expect(module_loader.private_loader).to be(module_loader)
+  end
+
   it 'makes parent loader win over entries in child' do
     module_dir = dir_containing('testmodule', {
       'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {


### PR DESCRIPTION
Before this commit it was not possible to call hiera_include
because of two problems:

* a missing requirement on the helper hiera/puppet_function
* the puppet system loader had no private loader and could not call
  to other puppet functions (i.e. the include() function).

This went undetected because of poor test covarage of hiera
related functionality.

The fix for this adds the requirement and ensures that the "puppet
system loader" (loading from puppet itself) has self as private loader.
(This because the concept of having functions that can only be called
from other functons in puppet does not exist; i.e. "puppet private".
This is not needed since puppet itself can always invoke common private
logic via other means).