### PR TITLE
(PUP-5026) Ensure that parser tokens are reported with position

### DIFF
--- a/lib/puppet/pops/parser/parser_support.rb
+++ b/lib/puppet/pops/parser/parser_support.rb
@@ -50,21 +50,28 @@ class Puppet::Pops::Parser::Parser
   # lexer. Line and position is produced if the given semantic is a Positioned object and have been given an offset.
   #
   def error(semantic, message)
-    semantic = semantic.current() if semantic.is_a?(Puppet::Pops::Model::Factory)
-    # Adapt the model so it is possible to get location information.
-    # The model may not have been added to the source tree, so give it the lexer's locator
-    # directly instead of searching for the root Program where the locator is normally stored.
-    #
-    if semantic.is_a?(Puppet::Pops::Model::Positioned)
-      adapter = Puppet::Pops::Adapters::SourcePosAdapter.adapt(semantic)
-      adapter.locator = @lexer.locator
-    else
-      adapter = nil
-    end
     except = Puppet::ParseError.new(message)
-    except.file = @lexer.locator.file
-    except.line = adapter.line if adapter
-    except.pos = adapter.pos if adapter
+    if semantic.is_a?(Puppet::Pops::Parser::LexerSupport::TokenValue)
+      except.file = semantic[:file];
+      except.line = semantic[:line];
+      except.pos = semantic[:pos];
+    else
+      semantic = semantic.current() if semantic.is_a?(Puppet::Pops::Model::Factory)
+
+      # Adapt the model so it is possible to get location information.
+      # The model may not have been added to the source tree, so give it the lexer's locator
+      # directly instead of searching for the root Program where the locator is normally stored.
+      #
+      if semantic.is_a?(Puppet::Pops::Model::Positioned)
+        adapter = Puppet::Pops::Adapters::SourcePosAdapter.adapt(semantic)
+        adapter.locator = @lexer.locator
+      else
+        adapter = nil
+      end
+      except.file = @lexer.locator.file
+      except.line = adapter.line if adapter
+      except.pos = adapter.pos if adapter
+    end
     raise except
   end
 

--- a/spec/unit/pops/parser/parser_spec.rb
+++ b/spec/unit/pops/parser/parser_spec.rb
@@ -44,4 +44,22 @@ describe Puppet::Pops::Parser::Parser do
     expect(the_error.line).to eq(1)
     expect(the_error.pos).to eq(6)
   end
+
+  it "should raise an error with position information when error is raised on token" do
+    parser = Puppet::Pops::Parser::Parser.new()
+    the_error = nil
+    begin
+      parser.parse_string(<<-EOF, 'fakefile.pp')
+class whoops($a,$b,$c) {
+  $d = "oh noes",  "b"
+}
+      EOF
+    rescue Puppet::ParseError => e
+      the_error = e
+    end
+    expect(the_error).to be_a(Puppet::ParseError)
+    expect(the_error.file).to eq('fakefile.pp')
+    expect(the_error.line).to eq(2)
+    expect(the_error.pos).to eq(17)
+  end
 end


### PR DESCRIPTION
This commit fixes the error method in the ParserSupport class so that
it correctly reports the position of TokenValue instances such as
COMMA when such tokens are misplaced.