### PR TITLE
(MAINT) Fix bug in hiera-in-templates test

### DIFF
--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -2,7 +2,7 @@ test_name "Calling Hiera function from inside templates"
 
 @module_name = "hieratest"
 @coderoot = master.tmpdir("#{@module_name}")
-@resultdir = agent.tmpdir("#{@module_name}_results")
+@resultdir = agents.first.tmpdir("#{@module_name}_results")
 
 @msg_default = 'message from default.yaml'
 @msg_production = 'message from production.yaml'


### PR DESCRIPTION
This test was written assuming that there would always be
exactly one agent SUT.  It threw an error when run in a
configuration that had multiple agent SUTs (such as Puppet Server);
this commit changes the code so that the test won't *definitely*
fail, but a better fix would probably mandate that the whole
test be restructured to support the ability to have a unique
tempdir per agent node.