### PR TITLE
(PUP-4960) Fix so that ruby modules are considered PRuntimeType

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -195,7 +195,7 @@ class Puppet::Pops::Types::TypeCalculator
   # @api public
   #
   def assignable?(t, t2)
-    if t.is_a?(Class)
+    if t.is_a?(Module)
       t = type(t)
     end
     t.is_a?(Types::PAnyType) ? t.assignable?(t2) : false
@@ -223,11 +223,11 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   # Answers 'what is the Puppet Type corresponding to the given Ruby class'
-  # @param c [Class] the class for which a puppet type is wanted
+  # @param c [Module] the class for which a puppet type is wanted
   # @api public
   #
   def type(c)
-    raise ArgumentError, 'Argument must be a Class' unless c.is_a? Class
+    raise ArgumentError, 'Argument must be a Module' unless c.is_a? Module
 
     # Can't use a visitor here since we don't have an instance of the class
     case
@@ -316,7 +316,7 @@ class Puppet::Pops::Types::TypeCalculator
   # @api public
   #
   def instance?(t, o)
-    if t.is_a?(Class)
+    if t.is_a?(Module)
       t = type(t)
     end
     t.is_a?(Types::PAnyType) ? t.instance?(o) : false
@@ -489,7 +489,7 @@ class Puppet::Pops::Types::TypeCalculator
   # @api public
   #
   def string(t)
-    if t.is_a?(Class)
+    if t.is_a?(Module)
       t = type(t)
     end
     @@string_visitor.visit_this_0(self, t)
@@ -499,7 +499,7 @@ class Puppet::Pops::Types::TypeCalculator
   # @api public
   #
   def debug_string(t)
-    if t.is_a?(Class)
+    if t.is_a?(Module)
       t = type(t)
     end
     @@inspect_visitor.visit_this_0(self, t)
@@ -520,11 +520,11 @@ class Puppet::Pops::Types::TypeCalculator
     reduce_type(enumerable.map {|o| infer(o) })
   end
 
-  # The type of all classes is PType
+  # The type of all modules is PType
   # @api private
   #
-  def infer_Class(o)
-    Types::PType::DEFAULT
+  def infer_Module(o)
+    Types::PType::new(Types::PRuntimeType.new(:ruby, o.name))
   end
 
   # @api private

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1414,7 +1414,7 @@ module Puppet::Pops
         # NOTE: This only supports Ruby, must change when/if the set of runtimes is expanded
         c1 = class_from_string(@runtime_type_name)
         c2 = class_from_string(o.runtime_type_name)
-        return false unless c1.is_a?(Class) && c2.is_a?(Class)
+        return false unless c1.is_a?(Module) && c2.is_a?(Module)
         !!(c2 <= c1)
       end
     end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -248,6 +248,30 @@ describe 'The type calculator' do
       expect(t.runtime_type_name).to eq('Foo')
     end
 
+    it 'Class Foo translates to PType[PRuntimeType[ruby, Foo]]' do
+      class Foo
+      end
+
+      t = calculator.infer(Foo)
+      expect(t.class).to eq(Puppet::Pops::Types::PType)
+      tt = t.type
+      expect(tt.class).to eq(Puppet::Pops::Types::PRuntimeType)
+      expect(tt.runtime).to eq(:ruby)
+      expect(tt.runtime_type_name).to eq('Foo')
+    end
+
+    it 'Module FooModule translates to PType[PRuntimeType[ruby, FooModule]]' do
+      module FooModule
+      end
+
+      t = calculator.infer(FooModule)
+      expect(t.class).to eq(Puppet::Pops::Types::PType)
+      tt = t.type
+      expect(tt.class).to eq(Puppet::Pops::Types::PRuntimeType)
+      expect(tt.runtime).to eq(:ruby)
+      expect(tt.runtime_type_name).to eq('FooModule')
+    end
+
     context 'array' do
       it 'translates to PArrayType' do
         expect(calculator.infer([1,2]).class).to eq(Puppet::Pops::Types::PArrayType)


### PR DESCRIPTION
This commit changes code in the `TypeCalculator` and the `PRuntimeType`
so that they test for ruby Module instead of ruby Class. It also
changes so that an inferred Module (or Class) becomes the PType for
the PRubyType that corresponds to the Module/Class instead of just the
default PType.