### PR TITLE
(PUP-4530) Fix FreeBSD service provider to parse service names correctly

### DIFF
--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
 
   # Extract service name
   def service_name
-    extract_value_name('service', 0, /# (.*)/, '\1')
+    extract_value_name('service', 0, /# (\S+).*/, '\1')
   end
 
   # Extract rcvar name

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -44,6 +44,22 @@ OUTPUT
     expect(@provider.rcvar).to eq(['# ntpd', 'ntpd=YES'])
   end
 
+  it 'should parse service names with a description' do
+    @provider.stubs(:execute).returns <<OUTPUT
+# local_unbound : local caching forwarding resolver
+local_unbound_enable="YES"
+OUTPUT
+    expect(@provider.service_name).to eq('local_unbound')
+  end
+
+  it 'should parse service names without a description' do
+    @provider.stubs(:execute).returns <<OUTPUT
+# local_unbound
+local_unbound="YES"
+OUTPUT
+    expect(@provider.service_name).to eq('local_unbound')
+  end
+
   it "should find the right rcvar_value for FreeBSD < 7" do
     @provider.stubs(:rcvar).returns(['# ntpd', 'ntpd_enable=YES'])
 


### PR DESCRIPTION
Take just the leading string of non-whitespace characters from the
first line of the rcvar output as the service name