### PR TITLE
(PDOC-16) Improve compatibility of skeleton module with puppet strings

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/.gitignore
+++ b/lib/puppet/module_tool/skeleton/templates/generator/.gitignore
@@ -13,3 +13,6 @@ tmtags
 ## VIM
 *.swp
 tags
+
+## Yard gem
+.yardoc

--- a/lib/puppet/module_tool/skeleton/templates/generator/.yardopts
+++ b/lib/puppet/module_tool/skeleton/templates/generator/.yardopts
@@ -1,0 +1,1 @@
+--markup markdown

--- a/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/manifests/init.pp.erb
@@ -1,37 +1,44 @@
-# == Class: <%= metadata.name %>
+# Class: <%= metadata.name %>
+# ===========================
 #
 # Full description of class <%= metadata.name %> here.
 #
-# === Parameters
+# Parameters
+# ----------
 #
 # Document parameters here.
 #
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
+# * `sample parameter`
+# Explanation of what this parameter affects and what it defaults to.
+# e.g. "Specify one or more upstream ntp servers as an array."
 #
-# === Variables
+# Variables
+# ----------
 #
 # Here you should define a list of variables that this module would require.
 #
-# [*sample_variable*]
-#   Explanation of how this variable affects the function of this class and if
-#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should be avoided in favor of class parameters as
-#   of Puppet 2.6.)
+# * `sample variable`
+#  Explanation of how this variable affects the function of this class and if
+#  it has a default. e.g. "The parameter enc_ntp_servers must be set by the
+#  External Node Classifier as a comma separated list of hostnames." (Note,
+#  global variables should be avoided in favor of class parameters as
+#  of Puppet 2.6.)
 #
-# === Examples
+# Examples
+# --------
 #
-#  class { '<%= metadata.name %>':
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
-#  }
+# @example
+#    class { '<%= metadata.name %>':
+#      servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
+#    }
 #
-# === Authors
+# Authors
+# -------
 #
 # Author Name <author@domain.com>
 #
-# === Copyright
+# Copyright
+# ---------
 #
 # Copyright <%= Time.now.year %> Your name here, unless otherwise noted.
 #


### PR DESCRIPTION
* Add .yardopts file. This tells yard to use markdown, not rdoc because we
  anticipate that this is what most people will actually want.
* Add generated .yardoc to .gitignore. Yard generates this file and you don't
  care about it.
* Convert init.pp comments to use markdown.