### PR TITLE
(PUP-4336) Fix issues with trace and structured logging

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -594,10 +594,6 @@ module Puppet::Pops::Issues
     "Unrecognized escape sequence '\\#{ch}'"
   end
 
-  UNRECOGNIZED_QUOTE = hard_issue :UNRECOGNIZED_QUOTE, :followed_by do
-    "Unclosed quote after \"'\" followed by '#{followed_by}'"
-  end
-
   UNCLOSED_QUOTE = hard_issue :UNCLOSED_QUOTE, :after, :followed_by do
     "Unclosed quote after #{after} followed by '#{followed_by}'"
   end
@@ -624,10 +620,6 @@ module Puppet::Pops::Issues
 
   HEREDOC_WITHOUT_END_TAGGED_LINE = hard_issue :HEREDOC_WITHOUT_END_TAGGED_LINE do
     'Heredoc without end-tagged line'
-  end
-
-  HEREDOC_MISSING_END_TAG = hard_issue :HEREDOC_MISSING_END_TAG do
-    'Missing end tag in heredoc'
   end
 
   HEREDOC_INVALID_ESCAPE = hard_issue :HEREDOC_INVALID_ESCAPE, :actual do

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -545,4 +545,21 @@ module Puppet::Pops::Issues
   MULTIPLE_ATTRIBUTES_UNFOLD = hard_issue :MULTIPLE_ATTRIBUTES_UNFOLD do
     "Unfolding of attributes from Hash can only be used once per resource body"
   end
+
+  SYNTAX_ERROR = hard_issue :SYNTAX_ERROR, :where do
+    "Syntax error at #{where}"
+  end
+
+  LEX_ERROR = hard_issue :LEX_ERROR do
+    # Error here for completeness. It's never printed
+    "Unable to create lexical token stream"
+  end
+
+  ILLEGAL_UNICODE_ESCAPE = issue :ILLEGAL_UNICODE_ESCAPE do
+    "Unicode escape '\\u' was not followed by 4 hex digits"
+  end
+
+  UNRECOGNIZED_ESCAPE = issue :UNRECOGNIZED_ESCAPE, :ch do
+    "Unrecognized escape sequence '\\#{ch}'"
+  end
 end

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -550,16 +550,99 @@ module Puppet::Pops::Issues
     "Syntax error at #{where}"
   end
 
-  LEX_ERROR = hard_issue :LEX_ERROR do
-    # Error here for completeness. It's never printed
-    "Unable to create lexical token stream"
+  ILLEGAL_CLASS_REFERENCE = hard_issue :ILLEGAL_CLASS_REFERENCE do
+    'Illegal class reference'
+  end
+
+  ILLEGAL_FULLY_QUALIFIED_CLASS_REFERENCE = hard_issue :ILLEGAL_FULLY_QUALIFIED_CLASS_REFERENCE do
+    'Illegal fully qualified class reference'
+  end
+
+  ILLEGAL_FULLY_QUALIFIED_NAME = hard_issue :ILLEGAL_FULLY_QUALIFIED_NAME do
+    'Illegal fully qualified name'
+  end
+
+  ILLEGAL_NAME_OR_BARE_WORD = hard_issue :ILLEGAL_NAME_OR_BARE_WORD do
+    'Illegal name or bare word'
+  end
+
+  ILLEGAL_NUMBER = hard_issue :ILLEGAL_NUMBER do
+    'Illegal number'
   end
 
   ILLEGAL_UNICODE_ESCAPE = issue :ILLEGAL_UNICODE_ESCAPE do
     "Unicode escape '\\u' was not followed by 4 hex digits"
   end
 
+  INVALID_HEX_NUMBER = hard_issue :INVALID_HEX_NUMBER, :value do
+    "Not a valid hex number #{value}"
+  end
+
+  INVALID_OCTAL_NUMBER = hard_issue :INVALID_OCTAL_NUMBER, :value do
+    "Not a valid octal number #{value}"
+  end
+
+  INVALID_DECIMAL_NUMBER = hard_issue :INVALID_DECIMAL_NUMBER, :value do
+    "Not a valid decimal number #{value}"
+  end
+
+  NO_INPUT_TO_LEXER = hard_issue :NO_INPUT_TO_LEXER do
+    "Internal Error: No string or file given to lexer to process."
+  end
+
   UNRECOGNIZED_ESCAPE = issue :UNRECOGNIZED_ESCAPE, :ch do
     "Unrecognized escape sequence '\\#{ch}'"
