### PR TITLE
(PUP-1295) Fix always purging package resources that are not installed.

### DIFF
--- a/lib/puppet/property/ensure.rb
+++ b/lib/puppet/property/ensure.rb
@@ -49,7 +49,7 @@ class Puppet::Property::Ensure < Puppet::Property
 
   def change_to_s(currentvalue, newvalue)
     begin
-      if currentvalue == :absent or currentvalue.nil?
+      if currentvalue == :absent || currentvalue.nil?
         return "created"
       elsif newvalue == :absent
         return "removed"

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -174,10 +174,10 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       # because of multiarch
       return "#{upd[:epoch]}:#{upd[:version]}-#{upd[:release]}"
     else
-      # Yum didn't find updates, pretend the current
-      # version is the latest
-      raise Puppet::DevError, "Tried to get latest on a missing package" if properties[:ensure] == :absent
-      return properties[:ensure]
+      # Yum didn't find updates, pretend the current version is the latest
+      version = properties[:ensure]
+      raise Puppet::DevError, "Tried to get latest on a missing package" if version == :absent || version == :purged
+      return version
     end
   end
 

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -144,7 +144,7 @@ module Puppet
             return true unless [:absent, :purged, :held].include?(is)
           when :latest
             # Short-circuit packages that are not present
-            return false if is == :absent or is == :purged
+            return false if is == :absent || is == :purged
 
             # Don't run 'latest' more than about every 5 minutes
             if @latest and ((Time.now.to_i - @lateststamp) / 60) < 5
@@ -175,7 +175,7 @@ module Puppet
 
 
           when :absent
-            return true if is == :absent or is == :purged
+            return true if is == :absent || is == :purged
           when :purged
             return true if is == :purged
           # this handles version number matches and
@@ -204,6 +204,17 @@ module Puppet
         else
           super(newvalue)
         end
+      end
+
+      def change_to_s(currentvalue, newvalue)
+        # Handle transitioning from any previous state to 'purged'
+        return 'purged' if newvalue == :purged
+
+        # Check for transitions from nil/purged/absent to 'created' (any state that is not absent and not purged)
+        return 'created' if (currentvalue.nil? || currentvalue == :absent || currentvalue == :purged) && (newvalue != :absent && newvalue != :purged)
+
+        # The base should handle the normal property transitions
+        super(currentvalue, newvalue)
       end
     end
 

--- a/spec/unit/provider/package/aptrpm_spec.rb
+++ b/spec/unit/provider/package/aptrpm_spec.rb
@@ -24,9 +24,9 @@ describe Puppet::Type.type(:package).provider(:aptrpm) do
       pkg.provider.expects(:rpm).with(*args)
     end
 
-    it "should report absent packages" do
+    it "should report purged packages" do
       rpm.raises(Puppet::ExecutionFailure, "couldn't find rpm")
-      expect(pkg.property(:ensure).retrieve).to eq(:absent)
+      expect(pkg.property(:ensure).retrieve).to eq(:purged)
     end
 
     it "should report present packages correctly" do

--- a/spec/unit/provider/package/base_spec.rb
+++ b/spec/unit/provider/package/base_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'puppet/provider/package'
+
+describe Puppet::Provider::Package do
+  it 'returns absent for uninstalled packages when not purgeable' do
+    provider = Puppet::Provider::Package.new
+    provider.expects(:query).returns nil
+    provider.class.expects(:feature?).with(:purgeable).returns false
+    expect(provider.properties[:ensure]).to eq(:absent)
+  end
+
+  it 'returns purged for uninstalled packages when purgeable' do
+    provider = Puppet::Provider::Package.new
+    provider.expects(:query).returns nil
+    provider.class.expects(:feature?).with(:purgeable).returns true
+    expect(provider.properties[:ensure]).to eq(:purged)
+  end
+end


### PR DESCRIPTION
For package providers, the base package provider was defaulting to a
property hash with a status of :absent when the package was missing.

When the resource is `ensure => purged`, an :absent status causes it to
be purged.  This is because an absent package could represent a
"partially installed" package that is not truly installed and can
therefore be purged (see the dpkg provider).  If the base provider
always returns a status of :absent for missing packages then purgeable
providers will always attempt to purge a missing resource.

The fix is to have the base provider default to a :purged status when
the resource is missing and the provider supports purging.  Otherwise,
it defaults to :absent like before.