### PR TITLE
(docs) Clarify that module_groups is an internal setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -555,7 +555,7 @@ module Puppet
     },
     :module_groups => {
         :default  => nil,
-        :desc     => "Extra module groups to request from the Puppet Forge",
+        :desc     => "Extra module groups to request from the Puppet Forge. This is an internal setting, and users should never change it.",
     }
   )
 


### PR DESCRIPTION
This can be revisited if the Puppet Forge team ever develops a non-internal use
for module groups.

When this is merged, please resolve https://tickets.puppetlabs.com/browse/DOC-2266. 