### PR TITLE
(PUP-5391) Fixup AIX nim provider acceptance test

### DIFF
--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -4,6 +4,11 @@ confine :to, :platform => "aix"
 
 # NOTE: This test is duplicated in the pe_acceptance_tests repo
 
+teardown do
+    test_apply('cdrecord', 'absent', '')
+    test_apply('bos.atm.atmle', 'absent', '')
+end
+
 def assert_package_version(package, expected_version)
   # The output of lslpp is a colon-delimited list like:
   # sudo:sudo.rte:1.8.6.4: : :C: :Configurable super-user privileges runtime: : : : : : :0:0:/:
@@ -90,7 +95,7 @@ package_types.each do |package_type, details|
        { :stdin => manifest,
          :acceptable_exit_codes => [4,6] } do
 
-        assert_match(/NIM package provider is unable to downgrade packages/, stdout, "Didn't get an error about downgrading packages")
+        assert_match(/NIM package provider is unable to downgrade packages/, stderr, "Didn't get an error about downgrading packages")
     end
   end
 


### PR DESCRIPTION
This commit adds a teardown step to the nim package provider
test which removes the packages it installs once the test is
complete. This prevents failures on subsequent runs on the same
host when the test attempts to install the same package. In addition,
we now check stderr instead of stdout for the expected downgrade
error.