### PR TITLE
(PUP-5427) Don't set PATH in puppet's service scripts

### DIFF
--- a/ext/debian/puppet.init
+++ b/ext/debian/puppet.init
@@ -8,7 +8,6 @@
 # Default-Stop:      0 1 6
 ### END INIT INFO
 
-PATH=/opt/puppetlabs/puppet/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/opt/puppetlabs/puppet/bin/puppet
 DAEMON_OPTS=""
 NAME="agent"

--- a/ext/osx/puppet.plist
+++ b/ext/osx/puppet.plist
@@ -4,8 +4,6 @@
 <dict>
         <key>EnvironmentVariables</key>
         <dict>
-                <key>PATH</key>
-                <string>/opt/puppetlabs/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
                 <key>LANG</key>
                 <string>en_US.UTF-8</string>
         </dict>

--- a/ext/redhat/client.init
+++ b/ext/redhat/client.init
@@ -13,9 +13,6 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-PATH=/opt/puppetlabs/puppet/bin:/usr/bin:/sbin:/bin:/usr/sbin
-export PATH
-
 [ -f /etc/sysconfig/puppet ] && . /etc/sysconfig/puppet
 lockfile=/var/lock/subsys/puppet
 piddir=/var/run/puppetlabs


### PR DESCRIPTION
Prior to this commit, some of puppet's service
scripts were setting PATH. This appears to be
unneccesary. Additionally, the specific PATH that
was being set could lead to unexpected use of the
puppet-agent's "private" utilities, such as gem.

This commit removes PATH where it was set in
puppet's service scripts.