### PR TITLE
(PUP-5025) RPM Epoch should be included in ensure field

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -281,6 +281,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
       self::NEVRA_FIELDS.zip(match.captures) { |f, v| hash[f] = v }
       hash[:provider] = self.name
       hash[:ensure] = "#{hash[:version]}-#{hash[:release]}"
+      hash[:ensure].prepend("#{hash[:epoch]}:") if hash[:epoch] != '0'
     else
       Puppet.debug("Failed to match rpm line #{line}")
     end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -12,6 +12,7 @@ describe provider_class do
     chkconfig 0 1.3.30.2 2.el5 x86_64
     myresource 0 1.2.3.4 5.el4 noarch
     mysummaryless 0 1.2.3.4 5.el4 noarch
+    tomcat 1 1.2.3.4 5.fc22 noarch
     RPM_OUTPUT
   end
 
@@ -116,7 +117,18 @@ describe provider_class do
           :ensure => "1.3.30.2-2.el5",
         }
       )
-      expect(installed_packages.last.properties).to eq(
+      expect(installed_packages[3].properties).to eq(
+        {
+          :provider    => :rpm,
+          :name        => "myresource",
+          :epoch       => "0",
+          :version     => "1.2.3.4",
+          :release     => "5.el4",
+          :arch        => "noarch",
+          :ensure      => "1.2.3.4-5.el4",
+        }
+      )
+      expect(installed_packages[4].properties).to eq(
         {
           :provider    => :rpm,
           :name        => "mysummaryless",
@@ -125,6 +137,17 @@ describe provider_class do
           :release     => "5.el4",
           :arch        => "noarch",
           :ensure      => "1.2.3.4-5.el4",
+        }
+      )
+      expect(installed_packages[5].properties).to eq(
+        {
+          :provider    => :rpm,
+          :name        => "tomcat",
+          :epoch       => "1",
+          :version     => "1.2.3.4",
+          :release     => "5.fc22",
+          :arch        => "noarch",
+          :ensure      => "1:1.2.3.4-5.fc22",
         }
       )
     end
@@ -269,7 +292,7 @@ describe provider_class do
           line.gsub(field, delimiter),
           package_hash.merge(
             field.to_sym => delimiter,
-            :ensure => 'version-release'.gsub(field, delimiter)
+            :ensure => 'epoch:version-release'.gsub(field, delimiter)
           )
         )
       end


### PR DESCRIPTION
Prior to this commit, the RPM provider did not include non-zero
epoch values in the :ensure field when calling RPM to install or
query packages.

This commit ensures that non-zero epochs are included.