### PR TITLE
(PUP-4665) Add inspect function to scope class

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -768,6 +768,8 @@ class Puppet::Parser::Scope
     "Scope(#{@resource})"
   end
 
+  alias_method :inspect, :to_s
+
   # remove ephemeral scope up to level
   # TODO: Who uses :all ? Remove ??
   #

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -33,6 +33,15 @@ describe Puppet::Parser::Scope do
     end
   end
 
+  it "should generate a simple string when inspecting a scope" do
+    @scope.inspect.should eq("Scope()")
+  end
+
+  it "should generate a simple string when inspecting a scope with a resource" do
+    @scope.resource="foo::bar"
+    @scope.inspect.should eq("Scope(foo::bar)")
+  end
+
   it "should return a scope for use in a test harness" do
     create_test_scope_for_node("node_name_foo").should be_a_kind_of(Puppet::Parser::Scope)
   end


### PR DESCRIPTION
Add an inspect function to the Puppet::Parser::Scope class that
aliases to the to_s method so that calling inspect on a scope no
longer generates a massive, unused string.