### PR TITLE
(PUP-4438) Add required_repeated_param to 4.x function API

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -331,6 +331,23 @@ module Puppet::Functions
       internal_param(type, name)
       @max = :default
     end
+    alias optional_repeated_param repeated_param
+
+    # Defines a repeated positional parameter with _type_ and _name_ that may occur 1 to "infinite" number of times.
+    # It may only appear last or just before a block parameter.
+    #
+    # @param type [String] The type specification for the parameter.
+    # @param name [Symbol] The name of the parameter. This is primarily used
+    #   for error message output and does not have to match an implementation
+    #   method parameter.
+    # @return [Void]
+    #
+    # @api public
+    def required_repeated_param(type, name)
+      internal_param(type, name)
+      @min += 1
+      @max = :default
+    end
 
     # Defines one required block parameter that may appear last. If type and name is missing the
     # default type is "Callable", and the name is "block". If only one


### PR DESCRIPTION
Adds the ability to declare a repeated parameter as being required
using the method `required_repeated_parameter` with the meaning that
at least one argument must be passed to it.

For consistency, this commit also adds an `optional_repeated_parameter`
alias for the already existing `repeated_parameter` method.