### PR TITLE
(PUP-4847) Reset Facter after changing $LOAD_PATH

### DIFF
--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,0 +1,58 @@
+test_name "Pluginsync'ed custom facts should be resolvable during application runs"
+
+#
+# This test is intended to ensure that custom facts downloaded onto an agent via
+# pluginsync are resolvable by puppet applications besides agent/apply.
+#
+
+step "Create a codedir with a test module with external fact"
+codedir = master.tmpdir('4847-codedir')
+
+agents.each do |agent|
+  on agent, "mkdir -p #{codedir}/lib/facter"
+
+  on agent, "mkdir -p #{codedir}/lib/puppet/{type,provider/test4847}"
+  on agent, "cat > #{codedir}/lib/puppet/type/test4847.rb", :stdin => <<TYPE
+Puppet::Type.newtype(:test4847) do
+  newparam(:name, :namevar => true)
+end
+TYPE
+
+  on agent, "cat > #{codedir}/lib/puppet/provider/test4847/only.rb", :stdin => <<PROVIDER
+Puppet::Type.type(:test4847).provide(:only) do
+  commands :anything => "#{codedir}/must_exist.exe"
+  def self.instances
+    warn "fact foo=\#{Facter.value('foo')}"
+  end
+end
+PROVIDER
+
+  fact = <<FACT
+Facter.add('foo') do
+  setcode do
+    'bar'
+  end
+end
+FACT
+
+  on agent, puppet('apply'), :stdin => <<MANIFEST
+  # The file name is chosen to work on Windows and *nix.
+  file { "#{codedir}/must_exist.exe":
+    ensure => file,
+    mode   => "0755",
+  }
+
+  file { "#{codedir}/lib/facter/foo.rb":
+    ensure  => file,
+    content => "#{fact}",
+  }
+MANIFEST
+
+  on agent, puppet('resource', 'test4847', '--libdir', "#{codedir}/lib") do
+    assert_match(/fact foo=bar/, stdout)
+  end
+
+  teardown do
+    on(agent, "rm -rf #{codedir}")
+  end
+end

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -117,6 +117,10 @@ module Puppet
               configured_environment.each_plugin_directory do |dir|
                 $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
               end
+
+              # Puppet requires Facter, which initializes its lookup paths. Reset Facter to
+              # pickup the new $LOAD_PATH.
+              Facter.reset
             end
           end
 


### PR DESCRIPTION
Facters behavior in 2.x was to query the $LOAD_PATH when requesting
Facts it doesn't know about, but only if querying individual facts or
querying all facts when they haven't been cached yet. This can lead to
very strange behavior, where different ways of querying facts yield
different results.

Facter 3.0 made that behavior consistent, but requires Facter.reset
when the $LOAD_PATH changes. Add that for cases besides apply and agent,
which already do Facter.reset.