### PR TITLE
(PUP-735) Ensure reports are finalized when catalog.apply fails

### DIFF
--- a/acceptance/tests/reports/finalized_on_cycle.rb
+++ b/acceptance/tests/reports/finalized_on_cycle.rb
@@ -1,0 +1,37 @@
+test_name "Reports are finalized on resource cycles"
+
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CommandUtils
+
+check_script = <<CHECK
+require 'yaml'
+require 'puppet'
+
+exit YAML.load_file(ARGV[0]).metrics.empty? ? 1 : 0
+CHECK
+
+cyclic_manifest = <<MANIFEST
+notify { 'foo':
+  require => Notify['bar']
+}
+
+notify { 'bar':
+  require => Notify['foo']
+}
+MANIFEST
+
+agents.each do |agent|
+  tmpdir = agent.tmpdir('report_finalized')
+  check = "#{tmpdir}/check_report.rb"
+  manifest = "#{tmpdir}/manifest.pp"
+  report = "#{agent.puppet['vardir']}/state/last_run_report.yaml"
+
+  create_remote_file(agent, check, check_script)
+
+  # We can't use apply_manifest_on here because we can't tell it not
+  # to fail the test when it encounters a cyclic manifest.
+  create_remote_file(agent, manifest, cyclic_manifest)
+  on(agent, puppet("apply", manifest), :acceptable_exit_codes => [1])
+  result = on(agent, "#{ruby_command(agent)} #{check} #{report}", :acceptable_exit_codes => [0,1])
+  fail_test("Report was not finalized") if result.exit_code == 1
+end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -114,13 +114,15 @@ class Puppet::Configurer
   # the options, then apply that one, otherwise retrieve it.
   def apply_catalog(catalog, options)
     report = options[:report]
-    report.configuration_version = catalog.version
+    begin
+      report.configuration_version = catalog.version
 
-    benchmark(:notice, "Applied catalog") do
-      catalog.apply(options)
+      benchmark(:notice, "Applied catalog") do
+        catalog.apply(options)
+      end
+    ensure
+      report.finalize_report
     end
-
-    report.finalize_report
     report
   end
 


### PR DESCRIPTION
After the initial work on PUP-735, we were left with a situation where
certain catalog apply errors (including resource cycles) could casue a
report to not be finalized. An easy symptom of this to see is that the
metrics section of the report is empty.

This fixes the configurer to always finalize the report, and adds a
test.