### PR TITLE
(PUP-5311) Update teardown for aix pkg acceptance

### DIFF
--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -4,10 +4,6 @@ confine :to, :platform => /aix/
 
 dir = "/tmp/aix-packages-#{$$}"
 
-teardown do
-  on hosts, "rm -rf #{dir}"
-end
-
 def assert_package_version(package, expected_version)
   # The output of lslpp is a colon-delimited list like:
   # sudo:sudo.rte:1.8.6.4: : :C: :Configurable super-user privileges runtime: : : : : : :0:0:/:
@@ -21,6 +17,11 @@ end
 package = 'sudo.rte'
 version1 = '1.7.10.4'
 version2 = '1.8.6.4'
+
+teardown do
+  on hosts, "rm -rf #{dir}"
+  on hosts, puppet('resource', 'package', "'#{package}' ensure=absent")
+end
 
 step "download packages to use for test"
 


### PR DESCRIPTION
This commit updates the teardown step in the `aix_package_provider`
test to ensure that the packages involved in the test are removed
when the test is completed.