### PR TITLE
(PUP-4475) Add explain-ability to the lookup and data provider APIs

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -1,19 +1,19 @@
 require 'puppet/application'
-require 'puppet/pops/lookup'
+require 'puppet/pops'
 require 'puppet/node'
 require 'puppet/parser/compiler'
 
 class Puppet::Application::Lookup < Puppet::Application
 
-  RUNHELP = "Run 'puppet lookup --help' for more details".freeze
-  DEEP_MERGE_OPTIONS = "--knock_out_prefix, --sort_merged_arrays, --unpack_arrays, and --merge_hash_arrays".freeze
+  RUN_HELP = "Run 'puppet lookup --help' for more details".freeze
+  DEEP_MERGE_OPTIONS = '--knock-out-prefix, --sort-merged-arrays, --unpack-arrays, and --merge-hash-arrays'.freeze
 
   # Options for lookup
   option('--merge TYPE') do |arg|
     if %w{unique hash deep}.include?(arg)
       options[:merge] = arg
     else
-      raise "The --merge option only accepts 'unique', 'hash', or 'deep' as arguments.\n#{RUNHELP}"
+      raise "The --merge option only accepts 'unique', 'hash', or 'deep' as arguments.\n#{RUN_HELP}"
     end
   end
 
@@ -21,17 +21,17 @@ class Puppet::Application::Lookup < Puppet::Application
     options[:type] = arg
   end
 
-  option('--knock_out_prefix PREFIX_STRING') do |arg|
+  option('--knock-out-prefix PREFIX_STRING') do |arg|
     options[:prefix] = arg
   end
 
-  option('--sort_merge_arrays')
+  option('--sort-merge-arrays')
 
-  option('--unpack_arrays') do |arg|
+  option('--unpack-arrays') do |arg|
     options[:unpack_arrays] = arg
   end
 
-  option('--merge_hash_arrays')
+  option('--merge-hash-arrays')
 
   # not yet supported
   option('--explain')
@@ -53,23 +53,20 @@ class Puppet::Application::Lookup < Puppet::Application
     if %w{.yaml .yml .json}.include?(arg.match(/\.[^.]*$/)[0])
       options[:fact_file] = arg
     else
-      raise "The --fact file only accepts yaml and json files as arguments.\n#{RUNHELP}"
+      raise "The --fact file only accepts yaml and json files as arguments.\n#{RUN_HELP}"
     end
   end
 
-  def run_command
-    options[:keys] = command_line.args
+  def main
+    keys = command_line.args
+    raise 'No keys were given to lookup.' if keys.empty?
 
-    if options[:keys].empty?
-     raise "No keys were given to lookup."
-    end
-
-    if !options[:node]
+    unless options[:node]
       raise "No node was given via the '--node' flag for the scope of the lookup."
     end
 
     if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix] || options[:unpack_arrays]) && options[:merge] != 'deep'
-      raise "The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUNHELP}"
+      raise "The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUN_HELP}"
     end
 
     scope = generate_scope
@@ -96,7 +93,7 @@ class Puppet::Application::Lookup < Puppet::Application
       end
     end
 
-    puts Puppet::Pops::Lookup.lookup(options[:keys], options[:type], options[:default_value], use_default_value, merge_options, Puppet::DataBinding::LookupInvocation.new(scope, {}, {}))
+    puts Puppet::Pops::Lookup.lookup(keys, options[:type], options[:default_value], use_default_value, merge_options, Puppet::Pops::Lookup::Invocation.new(scope, {}, {}))
   end
 
   def generate_scope

--- a/lib/puppet/data_binding.rb
+++ b/lib/puppet/data_binding.rb
@@ -11,36 +11,4 @@ class Puppet::DataBinding
   class LookupError < Puppet::PreformattedError; end
 
   class RecursiveLookupError < Puppet::DataBinding::LookupError; end
-
-  class LookupInvocation
-    attr_reader :scope, :override_values, :default_values
-
-    # @param scope [Puppet::Parser::Scope] The scope to use for the lookup
-    # @param override_values [Hash<String,Object>|nil] A map to use as override. Values found here are returned immediately (no merge)
-    # @param default_values [Hash<String,Object>] A map to use as the last resort (but before default)
-    def initialize(scope, override_values = {}, default_values = {})
-      @name_stack = []
-      @scope = scope
-      @override_values = override_values
-      @default_values = default_values
-    end
-
-    def check(name)
-      if @name_stack.include?(name)
-        raise RecursiveLookupError, "Recursive lookup detected in [#{@name_stack.join(', ')}]"
-      end
-      return unless block_given?
-
-      @name_stack.push(name)
-      begin
-        yield
-      rescue LookupError
-        raise
-      rescue Puppet::Error => detail
-        raise LookupError.new(detail.message, detail)
-      ensure
-        @name_stack.pop
-      end
-    end
-  end
 end

