### PR TITLE
(packaging)(RE-4770) Update puppet init script to handle AIO pathing

### DIFF
--- a/ext/suse/client.init
+++ b/ext/suse/client.init
@@ -35,7 +35,7 @@
 [ -f /etc/sysconfig/puppet ] && . /etc/sysconfig/puppet
 lockfile=${LOCKFILE-/var/lock/subsys/puppet}
 pidfile=${PIDFILE-/var/run/puppetlabs/agent.pid}
-puppetd=${PUPPETD-/usr/bin/puppet}
+puppetd=${PUPPETD-/opt/puppetlabs/puppet/bin/puppet}
 RETVAL=0
 
 PUPPET_OPTS="agent"


### PR DESCRIPTION
This was an oversite when the init script was initially updated for AIO
pathing. This commit just adds in a (hopefully) final update