### PR TITLE
(PUP-5350) Ensure consistent behavior of filter function

### DIFF
--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -57,14 +57,14 @@ Puppet::Functions.create_function(:filter) do
   end
 
   def filter_Hash_1(hash)
-    result = hash.select {|x, y| yield([x, y]) }
+    result = hash.select {|x, y| yield([x, y]) == true }
     # Ruby 1.8.7 returns Array
     result = Hash[result] unless result.is_a? Hash
     result
   end
 
   def filter_Hash_2(hash)
-    result = hash.select {|x, y| yield(x, y) }
+    result = hash.select {|x, y| yield(x, y) == true }
     # Ruby 1.8.7 returns Array
     result = Hash[result] unless result.is_a? Hash
     result

--- a/spec/unit/functions/filter_spec.rb
+++ b/spec/unit/functions/filter_spec.rb
@@ -126,6 +126,24 @@ describe 'the filter method' do
     expect(catalog).to have_resource("File[/file_blueb]").with_parameter(:ensure, 'present')
   end
 
+  it 'filters on an array will not include elements for which the block returns truthy but not true' do
+    catalog = compile_to_catalog(<<-MANIFEST)
+      $r = [1, 2, 3].filter |$v| { $v } == []
+      notify { "eval_${$r}": }
+    MANIFEST
+
+    expect(catalog).to have_resource('Notify[eval_true]')
+  end
+
+  it 'filters on a hash will not include elements for which the block returns truthy but not true' do
+    catalog = compile_to_catalog(<<-MANIFEST)
+      $r = {a => 1, b => 2, c => 3}.filter |$k, $v| { $v } == {}
+      notify { "eval_${$r}": }
+    MANIFEST
+
+    expect(catalog).to have_resource('Notify[eval_true]')
+  end
+
   it_should_behave_like 'all iterative functions argument checks', 'filter'
   it_should_behave_like 'all iterative functions hash handling', 'filter'
 end


### PR DESCRIPTION
This commit ensures that the filter function behaves consistently
with respect to how the block return value affects the filter.
Prior to this commit, filters on Hash would check if the block
returned truthy and filters on Array would check if it returned
`true`. Now both uses the latter.