### PR TITLE
issue/pup-4206-fedora-package-names

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -126,7 +126,6 @@ module Puppet
         case platform
           when /^(fedora|el|centos)-(\d+)-(.+)$/
             variant = (($1 == 'centos') ? 'el' : $1)
-            fedora_prefix = ((variant == 'fedora') ? 'f' : '')
             version = $2
             arch = $3
 
@@ -136,12 +135,11 @@ module Puppet
               platform_configs_dir
             )
 
-            pattern = "pl-%s%s-%s-%s%s-%s.repo"
+            pattern = "pl-%s%s-%s-%s-%s.repo"
             repo_filename = pattern % [
               project,
               sha ? '-' + sha : '',
               variant,
-              fedora_prefix,
               version,
               arch
             ]
@@ -151,23 +149,21 @@ module Puppet
               platform_configs_dir
             )
 
-            link = "http://%s/%s/%s/repos/%s/%s%s/products/%s/" % [
+            link = "http://%s/%s/%s/repos/%s/%s/products/%s/" % [
               tld,
               project,
               sha,
               variant,
-              fedora_prefix,
               version,
               arch
             ]
 
             if not link_exists?(link)
-              link = "http://%s/%s/%s/repos/%s/%s%s/devel/%s/" % [
+              link = "http://%s/%s/%s/repos/%s/%s/devel/%s/" % [
                 tld,
                 project,
                 sha,
                 variant,
-                fedora_prefix,
                 version,
                 arch
               ]

--- a/acceptance/lib/puppet/acceptance/install_utils_spec.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils_spec.rb
@@ -151,7 +151,7 @@ describe 'InstallUtils' do
         platform_configs_dir
       ).returns("#{platform_configs_dir}/#{repo_dir}")
       testcase.expects(:link_exists?).returns( true )
-  
+
       testcase.expects(:on).with(host, regexp_matches(/rm.*repo; rm.*rpm; rm.*#{repo_dir}/))
       testcase.expects(:scp_to).with(host, "#{platform_configs_dir}/#{rpm_file}", '/root')
       testcase.expects(:scp_to).with(host, "#{platform_configs_dir}/#{repo_file}", '/root')
@@ -196,10 +196,10 @@ describe 'InstallUtils' do
         ],
         :repo => [
           "http://builds.puppetlabs.lan/puppet/abcdef10/repo_configs/rpm/",
-          "pl-puppet-abcdef10-fedora-f20-x86_64.repo",
+          "pl-puppet-abcdef10-fedora-20-x86_64.repo",
         ],
         :repo_dir => [
-          "http://builds.puppetlabs.lan/puppet/abcdef10/repos/fedora/f20/products/x86_64/",
+          "http://builds.puppetlabs.lan/puppet/abcdef10/repos/fedora/20/products/x86_64/",
           "x86_64",
         ],
       },


### PR DESCRIPTION
Puppet acceptance assumes `f20` instead of `20` in various places, e.g. fedora repo configs are named like `...fedora-f20-...` but the actual packages are named like `...fedora-20-...`.

This could be fixed in packaging or fixed in acceptance. This PR assumes the latter is what we want to do but I don't care much. 

/cc @justinstoller @haus for comments.