### PR TITLE
(PUP-1279) ADSI - Explicitly set user/group deleted

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -9,6 +9,13 @@ Puppet::Type.type(:group).provide :windows_adsi do
 
   has_features :manages_members
 
+  attr_accessor :deleted
+
+  def initialize(value={})
+    super(value)
+    @deleted = false
+  end
+
   def members_insync?(current, should)
     return false unless current
 
@@ -72,11 +79,13 @@ Puppet::Type.type(:group).provide :windows_adsi do
 
   def delete
     Puppet::Util::Windows::ADSI::Group.delete(@resource[:name])
+
+    @deleted = true
   end
 
   # Only flush if we created or modified a group, not deleted
   def flush
-    @group.commit if @group
+    @group.commit if @group && !@deleted
   end
 
   def gid

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -8,6 +8,13 @@ Puppet::Type.type(:user).provide :windows_adsi do
 
   has_features :manages_homedir, :manages_passwords
 
+  attr_accessor :deleted
+
+  def initialize(value={})
+    super(value)
+    @deleted = false
+  end
+
   def user
     @user ||= Puppet::Util::Windows::ADSI::User.new(@resource[:name])
   end
@@ -47,11 +54,13 @@ Puppet::Type.type(:user).provide :windows_adsi do
     if sid
       Puppet::Util::Windows::ADSI::UserProfile.delete(sid)
     end
+
+    @deleted = true
   end
 
   # Only flush if we created or modified a user, not deleted
   def flush
-    @user.commit if @user
+    @user.commit if @user && !@deleted
   end
 
   def comment

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -184,6 +184,14 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
     provider.delete
   end
 
+  it 'should not run commit on a deleted group' do
+    connection.expects(:Delete).with('group', 'testers')
+    connection.expects(:SetInfo).never
+
+    provider.delete
+    provider.flush
+  end
+
   it "should report the group's SID as gid" do
     Puppet::Util::Windows::SID.expects(:name_to_sid).with('testers').returns('S-1-5-32-547')
     provider.gid.should == 'S-1-5-32-547'

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -136,6 +136,14 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
     provider.delete
   end
 
+  it 'should not run commit on a deleted user' do
+    connection.expects(:Delete).with('user', 'testuser')
+    connection.expects(:SetInfo).never
+
+    provider.delete
+    provider.flush
+  end
+
   it 'should delete the profile if managehome is set' do
     resource[:managehome] = true
 


### PR DESCRIPTION
Previously, flush would only check against whether the
user/group variable was set before deciding to commit. This is
erroneous as the variable could be set (and sometimes is) by other
means. Explicitly set a  flag when a user/group is deleted if the
user/group variable is set.

Without this change there are cases when the user/group variable will
be set and flush will fail, throwing an error even though the deletion
is successful.