### PR TITLE
(PUP-1291) Scheduled Tasks Support for Repeat Triggers

### DIFF
--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -76,7 +76,6 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
                   nil
                 end
       next unless trigger and scheduler_trigger_types.include?(trigger['trigger_type'])
-
       puppet_trigger = {}
       case trigger['trigger_type']
       when Win32::TaskScheduler::TASK_TIME_TRIGGER_DAILY
@@ -101,6 +100,8 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
       puppet_trigger['start_date'] = self.class.normalized_date("#{trigger['start_year']}-#{trigger['start_month']}-#{trigger['start_day']}")
       puppet_trigger['start_time'] = self.class.normalized_time("#{trigger['start_hour']}:#{trigger['start_minute']}")
       puppet_trigger['enabled']    = trigger['flags'] & Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED == 0
+      puppet_trigger['minutes_interval'] = trigger['minutes_interval'] ||= 0
+      puppet_trigger['minutes_duration'] = trigger['minutes_duration'] ||= 0
       puppet_trigger['index']      = i
 
       @triggers << puppet_trigger
@@ -209,7 +210,6 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   def create
     clear_task
     @task = Win32::TaskScheduler.new(resource[:name], dummy_time_trigger)
-
     self.command = resource[:command]
 
     [:arguments, :working_dir, :enabled, :trigger, :user].each do |prop|
@@ -239,6 +239,8 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
     desired['months']      ||= current_trigger['months']      if current_trigger.has_key?('months')
     desired['on']          ||= current_trigger['on']          if current_trigger.has_key?('on')
     desired['day_of_week'] ||= current_trigger['day_of_week'] if current_trigger.has_key?('day_of_week')
+    desired['minutes_interval'] ||= current_trigger['minutes_interval'] if current_trigger.has_key?('minutes_interval')
+    desired['minutes_duration'] ||= current_trigger['minutes_duration'] if current_trigger.has_key?('minutes_duration')
 
     translate_hash_to_trigger(current_trigger) == translate_hash_to_trigger(desired)
   end
@@ -258,10 +260,10 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
       'flags'                   => 0,
       'random_minutes_interval' => 0,
       'end_day'                 => 0,
-      "end_year"                => 0,
-      "minutes_interval"        => 0,
-      "end_month"               => 0,
-      "minutes_duration"        => 0,
+      'end_year'                => 0,
+      'minutes_interval'        => 0,
+      'end_month'               => 0,
+      'minutes_duration'        => 0,
       'start_year'              => now.year,
       'start_month'             => now.month,
       'start_day'               => now.day,
@@ -280,7 +282,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
       trigger['flags'] &= ~Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED
     end
 
-    extra_keys = puppet_trigger.keys.sort - ['index', 'enabled', 'schedule', 'start_date', 'start_time', 'every', 'months', 'on', 'which_occurrence', 'day_of_week']
+    extra_keys = puppet_trigger.keys.sort - ['index', 'enabled', 'schedule', 'start_date', 'start_time', 'every', 'months', 'on', 'which_occurrence', 'day_of_week', 'minutes_interval', 'minutes_duration']
     self.fail "Unknown trigger option(s): #{Puppet::Parameter.format_value_for_display(extra_keys)}" unless extra_keys.empty?
     self.fail "Must specify 'start_time' when defining a trigger" unless puppet_trigger['start_time']
 
@@ -331,6 +333,24 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
       trigger['trigger_type'] = Win32::TaskScheduler::ONCE
     else
       self.fail "Unknown schedule type: #{puppet_trigger["schedule"].inspect}"
+    end
+
+    integer_interval = -1
+    if puppet_trigger['minutes_interval']
+      integer_interval = Integer(puppet_trigger['minutes_interval'])
+      self.fail 'minutes_interval must be an integer greater or equal to 0' if integer_interval < 0
+      trigger['minutes_interval'] = integer_interval
+    end
+
+    integer_duration = -1
+    if puppet_trigger['minutes_duration']
+      integer_duration = Integer(puppet_trigger['minutes_duration'])
+      self.fail 'minutes_duration must be an integer greater than minutes_interval and equal to or greater than 0' if integer_duration <= integer_interval && integer_duration != 0
+      trigger['minutes_duration'] = integer_duration
+    end
+
+    if integer_interval >= integer_duration && integer_interval > 0
+      self.fail 'minutes_interval cannot be set without minutes_duration also being set to a number greater than 0'
     end
 
     if start_date = puppet_trigger['start_date']

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -92,30 +92,35 @@ Puppet::Type.newtype(:scheduled_task) do
       A trigger can contain the following keys:
 
       * For all triggers:
