### PR TITLE
(PUP-4191,PUP-4203) Use execute function to run gem uninstall

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -122,7 +122,12 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
   end
 
   def uninstall
-    gemcmd "uninstall", "-x", "-a", resource[:name]
+    command = [command(:gemcmd), "uninstall"]
+    command << "-x" << "-a" << resource[:name]
+    output = execute(command)
+    
+    # Apparently some stupid gem versions don't exit non-0 on failure
+    self.fail "Could not uninstall: #{output.chomp}" if output.include?("ERROR")
   end
 
   def update

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -8,11 +8,12 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     interpreted as the path to a local gem file.  If source is not present at all,
     the gem will be installed from the default gem repositories.
 
-    This provider supports the `install_options` attribute, which allows command-line flags to be passed to the gem command.
+    This provider supports the `install_options` and `uninstall_options` attributes,
+    which allow command-line flags to be passed to the gem command.
     These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
     or an array where each element is either a string or a hash."
 
-  has_feature :versionable, :install_options
+  has_feature :versionable, :install_options, :uninstall_options
 
   commands :gemcmd => "gem"
 
@@ -124,6 +125,9 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
   def uninstall
     command = [command(:gemcmd), "uninstall"]
     command << "--executables" << "--all" << resource[:name]
+
+    command += uninstall_options if resource[:uninstall_options]
+ 
     output = execute(command)
     
     # Apparently some stupid gem versions don't exit non-0 on failure
@@ -136,5 +140,9 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
   def install_options
     join_options(resource[:install_options])
+  end
+
+  def uninstall_options
+    join_options(resource[:uninstall_options])
   end
 end

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -123,7 +123,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
   def uninstall
     command = [command(:gemcmd), "uninstall"]
-    command << "-x" << "-a" << resource[:name]
+    command << "--executables" << "--all" << resource[:name]
     output = execute(command)
     
     # Apparently some stupid gem versions don't exit non-0 on failure

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -187,3 +187,52 @@ context 'installing myresource' do
     end
   end
 end
+
+context 'uninstalling myresource' do
+  describe provider_class do
+    let(:resource) do
+      Puppet::Type.type(:package).new(
+        :name     => 'myresource',
+        :ensure   => :absent
+      )
+    end
+
+    let(:provider) do
+      provider = provider_class.new
+      provider.resource = resource
+      provider
+    end
+
+    before :each do
+      resource.provider = provider
+    end
+
+    describe "when uninstalling" do
+      it "should use the path to the gem" do
+        provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+        provider.expects(:execute).with { |args| args[0] == "/my/gem" }.returns ""
+        provider.uninstall
+      end
+
+      it "should specify that the gem is being uninstalled" do
+        provider.expects(:execute).with { |args| args[1] == "uninstall" }.returns ""
+        provider.uninstall
+      end
+
+      it "should specify that the relevant executables should be removed without confirmation" do
+        provider.expects(:execute).with { |args| args[2] == "--executables" }.returns ""
+        provider.uninstall
+      end
+
+      it "should specify that all the matching versions should be removed" do
+        provider.expects(:execute).with { |args| args[3] == "--all" }.returns ""
+        provider.uninstall
+      end
+
+      it "should specify the package name" do
+        provider.expects(:execute).with { |args| args[4] == "myresource" }.returns ""
+        provider.uninstall
+      end
+    end
+  end
+end

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -233,6 +233,17 @@ context 'uninstalling myresource' do
         provider.expects(:execute).with { |args| args[4] == "myresource" }.returns ""
         provider.uninstall
       end
+
+      it "should not append uninstall_options by default" do
+        provider.expects(:execute).with { |args| args.length == 5 }.returns ""
+        provider.uninstall
+      end
+
+      it "should allow setting an uninstall_options parameter" do
+        resource[:uninstall_options] = [ '--ignore-dependencies', {'--version' => '0.1.1' } ]
+        provider.expects(:execute).with { |args| args[5] == '--ignore-dependencies' && args[6] == '--version=0.1.1' }.returns ''
+        provider.uninstall
+      end
     end
   end
 end

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -3,184 +3,186 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:package).provider(:gem)
 
-describe provider_class do
-  let(:resource) do
-    Puppet::Type.type(:package).new(
-      :name     => 'myresource',
-      :ensure   => :installed
-    )
-  end
-
-  let(:provider) do
-    provider = provider_class.new
-    provider.resource = resource
-    provider
-  end
-
-  before :each do
-    resource.provider = provider
-  end
-
-  describe "when installing" do
-    it "should use the path to the gem" do
-      provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
-      provider.expects(:execute).with { |args| args[0] == "/my/gem" }.returns ""
-      provider.install
+context 'installing myresource' do
+  describe provider_class do
+    let(:resource) do
+      Puppet::Type.type(:package).new(
+        :name     => 'myresource',
+        :ensure   => :installed
+      )
     end
 
