### PR TITLE
PUP-5289 adding interface mode auto, encapsulation negotiate to puppet device

### DIFF
--- a/lib/puppet/type/interface.rb
+++ b/lib/puppet/type/interface.rb
@@ -45,19 +45,24 @@ Puppet::Type.newtype(:interface) do
       newvalues(:auto, :full, :half)
     end
 
+    newproperty(:access_vlan) do
+      desc "Interface static access vlan."
+      newvalues(/^\d+/)
+    end
+
     newproperty(:native_vlan) do
-      desc "Interface native vlan (for access mode only)."
+      desc "Interface native vlan when trunking."
       newvalues(/^\d+/)
     end
 
     newproperty(:encapsulation) do
       desc "Interface switchport encapsulation."
-      newvalues(:none, :dot1q, :isl )
+      newvalues(:none, :dot1q, :isl, :negotiate)
     end
 
     newproperty(:mode) do
       desc "Interface switchport mode."
-      newvalues(:access, :trunk)
+      newvalues(:access, :trunk, 'dynamic auto', 'dynamic desirable')
     end
 
     newproperty(:allowed_trunk_vlans) do

--- a/lib/puppet/util/network_device/cisco/device.rb
+++ b/lib/puppet/util/network_device/cisco/device.rb
@@ -234,20 +234,28 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
           trunking[:mode] = :trunk
         when "static access"
           trunking[:mode] = :access
+        when "dynamic auto"
+          trunking[:mode] = 'dynamic auto'
+        when "dynamic desirable"
+          trunking[:mode] = 'dynamic desirable'
         else
           raise "Unknown switchport mode: #{$1} for #{interface}"
         end
       when /^Administrative Trunking Encapsulation:\s+(.*)$/
         case $1
         when "dot1q","isl"
-          trunking[:encapsulation] = $1.to_sym if trunking[:mode] == :trunk
+          trunking[:encapsulation] = $1.to_sym if trunking[:mode] != :access
+        when "negotiate"
+          trunking[:encapsulation] = :negotiate
         else
           raise "Unknown switchport encapsulation: #{$1} for #{interface}"
         end
       when /^Access Mode VLAN:\s+(.*) \(\(Inactive\)\)$/
         # nothing
       when /^Access Mode VLAN:\s+(.*) \(.*\)$/
-        trunking[:native_vlan] = $1 if trunking[:mode] == :access
+        trunking[:access_vlan] = $1 if trunking[:mode] != :trunk
+      when /^Trunking Native Mode VLAN:\s+(.*) \(.*\)$/
+        trunking[:native_vlan] = $1 if trunking[:mode] != :access
       when /^Trunking VLANs Enabled:\s+(.*)$/
         next if trunking[:mode] == :access
         vlans = $1

--- a/lib/puppet/util/network_device/cisco/interface.rb
+++ b/lib/puppet/util/network_device/cisco/interface.rb
@@ -19,17 +19,18 @@ class Puppet::Util::NetworkDevice::Cisco::Interface
     :description   => [1, "description %s"],
     :speed         => [2, "speed %s"],
     :duplex        => [3, "duplex %s"],
-    :native_vlan   => [4, "switchport access vlan %s"],
-    :encapsulation => [5, "switchport trunk encapsulation %s"],
-    :mode          => [6, "switchport mode %s"],
-    :allowed_trunk_vlans => [7, "switchport trunk allowed vlan %s"],
-    :etherchannel  => [8, ["channel-group %s", "port group %s"]],
-    :ipaddress     => [9,
+    :encapsulation => [4, "switchport trunk encapsulation %s"],
+    :mode          => [5, "switchport mode %s"],
+    :access_vlan   => [6, "switchport access vlan %s"],
+    :native_vlan   => [7, "switchport trunk native vlan %s"],
+    :allowed_trunk_vlans => [8, "switchport trunk allowed vlan %s"],
+    :etherchannel  => [9, ["channel-group %s", "port group %s"]],
+    :ipaddress     => [10,
       lambda do |prefix,ip,option|
         ip.ipv6? ? "ipv6 address #{ip.to_s}/#{prefix} #{option}" :
                    "ip address #{ip.to_s} #{netmask(Socket::AF_INET,prefix)}"
       end],
-      :ensure        => [10, lambda { |value| value == :present ? "no shutdown" : "shutdown" } ]
+    :ensure        => [11, lambda { |value| value == :present ? "no shutdown" : "shutdown" } ]
   }
 
   def update(is={}, should={})
@@ -37,8 +38,20 @@ class Puppet::Util::NetworkDevice::Cisco::Interface
     command("conf t")
     command("interface #{name}")
 
-    # apply changes in a defined orders for cisco IOS devices
+    # apply changes in a defined order for cisco IOS devices
     [is.keys, should.keys].flatten.uniq.sort {|a,b| COMMANDS[a][0] <=> COMMANDS[b][0] }.each do |property|
+      # Work around for old documentation which shows :native_vlan used for access vlan
+      if property == :access_vlan and should[:mode] != :trunk and should[:access_vlan].nil?
+        should[:access_vlan] = should[:native_vlan]
+      end
+
+      # Don't change non-operational mode parameters
+      next if property == :access_vlan and should[:mode] == :trunk
+      next if property == :native_vlan and should[:mode] == :access
+      next if property == :encapsulation and should[:mode] == :access
+
+      Puppet.debug("comparing #{property}: #{is[property]} == #{should[property]}")
+
       # They're equal, so do nothing.
       next if is[property] == should[property]
 

--- a/spec/unit/type/interface_spec.rb
+++ b/spec/unit/type/interface_spec.rb
@@ -67,6 +67,38 @@ describe Puppet::Type.type(:interface) do
       end
     end
 
+    describe "interface mode" do
+      it "should allow :access" do
+        Puppet::Type.type(:interface).new(:name => "FastEthernet 0/1", :mode => :access)
+      end
+
+      it "should allow :trunk" do
+        Puppet::Type.type(:interface).new(:name => "FastEthernet 0/1", :mode => :trunk)
+      end
+
+      it "should allow 'dynamic auto'" do
+        Puppet::Type.type(:interface).new(:name => "FastEthernet 0/1", :mode => 'dynamic auto')
+      end
+
+      it "should allow 'dynamic desirable'" do
+        Puppet::Type.type(:interface).new(:name => "FastEthernet 0/1", :mode => 'dynamic desirable')
+      end
+    end
+
+    describe "interface encapsulation" do
+      it "should allow :dot1q" do
+        Puppet::Type.type(:interface).new(:name => "FastEthernet 0/1", :encapsulation => :dot1q)
+      end
+
+      it "should allow :isl" do
+        Puppet::Type.type(:interface).new(:name => "FastEthernet 0/1", :encapsulation => :isl)
+      end
+
+      it "should allow :negotiate" do
+        Puppet::Type.type(:interface).new(:name => "FastEthernet 0/1", :encapsulation => :negotiate)
+      end
+    end
+
     describe "especially ipaddress" do
       it "should allow ipv4 addresses" do
         Puppet::Type.type(:interface).new(:name => "FastEthernet 0/1", :ipaddress => "192.168.0.1/24")


### PR DESCRIPTION
This patch adds full support for interface mode auth, and encapsulation negotiate to the cisco device. It also adds new tests for mode and encapsulation to the interface resource which didn't exist before.