### PR TITLE
(maint) Ignore acceptance/tmp directory

### DIFF
--- a/acceptance/.gitignore
+++ b/acceptance/.gitignore
@@ -9,3 +9,4 @@ id_rsa-acceptance
 id_rsa-acceptance.pub
 preserved_config.yaml
 merged_options.rb
+tmp


### PR DESCRIPTION
Acceptance runs create a `tmp` directory in `acceptance/tmp`. Add it to
gitignore so I no longer accidentally add it to my PRs.