### PR TITLE
(PUP-4633) fix non-ASCII user comment with ruby >= 2.1

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -170,8 +170,10 @@ module Puppet
 
     newproperty(:comment) do
       desc "A description of the user.  Generally the user's full name."
-      munge do |v|
-        v.respond_to?(:force_encoding) ? v.force_encoding(Encoding::ASCII_8BIT) : v
+      if RUBY_VERSION < "2.1.0"
+        munge do |v|
+          v.respond_to?(:force_encoding) ? v.force_encoding(Encoding::ASCII_8BIT) : v
+        end
       end
     end
 

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -344,13 +344,20 @@ describe Puppet::Type.type(:user) do
     end
   end
 
-  describe "when managing comment on Ruby 1.9", :if => String.method_defined?(:encode) do
-    it "should force value encoding to ASCII-8BIT" do
-      value = 'abcd™'
-      expect(value.encoding).to eq(Encoding::UTF_8)
-      user = described_class.new(:name => 'foo', :comment => value)
-      expect(user[:comment].encoding).to eq(Encoding::ASCII_8BIT)
-      expect(user[:comment]).to eq(value.force_encoding(Encoding::ASCII_8BIT))
+  describe "when managing comment" do
+    before :each do
+      @value = 'abcd™'
+      expect(@value.encoding).to eq(Encoding::UTF_8)
+      @user = described_class.new(:name => 'foo', :comment => @value)
+    end
+
+    it "should be converted to ASCII_8BIT for ruby 1.9 / 2.0", :if => RUBY_VERSION < "2.1.0" && String.method_defined?(:encode) do
+      expect(@user[:comment].encoding).to eq(Encoding::ASCII_8BIT)
+      expect(@user[:comment]).to eq(@value.force_encoding(Encoding::ASCII_8BIT))
+    end
+
+    it "must not be converted for ruby >= 2.1", :if => RUBY_VERSION >= "2.1.0" do
+      expect(@user[:comment].encoding).to eq(Encoding::UTF_8)
     end
   end
 


### PR DESCRIPTION
I submit this PR as a trivial fix for PUP-4633.

More details are available in the debian bug report :
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782494

PS: I did not sign the CLA but it looks like it complies with the Trivial Patch Exemption Policy.