### PR TITLE
(maint) Add acceptance configs for OSX

### DIFF
--- a/acceptance/config/nodes/osx-1010-x86_64.yaml
+++ b/acceptance/config/nodes/osx-1010-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: osx-yosemite-x86_64
+    hypervisor: vcloud
+    template: osx-1010-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/osx-109-x86_64.yaml
+++ b/acceptance/config/nodes/osx-109-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: osx-mavericks-x86_64
+    hypervisor: vcloud
+    template: osx-109-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/


### PR DESCRIPTION
Note: We currently aren't building packages for Vivid yet so I don't have an artifact to test these configs with. Having said that, I copied existing configs and updated them, this should be a very low risk change.

I used a "code name" approach to the platform as is done with Debian. I don't know if this is how you folks prefer the OSX testing or if you'd want to refer to their platform as numeric.