### PR TITLE
(PUP-4436) Relax regexp to handle carriage return on 2003

### DIFF
--- a/acceptance/tests/windows/eventlog.rb
+++ b/acceptance/tests/windows/eventlog.rb
@@ -21,6 +21,6 @@ agents.each do |agent|
   # cygwin + ssh + wmic hangs trying to read stdin, so echo '' |
   on agent, "cmd /c echo '' | wmic ntevent where \"LogFile='Application' and SourceName='Puppet' and TimeWritten >= '#{now}'\"  get Message,Type /format:csv" do
     fail_test "Event not found in Application event log" unless
-      stdout =~ /Could not retrieve catalog.*skipping run,Error/mi
+      stdout =~ /Could not retrieve catalog.*skipping run.*,Error/mi
   end
 end


### PR DESCRIPTION
The acceptance test fails on 2003, because the messages in the event log
contains a trailing carriage return "\r" as can be seen from the
message:

    U5OCQ1AVU5DNJ72,Could not retrieve catalog; skipping run
    ,Error

The same test doesn't fail on 2012, because the message does not contain
a carriage return:

    REQSRXS29NWN1ZY,Could not retrieve catalog; skipping run,Error

I verified that puppet is not calling Win32 ReportEvent with a
carriage return. Instead, it seems 2003 always adds a carriage return to
events as can be seen when copying the message to the clipboard:

    Description:
    Could not retrieve catalog; skipping run

This commit adds back the extra .* in the regexp to account for 2003 vs
later differences.