### PR TITLE
(maint) Use tags for Windows MSI dependencies

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -16,7 +16,7 @@ build_gem: TRUE
 build_dmg: TRUE
 build_msi:
   puppet_for_the_win:
-    ref: '2476cd007b1b52fb1b9f22202b56218629626b5c'
+    ref: 'refs/tags/3.8.0'
     repo: 'git://github.com/puppetlabs/puppet_for_the_win.git'
   facter:
     ref: 'refs/tags/2.4.4'
@@ -26,8 +26,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/hiera.git'
   sys:
     ref:
-      x86: '766c286233138db2140ab3c3cdcc0de9c3041203'
-      x64: '808e292150274f7eaded27445ad33174a1410716'
+      x86: 'refs/tags/1.9.3-p551.4'
+      x64: 'refs/tags/2.0.0.7-x64'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
 - We recently had to recall the Windows 3.7.5 builds due to an errant
   commit 8c73637a1e2e001008b674c8c5b63736aa7ab0a7 which accidentally
   switched the vendored Ruby from 1.9.3 on x86 and 2.0.0 on x64 to
   2.1.x on both architectures.

   Fortunately, this was later unknowingly corrected in
   b9c6b9b5f471ab709858178d82c8af59d545714f when the vendored Ruby was
   switched back to what it should have been.

   Given SHAs are not human readable, attempt to limit the possibility
   for another human error by using git tags as much as possible.

   Note: This only affects the 3.x line of Puppet builds.  Since 4.x AIO
   builds use the puppet-agent repo, these defaults are no longer set
   in this repository.  That repository is already following the model
   of using tags rather than SHAs for maintainability.