### PR TITLE
(PUP-4503)(PUP-2023) Update service provider default for newer debian…

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -16,7 +16,8 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   # is resolved.
   commands :invoke_rc => "/usr/sbin/invoke-rc.d"
 
-  defaultfor :operatingsystem => [:debian, :cumuluslinux]
+  defaultfor :operatingsystem => :cumuluslinux
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ['5','6','7']
 
   # Remove the symlinks
   def disable

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -5,10 +5,14 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   commands :systemctl => "systemctl"
 
+  confine :exists => "/run/systemd/system"
+
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => "7"
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora, :operatingsystemmajrelease => ["17", "18", "19", "20", "21"]
   defaultfor :osfamily => :suse, :operatingsystemmajrelease => ["12", "13"]
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => "8"
+  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => "15.04"
 
   def self.instances
     i = []
@@ -25,6 +29,10 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     output = systemctl(:disable, @resource[:name])
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not disable #{self.name}: #{output}", $!.backtrace
+  end
+
+  def get_start_link_count
+    Dir.glob("/etc/rc*.d/S??#{@resource[:name]}").length
   end
 
   def enabled?
@@ -51,6 +59,10 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
       # flapping when simply trying to disable a masked service.
       return :mask if (@resource[:enable] == :mask) && (svc_info[:LoadState] == 'masked')
       return :true if svc_info[:UnitFileState] == 'enabled'
+      if Facter.value(:osfamily) == 'debian'
+        ret = debian_enabled?(svc_info)
+        return ret if ret
+      end
     rescue Puppet::ExecutionFailure
       # The execution of the systemd command can fail for quite a few reasons.
       # In all of these cases, the failure of the query indicates that the
@@ -58,6 +70,29 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     end
 
     return :false
+  end
+
+  def debian_enabled?(svc_info)
+    # If UnitFileState == UnitFileState then we query the older way.
+    if svc_info[:UnitFileState] == 'UnitFileState'
+      system("/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start")
+      if [104, 106].include?($CHILD_STATUS.exitstatus)
+        return :true
+      elsif [101, 105].include?($CHILD_STATUS.exitstatus)
+        # 101 is action not allowed, which means we have to do the check manually.
+        # 105 is unknown, which generally means the iniscript does not support query
+        # The debian policy states that the initscript should support methods of query
+        # For those that do not, peform the checks manually
+        # http://www.debian.org/doc/debian-policy/ch-opersys.html
+        if get_start_link_count >= 4
+          return :true
+        else
+          return :false
+        end
+      else
+        return :false
+      end
+    end
   end
 
   def status

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
     Facter.value(:operatingsystem) == 'LinuxMint',
   ]
 
-  defaultfor :operatingsystem => :ubuntu
+  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"]
 
   commands :start   => "/sbin/start",
            :stop    => "/sbin/stop",

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -35,7 +35,10 @@ describe provider_class do
   operatingsystem = [ 'Debian', 'CumulusLinux' ]
   operatingsystem.each do |os|
     it "should be the default provider on #{os}" do
-      Facter.expects(:value).with(:operatingsystem).returns(os)
+      Facter.expects(:value).with(:operatingsystem).at_least_once.returns(os)
+      if os == 'Debian'
+        Facter.expects(:value).with(:operatingsystemmajrelease).returns('7')
+      end
       expect(provider_class.default?).to be_truthy
     end
   end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
       # In Ruby 1.8.7, the order of hash elements differs from 1.9+ and
       # caused short-circuiting of the logic used by default.all? in the
       # provider. As a workaround we need to use stubs() instead of
-      # expects() here. 
+      # expects() here.
       Facter.expects(:value).with(:osfamily).at_least_once.returns(:redhat)
       Facter.stubs(:value).with(:operatingsystem).returns(:redhat)
       Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
@@ -51,7 +51,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
       expect(described_class.default?).to be_truthy
     end
   end
-  
+
   it "should be the default provider on sles12" do
     Facter.expects(:value).with(:osfamily).at_least_once.returns(:suse)
     Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("12")
@@ -217,7 +217,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
       provider.disable
     end
   end
-  
+
   describe "#mask" do
     it "should run systemctl to disable and mask a service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
@@ -264,8 +264,6 @@ describe Puppet::Type.type(:service).provider(:systemd) do
   end
 
   it "(#16451) has command systemctl without being fully qualified" do
-    expect(described_class.instance_variable_get(:@commands)).
-      to include(:systemctl => 'systemctl')
+    expect(described_class.instance_variable_get(:@commands)).to include(:systemctl => 'systemctl')
   end
-
 end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -66,9 +66,39 @@ describe Puppet::Type.type(:service).provider(:systemd) do
 
   it "should not be the default provider on sles11" do
     Facter.expects(:value).with(:osfamily).at_least_once.returns(:suse)
+    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:suse)
     Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("11")
     expect(described_class.default?).not_to be_truthy
   end
+
+  it "should not be the default provider on debian7" do
+    Facter.expects(:value).with(:osfamily).at_least_once.returns(:debian)
+    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:debian)
+    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("7")
+    expect(described_class.default?).not_to be_truthy
+  end
+
+  it "should be the default provider on debian8" do
+    Facter.expects(:value).with(:osfamily).at_least_once.returns(:debian)
+    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:debian)
+    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("8")
+    expect(described_class.default?).to be_truthy
+  end
+
+  it "should not be the default provider on ubuntu14.04" do
+    Facter.expects(:value).with(:osfamily).at_least_once.returns(:debian)
+    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:ubuntu)
+    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("14.04")
+    expect(described_class.default?).not_to be_truthy
+  end
+
+  it "should be the default provider on ubuntu15.04" do
+    Facter.expects(:value).with(:osfamily).at_least_once.returns(:debian)
+    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:ubuntu)
+    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("15.04")
+    expect(described_class.default?).to be_truthy
+  end
+
 
   [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|
     it "should have a #{method} method" do

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -24,6 +24,7 @@ describe Puppet::Type.type(:service).provider(:upstart) do
 
   it "should be the default provider on Ubuntu" do
     Facter.expects(:value).with(:operatingsystem).returns("Ubuntu")
+    Facter.expects(:value).with(:operatingsystemmajrelease).returns("12.04")
     expect(described_class.default?).to be_truthy
   end
 


### PR DESCRIPTION
…/ubuntu releases

With the release of Debian 8 (Jessie) and Ubuntu 15.04 (Vivid Vervet),
ubuntu and debian now default to systemd as the main service manager,
rather than init or upstart. This commit updates Puppet to
use systemd as the default service provider on these two systems, while
also defaulting back to other service providers if necessary.

Additionally, there is a bug on debian systemd where it is unable to
correctly detect SysV style services[1]. This commit also adds in a
workaround to correctly detect `is-enabled` for these services.

[1] - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=751638