### PR TITLE
(maint) Remove RSpec::Matchers::Pretty usage.

### DIFF
--- a/spec/lib/matchers/include_in_order.rb
+++ b/spec/lib/matchers/include_in_order.rb
@@ -1,5 +1,4 @@
 RSpec::Matchers.define :include_in_order do |*expected|
-  include RSpec::Matchers::Pretty
 
   match do |actual|
     elements = expected.dup


### PR DESCRIPTION
The rspec-expectations gem removed `RSpec::Matchers::Pretty` in version
3.3.0.  This resulted in spec failures in CI when 3.3.0 was used.

See related commit:
https://github.com/rspec/rspec-expectations/commit/be1d897d48b8a41ef2869fefe8404e3d26b1f5fc

This fix removes the include of this module.  This may make failure
messages "not pretty" for anyone using rspec-expectations older than
3.3.0.