### PR TITLE
(PUP-4602) Add rcng service provider

### DIFF
--- a/lib/puppet/provider/service/bsd.rb
+++ b/lib/puppet/provider/service/bsd.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:service).provide :bsd, :parent => :init do
     Uses `rc.conf.d` for service enabling and disabling.
   EOT
 
-  confine :operatingsystem => [:freebsd, :netbsd, :dragonfly]
+  confine :operatingsystem => [:freebsd, :dragonfly]
 
   def rcconf_dir
     '/etc/rc.conf.d'

--- a/lib/puppet/provider/service/rcng.rb
+++ b/lib/puppet/provider/service/rcng.rb
@@ -1,0 +1,51 @@
+Puppet::Type.type(:service).provide :rcng, :parent => :bsd do
+  desc <<-EOT
+    RCng service management with rc.d
+  EOT
+
+  defaultfor :operatingsystem => [:netbsd, :cargos]
+  confine :operatingsystem => [:netbsd, :cargos]
+
+  def self.defpath
+    "/etc/rc.d"
+  end
+
+  # if the service file exists in rc.conf.d AND matches an expected pattern
+  # then it's already enabled
+  def enabled?
+    rcfile = File.join(rcconf_dir, @resource[:name])
+    if Puppet::FileSystem.exist?(rcfile)
+      File.open(rcfile).readlines.each do |line|
+        # Now look for something that looks like "service=${service:=YES}" or "service=YES"
+        if line.match(/^\s*#{@resource[:name]}=(?:YES|\${#{@resource[:name]}:=YES})/)
+          return :true
+        end
+      end
+    end
+
+    :false
+  end
+
+  # enable service by creating a service file under rc.conf.d with the
+  # proper contents, or by modifying it's contents to to enable the service.
+  def enable
+    Dir.mkdir(rcconf_dir) if not Puppet::FileSystem.exist?(rcconf_dir)
+    rcfile = File.join(rcconf_dir, @resource[:name])
+    if Puppet::FileSystem.exist?(rcfile)
+      newcontents = []
+      File.open(rcfile).readlines.each do |line|
+        if line.match(/^\s*#{@resource[:name]}=(NO|\$\{#{@resource[:name]}:NO\})/)
+          line = "#{@resource[:name]}=${#{@resource[:name]}:=YES}"
+        end
+        newcontents.push(line)
+      end
+      Puppet::Util.replace_file(rcfile, 0644) do |f|
+        f.puts newcontents
+      end
+    else
+      Puppet::Util.replace_file(rcfile, 0644) do |f|
+        f.puts "%s=${%s:=YES}\n" % [@resource[:name], @resource[:name]]
+      end
+    end
+  end
+end

--- a/spec/unit/provider/service/rcng_spec.rb
+++ b/spec/unit/provider/service/rcng_spec.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:service).provider(:rcng)
+
+describe provider_class, :unless => Puppet.features.microsoft_windows? do
+  before :each do
+    Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
+    Facter.stubs(:value).with(:operatingsystem).returns :netbsd
+    Facter.stubs(:value).with(:osfamily).returns 'NetBSD'
+    described_class.stubs(:defpath).returns('/etc/rc.d')
+    @provider = provider_class.new
+    @provider.stubs(:initscript)
+  end
+
+  describe "#enable" do
+    it "should have an enable method" do
+      expect(@provider).to respond_to(:enable)
+    end
+
+    it "should set the proper contents to enable" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
+      Dir.stubs(:mkdir).with('/etc/rc.conf.d')
+      fh = stub 'fh'
+      Puppet::Util.expects(:replace_file).with('/etc/rc.conf.d/sshd', 0644).yields(fh)
+      fh.expects(:puts).with("sshd=${sshd:=YES}\n")
+      provider.enable
+    end
+
+    it "should set the proper contents to enable when disabled" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
+      Dir.stubs(:mkdir).with('/etc/rc.conf.d')
+      File.stubs(:read).with('/etc/rc.conf.d/sshd').returns("sshd_enable=\"NO\"\n")
+      fh = stub 'fh'
+      Puppet::Util.expects(:replace_file).with('/etc/rc.conf.d/sshd', 0644).yields(fh)
+      fh.expects(:puts).with("sshd=${sshd:=YES}\n")
+      provider.enable
+    end
+  end
+end


### PR DESCRIPTION
Here's a new provider for service functionality through rcng, while it shares some traits with the `bsd` provider it differs enough to warrant a new one due to the different paths and content of files that need to be enabled.