### PR TITLE
(maint) add PE platform configs

### DIFF
--- a/acceptance/config/nodes/centos-4-i386.yaml
+++ b/acceptance/config/nodes/centos-4-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: centos-4-i386
+    hypervisor: vcloud
+    template: centos-4-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/centos-4-x86_64.yaml
+++ b/acceptance/config/nodes/centos-4-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: centos-4-x86_64
+    hypervisor: vcloud
+    template: centos-4-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/centos-7-x86_64.yaml
+++ b/acceptance/config/nodes/centos-7-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: centos-7-x86_64
+    hypervisor: vcloud
+    template: centos-7-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/oracle-5-i386.yaml
+++ b/acceptance/config/nodes/oracle-5-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-5-i386
+    hypervisor: vcloud
+    template: oracle-5-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/oracle-5-x86_64.yaml
+++ b/acceptance/config/nodes/oracle-5-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-5-x86_64
+    hypervisor: vcloud
+    template: oracle-5-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/oracle-6-i386.yaml
+++ b/acceptance/config/nodes/oracle-6-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-6-i386
+    hypervisor: vcloud
+    template: oracle-6-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/oracle-6-x86_64.yaml
+++ b/acceptance/config/nodes/oracle-6-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-6-x86_64
+    hypervisor: vcloud
+    template: oracle-6-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/oracle-7-x86_64.yaml
+++ b/acceptance/config/nodes/oracle-7-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: oracle-7-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/redhat-4-i386.yaml
+++ b/acceptance/config/nodes/redhat-4-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-4-i386
+    hypervisor: vcloud
+    template: redhat-4-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/redhat-4-x86_64.yaml
+++ b/acceptance/config/nodes/redhat-4-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-4-x86_64
+    hypervisor: vcloud
+    template: redhat-4-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/scientific-5-i386.yaml
+++ b/acceptance/config/nodes/scientific-5-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-5-i386
+    hypervisor: vcloud
+    template: scientific-5-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/scientific-5-x86_64.yaml
+++ b/acceptance/config/nodes/scientific-5-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-5-x86_64
+    hypervisor: vcloud
+    template: scientific-5-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/scientific-6-i386.yaml
+++ b/acceptance/config/nodes/scientific-6-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-6-i386
+    hypervisor: vcloud
+    template: scientific-6-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/scientific-6-x86_64.yaml
+++ b/acceptance/config/nodes/scientific-6-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-6-x86_64
+    hypervisor: vcloud
+    template: scientific-6-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/scientific-7-x86_64.yaml
+++ b/acceptance/config/nodes/scientific-7-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: scientific-7-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/sles-10-i386.yaml
+++ b/acceptance/config/nodes/sles-10-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: sles-10-i386
+    hypervisor: vcloud
+    template: sles-10-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/sles-10-x86_64.yaml
+++ b/acceptance/config/nodes/sles-10-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: sles-10-x86_64
+    hypervisor: vcloud
+    template: sles-10-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/sles-11-i386.yaml
+++ b/acceptance/config/nodes/sles-11-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: sles-11-i386
+    hypervisor: vcloud
+    template: sles-11-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/sles-11-x86_64.yaml
+++ b/acceptance/config/nodes/sles-11-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: sles-11-x86_64
+    hypervisor: vcloud
+    template: sles-11-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/sles-12-x86_64.yaml
+++ b/acceptance/config/nodes/sles-12-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: sles-12-x86_64
+    hypervisor: vcloud
+    template: sles-12-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/ubuntu-1004-i386.yaml
+++ b/acceptance/config/nodes/ubuntu-1004-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: ubuntu-lucid-i386
+    hypervisor: vcloud
+    template: ubuntu-1004-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/ubuntu-1004-x86_64.yaml
+++ b/acceptance/config/nodes/ubuntu-1004-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: ubuntu-lucid-amd64
+    hypervisor: vcloud
+    template: ubuntu-1004-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/


### PR DESCRIPTION
Prior to this there were no acceptance test host config files for PE
only platforms. The distinction between PE and FOSS is largely going
away (save for where the failures are reported).

This commit adds the necessary host configs to test Puppet against all
the platforms we will distribute puppet-agent on in the Shallow Gravy
timeframe.