### PR TITLE
(PUP-4485) Add 'hiera' data provider

### DIFF
--- a/lib/puppet/data_binding.rb
+++ b/lib/puppet/data_binding.rb
@@ -2,11 +2,43 @@ require 'puppet/indirector'
 
 # A class for managing data lookups
 class Puppet::DataBinding
-  class LookupError < Puppet::Error; end
-
   # Set up indirection, so that data can be looked for in the compiler
   extend Puppet::Indirector
 
   indirects(:data_binding, :terminus_setting => :data_binding_terminus,
     :doc => "Where to find external data bindings.")
+
+  class LookupError < Puppet::Error; end
+
+  class RecursiveLookup < Puppet::DataBinding::LookupError; end
+
+  class LookupInvocation
+    attr_reader :scope, :override_values, :default_values
+
+    # @param scope [Puppet::Parser::Scope] The scope to use for the lookup
+    # @param override_values [Hash<String,Object>|nil] A map to use as override. Values found here are returned immediately (no merge)
+    # @param default_values [Hash<String,Object>] A map to use as the last resort (but before default)
+    def initialize(scope, override_values = {}, default_values = {})
+      @name_stack = []
+      @scope = scope
+      @override_values = override_values
+      @default_values = default_values
+    end
+
+    def check(name)
+      raise RecursiveLookup, "Detected in [#{@seen.join(', ')}]" if @name_stack.include?(name)
+      return unless block_given?
+
+      @name_stack.push(name)
+      begin
+        yield
+      rescue LookupError
+        raise
+      rescue Puppet::Error => detail
+        raise LookupError.new(detail.message, detail)
+      ensure
+        @name_stack.pop
+      end
+    end
+  end
 end

--- a/lib/puppet/data_binding.rb
+++ b/lib/puppet/data_binding.rb
@@ -8,9 +8,9 @@ class Puppet::DataBinding
   indirects(:data_binding, :terminus_setting => :data_binding_terminus,
     :doc => "Where to find external data bindings.")
 
-  class LookupError < Puppet::Error; end
+  class LookupError < Puppet::PreformattedError; end
 
-  class RecursiveLookup < Puppet::DataBinding::LookupError; end
+  class RecursiveLookupError < Puppet::DataBinding::LookupError; end
 
   class LookupInvocation
     attr_reader :scope, :override_values, :default_values
@@ -26,7 +26,9 @@ class Puppet::DataBinding
     end
 
     def check(name)
-      raise RecursiveLookup, "Detected in [#{@seen.join(', ')}]" if @name_stack.include?(name)
+      if @name_stack.include?(name)
+        raise RecursiveLookupError, "Recursive lookup detected in [#{@name_stack.join(', ')}]"
+      end
       return unless block_given?
 
       @name_stack.push(name)

--- a/lib/puppet/data_providers.rb
+++ b/lib/puppet/data_providers.rb
@@ -8,15 +8,15 @@ module Puppet::DataProviders
     @loaded = true
   end
 
-  def self.lookup_in_environment(name, scope, merge)
+  def self.lookup_in_environment(name, lookup_invocation, merge)
     assert_loaded()
     adapter = DataAdapter.adapt(Puppet.lookup(:current_environment))
-    adapter.env_provider.lookup(name, scope, merge)
+    adapter.env_provider.lookup(name, lookup_invocation, merge)
   end
 
   MODULE_NAME = 'module_name'.freeze
 
-  def self.lookup_in_module(name, scope, merge)
+  def self.lookup_in_module(name, lookup_invocation, merge)
     # Do not attempt to do a lookup in a module unless the name is qualified.
     qual_index = name.index('::')
     throw :no_such_key if qual_index.nil?
@@ -26,6 +26,6 @@ module Puppet::DataProviders
     adapter = DataAdapter.adapt(Puppet.lookup(:current_environment))
     data_provider = adapter.module_provider(module_name)
     throw :no_such_key if data_provider.nil?
-    data_provider.lookup(name, scope, merge)
+    data_provider.lookup(name, lookup_invocation, merge)
   end
 end

--- a/lib/puppet/data_providers.rb
+++ b/lib/puppet/data_providers.rb
@@ -10,7 +10,7 @@ module Puppet::DataProviders
 
   def self.lookup_in_environment(name, scope, merge)
     assert_loaded()
-    adapter = Puppet::DataProviders::DataAdapter.adapt(Puppet.lookup(:current_environment))
+    adapter = DataAdapter.adapt(Puppet.lookup(:current_environment))
     adapter.env_provider.lookup(name, scope, merge)
   end
 
@@ -23,7 +23,7 @@ module Puppet::DataProviders
     module_name = name[0..qual_index-1]
 
     assert_loaded()
-    adapter = Puppet::DataProviders::DataAdapter.adapt(Puppet.lookup(:current_environment))
+    adapter = DataAdapter.adapt(Puppet.lookup(:current_environment))
     data_provider = adapter.module_provider(module_name)
     throw :no_such_key if data_provider.nil?
     data_provider.lookup(name, scope, merge)

--- a/lib/puppet/data_providers/data_adapter.rb
+++ b/lib/puppet/data_providers/data_adapter.rb
@@ -76,7 +76,7 @@ class Puppet::DataProviders::DataAdapter < Puppet::Pops::Adaptable::Adapter
     # Get the environment's configuration since we need to know which data provider
     # should be used (includes 'none' which gets a null implementation).
     #
-    env_conf = Puppet.lookup(:environments).get_conf(@env.name)
+    env_conf = @env.configuration
 
     # Get the data provider and find the bound implementation
     # TODO: PUP-1640, drop the nil check when legacy env support is dropped

--- a/lib/puppet/data_providers/data_adapter.rb
+++ b/lib/puppet/data_providers/data_adapter.rb
@@ -1,6 +1,8 @@
 # A DataAdapter adapts an object with a Hash of data
 #
 class Puppet::DataProviders::DataAdapter < Puppet::Pops::Adaptable::Adapter
+  include Puppet::Plugins::DataProviders
+
   attr_accessor :data
   attr_accessor :env_provider
 
@@ -45,16 +47,16 @@ class Puppet::DataProviders::DataAdapter < Puppet::Pops::Adaptable::Adapter
     injector = Puppet.lookup(:injector) { nil }
 
     # Support running tests without an injector being configured == using a null implementation
-    return Puppet::Plugins::DataProviders::ModuleDataProvider.new() unless injector
+    return ModuleDataProvider.new() unless injector
 
     # Get the registry of module to provider implementation name
-    module_service_type = Puppet::Plugins::DataProviders.hash_of_per_module_data_provider
-    module_service_name = Puppet::Plugins::DataProviders::PER_MODULE_DATA_PROVIDER_KEY
+    module_service_type = Registry.hash_of_per_module_data_provider
+    module_service_name = PER_MODULE_DATA_PROVIDER_KEY
     module_service = injector.lookup(nil, module_service_type, module_service_name)
     provider_name = module_service[module_name] || 'none'
 
-    service_type = Puppet::Plugins::DataProviders.hash_of_module_data_providers
-    service_name = Puppet::Plugins::DataProviders::MODULE_DATA_PROVIDERS_KEY
+    service_type = Registry.hash_of_module_data_providers
+    service_name = MODULE_DATA_PROVIDERS_KEY
 
     # Get the service (registry of known implementations)
     service = injector.lookup(nil, service_type, service_name)
@@ -69,7 +71,7 @@ class Puppet::DataProviders::DataAdapter < Puppet::Pops::Adaptable::Adapter
     injector = Puppet.lookup(:injector) { nil }
 
     # Support running tests without an injector being configured == using a null implementation
-    return Puppet::Plugins::DataProviders::EnvironmentDataProvider.new() unless injector
+    return EnvironmentDataProvider.new() unless injector
 
     # Get the environment's configuration since we need to know which data provider
     # should be used (includes 'none' which gets a null implementation).
@@ -79,8 +81,8 @@ class Puppet::DataProviders::DataAdapter < Puppet::Pops::Adaptable::Adapter
     # Get the data provider and find the bound implementation
     # TODO: PUP-1640, drop the nil check when legacy env support is dropped
     provider_name = env_conf.nil? ? 'none' : env_conf.environment_data_provider
-    service_type = Puppet::Plugins::DataProviders.hash_of_environment_data_providers
-    service_name = Puppet::Plugins::DataProviders::ENV_DATA_PROVIDERS_KEY
+    service_type = Registry.hash_of_environment_data_providers
+    service_name = ENV_DATA_PROVIDERS_KEY
 
     # Get the service (registry of known implementations)
     service = injector.lookup(nil, service_type, service_name)

--- a/lib/puppet/data_providers/data_function_support.rb
+++ b/lib/puppet/data_providers/data_function_support.rb
@@ -1,30 +1,8 @@
 module Puppet::DataProviders::DataFunctionSupport
