### PR TITLE
(PUP-2575) Sort OSX group membership before comparison

### DIFF
--- a/lib/puppet/provider/group/directoryservice.rb
+++ b/lib/puppet/provider/group/directoryservice.rb
@@ -9,4 +9,18 @@ Puppet::Type.type(:group).provide :directoryservice, :parent => Puppet::Provider
   confine :operatingsystem => :darwin
   defaultfor :operatingsystem => :darwin
   has_feature :manages_members
+
+  def members_insync?(current, should)
+    return false unless current
+    if current == :absent and should.empty?
+      return true
+    else
+      if current.respond_to?(:sort) and should.respond_to?(:sort)
+        return current.sort.uniq == should.sort.uniq
+      else
+        return current == should
+      end
+    end
+  end
+
 end

--- a/lib/puppet/provider/group/directoryservice.rb
+++ b/lib/puppet/provider/group/directoryservice.rb
@@ -12,14 +12,10 @@ Puppet::Type.type(:group).provide :directoryservice, :parent => Puppet::Provider
 
   def members_insync?(current, should)
     return false unless current
-    if current == :absent and should.empty?
-      return true
+    if current == :absent
+      return should.empty?
     else
-      if current.respond_to?(:sort) and should.respond_to?(:sort)
-        return current.sort.uniq == should.sort.uniq
-      else
-        return current == should
-      end
+      return current.sort.uniq == should.sort.uniq
     end
   end
 

--- a/spec/unit/provider/group/directoryservice_spec.rb
+++ b/spec/unit/provider/group/directoryservice_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:group).provider(:directoryservice) do
+  let :resource do
+    Puppet::Type.type(:group).new(
+      :title => 'testgroup',
+      :provider => :directoryservice,
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  it 'should return true for same lists of unordered members' do
+    expect(provider.members_insync?(['user1', 'user2'], ['user2', 'user1'])).to be_truthy
+  end
+
+  it 'should return false when the group currently has no members' do
+    expect(provider.members_insync?([], ['user2', 'user1'])).to be_falsey
+  end
+
+  it 'should return true for the same lists of members irrespective of duplicates' do
+    expect(provider.members_insync?(['user1', 'user2', 'user2'], ['user1', 'user2'])).to be_truthy
+  end
+
+  it "should return true when current and should members are empty lists" do
+    expect(provider.members_insync?([], [])).to be_truthy
+  end
+
+end

--- a/spec/unit/provider/group/directoryservice_spec.rb
+++ b/spec/unit/provider/group/directoryservice_spec.rb
@@ -26,4 +26,8 @@ describe Puppet::Type.type(:group).provider(:directoryservice) do
     expect(provider.members_insync?([], [])).to be_truthy
   end
 
+  it "should return true when current is :absent and should members is empty list" do
+    expect(provider.members_insync?(:absent, [])).to be_truthy
+  end
+
 end


### PR DESCRIPTION
OSX group membership is currently returned as simple Arrays. Comparing these
is strict, and the order of the resource must exactly match the order given
in the manifest, or a spurious change notice will be generated.

To fix this, add a members_insync? method on the directoryservice group
provider.