### PR TITLE
(PUP-4780) convert versioncmp() function to 4x API

### DIFF
--- a/lib/puppet/functions/versioncmp.rb
+++ b/lib/puppet/functions/versioncmp.rb
@@ -1,0 +1,36 @@
+require 'puppet/util/package'
+
+# Compares two version numbers.
+#
+# Prototype:
+#
+#     \$result = versioncmp(a, b)
+#
+# Where a and b are arbitrary version strings.
+#
+# This function returns:
+#
+# * `1` if version a is greater than version b
+# * `0` if the versions are equal
+# * `-1` if version a is less than version b
+#
+# @example
+#
+#     if versioncmp('2.6-1', '2.4.5') > 0 {
+#         notice('2.6-1 is > than 2.4.5')
+#     }
+#
+# This function uses the same version comparison algorithm used by Puppet's
+# `package` type.
+#
+Puppet::Functions.create_function(:versioncmp) do
+
+  dispatch :versioncmp do
+    param 'String', :a
+    param 'String', :b
+  end
+
+  def versioncmp(a, b)
+    Puppet::Util::Package.versioncmp(a, b)
+  end
+end

--- a/spec/unit/functions/versioncmp_spec.rb
+++ b/spec/unit/functions/versioncmp_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet/loaders'
+
+describe "the versioncmp function" do
+
+  before(:all) do
+    loaders = Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, []))
+    Puppet.push_context({:loaders => loaders}, "test-examples")
+  end
+
+  after(:all) do
+    Puppet::Pops::Loaders.clear
+    Puppet::pop_context()
+  end
+
+  def versioncmp(*args)
+    Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'versioncmp').call({}, *args)
+  end
+
+  let(:type_parser) { Puppet::Pops::Types::TypeParser.new }
+
+  it 'should raise an Error if there is less than 2 arguments' do
+    expect { versioncmp('a,b') }.to raise_error(/called with mis-matched arguments/)
+  end
+
+  it 'should raise an Error if there is more than 2 arguments' do
+    expect { versioncmp('a,b','foo', 'bar') }.to raise_error(/called with mis-matched arguments/)
+  end
+
+  it "should call Puppet::Util::Package.versioncmp (included in scope)" do
+    Puppet::Util::Package.expects(:versioncmp).with('1.2', '1.3').returns(-1)
+
+    expect(versioncmp('1.2', '1.3')).to eq -1
+  end
+end


### PR DESCRIPTION
The conversion is needed to work around improper string -> float conversion
that appears to be happening when calling 3x functions.