### PR TITLE
(PUP-4404) Use current user for SID spec test

### DIFF
--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -15,7 +15,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
   context "#octet_string_to_sid_object" do
     it "should properly convert an array of bytes for the local Administrator SID" do
       host = '.'
-      username = 'Administrator'
+      username = ENV['USERNAME']
       admin = WIN32OLE.connect("WinNT://#{host}/#{username},user")
       converted = subject.octet_string_to_sid_object(admin.objectSID)
 


### PR DESCRIPTION
The SID generation spec needs the name of a user that exists; that account
doesn't need to have any particular permissions. Previously the test would
expect an 'Administrator' account to exist and hard-coded that name; on
systems where no user named 'Administrator' exists the spec would fail.

Change the user name used in the test to be the current account - accessed
via the USERNAME environment variable - instead of hard-coding
'Administrator'.