### PR TITLE
(PUP-5012) Add feature flag for authorization

### DIFF
--- a/acceptance/tests/authorization/external_authorization.rb
+++ b/acceptance/tests/authorization/external_authorization.rb
@@ -1,0 +1,50 @@
+test_name "Authorization can be disabled with bypass_authorization"
+
+authconf_path = on(master, puppet('config print rest_authconfig')).stdout.strip
+
+step "Copy default auth.conf to restore on teardown" do
+  original_authconf = on(master, "cat #{authconf_path}").stdout
+  teardown do
+    create_remote_file(master, authconf_path, original_authconf)
+  end
+end
+
+cert = on(master, puppet('config print hostcert')).stdout.strip
+key = on(master, puppet('config print hostprivkey')).stdout.strip
+cacert = on(master, puppet('config print localcacert')).stdout.strip
+curl = "curl --cert #{cert} --key #{key} --cacert #{cacert} https://#{master}:8140"
+
+step "Authorization enabled by default" do
+  with_puppet_running_on(master, {}) do
+    on(master, curl + "/puppet/v3/node/foo?environment=production") do
+      assert_match(/Forbidden request/, stdout, 'Expected request denied')
+    end
+  end
+end
+
+step "Authorization disabled with bypass_authorization" do
+
+  step "Install deny-all auth.conf" do
+    create_remote_file(master, authconf_path, <<AUTHCONF)
+path /
+auth any
+deny all
+AUTHCONF
+  end
+
+  step "Verify requests denied by auth.conf" do
+    with_puppet_running_on(master, {:master => {:bypass_authorization => false}}) do
+      on(master, curl + "/puppet/v3/node/#{master}?environment=production") do
+        assert_match(/Forbidden request/, stdout, 'Expected request denied')
+      end
+    end
+  end
+
+  step "Enable bypass_authorization and verify requests succeed" do
+    with_puppet_running_on(master, {:master => {:bypass_authorization => true}}) do
+      on(master, curl + "/puppet/v3/node/#{master}?environment=production") do
+        assert_no_match(/Forbidden request/, stdout, 'Expected request success')
+      end
+    end
+  end
+end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1085,6 +1085,14 @@ EOT
       rest indirections.  This can be used as a fine-grained
       authorization system for `puppet master`.",
     },
+    :bypass_authorization => {
+      :type    => :boolean,
+      :default => false,
+      :desc    => "If false perform authorization checks using auth.conf rules.
+      If true, bypass authorization checks entirely. Authorization should be
+      handled externally, e.g. using trapperkeeper-authorization. Note, this
+      setting does not affect authentication behaviors; only authorization.",
+    },
     :ca => {
       :default    => true,
       :type       => :boolean,

--- a/lib/puppet/network/authconfig.rb
+++ b/lib/puppet/network/authconfig.rb
@@ -78,6 +78,12 @@ module Puppet
     # raise an Puppet::Network::AuthorizedError if the request
     # is denied.
     def check_authorization(method, path, params)
+      if Puppet.settings[:bypass_authorization]
+        Puppet.debug("Bypassing authorization check for call " +
+          "#{method} on #{path} because bypass_authorization is true")
+        return
+      end
+
       if authorization_failure_exception = @rights.is_request_forbidden_and_why?(method, path, params)
         Puppet.warning("Denying access: #{authorization_failure_exception}")
         raise authorization_failure_exception
@@ -86,7 +92,13 @@ module Puppet
 
     def initialize(rights=nil)
       @rights = rights || Puppet::Network::Rights.new
-      insert_default_acl
+
+      if Puppet.settings[:bypass_authorization]
+        Puppet.info("Bypassing insertion of default ACL " +
+          "because bypass_authorization is true")
+      else
+        insert_default_acl
+      end
     end
   end
 end

--- a/spec/unit/network/authconfig_spec.rb
+++ b/spec/unit/network/authconfig_spec.rb
@@ -105,5 +105,27 @@ describe Puppet::Network::AuthConfig do
 
       described_class.new.check_authorization(:save, "/path/to/resource", params)
     end
+
+    describe "and bypass_authorization is true" do
+      before :all do
+        Puppet.settings[:bypass_authorization] = true
+      end
+
+      after :all do
+        Puppet.settings[:bypass_authorization] = false
+      end
+
+      it "should log a message at debug level" do
+        expected_msg = "Bypassing authorization check for call save on /path/to/resource because bypass_authorization is true"
+        Puppet.expects(:debug).with(expected_msg)
+        described_class.new.check_authorization(:save, '/path/to/resource', {})
+      end
+
+      it "should allow the request" do
+        expect {
+          described_class.new.check_authorization(:save, '/path/to/resource', {})
+        }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit introduces a new feature flag called 'bypass_authorization'
that toggles on/off auth.conf authorization.

This is part of the larger effort towards replacing auth.conf with an
external system. See SERVER-111 for more information.