### PR TITLE
(PUP-4230) Log content hash when removing a file

### DIFF
--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -68,7 +68,7 @@ module Puppet
       if currentvalue == :absent
         return "defined content as '#{newvalue}'"
       elsif newvalue == :absent
-        return "undefined content from '#{currentvalue}'"
+        return "removed file with content '#{currentvalue}'"
       else
         return "content changed '#{currentvalue}' to '#{newvalue}'"
       end


### PR DESCRIPTION
When removing a file with `ensure => absent`, the message logged is that
the file was removed. By contrast, when files are created or modified,
the message logged contains a hash of current and, if applicable,
previous contents. This changes file removal log entries to also contain
the hash of the removed file.