### PR TITLE
(PUP-4466) Add acceptance for functions in the puppet language

### DIFF
--- a/acceptance/tests/language/invoke_pp_function_from_dependent_module.rb
+++ b/acceptance/tests/language/invoke_pp_function_from_dependent_module.rb
@@ -1,0 +1,67 @@
+test_name 'Puppet-language functions can be called from inside an another module' do
+
+  mini_func = 'function jenny::mini($a, $b) {if $a <= $b {$a} else {$b}}'
+  maxi_func = 'function jenny::nested::maxi($a, $b) {if $a >= $b {$a} else {$b}}'
+  
+  step 'Create PP functions on master' do
+    manifest = <<-EOM.gsub(/^ {6}/,'')
+      File {
+        ensure => present,
+        owner => 'puppet',
+        group => 'puppet',
+        mode => '0644',
+      }
+      file {['/etc/puppetlabs',
+          '/etc/puppetlabs/code',
+          '/etc/puppetlabs/code/modules',
+          '/etc/puppetlabs/code/modules/jenny',
+          '/etc/puppetlabs/code/modules/jenny/functions',
+          '/etc/puppetlabs/code/modules/jenny/functions/nested',
+          '/etc/puppetlabs/code/modules/tutone',
+          '/etc/puppetlabs/code/modules/tutone/manifests']:
+        ensure => directory,
+        owner => 'puppet',
+        group => 'puppet',
+        mode => '0755',
+      }  
+      file {'/etc/puppetlabs/code/modules/jenny/functions/mini.pp':
+        content => '#{mini_func}',
+      }
+      file {'/etc/puppetlabs/code/modules/jenny/functions/nested/maxi.pp':
+        content => '#{maxi_func}',
+      }
+      file {'/etc/puppetlabs/code/modules/tutone/manifests/testmini.pp':
+        content => 'notify {"mini": message => jenny::mini(1,2)}'
+      }
+      file {'/etc/puppetlabs/code/modules/tutone/manifests/testmaxi.pp':
+        content => 'notify {"maxi": message => jenny::nested::maxi(1,2)}'
+      }
+    EOM
+    apply_manifest_on(master, manifest)
+  end
+  
+  step 'Call a simple PP function from another module' do
+    rc = on master, puppet('apply /etc/puppetlabs/code/modules/tutone/manifests/testmini.pp')
+    fail_test "Dependent simple PP function failed; returned #{rc.stdout}" \
+      unless rc.stdout.include? "defined 'message' as '1'"
+  end
+
+  step 'Call a nested PP function from another module' do
+    rc = on master, puppet('apply /etc/puppetlabs/code/modules/tutone/manifests/testmaxi.pp')
+    fail_test "Dependent nested PP function failed; returned #{rc.stdout}" \
+      unless rc.stdout.include? "defined 'message' as '2'"
+  end
+
+    step 'Call a simple PP function from outside the scope of any module' do
+    rc = apply_manifest_on(master, 'notify {"mini": message => jenny::mini(1,2)}')
+    fail_test "Simple PP function failed; returned #{rc.stdout}" \
+      unless rc.stdout.include? "defined 'message' as '1'"
+  end
+  
+  step 'Call a nested PP function from outside the scope of any module' do
+    rc = apply_manifest_on(master, 'notify {"maxi": message => jenny::nested::maxi(1,2)}')
+    fail_test "Nested PP function failed: returned #{rc.stdout}" \
+      unless rc.stdout.include? "defined 'message' as '2'"
+  end
+
+end

