### PR TITLE
(PUP-4340) Fix intermittent failure in test case

### DIFF
--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -169,14 +169,11 @@ with_puppet_running_on(master, master_opts, testdir) do
   end
 
   step "touch files and verify they're updated with ctime/mtime"
-  # wait until we're not at the file's mtime
-  #   mod_dir_source_file is the last file modified
-  #   This stat will not work on most BSDs
-  dir_file_mtime = on(master, "stat --format '%Y' #{mod_source_dir_file}").stdout.chomp
-  master_time    = on(master, 'date +%s').stdout.chomp
-  until master_time > dir_file_mtime do
-    master_time  = on(master, 'date +%s').stdout.chomp
-  end
+  # wait until we're not at the mtime of files on the agents
+  # this could be done cross-platform using Puppet, but a single puppet query is unlikely to be less than a second,
+  # and iterating over all agents would be much slower
+  sleep(1)
+
   on master, "touch #{mod_source_file} #{mod_source_dir_file}"
   agents.each do |agent|
     on(agent, puppet('agent', "--test --server #{master}"), :acceptable_exit_codes => [0,2]) do


### PR DESCRIPTION
The source_attribute test was modified to wait for time to pass
sufficient that touching source files on the master would cause puppet
agent runs to resync the files. However, the test only checked
mtime/ctime on the master - which is unrelated to ctime/mtime of the
target files on the agents - and the agent target files are what will be
compared to the ctime/mtime of the source file to see if they need to be
resynced.

We could fix this by iterating over the agents - or assuming they'll
always be done in order and only querying the last agent - to check the
ctime/mtime stats of the target files using `puppet resource file
<filename>`, but that's more complicated and unlikely to be
significantly less than the 1 second sleep we used to have.

Revert to the previous behavior of waiting 1 second to touch the files
and try resyncing.