--- a/lib/puppet/data_providers.rb
+++ b/lib/puppet/data_providers.rb
@@ -23,9 +23,14 @@ module Puppet::DataProviders
     module_name = name[0..qual_index-1]
 
     assert_loaded()
-    adapter = DataAdapter.adapt(Puppet.lookup(:current_environment))
-    data_provider = adapter.module_provider(module_name)
-    throw :no_such_key if data_provider.nil?
-    data_provider.lookup(name, lookup_invocation, merge)
+    env = Puppet.lookup(:current_environment)
+    adapter = DataAdapter.adapt(env)
+    lookup_invocation.with(:module, module_name) do
+      if env.module(module_name).nil?
+        lookup_invocation.report_module_not_found
+        throw :no_such_key
+      end
+      adapter.module_provider(module_name).lookup(name, lookup_invocation, merge)
+    end
   end
 end

--- a/lib/puppet/data_providers/hiera_config.rb
+++ b/lib/puppet/data_providers/hiera_config.rb
@@ -49,6 +49,8 @@ module Puppet::DataProviders
     end
     private_class_method :create_config_type
 
+    attr_reader :config_path, :version
+
     # Creates a new HieraConfig from the given _config_root_. This is where the 'hiera.yaml' is expected to be found
     # and is also the base location used when resolving relative paths.
     #
@@ -64,6 +66,7 @@ module Puppet::DataProviders
       else
         @config = DEFAULT_CONFIG
       end
+      @version = @config['version']
     end
 
     def create_data_providers(lookup_invocation)

--- a/lib/puppet/data_providers/hiera_support.rb
+++ b/lib/puppet/data_providers/hiera_support.rb
@@ -1,24 +1,38 @@
 require_relative 'hiera_config'
 
 module Puppet::DataProviders::HieraSupport
+  def config_path
+    @hiera_config.nil? ? 'not yet configured' : @hiera_config.config_path
+  end
+
+  def name
+    'Hiera Data Provider' + (@hiera_config.nil? ? '' : ", version #{@hiera_config.version}")
+  end
+
   # Performs a lookup by searching all given paths for the given _key_. A merge will be performed if
   # the value is found in more than one location and _merge_ is not nil.
   #
   # @param key [String] The key to lookup
-  # @param lookup_invocation [Puppet::DataBinding::LookupInvocation] The current lookup invocation
+  # @param lookup_invocation [Puppet::Pops::Lookup::Invocation] The current lookup invocation
   # @param merge [String|Hash<String,Object>|nil] Merge strategy or hash with strategy and options
   #
   # @api public
   def unchecked_lookup(key, lookup_invocation, merge)
-    result = Puppet::Pops::MergeStrategy.strategy(merge).merge_lookup(data_providers(data_key(key), lookup_invocation)) do |data_provider|
-      data_provider.unchecked_lookup(key, lookup_invocation, merge)
+    lookup_invocation.with(:data_provider, self) do
+      merge_strategy = Puppet::Pops::MergeStrategy.strategy(merge)
+      lookup_invocation.with(:merge, merge_strategy) do
+        merged_result = merge_strategy.merge_lookup(data_providers(data_key(key), lookup_invocation)) do |data_provider|
+          data_provider.unchecked_lookup(key, lookup_invocation, merge)
+        end
+        throw :no_such_key if merged_result.equal?(Puppet::Pops::MergeStrategy::NOT_FOUND)
+        lookup_invocation.report_result(merged_result)
+      end
     end
-    throw :no_such_key if result.equal?(Puppet::Pops::MergeStrategy::NOT_FOUND)
-    result
   end
 
   def data_providers(data_key, lookup_invocation)
-    @data_providers ||= Puppet::DataProviders::HieraConfig.new(provider_root(data_key, lookup_invocation.scope)).create_data_providers(lookup_invocation)
+    @hiera_config ||= Puppet::DataProviders::HieraConfig.new(provider_root(data_key, lookup_invocation.scope))
+    @data_providers ||= @hiera_config.create_data_providers(lookup_invocation)
   end
   private :data_providers
 end

--- a/lib/puppet/functions/lookup.rb
+++ b/lib/puppet/functions/lookup.rb
@@ -222,7 +222,7 @@ Puppet::Functions.create_function(:lookup, Puppet::Functions::InternalFunction) 
   end
 
   def do_lookup(scope, name, value_type, default_value, has_default, override, default_values_hash, merge, &block)
