### PR TITLE
(maint) Fix failing test caused by databinding being in effect

### DIFF
--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -16,6 +16,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
   include PuppetSpec::Scope
   before(:each) do
     Puppet[:strict_variables] = true
+    Puppet[:data_binding_terminus] = 'none'
 
     # Tests needs a known configuration of node/scope/compiler since it parses and evaluates
     # snippets as the compiler will evaluate them, butwithout the overhead of compiling a complete


### PR DESCRIPTION
The evaluator spec tests started failing when Hiera 3.0.1 was brought
in. This was unexpected as the tests does not rely on data binding being
in effect. Instead it is running with string variables to ensure that no
unknown variables are used in the tests. At the same time, tests had not
made the now required variables $environment and $trusted available.

The fix is to run these tests without databinding.