### PR TITLE
(PUP-5228) Fixup ssh_authorized_key tests

### DIFF
--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -1,7 +1,6 @@
 test_name "should delete an entry for an SSH authorized key"
 
 confine :except, :platform => ['windows']
-confine :except, :platform => /centos-4|el-4/ # PUP-5228
 
 auth_keys = '~/.ssh/authorized_keys'
 name = "pl#{rand(999999).to_i}"
@@ -17,7 +16,7 @@ agents.each do |agent|
   on(agent, "cp #{auth_keys} /tmp/auth_keys", :acceptable_exit_codes => [0,1])
 
   step "(setup) create an authorized key in the #{auth_keys} file"
-  on(agent, "echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
+  on(agent, "echo '' >> #{auth_keys} && echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
 
   #------- TESTS -------#
   step "delete an authorized key entry with puppet (absent)"

--- a/acceptance/tests/resource/ssh_authorized_key/modify.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/modify.rb
@@ -16,7 +16,7 @@ agents.each do |agent|
   on(agent, "cp #{auth_keys} /tmp/auth_keys", :acceptable_exit_codes => [0,1])
 
   step "(setup) create an authorized key in the #{auth_keys} file"
-  on(agent, "echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
+  on(agent, "echo '' >> #{auth_keys} && echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
 
   #------- TESTS -------#
   step "update an authorized key entry with puppet (present)"
@@ -30,6 +30,7 @@ agents.each do |agent|
   step "verify entry updated in #{auth_keys}"
   on(agent, "cat #{auth_keys}")  do |res|
     fail_test "didn't find the updated key for #{name}" unless stdout.include? "mynewshinykey #{name}"
+    fail_test "Found old key mykey #{name}" if stdout.include? "mykey #{name}"
   end
 
 end

--- a/acceptance/tests/resource/ssh_authorized_key/query.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/query.rb
@@ -18,12 +18,12 @@ agents.each do |agent|
   on(agent, "cp #{auth_keys} /tmp/auth_keys", :acceptable_exit_codes => [0,1])
 
   step "(setup) create an authorized key in the #{auth_keys} file"
-  on(agent, "echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
+  on(agent, "echo '' >> #{auth_keys} && echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
 
   #------- TESTS -------#
   step "verify SSH authorized key query with puppet"
   on(agent, puppet_resource('ssh_authorized_key', "/#{name}")) do |res|
-    fail_test "found the ssh_authorized_key for #{name}" unless stdout.include? "#{name}"
+    fail_test "Didn't find the ssh_authorized_key for #{name}" unless stdout.include? "#{name}"
   end
 
 end


### PR DESCRIPTION
Previously, the ssh_authorized_key tests would append a new
key to authorized_keys with `echo.` On CentOS 4. simply appending
did not create a newline, and so the key was appended to the end
of the last key, meaning Puppet couldn't find or remove it.

This commit updates the test to add a newline to the file before
appending the new key.

In addition, there was an issue with the modifcation test in which the
key was appended improperly, and we then mistook Puppet's newly generated
key for a modified version of the old key, when in reality
'ensure=present' was just adding a brand new key.