### PR TITLE
(PUP-2638) Use settings during puppet apply setup

### DIFF
--- a/acceptance/tests/apply/puppet_apply_graph.rb
+++ b/acceptance/tests/apply/puppet_apply_graph.rb
@@ -1,0 +1,15 @@
+test_name 'puppet apply should generate a graph'
+
+agents.each do |agent|
+  step "Create var temp directory"
+  vardir = agent.tmpdir('vardir')
+  graphdir = File.join(vardir, 'state', 'graphs')
+
+  step "Ensure it creates parent directories and generates the graph"
+  on(agent, puppet("apply --graph --graphdir #{graphdir} --vardir #{vardir} -e 'notify { \"hi\": }'")) do
+    resources_dot = File.join(graphdir, 'resources.dot')
+    if !agent.file_exist?(resources_dot)
+      fail_test("Failed to create graph: #{resources_dot}")
+    end
+  end
+end

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -304,6 +304,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       exit(1)
     end
 
+    Puppet.settings.use :main, :agent, :ssl
+
     # we want the last report to be persisted locally
     Puppet::Transaction::Report.indirection.cache_class = :yaml
 

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -45,8 +45,6 @@ class Puppet::Configurer
   end
 
   def initialize(factory = Puppet::Configurer::DownloaderFactory.new)
-    Puppet.settings.use(:main, :ssl, :agent)
-
     @running = false
     @splayed = false
     @environment = Puppet[:environment]

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -947,6 +947,8 @@ Generated on #{Time.now}.
 
     return if sections.empty?
 
+    Puppet.debug("Applying settings catalog for sections #{sections.join(', ')}")
+
     begin
       catalog = to_catalog(*sections).to_ral
     rescue => detail

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -120,6 +120,13 @@ describe Puppet::Application::Apply do
       expect { @apply.setup }.to exit_with 1
     end
 
+    it "should use :main, :puppetd, and :ssl" do
+      Puppet.settings.unstub(:use)
+      Puppet.settings.expects(:use).with(:main, :agent, :ssl)
+
+      @apply.setup
+    end
+
     it "should tell the report handler to cache locally as yaml" do
       Puppet::Transaction::Report.indirection.expects(:cache_class=).with(:yaml)
 


### PR DESCRIPTION
Previously, if you installed puppet, and never executed `puppet agent`,
but immediately executed `puppet apply` (such as with vagrant
workflows), and `graph` was true (as is the default in PE), then
puppet would fail to write the graph. This occurred because `puppet
apply` tries to write the graph (during `Catalog#to_ral`) before
creating the necessary settings related directories (as a side-effect
of calling `Puppet::Configurer.new`).

The `agent` and `device` applications also use the Configurer to apply
the catalog, but they explicitly use the `main`, `ssl`, and `agent`
sections during application setup, and before calling `Catalog#to_ral`.

This commit modifies `apply` to match the other two. Alternatively, the
setup logic could be added to the base `Puppet::Application#setup`, but
it's more complex due to run_mode.

This commit adds an acceptance test, which uses a temporary vardir to
ensure `statedir` and `graphdir` do not exist. It also adds a debug
message to print which settings-related sections are applied.