### PR TITLE
Revert "(PUP-5292) Allow empty arrays as first parameter to regsubst"

### DIFF
--- a/lib/puppet/functions/regsubst.rb
+++ b/lib/puppet/functions/regsubst.rb
@@ -10,7 +10,7 @@
 #
 #   $x = regsubst($ipaddress, /([0-9]+)/, '<\\1>', 'G')
 #
-# @param target [Array[Optional[String]]|String]
+# @param target [Array[String]|String]
 #      The string or array of strings to operate on.  If an array, the replacement will be
 #      performed on each of the elements in the array, and the return value will be an array.
 # @param regexp [String|Regexp|Type[Regexp]]
@@ -37,7 +37,7 @@
 #
 Puppet::Functions.create_function(:regsubst) do
   dispatch :regsubst_string do
-    param          'Variant[Array[Optional[String]],String]',  :target
+    param          'Variant[Array[String],String]',  :target
     param          'String',                         :pattern
     param          'String',                         :replacement
     optional_param 'Optional[Pattern[/^[GEIM]*$/]]', :flags
@@ -45,7 +45,7 @@ Puppet::Functions.create_function(:regsubst) do
   end
 
   dispatch :regsubst_regexp do
-    param          'Variant[Array[Optional[String]],String]',  :target
+    param          'Variant[Array[String],String]',  :target
     param          'Variant[Regexp,Type[Regexp]]',   :pattern
     param          'String',                         :replacement
     optional_param 'Pattern[/^G?$/]',                :flags

--- a/spec/unit/functions/regsubst_spec.rb
+++ b/spec/unit/functions/regsubst_spec.rb
@@ -94,13 +94,5 @@ describe 'the regsubst function' do
                  'G')
       ).to eql(['<130>.<236>.<254>.<10>', '<foo>.<example>.<com>','<coconut>', '<10>.<20>.<30>.<40>'])
     end
-
-    it 'should return an empty array if given an empty array and string pattern' do
-      expect(regsubst([], '', '')).to eql([])
-    end
-
-    it 'should return an empty array if given an empty array and regexp pattern' do
-      expect(regsubst([], //, '')).to eql([])
-    end
   end
 end


### PR DESCRIPTION
This reverts commit 4d2ad0f167d39624da282ac0b8260256746fe488.

Henrik discovered that this allows [undef, undef, undef,...] to be passed
to regsubst, which is not ideal. We'll instead wait for the underlying type system
bug to be fixed instead.