-  # Gets the data from the compiler, or initializes it from a function call if not present in the compiler.
-  # This means, that the function providing the data is called once per compilation, and the data is cached for
-  # as long as the compiler lives (which is for one catalog production).
-  # This makes it possible to return data that is tailored for the request.
-  # The class including this module must implement `loader(scope)` to return the apropriate loader.
-  #
-  # If a block is given, it will be called to validate the data hash when it is retrieved from a function call. The
-  # block must return the validated data or raise a {Puppet::Error} to indicate that the data is invalid.
-  # The block is not called when the data is found in the compiler or in the cache.
-  #
-  # @param key [String] The data key such as the name of a module or the constant 'environment'
-  # @param scope [Parser::Scope] The scope
-  # @return [Hash] The data hash for the given _key_
-  # @yield An optional block that can be used for validation of the data returned from the function
-  # @yieldparam [Hash] data The data to validate
-  # @yieldreturn [Hash] The validated data
-  #
-  def data(key, scope, &block)
-    compiler = scope.compiler
-    adapter = Puppet::DataProviders::DataAdapter.get(compiler) || Puppet::DataProviders::DataAdapter.adapt(compiler)
-    adapter.data[key] ||= initialize_data_from_function("#{key}::data", key, scope, &block)
-  end
-
-  def initialize_data_from_function(name, key, scope)
-    Puppet::Util::Profiler.profile("Called #{name}", [ :functions, name ]) do
-      loader = loader(key, scope)
+  def initialize_data(data_key, scope)
+    name = "#{data_key}::data"
+      Puppet::Util::Profiler.profile("Called #{name}", [ :functions, name ]) do
+      loader = loader(data_key, scope)
       if loader && func = loader.load(:function, name)
         # function found, call without arguments, must return a Hash
         # TODO: Validate the function - to ensure it does not contain unwanted side effects

--- a/lib/puppet/data_providers/data_function_support.rb
+++ b/lib/puppet/data_providers/data_function_support.rb
@@ -1,7 +1,8 @@
 module Puppet::DataProviders::DataFunctionSupport
-  def initialize_data(data_key, scope)
+  def initialize_data(data_key, lookup_invocation)
     name = "#{data_key}::data"
-      Puppet::Util::Profiler.profile("Called #{name}", [ :functions, name ]) do
+    scope = lookup_invocation.scope
+    Puppet::Util::Profiler.profile("Called #{name}", [ :functions, name ]) do
       loader = loader(data_key, scope)
       if loader && func = loader.load(:function, name)
         # function found, call without arguments, must return a Hash

--- a/lib/puppet/data_providers/function_env_data_provider.rb
+++ b/lib/puppet/data_providers/function_env_data_provider.rb
@@ -11,16 +11,6 @@ module Puppet::DataProviders; end
 class Puppet::DataProviders::FunctionEnvDataProvider < Puppet::Plugins::DataProviders::EnvironmentDataProvider
   include Puppet::DataProviders::DataFunctionSupport
 
-  def lookup(name, scope, merge)
-    begin
-      hash = data('environment', scope)
-      throw :no_such_key unless hash.include?(name)
-      hash[name]
-    rescue *Puppet::Error => detail
-      raise Puppet::DataBinding::LookupError.new(detail.message, detail)
-    end
-  end
-
   def loader(key, scope)
     # This loader allows the data function to be private or public in the environment
     scope.compiler.loaders.private_environment_loader

--- a/lib/puppet/data_providers/function_module_data_provider.rb
+++ b/lib/puppet/data_providers/function_module_data_provider.rb
@@ -9,29 +9,7 @@ module Puppet::DataProviders; end
 # is only produced once per compilation.
 #
 class Puppet::DataProviders::FunctionModuleDataProvider < Puppet::Plugins::DataProviders::ModuleDataProvider
-  MODULE_NAME = 'module_name'.freeze
   include Puppet::DataProviders::DataFunctionSupport
-
-  def lookup(name, scope, merge)
-    # Do not attempt to do a lookup in a module unless the name is qualified.
-    qual_index = name.index('::')
-    throw :no_such_key if qual_index.nil?
-    module_name = name[0..qual_index-1]
-    begin
-      hash = data(module_name, scope) do | data |
-        module_prefix = "#{module_name}::"
-        data.each_pair do |k,v|
-          unless k.is_a?(String) && k.start_with?(module_prefix)
-            raise Puppet::Error, "Module data for module '#{module_name}' must use keys qualified with the name of the module"
-          end
-        end
-      end
-      throw :no_such_key unless hash.include?(name)
-      hash[name]
-    rescue *Puppet::Error => detail
-      raise Puppet::DataBinding::LookupError.new(detail.message, detail)
-    end
-  end
 
   def loader(key, scope)
     scope.compiler.loaders.private_loader_for_module(key)

--- a/lib/puppet/data_providers/hiera_config.rb
+++ b/lib/puppet/data_providers/hiera_config.rb
@@ -1,0 +1,103 @@
+require 'pathname'
+require_relative 'hiera_interpolate'
+
+module Puppet::DataProviders
+  class HieraConfig
+    include Puppet::Plugins::DataProviders
+    include HieraInterpolate
+
+    DEFAULT_CONFIG = {
+      'version' => 4,
+      'datadir' => 'data',
+      'hierarchy' => [
+        {
+          'name' => 'common',
+          'backend' => 'yaml'
+        }
+      ]
+    }.freeze
+
+    def self.config_type
+      @@CONFIG_TYPE ||= create_config_type
+    end
+
+    def self.symkeys_to_string(struct)
+      case(struct)
+      when Hash
+        Hash[struct.map { |k,v| [k.to_s, symkeys_to_string(v)] }]
+      when Array
+        struct.map { |v| symkeys_to_string(v) }
+      else
+        struct
+      end
+    end
+
+    def self.create_config_type
+      hierarchy_elem_type_base = 'Struct[{'\
+        'backend=>String[1],'\
+        'name=>String[1],'\
+        'datadir=>Optional[String[1]]'
+
+      hierarchy_elem_type_v1 = hierarchy_elem_type_base + ',path=>String[1]}]'
+      hierarchy_elem_type_v2 = hierarchy_elem_type_base + ',paths=>Array[String[1]]}]'
+      hierarchy_elem_type_v3 = hierarchy_elem_type_base + '}]'
+
+      Puppet::Pops::Types::TypeParser.new.parse('Struct[{'\
+        'version=>Integer[4],'\
+        "hierarchy=>Optional[Array[Variant[#{hierarchy_elem_type_v1},#{hierarchy_elem_type_v2},#{hierarchy_elem_type_v3}]]],"\
+        'datadir=>Optional[String[1]]}]')
+    end
+    private_class_method :create_config_type
+
+    # Creates a new HieraConfig from teh given _config_root_. This is where the 'hiera.yaml' is expected to be found
+    # and is also the base location used when resolving relative paths.
+    #
+    # @param config_root [Pathname] Absolute path to the configuration root
+    # @api public
+    def initialize(config_root)
+      @config_root = config_root
+      @config_path = config_root + 'hiera.yaml'
+      if @config_path.exist?
+        @config = validate_config(HieraConfig.symkeys_to_string(YAML.load_file(@config_path)))
+        @config['hierarchy'] ||= DEFAULT_CONFIG['hierarchy']
+        @config['datadir'] ||= DEFAULT_CONFIG['datadir']
+      else
+        @config = DEFAULT_CONFIG
+      end
+    end
+
+    def create_data_providers(lookup_invocation)
+      injector = Puppet.lookup(:injector)
+      service_type = Registry.hash_of_path_based_data_provider_factories
+      default_datadir = @config['datadir']
+
+      # Hashes enumerate their values in the order that the corresponding keys were inserted so it's safe to use
+      # a hash for the data_providers.
+      data_providers = {}
+      @config['hierarchy'].each do |he|
+        name = he['name']
+        raise Puppet::DataBinding::LookupError, "#{path}: Name '#{name}' defined more than once" if data_providers.include?(name)
+        original_paths = he['paths']
+        if original_paths.nil?
+          single_path = he['path']
+          single_path = name if single_path.nil?
+          original_paths = [single_path]
+        end
+        paths = original_paths.map { |path| interpolate(path, lookup_invocation, false)}
+        provider_name = he['backend']
+        provider_factory = injector.lookup(nil, service_type, PATH_BASED_DATA_PROVIDER_FACTORIES_KEY)[provider_name]
+        raise Puppet::DataBinding::LookupError, "#{@config_path}: No data provider is registered for backend '#{provider_name}' " unless provider_factory
+
+        datadir = @config_root + (he['datadir'] || default_datadir)
+        resolved_paths = provider_factory.resolve_paths(datadir, original_paths, paths, lookup_invocation)
+        data_providers[name] = provider_factory.create(name, resolved_paths)
+      end
+      data_providers.values
+    end
+
+    def validate_config(hiera_config)
+      Puppet::Pops::Types::TypeAsserter.assert_instance_of(@config_path, self.class.config_type, hiera_config)
+    end
+    private :validate_config
+  end
+end

