### PR TITLE
(doc) Clarify auth_membership

### DIFF
--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -80,7 +80,9 @@ module Puppet
 
     newproperty(:members, :array_matching => :all, :required_features => :manages_members) do
       desc "The members of the group. For directory services where group
-      membership is stored in the group objects, not the users."
+      membership is stored in the group objects, not the users. Use
+      with auth_membership to determine whether the specified members
+      are inclusive or the minimum."
 
       def change_to_s(currentvalue, newvalue)
         currentvalue = currentvalue.join(",") if currentvalue != :absent
@@ -108,7 +110,9 @@ module Puppet
     end
 
     newparam(:auth_membership, :boolean => true, :parent => Puppet::Parameter::Boolean) do
-      desc "whether the provider is authoritative for group membership."
+      desc "Whether the provider is authoritative for group membership. This
+        must be set to true to allow setting the group to no members with
+        `members => [],`."
       defaultto true
     end
 


### PR DESCRIPTION
Auth_membership plays a role in how a provider can set a group to
empty based on whether it is considered authoritative or not. The
documentation should provide an indication that setting a group
empty is possible.