### PR TITLE
(PUP-2630) Populate $server_facts during puppet apply

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -204,6 +204,11 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       # Merge in the facts.
       node.merge(facts.values) if facts
 
+      # Add server facts so $server_facts[environment] exists when doing a puppet apply
+      if Puppet[:trusted_server_facts]
+        node.add_server_facts({})
+      end
+
       # Allow users to load the classes that puppet agent creates.
       if options[:loadclasses]
         file = Puppet[:classfile]

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -41,6 +41,18 @@ describe "apply" do
     expect(@logs.map(&:to_s)).to include('it was applied')
   end
 
+  it "adds environment to the $server_facts variable if trusted_server_facts is true" do
+    manifest = file_containing("manifest.pp", "notice(\"$server_facts\")")
+    Puppet[:trusted_server_facts] = true
+
+    puppet = Puppet::Application[:apply]
+    puppet.stubs(:command_line).returns(stub('command_line', :args => [manifest]))
+
+    expect { puppet.run_command }.to exit_with(0)
+
+    expect(@logs.map(&:to_s)).to include(/{environment =>.*/)
+  end
+
   it "applies a given file even when an ENC is configured", :if => !Puppet.features.microsoft_windows? do
     manifest = file_containing("manifest.pp", "notice('specific manifest applied')")
     site_manifest = file_containing("site_manifest.pp", "notice('the site manifest was applied instead')")


### PR DESCRIPTION
Prior to this commit, $server_facts would only be populated during
an agent run. This it made it difficult for users to use
`$server_facts[environment]` in their puppet code since they could
not test it via a puppet apply.

Now that variable will be populated during an apply if
trusted_server_facts is true. It will only contain the environment
portion of the hash.