### PR TITLE
(PUP-4111) environment scenario tests should assert success

### DIFF
--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -1,4 +1,4 @@
-test_name "Test behavior of directory environments when environmentpath is set to a non-existent directory"
+test_name 'Test behavior of directory environments when environmentpath is set to a non-existent directory'
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
@@ -6,26 +6,25 @@ extend Puppet::Acceptance::ClassifierUtils
 
 classify_nodes_as_agent_specified_if_classifer_present
 
-step "setup environments"
+step 'setup environments'
 
 stub_forge_on(master)
 
-testdir = create_tmpdir_for_user master, "confdir"
+testdir = create_tmpdir_for_user master, 'confdir'
 puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
-step  "Test"
+step  'Test'
 master_opts = {
   'main' => {
     'environmentpath' => '/doesnotexist',
   }
 }
-general = [ master_opts, testdir, puppet_conf_backup_dir, { :directory_environments => true } ]
-env = 'doesnotexist'
+env = 'testing'
 path = master.puppet('master')['codedir']
 
-results = use_an_environment("testing", "bad environmentpath", master_opts, testdir, puppet_conf_backup_dir, :directory_environments => true)
+results = use_an_environment(env, 'bad environmentpath', master_opts, testdir, puppet_conf_backup_dir, :directory_environments => true)
 
 expectations = {
   :puppet_config => {
@@ -46,9 +45,9 @@ expectations = {
   },
   :puppet_agent => {
     :exit_code => 1,
-    :matches => [%r{Warning.*404.*Could not find environment '#{env}'},
+    :matches => [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
                  %r{Could not retrieve catalog; skipping run}],
   },
 }
 
-review_results(results,expectations)
+assert_review(review_results(results,expectations))

--- a/acceptance/tests/environment/environment_scenario-default.rb
+++ b/acceptance/tests/environment/environment_scenario-default.rb
@@ -57,4 +57,4 @@ expectations = {
   }
 }
 
-review_results(results,expectations)
+assert_review(review_results(results,expectations))

--- a/acceptance/tests/environment/environment_scenario-existing.rb
+++ b/acceptance/tests/environment/environment_scenario-existing.rb
@@ -56,4 +56,4 @@ expectations = {
   },
 }
 
-review_results(results, expectations)
+assert_review(review_results(results, expectations))

--- a/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
+++ b/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
@@ -60,4 +60,4 @@ expectations = {
   },
 }
 
-review_results(results,expectations)
+assert_review(review_results(results,expectations))

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -46,9 +46,9 @@ expectations = {
   },
   :puppet_agent => {
     :exit_code => 1,
-    :matches => [%r{Warning.*404.*Could not find environment '#{env}'},
+    :matches => [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
                  %r{Could not retrieve catalog; skipping run}],
   }
 }
 
-review_results(results,expectations)
+assert_review(review_results(results,expectations))

--- a/acceptance/tests/environment/environment_scenario-with_explicit_environment_conf.rb
+++ b/acceptance/tests/environment/environment_scenario-with_explicit_environment_conf.rb
@@ -54,4 +54,4 @@ expectations = {
   },
 }
 
-review_results(results,expectations)
+assert_review(review_results(results,expectations))


### PR DESCRIPTION
This change ensures all the environment tests assert on the proper
outputs to finalize the tests that gather results into one step.
Prior to this change, some tests could result in false passes.
This change also fixes the "bad" scenario test, which tests for a bad
environmentpath.