### PR TITLE
(PUP-5258) Unquote PUPPET_EXTRA_OPTS in SUSE init script

### DIFF
--- a/ext/suse/client.init
+++ b/ext/suse/client.init
@@ -73,7 +73,7 @@ case "$1" in
                 rc_exit
             fi
         fi
-        startproc -f -w -p "${pidfile}" "${puppetd}" "${PUPPET_OPTS}" "${PUPPET_EXTRA_OPTS}" && touch "${lockfile}"
+        startproc -f -w -p "${pidfile}" "${puppetd}" "${PUPPET_OPTS}" ${PUPPET_EXTRA_OPTS} && touch "${lockfile}"
         # Remember status and be verbose
         rc_status -v
         ;;
@@ -145,7 +145,7 @@ case "$1" in
         ;;
     once)
         shift
-        $puppetd "${PUPPET_OPTS}" --onetime "${PUPPET_EXTRA_OPTS}" $@
+        $puppetd "${PUPPET_OPTS}" --onetime ${PUPPET_EXTRA_OPTS} $@
         ;;
     *)
         echo "Usage: $0 {start|stop|status|try-restart|condrestart|restart|force-reload|reload|once}"


### PR DESCRIPTION
Prior to this commit, the Puppet service fails to start
on SLES11 with the error "Could not prepare for execution:
The puppet agent command does not take parameters".

This appears to be caused by an empty '' at the end of
Puppet's SUSE init script startproc call.

Since PUPPET_EXTRA_OPS is set to an empty string in the
default /etc/sysconfig/puppet, we update the SUSE
init script to remove the double quotes from
"${PUPPET_EXTRA_OPTS}".