### PR TITLE
(PUP-2894) Add multi assignment of variables in array

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -179,6 +179,11 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
     fail(Issues::ILLEGAL_ASSIGNMENT, o)
   end
 
+  # An array is assignable if all entries are lvalues
+  def lvalue_LiteralList(o, scope)
+    o.values.map {|x| lvalue(x, scope) }
+  end
+
   # Assign value to named variable.
   # The '$' sign is never part of the name.
   # @example In Puppet DSL
@@ -205,6 +210,14 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
   #
   def assign_Object(name, value, o, scope)
     fail(Issues::ILLEGAL_ASSIGNMENT, o)
+  end
+
+  def assign_Array(lvalues, values, o, scope)
+    values = [values] unless values.is_a?(Array)
+    if values.size != lvalues.size
+      fail(Issues::ILLEGL_MULTI_ASSIGNMENT_SIZE, o, :expected =>lvalues.size, :actual => values.size)
+    end
+    lvalues.zip(values).map { |lval, val| assign(lval, val, o, scope) }
   end
 
   def eval_Factory(o, scope)

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -194,6 +194,10 @@ module Puppet::Pops::Issues
     "Illegal attempt to assign to #{label.a_an(semantic)} via [index/key]. Not an assignable reference"
   end
 
+  ILLEGL_MULTI_ASSIGNMENT_SIZE = hard_issue :ILLEGL_MULTI_ASSIGNMENT_SIZE, :expected, :actual do
+    "Mismatched number of assignable entries and values, expected #{expected}, got #{actual}"
+  end
+
   APPENDS_DELETES_NO_LONGER_SUPPORTED = hard_issue :APPENDS_DELETES_NO_LONGER_SUPPORTED, :operator do
     "The operator '#{operator}' is no longer supported. See http://links.puppetlabs.com/remove-plus-equals"
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -130,6 +130,10 @@ class Puppet::Pops::Validation::Checker4_0
     end
   end
 
+  def assign_LiteralList(o, via_index)
+    o.values.each {|x| assign(x) }
+  end
+
   def assign_Object(o, via_index)
     # Can not assign to anything else (differentiate if this is via index or not)
     # i.e. 10 = 'hello' vs. 10['x'] = 'hello' (the root is reported as being in error in both cases)

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -430,18 +430,26 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "$a = 5; $a"                 => 5,
       "$a = 5; $b = 6; $a"         => 5,
       "$a = $b = 5; $a == $b"      => true,
+      "[$a] = 1 $a"                              => 1,
+      "[$a] = [1] $a"                            => 1,
+      "[$a, $b] = [1,2] $a+$b"                   => 3,
+      "[$a, [$b, $c]] = [1,[2, 3]] $a+$b+$c"     => 6,
     }.each do |source, result|
         it "should parse and evaluate the expression '#{source}' to #{result}" do
           expect(parser.evaluate_string(scope, source, __FILE__)).to eq(result)
         end
       end
 
-    {
-      "[a,b,c] = [1,2,3]"               => /attempt to assign to 'an Array Expression'/,
-      "[a,b,c] = {b=>2,c=>3,a=>1}"      => /attempt to assign to 'an Array Expression'/,
-    }.each do |source, result|
-        it "should parse and evaluate the expression '#{source}' to error with #{result}" do
-          expect { parser.evaluate_string(scope, source, __FILE__)}.to raise_error(Puppet::ParseError, result)
+    [
+      "[a,b,c] = [1,2,3]",
+      "[a,b,c] = {b=>2,c=>3,a=>1}",
+      "[$a, $b] = 1",
+      "[$a, $b] = [1,2,3]",
+      "[$a, [$b,$c]] = [1,[2]]",
+      "[$a, [$b,$c]] = [1,[2,3,4]]",
+    ].each do |source|
+        it "should parse and evaluate the expression '#{source}' to error" do
+          expect { parser.evaluate_string(scope, source, __FILE__)}.to raise_error(Puppet::ParseError)
         end
       end
   end


### PR DESCRIPTION
Before this it was not possible to directly assign multiple variables
from values in an array.:

This commit adds this ability so that:
```
[$a, $b, $c] = [1,2,3]
```
assigns the values 1,2,3 to $a, $b, $c respectively.

Nested arrays are supported:
```
[$a, [$b, $c]] = [1,[2,3]]
```

And if RHS is not an array, it is treated as an array of 1 value.

The numbers of variables and values must be the same.