### PR TITLE
(PUP-5032) Change configured_environment behavior

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -154,12 +154,14 @@ class Puppet::Configurer
         query_options = get_facts(options)
       end
 
+      configured_environment = Puppet[:environment] if Puppet.settings.set_by_config?(:environment)
+
       # We only need to find out the environment to run in if we don't already have a catalog
       unless options[:catalog]
         begin
           if node = Puppet::Node.indirection.find(Puppet[:node_name_value],
               :environment => Puppet::Node::Environment.remote(@environment),
-              :configured_environment => Puppet[:environment],
+              :configured_environment => configured_environment,
               :ignore_cache => true,
               :transaction_uuid => @transaction_uuid,
               :fail_on_404 => true)
@@ -197,7 +199,7 @@ class Puppet::Configurer
 
       query_options = get_facts(options) unless query_options
       query_options[:transaction_uuid] = @transaction_uuid
-      query_options[:configured_environment] = Puppet[:environment]
+      query_options[:configured_environment] = configured_environment
 
       unless catalog = prepare_and_retrieve_catalog(options, query_options)
         return nil
@@ -218,7 +220,7 @@ class Puppet::Configurer
 
         query_options = get_facts(options)
         query_options[:transaction_uuid] = @transaction_uuid
-        query_options[:configured_environment] = Puppet[:environment]
+        query_options[:configured_environment] = configured_environment
 
         return nil unless catalog = prepare_and_retrieve_catalog(options, query_options)
         tries += 1

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -828,9 +828,9 @@ class Puppet::Settings
 
   # Allow later inspection to determine if the setting was set by user
   # config, rather than a default setting.
-  def set_by_config?(param)
+  def set_by_config?(param, environment = nil, run_mode = preferred_run_mode)
     param = param.to_sym
-    configsearchpath.any? do |source|
+    configsearchpath(environment, run_mode).any? do |source|
       if vals = searchpath_values(source)
         vals.lookup(param)
       end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -532,8 +532,14 @@ describe Puppet::Configurer do
       @agent.run
     end
 
-    it "sends the configured environment in the request" do
+    it "sends an explicitly configured environment request" do
+      Puppet.settings.expects(:set_by_config?).with(:environment).returns(true)
       Puppet::Node.indirection.expects(:find).with(anything, has_entries(:configured_environment => Puppet[:environment])).twice
+      @agent.run
+    end
+
+    it "does not send a configured_environment when using the default" do
+      Puppet::Node.indirection.expects(:find).with(anything, has_entries(:configured_environment => nil)).twice
       @agent.run
     end
   end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -287,6 +287,57 @@ describe Puppet::Settings do
       expect(@settings.set_by_cli?(:myval)).to be_falsey
     end
 
+    it "should find no configured settings by default" do
+      expect(@settings.set_by_config?(:myval)).to be_falsey
+    end
+
+    it "should identify configured settings in memory" do
+      @settings.instance_variable_get(:@value_sets)[:memory].expects(:lookup).with(:myval).returns('foo')
+      expect(@settings.set_by_config?(:myval)).to be_truthy
+    end
+
+    it "should identify configured settings from CLI" do
+      @settings.instance_variable_get(:@value_sets)[:cli].expects(:lookup).with(:myval).returns('foo')
+      expect(@settings.set_by_config?(:myval)).to be_truthy
+    end
+
+    it "should not identify configured settings from environment" do
+      Puppet.lookup(:environments).expects(:get_conf).with(Puppet[:environment].to_sym).never
+      expect(@settings.set_by_config?(:manifest)).to be_falsey
+    end
+
+    it "should identify configured settings from the preferred run mode" do
+      user_config_text = "[#{@settings.preferred_run_mode}]\nmyval = foo"
+      seq = sequence "config_file_sequence"
+
+      Puppet.features.stubs(:root?).returns(false)
+      Puppet::FileSystem.expects(:exist?).
+        with(user_config_file_default_location).
+        returns(true).in_sequence(seq)
+      @settings.expects(:read_file).
+        with(user_config_file_default_location).
+        returns(user_config_text).in_sequence(seq)
+
+      @settings.send(:parse_config_files)
+      expect(@settings.set_by_config?(:myval)).to be_truthy
+    end
+
+    it "should identify configured settings from the main section" do
+      user_config_text = "[main]\nmyval = foo"
+      seq = sequence "config_file_sequence"
+
+      Puppet.features.stubs(:root?).returns(false)
+      Puppet::FileSystem.expects(:exist?).
+        with(user_config_file_default_location).
+        returns(true).in_sequence(seq)
+      @settings.expects(:read_file).
+        with(user_config_file_default_location).
+        returns(user_config_text).in_sequence(seq)
+
+      @settings.send(:parse_config_files)
+      expect(@settings.set_by_config?(:myval)).to be_truthy
+    end
+
     it "should clear the cache when setting getopt-specific values" do
       @settings.define_settings :mysection,
           :one => { :default => "whah", :desc => "yay" },


### PR DESCRIPTION
Puppet's communication with the node and catalog terminus included a
configured_environment option in the last release. That option sometimes
includes redundant or irrelevant information when `Puppet[:environment]`
has the default setting. That redundant information precludes it from
being used to identify when an agent has explicitly requested a
particular environment.

Change the behavior of configured_environment to only be set when the
`environment` setting is explicitly set.