### PR TITLE
(PUP-4653) stop using hardcoded REST URLs around the filebucket

### DIFF
--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -22,7 +22,7 @@ class Puppet::FileBucket::Dipper
       @rest_path  = nil
     else
       @local_path = nil
-      @rest_path = "https://#{server}:#{port}/#{environment}/file_bucket_file/"
+      @rest_path = "filebucket://#{server}:#{port}/"
     end
     @checksum_type = Puppet[:digest_algorithm].to_sym
     @digest = method(@checksum_type)

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -243,15 +243,14 @@ class Puppet::Indirector::Request
       @port = uri.port.to_i
     end
 
-    @protocol = uri.scheme
-
-    if uri.scheme == 'puppet'
-      @key = URI.unescape(uri.path.sub(/^\//, ''))
-      return
+    # filebucket:// is only used internally to pass request details
+    # from Dipper objects to the indirector. The wire always uses HTTPS.
+    if uri.scheme == 'filebucket'
+      @protocol = 'https'
+    else
+      @protocol = uri.scheme
     end
 
-    env, indirector, @key = URI.unescape(uri.path.sub(/^\//, '')).split('/',3)
-    @key ||= ''
-    self.environment = env unless env == ''
+    @key = URI.unescape(uri.path.sub(/^\//, ''))
   end
 end

--- a/spec/integration/file_bucket/file_spec.rb
+++ b/spec/integration/file_bucket/file_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::FileBucket::File do
 
       {
         "md5/d41d8cd98f00b204e9800998ecf8427e" => :file,
-        "https://puppetmaster:8140/production/file_bucket_file/md5/d41d8cd98f00b204e9800998ecf8427e" => :file,
+        "filebucket://puppetmaster:8140/md5/d41d8cd98f00b204e9800998ecf8427e" => :file,
       }.each do |key, terminus|
         it "should use the #{terminus} terminus when requesting #{key.inspect}" do
           described_class.indirection.terminus(terminus).class.any_instance.expects(:find)
@@ -31,7 +31,7 @@ describe Puppet::FileBucket::File do
     describe "when running another application" do
       {
         "md5/d41d8cd98f00b204e9800998ecf8427e" => :file,
-        "https://puppetmaster:8140/production/file_bucket_file/md5/d41d8cd98f00b204e9800998ecf8427e" => :rest,
+        "filebucket://puppetmaster:8140/md5/d41d8cd98f00b204e9800998ecf8427e" => :rest,
       }.each do |key, terminus|
         it "should use the #{terminus} terminus when requesting #{key.inspect}" do
           described_class.indirection.terminus(terminus).class.any_instance.expects(:find)

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -116,32 +116,32 @@ describe Puppet::Indirector::Request do
       end
 
       it "should set the protocol to the URI scheme" do
-        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/an_environment", nil).protocol).to eq("http")
+        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/", nil).protocol).to eq("http")
       end
 
       it "should set the server if a server is provided" do
-        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/an_environment", nil).server).to eq("host")
+        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/", nil).server).to eq("host")
       end
 
       it "should set the server and port if both are provided" do
-        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host:543/an_environment", nil).port).to eq(543)
+        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host:543/", nil).port).to eq(543)
       end
 
       it "should default to the masterport if the URI scheme is 'puppet'" do
         Puppet[:masterport] = "321"
-        expect(Puppet::Indirector::Request.new(:ind, :method, "puppet://host/an_environment", nil).port).to eq(321)
+        expect(Puppet::Indirector::Request.new(:ind, :method, "puppet://host/", nil).port).to eq(321)
       end
 
       it "should use the provided port if the URI scheme is not 'puppet'" do
-        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/an_environment", nil).port).to eq(80)
+        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/", nil).port).to eq(80)
       end
 
-      it "should set the request key to the unescaped key part path from the URI" do
-        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/an_environment/terminus/stuff with spaces", nil).key).to eq("stuff with spaces")
+      it "should set the request key to the unescaped path from the URI" do
+        expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/stuff with spaces", nil).key).to eq("stuff with spaces")
       end
 
       it "should set the :uri attribute to the full URI" do
-        expect(Puppet::Indirector::Request.new(:ind, :method, "http:///an_environment/stu ff", nil).uri).to eq('http:///an_environment/stu ff')
+        expect(Puppet::Indirector::Request.new(:ind, :method, "http:///a/path/stu ff", nil).uri).to eq('http:///a/path/stu ff')
       end
 
       it "should not parse relative URI" do


### PR DESCRIPTION
Network communication with filebuckets used to be implemented by

 1. building a REST URL using logic that duplicated that from
    Puppet::Network::HTTP::API::IndirectedRoutes
 2. deconstructing the URL when handling this special case
    of Puppet::Indirector::Request

This is a relic from API v1 (release 0.25.5) and has not been
necessary for a while, apparently.

We can just stop doing both of those things and the filebucket
Just Works.