### PR TITLE
(maint) Windows 2003 registry test fails

### DIFF
--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -260,7 +260,7 @@ module Puppet::Util::Windows
 
         if result != FFI::ERROR_SUCCESS
           msg = "Failed to delete registry value #{name} at #{key.keyname}"
-          raise Puppet::Util::Windows::Error.new(msg)
+          raise Puppet::Util::Windows::Error.new(msg, result)
         end
       end
 
@@ -274,8 +274,8 @@ module Puppet::Util::Windows
         result = RegDeleteKeyExW(key.hkey, name_ptr, regsam, 0)
 
         if result != FFI::ERROR_SUCCESS
-          msg = "Failed to delete registry value #{name} at #{key.keyname}"
-          raise Puppet::Util::Windows::Error.new(msg)
+          msg = "Failed to delete registry key #{name} at #{key.keyname}"
+          raise Puppet::Util::Windows::Error.new(msg, result)
         end
       end
 

--- a/spec/unit/util/windows/registry_spec.rb
+++ b/spec/unit/util/windows/registry_spec.rb
@@ -111,6 +111,7 @@ describe Puppet::Util::Windows::Registry, :if => Puppet::Util::Platform.windows?
       let (:puppet_key) { "SOFTWARE\\Puppet Labs"}
       let (:subkey_name) { "PuppetRegistryTest" }
       let (:guid) { SecureRandom.uuid }
+      let (:regsam) { Puppet::Util::Windows::Registry::KEY32 }
 
       after(:each) do
         # Ruby 2.1.5 has bugs with deleting registry keys due to using ANSI
@@ -118,8 +119,8 @@ describe Puppet::Util::Windows::Registry, :if => Puppet::Util::Platform.windows?
         # https://github.com/ruby/ruby/blob/v2_1_5/ext/win32/lib/win32/registry.rb#L323-L329
         # therefore, use our own built-in registry helper code
 
-        hklm.open(puppet_key, Win32::Registry::KEY_ALL_ACCESS) do |reg|
-          subject.delete_key(reg, subkey_name)
+        hklm.open(puppet_key, Win32::Registry::KEY_ALL_ACCESS | regsam) do |reg|
+          subject.delete_key(reg, subkey_name, regsam)
         end
       end
 
@@ -145,7 +146,7 @@ describe Puppet::Util::Windows::Registry, :if => Puppet::Util::Platform.windows?
         Win32::Registry.expects(:each_key).never
         Win32::Registry.expects(:each_value).never
 
-        hklm.create("#{puppet_key}\\#{subkey_name}", Win32::Registry::KEY_ALL_ACCESS) do |reg|
+        hklm.create("#{puppet_key}\\#{subkey_name}", Win32::Registry::KEY_ALL_ACCESS | regsam) do |reg|
           reg.write("#{guid}", Win32::Registry::REG_SZ, utf_16_str)
 
           # trigger Puppet::Util::Windows::Registry FFI calls


### PR DESCRIPTION
Changes were introduced in b46ede7
  to work around string encoding issues discovered internal to
  Ruby 2.1.5 Registry handling.  Additional tests were added to
  demonstrate the behavior around round-tripping Unicode characters
  properly.  Interestingly, this test caused a test failure only
  in Windows 2003.

 - On Windows 2003, the following behavior was observed:

   - Calls to create generated registry keys under
     HKLM\SOFTWARE\Wow6432Node\
     This is equivalent to passing KEY_WOW64_32KEY to RegCreateKeyEx

   - Calls to open try to open registry keys under
     HKLM\SOFTWARE\
     This is equivalent to passing KEY_WOW64_64KEY to RegOpenKeyEx

   This generates a test failure because the key created is not the same
   one that the code later attempts to open, and hence the handle is
   invalid, and the key cannot be deleted.

   Strangely, other operating systems do not encounter this behavior,
   which may mean that advapi32.dll has different default values for
   the registry redirection configuration values with Windows 2003.

   The fix here is to always specify the 0x200 / KEY_WOW64_32KEY to
   be explicit about opening the same key.