### PR TITLE
(PUP-4503,PUP-4540,PUP-2023) Update service provider default for newe…

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -16,7 +16,8 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   # is resolved.
   commands :invoke_rc => "/usr/sbin/invoke-rc.d"
 
-  defaultfor :operatingsystem => [:debian, :cumuluslinux]
+  defaultfor :operatingsystem => :cumuluslinux
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ['5','6','7']
 
   # Remove the symlinks
   def disable

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
     Facter.value(:operatingsystem) == 'LinuxMint',
   ]
 
-  defaultfor :operatingsystem => :ubuntu
+  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"]
 
   commands :start   => "/sbin/start",
            :stop    => "/sbin/stop",


### PR DESCRIPTION
…r debian/ubuntu releases

With the release of Debian 8 Jessie and Ubuntu 15.04 (Vivid Vervet),
ubuntu and debian are noew defaulting the available service manager to
systemd, rather than init or upstart. This commit updates Puppet to
use systemd as the default service provider on these two systems, while
also defaulting back to other service providers if necessary.