-    it "should specify that the gem is being installed" do
-      provider.expects(:execute).with { |args| args[1] == "install" }.returns ""
-      provider.install
+    let(:provider) do
+      provider = provider_class.new
+      provider.resource = resource
+      provider
     end
 
-    it "should specify that documentation should not be included" do
-      provider.expects(:execute).with { |args| args[2] == "--no-rdoc" }.returns ""
-      provider.install
+    before :each do
+      resource.provider = provider
     end
 
-    it "should specify that RI should not be included" do
-      provider.expects(:execute).with { |args| args[3] == "--no-ri" }.returns ""
-      provider.install
-    end
+    describe "when installing" do
+      it "should use the path to the gem" do
+        provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+        provider.expects(:execute).with { |args| args[0] == "/my/gem" }.returns ""
+        provider.install
+      end
 
-    it "should specify the package name" do
-      provider.expects(:execute).with { |args| args[4] == "myresource" }.returns ""
-      provider.install
-    end
+      it "should specify that the gem is being installed" do
+        provider.expects(:execute).with { |args| args[1] == "install" }.returns ""
+        provider.install
+      end
 
-    it "should not append install_options by default" do
-      provider.expects(:execute).with { |args| args.length == 5 }.returns ""
-      provider.install
-    end
+      it "should specify that documentation should not be included" do
+        provider.expects(:execute).with { |args| args[2] == "--no-rdoc" }.returns ""
+        provider.install
+      end
 
-    it "should allow setting an install_options parameter" do
-      resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      provider.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
-      provider.install
-    end
+      it "should specify that RI should not be included" do
+        provider.expects(:execute).with { |args| args[3] == "--no-ri" }.returns ""
+        provider.install
+      end
 
-    describe "when a source is specified" do
-      describe "as a normal file" do
-        it "should use the file name instead of the gem name" do
-          resource[:source] = "/my/file"
-          provider.expects(:execute).with { |args| args[2] == "/my/file" }.returns ""
-          provider.install
+      it "should specify the package name" do
+        provider.expects(:execute).with { |args| args[4] == "myresource" }.returns ""
+        provider.install
+      end
+
+      it "should not append install_options by default" do
+        provider.expects(:execute).with { |args| args.length == 5 }.returns ""
+        provider.install
+      end
+
+      it "should allow setting an install_options parameter" do
+        resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
+        provider.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
+        provider.install
+      end
+
+      describe "when a source is specified" do
+        describe "as a normal file" do
+          it "should use the file name instead of the gem name" do
+            resource[:source] = "/my/file"
+            provider.expects(:execute).with { |args| args[2] == "/my/file" }.returns ""
+            provider.install
+          end
+        end
+        describe "as a file url" do
+          it "should use the file name instead of the gem name" do
+            resource[:source] = "file:///my/file"
+            provider.expects(:execute).with { |args| args[2] == "/my/file" }.returns ""
+            provider.install
+          end
+        end
+        describe "as a puppet url" do
+          it "should fail" do
+            resource[:source] = "puppet://my/file"
+            expect { provider.install }.to raise_error(Puppet::Error)
+          end
+        end
+        describe "as a non-file and non-puppet url" do
+          it "should treat the source as a gem repository" do
+            resource[:source] = "http://host/my/file"
+            provider.expects(:execute).with { |args| args[2..4] == ["--source", "http://host/my/file", "myresource"] }.returns ""
+            provider.install
+          end
+        end
+        describe "with an invalid uri" do
+          it "should fail" do
+            URI.expects(:parse).raises(ArgumentError)
+            resource[:source] = "http:::::uppet:/:/my/file"
+            expect { provider.install }.to raise_error(Puppet::Error)
+          end
         end
       end
-      describe "as a file url" do
-        it "should use the file name instead of the gem name" do
-          resource[:source] = "file:///my/file"
-          provider.expects(:execute).with { |args| args[2] == "/my/file" }.returns ""
-          provider.install
-        end
-      end
-      describe "as a puppet url" do
-        it "should fail" do
-          resource[:source] = "puppet://my/file"
-          expect { provider.install }.to raise_error(Puppet::Error)
-        end
-      end
-      describe "as a non-file and non-puppet url" do
-        it "should treat the source as a gem repository" do
-          resource[:source] = "http://host/my/file"
-          provider.expects(:execute).with { |args| args[2..4] == ["--source", "http://host/my/file", "myresource"] }.returns ""
-          provider.install
-        end
-      end
-      describe "with an invalid uri" do
-        it "should fail" do
-          URI.expects(:parse).raises(ArgumentError)
-          resource[:source] = "http:::::uppet:/:/my/file"
-          expect { provider.install }.to raise_error(Puppet::Error)
-        end
-      end
     end
