### PR TITLE
(PUP-4527) Add MigrationChecker method to provide available migrations

### DIFF
--- a/lib/puppet/pops/migration/migration_checker.rb
+++ b/lib/puppet/pops/migration/migration_checker.rb
@@ -6,27 +6,40 @@ class Puppet::Pops::Migration::MigrationChecker
   def initialize()
   end
 
+  # Produces a hash of available migrations; a map from a symbolic name in string form to a brief description.
+  def available_migrations()
+    { '3.8/4.0' => '3.8 future parser to 4.0 language migrations'}
+  end
+
+  # For 3.8/4.0
   def report_ambiguous_integer(o)
   end
 
+  # For 3.8/4.0
   def report_ambiguous_float(o)
   end
 
+  # For 3.8/4.0
   def report_empty_string_true(value, o)
   end
 
+  # For 3.8/4.0
   def report_uc_bareword_type(value, o)
   end
 
+  # For 3.8/4.0
   def report_equality_type_mismatch(left, right, o)
   end
 
+  # For 3.8/4.0
   def report_option_type_mismatch(test_value, option_value, option_expr, matching_expr)
   end
 
+  # For 3.8/4.0
   def report_in_expression(o)
   end
 
+  # For 3.8/4.0
   def report_array_last_in_block(o)
   end
 end


### PR DESCRIPTION
Befoe this, reflection had to be used to see what a version of a
MigrationChecker implements.

This is now changed so all versions of puppet after 3.8.0 has a method
that returns the migration checks that are implemented. This makes it
possible to have newer versions of the migration checker support older
versions of puppet (>= 3.8.0).