### PR TITLE
(PUP-4373) Windows ADSI User groups property should behave similarly to Groups members property

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -30,7 +30,6 @@ Puppet::Type.type(:group).provide :windows_adsi do
     if @resource[:auth_membership]
       current_users == specified_users
     else
-      return true if specified_users.empty?
       (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
     end
   end

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -41,7 +41,6 @@ Puppet::Type.type(:user).provide :windows_adsi do
     if @resource[:membership] == :inclusive
       current_users == specified_users
     else
-      return true if specified_users.empty?
       (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
     end
   end

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -25,6 +25,27 @@ Puppet::Type.type(:user).provide :windows_adsi do
     user.set_groups(groups, @resource[:membership] == :minimum)
   end
 
+  def groups_insync?(current, should)
+    return false unless current
+
+    # By comparing account SIDs we don't have to worry about case
+    # sensitivity, or canonicalization of account names.
+
+    # Cannot use munge of the group property to canonicalize @should
+    # since the default array_matching comparison is not commutative
+
+    # dupes automatically weeded out when hashes built
+    current_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
+    specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
+
+    if @resource[:membership] == :inclusive
+      current_users == specified_users
+    else
+      return true if specified_users.empty?
+      (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
+    end
+  end
+
   def create
     @user = Puppet::Util::Windows::ADSI::User.create(@resource[:name])
     @user.password = @resource[:password]

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -274,6 +274,14 @@ module Puppet
         raise ArgumentError, "Group names must be provided as an array, not a comma-separated list." if value.include?(",")
         raise ArgumentError, "Group names must not be empty. If you want to specify \"no groups\" pass an empty array" if value.empty?
       end
+
+      def insync?(current)
+        if provider.respond_to?(:groups_insync?)
+          return provider.groups_insync?(current, @should)
+        end
+
+        super(current)
+      end
     end
 
     newparam(:name) do

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -265,8 +265,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def set_groups(desired_groups, minimum = true)
-      return if desired_groups.nil? or desired_groups.empty?
-      # this needs fixed up once PUP-3653 is merged up
+      return if desired_groups.nil?
 
       desired_groups = desired_groups.split(',').map(&:strip)
 
@@ -282,7 +281,12 @@ module Puppet::Util::Windows::ADSI
       # Then we remove the user from all groups it is in but shouldn't be, if
       # that's been requested
       if !minimum
-        groups_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
+        if desired_hash.empty?
+          groups_to_remove = current_hash.values
+        else
+          groups_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
+        end
+
         remove_group_sids(*groups_to_remove)
       end
     end

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -97,18 +97,18 @@ module Puppet::Util::Windows::ADSI
       [:lpwstr, :lpdword], :win32_bool
   end
 
-  class User
-    extend Enumerable
-    extend FFI::Library
+  module Shared
+    def uri(name, host = '.')
+      if sid_uri = Puppet::Util::Windows::ADSI.sid_uri_safe(name) then return sid_uri end
 
-    attr_accessor :native_user
-    attr_reader :name, :sid
-    def initialize(name, native_user = nil)
-      @name = name
-      @native_user = native_user
+      host = '.' if ['NT AUTHORITY', 'BUILTIN', Socket.gethostname].include?(host)
+
+      account_type = self.name.split('::').last.downcase
+
+      Puppet::Util::Windows::ADSI.uri(name, account_type, host)
     end
 
-    def self.parse_name(name)
+    def parse_name(name)
       if name =~ /\//
         raise Puppet::Error.new( "Value must be in DOMAIN\\user style syntax" )
       end
@@ -120,20 +120,51 @@ module Puppet::Util::Windows::ADSI
       return account, domain
     end
 
+    def get_sids(adsi_child_collection)
+      sids = []
+      adsi_child_collection.each do |m|
+        sids << Puppet::Util::Windows::SID.octet_string_to_sid_object(m.objectSID)
+      end
+
+      sids
+    end
+
+    def name_sid_hash(names)
+      return {} if names.nil? || names.empty?
+
+      sids = names.map do |name|
+        sid = Puppet::Util::Windows::SID.name_to_sid_object(name)
+        raise Puppet::Error.new( "Could not resolve name: #{name}" ) if !sid
+        [sid.to_s, sid]
+      end
+
+      Hash[ sids ]
+    end
+  end
+
+  class User
+    extend Enumerable
+    extend Puppet::Util::Windows::ADSI::Shared
+    extend FFI::Library
+
+    # https://msdn.microsoft.com/en-us/library/aa746340.aspx
+    # IADsUser interface
+
+    require 'puppet/util/windows/sid'
+
+    attr_accessor :native_user
+    attr_reader :name, :sid
+    def initialize(name, native_user = nil)
+      @name = name
+      @native_user = native_user
+    end
+
     def native_user
       @native_user ||= Puppet::Util::Windows::ADSI.connect(self.class.uri(*self.class.parse_name(@name)))
     end
 
     def sid
       @sid ||= Puppet::Util::Windows::SID.octet_string_to_sid_object(native_user.objectSID)
-    end
-
-    def self.uri(name, host = '.')
-      if sid_uri = Puppet::Util::Windows::ADSI.sid_uri_safe(name) then return sid_uri end
-
-      host = '.' if ['NT AUTHORITY', 'BUILTIN', Socket.gethostname].include?(host)
-
-      Puppet::Util::Windows::ADSI.uri(name, 'user', host)
     end
 
     def uri
@@ -189,6 +220,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def groups
+      # https://msdn.microsoft.com/en-us/library/aa746342.aspx
       # WIN32OLE objects aren't enumerable, so no map
       groups = []
       native_user.Groups.each {|g| groups << g.Name} rescue nil
@@ -209,21 +241,50 @@ module Puppet::Util::Windows::ADSI
     end
     alias remove_from_group remove_from_groups
 
+
+    def add_group_sids(*sids)
+      group_names = []
+      sids.each do |sid|
+        group_names << Puppet::Util::Windows::SID.sid_to_name(sid)
+      end
+
+      add_to_groups(*group_names)
+    end
+
+    def remove_group_sids(*sids)
+      group_names = []
+      sids.each do |sid|
+        group_names << Puppet::Util::Windows::SID.sid_to_name(sid)
+      end
+
+      remove_from_groups(*group_names)
+    end
+
+    def group_sids
+      self.class.get_sids(native_user.Groups)
+    end
+
     def set_groups(desired_groups, minimum = true)
       return if desired_groups.nil? or desired_groups.empty?
+      # this needs fixed up once PUP-3653 is merged up
 
       desired_groups = desired_groups.split(',').map(&:strip)
 
-      current_groups = self.groups
+      current_hash = Hash[ self.group_sids.map { |sid| [sid.to_s, sid] } ]
+      desired_hash = self.class.name_sid_hash(desired_groups)
 
       # First we add the user to all the groups it should be in but isn't
-      groups_to_add = desired_groups - current_groups
-      add_to_groups(*groups_to_add)
+      if !desired_groups.empty?
+        groups_to_add = (desired_hash.keys - current_hash.keys).map { |sid| desired_hash[sid] }
+        add_group_sids(*groups_to_add)
+      end
 
       # Then we remove the user from all groups it is in but shouldn't be, if
       # that's been requested
-      groups_to_remove = current_groups - desired_groups
-      remove_from_groups(*groups_to_remove) unless minimum
+      if !minimum
+        groups_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
+        remove_group_sids(*groups_to_remove)
+      end
     end
 
     def self.create(name)
@@ -301,6 +362,10 @@ module Puppet::Util::Windows::ADSI
 
   class Group
     extend Enumerable
+    extend Puppet::Util::Windows::ADSI::Shared
+
+    # https://msdn.microsoft.com/en-us/library/aa706021.aspx
+    # IADsGroup interface
 
     attr_accessor :native_group
     attr_reader :name, :sid
@@ -310,17 +375,11 @@ module Puppet::Util::Windows::ADSI
     end
 
     def uri
-      self.class.uri(name)
-    end
-
-    def self.uri(name, host = '.')
-      if sid_uri = Puppet::Util::Windows::ADSI.sid_uri_safe(name) then return sid_uri end
-
-      Puppet::Util::Windows::ADSI.uri(name, 'group', host)
+      self.class.uri(sid.account, sid.domain)
     end
 
     def native_group
-      @native_group ||= Puppet::Util::Windows::ADSI.connect(uri)
+      @native_group ||= Puppet::Util::Windows::ADSI.connect(self.class.uri(*self.class.parse_name(name)))
     end
 
     def sid
@@ -344,18 +403,6 @@ module Puppet::Util::Windows::ADSI
       self
     end
 
-    def self.name_sid_hash(names)
-      return {} if names.nil? or names.empty?
-
-      sids = names.map do |name|
-        sid = Puppet::Util::Windows::SID.name_to_sid_object(name)
-        raise Puppet::Error.new( "Could not resolve username: #{name}" ) if !sid
-        [sid.to_s, sid]
-      end
-
-      Hash[ sids ]
-    end
-
     def add_member_sids(*sids)
       sids.each do |sid|
         native_group.Add(Puppet::Util::Windows::ADSI.sid_uri(sid))
@@ -372,15 +419,12 @@ module Puppet::Util::Windows::ADSI
       # WIN32OLE objects aren't enumerable, so no map
       members = []
       native_group.Members.each {|m| members << m.Name}
+
       members
     end
 
     def member_sids
-      sids = []
-      native_group.Members.each do |m|
-        sids << Puppet::Util::Windows::SID.octet_string_to_sid_object(m.objectSID)
-      end
-      sids
+      self.class.get_sids(native_group.Members)
     end
 
     def set_members(desired_members, inclusive = true)

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -43,10 +43,6 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
     end
 
     describe "#members_insync?" do
-      it "should return false when current is nil" do
-        expect(provider.members_insync?(nil, ['user2'])).to be_falsey
-      end
-
       it "should return true for same lists of members" do
         expect(provider.members_insync?(['user1', 'user2'], ['user1', 'user2'])).to be_truthy
       end
@@ -59,8 +55,16 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         expect(provider.members_insync?(['user1', 'user2', 'user2'], ['user2', 'user1', 'user1'])).to be_truthy
       end
 
-      it "should return true when current user(s) and should user(s) are empty lists" do
+      it "should return true when current and should members are empty lists" do
         expect(provider.members_insync?([], [])).to be_truthy
+      end
+
+      # invalid scenarios
+      #it "should return true when current and should members are nil lists" do
+      #it "should return true when current members is nil and should members is empty" do
+
+      it "should return true when current members is empty and should members is nil" do
+        expect(provider.members_insync?([], nil)).to be_truthy
       end
 
       context "when auth_membership => true" do
@@ -68,12 +72,16 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
           resource[:auth_membership] = true
         end
 
-        it "should return false when current contains different users than should" do
-          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
+        it "should return false when current is nil" do
+          expect(provider.members_insync?(nil, ['user2'])).to be_falsey
         end
 
         it "should return false when should is nil" do
           expect(provider.members_insync?(['user1'], nil)).to be_falsey
+        end
+
+        it "should return false when current contains different users than should" do
+          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
         end
 
         it "should return false when current contains members and should is empty" do
@@ -99,12 +107,16 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
           resource[:auth_membership] = false
         end
 
-        it "should return false when current contains different users than should" do
-          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
+        it "should return false when current is nil" do
+          expect(provider.members_insync?(nil, ['user2'])).to be_falsey
         end
 
         it "should return true when should is nil" do
           expect(provider.members_insync?(['user1'], nil)).to be_truthy
+        end
+
+        it "should return false when current contains different users than should" do
+          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
         end
 
         it "should return true when current contains members and should is empty" do

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -72,14 +72,6 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group3').returns(group3)
     end
 
-    it "should return false when current is nil" do
-      expect(provider.groups_insync?(nil, ['group2'])).to be_falsey
-    end
-
-    it "should return true when should is nil" do
-      expect(provider.groups_insync?(['group1'], nil)).to be_truthy
-    end
-
     it "should return true for same lists of members" do
       expect(provider.groups_insync?(['group1', 'group2'], ['group1', 'group2'])).to be_truthy
     end
@@ -92,9 +84,29 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       expect(provider.groups_insync?(['group1', 'group2', 'group2'], ['group2', 'group1', 'group1'])).to be_truthy
     end
 
+    it "should return true when current and should groups are empty lists" do
+      expect(provider.groups_insync?([], [])).to be_truthy
+    end
+
+    # invalid scenarios
+    #it "should return true when current and should groups are nil lists" do
+    #it "should return true when current groups is nil and should groups is empty" do
+
+    it "should return true when current groups is empty and should groups is nil" do
+      expect(provider.groups_insync?([], nil)).to be_truthy
+    end
+
     context "when membership => inclusive" do
       before :each do
         resource[:membership] = :inclusive
+      end
+
+      it "should return false when current is nil" do
+        expect(provider.groups_insync?(nil, ['group2'])).to be_falsey
+      end
+
+      it "should return false when should is nil" do
+        expect(provider.groups_insync?(['group1'], nil)).to be_falsey
       end
 
       it "should return false when current contains different users than should" do
@@ -118,6 +130,14 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       before :each do
         # this is also the default
         resource[:membership] = :minimum
+      end
+
+      it "should return false when current is nil" do
+        expect(provider.groups_insync?(nil, ['group2'])).to be_falsey
+      end
+
+      it "should return true when should is nil" do
+        expect(provider.groups_insync?(['group1'], nil)).to be_truthy
       end
 
       it "should return false when current contains different users than should" do

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -60,6 +60,88 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
     end
   end
 
+  describe "groups_insync?" do
+
+    let(:group1) { stub(:account => 'group1', :domain => '.', :to_s => 'group1sid') }
+    let(:group2) { stub(:account => 'group2', :domain => '.', :to_s => 'group2sid') }
+    let(:group3) { stub(:account => 'group3', :domain => '.', :to_s => 'group3sid') }
+
+    before :each do
+      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group1').returns(group1)
+      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group2').returns(group2)
+      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group3').returns(group3)
+    end
+
+    it "should return false when current is nil" do
+      expect(provider.groups_insync?(nil, ['group2'])).to be_falsey
+    end
+
+    it "should return true when should is nil" do
+      expect(provider.groups_insync?(['group1'], nil)).to be_truthy
+    end
+
+    it "should return true for same lists of members" do
+      expect(provider.groups_insync?(['group1', 'group2'], ['group1', 'group2'])).to be_truthy
+    end
+
+    it "should return true for same lists of unordered members" do
+      expect(provider.groups_insync?(['group1', 'group2'], ['group2', 'group1'])).to be_truthy
+    end
+
+    it "should return true for same lists of members irrespective of duplicates" do
+      expect(provider.groups_insync?(['group1', 'group2', 'group2'], ['group2', 'group1', 'group1'])).to be_truthy
+    end
+
+    context "when membership => inclusive" do
+      before :each do
+        resource[:membership] = :inclusive
+      end
+
+      it "should return false when current contains different users than should" do
+        expect(provider.groups_insync?(['group1'], ['group2'])).to be_falsey
+      end
+
+      it "should return false when current contains members and should is empty" do
+        expect(provider.groups_insync?(['group1'], [])).to be_falsey
+      end
+
+      it "should return false when current is empty and should contains members" do
+        expect(provider.groups_insync?([], ['group2'])).to be_falsey
+      end
+
+      it "should return false when should user(s) are not the only items in the current" do
+        expect(provider.groups_insync?(['group1', 'group2'], ['group1'])).to be_falsey
+      end
+    end
+
+    context "when membership => minimum" do
+      before :each do
+        # this is also the default
+        resource[:membership] = :minimum
+      end
+
+      it "should return false when current contains different users than should" do
+        expect(provider.groups_insync?(['group1'], ['group2'])).to be_falsey
+      end
+
+      it "should return true when current contains members and should is empty" do
+        expect(provider.groups_insync?(['group1'], [])).to be_truthy
+      end
+
+      it "should return false when current is empty and should contains members" do
+        expect(provider.groups_insync?([], ['group2'])).to be_falsey
+      end
+
+      it "should return true when current user(s) contains at least the should list" do
+        expect(provider.groups_insync?(['group1','group2'], ['group1'])).to be_truthy
+      end
+
+      it "should return true when current user(s) contains at least the should list, even unordered" do
+        expect(provider.groups_insync?(['group3','group1','group2'], ['group2','group1'])).to be_truthy
+      end
+    end
+  end
+
   describe "when creating a user" do
     it "should create the user on the system and set its other properties" do
       resource[:groups]     = ['group1', 'group2']

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -189,24 +189,21 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       end
 
       describe "when given a set of groups to which to add the user" do
+        let(:existing_groups) { ['group2','group3'] }
+        let(:group_sids) { existing_groups.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])} }
+
         let(:groups_to_set) { 'group1,group2' }
