### PR TITLE
(PUP-4776) Make 'puppet agent arg' error instead of silently running the catalog

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -372,6 +372,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup
+    raise ArgumentError, "The puppet agent command does not take parameters" unless command_line.args.empty?
+
     setup_test if options[:test]
 
     setup_logs

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -197,6 +197,11 @@ describe Puppet::Application::Agent do
       Puppet.stubs(:settraps)
     end
 
+    it "should not run with extra arguments" do
+      @puppetd.command_line.stubs(:args).returns(%w{disable})
+      expect{@puppetd.setup}.to raise_error ArgumentError, /does not take parameters/
+    end
+
     describe "with --test" do
       it "should call setup_test" do
         @puppetd.options[:test] = true


### PR DESCRIPTION
Currently, 'puppet agent' only analyses options beginning with '--', such as '--test' and
'--disable'.  Any other words after agent are ignored.  That is different from the way that
commands like 'puppet resource' and 'puppet apply' work, mainly because those require
an argument, while 'puppet agent' does not.  This has led to, for instance, one of our new
sysadmins typing 'puppet agent disable' instead of 'puppet agent --disable' and being
terribly surprised when about 5 minutes later the server died.

This patch raises an error if someone on the CLI tries to invoke 'puppet agent' with what
has to be an invalid argument.