### PR TITLE
(PUP-3895) Make epp command error correctly

### DIFF
--- a/lib/puppet/pops/evaluator/epp_evaluator.rb
+++ b/lib/puppet/pops/evaluator/epp_evaluator.rb
@@ -24,10 +24,15 @@ class Puppet::Pops::Evaluator::EppEvaluator
       raise ArgumentError, "epp(): the first argument must be a String with the filename, got a #{file.class}"
     end
 
-    file = file + ".epp" unless file =~ /\.epp$/
+    unless Puppet::FileSystem.exist?(file)
+      unless file =~ /\.epp$/
+        file = file + ".epp"
+      end
+    end
+
     scope.debug "Retrieving epp template #{file}"
     template_file = Puppet::Parser::Files.find_template(file, env_name)
-    unless template_file
+    if template_file.nil? ||  !Puppet::FileSystem.exist?(template_file)
       raise Puppet::ParseError, "Could not find template '#{file}'"
     end
 


### PR DESCRIPTION
Before this, if the epp tool was asked to process a file it would
automatically append ".epp" to any file that did not end with ".epp". It
would also, depending on code path end up not checking if the file
exists or not before processing.

The fix is to:
* Allow a file that does not end with .epp to be processed, but only
if it exists
* Treat a missing file the same way for the different code paths.

While not explicitly supported to use other extensions than .epp when
templates are in modules and a search is made for them, it is of value
to be able to take a sample file and process it as if it was epp to
assert that the text itself does not need escapes etc. as this could be
the first step in converting a sample file into an epp template.