### PR TITLE
Revert "(maint) Optimize adding tags"

### DIFF
--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -136,7 +136,7 @@ describe Puppet::Util::Tagging do
     end
 
     it "protects against empty tags" do
-      expect { tagger.tags = "one,,two"}.to raise_error(/Invalid tag ''/)
+      expect { tagger.tags = "one,,two"}.to raise_error(/Invalid tag ""/)
     end
 
     it "takes an array of tags" do


### PR DESCRIPTION
This reverts commit 0412515e2f9d75f00687bc5c01915da5a51c58e3.

This change to tag filtering meant that a single tag like foo::bar
would be split on the :: seperator and expaned into:
['foo::bar', 'foo', 'bar']. This meant that an agent would sync more
resources than the used intended when tag filtering is in effect.

In order to fix this problem, revert the commit that initially made
this change to filtering behavior.