### PR TITLE
(PUP-4178) Move defined function to 4.x to correct behavior

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -328,7 +328,7 @@ module Puppet::Functions
     #
     # @api public
     def repeated_param(type, name)
-      internal_param(type, name)
+      internal_param(type, name, true)
       @max = :default
     end
     alias optional_repeated_param repeated_param
@@ -344,7 +344,7 @@ module Puppet::Functions
     #
     # @api public
     def required_repeated_param(type, name)
-      internal_param(type, name)
+      internal_param(type, name, true)
       raise ArgumentError, 'A required repeated parameter cannot be added after an optional parameter' if @min != @max
       @min += 1
       @max = :default
@@ -403,14 +403,18 @@ module Puppet::Functions
     private
 
     # @api private
-    def internal_param(type, name)
+    def internal_param(type, name, repeat = false)
       raise ArgumentError, 'Parameters cannot be added after a block parameter' unless @block_type.nil?
       raise ArgumentError, 'Parameters cannot be added after a repeated parameter' if @max == :default
       if type.is_a?(String)
         @types << type
         @names << name
         # mark what should be picked for this position when dispatching
-        @weaving << @names.size()-1
+        if repeat
+          @weaving << -@names.size()
+        else
+          @weaving << @names.size()-1
+        end
       else
         raise ArgumentError, "Parameter 'type' must be a String reference to a Puppet Data Type. Got #{type.class}"
       end

--- a/lib/puppet/functions/defined.rb
+++ b/lib/puppet/functions/defined.rb
@@ -70,8 +70,7 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
 
   dispatch :is_defined do
     scope_param
-    param          ARG_TYPE, 'first_arg'
-    repeated_param ARG_TYPE, 'additional_args'
+    optional_repeated_param ARG_TYPE, 'additional_args'
   end
 
   def is_defined(scope, *vals)

--- a/lib/puppet/functions/defined.rb
+++ b/lib/puppet/functions/defined.rb
@@ -65,15 +65,14 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
         if m = /^\$(.+)$/.match(val)
           scope.exist?(m[1])
         else
-          val = case val
+          case val
           when ''
             next nil
           when 'main'
-            ''
+            scope.compiler.findresource(:class, '') # scope.find_hostclass('')
           else
-            val
+            scope.find_resource_type(val) || scope.find_definition(val) || scope.compiler.findresource(:class, val)
           end
-          scope.find_resource_type(val) || scope.find_definition(val) || scope.find_hostclass(val)
         end
       when Puppet::Resource
         scope.compiler.findresource(val.type, val.title)

--- a/lib/puppet/functions/defined.rb
+++ b/lib/puppet/functions/defined.rb
@@ -88,7 +88,7 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
 
       when Puppet::Pops::Types::PHostClassType
         raise  ArgumentError, "The given class type is a reference to all classes" if val.class_name.nil?
-        scope.find_hostclass(val.class_name)
+        scope.compiler.findresource(:class, val.class_name)
 
       else
         raise ArgumentError, "Invalid argument of type '#{val.class}' to 'defined'"

