### PR TITLE
(maint) Fix paths with spaces in Windows acceptance setup

### DIFF
--- a/acceptance/setup/git/pre-suite/010_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/010_TestSetup.rb
@@ -50,10 +50,10 @@ test_name "Install packages and repositories on target machines..." do
       puppetconf = File.join(confdir, 'puppet.conf')
 
       if host['roles'].include?('agent')
-        on host, "echo '[agent]' > #{puppetconf} && " +
-                 "echo server=#{master} >> #{puppetconf}"
+        on host, "echo '[agent]' > '#{puppetconf}' && " +
+                 "echo server=#{master} >> '#{puppetconf}'"
       else
-        on host, "touch #{puppetconf}"
+        on host, "touch '#{puppetconf}'"
       end
     end
   end


### PR DESCRIPTION
Without this change, acceptance tests will fail if puppetconfdir
contains a space. This wasn't a problem previously because Beaker uses
cygpath to generate DOS-style paths, such as
`C:/PROGRA~3/PuppetLabs/puppet/etc`. It has become a problem during
testing of new AIO agent paths, that contain spaces in Windows Server
2003.

Fix handling of paths with spaces by quoting them when they're used.