### PR TITLE
(PUP-5215) Update Ruby to include an updated openssl

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -26,8 +26,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/hiera.git'
   sys:
     ref:
-      x86: 'refs/tags/1.9.3-p551.4'
-      x64: 'refs/tags/2.0.0.7-x64'
+      x86: 'refs/tags/1.9.3-p551.5'
+      x64: 'refs/tags/2.0.0.8-x64'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
This commit updates the ruby build we are including in the puppet-agent
package. This new build is against an updated build of OpenSSL 1.0.0s