### PR TITLE
(PUP-4379) Fix interpolation of shortform var with _ continued with [

### DIFF
--- a/lib/puppet/pops/parser/interpolation_support.rb
+++ b/lib/puppet/pops/parser/interpolation_support.rb
@@ -193,9 +193,15 @@ module Puppet::Pops::Parser::InterpolationSupport
         token_name = token[0]
         ctx[:after] = token_name
         if token_name == :RBRACE && ctx[:brace_count] == brace_count
-          if queue.size - queue_size == 1
+          qlength = queue.size - queue_size
+          if qlength == 1
             # Single token is subject to replacement
             queue[-1] = transform_to_variable(queue[-1])
+          elsif qlength > 1 && [:DOT, :LBRACK].include?(queue[queue_size + 1][0])
+            # A first word, number of name token followed by '[' or '.' is subject to replacement
+            # But not for other operators such as ?, +, - etc. where user must use a $ before the name
+            # to get a variable
+            queue[queue_size] = transform_to_variable(queue[queue_size])
           end
           return
         end

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -234,6 +234,19 @@ describe 'Lexer2' do
     '"a${y::_x}"' => [[:DQPRE,    'a',   {:line => 1, :pos=>1, :length=>4 }],
                       [:VARIABLE, 'y::_x',  {:line => 1, :pos=>5, :length=>5 }],
                       [:DQPOST,   '',    {:line => 1, :pos=>11, :length=>1 }]],
+
+    '"a${_x[1]}"' => [[:DQPRE,    'a',   {:line => 1, :pos=>1, :length=>4 }],
+                      [:VARIABLE, '_x',  {:line => 1, :pos=>5, :length=>2 }],
+                      [:LBRACK,   '[',   {:line => 1, :pos=>7, :length=>1 }],
+                      [:NUMBER,   '1',   {:line => 1, :pos=>8, :length=>1 }],
+                      [:RBRACK,   ']',   {:line => 1, :pos=>9, :length=>1 }],
+                      [:DQPOST,   '',    {:line => 1, :pos=>11, :length=>1 }]],
+
+    '"a${_x.foo}"'=> [[:DQPRE,    'a',   {:line => 1, :pos=>1, :length=>4 }],
+                      [:VARIABLE, '_x',  {:line => 1, :pos=>5, :length=>2 }],
+                      [:DOT,      '.',   {:line => 1, :pos=>7, :length=>1 }],
+                      [:NAME,     'foo', {:line => 1, :pos=>8, :length=>3 }],
+                      [:DQPOST,   '',    {:line => 1, :pos=>12, :length=>1 }]],
   }.each do |source, expected|
     it "should lex an interpolated variable 'x' from #{source}" do
       tokens_scanned_from(source).should match_tokens2(*expected)


### PR DESCRIPTION
Before this, it was not possible to use the short form interpolation
of a variable starting with _ if continued with '[' or '.'. This is
caused by the fact that names cannot start with '_' and the
transformation of interpolated expressions did instead receive the
bare word '_x' as a LiteralString (which cannot be transformed to
a variable).

The fix modifies the lexer so that the first token is always
transformed if it is a NAME or a WORD, and if it is followed by
'[' or '.'.(Logic already in place handles the case where there is
only one expression being interpolated.