### PR TITLE
(maint) Ensure acceptance fixtures are removed

### DIFF
--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -1,5 +1,12 @@
 test_name 'Puppet executes functions written in the Puppet language'
 
+teardown do
+  on master, 'rm -rf /etc/puppetlabs/code/modules/jenny'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/production/modules/one'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/production/modules/three'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/tommy'
+end
+
 step 'Create some functions' do
 
   manifest = <<-EOF


### PR DESCRIPTION
Previously, if the functions_in_puppet_language test was run prior to
the module acceptance tests, the former would leave behind modules that
caused the latter to fail.

This commit adds a teardown to remove acceptance fixtures.