### PR TITLE
(PUP-4698) Change fqdn_rand's return type to Integer

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -4,7 +4,7 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
   "Usage: `fqdn_rand(MAX, [SEED])`. MAX is required and must be a positive
   integer; SEED is optional and may be any number or string.
 
-  Generates a random whole number greater than or equal to 0 and less than MAX,
+  Generates a random Integer number greater than or equal to 0 and less than MAX,
   combining the `$fqdn` fact and the value of SEED for repeatable randomness.
   (That is, each node will get a different random number from this function, but
   a given node's result will be the same every time unless its hostname changes.)
@@ -17,5 +17,5 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
   `fqdn_rand(30, 'expensive job 2')` will produce totally different numbers.)") do |args|
     max = args.shift.to_i
     seed = Digest::MD5.hexdigest([self['::fqdn'],args].join(':')).hex
-    Puppet::Util.deterministic_rand(seed,max)
+    Puppet::Util.deterministic_rand_int(seed,max)
 end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -454,16 +454,21 @@ module Util
   module_function :exit_on_fail
 
   def deterministic_rand(seed,max)
+    deterministic_rand_int(seed, max).to_s
+  end
+  module_function :deterministic_rand
+
+  def deterministic_rand_int(seed,max)
     if defined?(Random) == 'constant' && Random.class == Class
-      Random.new(seed).rand(max).to_s
+      Random.new(seed).rand(max)
     else
       srand(seed)
-      result = rand(max).to_s
+      result = rand(max)
       srand()
       result
     end
   end
-  module_function :deterministic_rand
+  module_function :deterministic_rand_int
 end
 end
 

--- a/spec/unit/parser/functions/fqdn_rand_spec.rb
+++ b/spec/unit/parser/functions/fqdn_rand_spec.rb
@@ -6,11 +6,11 @@ describe "the fqdn_rand function" do
   include PuppetSpec::Scope
 
   it "returns an integer" do
-    expect(fqdn_rand(3)).to satisfy {|n| n.is_a?(Integer) }
+    expect(fqdn_rand(3)).to be_an(Integer)
   end
 
   it "provides a random number strictly less than the given max" do
-    expect(fqdn_rand(3)).to satisfy {|n| n.to_i < 3 }
+    expect(fqdn_rand(3)).to satisfy {|n| n < 3 }
   end
 
   it "provides the same 'random' value on subsequent calls for the same host" do

--- a/spec/unit/parser/functions/fqdn_rand_spec.rb
+++ b/spec/unit/parser/functions/fqdn_rand_spec.rb
@@ -4,7 +4,11 @@ require 'puppet_spec/scope'
 
 describe "the fqdn_rand function" do
   include PuppetSpec::Scope
-  
+
+  it "returns an integer" do
+    expect(fqdn_rand(3)).to satisfy {|n| n.is_a?(Integer) }
+  end
+
   it "provides a random number strictly less than the given max" do
     expect(fqdn_rand(3)).to satisfy {|n| n.to_i < 3 }
   end


### PR DESCRIPTION
Before this, fqdn_rand always returned a String. That is not the best
choice for a numeric value now that the evaluator is aware of different
data types as comparissons will typically be wrong (since '2' > '19'
when compared leicographically).

This fix adds a utility method that returns an integer version while the
old utility method producing a string is retained for those that use
Puppet as an API. The function now uses the integer version of this
utility method.

A test is added that asserts that an Integer is produced.

At some point it would be beneficial to reimplement the function using
the 4.x function API as it will simply raise a generic error if given
input of the wrong type. It will also magically change a floating point
input value to integer.