+  end
+
+  UNRECOGNIZED_QUOTE = hard_issue :UNRECOGNIZED_QUOTE, :followed_by do
+    "Unclosed quote after \"'\" followed by '#{followed_by}'"
+  end
+
+  UNCLOSED_QUOTE = hard_issue :UNCLOSED_QUOTE, :after, :followed_by do
+    "Unclosed quote after #{after} followed by '#{followed_by}'"
+  end
+
+  EPP_INTERNAL_ERROR = hard_issue :EPP_INTERNAL_ERROR, :error do
+    "Internal error: #{error}"
+  end
+
+  EPP_UNBALANCED_TAG = hard_issue :EPP_UNBALANCED_TAG do
+    'Unbalanced epp tag, reached <eof> without closing tag.'
+  end
+
+  EPP_UNBALANCED_COMMENT = hard_issue :EPP_UNBALANCED_COMMENT do
+    'Reaching end after opening <%# without seeing %>'
+  end
+
+  EPP_UNBALANCED_EXPRESSION = hard_issue :EPP_UNBALANCED_EXPRESSION do
+    'Unbalanced embedded expression - opening <% and reaching end of input'
+  end
+
+  HEREDOC_UNCLOSED_PARENTHESIS = hard_issue :HEREDOC_UNCLOSED_PARENTHESIS, :followed_by do
+    "Unclosed parenthesis after '@(' followed by '#{followed_by}'"
+  end
+
+  HEREDOC_WITHOUT_END_TAGGED_LINE = hard_issue :HEREDOC_WITHOUT_END_TAGGED_LINE do
+    'Heredoc without end-tagged line'
+  end
+
+  HEREDOC_MISSING_END_TAG = hard_issue :HEREDOC_MISSING_END_TAG do
+    'Missing end tag in heredoc'
+  end
+
+  HEREDOC_INVALID_ESCAPE = hard_issue :HEREDOC_INVALID_ESCAPE, :actual do
+    "Invalid heredoc escape char. Only t, r, n, s,  u, L, $ allowed. Got '#{actual}'"
+  end
+
+  HEREDOC_INVALID_SYNTAX = hard_issue :HEREDOC_INVALID_SYNTAX do
+    'Invalid syntax in heredoc expected @(endtag[:syntax][/escapes])'
+  end
+
+  HEREDOC_WITHOUT_TEXT = hard_issue :HEREDOC_WITHOUT_TEXT do
+    'Heredoc without any following lines of text'
+  end
+
+  HEREDOC_MULTIPLE_AT_ESCAPES = hard_issue :HEREDOC_MULTIPLE_AT_ESCAPES, :escapes do
+    "An escape char for @() may only appear once. Got '#{escapes.join(', ')}'"
   end
 end

--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -20,6 +20,8 @@ class Puppet::Pops::Parser::EvaluatingParser
     #
     begin
       assert_and_report(parser.parse_string(s))
+    rescue Puppet::ParseErrorWithIssue => e
+      raise e
     rescue Puppet::ParseError => e
       # TODO: This is not quite right, why does not the exception have the correct file?
       e.file = @file_source unless e.file.is_a?(String) && !e.file.empty?

--- a/lib/puppet/pops/parser/heredoc_support.rb
+++ b/lib/puppet/pops/parser/heredoc_support.rb
@@ -1,4 +1,5 @@
 module Puppet::Pops::Parser::HeredocSupport
+  include Puppet::Pops::Parser::LexerSupport
 
   # Pattern for heredoc `@(endtag[:syntax][/escapes])
   # Produces groups for endtag (group 1), syntax (group 2), and escapes (group 3)
@@ -14,7 +15,7 @@ module Puppet::Pops::Parser::HeredocSupport
 
     # scanner is at position before @(
     # find end of the heredoc spec
-    str = scn.scan_until(/\)/) || lexer.lex_error(Puppet::Pops::Issues::HEREDOC_UNCLOSED_PARENTHESIS, :followed_by => followed_by)
+    str = scn.scan_until(/\)/) || lex_error(Puppet::Pops::Issues::HEREDOC_UNCLOSED_PARENTHESIS, :followed_by => followed_by)
     pos_after_heredoc = scn.pos
 
     # Note: allows '+' as separator in syntax, but this needs validation as empty segments are not allowed
@@ -32,7 +33,7 @@ module Puppet::Pops::Parser::HeredocSupport
       endtag = $1.strip
     end
 
-    lexer.lex_error(Puppet::Pops::Issues::HEREDOC_MISSING_ENDTAG) unless endtag.length >= 1
+    lex_error(Puppet::Pops::Issues::HEREDOC_MISSING_ENDTAG) unless endtag.length >= 1
 
     resulting_escapes = []
     if escapes

