### PR TITLE
(maint) Skip failing tests on EL/Centos 4

### DIFF
--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -2,6 +2,7 @@ test_name "Exercise loading a face from a module"
 
 # Because the module tool does not work on windows, we can't run this test there
 confine :except, :platform => 'windows'
+confine :except, {:platform => /centos-4|el-4/}, agents # PUP-5225
 
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -1,6 +1,7 @@
 test_name "ticket 1073: common package name in two different providers should be allowed"
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
+confine :except, {:platform => /centos-4|el-4/}, agents # PUP-5227
 
 require 'puppet/acceptance/rpm_util'
 extend Puppet::Acceptance::RpmUtils

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -1,6 +1,7 @@
 test_name "test the yum package provider"
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
+confine :except, {:platform => /centos-4|el-4/}, agents # PUP-5227
 
 require 'puppet/acceptance/rpm_util'
 extend Puppet::Acceptance::RpmUtils

--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -1,6 +1,7 @@
 test_name "should delete an entry for an SSH authorized key"
 
 confine :except, :platform => ['windows']
+confine :except, {:platform => /centos-4|el-4/}, agents # PUP-5228
 
 auth_keys = '~/.ssh/authorized_keys'
 name = "pl#{rand(999999).to_i}"


### PR DESCRIPTION
Several tests fail on EL/Centos 4 and have been filed as separate tasks.
This commit skips those tests until we resolve those issues. See
PUP-5225, PUP-5226, PUP-5227, and PUP-5228.