### PR TITLE
(PUP-5317) Exit with 74 when trying to run a master with no puppet user

### DIFF
--- a/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
+++ b/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
@@ -72,9 +72,8 @@ step "Remove system users" do
 end
 
 step "Ensure master fails to start when missing system user" do
-  on master, puppet('master'), :acceptable_exit_codes => [74] do
-    assert_match(/could not change to group "#{original_state[master][:group]}"/, result.output)
-    assert_match(/Could not change to user #{original_state[master][:user]}/, result.output)
+  on master, puppet('master', '--no-daemonize'), :acceptable_exit_codes => [74] do
+    assert_match(/Could not change user to #{original_state[master][:user]}/, result.output)
   end
 end
 

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -198,7 +198,8 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
           exit(39)
         end
       else
-        raise Puppet::Error.new("Could not change user to #{Puppet[:user]}. User does not exist and is required to continue.")
+        Puppet.err("Could not change user to #{Puppet[:user]}. User does not exist and is required to continue.")
+        exit(74)
       end
     end
 

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -333,8 +333,8 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
         it "should exit and log an error if running as root and the puppet user does not exist" do
           Puppet.features.stubs(:root?).returns true
           a_user_type_for("puppet").expects(:exists?).returns false
-
-          expect { @master.main }.to raise_error(Puppet::Error, /Could not change user to puppet\. User does not exist and is required to continue\./)
+          Puppet.expects(:err).with('Could not change user to puppet. User does not exist and is required to continue.')
+          expect { @master.main }.to exit_with 74
         end
       end
 


### PR DESCRIPTION
Commit 144ea123 changed Puppet's behavior when a master is run
with no Puppet user existing. This commit maintains the more
graceful behavior of failing in main rather than down the line,
but restores the behavior of exiting with `74`.

The test `puppet_manages_own_configuration_in_robust_manner` is
also updated to account for the fact that we no longer attempt
to change groups if the user is missing.