--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -274,7 +274,7 @@ class Puppet::Pops::Parser::Lexer2
     ctx   = @lexing_context
     queue = @token_queue
 
-    lex_error_without_pos("Internal Error: No string or file given to lexer to process.") unless scn
+    lex_error_without_pos(Puppet::Pops::Issues::NO_INPUT_TO_LEXER) unless scn
 
     scn.skip(PATTERN_WS)
 
@@ -533,7 +533,7 @@ class Puppet::Pops::Parser::Lexer2
           else
             # move to faulty position ('::<uc-letter>' was ok)
             scn.pos = scn.pos + 3
-            lex_error("Illegal fully qualified class reference")
+            lex_error(Puppet::Pops::Issues::ILLEGAL_FULLY_QUALIFIED_CLASS_REFERENCE)
           end
         else
           value = scn.scan(PATTERN_BARE_WORD)
@@ -546,7 +546,7 @@ class Puppet::Pops::Parser::Lexer2
           else
             # move to faulty position ('::' was ok)
             scn.pos = scn.pos + 2
-            lex_error("Illegal fully qualified name")
+            lex_error(Puppet::Pops::Issues::ILLEGAL_FULLY_QUALIFIED_NAME)
           end
         end
       else
@@ -578,7 +578,7 @@ class Puppet::Pops::Parser::Lexer2
       else
         # move to faulty position ([0-9] was ok)
         scn.pos = scn.pos + 1
-        lex_error("Illegal number")
+        lex_error(Puppet::Pops::Issues::ILLEGAL_NUMBER)
       end
 
     when 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -594,9 +594,9 @@ class Puppet::Pops::Parser::Lexer2
         scn.pos = scn.pos + 1
         fully_qualified = scn.match?(/::/)
         if fully_qualified
-          lex_error("Illegal fully qualified name")
+          lex_error(Puppet::Pops::Issues::ILLEGAL_FULLY_QUALIFIED_NAME)
         else
-          lex_error("Illegal name or bare word")
+          lex_error(Puppet::Pops::Issues::ILLEGAL_NAME_OR_BARE_WORD)
         end
       end
 
@@ -608,7 +608,7 @@ class Puppet::Pops::Parser::Lexer2
       else
         # move to faulty position ([A-Z] was ok)
         scn.pos = scn.pos + 1
-        lex_error("Illegal class reference")
+        lex_error(Puppet::Pops::Issues::ILLEGAL_CLASS_REFERENCE)
       end
 
     when "\n"

--- a/lib/puppet/pops/parser/slurp_support.rb
+++ b/lib/puppet/pops/parser/slurp_support.rb
@@ -21,7 +21,7 @@ module Puppet::Pops::Parser::SlurpSupport
     # skip the leading '
     @scanner.pos += 1
     str = slurp(@scanner, SLURP_SQ_PATTERN, SQ_ESCAPES, :ignore_invalid_escapes)
-    lex_error(Puppet::Pops::Issues::UNRECOGNIZED_QUOTE, :followed_by => followed_by) unless str
+    lex_error(Puppet::Pops::Issues::UNCLOSED_QUOTE, :after => "\"'\"", :followed_by => followed_by) unless str
     str[0..-2] # strip closing "'" from result
   end
 

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -107,7 +107,7 @@ Puppet::Util::Log.newdesttype :file do
   def handle(msg)
     if @json > 0
       @json > 1 ? @file.puts(',') : @json = 2
-      JSON.dump(msg.to_hash, @file)
+      JSON.dump(msg.to_structured_hash, @file)
     else
       @file.puts("#{msg.time} #{msg.source} (#{msg.level}): #{msg}")
     end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1100,7 +1100,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     it "a lex error should be raised for '$foo::::bar'" do
-      expect { parser.evaluate_string(scope, "$foo::::bar") }.to raise_error(Puppet::LexError, /Illegal fully qualified name at line 1:7/)
+      expect { parser.evaluate_string(scope, "$foo::::bar") }.to raise_error(Puppet::ParseErrorWithIssue, /Illegal fully qualified name at line 1:7/)
     end
 
     { '$a = $0'   => nil,

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -361,6 +361,63 @@ describe 'Lexer2' do
         [:DQPOST, " After"]
         )
     end
