### PR TITLE
(PUP-4703) Optimize copy_as_resource checks for future parser

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -430,6 +430,8 @@ class Puppet::Resource
     result.environment = environment
     result.instance_variable_set(:@rstype, resource_type)
 
+    future_parser_not_in_use = !Puppet.future_parser?(result.environment)
+
     to_hash.each do |p, v|
       if v.is_a?(Puppet::Resource)
         v = Puppet::Resource.new(v.type, v.title)
@@ -442,7 +444,7 @@ class Puppet::Resource
         end
       end
 
-      if !Puppet.future_parser?
+      if future_parser_not_in_use # !Puppet.future_parser?
         # If the value is an array with only one value, then
         # convert it to a single value.  This is largely so that
         # the database interaction doesn't have to worry about


### PR DESCRIPTION
Before this, there would be one call to Puppet.future_parser? for every
attribute of a resource. This call is expensive esp. when it is not
given an environment as an argument. Users report 20-30% of catalog
compilation time spent on this alone!

Now, the check is only performed once per resource, and then with the
environment of the resource. This is safe because all attributes of a
resource are natually also in the same environment, and the parser
setting cannot change (at least in a sane way) between attributes being
copied.