### PR TITLE
(PUP-4662) Fix :: access to top scope from within top scope

### DIFF
--- a/spec/unit/pops/evaluator/variables_spec.rb
+++ b/spec/unit/pops/evaluator/variables_spec.rb
@@ -41,7 +41,7 @@ describe 'Puppet::Pops::Impl::EvaluatorImpl' do
 
       it "access to global names works in local scope" do
         top_scope_block     = block( var('a').set(literal(2)+literal(2)))
-        local_scope_block   = block( var('a').set(var('::a')+literal(2)), var('::a'))
+        local_scope_block   = block( var('a').set(literal(100)), var('b').set(var('::a')+literal(2)), var('b'))
         evaluate_l(top_scope_block, local_scope_block).should == 6
       end
 


### PR DESCRIPTION
Before this, it was not possible to access top scope variables (e.g.
$::x) from a local scope with top scope as parent if a local scope
shadowed the variable.

The problem is primarily caused by the strange Scope implementation
where Scope represents both itself and all local/ephemeral scopes where
it is ultimately the parent. This has lead to complicated logic inside
scope when looking up variables.

The test that was supposed to test this case was flawed and in realtiy
tested that it did not work!

The fix is unfortunately to add yet another special case.