### PR TITLE
Remove unused argument from Puppet::Environments::Directories::create_environment

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -190,7 +190,7 @@ module Puppet::Environments
 
     private
 
-    def create_environment(name, setting_values = nil)
+    def create_environment(name)
       env_symbol = name.intern
       setting_values = Puppet.settings.values(env_symbol, Puppet.settings.preferred_run_mode)
       Puppet::Node::Environment.create(


### PR DESCRIPTION
Argument 'setting_values' is a dead code, does not do anything,
nor is it set at any create_environment() call.

Reference to this can be found in #3386 pull request.

b.
