### PR TITLE
(PUP-4050) Git acceptance requires AIO module dirs

### DIFF
--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -39,6 +39,20 @@ PACKAGES = {
   ],
 }
 
+# override incorrect FOSS (git) defaults from Beaker with AIO applicable ones
+#
+# Remove after PUP-4867 breaks distmoduledir and sitemoduledir into individual
+# settings from modulepath and Beaker can properly introspect these settings
+hosts.each do |host|
+  platform = host['platform'] =~ /windows/ ? 'windows' : 'unix'
+
+  # Beakers add_aio_defaults_on helper is not appropriate here as it
+  # also alters puppetbindir / privatebindir to use package installed
+  # paths rather than git installed paths
+  host['distmoduledir'] = AIO_DEFAULTS[platform]['distmoduledir']
+  host['sitemoduledir'] = AIO_DEFAULTS[platform]['sitemoduledir']
+end
+
 hosts.each do |host|
   case host['platform']
   when  /solaris-10/

--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -46,6 +46,8 @@ PACKAGES = {
 hosts.each do |host|
   platform = host['platform'] =~ /windows/ ? 'windows' : 'unix'
 
+  host['puppetbindir'] = '/usr/bin' if platform == 'windows'
+
   # Beakers add_aio_defaults_on helper is not appropriate here as it
   # also alters puppetbindir / privatebindir to use package installed
   # paths rather than git installed paths


### PR DESCRIPTION
- Previously, Git based acceptance was still configured to use FOSS
   default paths for distmoduledir and sitemoduledir, which are
   incorrect given AIO pathing changes.  This would cause a number of
   acceptance test failures.  This commit effectively changes paths:

```
   Windows
   distmoduledir: "`cygpath -smF 35`/PuppetLabs/puppet/etc/modules"
   sitemoduledir: C:/usr/share/puppet/modules

   Other platforms
   distmoduledir: '/etc/puppet/modules'
   sitemoduledir: '/usr/share/puppet/modules'
```

   To those specified in Beaker's AIO_DEFAULTS hash.

```
   Windows
   distmoduledir: '`cygpath -smF 35`/PuppetLabs/code/modules'
   sitemoduledir:

   Other platforms
   distmoduledir: '/etc/puppetlabs/code/modules'
   sitemoduledir: '/opt/puppetlabs/puppet/modules'
```

 - Note that Windows sitemoduledir is now removed from the host
   configuration given it's not expressed in Beaker's AIO_DEFAULTS at
   this point in time - see PUP-4049.  To this point it has never
   used on Windows.

 - Note that Beaker does have an add_aio_defaults_on helper in the
   AIODefaults module.  However, this additionally modifies puppetbindir
   and privatebindir for AIO, when Git based installs actually use
   /usr/bin across the board when creating an on-the-fly installation.

 - Note that this can code can be removed once a split of modulepath
   into separate settings occurs as part of PUP-4867 and changes are
   made in Beaker to handle this