### PR TITLE
(PUP-5078) Validate export/consume metaparameters

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -211,11 +211,17 @@ class Puppet::Parser::Resource < Puppet::Resource
 
     map = {}
     [ self[:consume] ].flatten.map do |ref|
+      # Assert that the ref really is a resource reference
+      raise Puppet::Error, "Invalid consume in #{self.ref}: #{ref} is not a resource" unless ref.is_a?(Puppet::Resource)
+
       # Resolve references
       cap = catalog.resource(ref.type, ref.title)
       if cap.nil?
         raise "Resource #{ref} could not be found; it might not have been produced yet"
       end
+
+      # Ensure that the found resource is a capability resource
+      raise Puppet::Error, "Invalid consume in #{ref}: #{cap} is not a capability resource" unless cap.resource_type.is_capability?
       cap
     end.each do |cns|
       # Establish mappings

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -113,6 +113,10 @@ class Puppet::Resource::Type
     return unless definition?
 
     resource.export.map do |ex|
+      # Assert that the ref really is a resource reference
+      raise Puppet::Error, "Invalid export in #{resource.ref}: #{ex} is not a resource" unless ex.is_a?(Puppet::Resource)
+      raise Puppet::Error, "Invalid export in #{resource.ref}: #{ex} is not a capability resource" unless ex.resource_type.is_capability?
+
       blueprint = produces.find { |pr| pr[:capability] == ex.type }
       if blueprint.nil?
         raise Puppet::ParseError, "Resource type #{resource.type} does not produce #{ex.type}"

--- a/spec/unit/capability_spec.rb
+++ b/spec/unit/capability_spec.rb
@@ -296,5 +296,16 @@ Test consumes Cap {
       expect(catalog.resource("Cap[two]")["host"]).to eq("ahost")
       expect(catalog.resource("Test", "one")["hostname"]).to eq("nohost")
     end
+
+    ['export', 'consume'].each do |metaparam|
+
+      it "validates that #{metaparam} metaparameter rejects values that are not resources" do
+        expect { make_catalog("test { one: #{metaparam} => 'hello' }") }.to raise_error(Puppet::Error, /not a resource/)
+      end
+
+      it "validates that #{metaparam} metaparameter rejects resources that are not capability resources" do
+        expect { make_catalog("notify{hello:} test { one: #{metaparam} => Notify[hello] }") }.to raise_error(Puppet::Error, /not a capability resource/)
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds validation of values assigned to the export/consume
metaparameters. The validation ensures that the value is a capability
resource. It also asserts that the value is a resource before attempts
are made to use methods such as resource.type. This to avoid cryptical
"undefined method" errors in case user enters non resource RHS values.