### PR TITLE
(PUP-5088) Ensure only => can be used in capability mappings

### DIFF
--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -64,6 +64,7 @@ class Puppet::Pops::Model::ModelLabelProvider < Puppet::Pops::LabelProvider
   def label_UnlessExpression o            ; "'unless' Statement"                end
   def label_CallNamedFunctionExpression o ; "Function Call"                     end
   def label_CallMethodExpression o        ; "Method call"                       end
+  def label_CapabilityMapping o           ; "Capability Mapping"                end
   def label_CaseExpression o              ; "'case' statement"                  end
   def label_CaseOption o                  ; "Case Option"                       end
   def label_RenderStringExpression o      ; "Epp Text"                          end

--- a/lib/puppet/pops/model/model_meta.rb
+++ b/lib/puppet/pops/model/model_meta.rb
@@ -542,7 +542,7 @@ module Puppet::Pops::Model
     has_attr 'kind', String, :lowerBound => 1
     has_attr 'resource', String, :lowerBound => 1
     has_attr 'capability', String, :lowerBound => 1
-    contains_many_uni 'mappings', AttributeOperation
+    contains_many_uni 'mappings', AbstractAttributeOperation
   end
 
   # A resource defaults sets defaults for a resource type. This class inherits from AbstractResource

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -195,6 +195,8 @@ class Puppet::Pops::Validation::Checker4_0
     case parent1
     when Model::AbstractResource
     when Model::CollectExpression
+    when Model::CapabilityMapping
+      acceptor.accept(Issues::UNSUPPORTED_OPERATOR_IN_CONTEXT, parent1, :operator=>'* =>')
     else
       # protect against just testing a snippet that has no parent, error message will be a bit strange
       # but it is not for a real program.

--- a/spec/unit/capability_spec.rb
+++ b/spec/unit/capability_spec.rb
@@ -127,6 +127,34 @@ describe "Capability types" do
     expect(cns[:mappings]).to be_instance_of(Hash)
     expect(cns[:mappings]['host']).to be_instance_of(Puppet::Parser::AST::PopsBridge::Expression)
   end
+  it "does not allow operator '+>' in a mapping" do
+    expect do
+    compile_to_catalog(<<-MANIFEST)
+      define test($hostname) {
+        notify { "hostname ${hostname}":}
+      }
+
+      Test consumes Cap {
+        host +> $hostname
+      }
+    MANIFEST
+    end.to raise_error(Puppet::ParseErrorWithIssue, /Illegal \+> operation.*This operator can not be used in a Capability Mapping/)
+  end
+
+  it "does not allow operator '*=>' in a mapping" do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+      define test($hostname) {
+        notify { "hostname ${hostname}":}
+      }
+
+      Test consumes Cap {
+        *=> { host => $hostname }
+      }
+      MANIFEST
+    end.to raise_error(Puppet::ParseError, /The operator '\* =>' in a Capability Mapping is not supported/)
+  end
+
 
   ["produces", "consumes"].each do |kw|
     it "creates an error when #{kw} references nonexistent type" do


### PR DESCRIPTION
This commit relaxes that constraint that a CapabilityMapping
only can contain an AttributeOperation so that it instead can
contain an AbstractAttributeOperation. This was done to prevent
a cryptic error message when an AttributesOperation (note the
plural) was assigned due to use of *=> operator. The relaxed
constraint lets this pass so that it instead can be trapped
in the validator where a correct check was already in place.