### PR TITLE
(PUP-4824) Fixup acceptance group / user tests for OSX

### DIFF
--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -1,6 +1,5 @@
 test_name "should modify gid of existing group"
 confine :except, :platform => 'windows'
-confine :except, :platform => /osx/ # See PUP-4824
 
 name = "pl#{rand(999999).to_i}"
 gid1  = rand(999999).to_i
@@ -18,10 +17,8 @@ agents.each do |agent|
   end
 
   step "verify that the GID changed"
-  on(agent, "getent group #{name}") do
-    fail_test "gid is wrong through getent output" unless
-      stdout =~ /^#{name}:.*:#{gid2}:/
-  end
+  gid_output = agent.group_gid(name).to_i
+  fail_test "gid #{gid_output} does not match expected value of: #{gid2}" unless gid_output == gid2
 
   step "clean up the system after the test run"
   on(agent, puppet_resource('group', name, 'ensure=absent'))

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -1,7 +1,5 @@
 test_name "should create a user"
 
-confine :except, :platform => /osx/ # See PUP-4824
-
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
@@ -16,7 +14,7 @@ agents.each do |agent|
   agent.user_get(name)
 
   case agent['platform']
-  when /sles/, /solaris/, /windows/
+  when /sles/, /solaris/, /windows/, /osx/
     # no private user groups by default
   else
     agent.group_get(name)

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -1,29 +1,32 @@
 test_name "verifies that puppet resource creates a user and assigns the correct group"
 confine :except, :platform => 'windows'
-confine :except, :platform => /osx/ # See PUP-4824
 
 user = "pl#{rand(999999).to_i}"
 group = "gp#{rand(999999).to_i}"
 
 agents.each do |host|
   step "user should not exist"
-  on host, "if getent passwd #{user}; then userdel #{user}; fi"
+  agent.user_absent(user)
 
   step "group should exist"
-  on host, "getent group #{group} || groupadd #{group}"
+  agent.group_present(group)
 
   step "create user with group"
   on(host, puppet_resource('user', user, 'ensure=present', "gid=#{group}"))
 
   step "verify the group exists and find the gid"
-  on(host, "getent group #{group}") do
-      gid = stdout.split(':')[2]
+  group_gid = agent.group_gid(group)
 
-      step "verify that the user has that as their gid"
-      on(host, "getent passwd #{user}") do
-          got = stdout.split(':')[3]
-          fail_test "wanted gid #{gid} but found #{got}" unless gid == got
-      end
+  step "verify that the user has that as their gid"
+  agent.user_get(user) do |result|
+    if agent['platform'] =~ /osx/
+        match = result.stdout.match(/gid: (\d+)/)
+        user_gid = match ? match[1] : nil
+    else
+        user_gid = result.stdout.split(':')[3]
+    end
+
+    fail_test "expected gid #{group_gid} but got: #{user_gid}" unless group_gid == user_gid
   end
 
   step "clean up after the test is done"

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -1,6 +1,5 @@
 test_name "verify that we can modify the gid"
 confine :except, :platform => 'windows'
-confine :except, :platform => /osx/ # See PUP-4824
 
 user = "pl#{rand(99999).to_i}"
 group1 = "#{user}old"
@@ -15,25 +14,32 @@ agents.each do |host|
   on(host, puppet_resource('user', user, 'ensure=present', "gid=#{group1}"))
 
   step "verify that the user has the correct gid"
-  on(host, "getent group #{group1}") do
-      gid = stdout.split(':')[2]
-      on(host, "getent passwd #{user}") do
-          got = stdout.split(':')[3]
-          fail_test "didn't have the expected old GID, but #{got}" unless got == gid
-      end
+  group_gid1 = agent.group_gid(group1)
+  agent.user_get(user) do |result|
+    if agent['platform'] =~ /osx/
+        match = result.stdout.match(/gid: (\d+)/)
+        user_gid1 = match ? match[1] : nil
+    else
+        user_gid1 = result.stdout.split(':')[3]
+    end
+
+    fail_test "didn't have the expected old GID #{group_gid1}, but got: #{user_gid1}" unless group_gid1 == user_gid1
   end
 
   step "modify the GID of the user"
   on(host, puppet_resource('user', user, 'ensure=present', "gid=#{group2}"))
 
-
   step "verify that the user has the updated gid"
-  on(host, "getent group #{group2}") do
-      gid = stdout.split(':')[2]
-      on(host, "getent passwd #{user}") do
-          got = stdout.split(':')[3]
-          fail_test "didn't have the expected old GID, but #{got}" unless got == gid
-      end
+  group_gid2 = agent.group_gid(group2)
+  agent.user_get(user) do |result|
+    if agent['platform'] =~ /osx/
+        match = result.stdout.match(/gid: (\d+)/)
+        user_gid2 = match ? match[1] : nil
+    else
+        user_gid2 = result.stdout.split(':')[3]
+    end
+
+    fail_test "didn't have the expected old GID #{group_gid}, but got: #{user_gid2}" unless group_gid2 == user_gid2
   end
 
   step "ensure that we remove the things we made"


### PR DESCRIPTION
Previously, several user and group acceptance tests dependeded
on `getent` to create and query users and groups on the system.
This did not work in OSX, and caused several test failures.

We now have cross-platform beaker methods specifically meant for
user and group management which we can use to replace the bare
`getent` calls.