### PR TITLE
(PUP-2630) Ensure it is possible to get trusted server facts that cannot be overwritten

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -518,6 +518,12 @@ module Puppet
       :desc    => "Stores trusted node data in a hash called $trusted.
         When true also prevents $trusted from being overridden in any scope.",
     },
+    :trusted_server_facts => {
+      :default => false,
+      :type    => :boolean,
+      :desc    => "Stores a trusted set of server-side global variables in a hash
+        called $server_facts, which cannot be overridden by client facts.",
+    },
     :immutable_node_data => {
       :default => '$trusted_node_data',
       :type    => :boolean,

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -522,7 +522,9 @@ module Puppet
       :default => false,
       :type    => :boolean,
       :desc    => "Stores a trusted set of server-side global variables in a hash
-        called $server_facts, which cannot be overridden by client facts.",
+        called $server_facts, which cannot be cannot be overridden by client_facts 
+        or logic in manifests. Makes it illegal to assign to the variable $server_facts 
+        in any scope.",
     },
     :immutable_node_data => {
       :default => '$trusted_node_data',

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -78,7 +78,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   # Add any extra data necessary to the node.
   def add_node_data(node)
     # Merge in our server-side facts, so they can be used during compilation.
-    node.merge(@server_facts)
+    node.add_server_facts(@server_facts)
   end
 
   # Compile the actual catalog.

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -114,6 +114,18 @@ class Puppet::Node
     @parameters["environment"] ||= self.environment.name.to_s
   end
 
+  def add_server_facts(server_facts)
+   # Complete server facts
+
+   # Set the top scope variable $server facts if :trusted_server_facts is true
+   if Puppet[:trusted_server_facts]
+     @topscope.set_trusted(server_facts)
+   end
+
+    # Merge the server facts into the parameters for the node
+    merge(server_facts)
+  end
+
   # Calculate the list of names we might use for looking
   # up our node.  This is only used for AST nodes.
   def names

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -108,18 +108,23 @@ class Puppet::Node
   # Merge any random parameters into our parameter list.
   def merge(params)
     params.each do |name, value|
-      @parameters[name] = value unless @parameters.include?(name)
+      if @parameters.include?(name)
+        Puppet::Util::Warnings.warnonce("The node paramters #{name} for node #{@parameters["hostname"]} was already set to #{@parameters[name]}. It could not be set to #{value}")
+      else
+        @parameters[name] = value
+      end
     end
 
     @parameters["environment"] ||= self.environment.name.to_s
   end
 
   def add_server_facts(server_facts)
-   # Complete server facts
+   # Append the current environment to the list of server facts
+    complete_server_facts = server_facts.merge({ "environment" => self.environment.name.to_s})
 
-   # Set the top scope variable $server facts if :trusted_server_facts is true
+   # Set the top scope variable $server_facts if :trusted_server_facts is true
    if Puppet[:trusted_server_facts]
-     @topscope.set_trusted(server_facts)
+     @topscope.set_trusted(complete_server_facts)
    end
 
     # Merge the server facts into the parameters for the node

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -113,7 +113,7 @@ class Puppet::Node
   def merge(params)
     params.each do |name, value|
       if @parameters.include?(name)
-        Puppet::Util::Warnings.warnonce("The node paramter #{name} for node #{@parameters["hostname"]} was already set to #{@parameters[name]}. It could not be set to #{value}")
+        Puppet::Util::Warnings.warnonce("The node parameter #{name} for node #{@parameters["hostname"]} was already set to #{@parameters[name]}. It could not be set to #{value}")
       else
         @parameters[name] = value
       end

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -113,7 +113,7 @@ class Puppet::Node
   def merge(params)
     params.each do |name, value|
       if @parameters.include?(name)
-        Puppet::Util::Warnings.warnonce("The node parameter #{name} for node #{@parameters["hostname"]} was already set to #{@parameters[name]}. It could not be set to #{value}")
+        Puppet::Util::Warnings.warnonce("The node parameter '#{name}' for node '#{@name}' was already set to '#{@parameters[name]}'. It could not be set to '#{value}'")
       else
         @parameters[name] = value
       end

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -560,6 +560,11 @@ class Puppet::Parser::Compiler
     catalog.client_version = node.parameters["clientversion"]
     catalog.server_version = node.parameters["serverversion"]
     @topscope.set_trusted(node.trusted_data)
+
+    if Puppet[:trusted_server_facts]
+      @topscope.set_server_facts(node.server_facts)
+    end
+
     facts_hash = node.facts.nil? ? {} : node.facts.values
     @topscope.set_facts(facts_hash)
   end

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -637,7 +637,7 @@ class Puppet::Parser::Scope
   end
 
   def set_server_facts(hash)
-    setvar('server_facts', deep_freeze(hash), :priviledged => true)
+    setvar('server_facts', deep_freeze(hash), :privileged => true)
   end
 
   # Deeply freezes the given object. The object and its content must be of the types:

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -609,7 +609,7 @@ class Puppet::Parser::Scope
 
     # Check for server_facts reserved variable name if the trusted_sever_facts setting is true
     if Puppet[:trusted_server_facts] && name == 'server_facts' && !options[:privileged]
-      raise Puppet::ParseError, "Attempt to assign variable name: server_facts, which is reserved when the :trusted_server_facts setting is true"
+      raise Puppet::ParseError, "Attempt to assign to a reserved variable name: '#{name}'"
     end
 
     table = effective_symtable(options[:ephemeral])

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -587,7 +587,7 @@ class Puppet::Parser::Scope
     }
   end
 
