### PR TITLE
(maint) Don't rely on apply_manifest_on return value

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -51,7 +51,7 @@ collide1_manifest = <<MANIFEST
   package {'other-guid': name => 'guid', ensure => present}
 MANIFEST
 
-apply_manifest_on(agents, collide1_manifest, :acceptable_exit_codes => [1]).each do |result|
+apply_manifest_on(agents, collide1_manifest, :acceptable_exit_codes => [1]) do |result|
   assert_match(/Error while evaluating a Resource Statement, Cannot alias Package\[other-guid\] to \["guid", nil\]/, "#{result.host}: #{result.stderr}")
 end
 
@@ -62,7 +62,7 @@ collide2_manifest = <<MANIFEST
   package {'other-guid': name => 'guid', ensure => installed, provider => gem}
 MANIFEST
 
-apply_manifest_on(agents, collide2_manifest, :acceptable_exit_codes => [1]).each do |result|
+apply_manifest_on(agents, collide2_manifest, :acceptable_exit_codes => [1]) do |result|
   assert_match(/Error while evaluating a Resource Statement, Cannot alias Package\[other-guid\] to \["guid", "gem"\]/, "#{result.host}: #{result.stderr}")
 end
 
@@ -79,7 +79,7 @@ install_manifest = <<MANIFEST
   }
 MANIFEST
 
-apply_manifest_on(agents, install_manifest).each do |result|
+apply_manifest_on(agents, install_manifest) do |result|
   assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
   assert_match('Package[gem-guid]/ensure: created', "#{result.host}: #{result.stdout}")
 end
@@ -97,7 +97,7 @@ remove_manifest = <<MANIFEST
   package {'guid': ensure => absent}
 MANIFEST
 
-apply_manifest_on(agents, remove_manifest).each do |result|
+apply_manifest_on(agents, remove_manifest) do |result|
   assert_match('Package[guid]/ensure: removed', "#{result.host}: #{result.stdout}")
   assert_match('Package[gem-guid]/ensure: removed', "#{result.host}: #{result.stdout}")
 end

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -41,31 +41,31 @@ end
 
 step 'Installing a known package succeeds'
 verify_absent agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => installed}').each do |result|
+apply_manifest_on(agents, 'package {"guid": ensure => installed}') do |result|
   assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
 end
 
 step 'Removing a known package succeeds'
 verify_present agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => absent}').each do |result|
+apply_manifest_on(agents, 'package {"guid": ensure => absent}') do |result|
   assert_match('Package[guid]/ensure: removed', "#{result.host}: #{result.stdout}")
 end
 
 step 'Installing a specific version of a known package succeeds'
 verify_absent agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => "1.0"}').each do |result|
+apply_manifest_on(agents, 'package {"guid": ensure => "1.0"}') do |result|
   assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
 end
 
 step 'Removing a specific version of a known package succeeds'
 verify_present agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => absent}').each do |result|
+apply_manifest_on(agents, 'package {"guid": ensure => absent}') do |result|
   assert_match('Package[guid]/ensure: removed', "#{result.host}: #{result.stdout}")
 end
 
 step 'Installing a non-existant version of a known package fails'
 verify_absent agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => "1.1"}').each do |result|
+apply_manifest_on(agents, 'package {"guid": ensure => "1.1"}') do |result|
   assert_not_match(/Package\[guid\]\/ensure: created/, "#{result.host}: #{result.stdout}")
   assert_match('Package[guid]/ensure: change from purged to 1.1 failed', "#{result.host}: #{result.stderr}")
 end
@@ -73,7 +73,7 @@ verify_absent agents, 'guid'
 
 step 'Installing a non-existant package fails'
 verify_absent agents, 'not_a_package'
-apply_manifest_on(agents, 'package {"not_a_package": ensure => present}').each do |result|
+apply_manifest_on(agents, 'package {"not_a_package": ensure => present}') do |result|
   assert_not_match(/Package\[not_a_package\]\/ensure: created/, "#{result.host}: #{result.stdout}")
   assert_match('Package[not_a_package]/ensure: change from purged to present failed', "#{result.host}: #{result.stderr}")
 end
@@ -81,7 +81,7 @@ verify_absent agents, 'not_a_package'
 
 step 'Removing a non-existant package succeeds'
 verify_absent agents, 'not_a_package'
-apply_manifest_on(agents, 'package {"not_a_package": ensure => absent}').each do |result|
+apply_manifest_on(agents, 'package {"not_a_package": ensure => absent}') do |result|
   assert_not_match(/Package\[not_a_package\]\/ensure/, "#{result.host}: #{result.stdout}")
   assert_match('Applied catalog', "#{result.host}: #{result.stdout}")
 end

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -31,8 +31,6 @@ user { 'passwordtestuser':
 MANIFEST
 
 apply_manifest_on(hosts_to_test, adduser_manifest )
-results = apply_manifest_on(hosts_to_test, changepass_manifest )
-
-results.each do |result|
+apply_manifest_on(hosts_to_test, changepass_manifest ) do |result|
   assert_match( /current_value \[old password hash redacted\], should be \[new password hash redacted\]/ , "#{result.host}: #{result.stdout}" )
 end


### PR DESCRIPTION
Previously, these tests failed when using a rhel master and windows
agent, because apply_manifest_on will return nil when the agents array
is empty, see BKR-571.

This failure started occurring, because BKR-533 used to overwrite the
array of all hosts, making the test unsuitable for all hosts even if
there was only a single windows agent. That issue was fixed in beaker
2.25.0, and unmasked BKR-571.

However, the tests are not following best practice, which is to just
pass the block to the apply_manifest_on method, and that will yield each
result to the block.