### PR TITLE
(QENG-1453) Make use of Beaker's epel_url option

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -9,9 +9,13 @@ ONE_DAY_IN_SECS = 24 * 60 * 60
 REPO_CONFIGS_DIR = "repo-configs"
 CLEAN.include('*.tar', REPO_CONFIGS_DIR, 'merged_options.rb')
 
+# If elsewhere we're depending on internal network resources
+# then assume we can depend on them here
+EPEL_MIRROR = ENV['BEAKER_EPEL_MIRROR']
+
 module HarnessOptions
 
-  DEFAULTS = {
+  defaults = {
     :type => 'git',
     :helper => ['lib/helper.rb'],
     :tests  => ['tests'],
@@ -27,8 +31,10 @@ module HarnessOptions
     :add_el_extras => true,
     :preserve_hosts => 'onfail',
     :forge_host => 'forge-aio01-petest.puppetlabs.com',
-    :'master-start-curl-retries' => 30,
+    :'master-start-curl-retries' => 30
   }
+
+  DEFAULTS = EPEL_MIRROR ? defaults.merge(:epel_url => EPEL_MIRROR) : defaults
 
   class Aggregator
     attr_reader :mode


### PR DESCRIPTION
Previously we were depending on the "use-el-extras" feature of Beaker
but we were not taking full advantage of its ability to point at an EPEL
mirror.  We have sporadically seen failures based on the availability of
the mirrors at kernel.org.

This commit infers if we are running within the internal network by
looking for a well known environment variable and, if so, adds the
appropriate beaker configuration to use our internal epel mirror.