### PR TITLE
(MAINT) Fix duplicate key which ruby 2.2 complains about

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -486,10 +486,6 @@ module Puppet
       :default    => "stomp",
       :desc       => "Which type of queue to use for asynchronous processing.",
     },
-    :queue_type => {
-      :default    => "stomp",
-      :desc       => "Which type of queue to use for asynchronous processing.",
-    },
     :queue_source => {
       :default    => "stomp://localhost:61613/",
       :desc       => "Which type of queue to use for asynchronous processing.  If your stomp server requires


### PR DESCRIPTION
Ruby 2.2 complains with:
```
/usr/local/lib/ruby/site_ruby/2.2/puppet/defaults.rb:488: warning: duplicated key at line 489 ignored: :queue_type
```

The `:queue_type` is obviously duplicated so it's safe to remove one of them.