-          * `schedule` **(Required)** --- The schedule type. Valid values are
-            `daily`, `weekly`, `monthly`, or `once`.
+          * `schedule` **(Required)** --- What kind of trigger this is.
+            Valid values are `daily`, `weekly`, `monthly`, or `once`. Each kind
+            of trigger is configured with a different set of keys; see the
+            sections below. (`once` triggers only need a start time/date.)
           * `start_time` **(Required)** --- The time of day when the trigger should
             first become active. Several time formats will work, but we
             suggest 24-hour time formatted as HH:MM.
           * `start_date` ---  The date when the trigger should first become active.
             Defaults to the current date. You should format dates as YYYY-MM-DD,
             although other date formats may work. (Under the hood, this uses `Date.parse`.)
-      * For daily triggers:
+          * `minutes_interval` --- The repeat interval in minutes.
+          * `minutes_duration` --- The duration in minutes, needs to be greater than the
+            minutes_interval.
+      * For `daily` triggers:
           * `every` --- How often the task should run, as a number of days. Defaults
             to 1. ("2" means every other day, "3" means every three days, etc.)
-      * For weekly triggers:
+      * For `weekly` triggers:
           * `every` --- How often the task should run, as a number of weeks. Defaults
             to 1. ("2" means every other week, "3" means every three weeks, etc.)
           * `day_of_week` --- Which days of the week the task should run, as an array.
             Defaults to all days. Each day must be one of `mon`, `tues`,
             `wed`, `thurs`, `fri`, `sat`, `sun`, or `all`.
-      * For monthly-by-date triggers:
+      * For `monthly` (by date) triggers:
           * `months` --- Which months the task should run, as an array. Defaults to
             all months. Each month must be an integer between 1 and 12.
           * `on` **(Required)** --- Which days of the month the task should run,
             as an array. Each day must beeither an integer between 1 and 31,
             or the special value `last,` which is always the last day of the month.
-      * For monthly-by-weekday triggers:
+      * For `monthly` (by weekday) triggers:
           * `months` --- Which months the task should run, as an array. Defaults to
             all months. Each month must be an integer between 1 and 12.
           * `day_of_week` **(Required)** --- Which day of the week the task should
@@ -124,6 +129,7 @@ Puppet::Type.newtype(:scheduled_task) do
           * `which_occurrence` **(Required)** --- The occurrence of the chosen weekday
             when the task should run. Must be one of `first`, `second`, `third`,
             `fourth`, `fifth`, or `last`.
+
 
       Examples:
 
@@ -146,6 +152,15 @@ Puppet::Type.newtype(:scheduled_task) do
             months           => [1,3,5],      # Defaults to all
             which_occurrence => first,        # Must be specified
             day_of_week      => [mon],        # Must be specified
+          }
+
+          # Run daily repeating every 30 minutes between 9am and 5pm (480 minutes) starting after August 31st, 2011.
+          trigger => {
+            schedule         => daily,
+            start_date       => '2011-08-31', # Defaults to current date
+            start_time       => '8:00',       # Must be specified
+            minutes_interval => 30,
+            minutes_duration => 480,
           }
 
     EOT

--- a/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -143,13 +143,41 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
           })
 
           resource.provider.trigger.should == [{
-            'start_date' => '2011-9-12',
-            'start_time' => '13:20',
-            'schedule'   => 'daily',
-            'every'      => '2',
-            'enabled'    => true,
-            'index'      => 0,
+            'start_date'       => '2011-9-12',
+            'start_time'       => '13:20',
+            'schedule'         => 'daily',
+            'every'            => '2',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 0,
           }]
+        end
+
+        it 'should handle a single daily with repeat trigger' do
+          @mock_task.expects(:trigger).with(0).returns({
+            'trigger_type'     => Win32::TaskScheduler::TASK_TIME_TRIGGER_DAILY,
+            'start_year'       => 2011,
+            'start_month'      => 9,
+            'start_day'        => 12,
+            'start_hour'       => 13,
+            'start_minute'     => 20,
+            'minutes_interval' => 60,
+            'minutes_duration' => 180,
+            'flags'            => 0,
+            'type'             => { 'days_interval' => 2 },
+          })
+
+          expect(resource.provider.trigger).to eq([{
+            'start_date'       => '2011-9-12',
+            'start_time'       => '13:20',
+            'schedule'         => 'daily',
+            'every'            => '2',
+            'minutes_interval' => 60,
+            'minutes_duration' => 180,
+            'enabled'          => true,
+            'index'            => 0,
+          }])
         end
 
         it 'should handle a single weekly trigger' do
