### PR TITLE
(PUP-4761) Add --show-changes option to summarize changes

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -246,6 +246,7 @@ class Puppet::Configurer
   private :run_internal
 
   def send_report(report)
+    puts report.display_changes if Puppet[:show_changes]
     puts report.summary if Puppet[:summarize]
     save_last_run_summary(report)
     Puppet::Transaction::Report.indirection.save(report, nil, :environment => Puppet::Node::Environment.remote(@environment)) if Puppet[:report]

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1600,6 +1600,11 @@ EOT
         :default  => false,
         :type     => :boolean,
         :desc     => "Whether to print a transaction summary.",
+    },
+    :show_changes => {
+        :default  => false,
+        :type     => :boolean,
+        :desc     => "Whether to print the transaction changes.",
     }
   )
 


### PR DESCRIPTION
With this we can add the --changes option to puppet runs.
It will complement the --summarize output by adding changes's title and status (success, failure, ...).

This helps log parsing and human readability.