### PR TITLE
(PUP-5009) Fixup puppet-agent paths and pmt tests run on git install

### DIFF
--- a/acceptance/lib/puppet/acceptance/module_utils.rb
+++ b/acceptance/lib/puppet/acceptance/module_utils.rb
@@ -31,6 +31,23 @@ module Puppet
         get_modulepaths_for_host(host)[0]
       end
 
+      # Return a string of a non-default (second) path in modulepath for a given host.
+      #
+      # Example return value:
+      #
+      #   "/etc/puppetlabs/code/modules"
+      #
+      # @param host [String] hostname
+      # @return [String] second path for found modulepath
+      def get_nondefault_modulepath_for_host (host)
+        modulepath_array = get_modulepaths_for_host(host)
+        unless modulepath_array.length < 2 then
+          get_modulepaths_for_host(host)[1]
+        else
+          ""
+        end
+      end
+
       # Return an array of paths to installed modules for a given host.
       #
       # Example return value:

--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -2,6 +2,8 @@
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
 test_name 'PUP-4033: Ensure aio path spec is honored'
 
+skip_test "not an aio environment" unless options[:type] == 'aio'
+
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils
 

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (already installed elsewhere)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+secondary_moduledir = get_nondefault_modulepath_for_host(master)
+
+skip_test "no secondary moduledir available on master" if secondary_moduledir.empty?
+
 hosts.each do |host|
   skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
 end
@@ -23,10 +27,10 @@ stub_forge_on(master)
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['sitemoduledir']}',
-    '#{master['sitemoduledir']}/#{module_name}',
+    '#{secondary_moduledir}',
+    '#{secondary_moduledir}/#{module_name}',
   ]: ensure => directory;
-  '#{master['sitemoduledir']}/#{module_name}/metadata.json':
+  '#{secondary_moduledir}/#{module_name}/metadata.json':
     content => '{
       "name": "#{module_author}/#{module_name}",
       "version": "0.0.1",

--- a/acceptance/tests/modules/list/with_circular_dependencies.rb
+++ b/acceptance/tests/modules/list/with_circular_dependencies.rb
@@ -1,8 +1,15 @@
 test_name "puppet module list (with circular dependencies)"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+default_moduledir = get_default_modulepath_for_host(master)
+secondary_moduledir = get_nondefault_modulepath_for_host(master)
+
+skip_test "no secondary moduledir available on master" if secondary_moduledir.empty?
 
 teardown do
-  on master, "rm -rf #{master['distmoduledir']}/appleseed"
-  on master, "rm -rf #{master['sitemoduledir']}/crakorn"
+  on master, "rm -rf #{default_moduledir}/appleseed"
+  on master, "rm -rf #{secondary_moduledir}/crakorn"
 end
 
 step "Setup"
@@ -10,13 +17,13 @@ step "Setup"
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['distmoduledir']}/appleseed',
-    '#{master['sitemoduledir']}/crakorn',
+    '#{default_moduledir}/appleseed',
+    '#{secondary_moduledir}/crakorn',
   ]: ensure => directory,
      recurse => true,
      purge => true,
      force => true;
-  '#{master['sitemoduledir']}/crakorn/metadata.json':
+  '#{secondary_moduledir}/crakorn/metadata.json':
     content => '{
       "name": "jimmy/crakorn",
       "version": "0.4.0",
@@ -27,7 +34,7 @@ file {
         { "name": "jimmy/appleseed", "version_requirement": "1.1.0" }
       ]
     }';
-  '#{master['distmoduledir']}/appleseed/metadata.json':
+  '#{default_moduledir}/appleseed/metadata.json':
     content => '{
       "name": "jimmy/appleseed",
       "version": "1.1.0",
@@ -40,8 +47,8 @@ file {
     }';
 }
 PP
