### PR TITLE
(maint) Remove call to watching in Puppet::Environments

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -202,7 +202,6 @@ module Puppet::Environments
         setting_values.interpolate(:manifest),
         setting_values.interpolate(:config_version)
       )
-      env.watching = false
       env
     end
 


### PR DESCRIPTION
Due to a merge conflict, a call to the Puppet::Node::Environment
watching= method was restored in stable and master. However, that
method has been removed on these branches and so the chance was
causing test failures.

Remove the unneeded call to watching= to fix failing tests.