### PR TITLE
(PUP-4463) Make Regexp Type without pattern use '' when used as pattern

### DIFF
--- a/lib/puppet/functions/regsubst.rb
+++ b/lib/puppet/functions/regsubst.rb
@@ -68,7 +68,7 @@ Puppet::Functions.create_function(:regsubst) do
   end
 
   def regsubst_regexp(target, pattern, replacement, flags = nil)
-    pattern = pattern.pattern if pattern.is_a?(Puppet::Pops::Types::PRegexpType)
+    pattern = (pattern.pattern || '') if pattern.is_a?(Puppet::Pops::Types::PRegexpType)
     inner_regsubst(target, pattern, replacement, operation = flags == 'G' ? :gsub : :sub)
   end
 

--- a/lib/puppet/functions/split.rb
+++ b/lib/puppet/functions/split.rb
@@ -42,6 +42,6 @@ Puppet::Functions.create_function(:split) do
   end
 
   def split_RegexpType(str, pattern)
-    str.split(pattern.pattern)
+    str.split(pattern.regexp)
   end
 end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -162,7 +162,8 @@ module Puppet::Pops
     class PRegexpType < PScalarType
       module ClassModule
         def regexp_derived
-          @_regexp = Regexp.new(pattern) unless @_regexp && @_regexp.source == pattern
+          pattern_or_blank = pattern || ''
+          @_regexp = Regexp.new(pattern_or_blank) unless @_regexp && @_regexp.source == pattern_or_blank
           @_regexp
         end
 

--- a/spec/unit/functions/regsubst_spec.rb
+++ b/spec/unit/functions/regsubst_spec.rb
@@ -66,6 +66,10 @@ describe 'the regsubst function' do
     it 'should accept Type[Regexp]' do
       expect(regsubst('abc', type_parser.parse("Regexp['b']"), '_')).to eql('a_c')
     end
+
+    it 'should treat Regexp as Regexp[//]' do
+      expect(regsubst('abc', type_parser.parse("Regexp"), '_', 'G')).to eql('_a_b_c_')
+    end
   end
 
   context 'when using an array target' do

--- a/spec/unit/functions/split_spec.rb
+++ b/spec/unit/functions/split_spec.rb
@@ -43,4 +43,12 @@ describe 'the split function' do
   it 'should handle pattern in Regexp Type form' do
     expect(split('a,b',type_parser.parse('Regexp[/,/]'))).to eql(['a', 'b'])
   end
+
+  it 'should handle pattern in Regexp Type form with empty regular expression' do
+    expect(split('ab',type_parser.parse('Regexp[//]'))).to eql(['a', 'b'])
+  end
+
+  it 'should handle pattern in Regexp Type form with missing regular expression' do
+    expect(split('ab',type_parser.parse('Regexp'))).to eql(['a', 'b'])
+  end
 end


### PR DESCRIPTION
Before this, if a Regexp without a pattern was used as a regular
expression, it would present a nil pattern - which for the split
function means use a default split on whitespace (other methods on
string may give it different meaning).

This makes a Regexp without a pattern behave as if the pattern was
// when asking for the regexp's compiled regular expression.

This also updates the functions split, and regsubst to either use the
type's compiled regexp, or the same rule (pattern || '').

As a type, the Regexp still represents all possible patterns.