@@ -172,13 +200,15 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
           })
 
           resource.provider.trigger.should == [{
-            'start_date'  => '2011-9-12',
-            'start_time'  => '13:20',
-            'schedule'    => 'weekly',
-            'every'       => '2',
-            'day_of_week' => ['sun', 'mon', 'wed', 'fri'],
-            'enabled'     => true,
-            'index'       => 0,
+            'start_date'       => '2011-9-12',
+            'start_time'       => '13:20',
+            'schedule'         => 'weekly',
+            'every'            => '2',
+            'day_of_week'      => ['sun', 'mon', 'wed', 'fri'],
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 0,
           }]
         end
 
@@ -205,13 +235,15 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
           })
 
           resource.provider.trigger.should == [{
-            'start_date' => '2011-9-12',
-            'start_time' => '13:20',
-            'schedule'   => 'monthly',
-            'months'     => [1, 2, 8, 9, 12],
-            'on'         => [1, 3, 5, 15, 'last'],
-            'enabled'    => true,
-            'index'      => 0,
+            'start_date'       => '2011-9-12',
+            'start_time'       => '13:20',
+            'schedule'         => 'monthly',
+            'months'           => [1, 2, 8, 9, 12],
+            'on'               => [1, 3, 5, 15, 'last'],
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 0,
           }]
         end
 
@@ -247,6 +279,8 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
             'months'           => [1, 2, 8, 9, 12],
             'which_occurrence' => 'first',
             'day_of_week'      => ['sun', 'mon', 'wed', 'fri'],
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
             'enabled'          => true,
             'index'            => 0,
           }]
@@ -264,11 +298,13 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
           })
 
           resource.provider.trigger.should == [{
-            'start_date' => '2011-9-12',
-            'start_time' => '13:20',
-            'schedule'   => 'once',
-            'enabled'    => true,
-            'index'      => 0,
+            'start_date'       => '2011-9-12',
+            'start_time'       => '13:20',
+            'schedule'         => 'once',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 0,
           }]
         end
       end
@@ -305,27 +341,100 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
 
         resource.provider.trigger.should =~ [
           {
-            'start_date' => '2011-10-13',
-            'start_time' => '14:21',
-            'schedule'   => 'once',
-            'enabled'    => true,
-            'index'      => 0,
+            'start_date'       => '2011-10-13',
+            'start_time'       => '14:21',
+            'schedule'         => 'once',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 0,
           },
           {
-            'start_date' => '2012-11-14',
-            'start_time' => '15:22',
-            'schedule'   => 'once',
-            'enabled'    => true,
-            'index'      => 1,
+            'start_date'       => '2012-11-14',
+            'start_time'       => '15:22',
+            'schedule'         => 'once',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 1,
           },
           {
-            'start_date' => '2013-12-15',
-            'start_time' => '16:23',
-            'schedule'   => 'once',
-            'enabled'    => true,
-            'index'      => 2,
+            'start_date'       => '2013-12-15',
+            'start_time'       => '16:23',
+            'schedule'         => 'once',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 2,
           }
         ]
+      end
+
+      it 'should handle multiple triggers with repeat triggers' do
+        @mock_task.expects(:trigger_count).returns(3)
+        @mock_task.expects(:trigger).with(0).returns({
+          'trigger_type'     => Win32::TaskScheduler::TASK_TIME_TRIGGER_ONCE,
+          'start_year'       => 2011,
+          'start_month'      => 10,
+          'start_day'        => 13,
+          'start_hour'       => 14,
+          'start_minute'     => 21,
+          'minutes_interval' => 15,
+          'minutes_duration' => 60,
+          'flags'            => 0,
+        })
+        @mock_task.expects(:trigger).with(1).returns({
+          'trigger_type'     => Win32::TaskScheduler::TASK_TIME_TRIGGER_ONCE,
+          'start_year'       => 2012,
+          'start_month'      => 11,
+          'start_day'        => 14,
+          'start_hour'       => 15,
+          'start_minute'     => 22,
+          'minutes_interval' => 30,
+          'minutes_duration' => 120,
+          'flags'            => 0,
+        })
+        @mock_task.expects(:trigger).with(2).returns({
+          'trigger_type'     => Win32::TaskScheduler::TASK_TIME_TRIGGER_ONCE,
+          'start_year'       => 2013,
+          'start_month'      => 12,
+          'start_day'        => 15,
+          'start_hour'       => 16,
+          'start_minute'     => 23,
+          'minutes_interval' => 60,
+          'minutes_duration' => 240,
+          'flags'            => 0,
+        })
+
+        expect(resource.provider.trigger).to match_array([
+          {
+            'start_date'       => '2011-10-13',
+            'start_time'       => '14:21',
+            'schedule'         => 'once',
+            'minutes_interval' => 15,
+            'minutes_duration' => 60,
+            'enabled'          => true,
+            'index'            => 0,
+          },
+          {
+            'start_date'       => '2012-11-14',
+            'start_time'       => '15:22',
+            'schedule'         => 'once',
+            'minutes_interval' => 30,
+            'minutes_duration' => 120,
+            'enabled'          => true,
+            'index'            => 1,
+          },
+          {
+            'start_date'       => '2013-12-15',
+            'start_time'       => '16:23',
+            'schedule'         => 'once',
+            'minutes_interval' => 60,
+            'minutes_duration' => 240,
+            'enabled'          => true,
+            'index'            => 2,
+          }
+        ])
       end
 
       it 'should skip triggers Win32::TaskScheduler cannot handle' do
