### PR TITLE
(maint) (PUP-4466) Remove test fixtures in a teardown block

### DIFF
--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -1,5 +1,12 @@
 test_name 'Puppet executes functions written in the Puppet language'
 
+teardown do
+  on master, 'rm -rf /etc/puppetlabs/code/modules/jenny'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/tommy'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/production/modules/one'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/production/modules/three'
+end
+
 step 'Create some functions' do
 
   manifest = <<-EOF


### PR DESCRIPTION
Fixes the original commit by adding a teardown block to remove
test fixtures that break subsequent module-related tests