### PR TITLE
(PUP-4605) Unmask before attemping to start

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -105,7 +105,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def enable
-    output = systemctl("unmask", @resource[:name])
+    self.unmask
     output = systemctl("enable", @resource[:name])
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not enable #{self.name}: #{output}", $!.backtrace
@@ -113,11 +113,18 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   def mask
     self.disable
-
     begin
       output = systemctl("mask", @resource[:name])
     rescue Puppet::ExecutionFailure
       raise Puppet::Error, "Could not mask #{self.name}: #{output}", $!.backtrace
+    end
+  end
+
+  def unmask
+    begin
+      output = systemctl("unmask", @resource[:name])
+    rescue Puppet::ExecutionFailure
+      raise Puppet::Error, "Could not unmask #{self.name}: #{output}", $!.backtrace
     end
   end
 
@@ -126,6 +133,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def startcmd
+    self.unmask
     [command(:systemctl), "start", @resource[:name]]
   end
 

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -132,6 +132,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
 
     it "should start the service with systemctl start otherwise" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:systemctl).with('unmask', 'sshd.service')
       provider.expects(:execute).with(['/bin/systemctl','start','sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
       provider.start
     end


### PR DESCRIPTION
Prior to this commit, if a service was masked, and a user tried to start
the service, it would throw an error because it was masked. Even if the
user enabled the service (which calls unmask), an error would be thrown
because 'start' would be run before 'enable'. This commit ensures that
the start command has the ability to unmask a service before trying to
start it.