### PR TITLE
Revert "(PUP-4489) Add data_provider to module metadata"

### DIFF
--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -15,16 +15,15 @@ module Puppet::ModuleTool
     attr_accessor :module_name
 
     DEFAULTS = {
-      'name'          => nil,
-      'version'       => nil,
-      'author'        => nil,
-      'summary'       => nil,
-      'license'       => 'Apache-2.0',
-      'source'        => '',
-      'project_page'  => nil,
-      'issues_url'    => nil,
-      'dependencies'  => Set.new.freeze,
-      'data_provider' => nil,
+      'name'         => nil,
+      'version'      => nil,
+      'author'       => nil,
+      'summary'      => nil,
+      'license'      => 'Apache-2.0',
+      'source'       => '',
+      'project_page' => nil,
+      'issues_url'   => nil,
+      'dependencies' => Set.new.freeze,
     }
 
     def initialize
@@ -53,7 +52,6 @@ module Puppet::ModuleTool
       process_name(data) if data['name']
       process_version(data) if data['version']
       process_source(data) if data['source']
-      process_data_provider(data) if data['data_provider']
       merge_dependencies(data) if data['dependencies']
 
       @data.merge!(data)
@@ -130,10 +128,6 @@ module Puppet::ModuleTool
       validate_version(data['version'])
     end
 
-    def process_data_provider(data)
-      validate_data_provider(data['data_provider'])
-    end
-
     # Do basic parsing of the source parameter.  If the source is hosted on
     # GitHub, we can predict sensible defaults for both project_page and
     # issues_url.
@@ -192,26 +186,6 @@ module Puppet::ModuleTool
 
       err = "version string cannot be parsed as a valid Semantic Version"
       raise ArgumentError, "Invalid 'version' field in metadata.json: #{err}"
-    end
-
-    # Validates that the given data provider is and object with a valid name and arguments
-    def validate_data_provider(data_provider)
-      err = nil
-      if data_provider.is_a?(Hash)
-        name = data_provider['name']
-        if name.nil?
-          err = "missing required field 'name'"
-        elsif name =~ /^[a-zA-Z][a-zA-Z0-9_]*$/
-          args = data_provider['arguments']
-          err = "the field 'arguments' must be an array" unless args.nil? || args.is_a?(Array)
-        else
-          suffix = name =~ /^[a-zA-Z]/ ? 'contains non-alphanumeric characters' : 'must begin with a letter'
-          err = "the field 'name' #{suffix}"
-        end
-      else
-        err = 'argument must be an object'
-      end
-      raise ArgumentError, "Invalid 'data_provider' field in metadata.json: #{err}" if err
     end
 
     # Validates that the version range can be parsed by Semantic.

--- a/spec/unit/module_tool/metadata_spec.rb
+++ b/spec/unit/module_tool/metadata_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::ModuleTool::Metadata do
     subject { metadata }
 
     %w[ name version author summary license source project_page issues_url
-    dependencies dashed_name release_name description data_provider].each do |prop|
+    dependencies dashed_name release_name description ].each do |prop|
       describe "##{prop}" do
         it "responds to the property" do
           subject.send(prop)
@@ -224,39 +224,6 @@ describe Puppet::ModuleTool::Metadata do
         expect(subject.dependencies.size).to eq(1)
       end
     end
-
-    context 'with valid data_provider' do
-      let(:data) { {'data_provider' => {'name' => 'the_name', 'arguments' => ['arg']} }}
-
-      it 'validates the provider correctly' do
-        expect { subject }.not_to raise_error
-      end
-
-      it 'returns the provider' do
-        expect(subject.data_provider).to eq({'name' => 'the_name', 'arguments' => ['arg']})
-      end
-    end
-
-    context 'with invalid data_provider' do
-      let(:data) { }
-
-      it "raises exception on missing 'name'" do
-        expect { metadata.update('data_provider' => {}) }.to raise_error(ArgumentError, /missing required field 'name'/)
-      end
-
-      it "raises exception on 'name' that do not start with a letter" do
-        expect { metadata.update('data_provider' => {'name' => '_the_name'}) }.to raise_error(ArgumentError, /field 'name' must begin with a letter/)
-        expect { metadata.update('data_provider' => {'name' => ''}) }.to raise_error(ArgumentError, /field 'name' must begin with a letter/)
-      end
-
-      it "raises exception on 'name' that contain non-alphanumeric characters" do
-        expect { metadata.update('data_provider' => {'name' => 'the::name'}) }.to raise_error(ArgumentError, /field 'name' contains non-alphanumeric characters/)
-      end
-
-      it "raises exception if 'arguments' is not an array" do
-        expect { metadata.update('data_provider' => {'name' => 'the_name', 'arguments' => 'hello'}) }.to raise_error(ArgumentError, /field 'arguments' must be an array/)
-      end
-    end
   end
 
   describe '#dashed_name' do
@@ -304,7 +271,7 @@ describe Puppet::ModuleTool::Metadata do
     subject { metadata.to_hash }
 
     it "contains the default set of keys" do
-      expect(subject.keys.sort).to eq(%w[ name version author summary license source issues_url project_page dependencies data_provider].sort)
+      expect(subject.keys.sort).to eq(%w[ name version author summary license source issues_url project_page dependencies ].sort)
     end
 
     describe "['license']" do


### PR DESCRIPTION
Reverting this change. having binding arguments declared in metadata.json is too complex. A symbolic name will suffice.