### PR TITLE
(DOC-1887) Fix indirection reference comments for Puppet 4 url changes

### DIFF
--- a/lib/puppet/reference/indirection.rb
+++ b/lib/puppet/reference/indirection.rb
@@ -58,7 +58,7 @@ Values fetched from the terminus are written to the cache.
 
 ### Interaction with REST
 
-REST endpoints have the form `/{environment}/{indirection}/{key}`, where the indirection can be singular or plural, following normal English spelling rules.
+REST endpoints have the form `/{prefix}/{version}/{indirection}/{key}?environment={environment}`, where the indirection can be singular or plural, following normal English spelling rules.
 On the server side, REST responses are generated from the locally-configured endpoints.
 
 ### Indirections and Termini


### PR DESCRIPTION
These comments get generated and posted onto the docs site. This commit
updates them for the Puppet 4 url changes.