### PR TITLE
(PUP-4905) Add app managment feature switch

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -526,6 +526,15 @@ module Puppet
       :desc    => "The directory where catalog previews per node are generated."
     }
   )
+
+  define_settings(:main,
+      :app_management => {
+          :default  => false,
+          :type     => :boolean,
+          :desc     => "Whether the application management feature is on or off. A change of this setting requires a reboot.",
+      }
+  )
+
   Puppet.define_settings(:module_tool,
     :module_repository  => {
       :default  => 'https://forgeapi.puppetlabs.com',

--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -107,6 +107,12 @@ class Puppet::Pops::Parser::Lexer2
   # is not used, but is kept here for documentation purposes.
   TOKEN_OTHER        = [:OTHER,  nil,  0]
 
+  APP_MANAGEMENT_TOKENS = if Puppet[:app_management]
+    {:APPLICATION => :APPLICATION, :CONSUMES => :CONSUMES, :PRODUCES => :PRODUCES }
+  else
+    {:APPLICATION => :APPLICATION_R, :CONSUMES => :CONSUMES_R, :PRODUCES => :PRODUCES_R }
+  end
+
   # Keywords are all singleton tokens with pre calculated lengths.
   # Booleans are pre-calculated (rather than evaluating the strings "false" "true" repeatedly.
   #
@@ -131,11 +137,10 @@ class Puppet::Pops::Parser::Lexer2
     "type"     => [:TYPE,     'type',     4],
     "attr"     => [:ATTR,     'attr',     4],
     "private"  => [:PRIVATE,  'private',  7],
-    # The following tokens exist in reserved form. Later they will be made
-    # live subject to a feature switch.
-    "application"  => [:APPLICATION_R,  'application',  11],
-    "consumes"     => [:CONSUMES_R,  'consumes',  8],
-    "produces"     => [:PRODUCES_R,  'produces',  8],
+     # Feature-switched tokens; either reserved, or real tokens
+    "application"  => [APP_MANAGEMENT_TOKENS[:APPLICATION],  'application',  11],
+    "consumes"     => [APP_MANAGEMENT_TOKENS[:CONSUMES],  'consumes',  8],
+    "produces"     => [APP_MANAGEMENT_TOKENS[:PRODUCES],  'produces',  8],
   }
 
   KEYWORDS.each {|k,v| v[1].freeze; v.freeze }

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -100,13 +100,42 @@ describe 'Lexer2' do
     end
   end
 
-  {
-    "application"  => :APPLICATION_R,
-    "consumes"     => :CONSUMES_R,
-    "produces"     => :PRODUCES_R,
-  }.each do |string, name|
-    it "should lex a (future reserved) keyword from '#{string}'" do
-      expect(tokens_scanned_from(string)).to match_tokens2(name)
+  context 'when app_management is off (by default)' do
+    {
+      "application"  => :APPLICATION_R,
+      "consumes"     => :CONSUMES_R,
+      "produces"     => :PRODUCES_R,
+    }.each do |string, name|
+      it "should lex a (future reserved) keyword from '#{string}'" do
+        expect(tokens_scanned_from(string)).to match_tokens2(name)
+      end
+    end
+  end
+
+  context 'when app_managment is (turned) on' do
+    # Horrible things have to be done to test this as the Lexer sets up the KEYWORD table as a frozen constant,
+    # and this list depends on the Puppet[:app_management] setting. These 'before all' and 'after all' clauses
+    # forces Ruby to reload the Lexer
+    before(:all) do
+      Puppet[:app_management] = true
+      Puppet::Pops::Parser.send(:remove_const, :Lexer2)
+      load 'puppet/pops/parser/lexer2.rb'
+    end
+
+    after(:all) do
+      Puppet[:app_management] = false
+      Puppet::Pops::Parser.send(:remove_const, :Lexer2)
+      load 'puppet/pops/parser/lexer2.rb'
+    end
+
+    {
+      "application"  => :APPLICATION,
+      "consumes"     => :CONSUMES,
+      "produces"     => :PRODUCES,
+    }.each do |string, name|
+      it "should lex a keyword from '#{string}'" do
+        expect(tokens_scanned_from(string)).to match_tokens2(name)
+      end
     end
   end
 


### PR DESCRIPTION
Adds the ability to feature-switch tokens related to app_management. A setting is added, and used to configure to lexer. The work in the PR is just an enabler for future features. See ticket for more information.