### PR TITLE
(PUP-2455) Update service provider to use 'ctrun' on Solaris

### DIFF
--- a/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
+++ b/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
@@ -1,0 +1,132 @@
+test_name "(PUP-2455) Service provider should start Solaris init service in its own SMF contract"
+
+sleepy_daemon_script = <<SCRIPT
+#!/usr/bin/env ruby
+while true
+  sleep (2)
+end
+SCRIPT
+
+sleepy_daemon_initscript = <<INITSCRIPT
+#!/bin/sh
+FIXTURESERVICE="/tmp/sleepy_daemon"
+start(){
+    $FIXTURESERVICE &
+}
+
+stop(){
+    FIXTUREPID=`ps -ef | grep "$FIXTURESERVICE" | grep -v grep | awk '{print $2}'`
+    kill -9 $FIXTUREPID
+}
+
+status(){
+    FIXTUREPID=`ps -ef | grep "$FIXTURESERVICE" | grep -v grep | awk '{print $2}'`
+    if [ "x$FIXTUREPID" = "x" ]; then
+      exit 1
+    else
+      exit 0
+    fi
+}
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status
+        ;;
+esac
+INITSCRIPT
+
+step "Setup fixture service manifest on master"
+
+  testdir = master.tmpdir('solaris_services_in_own_smf_contract')
+
+  test_manifest = <<MANIFEST
+File {
+  ensure => directory,
+  mode => "0750",
+  owner => #{master.puppet['user']},
+  group => #{master.puppet['group']},
+}
+file { '#{testdir}': }
+file { '#{testdir}/environments': }
+file { '#{testdir}/environments/production': }
+file { '#{testdir}/environments/production/manifests': }
+file { '#{testdir}/environments/production/manifests/site.pp':
+  ensure  => file,
+  content => '
+    node default {
+      service { "sleepy_daemon":
+      provider => "init",
+      enable   => "true",
+      ensure   => "running",
+      status   => "/etc/init.d/sleepy_daemon status",
+      }
+    }
+  ',
+}
+MANIFEST
+
+  apply_manifest_on master, test_manifest
+
+step "Start master"
+
+  master_opts = {
+    'main' => {
+    'environmentpath' => "#{testdir}/environments",
+    }
+  }
+
+  with_puppet_running_on master, master_opts, testdir do
+
+    agents.each do |agent|
+
+    fixture_service = 'sleepy_daemon'
+    fixture_service_stop = '/etc/init.d/sleepy_daemon stop'
+
+      skip_test unless agent['platform'] =~ /solaris/
+
+      step "Setup fixture service on #{agent}"
+        sleepy_daemon_path = "/tmp/sleepy_daemon"
+        sleepy_daemon_initscript_path = "/etc/init.d/sleepy_daemon"
+        create_remote_file(agent, sleepy_daemon_path, sleepy_daemon_script)
+        create_remote_file(agent, sleepy_daemon_initscript_path, sleepy_daemon_initscript)
+        on(agent, "chmod +x #{sleepy_daemon_path} #{sleepy_daemon_initscript_path}")
+
+      step "Start the fixture service on #{agent} "
+        on(agent, puppet("resource service #{fixture_service} provider=init ensure=stopped"))
+        on(agent, puppet("resource service #{fixture_service} provider=init ensure=running"))
+
+        assert_match(/ensure changed 'stopped' to 'running'/, stdout, "The fixture service #{fixture_service} is not in a testable state on #{agent}.")
+
+      step "Verify whether the fixture process is alone in its SMF contract on #{agent}"
+        service_ctid = on(agent, "sleep 20;ps -eo ctid,args | grep #{fixture_service} | grep -v grep | awk '{print $1}'").stdout.chomp.to_i
+        number_in_contract = on(agent, "pgrep -c #{service_ctid} | wc -l").stdout.chomp.to_i
+        assert(number_in_contract == 1, "The fixture process #{fixture_service} is not alone in its SMF contract on #{agent}.")
+
+      if agent.is_pe?
+
+        step "Stop puppet on #{agent}"
+          on(agent, "svcadm disable #{agent_service};sleep 70;svcadm disable #{agent_service}")
+
+        step "Stop fixture service on #{agent}"
+          on(agent, "#{fixture_service_stop}")
+
+        step "Enable puppet service on #{agent}"
+          on(agent, "svcadm enable #{agent_service};sleep 10") do
+            puppet_ctid = on(agent, "svcs -Ho CTID #{agent_service} | awk '{print $1}'").stdout.chomp.to_i
+            service_ctid = on(agent, "ps -eo ctid,args | grep #{fixture_service} | grep -v grep | awk '{print $1}'").stdout.chomp.to_i
+
+          step "Compare SMF contract ids for puppet and #{fixture_service} on #{agent}"
+            unless ( puppet_ctid != "0" and service_ctid != "0" ) then
+              fail_test("SMF contract ids should not equal zero.")
+            end
+
+            assert(service_ctid != puppet_ctid, "Service is in the same SMF contract as puppet on #{agent}.")
+         end
+       end
+    end
+  end

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -152,6 +152,13 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     (@resource[:hasrestart] == :true) && [initscript, :restart]
   end
 
