### PR TITLE
(PUP-4997) Fix pip provider for EL6

### DIFF
--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -13,6 +13,6 @@ Puppet::Type.type(:package).provide :pip3,
   or an array where each element is either a string or a hash."
 
   def self.cmd
-    "pip3"
+    ["pip3"]
   end
 end


### PR DESCRIPTION
The issue is that the latest and only available python-pip package via EPEL for EL6 "python-pip-7.1.0-1.el6.noarch" doesn't have /usr/bin/pip-python anymore which is defined to be the binary for pip provider in puppet package resource check https://github.com/puppetlabs/puppet/blob/master/lib/puppet/provider/package/pip.rb#L42-L48
So I've added a backward compatibility, so pip provider will work either the binary is pip or pip-python