### PR TITLE
(PUP-4201) Add support for structured logging

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -12,37 +12,40 @@ module Puppet
     # This module implements logging with a filename and line number. Use this
     # for errors that need to report a location in a non-ruby file that we
     # parse.
-    attr_accessor :line, :file, :pos
+    attr_accessor :file, :issue_code, :environment, :node
+    attr_reader :line, :pos
 
-    # May be called with 3 arguments for message, file, line, and exception, or
-    # 4 args including the position on the line.
+    # Creates an error that contains external file information and optional issue code
     #
-    def initialize(message, file=nil, line=nil, pos=nil, original=nil)
+    # @param message [String] The error message
+    # @param file [String] Path to the file where the error was found
+    # @param line [Integer,String] The line number in the _file_
+    # @param pos [Integer,String] The position on the _line_
+    # @param original [Exception] Original exception
+    # @param issue_code [Symbol]
+    #
+    # @see Puppet::Pops::Issues::Issue
+    #
+    def initialize(message, file=nil, line=nil, pos=nil, original=nil, issue_code=nil)
       if pos.kind_of? Exception
         original = pos
         pos = nil
       end
       super(message, original)
+      @issue_code = issue_code
       @file = file unless (file.is_a?(String) && file.empty?)
-      @line = line
-      @pos = pos
+      self.line = line if line
+      self.pos = pos if pos
     end
-    def to_s
-      msg = super
-      @file = nil if (@file.is_a?(String) && @file.empty?)
-      if @file and @line and @pos
-        "#{msg} at #{@file}:#{@line}:#{@pos}"
-      elsif @file and @line
-        "#{msg} at #{@file}:#{@line}"
-      elsif @line and @pos
-          "#{msg} at line #{@line}:#{@pos}"
-      elsif @line
-        "#{msg} at line #{@line}"
-      elsif @file
-        "#{msg} in #{@file}"
-      else
-        msg
-      end
+
+    def line=(line)
+      line = line.to_i if line
+      @line = line
+    end
+
+    def pos=(pos)
+      pos = pos.to_i if pos
+      @pos = pos
     end
   end
 

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -325,7 +325,7 @@ Puppet::Face.define(:epp, '0.0.1') do
           begin
             buffer.print render_file(file, compiler, options, show_filename, file_nbr += 1)
           rescue Puppet::ParseError => detail
-            Puppet.err(detail.message)
+            Puppet.log_exception(detail)
             status = false
           end
         end
@@ -354,7 +354,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       if show_filename
         Puppet.err("--- #{filename}")
       end
-      Puppet.err(detail.message)
+      Puppet.log_exception(detail)
       ""
     end
   end

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -89,15 +89,9 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
     benchmark(:notice, str) do
       Puppet::Util::Profiler.profile(str, [:compiler, :compile, node.environment, node.name]) do
-        begin
-          config = Puppet::Parser::Compiler.compile(node)
-        rescue Puppet::Error => detail
-          Puppet.err(detail.to_s) if networked?
-          raise
-        end
+        config = Puppet::Parser::Compiler.compile(node)
       end
     end
-
     config
   end
 

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -488,6 +488,10 @@ class Puppet::Node::Environment
         parser.parse
       end
     end
+  rescue Puppet::ExternalFileError => parse_error
+    @known_resource_types.parse_failed = true
+    parse_error.environment = self
+    raise parse_error
   rescue => detail
     @known_resource_types.parse_failed = true
 

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -32,6 +32,10 @@ class Puppet::Parser::Compiler
     end
 
     new(node).compile {|resulting_catalog| resulting_catalog.to_resource }
+  rescue Puppet::ExternalFileError => detail
+    detail.node = node
+    Puppet.log_exception(detail)
+    raise detail
   rescue => detail
     message = "#{detail} on node #{node.name}"
     Puppet.log_exception(detail, message)

--- a/lib/puppet/pops/issue_reporter.rb
+++ b/lib/puppet/pops/issue_reporter.rb
@@ -37,10 +37,10 @@ class Puppet::Pops::IssueReporter
           # deprecation of constructs in manifests! (It is not designed for that purpose even if
           # used throughout the code base).
           #
-          Puppet.warning(formatter.format(w)) if emitted_dw < max_deprecations
+          log_message(:warning, formatter, w) if emitted_dw < max_deprecations
           emitted_dw += 1
         else
-          Puppet.warning(formatter.format(w)) if emitted_w < max_warnings
+          log_message(:warning, formatter, w) if emitted_w < max_warnings
           emitted_w += 1
         end
         break if emitted_w >= max_warnings && emitted_dw >= max_deprecations # but only then
