### PR TITLE
(PUP-735) Expect exit code 1 when cycles detected

### DIFF
--- a/acceptance/tests/cycle_detection.rb
+++ b/acceptance/tests/cycle_detection.rb
@@ -6,7 +6,7 @@ notify { "a1": require => Notify["a2"] }
 notify { "a2": require => Notify["a1"] }
 EOT
 
-apply_manifest_on(agents, manifest) do
+apply_manifest_on(agents, manifest, :acceptable_exit_codes => [1]) do
   assert_match(/Found 1 dependency cycle/, stderr,
                "found and reported the cycle correctly")
 end
@@ -20,7 +20,7 @@ notify { "b1": require => Notify["b2"] }
 notify { "b2": require => Notify["b1"] }
 EOT
 
-apply_manifest_on(agents, manifest) do
+apply_manifest_on(agents, manifest, :acceptable_exit_codes => [1]) do
   assert_match(/Found 2 dependency cycles/, stderr,
                "found and reported the cycle correctly")
 end


### PR DESCRIPTION
Prior to commit 3ca9e74b, if an error occurred during catalog
application, e.g. cycle detected, the `Puppet::Resource::Catalog#apply`
method would log the exception, eventually exiting puppet with code 0.

Commit 3ca9e74b modified the `apply` method to not rescue exceptions, so
failures propagate to the higher level `Puppet::Configurer`, and
eventually cause puppet to exit with code 1.

This commit modifies the acceptance test to expect exit code 1.