### PR TITLE
(PUP-5057) Add test for managing puppet and mcollective services

### DIFF
--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -14,6 +14,57 @@ module Puppet
         suitable = on(host, "#{ruby} -e \"require 'puppet'; puts Puppet::Type.type(:service).provider(:systemd).suitable?\"" ).stdout.chomp
         suitable == "true" ? true : false
       end
+
+      # Alter the state of a service using puppet apply.
+      # @param host [String] hostname.
+      # @param service [String] name of the service.
+      # @param property [String] name of the attribute to be changed.
+      # @param value [String] value which the property should be set.
+      # @return None
+      def ensure_service_on_host(host, service, property, value)
+        manifest = %Q{
+          service { '#{service}':
+            #{property} => '#{value}'
+          }
+        }
+        # the process of creating the service will also start it
+        # to avoid a flickering test from the race condition, this test will ensure
+        # that the exit code is either
+        #   2 => something changed, or
+        #   0 => no change needed
+        on host, puppet_apply(['--detailed-exitcodes', '--verbose']),
+          {:stdin => manifest, :acceptable_exit_codes => [0, 2]}
+        # ensure idempotency
+        on host, puppet_apply(['--detailed-exitcodes', '--verbose']),
+          {:stdin => manifest, :acceptable_exit_codes => [0]}
+      end
+
+      # Checks that the status of a service is as expected.
+      # @param host [String] hostname.
+      # @param service [String] name of the service.
+      # @param expected_status [String] expected service status.
+      # @return None
+      def assert_service_status_on_host(host, service, expected_status)
+        on(host, puppet_resource('service', service)) do
+          assert_match(/ensure => '#{expected_status}'/, stdout, "Expected service #{service} to have ensure => #{expected_status}")
+        end
+      end
+
+      # Refreshes a service.
+      # @param host [String] hostname.
+      # @param service [String] name of the service to refresh.
+      # @return None
+      def refresh_service_on_host(host, service)
+        refresh_manifest = %Q{
+          service { '#{service}': }
+
+          notify { 'Refreshing #{service}':
+            notify => Service['#{service}'],
+          }
+        }
+
+        apply_manifest_on(host, refresh_manifest)
+      end
     end
   end
 end

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -2,6 +2,9 @@ test_name 'AIX Service Provider Testing'
 
 confine :to, :platform =>  'aix'
 
+require 'puppet/acceptance/service_utils'
+extend Puppet::Acceptance::ServiceUtils
+
 sloth_daemon_script = <<SCRIPT
 #!/usr/bin/env sh
 while true; do sleep 1; done
@@ -41,24 +44,6 @@ def assert_service_status(host, service, expected_status)
     assert_match(/#{expected_output}\Z/, actual_output,
         "Service is not actually #{expected_status}")
   end
-end
-
-def ensure_service_on_host(host, service, property, value)
-  manifest =<<MANIFEST
-service { '#{service}':
-  #{property} => '#{value}'
-}
-MANIFEST
-  # the process of creating the service will also start it
-  # to avoid a flickering test from the race condition, this test will ensure
-  # that the exit code is either
-  #   2 => something changed, or
-  #   0 => no change needed
-  on host, puppet_apply(['--detailed-exitcodes', '--verbose']),
-    {:stdin => manifest, :acceptable_exit_codes => [0, 2]}
-  # ensure idempotency
-  on host, puppet_apply(['--detailed-exitcodes', '--verbose']),
-    {:stdin => manifest, :acceptable_exit_codes => [0]}
 end
 
 agents.each do |agent|

--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -1,0 +1,66 @@
+test_name "Puppet and Mcollective services should be manageable with Puppet"
+
+confine :except, :platform => 'windows' # See MCO-727
+
+#
+# This test is intended to ensure that the Puppet and Mcollective services can
+# be directly managed by Puppet. See PUP-5053, PUP-5257, and RE-5574 for
+# more context around circumstances that this can fail.
+#
+
+require 'puppet/acceptance/service_utils'
+extend Puppet::Acceptance::ServiceUtils
+
+# Set service status before running other 'ensure' operations on it
+def set_service_initial_status(host, service, status)
+  step "Establishing precondition: #{service}: ensure => #{status}"
+  ensure_service_on_host(host, service, 'ensure', status)
+  assert_service_status_on_host(agent, service, status)
+end
+
+# We want to test Puppet and Mcollective in the following conditions:
+# 1) Starting, stopping and refreshing while the service is initially stopped
+# 2) Starting, stopping and refreshing while the service is initially running
+agents.each do |agent|
+  ['puppet', 'mcollective'].each do |service|
+    ['stopped', 'running'].each do |status|
+      # --- service management using `puppet apply` --- #
+      step "#{service} service management using `puppet apply`"
+      step "Starting the #{service} service while it is #{status}: it should be running"
+      set_service_initial_status(agent, service, status)
+      ensure_service_on_host(agent, service, 'ensure', 'running')
+      assert_service_status_on_host(agent, service, 'running') # Status should always be 'running' after starting
+
+      step "Stopping the #{service} service while it is #{status}: it should be stopped"
+      set_service_initial_status(agent, service, status)
+      ensure_service_on_host(agent, service, 'ensure', 'stopped')
+      assert_service_status_on_host(agent, service, 'stopped') # Status should always be 'stopped' after stopping
+
+      step "Refreshing the #{service} service while it is #{status}: it should be #{status}"
+      set_service_initial_status(agent, service, status)
+      refresh_service_on_host(agent, service)
+
+      # The Solaris service provider currently doesn't wait for the Puppet service to finish
+      # restarting before returning from the run. Remove this check when resolved.
+      if agent.platform.variant =~ /solaris/ && service == 'puppet' && status == 'running'
+        expect_failure('Expected test to fail due to PUP-5262') do
+          assert_service_status_on_host(agent, service, status)
+        end
+      else
+        assert_service_status_on_host(agent, service, status) # Status should not change after refresh
+      end
+
+      # --- service management using `puppet resource` --- #
+      step "#{service} service management using `puppet resource`"
+      step "Starting the #{service} service while it is #{status}: it should be running"
+      set_service_initial_status(agent, service, status)
+      on(agent, puppet_resource('service', service, 'ensure=running'))
+      assert_service_status_on_host(agent, service, 'running') # Status should always be 'running' after starting
+
+      step "Stopping the #{service} service while it is #{status}: it should be stopped"
+      set_service_initial_status(agent, service, status)
+      on(agent, puppet_resource('service', service, 'ensure=stopped'))
+      assert_service_status_on_host(agent, service, 'stopped') # Status should always be 'stopped' after stopping
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a new acceptance test to ensure that the Puppet
and Mcollective services can be started, stopped and refreshed
in a number of scenarios.