### PR TITLE
(PUP-5097) Rename domainname trusted fact to domain

### DIFF
--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -104,7 +104,7 @@ test_name "certificate extensions available as trusted data" do
             '1.3.6.1.4.1.34380.1.2.2' => 'webops'
           },
           'hostname' => agent_hostname,
-          'domainname' => agent_domain
+          'domain' => agent_domain
         },
         trusted_data)
     end

--- a/lib/puppet/context/trusted_information.rb
+++ b/lib/puppet/context/trusted_information.rb
@@ -20,7 +20,7 @@ class Puppet::Context::TrustedInformation
   # The domain name derived from the validated certificate name
   #
   # @return [String]
-  attr_reader :domainname
+  attr_reader :domain
 
   # The hostname derived from the validated certificate name
   #
@@ -32,13 +32,13 @@ class Puppet::Context::TrustedInformation
     @certname = certname.freeze
     @extensions = extensions.freeze
     if @certname
-      hostname, domainname = @certname.split('.', 2)
+      hostname, domain = @certname.split('.', 2)
     else
       hostname = nil
-      domainname = nil
+      domain = nil
     end
     @hostname = hostname.freeze
-    @domainname = domainname.freeze
+    @domain = domain.freeze
   end
 
   def self.remote(authenticated, node_name, certificate)
@@ -70,7 +70,7 @@ class Puppet::Context::TrustedInformation
       'certname'.freeze => certname,
       'extensions'.freeze => extensions,
       'hostname'.freeze => hostname,
-      'domainname'.freeze => domainname,
+      'domain'.freeze => domain,
     }.freeze
   end
 end

--- a/spec/unit/context/trusted_information_spec.rb
+++ b/spec/unit/context/trusted_information_spec.rb
@@ -48,7 +48,7 @@ describe Puppet::Context::TrustedInformation do
         '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
       })
       expect(trusted.hostname).to eq('cert name')
-      expect(trusted.domainname).to be_nil
+      expect(trusted.domain).to be_nil
     end
 
     it "is remote but lacks certificate information when it is authenticated" do
@@ -72,7 +72,7 @@ describe Puppet::Context::TrustedInformation do
       expect(trusted.certname).to eq('cert name')
       expect(trusted.extensions).to eq({})
       expect(trusted.hostname).to eq('cert name')
-      expect(trusted.domainname).to be_nil
+      expect(trusted.domain).to be_nil
     end
 
     it "is authenticated local with no clientcert when there is no node" do
@@ -82,7 +82,7 @@ describe Puppet::Context::TrustedInformation do
       expect(trusted.certname).to be_nil
       expect(trusted.extensions).to eq({})
       expect(trusted.hostname).to be_nil
-      expect(trusted.domainname).to be_nil
+      expect(trusted.domain).to be_nil
     end
   end
 
@@ -97,22 +97,22 @@ describe Puppet::Context::TrustedInformation do
         '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
       },
       'hostname' => 'cert name',
-      'domainname' => nil
+      'domain' => nil
     })
   end
 
-  it "extracts domainname and hostname from certname" do
-    trusted = Puppet::Context::TrustedInformation.remote(true, 'hostname.domainname.long', cert)
+  it "extracts domain and hostname from certname" do
+    trusted = Puppet::Context::TrustedInformation.remote(true, 'hostname.domain.long', cert)
 
     expect(trusted.to_h).to eq({
       'authenticated' => 'remote',
-      'certname' => 'hostname.domainname.long',
+      'certname' => 'hostname.domain.long',
       'extensions' => {
         '1.3.6.1.4.1.34380.1.2.1' => 'CSR specific info',
         '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
       },
       'hostname' => 'hostname',
-      'domainname' => 'domainname.long'
+      'domain' => 'domain.long'
     })
   end
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1823,7 +1823,7 @@ describe Puppet::Settings do
   end
 
   describe "default_certname" do
-    describe "using hostname and domainname" do
+    describe "using hostname and domain" do
       before :each do
         Puppet::Settings.stubs(:hostname_fact).returns("testhostname")
         Puppet::Settings.stubs(:domain_fact).returns("domain.test.")


### PR DESCRIPTION
Renames the domainname trusted fact to domain, since the latter is what
we use for the Facter fact.