### PR TITLE
(PUP-4639) always add -w when starting launchd

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -246,8 +246,10 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     did_enable_job = false
     cmds = []
     cmds << :launchctl << :load
+    # always add -w so it always starts the job, it is a noop if it is not needed, this means we do
+    # not have to rescan all launchd plists.
+    cmds << "-w"
     if self.enabled? == :false  || self.status == :stopped # launchctl won't load disabled jobs
-      cmds << "-w"
       did_enable_job = true
     end
     cmds << job_path

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -89,13 +89,13 @@ describe Puppet::Type.type(:service).provider(:launchd) do
     it "should look for the relevant plist once" do
       subject.expects(:plist_from_label).returns([joblabel, {}]).once
       subject.expects(:enabled?).returns :true
-      subject.expects(:execute).with([:launchctl, :load, joblabel])
+      subject.expects(:execute).with([:launchctl, :load, "-w", joblabel])
       subject.start
     end
     it "should execute 'launchctl load' once without writing to the plist if the job is enabled" do
       subject.expects(:plist_from_label).returns([joblabel, {}])
       subject.expects(:enabled?).returns :true
-      subject.expects(:execute).with([:launchctl, :load, joblabel]).once
+      subject.expects(:execute).with([:launchctl, :load, "-w", joblabel]).once
       subject.start
     end
     it "should execute 'launchctl load' with writing to the plist once if the job is disabled" do


### PR DESCRIPTION
This is the right branch, closing #4170 although this should go to master as well.

Always adds `-w` when starting a job, as the status is cached and you can end up getting `unload -w` and then just `load`.

Adding the `-w` is a noop when it isn't needed.