### PR TITLE
(PUP-4663) Ensure Fedora uses the systemd service provider

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => "7"
-  defaultfor :osfamily => :redhat, :operatingsystem => :fedora, :operatingsystemmajrelease => ["17", "18", "19", "20", "21"]
+  defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse, :operatingsystemmajrelease => ["12", "13"]
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => "8"
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => "15.04"


### PR DESCRIPTION
- Add systemd service provider by default for fedora 22 and Rawhide

Signed-off-by: Gael Chamoulaud <gchamoul@redhat.com>