### PR TITLE
(PUP-4336) add test for puppet apply trace

### DIFF
--- a/acceptance/tests/apply/puppet_apply_trace.rb
+++ b/acceptance/tests/apply/puppet_apply_trace.rb
@@ -1,0 +1,7 @@
+test_name 'puppet apply --trace should provide a stack trace'
+
+agents.each do |agent|
+  on(agent, puppet('apply --trace -e "blue < 2"'), :acceptable_exit_codes => 1) do
+    assert_match(/apply\.rb.*in `main'.*command_line.*in `execute'.*puppet.*in `<main>'/m, stderr, "Did not print expected stack trace on stderr")
+  end
+end


### PR DESCRIPTION
This change adds a test for --trace using puppet apply.
Other tests use --trace with apply but don't check the output.
Create a dedicated test to protect against possible regressions.