@@ -354,18 +463,22 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
 
         resource.provider.trigger.should =~ [
           {
-            'start_date' => '2011-10-13',
-            'start_time' => '14:21',
-            'schedule'   => 'once',
-            'enabled'    => true,
-            'index'      => 0,
+            'start_date'       => '2011-10-13',
+            'start_time'       => '14:21',
+            'schedule'         => 'once',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 0,
           },
           {
-            'start_date' => '2013-12-15',
-            'start_time' => '16:23',
-            'schedule'   => 'once',
-            'enabled'    => true,
-            'index'      => 2,
+            'start_date'       => '2013-12-15',
+            'start_time'       => '16:23',
+            'schedule'         => 'once',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 2,
           }
         ]
       end
@@ -396,18 +509,22 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
 
         resource.provider.trigger.should =~ [
           {
-            'start_date' => '2011-10-13',
-            'start_time' => '14:21',
-            'schedule'   => 'once',
-            'enabled'    => true,
-            'index'      => 0,
+            'start_date'       => '2011-10-13',
+            'start_time'       => '14:21',
+            'schedule'         => 'once',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 0,
           },
           {
-            'start_date' => '2013-12-15',
-            'start_time' => '16:23',
-            'schedule'   => 'once',
-            'enabled'    => true,
-            'index'      => 2,
+            'start_date'       => '2013-12-15',
+            'start_time'       => '16:23',
+            'schedule'         => 'once',
+            'minutes_interval' => 0,
+            'minutes_duration' => 0,
+            'enabled'          => true,
+            'index'            => 2,
           }
         ]
       end
@@ -529,11 +646,13 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
       })
 
       mock_task_trigger = {
-        'start_date' => '2011-10-13',
-        'start_time' => '14:21',
-        'schedule'   => 'once',
-        'enabled'    => true,
-        'index'      => 0,
+        'start_date'       => '2011-10-13',
+        'start_time'       => '14:21',
+        'schedule'         => 'once',
+        'minutes_interval' => 0,
+        'minutes_duration' => 0,
+        'enabled'          => true,
+        'index'            => 0,
       }
 
       resource.provider.trigger.should == [mock_task_trigger]
@@ -542,11 +661,13 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
       resource.provider.clear_task
 
       resource.provider.trigger.should == [{
-        'start_date' => '2012-11-14',
-        'start_time' => '15:22',
-        'schedule'   => 'once',
-        'enabled'    => true,
-        'index'      => 0,
+        'start_date'       => '2012-11-14',
+        'start_time'       => '15:22',
+        'schedule'         => 'once',
+        'minutes_interval' => 0,
+        'minutes_duration' => 0,
+        'enabled'          => true,
+        'index'            => 0,
       }]
     end
   end
@@ -1044,6 +1165,130 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
     end
     let(:provider) { described_class.new(:name => 'Test Task', :command => 'C:\Windows\System32\notepad.exe') }
     let(:trigger)  { provider.translate_hash_to_trigger(@puppet_trigger) }
