### PR TITLE
(PUP-3429) task_scheduler should use 'day_of_week' instead of 'on'

### DIFF
--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -83,9 +83,9 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
         puppet_trigger['schedule'] = 'daily'
         puppet_trigger['every']    = trigger['type']['days_interval'].to_s
       when Win32::TaskScheduler::TASK_TIME_TRIGGER_WEEKLY
-        puppet_trigger['schedule'] = 'weekly'
-        puppet_trigger['every']    = trigger['type']['weeks_interval'].to_s
-        puppet_trigger['on']       = days_of_week_from_bitfield(trigger['type']['days_of_week'])
+        puppet_trigger['schedule']    = 'weekly'
+        puppet_trigger['every']       = trigger['type']['weeks_interval'].to_s
+        puppet_trigger['day_of_week'] = days_of_week_from_bitfield(trigger['type']['days_of_week'])
       when Win32::TaskScheduler::TASK_TIME_TRIGGER_MONTHLYDATE
         puppet_trigger['schedule'] = 'monthly'
         puppet_trigger['months']   = months_from_bitfield(trigger['type']['months'])

--- a/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -172,13 +172,13 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
           })
 
           resource.provider.trigger.should == [{
-            'start_date' => '2011-9-12',
-            'start_time' => '13:20',
-            'schedule'   => 'weekly',
-            'every'      => '2',
-            'on'         => ['sun', 'mon', 'wed', 'fri'],
-            'enabled'    => true,
-            'index'      => 0,
+            'start_date'  => '2011-9-12',
+            'start_time'  => '13:20',
+            'schedule'    => 'weekly',
+            'every'       => '2',
+            'day_of_week' => ['sun', 'mon', 'wed', 'fri'],
+            'enabled'     => true,
+            'index'       => 0,
           }]
         end
 


### PR DESCRIPTION
Populate 'day_of_week' instead of 'on' when loading existing triggers. This
should prevent constant changes from being registered.