### PR TITLE
(PUP-4407) Vim indentation: chaining arrows

### DIFF
--- a/ext/vim/indent/puppet.vim
+++ b/ext/vim/indent/puppet.vim
@@ -68,7 +68,7 @@ function! GetPuppetIndent()
     endif
 
     " Match } }, }; ] ]: )
-    if line =~ '^\s*\(}\(,\|;\)\?$\|]:\?$\|)\)'
+    if line =~ '^\s*\(}\(,\|;\|\s\?\(\(-\|\~\)>\|<\(-\|\~\)\)\)\?$\|]:\?$\|)\)'
         let ind = indent(s:OpenBrace(v:lnum))
     endif
 


### PR DESCRIPTION
Update the block end regex to recognize chaining arrows syntax