### PR TITLE
(PUP-3931) Change systemd KillMode to process for agent

### DIFF
--- a/ext/systemd/puppet.service
+++ b/ext/systemd/puppet.service
@@ -7,6 +7,7 @@ After=basic.target network.target puppetmaster.service
 EnvironmentFile=-/etc/sysconfig/puppetagent
 EnvironmentFile=-/etc/sysconfig/puppet
 ExecStart=/opt/puppetlabs/puppet/bin/puppet agent $PUPPET_EXTRA_OPTS --no-daemonize
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently, the entire control group is sent a kill; if a puppet agent run under the control group is running an upgrade of the puppet package, both the running agent process and the yum process doing the upgrade are killed as well as the daemon agent process, leaving the puppet installation in a bad state.  This brings the behavior in line with the behavior under the SysV init script.