### PR TITLE
(PUP-4932) Deprecate --cfacter option

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -21,7 +21,8 @@ module Puppet
         :default => false,
         :type    => :boolean,
         :desc    => 'Whether to enable a pre-Facter 3.0 release of native Facter (distributed as
-          the "cfacter" package). This is not necessary if Facter 3.0 or later is installed.',
+          the "cfacter" package). This is not necessary if Facter 3.0 or later is installed.
+          This setting is deprecated, as Facter 3 is now the default in puppet-agent.',
         :hook    => proc do |value|
           return unless value
           raise ArgumentError, 'facter has already evaluated facts.' if Facter.instance_variable_get(:@collection)

--- a/lib/puppet/feature/cfacter.rb
+++ b/lib/puppet/feature/cfacter.rb
@@ -2,6 +2,7 @@ require 'facter'
 require 'puppet/util/feature'
 
 Puppet.features.add :cfacter do
+  Puppet.deprecation_warning("The cfacter setting is deprecated. You can use Facter 3 and higher without this setting.")
   begin
     require 'cfacter'
 


### PR DESCRIPTION
This commit deprecates the --cfacter setting, as it is no longer
needed with native Facter being shipped in AIO by default.