### PR TITLE
PUP-4918 - Updated logrotate and init scripts

### DIFF
--- a/ext/debian/puppet.logrotate
+++ b/ext/debian/puppet.logrotate
@@ -1,11 +1,20 @@
-/var/log/puppetlabs/puppet.log {
-  missingok
-  sharedscripts
-  create 0644 puppet puppet
+/var/log/puppetlabs/masterhttp.log /var/log/puppet/masterhttp.log {
   compress
   rotate 4
+  missingok
+  notifempty
+  nocreate
+}
 
+/var/log/puppetlabs/puppetd.log /var/log/puppet/puppetd.log {
+  compress
+  rotate 4
+  missingok
+  notifempty
+  nocreate
+  sharedscripts
   postrotate
-    [ -e /etc/init.d/puppet ] && /etc/init.d/puppet reload > /dev/null 2>&1 || true
+   ([ -x /etc/init.d/puppet ] && /etc/init.d/puppet reload > /dev/null 2>&1) ||
+    ([ -x /usr/bin/systemctl ] && /usr/bin/systemctl kill -s USR2 puppet.service > /dev/null 2>&1) || true
   endscript
 }

--- a/ext/redhat/client.init
+++ b/ext/redhat/client.init
@@ -54,8 +54,16 @@ stop() {
 }
 
 reload() {
-    echo -n $"Restarting puppet agent: "
+    echo -n $"Reloading puppet agent: "
     killproc $pidopts $puppetd -HUP
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
+
+rotate() {
+    echo -n $"Reopening log files for puppet agent: "
+    killproc $pidopts $puppetd -USR2
     RETVAL=$?
     echo
     return $RETVAL
@@ -91,6 +99,9 @@ case "$1" in
     restart)
         restart
     ;;
+    rotate)
+        rotate
+    ;;
     reload|force-reload)
         reload
     ;;
@@ -109,7 +120,7 @@ case "$1" in
         genconfig
     ;;
     *)
-        echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart|once|genconfig}"
+        echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart|rotate|once|genconfig}"
         exit 1
 esac
 

--- a/ext/redhat/logrotate
+++ b/ext/redhat/logrotate
@@ -1,9 +1,21 @@
-/var/log/puppetlabs/puppet.log {
+# Generic logrotate config for Red Hat systems. Works with both official
+# Fedora and RHEL packages as well as PuppetLabs distributions.
+
+/var/log/puppetlabs/masterhttp.log /var/log/puppet/masterhttp.log {
+  compress
   missingok
   notifempty
-  create 0644 puppet puppet
+  nocreate
+}
+
+/var/log/puppetlabs/puppetd.log /var/log/puppet/puppetd.log {
+  compress
+  missingok
+  notifempty
+  nocreate
   sharedscripts
   postrotate
-    [ -e /etc/init.d/puppet ] && /etc/init.d/puppet reload > /dev/null 2>&1 || true
+   ([ -x /etc/init.d/puppet ] && /etc/init.d/puppet reload > /dev/null 2>&1) ||
+    ([ -x /usr/bin/systemctl ] && /usr/bin/systemctl kill -s USR2 puppet.service > /dev/null 2>&1) || true
   endscript
 }

--- a/ext/redhat/puppet.spec.erb
+++ b/ext/redhat/puppet.spec.erb
@@ -181,12 +181,15 @@ echo "D /var/run/%{name} 0755 %{name} %{name} -" > \
 # Create puppet modules directory for puppet module tool
 mkdir -p %{buildroot}%{_sysconfdir}/%{name}/modules
 
-
 # Install a NetworkManager dispatcher script to pickup changes to
 # # /etc/resolv.conf and such (https://bugzilla.redhat.com/532085).
 mkdir -p %{buildroot}%{_sysconfdir}/NetworkManager/dispatcher.d
 cp -pr ext/puppet-nm-dispatcher \
   %{buildroot}%{_sysconfdir}/NetworkManager/dispatcher.d/98-%{name}
+
+# Masterhttp.log is created on server start and should be distributed
+# with correct permissions
+touch %{buildroot}%{_localstatedir}/log/puppet/masterhttp.log
 
 %files
 %defattr(-, root, root, 0755)
@@ -280,6 +283,7 @@ cp -pr ext/puppet-nm-dispatcher \
 %{_sysconfdir}/puppet/environments/example_env/README.environment
 %{_mandir}/man8/puppet-ca.8.gz
 %{_mandir}/man8/puppet-master.8.gz
+%attr(660, puppet, puppet) %{_localstatedir}/log/puppet/masterhttp.log
 
 # Fixed uid/gid were assigned in bz 472073 (Fedora), 471918 (RHEL-5),
 # and 471919 (RHEL-4)

--- a/ext/systemd/puppet.service
+++ b/ext/systemd/puppet.service
@@ -8,6 +8,7 @@ EnvironmentFile=-/etc/sysconfig/puppetagent
 EnvironmentFile=-/etc/sysconfig/puppet
 EnvironmentFile=-/etc/default/puppet
 ExecStart=/opt/puppetlabs/puppet/bin/puppet agent $PUPPET_EXTRA_OPTS --no-daemonize
+ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 
 [Install]


### PR DESCRIPTION
This patch updates logrotate script and aligns it what is defined in
defaults.rb, specifically:

https://github.com/puppetlabs/puppet/blob/master/lib/puppet/defaults.rb#L1036-L1046

and

https://github.com/puppetlabs/puppet/blob/master/lib/puppet/defaults.rb#L1258-L1274

Because of logrotate and puppet during restart were both "fighting" for correct
file permissions, this was causing issues with SELinux. Also fixed paths which
has been incorrect for Fedora/RHEL systems (`/var/log/puppetlabs` vs
`/var/log/puppet`). It contains both now which seems to work just fine.

I am not adding logrotate scriplet for master tho as I don't know if it
supports signals. When running master under webrick one should not expect fully
working log rotation tho. Open for discussion.

As part of this patch, I am also updating Red Hat startup scripts:

* RHEL6 traditional UNIX-like "reload" command was actually sending HUP signal
 and therefore restarting daemon instead correct USR1
* RHEL7 systemd unit was extended with "reload" command using USR1 signal