### PR TITLE
(PUP-4374) Splat in all resource expressions

### DIFF
--- a/lib/puppet/pops/evaluator/collector_transformer.rb
+++ b/lib/puppet/pops/evaluator/collector_transformer.rb
@@ -27,7 +27,7 @@ class Puppet::Pops::Evaluator::CollectorTransformer
 
     if !o.operations.empty?
       overrides = {
-        :parameters => o.operations.map{ |x| to_3x_param(x).evaluate(scope)},
+        :parameters => o.operations.map{ |x| @@evaluator.evaluate(x, scope)}.flatten,
         :file       => file_path,
         :line       => [line_num, position],
         :source     => scope.source,
@@ -205,15 +205,5 @@ protected
 
   def match_Object(o, scope)
     raise ArgumentError, "Cannot transform object of class #{o.class}"
-  end
-
-  # Produces (name => expr) or (name +> expr)
-  def to_3x_param(o)
-    bridge = Puppet::Parser::AST::PopsBridge::Expression.new(:value => o.value_expr)
-    args = { :value => bridge }
-    args[:add] = true if o.operator == :'+>'
-    args[:param] = o.attribute_name
-    args= Puppet::Pops::Model::AstTransformer.new().merge_location(args, o)
-    Puppet::Parser::AST::ResourceParam.new(args)
   end
 end

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -335,7 +335,8 @@ module Puppet::Pops::Evaluator::Runtime3Support
     # TODO: Revisit and possible improve the accuracy.
     #
     file, line = extract_file_line(o)
-
+    # A *=> results in an array of arrays
+    evaluated_parameters = evaluated_parameters.flatten
     evaluated_resources.each do |r|
       unless r.is_a?(Puppet::Pops::Types::PResourceType) && r.type_name != 'class'
         fail(Puppet::Pops::Issues::ILLEGAL_OVERRIDEN_TYPE, o, {:actual => r} )

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -316,7 +316,7 @@ module Puppet::Pops::Evaluator::Runtime3Support
     # for the type of the name.
     # Note, locations are available per parameter.
     #
-    scope.define_settings(capitalize_qualified_name(type_name), evaluated_parameters)
+    scope.define_settings(capitalize_qualified_name(type_name), evaluated_parameters.flatten)
   end
 
   # Capitalizes each segment of a qualified name

--- a/lib/puppet/pops/model/model_meta.rb
+++ b/lib/puppet/pops/model/model_meta.rb
@@ -258,7 +258,7 @@ module Puppet::Pops::Model
   class CollectExpression < Expression
     contains_one_uni 'type_expr', Expression, :lowerBound => 1
     contains_one_uni 'query', QueryExpression, :lowerBound => 1
-    contains_many_uni 'operations', AttributeOperation
+    contains_many_uni 'operations', AbstractAttributeOperation
   end
 
   class Parameter < Positioned

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -188,12 +188,17 @@ class Puppet::Pops::Validation::Checker4_0
   def check_AttributesOperation(o)
     # Append operator use is constrained
     parent1 = o.eContainer
-    parent2 = parent1.eContainer unless parent1.nil?
-    unless parent2.is_a?(Model::AbstractResource) || parent1.is_a?(Model::AbstractResource)
-      containe = parent2.is_a?(Model::AbstractResource) ? parent2 : parent1
-      acceptor.accept(Issues::UNSUPPORTED_OPERATOR_IN_CONTEXT, container, :operator=>'* =>')
+    case parent1
+    when Model::AbstractResource
+    when Model::CollectExpression
+    else
+      # protect against just testing a snippet that has no parent, error message will be a bit strange
+      # but it is not for a real program.
+      parent2 = parent1.nil? ? o : parent1.eContainer
+      unless parent2.is_a?(Model::AbstractResource)
+        acceptor.accept(Issues::UNSUPPORTED_OPERATOR_IN_CONTEXT, parent2, :operator=>'* =>')
+      end
     end
-
     rvalue(o.expr)
   end
 

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -187,10 +187,11 @@ class Puppet::Pops::Validation::Checker4_0
 
   def check_AttributesOperation(o)
     # Append operator use is constrained
-    parent = o.eContainer
-    parent = parent.eContainer unless parent.nil?
-    unless parent.is_a?(Model::ResourceExpression)
-      acceptor.accept(Issues::UNSUPPORTED_OPERATOR_IN_CONTEXT, o, :operator=>'* =>')
+    parent1 = o.eContainer
+    parent2 = parent1.eContainer unless parent1.nil?
+    unless parent2.is_a?(Model::AbstractResource) || parent1.is_a?(Model::AbstractResource)
+      containe = parent2.is_a?(Model::AbstractResource) ? parent2 : parent1
+      acceptor.accept(Issues::UNSUPPORTED_OPERATOR_IN_CONTEXT, container, :operator=>'* =>')
     end
 
     rvalue(o.expr)

--- a/spec/integration/parser/collector_spec.rb
+++ b/spec/integration/parser/collector_spec.rb
@@ -313,5 +313,12 @@ describe Puppet::Parser::Collector do
     end
 
     it_behaves_like "virtual resource collection"
+
+    it "collects and overrides attributes specified with a * => hash" do
+      expect_the_message_to_be(["overridden1"], <<-MANIFEST)
+        notify { "testing": message => "original" }
+        Notify <|  |> { * => { message => 'overridden1' }}
+      MANIFEST
+    end
   end
 end

--- a/spec/integration/parser/resource_expressions_spec.rb
+++ b/spec/integration/parser/resource_expressions_spec.rb
@@ -170,6 +170,8 @@ describe "Puppet resource expressions" do
              path => '/somewhere',
              * => $y }"  => "File[$t][mode] == '0666' and File[$t][owner] == 'the_x' and File[$t][path] == '/somewhere'")
 
+      produces("notify{title:}; Notify[title] { * => { message => set}}" => "Notify[title][message] == 'set'")
+
       fails("notify { title: unknown => value }" => /Invalid parameter unknown/)
 
         # this really needs to be a better error message.

--- a/spec/integration/parser/resource_expressions_spec.rb
+++ b/spec/integration/parser/resource_expressions_spec.rb
@@ -171,6 +171,7 @@ describe "Puppet resource expressions" do
              * => $y }"  => "File[$t][mode] == '0666' and File[$t][owner] == 'the_x' and File[$t][path] == '/somewhere'")
 
       produces("notify{title:}; Notify[title] { * => { message => set}}" => "Notify[title][message] == 'set'")
+      produces("Notify { * => { message => set}}; notify{title:}"      => "Notify[title][message] == 'set'")
 
       fails("notify { title: unknown => value }" => /Invalid parameter unknown/)
 


### PR DESCRIPTION
There were parts missing in the implementation supporting * => $hash to set resource parameters; in overrides, and in collectors. There is no reason to forbid those using * => $hash. 

This corrects the implementation and adds test cases.