### PR TITLE
(PUP-5312) Skip concurrent requests test on AIX

### DIFF
--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -4,6 +4,7 @@ test_name "concurrent catalog requests (PUP-2659)"
 confine :except, :platform => 'windows'
 confine :except, :platform => /osx/ # see PUP-4820
 confine :except, :platform => 'solaris'
+confine :except, :platform => 'aix'
 
 step "setup a manifest"
 


### PR DESCRIPTION
This commit skips AIX agents when conducting the
`concurrency/ticket_2659_concurrent_catalog_requests` acceptance
test.