### PR TITLE
(PUP-4607) Fix loading external facts

### DIFF
--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -1,9 +1,11 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
+require 'puppet_spec/files'
 require 'puppet_spec/compiler'
 
 describe Puppet::Node::Facts::Facter do
+  include PuppetSpec::Files
   include PuppetSpec::Compiler
 
   it "preserves case in fact values" do
@@ -18,6 +20,55 @@ describe Puppet::Node::Facts::Facter do
     cat = compile_to_catalog('notify { $downcase_test: }',
                              Puppet::Node.indirection.find('foo'))
     expect(cat.resource("Notify[AaBbCc]")).to be
+  end
+
+  context "resolving file based facts" do
+    let(:factdir) { tmpdir('factdir') }
+
+    it "should resolve custom facts" do
+      test_module = File.join(factdir, 'module', 'lib', 'facter')
+      FileUtils.mkdir_p(test_module)
+
+      File.open(File.join(test_module, 'custom.rb'), 'wb') { |file| file.write(<<-EOF)}
+      Facter.add(:custom) do
+        setcode do
+          Facter.value('puppetversion')
+        end
+      end
+      EOF
+
+      Puppet.initialize_settings(['--modulepath', factdir])
+      apply = Puppet::Application.find(:apply).new(stub('command_line', :subcommand_name => :apply, :args => ['--modulepath', factdir, '-e', 'notify { $custom: }']))
+
+      expect do
+        expect { apply.run }.to exit_with(0)
+      end.to have_printed(Puppet.version)
+    end
+
+    it "should resolve external facts" do
+      external_fact = File.join(factdir, 'external')
+
+      if Puppet.features.microsoft_windows?
+        external_fact += '.bat'
+        File.open(external_fact, 'wb') { |file| file.write(<<-EOF)}
+        @echo foo=bar
+        EOF
+      else
+        File.open(external_fact, 'wb') { |file| file.write(<<-EOF)}
+        #!/bin/sh
+        echo "foo=bar"
+        EOF
+
+        Puppet::FileSystem.chmod(0755, external_fact)
+      end
+
+      Puppet.initialize_settings(['--pluginfactdest', factdir])
+      apply = Puppet::Application.find(:apply).new(stub('command_line', :subcommand_name => :apply, :args => ['--pluginfactdest', factdir, '-e', 'notify { $foo: }']))
+
+      expect do
+        expect { apply.run }.to exit_with(0)
+      end.to have_printed('bar')
+    end
   end
 
   it "adds the puppetversion fact" do


### PR DESCRIPTION
In Facter 2.x, upon the first Facter.add, the directory loaders
are created and cannot be changed.

PUP-4359 added the puppetversion fact before setting the external
fact directories, meaning that no other external facts were being
found by Puppet in puppet specific external fact directories.

This commit causes Puppet to first set its external fact directories,
and then add the puppetversion fact.