### PR TITLE
(PUP-5290) Log exceptions raised by saving to cache

### DIFF
--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -196,7 +196,12 @@ class Puppet::Indirector::Indirection
         result.expiration ||= self.expiration if result.respond_to?(:expiration)
         if cache?
           Puppet.info "Caching #{self.name} for #{request.key}"
-          cache.save request(:save, key, result, options)
+          begin
+            cache.save request(:save, key, result, options)
+          rescue => detail
+            Puppet.log_exception(detail)
+            raise detail
+          end
         end
 
         filtered = result

--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -393,6 +393,17 @@ describe Puppet::Indirector::Indirection do
 
           @indirection.find("/my/key")
         end
+
+        it "should fail if saving to the cache fails but log the exception" do
+          @cache.stubs(:find).returns nil
+
+          @terminus.stubs(:find).returns(@instance)
+          @cache.stubs(:save).raises RuntimeError
+
+          Puppet.expects(:log_exception)
+
+          expect { @indirection.find("/my/key") }.to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
Failing to cache requests could lead to silent exits. For example if the
apply application failed to cache to PuppetDB catalog terminus. This
will log the exception and continue.