### PR TITLE
(PUP-5074) Support consume/produces annotations site-wide

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -16,7 +16,7 @@ class Puppet::Resource::Type
   include Puppet::Util::Warnings
   include Puppet::Util::Errors
 
-  RESOURCE_KINDS = [:hostclass, :node, :definition]
+  RESOURCE_KINDS = [:hostclass, :node, :definition, :capability_mapping]
 
   # Map the names used in our documentation to the names used internally
   RESOURCE_KINDS_TO_EXTERNAL_NAMES = {

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -13,12 +13,14 @@ class Puppet::Resource::TypeCollection
     @definitions.clear
     @nodes.clear
     @notfound.clear
+    @capability_mappings.clear
   end
 
   def initialize(env)
     @environment = env
     @hostclasses = {}
     @definitions = {}
+    @capability_mappings = {}
     @nodes = {}
     @notfound = {}
 
@@ -33,7 +35,7 @@ class Puppet::Resource::TypeCollection
   end
 
   def inspect
-    "TypeCollection" + { :hostclasses => @hostclasses.keys, :definitions => @definitions.keys, :nodes => @nodes.keys }.inspect
+    "TypeCollection" + { :hostclasses => @hostclasses.keys, :definitions => @definitions.keys, :nodes => @nodes.keys, :capability_mappings => @capability_mappings.keys }.inspect
   end
 
   def <<(thing)
@@ -104,6 +106,11 @@ class Puppet::Resource::TypeCollection
     @definitions[instance.name] = instance
   end
 
+  def add_capability_mapping(instance)
+    dupe_check(instance, @capability_mappings) { |dupe| "'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as a mapping" }
+    @capability_mappings[instance.name] = instance
+  end
+
   def definition(name)
     @definitions[munge_name(name)]
   end
@@ -120,7 +127,7 @@ class Puppet::Resource::TypeCollection
     find_or_load(name, :definition)
   end
 
-  [:hostclasses, :nodes, :definitions].each do |m|
+  [:hostclasses, :nodes, :definitions, :capability_mappings].each do |m|
     define_method(m) do
       instance_variable_get("@#{m}").dup
     end


### PR DESCRIPTION
This commit ensures that the resolution of declared capability
mappings is deferred until all files for a particular environment
has been parsed.

The commit introduces a new Resource::Type named 'capability_mapping'
that acts as intermediate object created by the parser and added to a
hash in the known_resource_types TypeCollection which is later made
available to the compiler. The compiler uses these objects when it's
time to evaluate to perform the actual mapping between capabilities
and resources. Once the mapping is complete, the 'capability_mapping'
hash is no longer needed and is cleared out to conserve memory.