### PR TITLE
(PUP-4363) Support splay in apply as well

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -9,11 +9,12 @@ class Puppet::Agent
   require 'puppet/agent/disabler'
   include Puppet::Agent::Disabler
 
-  attr_reader :client_class, :client, :splayed, :should_fork
+  require 'puppet/util/splayer'
+  include Puppet::Util::Splayer
+
+  attr_reader :client_class, :client, :should_fork
 
   def initialize(client_class, should_fork=true)
-    @splayed = false
-
     @should_fork = can_fork? && should_fork
     @client_class = client_class
   end
@@ -58,22 +59,6 @@ class Puppet::Agent
 
   def stopping?
     Puppet::Application.stop_requested?
-  end
-
-  # Have we splayed already?
-  def splayed?
-    splayed
-  end
-
-  # Sleep when splay is enabled; else just return.
-  def splay(do_splay = Puppet[:splay])
-    return unless do_splay
-    return if splayed?
-
-    time = rand(Puppet[:splaylimit] + 1)
-    Puppet.info "Sleeping for #{time} seconds (splay is enabled)"
-    sleep(time)
-    @splayed = true
   end
 
   def run_in_fork(forking = true)

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -3,6 +3,8 @@ require 'puppet/configurer'
 require 'puppet/util/profiler/aggregate'
 
 class Puppet::Application::Apply < Puppet::Application
+  require 'puppet/util/splayer'
+  include Puppet::Util::Splayer
 
   option("--debug","-d")
   option("--execute EXECUTE","-e") do |arg|
@@ -175,6 +177,9 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       Puppet.warning("Only one file can be applied per run.  Skipping #{command_line.args.join(', ')}") if command_line.args.size > 0
     end
 
+    # splay if needed
+    splay
+
     unless Puppet[:node_name_fact].empty?
       # Collect our facts.
       unless facts = Puppet::Node::Facts.indirection.find(Puppet[:node_name_value])
@@ -252,6 +257,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   # Enable all of the most common test options.
   def setup_test
+    Puppet.settings.handlearg("--no-splay")
     Puppet.settings.handlearg("--show_diff")
     options[:verbose] = true
     options[:detailed_exitcodes] = true

--- a/lib/puppet/util/splayer.rb
+++ b/lib/puppet/util/splayer.rb
@@ -1,0 +1,18 @@
+# Handle splay options (sleeping for a random interval before executing)
+module Puppet::Util::Splayer
+  # Have we splayed already?
+  def splayed?
+    !!@splayed
+  end
+
+  # Sleep when splay is enabled; else just return.
+  def splay(do_splay = Puppet[:splay])
+    return unless do_splay
+    return if splayed?
+
+    time = rand(Puppet[:splaylimit] + 1)
+    Puppet.info "Sleeping for #{time} seconds (splay is enabled)"
+    sleep(time)
+    @splayed = true
+  end
+end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -234,44 +234,6 @@ describe Puppet::Agent do
     end
   end
 
-  describe "when splaying" do
-    before do
-      Puppet[:splay] = true
-      Puppet[:splaylimit] = "10"
-    end
-
-    it "should do nothing if splay is disabled" do
-      Puppet[:splay] = false
-      @agent.expects(:sleep).never
-      @agent.splay
-    end
-
-    it "should do nothing if it has already splayed" do
-      @agent.expects(:splayed?).returns true
-      @agent.expects(:sleep).never
-      @agent.splay
-    end
-
-    it "should log that it is splaying" do
-      @agent.stubs :sleep
-      Puppet.expects :info
-      @agent.splay
-    end
-
-    it "should sleep for a random portion of the splaylimit plus 1" do
-      Puppet[:splaylimit] = "50"
-      @agent.expects(:rand).with(51).returns 10
-      @agent.expects(:sleep).with(10)
-      @agent.splay
-    end
-
-    it "should mark that it has splayed" do
-      @agent.stubs(:sleep)
-      @agent.splay
-      expect(@agent).to be_splayed
-    end
-  end
-
   describe "when checking execution state" do
     describe 'with regular run status' do
       before :each do

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -243,6 +243,12 @@ describe Puppet::Application::Apply do
         expect(msg.level).to eq(:warning)
       end
 
+      it "should splay" do
+        @apply.expects(:splay)
+
+        expect { @apply.main }.to exit_with 0
+      end
+
       it "should raise an error if we can't find the node" do
         Puppet::Node.indirection.expects(:find).returns(nil)
 

--- a/spec/unit/util/splayer_spec.rb
+++ b/spec/unit/util/splayer_spec.rb
@@ -1,0 +1,45 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util/splayer'
+
+describe Puppet::Util::Splayer do
+  include Puppet::Util::Splayer
+
+  let (:subject) { self }
+
+  before do
+    Puppet[:splay] = true
+    Puppet[:splaylimit] = "10"
+  end
+
+  it "should do nothing if splay is disabled" do
+    Puppet[:splay] = false
+    subject.expects(:sleep).never
+    subject.splay
+  end
+
+  it "should do nothing if it has already splayed" do
+    subject.expects(:splayed?).returns true
+    subject.expects(:sleep).never
+    subject.splay
+  end
+
+  it "should log that it is splaying" do
+    subject.stubs :sleep
+    Puppet.expects :info
+    subject.splay
+  end
+
+  it "should sleep for a random portion of the splaylimit plus 1" do
+    Puppet[:splaylimit] = "50"
+    subject.expects(:rand).with(51).returns 10
+    subject.expects(:sleep).with(10)
+    subject.splay
+  end
+
+  it "should mark that it has splayed" do
+    subject.stubs(:sleep)
+    subject.splay
+    expect(subject).to be_splayed
+  end
+end


### PR DESCRIPTION
For masterless deploys it would be good if puppet apply supported splay just like agent does to avoid thundering herd issues (without the need of wrapping it in a shell script with a sleep).

The `--test` option should imply `--no-splay` just like it does in the agent.