### PR TITLE
(PUP-4201) Add support for structured logging

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -54,8 +54,34 @@ module Puppet
     include ExternalFileError
   end
 
+  # Contains an issue code and can be annotated with an environment and a node
+  class ParseErrorWithIssue < Puppet::ParseError
+    attr_reader :issue_code, :basic_message
+    attr_accessor :environment, :node
+
+    # @param message [String] The error message
+    # @param file [String] The path to the file where the error was found
+    # @param line [Integer] The line in the file
+    # @param pos [Integer] The position on the line
+    # @param original [Exception] Original exception
+    # @param issue_code [Symbol] The issue code
+    #
+    def initialize(message, file=nil, line=nil, pos=nil, original=nil, issue_code= nil)
+      super(message, file, line, pos, original)
+      @issue_code = issue_code
+      @basic_message = message
+    end
+
+    def to_s
+      msg = super
+      msg = "Could not parse for environment #{environment}: #{msg}" if environment
+      msg = "#{msg} on node #{node}" if node
+      msg
+    end
+  end
+
   # An error that already contains location information in the message text
-  class PreformattedError < Puppet::ParseError
+  class PreformattedError < Puppet::ParseErrorWithIssue
   end
 
   # An error class for when I don't know what happened.  Automatically

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -568,6 +568,10 @@ class Puppet::Node::Environment
         parser.parse
       end
     end
+  rescue Puppet::ParseErrorWithIssue => detail
+    @known_resource_types.parse_failed = true
+    detail.environment = self.name
+    raise
   rescue => detail
     @known_resource_types.parse_failed = true
 

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -32,6 +32,10 @@ class Puppet::Parser::Compiler
     end
 
     new(node).compile {|resulting_catalog| resulting_catalog.to_resource }
+  rescue Puppet::ParseErrorWithIssue => detail
+    detail.node = node.name
+    Puppet.log_exception(detail)
+    raise
   rescue => detail
     message = "#{detail} on node #{node.name}"
     Puppet.log_exception(detail, message)

--- a/lib/puppet/pops/issue_reporter.rb
+++ b/lib/puppet/pops/issue_reporter.rb
@@ -23,7 +23,7 @@ class Puppet::Pops::IssueReporter
     emit_warnings = options[:emit_warnings] || false
     emit_errors = options[:emit_errors].nil? ? true : !!options[:emit_errors]
     emit_message = options[:message]
-    emit_exception = options[:exception_class] || Puppet::ParseError
+    emit_exception = options[:exception_class] || Puppet::ParseErrorWithIssue
 
     # If there are warnings output them
     warnings = acceptor.warnings
@@ -37,10 +37,10 @@ class Puppet::Pops::IssueReporter
           # deprecation of constructs in manifests! (It is not designed for that purpose even if
           # used throughout the code base).
           #
-          Puppet.warning(formatter.format(w)) if emitted_dw < max_deprecations
+          log_message(:warning, formatter, w) if emitted_dw < max_deprecations
           emitted_dw += 1
         else
-          Puppet.warning(formatter.format(w)) if emitted_w < max_warnings
+          log_message(:warning, formatter, w) if emitted_w < max_warnings
           emitted_w += 1
         end
         break if emitted_w >= max_warnings && emitted_dw >= max_deprecations # but only then
@@ -56,7 +56,7 @@ class Puppet::Pops::IssueReporter
       formatter = Puppet::Pops::Validation::DiagnosticFormatterPuppetStyle.new
       if errors.size == 1 || max_errors <= 1
         # raise immediately
-        exception = emit_exception.new(format_with_prefix(emit_message, formatter.format(errors[0])))
+        exception = create_exception(emit_exception, emit_message, formatter, errors[0])
         # if an exception was given as cause, use it's backtrace instead of the one indicating "here"
         if errors[0].exception
           exception.set_backtrace(errors[0].exception.backtrace)
@@ -68,7 +68,7 @@ class Puppet::Pops::IssueReporter
         Puppet.err(emit_message)
       end
       errors.each do |e|
-        Puppet.err(formatter.format(e))
+        log_message(:err, formatter, e)
         emitted += 1
         break if emitted >= max_errors
       end
@@ -84,4 +84,35 @@ class Puppet::Pops::IssueReporter
     return message unless prefix
     [prefix, message].join(' ')
   end