-    Puppet::Pops::Lookup.lookup(name, value_type, default_value, has_default, merge, Puppet::DataBinding::LookupInvocation.new(scope, override, default_values_hash), &block)
+    Puppet::Pops::Lookup.lookup(name, value_type, default_value, has_default, merge, Puppet::Pops::Lookup::Invocation.new(scope, override, default_values_hash), &block)
   end
 
   def hash_args(options_hash)

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -27,6 +27,8 @@ module Puppet
     require 'puppet/pops/validation'
     require 'puppet/pops/issue_reporter'
     require 'puppet/pops/lookup'
+    require 'puppet/pops/lookup/invocation'
+    require 'puppet/pops/lookup/explainer'
 
     require 'puppet/pops/model/model'
 

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -89,7 +89,7 @@ module Puppet::Pops::Lookup
 
   def self.fail_lookup(names)
     name_part = names.size == 1 ? "the name '#{names[0]}'" : 'any of the names [' + names.map { |n| "'#{n}'" }.join(', ') + ']'
-    raise Puppet::Error, "Function lookup() did not find a value for #{name_part}"
+    raise Puppet::DataBinding::LookupError, "Function lookup() did not find a value for #{name_part}"
   end
   private_class_method :fail_lookup
 end

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -1,7 +1,7 @@
 # This class is the backing implementation of the Puppet function 'lookup'.
 # See puppet/functions/lookup.rb for documentation.
 #
-class Puppet::Pops::Lookup
+module Puppet::Pops::Lookup
   # Performs a lookup in the configured scopes and optionally merges the default.
   #
   # This is a backing function and all parameters are assumed to have been type checked.
@@ -12,7 +12,7 @@ class Puppet::Pops::Lookup
   # @param default_value [Object] The value to use as default when no value is found
   # @param has_default [Boolean] Set to _true_ if _default_value_ is included (_nil_ is a valid _default_value_)
   # @param merge [String|Hash<String,Object>|nil] Merge strategy or hash with strategy and options
-  # @param lookup_invocation [Puppet::DataBinding::LookupInvocation] Invocation data containing scope, overrides, and defaults
+  # @param lookup_invocation [Puppet::Pops::Lookup::Invocation] Invocation data containing scope, overrides, and defaults
   # @return [Object] The found value
   #
   def self.lookup(name, value_type, default_value, has_default, merge, lookup_invocation)
@@ -23,7 +23,7 @@ class Puppet::Pops::Lookup
     # with name and value.
     not_found = Puppet::Pops::MergeStrategy::NOT_FOUND
     override_values = lookup_invocation.override_values
-    result_with_name = names.reduce([nil,not_found]) do |memo, key|
+    result_with_name = names.reduce([nil, not_found]) do |memo, key|
       value = override_values.include?(key) ? assert_type('override', value_type, override_values[key]) : not_found
       value = search_and_merge(key, lookup_invocation, merge) if value.equal?(not_found)
       break [key, assert_type('found', value_type, value)] unless value.equal?(not_found)
@@ -36,7 +36,7 @@ class Puppet::Pops::Lookup
       unless default_values.empty?
         result_with_name = names.reduce(result_with_name) do |memo, key|
           value = default_values.include?(key) ? assert_type('default_values_hash', value_type, default_values[key]) : not_found
-          memo = [ key, value ]
+          memo = [key, value]
           break memo unless value.equal?(not_found)
           memo
         end
@@ -62,8 +62,14 @@ class Puppet::Pops::Lookup
       Puppet::DataProviders.method(:lookup_in_environment),
       Puppet::DataProviders.method(:lookup_in_module)
     ]
-    Puppet::Pops::MergeStrategy.strategy(merge).merge_lookup(@variants) do |f|
-      f.call(name, lookup_invocation, merge)
+
+    merge_strategy = Puppet::Pops::MergeStrategy.strategy(merge)
+    lookup_invocation.with(:merge, merge_strategy) do
+      merged_result = merge_strategy.merge_lookup(@variants) do |f|
+        f.call(name, lookup_invocation, merge)
+      end
+      lookup_invocation.report_result(merged_result) unless merged_result.equal?(Puppet::Pops::MergeStrategy::NOT_FOUND)
+      merged_result
     end
   end
   private_class_method :search_and_merge
@@ -82,7 +88,7 @@ class Puppet::Pops::Lookup
   private_class_method :assert_type
 
   def self.fail_lookup(names)
-    name_part = names.size == 1 ? "the name '#{names[0]}'" : 'any of the names [' + names.map {|n| "'#{n}'"} .join(', ') + ']'
+    name_part = names.size == 1 ? "the name '#{names[0]}'" : 'any of the names [' + names.map { |n| "'#{n}'" }.join(', ') + ']'
     raise Puppet::Error, "Function lookup() did not find a value for #{name_part}"
   end
   private_class_method :fail_lookup

