### PR TITLE
(PUP-4201) Add support for structured logging

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -12,37 +12,40 @@ module Puppet
     # This module implements logging with a filename and line number. Use this
     # for errors that need to report a location in a non-ruby file that we
     # parse.
-    attr_accessor :line, :file, :pos
+    attr_accessor :file, :issue_code, :environment, :node
+    attr_reader :line, :pos
 
-    # May be called with 3 arguments for message, file, line, and exception, or
-    # 4 args including the position on the line.
+    # Creates an error that contains external file information and optional issue code
     #
-    def initialize(message, file=nil, line=nil, pos=nil, original=nil)
+    # @param message [String] The error message
+    # @param file [String] Path to the file where the error was found
+    # @param line [Integer,String] The line number in the _file_
+    # @param pos [Integer,String] The position on the _line_
+    # @param original [Exception] Original exception
+    # @param issue_code [Symbol]
+    #
+    # @see Puppet::Pops::Issues::Issue
+    #
+    def initialize(message, file=nil, line=nil, pos=nil, original=nil, issue_code=nil)
       if pos.kind_of? Exception
         original = pos
         pos = nil
       end
       super(message, original)
+      @issue_code = issue_code
       @file = file unless (file.is_a?(String) && file.empty?)
-      @line = line
-      @pos = pos
+      self.line = line if line
+      self.pos = pos if pos
     end
-    def to_s
-      msg = super
-      @file = nil if (@file.is_a?(String) && @file.empty?)
-      if @file and @line and @pos
-        "#{msg} at #{@file}:#{@line}:#{@pos}"
-      elsif @file and @line
-        "#{msg} at #{@file}:#{@line}"
-      elsif @line and @pos
-          "#{msg} at line #{@line}:#{@pos}"
-      elsif @line
-        "#{msg} at line #{@line}"
-      elsif @file
-        "#{msg} in #{@file}"
-      else
-        msg
-      end
+
+    def line=(line)
+      line = line.to_i if line
+      @line = line
+    end
+
+    def pos=(pos)
+      pos = pos.to_i if pos
+      @pos = pos
     end
   end
 

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -91,15 +91,9 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
     benchmark(:notice, str) do
       Puppet::Util::Profiler.profile(str, [:compiler, :compile, node.environment, node.name]) do
-        begin
-          config = Puppet::Parser::Compiler.compile(node)
-        rescue Puppet::Error => detail
-          Puppet.err(detail.to_s) if networked?
-          raise
-        end
+        config = Puppet::Parser::Compiler.compile(node)
       end
     end
-
     config
   end
 

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -568,6 +568,10 @@ class Puppet::Node::Environment
         parser.parse
       end
     end
+  rescue Puppet::ExternalFileError => parse_error
+    @known_resource_types.parse_failed = true
+    parse_error.environment = self
+    raise parse_error
   rescue => detail
     @known_resource_types.parse_failed = true
 

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -32,6 +32,10 @@ class Puppet::Parser::Compiler
     end
 
     new(node).compile {|resulting_catalog| resulting_catalog.to_resource }
+  rescue Puppet::ExternalFileError => detail
+    detail.node = node
+    Puppet.log_exception(detail)
+    raise detail
   rescue => detail
     message = "#{detail} on node #{node.name}"
     Puppet.log_exception(detail, message)

--- a/lib/puppet/pops/issue_reporter.rb
+++ b/lib/puppet/pops/issue_reporter.rb
@@ -37,10 +37,10 @@ class Puppet::Pops::IssueReporter
           # deprecation of constructs in manifests! (It is not designed for that purpose even if
           # used throughout the code base).
           #
-          Puppet.warning(formatter.format(w)) if emitted_dw < max_deprecations
+          log_message(:warning, formatter, w) if emitted_dw < max_deprecations
           emitted_dw += 1
         else
-          Puppet.warning(formatter.format(w)) if emitted_w < max_warnings
+          log_message(:warning, formatter, w) if emitted_w < max_warnings
           emitted_w += 1
         end
         break if emitted_w >= max_warnings && emitted_dw >= max_deprecations # but only then
@@ -56,7 +56,7 @@ class Puppet::Pops::IssueReporter
       formatter = Puppet::Pops::Validation::DiagnosticFormatterPuppetStyle.new
       if errors.size == 1 || max_errors <= 1
         # raise immediately
-        exception = emit_exception.new(format_with_prefix(emit_message, formatter.format(errors[0])))
+        exception = create_exception(emit_exception, emit_message, formatter, errors[0])
         # if an exception was given as cause, use it's backtrace instead of the one indicating "here"
         if errors[0].exception
           exception.set_backtrace(errors[0].exception.backtrace)
