### PR TITLE
(PUP-1802) Update SHA to puppet_for_the_win

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -16,7 +16,7 @@ build_gem: TRUE
 build_dmg: TRUE
 build_msi:
   puppet_for_the_win:
-    ref: '4eb71b5b063f611eb447d561d51481831a66b5dd'
+    ref: '2476cd007b1b52fb1b9f22202b56218629626b5c'
     repo: 'git://github.com/puppetlabs/puppet_for_the_win.git'
   facter:
     ref: 'refs/tags/2.3.0'


### PR DESCRIPTION
Updates SHA to puppet_for_the_win to incorporate fix to start service
directly with ruby.exe instead of using a wrapper. This avoids warnings
in the service control manager; see PUP-1802 for details.