### PR TITLE
(PUP-4668) Fix leading 'class...' 3.x resource type conversion

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -140,7 +140,7 @@ class Runtime3Converter
       when Puppet::Pops::Types::PResourceType
         type_name = split_type.type_name
         title = split_type.title
-        if type_name =~ /^(::)?[Cc]lass/
+        if type_name =~ /^(::)?[Cc]lass$/
           ['class', title.nil? ? nil : title.sub(/^::/, '')]
         else
           # Ensure that title is '' if nil

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -1,0 +1,19 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/pops'
+require 'puppet/pops/types/type_factory'
+
+describe 'when converting to 3.x' do
+  it "converts a resource type starting with Class without confusing it with exact match on 'class'" do
+    t = Puppet::Pops::Types::TypeFactory.resource('classroom', 'kermit')
+    converted = Puppet::Pops::Evaluator::Runtime3Converter.instance.catalog_type_to_split_type_title(t)
+    expect(converted).to eql(['classroom', 'kermit'])
+  end
+
+  it "converts a resource type of exactly 'Class'" do
+    t = Puppet::Pops::Types::TypeFactory.resource('class', 'kermit')
+    converted = Puppet::Pops::Evaluator::Runtime3Converter.instance.catalog_type_to_split_type_title(t)
+    expect(converted).to eql(['class', 'kermit'])
+  end
+end


### PR DESCRIPTION
Before this the use of references such as Classroom, Classroom[x] would
when converted to a 3.x parameter value i.e. used this way:

notify { bad: require => Classroom[nbr3] }

would misinterpret the leading 'Class' (or 'class') as if it was a
reference to the class nbr3 not the resource Classroom[nbr3].

This was caused by a non end-anchored regular expression.