### PR TITLE
(maint) Don't use confine_block to skip tests

### DIFF
--- a/acceptance/tests/resource/file/should_create_symlink.rb
+++ b/acceptance/tests/resource/file/should_create_symlink.rb
@@ -2,10 +2,10 @@ test_name "should create symlink"
 
 message = 'hello world'
 agents.each do |agent|
-  confine_block :to, :platform => 'windows' do
+  if agent.platform.variant == 'windows'
     # symlinks are supported only on Vista+ (version 6.0 and higher)
-    on agents, facter('kernelmajversion') do
-      skip_test "Test not supported on this plaform" if stdout.chomp.to_f < 6.0
+    on agent, facter('kernelmajversion') do
+      skip_test "Test not supported on this platform" if stdout.chomp.to_f < 6.0
     end
   end
 

--- a/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
+++ b/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
@@ -1,10 +1,10 @@
 test_name "#7680: 'links => follow' should use the file source content"
 
 agents.each do |agent|
-  confine_block :to, :platform => 'windows' do
+  if agent.platform.variant == 'windows'
     # symlinks are supported only on Vista+ (version 6.0 and higher)
-    on agents, facter('kernelmajversion') do
-      skip_test "Test not supported on this plaform" if stdout.chomp.to_f < 6.0
+    on agent, facter('kernelmajversion') do
+      skip_test "Test not supported on this platform" if stdout.chomp.to_f < 6.0
     end
   end
 


### PR DESCRIPTION
Previously, we were using beaker's confine_block method to skip symlink
tests on 2003. Prior to beaker 2.24, the test would be skipped on all
platforms due to BKR-505. Beaker 2.24 fixed the issue, which causes the
test to execute correctly on non-2003 platforms, but fails on 2003. That
issue is filed as BKR-535.

This commit changes the acceptance tests to not use `confine_block` to
avoid any beaker incompatibilities.