### PR TITLE
(PUP-4740) Update HTTP APIs for source_permissions and configured_environment

### DIFF
--- a/api/docs/http_api_index.md
+++ b/api/docs/http_api_index.md
@@ -7,6 +7,9 @@ and they've historically relied on a lot of shared code to work correctly.
 This is gradually changing, although we expect external use of these APIs to
 remain low for the foreseeable future.
 
+Puppet will often send garbage URL parameters, such as `fail_on_404` and
+`ignore_cache`. The server will ignore any parameters it isn't expecting.
+
 V1/V2 HTTP APIs (Removed)
 ---------------
 

--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -8,7 +8,7 @@ Find
 
 Retrieve a catalog.
 
-    POST /puppet/v3/catalog/:nodename?environment=:environment
+    POST /puppet/v3/catalog/:nodename
     GET /puppet/v3/catalog/:nodename?environment=:environment
 
 ### Supported HTTP Methods
@@ -31,21 +31,26 @@ The examples below use the POST method.
 
 ### Parameters
 
-Three parameters should be provided to the POST or GET:
+Four parameters should be provided to the POST or GET:
 
+- `environment`: the environment name
 - `facts_format`: must be `pson`
 - `facts`: serialized pson of the facts hash.  One odd note: due to a long-ago misunderstanding in the code, this is
 doubly-escaped (it should just be singly-escaped).  To keep backward compatibility, the extraneous
 escaping is still used/supported.
 - `transaction_uuid`: a transaction uuid identifying the entire transaction (shows up in the report as well)
 
+An optional parameter can be provided to the POST or GET to notify a node classifier that the client requested a specific
+environment, which might differ from what the client believes is its current environment.
+- `configured_environment`: the environment configured on the client
+
 ### Example Response
 
 #### Catalog found
 
-    POST /puppet/v3/catalog/elmo.mydomain.com?environment=env
+    POST /puppet/v3/catalog/elmo.mydomain.com
 
-    facts_format=pson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c
+    environment=env&configured_environment=canary_env&facts_format=pson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c
 
     HTTP 200 OK
     Content-Type: text/pson

--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -41,7 +41,8 @@ escaping is still used/supported.
 - `transaction_uuid`: a transaction uuid identifying the entire transaction (shows up in the report as well)
 
 An optional parameter can be provided to the POST or GET to notify a node classifier that the client requested a specific
-environment, which might differ from what the client believes is its current environment.
+environment, which might differ from what the client believes is its current environment:
+
 - `configured_environment`: the environment configured on the client
 
 ### Example Response

--- a/api/docs/http_file_metadata.md
+++ b/api/docs/http_file_metadata.md
@@ -36,7 +36,14 @@ PSON
 
 ### Parameters
 
-None
+Optional parameters to GET:
+
+* `links` -- either `manage` (default) or `follow`.  See examples in Search below.
+* `checksum_type` -- the checksum type to calculate the checksum value for the result metadata; one of `md5` (default), `md5lite`, `sha256`, `sha256lite`, `mtime`, `ctime`, and `none`.
+* `source_permissions` -- whether (and how) Puppet should copy owner, group, and mode permissions; one of
+  * `ignore` (the default) will never apply the owner, group, or mode from the source when managing a file. When creating new files without explicit permissions, the permissions they receive will depend on platform-specific behavior. On POSIX, Puppet will use the umask of the user it is running as. On Windows, Puppet will use the default DACL associated with the user it is running as.
+  * `use` will cause Puppet to apply the owner, group, and mode from the source to any files it is managing.
+  * `use_when_creating` will only apply the owner, group, and mode from the source when creating a file; existing files will not have their permissions overwritten.
 
 ### Example Response
 
@@ -134,6 +141,11 @@ Accept: pson, text/pson
 * `recurse` -- should always be set to `yes`; unfortunately the default is `no`, which causes a search to behave like a find operation.
 * `ignore` -- file or directory regex to ignore; can be repeated.
 * `links` -- either `manage` (default) or `follow`.  See examples below.
