### PR TITLE
(PUP-4520) Fix regression with case default option not being done last

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -587,7 +587,7 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
           case c
           when Puppet::Pops::Model::LiteralDefault
             the_default = co.then_expr
-            is_match?(test, evaluate(c, scope), c, co, scope)
+            next false
           when Puppet::Pops::Model::UnfoldExpression
             # not ideal for error reporting, since it is not known which unfolded result
             # that caused an error - the entire unfold expression is blamed (i.e. the var c, passed to is_match?)

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -528,6 +528,10 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
          [/ee/, Integer[0,10], default] : { 'yes' }
          default :{ 'no' }}"                                => 'yes',
 
+      "case [green, 2, whatever] {
+         default :{ 'no' }
+         [/ee/, Integer[0,10], default] : { 'yes' }}"        => 'yes',
+
       "case {a=>1, b=>2, whatever=>3, extra => ignored} {
          { a => Integer[0,5],
            b => Integer[0,5],

--- a/spec/unit/pops/migration_spec.rb
+++ b/spec/unit/pops/migration_spec.rb
@@ -98,7 +98,7 @@ describe 'Puppet::Pops::MigrationMigrationChecker' do
         migration_checker.expects(:report_uc_bareword_type).once
         migration_checker.expects(:report_option_type_mismatch).once
         Puppet.override({:migration_checker => migration_checker}, "migration-context") do
-          Puppet::Pops::Parser::EvaluatingParser.new.evaluate_string(scope, "case Foo { default: {}}", __FILE__)
+          Puppet::Pops::Parser::EvaluatingParser.new.evaluate_string(scope, "case Foo { 'Foo': {}}", __FILE__)
         end
       end
 


### PR DESCRIPTION
Before this, and after 3.7.5, a case option being a literal default
was selected when encountered instead of being selected last if no other
option was selected.

This was introduced when adding either support for deep merge, or for
migration checking. There was no test finding this regression.
(A similar problem was found earlier with selector).

The fix was to remove the call to is_match? for the default option and
instead return false (to continue with other case option values in the
same option.

As a consequence, one migration test needed to be changed as it reported
a "type diff" for default vs. Resource type (which was actually wrong,
since a comparisson against default is not considered a type match diff)