### PR TITLE
(PUP-5293) Fix ref to nil in environment_compiler

### DIFF
--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -65,12 +65,16 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
 
     # Get downstream vertexes returns a hash where the keys are the resources and values nesting level
     rooted_in_main = @catalog.downstream_from_vertex(the_main_class_resource).keys
+
+    to_be_removed =
     if the_site_resource
       keep_from_site = @catalog.downstream_from_vertex(the_site_resource).keys
       keep_from_site << the_site_resource
+      rooted_in_main - keep_from_site
+    else
+      rooted_in_main
     end
 
-    to_be_removed = rooted_in_main - keep_from_site
     @catalog.remove_resource(*to_be_removed)
     # The compiler keeps a list of added resources, this shadows that list with the now pruned result
     @pruned_resources = @catalog.resources

--- a/spec/unit/appmgmt_spec.rb
+++ b/spec/unit/appmgmt_spec.rb
@@ -243,6 +243,14 @@ EOS
 
 
   describe "in the environment catalog" do
+    it "does not fail if there is no site expression" do
+      expect {
+      catalog = compile_to_env_catalog(<<-EOC).to_resource
+        notify { 'ignore me':}
+      EOC
+      }.to_not raise_error()
+    end
+
     it "includes components and capability resources" do
       catalog = compile_to_env_catalog(MANIFEST).to_resource
       apps = catalog.resources.select do |res|


### PR DESCRIPTION
Before this there was a problem if an environment compiler compiled a
manifest that did not have a site expression. The final pruning step
would then end up with a nil reference instead of an array of elements
to keep from the site expression.