### PR TITLE
(PUP-3228) Remove {} from PUPPET*_EXTRA_OPTS (backport)

### DIFF
--- a/ext/systemd/puppet.service
+++ b/ext/systemd/puppet.service
@@ -6,7 +6,7 @@ After=basic.target network.target puppetmaster.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/puppetagent
 EnvironmentFile=-/etc/sysconfig/puppet
-ExecStart=/usr/bin/puppet agent ${PUPPET_EXTRA_OPTS} --no-daemonize
+ExecStart=/usr/bin/puppet agent $PUPPET_EXTRA_OPTS --no-daemonize
 KillMode=process
 
 [Install]

--- a/ext/systemd/puppetmaster.service
+++ b/ext/systemd/puppetmaster.service
@@ -5,7 +5,7 @@ After=basic.target network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/puppetmaster
-ExecStart=/usr/bin/puppet master ${PUPPETMASTER_EXTRA_OPTS} --no-daemonize
+ExecStart=/usr/bin/puppet master $PUPPETMASTER_EXTRA_OPTS --no-daemonize
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
PUP-3228 was fixed by #3015 against master, but the fix was never backported to 3.X. This commit backports that fix to 3.X.