### PR TITLE
(PUP-4489) Add data_provider to module metadata

### DIFF
--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -15,15 +15,16 @@ module Puppet::ModuleTool
     attr_accessor :module_name
 
     DEFAULTS = {
-      'name'         => nil,
-      'version'      => nil,
-      'author'       => nil,
-      'summary'      => nil,
-      'license'      => 'Apache-2.0',
-      'source'       => '',
-      'project_page' => nil,
-      'issues_url'   => nil,
-      'dependencies' => Set.new.freeze,
+      'name'          => nil,
+      'version'       => nil,
+      'author'        => nil,
+      'summary'       => nil,
+      'license'       => 'Apache-2.0',
+      'source'        => '',
+      'project_page'  => nil,
+      'issues_url'    => nil,
+      'dependencies'  => Set.new.freeze,
+      'data_provider' => nil,
     }
 
     def initialize
@@ -52,6 +53,7 @@ module Puppet::ModuleTool
       process_name(data) if data['name']
       process_version(data) if data['version']
       process_source(data) if data['source']
+      process_data_provider(data) if data['data_provider']
       merge_dependencies(data) if data['dependencies']
 
       @data.merge!(data)
@@ -128,6 +130,10 @@ module Puppet::ModuleTool
       validate_version(data['version'])
     end
 
+    def process_data_provider(data)
+      validate_data_provider(data['data_provider'])
+    end
+
     # Do basic parsing of the source parameter.  If the source is hosted on
     # GitHub, we can predict sensible defaults for both project_page and
     # issues_url.
@@ -186,6 +192,23 @@ module Puppet::ModuleTool
 
       err = "version string cannot be parsed as a valid Semantic Version"
       raise ArgumentError, "Invalid 'version' field in metadata.json: #{err}"
+    end
+
+    # Validates that the given _value_ is a symbolic name that starts with a letter
+    # and then contains only letters, digits, or underscore. Will raise an ArgumentError
+    # if that's not the case.
+    #
+    # @param value [Object] The value to be tested
+    def validate_data_provider(value)
+      err = nil
+      if value.is_a?(String)
+        unless value =~ /^[a-zA-Z][a-zA-Z0-9_]*$/
+          err = value =~ /^[a-zA-Z]/ ? 'contains non-alphanumeric characters' : 'must begin with a letter'
+        end
+      else
+        err = 'must be a string'
+      end
+      raise ArgumentError, "field 'data_provider' #{err}" if err
     end
 
     # Validates that the version range can be parsed by Semantic.

--- a/spec/unit/module_tool/metadata_spec.rb
+++ b/spec/unit/module_tool/metadata_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::ModuleTool::Metadata do
     subject { metadata }
 
     %w[ name version author summary license source project_page issues_url
-    dependencies dashed_name release_name description ].each do |prop|
+    dependencies dashed_name release_name description data_provider].each do |prop|
       describe "##{prop}" do
         it "responds to the property" do
           subject.send(prop)
@@ -224,6 +224,35 @@ describe Puppet::ModuleTool::Metadata do
         expect(subject.dependencies.size).to eq(1)
       end
     end
+
+    context 'with valid data_provider' do
+      let(:data) { {'data_provider' => 'the_name'} }
+
+      it 'validates the provider correctly' do
+        expect { subject }.not_to raise_error
+      end
+
+      it 'returns the provider' do
+        expect(subject.data_provider).to eq('the_name')
+      end
+    end
+
+    context 'with invalid data_provider' do
+      let(:data) { }
+
+      it "raises exception unless argument starts with a letter" do
+        expect { metadata.update('data_provider' => '_the_name') }.to raise_error(ArgumentError, /field 'data_provider' must begin with a letter/)
+        expect { metadata.update('data_provider' => '') }.to raise_error(ArgumentError, /field 'data_provider' must begin with a letter/)
+      end
+
+      it "raises exception if argument contains non-alphanumeric characters" do
+        expect { metadata.update('data_provider' => 'the::name') }.to raise_error(ArgumentError, /field 'data_provider' contains non-alphanumeric characters/)
+      end
+
+      it "raises exception unless argument is a string" do
+        expect { metadata.update('data_provider' => 23) }.to raise_error(ArgumentError, /field 'data_provider' must be a string/)
+      end
+    end
   end
 
   describe '#dashed_name' do
@@ -271,7 +300,7 @@ describe Puppet::ModuleTool::Metadata do
     subject { metadata.to_hash }
 
     it "contains the default set of keys" do
-      expect(subject.keys.sort).to eq(%w[ name version author summary license source issues_url project_page dependencies ].sort)
+      expect(subject.keys.sort).to eq(%w[ name version author summary license source issues_url project_page dependencies data_provider].sort)
     end
 
     describe "['license']" do


### PR DESCRIPTION
Adds a 'data_provider' entry to metadata.json. The entry must be a
string that starts with a letter and then contains only letters,
digits, and underscores.