### PR TITLE
(PUP-5012) Introduce authorization delegate

### DIFF
--- a/lib/puppet/network/authconfig.rb
+++ b/lib/puppet/network/authconfig.rb
@@ -3,7 +3,7 @@ require 'puppet/network/http'
 
 module Puppet
   class ConfigurationError < Puppet::Error; end
-  class Network::AuthConfig
+  class Network::DefaultAuthProvider
     attr_accessor :rights
 
     def self.master_url_prefix
@@ -87,6 +87,26 @@ module Puppet
     def initialize(rights=nil)
       @rights = rights || Puppet::Network::Rights.new
       insert_default_acl
+    end
+  end
+
+  class Network::AuthConfig
+    @@authprovider_class = nil
+
+    def self.authprovider_class=(klass)
+      @@authprovider_class = klass
+    end
+
+    def self.authprovider_class
+      @@authprovider_class || Puppet::Network::DefaultAuthProvider
+    end
+
+    def initialize(rights=nil)
+      @authprovider = self.class.authprovider_class.new(rights)
+    end
+
+    def check_authorization(method, path, params)
+      @authprovider.check_authorization(method, path, params)
     end
   end
 end

--- a/spec/unit/network/authconfig_spec.rb
+++ b/spec/unit/network/authconfig_spec.rb
@@ -3,80 +3,80 @@ require 'spec_helper'
 
 require 'puppet/network/authconfig'
 
-describe Puppet::Network::AuthConfig do
+describe Puppet::Network::DefaultAuthProvider do
   before :each do
     Puppet::FileSystem.stubs(:stat).returns stub('stat', :ctime => :now)
     Time.stubs(:now).returns Time.now
 
-    Puppet::Network::AuthConfig.any_instance.stubs(:exists?).returns(true)
-    # FIXME @authconfig = Puppet::Network::AuthConfig.new("dummy")
+    Puppet::Network::DefaultAuthProvider.any_instance.stubs(:exists?).returns(true)
+    # FIXME @authprovider = Puppet::Network::DefaultAuthProvider.new("dummy")
   end
 
   describe "when initializing" do
     it "inserts default ACLs after setting initial rights" do
-      Puppet::Network::AuthConfig.any_instance.expects(:insert_default_acl)
-      Puppet::Network::AuthConfig.new
+      Puppet::Network::DefaultAuthProvider.any_instance.expects(:insert_default_acl)
+      Puppet::Network::DefaultAuthProvider.new
     end
   end
 
   describe "when defining an acl with mk_acl" do
     before :each do
-      Puppet::Network::AuthConfig.any_instance.stubs(:insert_default_acl)
-      @authconfig = Puppet::Network::AuthConfig.new
+      Puppet::Network::DefaultAuthProvider.any_instance.stubs(:insert_default_acl)
+      @authprovider = Puppet::Network::DefaultAuthProvider.new
     end
 
     it "should create a new right for each default acl" do
-      @authconfig.mk_acl(:acl => '/')
-      expect(@authconfig.rights['/']).to be
+      @authprovider.mk_acl(:acl => '/')
+      expect(@authprovider.rights['/']).to be
     end
 
     it "allows everyone for each default right" do
-      @authconfig.mk_acl(:acl => '/')
-      expect(@authconfig.rights['/']).to be_globalallow
+      @authprovider.mk_acl(:acl => '/')
+      expect(@authprovider.rights['/']).to be_globalallow
     end
 
     it "accepts an argument to restrict the method" do
-      @authconfig.mk_acl(:acl => '/', :method => :find)
-      expect(@authconfig.rights['/'].methods).to eq([:find])
+      @authprovider.mk_acl(:acl => '/', :method => :find)
+      expect(@authprovider.rights['/'].methods).to eq([:find])
     end
 
     it "creates rights with authentication set to true by default" do
-      @authconfig.mk_acl(:acl => '/')
-      expect(@authconfig.rights['/'].authentication).to be_truthy
+      @authprovider.mk_acl(:acl => '/')
+      expect(@authprovider.rights['/'].authentication).to be_truthy
     end
 
     it "accepts an argument to set the authentication requirement" do
-      @authconfig.mk_acl(:acl => '/', :authenticated => :any)
-      expect(@authconfig.rights['/'].authentication).to be_falsey
+      @authprovider.mk_acl(:acl => '/', :authenticated => :any)
+      expect(@authprovider.rights['/'].authentication).to be_falsey
     end
   end
 
   describe "when adding default ACLs" do
     before :each do
