### PR TITLE
(PUP-4919) static compiler always sets ensure parameter to 'file' if a

### DIFF
--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -41,6 +41,8 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     raise "Did not get catalog back" unless catalog.is_a?(model)
 
     catalog.resources.find_all { |res| res.type == "File" }.each do |resource|
+      next if resource[:ensure] == 'absent'
+
       next unless source = resource[:source]
       next unless source =~ /^puppet:/
 


### PR DESCRIPTION
The static_compiler catalog terminus always sets ensure to 'file' on
file resources as long as the resource has a source parameter declared.
It does this even if the ensure parameter is explicitly declared.

This is inconsistent with the behavior of the normal compiler, where a
file's ensure parameter gets enforced regardless of the value of the
source parameter.

This commit skips file resources with ensure set to 'absent' in the static
compiler.