### PR TITLE
(PUP-5278) Fix unhelpful reference in lookup explain output

### DIFF
--- a/lib/puppet/plugins/data_providers/data_provider.rb
+++ b/lib/puppet/plugins/data_providers/data_provider.rb
@@ -211,6 +211,7 @@ module Puppet::Plugins::DataProviders
               end
             end
           end
+          throw :no_such_key if merged_result.equal?(Puppet::Pops::MergeStrategy::NOT_FOUND)
           lookup_invocation.report_result(merged_result)
         end
       end

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/data/first.json
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/data/first.json
@@ -1,0 +1,3 @@
+{
+    "hieraprovider::test::param_a": "module data param_a is 100"
+}

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/hiera.yaml
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "two paths"
+    :backend: json
+    :paths:
+      - "first"
+      - "second_not_present"

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/manifests/init.pp
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/manifests/init.pp
@@ -1,0 +1,5 @@
+class hieraprovider {
+  class test($param_a = "param default is 100") {
+    notify { "$param_a": }
+  }
+}

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/metadata.json
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "example/hieraprovider",
+    "version": "0.0.2",
+    "source": "git@github.com/example/example-hieraprovider.git",
+    "dependencies": [],
+    "author": "Bob the Builder",
+    "license": "Apache-2.0",
+    "data_provider": "hiera"
+}


### PR DESCRIPTION
When a merge of hiera paths resulted in a not found, the singleton
object representing 'not found' was printed in the explanation. This
commit removes that printout since merging sources where nothing is
found doesn't yield a merged result.