### PR TITLE
(PUP-4190) Don't display credentials in output

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -169,7 +169,11 @@ Licensed under the Apache 2.0 License
     end
     devices.each_value do |device|
       begin
-        Puppet.info "starting applying configuration to #{device.name} at #{device.url}"
+        device_url = URI.parse(device.url)
+        # Handle nil scheme & port
+        scheme = "#{device_url.scheme}://" if device_url.scheme
+        port = ":#{device_url.port}" if device_url.port
+        Puppet.info "starting applying configuration to #{device.name} at #{scheme}#{device_url.host}#{port}#{device_url.path}"
 
         # override local $vardir and $certname
         Puppet[:confdir] = ::File.join(Puppet[:devicedir], device.name)

--- a/lib/puppet/util/network_device/config.rb
+++ b/lib/puppet/util/network_device/config.rb
@@ -82,6 +82,11 @@ class Puppet::Util::NetworkDevice::Config
     when "type"
       device.provider = value
     when "url"
+      begin
+        URI.parse(value)
+      rescue URI::InvalidURIError
+        raise Puppet::Error, "#{value} is an invalid url"
+      end
       device.url = value
     when "debug"
       device.options[:debug] = true

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -126,7 +126,6 @@ describe Puppet::Application::Device do
   describe "during setup" do
     before :each do
       @device.options.stubs(:[])
-      Puppet.stubs(:info)
       Puppet[:libdir] = "/dev/null/lib"
       Puppet::SSL::Host.stubs(:ca_location=)
       Puppet::Transaction::Report.indirection.stubs(:terminus_class=)
@@ -296,8 +295,8 @@ describe Puppet::Application::Device do
         Puppet[:confdir] = make_absolute("/dummy")
         Puppet[:certname] = "certname"
         @device_hash = {
-          "device1" => OpenStruct.new(:name => "device1", :url => "url", :provider => "cisco"),
-          "device2" => OpenStruct.new(:name => "device2", :url => "url", :provider => "cisco"),
+          "device1" => OpenStruct.new(:name => "device1", :url => "ssh://user:pass@testhost", :provider => "cisco"),
+          "device2" => OpenStruct.new(:name => "device2", :url => "https://user:pass@testhost/some/path", :provider => "rest"),
         }
         Puppet::Util::NetworkDevice::Config.stubs(:devices).returns(@device_hash)
         Puppet.stubs(:[]=)
@@ -331,6 +330,12 @@ describe Puppet::Application::Device do
 
       it "should initialize the device singleton" do
         Puppet::Util::NetworkDevice.expects(:init).with(@device_hash["device1"]).then.with(@device_hash["device2"])
+        @device.main
+      end
+
+      it "should print the device url scheme, host, and port" do
+        Puppet.expects(:info).with "starting applying configuration to device1 at ssh://testhost"
+        Puppet.expects(:info).with "starting applying configuration to device2 at https://testhost:443/some/path"
         @device.main
       end
 

--- a/spec/unit/util/network_device/config_spec.rb
+++ b/spec/unit/util/network_device/config_spec.rb
@@ -70,6 +70,12 @@ describe Puppet::Util::NetworkDevice::Config do
       config.devices['router.puppetlabs.com'].url.should == 'ssh://test/'
     end
 
+    it "should error with a malformed device url" do
+      write_device_config('[router.puppetlabs.com]', 'type cisco', 'url ssh://test node/')
+
+      expect { config.devices['router.puppetlabs.com'] }.to raise_error Puppet::Error
+    end
+
     it "should parse the debug mode" do
       write_device_config('[router.puppetlabs.com]', 'type cisco', 'url ssh://test/', 'debug')
 


### PR DESCRIPTION
The url contains the credentials for a device. Don't print them in plaintext.