### PR TITLE
(docs) Hiera function revisions

### DIFF
--- a/lib/puppet/functions/hiera.rb
+++ b/lib/puppet/functions/hiera.rb
@@ -1,7 +1,80 @@
 require 'hiera/puppet_function'
-
-# @see lib/puppet/parser/functions/hiera.rb for documentation
-# TODO: Move docs here when the format has been determined.
+# Performs a standard priority lookup of the hierarchy and returns the most specific value
+# for a given key. The returned value can be any type of data.
+#
+# The function takes up to three arguments, in this order:
+#
+# 1. A string key that Hiera searches for in the hierarchy. **Required**.
+# 2. An optional default value to return if Hiera doesn't find anything matching the key.
+#     * If this argument isn't provided and this function results in a lookup failure, Puppet
+#     fails with a compilation error.
+# 3. The optional name of an arbitrary
+# [hierarchy level](https://docs.puppetlabs.com/hiera/latest/hierarchy.html) to insert at the
+# top of the hierarchy. This lets you temporarily modify the hierarchy for a single lookup.
+#     * If Hiera doesn't find a matching key in the overriding hierarchy level, it continues
+#     searching the rest of the hierarchy.
+#
+# The `hiera` function does **not** find all matches throughout a hierarchy, instead
+# returining the first specific value starting at the top of the hierarchy. To search
+# throughout a hierarchy, use the `hiera_array` or `hiera_hash` functions.
+#
+# @example Using `hiera`
+#
+# ~~~ yaml
+# # Assuming hiera.yaml
+# # :hierarchy:
+# #   - web01.example.com
+# #   - common
+#
+# # Assuming web01.example.com.yaml:
+# # users:
+# #   - "Amy Barry"
+# #   - "Carrie Douglas"
+#
+# # Assuming common.yaml:
+# users:
+#   admins:
+#     - "Edith Franklin"
+#     - "Ginny Hamilton"
+#   regular:
+#     - "Iris Jackson"
+#     - "Kelly Lambert"
+# ~~~
+#
+# ~~~ puppet
+# # Assuming we are not web01.example.com:
+#
+# $users = hiera('users', undef)
+#
+# # $users contains {admins  => ["Edith Franklin", "Ginny Hamilton"],
+# #                  regular => ["Iris Jackson", "Kelly Lambert"]}
+# ~~~
+#
+# You can optionally generate the default value with a
+# [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+# takes one parameter.
+#
+# @example Using `hiera` with a lambda
+#
+# ~~~ puppet
+# # Assuming the same Hiera data as the previous example:
+#
+# $users = hiera('users') | $key | { "Key \'${key}\' not found" }
+#
+# # $users contains {admins  => ["Edith Franklin", "Ginny Hamilton"],
+# #                  regular => ["Iris Jackson", "Kelly Lambert"]}
+# # If hiera couldn't match its key, it would return the lambda result,
+# # "Key 'users' not found".
+# ~~~
+#
+# The returned value's data type depends on the types of the results. In the example 
+# above, Hiera matches the 'users' key and returns it as a hash.
+#
+# See
+# [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
+# for more information about Hiera lookup functions.
+#
+# @since 4.0.0
 #
 Puppet::Functions.create_function(:hiera, Hiera::PuppetFunction) do
   init_dispatch

--- a/lib/puppet/functions/hiera_array.rb
+++ b/lib/puppet/functions/hiera_array.rb
@@ -1,7 +1,69 @@
 require 'hiera/puppet_function'
 