--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -254,7 +254,8 @@ module Puppet::Pops::Lookup
 
     def to_hash
       hash = super
-      hash[:data_provider] = @provider.name
+      hash[:name] = @provider.name
+      hash[:configuration_path] = @provider.config_path.to_s if @provider.respond_to?(:config_path)
       hash
     end
 
@@ -281,7 +282,7 @@ module Puppet::Pops::Lookup
     def to_hash
       hash = super
       hash[:original_path] = @path.original_path
-      hash[:path] = @path.path
+      hash[:path] = @path.path.to_s
       hash
     end
 

--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -1,0 +1,375 @@
+module Puppet::Pops::Lookup
+
+# The ExplainNode contains information of a specific node in a tree traversed during
+# lookup. The tree can be traversed using the `parent` and `branches` attributes of
+# each node.
+#
+# Each leaf node contains information about what happened when the leaf of the branch
+# was traversed.
+  class ExplainNode
+    def branches
+      @branches ||= []
+    end
+
+    def to_hash
+      hash = {}
+      hash[:branches] = @branches.map {|b| b.to_hash} unless @branches.nil? || @branches.empty?
+      hash
+    end
+
+    def to_s
+      io = StringIO.new
+      dump_on(io, '', '')
+      io.string
+    end
+
+    def dump_on(io, indent, first_indent)
+    end
+  end
+
+  class ExplainTreeNode < ExplainNode
+    attr_reader :parent, :event, :key, :value
+
+    def initialize(parent)
+      @parent = parent
+      @event = nil
+    end
+
+    def found_in_overrides(key, value)
+      @key = key
+      @value = value
+      @event = :found_in_overrides
+    end
+
+    def found_in_defaults(key, value)
+      @key = key
+      @value = value
+      @event = :found_in_defaults
+    end
+
+    def found(key, value)
+      @key = key
+      @value = value
+      @event = :found
+    end
+
+    def result(value)
+      @value = value
+      @event = :result
+    end
+
+    def not_found(key)
+      @key = key
+      @event = :not_found
+    end
+
+    def path_not_found
+      @event = :path_not_found
+    end
+
+    def module_not_found
+      @event = :module_not_found
+    end
+
+    def increase_indent(indent)
+      indent + '  '
+    end
+
+    def to_hash
+      hash = super
+      hash[:key] = @key unless @key.nil?
+      hash[:value] = @value if [:found, :found_in_defaults, :found_in_overrides, :result].include?(@event)
+      hash[:event] = @event unless @event.nil?
+      hash[:type] = type
+      hash
+    end
+
+    def type
+      :root
+    end
+
+    def dump_outcome(io, indent)
+      io << indent << 'No such key: "' << @key << "\"\n" if @event == :not_found
+      if [:found, :found_in_overrides, :found_in_defaults].include?(@event)
+        io << indent << 'Found key: "' << @key << '" value: '
+        dump_value(io, indent, @value)
+        io << ' in overrides' if @event == :found_in_overrides
+        io << ' in defaults' if @event == :found_in_defaults
+        io << "\n"
+      end
+    end
+
+    def dump_value(io, indent, value)
+      case value
+      when Hash
+        io << '{'
+        unless value.empty?
+          inner_indent = increase_indent(indent)
+          value.reduce("\n") do |sep, (k, v)|
+            io << sep << inner_indent
+            dump_value(io, inner_indent, k)
+            io << ' => '
+            dump_value(io, inner_indent, v)
+            ",\n"
+          end
+          io << "\n" << indent
+        end
+        io << '}'
+      when Array
+        io << '['
+        unless value.empty?
+          inner_indent = increase_indent(indent)
+          value.reduce("\n") do |sep, v|
+            io << sep << inner_indent
+            dump_value(io, inner_indent, v)
+            ",\n"
+          end
+          io << "\n" << indent
+        end
+        io << ']'
+      else
+        io << value.inspect
+      end
+    end
+  end
+
+  class ExplainInterpolate < ExplainTreeNode
+    def initialize(parent, expression)
+      super(parent)
+      @expression = expression
+    end
+
+    def dump_on(io, indent, first_indent)
+      io << first_indent << 'Interpolation on "' << @expression << "\"\n"
+      indent = increase_indent(indent)
+      branches.each {|b| b.dump_on(io, indent, indent)}
+    end
+
+    def to_hash
+      hash = super
+      hash[:expression] = @expression
+      hash
+    end
+
+    def type
+      :interpolate
+    end
+  end
+
+  class ExplainMerge < ExplainTreeNode
+    def initialize(parent, merge)
+      super(parent)
+      @merge = merge
+    end
+
+    def dump_on(io, indent, first_indent)
+      # It's pointless to report a merge where there's only one branch
+      return branches[0].dump_on(io, indent, first_indent) if branches.size == 1
+
+      io << first_indent << 'Merge strategy ' << @merge.class.key << "\n"
+      indent = increase_indent(indent)
+      options = options_wo_strategy
+      unless options.nil?
+        io << indent << 'Options: '
+        dump_value(io, indent, options)
+        io << "\n"
+      end
+      branches.each {|b| b.dump_on(io, indent, indent)}
+      if @event == :result
+        io << indent << 'Merged result: '
+        dump_value(io, indent, @value)
+        io << "\n"
+      end
+    end
+
+    def to_hash
+      return branches[0].to_hash if branches.size == 1
+      hash = super
+      hash[:merge] = @merge.class.key
+      options = options_wo_strategy
+      hash[:options] = options unless options.nil?
+      hash
+    end
+
+    def type
+      :merge
+    end
+
+    def options_wo_strategy
+      options = @merge.options
+      if !options.nil? && options.include?('strategy')
+        options = options.dup
+        options.delete('strategy')
+      end
+      options.empty? ? nil : options
+    end
+  end
+
+  class ExplainModule < ExplainTreeNode
+    def initialize(parent, mod)
+      super(parent)
+      @module = mod
+    end
+
+    def dump_on(io, indent, first_indent)
+      io << indent << 'Module "' << @module << '"'
+      if branches.size == 1
+        branches[0].dump_on(io, indent, ' using ')
+      else
+        io << "\n"
+        indent = increase_indent(indent)
+        branches.each {|b| b.dump_on(io, indent, indent)}
+      end
+      io << indent << "Module not found\n" if @event == :module_not_found
+    end
+
+    def to_hash
+      if branches.size == 1
+        branches[0].to_hash.merge(:module => @module)
+      else
+        hash = super
+        hash[:module] = @module
+        hash
+      end
+    end
+
+    def type
+      :module
+    end
+  end
+
+  class ExplainDataProvider < ExplainTreeNode
+    def initialize(parent, provider)
+      super(parent)
+      @provider = provider
+    end
+
+    def dump_on(io, indent, first_indent)
+      io << first_indent << 'Data Provider "' << @provider.name << "\"\n"
+      indent = increase_indent(indent)
+      io << indent << 'ConfigurationPath "' << @provider.config_path << "\"\n" if @provider.respond_to?(:config_path)
+      branches.each {|b| b.dump_on(io, indent, indent)}
+      dump_outcome(io, indent)
+    end
+
+    def to_hash
+      hash = super
+      hash[:data_provider] = @provider.name
+      hash
+    end
+
+    def type
+      :data_provider
+    end
+  end
+
+  class ExplainPath < ExplainTreeNode
+    def initialize(parent, path)
+      super(parent)
+      @path = path
+    end
+
+    def dump_on(io, indent, first_indent)
+      io << indent << 'Path "' << @path.path << "\"\n"
+      indent = increase_indent(indent)
+      io << indent << 'Original path: ' << @path.original_path << "\n"
+      branches.each {|b| b.dump_on(io, indent, indent)}
+      io << indent << "Path not found\n" if @event == :path_not_found
+      dump_outcome(io, indent)
+    end
+
+    def to_hash
+      hash = super
+      hash[:original_path] = @path.original_path
+      hash[:path] = @path.path
+      hash
+    end
+
+    def type
+      :path
+    end
+  end
+
+  class ExplainScope < ExplainTreeNode
+    def initialize(parent)
+      super(parent)
+    end
+
+    def dump_on(io, indent, first_indent)
+      io << indent << 'Global Scope' << "\"\n"
+      indent = increase_indent(indent)
+      dump_outcome(io, indent)
+    end
+
+    def type
+      :scope
+    end
+  end
+
+  class Explainer < ExplainNode
+    def initialize
+      @current = self
+    end
+
+    def push(qualifier_type, qualifier)
+      node = case (qualifier_type)
+        when :path
+          ExplainPath.new(@current, qualifier)
+        when :module
+          ExplainModule.new(@current, qualifier)
+        when :interpolate
+          ExplainInterpolate.new(@current, qualifier)
+        when :data_provider
+          ExplainDataProvider.new(@current, qualifier)
+        when :merge
+          ExplainMerge.new(@current, qualifier)
+        when :scope
+          ExplainScope.new(@current)
+        else
+          raise ArgumentError, "Unknown Explain type #{qualifier_type}"
+        end
+      @current.branches << node
+      @current = node
+    end
+
+    def pop
+      @current = @current.parent unless @current.parent.nil?
+    end
+
+    def accept_found_in_overrides(key, value)
+      @current.found_in_overrides(key, value)
+    end
+
+    def accept_found_in_defaults(key, value)
+      @current.found_in_defaults(key, value)
+    end
+
+    def accept_found(key, value)
+      @current.found(key, value)
+    end
+
+    def accept_not_found(key)
+      @current.not_found(key)
+    end
+
+    def accept_path_not_found
+      @current.path_not_found
+    end
+
+    def accept_module_not_found
+      @current.module_not_found
+    end
+
+    def accept_result(result)
+      @current.result(result)
+    end
+
+    def dump_on(io, indent, first_indent)
+      branches.each { |b| b.dump_on(io, indent, first_indent) }
+    end
+
+    def to_hash
+      branches.size == 1 ? branches[0].to_hash : super
+    end
+  end
+end

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -1,0 +1,103 @@
+module Puppet::Pops::Lookup
+  class Invocation
+    attr_reader :scope, :override_values, :default_values, :explainer
+
+    # Creates a context object for a lookup invocation. The object contains the current scope, overrides, and default
+    # values and may optionally contain an {ExplanationAcceptor} instance that will receive book-keeping information
+    # about the progress of the lookup.
+    #
+    # If the _explain_ argument is a boolean, then _false_ means that no explanation is needed and _true_ means that
+    # the default explanation acceptor should be used. The _explain_ argument may also be an instance of the
+    # `ExplanationAcceptor` class.
+    #
+    # @param scope [Puppet::Parser::Scope] The scope to use for the lookup
+    # @param override_values [Hash<String,Object>|nil] A map to use as override. Values found here are returned immediately (no merge)
+    # @param default_values [Hash<String,Object>] A map to use as the last resort (but before default)
+    # @param explainer [boolean,Explanainer] An boolean true to use the default explanation acceptor or an explainer instance that will receive information about the lookup
+    def initialize(scope, override_values = {}, default_values = {}, explainer = nil)
+      @name_stack = []
+      @scope = scope
+      @override_values = override_values
+      @default_values = default_values
+      unless explainer.is_a?(Explainer)
+        explainer = explainer == true ? Explainer.new : nil
+      end
+      @explainer = explainer
+    end
+
+    def check(name)
+      if @name_stack.include?(name)
+        raise Puppet::DataBinding::RecursiveLookupError, "Recursive lookup detected in [#{@name_stack.join(', ')}]"
+      end
+      return unless block_given?
+
+      @name_stack.push(name)
+      begin
+        yield
+      rescue Puppet::DataBinding::LookupError
+        raise
+      rescue Puppet::Error => detail
+        raise Puppet::DataBinding::LookupError.new(detail.message, detail)
+      ensure
+        @name_stack.pop
+      end
+    end
+
+    # The qualifier_type can be one of:
+    # :data_provider - qualifier a DataProvider instance
+    # :path - qualifier is a ResolvedPath instance
+    # :merge - qualifier is a MergeStrategy instance
+    # :module - qualifier is the name of a module
+    # :interpolation - qualifier is the unresolved interpolation expression
+    #
+    # @param qualifier [Object] A branch, a provider, or a path
+    def with(qualifier_type, qualifier)
+      if @explainer.nil?
+        yield
+      else
+        @explainer.push(qualifier_type, qualifier)
+        begin
+          yield
+        ensure
+          @explainer.pop
+        end
+      end
+    end
+
+    def report_found_in_overrides(key, value)
+      @explainer.accept_found_in_overrides(key, value) unless @explainer.nil?
+      value
+    end
+
+    def report_found_in_defaults(key, value)
+      @explainer.accept_found_in_defaults(key, value) unless @explainer.nil?
+      value
+    end
+
+    def report_found(key, value)
+      @explainer.accept_found(key, value) unless @explainer.nil?
+      value
+    end
+
+    # Report the result of a merge or fully resolved interpolated string
+    # @param value [Object] The result to report
+    # @return [Object] the given value
+    def report_result(value)
+      @explainer.accept_result(value) unless @explainer.nil?
+      value
+    end
+
+    def report_not_found(key)
+      @explainer.accept_not_found(key) unless @explainer.nil?
+    end
+
+    def report_path_not_found
+      @explainer.accept_path_not_found unless @explainer.nil?
+    end
+
+    def report_module_not_found
+      @explainer.accept_module_not_found unless @explainer.nil?
+    end
+  end
+end
+

