### PR TITLE
(maint) skip upstart test if there are no ubuntu agents

### DIFF
--- a/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
+++ b/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
@@ -5,6 +5,7 @@ confine :to, :platform => 'ubuntu'
 
 # pick any ubuntu agent
 agent = agents.first
+skip_test "No suitable hosts found" if agent.nil?
 
 def manage_service_for(pkg, state, agent)
 


### PR DESCRIPTION
The handle_upstart acceptance test fails on ubuntu systems when using
passenger, because the master is ubuntu, but the agent is not. So the
confine would pass, but `agent` was nil, causing the test to fail later
with:

    undefined method `[]' for nil:NilClass

This commit skips the test if there are no ubuntu agents.