### PR TITLE
(maint) Pin to a released beaker version

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || 'git://github.com/puppetlabs/beaker#7d0cccf22cc7289113de862fe4a4494872f574bb')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.8')
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false


### PR DESCRIPTION
Previously we were tracking on the master branch of beaker, which makes
it hard to know which version of beaker was compatible with puppet 4
when it was released. For example, as we continue to support puppet
4.0.z releases while beaker development moves forward.

This commit pins us to beaker ~> 2.8, which includes 2.8.1 and 2.9.z
releases, but not 3.0.