### PR TITLE
(PUP-5197) Defer appmgmt-specific setup of lexer tables

### DIFF
--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -115,11 +115,11 @@ describe 'Lexer2' do
   end
 
   context 'when app_managment is (turned) on' do
-    before(:all) do
+    before(:each) do
       with_app_management(true)
     end
 
-    after(:all) do
+    after(:each) do
       with_app_management(false)
     end
 

--- a/spec/unit/pops/parser/parse_application_spec.rb
+++ b/spec/unit/pops/parser/parse_application_spec.rb
@@ -6,11 +6,11 @@ require_relative './parser_rspec_helper'
 describe "egrammar parsing of 'application'" do
   include ParserRspecHelper
 
-  before(:all) do
+  before(:each) do
     with_app_management(true)
   end
 
-  after(:all) do
+  after(:each) do
     with_app_management(false)
   end
 

--- a/spec/unit/pops/parser/parse_capabilities_spec.rb
+++ b/spec/unit/pops/parser/parse_capabilities_spec.rb
@@ -8,11 +8,11 @@ require File.join(File.dirname(__FILE__), '/parser_rspec_helper')
 describe "egrammar parsing of capability mappings" do
   include ParserRspecHelper
 
-  before(:all) do
+  before(:each) do
     with_app_management(true)
   end
 
-  after(:all) do
+  after(:each) do
     with_app_management(false)
   end
 

--- a/spec/unit/pops/parser/parser_rspec_helper.rb
+++ b/spec/unit/pops/parser/parser_rspec_helper.rb
@@ -6,16 +6,7 @@ module ParserRspecHelper
   include FactoryRspecHelper
 
   def with_app_management(flag)
-    # Horrible things have to be done to test this as the Lexer sets up the
-    # KEYWORD table as a frozen constant, and this list depends on the
-    # Puppet[:app_management] setting. These 'before all' and 'after all'
-    # clauses forces Ruby to reload the Lexer
     Puppet[:app_management] = flag
-    Puppet::Pops::Parser.send(:remove_const, :Lexer2)
-    if Puppet::Parser.const_defined?(:E4ParserAdapter)
-      Puppet::Parser::E4ParserAdapter.class_variable_set(:@@evaluating_parser, nil)
-    end
-    load 'puppet/pops/parser/lexer2.rb'
   end
 
   def parse(code)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -244,11 +244,11 @@ describe "validating 4x" do
   end
 
   context "capability annotations" do
-    before(:all) do
+    before(:each) do
       with_app_management(true)
     end
 
-    after(:all) do
+    after(:each) do
       with_app_management(false)
     end
 


### PR DESCRIPTION
The app_management feature flag governs which of two variants of lexer
tables we use for appmgmt specific language constructs. Previously, the
decision was made when code was loaded, which is too early for how
puppet-server loads the Ruby code.

We now defer the decision until we actually get ready to lex text, and make
the decision in the initvars method, rather than in the setup of constants
during loading of the Ruby code.

As an (untested) side-effect, it should now be possible to turn
app_management on or off per environment rather than just globally.

This change also required changing before(:all) to before(:each) as
Puppet[:app_management] is reset before each test automatically. On the
upside, we can now also get rid of the horrible hacks in
ParserRspecHelper::with_app_management