### PR TITLE
(PUP-4388) Remove START option from /etc/default/puppet on Debian

### DIFF
--- a/ext/debian/puppet.default
+++ b/ext/debian/puppet.default
@@ -1,9 +1,4 @@
 # Defaults for puppet - sourced by /etc/init.d/puppet
 
-# Enable puppet agent service?
-# Setting this to "yes" allows the puppet agent service to run.
-# Setting this to "no" keeps the puppet agent service from running.
-START=no
-
 # Startup options
 DAEMON_OPTS=""

--- a/ext/debian/puppet.init
+++ b/ext/debian/puppet.init
@@ -22,26 +22,12 @@ test -x $DAEMON || exit 0
 
 . /lib/lsb/init-functions
 
-is_true() {
-    if [ "x$1" = "xtrue" -o "x$1" = "xyes" -o "x$1" = "x0" ] ; then
-       return 0
-    else
-        return 1
-    fi
-}
-
 reload_puppet_agent() {
     start-stop-daemon --stop --quiet --signal HUP --pidfile $PIDFILE --name $PROCNAME
 }
 
 start_puppet_agent() {
-    if is_true "$START" ; then
-        start-stop-daemon --start --quiet --pidfile $PIDFILE \
-          --startas $DAEMON -- $NAME $DAEMON_OPTS
-    else
-        echo ""
-        echo "puppet not configured to start, please edit /etc/default/puppet to enable"
-    fi
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --startas $DAEMON -- $NAME $DAEMON_OPTS
 }
 
 stop_puppet_agent() {


### PR DESCRIPTION
In the new puppet-agent AIO package, services no longer
start on package installation, as there are a few required
configuration steps which must be addressed before the
service can be started.

This means we can remove the agent service START option from
/etc/default/puppet, a relic of old packages where debhelper
started services upon package installation.