### PR TITLE
(PUP-3263) Adds `architecture` parameter

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :install_options, :versionable, :virtual_packages
+  has_feature :install_options, :versionable, :virtual_packages, :architecture
 
   commands :yum => "yum", :rpm => "rpm"
 
@@ -149,6 +149,10 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
         self.debug "Downgrading package #{@resource[:name]} from version #{is[:ensure]} to #{should}"
         operation = :downgrade
       end
+    end
+
+    if @resource[:architecture]
+      wanted = "#{wanted}.#{@resource[:architecture]}"
     end
 
     # Yum on el-4 and el-5 returns exit status 0 when trying to install a package it doesn't recognize;

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -384,6 +384,10 @@ module Puppet
       desc "A read-only parameter set by the package."
     end
 
+    newproperty(:architecture) do
+      desc "The architecture version of a package."
+    end
+
     newparam(:adminfile) do
       desc "A file containing package defaults for installing packages.
 

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -250,6 +250,31 @@ describe provider_class do
     end
   end
 
+  describe 'when specifying package architecture' do
+    let(:name) { "mypackage" }
+    let(:resource) do
+      Puppet::Type.type(:package).new(
+        :name         => name,
+        :architecture => 'x86_64',
+        :provider     => 'yum'
+      )
+    end
+
+    it 'should be able to set version and detect architecture when installed' do
+      resource[:ensure] = :installed
+      provider.expects(:yum).with('-d', '0', '-e', '0', '-y', :install, "mypackage.x86_64")
+      provider.install
+    end
+
+    it 'should be able to set version and detect architecture when version given' do
+      version = '1.2'
+      resource[:ensure] = version
+      provider.stubs(:query).returns :ensure => version
+      provider.expects(:yum).with('-d', '0', '-e', '0', '-y', :install, "mypackage-1.2.x86_64")
+      provider.install
+    end
+  end
+
   describe 'when uninstalling' do
     it 'should use erase to purge' do
       provider.expects(:yum).with('-y', :erase, name)


### PR DESCRIPTION
Can specify arch wanted when installing a package.

This is extremely rough, needs some help getting it across the line :smile: 