### PR TITLE
(PUP-927) Read preserving line endings

### DIFF
--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -129,6 +129,19 @@ module Puppet::FileSystem
     @impl.read(assert_path(path))
   end
 
+  # Read a file keeping the original line endings intact. This
+  # attempts to open files using binary mode using some encoding
+  # overrides and falling back to IO.read when none of the
+  # encodings are valid.
+  #
+  # @return [String] The contents of the file
+  #
+  # @api public
+  #
+  def self.read_preserve_line_endings(path)
+    @impl.read_preserve_line_endings(assert_path(path))
+  end
+
   # @return [String] The binary contents of the file
   #
   # @api public

--- a/lib/puppet/file_system/file19windows.rb
+++ b/lib/puppet/file_system/file19windows.rb
@@ -91,6 +91,14 @@ class Puppet::FileSystem::File19Windows < Puppet::FileSystem::File19
     Puppet::Util::Windows::Security.set_mode(mode, path.to_s)
   end
 
+  def read_preserve_line_endings(path)
+    contents = path.read( :mode => 'rb', :encoding => Encoding::UTF_8)
+    contents = path.read( :mode => 'rb', :encoding => Encoding::default_external) unless contents.valid_encoding?
+    contents = path.read unless contents.valid_encoding?
+
+    contents
+  end
+
   private
 
   def raise_if_symlinks_unsupported

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -75,6 +75,10 @@ class Puppet::FileSystem::FileImpl
     path.read
   end
 
+  def read_preserve_line_endings(path)
+    read(path)
+  end
+
   def binread(path)
     raise NotImplementedError
   end

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -44,6 +44,10 @@ class Puppet::FileSystem::MemoryImpl
     handle.read
   end
 
+  def read_preserve_line_endings(path)
+    read(path)
+  end
+
   def open(path, *args, &block)
     handle = assert_path(path).handle
     if block_given?

--- a/lib/puppet/parser/functions/file.rb
+++ b/lib/puppet/parser/functions/file.rb
@@ -1,3 +1,5 @@
+require 'puppet/file_system'
+
 Puppet::Parser::Functions::newfunction(
   :file, :arity => -2, :type => :rvalue,
   :doc => "Loads a file from a module and returns its contents as a string.
@@ -24,7 +26,7 @@ Puppet::Parser::Functions::newfunction(
     end
 
     if path
-      File.read(path)
+      Puppet::FileSystem.read_preserve_line_endings(path)
     else
       raise Puppet::ParseError, "Could not find any files from #{vals.join(", ")}"
     end

--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -1,5 +1,6 @@
 require 'puppet/parser/files'
 require 'erb'
+require 'puppet/file_system'
 
 # A simple wrapper for templates, so they don't have full access to
 # the scope objects.
@@ -97,7 +98,7 @@ class Puppet::Parser::TemplateWrapper
     if string
       template_source = "inline template"
     else
-      string = File.read(@__file__)
+      string = Puppet::FileSystem.read_preserve_line_endings(@__file__)
       template_source = @__file__
     end
 

--- a/spec/unit/parser/functions/file_spec.rb
+++ b/spec/unit/parser/functions/file_spec.rb
@@ -15,7 +15,7 @@ describe "the 'file' function" do
 
   def with_file_content(content)
     path = tmpfile('file-function')
-    file = File.new(path, 'w')
+    file = File.new(path, 'wb')
     file.sync = true
     file.print content
     yield path
@@ -23,7 +23,13 @@ describe "the 'file' function" do
 
   it "should read a file" do
     with_file_content('file content') do |name|
-      scope.function_file([name]).should == "file content"
+      expect(scope.function_file([name])).to eq("file content")
+    end
+  end
+
+  it "should read a file keeping line endings intact" do
+    with_file_content("file content\r\n") do |name|
+      expect(scope.function_file([name])).to eq("file content\r\n")
     end
   end
 

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -82,7 +82,7 @@ describe "the template function" do
   end
 
   def eval_template(content)
-    File.stubs(:read).with("template").returns(content)
+    Puppet::FileSystem.stubs(:read_preserve_line_endings).with("template").returns(content)
     Puppet::Parser::Files.stubs(:find_template).returns("template")
     scope.function_template(['template'])
   end

--- a/spec/unit/parser/templatewrapper_spec.rb
+++ b/spec/unit/parser/templatewrapper_spec.rb
@@ -111,7 +111,7 @@ describe Puppet::Parser::TemplateWrapper do
     Puppet::Parser::Files.stubs(:find_template).
       with(name, anything()).
       returns(full_name)
-    File.stubs(:read).with(full_name).returns(contents)
+    Puppet::FileSystem.stubs(:read_preserve_line_endings).with(full_name).returns(contents)
 
     full_name
   end


### PR DESCRIPTION
Previously, puppet's built in `file` and `template` functions would
read file contents using `File.read`. This would not cause problems
on *nix but could cause EOL conversion from `\r\n` to `\n` on Windows.

Add `Puppet::FileSystem.read_preserve_line_endings` for cases where line
endings are important and use `:mode => 'rb'` checking first against utf-8
encoding, falling back to default_external when not valid, and falling back
to `File.read` when all else fails.

Supersedes #3722 