### PR TITLE
(PUP-4199) Add codedir to ARGV in config.ru example

### DIFF
--- a/ext/rack/config.ru
+++ b/ext/rack/config.ru
@@ -18,6 +18,7 @@ ARGV << "--confdir" << "/etc/puppetlabs/puppet"
 ARGV << "--vardir"  << "/opt/puppetlabs/server/data/puppetmaster"
 ARGV << "--logdir"  << "/var/log/puppetlabs/puppetmaster"
 ARGV << "--rundir"  << "/var/run/puppetlabs/puppetmaster"
+ARGV << "--codedir"  << "/etc/puppetlabs/code"
 
 # always_cache_features is a performance improvement and safe for a master to
 # apply. This is intended to allow agents to recognize new features that may be


### PR DESCRIPTION
While our config.ru was mostly modified to work with the AIO and Puppet
4, we missed adding the codedir option. This commit adds that with the
default of /etc/puppetlabs/code as the value.