### PR TITLE
(PUP-4378) Improve output of label for collector objects

### DIFF
--- a/lib/puppet/pops/evaluator/collectors/catalog_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/catalog_collector.rb
@@ -22,4 +22,8 @@ class Puppet::Pops::Evaluator::Collectors::CatalogCollector < Puppet::Pops::Eval
       resource.type == t && (q ?  q.call(resource) : true)
     end
   end
+
+  def to_s
+    "Catalog-Collector[#{@type.to_s}]"
+  end
 end

--- a/lib/puppet/pops/evaluator/collectors/exported_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/exported_collector.rb
@@ -63,4 +63,8 @@ class Puppet::Pops::Evaluator::Collectors::ExportedCollector < Puppet::Pops::Eva
 
     resources
   end
+
+  def to_s
+    "Exported-Collector[#{@type.to_s}]"
+  end
 end

--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -86,6 +86,8 @@ class Puppet::Pops::Model::ModelLabelProvider < Puppet::Pops::LabelProvider
   def label_QualifiedReference o          ; "Type-Name"                         end
   def label_PAnyType o                    ; "#{Puppet::Pops::Types::TypeCalculator.string(o)}-Type" end
   def label_ReservedWord o                ; "Reserved Word '#{o.word}'"         end
+  def label_CatalogCollector o            ; "Catalog-Collector"                 end
+  def label_ExportedCollector o           ; "Exported-Collector"                end
 
   def label_PResourceType o
     if o.title


### PR DESCRIPTION
Under certain circumstances, a Collector object may be assigned to
a variable or placed in an Array or Hash. When transormed to a string
for human output, the output showed the full classname and id.

This changes the output to be a label "Catalog-Collector[type]", or
"Exported-Collector[type]", where type is the type being collected
e.g. "CatalogColloector[Notify]".