### PR TITLE
(maint) Constrain ffi to less than 1.9.9

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -28,7 +28,7 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       # Pinning versions that require native extensions
-      ffi: '~> 1.9.6'
+      ffi: '< 1.9.9'
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.2'
       win32-process: '~> 0.7.4'
@@ -37,7 +37,7 @@ gem_platform_dependencies:
       minitar: '~> 0.5.4'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.6'
+      ffi: '< 1.9.9'
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.2'
       win32-process: '~> 0.7.4'


### PR DESCRIPTION
FFI gem 1.9.9 causes ruby to segfault on windows[1]. This is causing
Windows PRs on appveyor to fail, but not in our internal CI, because we
use our rubygems mirror.

This commit is a temporary measure to allow appveyor testing to pass.
Once the upstream issue is resolved, we can remove the constraint.

[1] https://github.com/ffi/ffi/issues/440