### PR TITLE
(PUP-4701) Fix so that yum provider thinks that user is root

### DIFF
--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -54,6 +54,7 @@ end
 
 describe Puppet::Type.type(:package), "when packages with the same name are sourced" do
   before :each do
+    Process.stubs(:euid).returns 0
     @provider = stub(
       'provider',
       :class           => Puppet::Type.type(:package).defaultprovider,
@@ -131,6 +132,7 @@ describe Puppet::Type.type(:package), 'logging package state transitions' do
   let(:provider) { stub('provider', :class => Puppet::Type.type(:package).defaultprovider, :clear => nil, :validate_source => nil) }
 
   before :each do
+    Process.stubs(:euid).returns 0
     provider.stubs(:satisfies?).with([:purgeable]).returns(true)
     provider.class.stubs(:instances).returns([])
     provider.stubs(:install).returns nil

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:package) do
   before do
+    Process.stubs(:euid).returns 0
     Puppet::Util::Storage.stubs(:store)
   end
 


### PR DESCRIPTION
This commit stubs the Process.euid to always return zero for tests
that potentially use the yum provider. This makes the provider think
that the user is root and prevents it from bailing out with the
message: "The yum provider can only be used as root".