### PR TITLE
(maint) Fix bad merge from 3.x branch.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -506,30 +506,13 @@ module Puppet
           essentially means that you can't have any code outside of a node,
           class, or definition other than in the site manifest.",
     },
-    :stringify_facts => {
-      :default => true,
-      :type    => :boolean,
-      :desc    => "Flatten fact values to strings using #to_s. Means you can't have arrays or
-        hashes as fact values. (DEPRECATED) This option will be removed in Puppet 4.0.",
-    },
-    :trusted_node_data => {
-      :default => false,
-      :type    => :boolean,
-      :desc    => "Stores trusted node data in a hash called $trusted.
-        When true also prevents $trusted from being overridden in any scope.",
-    },
     :trusted_server_facts => {
       :default => false,
       :type    => :boolean,
       :desc    => "Stores a trusted set of server-side global variables in a hash
-        called $server_facts, which cannot be cannot be overridden by client_facts 
-        or logic in manifests. Makes it illegal to assign to the variable $server_facts 
+        called $server_facts, which cannot be cannot be overridden by client_facts
+        or logic in manifests. Makes it illegal to assign to the variable $server_facts
         in any scope.",
-    },
-    :immutable_node_data => {
-      :default => '$trusted_node_data',
-      :type    => :boolean,
-      :desc    => "When true, also prevents $trusted and $facts from being overridden in any scope",
     },
     :preview_outputdir => {
       :default => '$vardir/preview',


### PR DESCRIPTION
Commit e1c8724df80190946ebde0559eb15fb4902797cc resolved a conflict
in defaults.rb that re-introduced the stringify_facts,
trusted_node_data, and immutable_node_data settings that were removed in
4.0.

This commit removes them again.