### PR TITLE
(PUP-1628) Fix mount provider for AIX

### DIFF
--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -4,6 +4,7 @@ require 'puppet/provider/mount'
 fstab = nil
 case Facter.value(:osfamily)
 when "Solaris"; fstab = "/etc/vfstab"
+when "AIX"; fstab = "/etc/filesystems"
 else
   fstab = "/etc/fstab"
 end
@@ -25,7 +26,12 @@ Puppet::Type.type(:mount).provide(
     @fields = [:device, :name, :fstype, :options, :dump, :pass]
   end
 
-  text_line :comment, :match => /^\s*#/
+  if Facter.value(:osfamily) == "AIX"
+    # * is the comment character on AIX /etc/filesystems
+    text_line :comment, :match => /^\s*\*/
+  else
+    text_line :comment, :match => /^\s*#/
+  end
   text_line :blank, :match => /^\s*$/
 
   optional_fields  = @fields - [:device, :name, :blockdevice]
@@ -36,7 +42,144 @@ Puppet::Type.type(:mount).provide(
   field_pattern = '(\s*(?>\S+))'
   text_line :incomplete, :match => /^(?!#{field_pattern}{#{mandatory_fields.length}})/
 
-  record_line self.name, :fields => @fields, :separator => /\s+/, :joiner => "\t", :optional => optional_fields
+  case Facter.value(:osfamily)
+  when "AIX"
+    # The only field that is actually ordered is :name. See `man filesystems` on AIX
+    @fields = [:name, :account, :boot, :check, :dev, :free, :mount, :nodename,
+               :options, :quota, :size, :type, :vfs, :vol, :log]
+    self.line_separator = "\n"
+    # Override lines and use scan instead of split, because we DON'T want to
+    # remove the separators
+    def self.lines(text)
+      lines = text.split("\n")
+      filesystem_stanza = false
+      filesystem_index = 0
+      ret = Array.new
+      lines.each_with_index do |line,i|
+        if line.match(%r{^\S+:})
+          # Begin new filesystem stanza and save the index
+          ret[filesystem_index] = filesystem_stanza.join("\n") if filesystem_stanza
+          filesystem_stanza = Array(line)
+          filesystem_index = i
+          # Eat the preceeding blank line
+          ret[i-1] = nil if i > 0 and ret[i-1] and ret[i-1].match(%r{^\s*$})
+          nil
+        elsif line.match(%r{^(\s*\*.*|\s*)$})
+          # Just a comment or blank line; add in place
+          ret[i] = line
+        else
+          # Non-comments or blank lines must be part of a stanza
+          filesystem_stanza << line
+        end
+      end
+      # Add the final stanza to the return
+      ret[filesystem_index] = filesystem_stanza.join("\n") if filesystem_stanza
+      ret = ret.compact.flatten
+      ret.reject { |line| line.match(/^\* HEADER/) }
+    end
+    def self.header
+      super.gsub(/^#/,'*')
+    end
+
+    record_line self.name,
+      :fields    => @fields,
+      :separator => /\n/,
+      :block_eval => :instance do
+
+      def post_parse(result)
+        property_map = {
+          :dev      => :device,
+          :nodename => :nodename,
+          :options  => :options,
+          :vfs      => :fstype,
+        }
+        # Result is modified in-place instead of being returned; icky!
+        memo = result.dup
+        result.clear
+        # Save the line for later, just in case it is unparsable
+        result[:line] = @fields.collect do |field|
+          memo[field] if memo[field] != :absent
+        end.compact.join("\n")
+        result[:record_type] = memo[:record_type]
+        special_options = Array.new
+        result[:name] = memo[:name].sub(%r{:\s*$},'').strip
+        memo.each do |_,k_v|
+          if k_v and k_v.is_a?(String) and k_v.match("=")
+            attr_name, attr_value = k_v.split("=",2).map(&:strip)
+            if attr_map_name = property_map[attr_name.to_sym]
+              # These are normal "options" options (see `man filesystems`)
+              result[attr_map_name] = attr_value
+            else
+              # These /etc/filesystem attributes have no mount resource simile,
+              # so are added to the "options" property for puppet's sake
+              special_options << "#{attr_name}=#{attr_value}"
+            end
+            if result[:nodename]
+              result[:device] = "#{result[:nodename]}:#{result[:device]}"
+              result.delete(:nodename)
+            end
+          end
+        end
+        result[:options] = [result[:options],special_options.sort].flatten.compact.join(',')
+        if ! result[:device]
+          result[:device] = :absent
+          Puppet.err "Prefetch: Mount[#{result[:name]}]: Field 'device' is missing"
+        end
+        if ! result[:fstype]
+          result[:fstype] = :absent
+          Puppet.err "Prefetch: Mount[#{result[:name]}]: Field 'fstype' is missing"
+        end
+      end
+      def to_line(result)
+        output = Array.new
+        output << "#{result[:name]}:"
+        if result[:device] and result[:device].match(%r{^/})
+          output << "\tdev\t\t= #{result[:device]}"
+        elsif result[:device] and result[:device] != :absent
+          if ! result[:device].match(%{^.+:/})
+            # Just skip this entry; it was malformed to begin with
+            Puppet.err "Mount[#{result[:name]}]: Field 'device' must be in the format of <absolute path> or <host>:<absolute path>"
+            return result[:line]
+          end
+          nodename, path = result[:device].split(":")
+          output << "\tdev\t\t= #{path}"
+          output << "\tnodename\t= #{nodename}"
+        else
+          # Just skip this entry; it was malformed to begin with
+          Puppet.err "Mount[#{result[:name]}]: Field 'device' is required"
+          return result[:line]
+        end
+        if result[:fstype] and result[:fstype] != :absent
+          output << "\tvfs\t\t= #{result[:fstype]}"
+        else
+          # Just skip this entry; it was malformed to begin with
+          Puppet.err "Mount[#{result[:name]}]: Field 'device' is required"
+          return result[:line]
+        end
+        if result[:options]
+          options = result[:options].split(',')
+          special_options = options.select do |x|
+            x.match('=') and
+              ["account", "boot", "check", "free", "mount", "size", "type",
+               "vol", "log", "quota"].include? x.split('=').first
+          end
+          options = options - special_options
+          special_options.sort.each do |x|
+            k, v = x.split("=")
+            output << "\t#{k}\t\t= #{v}"
+          end
+          output << "\toptions\t\t= #{options.join(",")}" unless options.empty?
+        end
+        if result[:line] and result[:line].split("\n").sort == output.sort
+          return "\n#{result[:line]}"
+        else
+          return "\n#{output.join("\n")}"
+        end
+      end
+    end
+  else
+    record_line self.name, :fields => @fields, :separator => /\s+/, :joiner => "\t", :optional => optional_fields
+  end
 
   # Every entry in fstab is :unmounted until we can prove different
   def self.prefetch_hook(target_records)

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -168,8 +168,11 @@ module Puppet
     end
 
     newproperty(:options) do
-      desc "Mount options for the mounts, as they would
-        appear in the fstab."
+      desc "Mount options for the mounts, comma-separated as they would appear
+      in the fstab on Linux. AIX options other than dev, nodename, or vfs may
+      be defined here. If specified, AIX options of account, boot, check, free,
+      mount, size, type, vol, log, and quota must be alphabetically sorted at
+      the end of the list."
 
       validate do |value|
         raise Puppet::Error, "option must not contain whitespace: #{value}" if value =~ /\s/
@@ -253,8 +256,16 @@ module Puppet
       newvalues(:true, :false)
       defaultto do
         case Facter.value(:operatingsystem)
-        when "FreeBSD", "Darwin", "AIX", "DragonFly", "OpenBSD"
+        when "FreeBSD", "Darwin", "DragonFly", "OpenBSD"
           false
+        when "AIX"
+          if Facter.value(:kernelmajversion) == "5300"
+            false
+          elsif resource[:device] and resource[:device].match(%r{^[^/]+:/})
+            false
+          else
+            true
+          end
         else
           true
         end

--- a/spec/fixtures/unit/provider/mount/parsed/aix.filesystems
+++ b/spec/fixtures/unit/provider/mount/parsed/aix.filesystems
@@ -35,110 +35,118 @@
 *
 
 /:
-        dev             = /dev/hd4
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = automatic
-        check           = false
-        type            = bootfs
-        vol             = root
-        free            = true
-        quota           = no
+	dev		= /dev/hd4
+	vfs		= jfs2
+	check		= false
+	free		= true
+	log		= NULL
+	mount		= automatic
+	quota		= no
+	type		= bootfs
+	vol		= root
 
 /home:
-        dev             = /dev/hd1
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = true
-        check           = true
-        vol             = /home
-        free            = false
-        quota           = no
+	dev		= /dev/hd1
+	vfs		= jfs2
+	check		= true
+	free		= false
+	log		= NULL
+	mount		= true
+	quota		= no
+	vol		= /home
 
 /usr:
-        dev             = /dev/hd2
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = automatic
-        check           = false
-        type            = bootfs
-        vol             = /usr
-        free            = false
-        quota           = no
+	dev		= /dev/hd2
+	vfs		= jfs2
+	check		= false
+	free		= false
+	log		= NULL
+	mount		= automatic
+	quota		= no
+	type		= bootfs
+	vol		= /usr
 
 /var:
-        dev             = /dev/hd9var
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = automatic
-        check           = false
-        type            = bootfs
-        vol             = /var
-        free            = false
-        quota           = no
+	dev		= /dev/hd9var
+	vfs		= jfs2
+	check		= false
+	free		= false
+	log		= NULL
+	mount		= automatic
+	quota		= no
+	type		= bootfs
+	vol		= /var
 
 /tmp:
-        dev             = /dev/hd3
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = automatic
-        check           = false
-        vol             = /tmp
-        free            = false
-        quota           = no
+	dev		= /dev/hd3
+	vfs		= jfs2
+	check		= false
+	free		= false
+	log		= NULL
+	mount		= automatic
+	quota		= no
+	vol		= /tmp
 
 /admin:
-        dev             = /dev/hd11admin
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = true
-        check           = false
-        vol             = /admin
-        free            = false
-        quota           = no
+	dev		= /dev/hd11admin
+	vfs		= jfs2
+	check		= false
+	free		= false
+	log		= NULL
+	mount		= true
+	quota		= no
+	vol		= /admin
 
 /proc:
-        dev       = /proc
-        vol       = "/proc"
-        mount     = true
-        check     = false
-        free      = false
-        vfs       = procfs
+	dev		= /proc
+	vol		= "/proc"
+	mount		= true
+	check		= false
+	free		= false
+	vfs		= procfs
 
 /opt:
-        dev             = /dev/hd10opt
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = true
-        check           = true
-        vol             = /opt
-        free            = false
-        quota           = no
+	dev		= /dev/hd10opt
+	vfs		= jfs2
+	log		= /dev/hd8
+	mount		= true
+	check		= true
+	vol		= /opt
+	free		= false
+	quota		= no
 
 /var/adm/ras/livedump:
-        dev             = /dev/livedump
-        vfs             = jfs2
-        log             = /dev/hd8
-        mount           = true
-        account         = false
-        quota           = no
+	dev		= /dev/livedump
+	vfs		= jfs2
+	log		= /dev/hd8
+	mount		= true
+	account		= false
+	quota		= no
 
 
 /stage/middleware:
-        dev             = "/stage/middleware"
-        vfs             = nfs
-        nodename        = 192.168.1.11
-        mount           = true
-        type            = nfs
-        options         = ro,bg,hard,intr,sec=sys
-        account         = false
+	dev		= "/stage/middleware"
+	vfs		= nfs
+	nodename	= 192.168.1.11
+	mount		= true
+	type		= nfs
+	options		= ro,bg,hard,intr,sec=sys
+	account		= false
 
 /home/u0010689:
-        dev             = "/userdata/20010689"
-        vfs             = nfs
-        nodename        = 192.168.1.11
-        mount           = true
-        type            = nfs
-        options         = bg,hard,intr
-        account         = false
+	dev		= "/userdata/20010689"
+	vfs		= nfs
+	nodename	= 192.168.1.11
+	mount		= true
+	type		= nfs
+	options		= bg,hard,intr
+	account		= false
 
+/srv/aix:
+	dev		= /srv/aix
+	nodename	= mynode
+	vfs		= nfs
+	account		= false
+	log		= NULL
+	mount		= true
+	options		= vers=2

--- a/spec/fixtures/unit/provider/mount/parsed/aix.mount
+++ b/spec/fixtures/unit/provider/mount/parsed/aix.mount
@@ -1,7 +1,11 @@
-node   mounted          mounted over  vfs    date              options   
-----   -------          ------------ ---  ------------   -------------------
-       /dev/hd0         /            jfs   Dec 17 08:04   rw, log  =/dev/hd8
-       /dev/hd3         /tmp         jfs   Dec 17 08:04   rw, log  =/dev/hd8
-       /dev/hd1         /home        jfs   Dec 17 08:06   rw, log  =/dev/hd8
-       /dev/hd2         /usr         jfs   Dec 17 08:06   rw, log  =/dev/hd8
-sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8
+  node       mounted        mounted over    vfs       date        options
+-------- ---------------  ---------------  ------ ------------ ---------------
+         /dev/hd4         /                jfs2   Feb 05 10:27 rw,log=NULL
+         /dev/hd2         /usr             jfs2   Feb 05 10:28 rw,log=NULL
+         /dev/hd9var      /var             jfs2   Feb 05 10:28 rw,log=NULL
+         /dev/hd3         /tmp             jfs2   Feb 05 10:28 rw,log=NULL
+         /dev/hd1         /home            jfs2   Feb 05 10:28 rw,log=NULL
+         /dev/hd11admin   /admin           jfs2   Feb 05 10:28 rw,log=NULL
+         /proc            /proc            procfs Feb 05 10:28 rw
+         /dev/hd10opt     /opt             jfs2   Feb 05 10:28 rw,log=NULL
+mynode   /srv/aix         /srv/aix         nfs    Mar 19 14:33 vers=2,rw 


### PR DESCRIPTION
The way that AIX tracks its mounted filesystems is different than other
unix or linux operatingsystems. AIX uses /etc/filesystems and has
entirely different filesystem options.

This commit takes advantage of two parsedfile hooks, post_parse and
to_line, to read & generate /etc/filesystem entries. Parsedfile was
not created with arbitrary-ordering in mind, and any /etc/filesystem
entries will have their attributes reordered by to_line

Options in AIX without related properties in Puppet's mount type are
placed under the "options" property.