### PR TITLE
(PUP-5275) Evalutate capability mappings after evaluating site

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -179,7 +179,10 @@ class Puppet::Parser::Compiler
 
       Puppet::Util::Profiler.profile("Compile: Evaluated main", [:compiler, :evaluate_main]) { evaluate_main }
 
-      Puppet::Util::Profiler.profile("Env Compile: Evaluated site", [:compiler, :evaluate_site]) { evaluate_site }
+      Puppet::Util::Profiler.profile("Compile: Evaluated site", [:compiler, :evaluate_site]) { evaluate_site }
+
+      # New capability mappings may have been defined when the site was evaluated
+      Puppet::Util::Profiler.profile("Compile: Evaluated site capability mappings", [:compiler, :evaluate_capability_mappings]) { evaluate_capability_mappings }
 
       Puppet::Util::Profiler.profile("Compile: Evaluated AST node", [:compiler, :evaluate_ast_node]) { evaluate_ast_node }
 


### PR DESCRIPTION
This commit ensures that capability mappings are evaluated twice. Once
before evaluate_main since it eventually calls on evaluate_classes
which may require capability mappings, and then again after
evaluate_site since it may introduce new mappings.

I have tested this manually in my own local setup (based on input from
Nick Lewis in the JIRA) but there should be acceptance tests for this
too.