### PR TITLE
(PUP-5274) Create settings related files with the correct mode

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -123,7 +123,22 @@ module Puppet
           end
         end
       end
+    end
 
+    module CommandUtils
+      def ruby_command(host)
+        "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
+      end
+      module_function :ruby_command
+
+      def gem_command(host)
+        if host['platform'] =~ /windows/
+          "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+        else
+          "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
+        end
+      end
+      module_function :gem_command
     end
   end
 end

--- a/acceptance/tests/ssl/ticket_5274_private_key_modes.rb
+++ b/acceptance/tests/ssl/ticket_5274_private_key_modes.rb
@@ -1,0 +1,44 @@
+test_name "PUP-5274: CA and host private keys should not be world readable"
+require 'puppet/acceptance/common_utils'
+
+confine :except, :platform => 'windows'
+
+def get_setting(host, ssldir, command)
+  on(host, puppet("agent --ssldir #{ssldir} #{command}")).stdout.chomp
+end
+
+def get_mode(host, path)
+  ruby = Puppet::Acceptance::CommandUtils.ruby_command(host)
+  on(host, "#{ruby} -e 'puts (File.stat(\"#{path}\").mode & 07777).to_s(8)'").stdout.chomp
+end
+
+hosts.each do |host|
+  ssldir        = host.tmpdir('ssldir')
+  cakey         = get_setting(host, ssldir, "--configprint cakey")
+  privatekeydir = get_setting(host, ssldir, "--configprint privatekeydir")
+  hostprivkey   = get_setting(host, ssldir, "--configprint hostprivkey --certname foo")
+
+  step "create ca and foo cert and private keys"
+  on(host, puppet("cert generate foo --ssldir #{ssldir}"))
+
+  expected_permissions = {
+    cakey         => "640",
+    privatekeydir => "750",
+    hostprivkey   => "640"
+  }
+
+  [cakey, privatekeydir, hostprivkey].each do |path|
+    step "verify #{path} has permissions #{expected_permissions[path]} initially"
+    current_mode = get_mode(host, path)
+    assert_equal(expected_permissions[path], current_mode, "The path #{path} should not be world readable initially")
+  end
+
+  step "generate a second cert"
+  on(host, puppet("cert generate bar --ssldir #{ssldir}"))
+
+  [cakey, privatekeydir, hostprivkey].each do |path|
+    step "verify #{path} still has permissions #{expected_permissions[path]}"
+    current_mode = get_mode(host, path)
+    assert_equal(expected_permissions[path], current_mode, "The path #{path} should not be changed to world readable")
+  end
+end

--- a/lib/puppet/settings/file_setting.rb
+++ b/lib/puppet/settings/file_setting.rb
@@ -219,15 +219,16 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
     Puppet::Util::SUIDManager.asuser(*chown) do
       # Update the umask to make non-executable files
       Puppet::Util.withumask(File.umask ^ 0111) do
-        mode = case mode.class
-                 when String
-                   mode.to_i(8)
-                 when NilClass
-                   0640
-                 else
-                   mode
-                 end
-        yield mode
+        yielded_value = case self.mode
+                        when String
+                          self.mode.to_i(8)
+                        when NilClass
+                          0640
+                        else
+                          self.mode
+                        end
+
+        yield yielded_value
       end
     end
   end


### PR DESCRIPTION
Previously, puppet would create settings related files using the process
umask, instead of the mode specified in defaults.rb, or overridden in
puppet.conf, and it would take a second puppet run to converge.

This issue was introduced in 691056e for PUP-2349, merged in 87b0b5d,
and has been present since 3.7.0. There are two issues with the code:

First, the case statement was trying to compare if mode was a string,
nil, or fixnum using ruby's case equality operator, but it was
actually comparing if mode's class was a string or nil, which was
never true, always falling through to the else case.

Second, the assignment statement `mode = case mode` introduced a `mode`
local variable whose value was set to nil, and shadowed the `mode`
accessor. This combined with above issue meant the method always yielded
nil, and Puppet would eventually call `File.open` with a nil mode when
creating the settings related file.

There is a DirectorySetting class that extends FileSetting, but it
doesn't have this problem because it uses puppet's file type to create
the directory, correctly passing mode to the `Dir.mkdir` call.

This commit avoids the shadow problem, and tests if `mode` is a String.
It also adds unit and acceptance tests as none of the existing tests
failed when the code was changed.