### PR TITLE
(PUP-4814) Use ENV variables in the path of scheduled tasks folder.

### DIFF
--- a/lib/puppet/util/windows/taskscheduler.rb
+++ b/lib/puppet/util/windows/taskscheduler.rb
@@ -809,7 +809,7 @@ module Win32
     # Returns whether or not the scheduled task exists.
     def exists?(job_name)
       bool = false
-      Dir.foreach('C:/Windows/Tasks'){ |file|
+      Dir.foreach("#{ENV['SystemRoot']}/Tasks"){ |file|
         if File.basename(file, '.job') == job_name
           bool = true
           break

--- a/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -600,6 +600,16 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
 
       expect(resource.provider.exists?).to eq(true)
     end
+
+    it "uses SystemRoot in the path of Task folder" do
+      Win32::TaskScheduler.unstub(:new)
+      exists_test_task = Win32::TaskScheduler.new
+      Dir.stubs(:foreach).with('D:/WinNT/Tasks').returns([])
+
+      Puppet::Util.withenv('SystemRoot' => 'D:/WinNT') do
+        exists_test_task.exists?('Test Task')
+      end
+    end
   end
 
   describe '#clear_task' do


### PR DESCRIPTION
This might be a rare case, but fixing it could improve the code actually.

If a Windows Server 2003 system is upgraded from Windows Server 2000 or NT, the default `%SYSTEMROOT%` or `%WINDIR%` is `C:\WINNT` rather than `C:\Windows`. This will cause failure of `scheduled_task` resource, because [`taskscheduler.rb`](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/util/windows/taskscheduler.rb#L812) hardcoded the path of scheduled tasks as `C:\Windows\Tasks` when testing if a job exists.

```
Error: /Stage[main]/test/Scheduled_task[foo]: Could not evaluate: No such file or directory @ dir_initialize - C:/Windows/Tasks
```

I don't think it's a good way :

- The windows directory doesn't have to be `C:\Windows`
- The system drive doesn't have to be `C:`

It's better to use `"#{ENV['windir']}/Tasks"` here.