### PR TITLE
(DO NOT MERGE)(PUP-4088) Fix new path acceptance for some Windows

### DIFF
--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -75,9 +75,9 @@ end
 
 step 'test configprint outputs'
 agents.each do |agent|
-  config_options(agent[:platform]).each do |config_option|
-    on(agent, puppet_agent('--configprint ' "#{config_option[:name]}")) do
-      assert_match(config_option[:expected], stdout)
+  on(agent, puppet_agent('--configprint all')) do
+    config_options(agent[:platform]).each do |config_option|
+      assert_match("#{config_option[:name]} = #{config_option[:expected]}", stdout)
     end
   end
 end

--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -6,53 +6,78 @@ test_name 'PUP-4033: Ensure aio path spec is honored'
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
 
-config_options = [
-  # code
-  {:name => :codedir, :posix_expected => '/etc/puppetlabs/code', :win_expected => 'C:/ProgramData/PuppetLabs/code', :installed => :dir},
-  {:name => :environmentpath, :posix_expected => '/etc/puppetlabs/code/environments', :win_expected => 'C:/ProgramData/PuppetLabs/code/environments'},
-  {:name => :hiera_config, :posix_expected => '/etc/puppetlabs/code/hiera.yaml', :win_expected => 'C:/ProgramData/PuppetLabs/code/hiera.yaml'},
+def config_options(platform)
+  case platform
+  when /windows/
+    if platform =~ /2003/
+      common_app_data = 'C:/Documents and Settings/All Users/Application Data'
+    else
+      common_app_data = 'C:/ProgramData'
+    end
+    puppetlabs_data = "#{common_app_data}/PuppetLabs"
 
-  # confdir
-  {:name => :confdir, :posix_expected => '/etc/puppetlabs/puppet', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc', :installed => :dir},
-  {:name => :rest_authconfig, :posix_expected => '/etc/puppetlabs/puppet/auth.conf', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/auth.conf'},
-  {:name => :autosign, :posix_expected => '/etc/puppetlabs/puppet/autosign.conf', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/autosign.conf'},
-  {:name => :binder_config, :posix_expected => '', :win_expected => ''},
-  {:name => :csr_attributes, :posix_expected => '/etc/puppetlabs/puppet/csr_attributes.yaml', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/csr_attributes.yaml'},
-  {:name => :trusted_oid_mapping_file, :posix_expected => '/etc/puppetlabs/puppet/custom_trusted_oid_mapping.yaml', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/custom_trusted_oid_mapping.yaml'},
-  {:name => :deviceconfig, :posix_expected => '/etc/puppetlabs/puppet/device.conf', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/device.conf'},
-  {:name => :fileserverconfig, :posix_expected => '/etc/puppetlabs/puppet/fileserver.conf', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/fileserver.conf'},
-  {:name => :config, :posix_expected => '/etc/puppetlabs/puppet/puppet.conf', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/puppet.conf', :installed => :file},
-  {:name => :route_file, :posix_expected => '/etc/puppetlabs/puppet/routes.yaml', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/routes.yaml'},
-  {:name => :ssldir, :posix_expected => '/etc/puppetlabs/puppet/ssl', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/etc/ssl', :installed => :dir},
+    codedir = "#{puppetlabs_data}/code"
+    confdir = "#{puppetlabs_data}/puppet/etc"
+    vardir = "#{puppetlabs_data}/puppet/cache"
+    logdir = "#{puppetlabs_data}/puppet/var/log"
+    rundir = "#{puppetlabs_data}/puppet/var/run"
+    sep = ";"
+  else
+    codedir = '/etc/puppetlabs/code'
+    confdir = '/etc/puppetlabs/puppet'
+    vardir = '/opt/puppetlabs/puppet/cache'
+    logdir = '/var/log/puppetlabs'
+    rundir = '/var/run/puppetlabs'
+    sep = ":"
+  end
 
-  # vardir
-  {:name => :vardir, :posix_expected => '/opt/puppetlabs/puppet/cache', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache', :installed => :dir},
-  {:name => :bucketdir, :posix_expected => '/opt/puppetlabs/puppet/cache/bucket', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/bucket'},
-  {:name => :clientyamldir, :posix_expected => '/opt/puppetlabs/puppet/cache/client_yaml', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/client_yaml', :installed => :dir},
-  {:name => :client_datadir, :posix_expected => '/opt/puppetlabs/puppet/cache/client_data', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/client_data', :installed => :dir},
-  {:name => :clientbucketdir, :posix_expected => '/opt/puppetlabs/puppet/cache/clientbucket', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/clientbucket', :installed => :dir},
-  {:name => :devicedir, :posix_expected => '/opt/puppetlabs/puppet/cache/devices', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/devices'},
-  {:name => :pluginfactdest, :posix_expected => '/opt/puppetlabs/puppet/cache/facts.d', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/facts.d', :installed => :dir},
-  {:name => :libdir, :posix_expected => '/opt/puppetlabs/puppet/cache/lib', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/lib', :installed => :dir},
-  {:name => :factpath, :posix_expected => '/opt/puppetlabs/puppet/cache/lib/facter:/opt/puppetlabs/puppet/cache/facts', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/lib/facter;C:/ProgramData/PuppetLabs/puppet/cache/facts', :not_path => true},
-  {:name => :module_working_dir, :posix_expected => '/opt/puppetlabs/puppet/cache/puppet-module', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/puppet-module'},
-  {:name => :reportdir, :posix_expected => '/opt/puppetlabs/puppet/cache/reports', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/reports'},
-  {:name => :server_datadir, :posix_expected => '/opt/puppetlabs/puppet/cache/server_data', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/server_data'},
-  {:name => :statedir, :posix_expected => '/opt/puppetlabs/puppet/cache/state', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/state', :installed => :dir},
-  {:name => :yamldir, :posix_expected => '/opt/puppetlabs/puppet/cache/yaml', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/cache/yaml'},
+  [
+    # code
+    {:name => :codedir,         :expected => codedir,                     :installed => :dir},
+    {:name => :environmentpath, :expected => "#{codedir}/environments"},
+    {:name => :hiera_config,    :expected => "#{codedir}/hiera.yaml"},
 
-  # logdir/rundir
-  {:name => :logdir, :posix_expected => '/var/log/puppetlabs', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/var/log', :installed => :dir},
-  {:name => :rundir, :posix_expected => '/var/run/puppetlabs', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/var/run', :installed => :dir},
-  {:name => :pidfile, :posix_expected => '/var/run/puppetlabs/agent.pid', :win_expected => 'C:/ProgramData/PuppetLabs/puppet/var/run/agent.pid'},
-]
+    # confdir
+    {:name => :confdir,         :expected => confdir,                     :installed => :dir},
+    {:name => :rest_authconfig, :expected => "#{confdir}/auth.conf"},
+    {:name => :autosign,        :expected => "#{confdir}/autosign.conf"},
+    {:name => :binder_config,   :expected => ""},
+    {:name => :csr_attributes,  :expected => "#{confdir}/csr_attributes.yaml"},
+    {:name => :trusted_oid_mapping_file, :expected => "#{confdir}/custom_trusted_oid_mapping.yaml"},
+    {:name => :deviceconfig,    :expected => "#{confdir}/device.conf"},
+    {:name => :fileserverconfig, :expected => "#{confdir}/fileserver.conf"},
+    {:name => :config,          :expected => "#{confdir}/puppet.conf",    :installed => :file},
+    {:name => :route_file,      :expected => "#{confdir}/routes.yaml"},
+    {:name => :ssldir,          :expected => "#{confdir}/ssl",            :installed => :dir},
+
+    # vardir
+    {:name => :vardir,          :expected => "#{vardir}",                 :installed => :dir},
+    {:name => :bucketdir,       :expected => "#{vardir}/bucket"},
+    {:name => :clientyamldir,   :expected => "#{vardir}/client_yaml",     :installed => :dir},
+    {:name => :client_datadir,  :expected => "#{vardir}/client_data",     :installed => :dir},
+    {:name => :clientbucketdir, :expected => "#{vardir}/clientbucket",    :installed => :dir},
+    {:name => :devicedir,       :expected => "#{vardir}/devices"},
+    {:name => :pluginfactdest,  :expected => "#{vardir}/facts.d",         :installed => :dir},
+    {:name => :libdir,          :expected => "#{vardir}/lib",             :installed => :dir},
+    {:name => :factpath,        :expected => "#{vardir}/lib/facter#{sep}#{vardir}/facts", :not_path => true},
+    {:name => :module_working_dir, :expected => "#{vardir}/puppet-module"},
+    {:name => :reportdir,       :expected => "#{vardir}/reports"},
+    {:name => :server_datadir,  :expected => "#{vardir}/server_data"},
+    {:name => :statedir,        :expected => "#{vardir}/state",           :installed => :dir},
+    {:name => :yamldir,         :expected => "#{vardir}/yaml"},
+
+    # logdir/rundir
+    {:name => :logdir,          :expected => logdir,                      :installed => :dir},
+    {:name => :rundir,          :expected => rundir,                      :installed => :dir},
+    {:name => :pidfile,         :expected => "#{rundir}/agent.pid"},
+  ]
+end
 
 step 'test configprint outputs'
 agents.each do |agent|
-  config_options.each do |config_option|
+  config_options(agent[:platform]).each do |config_option|
     on(agent, puppet_agent('--configprint ' "#{config_option[:name]}")) do
-      file = if agent['platform'] =~ /win/ then config_option[:win_expected] else config_option[:posix_expected] end
-      assert_match(file, stdout)
+      assert_match(config_option[:expected], stdout)
     end
   end
 end
@@ -60,17 +85,16 @@ end
 step 'test puppet genconfig entries'
 agents.each do |agent|
   on(agent, puppet_agent('--genconfig')) do
-    config_options.each do |config_option|
-      file = if agent['platform'] =~ /win/ then config_option[:win_expected] else config_option[:posix_expected] end
-      assert_match("#{config_option[:name]} = #{file}", stdout)
+    config_options(agent[:platform]).each do |config_option|
+      assert_match("#{config_option[:name]} = #{config_option[:expected]}", stdout)
     end
   end
 end
 
 step 'test puppet config paths exist'
 agents.each do |agent|
-  config_options.select {|v| !v[:not_path] }.each do |config_option|
-    path = if agent['platform'] =~ /win/ then config_option[:win_expected] else config_option[:posix_expected] end
+  config_options(agent[:platform]).select {|v| !v[:not_path] }.each do |config_option|
+    path = config_option[:expected]
     case config_option[:installed]
     when :dir
       if !dir_exists?(agent, path)
@@ -90,17 +114,37 @@ public_binaries = {
   :posix => ['puppet', 'facter', 'hiera', 'mco', 'cfacter'],
   :win   => ['puppet.bat', 'facter.bat', 'hiera.bat', 'cfacter.bat']
 }
-locations = {:posix => {:aio => '/opt/puppetlabs/bin',                     :git => '/usr/bin'},
-             :win   => {:aio => 'C:/Program Files/Puppet Labs/Puppet/bin', :git => '/usr/bin'}}
+
+def locations(platform, ruby_arch, type)
+  if type != 'aio'
+    return '/usr/bin'
+  end
+
+  case platform
+  when /windows/
+    # If undefined, ruby_arch defaults to x86
+    if ruby_arch == 'x64'
+      ruby_arch = /-64/
+    else
+      ruby_arch = /-32/
+    end
+    if platform =~ ruby_arch
+      return 'C:/Program Files/Puppet Labs/Puppet/bin'
+    else
+      return 'C:/Program Files (x86)/Puppet Labs/Puppet/bin'
+    end
+  else
+    return '/opt/puppetlabs/bin'
+  end
+end
 
 step 'test puppet binaries exist'
 agents.each do |agent|
-  os = agent['platform'] =~ /win/ ? :win : :posix
-  type = @options[:type] == 'aio' ? :aio : :git
+  dir = locations(agent[:platform], agent[:ruby_arch], @options[:type])
+  os = agent['platform'] =~ /windows/ ? :win : :posix
 
-  dir = locations[os][type]
   # Filter out cfacter outside of aio, as we don't install it as part of Puppet acceptance runs yet.
-  public_binaries[os].select {|v| type == :aio || v !~ /cfacter/}.each do |binary|
+  public_binaries[os].select {|v| @options[:type] == 'aio' || v !~ /cfacter/}.each do |binary|
     path = File.join(dir, binary)
     case os
     when :win


### PR DESCRIPTION
Without this change, the new ensure_puppet-agent_paths acceptance test
fails on Windows Server 2003, and when testing 32-bit puppet-agent
installs on 64-bit Windows.

Update the test to use the correct paths for both cases.