### PR TITLE
(PUP-4952) Use vendored curl in concurrency acceptance test

### DIFF
--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -85,7 +85,7 @@ with_puppet_running_on(master, master_opts, testdir) do
           sleep $sleep_for
           url='https://#{master}:8140/puppet/v3/catalog/#{agent_cert}?environment=production'
           echo "Curling: $url"
-          curl --tlsv1 -v -# -H 'Accept: text/pson' --cert #{cert_path} --key #{key_path} --cacert #{cacert_path} $url
+          env PATH='#{agent[:privatebindir]}:${PATH}' curl --tlsv1 -v -# -H 'Accept: text/pson' --cert #{cert_path} --key #{key_path} --cacert #{cacert_path} $url
           echo "$PPID Completed"
         ) > "#{agent_tmpdir}/catalog-request-$i.out" 2>&1 &
         echo "Launched $!"


### PR DESCRIPTION
Previously, the concurrent catalog request test was failing in
SLES 10 due to an old version of cURL on the system. This commit
updates the test to use our vendored cURL when it is present, or
fall back to the system cURL if it is not.