### PR TITLE
(PUP-4094) Update environment_timeout default in example environment.conf

### DIFF
--- a/conf/environment.conf
+++ b/conf/environment.conf
@@ -11,6 +11,8 @@
 # Allowed settings and default values:
 
 # modulepath = ./modules:$basemodulepath
-# manifest = (default_manifest from puppet.conf; defaults to ./manifests)
+# manifest = (default_manifest from puppet.conf, which defaults to ./manifests)
 # config_version = (no script; Puppet will use the time the catalog was compiled)
-# environment_timeout = (environment_timeout from puppet.conf; defaults to unlimited)
+# environment_timeout = (environment_timeout from puppet.conf, which defaults to 0)
+    # Note: unless you have a specific reason, we recommend only setting
+    # environment_timeout in puppet.conf.


### PR DESCRIPTION
There's a companion pull request, #3727, that edits the description of the setting in defaults.rb. The hope is that there'll be a merge-up from stable to master relatively soon, so we won't have to cherry-pick. This PR has to stay separate, because the example file doesn't exist in stable. 