### PR TITLE
(PUP-4483) Add NotUndef type to the Puppet type system

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -265,6 +265,27 @@ class Puppet::Pops::Evaluator::AccessOperator
     end
   end
 
+  def access_PNotUndefType(o, scope, keys)
+    keys.flatten!
+    case keys.size
+    when 0
+      TYPEFACTORY.not_undef
+    when 1
+      type = keys[0]
+      case type
+      when String
+        type = TYPEFACTORY.string(type)
+      when Puppet::Pops::Types::PAnyType
+        type = nil if type.class == Puppet::Pops::Types::PAnyType
+      else
+        fail(Puppet::Pops::Issues::BAD_NOT_UNDEF_SLICE_TYPE, @semantic.keys[0], {:base_type => 'NotUndef-Type', :actual => type.class})
+      end
+      TYPEFACTORY.not_undef(type)
+    else
+      fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, @semantic, {:base_type => 'NotUndef-Type', :min => 0, :max => 1, :actual => keys.size})
+    end
+  end
+
   def access_PType(o, scope, keys)
     keys.flatten!
     if keys.size == 1

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -374,6 +374,10 @@ module Puppet::Pops::Issues
     "#{label.a_an_uc(left_value)}[] cannot use #{actual} where #{expected_text} expected"
   end
 
+  BAD_NOT_UNDEF_SLICE_TYPE = issue :BAD_NOT_UNDEF_SLICE_TYPE, :base_type, :actual do
+    "#{base_type}[] argument must be a Type or a String. Got #{actual}"
+  end
+
   BAD_TYPE_SLICE_TYPE = issue :BAD_TYPE_SLICE_TYPE, :base_type, :actual do
     "#{base_type}[] arguments must be types. Got #{actual}"
   end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -464,9 +464,18 @@ class Puppet::Pops::Types::TypeCalculator
 
   def instance_of_PStructType(t, o)
     return false unless o.is_a?(Hash)
-    h = t.hashed_elements
-    # all keys must be present and have a value (even if nil/undef)
-    (o.keys - h.keys).empty? && h.all? { |k,v| instance_of(v, o[k]) }
+    matched = 0
+    t.elements.all? do |e|
+      key = e.name
+      v = o[key]
+      if v.nil? && !o.include?(key)
+        # Entry is missing. Only OK when key is optional
+        assignable?(e.key_type, @nil_t)
+      else
+        matched += 1
+        instance_of(e.value_type, v)
+      end
+    end && matched == o.size
   end
 
   def instance_of_PHashType(t, o)
@@ -954,27 +963,23 @@ class Puppet::Pops::Types::TypeCalculator
       type.key_type = Types::PUndefType.new
       type.element_type = Types::PUndefType.new
       type.size_type = size_as_type(o)
-    else
-      if o.keys.find {|k| !instance_of_PStringType(@non_empty_string_t, k) }
-        type = Types::PHashType.new
-        ktype = Types::PVariantType.new
-        ktype.types = o.keys.map {|k| infer_set(k) }
-        etype = Types::PVariantType.new
-        etype.types = o.values.map {|e| infer_set(e) }
-        type.key_type = unwrap_single_variant(ktype)
-        type.element_type = unwrap_single_variant(etype)
-        type.size_type = size_as_type(o)
-      else
-        elements = []
-        o.each_pair do |k,v|
-          element = Types::PStructElement.new
-          element.name = k
-          element.type = infer_set(v)
-          elements << element
-        end
-        type = Types::PStructType.new
-        type.elements = elements
+    elsif o.keys.all? {|k| instance_of_PStringType(@non_empty_string_t, k) }
+      type = Types::PStructType.new
+      type.elements = o.map do |k,v|
+        element = Types::PStructElement.new
+        element.key_type = infer_String(k)
+        element.value_type = infer_set(v)
+        element
       end
+    else
+      type = Types::PHashType.new
+      ktype = Types::PVariantType.new
+      ktype.types = o.keys.map {|k| infer_set(k) }
+      etype = Types::PVariantType.new
+      etype.types = o.values.map {|e| infer_set(e) }
+      type.key_type = unwrap_single_variant(ktype)
+      type.element_type = unwrap_single_variant(etype)
+      type.size_type = size_as_type(o)
     end
     type
   end
