### PR TITLE
(PUP-4231) Cover logs generated by ensure => present in file type

### DIFF
--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -272,7 +272,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           FileUtils.mkdir(path)
           set_mode(0777, path)
 
-          catalog.add_resource described_class.new(:path => path, :ensure => :file, :mode => 0666, :backup => false, :force => true)
+          catalog.add_resource described_class.new(:path => path, :ensure => :file, :mode => '0666', :backup => false, :force => true)
           catalog.apply
 
           expect(get_mode(path) & 07777).to eq(0666)


### PR DESCRIPTION
This commit adds spec tests to cover 'ensure => present' for
the file type.

Note: This PR is rebased on top of https://github.com/puppetlabs/puppet/pull/3752, and should be merged afterwards.