### PR TITLE
(PUP-5328) Fix crash when using qualified lookups in interpolation

### DIFF
--- a/lib/puppet/data_providers/hiera_interpolate.rb
+++ b/lib/puppet/data_providers/hiera_interpolate.rb
@@ -16,7 +16,7 @@ module Puppet::DataProviders::HieraInterpolate
 
       segments = key.split('.')
       value = interpolate_method(method_key).call(segments[0], lookup_invocation)
-      value = qualified_lookup(segments.drop(1), v) if segments.size > 1
+      value = qualified_lookup(segments.drop(1), value) if segments.size > 1
       value = lookup_invocation.check(key) { interpolate(value, lookup_invocation, allow_methods) } if value.is_a?(String)
 
       # break gsub and return value immediately if this was an alias substitution. The value might be something other than a String

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/data/common.yaml
@@ -23,3 +23,6 @@ km_literal: 'Value from interpolation %{literal("with literal")}'
 km_sqalias: "%{alias('target_alias')}"
 recursive: '%{r1}'
 
+km_qualified: "Value from qualified interpolation OS = %{os.name}"
+
+km_multi: "cluster/%{literal('%')}{::cluster}/%{literal('%')}{role}"

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -106,6 +106,16 @@ describe "when using a hiera data provider" do
     expect(resources).to include('Value from interpolation with default')
   end
 
+  it 'performs lookup using qualified expressions in interpolation' do
+    resources = compile_and_get_notifications('hiera_misc', "$os = { name => 'Fedora' } notify{lookup(km_qualified):}")
+    expect(resources).to include('Value from qualified interpolation OS = Fedora')
+  end
+
+  it 'can have multiple interpolate expressions in one value' do
+    resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(km_multi):}')
+    expect(resources).to include('cluster/%{::cluster}/%{role}')
+  end
+
   it 'performs single quoted interpolation' do
     resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(km_sqalias):}')
     expect(resources).to include('Value from interpolation with alias')


### PR DESCRIPTION
This commit fixes a typo in the hiera data provider and adds a test
to verify that interpolation expressions using qualified names such
as `%{os.name}` works as expected.

A test was also added to ensure that the hiera data provider does
not suffer from the problem described in HI-469.