### PR TITLE
(PUP-4781) filemode retrieved by static_compiler should be stringified

### DIFF
--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -91,9 +91,10 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
   # @param resource [Puppet::Resource] The resource to add the metadata to
   # @param metadata [Puppet::FileServing::Metadata] The metadata of the given fileserver based file
   def replace_metadata(request, resource, metadata)
-    [:mode, :owner, :group].each do |param|
-      resource[param] ||= metadata.send(param)
+    [:owner, :group].each do |param|
+      resource[param] ||= metadata.send(param).to_s
     end
+    resource[:mode] ||= metadata.send(:mode).to_s(8)
 
     resource[:ensure] = metadata.ftype
     if metadata.ftype == "file"


### PR DESCRIPTION
When a file resource is declared without an explicit mode, the mode
retrieved from the metadata by the static_compiler catalog terminus is
not stringified, resulting in file resources with integer file modes in
the resultant catalog and a depreciation warning such as:

Warning: Non-string values for the file mode property are deprecated. It
must be a string, either a symbolic mode like 'o+w,a+r' or an octal
representation like '0644' or '755'.
(at /usr/lib/ruby/vendor_ruby/puppet/type/file/mode.rb:69:in `block (2
levels) in <module:Puppet>')