### PR TITLE
(PUP-5024) Fix test on Windows

### DIFF
--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -8,6 +8,8 @@ module Puppet
       # @param host [String] hostname
       # @return [Boolean] whether the systemd provider is supported.
       def supports_systemd? (host)
+        # The Windows MSI doesn't put Puppet in the Ruby vendor or site dir, so loading it fails.
+        return false if host.platform.variant == 'windows'
         ruby = Puppet::Acceptance::CommandUtils.ruby_command(host)
         suitable = on(host, "#{ruby} -e \"require 'puppet'; puts Puppet::Type.type(:service).provider(:systemd).suitable?\"" ).stdout.chomp
         suitable == "true" ? true : false


### PR DESCRIPTION
On Windows, ruby.exe doesn't know where to `require 'puppet'`, as Puppet
is not put in Ruby's vendor or site dir in the MSI. Requiring puppet
fails in the systemd acceptance test.

Explicitly state Windows does not support systemd.