### PR TITLE
(PUP-5383) Don't restart puppetserver twice

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -3,6 +3,7 @@
   :is_puppetserver => true,
   :puppetservice => 'puppetserver',
   :'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
+  :restart_when_done => false,
   :pre_suite => [
     'setup/common/pre-suite/000-delete-puppet-when-none.rb',
     'setup/aio/pre-suite/010_Install.rb',

--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -33,10 +33,8 @@ tuples = [
     ["I'm busy; go away.'", true]
 ]
 
-tuples.each do |expected_message, explicitly_specify_message|
-
-  with_puppet_running_on(master, {}) do
-
+with_puppet_running_on(master, {}) do
+  tuples.each do |expected_message, explicitly_specify_message|
     step "disable the agent; specify message? '#{explicitly_specify_message}', message: '#{expected_message}'" do
       agents.each do |agent|
         if (explicitly_specify_message)
@@ -89,9 +87,7 @@ tuples.each do |expected_message, explicitly_specify_message|
         on(agent, puppet('agent', "--test --server #{master}"))
       end
     end
-
-  end # with_puppet_running_on block
-
-end # tuples block
+  end # tuples block
+end # with_puppet_running_on block
 
 @all_tests_passed = true

--- a/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
+++ b/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
@@ -30,26 +30,16 @@ include $enc_data
     MANIFEST
   end
 
-  def should_not_be_able_to_exploit(environmentpath, exploited_path)
-    master_opts = {
-      'main' => {
-        'environmentpath' => "#{environmentpath}",
-      },
-    }
+  def should_not_be_able_to_exploit(exploited_path)
+    agents.each do |agent|
+      next if agent['roles'].include?('master')
 
-    with_puppet_running_on(master, master_opts) do
+      step "Request a catalog to trigger the exploit" do
+        on agent, puppet('agent', '-t', "--server #{master}"), :acceptable_exit_codes => [1]
+      end
 
-      agents.each do |agent|
-        next if agent['roles'].include?('master')
-
-        step "Request a catalog to trigger the exploit" do
-          on agent, puppet('agent', '-t', "--server #{master}"), :acceptable_exit_codes => [1]
-        end
-
-        step "Check that the exploit marker was not created" do
-          on master, "test ! -e #{exploited_path}"
-        end
-
+      step "Check that the exploit marker was not created" do
+        on master, "test ! -e #{exploited_path}"
       end
     end
   end
@@ -62,16 +52,24 @@ include $enc_data
     on(master, "chmod 777 #{exploit_path}")
   end
 
-  step "Class name is not interpreted as an absolute path" do
-    create_exploit_manifest(testdir, 'tmp::exploit')
-    should_not_be_able_to_exploit("#{testdir}/environments", exploited_path)
-  end
+  master_opts = {
+    'main' => {
+      'environmentpath' => "#{testdir}/environments",
+    },
+  }
 
-  step "Class name cannot be used for a directory traversal out of the module path" do
-    # This is just a guess about how far back we need to go...
-    traversal_exploit_expression = "#{'::..' * 20}#{exploit_path.gsub(File::SEPARATOR,'::')}"
-    create_exploit_manifest(testdir, traversal_exploit_expression)
+  with_puppet_running_on(master, master_opts) do
+    step "Class name is not interpreted as an absolute path" do
+      create_exploit_manifest(testdir, 'tmp::exploit')
+      should_not_be_able_to_exploit(exploited_path)
+    end
 
-    should_not_be_able_to_exploit("#{testdir}/environments", exploited_path)
+    step "Class name cannot be used for a directory traversal out of the module path" do
+      # This is just a guess about how far back we need to go...
+      traversal_exploit_expression = "#{'::..' * 20}#{exploit_path.gsub(File::SEPARATOR,'::')}"
+      create_exploit_manifest(testdir, traversal_exploit_expression)
+
+      should_not_be_able_to_exploit(exploited_path)
+    end
   end
 end


### PR DESCRIPTION
Previously, we were restarting puppetserver twice during each call to
`with_puppet_running_on`, which takes about 30 seconds each time. The
first restart occurs because the test needs to change configuration,
e.g. autosign policy, destructive ssl operations, etc. The second
restart restores the original configuration and brings the server back
up. But that is useless, because we stop the server as soon as we call
`with_puppet_running_on` the next time.

This commit sets the `restart_when_done beaker` option globally in
AIO, which requires Beaker 2.27.0 to work correctly and is already the
minimum beaker version we depend on for acceptance.

Also two tests were calling `with_puppet_running_on` in a loop
unnecessarily, so the call was moved outside the loop.

In practice, acceptance tests on redhat-7-x86_64 dropped from 6345
seconds to 4756 seconds, saving over 25 minutes!

Finally, it doesn't make sense to backport to 3.x, since we only started
testing with puppetserver in 4.x.