### PR TITLE
(PUP-4373) Windows ADSI User groups property should behave similarly to Groups members property

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -30,7 +30,6 @@ Puppet::Type.type(:group).provide :windows_adsi do
     if @resource[:auth_membership]
       current_users == specified_users
     else
-      return true if specified_users.empty?
       (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
     end
   end

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -42,7 +42,6 @@ Puppet::Type.type(:user).provide :windows_adsi do
     if @resource[:membership] == :inclusive
       current_users == specified_users
     else
-      return true if specified_users.empty?
       (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
     end
   end

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -25,6 +25,27 @@ Puppet::Type.type(:user).provide :windows_adsi do
     user.set_groups(groups, @resource[:membership] == :minimum)
   end
 
+  def groups_insync?(current, should)
+    return false unless current
+
+    # By comparing account SIDs we don't have to worry about case
+    # sensitivity, or canonicalization of account names.
+
+    # Cannot use munge of the group property to canonicalize @should
+    # since the default array_matching comparison is not commutative
+
+    # dupes automatically weeded out when hashes built
+    current_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
+    specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
+
+    if @resource[:membership] == :inclusive
+      current_users == specified_users
+    else
+      return true if specified_users.empty?
+      (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
+    end
+  end
+
   def create
     @user = Puppet::Util::Windows::ADSI::User.create(@resource[:name])
     @user.password = @resource[:password]

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -274,6 +274,14 @@ module Puppet
         raise ArgumentError, "Group names must be provided as an array, not a comma-separated list." if value.include?(",")
         raise ArgumentError, "Group names must not be empty. If you want to specify \"no groups\" pass an empty array" if value.empty?
       end
+
+      def insync?(current)
+        if provider.respond_to?(:groups_insync?)
+          return provider.groups_insync?(current, @should)
+        end
+
+        super(current)
+      end
     end
 
     newparam(:name) do

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -266,8 +266,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def set_groups(desired_groups, minimum = true)
-      return if desired_groups.nil? or desired_groups.empty?
-      # this needs fixed up once PUP-3653 is merged up
+      return if desired_groups.nil?
 
       desired_groups = desired_groups.split(',').map(&:strip)
 
@@ -283,7 +282,12 @@ module Puppet::Util::Windows::ADSI
       # Then we remove the user from all groups it is in but shouldn't be, if
       # that's been requested
       if !minimum
-        groups_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
+        if desired_hash.empty?
+          groups_to_remove = current_hash.values
+        else
+          groups_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
+        end
+
         remove_group_sids(*groups_to_remove)
       end
     end

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -346,11 +346,11 @@ module Puppet::Util::Windows::ADSI
     end
 
     def uri
-      self.class.uri(name)
+      self.class.uri(sid.account, sid.domain)
     end
 
     def native_group
-      @native_group ||= Puppet::Util::Windows::ADSI.connect(uri)
+      @native_group ||= Puppet::Util::Windows::ADSI.connect(self.class.uri(*self.class.parse_name(name)))
     end
 
     def sid

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -43,10 +43,6 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
     end
 
     describe "#members_insync?" do
-      it "should return false when current is nil" do
-        expect(provider.members_insync?(nil, ['user2'])).to be_falsey
-      end
-
       it "should return true for same lists of members" do
         expect(provider.members_insync?(['user1', 'user2'], ['user1', 'user2'])).to be_truthy
       end
@@ -59,8 +55,16 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         expect(provider.members_insync?(['user1', 'user2', 'user2'], ['user2', 'user1', 'user1'])).to be_truthy
       end
 
-      it "should return true when current user(s) and should user(s) are empty lists" do
+      it "should return true when current and should members are empty lists" do
         expect(provider.members_insync?([], [])).to be_truthy
+      end
+
+      # invalid scenarios
+      #it "should return true when current and should members are nil lists" do
+      #it "should return true when current members is nil and should members is empty" do
+
+      it "should return true when current members is empty and should members is nil" do
+        expect(provider.members_insync?([], nil)).to be_truthy
       end
 
       context "when auth_membership => true" do
@@ -68,12 +72,16 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
           resource[:auth_membership] = true
         end
 
-        it "should return false when current contains different users than should" do
-          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
+        it "should return false when current is nil" do
+          expect(provider.members_insync?(nil, ['user2'])).to be_falsey
         end
 
         it "should return false when should is nil" do
           expect(provider.members_insync?(['user1'], nil)).to be_falsey
+        end
+
+        it "should return false when current contains different users than should" do
+          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
         end
 
         it "should return false when current contains members and should is empty" do
@@ -99,12 +107,16 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
           resource[:auth_membership] = false
         end
 
-        it "should return false when current contains different users than should" do
-          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
+        it "should return false when current is nil" do
+          expect(provider.members_insync?(nil, ['user2'])).to be_falsey
         end
 
         it "should return true when should is nil" do
           expect(provider.members_insync?(['user1'], nil)).to be_truthy
+        end
+
+        it "should return false when current contains different users than should" do
+          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
         end
 
         it "should return true when current contains members and should is empty" do

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -60,6 +60,108 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
     end
   end
 
+  describe "#groups_insync?" do
+
+    let(:group1) { stub(:account => 'group1', :domain => '.', :to_s => 'group1sid') }
+    let(:group2) { stub(:account => 'group2', :domain => '.', :to_s => 'group2sid') }
+    let(:group3) { stub(:account => 'group3', :domain => '.', :to_s => 'group3sid') }
+
+    before :each do
+      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group1').returns(group1)
+      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group2').returns(group2)
+      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group3').returns(group3)
+    end
+
+    it "should return false when current is nil" do
+      expect(provider.groups_insync?(nil, ['group2'])).to be_falsey
+    end
+
+    it "should return true when should is nil" do
+      expect(provider.groups_insync?(['group1'], nil)).to be_truthy
+    end
+
+    it "should return true for same lists of members" do
+      expect(provider.groups_insync?(['group1', 'group2'], ['group1', 'group2'])).to be_truthy
+    end
+
+    it "should return true for same lists of unordered members" do
+      expect(provider.groups_insync?(['group1', 'group2'], ['group2', 'group1'])).to be_truthy
+    end
+
+    it "should return true for same lists of members irrespective of duplicates" do
+      expect(provider.groups_insync?(['group1', 'group2', 'group2'], ['group2', 'group1', 'group1'])).to be_truthy
+    end
+
+    it "should return true when current group(s) and should group(s) are empty lists" do
+      expect(provider.groups_insync?([], [])).to be_truthy
+    end
+
+    context "when membership => inclusive" do
+      before :each do
+        resource[:membership] = :inclusive
+      end
+
+      it "should return false when current contains different groups than should" do
+        expect(provider.groups_insync?(['group1'], ['group2'])).to be_falsey
+      end
+
+      it "should return false when should is nil" do
+        expect(provider.groups_insync?(['group1'], nil)).to be_falsey
+      end
+
+      it "should return false when current contains members and should is empty" do
+        expect(provider.groups_insync?(['group1'], [])).to be_falsey
+      end
+
+      it "should return false when current is empty and should contains members" do
+        expect(provider.groups_insync?([], ['group2'])).to be_falsey
+      end
+
+      it "should return false when should groups(s) are not the only items in the current" do
+        expect(provider.groups_insync?(['group1', 'group2'], ['group1'])).to be_falsey
+      end
+
+      it "should return false when current group(s) is not empty and should is an empty list" do
+        expect(provider.groups_insync?(['group1','group2'], [])).to be_falsey
+      end
+    end
+
+    context "when membership => minimum" do
+      before :each do
+        # this is also the default
+        resource[:membership] = :minimum
+      end
+
+      it "should return false when current contains different groups than should" do
+        expect(provider.groups_insync?(['group1'], ['group2'])).to be_falsey
+      end
+
+      it "should return true when should is nil" do
+        expect(provider.groups_insync?(['group1'], nil)).to be_truthy
+      end
+
+      it "should return true when current contains members and should is empty" do
+        expect(provider.groups_insync?(['group1'], [])).to be_truthy
+      end
+
+      it "should return false when current is empty and should contains members" do
+        expect(provider.groups_insync?([], ['group2'])).to be_falsey
+      end
+
+      it "should return true when current group(s) contains at least the should list" do
+        expect(provider.groups_insync?(['group1','group2'], ['group1'])).to be_truthy
+      end
+
+      it "should return true when current group(s) is not empty and should is an empty list" do
+        expect(provider.groups_insync?(['group1','group2'], [])).to be_truthy
+      end
+
+      it "should return true when current group(s) contains at least the should list, even unordered" do
+        expect(provider.groups_insync?(['group3','group1','group2'], ['group2','group1'])).to be_truthy
+      end
+    end
+  end
+
   describe "when creating a user" do
     it "should create the user on the system and set its other properties" do
       resource[:groups]     = ['group1', 'group2']

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -35,16 +35,18 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
   end
 
   describe "when managing groups" do
-    it 'should return the list of groups as a comma-separated list' do
-      provider.user.stubs(:groups).returns ['group1', 'group2', 'group3']
+    it 'should return the list of groups as an array of strings' do
+      provider.user.stubs(:groups).returns nil
+      groups = {'group1' => nil, 'group2' => nil, 'group3' => nil}
+      Puppet::Util::Windows::ADSI::Group.expects(:name_sid_hash).returns(groups)
 
-      expect(provider.groups).to eq('group1,group2,group3')
+      expect(provider.groups).to eq(groups.keys)
     end
 
-    it "should return absent if there are no groups" do
+    it "should return an empty array if there are no groups" do
       provider.user.stubs(:groups).returns []
 
-      expect(provider.groups).to eq('')
+      expect(provider.groups).to eq([])
     end
 
     it 'should be able to add a user to a set of groups' do

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -74,14 +74,6 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group3').returns(group3)
     end
 
-    it "should return false when current is nil" do
-      expect(provider.groups_insync?(nil, ['group2'])).to be_falsey
-    end
-
-    it "should return true when should is nil" do
-      expect(provider.groups_insync?(['group1'], nil)).to be_truthy
-    end
-
     it "should return true for same lists of members" do
       expect(provider.groups_insync?(['group1', 'group2'], ['group1', 'group2'])).to be_truthy
     end
@@ -98,6 +90,10 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       expect(provider.groups_insync?([], [])).to be_truthy
     end
 
+    it "should return true when current groups is empty and should groups is nil" do
+      expect(provider.groups_insync?([], nil)).to be_truthy
+    end
+
     context "when membership => inclusive" do
       before :each do
         resource[:membership] = :inclusive
@@ -105,6 +101,10 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
 
       it "should return false when current contains different groups than should" do
         expect(provider.groups_insync?(['group1'], ['group2'])).to be_falsey
+      end
+
+      it "should return false when current is nil" do
+        expect(provider.groups_insync?(nil, ['group2'])).to be_falsey
       end
 
       it "should return false when should is nil" do
@@ -136,6 +136,10 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
 
       it "should return false when current contains different groups than should" do
         expect(provider.groups_insync?(['group1'], ['group2'])).to be_falsey
+      end
+
+      it "should return false when current is nil" do
+        expect(provider.groups_insync?(nil, ['group2'])).to be_falsey
       end
 
       it "should return true when should is nil" do

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -386,6 +386,9 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
 
       it "should generate the correct URI" do
         Puppet::Util::Windows::ADSI.stubs(:sid_uri_safe).returns(nil)
+        adsi_group.expects(:objectSID).returns([0])
+        Socket.expects(:gethostname).returns('testcomputername')
+        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(stub(:account => groupname,:domain => 'testcomputername'))
         expect(group.uri).to eq("WinNT://./#{groupname},group")
       end
     end

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -380,7 +380,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           expect {
             adsi_group.expects(:Members).returns []
             group.set_members(['foobar'])
-          }.to raise_error(Puppet::Error, /Could not resolve username: foobar/)
+          }.to raise_error(Puppet::Error, /Could not resolve name: foobar/)
         end
       end
 


### PR DESCRIPTION
Supercedes #3876, which superceded #3788 


Previously, when specifying a user's groups, the names were compared
as strings and needed to be an exact match. The group resource uses
SIDs when comparing the users, so the user resource should mimic that
behavior.

Without this change casing and names must match exactly and can 
produce erroneous results.

With this change, the comparison will be by SIDs so it will allow for
the following when a user is a member of Administrators and Users
groups:

```puppet
user { 'tim':
  ensure => present,
  groups => ['BUILTIN\Administrators','users'],
}
```

Groups members can also be set to an empty list and the user's groups will
report that it does but will not make the changes. Allow that the user groups to
be set to an empty list so that group's members and user's groups behavior
is the same. Without this change an existing user with groups modeled in the
following resource will continue to give the message that it is removing the 
groups without actually making any changes:

```puppet
user { 'tim':
  ensure => present,
  groups => [],
}
```

There is also shared behavior between `Puppet::Util::Windows::ADSI::User`
and `Puppet::Util::Windows::ADSI::Group` so it makes sense to start
combining shared functionality to a common class named
`Puppet::Util::Windows::ADSI::Shared`.
