### PR TITLE
(PUP-4205) Fix syntax error in heredoc support.

### DIFF
--- a/lib/puppet/pops/parser/heredoc_support.rb
+++ b/lib/puppet/pops/parser/heredoc_support.rb
@@ -64,7 +64,7 @@ module Puppet::Pops::Parser::HeredocSupport
     # and it should start scanning after the first found \n (or if not found == error).
 
     if ctx[:newline_jump]
-      scn.pos = lexing_context[:newline_jump]
+      scn.pos = @lexing_context[:newline_jump]
     else
       scn.scan_until(/\n/) || lex_error("Heredoc without any following lines of text")
     end


### PR DESCRIPTION
Missing a '@' when referencing lexing_context.  This prevented multiple
heredocs on the same line from being parsed correctly.