### PR TITLE
(PUP-3045) Re-factor timeout spec test for windows

### DIFF
--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -396,18 +396,23 @@ describe Puppet::Type.type(:exec) do
         end
       end
 
-      context 'when timeout is exceeded on POSIX', :as_platform => :posix do
-        it 'sends a SIGTERM and raises a Puppet::Error' do
+      describe 'when timeout is exceeded' do
+        subject do
           ruby_path = Puppet::Util::Execution.ruby_path()
+          Puppet::Type.type(:exec).new(:name => "#{ruby_path} -e 'sleep 1'", :timeout => '0.1')
+        end
 
-          ## Leaving this commented version in here because it fails on windows, due to what appears to be
-          ##  an assumption about hash iteration order in lib/puppet/type.rb#hash2resource, where
-          ##  resource[]= will overwrite the namevar with ":name" if the iteration is in the wrong order
-          #sleep_exec = Puppet::Type.type(:exec).new(:name => 'exec_spec sleep command', :command => "#{ruby_path} -e 'sleep 0.02'", :timeout => '0.01')
-          sleep_exec = Puppet::Type.type(:exec).new(:name => "#{ruby_path} -e 'sleep 0.02'", :timeout => '0.01')
+        context 'on POSIX', :unless => Puppet.features.microsoft_windows? do
+          it 'sends a SIGTERM and raises a Puppet::Error' do
+            Process.expects(:kill).at_least_once
+            expect { subject.refresh }.to raise_error Puppet::Error, "Command exceeded timeout"
+          end
+        end
 
-          Process.expects(:kill).at_least_once
-          expect { sleep_exec.refresh }.to raise_error Puppet::Error, "Command exceeded timeout"
+        context 'on Windows', :if => Puppet.features.microsoft_windows? do
+          it 'raises a Puppet::Error' do
+            expect { subject.refresh }.to raise_error Puppet::Error, "Command exceeded timeout"
+          end
         end
       end
 


### PR DESCRIPTION
This patch splits the spec test for exec timeouts into separate Windows and
POSIX cases.