### PR TITLE
(FACT-1123) Adding acceptance test for facter with invalid locale

### DIFF
--- a/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
+++ b/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
@@ -1,0 +1,7 @@
+test_name "ticket 1123  facter should not crash with invalid locale setting"
+confine :except, :platform => 'windows'
+agents.each do |host|
+  step "set an invalid value for locale and run facter"
+  on host,( "LANG=ABCD facter facterversion"), :acceptable_exit_codes => [ 0 , 2 ]
+end
+


### PR DESCRIPTION
This commit adds an acceptance test to make sure facter is not crashing
when locale is set to an invalid value