### PR TITLE
(PUP-4516) Add signal name in exit message

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -110,7 +110,7 @@ class Puppet::Daemon
   def set_signal_traps
     [:INT, :TERM].each do |signal|
       Signal.trap(signal) do
-        Puppet.notice "Exiting..."
+        Puppet.notice "Caught #{signal}; exiting"
         stop
       end
     end

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -50,7 +50,7 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
     [:INT, :TERM].each do |signal|
       it "logs a notice and exits when sent #{signal}" do
         Signal.stubs(:trap).with(signal).yields
-        Puppet.expects(:notice).with('Exiting...')
+        Puppet.expects(:notice).with("Caught #{signal}; exiting")
         daemon.expects(:stop)
 
         daemon.set_signal_traps


### PR DESCRIPTION
PUP-4516 and commit c9a7e6d506768cb1c00767f785339bec512d069e introduce
a message before exiting after receiving a TERM or INT signal.

This commit adds the signal name to this error message, clarifying the
fact that we actually exit because we receive a signal and specifying
the signal.