### PR TITLE
(DOCUMENT-404) Fix documentation formatting for `hiera`, et.al. …

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -6,12 +6,18 @@ module Puppet::Parser::Functions
   The returned value can be data of any type (strings, arrays, or hashes). 
 
   The function can be called in one of three ways:
+
   1. Using 1 to 3 arguments where the arguments are:
-     'key'      [String] Required
+
+     - `key`       [String] Required
+
            The key to lookup.
-     'default`  [Any] Optional
+
+     - `default`   [Any] Optional
+
            A value to return when there's no match for `key`. Optional
-     `override` [Any] Optional
+
+     - `override`  [Any] Optional
            An argument in the third position, providing a data source
            to consult for matching values, even if it would not ordinarily be
            part of the matched hierarchy. If Hiera doesn't find a matching key

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -6,12 +6,18 @@ module Puppet::Parser::Functions
   If any of the matched values are arrays, they're flattened and included in the results.
 
   The function can be called in one of three ways:
+
   1. Using 1 to 3 arguments where the arguments are:
-     'key'      [String] Required
+
+     - `key`       [String] Required
+
            The key to lookup.
-     'default`  [Any] Optional
+
+     - `default`   [Any] Optional
+
            A value to return when there's no match for `key`. Optional
-     `override` [Any] Optional
+
+     - `override`  [Any] Optional
            An argument in the third position, providing a data source
            to consult for matching values, even if it would not ordinarily be
            part of the matched hierarchy. If Hiera doesn't find a matching key

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -7,12 +7,18 @@ module Puppet::Parser::Functions
   used in the returned hash, with the pair in the highest priority data source winning.
 
   The function can be called in one of three ways:
+
   1. Using 1 to 3 arguments where the arguments are:
-     'key'      [String] Required
+
+     - `key`       [String] Required
+
            The key to lookup.
-     'default`  [Any] Optional
+
+     - `default`   [Any] Optional
+
            A value to return when there's no match for `key`. Optional
-     `override` [Any] Optional
+
+     - `override`  [Any] Optional
            An argument in the third position, providing a data source
            to consult for matching values, even if it would not ordinarily be
            part of the matched hierarchy. If Hiera doesn't find a matching key

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -20,12 +20,18 @@ module Puppet::Parser::Functions
               - apache::passenger
 
   The function can be called in one of three ways:
+
   1. Using 1 to 3 arguments where the arguments are:
-     'key'      [String] Required
+
+     - `key`       [String] Required
+
            The key to lookup.
-     'default`  [Any] Optional
+
+     - `default`   [Any] Optional
+
            A value to return when there's no match for `key`. Optional
-     `override` [Any] Optional
+
+     - `override`  [Any] Optional
            An argument in the third position, providing a data source
            to consult for matching values, even if it would not ordinarily be
            part of the matched hierarchy. If Hiera doesn't find a matching key


### PR DESCRIPTION
The current documentation for the `hiera` and related functions
does not properly format in markdown, resulting in documentation
that is hard to read and understand.  This patch corrects the
formatting of the markdown documentation.