### PR TITLE
(PUP-5079) Check that 'nodes' parameter for applications is sound

### DIFF
--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -20,14 +20,13 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
     applications.each do |app|
       app_components = {}
       # Turn the 'nodes' hash into a map component ref => node name
-      node_mapping = app['nodes'].map do |k,v|
-        k.type == "Node" ? [k, v] : [v, k]
-      end.reduce({}) do |map, (node, comp)|
-        unless map[comp.ref].nil?
-          raise Puppet::ParseError, "Application #{app} maps component #{comp} to mutiple nodes"
+      node_mapping = {}
+      app['nodes'].each do |node, comps|
+        comps = [comps] unless comp.is_a?(Array)
+        comps.each do |comp|
+          raise Puppet::ParseError, "Application #{app} maps component #{comp} to multiple nodes" if node_mapping.include?(comp.ref)
+          node_mapping[comp.ref] = node.title
         end
-        map[comp.ref] = node.title
-        map
       end
 
       catalog.direct_dependents_of(app).each do |comp|


### PR DESCRIPTION
This commit adds validation of the 'nodes' parameter in application
instances such that it must be a Hash where each key is a Node and
each value is a resource or an array of resources.

The code also checks that no resource is mapped to more than one
node.

A change was made to remove the prior more relaxed scheme where the
node could be on either side of the association in the hash. Now
it must be the key. This is natural since the node must be unique
and since the resources that it is associated with can be an array.