### PR TITLE
(PUP-4056) Use privatebindir to resolve ruby

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || 'git://github.com/puppetlabs/beaker#31bc7aa4405ac4fa0a2896be1c644dee34a0ea3e')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || 'git://github.com/puppetlabs/beaker#7d0cccf22cc7289113de862fe4a4494872f574bb')
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,6 +1,8 @@
 {
   :type => 'aio',
   :is_puppetserver => true,
+  :puppetservice => 'puppetserver',
+  :'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
   :pre_suite => [
     'setup/aio/pre-suite/010_Install.rb',
     'setup/aio/pre-suite/015_PackageHostsPresets.rb',

--- a/acceptance/config/nodes/rhel7.yaml
+++ b/acceptance/config/nodes/rhel7.yaml
@@ -6,27 +6,12 @@ HOSTS:
     platform: el-7-x86_64
     hypervisor: vcloud
     template: redhat-7-x86_64
-    puppetcodedir: /etc/puppetlabs/code
-    distmoduledir: /etc/puppetlabs/code/modules
-    hieraconf:     /etc/puppetlabs/code/hiera.yaml
-    puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
-    puppetbindir:  /opt/puppetlabs/puppet/bin
-    puppetvardir:  /opt/puppetlabs/puppet/cache
-    sitemoduledir: /opt/puppetlabs/puppet/modules
   agent:
     roles:
       - agent
     platform: el-7-x86_64
     hypervisor: vcloud
     template: redhat-7-x86_64
-    puppetcodedir: /etc/puppetlabs/code
-    distmoduledir: /etc/puppetlabs/code/modules
-    hieraconf:     /etc/puppetlabs/code/hiera.yaml
-    puppetconfdir: /etc/puppetlabs/puppet
-    puppetbindir:  /opt/puppetlabs/puppet/bin
-    puppetvardir:  /opt/puppetlabs/puppet/cache
-    sitemoduledir: /opt/puppetlabs/puppet/modules
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/config/nodes/trusty.yaml
+++ b/acceptance/config/nodes/trusty.yaml
@@ -6,27 +6,12 @@ HOSTS:
     platform: ubuntu-trusty-x86_64
     hypervisor: vcloud
     template: ubuntu-1404-x86_64
-    puppetcodedir: /etc/puppetlabs/code
-    distmoduledir: /etc/puppetlabs/code/modules
-    hieraconf:     /etc/puppetlabs/code/hiera.yaml
-    puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
-    puppetbindir:  /opt/puppetlabs/puppet/bin
-    puppetvardir:  /opt/puppetlabs/puppet/cache
-    sitemoduledir: /opt/puppetlabs/puppet/modules
   agent:
     roles:
       - agent
     platform: ubuntu-trusty-i386
     hypervisor: vcloud
     template: ubuntu-1404-i386
-    puppetcodedir: /etc/puppetlabs/code
-    distmoduledir: /etc/puppetlabs/code/modules
-    hieraconf:     /etc/puppetlabs/code/hiera.yaml
-    puppetconfdir: /etc/puppetlabs/puppet
-    puppetbindir:  /opt/puppetlabs/puppet/bin
-    puppetvardir:  /opt/puppetlabs/puppet/cache
-    sitemoduledir: /opt/puppetlabs/puppet/modules
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/config/nodes/wheezy.yaml
+++ b/acceptance/config/nodes/wheezy.yaml
@@ -6,27 +6,12 @@ HOSTS:
     platform: debian-wheezy-x86_64
     hypervisor: vcloud
     template: debian-7-x86_64
-    puppetcodedir: /etc/puppetlabs/code
-    distmoduledir: /etc/puppetlabs/code/modules
-    hieraconf:     /etc/puppetlabs/code/hiera.yaml
-    puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
-    puppetbindir:  /opt/puppetlabs/puppet/bin
-    puppetvardir:  /opt/puppetlabs/puppet/cache
-    sitemoduledir: /opt/puppetlabs/puppet/modules
   agent:
     roles:
       - agent
     platform: debian-wheezy-i386
     hypervisor: vcloud
     template: debian-7-i386
-    puppetcodedir: /etc/puppetlabs/code
-    distmoduledir: /etc/puppetlabs/code/modules
-    hieraconf:     /etc/puppetlabs/code/hiera.yaml
-    puppetconfdir: /etc/puppetlabs/puppet
-    puppetbindir:  /opt/puppetlabs/puppet/bin
-    puppetvardir:  /opt/puppetlabs/puppet/cache
-    sitemoduledir: /opt/puppetlabs/puppet/modules
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/config/nodes/win2012r2-rubyx64.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx64.yaml
@@ -5,14 +5,6 @@ HOSTS:
     platform: el-7-x86_64
     hypervisor: vcloud
     template: redhat-7-x86_64
-    puppetcodedir: /etc/puppetlabs/code
-    distmoduledir: /etc/puppetlabs/code/modules
-    hieraconf:     /etc/puppetlabs/code/hiera.yaml
-    puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
-    puppetbindir:  /opt/puppetlabs/puppet/bin
-    puppetvardir:  /opt/puppetlabs/puppet/cache
-    sitemoduledir: /opt/puppetlabs/puppet/modules
   agent-2012r2-x86_64-rubyx64:
     roles:
       - agent
@@ -20,12 +12,6 @@ HOSTS:
     ruby_arch: x64
     hypervisor: vcloud
     template: win-2012r2-x86_64
-    puppetconfdir: C:/ProgramData/PuppetLabs/puppet/etc
-    puppetcodedir: C:/ProgramData/PuppetLabs/code
-    puppetvardir: C:/ProgramData/PuppetLabs/puppet/cache
-    distmoduledir: C:/ProgramData/PuppetLabs/code/modules
-    sitemoduledir: C:/opt/puppetlabs/puppet/modules
-    hieraconf: C:/ProgramData/PuppetLabs/code/hiera.yaml
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/config/nodes/win2012r2-rubyx86.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx86.yaml
@@ -5,14 +5,6 @@ HOSTS:
     platform: el-7-x86_64
     hypervisor: vcloud
     template: redhat-7-x86_64
-    puppetcodedir: /etc/puppetlabs/code
-    distmoduledir: /etc/puppetlabs/code/modules
-    hieraconf:     /etc/puppetlabs/code/hiera.yaml
-    puppetconfdir: /etc/puppetlabs/puppet
-    puppetserver-confdir: /etc/puppetlabs/puppetserver/conf.d
-    puppetbindir:  /opt/puppetlabs/puppet/bin
-    puppetvardir:  /opt/puppetlabs/puppet/cache
-    sitemoduledir: /opt/puppetlabs/puppet/modules
   agent-2012r2-x86_64-rubyx86:
     roles:
       - agent
@@ -20,12 +12,6 @@ HOSTS:
     ruby_arch: x86
     hypervisor: vcloud
     template: win-2012r2-x86_64
-    puppetconfdir: C:/ProgramData/PuppetLabs/puppet/etc
-    puppetcodedir: C:/ProgramData/PuppetLabs/code
-    puppetvardir: C:/ProgramData/PuppetLabs/puppet/cache
-    distmoduledir: C:/ProgramData/PuppetLabs/code/modules
-    sitemoduledir: C:/opt/puppetlabs/puppet/modules
-    hieraconf: C:/ProgramData/PuppetLabs/code/hiera.yaml
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -123,7 +123,22 @@ module Puppet
           end
         end
       end
+    end
 
+    module CommandUtils
+      def ruby_command(host)
+        "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
+      end
+      module_function :ruby_command
+
+      def gem_command(host)
+        if host['platform'] =~ /windows/
+          "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+        else
+          "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
+        end
+      end
+      module_function :gem_command
     end
   end
 end

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -1,6 +1,7 @@
 require 'open-uri'
 require 'open3'
 require 'uri'
+require 'puppet/acceptance/common_utils'
 
 module Puppet
   module Acceptance
@@ -231,13 +232,7 @@ module Puppet
         gem_source = ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
         hosts.each do |host|
-          case host['platform']
-          when /windows/
-            gem = 'cmd /c gem'
-          else
-            gem = 'gem'
-          end
-
+          gem = Puppet::Acceptance::CommandUtils.gem_command(host)
           on host, "#{gem} source --clear-all"
           on host, "#{gem} source --add #{gem_source}"
         end
@@ -257,7 +252,8 @@ module Puppet
         # make sure install is sane, beaker has already added puppet and ruby
         # to PATH in ~/.ssh/environment
         on host, puppet('--version')
-        on host, 'ruby --version'
+        ruby = Puppet::Acceptance::CommandUtils.ruby_command(host)
+        on host, "#{ruby} --version"
       end
     end
   end

--- a/acceptance/lib/puppet/acceptance/module_utils.rb
+++ b/acceptance/lib/puppet/acceptance/module_utils.rb
@@ -15,12 +15,8 @@ module Puppet
       # @param host [String] hostname
       # @return [Array] paths for found modulepath
       def get_modulepaths_for_host (host)
-        separator = ':'
-        if host['platform'] =~ /windows/
-          separator = ';'
-        end
         environment = on(host, puppet("config print environment")).stdout.chomp
-        on(host, puppet("config print modulepath --environment #{environment}")).stdout.chomp.split(separator)
+        on(host, puppet("config print modulepath --environment #{environment}")).stdout.chomp.split(host['pathseparator'])
       end
 
       # Return a string of the default (first) path in modulepath for a given host.

--- a/acceptance/lib/puppet/acceptance/windows_utils.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils.rb
@@ -1,25 +1,16 @@
+require 'puppet/acceptance/common_utils'
+
 module Puppet
   module Acceptance
     module WindowsUtils
       def profile_base(agent)
+        ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)
         getbasedir = <<'END'
 require 'win32/dir'
 puts Dir::PROFILE.match(/(.*)\\\\[^\\\\]*/)[1]
 END
-        on(agent, "#{ruby_cmd(agent)} -rubygems -e \"#{getbasedir}\"").stdout.chomp
+        on(agent, "#{ruby} -rubygems -e \"#{getbasedir}\"").stdout.chomp
       end
-
-      # ruby for Windows on a PE install lives in <path to Puppet Enterprise>/sys/ruby/bin/ruby.exe
-      # However, FOSS can just use "ruby".
-      def ruby_cmd(agent)
-        if options[:type] =~ /pe/
-          pre_env = agent['puppetbindir'] ? "env PATH=\"#{agent['puppetbindir']}:#{agent['puppetbindir']}/../sys/ruby/bin/:${PATH}\"" : ''
-          "#{pre_env} ruby.exe"
-        else
-          'ruby'
-        end
-      end
-
     end
   end
 end

--- a/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
+++ b/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
@@ -7,7 +7,7 @@ test_name "Agent should pluginsync with the environment the agent resolves to"
 testdir = create_tmpdir_for_user master, 'environment_resolve'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END
-#!#{master['puppetbindir']}/ruby
+#!#{master['privatebindir']}/ruby
 filename = '#{testdir}/enc.lock'
 if !File.exists?(filename)
   puts "environment: production"

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -37,7 +37,7 @@ else
     file { "#{testdir}/enc.rb":
       ensure  => file,
       mode    => '0775',
-      content => '#!#{master['puppetbindir']}/ruby
+      content => '#!#{master['privatebindir']}/ruby
         puts "environment: doesnotexist"
       ';
     }

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -7,7 +7,7 @@ classify_nodes_as_agent_specified_if_classifer_present
 testdir = create_tmpdir_for_user master, 'use_agent_env'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END
-#!#{master['puppetbindir']}/ruby
+#!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 YAML

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -15,7 +15,7 @@ if master.is_pe?
 else
 
 create_remote_file master, "#{testdir}/enc.rb", <<END
-#!#{master['puppetbindir']}/ruby
+#!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 environment: special

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -3,7 +3,7 @@ test_name "Agent should use environment given by ENC for fetching remote files"
 testdir = create_tmpdir_for_user master, 'respect_enc_test'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END
-#!#{master['puppetbindir']}/ruby
+#!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 environment: special

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -3,7 +3,7 @@ test_name "Agent should use environment given by ENC for pluginsync"
 testdir = create_tmpdir_for_user master, 'respect_enc_test'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END
-#!#{master['puppetbindir']}/ruby
+#!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 environment: special

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -37,7 +37,7 @@ if master.is_pe?
       json = JSON.load(result)
       puts json.first["receive-time"]
     EOS
-    on(puppetdb, "#{master[:puppetbindir]}/ruby -e '#{time_query_script}'").output.chomp
+    on(puppetdb, "#{master[:privatebindir]}/ruby -e '#{time_query_script}'").output.chomp
   end
 
   last_times = {}

--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -3,12 +3,15 @@ confine :except, :platform => 'windows'
 
 target = "/test-socket-#{$$}"
 
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CommandUtils
+
 agents.each do |agent|
   step "clean up the system before we begin"
   on(agent, "rm -f #{target}")
 
   step "create UNIX domain socket"
-  on(agent, %Q{#{agent['puppetbindir']}/ruby -e "require 'socket'; UNIXServer::new('#{target}').close"})
+  on(agent, "#{ruby_command(agent)} -e \"require 'socket'; UNIXServer::new('#{target}').close\"")
 
   step "query for all files, which should return nothing"
   on(agent, puppet_resource('file'), :acceptable_exit_codes => [1]) do

--- a/acceptance/tests/security/cve-2013-1654_sslv2_downgrade_agent.rb
+++ b/acceptance/tests/security/cve-2013-1654_sslv2_downgrade_agent.rb
@@ -1,19 +1,14 @@
 test_name "CVE 2013-1654 SSL2 Downgrade of Agent connection" do
 
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CommandUtils
+
 require 'puppet/acceptance/windows_utils'
 extend Puppet::Acceptance::WindowsUtils
 
-  def which_ruby(host)
-    if host['platform'] =~ /windows/
-      ruby_cmd(host)
-    else
-      host['puppetbindir'] ? "#{host['puppetbindir']}/ruby" : 'ruby'
-    end
-  end
-
   def suitable?(host)
     cmd = <<END
-#{which_ruby(host)} -ropenssl -e "puts OpenSSL::SSL::SSLContext::METHODS.include?(:SSLv2)"
+#{ruby_command(host)} -ropenssl -e "puts OpenSSL::SSL::SSLContext::METHODS.include?(:SSLv2)"
 END
     on(host, cmd).stdout.chomp == "true"
   end
@@ -71,7 +66,7 @@ END
       end
 
       create_remote_file(agent, "#{testdir}/sslserver.rb", sslserver)
-      on agent, "#{which_ruby(agent)} #{testdir}/sslserver.rb &>/dev/null &"
+      on agent, "#{ruby_command(agent)} #{testdir}/sslserver.rb &>/dev/null &"
 
       timeout = 15
       begin

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -1,8 +1,11 @@
 test_name "#6857: redact password hashes when applying in noop mode"
 
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CommandUtils
+
 hosts_to_test = agents.reject do |agent|
   if agent['platform'].match /(?:ubuntu|centos|debian|el-|fedora)/
-    result = on(agent, %Q{#{agent['puppetbindir']}/ruby -e 'require "shadow" or raise'}, :acceptable_exit_codes => [0,1])
+    result = on(agent, "#{ruby_command(agent)} -e \"require 'shadow' or raise\"", :acceptable_exit_codes => [0,1])
     result.exit_code != 0
   else
     # Non-linux platforms do not rely on ruby-libshadow for password management

--- a/acceptance/tests/windows/eventlog.rb
+++ b/acceptance/tests/windows/eventlog.rb
@@ -2,12 +2,15 @@ test_name "Write to Windows eventlog"
 
 confine :to, :platform => 'windows'
 
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CommandUtils
+
 require 'puppet/acceptance/windows_utils'
 extend Puppet::Acceptance::WindowsUtils
 
 agents.each do |agent|
   # get remote time
-  now = on(agent, "#{ruby_cmd(agent)} -e \"puts Time.now.utc.strftime('%m/%d/%Y %H:%M:%S')\"").stdout.chomp
+  now = on(agent, "#{ruby_command(agent)} -e \"puts Time.now.utc.strftime('%m/%d/%Y %H:%M:%S')\"").stdout.chomp
 
   # it should fail to start since parent directories don't exist
   confdir = "/does/not/exist"


### PR DESCRIPTION
* Prepends privatebindir to the PATH environment used to execute `ruby` and `gem` on all hosts.
* For ruby-based ENC scripts executing on the master, resolve `ruby` relative to `privatebindir`.
* Moves the beaker pin to the version that contains the AIO pathing changes
* Removes the AIO path overrides from node config files