### PR TITLE
(PUP-5037) Fixed `service puppetmaster status` incorrectly returning "puppet dead but subsys locked" on RHEL and derivatives

### DIFF
--- a/ext/redhat/server.init
+++ b/ext/redhat/server.init
@@ -89,7 +89,7 @@ genconfig() {
 }
 
 rh_status() {
-    status $pidopts $PUPPETMASTER
+    status $pidopts -l $lockfile $PUPPETMASTER
     RETVAL=$?
     return $RETVAL
 }


### PR DESCRIPTION
Details here: https://tickets.puppetlabs.com/browse/PUP-5037