### PR TITLE
(PUP-4420) Ensure pluginfacts don't ignore source permissions

### DIFF
--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -1,0 +1,115 @@
+test_name "Pluginsync'ed external facts should be resolvable on the agent"
+
+#
+# This test is intended to ensure that external facts downloaded onto an agent via
+# pluginsync are resolvable. In Linux, the external fact should have the same
+# permissions as its source on the master.
+#
+
+step "Create a codedir with a manifest and test module with external fact"
+codedir = master.tmpdir('4420-codedir')
+
+site_manifest_content =<<EOM
+node default {
+  include mymodule
+  notify { "foo is ${foo}": }
+}
+EOM
+
+unix_fact =<<EOM
+#!/bin/sh
+echo "foo=bar"
+EOM
+
+win_fact =<<EOM
+@echo off
+echo foo=bar
+EOM
+
+if agent['platform'] =~ /windows/
+  fact_content = win_fact
+  extension = '.bat'
+else
+  fact_content = unix_fact
+  extension = '.sh'
+end
+
+apply_manifest_on(master, <<MANIFEST, :catch_failures => true)
+File {
+  ensure => directory,
+  mode   => "0755",
+  owner  => #{master.puppet['user']},
+  group  => #{master.puppet['group']},
+}
+
+file {
+  '#{codedir}':;
+  '#{codedir}/environments':;
+  '#{codedir}/environments/production':;
+  '#{codedir}/environments/production/manifests':;
+  '#{codedir}/environments/production/modules':;
+  '#{codedir}/environments/production/modules/mymodule':;
+  '#{codedir}/environments/production/modules/mymodule/manifests':;
+  '#{codedir}/environments/production/modules/mymodule/facts.d':;
+}
+
+file { '#{codedir}/environments/production/manifests/site.pp':
+  ensure => file,
+  content => '#{site_manifest_content}',
+}
+
+file { '#{codedir}/environments/production/modules/mymodule/manifests/init.pp':
+  ensure => file,
+  content => 'class mymodule {}',
+}
+
+file { '#{codedir}/environments/production/modules/mymodule/facts.d/external_fact#{extension}':
+  ensure  => file,
+  content => '#{fact_content}',
+}
+MANIFEST
+
+master_opts = {
+  'main' => {
+    'environmentpath' => "#{codedir}/environments"
+  }
+}
+
+with_puppet_running_on master, master_opts, codedir do
+  agents.each do |agent|
+    factsd   = agent.tmpdir('facts.d')
+    tmpdir   = agent.tmpdir('tmpdir')
+    testfile = File.join(tmpdir, 'testfile')
+
+    teardown do
+      on(master, "rm -rf #{codedir}")
+      on(agent, "rm -rf #{factsd}")
+    end
+
+    step "Pluginsync the external fact to the agent and ensure it resolves correctly"
+    on(agent, puppet('agent', "-t --server #{master} --pluginfactdest #{factsd}"), :acceptable_exit_codes => [2])
+    assert_match(/foo is bar/, stdout)
+
+    # Linux specific tests
+    next if agent['platform'] =~ /windows/
+
+    step "In Linux, ensure the pluginsync'ed external fact has the same permissions as its source"
+    on(agent, puppet('resource', "file #{factsd}/external_fact#{extension}"))
+    assert_match(/0755/, stdout)
+
+    step "In Linux, ensure puppet apply uses the correct permissions"
+    test_source = File.join('/', 'tmp', 'test')
+    on(agent, puppet('apply', "-e \"file { '#{test_source}': ensure => file, mode => '0456' }\""))
+
+    {'source_permissions => use,'    => /0456/,
+     'source_permissions => ignore,' => /0644/,
+     ''                              => /0644/
+    }.each do |source_permissions, mode|
+      on(agent, puppet('apply', "-e \"file { '/tmp/test_target': ensure => file, #{source_permissions} source => '#{test_source}' }\""))
+      on(agent, puppet('resource', "file /tmp/test_target"))
+      assert_match(mode, stdout)
+
+      on(agent, "rm /tmp/test_target")
+    end
+  end
+end

--- a/lib/puppet/file_serving/terminus_helper.rb
+++ b/lib/puppet/file_serving/terminus_helper.rb
@@ -26,7 +26,8 @@ module Puppet::FileServing::TerminusHelper
     end
 
     Puppet::FileServing::Fileset.merge(*filesets).collect do |file, base_path|
