### PR TITLE
(PUP-5075) Check that types that produces caps can use qualified names

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -16,7 +16,7 @@ class Puppet::Resource::Type
   include Puppet::Util::Warnings
   include Puppet::Util::Errors
 
-  RESOURCE_KINDS = [:hostclass, :node, :definition]
+  RESOURCE_KINDS = [:hostclass, :node, :definition, :capability_mapping]
 
   # Map the names used in our documentation to the names used internally
   RESOURCE_KINDS_TO_EXTERNAL_NAMES = {

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -13,12 +13,14 @@ class Puppet::Resource::TypeCollection
     @definitions.clear
     @nodes.clear
     @notfound.clear
+    @capability_mappings.clear
   end
 
   def initialize(env)
     @environment = env
     @hostclasses = {}
     @definitions = {}
+    @capability_mappings = {}
     @nodes = {}
     @notfound = {}
 
@@ -33,7 +35,7 @@ class Puppet::Resource::TypeCollection
   end
 
   def inspect
-    "TypeCollection" + { :hostclasses => @hostclasses.keys, :definitions => @definitions.keys, :nodes => @nodes.keys }.inspect
+    "TypeCollection" + { :hostclasses => @hostclasses.keys, :definitions => @definitions.keys, :nodes => @nodes.keys, :capability_mappings => @capability_mappings.keys }.inspect
   end
 
   def <<(thing)
@@ -104,6 +106,11 @@ class Puppet::Resource::TypeCollection
     @definitions[instance.name] = instance
   end
 
+  def add_capability_mapping(instance)
+    dupe_check(instance, @capability_mappings) { |dupe| "'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as a mapping" }
+    @capability_mappings[instance.name] = instance
+  end
+
   def definition(name)
     @definitions[munge_name(name)]
   end
@@ -120,7 +127,7 @@ class Puppet::Resource::TypeCollection
     find_or_load(name, :definition)
   end
 
-  [:hostclasses, :nodes, :definitions].each do |m|
+  [:hostclasses, :nodes, :definitions, :capability_mappings].each do |m|
     define_method(m) do
       instance_variable_get("@#{m}").dup
     end

--- a/spec/unit/capability_spec.rb
+++ b/spec/unit/capability_spec.rb
@@ -94,6 +94,40 @@ describe "Capability types" do
     expect(cns[:mappings]['host']).to be_instance_of(Puppet::Parser::AST::PopsBridge::Expression)
   end
 
+  it 'can place use a qualified name for defines that produces capabilities' do
+    parse_results = []
+    parser = Puppet::Parser::ParserFactory.parser
+
+    parser.string = <<-MANIFEST
+      class mod {
+        define test($hostname) {
+          notify { "hostname ${hostname}":}
+        }
+      }
+      include mod
+    MANIFEST
+    parse_results << parser.parse
+
+    parser.string = <<-MANIFEST
+      Mod::Test consumes Cap {
+        host => $hostname
+      }
+    MANIFEST
+    parse_results << parser.parse
+
+    main = Puppet::Parser::AST::Hostclass.new('', :code => Puppet::Parser::ParserFactory.code_merger.concatenate(parse_results))
+    Puppet::Node::Environment.any_instance.stubs(:perform_initial_import).returns main
+
+    type = compile_to_catalog(nil).environment_instance.known_resource_types.definition('Mod::Test')
+    expect(type.produces).to be_instance_of(Array)
+    cns = type.consumes.first
+
+    expect(cns).to be_instance_of(Hash)
+    expect(cns[:capability]).to eq('Cap')
+    expect(cns[:mappings]).to be_instance_of(Hash)
+    expect(cns[:mappings]['host']).to be_instance_of(Puppet::Parser::AST::PopsBridge::Expression)
+  end
+
   ["produces", "consumes"].each do |kw|
     it "creates an error when #{kw} references nonexistent type" do
       manifest = <<-MANIFEST


### PR DESCRIPTION
This commit adds a test that verifies that a resource type that
consumes/produces capabilities may have a qualified name.

This PR sits on top of https://github.com/puppetlabs/puppet/pull/4183. The PUP-5075 commit is the only one to consider here.