+        let(:desired_sids) { groups_to_set.split(',').each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i-1])} }
 
         before(:each) do
-          Puppet::Util::Windows::SID.stubs(:octet_string_to_sid_object).returns(sid)
-          user.expects(:groups).returns ['group2', 'group3']
+          user.expects(:group_sids).returns(group_sids.map {|s| s.objectSID})
+          Puppet::Util::Windows::ADSI::User.expects(:name_sid_hash).returns(Hash[ desired_sids.map { |s| [s.objectSID.to_s, s.objectSID] }])
         end
 
         describe "if membership is specified as inclusive" do
           it "should add the user to those groups, and remove it from groups not in the list" do
-            group1 = stub 'group1'
-            group1.expects(:Add).with("WinNT://testcomputername/#{username},user")
-
-            group3 = stub 'group1'
-            group3.expects(:Remove).with("WinNT://testcomputername/#{username},user")
-
-            Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sid).returns("WinNT://testcomputername/#{username},user").twice
-            Puppet::Util::Windows::ADSI.expects(:connect).with('WinNT://./group1,group').returns group1
-            Puppet::Util::Windows::ADSI.expects(:connect).with('WinNT://./group3,group').returns group3
+            user.expects(:add_group_sids).with([-1])
+            user.expects(:remove_group_sids).with([1])
 
             user.set_groups(groups_to_set, false)
           end
