### PR TITLE
(PUP-3774) Only apply necessary group membership changes

### DIFF
--- a/lib/puppet/property/list.rb
+++ b/lib/puppet/property/list.rb
@@ -38,14 +38,34 @@ module Puppet
         array.sort.join(delimiter)
       end
 
-      def should
+      def members
         return nil unless @should
 
-        members = @should
         #inclusive means we are managing everything so if it isn't in should, its gone
-        members = add_should_with_current(members, retrieve) if ! inclusive?
+        if inclusive?
+          @should
+        else
+          add_should_with_current(@should, retrieve)
+        end
+      end
 
-        dearrayify(members)
+      def should
+        tmp = members
+        dearrayify(tmp) if ! tmp.nil?
+      end
+
+      # Returns any values from the list that were returned by
+      # retrieve but are not set as being managed.
+      def is_but_shouldnt
+        # We know that if inclusive is not set, we won't have to
+        # remove any values from the system.
+        inclusive? ? Set.new(retrieve) - Set.new(@should) : Set.new()
+      end
+
+      # Returns any values from the list that we are managing but that
+      # were not returned by retrieve
+      def should_but_isnt
+        Set.new(@should) - Set.new(retrieve)
       end
 
       def delimiter

--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -241,7 +241,7 @@ class Puppet::Provider::NameService < Puppet::Provider
 
   # The list of all groups the user is a member of.  Different
   # user mgmt systems will need to override this method.
-  def groups
+  def fetch_groups
     groups = []
 
     # Reset our group list
@@ -262,6 +262,10 @@ class Puppet::Provider::NameService < Puppet::Provider
     Etc.endgrent
 
     groups.join(",")
+  end
+
+  def groups
+    @groups ||= fetch_groups
   end
 
   # Convert the Etc struct into a hash.

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -349,7 +349,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
   # expects to be returned by modifycmd. Thus we don't bother defining modifycmd.
 
   def set(param, value)
-    self.class.validate(param, value)
+    self.class.validate(param, value, self)
     current_members = @property_value_cache_hash[:members]
     if param == :members
       # If we are meant to be authoritative for the group membership

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -9,7 +9,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     install Ruby's shadow password library (often known as `ruby-libshadow`)
     if you wish to manage user passwords."
 
+  # These commands have special names for use with the base ObjectAdd provider
   commands :add => "useradd", :delete => "userdel", :modify => "usermod", :password => "chage"
+
+  # This is used in our local implementation and has no special name
+  commands :gpasswd => "gpasswd"
 
   options :home, :flag => "-d", :method => :dir
   options :comment, :method => :gecos
@@ -90,7 +94,36 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   end
 
   verify :groups, "Groups must be comma-separated" do |value|
-    value !~ /\s/
+    prop = @resource.parameters[:groups]
+    changes = prop.should_but_isnt + prop.is_but_shouldnt
+    changes.all? do |change|
+      change !~ /\s/
+    end
+  end
+
+  def groups=(value)
+    prop = @resource.parameters[:groups]
+    changes = []
+
+    prop.should_but_isnt.each do |group|
+      changes << { :name => group, :action => '--add' }
+    end
+
+    prop.is_but_shouldnt.each do |group|
+      changes << { :name => group, :action => '--delete' }
+    end
+
+    changes.each do |group|
+      cmd = [ command(:gpasswd),
+              group[:name],
+              group[:action],
+              @resource[:name] ]
+      begin
+        execute(cmd)
+      rescue Puppet::ExecutionFailure => detail
+        raise Puppet::Error, "Could not set groups on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
+      end
+    end
   end
 
   has_features :manages_homedir, :allows_duplicates, :manages_expiry

--- a/spec/unit/property/list_spec.rb
+++ b/spec/unit/property/list_spec.rb
@@ -169,5 +169,48 @@ describe list_class do
         @property.dearrayify(array)
       end
     end
+
+    describe "when calling is_but_shouldnt" do
+      describe "when membership is inclusive" do
+        before(:each) do
+          @property.stubs(:inclusive?).returns(true)
+        end
+
+        it "should return an empty list when membership matches system" do
+          @property.expects(:retrieve).returns(["foo", "bar"])
+          @property.should = ["bar","foo"]
+          expect(@property.is_but_shouldnt).to eq(Set.new())
+        end
+
+        it "should return the list of items to remove" do
+          @property.expects(:retrieve).returns(["foo", "bar", "baz"])
+          @property.should = ["bar","foo", "qux"]
+          expect(@property.is_but_shouldnt).to eq(Set.new(["baz"]))
+        end
+      end
+
+      describe "when membership is not inclusive" do
+        before(:each) do
+          @property.stubs(:inclusive?).returns(false)
+        end
+
+        it "should not call retrieve" do
+          @property.expects(:retrieve).never
+          @property.is_but_shouldnt
+        end
+
+        it "should return an empty list" do
+          expect(@property.is_but_shouldnt).to eq(Set.new())
+        end
+      end
+    end
+
+    describe "when calling should_but_isnt" do
+      it "should return the set of elements to add" do
+        @property.expects(:retrieve).returns(["foo", "bar", "qux"])
+        @property.should = ["baz", "bar", "foo"]
+        expect(@property.should_but_isnt).to eq(Set.new(["baz"]))
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously, the useradd provider would set all of a user's groups at
once using usermod. This would cause problems when a user had existing
groups coming from AD, which would not be valid as arguments to
usermod.

The new implementation uses `gpasswd` to modify the user/group
mappings only as needed. This means Puppet will completely ignore any
existing groups when adding a user to a new group.

Validation will still fail if Puppet is asked to make changes to a
user/group mapping when the group has spaces in it, as that is not a
valid operation.