### PR TITLE
(PUP-4648) Fix EPP trimming/indentation problems

### DIFF
--- a/lib/puppet/pops/parser/epp_support.rb
+++ b/lib/puppet/pops/parser/epp_support.rb
@@ -183,7 +183,7 @@ module Puppet::Pops::Parser::EppSupport
       until scanner.eos?
         part = @scanner.scan_until(/(<%)|\z/)
         if @skip_leading
-          part.gsub!(/^[ \t]*\r?\n?/,'')
+          part.sub!(/^[ \t]*\r?(?:\n|\z)?/,'')
           @skip_leading = false
         end
         # The spec for %%> is to transform it into a literal %>. This is done here, as %%> otherwise would go
@@ -208,7 +208,7 @@ module Puppet::Pops::Parser::EppSupport
           # trim trailing whitespace on same line from accumulated s
           # return text and signal switch to pp mode
           @scanner.getch # drop the -
-          s.gsub!(/\r?\n?[ \t]*<%\z/, '')
+          s.sub!(/[ \t]*<%\z/, '')
           @mode = :epp
           return s
 
@@ -240,6 +240,8 @@ module Puppet::Pops::Parser::EppSupport
             @mode = :error
             return s
           end
+          # Always trim leading whitespace on the same line when there is a comment
+          s.sub!(/[ \t]*\z/, '')
           @skip_leading = true if part.end_with?("-%>")
           # Continue scanning for more text
 

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -535,7 +535,7 @@ describe 'Lexer2' do
       [:VARIABLE, "x"],
       :EQUALS,
       [:NUMBER, "10"],
-      [:RENDER_STRING, "just text\n"]
+      [:RENDER_STRING, "      just text\n"]
       )
     end
 
@@ -551,7 +551,39 @@ describe 'Lexer2' do
       [:VARIABLE, "x"],
       :EQUALS,
       [:NUMBER, "10"],
-      [:RENDER_STRING, "just text\n"]
+      [:RENDER_STRING, "      just text\n"]
+      )
+    end
+
+    it 'epp comments strips left whitespace when preceding is right trim' do
+      code = <<-CODE
+      This is <% $x=10 -%>
+      space-before-me-but-not-after   <%# This is an epp comment %>
+      just text
+      CODE
+      epp_tokens_scanned_from(code).should match_tokens2(
+      :EPP_START,
+      [:RENDER_STRING, "      This is "],
+      [:VARIABLE, "x"],
+      :EQUALS,
+      [:NUMBER, "10"],
+      [:RENDER_STRING, "      space-before-me-but-not-after\n      just text\n"]
+      )
+    end
+
+    it 'epp comments strips left whitespace on same line when preceding is not right trim' do
+      code = <<-CODE
+      This is <% $x=10 %>
+      <%# This is an epp comment -%>
+      just text
+      CODE
+      epp_tokens_scanned_from(code).should match_tokens2(
+      :EPP_START,
+      [:RENDER_STRING, "      This is "],
+      [:VARIABLE, "x"],
+      :EQUALS,
+      [:NUMBER, "10"],
+      [:RENDER_STRING, "\n      just text\n"]
       )
     end
 
@@ -566,7 +598,7 @@ describe 'Lexer2' do
       [:VARIABLE, "x"],
       :EQUALS,
       [:NUMBER, "10"],
-      [:RENDER_STRING, "<% this is escaped epp %>\n"]
+      [:RENDER_STRING, "      <% this is escaped epp %>\n"]
       )
     end
 

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -561,7 +561,7 @@ describe 'Lexer2' do
       space-before-me-but-not-after   <%# This is an epp comment %>
       just text
       CODE
-      epp_tokens_scanned_from(code).should match_tokens2(
+      expect(epp_tokens_scanned_from(code)).to match_tokens2(
       :EPP_START,
       [:RENDER_STRING, "      This is "],
       [:VARIABLE, "x"],
@@ -577,7 +577,7 @@ describe 'Lexer2' do
       <%# This is an epp comment -%>
       just text
       CODE
-      epp_tokens_scanned_from(code).should match_tokens2(
+      expect(epp_tokens_scanned_from(code)).to match_tokens2(
       :EPP_START,
       [:RENDER_STRING, "      This is "],
       [:VARIABLE, "x"],


### PR DESCRIPTION
Before this, a right trim would replace the whitespace on each following
line up to the next tag instead of just trimming the space on the same
line as the ending tag.

A similar problem occured for a left trim, as it removed the line ending
of the previous line.

Fixing these issues means more strictness wrt which whitespace is
trimmed by each rule.
* A right trim rule trims at most to (including) a line break, stopping
on the first non whitespace.
* A left trim rule troms at most to the beginning of the same line as
the opening (left trimming tag).

This has consequences for comment tags (as they cannot start with a left
trim). Instead, they are now always made left trimming. This is the most
reasonable thing to do since they otherwise needs to be placed
immediately adjacent to a tag or text on a line, cannot be indented etc.