### PR TITLE
(PUP-4752) Improve validation of parameter names

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -243,11 +243,15 @@ module Puppet::Pops::Issues
   end
 
   ILLEGAL_NAME = hard_issue :ILLEGAL_NAME, :name do
-    "Illegal name. The given name #{name} does not conform to the naming rule /^((::)?[a-z_]\w*)(::[a-z]\w*)*$/"
+    "Illegal name. The given name '#{name}' does not conform to the naming rule /^((::)?[a-z_]\w*)(::[a-z]\\w*)*$/"
+  end
+
+  ILLEGAL_PARAM_NAME = hard_issue :ILLEGAL_PARAM_NAME, :name do
+    "Illegal parameter name. The given name '#{name}' does not conform to the naming rule /^[a-z_]\\w*$/"
   end
 
   ILLEGAL_VAR_NAME = hard_issue :ILLEGAL_VAR_NAME, :name do
-    "Illegal variable name, The given name '#{name}' does not conform to the naming rule /^((::)?[a-z]\w*)*((::)?[a-z_]\w*)$/"
+    "Illegal variable name, The given name '#{name}' does not conform to the naming rule /^((::)?[a-z]\\w*)*((::)?[a-z_]\\w*)$/"
   end
 
   ILLEGAL_NUMERIC_VAR_NAME = hard_issue :ILLEGAL_NUMERIC_VAR_NAME, :name do

--- a/lib/puppet/pops/patterns.rb
+++ b/lib/puppet/pops/patterns.rb
@@ -38,6 +38,9 @@ module Puppet::Pops::Patterns
   # Note, that only the final segment may start with an underscore.
   VAR_NAME = %r{\A(:?(::)?[a-z]\w*)*(:?(::)?[a-z_]\w*)\z}
 
+  # PARAM_NAME matches the name part of a parameter (The $ character is not included)
+  PARAM_NAME = %r{\A[a-z_]\w*\z}
+
   # A Numeric var name must be the decimal number 0, or a decimal number not starting with 0
   NUMERIC_VAR_NAME = %r{\A(?:0|(?:[1-9][0-9]*))\z}
 

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -427,6 +427,10 @@ class Puppet::Pops::Validation::Checker4_0
     if o.name =~ /^(?:0x)?[0-9]+$/
       acceptor.accept(Issues::ILLEGAL_NUMERIC_PARAMETER, o, :name => o.name)
     end
+
+    unless o.name =~ Puppet::Pops::Patterns::PARAM_NAME
+      acceptor.accept(Issues::ILLEGAL_PARAM_NAME, o, :name => o.name)
+    end
   end
 
   #relationship_side: resource

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -177,6 +177,25 @@ describe "validating 4x" do
     end
   end
 
+  context 'for badly formed non-numeric parameter names' do
+    ['Ateam', 'a::team'].each do |word|
+      it "produces an error when $#{word} is used as a parameter in a class" do
+        source = "class x ($#{word}) {}"
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::ILLEGAL_PARAM_NAME)
+      end
+
+      it "produces an error when $#{word} is used as a parameter in a define" do
+        source = "define x ($#{word}) {}"
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::ILLEGAL_PARAM_NAME)
+      end
+
+      it "produces an error when $#{word} is used as a parameter in a lambda" do
+        source = "with() |$#{word}| {}"
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::ILLEGAL_PARAM_NAME)
+      end
+    end
+  end
+
   context 'top level constructs in conditionals' do
     ['class', 'define', 'node'].each do |word|
       it "produces an error when $#{word} is nested in an if expression" do


### PR DESCRIPTION
Before this, a badly formed parameter name would go unnoticed. This
causes a problem when not running with --strict_parameters beause
references to a non existing parameter does not cause a failure.
A user may have defined a parameter with 'define foo($Ateam) {}' and
tries to reference it with '$ateam' or '$Ateam' (the former would not
find the value, and the latter would fail with illegal parameter name).

This commit adds validation of the parameter name. It may start with a
lower case letter or underscore, and then any number of word characters.
A new issue code is added, and a new pattern since all existing patterns
(and error messages) are for fully qualified names.

This also correct typos on existing issues where \w did not output correctly.