### PR TITLE
(PUP-4351) Cumulus Linux should set defaults

### DIFF
--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -19,6 +19,11 @@ describe provider_class do
     provider
   end
 
+  it "should be the default provider on :osfamily => Debian" do
+    Facter.expects(:value).with(:osfamily).returns("Debian")
+    expect(described_class.default?).to be_truthy
+  end
+
   it "should be versionable" do
     expect(provider_class).to be_versionable
   end

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -32,6 +32,14 @@ describe provider_class do
     @provider.stubs(:invoke_rc)
   end
 
+  operatingsystem = [ 'Debian', 'CumulusLinux' ]
+  operatingsystem.each do |os|
+    it "should be the default provider on #{os}" do
+      Facter.expects(:value).with(:operatingsystem).returns(os)
+      expect(provider_class.default?).to be_truthy
+    end
+  end
+
   it "should have an enabled? method" do
     expect(@provider).to respond_to(:enabled?)
   end


### PR DESCRIPTION
We've recently updated Cumulus Linux to default to the apt package
provider and debian service type. This commit adds in spec tests for
those changes to verify that those defaults are assigned correctly.