### PR TITLE
(PUP-4122) Update future_parser? to accept environment

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -259,9 +259,13 @@ module Puppet
   # The single instance used for normal operation
   @context = Puppet::Context.new(bootstrap_context)
 
-  def self.future_parser?
-    env = Puppet.lookup(:current_environment) { return Puppet[:parser] == 'future' }
-    env_conf = Puppet.lookup(:environments).get_conf(env.name)
+  def self.future_parser?(in_env = nil)
+    if in_env
+      env_conf = Puppet.lookup(:environments).get_conf(in_env)
+    else
+      env = Puppet.lookup(:current_environment) { return Puppet[:parser] == 'future' }
+      env_conf = Puppet.lookup(:environments).get_conf(env.name)
+    end
 
     if env_conf.nil?
       # Case for non-directory environments


### PR DESCRIPTION
Prior to this commit the Puppet.future_parser? method only worked
with the current environment. So that we can do validation around
the parser setting in puppet preview, update the method so it can
accept an environment as an argument and check the parser setting
for that specific environment.