### PR TITLE
(PUP-4490) Pick up bindings from module's metadata.json

### DIFF
--- a/lib/puppet/pops/binder/bindings_loader.rb
+++ b/lib/puppet/pops/binder/bindings_loader.rb
@@ -38,11 +38,10 @@ class Puppet::Pops::Binder::BindingsLoader
     paths_for_name(name).find {|p| Puppet::FileSystem.exist?(File.join(basedir, "lib/puppet/bindings", p)+'.rb') }
   end
 
-  private
-
   def self.loader()
     @autoloader ||= Puppet::Util::Autoload.new("BindingsLoader", "puppet/bindings")
   end
+  private_class_method :loader
 
   def self.provide_from_string(scope, name)
     name_path = name.split('::')
@@ -52,6 +51,7 @@ class Puppet::Pops::Binder::BindingsLoader
     end
     provide_from_name_path(scope, name, name_path)
   end
+  private_class_method :provide_from_string
 
   def self.provide_from_name_path(scope, name, name_path)
     # If bindings is already loaded, try this first
@@ -64,14 +64,17 @@ class Puppet::Pops::Binder::BindingsLoader
     end
     result
   end
+  private_class_method :provide_from_name_path
 
   def self.paths_for_name(fq_name)
     [de_camel(fq_name), downcased_path(fq_name)].uniq
   end
+  private_class_method :paths_for_name
 
   def self.downcased_path(fq_name)
     fq_name.to_s.gsub(/::/, '/').downcase
   end
+  private_class_method :downcased_path
 
   def self.de_camel(fq_name)
     fq_name.to_s.gsub(/::/, '/').
@@ -80,4 +83,5 @@ class Puppet::Pops::Binder::BindingsLoader
     tr("-", "_").
     downcase
   end
+  private_class_method :de_camel
 end

--- a/lib/puppet/pops/binder/config/binder_config.rb
+++ b/lib/puppet/pops/binder/config/binder_config.rb
@@ -23,7 +23,7 @@ module Puppet::Pops::Binder::Config
 
     DEFAULT_LAYERS = [
       { 'name' => 'site',    'include' => [ 'confdir:/default?optional'] },
-      { 'name' => 'modules', 'include' => [ 'module:/*::default'] },
+      { 'name' => 'modules', 'include' => [ 'module:/*::default', 'module:/*::metadata'] },
     ]
 
     DEFAULT_SCHEME_EXTENSIONS = {}

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/meta/lib/puppet/functions/meta/data.rb
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/meta/lib/puppet/functions/meta/data.rb
@@ -1,0 +1,9 @@
+Puppet::Functions.create_function(:'meta::data') do
+  def data()
+    { 'meta::b' => 'module_b',
+      'meta::c' => 'module_c',
+      'meta::e' => { 'k1' => 'module_e1', 'k2' => 'module_e2' },
+      'meta::f' => { 'k1' => { 's1' => 'module_f11', 's3' => 'module_f13' },  'k2' => { 's1' => 'module_f21', 's2' => 'module_f22' }},
+    }
+  end
+end

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/meta/manifests/init.pp
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/meta/manifests/init.pp
@@ -1,0 +1,3 @@
+class meta {
+  $result = lookup(*$args)
+}

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/meta/metadata.json
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/meta/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "example/meta",
+    "version": "0.0.2",
+    "source": "git@github.com/example/example-meta.git",
+    "dependencies": [],
+    "author": "Bob the Builder",
+    "license": "Apache-2.0",
+    "data_provider": "function"
+}

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/metawcp/lib/puppet/bindings/metawcp/default.rb
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/metawcp/lib/puppet/bindings/metawcp/default.rb
@@ -1,0 +1,10 @@
+Puppet::Bindings.newbindings('metawcp::default') do
+  # Make the SampleModuleData provider available for use in modules
+  # as 'sample'.
+  #
+  bind {
+    name 'sample'
+    in_multibind 'puppet::module_data_providers'
+    to_instance 'PuppetX::Thallgren::SampleModuleData'
+  }
+end

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/metawcp/lib/puppet_x/thallgren/sample_module_data.rb
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/metawcp/lib/puppet_x/thallgren/sample_module_data.rb
@@ -1,0 +1,22 @@
+# The module is named after the author, to ensure that names under PuppetX namespace
+# does not clash.
+#
+require 'puppet_x'
+
+module PuppetX::Thallgren
+  class SampleModuleData < Puppet::Plugins::DataProviders::ModuleDataProvider
+    def initialize()
+      @data = {
+        'metawcp::b' => 'module_b',
+        'metawcp::c' => 'module_c',
+        'metawcp::e' => { 'k1' => 'module_e1', 'k2' => 'module_e2' },
+        'metawcp::f' => { 'k1' => { 's1' => 'module_f11', 's3' => 'module_f13' },  'k2' => { 's1' => 'module_f21', 's2' => 'module_f22' }},
+      }
+    end
+
+    def lookup(name, scope, merge)
+      @data[name]
+    end
+  end
+end
+

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/metawcp/manifests/init.pp
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/metawcp/manifests/init.pp
@@ -1,0 +1,3 @@
+class metawcp {
+  $result = lookup(*$args)
+}

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/metawcp/metadata.json
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/metawcp/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "example/metawcp",
+    "version": "0.0.2",
+    "source": "git@github.com/example/example-metawcp.git",
+    "dependencies": [],
+    "author": "Bob the Builder",
+    "license": "Apache-2.0",
+    "data_provider": "sample"
+}

--- a/spec/unit/pops/binder/config/binder_config_spec.rb
+++ b/spec/unit/pops/binder/config/binder_config_spec.rb
@@ -16,7 +16,7 @@ describe 'BinderConfig' do
     expect(config.layering_config[0]['name']).to    be == 'site'
     expect(config.layering_config[0]['include']).to be == ['confdir:/default?optional']
     expect(config.layering_config[1]['name']).to    be == 'modules'
-    expect(config.layering_config[1]['include']).to be == ['module:/*::default']
+    expect(config.layering_config[1]['include']).to be == ['module:/*::default', 'module:/*::metadata']
   end
 
   it 'should load binder_config.yaml if it exists in confdir)' do


### PR DESCRIPTION
This PR adds a 'module:/*::metadata' pattern to the includes
for the binding layer 'modules'. The ModuleScheme will recognize
the matching entries and assume that contributed bindings are
specified in the module's metadata.json file using the key
'data_provider'.

Unit tests are provided to verify that a data_provider that appoints
a Puppet provided binding (such as 'function') works OK and that
a user provided binding (such as 'sample') also works.