--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -4,7 +4,6 @@ module Puppet::Pops
   # Merges to objects into one based on an implemented strategy.
   #
   class MergeStrategy
-
     NOT_FOUND = Object.new.freeze
 
     TypeAsserter = Puppet::Pops::Types::TypeAsserter
@@ -130,11 +129,11 @@ module Puppet::Pops
       value
     end
 
-    protected
-
     def options
       @options
     end
+
+    protected
 
     # Returns the type used to validate the options hash
     #

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -469,7 +469,7 @@ class Puppet::Resource
   def lookup_in_environment(name, scope)
     found = false
     value = catch(:no_such_key) do
-      v = Puppet::DataProviders.lookup_in_environment(name, Puppet::DataBinding::LookupInvocation.new(scope), nil)
+      v = Puppet::DataProviders.lookup_in_environment(name, Puppet::Pops::Lookup::Invocation.new(scope), nil)
       found = true
       v
     end
@@ -480,7 +480,7 @@ class Puppet::Resource
   def lookup_in_module(name, scope)
     found = false
     value = catch(:no_such_key) do
-      v = Puppet::DataProviders.lookup_in_module(name, Puppet::DataBinding::LookupInvocation.new(scope), nil)
+      v = Puppet::DataProviders.lookup_in_module(name, Puppet::Pops::Lookup::Invocation.new(scope), nil)
       found = true
       v
     end