@@ -68,7 +68,7 @@ class Puppet::Pops::IssueReporter
         Puppet.err(emit_message)
       end
       errors.each do |e|
-        Puppet.err(formatter.format(e))
+        log_message(:err, formatter, e)
         emitted += 1
         break if emitted >= max_errors
       end
@@ -84,4 +84,35 @@ class Puppet::Pops::IssueReporter
     return message unless prefix
     [prefix, message].join(' ')
   end
+
+  def self.create_exception(exception_class, emit_message, formatter, diagnostic)
+    file = diagnostic.file
+    file = (file.is_a?(String) && file.empty?) ? nil : file
+    line = pos = nil
+    if diagnostic.source_pos
+      line = diagnostic.source_pos.line
+      pos = diagnostic.source_pos.pos
+    end
+    exception_class.new(format_with_prefix(emit_message, formatter.format_message(diagnostic)), file, line, pos, nil, diagnostic.issue.issue_code)
+  end
+  private_class_method :create_exception
+
+  def self.log_message(severity, formatter, diagnostic)
+    file = diagnostic.file
+    file = (file.is_a?(String) && file.empty?) ? nil : file
+    line = pos = nil
+    if diagnostic.source_pos
+      line = diagnostic.source_pos.line
+      pos = diagnostic.source_pos.pos
+    end
+    Puppet::Util::Log.create({
+        :level => severity,
+        :message => formatter.format_message(diagnostic),
+        :issue_code => diagnostic.issue.issue_code,
+        :file => file,
+        :line => line,
+        :pos => pos,
+      })
+  end
+  private_class_method :log_message
 end

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -17,11 +17,11 @@ class Puppet::Util::Log
   @desttypes = {}
 
   # Create a new destination type.
