### PR TITLE
(PUP-4522) Set agent_specified_environment

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -37,7 +37,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
 
     Facter.add(:agent_specified_environment) do
       setcode do
-        if Puppet.settings.set_by_cli?(:environment)
+        if Puppet.settings.set_by_config?(:environment)
           Puppet[:environment]
         end
       end

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -35,6 +35,14 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       setcode { Puppet.version.to_s }
     end
 
+    Facter.add(:agent_specified_environment) do
+      setcode do
+        if Puppet.settings.set_by_cli?(:environment)
+          Puppet[:environment]
+        end
+      end
+    end
+
     result = Puppet::Node::Facts.new(request.key, Facter.to_hash)
     result.add_local_facts
     result.sanitize

--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -78,4 +78,31 @@ describe Puppet::Node::Facts::Facter do
                              Puppet::Node.indirection.find('foo'))
     expect(cat.resource("Notify[#{Puppet.version.to_s}]")).to be
   end
+
+  it "the agent_specified_environment fact is nil when not set" do
+    expect do
+      compile_to_catalog('notify { $::agent_specified_environment: }',
+                         Puppet::Node.indirection.find('foo'))
+    end.to raise_error(Puppet::PreformattedError)
+  end
+
+  it "the agent_specified_environment fact is nil when set in puppet.conf" do
+    FileUtils.mkdir_p(Puppet[:confdir])
+    File.open(File.join(Puppet[:confdir], 'puppet.conf'), 'w') do |f|
+      f.puts("environment=bar")
+    end
+
+    Puppet.initialize_settings
+    expect do
+      compile_to_catalog('notify { $::agent_specified_environment: }',
+                         Puppet::Node.indirection.find('foo'))
+    end.to raise_error(Puppet::PreformattedError)
+  end
+
+  it "adds the agent_specified_environment fact when set via command-line" do
+    Puppet.initialize_settings(['--environment', 'bar'])
+    cat = compile_to_catalog('notify { $::agent_specified_environment: }',
+                             Puppet::Node.indirection.find('foo'))
+    expect(cat.resource("Notify[bar]")).to be
+  end
 end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -43,10 +43,11 @@ describe Puppet::Node::Facts::Facter do
       @facter.find(@request)
     end
 
-    it 'should add the puppetversion fact' do
+    it 'should add the puppetversion and agent_specified_environment facts' do
       reset = sequence 'reset'
       Facter.expects(:reset).in_sequence(reset)
       Facter.expects(:add).with(:puppetversion)
+      Facter.expects(:add).with(:agent_specified_environment)
       @facter.find(@request)
     end
 


### PR DESCRIPTION
Creates an `agent_specified_environment` fact with the value being the
environment name if the environment was set on the agent by the user.