### PR TITLE
(PUP-5133) Add Solaris 10/11 SPARC node defs

### DIFF
--- a/acceptance/config/nodes/pe/solaris-10-sparc
+++ b/acceptance/config/nodes/pe/solaris-10-sparc
@@ -1,0 +1,16 @@
+HOSTS:
+  master:
+    roles:
+      - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  solaris-10-sparc:
+    roles:
+      - agent
+    platform: solaris-10-sparc
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/pe/solaris-11-sparc
+++ b/acceptance/config/nodes/pe/solaris-11-sparc
@@ -1,0 +1,16 @@
+HOSTS:
+  master:
+    roles:
+      - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  solaris-11-sparc:
+    roles:
+      - agent
+    platform: solaris-11-sparc
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/


### PR DESCRIPTION
This commit adds node definitions for solaris sparc 10 and 11
agents using the SPARC architecture.