### PR TITLE
(PUP-4398) Fix problem with splatted args in parentheses

### DIFF
--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -78,6 +78,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "[1,2,3] != [1,2,3]"                              => false,
       "[1,2,3][2]"                                      => 3,
       "[1,2,3] + [4,5]"                                 => [1,2,3,4,5],
+      "[1,2,3, *[4,5]]"                                 => [1,2,3,4,5],
+      "[1,2,3, (*[4,5])]"                               => [1,2,3,4,5],
+      "[1,2,3, ((*[4,5]))]"                             => [1,2,3,4,5],
       "[1,2,3] + [[4,5]]"                               => [1,2,3,[4,5]],
       "[1,2,3] + 4"                                     => [1,2,3,4],
       "[1,2,3] << [4,5]"                                => [1,2,3,[4,5]],
@@ -511,6 +514,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "case ringo {
          *[paul, john, ringo, george] : { 'beatle' } }"      => 'beatle',
 
+      "case ringo {
+         (*[paul, john, ringo, george]) : { 'beatle' } }"    => 'beatle',
+
       "case undef {
          undef : { 'yes' } }"                                => 'yes',
 
@@ -545,6 +551,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "'banana' ? { /.*(ana).*/  => $1 }"                 => 'ana',
       "[2] ? { Array[String] => yes, Array => yes}"       => 'yes',
       "ringo ? *[paul, john, ringo, george] => 'beatle'"  => 'beatle',
+      "ringo ? (*[paul, john, ringo, george]) => 'beatle'"=> 'beatle',
       "undef ? undef => 'yes'"                            => 'yes',
       "undef ? {*undef => 'no', default => 'yes'}"        => 'yes',
 
@@ -925,6 +932,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       'sprintf( "x%iy", $a )'                 => "x10y",
       # unfolds
       'sprintf( *["x%iy", $a] )'              => "x10y",
+      '( *["x%iy", $a] ).sprintf'             => "x10y",
+      '((*["x%iy", $a])).sprintf'             => "x10y",
       '"x%iy".sprintf( $a )'                  => "x10y",
       '$b.reduce |$memo,$x| { $memo + $x }'   => 6,
       'reduce($b) |$memo,$x| { $memo + $x }'  => 6,


### PR DESCRIPTION
Before this, if a splat or arguments was placed in parentheses in
a context where an unfold/splat has special meaning it would not be
recognized as a splat.

e.g.
```
(*[1,2,3]).with |$x, $y, $z| { notice $x, $y, $z }
```

would give the array to $x, and then fail because $y and $z was not
given.

This was caused by not unwinding parenthesized expressions in positions
where an UnfoldExpression is recognized - i.e. arguments in calls, case
and selector options.

The problem was reported against method call, since there, if splatting
is wanted, it must be in parentheses because of precedence.

This fixes all three places where splatting is recognized as special.