### PR TITLE
(PUP-1628) Fix mount provider for AIX

### DIFF
--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -168,7 +168,7 @@ Puppet::Type.type(:mount).provide(
             k, v = x.split("=")
             output << "\t#{k}\t\t= #{v}"
           end
-          output << "\toptions\t\t= #{options.sort.join(",")}" unless options.empty?
+          output << "\toptions\t\t= #{options.join(",")}" unless options.empty?
         end
         if result[:line] and result[:line].split("\n").sort == output.sort
           return "\n#{result[:line]}"

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -168,9 +168,11 @@ module Puppet
     end
 
     newproperty(:options) do
-      desc "Mount options for the mounts, as they would
-        appear in the fstab. AIX options other than dev,
-        nodename, or vfs may be defined here."
+      desc "Mount options for the mounts, comma-separated as they would appear
+      in the fstab on Linux. AIX options other than dev, nodename, or vfs may
+      be defined here. If specified, AIX options of account, boot, check, free,
+      mount, size, type, vol, log, and quota must be alphabetically sorted at
+      the end of the list."
 
       validate do |value|
         raise Puppet::Error, "option must not contain whitespace: #{value}" if value =~ /\s/

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -169,7 +169,8 @@ module Puppet
 
     newproperty(:options) do
       desc "Mount options for the mounts, as they would
-        appear in the fstab."
+        appear in the fstab. AIX options other than dev,
+        nodename, or vfs may be defined here."
 
       validate do |value|
         raise Puppet::Error, "option must not contain whitespace: #{value}" if value =~ /\s/

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -254,7 +254,7 @@ module Puppet
       newvalues(:true, :false)
       defaultto do
         case Facter.value(:operatingsystem)
-        when "FreeBSD", "Darwin", "AIX", "DragonFly", "OpenBSD"
+        when "FreeBSD", "Darwin", "DragonFly", "OpenBSD"
           false
         else
           true

--- a/spec/fixtures/unit/provider/mount/parsed/aix.filesystems
+++ b/spec/fixtures/unit/provider/mount/parsed/aix.filesystems
@@ -35,110 +35,118 @@
 *
 
 /:
-        dev             = /dev/hd4
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = automatic
-        check           = false
-        type            = bootfs
-        vol             = root
-        free            = true
-        quota           = no
+	dev		= /dev/hd4
+	vfs		= jfs2
+	check		= false
+	free		= true
+	log		= NULL
+	mount		= automatic
+	quota		= no
+	type		= bootfs
+	vol		= root
 
 /home:
-        dev             = /dev/hd1
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = true
-        check           = true
-        vol             = /home
-        free            = false
-        quota           = no
+	dev		= /dev/hd1
+	vfs		= jfs2
+	check		= true
+	free		= false
+	log		= NULL
+	mount		= true
+	quota		= no
+	vol		= /home
 
 /usr:
-        dev             = /dev/hd2
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = automatic
-        check           = false
-        type            = bootfs
-        vol             = /usr
-        free            = false
-        quota           = no
+	dev		= /dev/hd2
+	vfs		= jfs2
+	check		= false
+	free		= false
+	log		= NULL
+	mount		= automatic
+	quota		= no
+	type		= bootfs
+	vol		= /usr
 
 /var:
-        dev             = /dev/hd9var
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = automatic
-        check           = false
-        type            = bootfs
-        vol             = /var
-        free            = false
-        quota           = no
+	dev		= /dev/hd9var
+	vfs		= jfs2
+	check		= false
+	free		= false
+	log		= NULL
+	mount		= automatic
+	quota		= no
+	type		= bootfs
+	vol		= /var
 
 /tmp:
-        dev             = /dev/hd3
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = automatic
-        check           = false
-        vol             = /tmp
-        free            = false
-        quota           = no
+	dev		= /dev/hd3
+	vfs		= jfs2
+	check		= false
+	free		= false
+	log		= NULL
+	mount		= automatic
+	quota		= no
+	vol		= /tmp
 
 /admin:
-        dev             = /dev/hd11admin
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = true
-        check           = false
-        vol             = /admin
-        free            = false
-        quota           = no
+	dev		= /dev/hd11admin
+	vfs		= jfs2
+	check		= false
+	free		= false
+	log		= NULL
+	mount		= true
+	quota		= no
+	vol		= /admin
 
 /proc:
-        dev       = /proc
-        vol       = "/proc"
-        mount     = true
-        check     = false
-        free      = false
-        vfs       = procfs
+	dev		= /proc
+	vol		= "/proc"
+	mount		= true
+	check		= false
+	free		= false
+	vfs		= procfs
 
 /opt:
-        dev             = /dev/hd10opt
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = true
-        check           = true
-        vol             = /opt
-        free            = false
-        quota           = no
+	dev		= /dev/hd10opt
+	vfs		= jfs2
+	log		= /dev/hd8
+	mount		= true
+	check		= true
+	vol		= /opt
+	free		= false
+	quota		= no
 
 /var/adm/ras/livedump:
-        dev             = /dev/livedump
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = true
-        account         = false
-        quota           = no
+	dev		= /dev/livedump
+	vfs		= jfs2
+	log		= /dev/hd8
+	mount		= true
+	account		= false
+	quota		= no
 
 
 /stage/middleware:
-        dev             = "/stage/middleware"
-        vfs             = nfs
-        nodename        = 192.168.1.11
-        mount           = true
-        type            = nfs
-        options         = ro,bg,hard,intr,sec=sys
-        account         = false
+	dev		= "/stage/middleware"
+	vfs		= nfs
+	nodename	= 192.168.1.11
+	mount		= true
+	type		= nfs
+	options		= ro,bg,hard,intr,sec=sys
+	account		= false
 
 /home/u0010689:
-        dev             = "/userdata/20010689"
-        vfs             = nfs
-        nodename        = 192.168.1.11
-        mount           = true
-        type            = nfs
-        options         = bg,hard,intr
-        account         = false
+	dev		= "/userdata/20010689"
+	vfs		= nfs
+	nodename	= 192.168.1.11
+	mount		= true
+	type		= nfs
+	options		= bg,hard,intr
+	account		= false
 
+/srv/aix:
+	dev		= /srv/aix
+	nodename	= mynode
+	vfs		= nfs
+	account		= false
+	log		= NULL
+	mount		= true
+	options		= vers=2

--- a/spec/fixtures/unit/provider/mount/parsed/aix.mount
+++ b/spec/fixtures/unit/provider/mount/parsed/aix.mount
@@ -1,7 +1,11 @@
-node   mounted          mounted over  vfs    date              options   
-----   -------          ------------ ---  ------------   -------------------
-       /dev/hd0         /            jfs   Dec 17 08:04   rw, log  =/dev/hd8
-       /dev/hd3         /tmp         jfs   Dec 17 08:04   rw, log  =/dev/hd8
-       /dev/hd1         /home        jfs   Dec 17 08:06   rw, log  =/dev/hd8
-       /dev/hd2         /usr         jfs   Dec 17 08:06   rw, log  =/dev/hd8
-sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8
+  node       mounted        mounted over    vfs       date        options
+-------- ---------------  ---------------  ------ ------------ ---------------
+         /dev/hd4         /                jfs2   Feb 05 10:27 rw,log=NULL
+         /dev/hd2         /usr             jfs2   Feb 05 10:28 rw,log=NULL
+         /dev/hd9var      /var             jfs2   Feb 05 10:28 rw,log=NULL
+         /dev/hd3         /tmp             jfs2   Feb 05 10:28 rw,log=NULL
+         /dev/hd1         /home            jfs2   Feb 05 10:28 rw,log=NULL
+         /dev/hd11admin   /admin           jfs2   Feb 05 10:28 rw,log=NULL
+         /proc            /proc            procfs Feb 05 10:28 rw
+         /dev/hd10opt     /opt             jfs2   Feb 05 10:28 rw,log=NULL
+mynode   /srv/aix         /srv/aix         nfs    Mar 19 14:33 vers=2,rw 


### PR DESCRIPTION
The way that AIX tracks its mounted filesystems is different than other
unix or linux operatingsystems. AIX uses /etc/filesystems and has
entirely different filesystem options.

This commit takes advantage of two parsedfile hooks, `post_parse` and
`to_line`, to read & generate /etc/filesystem entries. Parsedfile was
not created with arbitrary-ordering in mind, and any /etc/filesystem
entries will have their attributes reordered by `to_line`

Options in AIX without related properties in Puppet's mount type are
placed under the "options" property.