### PR TITLE
(PUP-3653) Create/set empty Windows groups

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -22,9 +22,6 @@ Puppet::Type.type(:group).provide :windows_adsi do
 
     # Cannot use munge of the group property to canonicalize @should
     # since the default array_matching comparison is not commutative
-    should_empty = should.nil? or should.empty?
-
-    return false if current.empty? != should_empty
 
     # dupes automatically weeded out when hashes built
     current_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
@@ -33,6 +30,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
     if @resource[:auth_membership]
       current_users == specified_users
     else
+      return true if specified_users.empty?
       (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
     end
   end

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -388,19 +388,27 @@ module Puppet::Util::Windows::ADSI
     end
 
     def set_members(desired_members, inclusive = true)
-      return if desired_members.nil? or desired_members.empty?
+      return if desired_members.nil?
 
       current_hash = Hash[ self.member_sids.map { |sid| [sid.to_s, sid] } ]
       desired_hash = self.class.name_sid_hash(desired_members)
 
       # First we add all missing members
-      members_to_add = (desired_hash.keys - current_hash.keys).map { |sid| desired_hash[sid] }
-      add_member_sids(*members_to_add)
+      if !desired_members.empty?
+        members_to_add = (desired_hash.keys - current_hash.keys).map { |sid| desired_hash[sid] }
+        add_member_sids(*members_to_add)
+      end
 
-      # Then we remove all extra members
-      members_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
+      # Then we remove all extra members if inclusive
+      if inclusive
+        if desired_members.empty?
+          members_to_remove = (current_hash.keys).map { |sid| current_hash[sid] }
+        else
+          members_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
+        end
 
-      remove_member_sids(*members_to_remove) if inclusive
+        remove_member_sids(*members_to_remove)
+      end
     end
 
     def self.create(name)

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -69,6 +69,10 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         provider.members_insync?(['user1', 'user2', 'user2'], ['user2', 'user1', 'user1']).should be_true
       end
 
+      it "should return true when current user(s) and should user(s) are empty lists" do
+        provider.members_insync?([], []).should be_true
+      end
+
       context "when auth_membership => true" do
         before :each do
           # this is also the default
@@ -77,6 +81,10 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return false when should user(s) are not the only items in the current" do
           provider.members_insync?(['user1', 'user2'], ['user1']).should be_false
+        end
+
+        it "should return false when current user(s) is not empty and should is an empty list" do
+          provider.members_insync?(['user1','user2'], []).should be_false
         end
       end
 
@@ -87,7 +95,11 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return true when current user(s) contains at least the should list" do
           provider.members_insync?(['user1','user2'], ['user1']).should be_true
-          end
+        end
+
+        it "should return true when current user(s) is not empty and should is an empty list" do
+          provider.members_insync?(['user1','user2'], []).should be_true
+        end
 
         it "should return true when current user(s) contains at least the should list, even unordered" do
           provider.members_insync?(['user3','user1','user2'], ['user2','user1']).should be_true

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -315,38 +315,118 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
         group.members.should =~ names
       end
 
-      it "should be able to add a list of users to a group" do
-        names = ['DOMAIN\user1', 'user2']
-        sids = [
-          stub(:account => 'user1', :domain => 'DOMAIN'),
-          stub(:account => 'user2', :domain => 'testcomputername'),
-          stub(:account => 'user3', :domain => 'DOMAIN2'),
-        ]
+      context "calling .set_members" do
+        it "should set the members of a group to only desired_members when inclusive" do
+          names = ['DOMAIN\user1', 'user2']
+          sids = [
+              stub(:account => 'user1', :domain => 'DOMAIN'),
+              stub(:account => 'user2', :domain => 'testcomputername'),
+              stub(:account => 'user3', :domain => 'DOMAIN2'),
+          ]
 
-        # use stubbed objectSid on member to return stubbed SID
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          # use stubbed objectSid on member to return stubbed SID
+          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
 
-        Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(sids[1])
-        Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('DOMAIN2\user3').returns(sids[2])
+          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('DOMAIN2\user3').returns(sids[2])
 
-        Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[0]).returns("WinNT://DOMAIN/user1,user")
-        Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[2]).returns("WinNT://DOMAIN2/user3,user")
+          Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[0]).returns("WinNT://DOMAIN/user1,user")
+          Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[2]).returns("WinNT://DOMAIN2/user3,user")
 
