### PR TITLE
(PUP-4527) merge 4527 from 3.x and fix up earlier merge mistakes

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -1108,7 +1108,6 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
   # of value except regular expression where a match is performed.
   #
   def is_match?(left, right, o, option_expr, scope)
-    @migration_checker.report_option_type_mismatch(left, right, option_expr, o)
     if right.is_a?(Regexp)
       return false unless left.is_a? String
       matched = right.match(left)
@@ -1119,7 +1118,6 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
       # (The reverse is not terribly meaningful - computing which of the case options that first produces
       # an instance of a given type).
       #
-      @migration_checker.report_uc_bareword_type(right, o)
       @@type_calculator.instance?(right, left)
     else
       # Handle equality the same way as the language '==' operator (case insensitive etc.)

--- a/lib/puppet/pops/migration/migration_checker.rb
+++ b/lib/puppet/pops/migration/migration_checker.rb
@@ -7,39 +7,48 @@ class Puppet::Pops::Migration::MigrationChecker
   end
 
   # Produces a hash of available migrations; a map from a symbolic name in string form to a brief description.
+  # This version has no such supported migrations.
   def available_migrations()
-    { '3.8/4.0' => '3.8 future parser to 4.0 language migrations'}
+    { }
   end
 
   # For 3.8/4.0
   def report_ambiguous_integer(o)
+    raise Puppet::DevError, "Unsupported migration method called"
   end
 
   # For 3.8/4.0
   def report_ambiguous_float(o)
+    raise Puppet::DevError, "Unsupported migration method called"
   end
 
   # For 3.8/4.0
   def report_empty_string_true(value, o)
+    raise Puppet::DevError, "Unsupported migration method called"
   end
 
   # For 3.8/4.0
   def report_uc_bareword_type(value, o)
+    raise Puppet::DevError, "Unsupported migration method called"
   end
 
   # For 3.8/4.0
   def report_equality_type_mismatch(left, right, o)
+    raise Puppet::DevError, "Unsupported migration method called"
   end
 
   # For 3.8/4.0
   def report_option_type_mismatch(test_value, option_value, option_expr, matching_expr)
+    raise Puppet::DevError, "Unsupported migration method called"
   end
 
   # For 3.8/4.0
   def report_in_expression(o)
+    raise Puppet::DevError, "Unsupported migration method called"
   end
 
   # For 3.8/4.0
   def report_array_last_in_block(o)
+    raise Puppet::DevError, "Unsupported migration method called"
   end
 end


### PR DESCRIPTION
This merges the implementation of PUP 4527 into stable (from 3x) and provides fix up of earlier merges that added back calls to the migration checker (from PUP 4127).

A safety mechanism is added (raising errors) if any of the methods that should not be called in the migration checker is called by mistake.