### PR TITLE
(PUP-5310) Shorten username for AIX acceptance

### DIFF
--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -15,15 +15,25 @@ hosts_to_test = agents.reject do |agent|
 end
 skip_test "No suitable hosts found" if hosts_to_test.empty?
 
+username = "pl#{rand(99999).to_i}"
+
+teardown do
+  step "Teardown: Ensure test user is removed"
+  hosts_to_test.each do |host|
+    on agent, puppet('resource', 'user', username, 'ensure=absent')
+    on agent, puppet('resource', 'group', username, 'ensure=absent')
+  end
+end
+
 adduser_manifest = <<MANIFEST
-user { 'passwordtestuser':
+user { '#{username}':
   ensure   => 'present',
   password => 'apassword',
 }
 MANIFEST
 
 changepass_manifest = <<MANIFEST
-user { 'passwordtestuser':
+user { '#{username}':
   ensure   => 'present',
   password => 'newpassword',
   noop     => true,


### PR DESCRIPTION
This commit shortens the username used in the
`ticket_6857_password-disclosure-when-changing-a-users-password`
acceptance test to adhere to the default 8 character limit in AIX.