### PR TITLE
(PUP-2400) Load loop kernel module for mount tests

### DIFF
--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -28,6 +28,9 @@ agents.each do |agent|
   step "(setup) create mount point"
   on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
 
+  step "(setup) ensure loop kernel module is installed"
+  on(agent, "modprobe loop", :acceptable_exit_codes => (0..254))
+
   step "(setup) add entry to filesystem table"
   on(agent, "echo '/tmp/#{name}  /#{name}  ext3  loop  0  0' >> #{fstab}")
 

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -29,6 +29,9 @@ agents.each do |agent|
   step "(setup) create mount point"
   on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
 
+  step "(setup) ensure loop kernel module is installed"
+  on(agent, "modprobe loop", :acceptable_exit_codes => (0..254))
+
   step "(setup) add entry to filesystem table"
   on(agent, "echo '/tmp/#{name}  /#{name}  ext3  loop  0  0' >> #{fstab}")
 

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -28,6 +28,9 @@ agents.each do |agent|
   step "(setup) create mount point"
   on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
 
+  step "(setup) ensure loop kernel module is installed"
+  on(agent, "modprobe loop", :acceptable_exit_codes => (0..254))
+
   #------- TESTS -------#
   step "create a mount with puppet (mounted)"
   args = ['ensure=mounted',


### PR DESCRIPTION
This commit adds a setup step to the mount resource tests to make
sure that the `loop` kernel module is loaded in order to allow the
system under test to mount loopback devices.