### PR TITLE
(PUP-4390) Patch win32-service gem 0.8.6 for 2003

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -26,8 +26,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/hiera.git'
   sys:
     ref:
-      x86: '8db9d84da9950760144b5dfcd807213eecee4842'
-      x64: '12030f11e9bb2f085c68108bff34be6956b25df9'
+      x86: '2f25839c5c11ec10b781debf4808095d6895a844'
+      x64: '017c63ca11e38f74b7e011ecd2006100452c620b'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
 - As part of PUP-1283, the win32-service gem was upgraded to 0.8.5 from
   0.7.2 on 7/3/2014.  Unfortunately, this picked up a bug introduced
   to the win32-service gem that broke service enumeration under
   Windows 2003 in commit:
   https://github.com/djberg96/win32-service/commit/f65181283bd8f1f51d6f4dca3f38cbbebcaf0b60

   Support for SERVICE_DELAYED_AUTO_START_INFO was added as part of this
   change to support configuring and retrieving delayed start service
   status, but this startup type is not supported on 2003.  Simply
   executing the code yields the error:

   Error: Could not run: The system call level is not correct. -
   QueryServiceConfig2: The system call level is not correct.

 - A PR is outstanding against the gem, but until then, our vendored
   gem modifications will remain in effect until 0.8.7 ships and our
   vendored bits can be updated accordingly.