### PR TITLE
(PUP-3829) : call 'pip' instead of 'pip-python' on RedHat > 6 in the pip package provider

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -36,11 +36,10 @@ Puppet::Type.type(:package).provide :pip,
   end
 
   def self.cmd
-    case Facter.value(:osfamily)
-      when "RedHat"
-        "pip-python"
-      else
-        "pip"
+    if Facter.value(:osfamily) == "RedHat" and Facter.value(:operatingsystemmajrelease).to_i < 7
+      "pip-python"
+    else
+      "pip"
     end
   end
 


### PR DESCRIPTION
This backports commit 6ee0339675e7460073483ebc74d4136b27687ae9 to 3.x.

See [PUP-4604](https://tickets.puppetlabs.com/browse/PUP-4604) for the task ticket to backport this fix for PUP-3829.