### PR TITLE
(RE-5087) Fix init script behavior on sles/suse when run by puppet

### DIFF
--- a/ext/suse/client.init
+++ b/ext/suse/client.init
@@ -36,7 +36,6 @@
 lockfile=/var/lock/subsys/puppet
 pidfile=/var/run/puppetlabs/agent.pid
 puppetd=/opt/puppetlabs/puppet/bin/puppet
-RETVAL=0
 
 PUPPET_OPTS="agent"
 
@@ -74,7 +73,7 @@ case "$1" in
                 rc_exit
             fi
         fi
-        startproc -f -w -p ${pidfile} $puppetd ${PUPPET_OPTS} ${PUPPET_EXTRA_OPTS} && touch ${lockfile}
+        startproc -f -w -p "${pidfile}" "${puppetd}" "${PUPPET_OPTS}" "${PUPPET_EXTRA_OPTS}" && touch "${lockfile}"
         # Remember status and be verbose
         rc_status -v
         ;;
@@ -83,7 +82,7 @@ case "$1" in
         ## Stop daemon with killproc(8) and if this fails
         ## set echo the echo return value.
 
-        killproc -QUIT -p ${pidfile} $puppetd && rm -f ${lockfile} ${pidfile}
+        killproc -QUIT -p "${pidfile}" "${puppetd}" && rm -f "${lockfile}" "${pidfile}"
 
         # Remember status and be verbose
         rc_status -v
@@ -112,7 +111,7 @@ case "$1" in
 
         echo -n "Reload service puppet"
         ## if it supports it:
-        killproc -HUP -p ${pidfile} $puppetd
+        killproc -HUP -p "${pidfile}" "${puppetd}"
         rc_status -v
         ;;
     reload)
@@ -121,7 +120,7 @@ case "$1" in
 
         # If it supports signalling:
         echo -n "Reload puppet services."
-        killproc -HUP -p ${pidfile} $puppetd
+        killproc -HUP -p "${pidfile}" "${puppetd}"
         rc_status -v
         ;;
     status)
@@ -137,7 +136,7 @@ case "$1" in
 
         # NOTE: checkproc returns LSB compliant status values.
         if [ -f "${pidfile}" ]; then
-            checkproc -p ${pidfile} $puppetd
+            checkproc -p "${pidfile}" "${puppetd}"
             rc_status -v
         else
             rc_failed 3
@@ -146,7 +145,7 @@ case "$1" in
         ;;
     once)
         shift
-        $puppetd ${PUPPET_OPTS} --onetime ${PUPPET_EXTRA_OPTS} $@
+        $puppetd "${PUPPET_OPTS}" --onetime "${PUPPET_EXTRA_OPTS}" $@
         ;;
     *)
         echo "Usage: $0 {start|stop|status|try-restart|restart|force-reload|reload|once}"

--- a/ext/suse/client.init
+++ b/ext/suse/client.init
@@ -63,9 +63,18 @@ case "$1" in
         ## Start daemon with startproc(8). If this fails
         ## the echo return value is set appropriate.
 
-        # startproc should return 0, even if service is
-        # already running to match LSB spec.
-        startproc -p ${pidfile} $puppetd ${PUPPET_OPTS} ${PUPPET_EXTRA_OPTS} && touch ${lockfile}
+        ## This accounts for the behavior of startproc on sles 10.
+        ## Check to see if a running process matches the contents
+        ## of the pidfile, and do nothing if true. Otherwise
+        ## force a process start
+        if [ -f "${pidfile}" ]; then
+            PID=$(cat "$pidfile")
+            if [ "$PID" -eq $(pgrep -f "$puppetd") ] ; then
+                rc_status -v
+                rc_exit
+            fi
+        fi
+        startproc -f -w -p ${pidfile} $puppetd ${PUPPET_OPTS} ${PUPPET_EXTRA_OPTS} && touch ${lockfile}
         # Remember status and be verbose
         rc_status -v
         ;;
@@ -127,8 +136,13 @@ case "$1" in
         # 3 - service not running
 
         # NOTE: checkproc returns LSB compliant status values.
-        checkproc -p ${pidfile} $puppetd
-        rc_status -v
+        if [ -f "${pidfile}" ]; then
+            checkproc -p ${pidfile} $puppetd
+            rc_status -v
+        else
+            rc_failed 3
+            rc_status -v
+        fi
         ;;
     once)
         shift


### PR DESCRIPTION
On suse/sles 10, when executed by puppet, the init script will not start the puppet
service because startproc checks and finds a puppet process running.

This updates the init script to force start the process unless there is
a running process matching the pid in the pidfile. It also updates the status
command to only return true if the pidfile matches a running puppet pid.

This is a direct port of a fix for SLES 10 from previous PE releases.