### PR TITLE
(PUP-5016) Fixup systemd / sysvinit issues in Debian and Ubuntu

### DIFF
--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -1,7 +1,7 @@
 test_name 'SysV and Systemd Service Provider Validation'
 
 
-confine :to, :platform => /el|centos|fedora|debian|sles|ubuntu-[v-z]/
+confine :to, :platform => /el|centos|fedora|debian|sles|ubuntu-v/
 # osx covered by launchd_provider.rb
 # ubuntu-[a-u] upstart covered by ticket_14297_handle_upstart.rb
 
@@ -10,16 +10,12 @@ package_name = {'el'     => 'httpd',
                 'fedora' => 'httpd',
                 'debian' => 'apache2',
                 'sles'   => 'apache2',
-                'ubuntu' => 'apache2',
+                'ubuntu' => 'cron', # See https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1447807
 }
 
 agents.each do |agent|
   platform = agent.platform.variant
   majrelease = on(agent, facter('operatingsystemmajrelease')).stdout.chomp.to_i
-
-  if ((platform == 'debian' && majrelease == 8) || (platform == 'ubuntu' && majrelease == 15))
-    skip_test 'legit failures on debian8 and ubuntu15; see: PUP-5149'
-  end
 
   init_script_systemd = "/usr/lib/systemd/system/#{package_name[platform]}.service"
   symlink_systemd     = "/etc/systemd/system/multi-user.target.wants/#{package_name[platform]}.service"
@@ -45,27 +41,34 @@ agents.each do |agent|
     kill_symlink      = "K01apache2"
     start_runlevels   = ["3", "5"]
     kill_runlevels    = ["3", "5"]
+  elsif platform == 'ubuntu'
+    # Due to https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1447807, we can't test
+    # a service without a systemd unit file. Instead we use the systemd-managed cron.service.
+    start_symlink     = "S02cron"
+    kill_symlink      = "K01cron"
+    start_runlevels   = ["2", "3", "4", "5"]
+    kill_runlevels    = ["2", "3", "4", "5"]
   else
     start_symlink     = "S85httpd"
     kill_symlink      = "K15httpd"
   end
 
