### PR TITLE
(PUP-4659) Update environment tests

### DIFF
--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -22,7 +22,7 @@ master_opts = {
   }
 }
 env = 'testing'
-path = master.puppet('master')['codedir']
+path = '/doesnotexist'
 
 results = use_an_environment(env, 'bad environmentpath', master_opts, testdir, puppet_conf_backup_dir, :directory_environments => true)
 

--- a/acceptance/tests/environment/environment_scenario-default.rb
+++ b/acceptance/tests/environment/environment_scenario-default.rb
@@ -23,9 +23,9 @@ master_opts = {
   }
 }
 general = [ master_opts, testdir, puppet_code_backup_dir, { :directory_environments => true } ]
-env = nil
+env = 'production'
 
-results = use_an_environment(env, "default environment", *general)
+results = use_an_environment(nil, "default environment", *general)
 
 expectations = {
   :puppet_config => {

--- a/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
+++ b/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
@@ -19,12 +19,12 @@ apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true
 step  "Test"
 master_opts = {
   'master' => {
-    'environmentpath' => '$codedir/environments',
+    'environmentpath' => "#{testdir}/environments",
   }
 }
 env = 'testing'
 
-results = use_an_environment("testing", "master environmentpath", master_opts, testdir, puppet_code_backup_dir, :directory_environments => true, :config_print => '--section=master')
+results = use_an_environment(env, "master environmentpath", master_opts, testdir, puppet_code_backup_dir, :directory_environments => true)
 
 expectations = {
   :puppet_config => {
@@ -35,22 +35,19 @@ expectations = {
   },
   :puppet_module_install => {
     :exit_code => 0,
-    :matches => [%r{Preparing to install into #{codedir}/modules},
+    :matches => [%r{Preparing to install into #{codedir}/environments/#{env}/modules},
                  %r{pmtacceptance-nginx}],
-    :expect_failure => true,
-    :notes => "Runs in user mode and doesn't see the master environmenetpath setting.",
+    :notes => "Runs in user mode and doesn't see the master environmentpath setting.",
   },
   :puppet_module_uninstall => {
     :exit_code => 0,
-    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{codedir}/modules}],
-    :expect_failure => true,
-    :notes => "Runs in user mode and doesn't see the master environmenetpath setting.",
+    :matches => [%r{Removed.*pmtacceptance-nginx.*from #{codedir}/environments/#{env}/modules}],
+    :notes => "Runs in user mode and doesn't see the master environmentpath setting.",
   },
   :puppet_apply => {
     :exit_code => 0,
-    :matches => [%r{include default environment testing_mod}],
-    :expect_failure => true,
-    :notes => "Runs in user mode and doesn't see the master environmenetpath setting.",
+    :matches => [%r{include directory #{env} environment testing_mod}],
+    :notes => "Runs in user mode and doesn't see the master environmentpath setting.",
   },
   :puppet_agent => {
     :exit_code => 2,

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -54,8 +54,6 @@ with_puppet_running_on master, master_opts, testdir do
 file { "#{atmp}/special_testy":
   source => "puppet:///modules/amod/testy",
 }
-
-notify { "mytemp is ${::mytemp}": }
 END
     on master, "chmod 644 #{testdir}/environments/special/manifests/different.pp"
 

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -48,9 +48,12 @@ with_puppet_running_on master, master_opts, testdir do
 
   agents.each do |agent|
     agent_vardir = agent.puppet['vardir']
+    teardown do
+      on agent, "rm -rf \"#{agent_vardir}/lib\""
+    end
+
     run_agent_on(agent, "--no-daemonize --onetime --server #{master}")
     on agent, "cat \"#{agent_vardir}/lib/puppet/foo.rb\""
     assert_match(/#special_version/, stdout, "The plugin from environment 'special' was not synced")
-    on agent, "rm -rf \"#{agent_vardir}/lib\""
   end
 end

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -67,11 +67,10 @@ def generate_site_manifest(path_to_manifest, *modules_to_include)
   EOS
 end
 
-master_user = on(master, puppet("master --configprint user")).stdout.strip
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
-  owner => #{master_user},
+  owner => #{master.puppet['user']},
   group => #{master.puppet['group']},
   mode => "0770",
 }


### PR DESCRIPTION
Previously, the tests failed when the master had the agent role. This
wasn't noticed originally due to PUP-4111. We also stopped testing the
agent role on the master in the lead up to Puppet 4, so once PUP-4111
was fixed, we didn't see the problem in platform CI. But puppetserver CI
does test that combination and was failing.

These commits update some of the environment related tests to
match the current and expected behavior.