### PR TITLE
(PUP-4132) Pass merge strategy to Hiera

### DIFF
--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -17,7 +17,8 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
 
   def find(request)
     not_found = Object.new
-    value = hiera.lookup(request.key, not_found, Hiera::Scope.new(request.options[:variables]), nil, nil)
+    options = request.options
+    value = hiera.lookup(request.key, not_found, Hiera::Scope.new(options[:variables]), nil, convert_merge(options[:merge]))
     throw :no_such_key if value.equal?(not_found)
     value
   rescue *DataBindingExceptions => detail
@@ -25,6 +26,40 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
   end
 
   private
+
+  # Converts a lookup 'merge' parameter argument into a Hiera 'resolution_type' argument.
+  #
+  # @param merge [String,Hash,nil] The lookup 'merge' argument
+  # @return [Symbol,Hash,nil] The Hiera 'resolution_type'
+  def convert_merge(merge)
+    case merge
+    when nil
+      # Nil is OK. Defaults to Hiera :priority
+      nil
+    when 'unique'
+      # Equivalent to Hiera :array
+      :array
+    when 'hash'
+      # Equivalent to Hiera :hash with default :native merge behavior. A Hash must be passed here
+      # to override possible Hiera deep merge config settings.
+      { :behavior => :native }
+    when 'deep'
+      # Equivalent to Hiera :hash with :deeper merge behavior.
+      { :behavior => :deeper }
+    when Hash
+      strategy = merge['strategy']
+      if strategy == 'deep'
+        result = { :behavior => :deeper }
+        # Remaining entries must have symbolic keys
+        merge.each_pair { |k,v| result[k.to_sym] = v unless k == 'strategy' }
+        result
+      else
+        convert_merge(strategy)
+      end
+    else
+      raise Puppet::DataBinding::LookupError, "Unrecognized value for request 'merge' parameter: '#{merge}'"
+    end
+  end
 
   def self.hiera_config
     hiera_config = Puppet.settings[:hiera_config]

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -55,7 +55,7 @@ class Puppet::Pops::Lookup
   end
 
   def self.search_and_merge(name, scope, merge, not_found)
-    in_global = lambda { lookup_with_databinding(name, scope) }
+    in_global = lambda { lookup_with_databinding(name, scope, merge) }
     in_env = lambda { Puppet::DataProviders.lookup_in_environment(name, scope, merge) }
     in_module = lambda { Puppet::DataProviders.lookup_in_module(name, scope, merge) }
 
@@ -74,9 +74,9 @@ class Puppet::Pops::Lookup
   end
   private_class_method :search_and_merge
 
-  def self.lookup_with_databinding(key, scope)
+  def self.lookup_with_databinding(key, scope, merge)
     begin
-      Puppet::DataBinding.indirection.find(key, { :environment => scope.environment.to_s, :variables => scope })
+      Puppet::DataBinding.indirection.find(key, { :environment => scope.environment.to_s, :variables => scope, :merge => merge })
     rescue Puppet::DataBinding::LookupError => e
       raise Puppet::Error, "Error from DataBinding '#{Puppet[:data_binding_terminus]}' while looking up '#{name}': #{e.message}", e
     end

--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -251,8 +251,10 @@ module Puppet::Pops
     end
 
     def checked_merge(e1, e2)
+      dm_options = { :preserve_unmergeables => false }
+      options.each_pair { |k,v| dm_options[k.to_sym] = v unless k == 'strategy' }
       # e2 (the destination) is dup'ed to avoid that the passed in object mutates
-      DeepMerge.deep_merge!(e1, e2.dup, { :preserve_unmergeables => false }.merge(options))
+      DeepMerge.deep_merge!(e1, e2.dup, dm_options)
     end
 
     protected

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -178,6 +178,30 @@ describe "when performing lookup" do
       expect(resources).to include('global_f11_env_f12_module_f13_env_f21_module_f22_global_f23')
     end
 
+    it 'will propagate resolution_type :array to Hiera when merge == \'unique\''  do
+      Hiera.any_instance.expects(:lookup).with('c', anything, anything, anything, :array).returns(['global_c'])
+      resources = assemble_and_compile('${r[0]}_${r[1]}_${r[2]}', "'c'", 'Array[String]', "'unique'")
+      expect(resources).to include('global_c_env_c_module_c')
+    end
+
+    it 'will propagate a Hash resolution_type with :behavior => :native to Hiera when merge == \'hash\''  do
+      Hiera.any_instance.expects(:lookup).with('e', anything, anything, anything, { :behavior => :native }).returns({ 'k1' => 'global_e1' })
+      resources = assemble_and_compile('${r[k1]}_${r[k2]}_${r[k3]}', "'e'", 'Hash[String,String]', "{strategy => 'hash'}")
+      expect(resources).to include('global_e1_module_e2_env_e3')
+    end
+
+    it 'will propagate a Hash resolution_type with :behavior => :deeper to Hiera when merge == \'deep\''  do
+      Hiera.any_instance.expects(:lookup).with('f', anything, anything, anything, { :behavior => :deeper }).returns({ 'k1' => { 's1' => 'global_f11' }, 'k2' => { 's3' => 'global_f23' }})
+      resources = assemble_and_compile('${r[k1][s1]}_${r[k1][s2]}_${r[k1][s3]}_${r[k2][s1]}_${r[k2][s2]}_${r[k2][s3]}', "'f'", 'Hash[String,Hash[String,String]]', "'deep'")
+      expect(resources).to include('global_f11_env_f12_module_f13_env_f21_module_f22_global_f23')
+    end
+
+    it 'will propagate a Hash resolution_type with symbolic deep merge options to Hiera'  do
+      Hiera.any_instance.expects(:lookup).with('f', anything, anything, anything, { :behavior => :deeper, :knockout_prefix => '--' }).returns({ 'k1' => { 's1' => 'global_f11' }, 'k2' => { 's3' => 'global_f23' }})
+      resources = assemble_and_compile('${r[k1][s1]}_${r[k1][s2]}_${r[k1][s3]}_${r[k2][s1]}_${r[k2][s2]}_${r[k2][s3]}', "'f'", 'Hash[String,Hash[String,String]]', "{ 'strategy' => 'deep', 'knockout_prefix' => '--' }")
+      expect(resources).to include('global_f11_env_f12_module_f13_env_f21_module_f22_global_f23')
+    end
+
     context 'with provided default' do
       it 'will return default when lookup fails' do
         resources = assemble_and_compile('${r}', "'x'", 'String', 'undef', "'dflt_x'")


### PR DESCRIPTION
(PUP-4132) Pass merge strategy to Hiera

Hiera version 2.x will recognize a resolution_type parameter value
that is a Hash to mean a `:hash` _resolution_type_ with configured deep
merge options. This commit ensures that the lookup _merge_ parameter
is correctly converted into such a Hash when needed. The conversion
also translates the `'unique'` merge type into the Hiera `:array`
equivalence.