-# @see lib/puppet/parser/functions/hiera_array.rb for documentation
-# TODO: Move docs here when the format has been determined.
+# Finds all matches of a key throughout the hierarchy and returns them as a single flattened
+# array of unique values. If any of the matched values are arrays, they're flattened and
+# included in the results. This is called an
+# [array merge lookup](https://docs.puppetlabs.com/hiera/latest/lookup_types.html#array-merge).
+#
+# The `hiera_array` function takes up to three arguments, in this order:
+#
+# 1. A string key that Hiera searches for in the hierarchy. **Required**.
+# 2. An optional default value to return if Hiera doesn't find anything matching the key.
+#     * If this argument isn't provided and this function results in a lookup failure, Puppet
+#     fails with a compilation error.
+# 3. The optional name of an arbitrary
+# [hierarchy level](https://docs.puppetlabs.com/hiera/latest/hierarchy.html) to insert at the
+# top of the hierarchy. This lets you temporarily modify the hierarchy for a single lookup.
+#     * If Hiera doesn't find a matching key in the overriding hierarchy level, it continues
+#     searching the rest of the hierarchy.
+#
+# @example Using `hiera_array`
+#
+# ~~~ yaml
+# # Assuming hiera.yaml
+# # :hierarchy:
+# #   - web01.example.com
+# #   - common
+#
+# # Assuming common.yaml:
+# # users:
+# #   - 'cdouglas = regular'
+# #   - 'efranklin = regular'
+#
+# # Assuming web01.example.com.yaml:
+# # users: 'abarry = admin'
+# ~~~
+#
+# ~~~ puppet
+# $allusers = hiera_array('users', undef)
+#
+# # $allusers contains ["cdouglas = regular", "efranklin = regular", "abarry = admin"].
+# ~~~
+#
+# You can optionally generate the default value with a
+# [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+# takes one parameter.
+#
+# @example Using `hiera_array` with a lambda
+#
+# ~~~ puppet
+# # Assuming the same Hiera data as the previous example:
+#
+# $allusers = hiera_array('users') | $key | { "Key \'${key}\' not found" }
+#
+# # $allusers contains ["cdouglas = regular", "efranklin = regular", "abarry = admin"].
+# # If hiera_array couldn't match its key, it would return the lambda result,
+# # "Key 'users' not found".
+# ~~~
+#
+# `hiera_array` expects that all values returned will be strings or arrays. If any matched
+# value is a hash, Puppet raises a type mismatch error.
+#
+# See
+# [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
+# for more information about Hiera lookup functions.
+#
+# @since 4.0.0
 #
 Puppet::Functions.create_function(:hiera_array, Hiera::PuppetFunction) do
   init_dispatch

--- a/lib/puppet/functions/hiera_hash.rb
+++ b/lib/puppet/functions/hiera_hash.rb
@@ -1,7 +1,79 @@
 require 'hiera/puppet_function'
 
-# @see lib/puppet/parser/functions/hiera_hash.rb for documentation
-# TODO: Move docs here when the format has been determined.
+# Finds all matches of a key throughout the hierarchy and returns them in a merged hash.
+# If any of the matched hashes share keys, the final hash uses the value from the
+# highest priority match. This is called a
+# [hash merge lookup](https://docs.puppetlabs.com/hiera/latest/lookup_types.html#hash-merge).
+#
+# The merge strategy is determined by Hiera's
+# [`:merge_behavior`](https://docs.puppetlabs.com/hiera/latest/configuring.html#mergebehavior)
+# setting.
+#
+# The `hiera_hash` function takes up to three arguments, in this order:
+#
+# 1. A string key that Hiera searches for in the hierarchy. **Required**.
+# 2. An optional default value to return if Hiera doesn't find anything matching the key.
+#     * If this argument isn't provided and this function results in a lookup failure, Puppet
+#     fails with a compilation error.
+# 3. The optional name of an arbitrary
+# [hierarchy level](https://docs.puppetlabs.com/hiera/latest/hierarchy.html) to insert at the
+# top of the hierarchy. This lets you temporarily modify the hierarchy for a single lookup.
+#     * If Hiera doesn't find a matching key in the overriding hierarchy level, it continues
+#     searching the rest of the hierarchy.
+#
+# @example Using `hiera_hash`
+#
+# ~~~ yaml
+# # Assuming hiera.yaml
+# # :hierarchy:
+# #   - web01.example.com
+# #   - common
+#
+# # Assuming common.yaml:
+# # users:
+# #   regular:
+# #     'cdouglas': 'Carrie Douglas'
+#
+# # Assuming web01.example.com.yaml:
+# # users:
+# #   administrators:
+# #     'aberry': 'Amy Berry'
+# ~~~
+#
+# ~~~ puppet
+# # Assuming we are not web01.example.com:
+#
+# $allusers = hiera_hash('users', undef)
+#
+# # $allusers contains {regular => {"cdouglas" => "Carrie Douglas"},
+# #                     administrators => {"aberry" => "Amy Berry"}}
+# ~~~
+#
+# You can optionally generate the default value with a
+# [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+# takes one parameter.
+#
+# @example Using `hiera_hash` with a lambda
+#
+# ~~~ puppet
+# # Assuming the same Hiera data as the previous example:
+#
+# $allusers = hiera_hash('users') | $key | { "Key \'${key}\' not found" }
+#
+# # $allusers contains {regular => {"cdouglas" => "Carrie Douglas"},
+# #                     administrators => {"aberry" => "Amy Berry"}}
+# # If hiera_hash couldn't match its key, it would return the lambda result,
+# # "Key 'users' not found".
+# ~~~
+#
+# `hiera_hash` expects that all values returned will be hashes. If any of the values
+# found in the data sources are strings or arrays, Puppet raises a type mismatch error.
+#
+# See
+# [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
+# for more information about Hiera lookup functions.
+#
+# @since 4.0.0
 #
 Puppet::Functions.create_function(:hiera_hash, Hiera::PuppetFunction) do
   init_dispatch

