### PR TITLE
(PUP-4385) Add support for 1-6 hex digits in \u escape

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -571,7 +571,7 @@ module Puppet::Pops::Issues
   end
 
   ILLEGAL_UNICODE_ESCAPE = issue :ILLEGAL_UNICODE_ESCAPE do
-    "Unicode escape '\\u' was not followed by 4 hex digits"
+    "Unicode escape '\\u' was not followed by 4 hex digits or 1-6 hex digits in {} or was > 10ffff"
   end
 
   INVALID_HEX_NUMBER = hard_issue :INVALID_HEX_NUMBER, :value do

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -433,6 +433,18 @@ describe 'Lexer2' do
         tokens_scanned_from(code).should match_tokens2([:STRING, "x\u2713y"])
       end
     end
+    it 'should support unicode characters in long form' do
+      code = <<-CODE
+      "x\\u{1f452}y"
+      CODE
+      if Puppet::Pops::Parser::Locator::RUBYVER < Puppet::Pops::Parser::Locator::RUBY_1_9_3
+        # Ruby 1.8.7 reports the multibyte char as several octal characters
+        tokens_scanned_from(code).should match_tokens2([:STRING, "x\360\237\221\222y"])
+      else
+        # >= Ruby 1.9.3 reports \u
+        tokens_scanned_from(code).should match_tokens2([:STRING, "x\u{1f452}y"])
+      end
+    end
 
     it 'should not select LISTSTART token when preceded by multibyte chars' do
       # This test is sensitive to the number of multibyte characters and position of the expressions


### PR DESCRIPTION
Before this it was not possible to enter \u escapes unless the
char was expressed with exactly 4 hex digits.
1
This commit makes it possible to use 1-6 (max 10ffff value) hex
digits by enclosing them in braces. Thus "\u{1f452}" results in
an emoji hat icon.