### PR TITLE
(maint) Update contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ for advice.
 For changes of a trivial nature to comments and documentation, it is not
 always necessary to create a new ticket in Jira. In this case, it is
 appropriate to start the first line of a commit with '(doc)' instead of
-a ticket number. 
+a ticket number.
 
 ````
     (doc) Add documentation commit example to CONTRIBUTING
@@ -83,7 +83,7 @@ a ticket number.
     is left to assume how a commit of this nature may appear.
 
     The first line is a real life imperative statement with '(doc)' in
-    place of what would have been the ticket number in a 
+    place of what would have been the ticket number in a
     non-documentation related commit. The body describes the nature of
     the new documentation or comments added.
 ````
@@ -97,15 +97,20 @@ a ticket number.
   * Include a link to the pull request in the ticket.
 * The core team looks at Pull Requests on a regular basis in a weekly triage
   meeting that we hold in a public Google Hangout. The hangout is announced in
-  the weekly status updates that are sent to the puppet-dev list.
+  the weekly status updates that are sent to the puppet-dev list. Notes are
+  posted to the [Puppet Community community-triage
+  repo](https://github.com/puppet-community/community-triage/tree/master/core/notes)
+  and include a link to a YouTube recording of the hangout.
 * After feedback has been given we expect responses within two weeks. After two
-  weeks will may close the pull request if it isn't showing any activity.
+  weeks we may close the pull request if it isn't showing any activity.
 
 # Additional Resources
 
-* [More information on contributing](http://links.puppetlabs.com/contribute-to-puppet)
+* [Puppet Labs community guildelines](http://docs.puppetlabs.com/community/community_guidelines.html)
 * [Bug tracker (Jira)](http://tickets.puppetlabs.com)
 * [Contributor License Agreement](http://links.puppetlabs.com/cla)
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
-* #puppet-dev IRC channel on freenode.org
+* #puppet-dev IRC channel on freenode.org ([Archive](https://botbot.me/freenode/puppet-dev/))
+* [puppet-dev mailing list](http://links.puppetlabs.com/contribute-to-puppet)
+* [Community PR Triage notes](https://github.com/puppet-community/community-triage/tree/master/core/notes)


### PR DESCRIPTION
Remove an old link to the mostly-dead wiki, add links to puppet-dev email list
archive, #puppet-dev IRC archive, and community triage notes. Clean up some
white space errors.