### PR TITLE
(PUP-3742) Smoke test gems

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -295,6 +295,17 @@ EOS
     end
 
     desc <<-EOS
+Install puppet as a gem on a predefined set of hosts using Beaker, and run a basic smoke test.
+
+  $ env SHA=<full sha> bundle exec rake:ci:gem
+EOS
+    task :gem => 'ci:check_env' do
+      ENV['TESTS'] = 'setup/gem/pre-suite/010_GemInstall.rb'
+      ENV['CONFIG'] = 'config/nodes/gem.yaml'
+      beaker_test(:gem)
+    end
+
+    desc <<-EOS
 Run the acceptance tests through Beaker and install from git on the configuration targets.
 #{USAGE}
 EOS

--- a/acceptance/config/gem/options.rb
+++ b/acceptance/config/gem/options.rb
@@ -1,0 +1,8 @@
+{
+  :type => 'git',
+  :install => [
+  ],
+  :pre_suite => [
+    'setup/git/pre-suite/000_EnvSetup.rb',
+  ],
+}

--- a/acceptance/config/nodes/gem.yaml
+++ b/acceptance/config/nodes/gem.yaml
@@ -1,0 +1,33 @@
+---
+HOSTS:
+  win-2012r2-rubyx86:
+    roles:
+    - agent
+    platform: windows-2012r2-64
+    ruby_arch: x86
+    hypervisor: vcloud
+    template: win-2012r2-x86_64
+  win-2012r2-rubyx64:
+    roles:
+    - agent
+    platform: windows-2012r2-64
+    ruby_arch: x64
+    hypervisor: vcloud
+    template: win-2012r2-x86_64
+  osx-1010:
+    roles:
+    - agent
+    platform: osx-yosemite-x86_64
+    hypervisor: vcloud
+    template: osx-1010-x86_64
+  redhat-7:
+    roles:
+    - agent
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/setup/gem/pre-suite/010_GemInstall.rb
+++ b/acceptance/setup/gem/pre-suite/010_GemInstall.rb
@@ -1,0 +1,40 @@
+test_name "Install puppet gem"
+
+require 'puppet/acceptance/common_utils'
+
+agents.each do |agent|
+  sha = ENV['SHA']
+  base_url = "http://builds.puppetlabs.lan/puppet/#{sha}/artifacts"
+
+  ruby_command = Puppet::Acceptance::CommandUtils.ruby_command(agent)
+  gem_command = Puppet::Acceptance::CommandUtils.gem_command(agent)
+
+  # retrieve the build data, since the gem version is based on the short git
+  # describe, not the full git SHA
+  on(agent, "curl -s -o build_data.yaml #{base_url}/#{sha}.yaml")
+  gem_version = on(agent, "#{ruby_command} -ryaml -e 'puts YAML.load_file(\"build_data.yaml\")[:gemversion]'").stdout.chomp
+
+  if agent['platform'] =~ /windows/
+    # wipe existing gems first
+    default_dir = on(agent, "#{ruby_command} -rrbconfig -e 'puts Gem.default_dir'").stdout.chomp
+    on(agent, "rm -rf '#{default_dir}'")
+
+    arch = agent[:ruby_arch] || 'x86'
+    gem_arch = arch == 'x64' ? 'x64-mingw32' : 'x86-mingw32'
+    url = "#{base_url}/puppet-#{gem_version}-#{gem_arch}.gem"
+  else
+    url = "#{base_url}/puppet-#{gem_version}.gem"
+  end
+
+  step "Download puppet gem from #{url}"
+  on(agent, "curl -s -o puppet.gem #{url}")
+
+  step "Install puppet.gem"
+  on(agent, "#{gem_command} install puppet.gem")
+
+  step "Verify it's sane"
+  on(agent, puppet('--version'))
+  on(agent, puppet('apply', "-e \"notify { 'hello': }\"")) do |result|
+    assert_match(/defined 'message' as 'hello'/, result.stdout)
+  end
+end


### PR DESCRIPTION
Creates a rake task `ci:test:gem` and an acceptance test for installing
puppet as a gem and smoke testing the install against a predefined set
of hosts windows (ruby x86 and x64), osx and redhat. The osx case is
needed because we have a darwin-specific facter gem that has a
dependency on CFPropertyList.

The `ci:test:gem` task relies on the existing git setup step that
installs `git` and `ruby` on each host, even though we really only need
`ruby`.

Also on Windows, we're using the our vendored ruby, which already
includes some gems, e.g. win32-service, ffi. So the test setup step
wipes the current set of installed gems. Alternatively, it would be nice
to only install our vendored ruby, but we do not current publish that as
a build artifact.