### PR TITLE
(PUP-4890) Thread code_id into compiler

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -47,10 +47,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     node = node_from_request(request)
     node.trusted_data = Puppet.lookup(:trusted_information) { Puppet::Context::TrustedInformation.local(node) }.to_h
 
-    if catalog = compile(node)
-      if code_id = request.options[:code_id]
-        catalog.code_id = code_id
-      end
+    if catalog = compile(node, request.options[:code_id])
       return catalog
     else
       # This shouldn't actually happen; we should either return
@@ -85,7 +82,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   end
 
   # Compile the actual catalog.
-  def compile(node)
+  def compile(node, code_id)
     str = "Compiled catalog for #{node.name}"
     str += " in environment #{node.environment}" if node.environment
     config = nil
@@ -93,7 +90,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     benchmark(:notice, str) do
       Puppet::Util::Profiler.profile(str, [:compiler, :compile, node.environment, node.name]) do
         begin
-          config = Puppet::Parser::Compiler.compile(node)
+          config = Puppet::Parser::Compiler.compile(node, code_id)
         rescue Puppet::Error => detail
           Puppet.err(detail.to_s) if networked?
           raise

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -19,7 +19,7 @@ class Puppet::Parser::Compiler
   include Puppet::Resource::TypeCollectionHelper
   include Puppet::Pops::Evaluator::Runtime3Support
 
-  def self.compile(node)
+  def self.compile(node, code_id = nil)
     $env_module_directories = nil
     node.environment.check_for_reparse
 
@@ -33,7 +33,7 @@ class Puppet::Parser::Compiler
       raise(Puppet::Error, errmsg.join(' '))
     end
 
-    new(node).compile {|resulting_catalog| resulting_catalog.to_resource }
+    new(node, :code_id => code_id).compile {|resulting_catalog| resulting_catalog.to_resource }
   rescue Puppet::ParseErrorWithIssue => detail
     detail.node = node.name
     Puppet.log_exception(detail)
@@ -66,6 +66,10 @@ class Puppet::Parser::Compiler
   # @api private
   #
   attr_accessor :boot_injector
+
+  # The id of code input to the compiler.
+  # @api private
+  attr_accessor :code_id
 
   # Add a collection to the global list.
   def_delegator :@collections,   :<<, :add_collection
@@ -605,7 +609,7 @@ class Puppet::Parser::Compiler
     @relationships = []
 
     # For maintaining the relationship between scopes and their resources.
-    @catalog = Puppet::Resource::Catalog.new(@node.name, @node.environment)
+    @catalog = Puppet::Resource::Catalog.new(@node.name, @node.environment, @code_id)
 
     # MOVED HERE - SCOPE IS NEEDED (MOVE-SCOPE)
     # Create the initial scope, it is needed early

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -250,7 +250,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     host_config
   end
 
-  def initialize(name = nil, environment = Puppet::Node::Environment::NONE)
+  def initialize(name = nil, environment = Puppet::Node::Environment::NONE, code_id = nil)
     super()
     @name = name
     @classes = []
@@ -261,6 +261,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     @host_config = true
     @environment_instance = environment
     @environment = environment.to_s
+    @code_id = code_id
 
     @aliases = {}
 
@@ -514,6 +515,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     result = self.class.new(self.name, self.environment_instance)
 
     result.version = self.version
+    result.code_id = self.code_id
 
     map = {}
     resources.each do |resource|

--- a/spec/integration/resource/catalog_spec.rb
+++ b/spec/integration/resource/catalog_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Resource::Catalog do
       node.stub_everything
 
       Puppet::Node.indirection.expects(:find).returns(node)
-      compiler.expects(:compile).with(node).returns nil
+      compiler.expects(:compile).with(node, anything).returns nil
 
       expect(Puppet::Resource::Catalog.indirection.find("me")).to be_nil
     end

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -145,6 +145,14 @@ describe Puppet::Parser::Compiler do
       expect(compiler.classlist).to match_array(['foo', 'bar'])
     end
 
+    it "should return a catalog with the specified code_id" do
+      node = Puppet::Node.new("mynode")
+      code_id = 'b59e5df0578ef411f773ee6c33d8073c50e7b8fe'
+      compiler = Puppet::Parser::Compiler.new(node, :code_id => code_id)
+
+      expect(compiler.catalog.code_id).to eq(code_id)
+    end
+
     it "should add a 'main' stage to the catalog" do
       expect(@compiler.catalog.resource(:stage, :main)).to be_instance_of(Puppet::Parser::Resource)
     end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -258,6 +258,16 @@ describe Puppet::Resource::Catalog, "when compiling" do
         r == @r1
       end.edge?(@r1,@r2)).not_to be
     end
+
+    it "copies the version" do
+      @original.version = '123'
+      expect(@original.filter.version).to eq(@original.version)
+    end
+
+    it 'copies the code_id' do
+      @original.code_id = 'b59e5df0578ef411f773ee6c33d8073c50e7b8fe'
+      expect(@original.filter.code_id).to eq(@original.code_id)
+    end
   end
 
   describe "when functioning as a resource container" do


### PR DESCRIPTION
Commit e14f2bc modified the catalog's compiler terminus to copy the
code_id from the request to the catalog that it returned. However, this
isn't sufficient as the code_id needs to be set on the catalog and
available during compilation.

This commit modifies the catalog's compiler terminus to pass the code_id
from the request to the compiler (Puppet::Parser::Compiler), which sets
it on the catalog it creates and returns.

Note the compiler terminus calls `catalog.filter` to remove exported
resources, making a copy of the catalog in the process, and is why the
catalog's `convert` method needs to copy the code_id.