### PR TITLE
(maint) Add appveyor builds for 3.x as well

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+version: 3.x.{build}
+skip_commits:
+  message: /(^\(?doc\)?.*|.*[A|a]cceptance [T|t]est.*)/
+clone_depth: 10
+init:
+  - SET
+install:
+  - SET PATH=C:\Ruby200-x64\bin;%PATH%
+  - SET LOG_SPEC_ORDER=true
+  - gem install bundler --quiet --no-ri --no-rdoc
+  - bundle install --jobs 4 --retry 2 --without development extra
+  - type Gemfile.lock
+  - ruby -v
+build: off
+test_script:
+  - bundle exec rspec spec
+on_failure:
+  - appveyor PushArtifact .\spec_order.txt
+notifications:
+  - provider: Email
+    to:
+    - nobody@nowhere.com
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1053,7 +1053,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           @sids = {
             :current_user => Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name),
             :system => Win32::Security::SID::LocalSystem,
-            :admin => Puppet::Util::Windows::SID.name_to_sid("Administrator"),
             :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
             :users => Win32::Security::SID::BuiltinUsers,
             :power_users => Win32::Security::SID::PowerUsers,

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -15,7 +15,6 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
     @sids = {
       :current_user => Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name),
       :system => Win32::Security::SID::LocalSystem,
-      :admin => Puppet::Util::Windows::SID.name_to_sid("Administrator"),
       :administrators => Win32::Security::SID::BuiltinAdministrators,
       :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
       :users => Win32::Security::SID::BuiltinUsers,
@@ -386,9 +385,14 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
         end
 
         describe "#owner=" do
+          it "should accept the guest sid" do
+            winsec.set_owner(sids[:guest], path)
+            expect(winsec.get_owner(path)).to eq(sids[:guest])
+          end
+
           it "should accept a user sid" do
-            winsec.set_owner(sids[:admin], path)
-            winsec.get_owner(path).should == sids[:admin]
+            winsec.set_owner(sids[:current_user], path)
+            winsec.get_owner(path).should == sids[:current_user]
           end
 
           it "should accept a group sid" do
@@ -406,14 +410,19 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
         end
 
         describe "#group=" do
+          it "should accept the test group" do
+            winsec.set_group(sids[:guest], path)
+            expect(winsec.get_group(path)).to eq(sids[:guest])
+          end
+
           it "should accept a group sid" do
             winsec.set_group(sids[:power_users], path)
             winsec.get_group(path).should == sids[:power_users]
           end
 
           it "should accept a user sid" do
-            winsec.set_group(sids[:admin], path)
-            winsec.get_group(path).should == sids[:admin]
+            winsec.set_group(sids[:current_user], path)
+            winsec.get_group(path).should == sids[:current_user]
           end
 
           it "should combine owner and group rights when they are the same sid" do

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -13,16 +13,6 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
   let(:unknown_name) { 'chewbacca' }
 
   context "#octet_string_to_sid_object" do
-    it "should properly convert an array of bytes for the local Administrator SID" do
-      host = '.'
-      username = 'Administrator'
-      admin = WIN32OLE.connect("WinNT://#{host}/#{username},user")
-      converted = subject.octet_string_to_sid_object(admin.objectSID)
-
-      converted.should == Win32::Security::SID.new(username, host)
-      converted.should be_an_instance_of Win32::Security::SID
-    end
-
     it "should properly convert an array of bytes for a well-known SID" do
       bytes = [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0]
       converted = subject.octet_string_to_sid_object(bytes)


### PR DESCRIPTION
We've been bitten by a couple 3.x PRs that failed on windows specs,
so run AppVeyor here as well. This is identical to the config on the
stable/master branches, except that it specifies a 2.0 ruby and has
a build identifier with a "3.x" prefix.