### PR TITLE
(PUP-3908) Make tidy type messages less verbose

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -253,7 +253,9 @@ Puppet::Type.newtype(:tidy) do
     else
       files = [self[:path]]
     end
-    result = files.find_all { |path| tidy?(path) }.collect { |path| mkfile(path) }.each { |file| notice "Tidying #{file.ref}" }.sort { |a,b| b[:path] <=> a[:path] }
+    found_files = files.find_all { |path| tidy?(path) }.collect { |path| mkfile(path) }
+    result = found_files.each { |file| debug "Tidying #{file.ref}" }.sort { |a,b| b[:path] <=> a[:path] }
+    notice "Tidying #{found_files.size} files"
 
     # No need to worry about relationships if we don't have rmdirs; there won't be
     # any directories.


### PR DESCRIPTION
This patch reduces the amount of notifications tidy generates when working
with a large number of files.  Tidy now reports the number of changed files
using 'notify,' and reports the list of files (the old behavior) with 'debug.'