--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -1,7 +1,80 @@
 require 'hiera/puppet_function'
 
-# @see lib/puppet/parser/functions/hiera_include.rb for documentation
-# TODO: Move docs here when the format has been determined.
+# Assigns classes to a node using an
+# [array merge lookup](https://docs.puppetlabs.com/hiera/latest/lookup_types.htmlarray-merge)
+# that retrieves the value for a user-specified key from Hiera's data.
+#
+# The `hiera_include` function requires:
+#
+# - A string key name to use for classes.
+# - A call to this function (i.e. `hiera_include('classes')`) in your environment's
+# `sites.pp` manifest, outside of any node definitions and below any top-scope variables
+# that Hiera uses in lookups.
+# - `classes` keys in the appropriate Hiera data sources, with an array for each
+# `classes` key and each value of the array containing the name of a class.
+#
+# The function takes up to three arguments, in this order:
+#
+# 1. A string key that Hiera searches for in the hierarchy. **Required**.
+# 2. An optional default value to return if Hiera doesn't find anything matching the key.
+#     * If this argument isn't provided and this function results in a lookup failure, Puppet
+#     fails with a compilation error.
+# 3. The optional name of an arbitrary
+# [hierarchy level](https://docs.puppetlabs.com/hiera/latest/hierarchy.html) to insert at the
+# top of the hierarchy. This lets you temporarily modify the hierarchy for a single lookup.
+#     * If Hiera doesn't find a matching key in the overriding hierarchy level, it continues
+#     searching the rest of the hierarchy.
+#
+# The function uses an
+# [array merge lookup](https://docs.puppetlabs.com/hiera/latest/lookup_types.htmlarray-merge)
+# to retrieve the `classes` array, so every node gets every class from the hierarchy.
+#
+# @example Using `hiera_include`
+#
+# ~~~ yaml
+# # Assuming hiera.yaml
+# # :hierarchy:
+# #   - web01.example.com
+# #   - common
+#
+# # Assuming web01.example.com.yaml:
+# # classes:
+# #   - apache::mod::php
+#
+# # Assuming common.yaml:
+# # classes:
+# #   - apache
+# ~~~
+#
+# ~~~ puppet
+# # In site.pp, outside of any node definitions and below any top-scope variables:
+# hiera_include('classes', undef)
+#
+# # Puppet assigns the apache and apache::mod::php classes to the web01.example.com node.
+# ~~~
+#
+# You can optionally generate the default value with a
+# [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+# takes one parameter.
+#
+# @example Using `hiera_include` with a lambda
+#
+# ~~~ puppet
+# # Assuming the same Hiera data as the previous example:
+#
+# # In site.pp, outside of any node definitions and below any top-scope variables:
+# hiera_include('classes') | $key | {"Key \'${key}\' not found" }
+#
+# # Puppet assigns the apache and apache::mod::php classes to the web01.example.com node.
+# # If hiera_include couldn't match its key, it would return the lambda result,
+# # "Key 'classes' not found".
+# ~~~
+#
+# See [the documentation](http://links.puppetlabs.com/hierainclude) for more information
+# and a more detailed example of how `hiera_include` uses array merge lookups to classify
+# nodes.
+#
+# @since 4.0.0
 #
 Puppet::Functions.create_function(:hiera_include, Hiera::PuppetFunction) do
   init_dispatch

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -1,33 +1,89 @@
 require 'hiera_puppet'
 
 module Puppet::Parser::Functions