+
+  def self.create_exception(exception_class, emit_message, formatter, diagnostic)
+    file = diagnostic.file
+    file = (file.is_a?(String) && file.empty?) ? nil : file
+    line = pos = nil
+    if diagnostic.source_pos
+      line = diagnostic.source_pos.line
+      pos = diagnostic.source_pos.pos
+    end
+    exception_class.new(format_with_prefix(emit_message, formatter.format_message(diagnostic)), file, line, pos, nil, diagnostic.issue.issue_code)
+  end
+  private_class_method :create_exception
+
+  def self.log_message(severity, formatter, diagnostic)
+    file = diagnostic.file
+    file = (file.is_a?(String) && file.empty?) ? nil : file
+    line = pos = nil
+    if diagnostic.source_pos
+      line = diagnostic.source_pos.line
+      pos = diagnostic.source_pos.pos
+    end
+    Puppet::Util::Log.create({
+        :level => severity,
+        :message => formatter.format_message(diagnostic),
+        :issue_code => diagnostic.issue.issue_code,
+        :file => file,
+        :line => line,
+        :pos => pos,
+      })
+  end
+  private_class_method :log_message
 end

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -65,6 +65,8 @@ Puppet::Util::Log.newdesttype :file do
 
   def initialize(path)
     @name = path
+    @json = path.end_with?('.json') ? 1 : 0
+
     # first make sure the directory exists
     # We can't just use 'Config.use' here, because they've
     # specified a "special" destination.
@@ -74,7 +76,21 @@ Puppet::Util::Log.newdesttype :file do
     end
 
     # create the log file, if it doesn't already exist
-    file = File.open(path, File::WRONLY|File::CREAT|File::APPEND)
+    need_array_start = false
+    if @json == 1
+      need_array_start = true
+      if File.exists?(path)
+        sz = File.size(path)
+        need_array_start = sz == 0
+
+        # Assume that entries have been written and that a comma
+        # is needed before next entry
+        @json = 2 if sz > 2
+      end
+    end
+
+    file = File.open(path,  File::WRONLY|File::CREAT|File::APPEND)
+    file.puts('[') if need_array_start
 
     # Give ownership to the user and group puppet will run as
     begin
@@ -89,7 +105,12 @@ Puppet::Util::Log.newdesttype :file do
   end
 
   def handle(msg)
-    @file.puts("#{msg.time} #{msg.source} (#{msg.level}): #{msg}")
+    if @json > 0
+      @json > 1 ? @file.puts(',') : @json = 2
+      JSON.dump(msg.to_hash, @file)
+    else
+      @file.puts("#{msg.time} #{msg.source} (#{msg.level}): #{msg}")
+    end
 
     @file.flush if @autoflush
   end

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -24,8 +24,44 @@ module Puppet::Util::Logging
   #    wish to log a message at all; in this case it is likely that you are only calling this method in order
   #    to take advantage of the backtrace logging.
   def log_exception(exception, message = :default, options = {})
-    err(format_exception(exception, message, Puppet[:trace] || options[:trace]))
+    trace = Puppet[:trace] || options[:trace]
+    if message == :default && exception.is_a?(Puppet::ParseErrorWithIssue)
+      # Retain all detailed info and keep plain message and stacktrace separate
+      backtrace = []
+      build_exception_trace(backtrace, exception, trace)
+      Puppet::Util::Log.create({
+          :level => :err,
+          :source => log_source,
+          :message => exception.basic_message,
+          :issue_code => exception.issue_code,
+          :backtrace => backtrace.empty? ? nil : backtrace,
+          :file => exception.file,
+          :line => exception.line,
+          :pos => exception.pos,
+          :environment => exception.environment,
+          :node => exception.node
+        }.merge(log_metadata))
+    else
+      err(format_exception(exception, message, trace))
+    end
   end
+
+  def build_exception_trace(arr, exception, trace = true)
+    if trace and exception.backtrace
+      exception.backtrace.each do |line|
+        arr << line =~ /^(.+):(\d+.*)$/ ? ("#{Pathname($1).realpath}:#{$2}" rescue line) : line
+      end
+    end
+    if exception.respond_to?(:original)
+      original =  exception.original
+      unless original.nil?
+        arr << 'Wrapped exception:'
+        arr << original.message
+        build_exception_trace(arr, original, trace)
+      end
+    end
+  end
+  private :build_exception_trace
 
   def format_exception(exception, message = :default, trace = true)
     arr = []

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1266,14 +1266,14 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     it 'for non r-value producing define' do
-      Puppet.expects(:err).with("Invalid use of expression. A 'define' expression does not produce a value at line 1:6")
-      Puppet.expects(:err).with("Classes, definitions, and nodes may only appear at toplevel or inside other classes at line 1:6")
+      Puppet::Util::Log.expects(:create).with(has_entries(:level => :err, :message => "Invalid use of expression. A 'define' expression does not produce a value", :line => 1, :pos => 6))
+      Puppet::Util::Log.expects(:create).with(has_entries(:level => :err, :message => 'Classes, definitions, and nodes may only appear at toplevel or inside other classes', :line => 1, :pos => 6))
       expect { parser.parse_string("$a = define foo { }", nil) }.to raise_error(/2 errors/)
     end
 
     it 'for non r-value producing class' do
