### PR TITLE
(PUP-3804) User resource active directory handling

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -161,7 +161,14 @@ module Puppet::Util::Windows::ADSI
     def commit
       begin
         native_user.SetInfo unless native_user.nil?
-      rescue Exception => e
+      rescue WIN32OLERuntimeError => e
+        if e.message =~ /8007089A/m
+          raise Puppet::Error.new(
+           "Puppet is not able to create/delete domain users with the user resource.\nPlease see http://links.puppetlabs.com/windows_usersgroups for details.",
+           e
+          )
+        end
+
         raise Puppet::Error.new( "User update failed: #{e}", e )
       end
       self
@@ -328,7 +335,14 @@ module Puppet::Util::Windows::ADSI
     def commit
       begin
         native_group.SetInfo unless native_group.nil?
-      rescue Exception => e
+      rescue WIN32OLERuntimeError => e
+        if e.message =~ /8007089A/m
+          raise Puppet::Error.new(
+            "Puppet is not able to create/delete domain groups with the group resource.\nPlease see http://links.puppetlabs.com/windows_usersgroups for details.",
+            e
+          )
+        end
+
         raise Puppet::Error.new( "Group update failed: #{e}", e )
       end
       self

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -119,6 +119,19 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       expect{ provider.create }.to raise_error( Puppet::Error,
         /Cannot create user if group 'testuser' exists./ )
     end
+
+    it "should fail with an actionable message when trying to create an active directory user" do
+      resource[:name] = 'DOMAIN\testdomainuser'
+      Puppet::Util::Windows::ADSI::Group.expects(:exists?).with(resource[:name]).returns(false)
+      connection.expects(:Create)
+      connection.expects(:SetPassword)
+      connection.expects(:SetInfo).raises( WIN32OLERuntimeError.new("(in OLE method `SetInfo': )\n    OLE error code:8007089A in Active Directory\n      The specified username is invalid.\r\n\n    HRESULT error code:0x80020009\n      Exception occurred."))
+
+      expect{ provider.create }.to raise_error(
+        Puppet::Error,
+        /not able to create\/delete domain users/
+      )
+    end
   end
 
   it 'should be able to test whether a user exists' do


### PR DESCRIPTION
Error messages on user/group resources attempting to create
Active Directory users or groups are not very sufficient. Provide
an actionable error to the user so it is clear that Puppet cannot
handle creation and deletion of those types of users/groups.