### PR TITLE
(PUP-5080) Check parameters consumed from capabilities are unique

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -222,6 +222,11 @@ class Puppet::Resource::Type
 
   def add_consumes(blueprint)
     @consumes ||= []
+    mappings = blueprint[:mappings]
+    @consumes.each do |bp|
+      dup = bp[:mappings].keys.find {|p| mappings.include?(p) }
+      fail "'#{name}' consumes '#{dup}' from both '#{bp[:capability]}' and  '#{blueprint[:capability]}'" unless dup.nil?
+    end
     @consumes << blueprint
   end
 

--- a/spec/unit/capability_spec.rb
+++ b/spec/unit/capability_spec.rb
@@ -177,6 +177,23 @@ describe "Capability types" do
                          /#{kw} clause references nonexistent type Test/)
       end
     end
+
+    it 'raises an exception if the same parameter is consumed from more than one capability' do
+      expect do compile_to_catalog(<<-MANIFEST)
+      define test($hostname = nohost) {
+        notify { "hostname ${hostname}":}
+      }
+
+      Test consumes Cap {
+        hostname => $host
+      }
+
+      Test consumes Conflict_cap {
+        hostname => $host
+      }
+      MANIFEST
+      end.to raise_error(Puppet::Error, /'test' consumes 'hostname' from both 'Cap' and  'Conflict_cap'/)
+    end
   end
 
   describe "exporting a capability" do


### PR DESCRIPTION
This commit adds the validation necessary to raise an error when more
than one consumed capability mapping tries to map the same parameter.