### PR TITLE
(PUP-4775) Make Puppet::Node serialize env as a string in YAML

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -9,6 +9,9 @@ class Puppet::Node
   # the node sources.
   extend Puppet::Indirector
 
+  # Asymmetric serialization/deserialization required in this class via to/from datahash
+  include Puppet::Util::PsychSupport
+
   # Use the node source as the indirection terminus.
   indirects :node, :terminus_setting => :node_terminus, :doc => "Where to find node information.
     A node is composed of its name, its facts, and its environment."
@@ -18,13 +21,18 @@ class Puppet::Node
 
   attr_reader :server_facts
 
+  def initialize_from_hash(data)
+    @name = data['name']
+    @classes = data['classes']
+    @parameters = data['parameters']
+    @environment_name = data['environment']
+  end
+
   def self.from_data_hash(data)
     raise ArgumentError, "No name provided in serialized data" unless name = data['name']
 
     node = new(name)
-    node.classes = data['classes']
-    node.parameters = data['parameters']
-    node.environment_name = data['environment']
+    node.initialize_from_hash(data)
     node
   end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -88,6 +88,21 @@ describe Puppet::Node do
     end
   end
 
+  describe "when serializing using yaml" do
+    before do
+      @node = Puppet::Node.new("mynode")
+    end
+
+    it "a node can roundtrip" do
+      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
+    end
+
+    it "limits the serialization of environment to be just the name" do
+      # it is something like 138 when serializing everything in a default environment
+      expect(@node.to_yaml.size).to be < 70
+    end
+  end
+
   describe "when converting to json" do
     before do
       @node = Puppet::Node.new("mynode")


### PR DESCRIPTION
Before this, a Puppet::Node would serialize to YAML in such a way
that all of its instance variables were serialized. This caused
everything in a compelte Environment to be serialized (everything
loaded and evaluated), which in turn can cause OOM, or OOStack errors.

The cause of the problem is that Puppet::Node did not correctly
include Puppet::Util::PsyckSupport which handles the Yaml serialization
API and turns them into calls: to_data_hash, and initialize_from_hash.

The older way of using 'to_yaml' (one such implementation is found in
Environment itself) never gets called when it is not at the root of the
serialization.

This commit adds the missing include and refactors the initialization
from a hash to use the correct API. It also keeps the older way of a
class method from_data_hash, since it is not known if there are any
usage of this in modules implementing indirectors/caches. (It now
delegates to initialize_from_hash to keep the implementation DRY).