### PR TITLE
(PUP-5294) Do not validate parameters of unevaluated consumers

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -134,6 +134,15 @@ class Puppet::Parser::Resource < Puppet::Resource
     end
   end
 
+  def is_unevaluated_consumer?
+    # We don't declare a new variable here just to test. Saves memory
+    instance_variable_defined?(:@unevaluated_consumer)
+  end
+
+  def mark_unevaluated_consumer
+    @unevaluated_consumer = true
+  end
+
   # Merge an override resource in.  This will throw exceptions if
   # any overrides aren't allowed.
   def merge(resource)

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -412,7 +412,7 @@ class Puppet::Resource::Type
   private :assign_defaults
 
   def validate_resource_hash(resource, resource_hash)
-    Puppet::Pops::Types::TypeMismatchDescriber.validate_parameters(resource.to_s, parameter_struct, resource_hash)
+    Puppet::Pops::Types::TypeMismatchDescriber.validate_parameters(resource.to_s, parameter_struct, resource_hash, resource.is_unevaluated_consumer?)
   end
   private :validate_resource_hash
 

--- a/spec/unit/appmgmt_spec.rb
+++ b/spec/unit/appmgmt_spec.rb
@@ -47,6 +47,7 @@ describe "Application instantiation" do
       application app {
         prod { one: host => ahost, export => Cap[cap] }
         cons { two: host => ahost, consume => Cap[cap] }
+        cons { three: consume => Cap[cap] }
       }
 
       site {
@@ -358,7 +359,7 @@ EOS
       app = apps.first
       expect(app["nodes"]).not_to be_nil
       comps = catalog.direct_dependents_of(app).map(&:ref).sort
-      expect(comps).to eq(["Cons[two]", "Prod[one]"])
+      expect(comps).to eq(["Cons[three]", "Cons[two]", "Prod[one]"])
 
       prod = catalog.resource("Prod[one]")
       expect(prod).not_to be_nil


### PR DESCRIPTION
When compiled with the environment compiler, consumers of capability
resources that has non-default parameters will fail with a validation
error on parameters that are expected to be consumed from the
capability. At validation time only the type and title of the
capability is known.

This commit relaxes the parameter validation when the environment
compiler is used. The compiler will detect resources that consumes
capabilities (using require or consume meta parameters) and mark such
resources as `unevaluated_consumer`. The validation of such resources
will not consider a missing but required parameter an error.