-  def self.newdesttype(name, options = {}, &block)
+  def self.newdesttype(name, options = {}, parent = nil, &block)
 
     dest = genclass(
       name,
-      :parent     => Puppet::Util::Log::Destination,
+      :parent     => parent || Puppet::Util::Log::Destination,
       :prefix     => "Dest",
       :block      => block,
       :hash       => @desttypes,
@@ -79,9 +79,20 @@ class Puppet::Util::Log
   # Create a new log message.  The primary role of this method is to
   # avoid creating log messages below the loglevel.
   def Log.create(hash)
-    raise Puppet::DevError, "Logs require a level" unless hash.include?(:level)
-    raise Puppet::DevError, "Invalid log level #{hash[:level]}" unless @levels.index(hash[:level])
-    @levels.index(hash[:level]) >= @loglevel ? Puppet::Util::Log.new(hash) : nil
+    level = hash[:level]
+    raise Puppet::DevError, "Logs require a level which is a symbol or string" unless level.respond_to? "to_sym"
+
+    level = level.to_sym
+    index = @levels.index(level)
+    raise Puppet::DevError, "Invalid log level #{level}" if index.nil?
+
+    if index >= @loglevel
+      log = Puppet::Util::Log.new(hash)
+      newmessage(log)
+      log
+    else
+      nil
+    end
   end
 
   def Log.destinations
@@ -234,9 +245,9 @@ class Puppet::Util::Log
   end
 
   def self.from_data_hash(data)
-    obj = allocate
-    obj.initialize_from_hash(data)
-    obj
+    symkeyed_data = {}
+    data.each_pair { |k,v| symkeyed_data[k.to_sym] = v }
+    new(symkeyed_data)
   end
 
   def self.from_pson(data)
@@ -244,39 +255,36 @@ class Puppet::Util::Log
     self.from_data_hash(data)
   end
 
-  attr_accessor :time, :remote, :file, :line, :source
-  attr_reader :level, :message
+  attr_reader :level, :message, :issue_code, :time, :file, :line, :pos, :backtrace, :source, :node, :environment
 
   def initialize(args)
-    self.level = args[:level]
-    self.message = args[:message]
-    self.source = args[:source] || "Puppet"
+    level = args[:level]
+    raise ArgumentError, "Puppet::Util::Log requires a log level" if level.nil?
+    raise ArgumentError, "Puppet::Util::Log requires that log level is a symbol or string" unless level.respond_to? "to_sym"
 
-    @time = Time.now
+    level = level.to_sym
+    raise ArgumentError, "Invalid log level #{level}" unless self.class.validlevel?(level)
+    @level = level
+    # Tag myself with my log level
+    tag(level)
 
-    if tags = args[:tags]
-      tags.each { |t| self.tag(t) }
+    message = args[:message]
+    raise ArgumentError, "Puppet::Util::Log requires a message" if message.nil?
+    @message = message.to_s
+
+    # Avoid setting these instance variables. We don't want them defined unless they exist
+    [:backtrace, :environment, :node, :issue_code, :file, :line, :pos].each do |attr|
+      value = args[attr]
+      instance_variable_set("@#{attr}", value) unless value.nil?
     end
 
-    [:file, :line].each do |attr|
-      next unless value = args[attr]
-      send(attr.to_s + "=", value)
-    end
+    self.source = args[:source]
+    tags = args[:tags]
+    tags.each { |t| tag(t) } unless tags.nil?
 
-    Log.newmessage(self)
-  end
-
-  def initialize_from_hash(data)
-    @level = data['level'].intern
-    @message = data['message']
-    @source = data['source']
-    @tags = Puppet::Util::TagSet.new(data['tags'])
-    @time = data['time']
-    if @time.is_a? String
-      @time = Time.parse(@time)
-    end
-    @file = data['file'] if data['file']
-    @line = data['line'] if data['line']
+    time = args[:time]
+    time = Time.parse(time) if time.is_a?(String)
+    @time = time || Time.now
   end
 
   def to_hash
@@ -284,47 +292,34 @@ class Puppet::Util::Log
   end
 
   def to_data_hash
-    {
+    hash = {
       'level' => @level,
       'message' => @message,
       'source' => @source,
       'tags' => @tags,
       'time' => @time.iso8601(9),
-      'file' => @file,
-      'line' => @line,
     }
+    [:backtrace, :environment, :node, :issue_code, :file, :line, :pos].each do |attr|
+      iv = "@#{attr}"
+      hash[attr.to_s] = instance_variable_get(iv) if instance_variable_defined?(iv)
+    end
+    hash
   end
 
   def to_pson(*args)
     to_data_hash.to_pson(*args)
   end
 
-  def message=(msg)
-    raise ArgumentError, "Puppet::Util::Log requires a message" unless msg
-    @message = msg.to_s
-  end
-
-  def level=(level)
-    raise ArgumentError, "Puppet::Util::Log requires a log level" unless level
-    raise ArgumentError, "Puppet::Util::Log requires a symbol or string" unless level.respond_to? "to_sym"
-    @level = level.to_sym
-    raise ArgumentError, "Invalid log level #{@level}" unless self.class.validlevel?(@level)
-
-    # Tag myself with my log level
-    tag(level)
-  end
-
   # If they pass a source in to us, we make sure it is a string, and
   # we retrieve any tags we can.
   def source=(source)
     if source.respond_to?(:path)
-      @source = source.path
       source.tags.each { |t| tag(t) }
-      self.file = source.file
-      self.line = source.line
-    else
-      @source = source.to_s
+      @file ||= source.file
+      @line ||= source.line
+      source = source.path
     end
+    @source = source.nil? ? 'Puppet' : source.to_s
   end
 
   def to_report
@@ -332,9 +327,24 @@ class Puppet::Util::Log
   end
 
   def to_s
-    message
+    msg = @message
+    @file = nil if (@file.is_a?(String) && @file.empty?)
+    if @file and @line and @pos
+      msg = "#{msg} at #{@file}:#{@line}:#{@pos}"
+    elsif @file and @line
+      msg ="#{msg} at #{@file}:#{@line}"
+    elsif @line and @pos
+      msg ="#{msg} at line #{@line}:#{@pos}"
+    elsif @line
+      msg ="#{msg} at line #{@line}"
+    elsif @file
+      msg ="#{msg} in #{@file}"
+    end
+    msg = "Could not parse for environment #{@environment}: #{msg}" if @environment
+    msg = "#{msg} on node #{@node}" if @node
+    msg = ([msg] + @backtrace).join("\n") if @backtrace
+    msg
   end
-
 end
 
 # This is for backward compatibility from when we changed the constant to Puppet::Util::Log

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -43,11 +43,11 @@ Puppet::Util::Log.newdesttype :syslog do
   end
 end
 
-Puppet::Util::Log.newdesttype :file do
+file_dest = Puppet::Util::Log.newdesttype :file do
   require 'fileutils'
 
   def self.match?(obj)
-    Puppet::Util.absolute_path?(obj)
+    Puppet::Util.absolute_path?(obj) && !(obj =~ /\.json$/)
   end
 
   def close
@@ -92,6 +92,32 @@ Puppet::Util::Log.newdesttype :file do
     @file.puts("#{msg.time} #{msg.source} (#{msg.level}): #{msg}")
 
     @file.flush if @autoflush
+  end
+end
+
+# Inherits all behavior from the `:file` type. It matches all files with extension '.json' and will output
+# the message as a json structure.
+Puppet::Util::Log.newdesttype(:json_file, {}, file_dest) do
+  # Returns true for any string that is an absolute path that ends with '.json'
+  def self.match?(obj)
+    'console.json' == obj || Puppet::Util.absolute_path?(obj) && obj =~ /\.json$/
+  end
+
+  def initialize(path)
+    if 'console.json' == path
+      @file = $stderr
+      @autoflush = true
+    else
+      super
+    end
+  end
+
+  # Outputs the log message as a JSON structure
+  # @param msg [Puppet::Util::Log] The log message
+  def handle(msg)
+    JSON.dump(msg, @file)
+    @file.puts
+    flush if autoflush
   end
 end
 

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -24,8 +24,44 @@ module Puppet::Util::Logging
   #    wish to log a message at all; in this case it is likely that you are only calling this method in order
   #    to take advantage of the backtrace logging.
   def log_exception(exception, message = :default, options = {})
-    err(format_exception(exception, message, Puppet[:trace] || options[:trace]))
+    trace = Puppet[:trace] || options[:trace]
+    if message == :default && exception.is_a?(Puppet::ExternalFileError)
+      # Retain all detailed info and keep plain message and stacktrace separate
+      backtrace = []
+      build_exception_trace(backtrace, exception, trace)
+      Puppet::Util::Log.create({
+          :level => :err,
+          :source => log_source,
+          :message => exception.message,
+          :issue_code => exception.issue_code,
+          :backtrace => backtrace.empty? ? nil : backtrace,
+          :file => exception.file,
+          :line => exception.line,
+          :pos => exception.pos,
+          :environment => exception.environment.nil? ? nil : exception.environment.name,
+          :node => exception.node.nil? ? nil : exception.node.name
+        }.merge(log_metadata))
+    else
+      err(format_exception(exception, message, trace))
+    end
   end
+
+  def build_exception_trace(arr, exception, trace = true)
+    if trace and exception.backtrace
+      exception.backtrace.each do |line|
+        arr << line =~ /^(.+):(\d+.*)$/ ? ("#{Pathname($1).realpath}:#{$2}" rescue line) : line
+      end
+    end
+    if exception.respond_to?(:original)
+      original =  exception.original
+      unless original.nil?
+        arr << 'Wrapped exception:'
+        arr << original.message
+        build_exception_trace(arr, original, trace)
+      end
+    end
+  end
+  private :build_exception_trace
 
   def format_exception(exception, message = :default, trace = true)
     arr = []
@@ -42,10 +78,10 @@ module Puppet::Util::Logging
       arr << Puppet::Util.pretty_backtrace(exception.backtrace)
     end
     if exception.respond_to?(:original) and exception.original
-      arr << "Wrapped exception:"
+      arr << 'Wrapped exception:'
       arr << format_exception(exception.original, :default, trace)
     end
-    arr.flatten.join("\n")
+    arr.join("\n")
   end
 
   def log_and_raise(exception, message)

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -146,7 +146,7 @@ describe "Puppet::Parser::Compiler" do
         Puppet::Parser::Compiler.compile(Puppet::Node.new("mynode"))
         raise "compilation should have raised Puppet::Error"
       rescue Puppet::Error => e
-        e.message.should =~ /at line 2/
+        e.line.should eq(2)
       end
     end
   end

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -620,12 +620,14 @@ describe "Two step scoping for variables" do
       it "does not allow the enc to specify an existing top scope var" do
         enc_node = Puppet::Node.new("the_node", { :parameters => { "var" => 'from_enc' } })
 
-        expect {
-          compile_to_catalog("$var = 'top scope'", enc_node)
-        }.to raise_error(
-          Puppet::Error,
-          /Cannot reassign variable var at line 1(\:6)? on node the_node/
-        )
+      expect {
+        compile_to_catalog("$var = 'top scope'", enc_node)
+      }.to raise_error(Puppet::ExternalFileError, /Cannot reassign variable var/) do |e|
+          expect(e.node).to be_a(Puppet::Node)
+          expect(e.node.name).to eq('the_node')
+          expect(e.line).to eq(1)
+          expect(e.pos).to eq(6)
+        end
       end
 
       it "evaluates enc classes in top scope when there is no node" do

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -103,7 +103,10 @@ describe 'function for dynamically creating resources' do
 
           create_resources('foocreateresource', {'blah'=>{}})
         MANIFEST
-      }.to raise_error(Puppet::Error, 'Must pass one to Foocreateresource[blah] on node foonode')
+      }.to raise_error(Puppet::ExternalFileError, 'Must pass one to Foocreateresource[blah]') do |e|
+          expect(e.node).to be_a(Puppet::Node)
+          expect(e.node.name).to eq('foonode')
+      end
     end
 
     it 'should be able to add multiple defines' do
