### PR TITLE
(PUP-4753) Add ability to call 3.x and 4.x function from scope

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -927,7 +927,7 @@ class Puppet::Parser::Scope
 
   # Calls a 3.x or 4.x function by name with arguments given in an array using the 4.x calling convention
   # and returns the result.
-  # Note that it is the caller's responsability to rescue the given ArgumentError and provide location information
+  # Note that it is the caller's responsibility to rescue the given ArgumentError and provide location information
   # to aid the user find the problem. The problem is otherwise reported against the source location that
   # invoked the function that ultimately called this method.
   #

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -937,7 +937,7 @@ class Puppet::Parser::Scope
     if !Puppet.future_parser?(compiler.environment)
       return self.send("function_#{func_name}", args, &block)
     else
-      Puppet::Pops::Parser::EvaluatingParser.new.external_call(func_name, args, self, &block)
+      Puppet::Pops::Parser::EvaluatingParser.new.evaluator.external_call(func_name, args, self, &block)
     end
   end
 

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -937,7 +937,7 @@ class Puppet::Parser::Scope
     if !Puppet.future_parser?(compiler.environment)
       return self.send("function_#{func_name}", args, &block)
     else
-      Puppet::Pops::Parser::EvaluatingParser.new.evaluator.external_call(func_name, args, self, &block)
+      Puppet::Pops::Parser::EvaluatingParser.new.evaluator.external_call_function(func_name, args, self, &block)
     end
   end
 

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -925,6 +925,22 @@ class Puppet::Parser::Scope
     end
   end
 
+  # Calls a 3.x or 4.x function by name with arguments given in an array using the 4.x calling convention
+  # and returns the result.
+  # Note that it is the caller's responsability to rescue the given ArgumentError and provide location information
+  # to aid the user find the problem. The problem is otherwise reported against the source location that
+  # invoked the function that ultimately called this method.
+  #
+  # @return [Object] the result of the called function
+  # @raise ArgumentError if the function does not exist
+  def call_function(func_name, args, &block)
+    if !Puppet.future_parser?(compiler.environment)
+      return self.send("function_#{func_name}", args, &block)
+    else
+      Puppet::Pops::Parser::EvaluatingParser.new.external_call(func_name, args, self, &block)
+    end
+  end
+
   private
 
   def assert_class_and_title(type_name, title)

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -229,6 +229,37 @@ module Puppet::Pops::Evaluator::Runtime3Support
     n
   end
 
+  # Provides the ability to call a 3.x or 4.x function from the perspective of a 3.x function or ERB template.
+  # The arguments to the function must be an Array containing values compliant with the 4.x calling convention.
+  # If the targeted function is a 3.x function, the values will be transformed.
+  # @param name [String] the name of the function (without the 'function_' prefix used by scope)
+  # @param args [Array] arguments, may be empty
+  # @param scope [Object] the (runtime specific) scope where evaluation takes place
+  # @raise ArgumentError 'unknown function' if the function does not exist
+  #
+  def external_call_function(name, args, scope, &block)
+    # Call via 4x API if the function exists there
+    loaders = scope.compiler.loaders
+    # Since this is a call from non puppet code, it is not possible to relate it to a module loader
+    # It is known where the call originates by using the scope associated module - but this is the calling scope
+    # and it does not defined the visibility of functions from a ruby function's perspective. Instead,
+    # this is done from the perspective of the environment.
+    loader = loaders.private_environment_loader
+    if loader && func = loader.load(:function, name)
+      return func.call(scope, *args, &block)
+    end
+
+    # Call via 3x API if function exists there
+    raise ArgumentError, "Unknown function '#{name}'" unless Puppet::Parser::Functions.function(name)
+
+    # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.
+    # NOTE: Passing an empty string last converts nil/:undef to empty string
+    mapped_args = Puppet::Pops::Evaluator::Runtime3Converter.map_args(args, scope, '')
+    result = scope.send("function_#{name}", mapped_args, &block)
+    # Prevent non r-value functions from leaking their result (they are not written to care about this)
+    Puppet::Parser::Functions.rvalue?(name) ? result : nil
+  end
+
   def call_function(name, args, o, scope, &block)
     # Call via 4x API if the function exists there
     loaders = scope.compiler.loaders

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -32,6 +32,25 @@ describe "Two step scoping for variables" do
         end
       end
     end
+
+    describe 'handles 3.x/4.x functions' do
+      it 'can call a 3.x function via call_function' do
+        expect_the_message_to_be('yes') do <<-MANIFEST
+          $msg = inline_template('<%= scope().call_function("fqdn_rand", [30]).to_i <= 30 ? "yes" : "no" %>')
+          notify { 'something': message => $msg }
+          MANIFEST
+        end
+      end
+
+      it 'can cannot call a 4.x function via call_function' do
+        expect do 
+          catalog = compile_to_catalog(<<-MANIFEST)
+          $msg = inline_template('<%= scope().call_function("with", ["yes"]) { |x| x } %>')
+          notify { 'something': message => $msg }
+          MANIFEST
+        end.to raise_error
+      end
+    end
   end
 
   context 'using future parser' do
@@ -118,6 +137,24 @@ describe "Two step scoping for variables" do
             notify { 'something': message => inline_template("<%= @var %>"), }
           }
         MANIFEST
+      end
+    end
+
+    describe 'handles 3.x/4.x functions' do
+      it 'can call a 3.x function via call_function' do
+        expect_the_message_to_be('yes') do <<-MANIFEST
+          $msg = inline_template('<%= scope().call_function("fqdn_rand", [30]).to_i <= 30 ? "yes" : "no" %>')
+          notify { 'something': message => $msg }
+          MANIFEST
+        end
+      end
+
+      it 'it can call a 4.x function via call_function' do
+        expect_the_message_to_be('yes') do <<-MANIFEST
+          $msg = inline_template('<%= scope().call_function("with", ["yes"]) { |x| x } %>')
+          notify { 'something': message => $msg }
+          MANIFEST
+        end
       end
     end
   end


### PR DESCRIPTION
Before this it was close to impossible to correctly call a function in
an agnostic way from a 3.x function or ERB template.

This commit adds the ablity to call a function by given name, with
arguments given using 4.x semantics. It will load and call either a 4.x
function or a 3.x function. For a 3.x function it will perform argument
transformation as needed (just as if the call came from 4.x puppet
code).

Since there is no (easily obtained) information abailable about which
module the call originates from a 4.x call is done from the perpective
of the environment (thus, later when there are module private functions,
those will not be callable; but for now, this distinction does not
exist).