-      Puppet.expects(:err).with("Invalid use of expression. A Host Class Definition does not produce a value at line 1:6")
-      Puppet.expects(:err).with("Classes, definitions, and nodes may only appear at toplevel or inside other classes at line 1:6")
+      Puppet::Util::Log.expects(:create).with(has_entries(:level => :err, :message => 'Invalid use of expression. A Host Class Definition does not produce a value', :line => 1, :pos => 6))
+      Puppet::Util::Log.expects(:create).with(has_entries(:level => :err, :message => 'Classes, definitions, and nodes may only appear at toplevel or inside other classes', :line => 1, :pos => 6))
       expect { parser.parse_string("$a = class foo { }", nil) }.to raise_error(/2 errors/)
     end
 
@@ -1287,8 +1287,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     it 'for multiple errors with a summary exception' do
-      Puppet.expects(:err).with("Invalid use of expression. A Node Definition does not produce a value at line 1:6")
-      Puppet.expects(:err).with("Classes, definitions, and nodes may only appear at toplevel or inside other classes at line 1:6")
+      Puppet::Util::Log.expects(:create).with(has_entries(:level => :err, :message => 'Invalid use of expression. A Node Definition does not produce a value', :line => 1, :pos => 6))
+      Puppet::Util::Log.expects(:create).with(has_entries(:level => :err, :message => 'Classes, definitions, and nodes may only appear at toplevel or inside other classes', :line => 1, :pos => 6))
       expect { parser.parse_string("$a = node x { }",nil) }.to raise_error(/2 errors/)
     end
 

--- a/spec/unit/pops/issues_spec.rb
+++ b/spec/unit/pops/issues_spec.rb
@@ -62,19 +62,19 @@ describe "Puppet::Pops::IssueReporter" do
     end
 
     it "emits warnings if told to emit them" do
-      Puppet.expects(:warning).twice.with(regexp_matches(/warning1|deprecation1/))
+      Puppet::Log.expects(:create).twice.with(has_entries(:level => :warning, :message => regexp_matches(/warning1|deprecation1/)))
       Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :emit_warnings => true })
     end
 
     it "does not emit warnings if not told to emit them" do
-      Puppet.expects(:warning).never
+      Puppet::Log.expects(:create).never
       Puppet::Pops::IssueReporter.assert_and_report(acceptor, {})
     end
 
     it "emits no warnings if :max_warnings is 0" do
       acceptor.accept( warning(2) )
       Puppet[:max_warnings] = 0
-      Puppet.expects(:warning).once.with(regexp_matches(/deprecation1/))
+      Puppet::Log.expects(:create).once.with(has_entries(:level => :warning, :message => regexp_matches(/deprecation1/)))
       Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :emit_warnings => true })
     end
 
@@ -82,20 +82,20 @@ describe "Puppet::Pops::IssueReporter" do
       acceptor.accept( warning(2) )
       acceptor.accept( warning(3) )
       Puppet[:max_warnings] = 1
-      Puppet.expects(:warning).twice.with(regexp_matches(/warning1|deprecation1/))
+      Puppet::Log.expects(:create).twice.with(has_entries(:level => :warning, :message => regexp_matches(/warning1|deprecation1/)))
       Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :emit_warnings => true })
     end
 
     it "does not emit more deprecations warnings than the max deprecation warnings" do
       acceptor.accept( deprecation(2) )
       Puppet[:max_deprecations] = 0
-      Puppet.expects(:warning).once.with(regexp_matches(/warning1/))
+      Puppet::Log.expects(:create).once.with(has_entries(:level => :warning, :message => regexp_matches(/warning1/)))
       Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :emit_warnings => true })
     end
 
     it "does not emit deprecation warnings, but does emit regular warnings if disable_warnings includes deprecations" do
       Puppet[:disable_warnings] = 'deprecations'
-      Puppet.expects(:warning).once.with(regexp_matches(/warning1/))
+      Puppet::Log.expects(:create).once.with(has_entries(:level => :warning, :message => regexp_matches(/warning1/)))
       Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :emit_warnings => true })
     end
   end
@@ -103,7 +103,7 @@ describe "Puppet::Pops::IssueReporter" do
   context "given errors" do
     it "logs nothing, but raises the given :message if :emit_errors is repressing error logging" do
       acceptor.accept( error(1) )
-      Puppet.expects(:err).never
+      Puppet::Log.expects(:create).never
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :emit_errors => false, :message => 'special'})
       end.to raise_error(Puppet::ParseError, 'special')
@@ -111,7 +111,7 @@ describe "Puppet::Pops::IssueReporter" do
 
     it "prefixes :message if a single error is raised" do
       acceptor.accept( error(1) )