--- a/lib/puppet/functions/defined.rb
+++ b/lib/puppet/functions/defined.rb
@@ -1,0 +1,98 @@
+# Determines whether
+# a given class or resource type is defined. This function can also determine whether a
+# specific resource has been declared, or whether a variable has been assigned a value
+# (including undef...as opposed to never having been assigned anything). Returns true
+# or false. Accepts class names, type names, resource references, and variable
+# reference strings of the form '$name'.  When more than one argument is
+# supplied, defined() returns true if any are defined.
+#
+# The `defined` function checks both native and defined types, including types
+# provided as plugins via modules. Types and classes are both checked using their names:
+#
+#     defined("file")
+#     defined("customtype")
+#     defined("foo")
+#     defined("foo::bar")
+#     defined('$name')
+#
+# Resource declarations are checked using resource references, e.g.
+# `defined( File['/tmp/myfile'] )`. Checking whether a given resource
+# has been declared is, unfortunately, dependent on the evaluation order of
+# the configuration, and the following code will not work:
+#
+#     if defined(File['/tmp/foo']) {
+#         notify { "This configuration includes the /tmp/foo file.":}
+#     }
+#     file { "/tmp/foo":
+#         ensure => present,
+#     }
+#
+# However, this order requirement refers to evaluation order only, and ordering of
+# resources in the configuration graph (e.g. with `before` or `require`) does not
+# affect the behavior of `defined`.
+#
+# If the future parser is in effect, you may also search using types:
+#
+#     defined(Resource['file','/some/file'])
+#     defined(File['/some/file'])
+#     defined(Class['foo'])
+#
+# When used with the future parser (4.x), the `defined` function does not answer if data
+# types (e.g. `Integer`) are defined, and the rules for asking for undef, empty strings, and
+# the main class are different:
+#
+#     defined('')     # 3.x => true,  4.x => false
+#     defined(undef)  # 3.x => true,  4.x => error
+#     defined('main') # 3.x => false, 4.x => true
+#
+# @since 2.7.0
+# @since 3.6.0 variable reference and future parser types")
+#
+Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunction) do
+
+  ARG_TYPE = 'Variant[String,Type[CatalogEntry]]'
+
+  dispatch :is_defined do
+    scope_param
+    param          ARG_TYPE, 'first_arg'
+    repeated_param ARG_TYPE, 'additional_args'
+  end
+
+  def is_defined(scope, *vals)
+    vals.any? do |val|
+      case val
+      when String
+        if m = /^\$(.+)$/.match(val)
+          scope.exist?(m[1])
+        else
+          val = case val
+          when ''
+            next nil
+          when 'main'
+            ''
+          else
+            val
+          end
+          scope.find_resource_type(val) || scope.find_definition(val) || scope.find_hostclass(val)
+        end
+      when Puppet::Resource
+        scope.compiler.findresource(val.type, val.title)
+
+      when Puppet::Pops::Types::PResourceType
+        raise ArgumentError, "The given resource type is a reference to all kind of types" if val.type_name.nil?
+        if val.title.nil?
+          scope.find_builtin_resource_type(val.type_name) || scope.find_definition(val.type_name)
+        else
+          scope.compiler.findresource(val.type_name, val.title)
+        end
+
+      when Puppet::Pops::Types::PHostClassType
+        raise  ArgumentError, "The given class type is a reference to all classes" if val.class_name.nil?
+        scope.find_hostclass(val.class_name)
+
+      else
+        raise ArgumentError, "Invalid argument of type '#{val.class}' to 'defined'"
+      end
+    end
+  end
+end

