### PR TITLE
(maint) Set up logging for lookup application

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -64,12 +64,20 @@ class Puppet::Application::Lookup < Puppet::Application
     end
   end
 
+  def setup
+    # This sets up logging based on --debug or --verbose if they are set in `options`
+    set_log_level
+
+    # This uses console for everything that is not a compilation
+    Puppet::Util::Log.newdestination(:console)
+  end
+
   def main
     keys = command_line.args
     raise 'No keys were given to lookup.' if keys.empty?
 
     unless options[:node]
-      raise "No node was given via the '--node' flag for the scope of the lookup."
+      raise "No node was given via the '--node' flag for the scope of the lookup.\n#{RUN_HELP}"
     end
 
     if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix] || options[:unpack_arrays]) && options[:merge] != 'deep'

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Application::Lookup do
     it "errors if no node was given via the --node flag" do
       lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
 
-      expected_error = "No node was given via the '--node' flag for the scope of the lookup."
+      expected_error = "No node was given via the '--node' flag for the scope of the lookup.\nRun 'puppet lookup --help' for more details"
 
       expect{ lookup.run_command }.to raise_error(RuntimeError, expected_error)
     end


### PR DESCRIPTION
Prior to this commit, logging was not being registered for the
lookup application which meant that errors would not appear on
standard out. Add a setup method which will register logging so
errors appear accordingly.