### PR TITLE
(PUP-5313) Fix user gid test for AIX

### DIFF
--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -22,6 +22,9 @@ agents.each do |host|
     if host['platform'] =~ /osx/
         match = result.stdout.match(/gid: (\d+)/)
         user_gid = match ? match[1] : nil
+    elsif host['platform'] =~ /aix/
+        match = result.stdout.match(/pgrp=([^\s\\]+)/)
+        user_gid = match ? host.group_gid(match[1]) : nil
     else
         user_gid = result.stdout.split(':')[3]
     end


### PR DESCRIPTION
This commit updates the `resource/user/should_create_with_gid`
acceptance test to accommodate finding the gid for the user under
test on AIX.