### PR TITLE
Add -H flag to svcs to strip column headers

### DIFF
--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
   end
 
   def self.instances
-   svcs.split("\n").select{|l| l !~ /^legacy_run/ }.collect do |line|
+   svcs("-H").split("\n").select{|l| l !~ /^legacy_run/ }.collect do |line|
      state,stime,fmri = line.split(/\s+/)
      status =  case state
                when /online/; :running

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -28,7 +28,7 @@ describe provider_class, :if => Puppet.features.posix? do
     end
 
     it "should get a list of services (excluding legacy)" do
-      provider_class.expects(:svcs).with().returns File.read(my_fixture('svcs.out'))
+      provider_class.expects(:svcs).with('-H').returns File.read(my_fixture('svcs.out'))
       instances = provider_class.instances.map { |p| {:name => p.get(:name), :ensure => p.get(:ensure)} }
       # we dont manage legacy
       expect(instances.size).to eq(2)


### PR DESCRIPTION
This change adds the -H flag to /usr/bin/svcs to strip out the column headers.