### PR TITLE
(PUP-4086) Patch ParseErrors with location if missing

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -54,6 +54,10 @@ module Puppet
     include ExternalFileError
   end
 
+  # An error that already contains location information in the message text
+  class PreformattedError < Puppet::ParseError
+  end
+
   # An error class for when I don't know what happened.  Automatically
   # prints a stack trace when in debug mode.
   class DevError < Puppet::Error

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -98,7 +98,7 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       if e.file || e.line
         raise e
       else
-        # Since it had no location information, threat it as user intended a general purpose
+        # Since it had no location information, treat it as user intended a general purpose
         # error. Pass on its call stack.
         fail(Issues::RUNTIME_ERROR, target, {:detail => e.message}, e)
       end

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -470,7 +470,11 @@ module Puppet::Pops::Evaluator::Runtime3Support
   class ExceptionRaisingAcceptor < Puppet::Pops::Validation::Acceptor
     def accept(diagnostic)
       super
-      Puppet::Pops::IssueReporter.assert_and_report(self, {:message => "Evaluation Error:", :emit_warnings => true })
+      Puppet::Pops::IssueReporter.assert_and_report(self, {
+        :message => "Evaluation Error:", 
+        :emit_warnings => true,  # log warnings
+        :exception_class => Puppet::PreformattedError
+      })
       if errors?
         raise ArgumentError, "Internal Error: Configuration of runtime error handling wrong: should have raised exception"
       end

--- a/lib/puppet/util/errors.rb
+++ b/lib/puppet/util/errors.rb
@@ -14,7 +14,7 @@ module Puppet::Util::Errors
   # Add line and file info to the supplied exception if info is available from
   # this object, is appropriately populated and the supplied exception supports
   # it.  When other is supplied, the backtrace will be copied to the error
-  # object.
+  # object and the 'original' will be dropped from the error.
   #
   # @param error [Exception] exception that is populated with info
   # @param other [Exception] original exception, source of backtrace info
@@ -25,7 +25,9 @@ module Puppet::Util::Errors
     error.original ||= other if error.respond_to?(:original=)
 
     error.set_backtrace(other.backtrace) if other and other.respond_to?(:backtrace)
-
+    # It is not meaningful to keep the wrapped exception since its backtrace has already
+    # been adopted by the error. (The instance variable is private for good reasons).
+    error.instance_variable_set(:@original, nil)
     error
   end
 


### PR DESCRIPTION
Before this commit, ParseErrors that occured in a call from the
evaluator was passed on verbatim to the higher powers. The intent is
that ParseError is used when the file and line in a .pp file is known.
The use of raised ParseErrors without such information does however
permeate throughput the puppet code base and in modules.

This was bad because many errors would then not be associated with
a location in a manifest.

Further complications were that a) some errors were already preformatted
with location information being baked into the message text when
reaching the evaluator (these should pass verbatim), and b) the way
safeevaluate of AST objects work meant that all errors would end up with
a wrapped 'original' exception which leads to duplicated output of the
message and the text 'Wrapped Exception'.

This commit fixes these problems by:

* Introducing a specialized PreformattedError which is a specialized
variant of ParseError (that enables the evaluator to no yet again add
location information). A choice was made to derive it from ParseError to
ensure that all that rescues ParseError would still recognize it.
* Making the evaluator do more extensive introspection and rewrite of
the different kinds of errors that occur while evaluating one
instruction.
* Making the Errors.adderrorcontext method strip away the original error
since it has already effectively made it superflous by poking its
backtrace into its parent error.

Summary - solution means:
* no superflous Wrapped Exception output
* location information for ParseErrors "in the wild" that do not provide
this.

A possible downside is the dropped original error may cause loss of
information in corner cases (non covered by spec tests at least) if
someone explicitly depends on the original error being kept after a
safeevaluate, or a call path that passes through the evaluator. (No such
cases where found in the puppet code base though).