### PR TITLE
(PUP-5282) Use absolute_path to detect local installation of gem on windows

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -111,8 +111,13 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
         # we don't support puppet:// URLs (yet)
         raise Puppet::Error.new("puppet:// URLs are not supported as gem sources")
       else
-        # interpret it as a gem repository
-        command << "--source" << "#{source}" << resource[:name]
+        # check whether it's an absolute file path to help Windows out
+        if Puppet::Util.absolute_path?(source)
+          command << source
+        else
+          # interpret it as a gem repository
+          command << "--source" << "#{source}" << resource[:name]
+        end
       end
     else
       command << "--no-rdoc" << "--no-ri" << resource[:name]

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -88,6 +88,13 @@ context 'installing myresource' do
             provider.install
           end
         end
+        describe "as a windows path on windows", :if => Puppet.features.microsoft_windows? do
+          it "should treat the source as a local path" do
+            resource[:source] = "c:/this/is/a/path/to/a/gem.gem"
+            provider.expects(:execute).with { |args| args[2] == "c:/this/is/a/path/to/a/gem.gem" }.returns ""
+            provider.install
+          end
+        end
         describe "with an invalid uri" do
           it "should fail" do
             URI.expects(:parse).raises(ArgumentError)


### PR DESCRIPTION
Attempting to install a gem from a local source on windows fails because of the way
that the provider code detects using URI.  This patch preserves the current behaviour
but allows the a puppet util method to detect a fully qualified path to pass to the gem
command, which allows install