### PR TITLE
(PDOC-16) Improve strings compatibility

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/.gitignore
+++ b/lib/puppet/module_tool/skeleton/templates/generator/.gitignore
@@ -13,3 +13,6 @@ tmtags
 ## VIM
 *.swp
 tags
+
+## Yard gem
+.yardoc

--- a/lib/puppet/module_tool/skeleton/templates/generator/.yardopts
+++ b/lib/puppet/module_tool/skeleton/templates/generator/.yardopts
@@ -1,0 +1,1 @@
+--markup markdown

--- a/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
@@ -1,37 +1,44 @@
-# == Class: <%= metadata.name %>
+# Class: <%= metadata.name %>
+# ===========================
 #
 # Full description of class <%= metadata.name %> here.
 #
-# === Parameters
+# Parameters
+# ----------
 #
 # Document parameters here.
 #
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
+# * `sample parameter`
+# Explanation of what this parameter affects and what it defaults to.
+# e.g. "Specify one or more upstream ntp servers as an array."
 #
-# === Variables
+# Variables
+# ----------
 #
 # Here you should define a list of variables that this module would require.
 #
-# [*sample_variable*]
-#   Explanation of how this variable affects the function of this class and if
-#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should be avoided in favor of class parameters as
-#   of Puppet 2.6.)
+# * `sample variable`
+#  Explanation of how this variable affects the function of this class and if
+#  it has a default. e.g. "The parameter enc_ntp_servers must be set by the
+#  External Node Classifier as a comma separated list of hostnames." (Note,
+#  global variables should be avoided in favor of class parameters as
+#  of Puppet 2.6.)
 #
-# === Examples
+# Examples
+# --------
 #
-#  class { '<%= metadata.name %>':
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
-#  }
+# @example
+#    class { '<%= metadata.name %>':
+#      servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
+#    }
 #
-# === Authors
+# Authors
+# -------
 #
 # Author Name <author@domain.com>
 #
-# === Copyright
+# Copyright
+# ---------
 #
 # Copyright <%= Time.now.year %> Your name here, unless otherwise noted.
 #


### PR DESCRIPTION
This PR improves the compatibility of generated modules with the new puppet strings documentation
parser.
The .yardopts file tells yard, a code parsing library used by puppet strings, to parse documentation comments as markdown.
Yard has also been added to the Gemfile.
This PR addresses [PDOC 16](https://tickets.puppetlabs.com/browse/PDOC-16).