### PR TITLE
(PUP-4436) Generate error message in eventlog differently

### DIFF
--- a/acceptance/tests/windows/eventlog.rb
+++ b/acceptance/tests/windows/eventlog.rb
@@ -12,16 +12,15 @@ agents.each do |agent|
   # get remote time
   now = on(agent, "#{ruby_command(agent)} -e \"puts Time.now.utc.strftime('%m/%d/%Y %H:%M:%S')\"").stdout.chomp
 
-  # it should fail to start since parent directories don't exist
-  confdir = "/does/not/exist"
-
   # generate an error, no master on windows boxes
-  on agent, puppet_agent('--server', '127.0.0.1', '--test', '--confdir', confdir), :acceptable_exit_codes => [1]
+  # we use `agent` because it creates an eventlog log destination by default,
+  # whereas `apply` does not.
+  on agent, puppet('agent', '--server', '127.0.0.1', '--test'), :acceptable_exit_codes => [1]
 
   # make sure there's a Puppet error message in the log
   # cygwin + ssh + wmic hangs trying to read stdin, so echo '' |
   on agent, "cmd /c echo '' | wmic ntevent where \"LogFile='Application' and SourceName='Puppet' and TimeWritten >= '#{now}'\"  get Message,Type /format:csv" do
     fail_test "Event not found in Application event log" unless
-      stdout =~ /Cannot create [a-z]:\/does\/not\/exist.*,Error/mi
+      stdout =~ /Could not retrieve catalog.*skipping run,Error/mi
   end
 end


### PR DESCRIPTION
Prior to commit 88ae8a9, it was an error to specify a `confdir` whose
parent directory didn't exist. After the change, puppet would create the
ancestor directories `C:/does/not`, enabling puppet's settings catalog
to create the `confdir` named `C:/does/not/exist`.

This commit changes the test to no longer rely on setting an invalid
confdir.  Instead it just runs `puppet agent` trying to connect to a
non-existent master, as it did before, and it changes the expectation to
match the error we generate.

The commit also changes from the deprecated `puppet_agent` beaker
method to `puppet('agent', ...)`.

It would have been nice to test this behavior using:

    puppet apply -e "err('some message')"

However, `apply` uses the console as the default log destination. It is
possible to specify `puppet apply --logdest eventlog ...` but that
doesn't test the default `agent` behavior of always writing to the
eventlog.