### PR TITLE
(packaging) (re-4770) Update init script to ignore old/incorrect sysconfig values

### DIFF
--- a/ext/redhat/client.init
+++ b/ext/redhat/client.init
@@ -17,15 +17,12 @@ PATH=/opt/puppetlabs/puppet/bin:/usr/bin:/sbin:/bin:/usr/sbin
 export PATH
 
 [ -f /etc/sysconfig/puppet ] && . /etc/sysconfig/puppet
-lockfile=${LOCKFILE-/var/lock/subsys/puppet}
-pidfile=${PIDFILE-/var/run/puppetlabs/agent.pid}
-puppetd=${PUPPETD-/opt/puppetlabs/puppet/bin/puppet}
+lockfile=/var/lock/subsys/puppet
+pidfile=/var/run/puppetlabs/agent.pid
+puppetd=/opt/puppetlabs/puppet/bin/puppet
 RETVAL=0
 
 PUPPET_OPTS="agent "
-[ -n "${PUPPET_SERVER}" ] && PUPPET_OPTS="${PUPPET_OPTS} --server=${PUPPET_SERVER}"
-[ -n "$PUPPET_LOG" ] && PUPPET_OPTS="${PUPPET_OPTS} --logdest=${PUPPET_LOG}"
-[ -n "$PUPPET_PORT" ] && PUPPET_OPTS="${PUPPET_OPTS} --masterport=${PUPPET_PORT}"
 
 # Determine if we can use the -p option to daemon, killproc, and status.
 # RHEL < 5 can't.

--- a/ext/redhat/client.sysconfig
+++ b/ext/redhat/client.sysconfig
@@ -1,11 +1,2 @@
-# The puppetmaster server
-#PUPPET_SERVER=puppet
-
-# If you wish to specify the port to connect to do so here
-#PUPPET_PORT=8140
-
-# Where to log to. Specify syslog to send log messages to the system log.
-#PUPPET_LOG=/var/log/puppetlabs/puppet/puppet.log
-
-# You may specify other parameters to the puppet client here
+# You may specify parameters to the puppet client here
 #PUPPET_EXTRA_OPTS=--waitforcert=500

--- a/ext/suse/client.init
+++ b/ext/suse/client.init
@@ -33,15 +33,12 @@
 #      rc_exit          exit appropriate to overall rc status
 [ -f /etc/rc.status ] && . /etc/rc.status
 [ -f /etc/sysconfig/puppet ] && . /etc/sysconfig/puppet
-lockfile=${LOCKFILE-/var/lock/subsys/puppet}
-pidfile=${PIDFILE-/var/run/puppetlabs/agent.pid}
-puppetd=${PUPPETD-/opt/puppetlabs/puppet/bin/puppet}
+lockfile=/var/lock/subsys/puppet
+pidfile=/var/run/puppetlabs/agent.pid
+puppetd=/opt/puppetlabs/puppet/bin/puppet
 RETVAL=0
 
 PUPPET_OPTS="agent"
-[ -n "${PUPPET_SERVER}" ] && PUPPET_OPTS="${PUPPET_OPTS} --server=${PUPPET_SERVER}"
-[ -n "$PUPPET_LOG" ] && PUPPET_OPTS="${PUPPET_OPTS} --logdest=${PUPPET_LOG}"
-[ -n "$PUPPET_PORT" ] && PUPPET_OPTS="${PUPPET_OPTS} --port=${PUPPET_PORT}"
 
 # First reset status of this service
 rc_reset


### PR DESCRIPTION
…onfig values

Currently, the EL and SLES init scripts will read variables from /etc/sysconfig/puppet
and override variables set in puppet.conf or the init sctipt. This can lead to
undesired behavior, like an old sysconfig file setting variables incorrectly, causing
startup failures, etc.

This updates the sysconfig files to be more conistent with the defaults file we
ship for Debian, and updates the EL and SUSE init scripts to only use the
PUPPET_EXTRA_OPTS variable if it exists, and to ignore other settings that
are better set in puppet.conf or that should not need to be overridden at
all (like pidfile for example).