### PR TITLE
(PUP-5340) Accept catalog_cache_terminus for apply

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -315,6 +315,10 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     Puppet.settings.use :main, :agent, :ssl
 
+    if Puppet[:catalog_cache_terminus]
+      Puppet::Resource::Catalog.indirection.cache_class = Puppet[:catalog_cache_terminus]
+    end
+
     # we want the last report to be persisted locally
     Puppet::Transaction::Report.indirection.cache_class = :yaml
 

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -470,4 +470,12 @@ describe Puppet::Application::Apply do
       @apply.send(:apply_catalog, catalog)
     end
   end
+
+  it "should honor the catalog_cache_terminus setting" do
+    Puppet.settings[:catalog_cache_terminus] = "json"
+    Puppet::Resource::Catalog.indirection.expects(:cache_class=).with(:json)
+
+    @apply.initialize_app_defaults
+    @apply.setup
+  end
 end


### PR DESCRIPTION
Previously, the 'puppet agent' command accepted catalog_cache_terminus,
but 'puppet apply' did not. This makes 'apply' match 'agent'.