### PR TITLE
(PUP-4546) Fix retrieving package version in #instances

### DIFF
--- a/lib/puppet/provider/package/pkgin.rb
+++ b/lib/puppet/provider/package/pkgin.rb
@@ -5,15 +5,15 @@ Puppet::Type.type(:package).provide :pkgin, :parent => Puppet::Provider::Package
 
   commands :pkgin => "pkgin"
 
-  defaultfor :operatingsystem => [ :dragonfly , :smartos ]
+  defaultfor :operatingsystem => [ :dragonfly , :smartos, :netbsd ]
 
   has_feature :installable, :uninstallable, :upgradeable, :versionable
 
   def self.parse_pkgin_line(package)
 
     # e.g.
-    #   vim-7.2.446 =        Vim editor (vi clone) without GUI
-    match, name, version, status = *package.match(/(\S+)-(\S+)(?: (=|>|<))?\s+.+$/)
+    #   vim-7.2.446;Vim editor (vi clone) without GUI
+    match, name, version, status = *package.match(/([^\s;]+)-([^\s;]+)[;\s](=|>|<)?.+$/)
     if match
       {
         :name     => name,

--- a/spec/unit/provider/package/pkgin_spec.rb
+++ b/spec/unit/provider/package/pkgin_spec.rb
@@ -41,7 +41,7 @@ describe provider_class do
 
   describe "#instances" do
     let(:pkgin_ls_output) do
-      "zlib-1.2.3           General purpose data compression library\nzziplib-0.13.59      Library for ZIP archive handling\n"
+      "zlib-1.2.3;General purpose data compression library\nzziplib-0.13.59;Library for ZIP archive handling\n"
     end
 
     before do
@@ -72,7 +72,7 @@ describe provider_class do
 
     context "when the package is installed" do
       let(:pkgin_search_output) do
-        "vim-7.2.446 =        Vim editor (vi clone) without GUI\nvim-share-7.2.446 =  Data files for the vim editor (vi clone)\n\n=: package is installed and up-to-date\n<: package is installed but newer version is available\n>: installed package has a greater version than available package\n"
+        "vim-7.2.446;=;Vim editor (vi clone) without GUI\nvim-share-7.2.446;=;Data files for the vim editor (vi clone)\n\n=: package is installed and up-to-date\n<: package is installed but newer version is available\n>: installed package has a greater version than available package\n"
       end
 
       it "returns installed version" do
@@ -83,7 +83,7 @@ describe provider_class do
 
     context "when the package is out of date" do
       let(:pkgin_search_output) do
-        "vim-7.2.447 <        Vim editor (vi clone) without GUI\nvim-share-7.2.447 <  Data files for the vim editor (vi clone)\n\n=: package is installed and up-to-date\n<: package is installed but newer version is available\n>: installed package has a greater version than available package\n"
+        "vim-7.2.447;<;Vim editor (vi clone) without GUI\nvim-share-7.2.447;<;Data files for the vim editor (vi clone)\n\n=: package is installed and up-to-date\n<: package is installed but newer version is available\n>: installed package has a greater version than available package\n"
       end
 
       it "returns the version to be installed" do
@@ -93,7 +93,7 @@ describe provider_class do
 
     context "when the package is ahead of date" do
       let(:pkgin_search_output) do
-        "vim-7.2.446 >        Vim editor (vi clone) without GUI\nvim-share-7.2.446 >  Data files for the vim editor (vi clone)\n\n=: package is installed and up-to-date\n<: package is installed but newer version is available\n>: installed package has a greater version than available package\n"
+        "vim-7.2.446;>;Vim editor (vi clone) without GUI\nvim-share-7.2.446;>;Data files for the vim editor (vi clone)\n\n=: package is installed and up-to-date\n<: package is installed but newer version is available\n>: installed package has a greater version than available package\n"
       end
 
       it "returns current version" do
@@ -105,12 +105,12 @@ describe provider_class do
     context "when multiple candidates do exists" do
       let(:pkgin_search_output) do
         <<-SEARCH
-vim-7.1 >            Vim editor (vi clone) without GUI
-vim-share-7.1 >      Data files for the vim editor (vi clone)
-vim-7.2.446 =        Vim editor (vi clone) without GUI
-vim-share-7.2.446 =  Data files for the vim editor (vi clone)
-vim-7.3 <            Vim editor (vi clone) without GUI
-vim-share-7.3 <      Data files for the vim editor (vi clone)
+vim-7.1;>;Vim editor (vi clone) without GUI
+vim-share-7.1;>;Data files for the vim editor (vi clone)
+vim-7.2.446;=;Vim editor (vi clone) without GUI
+vim-share-7.2.446;=;Data files for the vim editor (vi clone)
+vim-7.3;<;Vim editor (vi clone) without GUI
+vim-share-7.3;<;Data files for the vim editor (vi clone)
 
 =: package is installed and up-to-date
 <: package is installed but newer version is available
@@ -137,7 +137,7 @@ SEARCH
 
   describe "#parse_pkgin_line" do
     context "with an installed package" do
-      let(:package) { "vim-7.2.446 =        Vim editor (vi clone) without GUI" }
+      let(:package) { "vim-7.2.446;=;Vim editor (vi clone) without GUI" }
 
       it "extracts the name and status" do
         expect(provider_class.parse_pkgin_line(package)).to eq({ :name => "vim" ,
@@ -147,7 +147,7 @@ SEARCH
     end
 
     context "with an installed package with a hyphen in the name" do
-      let(:package) { "ruby18-puppet-0.25.5nb1 > Configuration management framework written in Ruby" }
+      let(:package) { "ruby18-puppet-0.25.5nb1;>;Configuration management framework written in Ruby" }
 
       it "extracts the name and status" do
         expect(provider_class.parse_pkgin_line(package)).to eq({ :name =>  "ruby18-puppet",
@@ -156,8 +156,18 @@ SEARCH
       end
     end
 
+    context "with an installed package with a hyphen in the name and package description" do
+      let(:package) { "ruby200-facter-2.4.3nb1;=;Cross-platform Ruby library for retrieving facts from OS" }
+
+      it "extracts the name and status" do
+        expect(provider_class.parse_pkgin_line(package)).to eq({ :name =>  "ruby200-facter",
+                                                             :status => "=" ,
+                                                             :ensure => "2.4.3nb1" })
+      end
+    end
+
     context "with a package not yet installed" do
-      let(:package) { "vim-7.2.446          Vim editor (vi clone) without GUI" }
+      let(:package) { "vim-7.2.446;Vim editor (vi clone) without GUI" }
 
       it "extracts the name and status" do
         expect(provider_class.parse_pkgin_line(package)).to eq({ :name => "vim" ,


### PR DESCRIPTION
The output for 'pkgin list' has been changed to separate fields with ';'
for non-interactive terminals, so adjust the regex accordingly. To ensure
we'll always get this output pass '-p' to the list command (this is what pkgin
does internally for non-interactive terminals).