### PR TITLE
(PUP-4347) Add test for the File resource ignore attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ puppet-acceptance/
 acceptance/junit
 acceptance/log
 acceptance/.bundle
+# emacs backup files
+*~


### PR DESCRIPTION
This commit adds 5 tests for the `ignore` attribute of the File resource.