@@ -56,7 +56,7 @@ class Puppet::Pops::IssueReporter
       formatter = Puppet::Pops::Validation::DiagnosticFormatterPuppetStyle.new
       if errors.size == 1 || max_errors <= 1
         # raise immediately
-        exception = emit_exception.new(format_with_prefix(emit_message, formatter.format(errors[0])))
+        exception = create_exception(emit_exception, emit_message, formatter, errors[0])
         # if an exception was given as cause, use it's backtrace instead of the one indicating "here"
         if errors[0].exception
           exception.set_backtrace(errors[0].exception.backtrace)
@@ -68,7 +68,7 @@ class Puppet::Pops::IssueReporter
         Puppet.err(emit_message)
       end
       errors.each do |e|
-        Puppet.err(formatter.format(e))
+        log_message(:err, formatter, e)
         emitted += 1
         break if emitted >= max_errors
       end
@@ -84,4 +84,35 @@ class Puppet::Pops::IssueReporter
     return message unless prefix
     [prefix, message].join(' ')
   end
+
+  def self.create_exception(exception_class, emit_message, formatter, diagnostic)
+    file = diagnostic.file
+    file = (file.is_a?(String) && file.empty?) ? nil : file
+    line = pos = nil
+    if diagnostic.source_pos
+      line = diagnostic.source_pos.line
+      pos = diagnostic.source_pos.pos
+    end
+    exception_class.new(format_with_prefix(emit_message, formatter.format_message(diagnostic)), file, line, pos, nil, diagnostic.issue.issue_code)
+  end
+  private_class_method :create_exception
+
+  def self.log_message(severity, formatter, diagnostic)
+    file = diagnostic.file
+    file = (file.is_a?(String) && file.empty?) ? nil : file
+    line = pos = nil
+    if diagnostic.source_pos
+      line = diagnostic.source_pos.line
+      pos = diagnostic.source_pos.pos
+    end
+    Puppet::Util::Log.create({
+        :level => severity,
+        :message => formatter.format_message(diagnostic),
+        :issue_code => diagnostic.issue.issue_code,
+        :file => file,
+        :line => line,
+        :pos => pos,
+      })
+  end
+  private_class_method :log_message
 end

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -46,8 +46,44 @@ module Puppet::Util::Logging
   #    wish to log a message at all; in this case it is likely that you are only calling this method in order
   #    to take advantage of the backtrace logging.
   def log_exception(exception, message = :default, options = {})
-    err(format_exception(exception, message, Puppet[:trace] || options[:trace]))
+    trace = Puppet[:trace] || options[:trace]
+    if message == :default && exception.is_a?(Puppet::ExternalFileError)
+      # Retain all detailed info and keep plain message and stacktrace separate
+      backtrace = []
+      build_exception_trace(backtrace, exception, trace)
+      Puppet::Util::Log.create({
+          :level => :err,
+          :source => log_source,
+          :message => exception.message,
+          :issue_code => exception.issue_code,
+          :backtrace => backtrace.empty? ? nil : backtrace,
+          :file => exception.file,
+          :line => exception.line,
+          :pos => exception.pos,
+          :environment => exception.environment.nil? ? nil : exception.environment.name,
+          :node => exception.node.nil? ? nil : exception.node.name
+        }.merge(log_metadata))
+    else
+      err(format_exception(exception, message, trace))
+    end
   end
+
+  def build_exception_trace(arr, exception, trace = true)
+    if trace and exception.backtrace
+      exception.backtrace.each do |line|
+        arr << line =~ /^(.+):(\d+.*)$/ ? ("#{Pathname($1).realpath}:#{$2}" rescue line) : line
+      end
+    end
+    if exception.respond_to?(:original)
+      original =  exception.original
+      unless original.nil?
+        arr << 'Wrapped exception:'
+        arr << original.message
+        build_exception_trace(arr, original, trace)
+      end
+    end
+  end
+  private :build_exception_trace
 
   def format_exception(exception, message = :default, trace = true)
     arr = []
@@ -64,10 +100,10 @@ module Puppet::Util::Logging
       arr << Puppet::Util.pretty_backtrace(exception.backtrace)
     end
     if exception.respond_to?(:original) and exception.original
-      arr << "Wrapped exception:"
+      arr << 'Wrapped exception:'
       arr << format_exception(exception.original, :default, trace)
     end
