### PR TITLE
(PUP-5339) Update mount tests to work in AIX

### DIFF
--- a/acceptance/lib/puppet/acceptance/mount_utils.rb
+++ b/acceptance/lib/puppet/acceptance/mount_utils.rb
@@ -1,0 +1,81 @@
+module Puppet
+  module Acceptance
+    module MountUtils
+
+      # Return the absolute path to the filesystem table file.
+      # @param host [String] hostname
+      # @return [String] path to the filesystem table file.
+      def filesystem_file(host)
+        case host['platform']
+        when /aix/
+          '/etc/filesystems'
+        when /el|fedora|sles|debian|ubuntu/
+          '/etc/fstab'
+        else
+          # TODO: Add Solaris and OSX support, as per PUP-5201 and PUP-4823
+          fail_test("Unable to determine filesystem table file location for #{host['platform']}")
+        end
+      end
+
+      # Return a standard filesystem type to use when creating filesysytems.
+      # @param host [String] hostname
+      # @return [String] filesystem type.
+      def filesystem_type(host)
+        case host['platform']
+        when /aix/
+          maj_version = on(host, facter('operatingsystemmajrelease')).stdout.chomp.to_i
+          if maj_version >= 6100
+            'jfs2'
+          else
+            'jfs'
+          end
+        when /el|fedora|sles|debian|ubuntu/
+          'ext3'
+        else
+          # TODO: Add Solaris and OSX support, as per PUP-5201 and PUP-4823
+          fail_test("Unable to determine a standard filesystem table type for #{host['platform']}")
+        end
+      end
+
+      # Appends a new filesystem entry to the filesystem table.
+      # @param host [String] hostname.
+      # @param mount_name [String] the name of the mount point. We use /tmp/name as the
+      # new filesystem, and /name as the actual mount point.
+      def add_entry_to_filesystem_table(host, mount_name)
+        fs_file = filesystem_file(host)
+        fs_type = filesystem_type(host)
+
+        case host['platform']
+        when /aix/
+          # Note: /dev/hd8 is the default jfs logging device on AIX.
+          on(host, "echo '/#{mount_name}:\n  dev = /dev/#{mount_name}\n  vfs = #{fs_type}\n  log = /dev/hd8' >> #{fs_file}")
+        when /el|fedora|sles|debian|ubuntu/
+          on(host, "echo '/tmp/#{mount_name}  /#{mount_name}  #{fs_type}  loop  0  0' >> #{fs_file}")
+        else
+          # TODO: Add Solaris and OSX support, as per PUP-5201 and PUP-4823
+          fail_test("Adding entries to the filesystem table on #{host['platform']} is not currently supported.")
+        end
+      end
+
+      # Creates a new filesystem on the host.
+      # @param host [String] hostname
+      # @param mount_name [String] the name of the mount point.
+      def create_filesystem(host, mount_name)
+        fs_type = filesystem_type(host)
+
+        case host['platform']
+        when /aix/
+          volume_group = on(host, 'lsvg').stdout.split("\n")[0]
+          on(host, "mklv -y #{mount_name} #{volume_group} 1M")
+          on(host, "mkfs -V #{fs_type} -l #{mount_name} /dev/#{mount_name}")
+        when /el|fedora|sles|debian|ubuntu/
+          on(host, "dd if=/dev/zero of=/tmp/#{mount_name} count=10240", :acceptable_exit_codes => [0,1])
+          on(host, "yes | mkfs -t #{fs_type} -q /tmp/#{mount_name}", :acceptable_exit_codes => (0..254))
+        else
+          # TODO: Add Solaris and OSX support, as per PUP-5201 and PUP-4823
+          fail_test("Creating filesystems on #{host['platform']} is not currently supported.")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -2,16 +2,20 @@ test_name "defined should create an entry in filesystem table"
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
-confine :except, :platform => /solaris/
-confine :except, :platform => /aix/
+confine :except, :platform => /solaris/ # See PUP-5201
 
