### PR TITLE
(PUP-5133) Add Solaris 10/11 SPARC node defs

### DIFF
--- a/acceptance/config/nodes/solaris-10-sparc.yaml
+++ b/acceptance/config/nodes/solaris-10-sparc.yaml
@@ -6,12 +6,10 @@ HOSTS:
     platform: el-7-x86_64
     hypervisor: vcloud
     template: redhat-7-x86_64
-  agent:
+  solaris-10-sparc:
     roles:
       - agent
-    platform: solaris-10-x86_64
-    hypervisor: vcloud
-    template: solaris-10-x86_64
+    platform: solaris-10-sparc
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/config/nodes/solaris-11-sparc.yaml
+++ b/acceptance/config/nodes/solaris-11-sparc.yaml
@@ -6,12 +6,10 @@ HOSTS:
     platform: el-7-x86_64
     hypervisor: vcloud
     template: redhat-7-x86_64
-  agent:
+  solaris-11-sparc:
     roles:
       - agent
-    platform: solaris-10-x86_64
-    hypervisor: vcloud
-    template: solaris-10-x86_64
+    platform: solaris-11-sparc
 CONFIG:
   datastore: instance0
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic

--- a/acceptance/config/nodes/solaris-11-x86_64.yaml
+++ b/acceptance/config/nodes/solaris-11-x86_64.yaml
@@ -1,3 +1,4 @@
+---
 HOSTS:
   master:
     roles:


### PR DESCRIPTION
This commit adds node definitions for solaris sparc 10 and 11
agents using the SPARC architecture.