### PR TITLE
(PUP-5433) Set solaris zone teardown to exit cleanly

### DIFF
--- a/acceptance/tests/resource/zone/dataset.rb
+++ b/acceptance/tests/resource/zone/dataset.rb
@@ -17,8 +17,8 @@ def moresetup(agent)
 end
 
 def moreclean(agent)
-  on agent, "zfs destroy -r tstpool"
-  on agent, "zpool destroy tstpool"
+  on agent, "zfs destroy -r tstpool", :acceptable_exit_codes => [0,1]
+  on agent, "zpool destroy tstpool", :acceptable_exit_codes => [0,1]
   on agent, "rm -f /tstzones/dsk"
 end
 


### PR DESCRIPTION
This commit adds 1 as an acceptable exit code to the teardown steps
in the acceptance test `tests/resource/zone/dataset.rb`.

This prevents the test from failing when the system state was
already in the desired exit state.