-fstab = '/etc/fstab'
+require 'puppet/acceptance/mount_utils'
+extend Puppet::Acceptance::MountUtils
+
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
+  fs_file = filesystem_file(agent)
+  fs_type = filesystem_type(agent)
+
   teardown do
     #(teardown) restore the fstab file
-    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
+    on(agent, "mv /tmp/fs_file_backup #{fs_file}", :acceptable_exit_codes => (0..254))
     #(teardown) umount disk image
     on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
     #(teardown) delete disk image
@@ -21,20 +25,19 @@ agents.each do |agent|
   end
 
   #------- SETUP -------#
-  step "(setup) backup fstab file"
-  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
+  step "(setup) backup #{fs_file} file"
+  on(agent, "cp #{fs_file} /tmp/fs_file_backup", :acceptable_exit_codes => [0,1])
 
   #------- TESTS -------#
   step "create a mount with puppet (defined)"
   args = ['ensure=defined',
-          'fstype=ext3',
+          "fstype=#{fs_type}",
           "device='/tmp/#{name}'"
          ]
   on(agent, puppet_resource('mount', "/#{name}", args))
 
   step "verify entry in filesystem table"
-  on(agent, "cat #{fstab}")  do |res|
+  on(agent, "cat #{fs_file}")  do |res|
     fail_test "didn't find the mount #{name}" unless stdout.include? "#{name}"
   end
-
 end

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -2,50 +2,52 @@ test_name "should delete an entry in filesystem table and unmount it"
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
-confine :except, :platform => /solaris/
-confine :except, :platform => /aix/
+confine :except, :platform => /solaris/ # See PUP-5201
 
-fstab = '/etc/fstab'
+require 'puppet/acceptance/mount_utils'
+extend Puppet::Acceptance::MountUtils
+
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
+  fs_file = filesystem_file(agent)
+
   teardown do
-    #(teardown) restore the fstab file
-    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
     #(teardown) umount disk image
     on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
     #(teardown) delete disk image
-    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    if agent['platform'] =~ /aix/
+      on(agent, "rmlv -f #{name}", :acceptable_exit_codes => (0..254))
+    else
+      on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    end
     #(teardown) delete mount point
     on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) restore the fstab file
+    on(agent, "mv /tmp/fs_backup_file #{fs_file}", :acceptable_exit_codes => (0..254))
   end
 
   #------- SETUP -------#
-  step "(setup) backup fstab file"
-  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
-
-  step "(setup) create disk image"
-  on(agent, "dd if=/dev/zero of=/tmp/#{name} count=10240", :acceptable_exit_codes => [0,1])
-  on(agent, "yes | mkfs -t ext3 -q /tmp/#{name}")
+  step "(setup) backup #{fs_file} file"
+  on(agent, "cp #{fs_file} /tmp/fs_backup_file", :acceptable_exit_codes => [0,1])
 
   step "(setup) create mount point"
   on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
 
-  step "(setup) add entry to filesystem table"
-  on(agent, "echo '/tmp/#{name}  /#{name}  ext3  loop  0  0' >> #{fstab}")
+  step "(setup) create new filesystem to be mounted"
+  create_filesystem(agent, name)
+
+  step "(setup) add entry to the filesystem table"
+  add_entry_to_filesystem_table(agent, name)
 
   step "(setup) mount entry"
   on(agent, "mount /#{name}")
 
-  #------- TESTS -------#
   step "destroy a mount with puppet (absent)"
-  args = ['ensure=absent',
-          "device='/tmp/#{name}'"
-         ]
-  on(agent, puppet_resource('mount', "/#{name}", args))
+  on(agent, puppet_resource('mount', "/#{name}", 'ensure=absent'))
 
   step "verify entry removed from filesystem table"
-  on(agent, "cat #{fstab}") do |res|
+  on(agent, "cat #{fs_file}") do |res|
     fail_test "found the mount #{name}" if res.stdout.include? "#{name}"
   end
 

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -2,38 +2,44 @@ test_name "should modify an entry in filesystem table"
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
-confine :except, :platform => /solaris/
-confine :except, :platform => /aix/
+confine :except, :platform => /solaris/ # See PUP-5201
 
