### PR TITLE
(DO NOT MERGE) (PUP-4194) Set logdir permissions to 0755

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -74,7 +74,7 @@ module Puppet
     :logdir => {
         :default  => nil,
         :type     => :directory,
-        :mode     => "0750",
+        :mode     => "0755",
         :owner    => "service",
         :group    => "service",
         :desc     => "The directory in which to store log files",


### PR DESCRIPTION
Previously, if you only installed `puppet-agent`, but not
`puppetserver`, then executing `puppet agent` or `puppet apply` would
set permissions of its `$logdir` to `root:root` and mode 0750.

    Debug: /File[/var/log/puppetlabs]/mode: mode changed '0755' to '0750'

If you then installed `puppetserver` as root, the package would create the
`puppet` user and group, create a `$logdir/puppetserver` directory, and
set its permissions to `puppet:puppet` with mode 0700.

However, the puppetserver could not start, because it starts as
as `puppet` and could not write to its log file, as it doesn't have
permssion to traverse the grandparent `$logdir`. Note, the JVM based
puppetserver does not have the ability to start as root and switch uids
like ruby/webrick can.

This commit modifies puppet to manage its `:logdir` with mode 0755,
which is consistent with `puppet-agent` packaging. It is ok to
relax permissions on this directory, because puppet normally writes
to syslog. It is theoretically possible for puppet to write to its
`:puppetdlog` instead, but in practice this never happens, and even
if it did, puppet would set its mode to 0640.

The only other log that puppet writes to `:logdir` is when running
webrick. But puppet manages the webrick log file `:masterhttplog` with
mode 0660.