### PR TITLE
(PUP-4890) Add code_id to the catalog

### DIFF
--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -58,6 +58,7 @@ escaping is still used/supported.
       ],
       "name": "elmo.mydomain.com",
       "version": 1377473054,
+      "code_id": null,
       "environment": "production",
       "resources": [
         {

--- a/api/schemas/catalog.json
+++ b/api/schemas/catalog.json
@@ -18,6 +18,9 @@
         "version": {
             "type": "integer"
         },
+        "code_id": {
+            "type": ["string", "null"]
+        },
         "environment": {
             "type": "string"
         },
@@ -90,6 +93,6 @@
             }
         }
     },
-    "required": ["tags", "name", "version", "environment", "resources", "edges", "classes"],
+    "required": ["tags", "name", "version", "code_id", "environment", "resources", "edges", "classes"],
     "additionalProperties": false
 }

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -48,6 +48,9 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     node.trusted_data = Puppet.lookup(:trusted_information) { Puppet::Context::TrustedInformation.local(node) }.to_h
 
     if catalog = compile(node)
+      if code_id = request.options[:code_id]
+        catalog.code_id = code_id
+      end
       return catalog
     else
       # This shouldn't actually happen; we should either return

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -29,6 +29,9 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
   # is up to date.
   attr_accessor :version
 
+  # The id of the code input to the compiler.
+  attr_accessor :code_id
+
   # How long this catalog took to retrieve.  Used for reporting stats.
   attr_accessor :retrieval_duration
 
@@ -351,6 +354,10 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       result.version = version
     end
 
+    if code_id = data['code_id']
+      result.code_id = code_id
+    end
+
     if environment = data['environment']
       result.environment = environment
       result.environment_instance = Puppet::Node::Environment.remote(environment.to_sym)
@@ -391,6 +398,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       'tags'      => tags,
       'name'      => name,
       'version'   => version,
+      'code_id'   => code_id,
       'environment' => environment.to_s,
       'resources' => @resources.collect { |v| @resource_table[v].to_data_hash },
       'edges'     => edges.   collect { |e| e.to_data_hash },

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -119,11 +119,19 @@ describe Puppet::Resource::Catalog::Compiler do
 
     it "should return the results of compiling as the catalog" do
       Puppet::Node.indirection.stubs(:find).returns(@node)
-      config = mock 'config'
-      result = mock 'result'
+      catalog = Puppet::Resource::Catalog.new(@node.name)
+      Puppet::Parser::Compiler.stubs(:compile).returns catalog
 
-      Puppet::Parser::Compiler.expects(:compile).returns result
-      expect(@compiler.find(@request)).to equal(result)
+      expect(@compiler.find(@request)).to equal(catalog)
+    end
+
+    it "returns a catalog with a code_id from the request" do
+      Puppet::Node.indirection.stubs(:find).returns(@node)
+      catalog = Puppet::Resource::Catalog.new(@node.name)
+      Puppet::Parser::Compiler.stubs(:compile).returns catalog
+      @request.options[:code_id] = 'b59e5df0578ef411f773ee6c33d8073c50e7b8fe'
+
+      expect(@compiler.find(@request).code_id).to eq('b59e5df0578ef411f773ee6c33d8073c50e7b8fe')
     end
   end
 

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -86,6 +86,11 @@ describe Puppet::Resource::Catalog, "when compiling" do
     expect(@catalog.server_version).to eq(5)
   end
 
+  it "defaults code_id to nil" do
+    catalog = Puppet::Resource::Catalog.new("host")
+    expect(catalog.code_id).to be_nil
+  end
+
   describe "when compiling" do
     it "should accept tags" do
       config = Puppet::Resource::Catalog.new("mynode")
@@ -782,17 +787,23 @@ describe Puppet::Resource::Catalog, "when converting to pson" do
     @catalog = Puppet::Resource::Catalog.new("myhost")
   end
 
-  def pson_output_should
-    @catalog.class.expects(:from_data_hash).with { |hash| yield hash }.returns(:something)
+  { :name => 'myhost',
+    :version => 42,
+    :code_id => 'b59e5df0578ef411f773ee6c33d8073c50e7b8fe'
+  }.each do |param, value|
+    it "emits a #{param} equal to #{value.inspect}" do
+      @catalog.send(param.to_s + "=", value)
+      pson = PSON.parse(@catalog.to_pson)
+
+      expect(pson[param.to_s]).to eq(@catalog.send(param))
+    end
   end
 
-  [:name, :version, :classes].each do |param|
-    it "should set its #{param} to the #{param} of the resource" do
-      @catalog.send(param.to_s + "=", "testing") unless @catalog.send(param)
+  it "emits an array of classes" do
+    @catalog.add_class('foo')
+    pson = PSON.parse(@catalog.to_pson)
 
-      pson_output_should { |hash| expect(hash[param.to_s]).to eq(@catalog.send(param)) }
-      Puppet::Resource::Catalog.from_data_hash PSON.parse @catalog.to_pson
-    end
+    expect(pson['classes']).to eq(['foo'])
   end
 
   it "should convert its resources to a PSON-encoded array and store it as the 'resources' data" do
@@ -831,6 +842,7 @@ describe Puppet::Resource::Catalog, "when converting from pson" do
 
   it "should create it with the provided name" do
     @data['version'] = 50
+    @data['code_id'] = 'b59e5df0578ef411f773ee6c33d8073c50e7b8fe'
     @data['tags'] = %w{one two}
     @data['classes'] = %w{one two}
     @data['edges'] = [Puppet::Relationship.new("File[/foo]", "File[/bar]",
@@ -844,6 +856,7 @@ describe Puppet::Resource::Catalog, "when converting from pson" do
 
     expect(catalog.name).to eq('myhost')
     expect(catalog.version).to eq(@data['version'])
+    expect(catalog.code_id).to eq(@data['code_id'])
     expect(catalog).to be_tagged("one")
     expect(catalog).to be_tagged("two")
 


### PR DESCRIPTION
Adds a code_id accessor to the catalog, updates the api docs, schema, and tests.

Updates the compiler terminus' find method to add the code_id from the request to the catalog it returns.  