### PR TITLE
(PUP-4926) Make it possible to form relationship with 3x resource

### DIFF
--- a/lib/puppet/pops/evaluator/relationship_operator.rb
+++ b/lib/puppet/pops/evaluator/relationship_operator.rb
@@ -155,7 +155,7 @@ class Puppet::Pops::Evaluator::RelationshipOperator
       # Produce the transformed source RHS (if this is a chain, this does not need to be done again)
       real.slice(1)
     rescue NotCatalogTypeError => e
-      fail(Issues::ILLEGAL_RELATIONSHIP_OPERAND_TYPE, relationship_expression, {:type => @type_calculator.string(e.type)})
+      fail(Issues::NOT_CATALOG_TYPE, relationship_expression, {:type => @type_calculator.string(e.type)})
     rescue IllegalRelationshipOperandError => e
       fail(Issues::ILLEGAL_RELATIONSHIP_OPERAND_TYPE, relationship_expression, {:operand => e.operand})
     end

--- a/lib/puppet/pops/evaluator/relationship_operator.rb
+++ b/lib/puppet/pops/evaluator/relationship_operator.rb
@@ -48,6 +48,12 @@ class Puppet::Pops::Evaluator::RelationshipOperator
     raise IllegalRelationshipOperandError.new(o)
   end
 
+  # A Resource is by definition a Catalog type, but of 3.x type
+  # @api private
+  def transform_Resource(o, scope)
+    Puppet::Pops::Types::TypeFactory.resource(o.type, o.title)
+  end
+
   # A string must be a type reference in string format
   # @api private
   def transform_String(o, scope)

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1195,6 +1195,14 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       expect(scope.compiler).to have_relationship(['File', 'b', '->', 'File', 'y'])
     end
 
+    it 'should form a relation with 3.x resource -> resource' do
+      # Create a 3.x resource since this is the value given as arguments to defined type
+      scope['a_3x_resource']= Puppet::Parser::Resource.new('notify', 'a', {:scope => scope, :file => __FILE__, :line => 1})
+      source = "$a_3x_resource -> notify{b:}"
+      parser.evaluate_string(scope, source, __FILE__)
+      expect(scope.compiler).to have_relationship(['Notify', 'a', '->', 'Notify', 'b'])
+    end
+
     it 'should tolerate (eliminate) duplicates in operands' do
       source = "[File[a], File[a]] -> File[x]"
       parser.evaluate_string(scope, source, __FILE__)


### PR DESCRIPTION
Before this, passing a resource reference as an attribute value resulted in that value not being useful as an operand in a resource expression.

This also corrects a faulty choice of issue leading to an error message with less information.