### PR TITLE
(PUP-4196) Remove "{}" from variables in systemd files

### DIFF
--- a/ext/systemd/puppet.service
+++ b/ext/systemd/puppet.service
@@ -6,7 +6,7 @@ After=basic.target network.target puppetmaster.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/puppetagent
 EnvironmentFile=-/etc/sysconfig/puppet
-ExecStart=/usr/bin/puppet agent ${PUPPET_EXTRA_OPTS} --no-daemonize
+ExecStart=/usr/bin/puppet agent $PUPPET_EXTRA_OPTS --no-daemonize
 KillMode=process
 
 [Install]

--- a/ext/systemd/puppetmaster.service
+++ b/ext/systemd/puppetmaster.service
@@ -5,7 +5,7 @@ After=basic.target network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/puppetmaster
-ExecStart=/usr/bin/puppet master ${PUPPETMASTER_EXTRA_OPTS} --no-daemonize
+ExecStart=/usr/bin/puppet master $PUPPETMASTER_EXTRA_OPTS --no-daemonize
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The "{}" prevent systemd from interpreting values correctly and causes
services to fail to start. {} indicates that the variable is a single
argument[1].

This is largely a cherry-pick of the fix for PUP-3228.

[1] - http://www.freedesktop.org/software/systemd/man/systemd.service.html