### PR TITLE
(PUP-4442) Only rmdir if mkdir succeeded

### DIFF
--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -173,9 +173,11 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
     def locking(tmpname)
       lock = tmpname + '.lock'
       mkdir(lock)
-      yield
-    ensure
-      rmdir(lock) if lock
+      begin
+        yield
+      ensure
+        rmdir(lock)
+      end
     end
 
     def mkdir(*args)

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -46,6 +46,11 @@ describe Puppet::FileSystem::Uniquefile do
     expect(Puppet::FileSystem.exist?(filename)).to be_falsey
   end
 
+  it "raises a mkdir exception when an ancestor directory doesn't exist" do
+    expect do
+      Puppet::FileSystem::Uniquefile.new('foo', File.expand_path('/parent/dir/does/not/exist'))
+    end.to raise_error(Errno::ENOENT, /mkdir/)
+  end
 
   context "Ruby 1.9.3 Tempfile tests" do
     # the remaining tests in this file are ported directly from the ruby 1.9.3 source,


### PR DESCRIPTION
Previously, if you tried to manage a file with content and the parent
directory didn't exist, puppet would report `rmdir` failed:

    Error: Could not set 'file' on ensure: No such file or directory @
    dir_s_rmdir - .../file20150909-11354-3uzm9m.lock

The file type uses `Puppet::Util.replace_file` to atomically overwrite
file content, which creates a unique file in the same directory as
the file we're trying to manage, to ensure we're on the same filesystem.
But if the parent directory doesn't exist, `mkdir` raises ENOENT, and
then we called `rmdir`, which also raises ENOENT, masking the original
exception.

This commit changes uniquefile to only call `rmdir` if `mkdir` succeeds.