+
+    context 'with bad syntax' do
+      def expect_issue(code, issue)
+        expect { tokens_scanned_from(code) }.to raise_error(Puppet::ParseErrorWithIssue) { |e|
+          expect(e.issue_code).to be(issue.issue_code)
+        }
+      end
+
+      it 'detects and reports HEREDOC_UNCLOSED_PARENTHESIS' do
+        code = <<-CODE
+        @(END:syntax/t
+        Text
+        |- END
+        CODE
+        expect_issue(code, Puppet::Pops::Issues::HEREDOC_UNCLOSED_PARENTHESIS)
+      end
+
+      it 'detects and reports HEREDOC_WITHOUT_END_TAGGED_LINE' do
+        code = <<-CODE
+        @(END:syntax/t)
+        Text
+        CODE
+        expect_issue(code, Puppet::Pops::Issues::HEREDOC_WITHOUT_END_TAGGED_LINE)
+      end
+
+      it 'detects and reports HEREDOC_INVALID_ESCAPE' do
+        code = <<-CODE
+        @(END:syntax/x)
+        Text
+        |- END
+        CODE
+        expect_issue(code, Puppet::Pops::Issues::HEREDOC_INVALID_ESCAPE)
+      end
+
+      it 'detects and reports HEREDOC_INVALID_SYNTAX' do
+        code = <<-CODE
+        @(END:syntax/t/p)
+        Text
+        |- END
+        CODE
+        expect_issue(code, Puppet::Pops::Issues::HEREDOC_INVALID_SYNTAX)
+      end
+
+      it 'detects and reports HEREDOC_WITHOUT_TEXT' do
+        code = '@(END:syntax/t)'
+        expect_issue(code, Puppet::Pops::Issues::HEREDOC_WITHOUT_TEXT)
+      end
+
+      it 'detects and reports HEREDOC_MULTIPLE_AT_ESCAPES' do
+        code = <<-CODE
+        @(END:syntax/tst)
+        Tex\\tt\\n
+        |- END
+        CODE
+        expect_issue(code, Puppet::Pops::Issues::HEREDOC_MULTIPLE_AT_ESCAPES)
+      end
+    end
   end
 
   context 'when dealing with multi byte characters' do
@@ -487,6 +544,75 @@ describe 'Lexer2' do
       [:RENDER_STRING, "<% this is escaped epp %>\n"]
       )
     end
+
+    context 'with bad epp syntax' do
+      def expect_issue(code, issue)
+        expect { epp_tokens_scanned_from(code) }.to raise_error(Puppet::ParseErrorWithIssue) { |e|
+          expect(e.issue_code).to be(issue.issue_code)
+        }
+      end
+
+      it 'detects and reports EPP_UNBALANCED_TAG' do
+        expect_issue('<% asf', Puppet::Pops::Issues::EPP_UNBALANCED_TAG)
+      end
+
+      it 'detects and reports EPP_UNBALANCED_COMMENT' do
+        expect_issue('<%# asf', Puppet::Pops::Issues::EPP_UNBALANCED_COMMENT)
+      end
+
+      it 'detects and reports EPP_UNBALANCED_EXPRESSION' do
+        expect_issue('asf <%', Puppet::Pops::Issues::EPP_UNBALANCED_EXPRESSION)
+      end
+    end
+  end
+
+  context 'when parsing bad code' do
+    def expect_issue(code, issue)
+      expect { tokens_scanned_from(code) }.to raise_error(Puppet::ParseErrorWithIssue) do |e|
+        expect(e.issue_code).to be(issue.issue_code)
+      end
+    end
+
+    it 'detects and reports issue ILLEGAL_CLASS_REFERENCE' do
+      expect_issue('A::3', Puppet::Pops::Issues::ILLEGAL_CLASS_REFERENCE)
+    end
+
+    it 'detects and reports issue ILLEGAL_FULLY_QUALIFIED_CLASS_REFERENCE' do
+      expect_issue('::A::3', Puppet::Pops::Issues::ILLEGAL_FULLY_QUALIFIED_CLASS_REFERENCE)
+    end
+
+    it 'detects and reports issue ILLEGAL_FULLY_QUALIFIED_NAME' do
+      expect_issue('::a::3', Puppet::Pops::Issues::ILLEGAL_FULLY_QUALIFIED_NAME)
+    end
+
+    it 'detects and reports issue ILLEGAL_NAME_OR_BARE_WORD' do
+      expect_issue('a::3', Puppet::Pops::Issues::ILLEGAL_NAME_OR_BARE_WORD)
+    end
+
+    it 'detects and reports issue ILLEGAL_NUMBER' do
+     expect_issue('3g', Puppet::Pops::Issues::ILLEGAL_NUMBER)
+    end
+
+    it 'detects and reports issue INVALID_HEX_NUMBER' do
+      expect_issue('0x3g', Puppet::Pops::Issues::INVALID_HEX_NUMBER)
+    end
+
+    it 'detects and reports issue INVALID_OCTAL_NUMBER' do
+      expect_issue('038', Puppet::Pops::Issues::INVALID_OCTAL_NUMBER)
+    end
+
+    it 'detects and reports issue INVALID_DECIMAL_NUMBER' do
+      expect_issue('4.3g', Puppet::Pops::Issues::INVALID_DECIMAL_NUMBER)
+    end
+
+    it 'detects and reports issue NO_INPUT_TO_LEXER' do
+      expect { Puppet::Pops::Parser::Lexer2.new.fullscan }.to raise_error(Puppet::ParseErrorWithIssue) { |e|
+        expect(e.issue_code).to be(Puppet::Pops::Issues::NO_INPUT_TO_LEXER.issue_code)
+      }
+    end
+
+    it 'detects and reports issue UNCLOSED_QUOTE' do
+      expect_issue('"asd', Puppet::Pops::Issues::UNCLOSED_QUOTE)
+    end
   end
 end
