### PR TITLE
(PUP-4231) Log file content hash when using ensure=>present

### DIFF
--- a/lib/puppet/type/file/ensure.rb
+++ b/lib/puppet/type/file/ensure.rb
@@ -115,7 +115,7 @@ module Puppet
     end
 
     def change_to_s(currentvalue, newvalue)
-      return super unless newvalue.to_s == "file"
+      return super unless ["file", "present"].include?(newvalue.to_s)
 
       return super unless property = @resource.property(:content)
 


### PR DESCRIPTION
When `ensure => present` and file content is provided via `content` or
`source`, the message logged was that the file was created. This is in
contrast to when `ensure => file` with content provided via `content` or
`source`, in which scenario the message logged contains the file's hash.
This makes both values log the file's hash.