### PR TITLE
(PUP-1189) declare report handlers with overwrite

### DIFF
--- a/lib/puppet/reports.rb
+++ b/lib/puppet/reports.rb
@@ -54,7 +54,11 @@ class Puppet::Reports
   def self.register_report(name, options = {}, &block)
     name = name.intern
 
-    mod = genmodule(name, :extend => Puppet::Util::Docs, :hash => instance_hash(:report), :block => block)
+    mod = genmodule(name,
+                    :extend    => Puppet::Util::Docs,
+                    :hash      => instance_hash(:report),
+                    :overwrite => true,
+                    :block     => block)
 
     mod.useyaml = true if options[:useyaml]
 

--- a/spec/unit/reports_spec.rb
+++ b/spec/unit/reports_spec.rb
@@ -43,6 +43,16 @@ describe Puppet::Reports, " when registering report types" do
     Puppet::Reports.register_report(:testing) { }
   end
 
+  it "should allow a successful report to be reloaded" do
+    Puppet::Reports.register_report(:testing) { }
+    Puppet::Reports.register_report(:testing) { }
+  end
+
+  it "should allow a failed report to be reloaded and show the correct exception both times" do
+    expect { Puppet::Reports.register_report(:testing) { raise TypeError, 'failed report' } }.to raise_error(TypeError)
+    expect { Puppet::Reports.register_report(:testing) { raise TypeError, 'failed report' } }.to raise_error(TypeError)
+  end
+
   it "should extend the report type with the Puppet::Util::Docs module" do
     mod = stub 'module', :define_method => true
 


### PR DESCRIPTION
Previously, if a report handler failed during initialization, it wasn't
cleaned up. So the second time a report was submitted, Puppet would try
to instantiate a new class, and then fail because it had already been
instantiated. This instructs the class loader to overwrite if needed.

(PUP-1189) add spec test

(PUP-1189) Corrected spec test for accuracy

Thanks for the help, @MikaelSmith