### PR TITLE
(PUP-4476) Call lookup with the correct parameters

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -96,7 +96,7 @@ class Puppet::Application::Lookup < Puppet::Application
       end
     end
 
-    puts Puppet::Pops::Lookup.lookup(scope, options[:keys], options[:type], options[:default_value], use_default_value, {}, {}, merge_options)
+    puts Puppet::Pops::Lookup.lookup(options[:keys], options[:type], options[:default_value], use_default_value, merge_options, Puppet::DataBinding::LookupInvocation.new(scope, {}, {}))
   end
 
   def generate_scope

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -37,22 +37,6 @@ describe Puppet::Application::Lookup do
   context "when running with correct command line options" do
     let (:lookup) { Puppet::Application[:lookup] }
 
-    it "calls the lookup method with the correct arguments" do
-      lookup.options[:node] = 'dantooine.local'
-      lookup.options[:merge_hash_arrays] = true
-      lookup.options[:merge] = 'deep'
-      lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
-      lookup.stubs(:generate_scope).returns('scope')
-
-      expected_merge = {"strategy"=> "deep", "sort_merge_arrays"=> false, "merge_hash_arrays"=> true}
-
-      Puppet::Pops::Lookup.stubs(:lookup).returns('rand')
-
-      (Puppet::Pops::Lookup).expects(:lookup).with('scope', ['atton', 'kreia'], nil, nil, false, {}, {}, expected_merge)
-
-      lookup.run_command
-    end
-
     it "prints the value found by lookup" do
       lookup.options[:node] = 'dantooine.local'
       lookup.command_line.stubs(:args).returns(['atton', 'kreia'])


### PR DESCRIPTION
Prior to this commit, the lookup application was calling the internal
lookup function in a way that was compatible with the old version
of the function (eight parameters) rather than the current version
of the function (six parameters). This meant that attempts to use
the lookup application would fail due to the function being called
improperly.

Fix this issue and also remove a test that had too much stubbing
and was not longer useful.