### PR TITLE
(PUP-4511) Ensure that unspecified contained types default to Any

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -1217,8 +1217,9 @@ class Puppet::Pops::Types::TypeCalculator
   # @api private
   def assignable_POptionalType(t, t2)
     return true if t2.is_a?(Types::PUndefType)
+    return true if t.optional_type.nil?
     if t2.is_a?(Types::POptionalType)
-      assignable?(t.optional_type, t2.optional_type)
+      assignable?(t.optional_type, t2.optional_type || @t)
     else
       assignable?(t.optional_type, t2)
     end
@@ -1389,11 +1390,11 @@ class Puppet::Pops::Types::TypeCalculator
   # @api private
   def assignable_PArrayType(t, t2)
     if t2.is_a?(Types::PArrayType)
-      return false unless assignable?(t.element_type, t2.element_type)
+      return false unless t.element_type.nil? || assignable?(t.element_type, t2.element_type || @t)
       assignable_PCollectionType(t, t2)
 
     elsif t2.is_a?(Types::PTupleType)
-      return false unless t2.types.all? {|t2_element| assignable?(t.element_type, t2_element) }
+      return false unless t.element_type.nil? || t2.types.all? {|t2_element| assignable?(t.element_type, t2_element) }
       t2_regular = t2.types[0..-2]
       t2_ranged = t2.types[-1]
       t2_from, t2_to = size_range(t2.size_type)
@@ -1431,7 +1432,8 @@ class Puppet::Pops::Types::TypeCalculator
     case t2
     when Types::PHashType
       return true if (t.size_type.nil? || t.size_type.from == 0) && t2.is_the_empty_hash?
-      return false unless assignable?(t.key_type, t2.key_type) && assignable?(t.element_type, t2.element_type)
+      return false unless t.key_type.nil? || assignable?(t.key_type, t2.key_type || @t)
+      return false unless t.element_type.nil? || assignable?(t.element_type, t2.element_type || @t)
       assignable_PCollectionType(t, t2)
     when Types::PStructType
       # hash must accept String as key type
@@ -1443,7 +1445,7 @@ class Puppet::Pops::Types::TypeCalculator
       key_type = t.key_type
       element_type = t.element_type
       ( struct_size >= min && struct_size <= max &&
-        t2.elements.all? {|e| instance_of(key_type, e.name) && assignable?(element_type, e.type) })
+        t2.elements.all? {|e| (key_type.nil? || instance_of(key_type, e.name)) && (element_type.nil? || assignable?(element_type, e.type)) })
     else
       false
     end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -553,6 +553,13 @@ describe 'The type calculator' do
   context 'computes assignability' do
     include_context "types_setup"
 
+    it 'such that all types are assignable to themselves' do
+      all_types.each do |tc|
+        t = tc.new
+        expect(t).to be_assignable_to(t)
+      end
+    end
+
     context 'for Unit, such that' do
       it 'all types are assignable to Unit' do
         t = Puppet::Pops::Types::PUnitType.new()
@@ -578,7 +585,7 @@ describe 'The type calculator' do
       end
 
       it 'Any is not assignable to anything but Any' do
-        tested_types = all_types() - [Puppet::Pops::Types::PAnyType]
+        tested_types = all_types() - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::POptionalType]
         t = Puppet::Pops::Types::PAnyType.new()
         tested_types.each { |t2| t.should_not be_assignable_to(t2.new) }
       end
@@ -610,7 +617,7 @@ describe 'The type calculator' do
       end
 
       it 'Data is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::PDataType] - scalar_types
+        tested_types = all_types - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::POptionalType, Puppet::Pops::Types::PDataType] - scalar_types
         t = Puppet::Pops::Types::PDataType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
@@ -647,7 +654,7 @@ describe 'The type calculator' do
       end
 
       it 'Scalar is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::PDataType] - scalar_types
+        tested_types = all_types - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::POptionalType, Puppet::Pops::Types::PDataType] - scalar_types
         t = Puppet::Pops::Types::PScalarType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
@@ -668,6 +675,7 @@ describe 'The type calculator' do
       it 'Numeric is not assignable to any disjunct type' do
         tested_types = all_types - [
           Puppet::Pops::Types::PAnyType,
+          Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PDataType,
           Puppet::Pops::Types::PScalarType,
           ] - numeric_types
@@ -689,7 +697,7 @@ describe 'The type calculator' do
       end
 
       it 'Collection is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PAnyType] - collection_types
+        tested_types = all_types - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::POptionalType] - collection_types
         t = Puppet::Pops::Types::PCollectionType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
@@ -708,6 +716,7 @@ describe 'The type calculator' do
       it 'Array is not assignable to any disjunct type' do
         tested_types = all_types - [
           Puppet::Pops::Types::PAnyType,
+          Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PArrayType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -727,6 +736,7 @@ describe 'The type calculator' do
       it 'Hash is not assignable to any disjunct type' do
         tested_types = all_types - [
           Puppet::Pops::Types::PAnyType,
+          Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PHashType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -762,6 +772,7 @@ describe 'The type calculator' do
       it 'Tuple is not assignable to any disjunct type' do
         tested_types = all_types - [
           Puppet::Pops::Types::PAnyType,
+          Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PTupleType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -781,6 +792,7 @@ describe 'The type calculator' do
       it 'Struct is not assignable to any disjunct type' do
         tested_types = all_types - [
           Puppet::Pops::Types::PAnyType,
+          Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PStructType.new()
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
@@ -792,7 +804,8 @@ describe 'The type calculator' do
         t = Puppet::Pops::Types::PCallableType.new()
         tested_types = all_types - [
           Puppet::Pops::Types::PCallableType,
-          Puppet::Pops::Types::PAnyType]
+          Puppet::Pops::Types::PAnyType,
+          Puppet::Pops::Types::POptionalType]
         tested_types.each {|t2| t.should_not be_assignable_to(t2.new) }
       end
     end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -584,7 +584,7 @@ describe 'The type calculator' do
         all_types.each { |t2| t2.new.should be_assignable_to(t) }
       end
 
-      it 'Any is not assignable to anything but Any' do
+      it 'Any is not assignable to anything but Any and Optional (implied Optional[Any])' do
         tested_types = all_types() - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::POptionalType]
         t = Puppet::Pops::Types::PAnyType.new()
         tested_types.each { |t2| t.should_not be_assignable_to(t2.new) }


### PR DESCRIPTION
The `Array`, `Hash`, and `Optional` all have contained types that may
be `nil`. The `TypeCalculator.assignable?` method didn't handle this
well (it passed `nil` in a recursive call to `assignable?`, an
operation that is permitted but will yield a `false` result).

This commit adds checks to ensure that if the contained type is `nil`,
then it will be considered to be of type `Any`.

Some tests were changed to accommodate the fact that `Optional[?]` now
considers everything to be assignable whereas nothing was assignable
before.