### PR TITLE
(maint) fix install repos on to use PC1 urls

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -162,6 +162,17 @@ module Puppet
             ]
 
             if not link_exists?(link)
+              link = "http://%s/%s/%s/repos/%s/%s%s/PC1/%s/" % [
+                tld,
+                project,
+                sha,
+                variant,
+                fedora_prefix,
+                version,
+                arch
+              ]
+            end
+            if not link_exists?(link)
               link = "http://%s/%s/%s/repos/%s/%s%s/devel/%s/" % [
                 tld,
                 project,


### PR DESCRIPTION
this change helps the install utilities find repo_configs from our new
PC1 URLS on build.puppetlabs.lan.  this WILL break again (PC2?) and we need to
refactor and repackage all this code elsewhere, sometime, RSN.