### PR TITLE
(PUP-5315) Fix acceptance tests for AIX

### DIFF
--- a/acceptance/tests/allow_symlinks_as_config_directories.rb
+++ b/acceptance/tests/allow_symlinks_as_config_directories.rb
@@ -23,7 +23,7 @@ agents.each do |agent|
   step "Check that the symlink and confdir are unchanged"
   on agent, "[ -L #{conflink} ]"
   on agent, "[ -d #{confdir} ]"
-  if agent[:platform] =~ /solaris/
+  if agent[:platform] =~ /solaris|aix/
     on agent, "[ $(ls -ld #{conflink} | sed 's/.*-> //') = #{confdir} ]"
   else
     on agent, "[ $(readlink #{conflink}) = #{confdir} ]"

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -54,18 +54,16 @@ if master.is_pe?
 end
 
 with_puppet_running_on(master, master_opts) do
-  agents.each do |agent|
-    step "Ensure that an unauthenticated client cannot access the environments list" do
-      on agent, "curl --tlsv1 -ksv https://#{master}:#{master_port(agent)}/puppet/v3/environments", :acceptable_exit_codes => [0,7] do
-        assert_match(/< HTTP\/1\.\d 403/, stderr)
-      end
+  step "Ensure that an unauthenticated client cannot access the environments list" do
+    on master, "curl --tlsv1 -ksv https://#{master}:#{master_port(master)}/puppet/v3/environments", :acceptable_exit_codes => [0,7] do
+      assert_match(/< HTTP\/1\.\d 403/, stderr)
     end
+  end
 
-    step "Ensure that an authenticated client can retrieve the list of environments" do
-      curl_master_from(agent, '/puppet/v3/environments') do
-        data = JSON.parse(stdout)
-        assert_equal(["env1", "env2", "production"], data["environments"].keys.sort)
-      end
+  step "Ensure that an authenticated client can retrieve the list of environments" do
+    curl_master_from(master, '/puppet/v3/environments') do
+      data = JSON.parse(stdout)
+      assert_equal(["env1", "env2", "production"], data["environments"].keys.sort)
     end
   end
 end

--- a/acceptance/tests/modules/install/already_installed.rb
+++ b/acceptance/tests/modules/install/already_installed.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -6,7 +6,7 @@ confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
 hosts.each do |host|
   case host['platform']
-  when /solaris/
+  when /solaris|aix/
     # see PUP-4822, PUP-3450
     # We now bundle the GeoTrust Global CA with our vendored openssl, so
     # this test will run correctly in OSX.

--- a/acceptance/tests/modules/install/force_ignores_dependencies.rb
+++ b/acceptance/tests/modules/install/force_ignores_dependencies.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/ignoring_dependencies.rb
+++ b/acceptance/tests/modules/install/ignoring_dependencies.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_debug.rb
+++ b/acceptance/tests/modules/install/with_debug.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_dependencies.rb
+++ b/acceptance/tests/modules/install/with_dependencies.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 tmpdir = master.tmpdir('module-install-with-environment')

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -5,7 +5,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 codedir = master.puppet('master')['codedir']

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
+  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
 end
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -6,7 +6,7 @@ confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
 hosts.each do |host|
   case host['platform']
-  when /solaris/
+  when /solaris|aix/
     # see PUP-4822, PUP-3450
     # We now bundle the GeoTrust Global CA with our vendored openssl, so
     # this test will run correctly in OSX.

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -81,8 +81,8 @@ class ModifiesModeTest < ActionModeTest
 
     @start_mode = start_mode
 
-    user = 'symbolictestuser'
-    group = 'symbolictestgroup'
+    user = 'symuser'
+    group = 'symgroup'
     agent.user_present(user)
     agent.group_present(group)
 

--- a/acceptance/tests/resource/group/should_not_create_existing.rb
+++ b/acceptance/tests/resource/group/should_not_create_existing.rb
@@ -1,6 +1,6 @@
 test_name "group should not create existing group"
 
-name = "test-group-#{Time.new.to_i}"
+name = "gr#{rand(999999).to_i}"
 
 agents.each do |agent|
   step "ensure the group exists on the target node"

