### PR TITLE
(PUP-4789) Make hiera_include function call include in calling scope

### DIFF
--- a/lib/hiera/puppet_function.rb
+++ b/lib/hiera/puppet_function.rb
@@ -43,13 +43,13 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
   end
 
   def hiera_no_default(scope, key)
-    post_lookup(key, lookup(scope, key, nil, nil))
+    post_lookup(scope, key, lookup(scope, key, nil, nil))
   end
 
   def hiera_with_default(scope, key, default, override = nil)
     undefined = (@@undefined_value ||= Object.new)
     result = lookup(scope, key, undefined, override)
-    post_lookup(key, result.equal?(undefined) ? default : result)
+    post_lookup(scope, key, result.equal?(undefined) ? default : result)
   end
 
   def hiera_block1(scope, key, &default_block)
@@ -63,20 +63,20 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
   def common(scope, key, override, default_block)
     undefined = (@@undefined_value ||= Object.new)
     result = lookup(scope, key, undefined, override)
-    post_lookup(key, result.equal?(undefined) ? default_block.call(key) : result)
+    post_lookup(scope, key, result.equal?(undefined) ? default_block.call(key) : result)
   end
 
   private :common
 
   def lookup(scope, key, default, override)
-    HieraPuppet.lookup(key, default,scope, override, merge_type)
+    HieraPuppet.lookup(key, default, scope, override, merge_type)
   end
 
   def merge_type
     :priority
   end
 
-  def post_lookup(key, result)
+  def post_lookup(scope, key, result)
     result
   end
 end

--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -43,8 +43,8 @@ Puppet::Functions.create_function(:hiera_include, Hiera::PuppetFunction) do
     :array
   end
 
-  def post_lookup(key, value)
+  def post_lookup(scope, key, value)
     raise Puppet::ParseError, "Could not find data item #{key}" if value.nil?
-    call_function('include', value) unless value.empty?
+    call_function_with_scope(scope, 'include', value) unless value.empty?
   end
 end

--- a/spec/unit/functions/hiera_spec.rb
+++ b/spec/unit/functions/hiera_spec.rb
@@ -112,7 +112,7 @@ describe 'when calling' do
 
     it 'should use the array resolution_type' do
       Hiera.any_instance.expects(:lookup).with { |*args| args[4].should be(:array) }.returns(%w[foo bar baz])
-      hiera_include.expects(:call_function).with('include', %w[foo bar baz])
+      hiera_include.expects(:call_function_with_scope).with(scope, 'include', %w[foo bar baz])
       hiera_include.call(scope, 'key', {'key' => 'foo_result'})
     end
 
@@ -122,7 +122,7 @@ describe 'when calling' do
     end
 
     it 'should use default block' do
-      hiera_include.expects(:call_function).with('include', %w[key foo])
+      hiera_include.expects(:call_function_with_scope).with(scope,'include', %w[key foo])
       hiera_include.call(scope, 'foo') { |k| ['key', k] }
     end
   end


### PR DESCRIPTION
Before this, the hiera_include function would call the include function
with its closure scope instead of the calling scope. This caused the
include function to not understand in which class the include was made,
and variable scoping would be wrong - not seeing variables in node
scope.

The hiera 4.x functions already received the calling scope, but did not
pass it on to the post processing method, that in hiera_include's case
performs the call to the include function.