### PR TITLE
(PUP-3088) Fix zone provider debug call

### DIFF
--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -336,7 +336,7 @@ class Puppet::Util::Log
   # If they pass a source in to us, we make sure it is a string, and
   # we retrieve any tags we can.
   def source=(source)
-    if source.respond_to?(:path)
+    if defined?(Puppet::Type) && source.is_a?(Puppet::Type)
       @source = source.path
       source.tags.each { |t| tag(t) }
       self.file = source.file

--- a/spec/unit/provider/zone/solaris_spec.rb
+++ b/spec/unit/provider/zone/solaris_spec.rb
@@ -85,7 +85,8 @@ describe Puppet::Type.type(:zone).provider(:solaris) do
     end
   end
   context "#getconfig" do
-    zone_info =<<-EOF
+    describe "with a shared iptype zone" do
+      zone_info =<<-EOF
 zonename: dummy
 zonepath: /dummy/z
 brand: native
@@ -104,17 +105,49 @@ net:
         address: 1.1.1.2
         physical: ex0002
         defrouter not specified
-    EOF
-    it "should correctly parse zone info" do
-      provider.expects(:zonecfg).with(:info).returns(zone_info)
-      provider.getconfig.should == {
-        :brand=>"native",
-        :autoboot=>"true",
-        :"ip-type"=>"shared",
-        :zonename=>"dummy",
-        "net"=>[{:physical=>"ex0001", :address=>"1.1.1.1"}, {:physical=>"ex0002", :address=>"1.1.1.2"}],
-        :zonepath=>"/dummy/z"
-      }
+      EOF
+      it "should correctly parse zone info" do
+        provider.expects(:zonecfg).with(:info).returns(zone_info)
+        provider.getconfig.should == {
+          :brand=>"native",
+          :autoboot=>"true",
+          :"ip-type"=>"shared",
+          :zonename=>"dummy",
+          "net"=>[{:physical=>"ex0001", :address=>"1.1.1.1"}, {:physical=>"ex0002", :address=>"1.1.1.2"}],
+          :zonepath=>"/dummy/z"
+        }
+      end
+    end
+    describe "with an exclusive iptype zone" do
+      zone_info =<<-EOF
+zonename: dummy
+zonepath: /dummy/z
+brand: native
+autoboot: true
+bootargs:
+pool:
+limitpriv:
+scheduling-class:
+ip-type: exclusive
+hostid:
+net:
+        address not specified
+        allowed-address not specified
+        configure-allowed-address: true
+        physical: net1
+        defrouter not specified
+      EOF
+      it "should correctly parse zone info" do
+        provider.expects(:zonecfg).with(:info).returns(zone_info)
+        provider.getconfig.should == {
+          :brand=>"native",
+          :autoboot=>"true",
+          :"ip-type"=>"exclusive",
+          :zonename=>"dummy",
+          "net"=>[{:physical=>"net1",:'configure-allowed-address'=>"true"}],
+          :zonepath=>"/dummy/z"
+        }
+      end
     end
   end
   context "#flush" do

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -425,7 +425,7 @@ describe Puppet::Util::Log do
         end
       end
 
-      it "should set the source to 'path', when available" do
+      it "should set the source to a type's 'path', when available" do
         source = Puppet::Type.type(:file).new :path => path
         source.tags = ["tag", "tag2"]
 
@@ -437,6 +437,17 @@ describe Puppet::Util::Log do
         log.source = source
 
         log.source.should == "/File[#{path}]"
+      end
+
+      it "should set the source to a provider's type's 'path', when available" do
+        source = Puppet::Type.type(:file).new :path => path
+        source.tags = ["tag", "tag2"]
+
+        log = Puppet::Util::Log.new(:level => "notice", :message => :foo)
+
+        log.source = source.provider
+
+        log.source.should == "File[#{path}](provider=posix)"
       end
 
       it "should copy over any file and line information" do


### PR DESCRIPTION
The provider should directly call `Puppet.debug` and `Puppet.err`
because of the issue described in the PUP ticket.