### PR TITLE
(maint) Default to facter#2.x for git based acceptance

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -85,7 +85,7 @@ def beaker_test(mode = :packages, options = {})
   if mode == :git
     # Build up project git urls based on git server and fork env variables or defaults
     final_options[:install].map! do |install|
-      if md = /^(\w+)#(\w+)$/.match(install)
+      if md = /^(\w+)#([\d.\w]+)$/.match(install)
         project, project_sha = md.captures
         "#{build_giturl(project)}##{project_sha}"
       elsif md = /^(\w+)$/.match(install)

--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -1,6 +1,6 @@
 {
   :install => [
-    'facter#stable',
+    'facter#2.x',
     'hiera#stable',
     'puppet',
   ],


### PR DESCRIPTION
Previously, git based acceptance (rake ci:test:git) defaulted to
facter#stable, but that branch was recently promoted to native facter,
so acceptance would fail trying to install facter `ruby install.rb`

This commit changes the default facter branch to 2.x, containing the
legacy ruby facter implementation. It also relaxes the regex to match
digits and a literal dot, when translating short branch names,
facter#2.x, to git URLs.