### PR TITLE
(PUP-5059) Add the --node feature to lookup CLI tool 

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -131,11 +131,10 @@ class Puppet::Application::Lookup < Puppet::Application
 
     setup_terminuses
 
-    # TODO: Do we need this in preview? It sets up a write only cache
+    # TODO: Do we need this in lookup? It sets up a write only cache
     setup_node_cache
 
     setup_ssl
-    puts "setup happened! o:"
   end
 
   def help
@@ -163,9 +162,7 @@ DESCRIPTION
 -----------
 The lookup command is a CLI interface for the puppet lookup function.
 When given one or more keys, the lookup command will return the first
-value found. The only component that is required in addition to the
-keys is a node (passed in via --node) which specifies which scope to
-perform the lookup in. 
+value found.
 
 When an explanation has not been requested and
 lookup is simply looking up a value, the application will exit with 0
@@ -222,8 +219,8 @@ the puppet lookup function linked to above.
 
 * --node <NODE-NAME>
   Specify node which defines the scope in which the lookup will be performed.
-  If a node is not given, lookup will raise an error as it requires a scope
-  in order to perform a lookup.
+  If a node is not given, lookup will default to the machine from which the
+  lookup is being run (which should be the master).
 
 * --facts <FILE>
   Specify a .json, or .yaml file holding key => value mappings that will
@@ -236,6 +233,10 @@ the puppet lookup function linked to above.
 
 EXAMPLE
 -------
+  If you wanted to lookup 'key_name' within the scope of the master, you would 
+  call lookup like this:
+  $ puppet lookup key_name
+
   If you wanted to lookup 'key_name' within the scope of the agent.local node,
   you would call lookup like this:
   $ puppet lookup --node agent.local key_name

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -14,14 +14,6 @@ describe Puppet::Application::Lookup do
       expect{ lookup.run_command }.to raise_error(RuntimeError, expected_error)
     end
 
-    it "errors if no node was given via the --node flag" do
-      lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
-
-      expected_error = "No node was given via the '--node' flag for the scope of the lookup.\nRun 'puppet lookup --help' for more details"
-
-      expect{ lookup.run_command }.to raise_error(RuntimeError, expected_error)
-    end
-
     it "does not allow deep merge options if '--merge' was not set to deep" do
       lookup.options[:node] = 'dantooine.local'
       lookup.options[:merge_hash_arrays] = true


### PR DESCRIPTION
Prior to this commit, the --node flag did not actually work as
intended, it would simply always default to the machine you were
running lookup on due to some settings not being configured properly.

Now you can specify a node with --node and the host name and lookup
will find and compile that node to obtain a scope. If you do not
specify a node then lookup will default to using the scope of the
machine you are running on (which is intended to be the master).