### PR TITLE
(PUP-4355) Update windows tests for ~/.puppetlabs

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1014,7 +1014,7 @@ Generated on #{Time.now}.
   #    --config)
   # 2. If we're running as a root process, use the system puppet.conf
   #    (usually /etc/puppetlabs/puppet/puppet.conf)
-  # 3. Otherwise, use the user puppet.conf (usually ~/.puppet/puppet.conf)
+  # 3. Otherwise, use the user puppet.conf (usually ~/.puppetlabs/etc/puppet/puppet.conf)
   #
   # @api private
   # @todo this code duplicates {Puppet::Util::RunMode#which_dir} as described

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -149,8 +149,8 @@ describe Puppet::Util::RunMode do
         as_root { expect(@run_mode.conf_dir).to eq(File.expand_path(File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "etc"))) }
       end
 
-      it "has confdir in ~/.puppet when run as non-root" do
-        as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path("~/.puppet")) }
+      it "has confdir in ~/.puppetlabs/etc/puppet when run as non-root" do
+        as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path("~/.puppetlabs/etc/puppet")) }
       end
 
       it "fails when asking for the conf_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%" do
@@ -171,8 +171,8 @@ describe Puppet::Util::RunMode do
         as_root { expect(@run_mode.code_dir).to eq(File.expand_path(File.join(Dir::COMMON_APPDATA, "PuppetLabs", "code"))) }
       end
 
-      it "has codedir in ~/.puppet/code when run as non-root" do
-        as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path("~/.puppet/code")) }
+      it "has codedir in ~/.puppetlabs/etc/code when run as non-root" do
+        as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path("~/.puppetlabs/etc/code")) }
       end
 
       it "fails when asking for the code_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%" do
@@ -193,8 +193,8 @@ describe Puppet::Util::RunMode do
         as_root { expect(@run_mode.var_dir).to eq(File.expand_path(File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "cache"))) }
       end
 
-      it "has vardir in ~/.puppet/var when run as non-root" do
-        as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path("~/.puppet/var")) }
+      it "has vardir in ~/.puppetlabs/opt/puppet/cache when run as non-root" do
+        as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path("~/.puppetlabs/opt/puppet/cache")) }
       end
 
       it "fails when asking for the conf_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%" do
@@ -218,8 +218,8 @@ describe Puppet::Util::RunMode do
       end
 
       describe "when run as non-root" do
-        it "has default logdir ~/.puppet/var/log" do
-          as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppet/var/log')) }
+        it "has default logdir ~/.puppetlabs/var/log" do
+          as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
         end
 
         it "fails when asking for the log_dir and there is no $HOME" do
@@ -244,8 +244,8 @@ describe Puppet::Util::RunMode do
       end
 
       describe "when run as non-root" do
-        it "has default rundir ~/.puppet/var/run" do
-          as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppet/var/run')) }
+        it "has default rundir ~/.puppetlabs/var/run" do
+          as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
         end
 
         it "fails when asking for the run_dir and there is no $HOME" do


### PR DESCRIPTION
Commit 4ae5aca changed the per-user directories from ~/.puppet to ~/.puppetlabs
but did not update the windows specs that only run on Windows.

This commit fixes the tests and fixes an old reference to ~/.puppet.