### PR TITLE
(PUP-4351) Default service type and package provider not set on CumulusL...

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
   commands :aptcache => "/usr/bin/apt-cache"
   commands :preseed => "/usr/bin/debconf-set-selections"
 
-  defaultfor :operatingsystem => [:debian, :ubuntu]
+  defaultfor :osfamily => :debian
 
   ENV['DEBIAN_FRONTEND'] = "noninteractive"
 

--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   # is resolved.
   commands :invoke_rc => "/usr/sbin/invoke-rc.d"
 
-  defaultfor :operatingsystem => :debian
+  defaultfor :operatingsystem => [:debian, :cumuluslinux]
 
   # Remove the symlinks
   def disable


### PR DESCRIPTION
...inux

This fix adds CumulusLinux to the defaultfor for its package and service
provider.

Thanks also to Barry Peddycord (@isharacomix) for work on this patch