### PR TITLE
(PUP-5382) Allow undefined nodes key on app declarations

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -330,6 +330,7 @@ class Puppet::Parser::Compiler
     @applications.each do |app|
       components = []
       mapping = app.parameters[:nodes] ? app.parameters[:nodes].value : {}
+      raise Puppet::Error, "Invalid node mapping in #{app.ref}: Mapping must be a hash" unless mapping.is_a?(Hash)
       all_mapped = Set.new
       mapping.each do |k,v|
         raise Puppet::Error, "Invalid node mapping in #{app.ref}: Key #{k} is not a Node" unless k.is_a?(Puppet::Resource) && k.type == 'Node'

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -328,8 +328,8 @@ class Puppet::Parser::Compiler
   # @api private
   def evaluate_applications
     @applications.each do |app|
-      mapping = app.parameters[:nodes].value
       components = []
+      mapping = app.parameters[:nodes] ? app.parameters[:nodes].value : {}
       all_mapped = Set.new
       mapping.each do |k,v|
         raise Puppet::Error, "Invalid node mapping in #{app.ref}: Key #{k} is not a Node" unless k.is_a?(Puppet::Resource) && k.type == 'Node'

--- a/spec/unit/appmgmt_spec.rb
+++ b/spec/unit/appmgmt_spec.rb
@@ -110,6 +110,28 @@ MANIFEST_WO_NODE = <<-EOS
     }
 EOS
 
+MANIFEST_WITH_STRING_NODES = <<-EOS
+    application app {
+    }
+
+    site {
+      app { anapp:
+        nodes => "foobar",
+      }
+    }
+EOS
+
+MANIFEST_WITH_FALSE_NODES = <<-EOS
+    application app {
+    }
+
+    site {
+      app { anapp:
+        nodes => false,
+      }
+    }
+EOS
+
 MANIFEST_REQ_WO_EXPORT = <<-EOS
     define prod($host) {
       notify { "host ${host}":}
@@ -276,6 +298,16 @@ EOS
 
     it "does not raise an error when node mappings are not provided" do
       expect { compile_to_catalog(MANIFEST_WO_NODE) }.to_not raise_error
+    end
+
+    it "raises an error if node mapping is a string" do
+      expect { compile_to_catalog(MANIFEST_WITH_STRING_NODES)
+      }.to raise_error(/Invalid node mapping in .*: Mapping must be a hash/)
+    end
+
+    it "raises an error if node mapping is false" do
+      expect { compile_to_catalog(MANIFEST_WITH_FALSE_NODES)
+      }.to raise_error(/Invalid node mapping in .*: Mapping must be a hash/)
     end
 
     it "detects that consumed capability is never exported" do

--- a/spec/unit/appmgmt_spec.rb
+++ b/spec/unit/appmgmt_spec.rb
@@ -86,6 +86,30 @@ MANIFEST_WO_EXPORT = <<-EOS
     }
 EOS
 
+MANIFEST_WO_NODE = <<-EOS
+    define prod($host) {
+      notify { "host ${host}":}
+    }
+
+    Prod produces Cap { }
+
+    define cons($host) {
+      notify { "host ${host}": }
+    }
+
+    Cons consumes Cap { }
+
+    application app {
+      prod { one: host => ahost, export => Cap[cap] }
+      cons { two: host => ahost, consume => Cap[cap] }
+    }
+
+    site {
+      app { anapp:
+      }
+    }
+EOS
+
 MANIFEST_REQ_WO_EXPORT = <<-EOS
     define prod($host) {
       notify { "host ${host}":}
@@ -248,6 +272,10 @@ EOS
     it "an application instance must be contained in a site" do
       expect { compile_to_catalog(FAULTY_MANIFEST, Puppet::Node.new('first'))
       }.to raise_error(/Application instances .* can only be contained within a Site/)
+    end
+
+    it "does not raise an error when node mappings are not provided" do
+      expect { compile_to_catalog(MANIFEST_WO_NODE) }.to_not raise_error
     end
 
     it "detects that consumed capability is never exported" do


### PR DESCRIPTION
Per the app spec, providing node mappings on app declarations is
optional. Prior to this commit, an error would be raised if the nodes
key on an app declaration was undefined. This commit prevents `.value`
from being called on an undefined value during application evaluation.