@@ -1132,6 +1137,17 @@ class Puppet::Pops::Types::TypeCalculator
     end
   end
 
+  # @api private
+  def self.is_kind_of_optional?(t, optional = true)
+    case t
+    when Types::POptionalType
+      true
+    when Types::PVariantType
+      t.types.all? {|t2| is_kind_of_optional?(t2, optional) }
+    else
+      false
+    end
+  end
 
   def callable_PArrayType(args_array, callable_t)
     return false unless assignable?(callable_t.param_types, args_array)
@@ -1215,22 +1231,34 @@ class Puppet::Pops::Types::TypeCalculator
   #
   def assignable_PStructType(t, t2)
     if t2.is_a?(Types::PStructType)
-      h = t.hashed_elements
       h2 = t2.hashed_elements
-      (h2.keys - h.keys).empty? && h.all? {|k, v| v2 = h2[k]; assignable?(v, v2.nil? ? @nil_t : v2) }
+      matched = 0
+      t.elements.all? do |e1|
+        e2 = h2[e1.name]
+        if e2.nil?
+          assignable?(e1.key_type, @nil_t)
+        else
+          matched += 1
+          assignable?(e1.key_type, e2.key_type) && assignable?(e1.value_type, e2.value_type)
+        end
+      end && matched == h2.size
     elsif t2.is_a?(Types::PHashType)
-      size_t2 = t2.size_type || @collection_default_size_t
-      size_t = Types::PIntegerType.new
-      elements = t.elements
-      size_t.from = elements.count {|e| !assignable?(e.type, @nil_t) }
-      size_t.to = elements.size
-      # compatible size
-      # hash key type must be string of min 1 size
-      # hash value t must be assignable to each key
-      element_type = t2.element_type
-      assignable_PIntegerType(size_t, size_t2) &&
-        (size_t2.to == 0 || assignable?(@non_empty_string_t, t2.key_type)) &&
-          elements.all? {|e| assignable?(e.type, element_type) }
+      required = 0
+      required_elements_assignable = t.elements.all? do |e|
+        if assignable?(e.key_type, @nil_t)
+          true
+        else
+          required += 1
+          assignable?(e.value_type, t2.element_type)
+        end
+      end
+      if required_elements_assignable
+        size_t2 = t2.size_type || @collection_default_size_t
+        size_t = Types::PIntegerType.new
+        size_t.from = required
+        size_t.to = t.elements.size
+        assignable_PIntegerType(size_t, size_t2)
+      end
     else
       false
     end
@@ -1467,7 +1495,7 @@ class Puppet::Pops::Types::TypeCalculator
       key_type = t.key_type
       element_type = t.element_type
       ( struct_size >= min && struct_size <= max &&
-        t2.elements.all? {|e| (key_type.nil? || instance_of(key_type, e.name)) && (element_type.nil? || assignable?(element_type, e.type)) })
+        t2.elements.all? {|e| (key_type.nil? || instance_of(key_type, e.name)) && (element_type.nil? || assignable?(element_type, e.value_type)) })
     else
       false
     end
@@ -1678,7 +1706,16 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   def string_PStructElement(t)
-    "'#{t.name}'=>#{string(t.type)}"
+    k = t.key_type
+    value_optional = assignable?(t.value_type, @nil_t)
+    key_string =
+      if k.is_a?(Types::POptionalType)
+        # Output as literal String
+        value_optional ? "'#{t.name}'" : string(k)
+      else
+        value_optional ? "NotUndef['#{t.name}']" : "'#{t.name}'"
+      end
+    "#{key_string}=>#{string(t.value_type)}"
   end
 
   # @api private

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -351,6 +351,22 @@ module Puppet::Pops::Types::TypeFactory
     type
   end
 
