### PR TITLE
(PUP-5055) parent attributes are set from metadata too early in static_compiler

### DIFF
--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -116,8 +116,6 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
   # @param resource [Puppet::Resource]
   # @param file [Puppet::Type::File] The file RAL associated with the resource
   def add_children(request, catalog, resource, file)
-    file = resource.to_ral
-
     children = get_child_resources(request, catalog, resource, file)
 
     remove_existing_resources(children, catalog)
@@ -161,10 +159,11 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
       end
     end
 
+    parent_meta = nil
     total.each do |meta|
       # This is the top-level parent directory
       if meta.relative_path == "."
-        replace_metadata(request, resource, meta)
+        parent_meta = meta
         next
       end
       child = children[meta.relative_path] ||=
@@ -180,6 +179,7 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
       end
       replace_metadata(request, child, meta)
     end
+    replace_metadata(request, resource, parent_meta)
 
     children
   end


### PR DESCRIPTION
In the static compiler we are setting the mode, owner and group
attributes on the parent too early. This is causing child
resources to inherit the same values.

Child resources should only inherit attribute values if they are
explicitly set on the parent resource. In other cases overriding
the child group, mode and owner attributes should depend on the
value of source_permissions.

This commit attempts to fix this by postponing the call to set the
parent's attributes until after all children have inherited.
It also prevents mode, owner and group from being set if
source_permissions is not set to 'use'.