### PR TITLE
(PUP-4499) and (PUP-4500) Issues with TypeCalculator.common_type and String

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -598,7 +598,7 @@ class Puppet::Pops::Types::TypeCalculator
 
     if t1.is_a?(Types::PStringType) && t2.is_a?(Types::PStringType)
       t = Types::PStringType.new()
-      t.values = t1.values | t2.values
+      t.values = t1.values | t2.values unless t1.values.empty? || t2.values.empty?
       t.size_type = common_type(t1.size_type, t2.size_type) unless t1.size_type.nil? || t2.size_type.nil?
       return t
     end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -599,6 +599,7 @@ class Puppet::Pops::Types::TypeCalculator
     if t1.is_a?(Types::PStringType) && t2.is_a?(Types::PStringType)
       t = Types::PStringType.new()
       t.values = t1.values | t2.values
+      t.size_type = common_type(t1.size_type, t2.size_type) unless t1.size_type.nil? || t2.size_type.nil?
       return t
     end
 

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -498,6 +498,16 @@ describe 'The type calculator' do
         expect(common_t.class).to eq(Puppet::Pops::Types::PStringType)
         expect(common_t.size_type).to be_nil
       end
+
+      it 'computes values to be empty of the types has empty values' do
+        t1 = string_t('apa')
+        t1.size_type = range_t(3,6)
+        t2 = string_t
+        t2.size_type = range_t(2,4)
+        common_t = calculator.common_type(t1,t2)
+        expect(common_t.class).to eq(Puppet::Pops::Types::PStringType)
+        expect(common_t.values).to be_empty
+      end
     end
 
     it 'computes pattern commonality' do

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -499,7 +499,7 @@ describe 'The type calculator' do
         expect(common_t.size_type).to be_nil
       end
 
-      it 'computes values to be empty of the types has empty values' do
+      it 'computes values to be empty if the one has empty values' do
         t1 = string_t('apa')
         t1.size_type = range_t(3,6)
         t2 = string_t

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -471,6 +471,35 @@ describe 'The type calculator' do
       calculator.string(calculator.common_type(r1, r2)).should == "Class"
     end
 
+    context 'of strings' do
+      it 'computes commonality' do
+        t1 = string_t('abc')
+        t2 = string_t('xyz')
+        common_t = calculator.common_type(t1,t2)
+        expect(common_t.class).to eq(Puppet::Pops::Types::PStringType)
+        expect(common_t.values).to eq(['abc', 'xyz'])
+      end
+
+      it 'computes common size_type' do
+        t1 = string_t
+        t1.size_type = range_t(3,6)
+        t2 = string_t
+        t2.size_type = range_t(2,4)
+        common_t = calculator.common_type(t1,t2)
+        expect(common_t.class).to eq(Puppet::Pops::Types::PStringType)
+        expect(common_t.size_type).to eq(range_t(2,6))
+      end
+
+      it 'computes common size_type to be undef when one of the types has no size_type' do
+        t1 = string_t
+        t2 = string_t
+        t2.size_type = range_t(2,4)
+        common_t = calculator.common_type(t1,t2)
+        expect(common_t.class).to eq(Puppet::Pops::Types::PStringType)
+        expect(common_t.size_type).to be_nil
+      end
+    end
+
     it 'computes pattern commonality' do
       t1 = pattern_t('abc')
       t2 = pattern_t('xyz')


### PR DESCRIPTION
This PR fixes two problems with the `TypeCalculator.common_type` when used to compute the common type for two `PStringType` instances. I chose to put them in the same PR since they touches on the exact same lines of code which inevitably would cause merge conflicts.