### PR TITLE
(PUP-4770) Revert "(maint) Fix debug and error output"

### DIFF
--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -234,10 +234,10 @@ Puppet::Type.type(:zone).provide(:solaris) do
           end
           current[$1.intern] = $2
         else
-          Puppet.err "Ignoring '#{line}'"
+          err "Ignoring '#{line}'"
         end
       else
-        Puppet.debug "Ignoring zone output '#{line}'"
+        debug "Ignoring zone output '#{line}'"
       end
     end
 

--- a/spec/unit/provider/zone/solaris_spec.rb
+++ b/spec/unit/provider/zone/solaris_spec.rb
@@ -149,6 +149,25 @@ net:
         })
       end
     end
+    describe "with an invalid or unrecognized config" do
+      it "should produce an error message with provider context when given an invalid config" do
+        erroneous_zone_info =<<-EOF
+          physical: net1'
+        EOF
+
+        provider.expects(:zonecfg).with(:info).returns(erroneous_zone_info)
+        provider.expects('err').with("Ignoring '          physical: net1''")
+        provider.getconfig
+      end
+
+
+      it "should produce a debugging message with provider context when given an unrecognized config" do
+        unrecognized_zone_info = "dummy"
+        provider.expects(:zonecfg).with(:info).returns(unrecognized_zone_info)
+        provider.expects('debug').with("Ignoring zone output 'dummy'")
+        provider.getconfig
+      end
+    end
   end
   context "#flush" do
     it "should correctly execute pending commands" do


### PR DESCRIPTION
This reverts commit 1764674bea168a9e6619ddcbc4e698eb236742f8.
Originally, this commit changed the Solaris Zone provider's debug
and error messages to use the global utilities, which means that
they aren't prefixed with the provider context. This was done to
circumvent PUP-3088, which is now fixed.