### PR TITLE
(PUP-5398) Fix regression causing file watching for dir environments

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -252,12 +252,14 @@ module Puppet::Environments
     def create_environment(name, setting_values = nil)
       env_symbol = name.intern
       setting_values = Puppet.settings.values(env_symbol, Puppet.settings.preferred_run_mode)
-      Puppet::Node::Environment.create(
+      env = Puppet::Node::Environment.create(
         env_symbol,
         Puppet::Node::Environment.split_path(setting_values.interpolate(:modulepath)),
         setting_values.interpolate(:manifest),
         setting_values.interpolate(:config_version)
       )
+      env.watching = false
+      env
     end
 
     def valid_directory?(envdir)


### PR DESCRIPTION
This commit fixes a regression that causes all manifests to be watched
and hence to be subject to the filetimeout in directory environments.
This causes reparse of the manifests even if the environment_timeout
is set to unlimited.