### PR TITLE
(PUP-585, PUP-4404) Add AppVeyor, fix specs expecting Administrator user

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+version: 4.0.0.{build}
+platform:
+    - x64
+install:
+    - SET PATH=C:\Ruby215\bin;%PATH%
+    - gem install bundler --quiet --no-ri --no-rdoc
+    - bundle install --without development
+build: off
+test_script:
+    - bundle exec rspec spec

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1111,7 +1111,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           @sids = {
             :current_user => Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name),
             :system => Win32::Security::SID::LocalSystem,
-            :admin => Puppet::Util::Windows::SID.name_to_sid("Administrator"),
             :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
             :users => Win32::Security::SID::BuiltinUsers,
             :power_users => Win32::Security::SID::PowerUsers,

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -15,7 +15,6 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
     @sids = {
       :current_user => Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name),
       :system => Win32::Security::SID::LocalSystem,
-      :admin => Puppet::Util::Windows::SID.name_to_sid("Administrator"),
       :administrators => Win32::Security::SID::BuiltinAdministrators,
       :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
       :users => Win32::Security::SID::BuiltinUsers,
@@ -387,9 +386,14 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
         end
 
         describe "#owner=" do
+          it "should accept the guest sid" do
+            winsec.set_owner(sids[:guest], path)
+            expect(winsec.get_owner(path)).to eq(sids[:guest])
+          end
+
           it "should accept a user sid" do
-            winsec.set_owner(sids[:admin], path)
-            expect(winsec.get_owner(path)).to eq(sids[:admin])
+            winsec.set_owner(sids[:current_user], path)
+            expect(winsec.get_owner(path)).to eq(sids[:current_user])
           end
 
           it "should accept a group sid" do
@@ -407,14 +411,19 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
         end
 
         describe "#group=" do
+          it "should accept the test group" do
+            winsec.set_group(sids[:guest], path)
+            expect(winsec.get_group(path)).to eq(sids[:guest])
+          end
+
           it "should accept a group sid" do
             winsec.set_group(sids[:power_users], path)
             expect(winsec.get_group(path)).to eq(sids[:power_users])
           end
 
           it "should accept a user sid" do
-            winsec.set_group(sids[:admin], path)
-            expect(winsec.get_group(path)).to eq(sids[:admin])
+            winsec.set_group(sids[:current_user], path)
+            expect(winsec.get_group(path)).to eq(sids[:current_user])
           end
 
           it "should combine owner and group rights when they are the same sid" do

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -15,7 +15,9 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
   context "#octet_string_to_sid_object" do
     it "should properly convert an array of bytes for the local Administrator SID" do
       host = '.'
-      username = 'Administrator'
+      # Bringing the ADSI module in isn't ideal, but we're leaving re-arranging the modules
+      # for a future breaking release.
+      username = Puppet::Util::Windows::ADSI::User.current_user_name
       admin = WIN32OLE.connect("WinNT://#{host}/#{username},user")
       converted = subject.octet_string_to_sid_object(admin.objectSID)
 


### PR DESCRIPTION
Windows spec tests cover behavior that's platform-specific and not
exposed by running spec tests on other CI platforms. This sometimes
leads to missing spec failures on pull requests that primarily affect
Windows.

Add AppVeyor configuration to run spec tests on Windows.

(PUP-4404) Use current user for SID spec test
(PUP-4404) Use current user for security specs