### PR TITLE
(PUP-4194) Move `logdir` default to /var/log/puppetlabs/puppet

### DIFF
--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -26,7 +26,7 @@ def config_options(platform)
     codedir = '/etc/puppetlabs/code'
     confdir = '/etc/puppetlabs/puppet'
     vardir = '/opt/puppetlabs/puppet/cache'
-    logdir = '/var/log/puppetlabs'
+    logdir = '/var/log/puppetlabs/puppet'
     rundir = '/var/run/puppetlabs'
     sep = ":"
   end

--- a/ext/redhat/client.sysconfig
+++ b/ext/redhat/client.sysconfig
@@ -5,7 +5,7 @@
 #PUPPET_PORT=8140
 
 # Where to log to. Specify syslog to send log messages to the system log.
-#PUPPET_LOG=/var/log/puppet/puppet.log
+#PUPPET_LOG=/var/log/puppetlabs/puppet/puppet.log
 
 # You may specify other parameters to the puppet client here
 #PUPPET_EXTRA_OPTS=--waitforcert=500

--- a/install.rb
+++ b/install.rb
@@ -211,7 +211,7 @@ def prepare_installation
     opts.on('--rundir[=OPTIONAL]', 'Installation directory for state files', 'Default /var/run/puppetlabs') do |rundir|
       InstallOptions.rundir = rundir
     end
-    opts.on('--logdir[=OPTIONAL]', 'Installation directory for log files', 'Default /var/log/puppetlabs') do |logdir|
+    opts.on('--logdir[=OPTIONAL]', 'Installation directory for log files', 'Default /var/log/puppetlabs/puppet') do |logdir|
       InstallOptions.logdir = logdir
     end
     opts.on('--bindir[=OPTIONAL]', 'Installation directory for binaries', 'overrides RbConfig::CONFIG["bindir"]') do |bindir|
@@ -299,7 +299,7 @@ def prepare_installation
   elsif $operatingsystem == "windows"
     logdir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "var", "log")
   else
-    logdir = "/var/log/puppetlabs"
+    logdir = "/var/log/puppetlabs/puppet"
   end
 
   if not InstallOptions.bindir.nil?

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -71,7 +71,7 @@ module Puppet
       end
 
       def log_dir
-        which_dir("/var/log/puppetlabs", "~/.puppet/var/log")
+        which_dir("/var/log/puppetlabs/puppet", "~/.puppet/var/log")
       end
     end
 

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -86,8 +86,8 @@ describe Puppet::Util::RunMode do
 
     describe "#log_dir" do
       describe "when run as root" do
-        it "has logdir /var/log/puppetlabs" do
-          as_root { expect(@run_mode.log_dir).to eq(File.expand_path('/var/log/puppetlabs')) }
+        it "has logdir /var/log/puppetlabs/puppet" do
+          as_root { expect(@run_mode.log_dir).to eq(File.expand_path('/var/log/puppetlabs/puppet')) }
         end
       end
 


### PR DESCRIPTION
Previously, puppet would set its `logdir` permissions to `root:root:750`
if run on a host without the `puppet` service user and group. If the
`puppetserver` package was installed later, it would create the `puppet`
user and group accounts, try to start, but fail to write to its log
directory `/var/log/puppetlabs/puppetserver`, because of the parent
directory permissions.

This commit moves puppet's logdir to `/var/log/puppetlabs/puppet`,
isolated from both `puppetserver` and `puppetmaster` packages, the latter
being the passenger-based compatibility packages.

This commit affects both the `puppetdlog` setting, which is pretty much
dead, and the puppet master webrick `masterhttplog` setting, which is
soon to be deprecated.