### PR TITLE
(PUP-4213) Add refreshonly attribute to notify resource

### DIFF
--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -6,6 +6,10 @@ module Puppet
   Type.newtype(:notify) do
     @doc = "Sends an arbitrary message to the agent run-time log."
 
+    def refresh
+      self.property(:message).sync
+    end
+
     newproperty(:message) do
       desc "The message to be sent to the log."
       def sync
@@ -23,6 +27,7 @@ module Puppet
       end
 
       def insync?(is)
+        return true if @resource["refreshonly"] == :true
         false
       end
 
@@ -33,6 +38,12 @@ module Puppet
       desc "Whether to show the full object path. Defaults to false."
       defaultto :false
 
+      newvalues(:true, :false)
+    end
+
+    newparam(:refreshonly) do
+      desc "Will cause the resource to be executed on refresh events only. Defaults to false."
+      defaultto :false
       newvalues(:true, :false)
     end
 

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -79,8 +79,8 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
   end
 
   it "can return an iterator for all set parameters" do
-    resource = Puppet::Type.type(:notify).new(:name=>'foo',:message=>'bar',:tag=>'baz',:require=> "File['foo']")
-    params = [:name, :message, :withpath, :loglevel, :tag, :require]
+    resource = Puppet::Type.type(:notify).new(:name=>'foo',:message=>'bar',:tag=>'baz',:refreshonly=>false,:require=> "File['foo']")
+    params = [:name, :message, :withpath, :loglevel, :tag, :refreshonly, :require]
     resource.eachparameter { |param|
       expect(params).to be_include(param.to_s.to_sym)
     }


### PR DESCRIPTION
Notify resources are always added to the catalog and run all the time, producing a notification message.

It would be useful to add a `refreshonly` attribute that mimics exec's `refreshonly`.
This attribute should trigger the execution of notify on refresh events only.

For example, it'd be useful to notify the user when some critical files are being changed.

Example:

```puppet
file { '/tmp/key.pem':
  content => 'PRIVATE_KEY',
  notify => Notify['private_key_content_change'],
}
notify { 'private_key_content_change':
  message => 'One of your private key\'s content has just changed!',
  refreshonly => true,
}
```

This results into the following output on the first run:

```shell
Notice: Compiled catalog for gds3562.local in environment production in 0.50 seconds
Notice: /Stage[main]/Main/File[/tmp/key.pem]/ensure: defined content as '{md5}ec6532e2d9d099e9b67c97dea5cd05fd'
Notice: One of your private key's content has just changed!
Notice: /Stage[main]/Main/Notify[private_key_content_change]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 0.07 seconds
```

And on the second run:

```shell
Notice: Compiled catalog for gds3562.local in environment production in 0.51 seconds
Notice: Applied catalog in 0.06 seconds
```