### PR TITLE
(PUP-5097) Adding hostname and domainname in trusted facts

### DIFF
--- a/lib/puppet/context/trusted_information.rb
+++ b/lib/puppet/context/trusted_information.rb
@@ -17,10 +17,28 @@ class Puppet::Context::TrustedInformation
   # @return [Hash{Object => Object}]
   attr_reader :extensions
 
+  # The domain name derived from the validated certificate name
+  #
+  # @return [String]
+  attr_reader :domainname
+
+  # The hostname derived from the validated certificate name
+  #
+  # @return [String]
+  attr_reader :hostname
+
   def initialize(authenticated, certname, extensions)
     @authenticated = authenticated.freeze
     @certname = certname.freeze
     @extensions = extensions.freeze
+    if @certname
+      hostname, domainname = @certname.split('.', 2)
+    else
+      hostname = nil
+      domainname = nil
+    end
+    @hostname = hostname.freeze
+    @domainname = domainname.freeze
   end
 
   def self.remote(authenticated, node_name, certificate)
@@ -50,7 +68,9 @@ class Puppet::Context::TrustedInformation
     {
       'authenticated'.freeze => authenticated,
       'certname'.freeze => certname,
-      'extensions'.freeze => extensions
+      'extensions'.freeze => extensions,
+      'hostname'.freeze => hostname,
+      'domainname'.freeze => domainname,
     }.freeze
   end
 end

--- a/spec/unit/context/trusted_information_spec.rb
+++ b/spec/unit/context/trusted_information_spec.rb
@@ -47,6 +47,8 @@ describe Puppet::Context::TrustedInformation do
         '1.3.6.1.4.1.34380.1.2.1' => 'CSR specific info',
         '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
       })
+      expect(trusted.hostname).to eq('cert name')
+      expect(trusted.domainname).to be_nil
     end
 
     it "is remote but lacks certificate information when it is authenticated" do
@@ -69,6 +71,8 @@ describe Puppet::Context::TrustedInformation do
       expect(trusted.authenticated).to eq('local')
       expect(trusted.certname).to eq('cert name')
       expect(trusted.extensions).to eq({})
+      expect(trusted.hostname).to eq('cert name')
+      expect(trusted.domainname).to be_nil
     end
 
     it "is authenticated local with no clientcert when there is no node" do
@@ -77,6 +81,8 @@ describe Puppet::Context::TrustedInformation do
       expect(trusted.authenticated).to eq('local')
       expect(trusted.certname).to be_nil
       expect(trusted.extensions).to eq({})
+      expect(trusted.hostname).to be_nil
+      expect(trusted.domainname).to be_nil
     end
   end
 
@@ -89,7 +95,24 @@ describe Puppet::Context::TrustedInformation do
       'extensions' => {
         '1.3.6.1.4.1.34380.1.2.1' => 'CSR specific info',
         '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
-      }
+      },
+      'hostname' => 'cert name',
+      'domainname' => nil
+    })
+  end
+
+  it "extracts domainname and hostname from certname" do
+    trusted = Puppet::Context::TrustedInformation.remote(true, 'hostname.domainname.long', cert)
+
+    expect(trusted.to_h).to eq({
+      'authenticated' => 'remote',
+      'certname' => 'hostname.domainname.long',
+      'extensions' => {
+        '1.3.6.1.4.1.34380.1.2.1' => 'CSR specific info',
+        '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
+      },
+      'hostname' => 'hostname',
+      'domainname' => 'domainname.long'
     })
   end
 


### PR DESCRIPTION
Before this there is no way to get the hostname/domain fact from a trustworthy source.

With this `hostname` and `domainname` are now part of the trusted facts. Both of them are derived
from the validated certificate name.

It can be used in Hiera as follows :
```yaml
:hierarchy:
  - "%{::trusted.domainname}/%{::trusted.hostname}"
  - "%{::trusted.domainname}"
  - common
```