--- a/acceptance/tests/language/invoke_pp_function_from_multiple_environments.rb
+++ b/acceptance/tests/language/invoke_pp_function_from_multiple_environments.rb
@@ -1,0 +1,61 @@
+test_name 'Puppet-language functions can be called from any environment' do
+
+  mini_func = 'function jenny::mini($a, $b) {if $a <= $b {$a} else {$b}}'
+  maxi_func = 'function jenny::nested::maxi($a, $b) {if $a >= $b {$a} else {$b}}'
+  step 'Create PP functions on master' do
+    manifest = <<-EOM.gsub(/^ {6}/,'')
+      File {
+        owner => 'puppet',
+        group => 'puppet',
+        ensure => present,
+        mode => '0644',
+      }
+      file {['/etc/puppetlabs',
+          '/etc/puppetlabs/code',
+          '/etc/puppetlabs/code/modules',
+          '/etc/puppetlabs/code/modules/jenny',
+          '/etc/puppetlabs/code/modules/jenny/functions',
+          '/etc/puppetlabs/code/modules/jenny/functions/nested',
+          '/etc/puppetlabs/code/environments',
+          '/etc/puppetlabs/code/environments/frick',
+          '/etc/puppetlabs/code/environments/frack',]:
+        ensure => directory,
+        mode => '0755',
+      }
+      file {'/etc/puppetlabs/code/modules/jenny/functions/mini.pp':
+        content => '#{mini_func}',
+      }
+      file {'/etc/puppetlabs/code/modules/jenny/functions/nested/maxi.pp':
+        content => '#{maxi_func}',
+      }
+    EOM
+    apply_manifest_on(master, manifest)
+  end
+
+  applyme = <<-EOM
+    class f {
+      notify { 'mini': message => jenny::mini(1,2), }
+      notify { 'maxi': message => jenny::nested::maxi(1,2), }
+    }
+    include 'f'
+  EOM
+
+  step 'Call a PP function from two environments' do
+    env_1 = on master, puppet("apply -e \"#{applyme}\" --environment frick")
+    fail_test "Calling PP function failed in environment 'frick'; returned #{env_1.stdout}" \
+      unless env_1.stdout.include? "frick"
+    fail_test "Simple PP function failed; returned #{env_1.stdout}" \
+      unless env_1.stdout.include? "defined 'message' as '1'"
+    fail_test "Nested PP function failed; returned #{env_1.stdout}" \
+      unless env_1.stdout.include? "defined 'message' as '2'"
+
+    env_2 = on master, puppet("apply -e '#{applyme}' --environment frack")
+    fail_test "Calling PP function failed in environment 'frack'; returned #{env_2.stdout}" \
+      unless env_1.stdout.include? "frick"
+    fail_test "Simple PP function failed; returned #{env_2.stdout}" \
+      unless env_1.stdout.include? "defined 'message' as '1'"
+    fail_test "Neted PP function failed; returned #{env_2.stdout}" \
+      unless env_1.stdout.include? "defined 'message' as '2'"        
+  end
+  
+end

--- a/acceptance/tests/language/invoke_pp_function_from_nondependent_module.rb
+++ b/acceptance/tests/language/invoke_pp_function_from_nondependent_module.rb
@@ -1,0 +1,58 @@
+test_name 'Puppet-language functions can be called from inside an another module' do
+
+  mini_func = 'function jenny::mini($a, $b) {if $a <= $b {$a} else {$b}}'
+  maxi_func = 'function jenny::nested::maxi($a, $b) {if $a >= $b {$a} else {$b}}'
+  
+  step 'Create PP functions on master' do
+    manifest = <<-EOM.gsub(/^ {6}/,'')
+      File {
+        ensure => present,
+        owner => 'puppet',
+        group => 'puppet',
+        mode => '0644',
+      }
+      file {['/etc/puppetlabs',
+        '/etc/puppetlabs/code',
+        '/etc/puppetlabs/code/modules/',
+        '/etc/puppetlabs/code/modules/jenny',
+        '/etc/puppetlabs/code/modules/jenny/functions',
+        '/etc/puppetlabs/code/modules/jenny/functions/nested',
+        '/etc/puppetlabs/code/modules/tommy',
+        '/etc/puppetlabs/code/modules/tommy/manifests',
+        '/etc/puppetlabs/code/modules/tutone',
+        '/etc/puppetlabs/code/modules/tutone/manifests']:
+        ensure => directory,
+        mode => '0755',
+      }      
+      file {'/etc/puppetlabs/code/modules/jenny/functions/mini.pp':
+        content => '#{mini_func}',
+      }
+      file {'/etc/puppetlabs/code/modules/jenny/functions/nested/maxi.pp':
+        content => '#{maxi_func}',
+      }
+      file {'/etc/puppetlabs/code/modules/tommy/manifests/init.pp':
+        content => 'class tommy { notify { "tommy says FOO": } }',
+      }
+      file {'/etc/puppetlabs/code/modules/tutone/manifests/testmini.pp':
+        content => 'require "tommy"; notify {"mini": message => jenny::mini(1,2)}'
+      }
+      file {'/etc/puppetlabs/code/modules/tutone/manifests/testmaxi.pp':
+        content => 'require "tommy"; notify {"maxi": message => jenny::nested::maxi(1,2)}'
+      }
+    EOM
+    apply_manifest_on(master, manifest)
+  end
+
+  step 'Call a simple PP function from another module' do
+    rc = on master, puppet('apply /etc/puppetlabs/code/modules/tutone/manifests/testmini.pp')
+    fail_test "Dependent simple PP function failed; returned #{rc.stdout}" \
+      unless rc.stdout.include? "defined 'message' as '1'"
+  end
+
+  step 'Call a nested PP function from another module' do
+    rc = on master, puppet('apply /etc/puppetlabs/code/modules/tutone/manifests/testmaxi.pp')
+    fail_test "Dependent nested PP function failed; returned #{rc.stdout}" \
+      unless rc.stdout.include? "defined 'message' as '2'"
+  end
+
+end