@@ -169,7 +172,12 @@ describe 'function for dynamically creating resources' do
         compile_to_catalog(<<-MANIFEST)
           create_resources('class', {'blah'=>{'one'=>'two'}})
         MANIFEST
-      end.to raise_error(/Could not find declared class blah at line 1 on node foonode/)
+      end.to raise_error(Puppet::ExternalFileError, /Could not find declared class blah/) do |e|
+          expect(e.node).to be_a(Puppet::Node)
+          expect(e.node.name).to eq('foonode')
+          expect(e.line).to eq(1)
+          expect(e.pos).to eq(11)
+      end
     end
 
     it 'should be able to add edges' do

--- a/spec/unit/parser/resource/param_spec.rb
+++ b/spec/unit/parser/resource/param_spec.rb
@@ -26,7 +26,10 @@ describe Puppet::Parser::Resource::Param do
     it "includes file/line context in errors" do
       expect {
         Puppet::Parser::Resource::Param.new(:file => 'foo.pp', :line => 42)
-      }.to raise_error(Puppet::Error, /foo.pp:42/)
+        }.to raise_error(Puppet::ExternalFileError) do |e|
+          expect(e.file).to eq('foo.pp')
+          expect(e.line).to eq(42)
+        end
     end
   end
 end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -918,7 +918,10 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       end
 
     it "provides location information on error in unparenthesized call logic" do
