### PR TITLE
(SERVER-832) Fix bug in stat function

### DIFF
--- a/acceptance/lib/puppet/acceptance/temp_file_utils.rb
+++ b/acceptance/lib/puppet/acceptance/temp_file_utils.rb
@@ -140,7 +140,7 @@ module Puppet
       # value containing only the file mode, excluding the type, e.g
       # S_IFDIR 0040000
       def stat(host, path)
-        stat_command = case agent['platform']
+        stat_command = case host['platform']
                        when /osx/
                          "stat -f '%Su:%Sg:%p'"
                        else


### PR DESCRIPTION
This is coming from a CI failure for `puppet-server`, which uses `puppet` 4.2.1, see [SERVER-832](https://tickets.puppetlabs.com/browse/SERVER-832) for details. 

It seems that the `stat` function references the `agent` variable when it should be using the `host` parameter that gets passed in. I'm actually a bit confused as to how it functions at all right now, since I can't reproduce the test failure locally.