### PR TITLE
(PUP-4394) Improve erroring for WEBrick server when Puppet user doesn't exist

### DIFF
--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -185,11 +185,15 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
     Puppet::SSL::Host.ca_location = :only if Puppet::SSL::CertificateAuthority.ca?
 
     if Puppet.features.root?
-      begin
-        Puppet::Util.chuser
-      rescue => detail
-        Puppet.log_exception(detail, "Could not change user to #{Puppet[:user]}: #{detail}")
-        exit(39)
+      if Puppet::Type.type(:user).new(:name => Puppet[:user]).exists?
+        begin
+          Puppet::Util.chuser
+        rescue => detail
+          Puppet.log_exception(detail, "Could not change user to #{Puppet[:user]}: #{detail}")
+          exit(39)
+        end
+      else
+        raise Puppet::Error.new("Could not change user to #{Puppet[:user]}. User does not exist and is required to continue.")
       end
     end
 

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -314,12 +314,28 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
         @master.main
       end
 
-      it "should drop privileges if running as root" do
-        Puppet.features.stubs(:root?).returns true
+      def a_user_type_for(username)
+        user = mock 'user'
+        Puppet::Type.type(:user).expects(:new).with { |args| args[:name] == username }.returns user
+        user
+      end
 
-        Puppet::Util.expects(:chuser)
+      context "user privileges" do
+        it "should drop privileges if running as root and the puppet user exists" do
+          Puppet.features.stubs(:root?).returns true
+          a_user_type_for("puppet").expects(:exists?).returns true
 
-        @master.main
+          Puppet::Util.expects(:chuser)
+
+          @master.main
+        end
+
+        it "should exit and log an error if running as root and the puppet user does not exist" do
+          Puppet.features.stubs(:root?).returns true
+          a_user_type_for("puppet").expects(:exists?).returns false
+
+          expect { @master.main }.to raise_error(Puppet::Error, /Could not change user to puppet\. User does not exist and is required to continue\./)
+        end
       end
 
       it "should daemonize if needed" do


### PR DESCRIPTION
The puppet-agent package does not create the puppet user or group
by default, meaning that attempting to run the webrick server without
manually creating the user results in Puppet failing hard.

This commit updates Puppet's webrick code to first check it the
puppet user exists, and only attempt to switch to it if it does.
Otherwise, we emit an error and exit. Previously, Puppet would
actually try to switch to the non-existent user and throw several
errors. We now only throw one.