+  # Produces a type for NotUndef[T]
+  # The given 'inst_type' can be a string in which case it will be converted into
+  # the type String[inst_type].
+  #
+  # @param inst_type [Type,String] the type to qualify
+  # @return [Puppet::Pops::Types::PNotUndefType] the NotUndef type
+  #
+  # @api public
+  #
+  def self.not_undef(inst_type = nil)
+    type = Types::PNotUndefType.new()
+    inst_type = string(inst_type) if inst_type.is_a?(String)
+    type.type = inst_type
+    type
+  end
+
   # Produces a type for Type[T]
   # @api public
   #

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -2,9 +2,9 @@
 # @api public
 #
 module Puppet::Pops::Types::TypeFactory
-  @type_calculator = Puppet::Pops::Types::TypeCalculator.new()
-
   Types = Puppet::Pops::Types
+  @type_calculator = Types::TypeCalculator.singleton
+  @undef_t = Types::PUndefType.new
 
   # Produces the Integer type
   # @api public
@@ -66,9 +66,17 @@ module Puppet::Pops::Types::TypeFactory
   end
 
   # Produces the Optional type, i.e. a short hand for Variant[T, Undef]
+  # If the given 'optional_type' argument is a String, then it will be
+  # converted into a String type that represents that string.
+  #
+  # @param optional_type [String,PAnyType,nil] the optional type
+  # @return [POptionalType] the created type
+  #
+  # @api public
+  #
   def self.optional(optional_type = nil)
     t = Types::POptionalType.new
-    t.optional_type = type_of(optional_type)
+    t.optional_type = optional_type.is_a?(String) ? string(optional_type) : type_of(optional_type)
     t
   end
 
@@ -91,21 +99,50 @@ module Puppet::Pops::Types::TypeFactory
   end
 
   # Produces the Struct type, either a non parameterized instance representing
-  # all structs (i.e. all hashes) or a hash with a given set of keys of String
-  # type (names), bound to a value of a given type. Type may be a Ruby Class, a
-  # Puppet Type, or an instance from which the type is inferred.
+  # all structs (i.e. all hashes) or a hash with entries where the key is
+  # either a literal String, an Enum with one entry, or a String representing exactly one value.
+  # The key type may also be wrapped in a NotUndef or an Optional.
   #
-  def self.struct(name_type_hash = {})
+  # The value can be a ruby class, a String (interpreted as the name of a ruby class) or
+  # a Type.
+  #
+  # @param hash [Hash<Object, Object>] key => value hash
+  # @return [PStructType] the created Struct type
+  #
+  def self.struct(hash = {})
+    tc = @type_calculator
     t = Types::PStructType.new
-    name_type_hash.map do |name, type|
-      elem = Types::PStructElement.new
-      if name.is_a?(String) && name.empty?
-        raise ArgumentError, "An empty String can not be used where a String[1, default] is expected"
+    t.elements = hash.map do |key_type, value_type|
+      value_type = type_of(value_type)
+      raise ArgumentError, 'Struct element value_type must be a Type' unless value_type.is_a?(Types::PAnyType)
+
+      # TODO: Should have stricter name rule
+      if key_type.is_a?(String)
+        raise ArgumentError, 'Struct element key cannot be an empty String' if key_type.empty?
+        key_type = string(key_type)
+        # Must make key optional if the value can be Undef
+        key_type = optional(key_type) if tc.assignable?(value_type, @undef_t)
+      else
+        # assert that the key type is one of String[1], NotUndef[String[1]] and Optional[String[1]]
+        case key_type
+        when Types::PNotUndefType
+          # We can loose the NotUndef wrapper here since String[1] isn't optional anyway
+          key_type = key_type.type
+          s = key_type
+        when Types::POptionalType
+          s = key_type.optional_type
+        else
+          s = key_type
+        end
+        unless (s.is_a?(Puppet::Pops::Types::PStringType) || s.is_a?(Puppet::Pops::Types::PEnumType)) && s.values.size == 1 && !s.values[0].empty?
+          raise ArgumentError, 'Unable to extract a non-empty literal string from Struct member key type' if key_type.empty?
+        end
       end
