### PR TITLE
(PUP-4810) 3x do not cache 0ttl evict aggressively

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -360,7 +360,12 @@ module Puppet::Environments
       if result = @cache[name]
         return result.value
       elsif (result = @loader.get(name))
-        @cache[name] = entry(result)
+        cache_entry = entry(result)
+        unless cache_entry.is_a?(NotCachedEntry)
+          @cache_expiration_service.created(result)
+          @cache[name] = cache_entry
+          Puppet.debug {"Caching environment '#{name}' #{cache_entry.label}"}
+        end
         result
       end
     end
@@ -393,7 +398,6 @@ module Puppet::Environments
     # Creates a suitable cache entry given the time to live for one environment
     #
     def entry(env)
-      @cache_expiration_service.created(env)
       ttl = (conf = get_conf(env.name)) ? conf.environment_timeout : Puppet.settings.value(:environment_timeout)
       case ttl
       when 0
@@ -427,12 +431,20 @@ module Puppet::Environments
       def expired?
         false
       end
+
+      def label
+        ""
+      end
     end
 
     # Always evicting entry
     class NotCachedEntry < Entry
       def expired?
         true
+      end
+
+      def label
+        "(ttl = 0 sec)"
       end
     end
 
@@ -441,10 +453,15 @@ module Puppet::Environments
       def initialize(value, ttl_seconds)
         super value
         @ttl = Time.now + ttl_seconds
+        @ttl_seconds = ttl_seconds
       end
 
       def expired?
         Time.now > @ttl
+      end
+
+      def label
+        "(ttl = #{@ttl_seconds} sec)"
       end
     end
   end

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -338,10 +338,19 @@ module Puppet::Environments
       @cache_expiration_service || DefaultCacheExpirationService.new
     end
 
+    END_OF_TIME = Time.gm(7137) # the next Mesoamerican Long Count cycle-end after 2012 (5125-2012)
+    START_OF_TIME = Time.gm(1)
+
     def initialize(loader)
       @loader = loader
-      @cache = {}
       @cache_expiration_service = Puppet::Environments::Cached.cache_expiration_service
+      @cache = {}
+
+      # Holds expiration times in sorted order - next to expire is first
+      @expirations = SortedSet.new
+
+      # Infinity since it there are no entries, this is a cache of the first to expire time
+      @next_expiration = END_OF_TIME
     end
 
     # @!macro loader_list
@@ -356,19 +365,33 @@ module Puppet::Environments
 
     # @!macro loader_get
     def get(name)
-      evict_if_expired(name)
+      # Aggressively evict all that has expired
+      # This strategy favors smaller memory footprint over environment
+      # retrieval time.
+      clear_all_expired
       if result = @cache[name]
+        # found in cache
         return result.value
       elsif (result = @loader.get(name))
+        # environment loaded, cache it
         cache_entry = entry(result)
-        unless cache_entry.is_a?(NotCachedEntry)
-          @cache_expiration_service.created(result)
-          @cache[name] = cache_entry
-          Puppet.debug {"Caching environment '#{name}' #{cache_entry.label}"}
-        end
+        @cache_expiration_service.created(result)
+        add_entry(name, cache_entry)
         result
       end
     end
+
+    # Adds a cache entry to the cache
+    def add_entry(name, cache_entry)
+      Puppet.debug("Caching environment '#{name}' #{cache_entry.label}")
+      @cache[name] = cache_entry
+      expires = cache_entry.expires
+      @expirations.add(expires)
+      if @next_expiration > expires
+        @next_expiration = expires
+      end
+    end
+    private :add_entry
 
     # Clears the cache of the environment with the given name.
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
@@ -380,6 +403,25 @@ module Puppet::Environments
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
     def clear_all()
       @cache = {}
+      @expirations.clear
+      @next_expiration = END_OF_TIME
+    end
+
+    # Clears all environments that have expired, either by exceeding their time to live, or
+    # through an explicit eviction determined by the cache expiration service.
+    #
+    def clear_all_expired()
+      t = Time.now
+      return if t < @next_expiration && ! @cache.any? {|name, _| @cache_expiration_service.expired?(name.to_sym) }
+      to_expire = @cache.select { |name, entry| entry.expires < t || @cache_expiration_service.expired?(name.to_sym) }
+      to_expire.each do |name, entry|
+        Puppet.debug("Evicting cache entry for environment '#{name}'")
+        @cache_expiration_service.evicted(name)
+        clear(name)
+        @expirations.delete(entry.expires)
+        Puppet.settings.clear_environment_settings(name)
+      end
+      @next_expiration = @expirations.first || END_OF_TIME
     end
 
     # This implementation evicts the cache, and always gets the current
