### PR TITLE
(PUP-4622) Fix acceptance test in Jenkins CI

### DIFF
--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -1,86 +1,72 @@
 test_name "ticket 4622 filebucket diff test."
 confine :except, :platform => 'windows'
+skip_test 'skip test, no non-Windows agents specified' if agents.empty?
 
-def create_testfile(filename, contents)
-  create_remote_file(agent, filename, "#{contents}")
-end
-
-def get_checksum_from_backup(filename, bucket_locale)
-  on agent, puppet("filebucket backup #{filename} #{bucket_locale}"), :acceptable_exit_codes => [ 0, 2 ]
+def get_checksum_from_backup_on(host, filename, bucket_locale)
+  on host, puppet("filebucket backup #{filename} #{bucket_locale}"), :acceptable_exit_codes => [ 0, 2 ]
   output = result.stdout.strip.split(": ")
   checksum = output.last
   return checksum
 end
 
-def validate_diff(item_one, item_two, bucket_locale)
-  on agent, puppet("filebucket diff #{item_one} #{item_two} #{bucket_locale}"), :acceptable_exit_codes => [ 0, 2 ]
+def validate_diff_on(host, item_one, item_two, bucket_locale)
+  on host, puppet("filebucket diff #{item_one} #{item_two} #{bucket_locale}"), :acceptable_exit_codes => [ 0, 2 ]
   assert_match("-foo", result.stdout.strip)
   assert_match('+bar', result.stdout.strip)
   assert_match('+baz', result.stdout.strip)
 end
 
 step "Master: Start Puppet Master" do
-  hostname = on(master, 'facter hostname').stdout.strip
-  fqdn = on(master, 'facter fqdn').stdout.strip
-  master_opts = {
-    :main => {
-      :dns_alt_names => "puppet,#{hostname},#{fqdn}",
-    },
-    :__service_args__ => {
-      :bypass_service_script => true,
-    },
-  }
+  with_puppet_running_on(master, {}) do
+    agents.each do |agent|
 
-  with_puppet_running_on(master, master_opts) do
-  agents.each do |agent|
+      tmpfile = agent.tmpfile('testfile')
+      remote_str = "--remote --server #{master}"
+      local_str = "--local"
 
-    tmpfile = agent.tmpfile('testfile')
-    remote_str = "--remote --server #{master}"
-    local_str = "--local"
+      teardown do
+        step "Cleanup tmpfile"
+        on(agent, "rm -f #{tmpfile}")
+      end
 
-    teardown do
-      step "Cleanup tmpfile"
-      on(agent, "rm -f #{tmpfile}")
+      step "Create a tmp file with single line 'foo'"
+      create_remote_file(agent, tmpfile, "foo")
+
+      step "Backup the file using remote filebucket and get the checksum"
+      remote_checksum_1 = get_checksum_from_backup_on(agent, tmpfile, remote_str)
+
+      step "Modify the tmpfile contents, remove line 'foo' and add lines 'bar' and 'baz'"
+      create_remote_file(agent, tmpfile, "bar\nbaz")
+
+      step "Backup the modified file using remote filebucket and get the new checksum"
+      remote_checksum_2 = get_checksum_from_backup_on(agent, tmpfile, remote_str)
+
+      step "Find the filebucket diff of the two checksums and validate the output "
+      validate_diff_on(agent, remote_checksum_1, remote_checksum_2, remote_str)
+
+      step "Find the filebucket diff of the first checksum and the local file and validate the output "
+      validate_diff_on(agent, remote_checksum_1, tmpfile, remote_str)
+
+      step "Repeat above steps for local file bucket"
+
+      step "Create a tmp file with single line 'foo'"
+      create_remote_file(agent, tmpfile, "foo")
+
+      step "Backup the file using local filebucket and get the checksum"
+      local_checksum_1 = get_checksum_from_backup_on(agent, tmpfile, local_str)
+
+      step "Modify the tmpfile contents, remove line 'foo' and add lines 'bar' and 'baz'"
+      create_remote_file(agent, tmpfile, "bar\nbaz")
+
+      step "Backup the modified file using local filebucket and get the new checksum"
+      local_checksum_2 = get_checksum_from_backup_on(agent, tmpfile, local_str)
+
+      step "Find the filebucket diff of the two checksums and validate the output "
+      validate_diff_on(agent, local_checksum_1, local_checksum_2, local_str)
+
+      step "Find the filebucket diff of the first checksum and the local file and validate the output "
+      validate_diff_on(agent, local_checksum_1, tmpfile, local_str)
+
     end
-
-    step "Create a tmp file with single line 'foo'"
-    create_testfile(tmpfile,"foo")
-
-    step "Backup the file using remote filebucket and get the checksum"
-    remote_checksum_1 = get_checksum_from_backup(tmpfile, remote_str)
-
-    step "Modify the tmpfile contents, remove line 'foo' and add lines 'bar' and 'baz'"
-    create_testfile(tmpfile,"bar\nbaz")
-
-    step "Backup the modified file using remote filebucket and get the new checksum"
-    remote_checksum_2 = get_checksum_from_backup(tmpfile, remote_str)
-
-    step "Find the filebucket diff of the two checksums and validate the output "
-    validate_diff(remote_checksum_1, remote_checksum_2, remote_str)
-
-    step "Find the filebucket diff of the first checksum and the local file and validate the output "
-    validate_diff(remote_checksum_1, tmpfile, remote_str)
-
-    step "Repeat above steps for local file bucket"
-
-    step "Create a tmp file with single line 'foo'"
-    create_testfile(tmpfile,"foo")
-
-    step "Backup the file using local filebucket and get the checksum"
-    local_checksum_1 = get_checksum_from_backup(tmpfile, local_str)
-
-    step "Modify the tmpfile contents, remove line 'foo' and add lines 'bar' and 'baz'"
-    create_testfile(tmpfile,"bar\nbaz")
-
-    step "Backup the modified file using local filebucket and get the new checksum"
-    local_checksum_2 = get_checksum_from_backup(tmpfile, local_str)
-
-    step "Find the filebucket diff of the two checksums and validate the output "
-    validate_diff(local_checksum_1, local_checksum_2, local_str)
-
-    step "Find the filebucket diff of the first checksum and the local file and validate the output "
-    validate_diff(local_checksum_1, tmpfile, local_str)
-
-  end
   end
 end


### PR DESCRIPTION
In the Jenkins environment, the master options being passed cause the
test to fail when attempting to kill the master. Use default options to
setup the master for the test.

The test would still setup a master, even if no agents were identified
to test (i.e. Windows). Skip the test if no agents are available after
the confine.

Also cleanup some magic and formatting.

[skip ci]