### PR TITLE
(PUP-4538) Use source permissions when using plugin application

### DIFF
--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -78,16 +78,28 @@ master_opts = {
 with_puppet_running_on master, master_opts, codedir do
   agents.each do |agent|
     factsd   = agent.tmpdir('facts.d')
+    pluginfactdest = agent.tmpdir('facts.d')
     tmpdir   = agent.tmpdir('tmpdir')
     testfile = File.join(tmpdir, 'testfile')
 
     teardown do
       on(master, "rm -rf #{codedir}")
       on(agent, "rm -rf #{factsd}")
+      on(agent, "rm -rf #{pluginfactdest}")
     end
 
     step "Pluginsync the external fact to the agent and ensure it resolves correctly"
-    on(agent, puppet('agent', "-t --server #{master} --pluginfactdest #{factsd}"), :acceptable_exit_codes => [2])
+    on(agent, puppet('agent', '-t', '--server', master, '--pluginfactdest', factsd), :acceptable_exit_codes => [2])
+    assert_match(/foo is bar/, stdout)
+
+    step "Use plugin face to download to the agent"
+    on(agent, puppet('plugin', 'download', '--server', master, '--pluginfactdest', pluginfactdest))
+    assert_match(/Downloaded these plugins: .*external_fact/, stdout)
+
+    step "Ensure it resolves correctly"
+    on(agent, puppet('apply', '--pluginfactdest', pluginfactdest, '-e', <<-EOM))
+    notify { "foo is ${foo}": }
+    EOM
     assert_match(/foo is bar/, stdout)
 
     # Linux specific tests

--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -12,12 +12,16 @@ class Puppet::Configurer::PluginHandler
   def download_plugins(environment)
     plugin_downloader = @factory.create_plugin_downloader(environment)
 
+    result = []
+
     if Puppet.features.external_facts?
       plugin_fact_downloader = @factory.create_plugin_facts_downloader(environment)
-      plugin_fact_downloader.evaluate
+      result += plugin_fact_downloader.evaluate
     end
 
-    plugin_downloader.evaluate
+    result += plugin_downloader.evaluate
     Puppet::Util::Autoload.reload_changed
+
+    result
   end
 end

--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -1,4 +1,7 @@
 require 'puppet/face'
+require 'puppet/configurer/downloader_factory'
+require 'puppet/configurer/plugin_handler'
+
 Puppet::Face.define(:plugin, '0.0.1') do
   copyright "Puppet Labs", 2011
   license   "Apache 2 license; see COPYING"
@@ -37,21 +40,11 @@ Puppet::Face.define(:plugin, '0.0.1') do
     EOT
 
     when_invoked do |options|
-      require 'puppet/configurer/downloader'
       remote_environment_for_plugins = Puppet::Node::Environment.remote(Puppet[:environment])
-      result = Puppet::Configurer::Downloader.new("plugin",
-                                         Puppet[:plugindest],
-                                         Puppet[:pluginsource],
-                                         Puppet[:pluginsignore],
-                                         remote_environment_for_plugins).evaluate
-      if Puppet.features.external_facts?
-          result += Puppet::Configurer::Downloader.new("pluginfacts",
-                                             Puppet[:pluginfactdest],
-                                             Puppet[:pluginfactsource],
-                                             Puppet[:pluginsignore],
-                                             remote_environment_for_plugins).evaluate
-      end
-      result
+
+      factory = Puppet::Configurer::DownloaderFactory.new
+      handler = Puppet::Configurer::PluginHandler.new(factory)
+      handler.download_plugins(remote_environment_for_plugins)
     end
 
     when_rendering :console do |value|

--- a/spec/unit/configurer/plugin_handler_spec.rb
+++ b/spec/unit/configurer/plugin_handler_spec.rb
@@ -14,26 +14,37 @@ describe Puppet::Configurer::PluginHandler do
     Puppet.expects(:err).never
   end
 
-  it "downloads plugins and facts" do
-    Puppet.features.stubs(:external_facts?).returns(true)
+  context "when external facts are supported" do
+    before :each do
+      Puppet.features.stubs(:external_facts?).returns(true)
+    end
 
-    plugin_downloader = stub('plugin-downloader', :evaluate => [])
-    facts_downloader = stub('facts-downloader', :evaluate => [])
+    it "downloads plugins and facts" do
+      plugin_downloader = stub('plugin-downloader', :evaluate => [])
+      facts_downloader = stub('facts-downloader', :evaluate => [])
 
-    factory.expects(:create_plugin_downloader).returns(plugin_downloader)
-    factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
+      factory.expects(:create_plugin_downloader).returns(plugin_downloader)
+      factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
 
-    pluginhandler.download_plugins(environment)
+      pluginhandler.download_plugins(environment)
+    end
   end
 
-  it "skips facts if not enabled" do
-    Puppet.features.stubs(:external_facts?).returns(false)
+  context "when external facts are not supported" do
+    before :each do
+      Puppet.features.stubs(:external_facts?).returns(false)
+    end
 
-    plugin_downloader = stub('plugin-downloader', :evaluate => [])
+    it "downloads plugins only" do
+      plugin_downloader = stub('plugin-downloader', :evaluate => [])
 
-    factory.expects(:create_plugin_downloader).returns(plugin_downloader)
-    factory.expects(:create_plugin_facts_downloader).never
+      factory.expects(:create_plugin_downloader).returns(plugin_downloader)
+      factory.expects(:create_plugin_facts_downloader).never
 
-    pluginhandler.download_plugins(environment)
+      pluginhandler.download_plugins(environment)
+    end
+
+
+
   end
 end

--- a/spec/unit/configurer/plugin_handler_spec.rb
+++ b/spec/unit/configurer/plugin_handler_spec.rb
@@ -28,6 +28,16 @@ describe Puppet::Configurer::PluginHandler do
 
       pluginhandler.download_plugins(environment)
     end
+
+    it "returns downloaded plugin and fact filenames" do
+      plugin_downloader = stub('plugin-downloader', :evaluate => %w[/a])
+      facts_downloader = stub('facts-downloader', :evaluate => %w[/b])
+
+      factory.expects(:create_plugin_downloader).returns(plugin_downloader)
+      factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
+
+      expect(pluginhandler.download_plugins(environment)).to match_array(%w[/a /b])
+    end
   end
 
   context "when external facts are not supported" do
@@ -44,7 +54,15 @@ describe Puppet::Configurer::PluginHandler do
       pluginhandler.download_plugins(environment)
     end
 
+    it "returns downloaded plugin filenames only" do
+      Puppet.features.stubs(:external_facts?).returns(false)
 
+      plugin_downloader = stub('plugin-downloader', :evaluate => %w[/a])
+      facts_downloader = stub('facts-downloader')
 
+      factory.expects(:create_plugin_downloader).returns(plugin_downloader)
+
+      expect(pluginhandler.download_plugins(environment)).to match_array(%w[/a])
+    end
   end
 end

--- a/spec/unit/face/plugin_spec.rb
+++ b/spec/unit/face/plugin_spec.rb
@@ -2,9 +2,38 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:plugin, '0.0.1'] do
-  [:download].each do |action|
-    it { is_expected.to be_action action }
-    it { is_expected.to respond_to action }
+describe Puppet::Face[:plugin, :current] do
+
+  let(:pluginface) { described_class }
+  let(:action) { pluginface.get_action(:download) }
+
+  def render(result)
+    action.when_rendering(:console).call(result)
+  end
+
+  context "download" do
+    before :each do
+      Puppet.features.stubs(:external_facts?).returns(true)
+    end
+
+    it "downloads plugins and external facts" do
+      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).twice.returns([])
+
+      pluginface.download
+    end
+
+    it "renders 'No plugins downloaded' if nothing was downloaded" do
+      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).twice.returns([])
+
+      result = pluginface.download
+      expect(render(result)).to eq('No plugins downloaded.')
+    end
+
+    it "renders comma separate list of downloaded file names" do
+      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).twice.returns(%w[/a]).then.returns(%w[/b])
+
+      result = pluginface.download
+      expect(render(result)).to eq('Downloaded these plugins: /a, /b')
+    end
   end
 end


### PR DESCRIPTION
Puppet has a `plugin` face application whose `download` action will perform a pluginsync. However, it did not `use` source permissions when downloading external facts. As a result, executable external facts could not be executed on the agent. This is similar to PUP-4420, but is a different code path that triggers the same bad behavior.

This commit modifies the `download` action to use the same code paths that the configurer uses to perform pluginsyncing of external facts and modules. It also adds spec and acceptance tests.