### PR TITLE
(PUP-2862) Make assignment in parameter default expr invalid

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -174,6 +174,11 @@ module Puppet::Pops::Issues
     "Illegal attempt to assign to the numeric match result variable '$#{varname}'. Numeric variables are not assignable"
   end
 
+  # Assignment can only be made to certain types of left hand expressions such as variables.
+  ILLEGAL_ASSIGNMENT_CONTEXT = hard_issue :ILLEGAL_ASSIGNMENT_CONTEXT do
+    "Assignment not allowed here"
+  end
+
   # parameters cannot have numeric names, clashes with match result variables
   ILLEGAL_NUMERIC_PARAMETER = issue :ILLEGAL_NUMERIC_PARAMETER, :name do
     "The numeric parameter name '$#{name}' cannot be used (clashes with numeric match result variables)"

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -413,13 +413,12 @@ class Puppet::Pops::Validation::Checker4_0
       acceptor.accept(Issues::ILLEGAL_NUMERIC_PARAMETER, o, :name => o.name)
     end
     return unless o.value
-    assignments =
+
     if o.value.is_a?(Puppet::Pops::Model::AssignmentExpression)
       [o.value]
-    else o.value
+    else
       o.value.eAllContents.select {|model| model.is_a? Puppet::Pops::Model::AssignmentExpression }
-    end
-    assignments.each do |assignment|
+    end.each do |assignment|
       acceptor.accept(Issues::ILLEGAL_ASSIGNMENT_CONTEXT, assignment)
     end
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -412,10 +412,11 @@ class Puppet::Pops::Validation::Checker4_0
     if o.name =~ /^(?:0x)?[0-9]+$/
       acceptor.accept(Issues::ILLEGAL_NUMERIC_PARAMETER, o, :name => o.name)
     end
+    return unless o.value
     assignments =
     if o.value.is_a?(Puppet::Pops::Model::AssignmentExpression)
       [o.value]
-    else
+    else o.value
       o.value.eAllContents.select {|model| model.is_a? Puppet::Pops::Model::AssignmentExpression }
     end
     assignments.each do |assignment|

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -412,6 +412,15 @@ class Puppet::Pops::Validation::Checker4_0
     if o.name =~ /^(?:0x)?[0-9]+$/
       acceptor.accept(Issues::ILLEGAL_NUMERIC_PARAMETER, o, :name => o.name)
     end
+    assignments =
+    if o.value.is_a?(Puppet::Pops::Model::AssignmentExpression)
+      [o.value]
+    else
+      o.value.eAllContents.select {|model| model.is_a? Puppet::Pops::Model::AssignmentExpression }
+    end
+    assignments.each do |assignment|
+      acceptor.accept(Issues::ILLEGAL_ASSIGNMENT_CONTEXT, assignment)
+    end
   end
 
   #relationship_side: resource


### PR DESCRIPTION
Before this it was possible to perform assignment of variables in
a parameter default expression. This is bad because the variable is
set in the calling context!

```
define bad_boy($a = ($b = 10)) { }
```

This commit adds validation and an error for such assignments.