### PR TITLE
(PUP-4848) Change CollExpr to check for future parser the correct way

### DIFF
--- a/lib/puppet/parser/ast/collexpr.rb
+++ b/lib/puppet/parser/ast/collexpr.rb
@@ -100,7 +100,7 @@ class CollExpr < AST::Branch
 
   def initialize(hash = {})
     super
-    if Puppet[:parser] == "future"
+    if Puppet.future_parser?
       @@compare_operator ||= Puppet::Pops::Evaluator::CompareOperator.new
     end
     raise ArgumentError, "Invalid operator #{@oper}" unless %w{== != and or}.include?(@oper)


### PR DESCRIPTION
When the feature enabling environment.conf to specify parser was added,
all checks for 'is future parser in effect' should be made via the
method `Puppet.future_parser?` instead of just checking
`Puppet[:parser]´ as the latter just checks what that setting is in
the MAIN section.

As a result, the collection expression would try to bring in 4.x code
that had not been required. This would happen if the runtime had never
executed a request where parser == 'future'. The 4.x code would not be
used, but it would instantiate a structure to support 4.x evaluation.

This fix is simply to use the correct way of checking if future parser
is in effect.