### PR TITLE
(PUP-5014) Base class for JSON indirection terminus calls

### DIFF
--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -17,7 +17,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
 
     Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance) }
   rescue TypeError => detail
-    Puppet.log_exception "Could not save #{self.name} #{request.key}: #{detail}"
+    Puppet.log_exception(detail, "Could not save #{self.name} #{request.key}: #{detail}")
   end
 
   def destroy(request)

--- a/lib/puppet/indirector/msgpack.rb
+++ b/lib/puppet/indirector/msgpack.rb
@@ -23,7 +23,7 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
 
     Puppet::Util.replace_file(filename, 0660) {|f| f.print to_msgpack(request.instance) }
   rescue TypeError => detail
-    Puppet.log_exception "Could not save #{self.name} #{request.key}: #{detail}"
+    Puppet.log_exception(detail, "Could not save #{self.name} #{request.key}: #{detail}")
   end
 
   def destroy(request)


### PR DESCRIPTION
log_exception() wrong.

In Puppet::Indirector::JSON, Puppet.log_exception() is called without
the required exception as the first argument value, instead the message
is passed.

This breaks further along in format_exception() as it attempts to get
the exception message attribute but finds a string: