### PR TITLE
(PUP-4055) Add DNF package provider

### DIFF
--- a/acceptance/lib/puppet/acceptance/rpm_util.rb
+++ b/acceptance/lib/puppet/acceptance/rpm_util.rb
@@ -4,19 +4,31 @@ module Puppet
       # Utilities for creating a basic rpm package and using it in tests
       @@defaults = {:repo => '/tmp/rpmrepo', :pkg => 'mypkg', :publisher => 'tstpub.lan', :version => '1.0'}
 
+      def rpm_provider(agent)
+        os = on(agent, facter('operatingsystem')).stdout.chomp
+        maj_version = on(agent, facter('operatingsystemmajrelease')).stdout.chomp
+        if os == 'Fedora' && maj_version.to_i >= 22
+          'dnf'
+        else
+          'yum'
+        end
+      end
+
       def setup(agent)
+        cmd = rpm_provider(agent)
         required_packages = ['createrepo', 'rpm-build']
         required_packages.each do |pkg|
-          unless ((on agent, "yum list installed #{pkg}", :acceptable_exit_codes => (0..255)).exit_code == 0) then
-            on agent, "yum install -y #{pkg}"
+          unless ((on agent, "#{cmd} list installed #{pkg}", :acceptable_exit_codes => (0..255)).exit_code == 0) then
+            on agent, "#{cmd} install -y #{pkg}"
           end
         end
       end
 
       def clean_rpm(agent, o={})
+        cmd = rpm_provider(agent)
         o = @@defaults.merge(o)
         on agent, "rm -rf #{o[:repo]}", :acceptable_exit_codes => (0..255)
-        on agent, "yum remove -y #{o[:pkg]}", :acceptable_exit_codes => (0..255)
+        on agent, "#{cmd} remove -y #{o[:pkg]}", :acceptable_exit_codes => (0..255)
         on agent, "rm -f /etc/yum.repos.d/#{o[:publisher]}.repo", :acceptable_exit_codes => (0..255)
       end
 
@@ -98,6 +110,12 @@ EOF
 "
         on agent, "rpmbuild -ba #{o[:repo]}/SPECS/#{o[:pkg]}.spec"
         on agent, "createrepo --update #{o[:repo]}"
+
+        cmd = rpm_provider(agent)
+        # DNF requires a cache reset to make local repositories accessible.
+        if cmd == 'dnf'
+          on agent, "dnf clean metadata"
+        end
       end
     end
   end

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -17,8 +17,9 @@ end
 
 def verify_state(hosts, pkg, state, match)
   hosts.each do |agent|
+    cmd = rpm_provider(agent)
     # Note yum lists packages as <name>.<arch>
