### PR TITLE
(PUP-4688) Update acceptance tests for OSX

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.8')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.16')
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -67,12 +67,20 @@ install_packages_on(master, MASTER_PACKAGES)
 install_packages_on(agents, AGENT_PACKAGES)
 
 agents.each do |agent|
-  if agent['platform'] =~ /windows/
+  case agent['platform']
+  when /windows/
     arch = agent[:ruby_arch] || 'x86'
     base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{ENV['SHA']}/artifacts/windows"
     filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
 
     install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
+  when /osx/
+    opts = {
+      :puppet_collection => 'PC1',
+      :puppet_agent_sha => ENV['SHA'],
+      :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
+    }
+    install_puppet_agent_dev_repo_on(agent, opts)
   end
 end
 

--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -2,6 +2,7 @@ test_name "concurrent catalog requests (PUP-2659)"
 
 # we're only testing the effects of loading a master with concurrent requests
 confine :except, :platform => 'windows'
+confine :except, :platform => /osx/ # see PUP-4820
 
 step "setup a manifest"
 

--- a/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
+++ b/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
@@ -16,11 +16,24 @@ agents.each do |agent|
   }
   SITE
 
-  on(agent, puppet('config', 'set', 'logdir', "'#{logdir} { owner = root, group = root, mode = 0700 }'", '--confdir', get_test_file_path(agent, '')))
+  user = root_user(agent)
+  group = root_group(agent)
+
+  # puppet only always the group to be 'root' or 'service', but not
+  # all platforms have a 'root' group, e.g. osx.
+  permissions =
+    if group == 'root'
+      "{ owner = #{user}, group = root, mode = 0700 }"
+    else
+      "{ owner = #{user}, mode = 0700 }"
+    end
+
+  on(agent, puppet('config', 'set', 'logdir', "'#{logdir} #{permissions}'", '--confdir', get_test_file_path(agent, '')))
 
   on(agent, puppet('apply', get_test_file_path(agent, 'site.pp'), '--confdir', get_test_file_path(agent, '')))
 
-  on(agent, "stat --format '%U:%G %a' #{logdir}") do
-    assert_match(/root:root 700/, stdout)
-  end
+  permissions = stat(agent, logdir)
+  assert_equal(user, permissions[0], "File owner #{permissions[0]} does not match expected user #{user}")
+  assert_equal(group, permissions[1], "File group #{permissions[1]} does not match expected group #{group}")
+  assert_equal(0700, permissions[2], "File mode #{permissions[2].to_s(8)} does not match expected mode 0700")
 end

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -1,5 +1,7 @@
 test_name "Can enumerate environments via an HTTP endpoint"
 
+confine :except, :platform => /osx/ # see PUP-4820
+
 def master_port(agent)
   setting_on(agent, "agent", "masterport")
 end

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -3,7 +3,11 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  case host['platform']
+  when /solaris/, /osx/
+    # see PUP-4822, PUP-3450
+    skip_test "skip tests requiring forge certs"
+  end
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -3,7 +3,11 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  case host['platform']
+  when /solaris/, /osx/
+    # see PUP-4822, PUP-3450
+    skip_test "skip tests requiring forge certs"
+  end
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -1,6 +1,8 @@
 test_name "tests that puppet correctly runs an exec."
 # original author: Dan Bode  --daniel 2010-12-23
 
+confine :except, :platform => /osx/ # see BKR-388
+
 def before(agent)
   step "file to be touched should not exist."
   touched = agent.tmpfile('test-exec')

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -1,5 +1,8 @@
 test_name "file resource: symbolic modes"
 
+require 'puppet/acceptance/temp_file_utils'
+extend Puppet::Acceptance::TempFileUtils
+
 module FileModeAssertions
   include Beaker::DSL::Assertions
 
@@ -12,8 +15,8 @@ module FileModeAssertions
   end
 
   def assert_mode(agent, path, expected_mode)
-    current_mode = testcase.on(agent, "stat --format '%a' #{path}").stdout.chomp.to_i(8)
-    assert_equal(expected_mode, current_mode, "current mode #{current_mode.to_s(8)} doesn't match expected mode #{expected_mode.to_s(8)}")
+    permissions = testcase.stat(agent, path)
+    assert_equal(expected_mode, permissions[2], "current mode #{permissions[2].to_s(8)} doesn't match expected mode #{expected_mode.to_s(8)}")
   end
 
   def assert_mode_change(agent, manifest, path, symbolic_mode, start_mode, expected_mode)

--- a/acceptance/tests/resource/group/should_create.rb
+++ b/acceptance/tests/resource/group/should_create.rb
@@ -1,5 +1,7 @@
 test_name "should create a group"
 
+confine :except, :platform => /osx/ # See PUP-4824
+
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -1,5 +1,6 @@
 test_name "should modify gid of existing group"
 confine :except, :platform => 'windows'
+confine :except, :platform => /osx/ # See PUP-4824
 
 name = "pl#{rand(999999).to_i}"
 gid1  = rand(999999).to_i

--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -1,6 +1,7 @@
 test_name "defined should create an entry in filesystem table"
 
 confine :except, :platform => ['windows']
+confine :except, :platform => /osx/ # See PUP-4823
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -1,6 +1,7 @@
 test_name "should delete an entry in filesystem table and unmount it"
 
 confine :except, :platform => ['windows']
+confine :except, :platform => /osx/ # See PUP-4823
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -1,6 +1,7 @@
 test_name "should modify an entry in filesystem table"
 
 confine :except, :platform => ['windows']
