### PR TITLE
(PUP-4777) Allow hiera 3 as a puppet dependency

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -43,13 +43,13 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<facter>, [">= 1.7", "< 3"])
-      s.add_runtime_dependency(%q<hiera>, [">= 2.0", "< 3"])
+      s.add_runtime_dependency(%q<hiera>, [">= 2.0", "< 4"])
     else
       s.add_dependency(%q<facter>, [">= 1.7", "< 3"])
-      s.add_dependency(%q<hiera>, [">= 2.0", "< 3"])
+      s.add_dependency(%q<hiera>, [">= 2.0", "< 4"])
     end
   else
     s.add_dependency(%q<facter>, [">= 1.7", "< 3"])
-    s.add_dependency(%q<hiera>, [">= 2.0", "< 3"])
+    s.add_dependency(%q<hiera>, [">= 2.0", "< 4"])
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 
 gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
-gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 3'])
+gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 gem "rake", "10.1.1", :require => false
 
 group(:development, :test) do

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -16,7 +16,7 @@ gem_default_executables: 'puppet'
 gem_forge_project: 'puppet'
 gem_runtime_dependencies:
   facter: ['> 2.0', '< 4']
-  hiera: ['>= 2.0', '< 3']
+  hiera: ['>= 2.0', '< 4']
   json_pure:
 gem_rdoc_options:
   - --title


### PR DESCRIPTION
Previously, installing puppet from source or a gem would refuse to use
hiera 3, even though that is the combination that will be included in
puppet-agent 1.2.0.

This commit allows puppet to use hiera 3 as a dependency. Bundler uses
the Gemfile to resolve dependencies when running puppet from source. Our
gem packaging tasks use ext/project_data.yaml when building puppet as a
gem. This way if you gem install puppet, its runtime dependencies will
also be installed. The .gemspec is special, because it only used when
other code, e.g. module, has a dependency on puppet and is running
against a source checkout of puppet (as opposed to a puppet gem).