### PR TITLE
(PUP-4278) Fix grammar error when unless then-part was empty

### DIFF
--- a/lib/puppet/pops/parser/egrammar.ra
+++ b/lib/puppet/pops/parser/egrammar.ra
@@ -354,7 +354,7 @@ unless_expression
       loc result, val[0], val[4]
     }
   | UNLESS expression LBRACE RBRACE unless_else {
-      result = Factory.UNLESS(val[1], nil, nil)
+      result = Factory.UNLESS(val[1], nil, val[4])
       loc result, val[0], val[4]
     }
 

--- a/lib/puppet/pops/parser/eparser.rb
+++ b/lib/puppet/pops/parser/eparser.rb
@@ -1927,7 +1927,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 352)
 
 module_eval(<<'.,.,', 'egrammar.ra', 356)
   def _reduce_105(val, _values, result)
-          result = Factory.UNLESS(val[1], nil, nil)
+          result = Factory.UNLESS(val[1], nil, val[4])
       loc result, val[0], val[4]
     
     result

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -473,6 +473,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "unless false {5}"                => 5,
       "unless true {5}"                 => nil,
       "unless true {2} else {5}"        => 5,
+      "unless true {} else {5}"         => 5,
       "$a = if true {5} $a"                     => 5,
       "$a = if false {5} $a"                    => nil,
       "$a = if false {2} else {5} $a"           => 5,


### PR DESCRIPTION
There was a problem in the grammar that caused an expression like:
   unless true {} else {1}

to result in nil because neither the then-, nor the else- part were
added to the generated UnlessExpression.

This corrects the call to generate the UnlessExpression.