### PR TITLE
Revert "(PUP-4775) Make Puppet::Node serialize env as a string in YAML"

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -9,9 +9,6 @@ class Puppet::Node
   # the node sources.
   extend Puppet::Indirector
 
-  # Asymmetric serialization/deserialization required in this class via to/from datahash
-  include Puppet::Util::PsychSupport
-
   # Use the node source as the indirection terminus.
   indirects :node, :terminus_setting => :node_terminus, :doc => "Where to find node information.
     A node is composed of its name, its facts, and its environment."
@@ -21,18 +18,13 @@ class Puppet::Node
 
   attr_reader :server_facts
 
-  def initialize_from_hash(data)
-    @name = data['name']
-    @classes = data['classes']
-    @parameters = data['parameters']
-    @environment_name = data['environment']
-  end
-
   def self.from_data_hash(data)
     raise ArgumentError, "No name provided in serialized data" unless name = data['name']
 
     node = new(name)
-    node.initialize_from_hash(data)
+    node.classes = data['classes']
+    node.parameters = data['parameters']
+    node.environment_name = data['environment']
     node
   end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -88,21 +88,6 @@ describe Puppet::Node do
     end
   end
 
-  describe "when serializing using yaml" do
-    before do
-      @node = Puppet::Node.new("mynode")
-    end
-
-    it "a node can roundtrip" do
-      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
-    end
-
-    it "limits the serialization of environment to be just the name" do
-      # it is something like 138 when serializing everything in a default environment
-      expect(@node.to_yaml.size).to be < 70
-    end
-  end
-
   describe "when converting to json" do
     before do
       @node = Puppet::Node.new("mynode")


### PR DESCRIPTION
Reverts puppetlabs/puppet#4051