### PR TITLE
(PUP-4447) Give better error message for assignment to name and title

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -610,9 +610,9 @@ class Puppet::Parser::Scope
     table = effective_symtable(options[:ephemeral])
     if table.bound?(name)
       if options[:append]
-        error = Puppet::ParseError.new("Cannot append, variable #{name} is defined in this scope")
+        error = Puppet::ParseError.new("Cannot append, variable '$#{name}' is defined in this scope")
       else
-        error = Puppet::ParseError.new("Cannot reassign variable #{name}")
+        error = Puppet::ParseError.new("Cannot reassign variable '$#{name}'")
       end
       error.file = options[:file] if options[:file]
       error.line = options[:line] if options[:line]

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -162,11 +162,16 @@ module Puppet::Pops::Issues
 
   # Variables are immutable, cannot reassign in the same assignment scope
   ILLEGAL_REASSIGNMENT = hard_issue :ILLEGAL_REASSIGNMENT, :name do
-    "Cannot reassign variable #{name}"
+    if Puppet::Pops::Validation::Checker4_0::RESERVED_PARAMETERS[name]
+      "Cannot reassign built in (or already assigned) variable '$#{name}'"
+    else
+      "Cannot reassign variable '$#{name}'"
+    end
   end
 
+  # Variables facts and trusted
   ILLEGAL_RESERVED_ASSIGNMENT = hard_issue :ILLEGAL_RESERVED_ASSIGNMENT, :name do
-    "Attempt to assign to a reserved variable name: '#{name}'"
+    "Attempt to assign to a reserved variable name: '$#{name}'"
   end
 
   # Assignment cannot be made to numeric match result variables

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -115,9 +115,9 @@ class Puppet::Pops::Validation::Checker4_0
         acceptor.accept(Issues::CROSS_SCOPE_ASSIGNMENT, o, :name => varname_string)
       end
     end
+
     # TODO: Could scan for reassignment of the same variable if done earlier in the same container
     #       Or if assigning to a parameter (more work).
-    # TODO: Investigate if there are invalid cases for += assignment
   end
 
   def assign_AccessExpression(o, via_index)

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -36,8 +36,30 @@ describe "Two step scoping for variables" do
     end
   end
 
-  it "when using a template ignores the dynamic value of the var when using the @varname syntax" do
-    expect_the_message_to_be('node_msg') do <<-MANIFEST
+    it "issues error about built-in variable when reassigning to name" do
+        enc_node = Puppet::Node.new("the_node", { :parameters => {  } })
+
+        expect {
+          compile_to_catalog("$name = 'never in a 0xF4240 years'", enc_node)
+        }.to raise_error(
+          Puppet::Error,
+          /Cannot reassign built in \(or already assigned\) variable '\$name' at line 1(\:7)? on node the_node/
+        )
+    end
+
+    it "issues error about built-in variable when reassigning to title" do
+        enc_node = Puppet::Node.new("the_node", { :parameters => {  } })
+
+        expect {
+          compile_to_catalog("$title = 'never in a 0xF4240 years'", enc_node)
+        }.to raise_error(
+          Puppet::Error,
+          /Cannot reassign built in \(or already assigned\) variable '\$title' at line 1(\:8)? on node the_node/
+        )
+    end
+
+    it "when using a template ignores the dynamic value of the var when using the @varname syntax" do
+      expect_the_message_to_be('node_msg') do <<-MANIFEST
           node default {
             $var = "node_msg"
             include foo
@@ -589,12 +611,11 @@ describe "Two step scoping for variables" do
 
     it "does not allow the enc to specify an existing top scope var" do
       enc_node = Puppet::Node.new("the_node", { :parameters => { "var" => 'from_enc' } })
-
       expect {
         compile_to_catalog("$var = 'top scope'", enc_node)
       }.to raise_error(
-      Puppet::Error,
-      /Cannot reassign variable var at line 1(\:6)? on node the_node/
+        Puppet::Error,
+        /Cannot reassign variable '\$var' at line 1(\:6)? on node the_node/
       )
     end
 

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -192,7 +192,7 @@ describe Puppet::Parser::Scope do
       @scope["var"] = "childval"
       expect {
         @scope["var"] = "change"
-      }.to raise_error(Puppet::Error, "Cannot reassign variable var")
+      }.to raise_error(Puppet::Error, "Cannot reassign variable '$var'")
     end
 
     it "should be able to detect when variables are not set" do
@@ -305,7 +305,7 @@ describe Puppet::Parser::Scope do
         @scope.setvar("var", "1", :append => true)
       }.to raise_error(
         Puppet::ParseError,
-        "Cannot append, variable var is defined in this scope"
+        "Cannot append, variable '$var' is defined in this scope"
       )
     end
 

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1288,9 +1288,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
     it "parses interpolated heredoc expression" do
       src = <<-CODE
-      $name = 'Fjodor'
+      $pname = 'Fjodor'
       @("END")
-      Hello $name
+      Hello $pname
       |- END
       CODE
       expect(parser.evaluate_string(scope, src)).to eq("Hello Fjodor")
@@ -1358,8 +1358,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
     it 'for a hostname with interpolation' do
       source = <<-SOURCE.gsub(/^ {6}/,'')
-      $name = 'fred'
-      node "macbook-owned-by$name" { }
+      $pname = 'fred'
+      node "macbook-owned-by$pname" { }
       SOURCE
       expect {
         parser.parse_string(source, nil)

--- a/spec/unit/pops/evaluator/variables_spec.rb
+++ b/spec/unit/pops/evaluator/variables_spec.rb
@@ -46,7 +46,7 @@ describe 'Puppet::Pops::Impl::EvaluatorImpl' do
       end
 
       it "can not change a variable value in same scope" do
-        expect { evaluate_l(block(var('a').set(10), var('a').set(20))) }.to raise_error(/Cannot reassign variable a/)
+        expect { evaluate_l(block(var('a').set(10), var('a').set(20))) }.to raise_error(/Cannot reassign variable '\$a'/)
       end
 
       context "access to numeric variables" do


### PR DESCRIPTION
Before this, an attempt to assign to $name o $title, when not in a
lambda where $name or $title is a parameter would result in an error
saying "Cannot reassign variable ...".

This was bad because users does not understand that $name and $title are
always assigned in the body of a class or a define, and that top-scope
is really in the body of Class['main'].

This commit improves the error in this situation to read:
"Cannot reassign built in (or already assigned) variable '$...'"

The vagueness "built in (or already assigned)" is used since when the
error occurs it is difficult to compute if the evaluated logic is in the
body of a class or define or not. Instead, it gives this alternative
output when the name of the variable is "name" or "title". The only
downside is the potential confusion if:

* the parameter name $name or $title is used in a lambda AND
* an attempt is made to reassign those variables

This should be an aceptable trade off vs. the performance penalty it
would mean to pass along a more comprehensive context for the sake of
only differentiating from where the assignment was made.