### PR TITLE
(PUP-4826) Make Integer and Float with one argument unbounded

### DIFF
--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -356,7 +356,7 @@ class Puppet::Pops::Types::TypeParser
       if parameters.size == 1
         case parameters[0]
         when Integer
-          TYPES.range(parameters[0], parameters[0])
+          TYPES.range(parameters[0], :default)
         when :default
           TYPES.integer # unbound
         end
@@ -370,7 +370,7 @@ class Puppet::Pops::Types::TypeParser
       if parameters.size == 1
         case parameters[0]
         when Integer, Float
-          TYPES.float_range(parameters[0], parameters[0])
+          TYPES.float_range(parameters[0], :default)
         when :default
           TYPES.float # unbound
         end

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -66,6 +66,14 @@ describe Puppet::Pops::Types::TypeParser do
     expect(parser.parse("Hash[Scalar, Integer]")).to be_the_type(types.hash_of(types.integer))
   end
 
+  it 'interprets an Integer with one parameter to have unbounded upper range' do
+    expect(parser.parse('Integer[0]')).to eq(parser.parse('Integer[0,default]'))
+  end
+
+  it 'interprets a Float with one parameter to have unbounded upper range' do
+    expect(parser.parse('Float[0]')).to eq(parser.parse('Float[0,default]'))
+  end
+
   it "parses a parameterized type into the type object" do
     parameterized_array = types.array_of(types.integer)
     parameterized_hash = types.hash_of(types.integer, types.boolean)


### PR DESCRIPTION
The Puppet evaluator will consider this statement to be true:

 Integer[0] == Integer[0,default]

The TypeParser (used in Ruby function API) will instead use the single
argument in both positions and thus consider this to be true:

 Integer[0] == Integer[0,0]

This commit changes the TypeParser to behave like the evaluator. The
change affects both Integer and Float.