### PR TITLE
(maint) Fix bug in stat function

### DIFF
--- a/acceptance/lib/puppet/acceptance/temp_file_utils.rb
+++ b/acceptance/lib/puppet/acceptance/temp_file_utils.rb
@@ -140,7 +140,7 @@ module Puppet
       # value containing only the file mode, excluding the type, e.g
       # S_IFDIR 0040000
       def stat(host, path)
-        stat_command = case agent['platform']
+        stat_command = case host['platform']
                        when /osx/
                          "stat -f '%Su:%Sg:%p'"
                        else


### PR DESCRIPTION
This is coming from a CI failure for `puppet-server`, which uses `puppet`
4.2.1, see SERVER-832 for details.

The stat function references an `agent` variable, which will coincidentally
be set correctly to the same value as `host` if the beaker config only has
one host with an agent role. But if there is more than one agent, the
'agent' variable will be a list of hosts, and the stat function will throw an
exception.

The bug was introduced in 8d2a872