### PR TITLE
(PUP-4458) Refactor validation of parameter signatures

### DIFF
--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -83,22 +83,6 @@ module Puppet
       end
     end
 
-    module Parser
-      require 'puppet/pops/parser/eparser'
-      require 'puppet/pops/parser/parser_support'
-      require 'puppet/pops/parser/locator'
-      require 'puppet/pops/parser/locatable'
-      require 'puppet/pops/parser/lexer2'
-      require 'puppet/pops/parser/evaluating_parser'
-      require 'puppet/pops/parser/epp_parser'
-      require 'puppet/pops/parser/code_merger'
-    end
-
-    module Validation
-      require 'puppet/pops/validation/checker4_0'
-      require 'puppet/pops/validation/validator_factory_4_0'
-    end
-
     module Evaluator
       require 'puppet/pops/evaluator/callable_signature'
       require 'puppet/pops/evaluator/runtime3_converter'
@@ -114,6 +98,22 @@ module Puppet
         require 'puppet/pops/evaluator/collectors/catalog_collector'
         require 'puppet/pops/evaluator/collectors/exported_collector'
       end
+    end
+
+    module Parser
+      require 'puppet/pops/parser/eparser'
+      require 'puppet/pops/parser/parser_support'
+      require 'puppet/pops/parser/locator'
+      require 'puppet/pops/parser/locatable'
+      require 'puppet/pops/parser/lexer2'
+      require 'puppet/pops/parser/evaluating_parser'
+      require 'puppet/pops/parser/epp_parser'
+      require 'puppet/pops/parser/code_merger'
+    end
+
+    module Validation
+      require 'puppet/pops/validation/checker4_0'
+      require 'puppet/pops/validation/validator_factory_4_0'
     end
 
     # Subsystem for puppet functions defined in ruby.

--- a/lib/puppet/pops/types/type_asserter.rb
+++ b/lib/puppet/pops/types/type_asserter.rb
@@ -1,6 +1,7 @@
 # Utility module for type assertion
 #
-module Puppet::Pops::Types::TypeAsserter
+module Puppet::Pops::Types
+module TypeAsserter
   # Asserts that a type_to_check is assignable to required_type and raises
   # a {Puppet::ParseError} if that's not the case
   #
@@ -9,6 +10,7 @@ module Puppet::Pops::Types::TypeAsserter
   # @param type_to_check [PAnyType] Type to check against the required type
   # @return The type_to_check argument
   #
+  # @api public
   def self.assert_assignable(subject, expected_type, type_to_check)
     check_assignability(Puppet::Pops::Types::TypeCalculator.singleton, subject, expected_type, type_to_check)
     type_to_check
@@ -23,6 +25,7 @@ module Puppet::Pops::Types::TypeAsserter
   # @param nil_ok [Boolean] Can be true to allow nil value. Optional and defaults to false
   # @return The value argument
   #
+  # @api public
   def self.assert_instance_of(subject, expected_type, value, nil_ok = false)
     unless value.nil? && nil_ok
       tc = Puppet::Pops::Types::TypeCalculator.singleton
@@ -36,10 +39,11 @@ module Puppet::Pops::Types::TypeAsserter
       # Do not give all the details for inferred types - i.e. format as Integer, instead of Integer[n, n] for exact
       # value, which is just confusing. (OTOH: may need to revisit, or provide a better "type diff" output).
       #