@@ -214,11 +211,8 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
 
         describe "if membership is specified as minimum" do
           it "should add the user to the specified groups without affecting its other memberships" do
-            group1 = stub 'group1'
-            group1.expects(:Add).with("WinNT://testcomputername/#{username},user")
-
-            Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sid).returns("WinNT://testcomputername/#{username},user")
-            Puppet::Util::Windows::ADSI.expects(:connect).with('WinNT://./group1,group').returns group1
+            user.expects(:add_group_sids).with([-1])
+            user.expects(:remove_group_sids).never
 
             user.set_groups(groups_to_set, true)
           end
@@ -380,12 +374,15 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           expect {
             adsi_group.expects(:Members).returns []
             group.set_members(['foobar'])
-          }.to raise_error(Puppet::Error, /Could not resolve username: foobar/)
+          }.to raise_error(Puppet::Error, /Could not resolve name: foobar/)
         end
       end
 
       it "should generate the correct URI" do
         Puppet::Util::Windows::ADSI.stubs(:sid_uri_safe).returns(nil)
+        adsi_group.expects(:objectSID).returns([0])
+        Socket.expects(:gethostname).returns('testcomputername')
+        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(stub(:account => groupname,:domain => 'testcomputername'))
         expect(group.uri).to eq("WinNT://./#{groupname},group")
       end
     end


### PR DESCRIPTION
This supersedes https://github.com/puppetlabs/puppet/pull/3788

Previously, when specifying a user's groups, the names were compared
as strings and needed to be an exact match. The group resource uses
SIDs when comparing the users, so the user resource should mimic that
behavior.

Without this change casing and names must match exactly and can 
produce erroneous results.

With this change, the comparison will be by SIDs so it will allow for
the following when a user is a member of Administrators and Users
groups:

```puppet
user { 'tim':
  ensure => present,
  groups => ['BUILTIN\Administrators','users'],
}
```

Groups members can also be set to an empty list and the user's groups will
report that it does but will not make the changes. Allow that the user groups to
be set to an empty list so that group's members and user's groups behavior
is the same. Without this change an existing user with groups modeled in the
following resource will continue to give the message that it is removing the 
groups without actually making any changes:

```puppet
user { 'tim':
  ensure => present,
  groups => [],
}
```

There is also shared behavior between `Puppet::Util::Windows::ADSI::User`
and `Puppet::Util::Windows::ADSI::Group` so it makes sense to start
combining shared functionality to a common class named
`Puppet::Util::Windows::ADSI::Shared`.
