### PR TITLE
Fix latest version lookup for pip configured with custom repo

### DIFF
--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -118,12 +118,6 @@ describe provider_class do
       expect(@provider.latest).to eq(nil)
     end
 
-    it "should handle a timeout gracefully" do
-      @resource[:name] = "fake_package"
-      @client.stubs(:call).raises(Timeout::Error)
-      expect { @provider.latest }.to raise_error(Puppet::Error)
-    end
-
   end
 
   describe "install" do

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -129,12 +129,6 @@ describe provider_class do
       expect(@provider.latest).to eq(nil)
     end
 
-    it "should handle a timeout gracefully" do
-      @resource[:name] = "fake_package"
-      @client.stubs(:call).raises(Timeout::Error)
-      expect { @provider.latest }.to raise_error(Puppet::Error)
-    end
-
   end
 
   describe "install" do


### PR DESCRIPTION
The current implementation has pypi.python.org hardcoded. With newer pip versions, it supports having a /etc/pip.conf file specifying a different location. Existing behavior results in `pip install` running on every single Puppet run, if used to install a package available in a custom repo, but not on pypi.python.org

The implementation is the least hackish way to have Pip return a list of versions