### PR TITLE
(maint) remove extra gems from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
   - SET PATH=C:\Ruby21-x64\bin;%PATH%
   - SET LOG_SPEC_ORDER=true
   - gem install bundler --quiet --no-ri --no-rdoc
-  - bundle install --jobs 4 --retry 2 --without development
+  - bundle install --jobs 4 --retry 2 --without development extra
   - type Gemfile.lock
   - ruby -v
 build: off


### PR DESCRIPTION
 - When running specs in our local Jenkins environment, the
   'extra' gems, which include 'msgpack' are not installed.  We do
   this because:

   - 'msgpack' requires building native code, which unnecessarily
     adds to the feedback loop
   - we intentionally try to maintain a clean environment without
     the Ruby DevKit installed

   This has previously worked on AppVeyor because they have the
   Ruby DevKit installed.