+confine :except, :platform => /osx/ # See PUP-4823
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -1,6 +1,7 @@
 test_name "mounted should create an entry in filesystem table and mount it"
 
 confine :except, :platform => ['windows']
+confine :except, :platform => /osx/ # See PUP-4823
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -12,11 +12,18 @@ confine :except, :platform => 'solaris'
 # must be present.
 
 agents.each do |agent|
+  service_name = case agent['platform']
+                 when /osx/
+                   "com.openssh.sshd"
+                 else
+                   "ssh[^']*"
+                 end
+
   step "list running services and make sure ssh reports running"
   on(agent, puppet('resource service'))
-  assert_match /service { 'ssh[^']*':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is not running"
+  assert_match /service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is not running"
 
   step "list running services again and make sure ssh is still running"
   on(agent, puppet('resource service'))
-  assert_match /service { 'ssh[^']*':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is no longer running"
+  assert_match /service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is no longer running"
 end

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -1,5 +1,7 @@
 test_name "should create a user"
 
+confine :except, :platform => /osx/ # See PUP-4824
+
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -1,5 +1,6 @@
 test_name "verifies that puppet resource creates a user and assigns the correct group"
 confine :except, :platform => 'windows'
+confine :except, :platform => /osx/ # See PUP-4824
 
 user = "pl#{rand(999999).to_i}"
 group = "gp#{rand(999999).to_i}"

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -1,5 +1,6 @@
 test_name "verify that we can modify the gid"
 confine :except, :platform => 'windows'
+confine :except, :platform => /osx/ # See PUP-4824
 
 user = "pl#{rand(99999).to_i}"
 group1 = "#{user}old"

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -27,6 +27,9 @@ agents.each do |agent|
     home_prop = "home='#{profile_base(agent)}\\#{name}'"
   when /solaris/
     pending_test("managehome needs work on solaris")
+  when /osx/
+    skip_test("OSX doesn't support managehome")
+    # we don't get here
   end
 
   teardown do

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -21,6 +21,9 @@ agents.each do |agent|
     home_prop = "home='#{profile_base(agent)}\\#{name}'"
   when /solaris/
     pending_test("managehome needs work on solaris")
+  when /osx/
+    skip_test("OSX doesn't support managehome")
+    # we don't get here
   end
 
   teardown do

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -2,6 +2,7 @@ require 'json'
 
 test_name "CVE 2013-1652 Improper query parameter validation" do
   confine :except, :platform => 'windows'
+  confine :except, :platform => /osx/ # see PUP-4820
 
   with_puppet_running_on master, {} do
     # Ensure each agent has a signed cert

--- a/acceptance/tests/security/cve-2013-4761_resource_type.rb
+++ b/acceptance/tests/security/cve-2013-4761_resource_type.rb
@@ -9,6 +9,7 @@ end
 
 test_name "CVE 2013-4761 Remote code execution via REST resource_type" do
   confine :except, :platform => 'windows'
+  confine :except, :platform => /osx/ # see PUP-4820
 
   create_test_file(master, 'auth.conf', <<-AUTH)
 path /resource_type

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -8,9 +8,9 @@ extend Puppet::Acceptance::TempFileUtils
 initialize_temp_dirs
 
 def assert_ownership(agent, location, expected_user, expected_group)
-  on(agent, "stat --format '%U:%G' #{location}") do
-    assert_match(/#{expected_user}:#{expected_group}/, stdout)
-  end
+  permissions = stat(agent, location)
+  assert_equal(expected_user, permissions[0], "Owner #{permissions[0]} does not match expected #{expected_user}")
+  assert_equal(expected_group, permissions[1], "Group #{permissions[1]} does not match expected #{expected_group}")
 end
 
 def missing_directory_for(agent, dir)
@@ -42,7 +42,7 @@ agents.each do |agent|
                    '--group', 'missinggroup') do
 
     assert_match(/puppet_run/, stdout)
-    assert_ownership(agent, logdir, 'root', 'root')
+    assert_ownership(agent, logdir, root_user(agent), root_group(agent))
   end
 end
 


### PR DESCRIPTION
#### OSX 10.10

```
# bundle exec rake ci:test:aio SUITE_VERSION=1.1.1.250.gb9e1783 SHA=b9e178350dd52c75ab98ffd05e9bc739d7609155 CONFIG=config/nodes/osx-1010-x86_64.yaml
...
       Total Suite Time: 5297.40 seconds
      Average Test Time: 18.99 seconds
              Attempted: 279
                 Passed: 221
                 Failed: 0
                Errored: 0
                Skipped: 58
                Pending: 0
                  Total: 279
```

#### OSX 10.9

```
# bundle exec rake ci:test:aio SUITE_VERSION=1.1.1.250.gb9e1783 SHA=b9e178350dd52c75ab98ffd05e9bc739d7609155 CONFIG=config/nodes/osx-109-x86_64.yaml
...
              - Test Case Summary for suite 'tests' -
       Total Suite Time: 5486.13 seconds
      Average Test Time: 19.66 seconds
              Attempted: 279
                 Passed: 221
                 Failed: 0
                Errored: 0
                Skipped: 58
                Pending: 0
                  Total: 279
```

This updates our beaker dependency to require at least 2.16, which is necessary for beaker's helpers to install dmgs, but has the potential to break non-OSX platforms.

The last CI run used beaker 2.15.1 and puppet#stable per-commit passed:
https://jenkins.puppetlabs.com/view/All%20in%20One%20Agent/view/Stable/view/Puppet/job/platform_aio-puppet_intn-sys_stable/146/SLAVE_LABEL=beaker,TEST_TARGET=redhat-7-x86_64/consoleFull