### PR TITLE
(PUP-4936) Add files needed for smf puppet service

### DIFF
--- a/ext/solaris/smf/puppet
+++ b/ext/solaris/smf/puppet
@@ -1,0 +1,44 @@
+#!/sbin/sh
+
+. /lib/svc/share/smf_include.sh
+
+[ -z "${SMF_FMRI}" ] && exit $SMF_EXIT_ERR
+
+CONF_FILE=/etc/puppetlabs/puppet/puppet.conf
+[ ! -f "${CONF_FILE}" ] && exit $SMF_EXIT_ERR_CONFIG
+
+PUPPET=/opt/puppetlabs/bin/puppet
+
+case "$1" in
+start)
+  exec $PUPPET agent
+  ;;
+
+stop)
+  # stop sends sigterm first followed by sigkill
+  # smf_kill_contract <CTID> TERM 1 30
+  # sends sigterm to all process in ctid and will continue
+  # to do so for 30 seconds with interval of 5 seconds
+  # smf_kill_contract <CTID> KILL 1
+  # continues until all processes are killed.
+  # svcs -p <fmri> lists all processes in the contract.
+  # http://bnsmb.de/solaris/My_Little_SMF_FAQ.html
+  ctid=`svcprop -p restarter/contract $SMF_FMRI`
+  if [ -n "$ctid" ]; then
+    smf_kill_contract $ctid TERM 1 30
+    ret=$?
+    [ $ret -eq 1 ] && exit $SMF_EXIT_ERR_FATAL
+
+    if [ $ret -eq 2 ] ; then
+      smf_kill_contract $ctid KILL 1
+      [ $? -ne 0 ] && exit $SMF_EXIT_ERR_FATAL
+    fi
+  fi
+  ;;
+*)
+  echo "Usage: $0 {start|stop}";
+  exit $SMF_EXIT_ERR_FATAL
+  ;;
+esac
+exit $SMF_EXIT_OK
+

--- a/ext/solaris/smf/puppet.xml
+++ b/ext/solaris/smf/puppet.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!-- Original puppet manifest: Luke Kanies - puppetlabs.com -->
+<service_bundle type="manifest" name="puppet">
+
+  <service name="network/puppet" type="service" version="1">
+
+    <create_default_instance enabled="false"/>
+    <single_instance/>
+
+    <dependency name="config-file" grouping="require_all" restart_on="none" type="path">
+      <service_fmri value="file:///etc/puppetlabs/puppet/puppet.conf"/>
+    </dependency>
+
+    <dependency name="loopback" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/network/loopback:default"/>
+    </dependency>
+
+    <dependency name="physical" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/network/physical:default"/>
+    </dependency>
+
+    <dependency name="fs-local" grouping="require_all" restart_on="none" type="service">
+      <service_fmri value="svc:/system/filesystem/local"/>
+    </dependency>
+
+    <exec_method type="method" name="start" exec="/lib/svc/method/puppet start" timeout_seconds="60"/>
+
+    <exec_method type="method" name="stop" exec="/lib/svc/method/puppet stop" timeout_seconds="60"/>
+
+  <stability value="Evolving"/>
+
+    <template>
+      <common_name>
+        <loctext xml:lang="C">Puppet Agent Daemon</loctext>
+      </common_name>
+      <documentation>
+        <manpage title="puppet" section="1"/>
+        <doc_link name="puppetlabs.com" uri="http://puppetlabs.com/puppet/introduction"/>
+      </documentation>
+    </template>
+  </service>
+
+</service_bundle>


### PR DESCRIPTION
There were previously no smf files for puppet that weren't geared toward
opencsw. This commit adds the smf files from the PE service, and updates
them for current pathing.