### PR TITLE
PUP-5291 fix "stream closed" problem with SSH transport

### DIFF
--- a/lib/puppet/util/network_device/transport/ssh.rb
+++ b/lib/puppet/util/network_device/transport/ssh.rb
@@ -73,6 +73,7 @@ class Puppet::Util::NetworkDevice::Transport::Ssh < Puppet::Util::NetworkDevice:
       @channel = nil
       @ssh.close if @ssh
     rescue IOError
+      Puppet.debug "device terminated ssh session impolitely"
     end
   end
 

--- a/lib/puppet/util/network_device/transport/ssh.rb
+++ b/lib/puppet/util/network_device/transport/ssh.rb
@@ -68,9 +68,12 @@ class Puppet::Util::NetworkDevice::Transport::Ssh < Puppet::Util::NetworkDevice:
   end
 
   def close
-    @channel.close if @channel
-    @channel = nil
-    @ssh.close if @ssh
+    begin
+      @channel.close if @channel
+      @channel = nil
+      @ssh.close if @ssh
+    rescue IOError
+    end
   end
 
   def expect(prompt)


### PR DESCRIPTION
PUP-5291 fix "stream closed" problem with SSH transport closing the session with the IO handles still open