### PR TITLE
(PUP-4501) Fix TypeCalculator.instance_of? for PStringType

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -434,8 +434,13 @@ class Puppet::Pops::Types::TypeCalculator
   def instance_of_PStringType(t, o)
     return false unless o.is_a?(String)
     # true if size compliant
-    size_t = t.size_type || @collection_default_size_t
-    instance_of_PIntegerType(size_t, o.size)
+    size_t = t.size_type
+    if size_t.nil? || instance_of_PIntegerType(size_t, o.size)
+      values = t.values
+      values.empty? || values.include?(o)
+    else
+      false
+    end
   end
 
   def instance_of_PTupleType(t, o)

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1281,6 +1281,13 @@ describe 'The type calculator' do
       calculator.instance?(range, 'abcd').should == false
     end
 
+    it 'should consider string values' do
+      string = string_t('a', 'b')
+      expect(calculator.instance?(string, 'a')).to eq(true)
+      expect(calculator.instance?(string, 'b')).to eq(true)
+      expect(calculator.instance?(string, 'c')).to eq(false)
+    end
+
     it 'should consider array in length range' do
       range = factory.constrain_size(array_t(integer_t), 1,3)
       calculator.instance?(range, [1]).should    == true


### PR DESCRIPTION
The current instance_of? method does not consider the `values`
of the string type. This commit adds that check.