### PR TITLE
(PUP-4131) Implement insync? for gem package provider.

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -551,6 +551,11 @@ class Puppet::Provider
     "#{@resource}(provider=#{self.class.name})"
   end
 
+  # @return [String] Returns a human readable string with information about the resource and the provider.
+  def inspect
+    to_s
+  end
+
   # Makes providers comparable.
   include Comparable
   # Compares this provider against another provider.

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -74,6 +74,22 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     end
   end
 
+  def insync?(is)
+    return false unless is && is != :absent
+
+    begin
+      dependency = Gem::Dependency.new('', resource[:ensure])
+    rescue Gem::Requirement::BadRequirementError
+      # Bad requirements will cause an error during gem command invocation, so just return not in sync
+      return false
+    end
+
+    is = [is] unless is.is_a? Array
+
+    # Check if any version matches the dependency
+    is.any? { |version| dependency.match?('', version) }
+  end
+
   def install(useversion = true)
     command = [command(:gemcmd), "install"]
     command << "-v" << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -185,6 +185,76 @@ context 'installing myresource' do
         end
       end
     end
+
+    describe 'insync?' do
+      describe 'for array of versions' do
+        let(:is) { ['1.3.4', '3.6.1', '5.1.2'] }
+
+        it 'returns true for ~> 1.3' do
+          resource[:ensure] = '~> 1.3'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns false for ~> 2' do
+          resource[:ensure] = '~> 2'
+          expect(provider).to_not be_insync(is)
+        end
+
+        it 'returns true for > 4' do
+          resource[:ensure] = '> 4'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns true for 3.6.1' do
+          resource[:ensure] = '3.6.1'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns false for 3.6.2' do
+          resource[:ensure] = '3.6.2'
+          expect(provider).to_not be_insync(is)
+        end
+      end
+
+      describe 'for string version' do
+        let(:is) { '1.3.4' }
+
+        it 'returns true for ~> 1.3' do
+          resource[:ensure] = '~> 1.3'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns false for ~> 2' do
+          resource[:ensure] = '~> 2'
+          expect(provider).to_not be_insync(is)
+        end
+
+        it 'returns false for > 4' do
+          resource[:ensure] = '> 4'
+          expect(provider).to_not be_insync(is)
+        end
+
+        it 'returns true for 1.3.4' do
+          resource[:ensure] = '1.3.4'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns false for 3.6.1' do
+          resource[:ensure] = '3.6.1'
+          expect(provider).to_not be_insync(is)
+        end
+      end
+
+      it 'should return false for bad version specifiers' do
+        resource[:ensure] = 'not a valid gem specifier'
+        expect(provider).to_not be_insync('1.0')
+      end
+
+      it 'should return false for :absent' do
+        resource[:ensure] = '~> 1.0'
+        expect(provider).to_not be_insync(:absent)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The gem package provider was previously not implementing insync? but
supported a provider-specific version string for gem version specifiers
(e.g. '~> 2.0').  This resulted in the resource always being out-of-sync
when a gem version specifier was used.

This adds an implementation of insync? that uses the rubygems API to
verify the version specifier matches.