### PR TITLE
(PUP-1931) Fix mount provider failure w/o options

### DIFF
--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -178,7 +178,21 @@ Puppet::Type.type(:mount).provide(
       end
     end
   else
-    record_line self.name, :fields => @fields, :separator => /\s+/, :joiner => "\t", :optional => optional_fields
+    record_line self.name, :fields => @fields, :separator => /\s+/, :joiner => "\t", :optional => optional_fields, :block_eval => :instance do
+      def pre_gen(record)
+        if !record[:options] || record[:options].empty?
+          if Facter.value(:kernel) == 'Linux'
+            record[:options] = 'defaults'
+          else
+            raise Puppet::Error, "Mount[#{record[:name]}]: Field 'options' is required"
+          end
+        end
+        if !record[:fstype] || record[:fstype].empty?
+          raise Puppet::Error, "Mount[#{record[:name]}]: Field 'fstype' is required"
+        end
+        record
+      end
+    end
   end
 
   # Every entry in fstab is :unmounted until we can prove different

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -164,6 +164,7 @@ module Puppet
 
       validate do |value|
         raise Puppet::Error, "fstype must not contain whitespace: #{value}" if value =~ /\s/
+        raise Puppet::Error, "fstype must not be an empty string" if value.empty?
       end
     end
 
@@ -174,6 +175,7 @@ module Puppet
 
       validate do |value|
         raise Puppet::Error, "options must not contain whitespace: #{value}" if value =~ /\s/
+        raise Puppet::Error, "options must not be an empty string" if value.empty?
       end
     end
 

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -197,6 +197,10 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
       it "should not support whitespace in fstype" do
         expect { described_class.new(:name => "/foo", :ensure => :present, :fstype => 'ext 3') }.to raise_error Puppet::Error, /fstype.*whitespace/
       end
+
+      it "should not support an empty string in fstype" do
+        expect { described_class.new(:name => "/foo", :ensure => :present, :fstype => "") }.to raise_error Puppet::Error, /fstype.*empty string/
+      end
     end
 
     describe "for options" do
@@ -210,6 +214,10 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
 
       it "should not support whitespace in options" do
         expect { described_class.new(:name => "/foo", :ensure => :present, :options => ['ro','foo bar','intr']) }.to raise_error Puppet::Error, /option.*whitespace/
+      end
+
+      it "should not support an empty string in options" do
+        expect { described_class.new(:name => "/foo", :ensure => :present, :options => "") }.to raise_error Puppet::Error, /option.*empty string/
       end
     end
 


### PR DESCRIPTION
Previously, when not specifying options to a mount resource, puppet
would fail with an opaque resource. It would create a bogus fstab entry
without an options field.

This commit adds in the `default` option to ensure that the options
field is created and valid for all mount resources.

Contribution originally from Mark Bainter <mbainter+github@gmail.com>