### PR TITLE
(PUP-4359) Add the puppetversion fact for cfacter

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -21,6 +21,13 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
   # Lookup a host's facts up in Facter.
   def find(request)
     Facter.reset
+
+    # Add the puppetversion fact; this is done before generating the hash so it is
+    # accessible to custom facts.
+    Facter.add(:puppetversion) do
+      setcode { Puppet.version.to_s }
+    end
+
     self.class.setup_external_search_paths(request) if Puppet.features.external_facts?
     self.class.setup_search_paths(request)
 

--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -19,4 +19,12 @@ describe Puppet::Node::Facts::Facter do
                              Puppet::Node.indirection.find('foo'))
     expect(cat.resource("Notify[AaBbCc]")).to be
   end
+
+  it "adds the puppetversion fact" do
+    Facter.stubs(:reset)
+
+    cat = compile_to_catalog('notify { $::puppetversion: }',
+                             Puppet::Node.indirection.find('foo'))
+    expect(cat.resource("Notify[#{Puppet.version.to_s}]")).to be
+  end
 end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -43,6 +43,13 @@ describe Puppet::Node::Facts::Facter do
       @facter.find(@request)
     end
 
+    it 'should add the puppetversion fact' do
+      reset = sequence 'reset'
+      Facter.expects(:reset).in_sequence(reset)
+      Facter.expects(:add).with(:puppetversion)
+      @facter.find(@request)
+    end
+
     it 'should include external facts when feature is present' do
       reset = sequence 'reset'
       Puppet.features.stubs(:external_facts?).returns true


### PR DESCRIPTION
cfacter - and in the future, Facter 3 - don't define the puppetversion
fact. This is done to avoid having the current cyclical dependency in
Facter.

Puppet already adds several facts to the node's facts. Add puppetversion
prior to loading custom facts, so the custom facts can access it.