### PR TITLE
(PUP-5432) Use node_name to validate report test

### DIFF
--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -71,7 +71,7 @@ else
     agents.each do |agent|
       on(agent, puppet('agent', "-t --server #{master}"))
 
-      on master, "grep -q #{agent} #{testdir}/*/*"
+      on master, "grep -q #{agent.node_name} #{testdir}/*/*"
     end
   end
 


### PR DESCRIPTION
This commit modifies the acceptance test `reports/submission.rb`
to use the `agent.node_name` rather than the beaker
`agent.hostname` value to validate the contents
of the submitted report on the master.

[skip ci]