### PR TITLE
(PUP-4044) Restore curl directly to host in install_repos_on

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -8,13 +8,12 @@ step "Install repositories on target machines..." do
 
   sha = ENV['SHA']
   server_version = ENV['SERVER_VERSION'] ||= 'nightly'
-  repo_configs_dir = 'repo-configs'
 
   hosts.each do |host|
-    install_repos_on(host, 'puppet-agent', sha, repo_configs_dir)
+    install_repos_on(host, 'puppet-agent', sha)
   end
 
-  install_repos_on(master, 'puppetserver', server_version, repo_configs_dir)
+  install_repos_on(master, 'puppetserver', server_version)
 end
 
 

--- a/acceptance/setup/packages/pre-suite/010_Install.rb
+++ b/acceptance/setup/packages/pre-suite/010_Install.rb
@@ -7,10 +7,9 @@ test_name "Install Packages"
 step "Install repositories on target machines..." do
 
   sha = ENV['SHA']
-  repo_configs_dir = 'repo-configs'
 
   hosts.each do |host|
-    install_repos_on(host, 'puppet', sha, repo_configs_dir)
+    install_repos_on(host, 'puppet', sha)
   end
 end
 


### PR DESCRIPTION
Prior commit was reverted because it didn't work on Debian and Ubuntu;
it downloaded the repo_configs dir to the wrong location on the host.

Restore those changes with a fix to download to the correct location.