+
+    context "working with repeat every x triggers" do
+      before :each do
+        @puppet_trigger['schedule'] = 'once'
+      end
+
+      it 'should succeed if minutes_interval is equal to 0' do
+        @puppet_trigger['minutes_interval'] = '0'
+
+        expect(trigger['minutes_interval']).to eq(0)
+      end
+
+      it 'should fail if minutes_interval is greater than 0 without setting minutes_duration' do
+        @puppet_trigger['minutes_interval'] = '1'
+
+        expect { trigger }.to raise_error(
+          Puppet::Error,
+          'minutes_interval cannot be set without minutes_duration also being set to a number greater than 0'
+        )
+      end
+
+      it 'should succeed if minutes_interval is greater than 0 and minutes_duration is also set' do
+        @puppet_trigger['minutes_interval'] = '1'
+        @puppet_trigger['minutes_duration'] = '2'
+
+        expect(trigger['minutes_interval']).to eq(1)
+      end
+
+      it 'should fail if minutes_interval is less than 0' do
+        @puppet_trigger['minutes_interval'] = '-1'
+
+        expect { trigger }.to raise_error(
+          Puppet::Error,
+          'minutes_interval must be an integer greater or equal to 0'
+        )
+      end
+
+      it 'should fail if minutes_interval is not an integer' do
+        @puppet_trigger['minutes_interval'] = 'abc'
+        expect { trigger }.to raise_error(ArgumentError)
+      end
+
+      it 'should succeed if minutes_duration is equal to 0' do
+        @puppet_trigger['minutes_duration'] = '0'
+        expect(trigger['minutes_duration']).to eq(0)
+      end
+
+      it 'should succeed if minutes_duration is greater than 0' do
+        @puppet_trigger['minutes_duration'] = '1'
+        expect(trigger['minutes_duration']).to eq(1)
+      end
+
+      it 'should fail if minutes_duration is less than 0' do
+        @puppet_trigger['minutes_duration'] = '-1'
+
+        expect { trigger }.to raise_error(
+          Puppet::Error,
+          'minutes_duration must be an integer greater than minutes_interval and equal to or greater than 0'
+        )
+      end
+
+      it 'should fail if minutes_duration is not an integer' do
+        @puppet_trigger['minutes_duration'] = 'abc'
+        expect { trigger }.to raise_error(ArgumentError)
+      end
+
+      it 'should succeed if minutes_duration is equal to a full day' do
+        @puppet_trigger['minutes_duration'] = '1440'
+        expect(trigger['minutes_duration']).to eq(1440)
+      end
+
+      it 'should succeed if minutes_duration is equal to three days' do
+        @puppet_trigger['minutes_duration'] = '4320'
+        expect(trigger['minutes_duration']).to eq(4320)
+      end
+
+      it 'should succeed if minutes_duration is greater than minutes_duration' do
+        @puppet_trigger['minutes_interval'] = '10'
+        @puppet_trigger['minutes_duration'] = '11'
+
+        expect(trigger['minutes_interval']).to eq(10)
+        expect(trigger['minutes_duration']).to eq(11)
+      end
+
+      it 'should fail if minutes_duration is equal to minutes_interval' do
+        # On Windows 2003, the duration must be greater than the interval
+        # on other platforms the values can be equal.
+        @puppet_trigger['minutes_interval'] = '10'
+        @puppet_trigger['minutes_duration'] = '10'
+
+        expect { trigger }.to raise_error(
+          Puppet::Error,
+          'minutes_duration must be an integer greater than minutes_interval and equal to or greater than 0'
+        )
+      end
+
+      it 'should succeed if minutes_duration and minutes_interval are both set to 0' do
+        @puppet_trigger['minutes_interval'] = '0'
+        @puppet_trigger['minutes_duration'] = '0'
+
+        expect(trigger['minutes_interval']).to eq(0)
+        expect(trigger['minutes_duration']).to eq(0)
+      end
+
+      it 'should fail if minutes_duration is less than minutes_interval' do
+        @puppet_trigger['minutes_interval'] = '10'
+        @puppet_trigger['minutes_duration'] = '9'
+
+        expect { trigger }.to raise_error(
+          Puppet::Error,
+          'minutes_duration must be an integer greater than minutes_interval and equal to or greater than 0'
+        )
+      end
+
+      it 'should fail if minutes_duration is less than minutes_interval and set to 0' do
+        @puppet_trigger['minutes_interval'] = '10'
+        @puppet_trigger['minutes_duration'] = '0'
+
+        expect { trigger }.to raise_error(
+          Puppet::Error,
+          'minutes_interval cannot be set without minutes_duration also being set to a number greater than 0'
+        )
+      end
+    end
 
     describe 'when given a one-time trigger' do
       before :each do


### PR DESCRIPTION
Previously, the scheduled_task resource did not support repetition for anything
less than 1 day. This is limiting as the cron resource can support repetition
in minutes. Task scheduler on Windows can support repeating tasks every x
number of minutes, and the win32-taskscheduler gem also allows this.

Allow Puppet's scheduled_task resource to support repetition every x number of
minutes. Without this change the schedule resource continues to be more limited
than on other platforms.

This supersedes #3747 - branch retargeted