-      actual_type = Puppet::Pops::Types::TypeCalculator.generalize(actual_type) if inferred
-      raise Puppet::Pops::Types::TypeAssertionError.new(
+      actual_type = TypeCalculator.generalize(actual_type) if inferred
+      raise TypeAssertionError.new(
         "#{subject} value has wrong type, expected #{tc.string(expected_type)}, actual #{tc.string(actual_type)}", expected_type, actual_type)
     end
   end
   private_class_method :check_assignability
+end
 end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -150,6 +150,8 @@ class Puppet::Pops::Types::TypeCalculator
     singleton.enumerable(t)
   end
 
+  # @return [TypeCalculator] the singleton instance
+  #
   # @api private
   def self.singleton
     @tc_instance ||= new

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -119,11 +119,13 @@ module Puppet::Pops::Types::TypeFactory
           s = key_type
         when Types::POptionalType
           s = key_type.optional_type
-        else
+        when Types::PStringType, Types::PEnumType
           s = key_type
+        else
+          raise ArgumentError, "Illegal Struct member key type. Expected NotUndef, Optional, String, or Enum. Got: #{key_type.class.name}"
         end
         unless (s.is_a?(Puppet::Pops::Types::PStringType) || s.is_a?(Puppet::Pops::Types::PEnumType)) && s.values.size == 1 && !s.values[0].empty?
-          raise ArgumentError, 'Unable to extract a non-empty literal string from Struct member key type' if key_type.empty?
+          raise ArgumentError, "Unable to extract a non-empty literal string from Struct member key type #{tc.string(key_type)}"
         end
       end
       Types::PStructElement.new(key_type, value_type)

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -11,8 +11,11 @@ class Puppet::Resource
   include Puppet::Util::Tagging
 
   include Enumerable
-  attr_accessor :file, :line, :catalog, :exported, :virtual, :validate_parameters, :strict
+  attr_accessor :file, :line, :catalog, :exported, :virtual, :strict
   attr_reader :type, :title
+
+  # @deprecated
+  attr_accessor :validate_parameters
 
   require 'puppet/indirector'
   extend Puppet::Indirector

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -424,74 +424,11 @@ class Puppet::Resource
   end
   private :missing_arguments
 
-  # Consult external data bindings for class parameter values which must be
-  # namespaced in the backend.
-  #
-  # Example:
-  #
-  #   class foo($port=0){ ... }
-  #
-  # We make a request to the backend for the key 'foo::port' not 'foo'
-  #
-  def lookup_external_default_for(param, scope)
-    # Only lookup parameters for host classes
-    return nil unless resource_type.type == :hostclass
-
-    name = "#{resource_type.name}::#{param}"
-    in_global = lambda { lookup_with_databinding(name, scope) }
-    in_env = lambda { lookup_in_environment(name, scope) }
-    in_module = lambda { lookup_in_module(name, scope) }
-    search(in_global, in_env, in_module)
-  end
-
-  def search(*search_functions)
-    search_functions.each {|f| x = f.call(); return x unless x.nil? }
-    nil
-  end
-
-  private :lookup_external_default_for
-
-  def lookup_with_databinding(name, scope)
-    begin
-      found = false
-      value = catch(:no_such_key) do
-        v = Puppet::DataBinding.indirection.find(
-          name,
-          :environment => scope.environment.to_s,
-          :variables => scope)
-        found = true
-        v
-      end
-      found ? value : nil
-    rescue Puppet::DataBinding::LookupError => e
-      raise Puppet::Error.new("Error from DataBinding '#{Puppet[:data_binding_terminus]}' while looking up '#{name}': #{e.message}", e)
-    end
-  end
-  private :lookup_with_databinding
-
-  def lookup_in_environment(name, scope)
-    found = false
-    value = catch(:no_such_key) do
-      v = Puppet::DataProviders.lookup_in_environment(name, Puppet::Pops::Lookup::Invocation.new(scope), nil)
-      found = true
-      v
-    end
-    found ? value : nil
-  end
-  private :lookup_in_environment
-
-  def lookup_in_module(name, scope)
-    found = false
-    value = catch(:no_such_key) do
-      v = Puppet::DataProviders.lookup_in_module(name, Puppet::Pops::Lookup::Invocation.new(scope), nil)
-      found = true
-      v
-    end
-    found ? value : nil
-  end
-  private :lookup_in_module
-
+  # @deprecated Not used by Puppet
+  # @api private
   def set_default_parameters(scope)
+    Puppet.deprecation_warning('The method Puppet::Resource.set_default_parameters is deprecated and will be removed in the next major release of Puppet.')
+
     return [] unless resource_type and resource_type.respond_to?(:arguments)
 
     unless is_a?(Puppet::Parser::Resource)
@@ -499,7 +436,9 @@ class Puppet::Resource
     end
 
     missing_arguments.collect do |param, default|
-      external_value = lookup_external_default_for(param, scope)
+      # Using 'send' since this private method moved from here to type. The caller method is deprecated
+      # and doesn't really motivate making the callee public
+      external_value = resource_type.send(:lookup_external_default_for, param, scope)
 
       if external_value.nil? && default.nil?
         next
@@ -526,7 +465,12 @@ class Puppet::Resource
   # have been provided with defaults.
   # Must be called after 'set_default_parameters'.  We can't join the methods
   # because Type#set_parameters needs specifically ordered behavior.
+  #
+  # @deprecated Not used by Puppet
+  # @api private
   def validate_complete
+    Puppet.deprecation_warning('The method Puppet::Resource.validate_complete is deprecated and will be removed in the next major release of Puppet.')
+
     return unless resource_type and resource_type.respond_to?(:arguments)
 
     resource_type.arguments.each do |param, default|

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -281,7 +281,7 @@ class Puppet::Resource::Type
     if parameters.nil?
       resource = scope.catalog.resource(resource_type, name)
       return resource unless resource.nil?
-    else
+    elsif parameters.is_a?(Hash)
       parameters = parameters.map {|k, v| Puppet::Parser::Resource::Param.new(:name => k, :value => v, :source => self)}
     end
     resource = Puppet::Parser::Resource.new(resource_type, name, :scope => scope, :source => self, :parameters => parameters)

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -659,7 +659,7 @@ describe Puppet::Parser::Compiler do
       @node.classes = klass
       klass = Puppet::Resource::Type.new(:hostclass, 'foo', :arguments => {'a' => nil, 'b' => nil})
       @compiler.topscope.known_resource_types.add klass
-      expect { @compiler.compile }.to raise_error(Puppet::ParseError, "Must pass b to Class[Foo]")
+      expect { @compiler.compile }.to raise_error(Puppet::ParseError, "Must pass 'b' to Class[Foo]")
     end
 
     it "should fail if invalid parameters are passed" do
@@ -1456,7 +1456,7 @@ describe Puppet::Parser::Compiler do
             define foo(Integer $x) { }
             foo { 'test': x =>'say friend' }
           MANIFEST
-        end.to raise_error(/type Integer, got String/)
+        end.to raise_error(/expected Integer, actual String/)
       end
 
       it 'denies undef for a non-optional type' do
@@ -1465,7 +1465,7 @@ describe Puppet::Parser::Compiler do
             define foo(Integer $x) { }
             foo { 'test': x => undef }
           MANIFEST
-        end.to raise_error(/type Integer, got Undef/)
+        end.to raise_error(/expected Integer, actual Undef/)
       end
 
       it 'denies non type compliant default argument' do
@@ -1474,7 +1474,7 @@ describe Puppet::Parser::Compiler do
             define foo(Integer $x = 'pow') { }
             foo { 'test':  }
           MANIFEST
-        end.to raise_error(/type Integer, got String/)
+        end.to raise_error(/expected Integer, actual String/)
       end
 
       it 'denies undef as the default for a non-optional type' do
@@ -1483,7 +1483,7 @@ describe Puppet::Parser::Compiler do
             define foo(Integer $x = undef) { }
             foo { 'test':  }
           MANIFEST
-        end.to raise_error(/type Integer, got Undef/)
+        end.to raise_error(/expected Integer, actual Undef/)
       end
 
       it 'accepts a Resource as a Type' do
@@ -1504,7 +1504,7 @@ describe Puppet::Parser::Compiler do
             define foo(Struct[{b => Integer, d=>String}] $a) { }
             foo{ bar: a => {b => 5, c => 'stuff'}}
           MANIFEST
-        end.to raise_error(/got Struct\[\{'b'=>Integer, 'c'=>String\}\]/)
+        end.to raise_error(/actual Struct\[\{'b'=>Integer, 'c'=>String\}\]/)
       end
     end
 
@@ -1542,7 +1542,7 @@ describe Puppet::Parser::Compiler do
             class foo(Integer $x) { }
             class { 'foo': x =>'say friend' }
           MANIFEST
-        end.to raise_error(/type Integer, got String/)
+        end.to raise_error(/expected Integer, actual String/)
       end
 
       it 'denies undef for a non-optional type' do
@@ -1551,7 +1551,7 @@ describe Puppet::Parser::Compiler do
             class foo(Integer $x) { }
             class { 'foo': x => undef }
           MANIFEST
-        end.to raise_error(/type Integer, got Undef/)
+        end.to raise_error(/expected Integer, actual Undef/)
       end
 
       it 'denies non type compliant default argument' do
@@ -1560,7 +1560,7 @@ describe Puppet::Parser::Compiler do
             class foo(Integer $x = 'pow') { }
             class { 'foo':  }
           MANIFEST
-        end.to raise_error(/type Integer, got String/)
+        end.to raise_error(/expected Integer, actual String/)
       end
 
       it 'denies undef as the default for a non-optional type' do
@@ -1569,7 +1569,7 @@ describe Puppet::Parser::Compiler do
             class foo(Integer $x = undef) { }
             class { 'foo':  }
           MANIFEST
-        end.to raise_error(/type Integer, got Undef/)
+        end.to raise_error(/expected Integer, actual Undef/)
       end
 
       it 'accepts a Resource as a Type' do

--- a/spec/integration/parser/undef_param_spec.rb
+++ b/spec/integration/parser/undef_param_spec.rb
@@ -78,7 +78,7 @@ describe "Parameter passing" do
   end
 
   it "errors when no parameter is provided and there is no default" do
-    expect_puppet_error(/^Must pass x to A\[a\].*/) do <<-MANIFEST
+    expect_puppet_error(/^Must pass 'x' to A\[a\].*/) do <<-MANIFEST
         define a($x) { notify { 'something': message => $x }}
         a {'a': }
     MANIFEST

--- a/spec/unit/appmgmt_spec.rb
+++ b/spec/unit/appmgmt_spec.rb
@@ -46,7 +46,7 @@ describe "Application instantiation" do
 
       application app {
         prod { one: host => ahost, export => Cap[cap] }
-        cons { two: consume => Cap[cap] }
+        cons { two: host => ahost, consume => Cap[cap] }
       }
 
       app { anapp:

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -633,7 +633,7 @@ describe Puppet::Parser::Compiler do
       @node.classes = klass
       klass = Puppet::Resource::Type.new(:hostclass, 'foo', :arguments => {'a' => nil, 'b' => nil})
       @compiler.topscope.known_resource_types.add klass
-      expect { @compiler.compile }.to raise_error(Puppet::ParseError, "Must pass b to Class[Foo]")
+      expect { @compiler.compile }.to raise_error(Puppet::ParseError, "Must pass 'b' to Class[Foo]")
     end
 
     it "should fail if invalid parameters are passed" do

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -103,7 +103,7 @@ describe 'function for dynamically creating resources' do
 
           create_resources('foocreateresource', {'blah'=>{}})
         MANIFEST
-      }.to raise_error(Puppet::Error, 'Must pass one to Foocreateresource[blah] on node foonode')
+      }.to raise_error(Puppet::Error, "Must pass 'one' to Foocreateresource[blah] on node foonode")
     end
 
     it 'should be able to add multiple defines' do

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -531,24 +531,6 @@ describe Puppet::Parser::Resource do
     end
   end
 
