### PR TITLE
(PUP-5271) ADSI User - Do not manage unspecified password

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -188,8 +188,11 @@ module Puppet::Util::Windows::ADSI
     end
 
     def password=(password)
-      native_user.SetPassword(password)
-      commit
+      if !password.nil?
+        native_user.SetPassword(password)
+        commit
+      end
+
       fADS_UF_DONT_EXPIRE_PASSWD = 0x10000
       add_flag("UserFlags", fADS_UF_DONT_EXPIRE_PASSWD)
     end

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -124,7 +124,8 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       resource[:name] = 'DOMAIN\testdomainuser'
       Puppet::Util::Windows::ADSI::Group.expects(:exists?).with(resource[:name]).returns(false)
       connection.expects(:Create)
-      connection.expects(:SetPassword)
+      connection.expects(:Get).with('UserFlags')
+      connection.expects(:Put).with('UserFlags', true)
       connection.expects(:SetInfo).raises( WIN32OLERuntimeError.new("(in OLE method `SetInfo': )\n    OLE error code:8007089A in Active Directory\n      The specified username is invalid.\r\n\n    HRESULT error code:0x80020009\n      Exception occurred."))
 
       expect{ provider.create }.to raise_error(

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -203,6 +203,19 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
         user.password = 'pwd'
       end
 
+       it "should be able manage a user without a password" do
+        adsi_user.expects(:SetPassword).with('pwd').never
+        adsi_user.expects(:SetInfo).at_least_once
+
+        flagname = "UserFlags"
+        fADS_UF_DONT_EXPIRE_PASSWD = 0x10000
+
+        adsi_user.expects(:Get).with(flagname).returns(0)
+        adsi_user.expects(:Put).with(flagname, fADS_UF_DONT_EXPIRE_PASSWD)
+
+        user.password = nil
+      end
+
       it "should generate the correct URI" do
         Puppet::Util::Windows::SID.stubs(:octet_string_to_sid_object).returns(sid)
         user.uri.should == "WinNT://testcomputername/#{username},user"


### PR DESCRIPTION
Currently when the password policy for "Password must meet complexity
requirements" is enabled, attempts to have puppet create Windows users
without passwords fail with result `"OLE error code:800708C5 in Active
Directory. The password does not meet the password policy requirements.
Check the minimum password length, password complexity and password
history requirements."`

This behavior is expected when the password is specified but doesn't meet
the password policy, but not expected when the user has not attempted to
manage the password, e.g. leaving it empty. Correct Puppet not to try to set
the password unless it is specified.

Note that when the password policy "Minimum password length" is greater than
0, the password must always be specified. This is due to how Windows
validates new user creation and it is not possible to leave password
unspecified once that password policy is set.

Also it's important to note that when a user is specified with
`managehome => true`, the password must always be specified if it is not
an already existing user with a password.