-    arr.flatten.join("\n")
+    arr.join("\n")
   end
 
   def log_and_raise(exception, message)

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -592,10 +592,12 @@ describe "Two step scoping for variables" do
 
       expect {
         compile_to_catalog("$var = 'top scope'", enc_node)
-      }.to raise_error(
-      Puppet::Error,
-      /Cannot reassign variable var at line 1(\:6)? on node the_node/
-      )
+      }.to raise_error(Puppet::ExternalFileError, /Cannot reassign variable var/) do |e|
+        expect(e.node).to be_a(Puppet::Node)
+        expect(e.node.name).to eq('the_node')
+        expect(e.line).to eq(1)
+        expect(e.pos).to eq(6)
+      end
     end
 
     it "evaluates enc classes in top scope when there is no node" do

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -150,7 +150,7 @@ describe Puppet::Face[:epp, :current] do
       dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
       template = File.join(dir, template_name)
       expect(eppface.dump(template, :validate => true)).to eq("")
-      expect(@logs.join).to match(/This Literal Integer has no effect.* line 1:4/)
+      expect(@logs.join).to match(/This Literal Integer has no effect.*\/template1.epp:1:4/)
     end
 
     it "validated content by default" do
@@ -158,7 +158,7 @@ describe Puppet::Face[:epp, :current] do
       dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
       template = File.join(dir, template_name)
       expect(eppface.dump(template)).to eq("")
-      expect(@logs.join).to match(/This Literal Integer has no effect.* line 1:4/)
+      expect(@logs.join).to match(/This Literal Integer has no effect.*\/template1.epp:1:4/)
     end
 
     it "informs the user of files that don't exist" do

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -469,7 +469,10 @@ describe Puppet::Node::Environment do
         Puppet[:code] = "oops {"
         expect do
           env.known_resource_types
-        end.to raise_error(Puppet::Error, /Could not parse for environment #{env.name}/)
+        end.to raise_error(Puppet::ParseError, 'Syntax error at end of file') do |e|
+          expect(e.environment).to be_a(Puppet::Node::Environment)
+          expect(e.environment.name).to eq(env.name)
+        end
       end
 
       it "should mark the type collection as needing a reparse when there is an error parsing" do

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -103,7 +103,10 @@ describe 'function for dynamically creating resources' do
 
           create_resources('foocreateresource', {'blah'=>{}})
         MANIFEST
-      }.to raise_error(Puppet::Error, 'Must pass one to Foocreateresource[blah] on node foonode')
+      }.to raise_error(Puppet::ExternalFileError, 'Must pass one to Foocreateresource[blah]') do |e|
+          expect(e.node).to be_a(Puppet::Node)
+          expect(e.node.name).to eq('foonode')
+      end
     end
 
     it 'should be able to add multiple defines' do
@@ -169,7 +172,12 @@ describe 'function for dynamically creating resources' do
         compile_to_catalog(<<-MANIFEST)
           create_resources('class', {'blah'=>{'one'=>'two'}})
         MANIFEST
-      end.to raise_error(/Could not find declared class blah at line 1:11 on node foonode/)
+      end.to raise_error(Puppet::ExternalFileError, /Could not find declared class blah/) do |e|
+          expect(e.node).to be_a(Puppet::Node)
+          expect(e.node.name).to eq('foonode')
+          expect(e.line).to eq(1)
+          expect(e.pos).to eq(11)
+      end
     end
 
     it 'should be able to add edges' do

--- a/spec/unit/parser/resource/param_spec.rb
+++ b/spec/unit/parser/resource/param_spec.rb
@@ -26,7 +26,10 @@ describe Puppet::Parser::Resource::Param do
     it "includes file/line context in errors" do
       expect {
         Puppet::Parser::Resource::Param.new(:file => 'foo.pp', :line => 42)
-      }.to raise_error(Puppet::Error, /foo.pp:42/)
+      }.to raise_error(Puppet::ExternalFileError) do |e|
+        expect(e.file).to eq('foo.pp')
+        expect(e.line).to eq(42)
+      end
     end
   end
 end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -323,14 +323,13 @@ describe Puppet::Resource::Catalog, "when compiling" do
       it "should print the locations of the original duplicated resource" do
         @catalog.add_resource(orig)
 
-        expect { @catalog.add_resource(dupe) }.to raise_error { |error|
-          expect(error).to be_a Puppet::Resource::Catalog::DuplicateResourceError
-
+        expect { @catalog.add_resource(dupe) }.to raise_error(Puppet::Resource::Catalog::DuplicateResourceError) do |error|
           expect(error.message).to match %r[Duplicate declaration: Notify\[duplicate-title\] is already declared]
           expect(error.message).to match %r[in file /path/to/orig/file:42]
           expect(error.message).to match %r[cannot redeclare]
-          expect(error.message).to match %r[at /path/to/dupe/file:314]
-        }
+          expect(error.file).to eq('/path/to/dupe/file')
+          expect(error.line).to eq(314)
+        end
       end
     end
 

