### PR TITLE
(PUP-4521) Add configured_environment to Node Facts find

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -161,6 +161,7 @@ class Puppet::Configurer
         begin
           if node = Puppet::Node.indirection.find(Puppet[:node_name_value],
               :environment => Puppet::Node::Environment.remote(@environment),
+              :configured_environment => Puppet[:environment],
               :ignore_cache => true,
               :transaction_uuid => @transaction_uuid,
               :fail_on_404 => true)
@@ -198,6 +199,7 @@ class Puppet::Configurer
 
       query_options = get_facts(options) unless query_options
       query_options[:transaction_uuid] = @transaction_uuid
+      query_options[:configured_environment] = Puppet[:environment]
 
       unless catalog = prepare_and_retrieve_catalog(options, query_options)
         return nil
@@ -218,6 +220,7 @@ class Puppet::Configurer
 
         query_options = get_facts(options)
         query_options[:transaction_uuid] = @transaction_uuid
+        query_options[:configured_environment] = Puppet[:environment]
 
         return nil unless catalog = prepare_and_retrieve_catalog(options, query_options)
         tries += 1

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -102,12 +102,13 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   end
 
   # Turn our host name into a node object.
-  def find_node(name, environment, transaction_uuid)
+  def find_node(name, environment, transaction_uuid, configured_environment)
     Puppet::Util::Profiler.profile("Found node information", [:compiler, :find_node]) do
       node = nil
       begin
         node = Puppet::Node.indirection.find(name, :environment => environment,
-                                             :transaction_uuid => transaction_uuid)
+                                             :transaction_uuid => transaction_uuid,
+                                             :configured_environment => configured_environment)
       rescue => detail
         message = "Failed when searching for node #{name}: #{detail}"
         Puppet.log_exception(detail, message)
@@ -142,7 +143,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     # node's catalog with only one certificate and a modification to auth.conf
     # If no key is provided we can only compile the currently connected node.
     name = request.key || request.node
-    if node = find_node(name, request.environment, request.options[:transaction_uuid])
+    if node = find_node(name, request.environment, request.options[:transaction_uuid], request.options[:configured_environment])
       return node
     end
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -531,6 +531,11 @@ describe Puppet::Configurer do
       Puppet::Node.indirection.expects(:find).with(anything, has_entries(:transaction_uuid => anything)).twice
       @agent.run
     end
+
+    it "sends the configured environment in the request" do
+      Puppet::Node.indirection.expects(:find).with(anything, has_entries(:configured_environment => Puppet[:environment])).twice
+      @agent.run
+    end
   end
 
   describe "when retrieving a catalog" do

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -200,6 +200,22 @@ describe Puppet::Resource::Catalog::Compiler do
 
       compiler.find(request)
     end
+
+    it "should pass the configured_environment to the node indirection" do
+      environment = 'foo'
+      node = Puppet::Node.new("thing")
+      compiler = Puppet::Resource::Catalog::Compiler.new
+      compiler.stubs(:compile)
+      request = Puppet::Indirector::Request.new(:catalog, :find, "thing",
+                                                nil, :configured_environment => environment)
+
+      Puppet::Node.indirection.expects(:find).with(
+        "thing",
+        has_entries(:configured_environment => environment)
+      ).returns(node)
+
+      compiler.find(request)
+    end
   end
 
   describe "after finding nodes" do


### PR DESCRIPTION
Prior to this commit, there was no way to write an external node
classifier that allows some agents - based on Facts - to override the
node classifier with its own requested environment.

The first request from the agent for the environment will not use the
correct Facts (that might need to include custom facts), which may end
up classifying it in the incorrect environment. Subsequent requests
will send that environment instead of the configured environment.

Fix by passing the configured environment to the Node::Facts find
request as a new option.