--- a/lib/puppet/data_providers/hiera_config.rb
+++ b/lib/puppet/data_providers/hiera_config.rb
@@ -49,7 +49,7 @@ module Puppet::DataProviders
     end
     private_class_method :create_config_type
 
-    # Creates a new HieraConfig from teh given _config_root_. This is where the 'hiera.yaml' is expected to be found
+    # Creates a new HieraConfig from the given _config_root_. This is where the 'hiera.yaml' is expected to be found
     # and is also the base location used when resolving relative paths.
     #
     # @param config_root [Pathname] Absolute path to the configuration root

--- a/lib/puppet/data_providers/hiera_env_data_provider.rb
+++ b/lib/puppet/data_providers/hiera_env_data_provider.rb
@@ -1,0 +1,18 @@
+# This file is loaded by the autoloader, and it does not find the hiera support unless required relative
+require_relative 'hiera_support'
+
+module Puppet::DataProviders
+  class HieraEnvDataProvider < Puppet::Plugins::DataProviders::EnvironmentDataProvider
+    include HieraSupport
+
+    # Return the root of the environment found in the given _scope_
+    #
+    # @param data_key [String] not used
+    # @param scope [Puppet::Parser::Scope] the parser scope where the environment is found
+    # @return [Pathname] Path to root of the environment
+    def provider_root(_, scope)
+      Pathname.new(scope.environment.configuration.path_to_env)
+    end
+    protected :provider_root
+  end
+end

--- a/lib/puppet/data_providers/hiera_interpolate.rb
+++ b/lib/puppet/data_providers/hiera_interpolate.rb
@@ -63,7 +63,7 @@ module Puppet::DataProviders::HieraInterpolate
       throw :no_such_key if value.nil?
       if segment =~ /^[0-9]+$/
         segment = segment.to_i
-        raise Puppet::DataBinding::LookupError, "Data provider type mismatch: Got #{value.class.name} when Array was expected enable lookup using key '#{segment}'" unless value.instance_of?(Array)
+        raise Puppet::DataBinding::LookupError, "Data provider type mismatch: Got #{value.class.name} when Array was expected to enable lookup using key '#{segment}'" unless value.instance_of?(Array)
         throw :no_such_key unless segment < value.size
       else
         raise Puppet::DataBinding::LookupError, "Data provider type mismatch: Got #{value.class.name} when a non Array object that responds to '[]' was expected to enable lookup using key '#{segment}'" unless value.respond_to?(:'[]') && !value.instance_of?(Array)

