### PR TITLE
(PUP-4356) Remove puppetversion from PMT metadata

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -56,7 +56,7 @@ class Puppet::Module
   attr_writer :environment
 
   attr_accessor :dependencies, :forge_name
-  attr_accessor :source, :author, :version, :license, :puppetversion, :summary, :description, :project_page
+  attr_accessor :source, :author, :version, :license, :summary, :description, :project_page
 
   def initialize(name, path, environment)
     @name = name
@@ -67,9 +67,21 @@ class Puppet::Module
 
     load_metadata if has_metadata?
 
-    validate_puppet_version
-
     @absolute_path_to_manifests = Puppet::FileSystem::PathPattern.absolute(manifests)
+  end
+
+  # @deprecated The puppetversion module metadata field is no longer used.
+  def puppetversion
+    nil
+  end
+
+  # @deprecated The puppetversion module metadata field is no longer used.
+  def puppetversion=(something)
+  end
+
+  # @deprecated The puppetversion module metadata field is no longer used.
+  def validate_puppet_version
+    return
   end
 
   def has_metadata?
@@ -136,11 +148,9 @@ class Puppet::Module
     @metadata = data = JSON.parse(File.read(metadata_file))
     @forge_name = data['name'].gsub('-', '/') if data['name']
 
-    [:source, :author, :version, :license, :puppetversion, :dependencies].each do |attr|
+    [:source, :author, :version, :license, :dependencies].each do |attr|
       unless value = data[attr.to_s]
-        unless attr == :puppetversion
-          raise MissingMetadata, "No #{attr} module metadata provided for #{self.name}"
-        end
+        raise MissingMetadata, "No #{attr} module metadata provided for #{self.name}"
       end
 
       if attr == :dependencies
@@ -305,11 +315,6 @@ class Puppet::Module
     end
 
     unmet_dependencies
-  end
-
-  def validate_puppet_version
-    return unless puppetversion and puppetversion != Puppet.version
-    raise IncompatibleModule, "Module #{self.name} is only compatible with Puppet version #{puppetversion}, not #{Puppet.version}"
   end
 
   def ==(other)

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -132,23 +132,6 @@ describe Puppet::Module do
       mod.description = "GPL2"
       expect(mod.description).to eq("GPL2")
     end
-
-    it "should support specifying a compatible puppet version" do
-      mod.puppetversion = "0.25"
-      expect(mod.puppetversion).to eq("0.25")
-    end
-  end
-
-  it "should validate that the puppet version is compatible" do
-    mod.puppetversion = "0.25"
-    Puppet.expects(:version).returns "0.25"
-    mod.validate_puppet_version
-  end
-
-  it "should fail if the specified puppet version is not compatible" do
-    mod.puppetversion = "0.25"
-    Puppet.stubs(:version).returns "0.24"
-    expect { mod.validate_puppet_version }.to raise_error(Puppet::Module::IncompatibleModule)
   end
 
   describe "when finding unmet dependencies" do
@@ -670,7 +653,6 @@ describe Puppet::Module do
         :author        => "luke",
         :version       => "1.0",
         :source        => "http://foo/",
-        :puppetversion => "0.25",
         :dependencies  => []
       }
       @module = a_module_with_metadata(@data)
@@ -691,11 +673,6 @@ describe Puppet::Module do
           "No #{attr} module metadata provided for foo"
         )
       end
-    end
-
-    it "should set puppetversion if present in the metadata file" do
-      @module.load_metadata
-      expect(@module.puppetversion).to eq(@data[:puppetversion])
     end
   end
 


### PR DESCRIPTION
Before this commit, there was an undocumented field, puppetversion, which was tracked by the Puppet::Module class.  An error would be thrown if the metadata value was present and was not an exact string match to Puppet.version.  This commit removes the recognition and checking of that metadata key:value pair.

Note: Accessors and validation for puppetversion still exist in order to not cause a breaking change, but they return nil.