### PR TITLE
(PUP-5452) Correct parsing of crontab environment variable lines

### DIFF
--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFi
 
   text_line :blank, :match => %r{^\s*$}
 
-  text_line :environment, :match => %r{^\s*\w+=}
+  text_line :environment, :match => %r{^\s*\w+\s*=}
 
   def self.filetype
   tabname = case Facter.value(:osfamily)

--- a/spec/unit/provider/cron/parsed_spec.rb
+++ b/spec/unit/provider/cron/parsed_spec.rb
@@ -139,6 +139,7 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
       expect(described_class.parse_line('MAILTO=""')).to eq({:record_type => :environment, :line => 'MAILTO=""'})
       expect(described_class.parse_line('FOO=BAR')).to eq({:record_type => :environment, :line => 'FOO=BAR'})
       expect(described_class.parse_line('FOO_BAR=BAR')).to eq({:record_type => :environment, :line => 'FOO_BAR=BAR'})
+      expect(described_class.parse_line('SPACE = BAR')).to eq({:record_type => :environment, :line => 'SPACE = BAR'})
     end
 
     it "should extract a cron entry" do


### PR DESCRIPTION
Without this, crontab files containing environment variables that have spaces after the variable name and before the equal sign cannot be parsed properly.