### PR TITLE
(MAINT) updates tests to work with beaker 2.x

### DIFF
--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -19,7 +19,9 @@ agents.each do |agent|
   step "  install module '#{module_author}-#{module_name}'"
 
   opts ||= Hash.new
-  opts['ENV']=Command::DEFAULT_GIT_ENV
+  if defined? Command::DEFAULT_GIT_ENV #this constant was removed in beaker 2
+    opts['ENV']=Command::DEFAULT_GIT_ENV
+  end
   command = agent['platform'] =~ /windows/ ?
     Command.new("'puppet module install --version \"<#{module_version}\" #{module_author}-#{module_name}'", [], opts) :
     puppet("module install --version \"<#{module_version}\" #{module_author}-#{module_name}")

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -1,9 +1,7 @@
 test_name "file resource: symbolic modes"
 
-require 'test/unit/assertions'
-
 module FileModeAssertions
-  include Test::Unit::Assertions
+  include Beaker::DSL::Assertions
 
   def assert_create(agent, manifest, path, expected_mode)
     testcase.apply_manifest_on(agent, manifest) do


### PR DESCRIPTION
- changes in beaker 2.x broke a few tests, update tests to function
  correctly with new beaker while maintaining backwards compatability