### PR TITLE
(PUP-4112) AIO path checks should verify mco.bat

### DIFF
--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -109,10 +109,9 @@ agents.each do |agent|
 end
 
 
-# mco.bat removed until it's added back to the MSI
 public_binaries = {
   :posix => ['puppet', 'facter', 'hiera', 'mco', 'cfacter'],
-  :win   => ['puppet.bat', 'facter.bat', 'hiera.bat', 'cfacter.bat']
+  :win   => ['puppet.bat', 'facter.bat', 'hiera.bat', 'mco.bat', 'cfacter.bat']
 }
 
 def locations(platform, ruby_arch, type)


### PR DESCRIPTION
 - Prior to MSI packaging changes that went into
   https://github.com/puppetlabs/puppet_for_the_win/commit/f8bfe7f
   the Windows MSI did not contain mco.bat

 - With the MSI changes made, the test can be updated accordingly