@@ -435,6 +477,10 @@ module Puppet::Environments
       def label
         ""
       end
+
+      def expires
+        END_OF_TIME
+      end
     end
 
     # Always evicting entry
@@ -445,6 +491,10 @@ module Puppet::Environments
 
       def label
         "(ttl = 0 sec)"
+      end
+
+      def expires
+        START_OF_TIME
       end
     end
 
@@ -462,6 +512,10 @@ module Puppet::Environments
 
       def label
         "(ttl = #{@ttl_seconds} sec)"
+      end
+
+      def expires
+        @ttl
       end
     end
   end

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -121,15 +121,17 @@ describe "Puppet::Parser::Compiler" do
     end
   end
 
-  it "should recompute the version after input files are re-parsed" do
+  it 'should recompute the version after input files are re-parsed' do
     Puppet[:code] = 'class foo { }'
-    Time.stubs(:now).returns(1)
+    first_time = Time.at(1)
+    second_time = Time.at(200)
+    Time.stubs(:now).returns(first_time)
     node = Puppet::Node.new('mynode')
-    Puppet::Parser::Compiler.compile(node).version.should == 1
-    Time.stubs(:now).returns(2)
-    Puppet::Parser::Compiler.compile(node).version.should == 1 # no change because files didn't change
-    Puppet::Resource::TypeCollection.any_instance.stubs(:stale?).returns(true).then.returns(false) # pretend change
-    Puppet::Parser::Compiler.compile(node).version.should == 2
+    expect(Puppet::Parser::Compiler.compile(node).version).to eq(first_time.to_i)
+    Time.stubs(:now).returns(second_time)
+    expect(Puppet::Parser::Compiler.compile(node).version).to eq(first_time.to_i) # no change because files didn't change
+    Puppet[:code] = nil
+    expect(Puppet::Parser::Compiler.compile(node).version).to eq(second_time.to_i)
   end
 
   ['class', 'define', 'node'].each do |thing|

--- a/spec/integration/parser/future_compiler_spec.rb
+++ b/spec/integration/parser/future_compiler_spec.rb
@@ -185,15 +185,17 @@ describe "Puppet::Parser::Compiler" do
       end
     end
 
-    it "should recompute the version after input files are re-parsed" do
+    it 'should recompute the version after input files are re-parsed' do
       Puppet[:code] = 'class foo { }'
-      Time.stubs(:now).returns(1)
+      first_time = Time.at(1)
+      second_time = Time.at(200)
+      Time.stubs(:now).returns(first_time)
       node = Puppet::Node.new('mynode')
-      Puppet::Parser::Compiler.compile(node).version.should == 1
-      Time.stubs(:now).returns(2)
-      Puppet::Parser::Compiler.compile(node).version.should == 1 # no change because files didn't change
-      Puppet::Resource::TypeCollection.any_instance.stubs(:stale?).returns(true).then.returns(false) # pretend change
-      Puppet::Parser::Compiler.compile(node).version.should == 2
+      expect(Puppet::Parser::Compiler.compile(node).version).to eq(first_time.to_i)
+      Time.stubs(:now).returns(second_time)
+      expect(Puppet::Parser::Compiler.compile(node).version).to eq(first_time.to_i) # no change because files didn't change
+      Puppet[:code] = nil
+      expect(Puppet::Parser::Compiler.compile(node).version).to eq(second_time.to_i)
     end
 
     ['define', 'class', 'node'].each do |thing|

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -642,6 +642,8 @@ config_version=$vardir/random/scripts
     end
 
     def expired?(env_name)
+      # make expired? idempotent
+      return true if @expired_envs.include? (env_name)
       @expired_envs << env_name
       @expiration_sequence.pop
     end


### PR DESCRIPTION
This back ports the fix for PUP-4810 on stable (4.x) to 3.x.

When merging this up to stable there will be conflicts due to:
* logging functions cannot take a lambda in 3.x
* spec tests moved around
* future_compiler_spec is removed in 4.x

When merging to stable - favor the stable version over everything in this PR, and make sure the deleted spec tests stay deleted.