-      Puppet.expects(:err).never
+      Puppet::Log.expects(:create).never
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :message => 'special'})
       end.to raise_error(Puppet::ParseError, /special error1/)
@@ -119,7 +119,7 @@ describe "Puppet::Pops::IssueReporter" do
 
     it "logs nothing and raises immediately if there is only one error" do
       acceptor.accept( error(1) )
-      Puppet.expects(:err).never
+      Puppet::Log.expects(:create).never
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { })
       end.to raise_error(Puppet::ParseError, /error1/)
@@ -129,7 +129,7 @@ describe "Puppet::Pops::IssueReporter" do
       acceptor.accept( error(1) )
       acceptor.accept( error(2) )
       Puppet[:max_errors] = 0
-      Puppet.expects(:err).never
+      Puppet::Log.expects(:create).never
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { })
       end.to raise_error(Puppet::ParseError, /error1/)
@@ -138,7 +138,7 @@ describe "Puppet::Pops::IssueReporter" do
     it "logs the :message if there is more than one allowed error" do
       acceptor.accept( error(1) )
       acceptor.accept( error(2) )
-      Puppet.expects(:err).times(3).with(regexp_matches(/error1|error2|special/))
+      Puppet::Log.expects(:create).times(3).with(has_entries(:level => :err, :message => regexp_matches(/error1|error2|special/)))
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :message => 'special'})
       end.to raise_error(Puppet::ParseError, /Giving up/)
@@ -149,7 +149,7 @@ describe "Puppet::Pops::IssueReporter" do
       acceptor.accept( error(2) )
       acceptor.accept( error(3) )
       Puppet[:max_errors] = 2
-      Puppet.expects(:err).times(2).with(regexp_matches(/error1|error2/))
+      Puppet::Log.expects(:create).times(2).with(has_entries(:level => :err, :message => regexp_matches(/error1|error2/)))
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { })
       end.to raise_error(Puppet::ParseError, /3 errors.*Giving up/)
@@ -160,7 +160,7 @@ describe "Puppet::Pops::IssueReporter" do
       acceptor.accept( error(2) )
       acceptor.accept( error(3) )
       Puppet[:max_errors] = 4
-      Puppet.expects(:err).times(3).with(regexp_matches(/error[123]/))
+      Puppet::Log.expects(:create).times(3).with(has_entries(:level => :err, :message => regexp_matches(/error[123]/)))
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { })
       end.to raise_error(Puppet::ParseError, /3 errors.*Giving up/)
@@ -170,7 +170,7 @@ describe "Puppet::Pops::IssueReporter" do
       acceptor.accept( error(1) )
       acceptor.accept( error(2) )
       Puppet[:disable_warnings] = 'deprecations'
-      Puppet.expects(:err).times(2).with(regexp_matches(/error1|error2/))
+      Puppet::Log.expects(:create).times(2).with(has_entries(:level => :err, :message => regexp_matches(/error1|error2/)))
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { })
       end.to raise_error(Puppet::ParseError, /Giving up/)
@@ -186,8 +186,8 @@ describe "Puppet::Pops::IssueReporter" do
       acceptor.accept( error(3) )
       acceptor.accept( deprecation(1) )
       Puppet[:max_errors] = 2
-      Puppet.expects(:warning).twice.with(regexp_matches(/warning1|deprecation1/))
-      Puppet.expects(:err).times(2).with(regexp_matches(/error[123]/))
+      Puppet::Log.expects(:create).twice.with(has_entries(:level => :warning, :message => regexp_matches(/warning1|deprecation1/)))
+      Puppet::Log.expects(:create).twice.with(has_entries(:level => :err, :message => regexp_matches(/error[123]/)))
       expect do
         Puppet::Pops::IssueReporter.assert_and_report(acceptor, { :emit_warnings => true })
       end.to raise_error(Puppet::ParseError, /3 errors.*2 warnings.*Giving up/)


### PR DESCRIPTION
The main objective for this commit is to retain backward compatility
with the 3.x stream. It only touches the logged messages that stems
from the Puppet::Pops::IssueReporter.

The commit removes the responsibility for formatting the log messages
from the IssueReporter. Instead it passes all details to the Log
instance that is created, either by direct logging och by raising an
error. A new class named ParseErrorWithIssue (a subclass of ParseError)
that keeps track of the basic message and the issue_code was needed to
accomplish this. This class is also has the attributes 'environment'
and 'node' that will be assigned in rescue blocks before the exception
is re-thrown. Prior to this change, the rescue block would create a
new error instance with additional information in the actual message
but loose the detailed information.

The 'file' log destination was altered slightly so that if the path
ends with '.json', it will output each Log entry in JSON format. The
list of entries will be prefixed by a '[' (added when the file is
first created) and delimited with ','. The file will contain almost
valid JSON at all times but the last ']' will be missing.