### PR TITLE
(PUP-4209) Introduce fail attribute in notify resource

### DIFF
--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -8,7 +8,14 @@ module Puppet
 
     newproperty(:message) do
       desc "The message to be sent to the log."
+
       def sync
+
+        case @resource["fail"]
+        when :true
+          self.fail self.should
+        end
+
         case @resource["withpath"]
         when :true
           send(@resource[:loglevel], self.should)
@@ -31,6 +38,13 @@ module Puppet
 
     newparam(:withpath) do
       desc "Whether to show the full object path. Defaults to false."
+      defaultto :false
+
+      newvalues(:true, :false)
+    end
+
+    newparam(:fail) do
+      desc "Triggers failure of the current puppet run. Defaults to false."
       defaultto :false
 
       newvalues(:true, :false)

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -79,8 +79,8 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
   end
 
   it "can return an iterator for all set parameters" do
-    resource = Puppet::Type.type(:notify).new(:name=>'foo',:message=>'bar',:tag=>'baz',:require=> "File['foo']")
-    params = [:name, :message, :withpath, :loglevel, :tag, :require]
+    resource = Puppet::Type.type(:notify).new(:name=>'foo',:message=>'bar',:tag=>'baz',:fail=>false,:require=> "File['foo']")
+    params = [:name, :message, :withpath, :loglevel, :tag, :fail, :require]
     resource.eachparameter { |param|
       expect(params).to be_include(param.to_s.to_sym)
     }


### PR DESCRIPTION
Notify resources can output messages, but cannot alert the users about errors or fail the current puppet run.

This commit introduces the fail attribute to notify resources, which, if set to true, will output the message as error and fail the puppet run. The fail attribute defaults to false and this doesn't modify the current behaviour of the notify resource.

Example:

```puppet
notify { 'fail_puppet_run':
  message => 'Puppet is going to fail... Bye!',
  fail => true,
}
```

Output:

```shell
Notice: Compiled catalog for gds3562.local in environment production in 0.30 seconds
Error: Puppet is going to fail... Bye!
Error: /Stage[main]/Main/Notify[fail_puppet_run]/message: change from absent to Puppet is going to fail... Bye! failed: Puppet is going to fail... Bye!
Notice: Applied catalog in 0.06 seconds
```