### PR TITLE
(PUP-3997) Run puppet apply to reset logdir owner

### DIFF
--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -80,4 +80,9 @@ SOURCE
     assert_match(/^Generated, 1 => 10, 2 => 20, 3 => 30$/, stdout, "Generated the wrong content")
   end
 
+  teardown do
+    # Run apply against standard puppet.conf to restore ownership of logdir
+    on agent, puppet('apply', '-e', "'notify {\"hello\":}'")
+  end
+
 end


### PR DESCRIPTION
This commit adds a teardown step in the
tests/loader/func4x_loadable_from_modules.rb acceptance test to
run puppet apply without a puppet.conf specified in order to
restore the ownership of the logdir.

Prior to this commit, the test left ownership of the logdir set to
the user and group specified in the test, which may not be the
proper standard ownership.