### PR TITLE
(PUP-4824) Fix typo on resource acceptance tests

### DIFF
--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -6,19 +6,19 @@ group = "gp#{rand(999999).to_i}"
 
 agents.each do |host|
   step "user should not exist"
-  agent.user_absent(user)
+  host.user_absent(user)
 
   step "group should exist"
-  agent.group_present(group)
+  host.group_present(group)
 
   step "create user with group"
   on(host, puppet_resource('user', user, 'ensure=present', "gid=#{group}"))
 
   step "verify the group exists and find the gid"
-  group_gid = agent.group_gid(group)
+  group_gid = host.group_gid(group)
 
   step "verify that the user has that as their gid"
-  agent.user_get(user) do |result|
+  host.user_get(user) do |result|
     if agent['platform'] =~ /osx/
         match = result.stdout.match(/gid: (\d+)/)
         user_gid = match ? match[1] : nil

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -14,8 +14,8 @@ agents.each do |host|
   on(host, puppet_resource('user', user, 'ensure=present', "gid=#{group1}"))
 
   step "verify that the user has the correct gid"
-  group_gid1 = agent.group_gid(group1)
-  agent.user_get(user) do |result|
+  group_gid1 = host.group_gid(group1)
+  host.user_get(user) do |result|
     if agent['platform'] =~ /osx/
         match = result.stdout.match(/gid: (\d+)/)
         user_gid1 = match ? match[1] : nil
@@ -30,8 +30,8 @@ agents.each do |host|
   on(host, puppet_resource('user', user, 'ensure=present', "gid=#{group2}"))
 
   step "verify that the user has the updated gid"
-  group_gid2 = agent.group_gid(group2)
-  agent.user_get(user) do |result|
+  group_gid2 = host.group_gid(group2)
+  host.user_get(user) do |result|
     if agent['platform'] =~ /osx/
         match = result.stdout.match(/gid: (\d+)/)
         user_gid2 = match ? match[1] : nil


### PR DESCRIPTION
No idea why this didn't fail in our pipeline or locally, but this should fix the acceptance failures on the puppet-server board.

![image](https://cloud.githubusercontent.com/assets/507621/9215542/e57b9838-4060-11e5-90e4-753db3c2f540.png)

