### PR TITLE
(maint) Archive spec_order.txt on appveyor failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ init:
   - SET
 install:
   - SET PATH=C:\Ruby21-x64\bin;%PATH%
+  - SET LOG_SPEC_ORDER=true
   - gem install bundler --quiet --no-ri --no-rdoc
   - bundle install --jobs 4 --retry 2 --without development
   - type Gemfile.lock
@@ -13,6 +14,8 @@ install:
 build: off
 test_script:
   - bundle exec rspec spec
+on_failure:
+  - appveyor PushArtifact .\spec_order.txt
 notifications:
   - provider: Email
     to:


### PR DESCRIPTION
Previously, tests executed in a platform-specific order in appveyor, and
if an order dependent failure happened, we didn't know what the order
was.

This commit sets the `LOG_SPEC_ORDER` environment variable which causes
puppet's spec helper to write each spec to `spec_order.txt` in the
project root.

It also adds an `on_failure` handler to archive the file, which can then
be downloaded from the job's Artifacts tab.