-on master, "[ -d #{master['distmoduledir']}/appleseed ]"
-on master, "[ -d #{master['sitemoduledir']}/crakorn ]"
+on master, "[ -d #{default_moduledir}/appleseed ]"
+on master, "[ -d #{secondary_moduledir}/crakorn ]"
 
 step "List the installed modules"
 on master, puppet("module list") do
@@ -51,6 +58,6 @@ end
 
 step "List the installed modules as a dependency tree"
 on master, puppet("module list --tree") do
-  assert_match /jimmy-crakorn.*\[#{master['sitemoduledir']}\]/, stdout, 'Could not find jimmy crakorn'
-  assert_match /jimmy-appleseed.*\[#{master['distmoduledir']}\]/, stdout, 'Could not find jimmy appleseed, but then again... wasnt it johnny appleseed?'
+  assert_match /jimmy-crakorn.*\[#{secondary_moduledir}\]/, stdout, 'Could not find jimmy crakorn'
+  assert_match /jimmy-appleseed.*\[#{default_moduledir}\]/, stdout, 'Could not find jimmy appleseed, but then again... wasnt it johnny appleseed?'
 end

--- a/acceptance/tests/modules/list/with_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_installed_modules.rb
@@ -1,10 +1,17 @@
 test_name "puppet module list (with installed modules)"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+default_moduledir = get_default_modulepath_for_host(master)
+secondary_moduledir = get_nondefault_modulepath_for_host(master)
+
+skip_test "no secondary moduledir available on master" if secondary_moduledir.empty?
 
 teardown do
-  on master, "rm -rf #{master['distmoduledir']}/thelock"
-  on master, "rm -rf #{master['distmoduledir']}/appleseed"
-  on master, "rm -rf #{master['distmoduledir']}/crakorn"
-  on master, "rm -rf #{master['sitemoduledir']}/crick"
+  on master, "rm -rf #{default_moduledir}/thelock"
+  on master, "rm -rf #{default_moduledir}/appleseed"
+  on master, "rm -rf #{default_moduledir}/crakorn"
+  on master, "rm -rf #{secondary_moduledir}/crick"
 end
 
 step "Setup"
@@ -12,15 +19,15 @@ step "Setup"
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['distmoduledir']}/crakorn',
-    '#{master['distmoduledir']}/appleseed',
-    '#{master['distmoduledir']}/thelock',
-    '#{master['sitemoduledir']}/crick',
+    '#{default_moduledir}/crakorn',
+    '#{default_moduledir}/appleseed',
+    '#{default_moduledir}/thelock',
+    '#{secondary_moduledir}/crick',
   ]: ensure => directory,
      recurse => true,
      purge => true,
      force => true;
-  '#{master['distmoduledir']}/crakorn/metadata.json':
+  '#{default_moduledir}/crakorn/metadata.json':
     content => '{
       "name": "jimmy/crakorn",
       "version": "0.4.0",
@@ -29,7 +36,7 @@ file {
       "license": "MIT",
       "dependencies": []
     }';
-  '#{master['distmoduledir']}/appleseed/metadata.json':
+  '#{default_moduledir}/appleseed/metadata.json':
     content => '{
       "name": "jimmy/appleseed",
       "version": "1.1.0",
@@ -40,7 +47,7 @@ file {
         { "name": "jimmy/crakorn", "version_requirement": "0.4.0" }
       ]
     }';
-  '#{master['distmoduledir']}/thelock/metadata.json':
+  '#{default_moduledir}/thelock/metadata.json':
     content => '{
       "name": "jimmy/thelock",
       "version": "1.0.0",
@@ -51,7 +58,7 @@ file {
         { "name": "jimmy/appleseed", "version_requirement": "1.x" }
       ]
     }';
-  '#{master['sitemoduledir']}/crick/metadata.json':
+  '#{secondary_moduledir}/crick/metadata.json':
     content => '{
       "name": "jimmy/crick",
       "version": "1.0.1",
@@ -65,38 +72,38 @@ file {
 }
 PP
 
