### PR TITLE
(PUP-5314) Switch to allowed shell on AIX in shell test

### DIFF
--- a/acceptance/tests/resource/user/should_manage_shell.rb
+++ b/acceptance/tests/resource/user/should_manage_shell.rb
@@ -19,7 +19,14 @@ agents.each do |agent|
   end
 
   step "modify the user with shell"
-  shell = '/bin/bash'
+
+  # We need to use an allowed shell in AIX, as according to `/etc/security/login.cfg`
+  if agent['platform'] =~ /aix/
+    shell = '/bin/ksh'
+  else
+    shell = '/bin/bash'
+  end
+
   on agent, puppet_resource('user', name, ["ensure=present", "shell=#{shell}"])
 
   step "verify the user shell matches the managed shell"


### PR DESCRIPTION
Previously, the should_manage_shell test tried to switch the
user's shell to /bin/bash, which actually won't work on AIX
because it is not specifically allowed in /etc/security/login.cfg
and thus is not considered valid.

Modify the test to use ksh for AIX instead, which is an allowed
shell.