### PR TITLE
(docs) Fix formatting in some API docs

### DIFF
--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -32,6 +32,7 @@ The examples below use the POST method.
 ### Parameters
 
 Three parameters should be provided to the POST or GET:
+
 - `facts_format`: must be `pson`
 - `facts`: serialized pson of the facts hash.  One odd note: due to a long-ago misunderstanding in the code, this is
 doubly-escaped (it should just be singly-escaped).  To keep backward compatibility, the extraneous

--- a/api/docs/http_file_metadata.md
+++ b/api/docs/http_file_metadata.md
@@ -7,9 +7,9 @@ of the endpoint; the search variant has a trailing 's' so is actually `file_meta
 Although the term 'file' is used generically in the endpoint name and documentation, each returned item can be one of
 the following three types:
 
-* file
-* directory
-* symbolic link
+* File
+* Directory
+* Symbolic link
 
 The endpoint path includes a `:mount` which can be one of three types:
 
@@ -17,7 +17,8 @@ The endpoint path includes a `:mount` which can be one of three types:
 * `modules/<module>` -- a semi-magical mount point which allows access to the `files` subdirectory of `module` -- see [the puppet file serving guide](http://docs.puppetlabs.com/guides/file_serving.html#serving-module-files)
 * `plugins` -- a highly magical mount point which merges many directories together: used for plugin sync, sub-paths can not be specified, not intended for general consumption
 
-Note: pson responses in the examples below are pretty-printed for readability.
+Note: PSON responses in the examples below are pretty-printed for readability.
+
 Find
 ----
 
@@ -130,8 +131,8 @@ Accept: pson, text/pson
 
 ### Parameters
 
-* `recurse` -- should always be set to `yes`; unfortunately the default is `no` which causes renders this a Find operation
-* `ignore` -- file or directory regex to ignore; can be repeated
+* `recurse` -- should always be set to `yes`; unfortunately the default is `no`, which causes a search to behave like a find operation.
+* `ignore` -- file or directory regex to ignore; can be repeated.
 * `links` -- either `manage` (default) or `follow`.  See examples below.
 
 ### Example Response
@@ -268,68 +269,68 @@ Accept: pson, text/pson
         }
     ]
 
-#### Search ignoring 'sub*' and links = follow
+#### Search ignoring "sub*" and links = follow
 
-This example is identical to the above example, except for the different links parameter.  The result pson, then,
+This example is identical to the above example, except for the links parameter.  The resulting PSON, then,
 is identical to the above example, except for:
 
-* the 'links' field is set to "follow" rather than "manage" in all metadata objects
-* in the 'link_to_file.txt' metadata:
-    * for 'manage' the 'destination' field is the link destination; for 'follow', it's null
-    * for 'manage' the 'type' field is 'link'; for 'follow' it's 'file'
-    * for 'manage' the 'mode', 'owner' and 'group' fields are the link's values; for 'follow' the destination's values
+* the "links" field is set to "follow" rather than "manage" in all metadata objects
+* in the "link_to_file.txt" metadata:
+    * for "manage" the "destination" field is the link destination; for "follow", it's null
+    * for "manage" the "type" field is "link"; for "follow" it's "file"
+    * for "manage" the "mode", "owner" and "group" fields are the link's values; for "follow" the destination's values
 
-` `
+~~~
+GET /puppet/v3/file_metadatas/modules/example?environment=env&recurse=true&ignore=sub*&links=follow
 
-    GET /puppet/v3/file_metadatas/modules/example?environment=env&recurse=true&ignore=sub*&links=follow
+HTTP 200 OK
+Content-Type: text/pson
 
-    HTTP 200 OK
-    Content-Type: text/pson
-
-    [
-        {
-            "checksum": {
-                "type": "ctime",
-                "value": "{ctime}2013-10-01 13:15:59 -0700"
-            },
-            "destination": null,
-            "group": 20,
-            "links": "follow",
-            "mode": 493,
-            "owner": 501,
-            "path": "/etc/puppetlabs/code/modules/example/files",
-            "relative_path": ".",
-            "type": "directory"
+[
+    {
+        "checksum": {
+            "type": "ctime",
+            "value": "{ctime}2013-10-01 13:15:59 -0700"
         },
-        {
-            "checksum": {
-                "type": "md5",
-                "value": "{md5}d0a10f45491acc8743bc5a82b228f89e"
-            },
-            "destination": null,
-            "group": 20,
-            "links": "follow",
-            "mode": 420,
-            "owner": 501,
-            "path": "/etc/puppetlabs/code/modules/example/files",
-            "relative_path": "just_a_file.txt",
-            "type": "file"
+        "destination": null,
+        "group": 20,
+        "links": "follow",
+        "mode": 493,
+        "owner": 501,
+        "path": "/etc/puppetlabs/code/modules/example/files",
+        "relative_path": ".",
+        "type": "directory"
+    },
+    {
+        "checksum": {
+            "type": "md5",
+            "value": "{md5}d0a10f45491acc8743bc5a82b228f89e"
         },
-        {
-            "checksum": {
-                "type": "md5",
-                "value": "{md5}d0a10f45491acc8743bc5a82b228f89e"
-            },
-            "destination": null,
-            "group": 20,
-            "links": "follow",
-            "mode": 420,
-            "owner": 501,
-            "path": "/etc/puppetlabs/code/modules/example/files",
-            "relative_path": "link_to_file.txt",
-            "type": "file"
-        }
-    ]
+        "destination": null,
+        "group": 20,
+        "links": "follow",
+        "mode": 420,
+        "owner": 501,
+        "path": "/etc/puppetlabs/code/modules/example/files",
+        "relative_path": "just_a_file.txt",
+        "type": "file"
+    },
+    {
+        "checksum": {
+            "type": "md5",
+            "value": "{md5}d0a10f45491acc8743bc5a82b228f89e"
+        },
+        "destination": null,
+        "group": 20,
+        "links": "follow",
+        "mode": 420,
+        "owner": 501,
+        "path": "/etc/puppetlabs/code/modules/example/files",
+        "relative_path": "link_to_file.txt",
+        "type": "file"
+    }
+]
+~~~
 
 Schema
 ------

--- a/api/docs/http_node.md
+++ b/api/docs/http_node.md
@@ -13,7 +13,7 @@ Find
 
 Retrieve data for a node
 
-  GET /puppet/v3/node/:certname?environment=:environment
+    GET /puppet/v3/node/:certname?environment=:environment
 
 
 ### Supported HTTP Methods


### PR DESCRIPTION
This commit is mostly about bad Markdown formatting that can limp along in some
renderers but will break others.