### PR TITLE
DO NOT MERGE: (PUP-4747) Change PopsBridge::Expression.to_s to return the source

### DIFF
--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -20,7 +20,8 @@ class Puppet::Parser::AST::PopsBridge
     end
 
     def to_s
-      Puppet::Pops::Model::ModelTreeDumper.new.dump(@value)
+      source_adapter = Puppet::Pops::Utils.find_closest_positioned(@value)
+      source_adapter ? source_adapter.extract_text() : nil
     end
 
     def evaluate(scope)


### PR DESCRIPTION
Before this, the PopsBridge::Expression would return a string from to_s
that was produed by the ModelTreeDumper. That format is S-expression
like and intended for AST tree debugging.

This commit changes the return to instead be the source code associated
with the expression.

There are naturally issues with this approach as 4.x accepts potentially
complex expressions as a default value expression. The receiving end of
the result must be prepared to deal with multiple lines being returned,
and text that possibly includes comments, conditional logic, etc.

The solution should be as ok as the 3.x implementation that would have
similar issues (although not supporting complex expressions).