### PR TITLE
(PUP-4810) Do not cache 0 ttl entries and evict aggressively

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -282,10 +282,19 @@ module Puppet::Environments
       @cache_expiration_service || DefaultCacheExpirationService.new
     end
 
+    END_OF_TIME = Time.gm(7137) # the next Mesoamerican Long Count cycle-end after 2012 (5125-2012)
+    START_OF_TIME = Time.gm(1)
+
     def initialize(loader)
       @loader = loader
-      @cache = {}
       @cache_expiration_service = Puppet::Environments::Cached.cache_expiration_service
+      @cache = {}
+
+      # Holds expiration times in sorted order - next to expire is first
+      @expirations = SortedSet.new
+
+      # Infinity since it there are no entries, this is a cache of the first to expire time
+      @next_expiration = END_OF_TIME
     end
 
     # @!macro loader_list
@@ -300,19 +309,33 @@ module Puppet::Environments
 
     # @!macro loader_get
     def get(name)
-      evict_if_expired(name)
+      # Aggressively evict all that has expired
+      # This strategy favors smaller memory footprint over environment
+      # retrieval time.
+      clear_all_expired
       if result = @cache[name]
+        # found in cache
         return result.value
       elsif (result = @loader.get(name))
+        # environment loaded, cache it
         cache_entry = entry(result)
-        unless cache_entry.is_a?(NotCachedEntry)
-          @cache_expiration_service.created(result)
-          @cache[name] = cache_entry
-          Puppet.debug {"Caching environment '#{name}' #{cache_entry.label}"}
-        end
+        @cache_expiration_service.created(result)
+        add_entry(name, cache_entry)
         result
       end
     end
+
+    # Adds a cache entry to the cache
+    def add_entry(name, cache_entry)
+      Puppet.debug {"Caching environment '#{name}' #{cache_entry.label}"}
+      @cache[name] = cache_entry
+      expires = cache_entry.expires
+      @expirations.add(expires)
+      if @next_expiration > expires
+        @next_expiration = expires
+      end
+    end
+    private :add_entry
 
     # Clears the cache of the environment with the given name.
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
@@ -324,6 +347,25 @@ module Puppet::Environments
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
     def clear_all()
       @cache = {}
+      @expirations.clear
+      @next_expiration = END_OF_TIME
+    end
+
+    # Clears all environments that have expired, either by exceeding their time to live, or
+    # through an explicit eviction determined by the cache expiration service.
+    #
+    def clear_all_expired()
+      t = Time.now
+      return if t < @next_expiration && ! @cache.any? {|name, _| @cache_expiration_service.expired?(name.to_sym) }
+      to_expire = @cache.select { |name, entry| entry.expires < t || @cache_expiration_service.expired?(name.to_sym) }
+      to_expire.each do |name, entry|
+        Puppet.debug {"Evicting cache entry for environment '#{name}'"}
+        @cache_expiration_service.evicted(name)
+        clear(name)
+        @expirations.delete(entry.expires)
+        Puppet.settings.clear_environment_settings(name)
+      end
+      @next_expiration = @expirations.first || END_OF_TIME
     end
 
     # This implementation evicts the cache, and always gets the current
@@ -380,6 +422,10 @@ module Puppet::Environments
       def label
         ""
       end
+
+      def expires
+        END_OF_TIME
+      end
     end
 
     # Always evicting entry
@@ -390,6 +436,10 @@ module Puppet::Environments
 
       def label
         "(ttl = 0 sec)"
+      end
+
+      def expires
+        START_OF_TIME
       end
     end
 
@@ -407,6 +457,10 @@ module Puppet::Environments
 
       def label
         "(ttl = #{@ttl_seconds} sec)"
+      end
+
+      def expires
+        @ttl
       end
     end
   end

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -1202,13 +1202,15 @@ describe Puppet::Parser::Compiler do
 
     it 'should recompute the version after input files are re-parsed' do
       Puppet[:code] = 'class foo { }'
-      Time.stubs(:now).returns(1)
+      first_time = Time.at(1)
+      second_time = Time.at(200)
+      Time.stubs(:now).returns(first_time)
       node = Puppet::Node.new('mynode')
-      expect(Puppet::Parser::Compiler.compile(node).version).to eq(1)
-      Time.stubs(:now).returns(2)
-      expect(Puppet::Parser::Compiler.compile(node).version).to eq(1) # no change because files didn't change
+      expect(Puppet::Parser::Compiler.compile(node).version).to eq(first_time.to_i)
+      Time.stubs(:now).returns(second_time)
+      expect(Puppet::Parser::Compiler.compile(node).version).to eq(first_time.to_i) # no change because files didn't change
       Puppet[:code] = nil
-      expect(Puppet::Parser::Compiler.compile(node).version).to eq(2)
+      expect(Puppet::Parser::Compiler.compile(node).version).to eq(second_time.to_i)
     end
 
     ['define', 'class', 'node'].each do |thing|

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -642,6 +642,8 @@ config_version=$vardir/random/scripts
     end
 
     def expired?(env_name)
+      # make expired? idempotent
+      return true if @expired_envs.include? (env_name)
       @expired_envs << env_name
       @expiration_sequence.pop
     end


### PR DESCRIPTION
This adds a better cache eviction algorithm to the environment cache. See commit comments for details.