### PR TITLE
(PUP-4030) Add missing require for Puppet::Util::HttpProxy.

### DIFF
--- a/lib/puppet/network/http/factory.rb
+++ b/lib/puppet/network/http/factory.rb
@@ -1,5 +1,6 @@
 require 'openssl'
 require 'net/http'
+require 'puppet/util/http_proxy'
 
 # Factory for <tt>Net::HTTP</tt> objects.
 #


### PR DESCRIPTION
A require for `puppet/util/http_proxy` was missing for
`puppet/network/http/factory` after code that uses
`Puppet::Util::HttpProxy` was added.

This originally passed specs because the spec required the file before
using the HTTP factory.