### PR TITLE
(maint) Bump facter version included in the MSI

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -19,7 +19,7 @@ build_msi:
     ref: '2476cd007b1b52fb1b9f22202b56218629626b5c'
     repo: 'git://github.com/puppetlabs/puppet_for_the_win.git'
   facter:
-    ref: 'refs/tags/2.3.0'
+    ref: 'refs/tags/2.4.4'
     repo: 'git://github.com/puppetlabs/facter.git'
   hiera:
     ref: 'refs/tags/1.3.4'


### PR DESCRIPTION
This commit bumps the version of facter included in the puppet msi to
the latest release available, which is facter 2.4.4