### PR TITLE
(PUP-5010) Skip upstart test on vivid

### DIFF
--- a/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
+++ b/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
@@ -2,6 +2,8 @@ test_name 'Upstart Testing'
 
 # only run these on ubuntu vms
 confine :to, :platform => 'ubuntu'
+# vivid and above use systemd rather than upstart
+confine :except, :platform => /ubuntu-[v-z]/
 
 # pick any ubuntu agent
 agent = agents.first


### PR DESCRIPTION
This commit sets the handle upstart test to skip the 'vivid'
version of ubuntu since it uses systemd rather than upstart to
manage services.