### PR TITLE
(packaging) Add condrestart to suse init scripts

### DIFF
--- a/ext/suse/client.init
+++ b/ext/suse/client.init
@@ -87,7 +87,7 @@ case "$1" in
         # Remember status and be verbose
         rc_status -v
         ;;
-    try-restart)
+    try-restart|condrestart)
         ## Stop the service and if this succeeds (i.e. the
         ## service was running before), start it again.
         $0 status >/dev/null &&  $0 restart
@@ -148,7 +148,7 @@ case "$1" in
         $puppetd "${PUPPET_OPTS}" --onetime "${PUPPET_EXTRA_OPTS}" $@
         ;;
     *)
-        echo "Usage: $0 {start|stop|status|try-restart|restart|force-reload|reload|once}"
+        echo "Usage: $0 {start|stop|status|try-restart|condrestart|restart|force-reload|reload|once}"
         exit 1
 esac
 rc_exit

--- a/ext/suse/server.init
+++ b/ext/suse/server.init
@@ -115,7 +115,7 @@ case "$1" in
         # Remember status and be verbose
         rc_status -v
         ;;
-    try-restart)
+    try-restart|condrestart)
         ## Stop the service and if this succeeds (i.e. the
         ## service was running before), start it again.
         $0 status >/dev/null &&  $0 restart
@@ -167,7 +167,7 @@ case "$1" in
         rc_status -v
         ;;
     *)
-        echo "Usage: $0 {start|stop|status|try-restart|restart|force-reload|reload}"
+        echo "Usage: $0 {start|stop|status|try-restart|condrestart|restart|force-reload|reload}"
         exit 1
 esac
 rc_exit


### PR DESCRIPTION
In the puppet-agent RPM spec we call the 'condrestart' action from
the %postun on package upgrade. This is currently missing from the
sles/suse init scripts.

This adds 'condrestart' as a synonym for the try-restart action.