### PR TITLE
(PUP-4917) Windows Packages Use QuietDisplayName

### DIFF
--- a/lib/puppet/provider/package/windows/exe_package.rb
+++ b/lib/puppet/provider/package/windows/exe_package.rb
@@ -8,7 +8,7 @@ class Puppet::Provider::Package::Windows
     def self.from_registry(name, values)
       if valid?(name, values)
         ExePackage.new(
-          values['DisplayName'],
+          get_display_name(values),
           values['DisplayVersion'],
           values['UninstallString']
         )
@@ -18,13 +18,15 @@ class Puppet::Provider::Package::Windows
     # Is this a valid executable package we should manage?
     def self.valid?(name, values)
       # See http://community.spiceworks.com/how_to/show/2238
-      !!(values['DisplayName'] and values['DisplayName'].length > 0 and
-         values['UninstallString'] and values['UninstallString'].length > 0 and
-         values['WindowsInstaller'] != 1 and # DWORD
-         name !~ /^KB[0-9]{6}/ and
-         values['ParentKeyName'] == nil and
-         values['Security Update'] == nil and
-         values['Update Rollup'] == nil and
+      displayName = get_display_name(values)
+      !!(displayName && displayName.length > 0 &&
+         values['UninstallString'] &&
+         values['UninstallString'].length > 0 &&
+         values['WindowsInstaller'] != 1 && # DWORD
+         name !~ /^KB[0-9]{6}/ &&
+         values['ParentKeyName'] == nil &&
+         values['Security Update'] == nil &&
+         values['Update Rollup'] == nil &&
          values['Hotfix'] == nil)
     end
 

--- a/lib/puppet/provider/package/windows/msi_package.rb
+++ b/lib/puppet/provider/package/windows/msi_package.rb
@@ -20,7 +20,7 @@ class Puppet::Provider::Package::Windows
         inst = installer
 
         if inst.ProductState(name) == INSTALLSTATE_DEFAULT
-          MsiPackage.new(values['DisplayName'],
+          MsiPackage.new(get_display_name(values),
                          values['DisplayVersion'],
                          name, # productcode
                          inst.ProductInfo(name, 'PackageCode'))
@@ -31,8 +31,9 @@ class Puppet::Provider::Package::Windows
     # Is this a valid MSI package we should manage?
     def self.valid?(name, values)
       # See http://community.spiceworks.com/how_to/show/2238
-      !!(values['DisplayName'] and values['DisplayName'].length > 0 and
-         values['WindowsInstaller'] == 1 and # DWORD
+      displayName = get_display_name(values)
+      !!(displayName && displayName.length > 0 &&
+         values['WindowsInstaller'] == 1 && # DWORD
          name =~ /\A\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}\Z/i)
     end
 

--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -71,7 +71,7 @@ class Puppet::Provider::Package::Windows
 
     def self.replace_forward_slashes(value)
       if value.include?('/')
-        value.gsub!('/', "\\") 
+        value.gsub!('/', "\\")
         Puppet.debug('Package source parameter contained /s - replaced with \\s')
       end
       value
@@ -79,6 +79,14 @@ class Puppet::Provider::Package::Windows
 
     def self.quote(value)
       value.include?(' ') ? %Q["#{value.gsub(/"/, '\"')}"] : value
+    end
+
+    def self.get_display_name(values)
+      return if values.nil?
+      return values['DisplayName'] if values['DisplayName'] && values['DisplayName'].length > 0
+      return values['QuietDisplayName'] if values['QuietDisplayName'] && values['QuietDisplayName'].length > 0
+
+      ''
     end
 
     def initialize(name, version)

--- a/spec/unit/provider/package/windows/package_spec.rb
+++ b/spec/unit/provider/package/windows/package_spec.rb
@@ -132,6 +132,47 @@ describe Puppet::Provider::Package::Windows::Package do
     end
   end
 
+  context '::get_display_name' do
+    it 'should return nil if values is nil' do
+      expect(subject.get_display_name(nil)).to be_nil
+    end
+
+    it 'should return empty if values is empty' do
+      reg_values =  {}
+      expect(subject.get_display_name(reg_values)).to eq('')
+    end
+
+    it 'should return DisplayName when available' do
+      reg_values =  { 'DisplayName' => 'Google' }
+      expect(subject.get_display_name(reg_values)).to eq('Google')
+    end
+
+    it 'should return DisplayName when available, even when QuietDisplayName is also available' do
+      reg_values =  { 'DisplayName' => 'Google', 'QuietDisplayName' => 'Google Quiet' }
+      expect(subject.get_display_name(reg_values)).to eq('Google')
+    end
+
+    it 'should return empty when QuietDisplayName when DisplayName is empty' do
+      reg_values =  { 'DisplayName' => '', 'QuietDisplayName' =>'Google Quiet' }
+      expect(subject.get_display_name(reg_values)).to eq('Google Quiet')
+    end
+
+    it 'should return QuietDisplayName when DisplayName is not available' do
+      reg_values =  { 'QuietDisplayName' =>'Google Quiet' }
+      expect(subject.get_display_name(reg_values)).to eq('Google Quiet')
+    end
+
+    it 'should return empty when DisplayName is empty and QuietDisplay name is not available' do
+      reg_values =  { 'DisplayName' => '' }
+      expect(subject.get_display_name(reg_values)).to eq('')
+    end
+
+    it 'should return empty when DisplayName is empty and QuietDisplay name is empty' do
+      reg_values =  { 'DisplayName' => '', 'QuietDisplayName' =>'' }
+      expect(subject.get_display_name(reg_values)).to eq('')
+    end
+  end
+
   it 'should implement instance methods' do
     pkg = subject.new('orca', '5.0')
 


### PR DESCRIPTION
When DisplayName is not available but QuietDisplayName is, use
QuietDisplayName instead. If neither are found, continue the
behavior of returning nothing. Some software in Windows 2012
will install to QuietDisplayName instead of DisplayName, which
possibly keeps it out of the Programs and Features list, but
the value should continue to show up for Puppet.