### PR TITLE
(PUP-3863) Ensure correct handling when undef is hiera default value

### DIFF
--- a/lib/hiera/puppet_function.rb
+++ b/lib/hiera/puppet_function.rb
@@ -12,10 +12,15 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
       param 'Tuple[String, Any, Any, 1, 3]', :args
     end
 
-    dispatch :hiera do
+    dispatch :hiera_no_default do
       scope_param
       param 'String',:key
-      optional_param 'Any',   :default
+    end
+
+    dispatch :hiera_with_default do
+      scope_param
+      param 'String',:key
+      param 'Any',   :default
       optional_param 'Any',   :override
     end
 
@@ -37,8 +42,14 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
     hiera(scope, *args)
   end
 
-  def hiera(scope, key, default = nil, override = nil)
-    post_lookup(key, lookup(scope, key, default, override))
+  def hiera_no_default(scope, key)
+    post_lookup(key, lookup(scope, key, nil, nil))
+  end
+
+  def hiera_with_default(scope, key, default, override = nil)
+    undefined = (@@undefined_value ||= Object.new)
+    result = lookup(scope, key, undefined, override)
+    post_lookup(key, result.equal?(undefined) ? default : result)
   end
 
   def hiera_block1(scope, key, &default_block)

--- a/spec/unit/functions/hiera_spec.rb
+++ b/spec/unit/functions/hiera_spec.rb
@@ -26,16 +26,18 @@ describe 'when calling' do
       expect(hiera.call(scope, 'key')).to eql('foo_result')
     end
 
-    it 'should propagate optional default' do
-      dflt = 'the_default'
-      Hiera.any_instance.expects(:lookup).with { |*args| args[1].should be(dflt) }.returns('foo_result')
-      expect(hiera.call(scope, 'key', dflt)).to eql('foo_result')
-    end
-
     it 'should propagate optional override' do
       ovr = 'the_override'
       Hiera.any_instance.expects(:lookup).with { |*args| args[3].should be(ovr) }.returns('foo_result')
       expect(hiera.call(scope, 'key', nil, ovr)).to eql('foo_result')
+    end
+
+    it 'should return default value nil when key is not found' do
+       expect(hiera.call(scope, 'foo', nil)).to be_nil
+    end
+
+    it "should return default value '' when key is not found" do
+      expect(hiera.call(scope, 'foo', '')).to eq('')
     end
 
     it 'should use default block' do


### PR DESCRIPTION
The Puppet function hiera() was not able to diffrentiate between the
lack of a default argument and a default argument passed as undef.
Instead, it would always treat undef as "no default" and consequently
raise an error when no value was found for a given key.

This commit changes this so that the hieara function (and it's
specializations) have different dispatchers for the cases when a
default parameter is provided or not. For the case when the default
is provied it will pass a special default value down to Hiera in its
place. On return of this special default means that the original
default should be used.