-    expect{parser.evaluate_string(scope, "include non_existing_class", __FILE__)}.to raise_error(Puppet::ParseError, /line 1\:1/)
+    expect{parser.evaluate_string(scope, "include non_existing_class", __FILE__)}.to raise_error(Puppet::ParseError) do |e|
+      expect(e.line).to eq(1)
+      expect(e.pos).to eq(1)
+      end
     end
 
     it 'defaults can be given in a lambda and used only when arg is missing' do
@@ -1242,38 +1245,58 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
   context "Handles Deprecations and Discontinuations" do
     it 'of import statements' do
       source = "\nimport foo"
-      # Error references position 5 at the opening '{'
-      # Set file to nil to make it easier to match with line number (no file name in output)
-      expect { parser.evaluate_string(scope, source) }.to raise_error(/'import' has been discontinued.*line 2:1/)
+      expect { parser.evaluate_string(scope, source) }.to raise_error(Puppet::ParseError, /'import' has been discontinued/) do |e|
+        expect(e.line).to eq(2)
+        expect(e.pos).to eq(1)
+      end
     end
   end
 
   context "Detailed Error messages are reported" do
     it 'for illegal type references' do
       source = '1+1 { "title": }'
-      # Error references position 5 at the opening '{'
-      # Set file to nil to make it easier to match with line number (no file name in output)
       expect { parser.evaluate_string(scope, source) }.to raise_error(
-        /Illegal Resource Type expression, expected result to be a type name, or untitled Resource.*line 1:2/)
+        /Illegal Resource Type expression, expected result to be a type name, or untitled Resource/) do |e|
+        expect(e.line).to eq(1)
+        expect(e.pos).to eq(2)
+      end
     end
 
     it 'for non r-value producing <| |>' do
-      expect { parser.parse_string("$a = File <| |>", nil) }.to raise_error(/A Virtual Query does not produce a value at line 1:6/)
+      expect { parser.parse_string("$a = File <| |>", nil) }.to raise_error(/A Virtual Query does not produce a value/) do |e|
+        expect(e.line).to eq(1)
+        expect(e.pos).to eq(6)
+      end
     end
 
     it 'for non r-value producing <<| |>>' do
-      expect { parser.parse_string("$a = File <<| |>>", nil) }.to raise_error(/An Exported Query does not produce a value at line 1:6/)
+      expect { parser.parse_string("$a = File <<| |>>", nil) }.to raise_error(/An Exported Query does not produce a value/) do |e|
+        expect(e.line).to eq(1)
+        expect(e.pos).to eq(6)
+      end
     end
 
     it 'for non r-value producing define' do