-  end
 
-  describe "#latest" do
-    it "should return a single value for 'latest'" do
-      #gemlist is used for retrieving both local and remote version numbers, and there are cases
-      # (particularly local) where it makes sense for it to return an array.  That doesn't make
-      # sense for '#latest', though.
-      provider.class.expects(:gemlist).with({ :justme => 'myresource'}).returns({
+    describe "#latest" do
+      it "should return a single value for 'latest'" do
+        #gemlist is used for retrieving both local and remote version numbers, and there are cases
+        # (particularly local) where it makes sense for it to return an array.  That doesn't make
+        # sense for '#latest', though.
+        provider.class.expects(:gemlist).with({ :justme => 'myresource'}).returns({
           :name     => 'myresource',
           :ensure   => ["3.0"],
           :provider => :gem,
+        })
+        expect(provider.latest).to eq("3.0")
+      end
+
+      it "should list from the specified source repository" do
+        resource[:source] = "http://foo.bar.baz/gems"
+        provider.class.expects(:gemlist).
+          with({:justme => 'myresource', :source => "http://foo.bar.baz/gems"}).
+          returns({
+            :name     => 'myresource',
+            :ensure   => ["3.0"],
+            :provider => :gem,
           })
-      expect(provider.latest).to eq("3.0")
+          expect(provider.latest).to eq("3.0")
+      end
     end
 
-    it "should list from the specified source repository" do
-      resource[:source] = "http://foo.bar.baz/gems"
-      provider.class.expects(:gemlist).
-        with({:justme => 'myresource', :source => "http://foo.bar.baz/gems"}).
-        returns({
-          :name     => 'myresource',
-          :ensure   => ["3.0"],
-          :provider => :gem,
-          })
-      expect(provider.latest).to eq("3.0")
-    end
-  end
+    describe "#instances" do
+      before do
+        provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+      end
 
-  describe "#instances" do
-    before do
-      provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
-    end
+      it "should return an empty array when no gems installed" do
+        provider_class.expects(:execute).with(%w{/my/gem list --local}).returns("\n")
+        expect(provider_class.instances).to eq([])
+      end
 
-    it "should return an empty array when no gems installed" do
-      provider_class.expects(:execute).with(%w{/my/gem list --local}).returns("\n")
-      expect(provider_class.instances).to eq([])
-    end
-
-    it "should return ensure values as an array of installed versions" do
-      provider_class.expects(:execute).with(%w{/my/gem list --local}).returns <<-HEREDOC.gsub(/        /, '')
+      it "should return ensure values as an array of installed versions" do
+        provider_class.expects(:execute).with(%w{/my/gem list --local}).returns <<-HEREDOC.gsub(/        /, '')
         systemu (1.2.0)
         vagrant (0.8.7, 0.6.9)
-      HEREDOC
+        HEREDOC
 
-      expect(provider_class.instances.map {|p| p.properties}).to eq([
-        {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
-        {:ensure => ["0.8.7", "0.6.9"], :provider => :gem, :name => 'vagrant'}
-      ])
-    end
+        expect(provider_class.instances.map {|p| p.properties}).to eq([
+          {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
+          {:ensure => ["0.8.7", "0.6.9"], :provider => :gem, :name => 'vagrant'}
+        ])
+      end
 
-    it "should ignore platform specifications" do
-      provider_class.expects(:execute).with(%w{/my/gem list --local}).returns <<-HEREDOC.gsub(/        /, '')
+      it "should ignore platform specifications" do
+        provider_class.expects(:execute).with(%w{/my/gem list --local}).returns <<-HEREDOC.gsub(/        /, '')
         systemu (1.2.0)
         nokogiri (1.6.1 ruby java x86-mingw32 x86-mswin32-60, 1.4.4.1 x86-mswin32)
-      HEREDOC
+        HEREDOC
 
-      expect(provider_class.instances.map {|p| p.properties}).to eq([
-        {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
-        {:ensure => ["1.6.1", "1.4.4.1"], :provider => :gem, :name => 'nokogiri'}
-      ])
+        expect(provider_class.instances.map {|p| p.properties}).to eq([
+          {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
+          {:ensure => ["1.6.1", "1.4.4.1"], :provider => :gem, :name => 'nokogiri'}
+        ])
+      end
+
+      it "should not fail when an unmatched line is returned" do
+        provider_class.expects(:execute).with(%w{/my/gem list --local}).
+          returns(File.read(my_fixture('line-with-1.8.5-warning')))
+
+        expect(provider_class.instances.map {|p| p.properties}).
+          to eq([{:provider=>:gem, :ensure=>["0.3.2"], :name=>"columnize"},
+                 {:provider=>:gem, :ensure=>["1.1.3"], :name=>"diff-lcs"},
+                 {:provider=>:gem, :ensure=>["0.0.1"], :name=>"metaclass"},
+                 {:provider=>:gem, :ensure=>["0.10.5"], :name=>"mocha"},
+                 {:provider=>:gem, :ensure=>["0.8.7"], :name=>"rake"},
+                 {:provider=>:gem, :ensure=>["2.9.0"], :name=>"rspec-core"},
+                 {:provider=>:gem, :ensure=>["2.9.1"], :name=>"rspec-expectations"},
+                 {:provider=>:gem, :ensure=>["2.9.0"], :name=>"rspec-mocks"},
+                 {:provider=>:gem, :ensure=>["0.9.0"], :name=>"rubygems-bundler"},
+                 {:provider=>:gem, :ensure=>["1.11.3.3"], :name=>"rvm"}])
+      end
     end
 
-    it "should not fail when an unmatched line is returned" do
-      provider_class.expects(:execute).with(%w{/my/gem list --local}).
-        returns(File.read(my_fixture('line-with-1.8.5-warning')))
-
-      expect(provider_class.instances.map {|p| p.properties}).
-        to eq([{:provider=>:gem, :ensure=>["0.3.2"], :name=>"columnize"},
-                   {:provider=>:gem, :ensure=>["1.1.3"], :name=>"diff-lcs"},
-                   {:provider=>:gem, :ensure=>["0.0.1"], :name=>"metaclass"},
-                   {:provider=>:gem, :ensure=>["0.10.5"], :name=>"mocha"},
-                   {:provider=>:gem, :ensure=>["0.8.7"], :name=>"rake"},
-                   {:provider=>:gem, :ensure=>["2.9.0"], :name=>"rspec-core"},
-                   {:provider=>:gem, :ensure=>["2.9.1"], :name=>"rspec-expectations"},
-                   {:provider=>:gem, :ensure=>["2.9.0"], :name=>"rspec-mocks"},
-                   {:provider=>:gem, :ensure=>["0.9.0"], :name=>"rubygems-bundler"},
-                   {:provider=>:gem, :ensure=>["1.11.3.3"], :name=>"rvm"}])
-    end
-  end
-
-  describe "listing gems" do
-    describe "searching for a single package" do
-      it "searches for an exact match" do
-        provider_class.expects(:execute).with(includes('^bundler$')).returns(File.read(my_fixture('gem-list-single-package')))
-        expected = {:name => 'bundler', :ensure => %w[1.6.2], :provider => :gem}
-        expect(provider_class.gemlist({:justme => 'bundler'})).to eq(expected)
+    describe "listing gems" do
+      describe "searching for a single package" do
+        it "searches for an exact match" do
+          provider_class.expects(:execute).with(includes('^bundler$')).returns(File.read(my_fixture('gem-list-single-package')))
+          expected = {:name => 'bundler', :ensure => %w[1.6.2], :provider => :gem}
+          expect(provider_class.gemlist({:justme => 'bundler'})).to eq(expected)
+        end
       end
     end
   end


### PR DESCRIPTION
When attempting to uninstall a gem using a custom gem provider inheriting gem.rb, the wrong gemcmd is issued.

For example, the [sensu-puppet](https://github.com/sensu/sensu-puppet) module introduces embedded ruby gem support through a custom [sensu_gem](https://github.com/sensu/sensu-puppet/blob/master/lib/puppet/provider/package/sensu_gem.rb) provider, inheriting puppet's `gem.rb`.

In sensu-gem, the `:gemcmd` is declared to match the embedded sensu gem path:
`commands :gemcmd => "/opt/sensu/embedded/bin/gem"`

When the following resource is run:
```
package { 'sensu-plugin':
  ensure   => absent,
  provider => 'sensu_gem',
}
```

`/usr/bin/gem uninstall -x -a sensu-plugin` is executed rather than
`/opt/sensu/embedded/bin/gem uninstall -x -a sensu-plugin`.

I noticed that in `gem.rb` the install and self.gemlist methods build a command array and pass it to the execute function. This results in using the right gemcmd.

This PR makes the uninstall method behave just like the self.gemlist and install methods.
An array of arguments is built and passed to the execute function, which runs the right command and returns the output. Since some versions of gem may return exit code 0 on error, a hard failure is triggered if the output contains the word 'ERROR'. This is compliant with the `install` method behaviour.