-      elem.name = name
-      elem.type = type_of(type)
+      elem = Types::PStructElement.new
+      elem.key_type = key_type
+      elem.value_type = value_type
       elem
-    end.each {|elem| t.addElements(elem) }
+    end
     t
   end
 

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -163,6 +163,9 @@ class Puppet::Pops::Types::TypeParser
     when "undef"
       TYPES.undef()
 
+    when "notundef"
+      TYPES.not_undef()
+
     when "default"
       TYPES.default()
 
@@ -405,6 +408,18 @@ class Puppet::Pops::Types::TypeParser
 
     when "any", "data", "catalogentry", "boolean", "scalar", "undef", "numeric", "default"
       raise_unparameterized_type_error(parameterized_ast.left_expr)
+
+    when "notundef"
+      case parameters.size
+      when 0
+        TYPES.not_undef
+      when 1
+        param = parameters[0]
+        assert_type(param) unless param.is_a?(String)
+        TYPES.not_undef(param)
+      else
+        raise_invalid_parameters_error("NotUndef", "0 to 1", parameters.size)
+      end
 
     when "type"
       if parameters.size != 1

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -13,6 +13,7 @@ class Puppet::Pops::Types::TypeParser
   def initialize
     @parser = Puppet::Pops::Parser::Parser.new()
     @type_transformer = Puppet::Pops::Visitor.new(nil, "interpret", 0, 0)
+    @undef_t = TYPES.undef
   end
 
   # Produces a *puppet type* based on the given string.
@@ -347,8 +348,9 @@ class Puppet::Pops::Types::TypeParser
     when "struct"
       # 1..m parameters being types (last two optionally integer or literal default
       raise_invalid_parameters_error("Struct", "1", parameters.size) unless parameters.size == 1
-      assert_struct_parameter(parameters[0])
-      TYPES.struct(parameters[0])
+      h = parameters[0]
+      raise_invalid_type_specification_error unless h.is_a?(Hash)
+      TYPES.struct(h)
 
     when "integer"
       if parameters.size == 1
@@ -451,15 +453,6 @@ class Puppet::Pops::Types::TypeParser
 
   def assert_range_parameter(t)
     raise_invalid_type_specification_error unless TYPES.is_range_parameter?(t)
-  end
-
-  def assert_struct_parameter(h)
-    raise_invalid_type_specification_error unless h.is_a?(Hash)
-    h.each do |k,v|
-      # TODO: Should have stricter name rule
-      raise_invalid_type_specification_error unless k.is_a?(String) && !k.empty?
-      assert_type(v)
-    end
   end
 
   def raise_invalid_type_specification_error

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -46,6 +46,18 @@ module Puppet::Pops
       end
     end
 
+    class PNotUndefType < PAnyType
+      module ClassModule
+        def hash
+          [self.class, type].hash
+        end
+
+        def ==(o)
+          self.class == o.class && type == o.type
+        end
+      end
+    end
+
     class PType < PAnyType
       module ClassModule
         def hash

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -232,11 +232,17 @@ module Puppet::Pops
     class PStructElement < TypeModelObject
       module ClassModule
         def hash
-          [self.class, type, name].hash
+          [self.class, value_type, key_type].hash
+        end
+
+        def name
+          k = key_type
+          k = k.optional_type if k.is_a?(POptionalType)
+          k.values[0]
         end
 
         def ==(o)
-          self.class == o.class && type == o.type && name == o.name
+          self.class == o.class && value_type == o.value_type && key_type == o.key_type
         end
       end
     end
@@ -245,7 +251,7 @@ module Puppet::Pops
     class PStructType < PAnyType
       module ClassModule
         def hashed_elements_derived
-          @_hashed ||= elements.reduce({}) {|memo, e| memo[e.name] = e.type; memo }
+          @_hashed ||= elements.reduce({}) {|memo, e| memo[e.name] = e; memo }
           @_hashed
         end
 

--- a/lib/puppet/pops/types/types_meta.rb
+++ b/lib/puppet/pops/types/types_meta.rb
@@ -27,6 +27,15 @@ module Puppet::Pops::Types
   class PAnyType < TypeModelObject
   end
 
