### PR TITLE
(PUP-2573) Make agent locker raise LockError if we fail to aquire lock

### DIFF
--- a/lib/puppet/agent/locker.rb
+++ b/lib/puppet/agent/locker.rb
@@ -27,7 +27,13 @@ module Puppet::Agent::Locker
     end
   end
 
+  # @deprecated
   def running?
+    Puppet.deprecation_warning <<-ENDHEREDOC
+Puppet::Agent::Locker.running? is deprecated as it is inherently unsafe.
+The only safe way to know if the lock is locked is to try lock and perform some
+action and then handle the LockError that may result.
+ENDHEREDOC
     lockfile.locked?
   end
 

--- a/lib/puppet/agent/locker.rb
+++ b/lib/puppet/agent/locker.rb
@@ -1,4 +1,5 @@
 require 'puppet/util/pidlock'
+require 'puppet/error'
 
 # This module is responsible for encapsulating the logic for "locking" the
 # puppet agent during a catalog run; in other words, keeping track of enough
@@ -12,8 +13,8 @@ require 'puppet/util/pidlock'
 # For more information, please see docs on the website.
 #  http://links.puppetlabs.com/agent_lockfiles
 module Puppet::Agent::Locker
-  # Yield if we get a lock, else do nothing.  Return
-  # true/false depending on whether we get the lock.
+  # Yield if we get a lock, else raise Puppet::LockError. Return
+  # value of block yielded.
   def lock
     if lockfile.lock
       begin
@@ -21,6 +22,8 @@ module Puppet::Agent::Locker
       ensure
         lockfile.unlock
       end
+    else
+      fail Puppet::LockError, 'Failed to aquire lock'
     end
   end
 

--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -87,12 +87,9 @@ class Puppet::Daemon
 
   def reload
     return unless agent
-    if agent.running?
-      Puppet.notice "Not triggering already-running agent"
-      return
-    end
-
     agent.run({:splay => false})
+  rescue Puppet::LockError
+    Puppet.notice "Not triggering already-running agent"
   end
 
   def restart

--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -93,4 +93,8 @@ module Puppet
   class MissingCommand < Puppet::Error
   end
 
+  # Raised when we failed to aquire a lock
+  class LockError < Puppet::Error
+  end
+
 end

--- a/spec/unit/agent/locker_spec.rb
+++ b/spec/unit/agent/locker_spec.rb
@@ -58,17 +58,17 @@ describe Puppet::Agent::Locker do
     expect(@locker.lock { :result }).to eq(:result)
   end
 
-  it "should return nil when the lock method does not receive the lock" do
+  it "should raise LockError when the lock method does not receive the lock" do
     @locker.send(:lockfile).expects(:lock).returns false
 
-    expect(@locker.lock {}).to be_nil
+    expect { @locker.lock {} }.to raise_error(Puppet::LockError)
   end
 
   it "should not yield when the lock method does not receive the lock" do
     @locker.send(:lockfile).expects(:lock).returns false
 
     yielded = false
-    @locker.lock { yielded = true }
+    expect { @locker.lock { yielded = true } }.to raise_error(Puppet::LockError)
     expect(yielded).to be_falsey
   end
 
@@ -76,7 +76,7 @@ describe Puppet::Agent::Locker do
     @locker.send(:lockfile).expects(:lock).returns false
     @locker.send(:lockfile).expects(:unlock).never
 
-    @locker.lock {}
+    expect { @locker.lock {} }.to raise_error(Puppet::LockError)
   end
 
   it "should unlock after yielding upon obtaining a lock" do

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -58,7 +58,6 @@ describe Puppet::Agent do
 
     client.expects(:run)
 
-    @agent.stubs(:running?).returns false
     @agent.stubs(:disabled?).returns false
     @agent.run
   end
@@ -75,19 +74,12 @@ describe Puppet::Agent do
   describe "when being run" do
     before do
       AgentTestClient.stubs(:lockfile_path).returns "/my/lock"
-      @agent.stubs(:running?).returns false
       @agent.stubs(:disabled?).returns false
     end
 
     it "should splay" do
       @agent.expects(:splay)
 
-      @agent.run
-    end
-
-    it "should do nothing if already running" do
-      @agent.expects(:running?).returns true
-      AgentTestClient.expects(:new).never
       @agent.run
     end
 

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -176,7 +176,8 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
     end
 
     it "should do nothing if the agent is running" do
-      agent.expects(:running?).returns true
+      agent.expects(:run).with({:splay => false}).raises Puppet::LockError, 'Failed to aquire lock'
+      Puppet.expects(:notice).with('Not triggering already-running agent')
 
       daemon.agent = agent
 
@@ -184,8 +185,8 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
     end
 
     it "should run the agent if one is available and it is not running" do
-      agent.expects(:running?).returns false
       agent.expects(:run).with({:splay => false})
+      Puppet.expects(:notice).with('Not triggering already-running agent').never
 
       daemon.agent = agent
 


### PR DESCRIPTION
This fixes a possible raise condition in the puppet agent where it first
checked if the lock was taken and then later on aquired it, possibly
having some other agent taking the lock in between with no handling of
that situation.

Also it updates the description of the lock method to actually match
what it does, namely return the value of the block itself. Not
true/false based on if lock was acquired. That was in fact impossible to
find out previously.