### PR TITLE
(PUP-5151) Don't allow remote file buckets to be listed

### DIFF
--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -47,11 +47,12 @@ restore:
   to its original location.
 
 diff:
-  Print a diff in unified format between two checksums in the filebucket or between a checksum and
-  its matching file.
+  Print a diff in unified format between two checksums in the filebucket
+  or between a checksum and its matching file.
 
 list:
-  List all files in the current filebucket.
+  List all files in the current local filebucket. Listing remote
+  filebuckets is not allowed.
 
 DESCRIPTION
 -----------

--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -153,6 +153,8 @@ class Puppet::FileBucket::Dipper
 
   # List Filebucket content.
   def list(fromdate, todate)
+    raise Puppet::Error, "Listing remote file buckets is not allowed" unless local?
+
     source_path = "#{@rest_path}#{@checksum_type}/"
     file_bucket_list = Puppet::FileBucket::File.indirection.find(
       source_path,

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -38,6 +38,10 @@ module Puppet::FileBucketFile
     end
 
     def list(request)
+      if request.remote?
+        raise Puppet::Error, "Listing remote file buckets is not allowed"
+      end
+
       fromdate = request.options[:fromdate] || "0:0:0 1-1-1970"
       todate = request.options[:todate] || Time.now.strftime("%F %T")
       begin

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -241,7 +241,6 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
   describe "when diffing on a remote filebucket" do
     describe "in non-windows environments", :unless => Puppet.features.microsoft_windows? do
       with_digest_algorithms do
-
         it "should fail in an informative way when one or more checksum doesn't exists" do
           @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port => "31337")
           wrong_checksum = "DEADBEEF"
@@ -252,7 +251,6 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
         end
 
         it "should properly diff files on the filebucket" do
-
           @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port => "31337")
 
           Puppet::FileBucketFile::Rest.any_instance.expects(:find).returns("Probably valid diff")
@@ -261,6 +259,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
         end
       end
     end
+
     describe "in windows environment", :if => Puppet.features.microsoft_windows? do
       it "should fail in an informative way when trying to diff" do
         @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port => "31337")
@@ -274,46 +273,12 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
   end
 
   describe "listing files in remote filebucket" do
-    with_digest_algorithms do
-      it "should list all files present" do
-        @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port=> "31337")
+    it "is not allowed" do
+      @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port=> "31337")
 
-        file = make_tmp_file(plaintext)
-        real_path = Pathname.new(file).realpath
-
-        date = Time.now.strftime("%F %T")
-
-        expect(digest(plaintext)).to eq(checksum)
-        expected_list = "#{checksum} #{date} #{file}\n"
-
-        Puppet::FileBucketFile::Rest.any_instance.expects(:find).with { |r| request = r }.returns(expected_list)
-
-        expect(@dipper.list(nil, nil)).to eq(expected_list)
-
-      end
-      it "should filter with the provided dates" do
-        @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port=> "31337")
-
-        file = make_tmp_file(plaintext)
-        date = Time.now
-        date_s = date.strftime("%F %T")
-
-        expect(digest(plaintext)).to eq(checksum)
-
-        expected_list = "#{checksum} #{date_s} #{file}\n"
-
-        Puppet::FileBucketFile::Rest.any_instance.expects(:find).with { |r| request = r }.returns("")
-        expect(@dipper.list((date + 3).strftime("%F %T"), nil )).to eq("")
-
-        Puppet::FileBucketFile::Rest.any_instance.expects(:find).with { |r| request = r }.returns(expected_list+expected_list)
-        expect(@dipper.list(nil, (date + 3).strftime("%F %T"))).to eq(expected_list + expected_list)
-
-        Puppet::FileBucketFile::Rest.any_instance.expects(:find).with { |r| request = r }.returns(expected_list)
-        expect(@dipper.list(date_s, (date + 3).strftime("%F %T"))).to eq(expected_list)
-
-        Puppet::FileBucketFile::Rest.any_instance.expects(:find).with { |r| request = r }.returns("")
-        expect(@dipper.list((date + 1).strftime("%F %T"), (date + 3).strftime("%F %T"))).to eq("")
-      end
+      expect {
+        @dipper.list(nil, nil)
+      }.to raise_error(Puppet::Error, "Listing remote file buckets is not allowed")
     end
   end
 

--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -114,6 +114,17 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
             expect(Puppet::FileBucket::File.indirection.find("#{digest_algorithm}/#{not_bucketed_checksum}/foo/bar", :list_all => true)).to eq(nil)
           end
 
+          it "raises when the request is remote" do
+            Puppet[:bucketdir] = tmpdir('bucket')
+
+            request = Puppet::Indirector::Request.new(:file_bucket_file, :find, "#{digest_algorithm}/#{checksum}/foo/bar", nil, :list_all => true)
+            request.node = 'client.example.com'
+
+            expect {
+              Puppet::FileBucketFile::File.new.find(request)
+            }.to raise_error(Puppet::Error, "Listing remote file buckets is not allowed")
+          end
+
           it "should return the list of bucketed files in a human readable way" do
             checksum1 = save_bucket_file("I'm the contents of a file", '/foo/bar1')
             checksum2 = save_bucket_file("I'm the contents of another file", '/foo/bar2')


### PR DESCRIPTION
Previously the filebucket list command was implemented using the `find`
method on the `file_bucket_file` endpoint passing along `list_all` as a
query parameter. However, the filebucket is accessible to all users, so
any remote user could list the contents of the filebucket and retrieve
file content backed up by other hosts. And since retrieve and list both
use `find` where the only difference is the `find_all` query parameter,
it wasn't possible to write an ACL that allowed access to the
former, but denied access to the latter.

This commit modifies the dipper client code to raise an error when
trying to list a remote filebucket. It also modifies the
Puppet::FileBucketFile::File#list server-side code to reject remote
requests, for example, if you curl the REST API directly.

Note the list method raises an AuthorizationError so that the REST
endpoint returns HTTP 403 to the caller.