### PR TITLE
(PUP-2400) Add mount acceptance tests

### DIFF
--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -1,0 +1,37 @@
+test_name "defined should create an entry in filesystem table"
+
+confine :except, :platform => ['windows']
+
+fstab = '/etc/fstab'
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the fstab file
+    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
+    #(teardown) umount disk image
+    on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete disk image
+    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete mount point
+    on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup fstab file"
+  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
+
+  #------- TESTS -------#
+  step "create a mount with puppet (defined)"
+  args = ['ensure=defined',
+          'fstype=ext3',
+          "device='/tmp/#{name}'"
+         ]
+  on(agent, puppet_resource('mount', "/#{name}", args))
+
+  step "verify entry in filesystem table"
+  on(agent, "cat #{fstab}")  do |res|
+    fail_test "didn't find the mount #{name}" unless stdout.include? "#{name}"
+  end
+
+end

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -1,0 +1,53 @@
+test_name "should delete an entry in filesystem table and unmount it"
+
+confine :except, :platform => ['windows']
+
+fstab = '/etc/fstab'
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the fstab file
+    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
+    #(teardown) umount disk image
+    on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete disk image
+    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete mount point
+    on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup fstab file"
+  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
+
+  step "(setup) create disk image"
+  on(agent, "dd if=/dev/zero of=/tmp/#{name} count=10240", :acceptable_exit_codes => [0,1])
+  on(agent, "yes | mkfs -t ext3 -q /tmp/#{name}")
+
+  step "(setup) create mount point"
+  on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
+
+  step "(setup) add entry to filesystem table"
+  on(agent, "echo '/tmp/#{name}  /#{name}  ext3  loop  0  0' >> #{fstab}")
+
+  step "(setup) mount entry"
+  on(agent, "mount /#{name}")
+
+  #------- TESTS -------#
+  step "destroy a mount with puppet (absent)"
+  args = ['ensure=absent',
+          "device='/tmp/#{name}'"
+         ]
+  on(agent, puppet_resource('mount', "/#{name}", args))
+
+  step "verify entry removed from filesystem table"
+  on(agent, "cat #{fstab}") do |res|
+    fail_test "found the mount #{name}" if res.stdout.include? "#{name}"
+  end
+
+  step "verify entry is not mounted"
+  on(agent, "mount") do |res|
+    fail_test "found the mount #{name} mounted" if res.stdout.include? "#{name}"
+  end
+end

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -1,0 +1,51 @@
+test_name "should modify an entry in filesystem table"
+
+confine :except, :platform => ['windows']
+
+fstab = '/etc/fstab'
+name = "pl#{rand(999999).to_i}"
+new_name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the fstab file
+    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
+    #(teardown) umount disk image
+    on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete disk image
+    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete mount point
+    on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup fstab file"
+  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
+
+  step "(setup) create disk image"
+  on(agent, "dd if=/dev/zero of=/tmp/#{name} count=10240", :acceptable_exit_codes => [0,1])
+  on(agent, "yes | mkfs -t ext3 -q /tmp/#{name}")
+
+  step "(setup) create mount point"
+  on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
+
+  step "(setup) add entry to filesystem table"
+  on(agent, "echo '/tmp/#{name}  /#{name}  ext3  loop  0  0' >> #{fstab}")
+
+  step "(setup) mount entry"
+  on(agent, "mount /#{name}")
+
+  #------- TESTS -------#
+  step "modify a mount with puppet (defined)"
+  args = ['ensure=defined',
+          'fstype=bogus',
+          "device='/tmp/#{name}'"
+         ]
+  on(agent, puppet_resource('mount', "/#{name}", args))
+
+  step "verify entry is updated in filesystem table"
+  on(agent, "cat #{fstab}") do |res|
+    fail_test "attributes not updated for the mount #{name}" unless res.stdout.include? "bogus"
+  end
+
+end

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -1,0 +1,49 @@
+test_name "mounted should create an entry in filesystem table and mount it"
+
+confine :except, :platform => ['windows']
+
+fstab = '/etc/fstab'
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the fstab file
+    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
+    #(teardown) umount disk image
+    on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete disk image
+    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete mount point
+    on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup fstab file"
+  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
+
+  step "(setup) create disk image"
+  on(agent, "dd if=/dev/zero of=/tmp/#{name} count=10240", :acceptable_exit_codes => [0,1])
+  on(agent, "yes | mkfs -t ext3 -q /tmp/#{name}")
+
+  step "(setup) create mount point"
+  on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
+
+  #------- TESTS -------#
+  step "create a mount with puppet (mounted)"
+  args = ['ensure=mounted',
+          'fstype=ext3',
+          'options=loop',
+          "device='/tmp/#{name}'"
+         ]
+  on(agent, puppet_resource('mount', "/#{name}", args))
+
+  step "verify entry in filesystem table"
+  on(agent, "cat #{fstab}") do |res|
+    fail_test "didn't find the mount #{name}" unless res.stdout.include? "#{name}"
+  end
+
+  step "verify entry is mounted"
+  on(agent, "mount") do |res|
+    fail_test "didn't find the mount #{name} mounted" unless res.stdout.include? "#{name}"
+  end
+end

--- a/acceptance/tests/resource/mount/query.rb
+++ b/acceptance/tests/resource/mount/query.rb
@@ -1,0 +1,33 @@
+test_name "should be able to find an existing filesystem table entry"
+
+confine :except, :platform => ['windows']
+
+fstab = '/etc/fstab'
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  teardown do
+    #(teardown) restore the fstab file
+    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
+    #(teardown) umount disk image
+    on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete disk image
+    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) delete mount point
+    on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+  end
+
+  #------- SETUP -------#
+  step "(setup) backup fstab file"
+  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
+
+  step "(setup) add entry to filesystem table"
+  on(agent, "echo '/tmp/#{name}  /#{name}  0  0' >> #{fstab}")
+
+  #------- TESTS -------#
+  step "verify mount with puppet"
+  on(agent, puppet_resource('mount', "/#{name}")) do |res|
+    fail_test "didn't find the mount #{name}" unless res.stdout.include? "#{name}"
+  end
+
+end


### PR DESCRIPTION
Add basic acceptance tests for mount type. This adds acceptance
tests for defined, mounted, query, modify, and destroy.