+* `checksum_type` -- the checksum type to calculate the checksum value for the result metadata; one of `md5` (default), `md5lite`, `sha256`, `sha256lite`, `mtime`, `ctime`, and `none`.
+* `source_permissions` -- whether (and how) Puppet should copy owner, group, and mode permissions; one of
+  * `ignore` (the default) will never apply the owner, group, or mode from the source when managing a file. When creating new files without explicit permissions, the permissions they receive will depend on platform-specific behavior. On POSIX, Puppet will use the umask of the user it is running as. On Windows, Puppet will use the default DACL associated with the user it is running as.
+  * `use` will cause Puppet to apply the owner, group, and mode from the source to any files it is managing.
+  * `use_when_creating` will only apply the owner, group, and mode from the source when creating a file; existing files will not have their permissions overwritten.
 
 ### Example Response
 

--- a/api/docs/http_file_metadata.md
+++ b/api/docs/http_file_metadata.md
@@ -84,9 +84,9 @@ None
         "type": "directory"
     }
 
-#### File metadata found for a link
+#### File metadata found for a link ignoring source permissions
 
-    GET /puppet/v3/file_metadata/modules/example/link_to_file.txt?environment=env
+    GET /puppet/v3/file_metadata/modules/example/link_to_file.txt?environment=env&source_permissions=ignore
 
     HTTP/1.1 200 OK
     Content-Type: text/pson
@@ -99,7 +99,7 @@ None
         "destination": "/etc/puppetlabs/code/modules/example/files/just_a_file.txt",
         "group": 20,
         "links": "manage",
-        "mode": 493,
+        "mode": 420,
         "owner": 501,
         "path": "/etc/puppetlabs/code/modules/example/files/link_to_file.txt",
         "relative_path": null,

--- a/api/docs/http_node.md
+++ b/api/docs/http_node.md
@@ -24,9 +24,20 @@ GET
 
 PSON
 
+### Parameters
+
+One parameter should be provided to the GET:
+
+- `transaction_uuid`: a transaction uuid identifying the entire transaction (shows up in the report as well)
+
+An optional parameter can be provided to the GET to notify a node classifier that the client requested a specific
+environment, which might differ from what the client believes is its current environment:
+
+- `configured_environment`: the environment configured on the client
+
 ### Examples
 
-    > GET /puppet/v3/node/mycertname?environment=production&configured_environment=production HTTP/1.1
+    > GET /puppet/v3/node/mycertname?environment=production&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c&configured_environment=production HTTP/1.1
     > Accept: pson, b64_zlib_yaml, yaml, raw
 
     < HTTP/1.1 200 OK

--- a/api/docs/http_node.md
+++ b/api/docs/http_node.md
@@ -13,7 +13,7 @@ Find
 
 Retrieve data for a node
 
-    GET /puppet/v3/node/:certname?environment=:environment
+    GET /puppet/v3/node/:certname?environment=:environment&transaction_uuid=:transaction_uuid&configured_environment=:environment
 
 
 ### Supported HTTP Methods
@@ -26,7 +26,7 @@ PSON
 
 ### Examples
 
-    > GET /puppet/v3/node/mycertname?environment=production HTTP/1.1
+    > GET /puppet/v3/node/mycertname?environment=production&configured_environment=production HTTP/1.1
     > Accept: pson, b64_zlib_yaml, yaml, raw
 
     < HTTP/1.1 200 OK


### PR DESCRIPTION
##### (PUP-4740) Update http file_metadata api with source_permissions

Previously the source_permissions parameter was added to file_metadata
without updating the API documentation. Update the API documentation
with examples of its use.

##### (PUP-4740) Add configured_environment to node and catalog APIs

The client includes which environment was configured on the client (if
not using the application default) as the configured_environment in node
and catalog requests. This may be used by a node classifier when
determining the environment the client should use, as added in PUP-4521.

Also adds that the transaction_uuid can be included in the node request.