### PR TITLE
(PUP-5041) "environment non existent" acceptance tests failing on puppetserver

### DIFF
--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -228,7 +228,6 @@ module Puppet
 
         results = {}
         safely_shadow_directory_contents_and_yield(master, master.puppet('master')['codedir'], envdir) do
-
           config_print = options[:config_print]
           directory_environments = options[:directory_environments]
 
@@ -246,31 +245,29 @@ module Puppet
                 agent_results[:puppet_agent] = result
               end
 
-              if agent == master
-                args = ["--trace"]
-                args << ["--environment", environment] if environment
+              args = ["--trace"]
+              args << ["--environment", environment] if environment
 
-                step "print puppet config for #{description} environment"
-                on(agent, puppet(*(["config", "print", "basemodulepath", "modulepath", "manifest", "config_version", config_print] + args)), :acceptable_exit_codes => (0..255)) do
-                  agent_results[:puppet_config] = result
-                end
+              step "print puppet config for #{description} environment"
+              on(master, puppet(*(["config", "print", "basemodulepath", "modulepath", "manifest", "config_version", config_print] + args)), :acceptable_exit_codes => (0..255)) do
+                agent_results[:puppet_config] = result
+              end
 
-                step "puppet apply using #{description} environment"
-                on(agent, puppet(*(["apply", '-e', '"include testing_mod"'] + args)), :acceptable_exit_codes => (0..255)) do
-                  agent_results[:puppet_apply] = result
-                end
+              step "puppet apply using #{description} environment"
+              on(master, puppet(*(["apply", '-e', '"include testing_mod"'] + args)), :acceptable_exit_codes => (0..255)) do
+                agent_results[:puppet_apply] = result
+              end
 
-                # Be aware that Puppet Module Tool will create the module directory path if it
-                # does not exist.  So these tests should be run last...
-                step "install a module into environment"
-                on(agent, puppet(*(["module", "install", "pmtacceptance-nginx"] + args)), :acceptable_exit_codes => (0..255)) do
-                  agent_results[:puppet_module_install] = result
-                end
+              # Be aware that Puppet Module Tool will create the module directory path if it
+              # does not exist.  So these tests should be run last...
+              step "install a module into environment"
+              on(master, puppet(*(["module", "install", "pmtacceptance-nginx"] + args)), :acceptable_exit_codes => (0..255)) do
+                agent_results[:puppet_module_install] = result
+              end
 
-                step "uninstall a module from #{description} environment"
-                on(agent, puppet(*(["module", "uninstall", "pmtacceptance-nginx"] + args)), :acceptable_exit_codes => (0..255)) do
-                  agent_results[:puppet_module_uninstall] = result
-                end
+              step "uninstall a module from #{description} environment"
+              on(master, puppet(*(["module", "uninstall", "pmtacceptance-nginx"] + args)), :acceptable_exit_codes => (0..255)) do
+                agent_results[:puppet_module_uninstall] = result
               end
             end
           end

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -16,32 +16,32 @@ puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir"
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
 step  'Test'
+env_path = '/doesnotexist'
 master_opts = {
   'main' => {
-    'environmentpath' => '/doesnotexist',
+    'environmentpath' => "#{env_path}",
   }
 }
 env = 'testing'
-path = '/doesnotexist'
 
 results = use_an_environment(env, 'bad environmentpath', master_opts, testdir, puppet_conf_backup_dir, :directory_environments => true)
 
 expectations = {
   :puppet_config => {
     :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{path}}],
+    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
   },
   :puppet_module_install => {
     :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{path}}],
+    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
   },
   :puppet_module_uninstall => {
     :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{path}}],
+    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
   },
   :puppet_apply => {
     :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{path}}],
+    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
   },
   :puppet_agent => {
     :exit_code => 1,

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -10,7 +10,7 @@ step "setup environments"
 
 stub_forge_on(master)
 
-testdir = create_tmpdir_for_user master, "codedir"
+testdir = create_tmpdir_for_user(master, File.basename(__FILE__))
 puppet_code_backup_dir = create_tmpdir_for_user(master, "puppet-code-backup-dir")
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
@@ -18,31 +18,30 @@ apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true
 step "Test"
 master_opts = {
   'main' => {
-    'environmentpath' => '$codedir/environments',
+    'environmentpath' => "#{testdir}/environments",
   }
 }
 general = [ master_opts, testdir, puppet_code_backup_dir, { :directory_environments => true } ]
 env = 'doesnotexist'
-path = master.puppet('master')['codedir']
 
 results = use_an_environment(env, "non existent environment", *general)
 
 expectations = {
   :puppet_config => {
     :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{path}}],
+    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{testdir}}],
   },
   :puppet_module_install => {
     :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{path}}],
+    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{testdir}}],
   },
   :puppet_module_uninstall => {
     :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{path}}],
+    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{testdir}}],
   },
   :puppet_apply => {
     :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{path}}],
+    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{testdir}}],
   },
   :puppet_agent => {
     :exit_code => 1,


### PR DESCRIPTION
This change ensures we run the apply, module, config tests on the master
even if the master does not have an agent role.  We removed the agent
role from the master in the puppet tests to decrease testing time at low
risk.
This change also fixes the environment_scenario-bad test which never
would have passed against current puppet nor server due to matching on
output that was fixed.

[skip ci]