### PR TITLE
(maint) fix service_enable_acceptance test on deb8 ubuntu15 sles12

### DIFF
--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -5,26 +5,37 @@ confine :except, :platform => /osx/  # covered by launchd_provider.rb
 confine :except, :platform => 'solaris'
 confine :except, :platform => /ubuntu-[a-u]/ # upstart covered by ticket_14297_handle_upstart.rb
 
-package_name = {'el'     => 'httpd',   'centos' => 'httpd', 'sles' => 'httpd', 'fedora' => 'httpd',
-                'ubuntu' => 'apache2', 'debian' => 'apache2'}
+package_name = {'el'     => 'httpd',
+                'centos' => 'httpd',
+                'fedora' => 'httpd',
+                'debian' => 'apache2',
+                'sles'   => 'apache2',
+                'ubuntu' => 'apache2',
+}
 
-init_script_el7   = "/usr/lib/systemd/system/httpd.service"
-symlink_el7       = "/etc/systemd/system/multi-user.target.wants/httpd.service"
-
-start_runlevels = ["2", "3", "4", "5"]
-kill_runlevels = ["0", "1", "6"]
-
+start_runlevels     = ["2", "3", "4", "5"]
+kill_runlevels      = ["0", "1", "6"]
 
 agents.each do |agent|
   platform = agent.platform.variant
   majrelease = on(agent, facter('operatingsystemmajrelease')).stdout.chomp.to_i
 
-  init_script       = "/etc/init.d/#{package_name[platform]}"
+  if ((platform == 'debian' && majrelease == 8) || (platform == 'ubuntu' && majrelease == 15))
+    skip_test 'legit failures on debian8 and ubuntu15; see: PUP-5149'
+  end
+
+  init_script_systemd = "/usr/lib/systemd/system/#{package_name[platform]}.service"
+  symlink_systemd     = "/etc/systemd/system/multi-user.target.wants/#{package_name[platform]}.service"
+
+  init_script         = "/etc/init.d/#{package_name[platform]}"
   if platform == 'debian' && majrelease == 6
     start_symlink     = "S20apache2"
     kill_symlink      = "K01apache2"
   elsif platform == 'debian' && majrelease == 7
     start_symlink     = "S17apache2"
+    kill_symlink      = "K01apache2"
+  elsif platform == 'debian' && majrelease == 8
+    start_symlink     = "S02apache2"
     kill_symlink      = "K01apache2"
   else
     start_symlink     = "S85httpd"
@@ -66,13 +77,13 @@ agents.each do |agent|
   apply_manifest_on(agent, manifest_install_httpd, :catch_failures => true)
   # chkconfig --del will remove all rc.d symlinks for this service
   on agent, "chkconfig --del httpd", :accept_all_exit_codes => true
-  # debian platforms using sysV put rc runlevels directly in /etc/
-  on agent, "ln -s /etc/ /etc/rc.d", :accept_all_exit_codes => true
 
   step "ensure enabling service creates the start & kill symlinks"
   is_sysV = ((platform == 'centos' || platform == 'el') && majrelease < 7) || platform == 'debian'
   apply_manifest_on(agent, manifest_httpd_enabled, :catch_failures => true) do
     if is_sysV
+      # debian platforms using sysV put rc runlevels directly in /etc/
+      on agent, "ln -s /etc/ /etc/rc.d", :accept_all_exit_codes => true
       start_runlevels.each do |runlevel|
         on agent, "test -L /etc/rc.d/rc#{runlevel}.d/#{start_symlink} && test -f #{init_script}"
       end
@@ -80,7 +91,7 @@ agents.each do |agent|
         on agent, "test -L /etc/rc.d/rc#{runlevel}.d/#{kill_symlink} && test -f #{init_script}"
       end
     else
-      on agent, "test -L #{symlink_el7} && test -f #{init_script_el7}"
+      on agent, "test -L #{symlink_systemd} && test -f #{init_script_systemd}"
     end
   end
 
@@ -91,7 +102,7 @@ agents.each do |agent|
         on agent, "test -L /etc/rc.d/rc#{runlevel}.d/#{kill_symlink} && test -f #{init_script}"
       end
     else
-      on agent, "test ! -e #{symlink_el7}"
+      on agent, "test ! -e #{symlink_systemd}"
     end
   end
 end


### PR DESCRIPTION
This change fixes many platforms this test was not setup to handle. It
skips ubuntu15 and debian8 for now as it seems to uncover legit
failures.