--- a/lib/puppet/data_providers/hiera_interpolate.rb
+++ b/lib/puppet/data_providers/hiera_interpolate.rb
@@ -1,0 +1,87 @@
+require_relative 'hiera_config'
+
+# Add support for Hiera-like interpolation expressions. The expressions may contain keys that uses dot-notation
+# to further navigate into hashes and arrays
+#
+module Puppet::DataProviders::HieraInterpolate
+  def interpolate(subject, lookup_invocation, allow_methods)
+    return subject unless subject.is_a?(String)
+
+    subject.gsub(/%\{([^\}]+)\}/) do |match|
+      method_key, key = get_method_and_data($1, allow_methods)
+      is_alias = method_key == 'alias'
+
+      # Alias is only permitted if the entire string is equal to the interpolate expression
+      raise Puppet::DataBinding::LookupError, "'alias' interpolation is only permitted if the expression is equal to the entire string" if is_alias && subject != match
+
+      segments = key.split('.')
+      value = interpolate_method(method_key).call(segments[0], lookup_invocation)
+      value = qualified_lookup(segments.drop(1), v) if segments.size > 1
+      value = lookup_invocation.check(key) { interpolate(value, lookup_invocation, allow_methods) } if value.is_a?(String)
+
+      # break gsub and return value immediately if this was an alias substitution. The value might be something other than a String
+      return value if is_alias
+
+      value || ''
+    end
+  end
+
+  private
+
+  def interpolate_method(method_key)
+    @@interpolate_methods ||= begin
+      global_lookup = lambda { |key, lookup_invocation| Puppet::Pops::Lookup.lookup(key, nil, '', true, nil, lookup_invocation) }
+      scope_lookup = lambda do |key, lookup_invocation|
+        ovr = lookup_invocation.override_values
+        if ovr.include?(key)
+          ovr[key]
+        else
+          scope = lookup_invocation.scope
+          if scope.include?(key)
+            scope[key]
+          else
+            lookup_invocation.default_values[key]
+          end
+        end
+      end
+
+      {
+        'lookup' => global_lookup,
+        'hiera' => global_lookup, # this is just an alias for 'lookup'
+        'alias' => global_lookup, # same as 'lookup' but expression must be entire string. The result that is not subject to string substitution
+        'scope' => scope_lookup,
+        'literal' => lambda { |key, _| key }
+      }
+    end
+    interpolate_method = @@interpolate_methods[method_key]
+    raise Puppet::DataBinding::LookupError, "Unknown interpolation method '#{method_key}'" unless interpolate_method
+    interpolate_method
+  end
+
+  def qualified_lookup(segments, value)
+    segments.each do |segment|
+      throw :no_such_key if value.nil?
+      if segment =~ /^[0-9]+$/
+        segment = segment.to_i
+        raise Puppet::DataBinding::LookupError, "Data provider type mismatch: Got #{value.class.name} when Array was expected enable lookup using key '#{segment}'" unless value.instance_of?(Array)
+        throw :no_such_key unless segment < value.size
+      else
+        raise Puppet::DataBinding::LookupError, "Data provider type mismatch: Got #{value.class.name} when a non Array object that responds to '[]' was expected to enable lookup using key '#{segment}'" unless value.respond_to?(:'[]') && !value.instance_of?(Array)
+        throw :no_such_key unless value.include?(segment)
+      end
+      value = value[segment]
+    end
+    value
+  end
+
+  def get_method_and_data(data, allow_methods)
+    if match = data.match(/^(\w+)\((?:["]([^"]+)["]|[']([^']+)['])\)$/)
+      raise Puppet::DataBinding::LoookupError, 'Interpolation using method syntax is not allowed in this context' unless allow_methods
+      key = match[1]
+      data = match[2] || match[3] # double or single qouted
+    else
+      key = 'scope'
+    end
+    [key, data]
+  end
+end

--- a/lib/puppet/data_providers/hiera_module_data_provider.rb
+++ b/lib/puppet/data_providers/hiera_module_data_provider.rb
@@ -1,0 +1,23 @@
+# This file is loaded by the autoloader, and it does not find the hiera support unless required relative
+require_relative 'hiera_support'
+
+module Puppet::DataProviders
+  class HieraModuleDataProvider < Puppet::Plugins::DataProviders::ModuleDataProvider
+    include HieraSupport
+
+    # Return the root of the module with the name equal to _data_key_ found in the environment of the given _scope_
+    #
+    # @param data_key [String] the name of the module
+    # @param scope [Puppet::Parser::Scope] the parser scope where the environment is found
+    # @return [Pathname] Path to root of the environment
+    # @raise [Puppet::DataBinder::LookupError] if the given module is can not be found
+    #
+    def provider_root(module_name, scope)
+      env = scope.environment
+      mod = env.modules.find { |m| m.name == module_name }
+      raise Puppet::DataBinder::LookupError, "Environment '#{env.name}', cannot find module '#{module_name}'" unless mod
+      Pathname.new(mod.path)
+    end
+    protected :provider_root
+  end
+end

--- a/lib/puppet/data_providers/hiera_support.rb
+++ b/lib/puppet/data_providers/hiera_support.rb
@@ -1,0 +1,24 @@
+require_relative 'hiera_config'
+
+module Puppet::DataProviders::HieraSupport
+  # Performs a lookup by searching all given paths for the given _key_. A merge will be performed if
+  # the value is found in more than one location and _merge_ is not nil.
+  #
+  # @param key [String] The key to lookup
+  # @param lookup_invocation [Puppet::DataBinding::LookupInvocation] The current lookup invocation
+  # @param merge [String|Hash<String,Object>|nil] Merge strategy or hash with strategy and options
+  #
+  # @api public
+  def unchecked_lookup(key, lookup_invocation, merge)
+    result = Puppet::Pops::MergeStrategy.strategy(merge).merge_lookup(data_providers(data_key(key), lookup_invocation)) do |data_provider|
+      data_provider.unchecked_lookup(key, lookup_invocation, merge)
+    end
+    throw :no_such_key if result.equal?(Puppet::Pops::MergeStrategy::NOT_FOUND)
+    result
+  end
+
+  def data_providers(data_key, lookup_invocation)
+    @data_providers ||= Puppet::DataProviders::HieraConfig.new(provider_root(data_key, lookup_invocation.scope)).create_data_providers(lookup_invocation)
+  end
+  private :data_providers
+end

--- a/lib/puppet/data_providers/json_data_provider_factory.rb
+++ b/lib/puppet/data_providers/json_data_provider_factory.rb
@@ -19,6 +19,9 @@ module Puppet::DataProviders
 
     def initialize_data(path, lookup_invocation)
       JSON.parse(File.read(path))
+    rescue JSON::ParserError => ex
+      # Filename not included in message, so we add it here.
+      raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
     end
 
     def post_process(value, lookup_invocation)

--- a/lib/puppet/data_providers/json_data_provider_factory.rb
+++ b/lib/puppet/data_providers/json_data_provider_factory.rb
@@ -1,0 +1,28 @@
+# This file is loaded by the autoloader, and it does not find the data function support unless required relative
+#
+require 'json'
+require_relative 'hiera_interpolate'
+
+module Puppet::DataProviders
+  class JsonDataProviderFactory < Puppet::Plugins::DataProviders::FileBasedDataProviderFactory
+    def create(name, paths)
+      JsonDataProvider.new(name, paths)
+    end
+
+    def path_extension
+      '.json'
+    end
+  end
+
+  class JsonDataProvider < Puppet::Plugins::DataProviders::PathBasedDataProvider
+    include HieraInterpolate
+
+    def initialize_data(path, lookup_invocation)
+      JSON.parse(File.read(path))
+    end
+
+    def post_process(value, lookup_invocation)
+      interpolate(value, lookup_invocation, true)
+    end
+  end
+end

--- a/lib/puppet/data_providers/yaml_data_provider_factory.rb
+++ b/lib/puppet/data_providers/yaml_data_provider_factory.rb
@@ -19,6 +19,10 @@ module Puppet::DataProviders
 
     def initialize_data(path, lookup_invocation)
       HieraConfig.symkeys_to_string(YAML.load_file(path))
+    rescue YAML::SyntaxError => ex
+      # Psych errors includes the absolute path to the file, so no need to add that
+      # to the message
+      raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"
     end
 
     def post_process(value, lookup_invocation)

--- a/lib/puppet/data_providers/yaml_data_provider_factory.rb
+++ b/lib/puppet/data_providers/yaml_data_provider_factory.rb
@@ -1,0 +1,28 @@
+# This file is loaded by the autoloader, and it does not find the data function support unless required relative
+#
+require 'yaml'
+require_relative 'hiera_interpolate'
+
+module Puppet::DataProviders
+  class YamlDataProviderFactory < Puppet::Plugins::DataProviders::FileBasedDataProviderFactory
+    def create(name, paths)
+      YamlDataProvider.new(name, paths)
+    end
+
+    def path_extension
+      '.yaml'
+    end
+  end
+
+  class YamlDataProvider < Puppet::Plugins::DataProviders::PathBasedDataProvider
+    include HieraInterpolate
+
+    def initialize_data(path, lookup_invocation)
+      HieraConfig.symkeys_to_string(YAML.load_file(path))
+    end
+
+    def post_process(value, lookup_invocation)
+      interpolate(value, lookup_invocation, true)
+    end
+  end
+end

--- a/lib/puppet/functions/lookup.rb
+++ b/lib/puppet/functions/lookup.rb
@@ -202,23 +202,27 @@ Puppet::Functions.create_function(:lookup, Puppet::Functions::InternalFunction) 
   end
 
   def lookup_1(scope, name, value_type=nil, merge=nil)
-    Puppet::Pops::Lookup.lookup(scope, name, value_type, nil, false, {}, {}, merge)
+    do_lookup(scope, name, value_type, nil, false, {}, {}, merge)
   end
 
   def lookup_2(scope, name, value_type, merge, default_value)
-    Puppet::Pops::Lookup.lookup(scope, name, value_type, default_value, true, {}, {}, merge)
+    do_lookup(scope, name, value_type, default_value, true, {}, {}, merge)
   end
 
   def lookup_3(scope, name, value_type=nil, merge=nil, &block)
-    Puppet::Pops::Lookup.lookup(scope, name, value_type, nil, false, {}, {}, merge, &block)
+    do_lookup(scope, name, value_type, nil, false, {}, {}, merge, &block)
   end
 
   def lookup_4(scope, options_hash, &block)
-    Puppet::Pops::Lookup.lookup(scope, options_hash['name'], *hash_args(options_hash), &block)
+    do_lookup(scope, options_hash['name'], *hash_args(options_hash), &block)
   end
 
   def lookup_5(scope, name, options_hash, &block)
-    Puppet::Pops::Lookup.lookup(scope, name, *hash_args(options_hash), &block)
+    do_lookup(scope, name, *hash_args(options_hash), &block)
+  end
+
+  def do_lookup(scope, name, value_type, default_value, has_default, override, default_values_hash, merge, &block)
+    Puppet::Pops::Lookup.lookup(name, value_type, default_value, has_default, merge, Puppet::DataBinding::LookupInvocation.new(scope, override, default_values_hash), &block)
   end
 
   def hash_args(options_hash)

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -182,9 +182,16 @@ class Puppet::Node::Environment
   # @api private
   def conflicting_manifest_settings?
     return false if !Puppet[:disable_per_environment_manifest]
-    environment_conf = Puppet.lookup(:environments).get_conf(name)
-    original_manifest = environment_conf.raw_setting(:manifest)
+    original_manifest = configuration.raw_setting(:manifest)
     !original_manifest.nil? && !original_manifest.empty? && original_manifest != Puppet[:default_manifest]
+  end
+
+  # Return the environment configuration
+  # @return [Puppet::Settings::EnvironmentConf] The configuration
+  #
+  # @api private
+  def configuration
+    Puppet.lookup(:environments).get_conf(name)
   end
 
   # Checks the environment and settings for any conflicts

--- a/lib/puppet/plugins/configuration.rb
+++ b/lib/puppet/plugins/configuration.rb
@@ -11,6 +11,7 @@ module Puppet::Plugins::Configuration
     require 'puppet/plugins/binding_schemes'
     require 'puppet/plugins/syntax_checkers'
     require 'puppet/plugins/data_providers'
+    require 'puppet/plugins/data_providers/registry'
 
     # Extension-points are registered here:
     #
@@ -33,7 +34,7 @@ module Puppet::Plugins::Configuration
 
     extensions.multibind(checkers_name).name(checkers_name).hash_of(checkers_type)
     extensions.multibind(schemes_name).name(schemes_name).hash_of(schemes_type)
-    Puppet::Plugins::DataProviders::register_extensions(extensions)
+    Puppet::Plugins::DataProviders::Registry.register_extensions(extensions)
 
     # Register injector boot bindings
     # -------------------------------
@@ -64,5 +65,5 @@ module Puppet::Plugins::Configuration
       in_multibind(checkers_name)
       to_instance('Puppet::SyntaxCheckers::Json')
     end
-    Puppet::Plugins::DataProviders::register_defaults(bindings)
+    Puppet::Plugins::DataProviders::Registry.register_defaults(bindings)
 end

--- a/lib/puppet/plugins/data_providers.rb
+++ b/lib/puppet/plugins/data_providers.rb
@@ -1,6 +1,6 @@
 module Puppet::Plugins; end
 
-class Puppet::Plugins::DataProviders
+module Puppet::Plugins::DataProviders
 
   # The lookup **key** for the multibind containing data provider name per module
   # @api public
@@ -25,66 +25,7 @@ class Puppet::Plugins::DataProviders
   # The lookup **type** for the multibind containing map of provider name to module data provider implementation.
   # @api public
   MODULE_DATA_PROVIDERS_TYPE         = 'Puppet::Plugins::DataProviders::ModuleDataProvider'
-
-  def self.register_extensions(extensions)
-    extensions.multibind(PER_MODULE_DATA_PROVIDER_KEY).name(PER_MODULE_DATA_PROVIDER_KEY).hash_of(PER_MODULE_DATA_PROVIDER_TYPE)
-    extensions.multibind(ENV_DATA_PROVIDERS_KEY).name(ENV_DATA_PROVIDERS_KEY).hash_of(ENV_DATA_PROVIDERS_TYPE)
-    extensions.multibind(MODULE_DATA_PROVIDERS_KEY).name(MODULE_DATA_PROVIDERS_KEY).hash_of(MODULE_DATA_PROVIDERS_TYPE)
-  end
-
-  def self.hash_of_per_module_data_provider
-    @@HASH_OF_PER_MODULE_DATA_PROVIDERS ||= Puppet::Pops::Types::TypeFactory.hash_of(PER_MODULE_DATA_PROVIDER_TYPE)
-  end
-
-  def self.hash_of_module_data_providers
-    @@HASH_OF_MODULE_DATA_PROVIDERS ||= Puppet::Pops::Types::TypeFactory.hash_of(
-      Puppet::Pops::Types::TypeFactory.type_of(MODULE_DATA_PROVIDERS_TYPE))
-  end
-
-  def self.hash_of_environment_data_providers
-    @@HASH_OF_ENV_DATA_PROVIDERS ||= Puppet::Pops::Types::TypeFactory.hash_of(
-      Puppet::Pops::Types::TypeFactory.type_of(ENV_DATA_PROVIDERS_TYPE))
-  end
-
-  # Registers a 'none' environment data provider, and a 'none' module data provider as the defaults.
-  # This is only done to allow that something binds to 'none' rather than removing the entire binding (which
-  # has the same effect).
-  #
-  def self.register_defaults(default_bindings)
-    default_bindings.bind do
-      name('none')
-      in_multibind(ENV_DATA_PROVIDERS_KEY)
-      to_instance(ENV_DATA_PROVIDERS_TYPE)
-    end
-
-    default_bindings.bind do
-      name('function')
-      in_multibind(ENV_DATA_PROVIDERS_KEY)
-      to_instance('Puppet::DataProviders::FunctionEnvDataProvider')
-    end
-
-    default_bindings.bind do
-      name('none')
-      in_multibind(MODULE_DATA_PROVIDERS_KEY)
-      to_instance(MODULE_DATA_PROVIDERS_TYPE)
-    end
-
-    default_bindings.bind do
-      name('function')
-      in_multibind(MODULE_DATA_PROVIDERS_KEY)
-      to_instance('Puppet::DataProviders::FunctionModuleDataProvider')
-    end
-  end
-
-  class ModuleDataProvider
-    def lookup(name, scope, merge)
-      throw :no_such_key
-    end
-  end
-
-  class EnvironmentDataProvider
-    def lookup(name, scope, merge)
-      throw :no_such_key
-    end
-  end
 end
+
+require_relative 'data_providers/data_provider'
+require_relative 'data_providers/registry'

--- a/lib/puppet/plugins/data_providers.rb
+++ b/lib/puppet/plugins/data_providers.rb
@@ -25,6 +25,17 @@ module Puppet::Plugins::DataProviders
   # The lookup **type** for the multibind containing map of provider name to module data provider implementation.
   # @api public
   MODULE_DATA_PROVIDERS_TYPE         = 'Puppet::Plugins::DataProviders::ModuleDataProvider'
+
+  # The lookup **key** for the multibind containing map of provider name to path based data provider factory
+  # implementation.
+  # @api public
+  PATH_BASED_DATA_PROVIDER_FACTORIES_KEY  = 'puppet::path_based_data_provider_factories'
+
+  # The lookup **type** for the multibind containing map of provider name to path based data provider factory
+  # implementation.
+  # @api public
+  PATH_BASED_DATA_PROVIDER_FACTORIES_TYPE = 'Puppet::Plugins::DataProviders::PathBasedDataProviderFactory'
+
 end
 
 require_relative 'data_providers/data_provider'

--- a/lib/puppet/plugins/data_providers/data_provider.rb
+++ b/lib/puppet/plugins/data_providers/data_provider.rb
@@ -1,0 +1,105 @@
+module Puppet::Plugins::DataProviders
+  module DataProvider
+    # Performs a lookup.
+    #
+    # @param key [String] The key to lookup
+    # @param scope [Puppet::Parser::Scope] The scope to use for the lookup
+    # @param merge [String|Hash<String,Object>|nil] Merge strategy or hash with strategy and options
+    #
+    # @api public
+    def lookup(key, scope, merge)
+      hash = data(data_key(key), scope)
+      value = hash[key]
+      throw :no_such_key unless value || hash.include?(key)
+      value
+    end
+
+    # Gets the data from the compiler, or initializes it by calling #initialize_data if not present in the compiler.
+    # This means, that data is initialized once per compilation, and the data is cached for as long as the compiler
+    # lives (which is for one catalog production). This makes it possible to return data that is tailored for the
+    # request.
+    #
+    # If data is obtained using the #initialize_data method it will be sent to the #validate_data for validation
+    #
+    # @param data_key [String] The data key such as the name of a module or the constant 'environment'
+    # @param scope [Puppet::Parser::Scope] The scope to use for the lookup
+    # @return [Hash] The data hash for the given _key_
+    #
+    # @api public
+    def data(data_key, scope)
+      compiler = scope.compiler
+      adapter = Puppet::DataProviders::DataAdapter.get(compiler) || Puppet::DataProviders::DataAdapter.adapt(compiler)
+      adapter.data[data_key] ||= validate_data(initialize_data(data_key, scope), data_key)
+    end
+    protected :data
+
+    # Obtain an optional key to use when retrieving the data.
+    #
+    # @param key [String] The key to lookup
+    # @return [String,nil] The data key or nil if not applicable
+    #
+    # @api public
+    def data_key(key)
+      nil
+    end
+    protected :data_key
+
+    # Should be reimplemented by subclass to provide the hash that corresponds to the given name.
+    #
+    # @param data_key [String] The data key such as the name of a module or the constant 'environment'
+    # @param scope [Puppet::Parser::Scope] The scope to use for the lookup
+    # @return [Hash] The hash of values
+    #
+    # @api public
+    def initialize_data(data_key, scope)
+      {}
+    end
+    protected :initialize_data
+
+    def validate_data(data, data_key)
+      data
+    end
+    protected :validate_data
+  end
+
+  class ModuleDataProvider
+    include DataProvider
+
+    # Retrieve the first segment of the qualified name _key_. This method will throw
+    # :no_such_key unless the segment can be extracted.
+    #
+    # @param key [String] The key
+    # @return [String] The first segment of the given key
+    def data_key(key)
+      # Do not attempt to do a lookup in a module unless the name is qualified.
+      qual_index = key.index('::')
+      throw :no_such_key if qual_index.nil?
+      key[0..qual_index-1]
+    end
+    protected :data_key
+
+    # Assert that all keys in the given _data_ are prefixed with the given _module_name_.
+    #
+    # @param data [Hash] The data hash
+    # @param module_name [String] The name of the module where the data was found
+    # @return [Hash] The data_hash unaltered
+    def validate_data(data, module_name)
+      module_prefix = "#{module_name}::"
+      data.each_key do |k|
+        unless k.is_a?(String) && k.start_with?(module_prefix)
+          raise Puppet::DataBinding::LookupError, "Module data for module '#{module_name}' must use keys qualified with the name of the module"
+        end
+      end
+    end
+    protected :validate_data
+  end
+
+  class EnvironmentDataProvider
+    include DataProvider
+
+    def data_key(key)
+      'environment'
+    end
+    protected :data_key
+  end
+end

--- a/lib/puppet/plugins/data_providers/registry.rb
+++ b/lib/puppet/plugins/data_providers/registry.rb
@@ -4,6 +4,7 @@ module Puppet::Plugins::DataProviders
       extensions.multibind(PER_MODULE_DATA_PROVIDER_KEY).name(PER_MODULE_DATA_PROVIDER_KEY).hash_of(PER_MODULE_DATA_PROVIDER_TYPE)
       extensions.multibind(ENV_DATA_PROVIDERS_KEY).name(ENV_DATA_PROVIDERS_KEY).hash_of(ENV_DATA_PROVIDERS_TYPE)
       extensions.multibind(MODULE_DATA_PROVIDERS_KEY).name(MODULE_DATA_PROVIDERS_KEY).hash_of(MODULE_DATA_PROVIDERS_TYPE)
+      extensions.multibind(PATH_BASED_DATA_PROVIDER_FACTORIES_KEY).name(PATH_BASED_DATA_PROVIDER_FACTORIES_KEY).hash_of(PATH_BASED_DATA_PROVIDER_FACTORIES_TYPE)
     end
 
     def self.hash_of_per_module_data_provider
@@ -18,6 +19,11 @@ module Puppet::Plugins::DataProviders
     def self.hash_of_environment_data_providers
       @@HASH_OF_ENV_DATA_PROVIDERS ||= Puppet::Pops::Types::TypeFactory.hash_of(
         Puppet::Pops::Types::TypeFactory.type_of(ENV_DATA_PROVIDERS_TYPE))
+    end
+
+    def self.hash_of_path_based_data_provider_factories
+      @@HASH_OF_PATH_BASED_DATA_PROVIDER_FACTORIES ||= Puppet::Pops::Types::TypeFactory.hash_of(
+        Puppet::Pops::Types::TypeFactory.type_of(PATH_BASED_DATA_PROVIDER_FACTORIES_TYPE))
     end
 
     # Registers a 'none' environment data provider, and a 'none' module data provider as the defaults.
@@ -38,6 +44,12 @@ module Puppet::Plugins::DataProviders
       end
 
       default_bindings.bind do
+        name('hiera')
+        in_multibind(ENV_DATA_PROVIDERS_KEY)
+        to_instance('Puppet::DataProviders::HieraEnvDataProvider')
+      end
+
+      default_bindings.bind do
         name('none')
         in_multibind(MODULE_DATA_PROVIDERS_KEY)
         to_instance(MODULE_DATA_PROVIDERS_TYPE)
@@ -47,6 +59,24 @@ module Puppet::Plugins::DataProviders
         name('function')
         in_multibind(MODULE_DATA_PROVIDERS_KEY)
         to_instance('Puppet::DataProviders::FunctionModuleDataProvider')
+      end
+
+      default_bindings.bind do
+        name('hiera')
+        in_multibind(MODULE_DATA_PROVIDERS_KEY)
+        to_instance('Puppet::DataProviders::HieraModuleDataProvider')
+      end
+
+      default_bindings.bind do
+        name('json')
+        in_multibind(PATH_BASED_DATA_PROVIDER_FACTORIES_KEY)
+        to_instance('Puppet::DataProviders::JsonDataProviderFactory')
+      end
+
+      default_bindings.bind do
+        name('yaml')
+        in_multibind(PATH_BASED_DATA_PROVIDER_FACTORIES_KEY)
+        to_instance('Puppet::DataProviders::YamlDataProviderFactory')
       end
     end
   end

--- a/lib/puppet/plugins/data_providers/registry.rb
+++ b/lib/puppet/plugins/data_providers/registry.rb
@@ -1,0 +1,54 @@
+module Puppet::Plugins::DataProviders
+  class Registry
+    def self.register_extensions(extensions)
+      extensions.multibind(PER_MODULE_DATA_PROVIDER_KEY).name(PER_MODULE_DATA_PROVIDER_KEY).hash_of(PER_MODULE_DATA_PROVIDER_TYPE)
+      extensions.multibind(ENV_DATA_PROVIDERS_KEY).name(ENV_DATA_PROVIDERS_KEY).hash_of(ENV_DATA_PROVIDERS_TYPE)
+      extensions.multibind(MODULE_DATA_PROVIDERS_KEY).name(MODULE_DATA_PROVIDERS_KEY).hash_of(MODULE_DATA_PROVIDERS_TYPE)
+    end
+
+    def self.hash_of_per_module_data_provider
+      @@HASH_OF_PER_MODULE_DATA_PROVIDERS ||= Puppet::Pops::Types::TypeFactory.hash_of(PER_MODULE_DATA_PROVIDER_TYPE)
+    end
+
+    def self.hash_of_module_data_providers
+      @@HASH_OF_MODULE_DATA_PROVIDERS ||= Puppet::Pops::Types::TypeFactory.hash_of(
+        Puppet::Pops::Types::TypeFactory.type_of(MODULE_DATA_PROVIDERS_TYPE))
+    end
+
+    def self.hash_of_environment_data_providers
+      @@HASH_OF_ENV_DATA_PROVIDERS ||= Puppet::Pops::Types::TypeFactory.hash_of(
+        Puppet::Pops::Types::TypeFactory.type_of(ENV_DATA_PROVIDERS_TYPE))
+    end
+
+    # Registers a 'none' environment data provider, and a 'none' module data provider as the defaults.
+    # This is only done to allow that something binds to 'none' rather than removing the entire binding (which
+    # has the same effect).
+    #
+    def self.register_defaults(default_bindings)
+      default_bindings.bind do
+        name('none')
+        in_multibind(ENV_DATA_PROVIDERS_KEY)
+        to_instance(ENV_DATA_PROVIDERS_TYPE)
+      end
+
+      default_bindings.bind do
+        name('function')
+        in_multibind(ENV_DATA_PROVIDERS_KEY)
+        to_instance('Puppet::DataProviders::FunctionEnvDataProvider')
+      end
+
+      default_bindings.bind do
+        name('none')
+        in_multibind(MODULE_DATA_PROVIDERS_KEY)
+        to_instance(MODULE_DATA_PROVIDERS_TYPE)
+      end
+
+      default_bindings.bind do
+        name('function')
+        in_multibind(MODULE_DATA_PROVIDERS_KEY)
+        to_instance('Puppet::DataProviders::FunctionModuleDataProvider')
+      end
+    end
+  end
+end
+

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -7,39 +7,41 @@ class Puppet::Pops::Lookup
   # This is a backing function and all parameters are assumed to have been type checked.
   # See puppet/functions/lookup.rb for full documentation and all parameter combinations.
   #
-  # @param scope [Puppet::Parser::Scope] The scope to use for the lookup
   # @param name [String|Array<String>] The name or names to lookup
   # @param type [Puppet::Pops::Types::PAnyType|nil] The expected type of the found value
   # @param default_value [Object] The value to use as default when no value is found
   # @param has_default [Boolean] Set to _true_ if _default_value_ is included (_nil_ is a valid _default_value_)
-  # @param override [Hash<String,Object>|nil] A map to use as override. Values found here are returned immediately (no merge)
-  # @param default_values_hash [Hash<String,Object>] A map to use as the last resort (but before default)
   # @param merge [String|Hash<String,Object>|nil] Merge strategy or hash with strategy and options
+  # @param lookup_invocation [Puppet::DataBinding::LookupInvocation] Invocation data containing scope, overrides, and defaults
   # @return [Object] The found value
   #
-  def self.lookup(scope, name, value_type, default_value, has_default, override, default_values_hash, merge)
+  def self.lookup(name, value_type, default_value, has_default, merge, lookup_invocation)
     value_type = Puppet::Pops::Types::PDataType::DEFAULT if value_type.nil?
     names = name.is_a?(Array) ? name : [name]
 
     # find first name that yields a non-nil result and wrap it in a two element array
     # with name and value.
     not_found = Object.new
+    override_values = lookup_invocation.override_values
     result_with_name = names.reduce([nil,not_found]) do |memo, key|
-      value = override.include?(key) ? assert_type('override', value_type, override[key]) : not_found
-      value = search_and_merge(key, scope, merge, not_found) if value.equal?(not_found)
+      value = override_values.include?(key) ? assert_type('override', value_type, override_values[key]) : not_found
+      value = search_and_merge(key, lookup_invocation, merge, not_found) if value.equal?(not_found)
       break [key, assert_type('found', value_type, value)] unless value.equal?(not_found)
       memo
     end
 
-    # Use the 'default_values_hash' map as a last resort if nothing is found
-    if result_with_name[1].equal?(not_found) && !default_values_hash.empty?
+    # Use the 'default_values' hash as a last resort if nothing is found
+    if result_with_name[1].equal?(not_found)
+      default_values = lookup_invocation.default_values
+      unless default_values.empty?
         result_with_name = names.reduce(result_with_name) do |memo, key|
-        value = default_values_hash.include?(key) ? assert_type('default_values_hash', value_type, default_values_hash[key]) : not_found
+          value = default_values.include?(key) ? assert_type('default_values_hash', value_type, default_values[key]) : not_found
           memo = [ key, value ]
           break memo unless value.equal?(not_found)
           memo
         end
       end
+    end
 
     answer = result_with_name[1]
     if answer.equal?(not_found)
@@ -54,10 +56,10 @@ class Puppet::Pops::Lookup
     answer
   end
 
-  def self.search_and_merge(name, scope, merge, not_found)
-    in_global = lambda { lookup_with_databinding(name, scope, merge) }
-    in_env = lambda { Puppet::DataProviders.lookup_in_environment(name, scope, merge) }
-    in_module = lambda { Puppet::DataProviders.lookup_in_module(name, scope, merge) }
+  def self.search_and_merge(name, lookup_invocation, merge, not_found)
+    in_global = lambda { lookup_with_databinding(name, lookup_invocation, merge) }
+    in_env = lambda { Puppet::DataProviders.lookup_in_environment(name, lookup_invocation, merge) }
+    in_module = lambda { Puppet::DataProviders.lookup_in_module(name, lookup_invocation, merge) }
 
     [in_global, in_env, in_module].reduce(not_found) do |memo, f|
       found = false # can't trust catch return value since nil is valid
@@ -74,12 +76,11 @@ class Puppet::Pops::Lookup
   end
   private_class_method :search_and_merge
 
-  def self.lookup_with_databinding(key, scope, merge)
-    begin
-      Puppet::DataBinding.indirection.find(key, { :environment => scope.environment.to_s, :variables => scope, :merge => merge })
-    rescue Puppet::DataBinding::LookupError => e
-      raise Puppet::Error, "Error from DataBinding '#{Puppet[:data_binding_terminus]}' while looking up '#{name}': #{e.message}", e
-    end
+  def self.lookup_with_databinding(key, lookup_invocation, merge)
+    scope = lookup_invocation.scope
+    Puppet::DataBinding.indirection.find(key, { :environment => scope.environment.to_s, :variables => scope, :merge => merge })
+  rescue Puppet::DataBinding::LookupError => e
+    raise Puppet::Error, "Error from DataBinding '#{Puppet[:data_binding_terminus]}' while looking up '#{name}': #{e.message}", e
   end
   private_class_method :lookup_with_databinding
 

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -33,13 +33,13 @@ class Puppet::Pops::Lookup
 
     # Use the 'default_values_hash' map as a last resort if nothing is found
     if result_with_name[1].equal?(not_found) && !default_values_hash.empty?
-      result_with_name = names.reduce(result_with_name) do |memo, key|
+        result_with_name = names.reduce(result_with_name) do |memo, key|
         value = default_values_hash.include?(key) ? assert_type('default_values_hash', value_type, default_values_hash[key]) : not_found
-        memo = [ key, value ]
-        break memo unless value.equal?(not_found)
-        memo
+          memo = [ key, value ]
+          break memo unless value.equal?(not_found)
+          memo
+        end
       end
-    end
 
     answer = result_with_name[1]
     if answer.equal?(not_found)

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -441,7 +441,7 @@ class Puppet::Resource
   def lookup_in_environment(name, scope)
     found = false
     value = catch(:no_such_key) do
-      v = Puppet::DataProviders.lookup_in_environment(name, scope, nil)
+      v = Puppet::DataProviders.lookup_in_environment(name, Puppet::DataBinding::LookupInvocation.new(scope), nil)
       found = true
       v
     end
@@ -452,7 +452,7 @@ class Puppet::Resource
   def lookup_in_module(name, scope)
     found = false
     value = catch(:no_such_key) do
-      v = Puppet::DataProviders.lookup_in_module(name, scope, nil)
+      v = Puppet::DataProviders.lookup_in_module(name, Puppet::DataBinding::LookupInvocation.new(scope), nil)
       found = true
       v
     end

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_json/data/bad.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_json/data/bad.json
@@ -1,0 +1,3 @@
+{
+    "test::param_a": "env data param_a is 10",
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_json/environment.conf
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_json/environment.conf
@@ -1,0 +1,2 @@
+# Use the 'sample' env data provider (in this fixture)
+environment_data_provider=hiera

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_json/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_json/hiera.yaml
@@ -1,0 +1,5 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "bad"
+    :backend: json

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_json/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_json/manifests/site.pp
@@ -1,0 +1,5 @@
+class test($param_a) {
+  notify { "$param_a": }
+}
+
+include test

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_yaml/data/bad.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_yaml/data/bad.yaml
@@ -1,0 +1,3 @@
+---
+ {
+one::test::param_c: env data param_c is 300

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_yaml/environment.conf
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_yaml/environment.conf
@@ -1,0 +1,2 @@
+# Use the 'sample' env data provider (in this fixture)
+environment_data_provider=hiera

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_yaml/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_yaml/hiera.yaml
@@ -1,0 +1,5 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "bad"
+    :backend: yaml

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_yaml/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_yaml/manifests/site.pp
@@ -1,0 +1,5 @@
+class test($param_a) {
+  notify { "$param_a": }
+}
+
+include test

--- a/spec/fixtures/unit/data_providers/environments/hiera_defaults/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_defaults/data/common.yaml
@@ -1,0 +1,2 @@
+---
+one::test::param_c: env data param_c is 300

--- a/spec/fixtures/unit/data_providers/environments/hiera_defaults/environment.conf
+++ b/spec/fixtures/unit/data_providers/environments/hiera_defaults/environment.conf
@@ -1,0 +1,2 @@
+# Use the 'sample' env data provider (in this fixture)
+environment_data_provider=hiera

--- a/spec/fixtures/unit/data_providers/environments/hiera_defaults/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_defaults/manifests/site.pp
@@ -1,0 +1,1 @@
+include one::test

--- a/spec/fixtures/unit/data_providers/environments/hiera_defaults/modules/one/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_defaults/modules/one/data/common.yaml
@@ -1,0 +1,2 @@
+---
+one::test::param_a: module data param_a is 100

--- a/spec/fixtures/unit/data_providers/environments/hiera_defaults/modules/one/manifests/init.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_defaults/modules/one/manifests/init.pp
@@ -1,0 +1,5 @@
+class one {
+  class test($param_a = "param default is 100", $param_b = "param default is 200", $param_c = "param default is 300") {
+    notify { "$param_a, $param_b, $param_c": }
+  }
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_defaults/modules/one/metadata.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_defaults/modules/one/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "example/one",
+    "version": "0.0.2",
+    "source": "git@github.com/example/example-one.git",
+    "dependencies": [],
+    "author": "Bob the Builder",
+    "license": "Apache-2.0",
+    "data_provider": "hiera"
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/first.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/first.json
@@ -1,0 +1,3 @@
+{
+    "test::param_a": "env data param_a is 10"
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/name.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/name.yaml
@@ -1,0 +1,2 @@
+---
+test::param_b: env data param_b is 20

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/second.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/second.json
@@ -1,0 +1,3 @@
+{
+    "test::param_c": "env data param_c is 30"
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/single.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/single.yaml
@@ -1,0 +1,2 @@
+---
+test::param_d: env data param_d is 40

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data2/single.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data2/single.yaml
@@ -1,0 +1,2 @@
+---
+test::param_e: env data param_e is 50

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/environment.conf
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/environment.conf
@@ -1,0 +1,2 @@
+# Use the 'sample' env data provider (in this fixture)
+environment_data_provider=hiera

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/hiera.yaml
@@ -1,0 +1,18 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "name"
+    :backend: yaml
+  - :name: "one path"
+    :backend: yaml
+    :path: "single"
+  - :name: "two paths"
+    :backend: json
+    :paths:
+      - "first"
+      - "second"
+  - :name:  'other datadir'
+    :backend: yaml
+    :datadir: "data2"
+    :path: "single"
+:datadir: "data1"

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/manifests/site.pp
@@ -1,0 +1,5 @@
+class test($param_a = 1, $param_b = 2, $param_c = 3, $param_d = 4, $param_e = 5) {
+  notify { "$param_a, $param_b, $param_c, $param_d, $param_e": }
+}
+
+include test

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/data/common.yaml
@@ -1,0 +1,25 @@
+---
+one::test::param:
+  key1: env 1
+
+one::array:
+  - second
+  - third
+  - fourth
+
+ukey1: Some value
+
+target_lookup: with lookup
+target_hiera: with hiera
+target_alias: Value from interpolation with alias
+
+km_default: 'Value from interpolation %{target_default}'
+km_alias: '%{alias("target_alias")}'
+km_lookup: 'Value from interpolation %{lookup("target_lookup")}'
+km_hiera: 'Value from interpolation %{hiera("target_hiera")}'
+km_scope: 'Value from interpolation %{scope("target_scope")}'
+km_literal: 'Value from interpolation %{literal("with literal")}'
+
+km_sqalias: "%{alias('target_alias')}"
+recursive: '%{r1}'
+

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/environment.conf
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/environment.conf
@@ -1,0 +1,2 @@
+# Use the 'sample' env data provider (in this fixture)
+environment_data_provider=hiera

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/manifests/site.pp
@@ -1,0 +1,1 @@
+include one::test

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/data/common.yaml
@@ -1,0 +1,11 @@
+---
+one::test::param:
+  key2: module 2
+
+one::array:
+  - first
+  - second
+  - third
+
+# should not be found since it's not qualified with module name
+ukey2: Some value

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/manifests/init.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/manifests/init.pp
@@ -1,0 +1,5 @@
+class one {
+  class test($param = { key1 => 'default 1', key2 => 'default 2' }) {
+    notify { "${param[key1]}, ${param[key2]}": }
+  }
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/metadata.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "example/one",
+    "version": "0.0.2",
+    "source": "git@github.com/example/example-one.git",
+    "dependencies": [],
+    "author": "Bob the Builder",
+    "license": "Apache-2.0",
+    "data_provider": "hiera"
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/environment.conf
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/environment.conf
@@ -1,0 +1,2 @@
+# Use the 'sample' env data provider (in this fixture)
+environment_data_provider=hiera

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/manifests/site.pp
@@ -1,0 +1,1 @@
+include one::test

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/first.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/first.json
@@ -1,0 +1,3 @@
+{
+    "one::test::param_a": "module data param_a is 100"
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/name.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/name.yaml
@@ -1,0 +1,1 @@
+one::test::param_b: module data param_b is 200

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/second.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/second.json
@@ -1,0 +1,3 @@
+{
+    "one::test::param_c": "module data param_c is 300"
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/single.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/single.yaml
@@ -1,0 +1,2 @@
+---
+one::test::param_d: module data param_d is 400

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data2/single.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data2/single.yaml
@@ -1,0 +1,2 @@
+---
+one::test::param_e: module data param_e is 500

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/hiera.yaml
@@ -1,0 +1,18 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "name"
+    :backend: yaml
+  - :name: "one path"
+    :backend: yaml
+    :path: "single"
+  - :name: "two paths"
+    :backend: json
+    :paths:
+      - "first"
+      - "second"
+  - :name:  'other datadir'
+    :backend: yaml
+    :datadir: "data2"
+    :path: "single"
+:datadir: "data1"

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/manifests/init.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/manifests/init.pp
@@ -1,0 +1,5 @@
+class one {
+  class test($param_a = "param default is 100", $param_b = "param default is 200", $param_c = "param default is 300", $param_d = "param default is 400", $param_e = "param default is 500") {
+    notify { "$param_a, $param_b, $param_c, $param_d, $param_e": }
+  }
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/metadata.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "example/one",
+    "version": "0.0.2",
+    "source": "git@github.com/example/example-one.git",
+    "dependencies": [],
+    "author": "Bob the Builder",
+    "license": "Apache-2.0",
+    "data_provider": "hiera"
+}

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -123,6 +123,18 @@ describe "when using a hiera data provider" do
     end.to raise_error(Puppet::DataBinding::LookupError, /'alias' interpolation is only permitted if the expression is equal to the entire string/)
   end
 
+  it 'reports syntax errors for JSON files' do
+    expect do
+      compile_and_get_notifications('hiera_bad_syntax_json')
+    end.to raise_error(Puppet::DataBinding::LookupError, /Unable to parse \(#{environmentpath}[^)]+\):/)
+  end
+
+  it 'reports syntax errors for YAML files' do
+    expect do
+      compile_and_get_notifications('hiera_bad_syntax_yaml')
+    end.to raise_error(Puppet::DataBinding::LookupError, /Unable to parse \(#{environmentpath}[^)]+\):/)
+  end
+
   def parent_fixture(dir_name)
     File.absolute_path(File.join(my_fixture_dir(), "../#{dir_name}"))
   end

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -1,0 +1,134 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+describe "when using a hiera data provider" do
+  include PuppetSpec::Compiler
+
+  # There is a fully configured 'sample' environment in fixtures at this location
+  let(:environmentpath) { parent_fixture('environments') }
+
+  let(:facts) { Puppet::Node::Facts.new("facts", {}) }
+
+  around(:each) do |example|
+    # Initialize settings to get a full compile as close as possible to a real
+    # environment load
+    Puppet.settings.initialize_global_settings
+    # Initialize loaders based on the environmentpath. It does not work to
+    # just set the setting environmentpath for some reason - this achieves the same:
+    # - first a loader is created, loading directory environments from the fixture (there is
+    # one environment, 'sample', which will be loaded since the node references this
+    # environment by name).
+    # - secondly, the created env loader is set as 'environments' in the puppet context.
+    #
+    loader = Puppet::Environments::Directories.new(environmentpath, [])
+    Puppet.override(:environments => loader) do
+      example.run
+    end
+  end
+
+  def compile_and_get_notifications(environment, code = nil)
+    Puppet[:code] = code if code
+    node = Puppet::Node.new("testnode", :facts => facts, :environment => environment)
+    compiler = Puppet::Parser::Compiler.new(node)
+    compiler.compile().resources.map(&:ref).select { |r| r.start_with?('Notify[') }.map { |r| r[7..-2] }
+  end
+
+  it 'uses default configuration for environment and module data' do
+    resources = compile_and_get_notifications('hiera_defaults')
+    expect(resources).to include('module data param_a is 100, param default is 200, env data param_c is 300')
+  end
+
+  it 'reads hiera.yaml in environment root and configures multiple json and yaml providers' do
+    resources = compile_and_get_notifications('hiera_env_config')
+    expect(resources).to include('env data param_a is 10, env data param_b is 20, env data param_c is 30, env data param_d is 40, env data param_e is 50')
+  end
+
+  it 'reads hiera.yaml in module root and configures multiple json and yaml providers' do
+    resources = compile_and_get_notifications('hiera_module_config')
+    expect(resources).to include('module data param_a is 100, module data param_b is 200, module data param_c is 300, module data param_d is 400, module data param_e is 500')
+  end
+
+  it 'reads does not perform merge of values declared in environment and module when resolving parameters' do
+    resources = compile_and_get_notifications('hiera_misc')
+    expect(resources).to include('env 1, ')
+  end
+
+  it 'reads performs hash merge of values declared in environment and module' do
+    resources = compile_and_get_notifications('hiera_misc', '$r = lookup(one::test::param, Hash[String,String], hash) notify{"${r[key1]}, ${r[key2]}":}')
+    expect(resources).to include('env 1, module 2')
+  end
+
+  it 'reads performs unique merge of values declared in environment and module' do
+    resources = compile_and_get_notifications('hiera_misc', '$r = lookup(one::array, Array[String], unique) notify{"${r}":}')
+    expect(resources.size).to eq(1)
+    expect(resources[0][1..-2].split(', ')).to contain_exactly('first', 'second', 'third', 'fourth')
+  end
+
+  it 'does find unqualified keys in the environment' do
+    resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(ukey1):}')
+    expect(resources).to include('Some value')
+  end
+
+  it 'does not find unqualified keys in the module' do
+    expect do
+      compile_and_get_notifications('hiera_misc', 'notify{lookup(ukey2):}')
+    end.to raise_error(Puppet::ParseError, /did not find a value for the name 'ukey2'/)
+  end
+
+  it 'can use interpolation lookup method "alias"' do
+    resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(km_alias):}')
+    expect(resources).to include('Value from interpolation with alias')
+  end
+
+  it 'can use interpolation lookup method "lookup"' do
+    resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(km_lookup):}')
+    expect(resources).to include('Value from interpolation with lookup')
+  end
+
+  it 'can use interpolation lookup method "hiera"' do
+    resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(km_hiera):}')
+    expect(resources).to include('Value from interpolation with hiera')
+  end
+
+  it 'can use interpolation lookup method "literal"' do
+    resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(km_literal):}')
+    expect(resources).to include('Value from interpolation with literal')
+  end
+
+  it 'can use interpolation lookup method "scope"' do
+    resources = compile_and_get_notifications('hiera_misc', '$target_scope = "with scope" notify{lookup(km_scope):}')
+    expect(resources).to include('Value from interpolation with scope')
+  end
+
+  it 'can use interpolation using default lookup method (scope)' do
+    resources = compile_and_get_notifications('hiera_misc', '$target_default = "with default" notify{lookup(km_default):}')
+    expect(resources).to include('Value from interpolation with default')
+  end
+
+  it 'performs single quoted interpolation' do
+    resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(km_sqalias):}')
+    expect(resources).to include('Value from interpolation with alias')
+  end
+
+  it 'traps endless interpolate recursion' do
+    expect do
+      compile_and_get_notifications('hiera_misc', '$r1 = "%{r2}" $r2 = "%{r1}" notify{lookup(recursive):}')
+    end.to raise_error(Puppet::DataBinding::RecursiveLookupError, /detected in \[recursive, r1, r2\]/)
+  end
+
+  it 'traps bad alias declarations' do
+    expect do
+      compile_and_get_notifications('hiera_misc', "$r1 = 'Alias within string %{alias(\"r2\")}' $r2 = '%{r1}' notify{lookup(recursive):}")
+    end.to raise_error(Puppet::DataBinding::LookupError, /'alias' interpolation is only permitted if the expression is equal to the entire string/)
+  end
+
+  def parent_fixture(dir_name)
+    File.absolute_path(File.join(my_fixture_dir(), "../#{dir_name}"))
+  end
+
+  def resources_in(catalog)
+    catalog.resources.map(&:ref)
+  end
+
+end


### PR DESCRIPTION
This PR will add everything that's needed to enable a 'Data in Modules' style data provider that mimics the behavior of the 'hiera' lookup. It also adds the 'yaml' and 'json' data providers needed to make the 'hiera' dataprovider work. So in essence, this PR also covers PUP-4486 and PUP-4487.

The PR is divided into several commits to make it easier to review. Please review the commit message on each individual commit for details.