### PR TITLE
(PUP-735) Disable finalized_on_cycle on Windows

### DIFF
--- a/acceptance/tests/reports/finalized_on_cycle.rb
+++ b/acceptance/tests/reports/finalized_on_cycle.rb
@@ -1,4 +1,6 @@
 test_name "Reports are finalized on resource cycles"
+# PUP-4548: Skip Windows until PUP-4547 can be resolved.
+confine :except, :platform => 'windows'
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils
@@ -24,7 +26,7 @@ agents.each do |agent|
   tmpdir = agent.tmpdir('report_finalized')
   check = "#{tmpdir}/check_report.rb"
   manifest = "#{tmpdir}/manifest.pp"
-  report = "#{agent.puppet['vardir']}/state/last_run_report.yaml"
+  report = agent.puppet['lastrunreport']
 
   create_remote_file(agent, check, check_script)
 


### PR DESCRIPTION
With our Windows MSI package, Puppet isn't installed into normal Ruby
library locations. For puppet/facter/etc we provide wrappers that setup
RUBYLIB, but the same isn't done for ruby/irb. Disable the test on
Windows until PUP-4547 can be fixed.