### PR TITLE
(PUP-5381) Fix access operator for Undef and Optional types

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -247,10 +247,14 @@ class Puppet::Pops::Evaluator::AccessOperator
     keys.flatten!
     if keys.size == 1
       type = keys[0]
-      unless type.is_a?(Puppet::Pops::Types::PAnyType) || type.is_a?(String)
-        fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[0], {:base_type => 'Optional-Type', :actual => type.class})
+      unless type.is_a?(Puppet::Pops::Types::PAnyType)
+        if type.is_a?(String)
+          type = TYPEFACTORY.string(nil, type)
+        else
+          fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[0], {:base_type => 'Optional-Type', :actual => type.class})
+        end
       end
-      Puppet::Pops::Types::POptionalType.new(keys[0])
+      Puppet::Pops::Types::POptionalType.new(type)
     else
       fail(Puppet::Pops::Issues::BAD_TYPE_SLICE_ARITY, @semantic, {:base_type => 'Optional-Type', :min => 1, :actual => keys.size})
     end
@@ -265,7 +269,7 @@ class Puppet::Pops::Evaluator::AccessOperator
       type = keys[0]
       case type
       when String
-        type = TYPEFACTORY.string(type)
+        type = TYPEFACTORY.string(nil, type)
       when Puppet::Pops::Types::PAnyType
         type = nil if type.class == Puppet::Pops::Types::PAnyType
       else

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -412,7 +412,13 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
     it 'produces a NotUndef instance with String type when given a literal String' do
       type_expr = fqr('NotUndef')[literal('hey')]
       tf = Puppet::Pops::Types::TypeFactory
-      expect(evaluate(type_expr)).to eql(tf.not_undef(tf.string('hey')))
+      expect(evaluate(type_expr)).to be_the_type(tf.not_undef(tf.string(nil, 'hey')))
+    end
+
+    it 'Produces Optional instance with String type when using a String argument' do
+      type_expr = fqr('Optional')[literal('hey')]
+      tf = Puppet::Pops::Types::TypeFactory
+      expect(evaluate(type_expr)).to be_the_type(tf.optional(tf.string(nil, 'hey')))
     end
 
     # Type Type


### PR DESCRIPTION
Passing a literal String as T to the Undef[T] or Optional[T] types
was handled badly in the AccessOperator and equally badly in the
unit test that verified the function (for Undef[T], there was no
unit test for Optional[T]).

This commit fixes the problem and the tests.