--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -3,6 +3,7 @@ test_name "defined should create an entry in filesystem table"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/
+confine :except, :platform => /aix/
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -3,6 +3,7 @@ test_name "should delete an entry in filesystem table and unmount it"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/
+confine :except, :platform => /aix/
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -3,6 +3,7 @@ test_name "should modify an entry in filesystem table"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/
+confine :except, :platform => /aix/
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -3,6 +3,7 @@ test_name "mounted should create an entry in filesystem table and mount it"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/
+confine :except, :platform => /aix/
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mount/query.rb
+++ b/acceptance/tests/resource/mount/query.rb
@@ -2,6 +2,7 @@ test_name "should be able to find an existing filesystem table entry"
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /solaris/
+confine :except, :platform => /aix/
 
 fstab = '/etc/fstab'
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -14,7 +14,7 @@ agents.each do |agent|
   agent.user_get(name)
 
   case agent['platform']
-  when /sles/, /solaris/, /windows/, /osx/
+  when /sles/, /solaris/, /windows/, /osx/, /aix/
     # no private user groups by default
   else
     agent.group_get(name)

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -1,9 +1,10 @@
 test_name "verify that we can modify the gid"
 confine :except, :platform => 'windows'
+confine :except, :platform => /aix/ # PUP-5358
 
-user = "pl#{rand(99999).to_i}"
-group1 = "#{user}old"
-group2 = "#{user}new"
+user = "u#{rand(99999).to_i}"
+group1 = "#{user}o"
+group2 = "#{user}n"
 
 agents.each do |host|
   step "ensure that the groups both exist"

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -1,7 +1,7 @@
 test_name "tests that user resource will not add users that already exist."
 
-user  = "user#{rand(999999).to_i}"
-group = "group#{rand(999999).to_i}"
+user  = "u#{rand(999999).to_i}"
+group = "g#{rand(999999).to_i}"
 
 teardown do
   hosts.each do |host|

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -3,6 +3,7 @@ require 'json'
 test_name "CVE 2013-1652 Improper query parameter validation" do
   confine :except, :platform => 'windows'
   confine :except, :platform => /osx/ # see PUP-4820
+  confine :except, :platform => /aix/
 
   with_puppet_running_on master, {} do
     # Ensure each agent has a signed cert

--- a/acceptance/tests/security/cve-2013-4761_resource_type.rb
+++ b/acceptance/tests/security/cve-2013-4761_resource_type.rb
@@ -10,6 +10,7 @@ end
 test_name "CVE 2013-4761 Remote code execution via REST resource_type" do
   confine :except, :platform => 'windows'
   confine :except, :platform => /osx/ # see PUP-4820
+  confine :except, :platform => /aix/
 
   create_test_file(master, 'auth.conf', <<-AUTH)
 path /resource_type

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -24,11 +24,11 @@ teardown do
   agents.each do |agent|
     step "ensure puppet resets it's user/group settings"
     on agent, puppet('apply', '-e', '"notify { puppet_run: }"')
-    on agent, "find \"#{agent.puppet['vardir']}\" -user existinguser", {:acceptable_exit_codes => [0, 1]} do
+    on agent, "find \"#{agent.puppet['vardir']}\" -user exist_u", {:acceptable_exit_codes => [0, 1]} do
       assert_equal('',stdout)
     end
-    on agent, puppet('resource', 'user', 'existinguser', 'ensure=absent')
-    on agent, puppet('resource', 'group', 'existinggroup', 'ensure=absent')
+    on agent, puppet('resource', 'user', 'exist_u', 'ensure=absent')
+    on agent, puppet('resource', 'group', 'exist_g', 'ensure=absent')
   end
 end
 
@@ -51,16 +51,16 @@ step "when the user and group exist"
 agents.each do |agent|
   logdir = missing_directory_for(agent, 'log')
 
-  on agent, puppet('resource', 'user', 'existinguser', 'ensure=present')
-  on agent, puppet('resource', 'group', 'existinggroup', 'ensure=present')
+  on agent, puppet('resource', 'user', 'exist_u', 'ensure=present')
+  on agent, puppet('resource', 'group', 'exist_g', 'ensure=present')
 
   on agent, puppet('apply',
                    '-e', '"notify { puppet_run: }"',
                    '--logdir', logdir,
-                   '--user', 'existinguser',
-                   '--group', 'existinggroup') do
+                   '--user', 'exist_u',
+                   '--group', 'exist_g') do
 
     assert_match(/puppet_run/, stdout)
-    assert_ownership(agent, logdir, 'existinguser', 'existinggroup')
+    assert_ownership(agent, logdir, 'exist_u', 'exist_g')
   end
 end


### PR DESCRIPTION
This commit patches acceptance tests for AIX. These changes fall
into three major categories.

  * PMT - skip tests due to lack of SSL cert chain for AIX
  * SSL - remove `-k` flag from curl calls
  * user/group - AIX limits user and group names to 9 characters
    by default. Test user and group names have been shorted.