-      Puppet.expects(:err).with("Invalid use of expression. A 'define' expression does not produce a value at line 1:6")
-      Puppet.expects(:err).with("Classes, definitions, and nodes may only appear at toplevel or inside other classes at line 1:6")
+      Puppet::Util::Log.expects(:create).with(has_entries(
+        :message  => "Invalid use of expression. A 'define' expression does not produce a value",
+        :line => 1,
+        :pos => 6))
+      Puppet::Util::Log.expects(:create).with(has_entries(
+        :message  => 'Classes, definitions, and nodes may only appear at toplevel or inside other classes',
+        :line => 1,
+        :pos => 6))
       expect { parser.parse_string("$a = define foo { }", nil) }.to raise_error(/2 errors/)
     end
 
     it 'for non r-value producing class' do
-      Puppet.expects(:err).with("Invalid use of expression. A Host Class Definition does not produce a value at line 1:6")
-      Puppet.expects(:err).with("Classes, definitions, and nodes may only appear at toplevel or inside other classes at line 1:6")
+      Puppet::Util::Log.expects(:create).with(has_entries(
+        :message => 'Invalid use of expression. A Host Class Definition does not produce a value',
+        :line => 1,
+        :pos => 6))
+      Puppet::Util::Log.expects(:create).with(has_entries(
+        :message => 'Classes, definitions, and nodes may only appear at toplevel or inside other classes',
+        :line => 1,
+        :pos => 6))
       expect { parser.parse_string("$a = class foo { }", nil) }.to raise_error(/2 errors/)
     end
 
@@ -1287,15 +1310,24 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     it 'for multiple errors with a summary exception' do
-      Puppet.expects(:err).with("Invalid use of expression. A Node Definition does not produce a value at line 1:6")
-      Puppet.expects(:err).with("Classes, definitions, and nodes may only appear at toplevel or inside other classes at line 1:6")
+      Puppet::Util::Log.expects(:create).with(has_entries(
+        :message => 'Invalid use of expression. A Node Definition does not produce a value',
+        :line => 1,
+        :pos => 6))
+      Puppet::Util::Log.expects(:create).with(has_entries(
+        :message => 'Classes, definitions, and nodes may only appear at toplevel or inside other classes',
+        :line => 1,
+        :pos => 6))
       expect { parser.parse_string("$a = node x { }",nil) }.to raise_error(/2 errors/)
     end
 
     it 'for a bad hostname' do
       expect {
         parser.parse_string("node 'macbook+owned+by+name' { }", nil)
-      }.to raise_error(/The hostname 'macbook\+owned\+by\+name' contains illegal characters.*at line 1:6/)
+      }.to raise_error(/The hostname 'macbook\+owned\+by\+name' contains illegal characters/) do |e|
+        expect(e.line).to eq(1)
+        expect(e.pos).to eq(6)
+      end
     end
 
     it 'for a hostname with interpolation' do
@@ -1305,7 +1337,10 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       SOURCE
       expect {
         parser.parse_string(source, nil)
-      }.to raise_error(/An interpolated expression is not allowed in a hostname of a node at line 2:23/)
+      }.to raise_error(/An interpolated expression is not allowed in a hostname of a node/) do |e|
+        expect(e.line).to eq(2)
+        expect(e.pos).to eq(23)
+      end
     end
 
   end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -323,14 +323,13 @@ describe Puppet::Resource::Catalog, "when compiling" do
       it "should print the locations of the original duplicated resource" do
         @catalog.add_resource(orig)
 
-        expect { @catalog.add_resource(dupe) }.to raise_error { |error|
-          error.should be_a Puppet::Resource::Catalog::DuplicateResourceError
-
-          error.message.should match %r[Duplicate declaration: Notify\[duplicate-title\] is already declared]
-          error.message.should match %r[in file /path/to/orig/file:42]
-          error.message.should match %r[cannot redeclare]
-          error.message.should match %r[at /path/to/dupe/file:314]
-        }
+        expect { @catalog.add_resource(dupe) }.to raise_error(Puppet::Resource::Catalog::DuplicateResourceError) do |error|
+          expect(error.message).to match %r[Duplicate declaration: Notify\[duplicate-title\] is already declared]
+          expect(error.message).to match %r[in file /path/to/orig/file:42]
+          expect(error.message).to match %r[cannot redeclare]
+          expect(error.file).to eq('/path/to/dupe/file')
+          expect(error.line).to eq(314)
+        end
       end
     end
 

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -83,21 +83,21 @@ describe Puppet::Resource::Status do
     end
 
     it "should set the tags to the event tags" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:tags] == %w{one two} }
