### PR TITLE
(PUP-2455) Fix logic in ticket_2455 acceptance test

### DIFF
--- a/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
+++ b/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
@@ -1,5 +1,7 @@
 test_name "(PUP-2455) Service provider should start Solaris init service in its own SMF contract"
 
+skip_test unless agents.any? {|agent| agent['platform'] =~ /solaris/ }
+
 sleepy_daemon_script = <<SCRIPT
 #!/usr/bin/env ruby
 while true
@@ -87,7 +89,7 @@ step "Start master"
     fixture_service = 'sleepy_daemon'
     fixture_service_stop = '/etc/init.d/sleepy_daemon stop'
 
-      skip_test unless agent['platform'] =~ /solaris/
+      next unless agent['platform'] =~ /solaris/
 
       step "Setup fixture service on #{agent}"
         sleepy_daemon_path = "/tmp/sleepy_daemon"


### PR DESCRIPTION
Prior to this commit, the ticket_2455 acceptance test
fails if there are no Solaris agents.

With no valid agents, the interaction of 'skip_test'
after the setup of 'with_puppet_running_on' causes
the whole test to fail.

This commit updates the acceptance test to skip the setup
if there are no Solaris agents.