### PR TITLE
(PUP-4758) Update Rspec `raise_error` calls for Rspec 3.3

### DIFF
--- a/spec/integration/provider/package_spec.rb
+++ b/spec/integration/provider/package_spec.rb
@@ -12,7 +12,7 @@ describe "Package provider" do
         options = {:name => "nosuch#{provider.name}", :provider => provider.name}
 
         pkg = Puppet::Type.newpackage(options)
-        expect { pkg.provider.install }.to raise_error
+        expect { pkg.provider.install }.to raise_error(/must specify a package source|Could not find a valid gem|Could not locate the pip\d? command/)
       end
 
       it "should be able to get a list of existing packages" do

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -359,7 +359,7 @@ describe Puppet::Application::Apply do
         it "should raise an error if we can't find the facts" do
           Puppet::Node::Facts.indirection.expects(:find).returns(nil)
 
-          expect { @apply.main }.to raise_error
+          expect { @apply.main }.to raise_error(RuntimeError, /Could not find facts/)
         end
       end
 

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -173,7 +173,7 @@ describe Puppet::Application::Filebucket do
     describe "the command backup" do
       it "should fail if no arguments are specified" do
         @filebucket.stubs(:args).returns([])
-        expect { @filebucket.backup }.to raise_error
+        expect { @filebucket.backup }.to raise_error(RuntimeError, /You must specify a file to back up/)
       end
 
       it "should call the client backup method for each given parameter" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -147,7 +147,7 @@ describe Puppet::Application do
           # no-op
         end
       end
-    }.to raise_error
+    }.to raise_error(Puppet::Settings::ValidationError, /Invalid run mode/)
   end
 
   it "should have a run entry-point" do
@@ -468,7 +468,7 @@ describe Puppet::Application do
         ROUTES
       end
 
-      expect { @app.configure_indirector_routes }.to raise_error
+      expect { @app.configure_indirector_routes }.to raise_error(Psych::SyntaxError, /mapping values are not allowed in this context/)
     end
   end
 
@@ -564,7 +564,7 @@ describe Puppet::Application do
             raise "I can't believe it, it works!"
           end
 