-on master, "[ -d #{master['distmoduledir']}/crakorn ]"
-on master, "[ -d #{master['distmoduledir']}/appleseed ]"
-on master, "[ -d #{master['distmoduledir']}/thelock ]"
-on master, "[ -d #{master['sitemoduledir']}/crick ]"
+on master, "[ -d #{default_moduledir}/crakorn ]"
+on master, "[ -d #{default_moduledir}/appleseed ]"
+on master, "[ -d #{default_moduledir}/thelock ]"
+on master, "[ -d #{secondary_moduledir}/crick ]"
 
 step "List the installed modules"
-on master, puppet("module list --modulepath #{master['distmoduledir']}") do
+on master, puppet("module list --modulepath #{default_moduledir}") do
   assert_equal <<-STDOUT, stdout
-#{master['distmoduledir']}
+#{default_moduledir}
 ├── jimmy-appleseed (\e[0;36mv1.1.0\e[0m)
 ├── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
 └── jimmy-thelock (\e[0;36mv1.0.0\e[0m)
 STDOUT
 end
 
-on master, puppet("module list --modulepath #{master['sitemoduledir']}") do |res|
+on master, puppet("module list --modulepath #{secondary_moduledir}") do |res|
   assert_match( /jimmy-crick/,
                 res.stdout,
                 'Did not find module jimmy-crick in module site path')
 end
 
 step "List the installed modules as a dependency tree"
-on master, puppet("module list --tree --modulepath #{master['distmoduledir']}") do
+on master, puppet("module list --tree --modulepath #{default_moduledir}") do
   assert_equal <<-STDOUT, stdout
-#{master['distmoduledir']}
+#{default_moduledir}
 └─┬ jimmy-thelock (\e[0;36mv1.0.0\e[0m)
   └─┬ jimmy-appleseed (\e[0;36mv1.1.0\e[0m)
     └── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
 STDOUT
 end
 
-on master, puppet("module list --tree --modulepath #{master['sitemoduledir']}") do |res|
+on master, puppet("module list --tree --modulepath #{secondary_moduledir}") do |res|
   assert_match( /jimmy-crakorn/,
                 res.stdout,
                 'Did not find module jimmy-crakorn in module site path')

--- a/acceptance/tests/modules/list/with_invalid_dependencies.rb
+++ b/acceptance/tests/modules/list/with_invalid_dependencies.rb
@@ -1,10 +1,17 @@
 test_name "puppet module list (with invalid dependencies)"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+default_moduledir = get_default_modulepath_for_host(master)
+secondary_moduledir = get_nondefault_modulepath_for_host(master)
+
+skip_test "no secondary moduledir available on master" if secondary_moduledir.empty?
 
 teardown do
-  on master, "rm -rf #{master['distmoduledir']}/thelock"
-  on master, "rm -rf #{master['distmoduledir']}/appleseed"
-  on master, "rm -rf #{master['distmoduledir']}/crakorn"
-  on master, "rm -rf #{master['sitemoduledir']}/crick"
+  on master, "rm -rf #{default_moduledir}/thelock"
+  on master, "rm -rf #{default_moduledir}/appleseed"
+  on master, "rm -rf #{default_moduledir}/crakorn"
+  on master, "rm -rf #{secondary_moduledir}/crick"
 end
 
 step "Setup"
@@ -12,15 +19,15 @@ step "Setup"
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['distmoduledir']}/appleseed',
-    '#{master['distmoduledir']}/crakorn',
-    '#{master['distmoduledir']}/thelock',
-    '#{master['sitemoduledir']}/crick',
+    '#{default_moduledir}/appleseed',
+    '#{default_moduledir}/crakorn',
+    '#{default_moduledir}/thelock',
+    '#{secondary_moduledir}/crick',
   ]: ensure => directory,
      recurse => true,
      purge => true,
      force => true;
-   '#{master['distmoduledir']}/crakorn/metadata.json':
+   '#{default_moduledir}/crakorn/metadata.json':
      content => '{
        "name": "jimmy/crakorn",
        "version": "0.3.0",
@@ -29,7 +36,7 @@ file {
        "license": "MIT",
        "dependencies": []
      }';
-  '#{master['distmoduledir']}/appleseed/metadata.json':
+  '#{default_moduledir}/appleseed/metadata.json':
     content => '{
       "name": "jimmy/appleseed",
       "version": "1.1.0",
@@ -40,7 +47,7 @@ file {
         { "name": "jimmy/crakorn", "version_requirement": "0.x" }
       ]
     }';
-  '#{master['distmoduledir']}/thelock/metadata.json':
+  '#{default_moduledir}/thelock/metadata.json':
     content => '{
       "name": "jimmy/thelock",
       "version": "1.0.0",
@@ -51,7 +58,7 @@ file {
         { "name": "jimmy/appleseed", "version_requirement": "1.x" }
       ]
     }';
-  '#{master['sitemoduledir']}/crick/metadata.json':
+  '#{secondary_moduledir}/crick/metadata.json':
     content => '{
       "name": "jimmy/crick",
       "version": "1.0.1",
@@ -65,10 +72,10 @@ file {
 }
 PP
 
-on master, "[ -d #{master['distmoduledir']}/appleseed ]"
-on master, "[ -d #{master['distmoduledir']}/crakorn ]"
-on master, "[ -d #{master['distmoduledir']}/thelock ]"
-on master, "[ -d #{master['sitemoduledir']}/crick ]"
+on master, "[ -d #{default_moduledir}/appleseed ]"
+on master, "[ -d #{default_moduledir}/crakorn ]"
+on master, "[ -d #{default_moduledir}/thelock ]"
+on master, "[ -d #{secondary_moduledir}/crick ]"
 
 step "List the installed modules"
 on master, puppet("module list") do |res|
@@ -90,5 +97,5 @@ on master, puppet("module list --tree") do |res|
   ].join("\n"), Regexp::MULTILINE)
   assert_match(pattern, result.stderr)
 
-  assert_match /jimmy-crakorn.*\[#{master['distmoduledir']}\].*invalid/, res.stdout
+  assert_match /jimmy-crakorn.*\[#{default_moduledir}\].*invalid/, res.stdout
 end

--- a/acceptance/tests/modules/list/with_repeated_dependencies.rb
+++ b/acceptance/tests/modules/list/with_repeated_dependencies.rb
@@ -1,11 +1,18 @@
 test_name "puppet module list (with repeated dependencies)"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+default_moduledir = get_default_modulepath_for_host(master)
+secondary_moduledir = get_nondefault_modulepath_for_host(master)
+
+skip_test "no secondary moduledir available on master" if secondary_moduledir.empty?
 
 teardown do
-  on master, "rm -rf #{master['distmoduledir']}/crakorn"
-  on master, "rm -rf #{master['distmoduledir']}/steward"
-  on master, "rm -rf #{master['distmoduledir']}/appleseed"
-  on master, "rm -rf #{master['distmoduledir']}/thelock"
-  on master, "rm -rf #{master['sitemoduledir']}/crick"
+  on master, "rm -rf #{default_moduledir}/crakorn"
+  on master, "rm -rf #{default_moduledir}/steward"
+  on master, "rm -rf #{default_moduledir}/appleseed"
+  on master, "rm -rf #{default_moduledir}/thelock"
+  on master, "rm -rf #{secondary_moduledir}/crick"
 end
 
 step "Setup"
@@ -13,16 +20,16 @@ step "Setup"
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['distmoduledir']}/crakorn',
-    '#{master['distmoduledir']}/steward',
-    '#{master['distmoduledir']}/appleseed',
-    '#{master['distmoduledir']}/thelock',
-    '#{master['sitemoduledir']}/crick',
+    '#{default_moduledir}/crakorn',
+    '#{default_moduledir}/steward',
+    '#{default_moduledir}/appleseed',
+    '#{default_moduledir}/thelock',
+    '#{secondary_moduledir}/crick',
   ]: ensure => directory,
      recurse => true,
      purge => true,
      force => true;
-  '#{master['distmoduledir']}/crakorn/metadata.json':
+  '#{default_moduledir}/crakorn/metadata.json':
     content => '{
       "name": "jimmy/crakorn",
       "version": "0.4.0",
@@ -33,7 +40,7 @@ file {
         { "name": "jimmy/steward", "version_requirement": ">= 0.0.0" }
       ]
     }';
-  '#{master['distmoduledir']}/steward/metadata.json':
+  '#{default_moduledir}/steward/metadata.json':
     content => '{
       "name": "jimmy/steward",
       "version": "0.9.0",
@@ -42,7 +49,7 @@ file {
       "license": "MIT",
       "dependencies": []
     }';
-  '#{master['distmoduledir']}/appleseed/metadata.json':
+  '#{default_moduledir}/appleseed/metadata.json':
     content => '{
       "name": "jimmy/appleseed",
       "version": "1.1.0",
@@ -53,7 +60,7 @@ file {
         { "name": "jimmy/crakorn", "version_requirement": "0.4.0" }
       ]
     }';
