### PR TITLE
(PUP-5441) Sanitize node's trusted info

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -223,6 +223,18 @@ module Puppet
     @context.override(bindings, description, &block)
   end
 
+  # @param name The name of a context key to ignore; intended for test usage.
+  # @api private
+  def self.ignore(name)
+    @context.ignore(name)
+  end
+
+  # @param name The name of a previously ignored context key to restore; intended for test usage.
+  # @api private
+  def self.restore(name)
+    @context.restore(name)
+  end
+
   # @api private
   def self.mark_context(name)
     @context.mark(name)


### PR DESCRIPTION
@hlindberg take another look. Since we chatted:
* I added the ability to ignore or restore a context key, which allowed me to flesh out the spec tests. 
* I also added some explanatory comments because the priority scheme for setting `trusted_data` begged for some explanation.
* Last, note that I moved the `to_h` to the *end* of the block passed to `lookup`. In the location I had it in the previous version of this PR, that would raise if lookup failed because it would try to call that `to_h` before it even got to the block. Fun stuff.