### PR TITLE
(PUP-5299) Flatten the code structure produced by the 4x code merger

### DIFF
--- a/lib/puppet/pops/parser/code_merger.rb
+++ b/lib/puppet/pops/parser/code_merger.rb
@@ -8,9 +8,21 @@ class Puppet::Pops::Parser::CodeMerger
     # this is a bit brute force as the result is already 3x ast with wrapped 4x content
     # this could be combined in a more elegant way, but it is only used to process a handful of files
     # at the beginning of a puppet run. TODO: Revisit for Puppet 4x when there is no 3x ast at the top.
+    # PUP-5299, some sites have thousands of entries, and run out of stack when evaluating - the logic
+    # below maps the logic as flatly as possible.
     #
     children = parse_results.select {|x| !x.nil? && x.code}.reduce([]) do |memo, parsed_class|
-      memo << parsed_class.code
+      case parsed_class.code
+      when Puppet::Parser::AST::BlockExpression
+        # the BlockExpression wraps a single 4x instruction that is most likely wrapped in a Factory
+        memo += parsed_class.code.children.map {|c| c.is_a?(Puppet::Pops::Model::Factory) ? c.model : c }
+      when Puppet::Pops::Model::Factory
+        # If it is a 4x instruction wrapped in a Factory
+        memo += parsed_class.code.model
+      else
+        # It is the instruction directly
+        memo << parsed_class.code
+      end
     end
     Puppet::Parser::AST::BlockExpression.new(:children => children)
   end

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -766,7 +766,7 @@ describe Puppet::Resource::Type do
       source = Puppet::Resource::Type.new(:hostclass, "foo", :code => scode)
 
       dest.merge(source)
-      expect(dest.code.children.collect { |l| l.children[0].value }).to eq(%w{dest source})
+      expect(dest.code.children.map { |c| c.value }).to eq(%w{dest source})
     end
   end
 end


### PR DESCRIPTION
Before this, if a site used thousands of manifests the code merger would
create a tree that was thousands of levels deep. When evaluating that,
the ruby stack will (most likely) hit its limit.

After this change the structure is flattened - rather than recursing
the merged instructions are simply concatenated (after unwrapping them
as much as possible).

As a consequnce, one test was changed since it depended on the internal
structure being build having a particular shape.