### PR TITLE
(PUP-4552) Use TypeCalculator.infer_set for type validation errors

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -488,7 +488,7 @@ class Puppet::Resource
       parameters.each do |name, value|
         next unless t = arg_types[name.to_s]  # untyped, and parameters are symbols here (aargh, strings in the type)
         unless Puppet::Pops::Types::TypeCalculator.instance?(t, value.value)
-          inferred_type = Puppet::Pops::Types::TypeCalculator.infer(value.value)
+          inferred_type = Puppet::Pops::Types::TypeCalculator.infer_set(value.value)
           actual = Puppet::Pops::Types::TypeCalculator.generalize!(inferred_type)
           fail Puppet::ParseError, "Expected parameter '#{name}' of '#{self}' to have type #{t.to_s}, got #{actual.to_s}"
         end

--- a/spec/integration/parser/future_compiler_spec.rb
+++ b/spec/integration/parser/future_compiler_spec.rb
@@ -506,6 +506,15 @@ describe "Puppet::Parser::Compiler" do
         MANIFEST
         expect(catalog).to have_resource("Notify[test]").with_parameter(:message, 'knock knock')
       end
+
+      it 'uses infer_set when reporting type mismatch' do
+        expect do
+          catalog = compile_to_catalog(<<-MANIFEST)
+            define foo(Struct[{b => Integer, d=>String}] $a) { }
+            foo{ bar: a => {b => 5, c => 'stuff'}}
+          MANIFEST
+        end.to raise_error(/got Struct\[\{'b'=>Integer, 'c'=>String\}\]/)
+      end
     end
 
     context 'when using typed parameters in class' do


### PR DESCRIPTION
The type validation for resource parameters currently uses
TypeCalculator.infer when reporting errors. This commit changes
this so that infer_set is used instead.