### PR TITLE
(docs) Show more useful defaults for special directories in configuration reference

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -22,10 +22,16 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
 
     # Now print the data about the item.
     val = object.default
-    if name.to_s == "vardir"
-      val = "/opt/puppetlabs/puppet/cache"
-    elsif name.to_s == "confdir"
-      val = "/etc/puppetlabs/puppet"
+    if name.to_s == 'vardir'
+      val = 'Unix/Linux: /opt/puppetlabs/puppet/cache -- Windows: C:\ProgramData\PuppetLabs\puppet\cache -- Non-root user: ~/.puppetlabs/opt/puppet/cache'
+    elsif name.to_s == 'confdir'
+      val = 'Unix/Linux: /etc/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\etc -- Non-root user: ~/.puppetlabs/etc/puppet'
+    elsif name.to_s == 'codedir'
+      val = 'Unix/Linux: /etc/puppetlabs/code -- Windows: C:\ProgramData\PuppetLabs\code -- Non-root user: ~/.puppetlabs/etc/code'
+    elsif name.to_s == 'rundir'
+      val = 'Unix/Linux: /var/run/puppetlabs -- Windows: C:\ProgramData\PuppetLabs\puppet\var\run -- Non-root user: ~/.puppetlabs/var/run'
+    elsif name.to_s == 'logdir'
+      val = 'Unix/Linux: /var/log/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\var\log -- Non-root user: ~/.puppetlabs/var/log'
     end
 
     # Leave out the section information; it was apparently confusing people.


### PR DESCRIPTION
The configuration reference was showing blank defaults for codedir, rundir, and
logdir, and it was showing root Unix paths only for confdir and vardir. Since
we're overriding these with simple strings when we generate the config reference
anyway, we can just make those strings more useful.