### PR TITLE
(maint) Enable version module if it's not already loaded

### DIFF
--- a/acceptance/setup/passenger/pre-suite/030_ConfigurePassenger.rb
+++ b/acceptance/setup/passenger/pre-suite/030_ConfigurePassenger.rb
@@ -6,5 +6,10 @@ else
   on(master, "sed -i 's|localhost|#{certname}|g' /etc/apache2/sites-available/puppet-passenger*")
   on(master, 'a2enmod headers')
   on(master, 'a2enmod ssl')
+
+  # only enable version module if it's not loaded
+  modules = on(master, 'apache2ctl -M').stdout
+  on(master, 'a2enmod version') if modules !~ /version_module/
+
   on(master, 'a2ensite puppet-passenger')
 end


### PR DESCRIPTION
The apache `version` module must be loaded to use the <IfVersion>
syntax. On debian 7 and ubuntu 14.04, the module is static, and it is
an error to try to enable it. On ubuntu 12.04, the module is not static,
and must be explicitly enabled, see RE-4465.

This commit enables the `version` module only if it is not already
loaded.