-  describe "when validating" do
-    it "should check each parameter" do
-      resource = Puppet::Parser::Resource.new :foo, "bar", :scope => @scope, :source => stub("source")
-      resource[:one] = :two
-      resource[:three] = :four
-      resource.expects(:validate_parameter).with(:one)
-      resource.expects(:validate_parameter).with(:three)
-      resource.send(:validate)
-    end
-
-    it "should raise a parse error when there's a failure" do
-      resource = Puppet::Parser::Resource.new :foo, "bar", :scope => @scope, :source => stub("source")
-      resource[:one] = :two
-      resource.expects(:validate_parameter).with(:one).raises ArgumentError
-      expect { resource.send(:validate) }.to raise_error(Puppet::ParseError)
-    end
-  end
-
   describe "when setting parameters" do
     before do
       @source = newclass "foobar"

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -105,9 +105,9 @@ describe Puppet::Parser::Resource do
       @arguments = {:scope => @scope}
     end
 
-    it "should fail unless #{name.to_s} is specified" do
+    it "should fail unless hash is specified" do
       expect {
-        Puppet::Parser::Resource.new('file', '/my/file')
+        Puppet::Parser::Resource.new('file', '/my/file', nil)
       }.to raise_error(ArgumentError, /Resources require a hash as last argument/)
     end
 


### PR DESCRIPTION
This commit unifies how parameters are validated so that instantiations
of nodes, classes, and definitions use a validatio logic that has more
in common with the validation of lambda invocations and function calls.
