### PR TITLE
(PUP-4673) Use proxy when fetching latest for pip packages

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -2,7 +2,7 @@
 # <http://pip.openplans.org/>
 
 require 'puppet/provider/package'
-require 'xmlrpc/client'
+require 'open-uri'
 
 Puppet::Type.type(:package).provide :pip,
   :parent => ::Puppet::Provider::Package do
@@ -56,11 +56,8 @@ Puppet::Type.type(:package).provide :pip,
   # cache of PyPI's package list so this operation will always have to
   # ask the web service.
   def latest
-    client = XMLRPC::Client.new2("http://pypi.python.org/pypi")
-    client.http_header_extra = {"Content-Type" => "text/xml"}
-    client.timeout = 10
-    result = client.call("package_releases", @resource[:name])
-    result.first
+    result = JSON.parse(open("https://pypi.python.org/pypi/#{@resource[:name]}/json").read)
+    result['releases'].first
   rescue Timeout::Error => detail
     raise Puppet::Error, "Timeout while contacting pypi.python.org: #{detail}", detail.backtrace
   end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -12,7 +12,6 @@ describe provider_class do
     @client = stub_everything('client')
     @client.stubs(:call).with('package_releases', 'real_package').returns(["1.3", "1.2.5", "1.2.4"])
     @client.stubs(:call).with('package_releases', 'fake_package').returns([])
-    XMLRPC::Client.stubs(:new2).returns(@client)
   end
 
   describe "parse" do


### PR DESCRIPTION
Puppet uses an xmlrpc request to ask pypi what the latest possible
version of the package is. This adds some inspection of the environment
to optionally set proxy information for the xmlrpc request. Future work
could refactor this to use pip search.