--- a/spec/fixtures/unit/application/environments/production/data/common.yaml
+++ b/spec/fixtures/unit/application/environments/production/data/common.yaml
@@ -1,0 +1,3 @@
+---
+a: This is A
+b: This is B

--- a/spec/fixtures/unit/application/environments/production/environment.conf
+++ b/spec/fixtures/unit/application/environments/production/environment.conf
@@ -1,0 +1,1 @@
+environment_data_provider = 'hiera'

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -62,4 +62,112 @@ describe Puppet::Application::Lookup do
       expect{ lookup.run_command }.to output("--- rand\n...\n").to_stdout
     end
   end
+
+
+  context 'when asked to explain' do
+    let (:lookup) { Puppet::Application[:lookup] }
+
+    # There is a fully configured 'sample' environment in fixtures at this location
+    let(:environmentpath) {  File.absolute_path(File.join(my_fixture_dir(), '../environments'))  }
+
+    let(:facts) { Puppet::Node::Facts.new("facts", {}) }
+
+    let(:node) { Puppet::Node.new("testnode", :facts => facts, :environment => environment) }
+
+    let(:expected_json_hash) { {
+      'branches' => [{
+          'branches' => [
+            {
+              'key' => 'a',
+              'value' => 'This is A',
+              'event' => 'found',
+              'type' => 'path',
+              'original_path' => 'common',
+              'path' => "#{environmentpath}/production/data/common.yaml",
+            }],
+          'type' => 'data_provider',
+          'name' => 'common'
+        }],
+      'configuration_path' => "#{environmentpath}/production/hiera.yaml",
+      'name' => 'Hiera Data Provider, version 4',
+      'type' => 'data_provider'
+    }}
+
+    let(:expected_yaml_hash) { {
+      :branches => [{
+          :branches => [
+            {
+              :key => 'a',
+              :value => 'This is A',
+              :event => :found,
+              :type => :path,
+              :original_path => 'common',
+              :path => "#{environmentpath}/production/data/common.yaml",
+            }],
+          :type => :data_provider,
+          :name => 'common'
+        }],
+      :configuration_path => "#{environmentpath}/production/hiera.yaml",
+      :name => 'Hiera Data Provider, version 4',
+      :type => :data_provider
+    }}
+
+    around(:each) do |example|
+      # Initialize settings to get a full compile as close as possible to a real
+      # environment load
+      Puppet.settings.initialize_global_settings
+      loader = Puppet::Environments::Directories.new(environmentpath, [])
+      Puppet.override(:environments => loader) do
+        example.run
+      end
+    end
+
+    it 'produces human readable text by default' do
+      lookup.options[:node] = Puppet::Node.new("testnode", :facts => facts, :environment => 'production')
+      lookup.options[:explain] = true
+      lookup.command_line.stubs(:args).returns(['a'])
+      expect{ lookup.run_command }.to output(<<-EXPLANATION).to_stdout
+Data Provider "Hiera Data Provider, version 4"
+  ConfigurationPath "#{environmentpath}/production/hiera.yaml"
+  Data Provider "common"
+    Path "#{environmentpath}/production/data/common.yaml"
+      Original path: common
+      Found key: "a" value: "This is A"
+EXPLANATION
+    end
+
+    it 'can produce a yaml explanation' do
+      lookup.options[:node] = Puppet::Node.new("testnode", :facts => facts, :environment => 'production')
+      lookup.options[:explain] = true
+      lookup.options[:render_as] = :yaml
+      lookup.command_line.stubs(:args).returns(['a'])
+      save_stdout = $stdout
+      output = nil
+      begin
+        $stdout = StringIO.new
+        lookup.run_command
+        output = $stdout.string
+      ensure
+        $stdout = save_stdout
+      end
+      expect(YAML.load(output)).to eq(expected_yaml_hash)
+    end
+
+    it 'can produce a json explanation' do
+      lookup.options[:node] = Puppet::Node.new("testnode", :facts => facts, :environment => 'production')
+      lookup.options[:explain] = true
+      lookup.options[:render_as] = :json
+      lookup.command_line.stubs(:args).returns(['a'])
+      save_stdout = $stdout
+      output = nil
+      begin
+        $stdout = StringIO.new
+        lookup.run_command
+        output = $stdout.string
+      ensure
+        $stdout = save_stdout
+      end
+      expect(JSON.parse(output)).to eq(expected_json_hash)
+    end
+  end
 end

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -37,14 +37,29 @@ describe Puppet::Application::Lookup do
   context "when running with correct command line options" do
     let (:lookup) { Puppet::Application[:lookup] }
 
