### PR TITLE
fix service_name for not include description

### DIFF
--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
 
   # Extract service name
   def service_name
-    extract_value_name('service', 0, /# (.*)/, '\1')
+    extract_value_name('service', 0, /# (.*)( : .*)?/, '\1')
   end
 
   # Extract rcvar name


### PR DESCRIPTION
FreeBSD service provider for not include description.

Ex.
  dns/bind99 package rc script

```
$ /usr/local/etc/rc.d/named rcvar
# named : named BIND startup script
#
named_enable="NO"
#   (default: "")

```

before fix:
 create file "/etc/rc.conf.d/named : named BIND startup script"
after fix:
 create file "/etc/rc.conf.d/named"

thx!