### PR TITLE
(PUP-4476) Add basic `puppet lookup` command

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -40,6 +40,9 @@ class Puppet::Application::Lookup < Puppet::Application
     options[:default_value] = arg
   end
 
+  # not yet supported
+  option('--trusted')
+
   # Options for facts/scope
   option('--node NODE_NAME') do |arg|
     options[:node] = arg
@@ -65,14 +68,11 @@ class Puppet::Application::Lookup < Puppet::Application
       raise "No node was given via the '--node' flag for the scope of the lookup."
     end
 
-    if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix] || options[:upack_arrays]) && options[:merge] != 'deep'
+    if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix] || options[:unpack_arrays]) && options[:merge] != 'deep'
       raise "The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUNHELP}"
     end
 
-    node = Puppet::Node.indirection.find("#{options[:node]}")
-    compiler = Puppet::Parser::Compiler.new(node)
-    compiler.compile
-    scope = compiler.topscope
+    scope = generate_scope
 
     use_default_value = !options[:default_value].nil?
     merge_options = nil
@@ -96,8 +96,13 @@ class Puppet::Application::Lookup < Puppet::Application
       end
     end
 
-    value = Puppet::Pops::Lookup.lookup(scope, options[:keys], options[:type], options[:default_value], use_default_value, {}, {}, merge_options)
+    puts Puppet::Pops::Lookup.lookup(scope, options[:keys], options[:type], options[:default_value], use_default_value, {}, {}, merge_options)
+  end
 
-    puts value
+  def generate_scope
+    node = Puppet::Node.indirection.find("#{options[:node]}")
+    compiler = Puppet::Parser::Compiler.new(node)
+    compiler.compile
+    compiler.topscope
   end
 end

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -1,4 +1,7 @@
 require 'puppet/application'
+require 'puppet/pops/lookup'
+require 'puppet/node'
+require 'puppet/parser/compiler'
 
 class Puppet::Application::Lookup < Puppet::Application
 
@@ -49,8 +52,20 @@ class Puppet::Application::Lookup < Puppet::Application
   def run_command
     options[:keys] = command_line.args
 
-    puts "Hello World!"
-    puts options
+    node = Puppet::Node.indirection.find("#{options[:node]}")
+    compiler = Puppet::Parser::Compiler.new(node)
+    compiler.compile
+    scope = compiler.topscope
+
+    require 'debugger'; debugger
+
+    if options[:default_value]
+     value = Puppet::Pops::Lookup.lookup(scope, options[:keys], options[:type], options[:default_value], true, {}, {}, options[:merge])
+    else
+      value = Puppet::Pops::Lookup.lookup(scope, options[:keys], options[:type], options[:default_value], false, {}, {}, options[:merge])
+    end
+
+    puts value
   end
 
 end

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -61,6 +61,10 @@ class Puppet::Application::Lookup < Puppet::Application
      raise "No keys were given to lookup."
     end
 
+    if !options[:node]
+      raise "No node was given via the '--node' flag for the scope of the lookup."
+    end
+
     if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix] || options[:upack_arrays]) && options[:merge] != 'deep'
       raise "The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUNHELP}"
     end
@@ -71,6 +75,7 @@ class Puppet::Application::Lookup < Puppet::Application
     scope = compiler.topscope
 
     use_default_value = !options[:default_value].nil?
+    merge_options = nil
 
     if options[:merge]
       if options[:merge] == 'deep'
@@ -89,11 +94,9 @@ class Puppet::Application::Lookup < Puppet::Application
       else
         merge_options = {'strategy' => options[:merge]}
       end
-
-      value = Puppet::Pops::Lookup.lookup(scope, options[:keys], options[:type], options[:default_value], use_default_value, {}, {}, merge_options)
-    else
-      value = Puppet::Pops::Lookup.lookup(scope, options[:keys], options[:type], options[:default_value], use_default_value, {}, {}, nil)
     end
+
+    value = Puppet::Pops::Lookup.lookup(scope, options[:keys], options[:type], options[:default_value], use_default_value, {}, {}, merge_options)
 
     puts value
   end

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+require 'puppet/application/lookup'
+require 'puppet/pops/lookup'
+
+describe Puppet::Application::Lookup do
+
+  context "when running with incorrect command line options" do
+    let (:lookup) { Puppet::Application[:lookup] }
+
+    it "errors if no keys are given via the command line" do
+      lookup.options[:node] = 'dantooine.local'
+      expected_error = "No keys were given to lookup."
+
+      expect{ lookup.run_command }.to raise_error(RuntimeError, expected_error)
+    end
+
+    it "errors if no node was given via the --node flag" do
+      lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
+
+      expected_error = "No node was given via the '--node' flag for the scope of the lookup."
+
+      expect{ lookup.run_command }.to raise_error(RuntimeError, expected_error)
+    end
+
+    it "does not allow deep merge options if '--merge' was not set to deep" do
+      lookup.options[:node] = 'dantooine.local'
+      lookup.options[:merge_hash_arrays] = true
+      lookup.options[:merge] = 'hash'
+      lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
+
+      expected_error = "The options --knock_out_prefix, --sort_merged_arrays, --unpack_arrays, and --merge_hash_arrays are only available with '--merge deep'\nRun 'puppet lookup --help' for more details"
+
+      expect{ lookup.run_command }.to raise_error(RuntimeError, expected_error)
+    end
+  end
+
+  context "when running with correct command line options" do
+    let (:lookup) { Puppet::Application[:lookup] }
+
+    it "calls the lookup method with the correct arguments" do
+      lookup.options[:node] = 'dantooine.local'
+      lookup.options[:merge_hash_arrays] = true
+      lookup.options[:merge] = 'deep'
+      lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
+      lookup.stubs(:generate_scope).returns('scope')
+
+      expected_merge = {"strategy"=> "deep", "sort_merge_arrays"=> false, "merge_hash_arrays"=> true}
+
+      Puppet::Pops::Lookup.stubs(:lookup).returns('rand')
+
+      (Puppet::Pops::Lookup).expects(:lookup).with('scope', ['atton', 'kreia'], nil, nil, false, {}, {}, expected_merge)
+
+      lookup.run_command
+    end
+
+    it "prints the value found by lookup" do
+      lookup.options[:node] = 'dantooine.local'
+      lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
+      lookup.stubs(:generate_scope).returns('scope')
+
+      Puppet::Pops::Lookup.stubs(:lookup).returns('rand')
+
+      expect{ lookup.run_command }.to output("rand\n").to_stdout
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds basically functionality to the `puppet lookup` command.
Right now the command basically serves as a conduit to the Puppet::Pops::Lookup.lookup
function and allows you to pass in parameters to that function. It does not yet support
the --explain or the --facts options.