+    it "calls the lookup method with the correct arguments" do
+      lookup.options[:node] = 'dantooine.local'
+      lookup.options[:render_as] = :s;
+      lookup.options[:merge_hash_arrays] = true
+      lookup.options[:merge] = 'deep'
+      lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
+      lookup.stubs(:generate_scope).yields('scope')
+
+      expected_merge = {"strategy"=> "deep", "sort_merge_arrays"=> false, "merge_hash_arrays"=> true}
+
+      (Puppet::Pops::Lookup).expects(:lookup).with(['atton', 'kreia'], nil, nil, false, expected_merge, anything).returns('rand')
+
+      expect{ lookup.run_command }.to output("rand\n").to_stdout
+    end
+
     it "prints the value found by lookup" do
       lookup.options[:node] = 'dantooine.local'
       lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
-      lookup.stubs(:generate_scope).returns('scope')
+      lookup.stubs(:generate_scope).yields('scope')
 
       Puppet::Pops::Lookup.stubs(:lookup).returns('rand')
 
-      expect{ lookup.run_command }.to output("rand\n").to_stdout
+      expect{ lookup.run_command }.to output("--- rand\n...\n").to_stdout
     end
   end
 end

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -28,7 +28,7 @@ describe Puppet::Application::Lookup do
       lookup.options[:merge] = 'hash'
       lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
 