--- a/spec/unit/transaction/event_spec.rb
+++ b/spec/unit/transaction/event_spec.rb
@@ -73,49 +73,49 @@ describe Puppet::Transaction::Event do
     end
 
     it "should set the level to 'notice' if the event status is 'success' and no resource is available" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:level] == :notice }
+      Puppet::Util::Log.expects(:create).with { |args| args[:level] == :notice }
       Puppet::Transaction::Event.new(:status => "success").send_log
     end
 
     it "should set the level to 'notice' if the event status is 'noop'" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:level] == :notice }
+      Puppet::Util::Log.expects(:create).with { |args| args[:level] == :notice }
       Puppet::Transaction::Event.new(:status => "noop").send_log
     end
 
     it "should set the level to 'err' if the event status is 'failure'" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:level] == :err }
+      Puppet::Util::Log.expects(:create).with { |args| args[:level] == :err }
       Puppet::Transaction::Event.new(:status => "failure").send_log
     end
 
     it "should set the 'message' to the event log" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:message] == "my message" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:message] == "my message" }
       Puppet::Transaction::Event.new(:message => "my message").send_log
     end
 
     it "should set the tags to the event tags" do
-      Puppet::Util::Log.expects(:new).with { |args| expect(args[:tags].to_a).to match_array(%w{one two}) }
+      Puppet::Util::Log.expects(:create).with { |args| expect(args[:tags].to_a).to match_array(%w{one two}) }
       Puppet::Transaction::Event.new(:tags => %w{one two}).send_log
     end
 
     [:file, :line].each do |attr|
       it "should pass the #{attr}" do
-        Puppet::Util::Log.expects(:new).with { |args| args[attr] == "my val" }
+        Puppet::Util::Log.expects(:create).with { |args| args[attr] == "my val" }
         Puppet::Transaction::Event.new(attr => "my val").send_log
       end
     end
 
     it "should use the source description as the source if one is set" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:source] == "/my/param" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:source] == "/my/param" }
       Puppet::Transaction::Event.new(:source_description => "/my/param", :resource => TestResource.new, :property => "foo").send_log
     end
 
     it "should use the property as the source if one is available and no source description is set" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:source] == "foo" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:source] == "foo" }
       Puppet::Transaction::Event.new(:resource => TestResource.new, :property => "foo").send_log
     end
 
     it "should use the property as the source if one is available and no property or source description is set" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:source] == "Foo[bar]" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:source] == "Foo[bar]" }
       Puppet::Transaction::Event.new(:resource => TestResource.new).send_log
     end
   end

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -537,7 +537,10 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       it "should include the file/line in the error" do
         Puppet::Type.type(:file).any_instance.stubs(:file).returns("example.pp")
         Puppet::Type.type(:file).any_instance.stubs(:line).returns(42)
-        expect { Puppet::Type.type(:file).new(:title => "/foo", :source => "unknown:///") }.to raise_error(Puppet::ResourceError, /example.pp:42/)
+        expect { Puppet::Type.type(:file).new(:title => "/foo", :source => "unknown:///") }.to raise_error(Puppet::ResourceError) do |e|
+          expect(e.file).to eq('example.pp')
+          expect(e.line).to eq(42)
+        end
       end
     end
 
@@ -627,7 +630,10 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
             :source => "puppet:///",
             :content => "foo"
           )
-        end.to raise_error(Puppet::ResourceError, /Validation.*example.pp:42/)
+        end.to raise_error(Puppet::ResourceError, /Validation/) do |e|
+          expect(e.file).to eq('example.pp')
+          expect(e.line).to eq(42)
+        end
       end
     end
   end
@@ -1026,10 +1032,9 @@ describe Puppet::Type::RelationshipMetaparam do
       end
 
       it "raises an error with context" do
-        expect { param.validate_relationship }.to raise_error do |error|
-          expect(error).to be_a Puppet::ResourceError
-          expect(error.message).to match %r[Class\[Test\]]
-          expect(error.message).to match %r[/hitchhikers/guide/to/the/galaxy:42]
+        expect { param.validate_relationship }.to raise_error(Puppet::ResourceError, %r[Class\[Test\]]) do |e|
+          expect(e.file).to eq('/hitchhikers/guide/to/the/galaxy')
+          expect(e.line).to eq(42)
         end
       end
     end


### PR DESCRIPTION
This pull-request removes the responsibility for formatting the log messages
from the `IssueReporter` and the `ExternalFilerError` classes. Instead,
the formatting is deferred and performed by the `Log.to_s` method (if
such formatting is at all needed).

Some instance variables were added, both to the `ExternalFileError` class
and to the Log class to accommodate detailed information about
issue_code, environment, node, and position.

A new Log destination _'json_file'_ was added. It will not use the
formatted message but instead output all details in a JSON style
Map. Exception backtrace is output as a JSON Array.