### PR TITLE
(PUP-3694) puppet cert fingerprint invalidhost returns zero instead of non-zero [#puppethack]

### DIFF
--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -140,7 +140,7 @@ module Puppet
             if value = ca.print(host)
               puts value
             else
-              Puppet.err "Could not find certificate for #{host}"
+              raise ArgumentError, "Could not find certificate for #{host}"
             end
           end
         end
@@ -151,7 +151,7 @@ module Puppet
             if cert = (Puppet::SSL::Certificate.indirection.find(host) || Puppet::SSL::CertificateRequest.indirection.find(host))
               puts "#{host} #{cert.digest(@digest)}"
             else
-              Puppet.err "Could not find certificate for #{host}"
+	      raise ArgumentError, "Could not find certificate for #{host}"
             end
           end
         end

--- a/spec/unit/ssl/certificate_authority/interface_spec.rb
+++ b/spec/unit/ssl/certificate_authority/interface_spec.rb
@@ -332,9 +332,10 @@ describe Puppet::SSL::CertificateAuthority::Interface do
           @applier.expects(:puts).with "h1"
 
           @ca.expects(:print).with("host2").returns nil
-          Puppet.expects(:err).with { |msg| msg.include?("host2") }
-
-          @applier.apply(@ca)
+    
+	  expect {
+            @applier.apply(@ca)
+	  }.to raise_error(ArgumentError, /Could not find certificate for host2/)
         end
       end
     end


### PR DESCRIPTION
  Enforce a non-zero return code for errors in the puppet cert print|fingerprint functions.