-    on agent, 'yum list installed' do
+    on agent, "#{cmd} list installed" do
       method(match).call(/^#{pkg}\./, stdout)
     end
 

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -17,8 +17,9 @@ end
 
 def verify_state(hosts, pkg, state, match)
   hosts.each do |agent|
-    # Note yum lists packages as <name>.<arch>
-    on agent, 'yum list installed' do
+    cmd = rpm_provider(agent)
+    # Note yum and dnf list packages as <name>.<arch>
+    on agent, "#{cmd} list installed" do
       method(match).call(/^#{pkg}\./, stdout)
     end
   end

--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -1,0 +1,36 @@
+Puppet::Type.type(:package).provide :dnf, :parent => :yum do
+  desc "Support via `dnf`.
+
+  Using this provider's `uninstallable` feature will not remove dependent packages. To
+  remove dependent packages with this provider use the `purgeable` feature, but note this
+  feature is destructive and should be used with the utmost care.
+
+  This provider supports the `install_options` attribute, which allows command-line flags to be passed to dnf.
+  These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
+  or an array where each element is either a string or a hash."
+
+  has_feature :install_options, :versionable, :virtual_packages
+
+  commands :cmd => "dnf", :rpm => "rpm"
+
+  if command('rpm')
+    confine :true => begin
+      rpm('--version')
+      rescue Puppet::ExecutionFailure
+        false
+      else
+        true
+      end
+  end
+
+  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => '22'
+
+  # The value to pass to DNF as its error output level.
+  # DNF differs from Yum slightly with regards to error outputting.
+  #
+  # @param None
+  # @return [String]
+  def self.error_level
+    '1'
+  end
+end

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
   has_feature :install_options, :versionable, :virtual_packages
 
-  commands :yum => "yum", :rpm => "rpm"
+  commands :cmd => "yum", :rpm => "rpm"
 
   if command('rpm')
     confine :true => begin
@@ -67,7 +67,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   # @return [Hash<String, Array<Hash<String, String>>>] All packages that were
   #   found with a list of found versions for each package.
   def self.check_updates(enablerepo, disablerepo, disableexcludes)
-    args = [command(:yum), 'check-update']
+    args = [command(:cmd), 'check-update']
     args.concat(enablerepo.map { |repo| ["--enablerepo=#{repo}"] }.flatten)
     args.concat(disablerepo.map { |repo| ["--disablerepo=#{repo}"] }.flatten)
     args.concat(disableexcludes.map { |repo| ["--disableexcludes=#{repo}"] }.flatten)
@@ -78,9 +78,9 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     if output.exitstatus == 100
       updates = parse_updates(output)
     elsif output.exitstatus == 0
-      self.debug "yum check-update exited with 0; no package updates available."
+      self.debug "#{command(:cmd)} check-update exited with 0; no package updates available."
     else
-      self.warn "Could not check for updates, 'yum check-update' exited with #{output.exitstatus}"
+      self.warn "Could not check for updates, '#{command(:cmd)} check-update' exited with #{output.exitstatus}"
     end
     updates
   end
@@ -126,11 +126,16 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     @latest_versions = nil
   end
 
+  def self.error_level
+    '0'
+  end
+
   def install
     wanted = @resource[:name]
+    error_level = self.class.error_level
     # If not allowing virtual packages, do a query to ensure a real package exists
     unless @resource.allow_virtual?
-      yum *['-d', '0', '-e', '0', '-y', install_options, :list, wanted].compact
+      execute([command(:cmd), '-d', '0', '-e', error_level, '-y', install_options, :list, wanted].compact)
     end
 
     should = @resource.should(:ensure)
@@ -154,8 +159,8 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     # Yum on el-4 and el-5 returns exit status 0 when trying to install a package it doesn't recognize;
     # ensure we capture output to check for errors.
     no_debug = if Facter.value(:operatingsystemmajrelease).to_i > 5 then ["-d", "0"] else [] end
-    args = no_debug + ["-e", "0", "-y", install_options, operation, wanted].compact
-    output = yum *args
+    command = [command(:cmd)] + no_debug + ["-e", error_level, "-y", install_options, operation, wanted].compact
+    output = execute(command)
 
     if output =~ /^No package #{wanted} available\.$/
       raise Puppet::Error, "Could not find package #{wanted}"
@@ -194,7 +199,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   end
 
   def purge
-    yum "-y", :erase, @resource[:name]
+    execute([command(:cmd), "-y", :erase, @resource[:name]])
   end
 
   # parse a yum "version" specification

--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+# Note that much of the functionality of the dnf provider is already tested with yum provider tests,
+# as yum is the parent provider.
+
+provider_class = Puppet::Type.type(:package).provider(:dnf)
+
+describe provider_class do
+  let(:name) { 'mypackage' }
+  let(:resource) do
+    Puppet::Type.type(:package).new(
+      :name => name,
+      :ensure => :installed,
+      :provider => 'dnf'
+    )
+  end
+
+  let(:provider) do
+    provider = provider_class.new
+    provider.resource = resource
+    provider
+  end
+
+  before do
+    provider_class.stubs(:command).with(:cmd).returns('/usr/bin/dnf')
+    provider.stubs(:rpm).returns 'rpm'
+    provider.stubs(:get).with(:version).returns '1'
+    provider.stubs(:get).with(:release).returns '1'
+    provider.stubs(:get).with(:arch).returns 'i386'
+  end
+
+  describe 'provider features' do
+    it { is_expected.to be_versionable }
+    it { is_expected.to be_install_options }
+    it { is_expected.to be_virtual_packages }
+  end
+
+  # provider should repond to the following methods
+   [:install, :latest, :update, :purge, :install_options].each do |method|
+     it "should have a(n) #{method}" do
+       expect(provider).to respond_to(method)
+    end
+  end
+
+  describe 'when installing' do
+    before(:each) do
+      Puppet::Util.stubs(:which).with("rpm").returns("/bin/rpm")
+      provider.stubs(:which).with("rpm").returns("/bin/rpm")
+      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "--version"], {:combine => true, :custom_environment => {}, :failonfail => true}).returns("4.10.1\n").at_most_once
+    end
+
+    it 'should call dnf install for :installed' do
+      resource.stubs(:should).with(:ensure).returns :installed
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/dnf', '-d', '0', '-e', '1', '-y', :install, 'mypackage'])
+      provider.install
+    end
+
+    it 'should be able to downgrade' do
+      current_version = '1.2'
+      version = '1.0'
+      resource[:ensure] = '1.0'
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/dnf', '-d', '0', '-e', '1', '-y', :downgrade, "#{name}-#{version}"])
+      provider.stubs(:query).returns(:ensure => current_version).then.returns(:ensure => version)
+      provider.install
+    end
+
+    it 'should accept install options' do
+      resource[:ensure] = :installed
+      resource[:install_options] = ['-t', {'-x' => 'expackage'}]
+
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/dnf', '-d', '0', '-e', '1', '-y', ['-t', '-x=expackage'], :install, name])
+      provider.install
+    end
+  end
+
+  describe 'when uninstalling' do
+    it 'should use erase to purge' do
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/dnf', '-y', :erase, name])
+      provider.purge
+    end
+  end
+
+  describe "executing yum check-update" do
+    it "passes repos to enable to 'yum check-update'" do
+      Puppet::Util::Execution.expects(:execute).with do |args, *rest|
+        expect(args).to eq %w[/usr/bin/dnf check-update --enablerepo=updates --enablerepo=fedoraplus]
+      end.returns(stub(:exitstatus => 0))
+      described_class.check_updates(%w[updates fedoraplus], [], [])
+    end
+  end
+end


### PR DESCRIPTION
This series of commits adds a new DNF provider to Puppet, which is necessary due to Fedora's move from Yum to DNF.

A few updates to the Yum provider were required to make way for the new provider, which is its child.