### PR TITLE
(PUP-5425) Lookup creates phantom node in PuppetDB

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -322,7 +322,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     if options[:node]
       node = options[:node]
     else
-      node = 'default'
+      node = Puppet[:node_name_value]
 
       # If we want to lookup the node we are currently on
       # we must returning these settings to their default values
@@ -332,7 +332,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     node = Puppet::Node.indirection.find(node) unless node.is_a?(Puppet::Node) # to allow unit tests to pass a node instance
 
-   fact_file = options[:fact_file]
+    fact_file = options[:fact_file]
 
     if fact_file
       original_facts = node.facts.values


### PR DESCRIPTION
Prior to this commit, since lookup searched for a node called "default"
to obtain the node the user was running lookup from, it was creating
a ghost node in PuppetDB that did not have a hostname and was unusable.
This meant that lookup would fail in the next run because it would
attempt to obtain the hostname of the ghost node.

In order to prevent this, switch to looking up the current node
using it's certname rather than "default" so that no false node is
created.