### PR TITLE
(PUP-4435) Deprecate WEBrick and Rack master servers

### DIFF
--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -198,8 +198,10 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
     end
 
     if options[:rack]
+      Puppet.deprecation_warning("The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information.")
       start_rack_master
     else
+      Puppet.deprecation_warning("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information.")
       start_webrick_master
     end
   end

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -338,6 +338,16 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
         end
       end
 
+      it "should log a deprecation notice when running a WEBrick server" do
+        Puppet.features.stubs(:root?).returns true
+        a_user_type_for("puppet").expects(:exists?).returns true
+        Puppet::Util.expects(:chuser)
+
+        Puppet.expects(:deprecation_warning).with("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information.")
+
+        @master.main
+      end
+
       it "should daemonize if needed" do
         Puppet[:daemonize] = true
 
@@ -371,6 +381,17 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
 
           app = @master.main
           expect(app).to equal(@app)
+        end
+
+        it "should log a deprecation notice" do
+          @master.options.stubs(:[]).with(:rack).returns(:true)
+          Puppet.features.stubs(:root?).returns true
+          a_user_type_for("puppet").expects(:exists?).returns true
+          Puppet::Util.expects(:chuser)
+
+          Puppet.expects(:deprecation_warning).with("The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information.")
+
+          @master.main
         end
       end
     end


### PR DESCRIPTION
This commit adds a deprecation warning to Puppet's
webrick code so that just before the server is started,
the warning will be emitted. We plan to eventually drop
WEBrick.