-fstab = '/etc/fstab'
+require 'puppet/acceptance/mount_utils'
+extend Puppet::Acceptance::MountUtils
+
 name = "pl#{rand(999999).to_i}"
 new_name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
+  fs_file = filesystem_file(agent)
+
   teardown do
-    #(teardown) restore the fstab file
-    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
     #(teardown) umount disk image
     on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
     #(teardown) delete disk image
-    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    if agent['platform'] =~ /aix/
+      on(agent, "rmlv -f #{name}", :acceptable_exit_codes => (0..254))
+    else
+      on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    end
     #(teardown) delete mount point
     on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) restore the fstab file
+    on(agent, "mv /tmp/fs_backup_file #{fs_file}", :acceptable_exit_codes => (0..254))
   end
 
   #------- SETUP -------#
-  step "(setup) backup fstab file"
-  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
-
-  step "(setup) create disk image"
-  on(agent, "dd if=/dev/zero of=/tmp/#{name} count=10240", :acceptable_exit_codes => [0,1])
-  on(agent, "yes | mkfs -t ext3 -q /tmp/#{name}")
+  step "(setup) backup #{fs_file} file"
+  on(agent, "cp #{fs_file} /tmp/fs_backup_file", :acceptable_exit_codes => [0,1])
 
   step "(setup) create mount point"
   on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
 
-  step "(setup) add entry to filesystem table"
-  on(agent, "echo '/tmp/#{name}  /#{name}  ext3  loop  0  0' >> #{fstab}")
+  step "(setup) create new filesystem to be mounted"
+  create_filesystem(agent, name)
+
+  step "(setup) add entry to the filesystem table"
+  add_entry_to_filesystem_table(agent, name)
 
   step "(setup) mount entry"
   on(agent, "mount /#{name}")
@@ -42,12 +48,11 @@ agents.each do |agent|
   step "modify a mount with puppet (defined)"
   args = ['ensure=defined',
           'fstype=bogus',
-          "device='/tmp/#{name}'"
          ]
   on(agent, puppet_resource('mount', "/#{name}", args))
 
   step "verify entry is updated in filesystem table"
-  on(agent, "cat #{fstab}") do |res|
+  on(agent, "cat #{fs_file}") do |res|
     fail_test "attributes not updated for the mount #{name}" unless res.stdout.include? "bogus"
   end
 

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -2,46 +2,62 @@ test_name "mounted should create an entry in filesystem table and mount it"
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
-confine :except, :platform => /solaris/
-confine :except, :platform => /aix/
+confine :except, :platform => /solaris/ # See PUP-5201
 
-fstab = '/etc/fstab'
+require 'puppet/acceptance/mount_utils'
+extend Puppet::Acceptance::MountUtils
+
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
+  fs_file = filesystem_file(agent)
+  fs_type = filesystem_type(agent)
+
   teardown do
-    #(teardown) restore the fstab file
-    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
     #(teardown) umount disk image
     on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
     #(teardown) delete disk image
-    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    if agent['platform'] =~ /aix/
+      on(agent, "rmlv -f #{name}", :acceptable_exit_codes => (0..254))
+    else
+      on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
+    end
     #(teardown) delete mount point
     on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+    #(teardown) restore the fstab file
+    on(agent, "mv /tmp/fs_backup_file #{fs_file}", :acceptable_exit_codes => (0..254))
   end
 
   #------- SETUP -------#
-  step "(setup) backup fstab file"
-  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
-
-  step "(setup) create disk image"
-  on(agent, "dd if=/dev/zero of=/tmp/#{name} count=10240", :acceptable_exit_codes => [0,1])
-  on(agent, "yes | mkfs -t ext3 -q /tmp/#{name}")
+  step "(setup) backup #{fs_file} file"
+  on(agent, "cp #{fs_file} /tmp/fs_backup_file", :acceptable_exit_codes => [0,1])
 
   step "(setup) create mount point"
   on(agent, "mkdir /#{name}", :acceptable_exit_codes => [0,1])
 
