### PR TITLE
(PUP-4517) Add type name to Puppet.newtype deprecation warning

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -142,7 +142,7 @@ module Puppet
   # code was deprecated in 2008, but this is still in heavy use.  I suppose
   # this can count as a soft deprecation for the next dev. --daniel 2011-04-12
   def self.newtype(name, options = {}, &block)
-    Puppet.deprecation_warning("Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.")
+    Puppet.deprecation_warning("Creating #{name} via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.")
     Puppet::Type.newtype(name, options, &block)
   end
 

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -41,7 +41,7 @@ describe Puppet do
 
   context "newtype" do
     it "should issue a deprecation warning" do
-      subject.expects(:deprecation_warning).with("Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.")
+      subject.expects(:deprecation_warning).with("Creating sometype via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.")
       subject.newtype("sometype")
     end
   end


### PR DESCRIPTION
Add type name to Puppet.newtype deprecation warning so it is easier to find and fix those occurrences.