### PR TITLE
(PUP-4636) Fix problem with environment.conf parser=future

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -259,8 +259,11 @@ module Puppet
   # The single instance used for normal operation
   @context = Puppet::Context.new(bootstrap_context)
 
-  def self.future_parser?
-    env = Puppet.lookup(:current_environment) { return Puppet[:parser] == 'future' }
+  # Is the future parser in effect for the given environment, or in :current_environment if no
+  # environment is given.
+  #
+  def self.future_parser?(in_environment = nil)
+    env = in_environment || Puppet.lookup(:current_environment) { return Puppet[:parser] == 'future' }
     env_conf = Puppet.lookup(:environments).get_conf(env.name)
 
     if env_conf.nil?

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -154,8 +154,7 @@ class Puppet::Parser::Compiler
 
   # Constructs the overrides for the context
   def context_overrides()
-    if Puppet.future_parser?
-      require 'puppet/loaders'
+    if Puppet.future_parser?(environment)
       {
         :current_environment => environment,
         :global_scope => @topscope,             # 4x placeholder for new global scope

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -128,4 +128,5 @@ module Puppet
   require 'puppet/parser/ast/pops_bridge'
   require 'puppet/bindings'
   require 'puppet/functions'
+  require 'puppet/loaders'
 end


### PR DESCRIPTION
Before this, when the compiler was instantiated from an environment that
was configured to use parser=current, the initialization of the context
for compilation would do this for parser=current. This led to not having
loaded the ruby code for Puppet::Pops::Loaders, and because of this, the
first function call made in a puppet manifest would fail.

This fixes the problem by making the compiler check if the environment
it is going to *set* as the current environment has parser=future set
(instead of checking in the current environment).

This also moves the requirement to load the ruby logic to the loading of
'puppet/pops' since the loaders since quite some time back are lazilily
initialized.