### PR TITLE
(PUP-4524) Stub command execution in base service provider spec.

### DIFF
--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -10,39 +10,52 @@ describe "base service provider" do
 
   let :type do Puppet::Type.type(:service) end
   let :provider do type.provider(:base) end
+  let(:executor) { Puppet::Util::Execution }
+  let(:start_command) { 'start' }
+  let(:status_command) { 'status' }
+  let(:stop_command) { 'stop' }
 
   subject { provider }
 
   context "basic operations" do
-    # Cross-platform file interactions.  Fun times.
-    Ruby = File.join(RbConfig::CONFIG["bindir"],
-                     RbConfig::CONFIG["RUBY_INSTALL_NAME"] +
-                     RbConfig::CONFIG["EXEEXT"])
-
-    Start  = [Ruby, '-rfileutils', '-e', 'FileUtils.touch(ARGV[0])']
-    Status = [Ruby, '-e' 'exit File.file?(ARGV[0])']
-    Stop   = [Ruby, '-e', 'File.exist?(ARGV[0]) and File.unlink(ARGV[0])']
-
-    let :flag do tmpfile('base-service-test') end
-
     subject do
-      type.new(:name  => "test", :provider => :base,
-               :start  => Start  + [flag],
-               :status => Status + [flag],
-               :stop   => Stop   + [flag]
+      type.new(
+         :name  => "test",
+         :provider => :base,
+         :start  => start_command,
+         :status => status_command,
+         :stop   => stop_command
       ).provider
     end
 
-    before :each do
-      Puppet::FileSystem.unlink(flag) if Puppet::FileSystem.exist?(flag)
+    def execute_command(command, options)
+      case command.shift
+      when start_command
+        expect(options[:failonfail]).to eq(true)
+        raise(Puppet::ExecutionFailure, 'failed to start') if @running
+        @running = true
+        return 'started'
+      when status_command
+        expect(options[:failonfail]).to eq(false)
+        $CHILD_STATUS.expects(:exitstatus).at_least(1).returns(@running ? 0 : 1)
+        return @running ? 'running' : 'not running'
+      when stop_command
+        expect(options[:failonfail]).to eq(true)
+        raise(Puppet::ExecutionFailure, 'failed to stop') unless @running
+        @running = false
+        return 'stopped'
+      else
+        raise "unexpected command execution: #{command}"
+      end
     end
 
-    it { is_expected.to be }
+    before :each do
+      @running = false
+      executor.expects(:execute).at_least(1).with { |command, options| execute_command(command, options) }
+    end
 
     it "should invoke the start command if not running" do
-      expect(File).not_to be_file(flag)
       subject.start
-      expect(File).to be_file(flag)
     end
 
     it "should be stopped before being started" do
@@ -59,19 +72,17 @@ describe "base service provider" do
       expect(subject.status).to eq(:running)
       subject.stop
       expect(subject.status).to eq(:stopped)
-      expect(File).not_to be_file(flag)
     end
 
-    it "should start again even if already running" do
+    it "should raise an error if started twice" do
       subject.start
-      subject.expects(:ucommand).with(:start)
-      subject.start
+      expect {subject.start }.to raise_error(Puppet::Error, 'Could not start Service[test]: failed to start')
     end
 
-    it "should stop again even if already stopped" do
+    it "should raise an error if stopped twice" do
+      subject.start
       subject.stop
-      subject.expects(:ucommand).with(:stop)
-      subject.stop
+      expect {subject.stop }.to raise_error(Puppet::Error, 'Could not stop Service[test]: failed to stop')
     end
   end
 end


### PR DESCRIPTION
Rather than rely on executing ruby to manipulate a file to "emulate" a
service start/status/stop command, stub command execution itself to
ensure the base service provider is executing the commands as expected.