-  newfunction(:hiera, :type => :rvalue, :arity => -2, :doc => "Performs a
-  standard priority lookup and returns the most specific value for a given key.
-  The returned value can be data of any type (strings, arrays, or hashes). 
+  newfunction(
+    :hiera,
+    :type => :rvalue,
+    :arity => -2,
+    :doc => <<DOC
+Performs a standard priority lookup of the hierarchy and returns the most specific value
+for a given key. The returned value can be any type of data.
 
-  The function can be called in one of three ways:
-  1. Using 1 to 3 arguments where the arguments are:
-     'key'      [String] Required
-           The key to lookup.
-     'default`  [Any] Optional
-           A value to return when there's no match for `key`. Optional
-     `override` [Any] Optional
-           An argument in the third position, providing a data source
-           to consult for matching values, even if it would not ordinarily be
-           part of the matched hierarchy. If Hiera doesn't find a matching key
-           in the named override data source, it will continue to search through the
-           rest of the hierarchy.
+The function takes up to three arguments, in this order:
 
-  2. Using a 'key' and an optional 'override' parameter like in #1 but with a block to
-     provide the default value. The block is called with one parameter (the key) and
-     should return the value.
+1. A string key that Hiera searches for in the hierarchy. **Required**.
+2. An optional default value to return if Hiera doesn't find anything matching the key.
+    * If this argument isn't provided and this function results in a lookup failure, Puppet
+    fails with a compilation error.
+3. The optional name of an arbitrary
+[hierarchy level](https://docs.puppetlabs.com/hiera/latest/hierarchy.html) to insert at the
+top of the hierarchy. This lets you temporarily modify the hierarchy for a single lookup.
+    * If Hiera doesn't find a matching key in the overriding hierarchy level, it continues
+    searching the rest of the hierarchy.
 
-  3. Like #1 but with all arguments passed in an array.
+The `hiera` function does **not** find all matches throughout a hierarchy, instead
+returining the first specific value starting at the top of the hierarchy. To search
+throughout a hierarchy, use the `hiera_array` or `hiera_hash` functions.
 
-  More thorough examples of `hiera` are available at:  
-  <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
-  ") do |*args|
+**Example**: Using `hiera`
+
+~~~ yaml
+# Assuming hiera.yaml
+# :hierarchy:
+#   - web01.example.com
+#   - common
+
+# Assuming web01.example.com.yaml:
+# users: 
+#   - "Amy Barry"
+#   - "Carrie Douglas"
+
+# Assuming common.yaml:
+users:
+  admins:
+    - "Edith Franklin"
+    - "Ginny Hamilton"
+  regular:
+    - "Iris Jackson"
+    - "Kelly Lambert"
+~~~
+
+~~~ puppet
+# Assuming we are not web01.example.com:
+
+$users = hiera('users', undef)
+
+# $users contains {admins  => ["Edith Franklin", "Ginny Hamilton"],
+#                  regular => ["Iris Jackson", "Kelly Lambert"]}
+~~~
+
+You can optionally generate the default value with a
+[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that 
+takes one parameter.
+
+**Example**: Using `hiera` with a lambda
+
+~~~ puppet
+# Assuming the same Hiera data as the previous example:
+
+$users = hiera('users') | $key | { "Key \'${key}\' not found" }
+
+# $users contains {admins  => ["Edith Franklin", "Ginny Hamilton"],
+#                  regular => ["Iris Jackson", "Kelly Lambert"]}
+# If hiera couldn't match its key, it would return the lambda result,
+# "Key 'users' not found".
+~~~
+
+The returned value's data type depends on the types of the results. In the example 
+above, Hiera matches the 'users' key and returns it as a hash.
+
+See
+[the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
+for more information about Hiera lookup functions.
+
+- Since 4.0.0
+DOC
+  ) do |*args|
     function_fail(["hiera() has been converted to 4x API"])
   end
 end
-

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -1,34 +1,77 @@
 require 'hiera_puppet'
 
 module Puppet::Parser::Functions
-  newfunction(:hiera_array, :type => :rvalue, :arity => -2,:doc => "Returns all 
-  matches throughout the hierarchy --- not just the first match --- as a flattened array of unique values.
-  If any of the matched values are arrays, they're flattened and included in the results.
+  newfunction(
+    :hiera_array,
+    :type => :rvalue,
+    :arity => -2,
+    :doc => <<-DOC
+Finds all matches of a key throughout the hierarchy and returns them as a single flattened
+array of unique values. If any of the matched values are arrays, they're flattened and
+included in the results. This is called an
+[array merge lookup](https://docs.puppetlabs.com/hiera/latest/lookup_types.html#array-merge).
 
-  The function can be called in one of three ways:
-  1. Using 1 to 3 arguments where the arguments are:
-     'key'      [String] Required
-           The key to lookup.
-     'default`  [Any] Optional
-           A value to return when there's no match for `key`. Optional
-     `override` [Any] Optional
-           An argument in the third position, providing a data source
-           to consult for matching values, even if it would not ordinarily be
-           part of the matched hierarchy. If Hiera doesn't find a matching key
-           in the named override data source, it will continue to search through the
-           rest of the hierarchy.
+The `hiera_array` function takes up to three arguments, in this order:
 
-  2. Using a 'key' and an optional 'override' parameter like in #1 but with a block to
-     provide the default value. The block is called with one parameter (the key) and
-     should return the value.
+1. A string key that Hiera searches for in the hierarchy. **Required**.
+2. An optional default value to return if Hiera doesn't find anything matching the key.
+    * If this argument isn't provided and this function results in a lookup failure, Puppet
+    fails with a compilation error.
+3. The optional name of an arbitrary
+[hierarchy level](https://docs.puppetlabs.com/hiera/latest/hierarchy.html) to insert at the
+top of the hierarchy. This lets you temporarily modify the hierarchy for a single lookup.
+    * If Hiera doesn't find a matching key in the overriding hierarchy level, it continues
+    searching the rest of the hierarchy.
 
-  3. Like #1 but with all arguments passed in an array.
+**Example**: Using `hiera_array`
 
-  If any matched value is a hash, puppet will raise a type mismatch error.
+~~~ yaml
+# Assuming hiera.yaml
+# :hierarchy:
+#   - web01.example.com
+#   - common
 
-  More thorough examples of `hiera` are available at:  
-  <http://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions>
-  ") do |*args|
+# Assuming common.yaml:
+# users:
+#   - 'cdouglas = regular'
+#   - 'efranklin = regular'
+
+# Assuming web01.example.com.yaml:
+# users: 'abarry = admin'
+~~~
+
+~~~ puppet
+$allusers = hiera_array('users', undef)
+
+# $allusers contains ["cdouglas = regular", "efranklin = regular", "abarry = admin"].
+~~~
+
+You can optionally generate the default value with a
+[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+takes one parameter.
+
+**Example**: Using `hiera_array` with a lambda
+
+~~~ puppet
+# Assuming the same Hiera data as the previous example:
+
+$allusers = hiera_array('users') | $key | { "Key \'${key}\' not found" }
+
+# $allusers contains ["cdouglas = regular", "efranklin = regular", "abarry = admin"].
+# If hiera_array couldn't match its key, it would return the lambda result,
+# "Key 'users' not found".
+~~~
+
+`hiera_array` expects that all values returned will be strings or arrays. If any matched
+value is a hash, Puppet raises a type mismatch error.
+
+See
+[the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
+for more information about Hiera lookup functions.
+
+- Since 4.0.0
+DOC
+) do |*args|
     function_fail(["hiera_array() has been converted to 4x API"])
   end
 end


### PR DESCRIPTION
Revising ~~lookup~~, `hiera`, `hiera_array`, `hiera_hash`, and `hiera_include`.

Squashed; per @nfagerlund, there's more discussion needed about 
terms we use in `lookup`.