-        members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
-        adsi_group.expects(:Members).returns members
+          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
+          adsi_group.expects(:Members).returns members
 
-        adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user')
-        adsi_group.expects(:Add).with('WinNT://DOMAIN2/user3,user')
+          adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user')
+          adsi_group.expects(:Add).with('WinNT://DOMAIN2/user3,user')
 
-        group.set_members(['user2', 'DOMAIN2\user3'])
-      end
+          group.set_members(['user2', 'DOMAIN2\user3'])
+        end
 
-      it "should raise an error when a username does not resolve to a SID" do
-        expect {
-          adsi_group.expects(:Members).returns []
-          group.set_members(['foobar'])
-        }.to raise_error(Puppet::Error, /Could not resolve username: foobar/)
+        it "should add the desired_members to an existing group when not inclusive" do
+          names = ['DOMAIN\user1', 'user2']
+          sids = [
+              stub(:account => 'user1', :domain => 'DOMAIN'),
+              stub(:account => 'user2', :domain => 'testcomputername'),
+              stub(:account => 'user3', :domain => 'DOMAIN2'),
+          ]
+
+          # use stubbed objectSid on member to return stubbed SID
+          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+
+          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('DOMAIN2\user3').returns(sids[2])
+
+          Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[2]).returns("WinNT://DOMAIN2/user3,user")
+
+          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
+          adsi_group.expects(:Members).returns members
+
+          adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user').never
+
+          adsi_group.expects(:Add).with('WinNT://DOMAIN2/user3,user')
+
+          group.set_members(['user2', 'DOMAIN2\user3'],false)
+        end
+
+        it "should return immediately when desired_members is nil" do
+          adsi_group.expects(:Members).never
+
+          adsi_group.expects(:Remove).never
+          adsi_group.expects(:Add).never
+
+          group.set_members(nil)
+        end
+
+        it "should remove all members when desired_members is empty and inclusive" do
+          names = ['DOMAIN\user1', 'user2']
+          sids = [
+              stub(:account => 'user1', :domain => 'DOMAIN'),
+              stub(:account => 'user2', :domain => 'testcomputername')
+          ]
+
+          # use stubbed objectSid on member to return stubbed SID
+          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+
+          Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[0]).returns("WinNT://DOMAIN/user1,user")
+          Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[1]).returns("WinNT://testcomputername/user2,user")
+
+          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
+          adsi_group.expects(:Members).returns members
+
+          adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user')
+          adsi_group.expects(:Remove).with('WinNT://testcomputername/user2,user')
+
+          group.set_members([])
+        end
+
+        it "should do nothing when desired_members is empty and not inclusive" do
+          names = ['DOMAIN\user1', 'user2']
+          sids = [
+              stub(:account => 'user1', :domain => 'DOMAIN'),
+              stub(:account => 'user2', :domain => 'testcomputername')
+          ]
+          # use stubbed objectSid on member to return stubbed SID
+          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+
+          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
+          adsi_group.expects(:Members).returns members
+
+          adsi_group.expects(:Remove).never
+          adsi_group.expects(:Add).never
+
+          group.set_members([],false)
+        end
+
+        it "should raise an error when a username does not resolve to a SID" do
+          expect {
+            adsi_group.expects(:Members).returns []
+            group.set_members(['foobar'])
+          }.to raise_error(Puppet::Error, /Could not resolve username: foobar/)
+        end
       end
 
       it "should generate the correct URI" do


### PR DESCRIPTION
Allow setting a Windows group to no users. Previously it was not possible to set
Windows groups with no members due to the way the checking of should versus
current was done. Without this change Puppet will not be able to set Windows
groups to empty lists.

- `group/windows_adsi.members_insync?` - Remove the short circuit check on `current.empty?` versus
  `should_empty` - this results in incorrect behavior when non-authoritative
- `group/windows_adsi.members_insync?` - Return true when non-athoritative and should is empty.
  This prevents a check on keys of an empty hash, which will result in an error.
- `adsi.set_members` - return early only if `desired_members` is nil
- `adsi.set_members` - skip adding members when `desired_members` is empty
- `adsi.set_members` - if `desired_members` is empty, remove all current members