### PR TITLE
Some of the user attributes in Aix could be UPPERCASE 

### DIFF
--- a/lib/puppet/provider/aixobject.rb
+++ b/lib/puppet/provider/aixobject.rb
@@ -196,7 +196,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
     end
 
     attrs.each { |val|
-      key = key_list.shift.downcase.to_sym
+      key = key_list.shift.to_sym
       properties = self.load_attribute(key, val, mapping, properties)
     }
     properties.empty? ? nil : properties


### PR DESCRIPTION
and they should maintain the original casing. 

We where experiencing a strange behavior with some users using Kerberos authentication, this implies setting the "SYSTEM" attribute to a value of KRB5Afiles.

In hiera this was the (redacted) definition of one such users:

```yaml
  xxxxx:
    ensure: present
    comment: XXXXXX
    gid: 'xxxxx'
    groups:
    - ssh_grp
    managehome: 'true'
    attributes:
    - SYSTEM=KRB5Afiles
    - registry=KRB5Afiles
    - auth_domain=DOMAIN.AD
    home: "%{::default_home}/xxxxx"
    shell: "%{::default_shell}"
    uid: 'xxxxx'
```
And this is the (redacted) output from "lsuser -c xxxxx":
```bash
#name:id:pgrp:groups:home:shell:gecos:login:su:rlogin:daemon:admin:sugroups:tpath:ttys:expires:auth1:auth2:umask:registry:SYSTEM:loginretries:pwdwarntime:account_locked:minage:maxage:maxexpired:minalpha:minother:mindiff:maxrepeats:minlen:histexpire:histsize:auth_domain:fsize:cpu:data:stack:core:rss:nofiles:stack_hard:time_last_login:tty_last_login:host_last_login:unsuccessful_login_count
xxxxx:xxxxx:adm_nix:adm_nix,ssh_grp:/home/xxxxx:/usr/bin/bash:XXXXX:true:true:true:true:false:ALL:nosak:ALL:0:SYSTEM:NONE:22:KRB5Afiles:KRB5Afiles:0:0:false:0:0:-1:0:0:0:8:0:0:0:DOMAIN.AD:-1:-1:-1:-1:-1:-1:-1:-1:1435654795:/dev/pts/4:10.X.X.X:0
```

Running puppet resulted in the users always been updated, at every run, because the "SYSTEM" (UPCASE) field from lsuser was converted to a ":system"  (downcase) property. This caused a mismatch between the expected attribute keys and what was parsed from lsuser output, causing the provider to think the user was missing one of the managed attributes at each run.