-      Puppet::Network::AuthConfig.any_instance.stubs(:insert_default_acl)
-      @authconfig = Puppet::Network::AuthConfig.new
-      Puppet::Network::AuthConfig.any_instance.unstub(:insert_default_acl)
+      Puppet::Network::DefaultAuthProvider.any_instance.stubs(:insert_default_acl)
+      @authprovider = Puppet::Network::DefaultAuthProvider.new
+      Puppet::Network::DefaultAuthProvider.any_instance.unstub(:insert_default_acl)
     end
 
-    Puppet::Network::AuthConfig::default_acl.each do |acl|
+    Puppet::Network::DefaultAuthProvider::default_acl.each do |acl|
       it "should create a default right for #{acl[:acl]}" do
-        @authconfig.stubs(:mk_acl)
-        @authconfig.expects(:mk_acl).with(acl)
-        @authconfig.insert_default_acl
+        @authprovider.stubs(:mk_acl)
+        @authprovider.expects(:mk_acl).with(acl)
+        @authprovider.insert_default_acl
       end
     end
 
     it "should log at info loglevel" do
       Puppet.expects(:info).at_least_once
-      @authconfig.insert_default_acl
+      @authprovider.insert_default_acl
     end
 
     it "creates an empty catch-all rule for '/' for any authentication request state" do
-      @authconfig.stubs(:mk_acl)
+      @authprovider.stubs(:mk_acl)
 
-      @authconfig.insert_default_acl
-      expect(@authconfig.rights['/']).to be_empty
-      expect(@authconfig.rights['/'].authentication).to be_falsey
+      @authprovider.insert_default_acl
+      expect(@authprovider.rights['/']).to be_empty
+      expect(@authprovider.rights['/'].authentication).to be_falsey
     end
 
     it '(CVE-2013-2275) allows report submission only for the node matching the certname by default' do
@@ -86,9 +86,9 @@ describe Puppet::Network::AuthConfig do
         :allow => '$1',
         :authenticated => true
       }
-      @authconfig.stubs(:mk_acl)
-      @authconfig.expects(:mk_acl).with(acl)
-      @authconfig.insert_default_acl
+      @authprovider.stubs(:mk_acl)
+      @authprovider.expects(:mk_acl).with(acl)
+      @authprovider.insert_default_acl
     end
   end
 
@@ -105,5 +105,35 @@ describe Puppet::Network::AuthConfig do
 
       described_class.new.check_authorization(:save, "/path/to/resource", params)
     end
+  end
+end
+
+describe Puppet::Network::AuthConfig do
+  after :each do
+    Puppet::Network::AuthConfig.authprovider_class = nil
+  end
+
+  class TestAuthProvider
+    def initialize(rights=nil); end
+    def check_authorization(method, path, params); end
+  end
+
+  it "instantiates authprovider_class with rights" do
+    Puppet::Network::AuthConfig.authprovider_class = TestAuthProvider
+    rights = Puppet::Network::Rights.new
+    TestAuthProvider.expects(:new).with(rights)
+    described_class.new(rights)
+  end
+
+  it "delegates authorization check to authprovider_class" do
+    Puppet::Network::AuthConfig.authprovider_class = TestAuthProvider
+    TestAuthProvider.any_instance.expects(:check_authorization).with(:save, '/path/to/resource', {})
+    described_class.new.check_authorization(:save, '/path/to/resource', {})
+  end
+
+  it "uses DefaultAuthProvider by default" do
+    Puppet::Network::AuthConfig.authprovider_class = nil
+    Puppet::Network::DefaultAuthProvider.any_instance.expects(:check_authorization).with(:save, '/path/to/resource', {})
+    described_class.new.check_authorization(:save, '/path/to/resource', {})
   end
 end

--- a/spec/unit/network/authorization_spec.rb
+++ b/spec/unit/network/authorization_spec.rb
@@ -26,7 +26,7 @@ describe Puppet::Network::Authorization do
 
     it "creates default ACL entries if no file has been read" do
       Puppet::Network::AuthConfigParser.expects(:new_from_file).raises Errno::ENOENT
-      Puppet::Network::AuthConfig.any_instance.expects(:insert_default_acl)
+      Puppet::Network::DefaultAuthProvider.any_instance.expects(:insert_default_acl)
 
       subject.authconfig
     end


### PR DESCRIPTION
This commit introduces an object seam in Puppet::Network::AuthConfig
that will allow Puppet Server to provide a no-op implementation and
effectively disable authorization so it can be handled externally.

---

The approach I took with this was to wholesale rename the existing `Puppet::Network::AuthConfig` class to `Puppet::Network::DefaultAuthProvider`.

Then, create a new AuthConfig class that simply forwards the `check_authorization` call to an instance of authprovider class, which it will instantiate during initialization. The class can be set, but defaults to `DefaultAuthProvider`.

Happy to change class/module names and structuring.