-      expected_error = "The options --knock_out_prefix, --sort_merged_arrays, --unpack_arrays, and --merge_hash_arrays are only available with '--merge deep'\nRun 'puppet lookup --help' for more details"
+      expected_error = "The options --knock-out-prefix, --sort-merged-arrays, --unpack-arrays, and --merge-hash-arrays are only available with '--merge deep'\nRun 'puppet lookup --help' for more details"
 
       expect{ lookup.run_command }.to raise_error(RuntimeError, expected_error)
     end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -478,14 +478,14 @@ EOS
                 :value => { 'k1' => 'env_e1', 'k3' => 'env_e3' },
                 :event => :found,
                 :type => :data_provider,
-                :data_provider => 'FunctionEnvDataProvider'
+                :name => 'FunctionEnvDataProvider'
               },
               {
                 :key => 'abc::e',
                 :value => { 'k1' => 'module_e1', 'k2' => 'module_e2' },
                 :event => :found,
                 :type => :data_provider,
-                :data_provider => 'FunctionModuleDataProvider',
+                :name => 'FunctionModuleDataProvider',
                 :module => 'abc'
               }
             ],


### PR DESCRIPTION
This commit adds report callbacks to the Lookup::Invocation object
which is passed down to all instances involved in the lookup. These
callbacks will either do nothing at all (no Explainer attached to
the Invocation) or tell the explainer to accept data for that
particular report.

A new 'with' method was also added. It is used when a lookup changes
its context. This happens when the lookup is branching due to things
like several paths, global/environment/module scopes, or when
evaluating interpolations in a string. The with method is used as
a wrapper (yields to a block where the lookup continues) and will
push and pop contextual objects in the Explainer and thereby build
a full DAG of all branches that the lookup invocation took part in.

The LookupInvocation that resided in Puppet::DataBinding was moved
to Puppet::Pops::Lookup and renamed to Invocation to make it adjacent
to the Explainer. This was motivated by their close affinity and that
neither of those classes are specific to DataBinding. The impact of
this will be very minor given that no release has gone out where the
LookupInvocation has been included.

The lookup CLI command was change so that it now exposes the explain
feature.