### PR TITLE
(PUP-4362) fix portage to list all installed packages

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -132,7 +132,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
   private
   def self.eix_search_format
-    "'<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] <homepage> <description>'"
+    "'<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] <homepage> <description>\n'"
   end
 
   def self.eix_result_format


### PR DESCRIPTION
In commit 9e7bf07580d79e5b68d28cc594162959cf2a8d7d, portage.rb was
refactored, but from this on, puppet resource package only lists
packages installed by puppet, but no packages installed by hand.
The other providers apt/dpkg and yum/rpm list _all_ installed packages.
The format string in portage.rb:L123 misses a tailing \n.