-  '#{master['distmoduledir']}/thelock/metadata.json':
+  '#{default_moduledir}/thelock/metadata.json':
     content => '{
       "name": "jimmy/thelock",
       "version": "1.0.0",
@@ -65,7 +72,7 @@ file {
         { "name": "jimmy/appleseed", "version_requirement": "1.x" }
       ]
     }';
-  '#{master['sitemoduledir']}/crick/metadata.json':
+  '#{secondary_moduledir}/crick/metadata.json':
     content => '{
       "name": "jimmy/crick",
       "version": "1.0.1",
@@ -79,19 +86,19 @@ file {
 }
 PP
 
-on master, "[ -d #{master['distmoduledir']}/crakorn ]"
-on master, "[ -d #{master['distmoduledir']}/steward ]"
-on master, "[ -d #{master['distmoduledir']}/appleseed ]"
-on master, "[ -d #{master['distmoduledir']}/thelock ]"
-on master, "[ -d #{master['sitemoduledir']}/crick ]"
+on master, "[ -d #{default_moduledir}/crakorn ]"
+on master, "[ -d #{default_moduledir}/steward ]"
+on master, "[ -d #{default_moduledir}/appleseed ]"
+on master, "[ -d #{default_moduledir}/thelock ]"
+on master, "[ -d #{secondary_moduledir}/crick ]"
 
 step "List the installed modules"
 on master, puppet('module list') # assertion is exit code 0
 
 step "List the installed modules as a dependency tree"
