### PR TITLE
(PUP-4629) Return values instead of augeas paths during the match operation

### DIFF
--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -73,9 +73,17 @@ Puppet::Type.newtype(:augeas) do
 
   newparam (:onlyif) do
     desc "Optional augeas command and comparisons to control the execution of this type.
+
+      Note: `values` is not an actual augeas API command. It calls `match` to retrieve an array of paths
+             in <MATCH_PATH> and then `get` to retrieve the values from each of the returned paths.
+
       Supported onlyif syntax:
 
       * `get <AUGEAS_PATH> <COMPARATOR> <STRING>`
+      * `values <MATCH_PATH> include <STRING>`
+      * `values <MATCH_PATH> not_include <STRING>`
+      * `values <MATCH_PATH> == <AN_ARRAY>`
+      * `values <MATCH_PATH> != <AN_ARRAY>`
       * `match <MATCH_PATH> size <COMPARATOR> <INT>`
       * `match <MATCH_PATH> include <STRING>`
       * `match <MATCH_PATH> not_include <STRING>`

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -195,6 +195,56 @@ describe provider_class do
     end
   end
 
+  describe "values filters" do
+    before do
+      augeas = stub("augeas", :match => ["set", "of", "values"])
+      augeas.stubs(:get).returns('set').then.returns('of').then.returns('values')
+      augeas.stubs("close")
+      @provider = provider_class.new(@resource)
+      @provider.aug = augeas
+    end
+
+    it "should return true for includes match" do
+      command = ["values", "fake value", "include values"]
+      expect(@provider.process_values(command)).to eq(true)
+    end
+
+    it "should return false for includes non match" do
+      command = ["values", "fake value", "include JarJar"]
+      expect(@provider.process_values(command)).to eq(false)
+    end
+
+    it "should return true for includes match" do
+      command = ["values", "fake value", "not_include JarJar"]
+      expect(@provider.process_values(command)).to eq(true)
+    end
+
+    it "should return false for includes non match" do
+      command = ["values", "fake value", "not_include values"]
+      expect(@provider.process_values(command)).to eq(false)
+    end
+
+    it "should return true for an array match" do
+      command = ["values", "fake value", "== ['set', 'of', 'values']"]
+      expect(@provider.process_values(command)).to eq(true)
+    end
+
+    it "should return false for an array non match" do
+      command = ["values", "fake value", "== ['this', 'should', 'not', 'match']"]
+      expect(@provider.process_values(command)).to eq(false)
+    end
+
+    it "should return false for an array match with noteq" do
+      command = ["values", "fake value", "!= ['set', 'of', 'values']"]
+      expect(@provider.process_values(command)).to eq(false)
+    end
+
+    it "should return true for an array non match with noteq" do
+      command = ["values", "fake value", "!= ['this', 'should', 'not', 'match']"]
+      expect(@provider.process_values(command)).to eq(true)
+    end
+  end
+
   describe "match filters" do
     before do
       augeas = stub("augeas", :match => ["set", "of", "values"])


### PR DESCRIPTION
This fixes PUP-4629 by using aug.get to return the values of the paths returned by the aug.match operation.