### PR TITLE
(PUP-4491) Add a proper confine for the openbsd user provider

### DIFF
--- a/lib/puppet/provider/user/openbsd.rb
+++ b/lib/puppet/provider/user/openbsd.rb
@@ -11,6 +11,7 @@ Puppet::Type.type(:user).provide :openbsd, :parent => :useradd do
            :password => "passwd"
 
   defaultfor :operatingsystem => :openbsd
+  confine    :operatingsystem => :openbsd
 
   options :home, :flag => "-d", :method => :dir
   options :comment, :method => :gecos


### PR DESCRIPTION
Note that an openbsd-specific user provider was added in
https://github.com/puppetlabs/puppet/commit/986281e1d. However,
that commit neglected to include a confine, so the provider
became suitable for all platforms (although it isn't actually
suitable). Since puppet resolves suitability ties alphabetically,
this meant that providers alphabetically after 'openbsd' would
lose out to this provider.