### PR TITLE
(PUP-4090) Zypper provider improvements

### DIFF
--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -80,7 +80,7 @@ describe provider_class do
       @resource.stubs(:should).with(:ensure).returns :latest
       @resource.stubs(:allow_virtual?).returns false
       @provider.stubs(:zypper_version).returns "0.6.104"
-      @provider.expects(:zypper).with('--terse', :install, '--auto-agree-with-licenses', '--no-confirm', '--name', 'mypackage')
+      @provider.expects(:zypper).with('--terse', :install, '--auto-agree-with-licenses', '--no-confirm', 'mypackage')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
@@ -101,7 +101,7 @@ describe provider_class do
       @resource.stubs(:should).with(:ensure).returns :latest
       @resource.stubs(:allow_virtual?).returns false
       @provider.stubs(:zypper_version).returns "0.6.13"
-      @provider.expects(:zypper).with('--terse', :install, '--no-confirm', '--name', 'mypackage')
+      @provider.expects(:zypper).with('--terse', :install, '--no-confirm', 'mypackage')
       @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
       @provider.install
     end
@@ -124,13 +124,24 @@ describe provider_class do
     end
   end
 
-  it "should install a virtual package" do
-    @resource.stubs(:should).with(:ensure).returns :installed
-    @resource.stubs(:allow_virtual?).returns true
-    @provider.stubs(:zypper_version).returns "0.6.13"
-    @provider.expects(:zypper).with('--terse', :install, '--no-confirm', 'mypackage')
-    @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
-    @provider.install
+  describe "should install a virtual package" do
+    it "when zypper version = 0.6.13" do
+      @resource.stubs(:should).with(:ensure).returns :installed
+      @resource.stubs(:allow_virtual?).returns true
+      @provider.stubs(:zypper_version).returns "0.6.13"
+      @provider.expects(:zypper).with('--terse', :install, '--no-confirm', 'mypackage')
+      @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
+      @provider.install
+    end
+
+    it "when zypper version >= 1.0.0" do
+      @resource.stubs(:should).with(:ensure).returns :installed
+      @resource.stubs(:allow_virtual?).returns true
+      @provider.stubs(:zypper_version).returns "1.2.8"
+      @provider.expects(:zypper).with('--quiet', :install, '--auto-agree-with-licenses', '--no-confirm', 'mypackage')
+      @provider.expects(:query).returns "mypackage 0 1.2.3 4.5.6 x86_64"
+      @provider.install
+    end
   end
 
   describe "when installing with zypper install options" do
@@ -141,8 +152,8 @@ describe provider_class do
       @resource.stubs(:allow_virtual?).returns false
       @provider.stubs(:zypper_version).returns "1.2.8"
 
-      @provider.expects(:zypper).with('--quiet', :install,
-        '--auto-agree-with-licenses', '--no-confirm', '--no-gpg-check', '-p=/vagrant/files/localrepo/', 'php5-5.4.10-4.5.6')
+      @provider.expects(:zypper).with('--quiet', '--no-gpg-check', :install,
+        '--auto-agree-with-licenses', '--no-confirm', '-p=/vagrant/files/localrepo/', 'php5-5.4.10-4.5.6')
       @provider.expects(:query).returns "php5 0 5.4.10 4.5.6 x86_64"
       @provider.install
     end
@@ -154,7 +165,7 @@ describe provider_class do
       @resource.stubs(:allow_virtual?).returns false
 
       @provider.stubs(:zypper_version).returns '1.2.8'
-      @provider.expects(:zypper).with('--quiet', :install, '--auto-agree-with-licenses', '--no-confirm', '--name', '--a=foo', '--b="quoted bar"', 'vim')
+      @provider.expects(:zypper).with('--quiet', :install, '--auto-agree-with-licenses', '--no-confirm', '--a=foo', '--b="quoted bar"', '--name', 'vim')
       @provider.expects(:query).returns 'package vim is not installed'
       @provider.install
     end
@@ -166,7 +177,7 @@ describe provider_class do
       @resource.stubs(:allow_virtual?).returns false
 
       @provider.stubs(:zypper_version).returns '1.2.8'
-      @provider.expects(:zypper).with('--quiet', :install, '--auto-agree-with-licenses', '--no-confirm', '--name', '--a', '--b', '--c', 'vim')
+      @provider.expects(:zypper).with('--quiet', :install, '--auto-agree-with-licenses', '--no-confirm', '--a', '--b', '--c', '--name', 'vim')
       @provider.expects(:query).returns 'package vim is not installed'
       @provider.install
     end
@@ -178,7 +189,7 @@ describe provider_class do
       @resource.stubs(:allow_virtual?).returns false
 
       @provider.stubs(:zypper_version).returns '1.2.8'
-      @provider.expects(:zypper).with('--quiet', :install, '--auto-agree-with-licenses', '--no-confirm', '--name', '--a --b --c', 'vim')
+      @provider.expects(:zypper).with('--quiet', :install, '--auto-agree-with-licenses', '--no-confirm', '--a --b --c', '--name', 'vim')
       @provider.expects(:query).returns 'package vim is not installed'
       @provider.install
     end


### PR DESCRIPTION
Prior to this commit, our zypper provider didn't work. When installing a
package with zypper, we pass in the `--name` flag, which is not
available in earlier versions of zypper that we account for. It also
breaks when you use `install_options`. It previously dropped in the
extra install options between `--name` and the package name to be
installed. This cuased it to fail.

This pull request reorders the options that we pass to the zypper
command. If the user has passed in the global option `--no-gpg-check`,
we pull that flag out, and pass it in where zypper expects it (after
`zypper` and before `install`).