### PR TITLE
(PUP-4954) Don't initialize environment object in indirector requests unless it's used

### DIFF
--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -29,16 +29,25 @@ class Puppet::Indirector::Request
   def environment
     # If environment has not been set directly, we should use the application's
     # current environment
-    @environment ||= Puppet.lookup(:current_environment)
+    @environment ||= if @environment_name
+                         Puppet.lookup(:environments).get!(@environment_name)
+                     else
+                         Puppet.lookup(:current_environment)
+                     end
   end
 
   def environment=(env)
-    @environment =
     if env.is_a?(Puppet::Node::Environment)
-      env
+      @environment = env
+      @environment_name = nil
     else
-      Puppet.lookup(:environments).get!(env)
+      @environment = nil
+      @environment_name = env
     end
+  end
+
+  def environment_name
+    @environment_name || self.environment.name
   end
 
   def escaped_key

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -226,7 +226,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
   def self.request_to_uri_and_body(request)
     url_prefix = IndirectionType.url_prefix_for(request.indirection_name.to_s)
     indirection = request.method == :search ? pluralize(request.indirection_name.to_s) : request.indirection_name.to_s
-    ["#{url_prefix}/#{indirection}/#{request.escaped_key}", "environment=#{request.environment.name}&#{request.query_string}"]
+    ["#{url_prefix}/#{indirection}/#{request.escaped_key}", "environment=#{request.environment_name}&#{request.query_string}"]
   end
 
   def self.pluralize(indirection)


### PR DESCRIPTION
Previously, any indirector request to a URI that had the appropriate
environment/indirector/key pathing would cause the request to
initialize an environment object. With directory environments, this
does not work - the agent probably doesn't have a dir for the
environment of the request, so initializing the environment object
fails.

This change makes initialization of the request-associated environment
object lazy, such that it only happens if the environment is actually
requested. It also makes a small change to the http indirected_routes
logic so that it does not force creation of the environment object
simply to query its name.