### PR TITLE
(PUP-4747) Format resource_type arguments as source code

### DIFF
--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -23,6 +23,11 @@ class Puppet::Parser::AST::PopsBridge
       Puppet::Pops::Model::ModelTreeDumper.new.dump(@value)
     end
 
+    def source_text
+      source_adapter = Puppet::Pops::Utils.find_closest_positioned(@value)
+      source_adapter ? source_adapter.extract_text() : nil
+    end
+
     def evaluate(scope)
       object = @@evaluator.evaluate(scope, @value)
       @@evaluator.convert_to_3x(object, scope)

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -82,8 +82,10 @@ class Puppet::Resource::Type
 
     # External documentation uses "parameters" but the internal name
     # is "arguments"
-    data['parameters'] = arguments.dup unless arguments.empty?
-
+    # Dump any arguments as source
+    data['parameters'] = Hash[arguments.map do |k,v|
+                                [k, v.respond_to?(:source_text) ? v.source_text : v]
+                              end]
     data['name'] = name
 
     unless RESOURCE_KINDS_TO_EXTERNAL_NAMES.has_key?(type)


### PR DESCRIPTION
In the Puppet 3 parser, default parameter values on a serialized
resource_type object would appear to be puppet source code. This makes the
Puppet 4 parser behave roughly the same way, by retrieving the original source
code representing an argument.