### PR TITLE
(docs) Clarify behavior of environment for /puppet/v3/status and /puppet-ca/v1

### DIFF
--- a/api/docs/http_certificate.md
+++ b/api/docs/http_certificate.md
@@ -4,6 +4,10 @@ Certificate
 The `certificate` endpoint returns the certificate for the specified name,
 which might be either a standard certname or `ca`.
 
+Under Puppet Server's CA service, the `environment` parameter is ignored and can
+be omitted. Under a Rack or WEBrick Puppet master, `environment` is required and
+must be a valid environment, but it has no effect on the response.
+
 Find
 ----
 
@@ -25,10 +29,6 @@ The returned certificate is always in the `.pem` format.
 ### Parameters
 
 None
-
-### Notes
-
-The environment field is ignored.
 
 ### Responses
 

--- a/api/docs/http_certificate_request.md
+++ b/api/docs/http_certificate_request.md
@@ -5,7 +5,9 @@ The `certificate_request` endpoint submits a Certificate Signing Request (CSR)
 to the master.  The master must be configured to be a CA.  The returned
 CSR is always in the `.pem` format.
 
-In all requests the `:environment` must be given, but it has no bearing on the request. CSRs are not managed within environments, all CSRs are global.
+Under Puppet Server's CA service, the `environment` parameter is ignored and can
+be omitted. Under a Rack or WEBrick Puppet master, `environment` is required and
+must be a valid environment, but it has no effect on the response.
 
 Find
 ----

--- a/api/docs/http_certificate_revocation_list.md
+++ b/api/docs/http_certificate_revocation_list.md
@@ -5,7 +5,13 @@ The `certificate_revocation_list` endpoint retrieves a Certificate Revocation Li
 from the master.  The master must be configured to be a CA.  The returned
 CRL is always in the `.pem` format.
 
-In all requests the `:environment` and `:nodename` must be given, but neither has any bearing on the request.
+Under Puppet Server's CA service, the `environment` parameter is ignored and can
+be omitted. Under a Rack or WEBrick Puppet master, `environment` is required and
+must be a valid environment, but it has no effect on the response.
+
+The `:nodename` should always be `ca`, due to the default auth.conf rules for
+WEBrick and Rack Puppet masters. (You can use a different `:nodename` if you
+change the auth rules, but it will have no effect on the response.)
 
 Find
 ----

--- a/api/docs/http_certificate_status.md
+++ b/api/docs/http_certificate_status.md
@@ -5,8 +5,9 @@ The `certificate status` endpoint allows a client to read or alter the
 status of a certificate or pending certificate request. It is only
 useful on the CA.
 
-In all requests the `:environment` must be given, but it has no bearing
-on the request. Certificates are global.
+Under Puppet Server's CA service, the `environment` parameter is ignored and can
+be omitted. Under a Rack or WEBrick Puppet master, `environment` is required and
+must be a valid environment, but it has no effect on the response.
 
 Find
 ----

--- a/api/docs/http_status.md
+++ b/api/docs/http_status.md
@@ -10,8 +10,8 @@ Get status for a master
 
     GET /puppet/v3/status/:name?environment=:environment
 
-The `:environment` and `:name` sections of the URL are both ignored, but a
-value must be provided for both.
+The `environment` parameter and the `:name` are both required, but have no
+effect on the response. The `environment` must be a valid environment.
 
 ### Supported HTTP Methods
 


### PR DESCRIPTION
The status endpoint docs stated the environment was ignored, but Puppet
validates it and will fail if it doesn't match a real environment.