-  RESERVED_VARIABLE_NAMES = ['trusted', 'facts'].freeze
+  RESERVED_VARIABLE_NAMES = ['trusted', 'facts', 'server_facts'].freeze
 
   # Set a variable in the current scope.  This will override settings
   # in scopes above, but will not allow variables in the current scope
@@ -634,6 +634,10 @@ class Puppet::Parser::Scope
 
   def set_facts(hash)
     setvar('facts', deep_freeze(hash), :privileged => true)
+  end
+
+  def set_server_facts(hash)
+    setvar('server_facts', deep_freeze(hash), :priviledged => true)
   end
 
   # Deeply freezes the given object. The object and its content must be of the types:

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -587,7 +587,7 @@ class Puppet::Parser::Scope
     }
   end
 
-  RESERVED_VARIABLE_NAMES = ['trusted', 'facts', 'server_facts'].freeze
+  RESERVED_VARIABLE_NAMES = ['trusted', 'facts'].freeze
 
   # Set a variable in the current scope.  This will override settings
   # in scopes above, but will not allow variables in the current scope
@@ -605,6 +605,11 @@ class Puppet::Parser::Scope
     # Check for reserved variable names
     if !options[:privileged] && RESERVED_VARIABLE_NAMES.include?(name)
       raise Puppet::ParseError, "Attempt to assign to a reserved variable name: '#{name}'"
+    end
+
+    # Check for server_facts reserved variable name if the trusted_sever_facts setting is true
+    if Puppet[:trusted_server_facts] && name == 'server_facts' && !options[:privileged]
+      raise Puppet::ParseError, "Attempt to assign variable name: server_facts, which is reserved when the :trusted_server_facts setting is true"
     end
 
     table = effective_symtable(options[:ephemeral])

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -60,6 +60,8 @@ module Puppet::Pops::Evaluator::Runtime3Support
     if scope.bound?(name)
       if Puppet::Parser::Scope::RESERVED_VARIABLE_NAMES.include?(name)
         fail(Puppet::Pops::Issues::ILLEGAL_RESERVED_ASSIGNMENT, o, {:name => name} )
+      elsif name == "server_facts" && Puppet[:trusted_server_facts]
+        fail(Puppet::Pops::Issues::ILLEGAL_RESERVED_ASSIGNMENT, o, {:name => name} )
       else
         fail(Puppet::Pops::Issues::ILLEGAL_REASSIGNMENT, o, {:name => name} )
       end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -221,7 +221,7 @@ describe Puppet::Node, "when merging facts" do
 
   it "warns when a parameter value is not updated" do
     @node = Puppet::Node.new("testnode", :parameters => {"one" => "a"})
-    Puppet.expects(:warning).with('The node parameter one for node  was already set to a. It could not be set to b')
+    Puppet.expects(:warning).with('The node parameter \'one\' for node \'testnode\' was already set to \'a\'. It could not be set to \'b\'')
     @node.merge "one" => "b"
   end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -219,6 +219,12 @@ describe Puppet::Node, "when merging facts" do
     expect(@node.parameters["two"]).to eq("b")
   end
 
+  it "warns when a parameter value is not updated" do
+    @node = Puppet::Node.new("testnode", :parameters => {"one" => "a"})
+    Puppet.expects(:warning).with('The node parameter one for node  was already set to a. It could not be set to b')
+    @node.merge "one" => "b"
+  end
+
   it "accepts arbitrary parameters to merge into its parameters" do
     @node = Puppet::Node.new("testnode", :parameters => {"one" => "a"})
     @node.merge "two" => "three"


### PR DESCRIPTION
Prior to this change, there was no way for module authors to ensure
that they were getting trusted server facts due to the fact that
server side global variables can be overwritten by client side
facts.

Add the $server_facts global variable which will contain a hash
of server side facts which cannot be overwritten. Add the
corresponding trusted_server_facts setting. The setting is false
by default, but if set to true by the user then the $server_facts
variable will be populated.

Additionally, if merge attempted to set a node parameter
that already existed, it would quietly fail to update the value.
This meant that if a client fact value was being used for one of
the server side facts, it would not be overwritten with the correct
value and the user would never know.

Since we cannot change the behavior without breaking API, simply
add a warning so that the user will be aware if merge failed to
change the value of a node parameter.