-

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -93,7 +93,84 @@ describe Puppet::Util::Log do
 
       expect(logs.collect(&:message)).to include("Inner block", "Outer block")
     end
+
+    it 'includes backtrace for RuntimeError in log message when trace is enabled' do
+      logs = []
+      destination = Puppet::Test::LogCollector.new(logs)
+
+      Puppet::Util::Log.newdestination(destination)
+      Puppet::Util::Log.with_destination(destination) do
+        begin
+          raise RuntimeError, 'Oops'
+        rescue RuntimeError => e
+          Puppet.log_exception(e, :default, :trace => true)
+        end
+      end
+      expect(logs.size).to eq(1)
+      log = logs[0]
+      expect(log.message).to match('/log_spec.rb')
+      expect(log.backtrace).to be_nil
+    end
+
+    it 'excludes backtrace for ParseErrorWithIssue from log message when trace is enabled' do
+      logs = []
+      destination = Puppet::Test::LogCollector.new(logs)
+
+      Puppet::Util::Log.newdestination(destination)
+      Puppet::Util::Log.with_destination(destination) do
+        begin
+          raise Puppet::ParseErrorWithIssue.new('Oops', '/tmp/test.pp', 30, 15, nil, :SYNTAX_ERROR)
+        rescue RuntimeError => e
+          Puppet.log_exception(e, :default, :trace => true)
+        end
+      end
+      expect(logs.size).to eq(1)
+      log = logs[0]
+      expect(log.message).to_not match('/log_spec.rb')
+      expect(log.backtrace).to be_a(Array)
+    end
+
+    it 'includes position details for ParseError in log message' do
+      logs = []
+      destination = Puppet::Test::LogCollector.new(logs)
+
+      Puppet::Util::Log.newdestination(destination)
+      Puppet::Util::Log.with_destination(destination) do
+        begin
+          raise Puppet::ParseError.new('Oops', '/tmp/test.pp', 30, 15)
+        rescue RuntimeError => e
+          Puppet.log_exception(e)
+        end
+      end
+      expect(logs.size).to eq(1)
+      log = logs[0]
+      expect(log.message).to match(/ at \/tmp\/test\.pp:30:15/)
+      expect(log.message).to be(log.to_s)
+    end
+
+    it 'excludes position details for ParseErrorWithIssue from log message' do
+      logs = []
+      destination = Puppet::Test::LogCollector.new(logs)
+
+      Puppet::Util::Log.newdestination(destination)
+      Puppet::Util::Log.with_destination(destination) do
+        begin
+          raise Puppet::ParseErrorWithIssue.new('Oops', '/tmp/test.pp', 30, 15, nil, :SYNTAX_ERROR)
+        rescue RuntimeError => e
+          Puppet.log_exception(e)
+        end
+      end
+      expect(logs.size).to eq(1)
+      log = logs[0]
+      expect(log.message).to_not match(/ at \/tmp\/test\.pp:30:15/)
+      expect(log.to_s).to match(/ at \/tmp\/test\.pp:30:15/)
+      expect(log.issue_code).to eq(:SYNTAX_ERROR)
+      expect(log.file).to eq('/tmp/test.pp')
+      expect(log.line).to eq(30)
+      expect(log.pos).to eq(15)
+    end
   end
+
   describe Puppet::Util::Log::DestConsole do
     before do
       @console = Puppet::Util::Log::DestConsole.new


### PR DESCRIPTION
This commit ensures that trace is output correctly for errors
that origins from the future parser. It also adds four new issues
related to the lexer and ensures that the errors and warnings related
to them are generated using the improved structured logging.