### PR TITLE
(PUP-5058) Update ssh_known_hosts file path for OSX 10.11

### DIFF
--- a/spec/unit/provider/sshkey/parsed_spec.rb
+++ b/spec/unit/provider/sshkey/parsed_spec.rb
@@ -68,4 +68,27 @@ describe "sshkey parsed provider" do
       end
     end
   end
+
+  context 'default ssh_known_hosts target path' do
+    ['9.10', '9.11', '10.10'].each do |version|
+      it 'should be `/etc/ssh_known_hosts` when OSX version 10.10 or older`' do
+        Facter.expects(:value).with(:operatingsystem).returns('Darwin')
+        Facter.expects(:value).with(:macosx_productversion_major).returns(version)
+        expect(subject.default_target).to eq('/etc/ssh_known_hosts')
+      end
+    end
+
+    ['10.11', '10.13', '11.0', '11.11'].each do |version|
+      it 'should be `/etc/ssh/ssh_known_hosts` when OSX version 10.11 or newer`' do
+        Facter.expects(:value).with(:operatingsystem).returns('Darwin')
+        Facter.expects(:value).with(:macosx_productversion_major).returns(version)
+        expect(subject.default_target).to eq('/etc/ssh/ssh_known_hosts')
+      end
+    end
+
+    it 'should be `/etc/ssh/ssh_known_hosts` on other operating systems' do
+      Facter.expects(:value).with(:operatingsystem).returns('RedHat')
+      expect(subject.default_target).to eq('/etc/ssh/ssh_known_hosts')
+    end
+  end
 end


### PR DESCRIPTION
Beginning with El Capitan (OSX 10.11), the new location for SSH
configuration files is `/etc/ssh`, rather than at the top level
in `/etc`. This commit updates the sshkey provider to store
our generated `ssh_known_hosts` file in the new location for
OSX 10.11 and above.