### PR TITLE
(PUP-4516) Exit immediately when sent INT or TERM

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -24,6 +24,7 @@ class Puppet::Daemon
   SIGNAL_CHECK_INTERVAL = 5
 
   attr_accessor :agent, :server, :argv
+  attr_reader :signals
 
   def initialize(pidfile, scheduler = Puppet::Scheduler::Scheduler.new())
     @scheduler = scheduler
@@ -107,13 +108,21 @@ class Puppet::Daemon
   # Trap a couple of the main signals.  This should probably be handled
   # in a way that anyone else can register callbacks for traps, but, eh.
   def set_signal_traps
-    signals = {:INT => :stop, :TERM => :stop }
-    # extended signals not supported under windows
-    signals.update({:HUP => :restart, :USR1 => :reload, :USR2 => :reopen_logs }) unless Puppet.features.microsoft_windows?
-    signals.each do |signal, method|
+    [:INT, :TERM].each do |signal|
       Signal.trap(signal) do
-        Puppet.notice "Caught #{signal}; storing #{method}"
-        @signals << method
+        Puppet.notice "Exiting..."
+        stop
+      end
+    end
+
+    # extended signals not supported under windows
+    if !Puppet.features.microsoft_windows?
+      signals = {:HUP => :restart, :USR1 => :reload, :USR2 => :reopen_logs }
+      signals.each do |signal, method|
+        Signal.trap(signal) do
+          Puppet.notice "Caught #{signal}; storing #{method}"
+          @signals << method
+        end
       end
     end
   end

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -47,15 +47,24 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
   let(:server) { stub("Server", :start => nil, :wait_for_shutdown => nil) }
 
   describe "when setting signal traps" do
-    signals = {:INT => :stop, :TERM => :stop }
-    signals.update({:HUP => :restart, :USR1 => :reload, :USR2 => :reopen_logs}) unless Puppet.features.microsoft_windows?
-    signals.each do |signal, method|
-      it "should log and call #{method} when it receives #{signal}" do
-        Signal.expects(:trap).with(signal).yields
-
-        Puppet.expects(:notice)
+    [:INT, :TERM].each do |signal|
+      it "logs a notice and exits when sent #{signal}" do
+        Signal.stubs(:trap).with(signal).yields
+        Puppet.expects(:notice).with('Exiting...')
+        daemon.expects(:stop)
 
         daemon.set_signal_traps
+      end
+    end
+
+    {:HUP => :restart, :USR1 => :reload, :USR2 => :reopen_logs}.each do |signal, method|
+      it "logs a notice and remembers to call #{method} when it receives #{signal}" do
+        Signal.stubs(:trap).with(signal).yields
+        Puppet.expects(:notice).with("Caught #{signal}; storing #{method}")
+
+        daemon.set_signal_traps
+
+        expect(daemon.signals).to eq([method])
       end
     end
   end


### PR DESCRIPTION
Starting in ruby 2, signal handlers are not allowed to acquire a
mutex[1], because it could deadlock[2]. For example, the main thread
acquires a mutex, is interrupted by a signal, signal handler runs in a
separate thread, and will deadlock if tries to acquire the already
locked mutex. In ruby 1.8/9, the behavior was allowed, but wasn't safe.
In ruby 2, it's a hard failure.

Commit 6238616 removed thread-safety code because it was incomplete and
puppet primarily runs single threaded -- exceptions being its signal
handler and webrick request processing. PUP-202 was marked as fixed
since we no longer tried to acquire a mutex from a trap context.
However, the signal handler would still call back into puppet code, e.g.
reload, which led to PUP-1635 "current thread not owner".

Commit 245de036f modified the signal handler to queue the method to
execute, e.g. reload, and have the Daemon's event_loop periodically
check if a new signal had been received, calling the method from the
main ruby thread.

However, the event loop checks for new signals every 5 seconds, so
puppet will not immediately exit when sent INT or TERM. Also, if puppet
is making a blocking system call, e.g. agent is blocked reading from a
socket, then puppet will not exit until the system call returns.

This commit changes puppet's signal handlers to exit immediately in
response to INT or TERM. We call stop instead of exit to gracefully
shutdown, e.g. delete our pid file. There is a possibility the stop
method could cause a mutex to be acquired, e.g. in ruby's webrick or
logger, but it doesn't seem to happen in practice.

Also we preserve the existing async handling for HUP, USR1, and USR2.

This commit affects the agent and webrick master as both support
daemonizing.

[1] https://github.com/ruby/ruby/blob/v2_1_7/thread.c#L4384-L4386
[2] https://bugs.ruby-lang.org/issues/6416