### PR TITLE
(PUP-5081) Lookup capabilities using code_id

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -325,7 +325,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       # @todo lutter 2015-03-10: this assumes that it is legal to just
       # mention a capability resource in code and have it automatically
       # made available, even if the current component does not require it
-      result = Puppet::Resource::CapabilityFinder.find(environment, res)
+      result = Puppet::Resource::CapabilityFinder.find(environment, code_id, res)
       add_resource(result) if result
     end
     result

--- a/spec/unit/resource/capability_finder_spec.rb
+++ b/spec/unit/resource/capability_finder_spec.rb
@@ -4,20 +4,28 @@ require_relative '../pops/parser/parser_rspec_helper'
 require 'puppet/resource/capability_finder'
 
 describe Puppet::Resource::CapabilityFinder do
-  it 'should error unless the PuppetDB is configured' do
-    expect { Puppet::Resource::CapabilityFinder.find('production', nil) }.to raise_error(/PuppetDB is not available/)
-  end
-
-  def make_cap_type
-    Puppet::Type.newtype :cap, :is_capability => true do
-      newparam :name
-      newparam :host
+  context 'when PuppetDB is not configured' do
+    it 'should error' do
+      Puppet::Util.expects(:const_defined?).with('Puppetdb').returns false
+      expect { Puppet::Resource::CapabilityFinder.find('production', nil, nil) }.to raise_error(/PuppetDB is not available/)
     end
   end
 
-  it 'should call Puppet::Util::PuppetDB::Http.action' do
-    make_cap_type
-    cap = Puppet::Resource.new('Cap', 'cap')
+  context 'when PuppetDB is configured' do
+    around(:each) do |example|
+      mock_pdb = !Puppet::Util.const_defined?('Puppetdb')
+      if mock_pdb
+        class Puppet::Util::Puppetdb
+          class Http; end
+        end
+      end
+      begin
+        make_cap_type
+        example.run
+      ensure
+        Puppet::Util.send(:remove_const, 'Puppetdb') if mock_pdb
+      end
+    end
 
     class MockResponse
       def body
@@ -25,14 +33,24 @@ describe Puppet::Resource::CapabilityFinder do
       end
     end
 
-    unless Puppet::Util.const_defined?('Puppetdb')
-      class Puppet::Util::Puppetdb
-        class Http; end
+    def make_cap_type
+      Puppet::Type.newtype :cap, :is_capability => true do
+        newparam :name
+        newparam :host
       end
     end
 
-    Puppet::Util::Puppetdb::Http.expects(:action).returns(MockResponse.new)
-    result = Puppet::Resource::CapabilityFinder.find('production', cap)
-    expect(result['host']).to eq('ahost')
+    it 'should call Puppet::Util::PuppetDB::Http.action' do
+      Puppet::Util::Puppetdb::Http.expects(:action).returns(MockResponse.new)
+      result = Puppet::Resource::CapabilityFinder.find('production', nil, Puppet::Resource.new('Cap', 'cap'))
+      expect(result['host']).to eq('ahost')
+    end
+
+    it 'should use pass code_id in query to Puppet::Util::PuppetDB::Http.action' do
+      code_id = 'b59e5df0578ef411f773ee6c33d8073c50e7b8fe'
+      Puppet::Util::Puppetdb::Http.expects(:action).with(regexp_matches(Regexp.new(CGI.escape('"=","code_id","' + code_id + "")))).returns(MockResponse.new)
+      result = Puppet::Resource::CapabilityFinder.find('production', code_id, Puppet::Resource.new('Cap', 'cap'))
+      expect(result['host']).to eq('ahost')
+    end
   end
 end


### PR DESCRIPTION
Ensure that code_id is part of the query when asking PuppetDB for
a capability.