### PR TITLE
(PUP-4551) Do not generalize struck key types

### DIFF
--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -2046,7 +2046,7 @@ describe 'The type calculator' do
       generic.element_type.values.should == []
     end
 
-    it "a generic result is created by generalize! given an instance specific result for a Hash" do
+    it 'a generic result is created by generalize! given an instance specific result for a Hash' do
       generic = calculator.infer({'a' =>1,'b' => 2})
       generic.key_type.values.sort.should == ['a', 'b']
       generic.element_type.from.should == 1
@@ -2055,6 +2055,20 @@ describe 'The type calculator' do
       generic.key_type.values.should == []
       generic.element_type.from.should == nil
       generic.element_type.to.should == nil
+    end
+
+    it 'ensures that Struct key types are not generalized' do
+      generic = calculator.generalize!(struct_t({'a' => object_t}))
+      expect(calculator.string(generic)).to eq("Struct[{'a'=>Any}]")
+      generic = calculator.generalize!(struct_t({not_undef_t('a') => object_t}))
+      expect(calculator.string(generic)).to eq("Struct[{NotUndef['a']=>Any}]")
+      generic = calculator.generalize!(struct_t({optional_t('a') => string_t}))
+      expect(calculator.string(generic)).to eq("Struct[{Optional['a']=>String}]")
+    end
+
+    it 'ensures that Struct value types are generalized' do
+      generic = calculator.generalize!(struct_t({'a' => range_t(1, 3)}))
+      expect(calculator.string(generic)).to eq("Struct[{'a'=>Integer}]")
     end
 
     it "does not reduce by combining types when using infer_set" do


### PR DESCRIPTION
This commit ensures that String types that represents keys in a
Struct type are excluded from generalization. The reason for this
is that such generalization would remove the value that the String
represents and thus, the name of the member.