+  # A type that is assignable from the same types as its contained `type` except the
+  # types assignable from {Puppet::Pops::Types::PUndefType}
+  #
+  # @api public
+  #
+  class PNotUndefType < PAnyType
+    contains_one_uni 'type', PAnyType
+  end
+
   # The type of types.
   # @api public
   #

--- a/lib/puppet/pops/types/types_meta.rb
+++ b/lib/puppet/pops/types/types_meta.rb
@@ -144,8 +144,10 @@ module Puppet::Pops::Types
   # @api public
   #
   class PStructElement < TypeModelObject
-    has_attr 'name', String, :lowerBound => 1
-    contains_one_uni 'type', PAnyType
+    # key_type must be either String[1] or Optional[String[1]] and the String[1] must
+    # have a values collection with exactly one element
+    contains_one_uni 'key_type', PAnyType, :lowerBound => 1
+    contains_one_uni 'value_type', PAnyType
   end
 
   # @api public

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -400,6 +400,25 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       expect {evaluate(expr)}.to raise_error(/Resource not found: File\['x'\]/)
     end
 
+    # NotUndef Type
+    #
+    it 'produces a NotUndef instance' do
+      type_expr = fqr('NotUndef')
+      expect(evaluate(type_expr)).to eql(Puppet::Pops::Types::TypeFactory.not_undef())
+    end
+
+    it 'produces a NotUndef instance with contained type' do
+      type_expr = fqr('NotUndef')[fqr('Integer')]
+      tf = Puppet::Pops::Types::TypeFactory
+      expect(evaluate(type_expr)).to eql(tf.not_undef(tf.integer))
+    end
+
+    it 'produces a NotUndef instance with String type when given a literal String' do
+      type_expr = fqr('NotUndef')[literal('hey')]
+      tf = Puppet::Pops::Types::TypeFactory
+      expect(evaluate(type_expr)).to eql(tf.not_undef(tf.string('hey')))
+    end
+
     # Type Type
     #
     it 'creates a Type instance when applied to a Type' do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -238,6 +238,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "$x = Pattern['a.*'] a =~ $x"     => true,
       "1 =~ Integer"                    => true,
       "1 !~ Integer"                    => false,
+      "undef =~ NotUndef"               => false,
+      "undef !~ NotUndef"               => true,
       "[1,2,3] =~ Array[Integer[1,10]]" => true,
     }.each do |source, result|
         it "should parse and evaluate the expression '#{source}' to #{result}" do
@@ -319,7 +321,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     {
-      'Any'  => ['Data', 'Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Collection',
+      'Any'  => ['NotUndef', 'Data', 'Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Collection',
                     'Array', 'Hash', 'CatalogEntry', 'Resource', 'Class', 'Undef', 'File', 'NotYetKnownResourceType'],
 
       # Note, Data > Collection is false (so not included)
@@ -733,6 +735,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "'abc'[x]"                    => "The value 'x' cannot be converted to Numeric",
       "'abc'[1.0]"                  => "A String[] cannot use Float where Integer is expected",
       "'abc'[1,2,3]"                => "String supports [] with one or two arguments. Got 3",
+      "NotUndef[0]"                 => 'NotUndef-Type[] argument must be a Type or a String. Got Fixnum',
+      "NotUndef[a,b]"               => 'NotUndef-Type[] accepts 0 to 1 arguments. Got 2',
       "Resource[0]"                 => 'First argument to Resource[] must be a resource type or a String. Got Integer',
       "Resource[a, 0]"              => 'Error creating type specialization of a Resource-Type, Cannot use Integer where a resource title String is expected',
       "File[0]"                     => 'Error creating type specialization of a File-Type, Cannot use Integer where a resource title String is expected',


### PR DESCRIPTION
This PR adds a new `NotUndef` type. The purpose of this type is to constrain its contained type so that it is not assignable from the `Undef` type. The contained type is optional and defaults to `Any`.

The PR also changes the behavior of the `Struct` type by allowing its members to be types. This change enables declaration of required members who's values may be optional.