-  manifest_uninstall_httpd = %Q{
+  manifest_uninstall_package = %Q{
     package { '#{package_name[platform]}':
       ensure => absent,
     }
   }
-  manifest_install_httpd = %Q{
+  manifest_install_package = %Q{
     package { '#{package_name[platform]}':
       ensure => present,
     }
   }
-  manifest_httpd_enabled = %Q{
+  manifest_service_enabled = %Q{
     service { '#{package_name[platform]}':
       enable => true,
     }
   }
-  manifest_httpd_disabled = %Q{
+  manifest_service_disabled = %Q{
     service { '#{package_name[platform]}':
       enable => false,
     }
@@ -75,7 +78,7 @@ agents.each do |agent|
     if platform == 'sles'
       on agent, 'zypper remove -y apache2 apache2-prefork apache2-worker libapr1 libapr-util1'
     else
-      apply_manifest_on(agent, manifest_uninstall_httpd)
+      apply_manifest_on(agent, manifest_uninstall_package)
     end
   end
 
@@ -85,15 +88,15 @@ agents.each do |agent|
     fail_test "Provider needs manual update to support Fedora #{majrelease}"
   end
 
-  step "installing httpd/apache"
-  apply_manifest_on(agent, manifest_install_httpd, :catch_failures => true)
+  step "installing #{package_name[platform]}"
+  apply_manifest_on(agent, manifest_install_package, :catch_failures => true)
 
   step "ensure enabling service creates the start & kill symlinks"
   is_sysV = ((platform == 'centos' || platform == 'el') && majrelease < 7) ||
-              platform == 'debian' ||
+              platform == 'debian' || platform == 'ubuntu' ||
              (platform == 'sles'                        && majrelease < 12)
-  apply_manifest_on(agent, manifest_httpd_disabled, :catch_failures => true)
-  apply_manifest_on(agent, manifest_httpd_enabled, :catch_failures => true) do
+  apply_manifest_on(agent, manifest_service_disabled, :catch_failures => true)
+  apply_manifest_on(agent, manifest_service_enabled, :catch_failures => true) do
     if is_sysV
       # debian platforms using sysV put rc runlevels directly in /etc/
       on agent, "ln -s /etc/ /etc/rc.d", :accept_all_exit_codes => true
@@ -102,8 +105,13 @@ agents.each do |agent|
         assert_match("#{runlevel}.d/#{start_symlink}", rc_symlinks, "did not find #{start_symlink} in runlevel #{runlevel}")
         assert_match(/\/etc(\/rc\.d)?\/init\.d\/#{package_name[platform]}/, rc_symlinks, "did not find #{package_name[platform]} init script")
       end
-      kill_runlevels.each do |runlevel|
-        assert_match("#{runlevel}.d/#{kill_symlink}", rc_symlinks, "did not find #{kill_symlink} in runlevel #{runlevel}")
+
+      # Temporary measure until the Ubuntu SysV bugs are fixed. The cron service doesn't keep kill symlinks around while
+      # the service is enabled, unlike Apache2.
+      unless platform == 'ubuntu'
+        kill_runlevels.each do |runlevel|
+          assert_match("#{runlevel}.d/#{kill_symlink}", rc_symlinks, "did not find #{kill_symlink} in runlevel #{runlevel}")
+        end
       end
     else
       rc_symlinks = on(agent, "ls #{symlink_systemd} #{init_script_systemd}", :accept_all_exit_codes => true).stdout
@@ -113,7 +121,7 @@ agents.each do |agent|
   end
 
   step "ensure disabling service removes start symlinks"
-  apply_manifest_on(agent, manifest_httpd_disabled, :catch_failures => true) do
+  apply_manifest_on(agent, manifest_service_disabled, :catch_failures => true) do
     if is_sysV
       rc_symlinks = on(agent, "find /etc/ -name *#{package_name[platform]}", :accept_all_exit_codes => true).stdout
       # sles removes rc.d symlinks

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -16,6 +16,12 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     end
   end
 
+  # Debian and Ubuntu should use the Debian provider.
+  confine :true => begin
+     os = Facter.value(:operatingsystem).downcase
+     !(os == 'debian' || os == 'ubuntu')
+  end
+
   # We can't confine this here, because the init path can be overridden.
   #confine :exists => defpath
 

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -59,7 +59,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
       # flapping when simply trying to disable a masked service.
       return :mask if (@resource[:enable] == :mask) && (svc_info[:LoadState] == 'masked')
       return :true if svc_info[:UnitFileState] == 'enabled'
-      if Facter.value(:osfamily) == 'debian'
+      if Facter.value(:osfamily).downcase == 'debian'
         ret = debian_enabled?(svc_info)
         return ret if ret
       end

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -32,7 +32,14 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def get_start_link_count
-    Dir.glob("/etc/rc*.d/S??#{@resource[:name]}").length
+    # Start links don't include '.service'. Just search for the service name.
+    if @resource[:name].match(/\.service/)
+      link_name = @resource[:name].split('.')[0]
+    else
+      link_name = @resource[:name]
+    end
+
+    Dir.glob("/etc/rc*.d/S??#{link_name}").length
   end
 
   def enabled?
@@ -72,6 +79,11 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     return :false
   end
 
+  # This method is required for Debian systems due to the way the SysVInit-Systemd
+  # compatibility layer works. When we are trying to manage a service which does not
+  # have a Systemd unit file, we need to go through the old init script to determine
+  # whether it is enabled or not. See PUP-5016 for more details.
+  #
   def debian_enabled?(svc_info)
     # If UnitFileState == UnitFileState then we query the older way.
     if svc_info[:UnitFileState] == 'UnitFileState'

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -141,4 +141,31 @@ describe provider_class do
     end
   end
 
+  describe "when checking service status" do
+    context "On systems which use the systemd-sysvinit compatibility layer" do
+      it "should call systemctl to determine running status in Debian" do
+        Facter.stubs(:value).with(:operatingsystem).returns('Debian')
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('8')
+        @resource.stubs(:[]).with(:hasstatus).returns(:true)
+        expect(@provider.statuscmd).to eq(["systemctl", "is-active", @resource[:name]])
+      end
+
+      it "should call systemctl to determine running status in Ubuntu" do
+        Facter.stubs(:value).with(:operatingsystem).returns('Ubuntu')
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('15.04')
+        @resource.stubs(:[]).with(:hasstatus).returns(:true)
+        expect(@provider.statuscmd).to eq(["systemctl", "is-active", @resource[:name]])
+      end
+    end
+
+    context "On systems which only use sysvinit" do
+      it "should use the service init script" do
+        Facter.stubs(:value).with(:operatingsystem).returns('Debian')
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('7')
+        @resource.stubs(:[]).with(:hasstatus).returns(:true)
+        @provider.stubs(:initscript).returns("/etc/init.d/script")
+        expect(@provider.statuscmd).to eq(["/etc/init.d/script", :status])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This series of commits makes some changes to the systemd, debian and init providers to work around the strange behavior of the sysvinit-systemd compatibility layer in Debian. In order:

### 1) Disable Init provider on Debian and Ubuntu

Previously, Debian 8 and Ubuntu 15.05, which are systemd-managed
platforms, would erroneously fall back to the init provider
when Systemd was unable to manage a SysVInit service without
a unit file. The Debian provider should be used instead, as
it inherits from init and provides the ability to enable and
disable services.

### 2) Fix check for Debian osfamily in systemd provider

Previously, we checked for lowercased 'debian' when trying
to determine if a platform is Debian-ish in the systemd provider.
Facter returns capitalized 'Debian', so this commit downcases
Facter's return value to ensure we properly detect the Debians.

### 3) Update linux services tests for Debian systemd behavior

Previously, services_enable_linux.rb was failing in Debian 8
and Ubuntu 15.05 due to issues with Systemd and SysVInit. The
Debian 8 issues are corrected by the actual fix to the systemd
and init providers, but the test continued to fail in Ubuntu
due to an upstream systemd-sysv compatibility bug.

This commit updates the test to use a service which has
a systemd unit file, cron, rather than apache2 which did not. This
allows the test to run correctly on Ubuntu. Once this upstream bug
is fixed, we'll probably want to undo the Ubuntu changes for
consistency.

In addition, the systemd masking test is also updated for strange
or broken Debian and Ubuntu systemd / Init behavior. In this case,
Ubuntu suffers from the same bug as above. In Debian, Apache2 does
not create the expected systemd symlinks as normal systemd services
do, so we use cron.service instead.

See https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1447807
for the upstream bug report.

### 4) Fix issue with Debian provider and SysVInit-Systemd compatibility layer

With the compatibility layer between systemd and SysVInit in Debian,
services can be managed in multiple ways. However, if a service is
masked with systemd, the equivalent SysVInit script becomes unable
to determine the status of the service. If we are trying to manage
the SysVInit version, we need to use systemctl to determine the
status in Debian 8 and Ubuntu 15.04.

Note that this is an issue only if querying the SysVInit version
of a service. `puppet resource service ntp` will fail to get the
status, while `puppet resource service ntp.service` will not.

### Testing efforts

I've run the full acceptance suite against several platforms, including Debian 8, Ubuntu 14.04, Centos 7, and Debian 7. This is still kind of a gnarly issue, so I wouldn't mind some help making sure everything is doing the right stuff.

### Other notes

A lot of this is solely necessary because of how weird things get in the SysVInit-Systemd compatibility layer. In Debian, you can manage the same services with either init scripts or unit files, but lots of services don't actually have real unit files. Puppet is currently taking into account that these init scripts and the compatibility-layer-generated unit scripts are different things, so we see services like `ntp` and `ntp.service`, where `ntp` is managed with the debian provider and `ntp.service` is managed with the systemd provider. There is a lot of weird overlap, such as the change I made in the Debian provider where we actually call `systemctl` in certain circumstances, even though we aren't trying to manage the service with systemd. 

(That particular case is necessary due to the init / systemd 'versions' of services not exactly playing along. Masking a service with systemd results in the init script not being able to determine the service status).