-          expect { @app.handle_test2 }.to raise_error
+          expect { @app.handle_test2 }.to raise_error(RuntimeError, /I can't believe it, it works!/)
         end
 
         it "should declare the option to OptionParser" do

--- a/spec/unit/face/node_spec.rb
+++ b/spec/unit/face/node_spec.rb
@@ -47,7 +47,7 @@ describe Puppet::Face[:node, '0.0.1'] do
     end
 
     it "should not accept a call with no arguments" do
-      expect { subject.clean() }.to raise_error
+      expect { subject.clean() }.to raise_error(RuntimeError, /At least one node should be passed/)
     end
 
     it "should accept a node name" do

--- a/spec/unit/file_serving/configuration_spec.rb
+++ b/spec/unit/file_serving/configuration_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::FileServing::Configuration do
   end
 
   it "should make :new a private method" do
-    expect { Puppet::FileServing::Configuration.new }.to raise_error
+    expect { Puppet::FileServing::Configuration.new }.to raise_error(NoMethodError, /private method `new' called/)
   end
 
   it "should return the same configuration each time 'configuration' is called" do

--- a/spec/unit/graph/sequential_prioritizer_spec.rb
+++ b/spec/unit/graph/sequential_prioritizer_spec.rb
@@ -27,6 +27,6 @@ describe Puppet::Graph::SequentialPrioritizer do
   it "fails to prioritize a key contained in an unknown container" do
     expect do
       priorities.generate_priority_contained_in("unknown", "child 1")
-    end.to raise_error
+    end.to raise_error(NoMethodError, /undefined method/)
   end
 end

--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -115,7 +115,7 @@ describe Puppet::Indirector::Indirection do
   describe "when initializing" do
     # (LAK) I've no idea how to test this, really.
     it "should store a reference to itself before it consumes its options" do
-      expect { @indirection = Puppet::Indirector::Indirection.new(Object.new, :testingness, :not_valid_option) }.to raise_error
+      expect { @indirection = Puppet::Indirector::Indirection.new(Object.new, :testingness, :not_valid_option) }.to raise_error(NoMethodError, /undefined method/)
       expect(Puppet::Indirector::Indirection.instance(:testingness)).to be_instance_of(Puppet::Indirector::Indirection)
       Puppet::Indirector::Indirection.instance(:testingness).delete
     end
@@ -509,7 +509,7 @@ describe Puppet::Indirector::Indirection do
 
           @cache.expects(:save).never
           @terminus.expects(:save).raises "eh"
-          expect { @indirection.save(@instance) }.to raise_error
+          expect { @indirection.save(@instance) }.to raise_error(RuntimeError, /eh/)
         end
       end
     end

--- a/spec/unit/indirector/ssl_file_spec.rb
+++ b/spec/unit/indirector/ssl_file_spec.rb
@@ -108,7 +108,7 @@ describe Puppet::Indirector::SslFile do
        "//?/c:/foo",
       ].each do |input|
         it "should resist directory traversal attacks (#{input.inspect})" do
-          expect { @searcher.path(input) }.to raise_error
+          expect { @searcher.path(input) }.to raise_error(ArgumentError, /invalid key/)
         end
       end
 

--- a/spec/unit/indirector/yaml_spec.rb
+++ b/spec/unit/indirector/yaml_spec.rb
@@ -82,7 +82,7 @@ describe Puppet::Indirector::Yaml do
      "//?/c:/foo",
     ].each do |input|
       it "should resist directory traversal attacks (#{input.inspect})" do
-        expect { @store.path(input) }.to raise_error
+        expect { @store.path(input) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/unit/module_tool/application_spec.rb
+++ b/spec/unit/module_tool/application_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::ModuleTool::Applications::Application do
 
     bad_versions.each do |ver|
       it "should not accept version string #{ver}" do
-        expect { app.parse_filename("puppetlabs-ntp-#{ver}") }.to raise_error
+        expect { app.parse_filename("puppetlabs-ntp-#{ver}") }.to raise_error(ArgumentError, /(Invalid version format|Could not parse filename)/)
       end
     end
   end

--- a/spec/unit/module_tool/applications/builder_spec.rb
+++ b/spec/unit/module_tool/applications/builder_spec.rb
@@ -319,7 +319,7 @@ symlinkfile
       end
 
       it "give an error about symlinks" do
-        expect { builder.run }.to raise_error
+        expect { builder.run }.to raise_error(Puppet::ModuleTool::Errors::ModuleToolError, /Found symlinks/)
       end
     end
 

--- a/spec/unit/network/authstore_spec.rb
+++ b/spec/unit/network/authstore_spec.rb
@@ -180,7 +180,7 @@ describe Puppet::Network::AuthStore::Declaration do
   ].each { |invalid_ip|
     describe "when the pattern is an invalid IPv6 address such as #{invalid_ip}" do
       it "should raise an exception" do
-        expect { Puppet::Network::AuthStore::Declaration.new(:allow,invalid_ip) }.to raise_error
+        expect { Puppet::Network::AuthStore::Declaration.new(:allow,invalid_ip) }.to raise_error(Puppet::AuthStoreError, /Invalid pattern/)
       end
     end
   }

--- a/spec/unit/network/http/compression_spec.rb
+++ b/spec/unit/network/http/compression_spec.rb
@@ -173,7 +173,7 @@ describe "http compression" do
       it "should raise the error the second time" do
         @inflater.stubs(:inflate).raises(Zlib::DataError.new("not a zlib stream"))
         Zlib::Inflate.expects(:new).with.returns(@inflater)
-        expect { @adapter.uncompress("chunk") }.to raise_error
+        expect { @adapter.uncompress("chunk") }.to raise_error(Zlib::DataError, /not a zlib stream/)
       end
 
       it "should finish the stream on close" do

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -133,7 +133,7 @@ describe Puppet::Network::HTTP::Handler do
 
     it "should raise an error if the request is formatted in an unknown format" do
       handler.stubs(:content_type_header).returns "unknown format"
-      expect { handler.request_format(request) }.to raise_error
+      expect { handler.request_format(request) }.to raise_error(NameError, /undefined local variable or method/)
     end
 
     it "should still find the correct format if content type contains charset information" do

--- a/spec/unit/network/rights_spec.rb
+++ b/spec/unit/network/rights_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Network::Rights do
   end
 
   it "should throw an error if type can't be determined" do
-    expect { @right.newright("name") }.to raise_error
+    expect { @right.newright("name") }.to raise_error(ArgumentError, /Unknown right type/)
   end
 
   describe "when creating new path ACLs" do
@@ -40,7 +40,7 @@ describe Puppet::Network::Rights do
     end
 
     it "should throw an error if the acl uri path is not absolute" do
-      expect { @right.newright("name")}.to raise_error
+      expect { @right.newright("name")}.to raise_error(ArgumentError, /Unknown right type/)
     end
 
     it "should create a new ACL with the correct path" do
@@ -351,7 +351,7 @@ describe Puppet::Network::Rights do
     it "should raise an error if the method is already filtered" do
       @acl.restrict_method(:save)
 
-      expect { @acl.restrict_method(:save) }.to raise_error
+      expect { @acl.restrict_method(:save) }.to raise_error(ArgumentError, /'save' is already in the '\/path'/)
     end
 
     it "should allow setting an environment filters" do

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -93,7 +93,7 @@ describe Puppet::Parser::AST::HostName do
   end
 
   it "should raise an error if hostname is not valid" do
-    expect { Puppet::Parser::AST::HostName.new( :value => "not a hostname!" ) }.to raise_error
+    expect { Puppet::Parser::AST::HostName.new( :value => "not a hostname!" ) }.to raise_error(Puppet::DevError, /'not a hostname!' is not a valid hostname/)
   end
 
   it "should not raise an error if hostname is a regex" do

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -230,7 +230,7 @@ describe Puppet::Property do
     it "should fail if the value is not a defined value or alias and does not match a regex" do
       subclass.newvalue(:foo)
 
-      expect { property.should = "bar" }.to raise_error
+      expect { property.should = "bar" }.to raise_error(Puppet::Error, /Invalid value "bar"./)
     end
 
     it "should succeeed if the value is one of the defined values" do

--- a/spec/unit/provider/ssh_authorized_key/parsed_spec.rb
+++ b/spec/unit/provider/ssh_authorized_key/parsed_spec.rb
@@ -261,7 +261,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
         @resource = Puppet::Type.type(:ssh_authorized_key).new(:name => "foo", :target => "/tmp/.ssh_dir/place_to_put_authorized_keys")
         @provider = provider_class.new(@resource)
 
-        expect { @provider.flush }.to raise_error
+        expect { @provider.flush }.to raise_error(Puppet::Error, /Cannot write SSH authorized keys without user/)
       end
     end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -428,11 +428,11 @@ describe Puppet::Resource do
     end
 
     it "should fail if invalid parameters are used" do
-      expect { Puppet::Resource.new("file", "/path", :strict => true, :parameters => {:nosuchparam => "bar"}) }.to raise_error
+      expect { Puppet::Resource.new("file", "/path", :strict => true, :parameters => {:nosuchparam => "bar"}) }.to raise_error(ArgumentError, /Invalid parameter/)
     end
 
     it "should fail if the resource type cannot be resolved" do
-      expect { Puppet::Resource.new("nosuchtype", "/path", :strict => true) }.to raise_error
+      expect { Puppet::Resource.new("nosuchtype", "/path", :strict => true) }.to raise_error(ArgumentError, /Invalid resource type/)
     end
   end
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -44,7 +44,7 @@ describe Puppet::Settings do
     it "should not allow specification of default values associated with a section as an array" do
       expect {
         @settings.define_settings(:section, :myvalue => ["defaultval", "my description"])
-      }.to raise_error
+      }.to raise_error(ArgumentError, /setting definition for 'myvalue' is not a hash!/)
     end
 
     it "should not allow duplicate parameter specifications" do

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -777,7 +777,7 @@ describe Puppet::SSL::CertificateAuthority do
       it "should raise an error if the certificate or CSR cannot be found" do
         Puppet::SSL::Certificate.indirection.expects(:find).with("myhost").returns nil
         Puppet::SSL::CertificateRequest.indirection.expects(:find).with("myhost").returns nil
-        expect { @ca.fingerprint("myhost") }.to raise_error
+        expect { @ca.fingerprint("myhost") }.to raise_error(ArgumentError, /Could not find a certificate/)
       end
 
       it "should try to find a CSR if no certificate can be found" do
@@ -863,8 +863,10 @@ describe Puppet::SSL::CertificateAuthority do
         @cert.expects(:content).returns "mycert"
 
         @store.expects(:verify).with("mycert").returns false
+        @store.expects(:error)
+        @store.expects(:error_string)
 
-        expect { @ca.verify("me") }.to raise_error
+        expect { @ca.verify("me") }.to raise_error(Puppet::SSL::CertificateAuthority::CertificateVerificationError)
       end
 
       describe "certificate_is_alive?" do
@@ -963,7 +965,7 @@ describe Puppet::SSL::CertificateAuthority do
         @ca.inventory.expects(:serials).with("host").returns []
 
         @ca.crl.expects(:revoke).never
-        expect { @ca.revoke('host') }.to raise_error
+        expect { @ca.revoke('host') }.to raise_error(ArgumentError, /Could not find a serial number for host/)
       end
 
       context "revocation by serial number (#16798)" do

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -422,7 +422,7 @@ describe Puppet::SSL::Host do
       @key.stubs(:generate)
       Puppet::SSL::Key.indirection.expects(:save).raises "eh"
 
-      expect { @host.generate_key }.to raise_error
+      expect { @host.generate_key }.to raise_error(RuntimeError)
       expect(@host.key).to be_nil
     end
 
@@ -496,7 +496,7 @@ describe Puppet::SSL::Host do
       Puppet::SSL::CertificateRequest.indirection.expects(:prepare).returns(terminus)
       terminus.expects(:save).with { |req| req.instance == @request && req.key == "myname" }.raises "eh"
 
-      expect { @host.generate_certificate_request }.to raise_error
+      expect { @host.generate_certificate_request }.to raise_error(RuntimeError)
 
       expect(@host.instance_eval { @certificate_request }).to be_nil
     end

--- a/spec/unit/type/host_spec.rb
+++ b/spec/unit/type/host_spec.rb
@@ -68,15 +68,15 @@ describe host do
     end
 
     it "should not accept malformed IPv4 addresses like 192.168.0.300" do
-      expect { @class.new(:name => "foo", :ip => '192.168.0.300') }.to raise_error
+      expect { @class.new(:name => "foo", :ip => '192.168.0.300') }.to raise_error(Puppet::ResourceError, /Parameter ip failed/)
     end
 
     it "should reject over-long IPv4 addresses" do
-      expect { @class.new(:name => "foo", :ip => '10.10.10.10.10') }.to raise_error
+      expect { @class.new(:name => "foo", :ip => '10.10.10.10.10') }.to raise_error(Puppet::ResourceError, /Parameter ip failed/)
     end
 
     it "should not accept malformed IP addresses like 2001:0dg8:85a3:08d3:1319:8a2e:0370:7344" do
-      expect { @class.new(:name => "foo", :ip => '2001:0dg8:85a3:08d3:1319:8a2e:0370:7344') }.to raise_error
+      expect { @class.new(:name => "foo", :ip => '2001:0dg8:85a3:08d3:1319:8a2e:0370:7344') }.to raise_error(Puppet::ResourceError, /Parameter ip failed/)
     end
 
     # Assorted, annotated IPv6 passes.
@@ -598,7 +598,7 @@ describe host do
      "::2222:3333:4444:5555:6666:7777:8888:",
     ].each do |ip|
       it "should reject #{ip.inspect} as an IPv6 address" do
-        expect { @class.new(:name => "foo", :ip => ip) }.to raise_error
+        expect { @class.new(:name => "foo", :ip => ip) }.to raise_error(Puppet::ResourceError, /Parameter ip failed/)
       end
     end
 

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -66,7 +66,7 @@ describe tidy do
       end
 
       it "should not allow arbitrary values" do
-        expect { @tidy[:recurse] = "whatever" }.to raise_error
+        expect { @tidy[:recurse] = "whatever" }.to raise_error(Puppet::ResourceError, /Parameter recurse failed/)
       end
     end
 
@@ -76,13 +76,13 @@ describe tidy do
       end
 
       it "should object if matches is given with recurse is not specified" do
-        expect { @tidy[:matches] = '*.doh' }.to raise_error
+        expect { @tidy[:matches] = '*.doh' }.to raise_error(Puppet::ResourceError, /Parameter matches failed/)
       end
       it "should object if matches is given and recurse is 0" do
-        expect { @tidy[:recurse] = 0; @tidy[:matches] = '*.doh' }.to raise_error
+        expect { @tidy[:recurse] = 0; @tidy[:matches] = '*.doh' }.to raise_error(Puppet::ResourceError, /Parameter matches failed/)
       end
       it "should object if matches is given and recurse is false" do
-        expect { @tidy[:recurse] = false; @tidy[:matches] = '*.doh' }.to raise_error
+        expect { @tidy[:recurse] = false; @tidy[:matches] = '*.doh' }.to raise_error(Puppet::ResourceError, /Parameter matches failed/)
       end
       it "should not object if matches is given and recurse is > 0" do
         expect { @tidy[:recurse] = 1; @tidy[:matches] = '*.doh' }.not_to raise_error

--- a/spec/unit/type/vlan_spec.rb
+++ b/spec/unit/type/vlan_spec.rb
@@ -38,7 +38,7 @@ describe Puppet::Type.type(:vlan) do
     end
 
     it "should fail if vlan name is not a number" do
-      expect { Puppet::Type.type(:vlan).new(:name => "notanumber", :ensure => :present) }.to raise_error
+      expect { Puppet::Type.type(:vlan).new(:name => "notanumber", :ensure => :present) }.to raise_error(Puppet::ResourceError, /Parameter name failed on Vlan/)
     end
   end
 end

--- a/spec/unit/util/ldap/generator_spec.rb
+++ b/spec/unit/util/ldap/generator_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::Util::Ldap::Generator do
   end
 
   it "should require a parameter name at initialization" do
-    expect { Puppet::Util::Ldap::Generator.new }.to raise_error
+    expect { Puppet::Util::Ldap::Generator.new }.to raise_error(ArgumentError, /wrong number of arguments/)
   end
 
   it "should always return its name as a string" do

--- a/spec/unit/util/network_device/cisco/device_spec.rb
+++ b/spec/unit/util/network_device/cisco/device_spec.rb
@@ -133,7 +133,7 @@ describe Puppet::Util::NetworkDevice::Cisco::Device do
     describe "when entering enable password" do
       it "should raise an error if no enable password has been set" do
         @cisco.enable_password = nil
-        expect{ @cisco.enable }.to raise_error
+        expect{ @cisco.enable }.to raise_error(RuntimeError, /Can't issue "enable" to enter privileged/)
       end
 
       it "should send the enable command and expect an enable prompt" do

--- a/spec/unit/util/network_device/transport/ssh_spec.rb
+++ b/spec/unit/util/network_device/transport/ssh_spec.rb
@@ -65,7 +65,7 @@ describe Puppet::Util::NetworkDevice::Transport::Ssh, :if => Puppet.features.ssh
 
     it "should raise an error if shell channel creation fails" do
       @channel.expects(:send_channel_request).with("shell").yields(@channel, false)
-      expect { @transport.connect }.to raise_error
+      expect { @transport.connect }.to raise_error(RuntimeError, /failed to open ssh shell channel/)
     end
 
     it "should register an on_data and on_extended_data callback" do

--- a/spec/unit/util/network_device_spec.rb
+++ b/spec/unit/util/network_device_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Util::NetworkDevice do
 
     it "should raise an error if the remote device instance can't be created" do
       Puppet::Util::NetworkDevice.stubs(:require).raises("error")
-      expect { Puppet::Util::NetworkDevice.init(@device) }.to raise_error
+      expect { Puppet::Util::NetworkDevice.init(@device) }.to raise_error(RuntimeError, /Can't load test for name/)
     end
 
     it "should let caller to access the singleton device" do

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -188,7 +188,7 @@ describe Puppet::Util::Storage do
       Dir.mkdir(Puppet[:statefile])
       Puppet::Util::Storage.cache(:yayness)
 
-      expect { Puppet::Util::Storage.store }.to raise_error
+      expect { Puppet::Util::Storage.store }.to raise_error(Errno::EISDIR, /Is a directory/)
 
       Dir.rmdir(Puppet[:statefile])
     end


### PR DESCRIPTION
In Rspec 3.3, any calls to `raise_error` without arguments
are met with loud warnings during test runs. This commit updates
every such call to include the expected exception type, and
expected exception output in most cases.