--- a/lib/puppet/parser/functions/defined.rb
+++ b/lib/puppet/parser/functions/defined.rb
@@ -38,6 +38,14 @@ Puppet::Parser::Functions::newfunction(:defined, :type => :rvalue, :arity => -2,
       defined(File[\'/some/file\'])
       defined(Class[\'foo\'])
 
+  When used with the future parser (4.x), the `defined` function does not answer if data
+  types (e.g. `Integer`) are defined, and the rules for asking for undef, empty strings, and
+  the main class are different:
+
+      defined('')     # 3.x => true, 4.x => false
+      defined(undef)  # 3.x => true, 4.x => error
+      defined('main') # 3.x => false, 4.x => true
+
  - Since 2.7.0
  - Since 3.6.0 variable reference and future parser types") do |vals|
     vals = [vals] unless vals.is_a?(Array)

--- a/lib/puppet/parser/functions/defined.rb
+++ b/lib/puppet/parser/functions/defined.rb
@@ -46,8 +46,22 @@ Puppet::Parser::Functions::newfunction(:defined, :type => :rvalue, :arity => -2,
       defined(undef)  # 3.x => true, 4.x => error
       defined('main') # 3.x => false, 4.x => true
 
+  With the future parser, it is also possible to ask specifically if a name is
+  a resource type (built in or defined), or a class, by giving its type:
+
+      defined(Type[Class['foo']])
+      defined(Type[Resource['foo']])
+
+  Which is different from asking:
+
+      defined('foo')
+
+  Since the later returns true if 'foo' is either a class, a built-in resource type, or a user defined
+  resource type, and a specific request like `Type[Class['foo']]` only returns true if `'foo'` is a class.
+
  - Since 2.7.0
- - Since 3.6.0 variable reference and future parser types") do |vals|
+ - Since 3.6.0 variable reference and future parser types
+ - Since 3.8.1 type specific requests with future parser") do |vals|
     vals = [vals] unless vals.is_a?(Array)
     vals.any? do |val|
       case val

--- a/lib/puppet/parser/functions/defined.rb
+++ b/lib/puppet/parser/functions/defined.rb
@@ -38,9 +38,12 @@ Puppet::Parser::Functions::newfunction(:defined, :type => :rvalue, :arity => -2,
       defined(File[\'/some/file\'])
       defined(Class[\'foo\'])
 
-  When used with the future parser (4.x), the `defined` function does not answer if data
-  types (e.g. `Integer`) are defined, and the rules for asking for undef, empty strings, and
-  the main class are different:
+  The `defined` function does not answer if 4.x data types (e.g. `Integer`) are defined. If
+  given the string 'integer' the result is false, and if given a non CatalogEntry type,
+  an error is raised.
+
+  The rules for asking for undef, empty strings, and the main class are different from 3.x
+  (non future parser) and 4.x (with future parser or in Puppet 4.0.0 and later):
 
       defined('')     # 3.x => true, 4.x => false
       defined(undef)  # 3.x => true, 4.x => error

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -71,7 +71,12 @@ class Puppet::Pops::Functions::Dispatch < Puppet::Pops::Evaluator::CallableSigna
         else
           # Careful so no new nil arguments are added since they would override default
           # parameter values in the received
-          new_args << args[knit] if knit < args.size
+          if knit < 0
+            idx = -knit -1
+            new_args += args[idx..-1] if idx < args.size
+          else
+            new_args << args[knit] if knit < args.size
+          end
         end
       end
       new_args

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -72,7 +72,7 @@ class Puppet::Pops::Functions::Dispatch < Puppet::Pops::Evaluator::CallableSigna
           # Careful so no new nil arguments are added since they would override default
           # parameter values in the received
           if knit < 0
-            idx = -knit -1
+            idx = -knit - 1
             new_args += args[idx..-1] if idx < args.size
           else
             new_args << args[knit] if knit < args.size

--- a/spec/unit/functions/defined_spec.rb
+++ b/spec/unit/functions/defined_spec.rb
@@ -19,7 +19,7 @@ describe "the 'defined' function" do
     Puppet[:parser] = 'future'
     # A fresh environment is needed for each test since tests creates types and resources
     environment = Puppet::Node::Environment.create(:testing, [])
-    @node = Puppet::Node.new("yaynode", :environment => environment)
+    @node = Puppet::Node.new('yaynode', :environment => environment)
     @known_resource_types = environment.known_resource_types
     @compiler = Puppet::Parser::Compiler.new(@node)
     @scope = Puppet::Parser::Scope.new(@compiler)
@@ -41,15 +41,15 @@ describe "the 'defined' function" do
 
   #--- CLASS
   #
-  context "can determine if a class" do
-    context "is defined" do
+  context 'can determine if a class' do
+    context 'is defined' do
 
-      it "by using the class name in string form" do
+      it 'by using the class name in string form' do
         newclass 'yayness'
-        expect(func.call(@scope, "yayness")).to be_true
+        expect(func.call(@scope, 'yayness')).to be_true
       end
 
-      it "by using a Type[Class[name]] type reference" do
+      it 'by using a Type[Class[name]] type reference' do
         name = 'yayness'
         newclass name
         class_type = Puppet::Pops::Types::TypeFactory.host_class(name)
@@ -58,12 +58,12 @@ describe "the 'defined' function" do
       end
     end
 
-    context "is not defined" do
-      it "by using the class name in string form" do
-        expect(func.call(@scope, "yayness")).to be_false
+    context 'is not defined' do
+      it 'by using the class name in string form' do
+        expect(func.call(@scope, 'yayness')).to be_false
       end
 
-      it "even if there is a define, by using a Type[Class[name]] type reference" do
+      it 'even if there is a define, by using a Type[Class[name]] type reference' do
         name = 'yayness'
         newdefine name
         class_type = Puppet::Pops::Types::TypeFactory.host_class(name)
@@ -72,9 +72,9 @@ describe "the 'defined' function" do
       end
     end
 
-    context "is defined and realized" do
-      it "by using a Class[name] reference" do
-        name = "cowabunga"
+    context 'is defined and realized' do
+      it 'by using a Class[name] reference' do
+        name = 'cowabunga'
         newclass name
         newresource(:class, name)
         class_type = Puppet::Pops::Types::TypeFactory.host_class(name)
@@ -82,16 +82,16 @@ describe "the 'defined' function" do
       end
     end
 
-    context "is not realized" do
-      it "(although defined) by using a Class[name] reference" do
-        name = "cowabunga"
+    context 'is not realized' do
+      it '(although defined) by using a Class[name] reference' do
+        name = 'cowabunga'
         newclass name
         class_type = Puppet::Pops::Types::TypeFactory.host_class(name)
         expect(func.call(@scope, class_type)).to be_false
       end
 
-      it "(and not defined) by using a Class[name] reference" do
-        name = "cowabunga"
+      it '(and not defined) by using a Class[name] reference' do
+        name = 'cowabunga'
         class_type = Puppet::Pops::Types::TypeFactory.host_class(name)
         expect(func.call(@scope, class_type)).to be_false
       end
@@ -100,38 +100,38 @@ describe "the 'defined' function" do
 
   #---RESOURCE TYPE
   #
-  context "can determine if a resource type" do
-    context "is defined" do
+  context 'can determine if a resource type' do
+    context 'is defined' do
 
-      it "by using the type name (of a built in type) in string form" do
-        expect(func.call(@scope, "file")).to be_true
+      it 'by using the type name (of a built in type) in string form' do
+        expect(func.call(@scope, 'file')).to be_true
       end
 
-      it "by using the type name (of a resource type) in string form" do
+      it 'by using the type name (of a resource type) in string form' do
         newdefine 'yayness'
-        expect(func.call(@scope, "yayness")).to be_true
+        expect(func.call(@scope, 'yayness')).to be_true
       end
 
-      it "by using a File type reference (built in type)" do
+      it 'by using a File type reference (built in type)' do
         resource_type = Puppet::Pops::Types::TypeFactory.resource('file')
         type_type = Puppet::Pops::Types::TypeFactory.type_type(resource_type)
         expect(func.call(@scope, type_type)).to be_true
       end
 
-      it "by using a Type[File] type reference" do
+      it 'by using a Type[File] type reference' do
         resource_type = Puppet::Pops::Types::TypeFactory.resource('file')
         type_type = Puppet::Pops::Types::TypeFactory.type_type(resource_type)
         expect(func.call(@scope, type_type)).to be_true
       end
 
-      it "by using a Resource[T] type reference (defined type)" do
+      it 'by using a Resource[T] type reference (defined type)' do
         name = 'yayness'
         newdefine name
         resource_type = Puppet::Pops::Types::TypeFactory.resource(name)
         expect(func.call(@scope, resource_type)).to be_true
       end
 
-      it "by using a Type[Resource[T]] type reference (defined type)" do
+      it 'by using a Type[Resource[T]] type reference (defined type)' do
         name = 'yayness'
         newdefine name
         resource_type = Puppet::Pops::Types::TypeFactory.resource(name)
@@ -140,12 +140,12 @@ describe "the 'defined' function" do
       end
     end
 
-    context "is not defined" do
-      it "by using the resource name in string form" do
-        expect(func.call(@scope, "notatype")).to be_false
+    context 'is not defined' do
+      it 'by using the resource name in string form' do
+        expect(func.call(@scope, 'notatype')).to be_false
       end
 
-      it "even if there is a class with the same name, by using a Type[Resource[T]] type reference" do
+      it 'even if there is a class with the same name, by using a Type[Resource[T]] type reference' do
         name = 'yayness'
         newclass name
         resource_type = Puppet::Pops::Types::TypeFactory.resource(name)
@@ -154,8 +154,8 @@ describe "the 'defined' function" do
       end
     end
 
-    context "is defined and instance realized" do
-      it "by using a Resource[T, title] reference for a built in type" do
+    context 'is defined and instance realized' do
+      it 'by using a Resource[T, title] reference for a built in type' do
         type_name = 'file'
         title = '/tmp/myfile'
         newdefine type_name
@@ -164,7 +164,7 @@ describe "the 'defined' function" do
         expect(func.call(@scope, class_type)).to be_true
       end
 
-      it "by using a Resource[T, title] reference for a defined type" do
+      it 'by using a Resource[T, title] reference for a defined type' do
         type_name = 'meme'
         title = 'cowabunga'
         newdefine type_name
@@ -174,10 +174,10 @@ describe "the 'defined' function" do
       end
     end
 
-    context "is not realized" do
-      it "(although defined) by using a Resource[T, title] reference or Type[Resource[T, title]] reference" do
+    context 'is not realized' do
+      it '(although defined) by using a Resource[T, title] reference or Type[Resource[T, title]] reference' do
         type_name = 'meme'
-        title = "cowabunga"
+        title = 'cowabunga'
         newdefine type_name
         resource_type = Puppet::Pops::Types::TypeFactory.resource(type_name, title)
         expect(func.call(@scope, resource_type)).to be_false
@@ -186,9 +186,9 @@ describe "the 'defined' function" do
         expect(func.call(@scope, type_type)).to be_false
       end
 
-      it "(and not defined) by using a Resource[T, title] reference or Type[Resource[T, title]] reference" do
+      it '(and not defined) by using a Resource[T, title] reference or Type[Resource[T, title]] reference' do
         type_name = 'meme'
-        title = "cowabunga"
+        title = 'cowabunga'
         resource_type = Puppet::Pops::Types::TypeFactory.resource(type_name, title)
         expect(func.call(@scope, resource_type)).to be_false
 
@@ -200,24 +200,24 @@ describe "the 'defined' function" do
 
   #---VARIABLES
   #
-  context "can determine if a variable" do
-    context "is defined" do
-      it "by giving the variable in string form" do
+  context 'can determine if a variable' do
+    context 'is defined' do
+      it 'by giving the variable in string form' do
         @scope['x'] = 'something'
         expect(func.call(@scope, '$x')).to be_true
       end
 
-      it "by giving a :: prefixed variable in string form" do
+      it 'by giving a :: prefixed variable in string form' do
         @compiler.topscope['x'] = 'something'
         expect(func.call(@scope, '$::x')).to be_true
       end
 
-      it "by giving a numeric variable in string form (when there is a match scope)" do
+      it 'by giving a numeric variable in string form (when there is a match scope)' do
         # with no match scope, there are no numeric variables defined
         expect(func.call(@scope, '$0')).to be_false
         expect(func.call(@scope, '$42')).to be_false
-        pattern = Regexp.new(".*")
-        @scope.new_match_scope(pattern.match("anything"))
+        pattern = Regexp.new('.*')
+        @scope.new_match_scope(pattern.match('anything'))
 
         # with a match scope, all numeric variables are set (the match defines if they have a value or not, but they are defined)
         # even if their value is undef.
@@ -226,58 +226,58 @@ describe "the 'defined' function" do
       end
     end
 
-    context "is undefined" do
-      it "by giving a :: prefixed or regular variable in string form" do
+    context 'is undefined' do
+      it 'by giving a :: prefixed or regular variable in string form' do
         expect(func.call(@scope, '$x')).to be_false
         expect(func.call(@scope, '$::x')).to be_false
       end
     end
   end
 
-  context "has any? semantics when given multiple arguments" do
-    it "and one of the names is a defined user defined type" do
-      newdefine "yayness"
-      expect(func.call(@scope, "meh", "yayness", "booness")).to be_true
+  context 'has any? semantics when given multiple arguments' do
+    it 'and one of the names is a defined user defined type' do
+      newdefine 'yayness'
+      expect(func.call(@scope, 'meh', 'yayness', 'booness')).to be_true
     end
 
-    it "and one of the names is a built type" do
-      expect(func.call(@scope, "meh", "file", "booness")).to be_true
+    it 'and one of the names is a built type' do
+      expect(func.call(@scope, 'meh', 'file', 'booness')).to be_true
     end
 
-    it "and one of the names is a defined class" do
-      newclass "yayness"
-      expect(func.call(@scope, "meh", "yayness", "booness")).to be_true
+    it 'and one of the names is a defined class' do
+      newclass 'yayness'
+      expect(func.call(@scope, 'meh', 'yayness', 'booness')).to be_true
     end
 
-    it "is true when at least one variable exists in scope" do
+    it 'is true when at least one variable exists in scope' do
       @scope['x'] = 'something'
       expect(func.call(@scope, '$y', '$x', '$z')).to be_true
     end
 
-    it "is false when none of the names are defined" do
-      expect(func.call(@scope, "meh", "yayness", "booness")).to be_false
+    it 'is false when none of the names are defined' do
+      expect(func.call(@scope, 'meh', 'yayness', 'booness')).to be_false
     end
   end
 
-  it "raises an argument error when asking if Resource type is defined" do
+  it 'raises an argument error when asking if Resource type is defined' do
     resource_type = Puppet::Pops::Types::TypeFactory.resource
     expect { func.call(@scope, resource_type)}.to raise_error(ArgumentError, /reference to all.*type/)
   end
 
-  it "raises an argument error if you ask if Class is defined" do
+  it 'raises an argument error if you ask if Class is defined' do
     class_type = Puppet::Pops::Types::TypeFactory.host_class
     expect { func.call(@scope, class_type) }.to raise_error(ArgumentError, /reference to all.*class/)
   end
 
-  it "raises error if referencing undef" do
+  it 'raises error if referencing undef' do
     expect{func.call(@scope, nil)}.to raise_error(ArgumentError, /mis-matched arguments/)
   end
 
-  it "raises error if referencing a number" do
+  it 'raises error if referencing a number' do
     expect{func.call(@scope, 42)}.to raise_error(ArgumentError, /mis-matched arguments/)
   end
 
-  it "is false if referencing empty string" do
+  it 'is false if referencing empty string' do
     expect(func.call(@scope, '')).to be_false
   end
 

--- a/spec/unit/functions/defined_spec.rb
+++ b/spec/unit/functions/defined_spec.rb
@@ -1,0 +1,146 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet/loaders'
+
+describe "the 'defined' function" do
+  after(:all) { Puppet::Pops::Loaders.clear }
+
+  # This loads the function once and makes it easy to call it
+  # It does not matter that it is not bound to the env used later since the function
+  # looks up everything via the scope that is given to it.
+  # The individual tests needs to have a fresh env/catalog set up
+  #
+  let(:loaders) { Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, [])) }
+  let(:func) { loaders.puppet_system_loader.load(:function, 'defined') }
+
+  before :each do
+    # This is only for the 4.x version of the defined function
+    Puppet[:parser] = 'future'
+    # A fresh environment is needed for each test since tests creates types and resources
+    environment = Puppet::Node::Environment.create(:testing, [])
+    @node = Puppet::Node.new("yaynode", :environment => environment)
+    @known_resource_types = environment.known_resource_types
+    @compiler = Puppet::Parser::Compiler.new(@node)
+    @scope = Puppet::Parser::Scope.new(@compiler)
+  end
+
+  def newclass(name)
+    @known_resource_types.add Puppet::Resource::Type.new(:hostclass, name)
+  end
+
+  def newdefine(name)
+    @known_resource_types.add Puppet::Resource::Type.new(:definition, name)
+  end
+
+  def newresource(type, title)
+    resource = Puppet::Resource.new(type, title)
+    @compiler.add_resource(@scope, resource)
+    resource
+  end
+
+  it "is true when the name is defined as a class" do
+    newclass 'yayness'
+    expect(func.call(@scope, "yayness")).to be_true
+  end
+
+  it "is true when the name is defined as a definition" do
+    newdefine "yayness"
+    expect(func.call(@scope, "yayness")).to be_true
+  end
+
+  it "is true when the name is defined as a builtin type" do
+    expect(func.call(@scope, "file")).to be_true
+  end
+
+  it "is true when any of the provided names are defined" do
+    newdefine "yayness"
+    expect(func.call(@scope, "meh", "yayness", "booness")).to be_true
+  end
+
+  it "is false when a single given name is not defined" do
+    expect(func.call(@scope, "meh")).to be_false
+  end
+
+  it "is false when none of the names are defined" do
+    expect(func.call(@scope, "meh", "yayness", "booness")).to be_false
+  end
+
+  it "is true when a resource reference is provided and the resource is in the catalog" do
+    resource = newresource("file", "/my/file")
+    expect(func.call(@scope, resource)).to be_true
+  end
+
+  context "with string variable references" do
+    it "is true when variable exists in scope" do
+      @scope['x'] = 'something'
+      expect(func.call(@scope, '$x')).to be_true
+    end
+
+    it "is true when ::variable exists in scope" do
+      @compiler.topscope['x'] = 'something'
+      expect(func.call(@scope, '$::x')).to be_true
+    end
+
+    it "is true when at least one variable exists in scope" do
+      @scope['x'] = 'something'
+      expect(func.call(@scope, '$y', '$x', '$z')).to be_true
+    end
+
+    it "is false when variable does not exist in scope" do
+      expect(func.call(@scope, '$x')).to be_false
+    end
+  end
+
+  it "is true when a future resource type reference is provided, and the resource is in the catalog" do
+    resource = newresource("file", "/my/file")
+    resource_type = Puppet::Pops::Types::TypeFactory.resource('file', '/my/file')
+    expect(func.call(@scope, resource_type)).to be_true
+  end
+
+  it "raises an argument error if you ask if Resource is defined" do
+    resource_type = Puppet::Pops::Types::TypeFactory.resource
+    expect { func.call(@scope, resource_type)}.to raise_error(ArgumentError, /reference to all.*type/)
+  end
+
+  it "is true if referencing a built in type" do
+    resource_type = Puppet::Pops::Types::TypeFactory.resource('file')
+    expect(func.call(@scope, resource_type)).to be_true
+  end
+
+  it "is true if referencing a defined type" do
+    @scope.known_resource_types.add Puppet::Resource::Type.new(:definition, "yayness")
+    resource_type = Puppet::Pops::Types::TypeFactory.resource('yayness')
+    expect(func.call(@scope, resource_type)).to be_true
+  end
+
+  it "is false if referencing an undefined type" do
+    resource_type = Puppet::Pops::Types::TypeFactory.resource('barbershops')
+    expect(func.call(@scope, resource_type)).to be_false
+  end
+
+  it "is true when a future class reference type is provided" do
+    @scope.known_resource_types.add Puppet::Resource::Type.new(:hostclass, "cowabunga")
+
+    class_type = Puppet::Pops::Types::TypeFactory.host_class("cowabunga")
+    expect(func.call(@scope, class_type)).to be_true
+  end
+
+  it "raises an argument error if you ask if Class is defined" do
+    class_type = Puppet::Pops::Types::TypeFactory.host_class
+    expect { func.call(@scope, class_type) }.to raise_error(ArgumentError, /reference to all.*class/)
+  end
+
+  it "is false if referencing nil" do
+  expect{func.call(@scope, nil)}.to raise_error(ArgumentError, /mis-matched arguments/)
+  end
+
+  it "is false if referencing empty string" do
+    expect(func.call(@scope, '')).to be_false
+  end
+
+  it "is true if referencing 'main'" do
+    expect(func.call(@scope, 'main')).to be_true
+  end
+
+end

--- a/spec/unit/functions/defined_spec.rb
+++ b/spec/unit/functions/defined_spec.rb
@@ -119,11 +119,19 @@ describe "the 'defined' function" do
     expect(func.call(@scope, resource_type)).to be_false
   end
 
-  it "is true when a future class reference type is provided" do
-    @scope.known_resource_types.add Puppet::Resource::Type.new(:hostclass, "cowabunga")
-
-    class_type = Puppet::Pops::Types::TypeFactory.host_class("cowabunga")
+  it "is true when a future class reference type is provided (and class is included)" do
+    name = "cowabunga"
+    newclass name
+    newresource(:class, name)
+    class_type = Puppet::Pops::Types::TypeFactory.host_class(name)
     expect(func.call(@scope, class_type)).to be_true
+  end
+
+  it "is false when a future class reference type is provided (and class is not included)" do
+    name = "cowabunga"
+    newclass name
+    class_type = Puppet::Pops::Types::TypeFactory.host_class(name)
+    expect(func.call(@scope, class_type)).to be_false
   end
 
   it "raises an argument error if you ask if Class is defined" do
@@ -131,7 +139,7 @@ describe "the 'defined' function" do
     expect { func.call(@scope, class_type) }.to raise_error(ArgumentError, /reference to all.*class/)
   end
 
-  it "is false if referencing nil" do
+  it "raises error if referencing undef" do
   expect{func.call(@scope, nil)}.to raise_error(ArgumentError, /mis-matched arguments/)
   end
 

--- a/spec/unit/functions/defined_spec.rb
+++ b/spec/unit/functions/defined_spec.rb
@@ -41,6 +41,7 @@ describe "the 'defined' function" do
 
   it "is true when the name is defined as a class" do
     newclass 'yayness'
+    newresource(:class, 'yayness')
     expect(func.call(@scope, "yayness")).to be_true
   end
 
@@ -148,6 +149,9 @@ describe "the 'defined' function" do
   end
 
   it "is true if referencing 'main'" do
+    # mimic what compiler does with "main" in intial import
+    newclass ''
+    newresource :class, ''
     expect(func.call(@scope, 'main')).to be_true
   end
 

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -218,6 +218,12 @@ actual:
   count_args(Undef{0}) - arg count {0}")
     end
 
+    it 'can create scope_param followed by repeated  parameter' do
+      f = create_function_with_scope_param_required_repeat
+      func = f.new(:closure_scope, :loader)
+      expect(func.call({}, 'yay', 1,2,3)).to eql([{}, 'yay',1,2,3])
+    end
+
     it 'a function can use inexact argument mapping' do
       f = create_function_with_inexact_dispatch
       func = f.new(:closure_scope, :loader)
@@ -764,6 +770,19 @@ actual:
       end
       def test(x)
         yield
+      end
+    end
+  end
+
+  def create_function_with_scope_param_required_repeat
+    f = Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
+      dispatch :test do
+        scope_param
+        param 'Any', 'extra'
+        repeated_param 'Any', 'the_block'
+      end
+      def test(scope, *args)
+        [scope, *args]
       end
     end
   end


### PR DESCRIPTION
Before this, the 3x defined() function beahaves in a strange way when
giving undef and empty string as input. A user may want to check if a
variable is defined and calls:
```
defined($not_defined)
```
and becomes surprised when true is returned even if the variable is not
defined. The user should have asked for:
```
defined('$not_defined')
```
This anomaly is caused by the 3.x functions inability to distinquish
between undef and an empty string, and the strange naming of the
Class[main] which is called '' (the empty string) internally, and 'main'
externally.

This commit fixes this problem by adding a 4.x implementation of the
defined() function. This version:
* does not accept undef input (protects users from the mistake of
  defined($foo)).
* the empty string produces false
* the string 'main' produces true (note that there is always a main
class)

The documentation for the 3x defined function is also updated to reflect
this (to avoid confusion).

This also fixes the ticket PUP-4331 since what it suggest (giving an
error when given undef) is implmented by typing the arguments to the
function.