-on master, puppet("module list --tree --modulepath #{master['distmoduledir']}") do
+on master, puppet("module list --tree --modulepath #{default_moduledir}") do
   assert_equal <<-STDOUT, stdout
-#{master['distmoduledir']}
+#{default_moduledir}
 └─┬ jimmy-thelock (\e[0;36mv1.0.0\e[0m)
   ├─┬ jimmy-crakorn (\e[0;36mv0.4.0\e[0m)
   │ └── jimmy-steward (\e[0;36mv0.9.0\e[0m)
@@ -100,10 +107,10 @@ STDOUT
 end
 
 on master, puppet("module list --tree") do
-  assert_match( /jimmy-crakorn.*\[#{master['distmoduledir']}\]/,
+  assert_match( /jimmy-crakorn.*\[#{default_moduledir}\]/,
                 stdout,
                 'Did not find cross modulepath reference to jimmy-crakorn' )
-  assert_match( /jimmy-steward.*\[#{master['distmoduledir']}\]/,
+  assert_match( /jimmy-steward.*\[#{default_moduledir}\]/,
                 stdout,
                 'Did not find cross modulepath reference to jimmy-steward' )
 end

--- a/acceptance/tests/modules/uninstall/with_active_dependency.rb
+++ b/acceptance/tests/modules/uninstall/with_active_dependency.rb
@@ -1,13 +1,17 @@
 test_name "puppet module uninstall (with active dependency)"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+default_moduledir = get_default_modulepath_for_host(master)
 
 step "Setup"
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['distmoduledir']}/crakorn',
-    '#{master['distmoduledir']}/appleseed',
+    '#{default_moduledir}/crakorn',
+    '#{default_moduledir}/appleseed',
   ]: ensure => directory;
-  '#{master['distmoduledir']}/crakorn/metadata.json':
+  '#{default_moduledir}/crakorn/metadata.json':
     content => '{
       "name": "jimmy/crakorn",
       "version": "0.4.0",
@@ -16,7 +20,7 @@ file {
       "license": "MIT",
       "dependencies": []
     }';
-  '#{master['distmoduledir']}/appleseed/metadata.json':
+  '#{default_moduledir}/appleseed/metadata.json':
     content => '{
       "name": "jimmy/appleseed",
       "version": "1.1.0",
@@ -31,12 +35,12 @@ file {
 PP
 
 teardown do
-  on master, "rm -rf #{master['distmoduledir']}/crakorn"
-  on master, "rm -rf #{master['distmoduledir']}/appleseed"
+  on master, "rm -rf #{default_moduledir}/crakorn"
+  on master, "rm -rf #{default_moduledir}/appleseed"
 end
 
-on master, "[ -d #{master['distmoduledir']}/crakorn ]"
-on master, "[ -d #{master['distmoduledir']}/appleseed ]"
+on master, "[ -d #{default_moduledir}/crakorn ]"
+on master, "[ -d #{default_moduledir}/appleseed ]"
 
 step "Try to uninstall the module jimmy-crakorn"
 on master, puppet('module uninstall jimmy-crakorn'), :acceptable_exit_codes => [1] do
@@ -49,8 +53,8 @@ on master, puppet('module uninstall jimmy-crakorn'), :acceptable_exit_codes => [
   ].join("\n"), Regexp::MULTILINE)
   assert_match(pattern, result.output)
 end
-on master, "[ -d #{master['distmoduledir']}/crakorn ]"
-on master, "[ -d #{master['distmoduledir']}/appleseed ]"
+on master, "[ -d #{default_moduledir}/crakorn ]"
+on master, "[ -d #{default_moduledir}/appleseed ]"
 
 step "Try to uninstall the module jimmy-crakorn with a version range"
 on master, puppet('module uninstall jimmy-crakorn --version 0.x'), :acceptable_exit_codes => [1] do
@@ -63,15 +67,15 @@ on master, puppet('module uninstall jimmy-crakorn --version 0.x'), :acceptable_e
   ].join("\n"), Regexp::MULTILINE)
   assert_match(pattern, result.output)
 end
-on master, "[ -d #{master['distmoduledir']}/crakorn ]"
-on master, "[ -d #{master['distmoduledir']}/appleseed ]"
+on master, "[ -d #{default_moduledir}/crakorn ]"
+on master, "[ -d #{default_moduledir}/appleseed ]"
 
 step "Uninstall the module jimmy-crakorn forcefully"
 on master, puppet('module uninstall jimmy-crakorn --force') do
   assert_equal <<-OUTPUT, stdout
 \e[mNotice: Preparing to uninstall 'jimmy-crakorn' ...\e[0m
-Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from #{master['distmoduledir']}
+Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from #{default_moduledir}
   OUTPUT
 end
-on master, "[ ! -d #{master['distmoduledir']}/crakorn ]"
-on master, "[ -d #{master['distmoduledir']}/appleseed ]"
+on master, "[ ! -d #{default_moduledir}/crakorn ]"
+on master, "[ -d #{default_moduledir}/appleseed ]"

--- a/acceptance/tests/modules/uninstall/with_module_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_module_installed.rb
@@ -1,16 +1,20 @@
 test_name "puppet module uninstall (with module installed)"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+
+default_moduledir = get_default_modulepath_for_host(master)
 
 teardown do
-  on master, "rm -rf #{master['distmoduledir']}/crakorn"
+  on master, "rm -rf #{default_moduledir}/crakorn"
 end
 
 step "Setup"
 apply_manifest_on master, <<-PP
 file {
   [
-    '#{master['distmoduledir']}/crakorn',
+    '#{default_moduledir}/crakorn',
   ]: ensure => directory;
-  '#{master['distmoduledir']}/crakorn/metadata.json':
+  '#{default_moduledir}/crakorn/metadata.json':
     content => '{
       "name": "jimmy/crakorn",
       "version": "0.4.0",
@@ -22,13 +26,13 @@ file {
 }
 PP
 
-on master, "[ -d #{master['distmoduledir']}/crakorn ]"
+on master, "[ -d #{default_moduledir}/crakorn ]"
 
 step "Uninstall the module jimmy-crakorn"
 on master, puppet('module uninstall jimmy-crakorn') do
   assert_equal <<-OUTPUT, stdout
 \e[mNotice: Preparing to uninstall 'jimmy-crakorn' ...\e[0m
-Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from #{master['distmoduledir']}
+Removed 'jimmy-crakorn' (\e[0;36mv0.4.0\e[0m) from #{default_moduledir}
   OUTPUT
 end
-on master, "[ ! -d #{master['distmoduledir']}/crakorn ]"
+on master, "[ ! -d #{default_moduledir}/crakorn ]"

--- a/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
+++ b/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
@@ -2,6 +2,8 @@ test_name "puppet module upgrade (in a secondary directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+default_moduledir = get_default_modulepath_for_host(master)
+
 hosts.each do |host|
   skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
 end
@@ -15,11 +17,11 @@ step 'Setup'
 
 stub_forge_on(master)
 
-on master, "mkdir -p #{master['distmoduledir']}"
-on master, puppet("module install pmtacceptance-java --version 1.6.0 --target-dir #{master['distmoduledir']}")
-on master, puppet("module list --modulepath #{master['distmoduledir']}") do
+on master, "mkdir -p #{default_moduledir}"
+on master, puppet("module install pmtacceptance-java --version 1.6.0 --target-dir #{default_moduledir}")
+on master, puppet("module list --modulepath #{default_moduledir}") do
   assert_equal <<-OUTPUT, stdout
-#{master['distmoduledir']}
+#{default_moduledir}
 ├── pmtacceptance-java (\e[0;36mv1.6.0\e[0m)
 └── pmtacceptance-stdlub (\e[0;36mv1.0.0\e[0m)
   OUTPUT
@@ -29,10 +31,10 @@ step "Upgrade a module that has a more recent version published"
 on master, puppet("module upgrade pmtacceptance-java") do
   assert_equal <<-OUTPUT, stdout
 \e[mNotice: Preparing to upgrade 'pmtacceptance-java' ...\e[0m
-\e[mNotice: Found 'pmtacceptance-java' (\e[0;36mv1.6.0\e[m) in #{master['distmoduledir']} ...\e[0m
+\e[mNotice: Found 'pmtacceptance-java' (\e[0;36mv1.6.0\e[m) in #{default_moduledir} ...\e[0m
 \e[mNotice: Downloading from https://forgeapi.puppetlabs.com ...\e[0m
 \e[mNotice: Upgrading -- do not interrupt ...\e[0m
-#{master['distmoduledir']}
+#{default_moduledir}
 └── pmtacceptance-java (\e[0;36mv1.6.0 -> v1.7.1\e[0m)
   OUTPUT
 end


### PR DESCRIPTION
This commit sets the ensure_puppet-agent_paths.rb test to skip
unless the beaker option 'type' is set to aio. This ensures that
the test does not erroneously fail in a non puppet-agent
environment.