### PR TITLE
(PUP-4751) Optimize & Secure safe_posix_fork

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -292,7 +292,15 @@ module Util
       $stdout.reopen(stdout)
       $stderr.reopen(stderr)
 
-      3.upto(256){|fd| IO::new(fd).close rescue nil}
+      begin
+        Dir.foreach('/proc/self/fd') do |f|
+          if f != '.' && f != '..' && f.to_i >= 3
+            IO::new(f.to_i).close rescue nil
+          end
+        end
+      rescue Errno::ENOENT # /proc/self/fd not found
+        3.upto(256){|fd| IO::new(fd).close rescue nil}
+      end
 
       block.call if block
     end


### PR DESCRIPTION
Before this, on POSIX systems, each time we execute a command, it forks a new process and this one will close inherited file descriptors by looping between 3 and 256 although there is more than 256 possible file descriptors. It's not safe and it's really slow.

Now, we try to list open file descriptors by reading "/proc/self/fd" and close the ones we don't want. This will fallback to the original method if it can't find "/proc/self/fd".