### PR TITLE
(PUP-4473) Extend ENC tests to Windows

### DIFF
--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -43,6 +43,20 @@ module PuppetSpec::Files
     file
   end
 
+  def script_containing(name, contents) PuppetSpec::Files.script_containing(name, contents) end
+  def self.script_containing(name, contents)
+    file = tmpfile(name)
+    if Puppet.features.microsoft_windows?
+      file += '.bat'
+      text = contents[:windows]
+    else
+      text = contents[:posix]
+    end
+    File.open(file, 'wb') { |f| f.write(text) }
+    Puppet::FileSystem.chmod(0755, file)
+    file
+  end
+
   def tmpdir(name) PuppetSpec::Files.tmpdir(name) end
   def self.tmpdir(name)
     dir = Dir.mktmpdir(name)

--- a/spec/unit/parser/functions/generate_spec.rb
+++ b/spec/unit/parser/functions/generate_spec.rb
@@ -92,18 +92,9 @@ describe "the generate function" do
   end
 
   let :command do
-    cmd = tmpfile('function_generate')
-
-    if Puppet.features.microsoft_windows?
-      cmd += '.bat'
-      text = '@echo off' + "\n" + 'echo a-%1 b-%2'
-    else
-      text = '#!/bin/sh' + "\n" + 'echo a-$1 b-$2'
-    end
-
-    File.open(cmd, 'w') {|fh| fh.puts text }
-    File.chmod 0700, cmd
-    cmd
+    script_containing('function_generate',
+      :windows => '@echo off' + "\n" + 'echo a-%1 b-%2',
+      :posix   => '#!/bin/sh' + "\n" + 'echo a-$1 b-$2')
   end
 
   after :each do


### PR DESCRIPTION
The ENC integration tests using the exec terminus were originally only
implemented with shell scripts. Extend the testing to create Windows batch
scripts and run on Windows.

Also create a new spec_helper script_containing to generate a script on
the appropriate platform. Since script languages also differ, usage
requires that you provide both Windows and shell versions of the script.