### PR TITLE
(PUP-4693) Confine the pw user and group providers to BSD (Puppet 4.x)

### DIFF
--- a/lib/puppet/provider/group/pw.rb
+++ b/lib/puppet/provider/group/pw.rb
@@ -7,6 +7,7 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
   has_features :manages_members
 
   defaultfor :operatingsystem => [:freebsd, :dragonfly]
+  confine    :operatingsystem => [:freebsd, :dragonfly]
 
   options :members, :flag => "-M", :method => :mem
 

--- a/lib/puppet/provider/user/pw.rb
+++ b/lib/puppet/provider/user/pw.rb
@@ -8,6 +8,7 @@ Puppet::Type.type(:user).provide :pw, :parent => Puppet::Provider::NameService::
   has_features :manages_homedir, :allows_duplicates, :manages_passwords, :manages_expiry, :manages_shell
 
   defaultfor :operatingsystem => [:freebsd, :dragonfly]
+  confine    :operatingsystem => [:freebsd, :dragonfly]
 
   options :home, :flag => "-d", :method => :dir
   options :comment, :method => :gecos


### PR DESCRIPTION
These providers were designed to function on systems similar to FreeBSD. If a
`pw` binary shows up on Linux, the providers will be activated and Puppet's
ability to manage users and groups will break.