### PR TITLE
(maint) Update pinned Beaker version to 2.22

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.19')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.22')
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false


### PR DESCRIPTION
This commit updates the pinned Beaker version to
2.22.0 to support changes to the puppet-agent
package name and PE repo structure for Mac OS X.