+  def texecute(type, command, fof = true, squelch = false, combine = true)
+    if type == :start && Facter.value(:osfamily) == "Solaris"
+        command =  ["/usr/bin/ctrun -l none", command].flatten.join(" ")
+    end
+    super(type, command, fof, squelch, combine)
+  end
+
   # If it was specified that the init script has a 'status' command, then
   # we just return that; otherwise, we return false, which causes it to
   # fallback to other mechanisms.

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -7,6 +7,7 @@ describe provider_class do
   before :each do
     @provider = provider_class.new
     @provider.stubs(:initscript)
+    Facter.stubs(:value).with(:osfamily).returns 'FreeBSD'
   end
 
   it "should correctly parse rcvar for FreeBSD < 7" do

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -9,6 +9,7 @@ describe Puppet::Type.type(:service).provider(:gentoo) do
     FileTest.stubs(:file?).with('/sbin/rc-update').returns true
     FileTest.stubs(:executable?).with('/sbin/rc-update').returns true
     Facter.stubs(:value).with(:operatingsystem).returns 'Gentoo'
+    Facter.stubs(:value).with(:osfamily).returns 'Gentoo'
 
     # The initprovider (parent of the gentoo provider) does a stat call
     # before it even tries to execute an initscript. We use sshd in all the

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -208,5 +208,23 @@ describe Puppet::Type.type(:service).provider(:init) do
         provider.restart
       end
     end
+
+    describe "when starting a service on Solaris" do
+      it "should use ctrun" do
+        Facter.stubs(:value).with(:osfamily).returns 'Solaris'
+        provider.expects(:execute).with('/usr/bin/ctrun -l none /service/path/myservice start', {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).returns("")
+        $CHILD_STATUS.stubs(:exitstatus).returns(0)
+        provider.start
+      end
+    end
+
+    describe "when starting a service on RedHat" do
+      it "should not use ctrun" do
+        Facter.stubs(:value).with(:osfamily).returns 'RedHat'
+        provider.expects(:execute).with(['/service/path/myservice', :start], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).returns("")
+        $CHILD_STATUS.stubs(:exitstatus).returns(0)
+        provider.start
+      end
+    end
   end
 end

--- a/spec/unit/provider/service/openbsd_spec.rb
+++ b/spec/unit/provider/service/openbsd_spec.rb
@@ -10,6 +10,7 @@ describe provider_class do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     Facter.stubs(:value).with(:operatingsystem).returns :openbsd
+    Facter.stubs(:value).with(:osfamily).returns 'OpenBSD'
   end
 
   let :rcscripts do

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -20,6 +20,7 @@ describe provider_class, :as_platform => :posix do
     FileTest.stubs(:file?).with('/sbin/service').returns true
     FileTest.stubs(:executable?).with('/sbin/service').returns true
     Facter.stubs(:value).with(:operatingsystem).returns('CentOS')
+    Facter.stubs(:value).with(:osfamily).returns 'RedHat'
   end
 
   osfamily = [ 'RedHat', 'Suse' ]


### PR DESCRIPTION
Prior to this commit, non-SMF Puppet-managed services on Solaris
are not started in their own SMF contracts. If started
by Puppet running as a daemon, the services end up in Puppet's
SMF contract.

There are several negative implications from this scenario:

(1) If Puppet is stopped or restarted, the non-SMF Puppet-managed
services in Puppet's SMF contract are killed (by SMF).

(2) If Puppet-managed services are in Puppet's SMF contract, certain
events impacting any one of the managed services can lead to SMF killing
killing Puppet's contract, also killing all Puppet-managed services
that have ended up in Puppet's SMF contract.

In both scenarios, SMF also places Puppet in the SMF "maintenance"
state.

This commit updates the Puppet service provider to use the Solaris
'ctrun' facility to start Puppet-managed services in their own
SMF contracts.

We also add an acceptance test and update spec tests to accomodate
use of :osfamily in the texecute method override.