### PR TITLE
(PUP-4537) Skip rdoc tests on windows

### DIFF
--- a/spec/integration/util/rdoc/parser_spec.rb
+++ b/spec/integration/util/rdoc/parser_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/rdoc'
 
-describe "RDoc::Parser" do
+describe "RDoc::Parser", :unless => Puppet.features.microsoft_windows? do
   require 'puppet_spec/files'
   include PuppetSpec::Files
 


### PR DESCRIPTION
Appveyor has transient failures running rdoc parser tests on windows
only. Puppet uses rdoc as part of its `puppet doc` command. The
puppet-strings project has mostly, but not yet completely, replaced the
`puppet doc` command. At a future date `puppet doc` will be deprecated
and removed. This commit skips the tests on windows.