### PR TITLE
(maint) Don't try to "require 'puppet'" in windows for systemd test

### DIFF
--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -8,9 +8,13 @@ module Puppet
       # @param host [String] hostname
       # @return [Boolean] whether the systemd provider is supported.
       def supports_systemd? (host)
-        ruby = Puppet::Acceptance::CommandUtils.ruby_command(host)
-        suitable = on(host, "#{ruby} -e \"require 'puppet'; puts Puppet::Type.type(:service).provider(:systemd).suitable?\"" ).stdout.chomp
-        suitable == "true" ? true : false
+        if host['platform'] =~ /windows/
+          false
+        else
+          ruby = Puppet::Acceptance::CommandUtils.ruby_command(host)
+          suitable = on(host, "#{ruby} -e \"require 'puppet'; puts Puppet::Type.type(:service).provider(:systemd).suitable?\"" ).stdout.chomp
+          suitable == "true" ? true : false
+        end
       end
     end
   end


### PR DESCRIPTION
The check in the acceptance `supports_systemd?` method should
immediately return false if run on a Windows host.