### PR TITLE
(PUP-4131) Rescue generic ArgumentError

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -79,7 +79,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
     begin
       dependency = Gem::Dependency.new('', resource[:ensure])
-    rescue Gem::Requirement::BadRequirementError
+    rescue ArgumentError
       # Bad requirements will cause an error during gem command invocation, so just return not in sync
       return false
     end


### PR DESCRIPTION
Prior to rubygems 2.0.0, creating a Gem::Dependency with an invalid
version, would raise an ArgumentError. During the rubygems 2.0.0 rc,
it was changed to raise IllformedRequirementError[1], but was renamed to
BadRequirementError prior to the 2.0.0 release[2].

As a result, if you ran puppet from source or a gem install, and tried
to manage a `gem` package using rubygems < 2.0 (so really ruby < 2.0),
then puppet would raise an exception due to the undefined constant
Gem::Requirement::BadRequirementError.

This commit rescues ArgumentError, which is the parent of
BadRequirementError, and so will work for all supported rubygems
versions.

[1] https://github.com/rubygems/rubygems/commit/c53ac0f5a
[2] https://github.com/rubygems/rubygems/commit/ccfbb4feb