### PR TITLE
(PUP-3988) Remove unused hostname checking feature

### DIFF
--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -52,8 +52,8 @@ class Puppet::Pops::Validation::Checker4_0
 
   # Performs check if this is a vaid hostname expression
   # @param single_feature_name [String, nil] the name of a single valued hostname feature of the value's container. e.g. 'parent'
-  def hostname(o, semantic, single_feature_name = nil)
-    @@hostname_visitor.visit_this_2(self, o, semantic, single_feature_name)
+  def hostname(o, semantic)
+    @@hostname_visitor.visit_this_1(self, o, semantic)
   end
 
   # Performs check if this is valid as a query
@@ -369,7 +369,6 @@ class Puppet::Pops::Validation::Checker4_0
   def check_NodeDefinition(o)
     # Check that hostnames are valid hostnames (or regular expressions)
     hostname(o.host_matches, o)
-    hostname(o.parent, o, 'parent') unless o.parent.nil?
     top(o.eContainer, o)
     if violator = ends_with_idem(o.body)
       acceptor.accept(Issues::IDEM_NOT_ALLOWED_LAST, violator, {:container => o})
@@ -506,14 +505,11 @@ class Puppet::Pops::Validation::Checker4_0
   #--- HOSTNAME CHECKS
 
   # Transforms Array of host matching expressions into a (Ruby) array of AST::HostName
-  def hostname_Array(o, semantic, single_feature_name)
-    if single_feature_name
-      acceptor.accept(Issues::ILLEGAL_EXPRESSION, o, {:feature=>single_feature_name, :container=>semantic})
-    end
-    o.each {|x| hostname(x, semantic, false) }
+  def hostname_Array(o, semantic)
+    o.each {|x| hostname(x, semantic) }
   end
 
-  def hostname_String(o, semantic, single_feature_name)
+  def hostname_String(o, semantic)
     # The 3.x checker only checks for illegal characters - if matching /[^-\w.]/ the name is invalid,
     # but this allows pathological names like "a..b......c", "----"
     # TODO: Investigate if more illegal hostnames should be flagged.
@@ -523,11 +519,11 @@ class Puppet::Pops::Validation::Checker4_0
     end
   end
 
-  def hostname_LiteralValue(o, semantic, single_feature_name)
-    hostname_String(o.value.to_s, o, single_feature_name)
+  def hostname_LiteralValue(o, semantic)
+    hostname_String(o.value.to_s, o)
   end
 
-  def hostname_ConcatenatedString(o, semantic, single_feature_name)
+  def hostname_ConcatenatedString(o, semantic)
     # Puppet 3.1. only accepts a concatenated string without interpolated expressions
     if the_expr = o.segments.index {|s| s.is_a?(Model::TextExpression) }
       acceptor.accept(Issues::ILLEGAL_HOSTNAME_INTERPOLATION, o.segments[the_expr].expr)
@@ -537,31 +533,31 @@ class Puppet::Pops::Validation::Checker4_0
     else
       # corner case, may be ok, but lexer may have replaced with plain string, this is
       # here if it does not
-      hostname_String(o.segments[0], o.segments[0], false)
+      hostname_String(o.segments[0], o.segments[0])
     end
   end
 
-  def hostname_QualifiedName(o, semantic, single_feature_name)
-    hostname_String(o.value.to_s, o, single_feature_name)
+  def hostname_QualifiedName(o, semantic)
+    hostname_String(o.value.to_s, o)
   end
 
-  def hostname_QualifiedReference(o, semantic, single_feature_name)
-    hostname_String(o.value.to_s, o, single_feature_name)
+  def hostname_QualifiedReference(o, semantic)
+    hostname_String(o.value.to_s, o)
   end
 
-  def hostname_LiteralNumber(o, semantic, single_feature_name)
+  def hostname_LiteralNumber(o, semantic)
     # always ok
   end
 
-  def hostname_LiteralDefault(o, semantic, single_feature_name)
+  def hostname_LiteralDefault(o, semantic)
     # always ok
   end
 
-  def hostname_LiteralRegularExpression(o, semantic, single_feature_name)
+  def hostname_LiteralRegularExpression(o, semantic)
     # always ok
   end
 
-  def hostname_Object(o, semantic, single_feature_name)
+  def hostname_Object(o, semantic)
     acceptor.accept(Issues::ILLEGAL_EXPRESSION, o, {:feature=> single_feature_name || 'hostname', :container=>semantic})
   end
 

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -558,7 +558,7 @@ class Puppet::Pops::Validation::Checker4_0
   end
 
   def hostname_Object(o, semantic)
-    acceptor.accept(Issues::ILLEGAL_EXPRESSION, o, {:feature=> single_feature_name || 'hostname', :container=>semantic})
+    acceptor.accept(Issues::ILLEGAL_EXPRESSION, o, {:feature => 'hostname', :container => semantic})
   end
 
   #---QUERY CHECKS


### PR DESCRIPTION
Before this, the validator had the ability to pass a single-feature
name when checking hostnames. This was used to check the parent of a
node. This is no longer needed since having a parent is now illegal.

This removes this feature. Tests that checked validation of parent
host name matches were removed a long time ago.