### PR TITLE
(WIP) (PUP-4386) Windows group invalid user error msgs

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -38,6 +38,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
     return '' if users.nil? or !users.kind_of?(Array)
     users = users.map do |user_name|
       sid = Puppet::Util::Windows::SID.name_to_sid_object(user_name)
+      raise Puppet::Util::Windows::Error.new("Could not resolve username: #{user_name} to a SID") if !sid
       if sid.account =~ /\\/
         account, _ = Puppet::Util::Windows::ADSI::User.parse_name(sid.account)
       else

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -99,7 +99,12 @@ module Puppet
       def is_to_s(currentvalue)
         if provider.respond_to?(:members_to_s)
           currentvalue = '' if currentvalue.nil?
-          return provider.members_to_s(currentvalue.split(','))
+          currentvalue = currentvalue.is_a?(Array) ? currentvalue : currentvalue.split(',')
+
+          begin
+            return provider.members_to_s(currentvalue)
+          rescue Puppet::Util::Windows::Error
+          end
         end
 
         super(currentvalue)


### PR DESCRIPTION
Assume that `puppet resource group guests` yields the following:

```puppet
group { 'guests':
  ensure  => 'present',
  gid     => 'S-1-5-32-546',
  members => ['Guest', 'Administrator'],
}
```

Previously, trying to apply the following manifest with a bad user,
would trigger a bug in Puppet:

```puppet
group { 'guests':
  ensure => present,
  members => ['Guest', 'Administrator', ''],
}
```

An error would be raised in resource_harness#sync_if_needed method, and
would lose important details about expected resource changes:

```
Notice: Compiled catalog for vagrant-2008r2.corp.puppetlabs.net in environment production in 0.22 seconds Error: Could not resolve username:
Error: /Group[Guests]: Could not evaluate: Puppet::Util::Log requires a message
Notice: Finished catalog run in 0.05 seconds
```

This change prevents both the loss of error detail, and triggering an
extraneous / misleading message about Puppet::Util::Log:

```
Notice: Compiled catalog for vagrant-2008r2.corp.puppetlabs.net in environment production in 0.22 seconds Error: Could not resolve username:
Error: /Stage[main]/Main/Group[Guests]/members: change from VAGRANT-2008R2\Guest,VAGRANT-2008R2\Administrator to ["Guest", "Administrator", ""] failed: Could not resolve username:
Notice: Finished catalog run in 0.05 seconds
```