### PR TITLE
(maint) Remove redundant travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.2.0
+    - rvm: 2.2.2
       env: "CHECK=rubocop"
     - rvm: 2.0.0
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
-    - rvm: 2.2.0
+    - rvm: 2.2.2
       env: "CHECK=commits"
     - rvm: 2.0.0
       env: "CHECK=commits"


### PR DESCRIPTION
When .travis.yml was updated for the latest 2.2 z release,
the exclusions matrix wasn't updated, which meant the commits
and rubocop jobs were being run on multiple rubies (no point
in that, never the intent).

So this commit just fixes up the excludes to prune those out
as intended.