### PR TITLE
(PUP-5351) AuthConfigLoader hook for Puppet Server

### DIFF
--- a/lib/puppet/network/authorization.rb
+++ b/lib/puppet/network/authorization.rb
@@ -21,8 +21,15 @@ module Puppet::Network
   end
 
   module Authorization
+    @@authconfigloader_class = nil
+
+    def self.authconfigloader_class=(klass)
+      @@authconfigloader_class = klass
+    end
+
     def authconfig
-      AuthConfigLoader.authconfig
+      authconfigloader = @@authconfigloader_class || AuthConfigLoader
+      authconfigloader.authconfig
     end
 
     # Verify that our client has access.


### PR DESCRIPTION
This commit provides an accessor for controlling the AuthConfigLoader
class which is used to load an authorization config.  This would be used
by Puppet Server to disable the default AuthConfigLoader when it is
configured to use its own trapperkeeper-based authorization instead.