### PR TITLE
(doc) 'JIRA tracker' link fix in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [LICENSE](LICENSE) file.
 Support
 -------
 
-Please log tickets and issues at our [JIRA tracker](http://tickets.puppetlabs.com).  A [mailing
+Please log tickets and issues at our [JIRA tracker](https://tickets.puppetlabs.com).  A [mailing
 list](https://groups.google.com/forum/?fromgroups#!forum/puppet-users) is
 available for asking questions and getting help from others. In addition there
 is an active #puppet channel on Freenode.


### PR DESCRIPTION
Currently, the 'JIRA tracker' link points to http://tickets.puppetlabs.com/
which redirects itself to https://tickets.puppetlabs.com/ with a 301 redirection.
I just changed this to point directly to the correct https page.