### PR TITLE
(PUP-5053) revert "(maint) fully qualify the label in the osx puppet plist"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,7 @@ task(:commits) do
   %x{git log --no-merges --pretty=%s master..$HEAD}.each_line do |commit_summary|
     # This regex tests for the currently supported commit summary tokens: maint, doc, packaging, or pup-<number>.
     # The exception tries to explain it in more full.
-    if /^\((maint|doc|docs|packaging|pup-\d+)\)/i.match(commit_summary).nil?
+    if /^\((maint|doc|docs|packaging|pup-\d+)\)|revert/i.match(commit_summary).nil?
       raise "\n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n" \
         "\n\t\t#{commit_summary}\n" \
         "\tThe commit summary (i.e. the first line of the commit message) should start with one of:\n"  \

--- a/ext/osx/puppet.plist
+++ b/ext/osx/puppet.plist
@@ -10,7 +10,7 @@
                 <string>en_US.UTF-8</string>
         </dict>
         <key>Label</key>
-        <string>com.puppetlabs.puppet</string>
+        <string>puppet</string>
         <key>KeepAlive</key>
         <true/>
         <key>ProgramArguments</key>


### PR DESCRIPTION
This reverts commit 13b54ace034f231e1744c9267bbb728b7d0edc5f, excepting
the white-space changes.

We realized that changing this name actually changes the service name, which impacts anyone trying to manage the service - such as PE. This seems high-impact for a patch release.

cc @heathseals @joshcooper