### PR TITLE
(maint) fix stacktrace matcher in apply trace test

### DIFF
--- a/acceptance/tests/apply/puppet_apply_trace.rb
+++ b/acceptance/tests/apply/puppet_apply_trace.rb
@@ -2,6 +2,6 @@ test_name 'puppet apply --trace should provide a stack trace'
 
 agents.each do |agent|
   on(agent, puppet('apply --trace -e "blue < 2"'), :acceptable_exit_codes => 1) do
-    assert_match(/apply\.rb.*in `main'.*command_line.*in `execute'.*puppet.*in `<main>'/m, stderr, "Did not print expected stack trace on stderr")
+    assert_match(/\.rb:\d+:in `\w+'/m, stderr, "Did not print expected stack trace on stderr")
   end
 end


### PR DESCRIPTION
The first commit of this test had an overly specific stack trace matcher
which did not work on certain ruby stacks.  This change uses a different
match that should only match stack traces but be forgiving to changes in
the code and across ruby versions.