--- a/acceptance/tests/language/invoke_pp_function_from_one_environment.rb
+++ b/acceptance/tests/language/invoke_pp_function_from_one_environment.rb
@@ -1,0 +1,63 @@
+test_name 'Puppet-language functions defined in one environment cannot be called from another environment' do
+
+  mini_func = 'function jenny::mini($a, $b) {if $a <= $b {$a} else {$b}}'
+  maxi_func = 'function jenny::nested::maxi($a, $b) {if $a >= $b {$a} else {$b}}'
+  step 'Create PP functions on master' do
+    manifest = <<-EOM.gsub(/^ {6}/,'')
+      File {
+        owner => 'puppet',
+        group => 'puppet',
+        ensure => present,
+        mode => '0644',
+      }
+      file {['/etc/puppetlabs',
+          '/etc/puppetlabs/code',
+          '/etc/puppetlabs/code/environments',
+          '/etc/puppetlabs/code/environments/frick',
+          '/etc/puppetlabs/code/environments/frick/modules',
+          '/etc/puppetlabs/code/environments/frick/modules/jenny/',
+          '/etc/puppetlabs/code/environments/frick/modules/jenny/functions',
+          '/etc/puppetlabs/code/environments/frick/modules/jenny/functions/nested',
+          '/etc/puppetlabs/code/environments/frack',]:
+        ensure => directory,
+        mode => '0755',
+      }
+      file {'/etc/puppetlabs/code/environments/frick/modules/jenny/functions/mini.pp':
+        content => '#{mini_func}',
+      }
+      file {'/etc/puppetlabs/code/environments/frick/modules/jenny/functions/nested/maxi.pp':
+        content => '#{maxi_func}',
+      }
+    EOM
+    apply_manifest_on(master, manifest)
+  end
+
+  applyme = <<-EOM
+    class f {
+      notify { 'mini': message => jenny::mini(1,2), }
+      notify { 'maxi': message => jenny::nested::maxi(1,2), }
+    }
+    include 'f'
+  EOM
+
+  step 'Call a PP function from owning environments' do
+    env_1 = on master, puppet("apply -e '#{applyme}' --environment frick")
+    fail_test "Calling PP function failed in defining env; returned #{env_1.stdout}" \
+      unless env_1.stdout.include? "frick"
+    fail_test "Simple PP function failed in defining env; returned #{env_1.stdout}" \
+      unless env_1.stdout.include? "defined 'message' as '1'"
+    fail_test "Nested PP function failed in defining env; returned #{env_1.stdout}" \
+      unless env_1.stdout.include? "defined 'message' as '2'"
+  end
+    
+  step 'Call a PP function defined in another environment' do
+    env_2 = on master, puppet("apply -e '#{applyme}' --environment frack")
+    fail_test "Calling PP function failed in non-defining env; returned #{env_2.stdout}" \
+      unless env_2.stdout.include? "frack"
+    fail_test "Simple PP function failed in non-defining env; returned #{env_2.stdout}" \
+      unless env_2.stdout.include? "defined 'message' as '1'"
+    fail_test "Nested PP function failed in non-defining env; returned #{env_2.stdout}" \
+      unless env_2.stdout.include? "defined 'message' as '2'"
+  end
+  
+end


### PR DESCRIPTION
Validate functions written in the Puppet DSL. They are under `.functions` relative to either a module or an environment. Puppet functions are handled by the 4.x function API, so they follow the visibility rules set based on a module's dependencies:
* An environment sees everything in every module on the module path
* A module with dependencies only sees what it is the environment and in modules it has a dependency on
* A module without dependencies (no declaration at all) can see all other modules