+      Puppet::Util::Log.expects(:create).with { |args| args[:tags] == %w{one two} }
       @status.stubs(:tags).returns %w{one two}
       @status.send_log :notice, "my message"
     end
 
     [:file, :line].each do |attr|
       it "should pass the #{attr}" do
-        Puppet::Util::Log.expects(:new).with { |args| args[attr] == "my val" }
+        Puppet::Util::Log.expects(:create).with { |args| args[attr] == "my val" }
         @status.send(attr.to_s + "=", "my val")
         @status.send_log :notice, "my message"
       end
     end
 
     it "should use the source description as the source" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:source] == "my source" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:source] == "my source" }
       @status.stubs(:source_description).returns "my source"
       @status.send_log :notice, "my message"
     end

--- a/spec/unit/transaction/event_spec.rb
+++ b/spec/unit/transaction/event_spec.rb
@@ -73,49 +73,49 @@ describe Puppet::Transaction::Event do
     end
 
     it "should set the level to 'notice' if the event status is 'success' and no resource is available" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:level] == :notice }
+      Puppet::Util::Log.expects(:create).with { |args| args[:level] == :notice }
       Puppet::Transaction::Event.new(:status => "success").send_log
     end
 
     it "should set the level to 'notice' if the event status is 'noop'" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:level] == :notice }
+      Puppet::Util::Log.expects(:create).with { |args| args[:level] == :notice }
       Puppet::Transaction::Event.new(:status => "noop").send_log
     end
 
     it "should set the level to 'err' if the event status is 'failure'" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:level] == :err }
+      Puppet::Util::Log.expects(:create).with { |args| args[:level] == :err }
       Puppet::Transaction::Event.new(:status => "failure").send_log
     end
 
     it "should set the 'message' to the event log" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:message] == "my message" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:message] == "my message" }
       Puppet::Transaction::Event.new(:message => "my message").send_log
     end
 
     it "should set the tags to the event tags" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:tags].to_a.should =~ %w{one two} }
+      Puppet::Util::Log.expects(:create).with { |args| expect(args[:tags].to_a).to match_array(%w{one two}) }
       Puppet::Transaction::Event.new(:tags => %w{one two}).send_log
     end
 
     [:file, :line].each do |attr|
       it "should pass the #{attr}" do
-        Puppet::Util::Log.expects(:new).with { |args| args[attr] == "my val" }
+        Puppet::Util::Log.expects(:create).with { |args| args[attr] == "my val" }
         Puppet::Transaction::Event.new(attr => "my val").send_log
       end
     end
 
     it "should use the source description as the source if one is set" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:source] == "/my/param" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:source] == "/my/param" }
       Puppet::Transaction::Event.new(:source_description => "/my/param", :resource => TestResource.new, :property => "foo").send_log
     end
 
     it "should use the property as the source if one is available and no source description is set" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:source] == "foo" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:source] == "foo" }
       Puppet::Transaction::Event.new(:resource => TestResource.new, :property => "foo").send_log
     end
 
     it "should use the property as the source if one is available and no property or source description is set" do
-      Puppet::Util::Log.expects(:new).with { |args| args[:source] == "Foo[bar]" }
+      Puppet::Util::Log.expects(:create).with { |args| args[:source] == "Foo[bar]" }
       Puppet::Transaction::Event.new(:resource => TestResource.new).send_log
     end
   end

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -466,7 +466,10 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       it "should include the file/line in the error" do
         Puppet::Type.type(:file).any_instance.stubs(:file).returns("example.pp")
         Puppet::Type.type(:file).any_instance.stubs(:line).returns(42)
-        expect { Puppet::Type.type(:file).new(:title => "/foo", :source => "unknown:///") }.to raise_error(Puppet::ResourceError, /example.pp:42/)
+        expect { Puppet::Type.type(:file).new(:title => "/foo", :source => "unknown:///") }.to raise_error(Puppet::ResourceError) do |e|
+          expect(e.file).to eq('example.pp')
+          expect(e.line).to eq(42)
+        end
       end
     end
 
@@ -556,7 +559,10 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
             :source => "puppet:///",
             :content => "foo"
           )
-        end.to raise_error(Puppet::ResourceError, /Validation.*example.pp:42/)
+        end.to raise_error(Puppet::ResourceError, /Validation/) do |e|
+          expect(e.file).to eq('example.pp')
+          expect(e.line).to eq(42)
+        end
       end
     end
   end
@@ -953,10 +959,9 @@ describe Puppet::Type::RelationshipMetaparam do
       end
 
       it "raises an error with context" do
