### PR TITLE
(PUP-4495) Fix tag filtering regression

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -350,11 +350,8 @@ class Puppet::Transaction
     resource.appliable_to_host? && resource.appliable_to_device?
   end
 
-  def handle_qualified_tags( qualified )
-    # The default behavior of Puppet::Util::Tagging is
-    # to split qualified tags into parts. That would cause
-    # qualified tags to match too broadly here.
-    return
+  def split_qualified_tags?
+    false
   end
 
   # Is this resource tagged appropriately?
@@ -364,6 +361,7 @@ class Puppet::Transaction
 
     not resource.tagged?(*tags)
   end
+
 end
 
 require 'puppet/transaction/report'

--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -14,8 +14,10 @@ module Puppet::Util::Tagging
       name = tag.to_s.downcase
       if name =~ ValidTagRegex
         @tags << name
-        name.split("::").each do |section|
-          @tags << section
+        if split_qualified_tags?
+          name.split("::").each do |section|
+            @tags << section
+          end
         end
       else
         fail(Puppet::ParseError, "Invalid tag '#{name}'")
@@ -67,6 +69,10 @@ module Puppet::Util::Tagging
 
   def valid_tag?(tag)
     tag.is_a?(String) and tag =~ ValidTagRegex
+  end
+
+  def split_qualified_tags?
+    true
   end
 
   def new_tags

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -707,6 +707,13 @@ describe Puppet::Transaction, " when determining tags" do
     @transaction.should be_tagged("one::two")
   end
 
+  it "should tag one::two only as 'one::two' and not 'one', 'two', and 'one::two'" do
+    @transaction.tags = "one::two"
+    @transaction.should be_tagged("one::two")
+    @transaction.should_not be_tagged("one")
+    @transaction.should_not be_tagged("two")
+  end
+
   it "should accept a comma-delimited string" do
     @transaction.tags = "one, two"
     @transaction.should be_tagged("one")


### PR DESCRIPTION
Prior to this commit a change made to the way tags are split when
filtering was causing the agent to create more resources than
nessecary.

Update the way a tag is recoreded when filtering to fix this issue.