### PR TITLE
(PUP-4622) Add a diff command in Puppet filebucket

### DIFF
--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -177,7 +177,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
           checksum2 = save_bucket_file("foo\nbiz\nbaz")
 
           diff = Puppet::FileBucket::File.indirection.find("#{digest_algorithm}/#{checksum1}", :diff_with => checksum2)
-          expect(diff).to eq("2c2\n< bar\n---\n> biz\n")
+          expect(diff).to include("-bar\n+biz\n")
         end
 
         it "should raise an exception if the hash to diff against isn't found" do


### PR DESCRIPTION
This patch adds a diff subcommand to the filebucket command.
It implements a way to diff filebucket files. Either between
them or between a filebucket file and the local one.