### PR TITLE
(PUP-5311) Check stderr for errors in AIX package test

### DIFF
--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -73,7 +73,7 @@ assert_package_version package, version2
 step "test that downgrading fails by trying to install an older version of the package"
 
 on hosts, puppet_apply("--verbose", "--detailed-exitcodes"), :stdin => version1_manifest, :acceptable_exit_codes => [4,6] do
-  assert_match(/aix package provider is unable to downgrade packages/, stdout, "Didn't get an error about downgrading packages")
+  assert_match(/aix package provider is unable to downgrade packages/, stderr, "Didn't get an error about downgrading packages")
 end
 
 step "uninstall the package"


### PR DESCRIPTION
Puppet sends error notices to stderr instead of stdout. Update
the aix package provider test to reflect this.