### PR TITLE
(PUP-4787) Initialize @vars of Puppet:Node with expected defaults

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -22,15 +22,13 @@ class Puppet::Node
   attr_reader :server_facts
 
   def initialize_from_hash(data)
-    @name = data['name']
-    @classes = data['classes'] || []
+    @name       = data['name']       || (raise ArgumentError, "No name provided in serialized data")
+    @classes    = data['classes']    || []
     @parameters = data['parameters'] || {}
     @environment_name = data['environment']
   end
 
   def self.from_data_hash(data)
-    raise ArgumentError, "No name provided in serialized data" unless name = data['name']
-
     node = new(name)
     node.initialize_from_hash(data)
     node

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -23,8 +23,8 @@ class Puppet::Node
 
   def initialize_from_hash(data)
     @name = data['name']
-    @classes = data['classes']
-    @parameters = data['parameters']
+    @classes = data['classes'] || []
+    @parameters = data['parameters'] || {}
     @environment_name = data['environment']
   end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -104,12 +104,13 @@ describe Puppet::Node do
   end
 
   describe "when serializing using yaml and values classes and parameters are missing in deserialized hash" do
-    before do
+    it "a node can roundtrip" do
       @node = Puppet::Node.from_data_hash({'name' => "mynode"})
+      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
     end
 
-    it "a node can roundtrip" do
-      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
+    it "errors if name is nil" do
+      expect { Puppet::Node.from_data_hash({ })}.to raise_error(ArgumentError, /No name provided in serialized data/)
     end
 
   end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -103,6 +103,17 @@ describe Puppet::Node do
     end
   end
 
+  describe "when serializing using yaml and values classes and parameters are missing in deserialized hash" do
+    before do
+      @node = Puppet::Node.from_data_hash({'name' => "mynode"})
+    end
+
+    it "a node can roundtrip" do
+      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
+    end
+
+  end
+
   describe "when converting to json" do
     before do
       @node = Puppet::Node.new("mynode")


### PR DESCRIPTION
Before this, (introduced in PUP-4775 where the serialization
was changed to use Psych support for asymetric serialization), two of
Puppet::Node's instance varaibles (@classes, and @parameters) where
initialized to nil on deserialization. When again serializing a check
was made if these where empty? (which fails).

This was caught by a roundtripping acceptance test where a
yaml-serialized node was turned into json via serialization.

The fix was to initialize to [] and {} respectively in the
initialize_from_hash method.

This also adds a unit test for a roundtrip serialization where classes
and parameters are not included in the serialized data.