### PR TITLE
(PUP-4697) Make systemd the default service provider for all suse's *except* 10 and 11

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -8,7 +8,8 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
 
   commands :chkconfig => "/sbin/chkconfig", :service => "/sbin/service"
 
-  defaultfor :osfamily => [:redhat, :suse]
+  defaultfor :osfamily => :redhat
+  defaultfor :osfamily => :suse, :operatingsystemmajrelease => ["10", "11"]
 
   # Remove the symlinks
   def disable

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => "7"
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
-  defaultfor :osfamily => :suse, :operatingsystemmajrelease => ["12", "13"]
+  defaultfor :osfamily => :suse
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => "8"
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => "15.04"
 

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -23,13 +23,20 @@ describe provider_class, :if => Puppet.features.posix? do
     Facter.stubs(:value).with(:osfamily).returns 'RedHat'
   end
 
-  osfamily = [ 'RedHat', 'Suse' ]
+  osfamily = [ 'RedHat' ]
 
   osfamily.each do |osfamily|
     it "should be the default provider on #{osfamily}" do
       Facter.expects(:value).with(:osfamily).returns(osfamily)
       expect(provider_class.default?).to be_truthy
     end
+  end
+
+  it "should be the default provider on sles11" do
+    Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystem).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("11")
+    expect(described_class.default?).to be_truthy
   end
 
   # test self.instances

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -10,7 +10,6 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     described_class.stubs(:which).with('systemctl').returns '/bin/systemctl'
   end
 
-
   let :provider do
     described_class.new(:name => 'sshd.service')
   end
@@ -19,14 +18,14 @@ describe Puppet::Type.type(:service).provider(:systemd) do
 
   osfamily.each do |osfamily|
     it "should be the default provider on #{osfamily}" do
-      Facter.expects(:value).with(:osfamily).returns(osfamily)
+      Facter.stubs(:value).with(:osfamily).returns(osfamily)
       expect(described_class.default?).to be_truthy
     end
   end
 
   it "should be the default provider on rhel7" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:redhat)
-    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("7")
+    Facter.stubs(:value).with(:osfamily).returns(:redhat)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("7")
     expect(described_class.default?).to be_truthy
   end
 
@@ -36,7 +35,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
       # caused short-circuiting of the logic used by default.all? in the
       # provider. As a workaround we need to use stubs() instead of
       # expects() here.
-      Facter.expects(:value).with(:osfamily).at_least_once.returns(:redhat)
+      Facter.stubs(:value).with(:osfamily).returns(:redhat)
       Facter.stubs(:value).with(:operatingsystem).returns(:redhat)
       Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
       expect(described_class.default?).not_to be_truthy
@@ -45,57 +44,64 @@ describe Puppet::Type.type(:service).provider(:systemd) do
 
   [ 17, 18, 19, 20, 21 ].each do |ver|
     it "should be the default provider on fedora#{ver}" do
-      Facter.expects(:value).with(:osfamily).at_least_once.returns(:redhat)
-      Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:fedora)
-      Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("#{ver}")
+      Facter.stubs(:value).with(:osfamily).returns(:redhat)
+      Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
+      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
       expect(described_class.default?).to be_truthy
     end
   end
 
   it "should be the default provider on sles12" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:suse)
-    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("12")
+    Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("12")
     expect(described_class.default?).to be_truthy
   end
 
   it "should be the default provider on opensuse13" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:suse)
-    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("13")
+    Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("13")
     expect(described_class.default?).to be_truthy
   end
 
-  it "should not be the default provider on sles11" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:suse)
-    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:suse)
-    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("11")
-    expect(described_class.default?).not_to be_truthy
+  # tumbleweed is a rolling release with date-based major version numbers
+  it "should be the default provider on tumbleweed" do
+    Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("20150829")
+    expect(described_class.default?).to be_truthy
+  end
+
+  # leap is the next generation suse release
+  it "should be the default provider on leap" do
+    Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("42")
+    expect(described_class.default?).to be_truthy
   end
 
   it "should not be the default provider on debian7" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:debian)
-    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:debian)
-    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("7")
+    Facter.stubs(:value).with(:osfamily).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystem).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("7")
     expect(described_class.default?).not_to be_truthy
   end
 
   it "should be the default provider on debian8" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:debian)
-    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:debian)
-    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("8")
+    Facter.stubs(:value).with(:osfamily).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystem).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("8")
     expect(described_class.default?).to be_truthy
   end
 
   it "should not be the default provider on ubuntu14.04" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:debian)
-    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:ubuntu)
-    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("14.04")
+    Facter.stubs(:value).with(:osfamily).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystem).returns(:ubuntu)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("14.04")
     expect(described_class.default?).not_to be_truthy
   end
 
   it "should be the default provider on ubuntu15.04" do
-    Facter.expects(:value).with(:osfamily).at_least_once.returns(:debian)
-    Facter.expects(:value).with(:operatingsystem).at_least_once.returns(:ubuntu)
-    Facter.expects(:value).with(:operatingsystemmajrelease).at_least_once.returns("15.04")
+    Facter.stubs(:value).with(:osfamily).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystem).returns(:ubuntu)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("15.04")
     expect(described_class.default?).to be_truthy
   end
 


### PR DESCRIPTION
Previously, the default service provider for suse was 'redhat' with
an override of 'systemd' for suse 12 and 13. However this doesn't work for the rolling
release of suse (tumbleweed) or the next (leap), which are both systemd
based.

This reverses the logic so the default service provider is 'systemd'
with overrides for suse 10 and suse 11.

I also updated some unrelated spec tests in provider/service/systemd_spec.rb
to use 'stubs' rather than 'expects' - the latter made the tests unnecessarily
brittle and was testing implementation rather than behavior.