### PR TITLE
(PUP-5035) undefined method `keys' for nil:NilClass in static_compiler

### DIFF
--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -118,6 +118,13 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     file = resource.to_ral
 
     children = get_child_resources(request, catalog, resource, file)
+    # get_child_resources() returned early because source is not
+    # a directory, but we still need to replace the metadata of the
+    # resource, so we do it here before returning.
+    if children.nil?
+      find_and_replace_metadata(request, resource, resource.to_ral)
+      return
+    end
 
     remove_existing_resources(children, catalog)
 


### PR DESCRIPTION
get_child_resources() can return nil if the source attribute of the file
resource points to a file instead of a directory.

This results in a raised NoMethodError with the static compiler set as
the catalog terminus and a file resource declared that has the recurse
parameter set to true.

This commit prevents the attempt to add child resources to the catalog when
there are none.