-        expect { param.validate_relationship }.to raise_error do |error|
-          error.should be_a Puppet::ResourceError
-          error.message.should match %r[Class\[Test\]]
-          error.message.should match %r["in /hitchhikers/guide/to/the/galaxy:42"]
+        expect { param.validate_relationship }.to raise_error(Puppet::ResourceError, %r[Class\[Test\]]) do |e|
+          expect(e.file).to eq('/hitchhikers/guide/to/the/galaxy')
+          expect(e.line).to eq(42)
         end
       end
     end

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -7,15 +7,15 @@ describe Puppet::Util::Log do
   include PuppetSpec::Files
 
   def log_notice(message)
-    Puppet::Util::Log.new(:level => :notice, :message => message)
+    Puppet::Util::Log.create(:level => :notice, :message => message)
   end
 
   it "should write a given message to the specified destination" do
     arraydest = []
     Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(arraydest))
-    Puppet::Util::Log.new(:level => :notice, :message => "foo")
+    Puppet::Util::Log.create(:level => :notice, :message => "foo")
     message = arraydest.last.message
-    message.should == "foo"
+    expect(message).to eq("foo")
   end
 
   describe ".setup_default" do
@@ -180,11 +180,10 @@ describe Puppet::Util::Log do
       Puppet::Util::Log.stubs(:newmessage)
     end
 
-    [:level, :message, :time, :remote].each do |attr|
+    [:level, :message, :time].each do |attr|
       it "should have a #{attr} attribute" do
         log = Puppet::Util::Log.new :level => :notice, :message => "A test message"
         log.should respond_to(attr)
-        log.should respond_to(attr.to_s + "=")
       end
     end
 
@@ -246,11 +245,12 @@ describe Puppet::Util::Log do
       Puppet::Util::Log.new(:level => "notice", :message => :foo, :source => "foo")
     end
 
-    [:file, :line].each do |attr|
-      it "should use #{attr} if provided" do
-        Puppet::Util::Log.any_instance.expects(attr.to_s + "=").with "foo"
-        Puppet::Util::Log.new(:level => "notice", :message => :foo, attr => "foo")
-      end
+    it "should use file if provided" do
+      expect(Puppet::Util::Log.new(:level => "notice", :message => :foo, :file => 'foo').file).to eq('foo')
+    end
+
+    it "should use line if provided" do
+      expect(Puppet::Util::Log.new(:level => "notice", :message => :foo, :line => 32).line).to eq(32)
     end
 
     it "should default to 'Puppet' as its source" do
@@ -259,7 +259,7 @@ describe Puppet::Util::Log do
 
     it "should register itself with Log" do
       Puppet::Util::Log.expects(:newmessage)
-      Puppet::Util::Log.new(:level => "notice", :message => :foo)
+      Puppet::Util::Log.create(:level => "notice", :message => :foo)
     end
 
     it "should update Log autoflush when Puppet[:autoflush] is set" do
@@ -316,14 +316,12 @@ describe Puppet::Util::Log do
         source = Puppet::Type.type(:file).new :path => path
         source.tags = ["tag", "tag2"]
 
-        log = Puppet::Util::Log.new(:level => "notice", :message => :foo)
-        log.expects(:tag).with("file")
-        log.expects(:tag).with("tag")
-        log.expects(:tag).with("tag2")
+        log = Puppet::Util::Log.new(:level => "notice", :message => :foo, :source => source)
 
-        log.source = source
-
-        log.source.should == "/File[#{path}]"
+        expect(log.source).to eq("/File[#{path}]")
+        expect(log.tags).to include('file')
+        expect(log.tags).to include('tag')
+        expect(log.tags).to include('tag2')
       end
 
       it "should copy over any file and line information" do


### PR DESCRIPTION
This commit removes the responsibility for formatting the log messages
from the `IssueReporter` and the `ExternalFileError` classes. Instead,
the formatting is deferred and performed by the `Log.to_s` method (if
such formatting is at all needed).

Some instance variables were added, both to the `ExternalFileError` class
and to the `Log` class to accommodate detailed information about
issue_code, environment, node, and position.

This commit also unifies the logic for a `Log` instance is created and
how its arguments are validated. All attributes except the source are
made read-only. The source can be changed because the `Puppet::Reports`
for `:log` alters it to include the name of the host.

A new `Log` destination _'json_file'_ was added. It will not use the
formatted message but instead output all details in a JSON style
Map. Exception backtrace is output as a JSON Array.

The merge to master will not be trivial. New tests have been added
that assumes that the file:line information is embedded in the
exception message (it no longer is since the formatting is handled
by the `Log.to_s`).