### PR TITLE
(maint) Fix/update AppVeyor settings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,22 @@
-version: 4.0.0.{build}
-platform:
-    - x64
+version: 4.1.0.{build}
+skip_commits:
+  message: /(^\(?doc\)?.*|.*[A|a]cceptance [T|t]est.*)/
+clone_depth: 10
+init:
+  - SET
 install:
-    - SET PATH=C:\Ruby215\bin;%PATH%
-    - gem install bundler --quiet --no-ri --no-rdoc
-    - bundle install --without development
+  - SET PATH=C:\Ruby21-x64\bin;%PATH%
+  - gem install bundler --quiet --no-ri --no-rdoc
+  - bundle install --jobs 4 --retry 2 --without development
+  - type Gemfile.lock
+  - ruby -v
 build: off
 test_script:
-    - bundle exec rspec spec
+  - bundle exec rspec spec
+notifications:
+  - provider: Email
+    to:
+    - nobody@nowhere.com
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false


### PR DESCRIPTION
The appveyor script gives the appearance of setting to Ruby 2.1.5,
but that particular folder doesn't actually exist, so it is actually running with Ruby 
1.9.3. When the build runs it should share the environment variables, the 
Gemfile.lock file and the Ruby version it is set on. ~~Additionally it should test both 
x86 and x64 architectures.~~

Additionally we should test against the x64 architecture, which should catch a 
reasonable amount of failures related to Windows. Adding a second architecture 
slows the build down quite a bit (to more than double the amount of time),
so we won't go the route of adding a matrix for now.