### PR TITLE
(PUP-4854) Shorten PMT TEMP location on Windows

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -592,7 +592,7 @@ module Puppet
       :desc     => "The module repository",
     },
     :module_working_dir => {
-        :default  => '$vardir/puppet-module',
+        :default  => (Puppet.features.microsoft_windows? ? Dir.tmpdir() : '$vardir/puppet-module'),
         :desc     => "The directory into which module tool data is stored",
     },
     :module_skeleton_dir => {

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -93,7 +93,7 @@ module Puppet::ModuleTool
       # @api private
       # @return [String] path to temporary unpacking location
       def tmpdir
-        @dir ||= Dir.mktmpdir('tmp-unpacker', Puppet::Forge::Cache.base_path)
+        @dir ||= Dir.mktmpdir('tmp', Puppet::Forge::Cache.base_path)
       end
     end
   end


### PR DESCRIPTION
 - For modules that install on Windows and use a long hierarchical
   directory structure, the default TEMP path where PMT extracts the
   modules tarball can be problematic. Windows has a default maximum
   path length of 260 characters that must be carefully navigated.

   By default, the extracted temp location looks like:

   C:\ProgramData\PuppetLabs\puppet\cache\puppet-module\cache\tmp-unpackerYYYYMMDD-XXXX-xxxxxxx

   The default install location of a puppet 4.0+ module is:

   C:\ProgramData\PuppetLabs\code\environments\production\modules

   This is based on the module_working_dir setting originally added in
   eb617e5d9093834588732e78f42e865c814b982b

   By initially extracting to such a long path, 30 valuable characters
   are wasted (92 char current temp path vs 62 char install path).

   On Windows, the TEMP directory can be used as a location to extract
   to, and this is the default for Dir.mktmpdir.  Depending on the user,
   this path will typically be one of the following:

   C:\Users\USERNAME\AppData\Local\Temp     (41 chars for Administrator)
   C:\Windows\Temp                          (15 chars) - for service

   The next part of the path has also been reduced to:

   cache\tmpYYYYMMDD-XXXX-xxxxxxx           (30 chars)

   Note: When run as SYSTEM, the following permissions are set on such
   a folder by default.

   C:/Windows/Temp/tmp-unpacker20150714-4228-1p6ldmc

   NT AUTHORITY\SYSTEM:(I)(OI)(CI)(S,RD)
   BUILTIN\IIS_IUSRS:(I)(OI)(CI)(S,RD)
   BUILTIN\Users:(I)(CI)(S,WD,AD,X)
   BUILTIN\Administrators:(I)(F)
   BUILTIN\Administrators:(I)(OI)(CI)(IO)(F)
   NT AUTHORITY\SYSTEM:(I)(F)
   NT AUTHORITY\SYSTEM:(I)(OI)(CI)(IO)(F)
   CREATOR OWNER:(I)(OI)(CI)(IO)(F)

   If running `puppet module install` as SYSTEM, there is a minor
   security issue given Users are granted granted Synchronize / Write /
   Append / Execute permissions.  However, this is not a normal method
   for installing modules.  Modules are typically pluginsync'd via the
   Puppet service, or `puppet module install` is run as a normal user
   that has a user-specific temporary directory.

   Given per-user temp directories are more secure by default, this is
   why the base_path on Windows has not been set to %SystemRoot%\Temp
   for all cases.