### PR TITLE
(PUP-5380) Cache future_parser flag in environment

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2052,6 +2052,10 @@ EOT
     },
     :parser => {
       :default => "current",
+      :hook    => proc do |value|
+        envs = Puppet.lookup(:environments) { nil }
+        envs.clear_all unless envs.nil?
+      end,
       :desc => <<-'EOT'
         Selects the parser to use for parsing puppet manifests (in puppet DSL
         language/'.pp' files). Available choices are `current` (the default)

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -38,6 +38,11 @@ module Puppet::Environments
         raise EnvironmentNotFound, name
       end
     end
+
+    def clear_all
+      root = Puppet.lookup(:root_environment) { nil }
+      root.instance_variable_set(:@future_parser, nil) unless root.nil?
+    end
   end
 
   # @!macro [new] loader_search_paths
@@ -311,6 +316,9 @@ module Puppet::Environments
       nil
     end
 
+    def clear_all
+      @loaders.each {|loader| loader.clear_all}
+    end
   end
 
   class Cached
@@ -412,6 +420,7 @@ module Puppet::Environments
     # Clears all cached environments.
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
     def clear_all()
+      super
       @cache = {}
       @expirations.clear
       @next_expiration = END_OF_TIME

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -258,6 +258,15 @@ class Puppet::Node::Environment
     !original_manifest.nil? && !original_manifest.empty? && original_manifest != Puppet[:default_manifest]
   end
 
+  # @api private
+  def future_parser?
+    if @future_parser.nil?
+      environment_conf = Puppet.lookup(:environments).get_conf(name)
+      @future_parser = 'future' == (environment_conf.nil? ? Puppet[:parser] : environment_conf.parser)
+    end
+    @future_parser
+  end
+
   # Return an environment-specific Puppet setting.
   #
   # @api public


### PR DESCRIPTION
Prior to this commit, the Puppet.future_parser? method would load
the environment configuration from disk each time the method was
called. This had a very negative performance impact since it happens
in a lot of places.

This commit ensures that the future_parser flag is cached in the
environment instance.

All caches are cleared when the global configuration is changed.
Individual environment caches are cleared when the environment times
out.