### PR TITLE
(PUP-4633) fix non-ASCII user comment with ruby >= 2.1

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -170,8 +170,10 @@ module Puppet
 
     newproperty(:comment) do
       desc "A description of the user.  Generally the user's full name."
-      munge do |v|
-        v.respond_to?(:force_encoding) ? v.force_encoding(Encoding::ASCII_8BIT) : v
+      if RUBY_VERSION < "2.1.0"
+        munge do |v|
+          v.respond_to?(:force_encoding) ? v.force_encoding(Encoding::ASCII_8BIT) : v
+        end
       end
     end
 


### PR DESCRIPTION
I submit this PR as a trivial fix for PUP-4633.

More details are available in the debian bug report :
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782494

PS: I did not sign the CLA but it looks like it complies with the Trivial Patch Exemption Policy.