### PR TITLE
(FOR REVIEW) (PUP-5013) move profiling block for resource eval

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -380,9 +380,7 @@ class Puppet::Parser::Compiler
     exceptwrap do
       Puppet::Util::Profiler.profile("Evaluated definitions", [:compiler, :evaluate_definitions]) do
         !unevaluated_resources.each do |resource|
-          Puppet::Util::Profiler.profile("Evaluated resource #{resource}", [:compiler, :evaluate_resource, resource]) do
-            resource.evaluate
-          end
+          resource.evaluate
         end.empty?
       end
     end

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -73,16 +73,19 @@ class Puppet::Parser::Resource < Puppet::Resource
   # Retrieve the associated definition and evaluate it.
   def evaluate
     return if evaluated?
-    @evaluated = true
-    if klass = resource_type and ! builtin_type?
-      finish
-      evaluated_code = klass.evaluate_code(self)
 
-      return evaluated_code
-    elsif builtin?
-      devfail "Cannot evaluate a builtin type (#{type})"
-    else
-      self.fail "Cannot find definition #{type}"
+    Puppet::Util::Profiler.profile("Evaluated resource #{self}", [:compiler, :evaluate_resource, self]) do
+      @evaluated = true
+      if klass = resource_type and ! builtin_type?
+        finish
+        evaluated_code = klass.evaluate_code(self)
+
+        return evaluated_code
+      elsif builtin?
+        devfail "Cannot evaluate a builtin type (#{type})"
+      else
+        self.fail "Cannot find definition #{type}"
+      end
     end
   end
 


### PR DESCRIPTION
This PR is for review only, I haven't run tests or anything.  Just trying to solicit input on the change in general.

When surfacing Puppet metrics in Puppet Server, w/o this change, a huge percentage of the metrics related to resource evaluation are never registered / tracked, because there are multiple code paths that can lead to resource evaluation during compilation, and only one of them has a profiling block around it.

e.g. whether or not a resource gets metrics tracked may depend on whether it was introduced via NC vs site.pp, etc.

In local tests where I've been experimenting with improvements for surfacing metrics data from Puppet Server, this change is a huge improvement and gives us much more interesting and complete data to look at.