### PR TITLE
(PUP-3953) single quotes in titles are escaped correctly

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -396,7 +396,8 @@ class Puppet::Resource
       "  %-#{attr_max}s => %s,\n" % [k, Puppet::Parameter.format_value_for_display(v)]
     }.join
 
-    "%s { '%s':\n%s}" % [self.type.to_s.downcase, self.title, attributes]
+    escaped = self.title.gsub(/'/,"\\\\'")
+    "%s { '%s':\n%s}" % [self.type.to_s.downcase, escaped, attributes]
   end
 
   def to_ref

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -657,6 +657,20 @@ describe Puppet::Resource do
       )
     end
 
+    it "should escape internal single quotes in a title" do
+      singlequote_resource = Puppet::Resource.new("one::two", "/my/file'b'a'r",
+        :parameters => {
+          :ensure => 'present',
+        }
+      )
+      expect(singlequote_resource.to_manifest).to eq <<-HEREDOC.gsub(/^\s{8}/, '').gsub(/\n$/, '')
+        one::two { '/my/file\\'b\\'a\\'r':
+          ensure => 'present',
+        }
+      HEREDOC
+
+    end
+
     it "should align, sort and add trailing commas to attributes with ensure first" do
       expect(@resource.to_manifest).to eq <<-HEREDOC.gsub(/^\s{8}/, '').gsub(/\n$/, '')
         one::two { '/my/file':


### PR DESCRIPTION
Previously, if you had a single quote in a resources' title,
running puppet resource would generate an invalid manifest.

Now, we escape any single quotes correctly.