### PR TITLE
(PUP-4854) Shorten default PMT TEMP location on Windows

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -531,7 +531,7 @@ module Puppet
       :desc     => "The module repository",
     },
     :module_working_dir => {
-        :default  => '$vardir/puppet-module',
+        :default  => (Puppet.features.microsoft_windows? ? Dir.tmpdir() : '$vardir/puppet-module'),
         :desc     => "The directory into which module tool data is stored",
     },
     :module_skeleton_dir => {

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -93,7 +93,7 @@ module Puppet::ModuleTool
       # @api private
       # @return [String] path to temporary unpacking location
       def tmpdir
-        @dir ||= Dir.mktmpdir('tmp-unpacker', Puppet::Forge::Cache.base_path)
+        @dir ||= Dir.mktmpdir('tmp', Puppet::Forge::Cache.base_path)
       end
     end
   end


### PR DESCRIPTION
 - For modules that install on Windows and use a long hierarchical
   directory structure, the default TEMP path where PMT extracts the
   modules tarball can be problematic. Windows has a default maximum
   path length of 260 characters that must be carefully navigated.

   By default, the extracted temp location looks like:

   C:\ProgramData\PuppetLabs\puppet\cache\puppet-module\cache\tmp-unpackerYYYYMMDD-XXXX-xxxxxxx

   The default install location of a puppet 4.0+ module is:

   C:\ProgramData\PuppetLabs\code\environments\production\modules

   By initially extracting to such a long path, 30 valuable characters
   are wasted (92 char current temp path vs 62 char install path).

   On Windows, the TEMP directory can be used as a location to extract
   to, and this is the default for Dir.mkdir.  Depending on the user,
   this path will typically be one of the following:

   C:\Users\Administrator\AppData\Local\Temp  (41 chars)
   C:\Windows\Temp                            (15 chars)