+  step "(setup) create new filesystem to be mounted"
+  create_filesystem(agent, name)
+
   #------- TESTS -------#
   step "create a mount with puppet (mounted)"
-  args = ['ensure=mounted',
-          'fstype=ext3',
-          'options=loop',
-          "device='/tmp/#{name}'"
-         ]
+  if agent['platform'] =~ /aix/
+    args = ['ensure=mounted',
+            "fstype=#{fs_type}",
+            "options='log=/dev/hd8'",
+            "device=/dev/#{name}",
+           ]
+  else
+    args = ['ensure=mounted',
+            "fstype=#{fs_type}",
+            'options=loop',
+            "device=/tmp/#{name}",
+           ]
+  end
+
   on(agent, puppet_resource('mount', "/#{name}", args))
 
   step "verify entry in filesystem table"
-  on(agent, "cat #{fstab}") do |res|
+  on(agent, "cat #{fs_file}") do |res|
     fail_test "didn't find the mount #{name}" unless res.stdout.include? "#{name}"
   end
 

--- a/acceptance/tests/resource/mount/query.rb
+++ b/acceptance/tests/resource/mount/query.rb
@@ -1,35 +1,32 @@
 test_name "should be able to find an existing filesystem table entry"
 
 confine :except, :platform => ['windows']
-confine :except, :platform => /solaris/
-confine :except, :platform => /aix/
+confine :except, :platform => /osx/ # See PUP-4823
+confine :except, :platform => /solaris/ # See PUP-5201
 
-fstab = '/etc/fstab'
+require 'puppet/acceptance/mount_utils'
+extend Puppet::Acceptance::MountUtils
+
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
+  fs_file = filesystem_file(agent)
+
   teardown do
     #(teardown) restore the fstab file
-    on(agent, "mv /tmp/fstab #{fstab}", :acceptable_exit_codes => (0..254))
-    #(teardown) umount disk image
-    on(agent, "umount /#{name}", :acceptable_exit_codes => (0..254))
-    #(teardown) delete disk image
-    on(agent, "rm /tmp/#{name}", :acceptable_exit_codes => (0..254))
-    #(teardown) delete mount point
-    on(agent, "rm -fr /#{name}", :acceptable_exit_codes => (0..254))
+    on(agent, "mv /tmp/fs_file_backup #{fs_file}", :acceptable_exit_codes => (0..254))
   end
 
   #------- SETUP -------#
-  step "(setup) backup fstab file"
-  on(agent, "cp #{fstab} /tmp/fstab", :acceptable_exit_codes => [0,1])
+  step "(setup) backup #{fs_file} file"
+  on(agent, "cp #{fs_file} /tmp/fs_file_backup", :acceptable_exit_codes => [0,1])
 
   step "(setup) add entry to filesystem table"
-  on(agent, "echo '/tmp/#{name}  /#{name}  0  0' >> #{fstab}")
+  add_entry_to_filesystem_table(agent, name)
 
   #------- TESTS -------#
   step "verify mount with puppet"
   on(agent, puppet_resource('mount', "/#{name}")) do |res|
-    fail_test "didn't find the mount #{name}" unless res.stdout.include? "#{name}"
+    fail_test "didn't find the mount #{name}" unless res.stdout.match(/'\/#{name}':\s+ensure\s+=>\s+'unmounted'/)
   end
-
 end


### PR DESCRIPTION
(PUP-5339) Add mount_utils acceptance helper library

This commit adds new helpers to assist with dealing with mountpoints
and fstab on testing hosts. It is used in the suite of mount resource tests.

(PUP-5339) Update mount tests to work in AIX

This commit updates each of the mount resource tests to work in
AIX. The main difference between AIX and regular Linuxes is that
we need to use crfs to properly create a filesystem. Slight
modifications have been made to deal with the small differences
in setup before running puppet.