### PR TITLE
(PUP-5355) Add more descriptive oid names

### DIFF
--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -48,7 +48,15 @@ module Puppet::SSL::Oids
     ["1.3.6.1.4.1.34380.1.1.15", 'pp_department', 'Puppet Node Department Name'],
     ["1.3.6.1.4.1.34380.1.1.16", 'pp_cluster', 'Puppet Node Cluster Name'],
     ["1.3.6.1.4.1.34380.1.1.17", 'pp_provisioner', 'Puppet Node Provisioner Name'],
-    
+    ["1.3.6.1.4.1.34380.1.1.18", 'pp_region', 'Puppet Node Region Name'],
+    ["1.3.6.1.4.1.34380.1.1.19", 'pp_datacenter', 'Puppet Node Datacenter Name'],
+    ["1.3.6.1.4.1.34380.1.1.20", 'pp_zone', 'Puppet Node Zone Name'],
+    ["1.3.6.1.4.1.34380.1.1.21", 'pp_network', 'Puppet Node Network Name'],
+    ["1.3.6.1.4.1.34380.1.1.22", 'pp_securitypolicy', 'Puppet Node Security Policy Name'],
+    ["1.3.6.1.4.1.34380.1.1.23", 'pp_cloudplatform', 'Puppet Node Cloud Platform Name'],
+    ["1.3.6.1.4.1.34380.1.1.24", 'pp_apptier', 'Puppet Node Application Tier'],
+    ["1.3.6.1.4.1.34380.1.1.25", 'pp_hostname', 'Puppet Node Hostname'],
+
     ["1.3.6.1.4.1.34380.1.2", 'ppPrivCertExt', 'Puppet Private Certificate Extension'],
   ]
 

--- a/spec/unit/ssl/oids_spec.rb
+++ b/spec/unit/ssl/oids_spec.rb
@@ -25,6 +25,14 @@ describe Puppet::SSL::Oids do
       'pp_department'       => "1.3.6.1.4.1.34380.1.1.15",
       'pp_cluster'          => "1.3.6.1.4.1.34380.1.1.16",
       'pp_provisioner'      => "1.3.6.1.4.1.34380.1.1.17",
+      'pp_region'           => "1.3.6.1.4.1.34380.1.1.18",
+      'pp_datacenter'       => "1.3.6.1.4.1.34380.1.1.19",
+      'pp_zone'             => "1.3.6.1.4.1.34380.1.1.20",
+      'pp_network'          => "1.3.6.1.4.1.34380.1.1.21",
+      'pp_securitypolicy'   => "1.3.6.1.4.1.34380.1.1.22",
+      'pp_cloudplatform'    => "1.3.6.1.4.1.34380.1.1.23",
+      'pp_apptier'          => "1.3.6.1.4.1.34380.1.1.24",
+      'pp_hostname'         => "1.3.6.1.4.1.34380.1.1.25",
       'ppPrivCertExt'       => '1.3.6.1.4.1.34380.1.2',
     }.each_pair do |sn, oid|
       it "defines #{sn} as #{oid}" do


### PR DESCRIPTION
Prior to this commit we were lacking cloud and puppet workflow specific
names.

This commit adds the following

"1.3.6.1.4.1.34380.1.1.18" = 'pp_region'
"1.3.6.1.4.1.34380.1.1.19" = 'pp_datacenter'
"1.3.6.1.4.1.34380.1.1.20" = 'pp_zone'
"1.3.6.1.4.1.34380.1.1.21" = 'pp_network'
"1.3.6.1.4.1.34380.1.1.22" = 'pp_securitypolicy'
"1.3.6.1.4.1.34380.1.1.23" = 'pp_cloudplatform'
"1.3.6.1.4.1.34380.1.1.24" = 'pp_apptier'
"1.3.6.1.4.1.34380.1.1.25" = 'pp_hostname'