-      path2instance(request, base_path, :ignore_source_permissions => true, :relative_path => file)
+      ignore_source_permissions = (!request.options[:source_permissions] || request.options[:source_permissions] == :ignore)
+      path2instance(request, base_path, :ignore_source_permissions => ignore_source_permissions, :relative_path => file)
     end
   end
 end

--- a/lib/puppet/file_serving/terminus_helper.rb
+++ b/lib/puppet/file_serving/terminus_helper.rb
@@ -2,19 +2,18 @@ require 'puppet/file_serving'
 require 'puppet/file_serving/fileset'
 
 # Define some common methods for FileServing termini.
+
 module Puppet::FileServing::TerminusHelper
   # Create model instance for a file in a file server.
   def path2instance(request, path, options = {})
     result = model.new(path, :relative_path => options[:relative_path])
-    result.checksum_type = request.options[:checksum_type] if request.options[:checksum_type]
     result.links = request.options[:links] if request.options[:links]
 
-    # :ignore_source_permissions is here pending investigation in PUP-3906.
-    if options[:ignore_source_permissions]
-      result.collect
-    else
-      result.collect(request.options[:source_permissions])
-    end
+    result.checksum_type = request.options[:checksum_type] if request.options[:checksum_type]
+    result.source_permissions = request.options[:source_permissions] if request.options[:source_permissions]
+
+    result.collect
+
     result
   end
 
@@ -26,8 +25,7 @@ module Puppet::FileServing::TerminusHelper
     end
 
     Puppet::FileServing::Fileset.merge(*filesets).collect do |file, base_path|
-      ignore_source_permissions = (!request.options[:source_permissions] || request.options[:source_permissions] == :ignore)
-      path2instance(request, base_path, :ignore_source_permissions => ignore_source_permissions, :relative_path => file)
+      path2instance(request, base_path, :relative_path => file)
     end
   end
 end

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -668,6 +668,7 @@ Puppet::Type.newtype(:file) do
       :links => self[:links],
       :recurse => (self[:recurse] == :remote ? true : self[:recurse]),
       :recurselimit => self[:recurselimit],
+      :source_permissions => self[:source_permissions],
       :ignore => self[:ignore],
       :checksum_type => (self[:source] || self[:content]) ? self[:checksum] : :none,
       :environment => catalog.environment_instance

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -179,7 +179,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
 
       stat = Puppet::FileSystem.stat(path)
 
-      win_stat = Puppet::FileServing::Metadata::WindowsStat.new(stat, path)
+      win_stat = Puppet::FileServing::Metadata::WindowsStat.new(stat, path, :ignore)
 
       expect(win_stat.owner).to eq('S-1-5-32-544')
       expect(win_stat.group).to eq('S-1-0-0')

--- a/spec/unit/file_serving/terminus_helper_spec.rb
+++ b/spec/unit/file_serving/terminus_helper_spec.rb
@@ -26,12 +26,11 @@ describe Puppet::FileServing::TerminusHelper do
 
   it "should pass through links, checksum_type, and source_permissions" do
     file = stub 'file', :checksum_type= => nil, :links= => nil, :collect => nil
-    [[:checksum_type, :sha256], [:links, true]].each {|k, v|
+    [[:checksum_type, :sha256], [:links, true], [:source_permissions, :use]].each {|k, v|
       file.expects(k.to_s+'=').with(v)
       @request.options[k] = v
     }
-    @request.options[:source_permissions] = :yes
-    file.expects(:collect).with(:yes)
+    file.expects(:collect)
     @model.expects(:new).with("/my/file", {:relative_path => :file}).returns(file)
     @helper.path2instance(@request, "/my/file", {:relative_path => :file})
   end


### PR DESCRIPTION
Prior to this commit, the :source_permissions attribute was
not being properly propagated into the Posix MetaStat class,
and so source permissions were ignored for all resources.

External facts are required to use source permissions so
that the facts are executable when they are downloaded onto
the agent. This means that due to this regression, external
facts were being pluginsync'd to the client without execution
permissions.

This commit re-enables using source permissions for fact
pluginsync, while continuing to ignore them otherwise.

See commit 21edcd6 for the first fix for of a similar, earlier
regression.