### PR TITLE
(maint) Add teardown block to remove test fixtures created by the test

### DIFF
--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -1,5 +1,12 @@
 test_name 'Puppet executes functions written in the Puppet language'
 
+teardown do
+  on master, 'rm -rf /etc/puppetlabs/code/modules/jenny'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/tommy'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/production/modules/one'
+  on master, 'rm -rf /etc/puppetlabs/code/environments/production/modules/three'
+end
+
 step 'Create some functions' do
 
   manifest = <<-EOF


### PR DESCRIPTION
The original commit for PUP-4466 did not clean up after itself, causing
tests that follow it, particularly modules tests, to fail. This commit
fixes that.