### PR TITLE
(PUP-4462) Fix problem with heredoc interpolation turning on escapes

### DIFF
--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -213,7 +213,7 @@ class Puppet::Pops::Parser::Lexer2
     @scanner = StringScanner.new(string)
     @locator = locator || Puppet::Pops::Parser::Locator.locator(string, '')
     @lexing_context[:escapes] = escapes || UQ_ESCAPES
-    @lexing_context[:uq_slurp_pattern] = (interpolate || !escapes.empty?) ? SLURP_UQ_PATTERN : SLURP_ALL_PATTERN
+    @lexing_context[:uq_slurp_pattern] = interpolate ? (!escapes.include?('$') ? SLURP_UQNE_PATTERN : SLURP_UQ_PATTERN) : SLURP_ALL_PATTERN
   end
 
   # Convenience method, and for compatibility with older lexer. Use the lex_file instead.

--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -213,7 +213,7 @@ class Puppet::Pops::Parser::Lexer2
     @scanner = StringScanner.new(string)
     @locator = locator || Puppet::Pops::Parser::Locator.locator(string, '')
     @lexing_context[:escapes] = escapes || UQ_ESCAPES
-    @lexing_context[:uq_slurp_pattern] = interpolate ? (!escapes.include?('$') ? SLURP_UQNE_PATTERN : SLURP_UQ_PATTERN) : SLURP_ALL_PATTERN
+    @lexing_context[:uq_slurp_pattern] = interpolate ? (escapes.include?('$') ? SLURP_UQ_PATTERN : SLURP_UQNE_PATTERN) : SLURP_ALL_PATTERN
   end
 
   # Convenience method, and for compatibility with older lexer. Use the lex_file instead.

--- a/lib/puppet/pops/parser/slurp_support.rb
+++ b/lib/puppet/pops/parser/slurp_support.rb
@@ -12,6 +12,8 @@ module Puppet::Pops::Parser::SlurpSupport
   SLURP_SQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*[']/
   SLURP_DQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*(["]|[$]\{?)/
   SLURP_UQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*([$]\{?|\z)/
+  # unquoted, no escapes
+  SLURP_UQNE_PATTERN  = /([$]\{?|\z)/m
   SLURP_ALL_PATTERN = /.*(\z)/m
   SQ_ESCAPES = %w{ \\ ' }
   DQ_ESCAPES = %w{ \\  $ ' " r n t s u}+["\r\n", "\n"]
@@ -43,6 +45,7 @@ module Puppet::Pops::Parser::SlurpSupport
      scn = @scanner
      last = scn.matched
      ignore = true
+
      str = slurp(scn, @lexing_context[:uq_slurp_pattern], @lexing_context[:escapes], :ignore_invalid_escapes)
 
      # Terminator may be a single char '$', two characters '${', or empty string '' at the end of intput.

--- a/lib/puppet/pops/parser/slurp_support.rb
+++ b/lib/puppet/pops/parser/slurp_support.rb
@@ -13,7 +13,7 @@ module Puppet::Pops::Parser::SlurpSupport
   SLURP_DQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*(["]|[$]\{?)/
   SLURP_UQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*([$]\{?|\z)/
   # unquoted, no escapes
-  SLURP_UQNE_PATTERN  = /([$]\{?|\z)/m
+  SLURP_UQNE_PATTERN  = /(\$\{?|\z)/m
   SLURP_ALL_PATTERN = /.*(\z)/m
   SQ_ESCAPES = %w{ \\ ' }
   DQ_ESCAPES = %w{ \\  $ ' " r n t s u}+["\r\n", "\n"]

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1273,6 +1273,16 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       parser.evaluate_string(scope, src).should == "Hello Fjodor"
     end
 
+    it "parses interpolated heredoc expression with escapes" do
+      src = <<-CODE
+      $name = 'Fjodor'
+      @("END")
+      Hello\\ \\$name
+      |- END
+      CODE
+      parser.evaluate_string(scope, src).should == "Hello\\ \\Fjodor"
+    end
+
   end
   context "Handles Deprecations and Discontinuations" do
     it 'of import statements' do

--- a/spec/unit/pops/parser/parse_heredoc_spec.rb
+++ b/spec/unit/pops/parser/parse_heredoc_spec.rb
@@ -71,6 +71,32 @@ describe "egrammar parsing heredoc" do
     ].join("\n")
   end
 
+  it "parses interpolated heredoc expression containing escapes" do
+    src = <<-CODE
+    @("END")
+    Hello \\$name
+    |- END
+    CODE
+    dump(parse(src)).should == [
+      "(@()",
+      "  (sublocated (cat 'Hello \\' (str $name) ''))",
+      ")"
+    ].join("\n")
+  end
+
+  it "parses interpolated heredoc expression containing escapes when escaping other things than $" do
+    src = <<-CODE
+    @("END"/t)
+    Hello \\$name
+    |- END
+    CODE
+    dump(parse(src)).should == [
+      "(@()",
+      "  (sublocated (cat 'Hello \\' (str $name) ''))",
+      ")"
+    ].join("\n")
+  end
+
   it "parses with escaped newlines without preceding whitespace" do
     src = <<-CODE
     @(END/L)


### PR DESCRIPTION
Before this, heredoc with interpolation would also turn on escapes. This
means input like \$name would not interpolate, and \\ would be required
to get a single \. It should be required to be explici about allowing
escapes by using /$ (to be allowed to escape interpolation).

The prolem was caused by the pattern used to find the start of an
interpolation. This pattern included the escapes that would make the
pattern skip the interpolation start - it would simply scan past the
interpolation start if escaped.

The solution was to create a new pattern for finding interpolation
starts when a $ is not one of the wanted escapes.