### PR TITLE
(PUP-5395) Fix problem with lookup_options not found in module

### DIFF
--- a/lib/puppet/data_providers/hiera_support.rb
+++ b/lib/puppet/data_providers/hiera_support.rb
@@ -21,7 +21,7 @@ module Puppet::DataProviders::HieraSupport
     lookup_invocation.with(:data_provider, self) do
       merge_strategy = Puppet::Pops::MergeStrategy.strategy(merge)
       lookup_invocation.with(:merge, merge_strategy) do
-        merged_result = merge_strategy.merge_lookup(data_providers(data_key(key), lookup_invocation)) do |data_provider|
+        merged_result = merge_strategy.merge_lookup(data_providers(data_key(key, lookup_invocation), lookup_invocation)) do |data_provider|
           data_provider.unchecked_lookup(key, lookup_invocation, merge_strategy)
         end
         lookup_invocation.report_result(merged_result)

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -1,6 +1,6 @@
 module Puppet::Pops::Lookup
   class Invocation
-    attr_reader :scope, :override_values, :default_values, :explainer
+    attr_reader :scope, :override_values, :default_values, :explainer, :module_name
 
     # Creates a context object for a lookup invocation. The object contains the current scope, overrides, and default
     # values and may optionally contain an {ExplanationAcceptor} instance that will receive book-keeping information
@@ -49,17 +49,30 @@ module Puppet::Pops::Lookup
     # :merge - qualifier is a MergeStrategy instance
     # :module - qualifier is the name of a module
     # :interpolation - qualifier is the unresolved interpolation expression
+    # :meta - qualifier is the name of a module or nil if that's not applicable
     #
     # @param qualifier [Object] A branch, a provider, or a path
     def with(qualifier_type, qualifier)
+      is_meta = qualifier_type == :meta
+      @module_name = qualifier if is_meta
       if @explainer.nil?
         yield
       else
-        @explainer.push(qualifier_type, qualifier)
-        begin
-          yield
-        ensure
-          @explainer.pop
+        if is_meta
+          save_explainer = @explainer
+          @explainer = nil
+          begin
+            yield
+          ensure
+            @explainer = save_explainer
+          end
+        else
+          @explainer.push(qualifier_type, qualifier)
+          begin
+            yield
+          ensure
+            @explainer.pop
+          end
         end
       end
     end

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/data/common.yaml
@@ -18,6 +18,13 @@ one::lopts_test::hash:
     ma: MA
     mb: MB
 
+one::loptsm_test::hash:
+  a: A
+  b: B
+  m:
+    ma: MA
+    mb: MB
+
 ukey1: Some value
 
 target_lookup: with lookup

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/data/common.yaml
@@ -14,5 +14,17 @@ one::lopts_test::hash:
     ma: MA
     mc: MC
 
+one::loptsm_test::hash:
+  a: A
+  c: C
+  m:
+    ma: MA
+    mc: MC
+
+lookup_options:
+  one::loptsm_test::hash:
+    merge: deep
+
+
 # should not be found since it's not qualified with module name
 ukey2: Some value

--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/manifests/init.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/modules/one/manifests/init.pp
@@ -6,4 +6,8 @@ class one {
   class lopts_test($hash = { a => 'default A', b => 'default B', c => 'default C', m => {} }) {
     notify { "${hash[a]}, ${hash[b]}, ${hash[c]}, ${hash[m]['ma']}, ${hash[m]['mb']}, ${hash[m]['mc']}": }
   }
+
+  class loptsm_test($hash = { a => 'default A', b => 'default B', c => 'default C', m => {} }) {
+    notify { "${hash[a]}, ${hash[b]}, ${hash[c]}, ${hash[m]['ma']}, ${hash[m]['mb']}, ${hash[m]['mc']}": }
+  }
 }

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -69,8 +69,14 @@ describe "when using a hiera data provider" do
     expect(resources[0][1..-2].split(', ')).to contain_exactly('first', 'second', 'third', 'fourth')
   end
 
-  it 'reads performs merge found in lookup_options of values declared in environment and module' do
+  it 'reads performs merge found in lookup_options in environment of values declared in environment and module' do
     resources = compile_and_get_notifications('hiera_misc', 'include one::lopts_test')
+    expect(resources.size).to eq(1)
+    expect(resources[0]).to eq('A, B, C, MA, MB, MC')
+  end
+
+  it 'reads performs merge found in lookup_options in module of values declared in environment and module' do
+    resources = compile_and_get_notifications('hiera_misc', 'include one::loptsm_test')
     expect(resources.size).to eq(1)
     expect(resources[0]).to eq('A, B, C, MA, MB, MC')
   end

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -53,32 +53,38 @@ describe "when using a hiera data provider" do
     expect(resources).to include('module data param_a is 100, module data param_b is 200, module data param_c is 300, module data param_d is 400, module data param_e is 500')
   end
 
-  it 'reads does not perform merge of values declared in environment and module when resolving parameters' do
+  it 'does not perform merge of values declared in environment and module when resolving parameters' do
     resources = compile_and_get_notifications('hiera_misc')
     expect(resources).to include('env 1, ')
   end
 
-  it 'reads performs hash merge of values declared in environment and module' do
+  it 'performs hash merge of values declared in environment and module' do
     resources = compile_and_get_notifications('hiera_misc', '$r = lookup(one::test::param, Hash[String,String], hash) notify{"${r[key1]}, ${r[key2]}":}')
     expect(resources).to include('env 1, module 2')
   end
 
-  it 'reads performs unique merge of values declared in environment and module' do
+  it 'performs unique merge of values declared in environment and module' do
     resources = compile_and_get_notifications('hiera_misc', '$r = lookup(one::array, Array[String], unique) notify{"${r}":}')
     expect(resources.size).to eq(1)
     expect(resources[0][1..-2].split(', ')).to contain_exactly('first', 'second', 'third', 'fourth')
   end
 
-  it 'reads performs merge found in lookup_options in environment of values declared in environment and module' do
+  it 'performs merge found in lookup_options in environment of values declared in environment and module' do
     resources = compile_and_get_notifications('hiera_misc', 'include one::lopts_test')
     expect(resources.size).to eq(1)
     expect(resources[0]).to eq('A, B, C, MA, MB, MC')
   end
 
-  it 'reads performs merge found in lookup_options in module of values declared in environment and module' do
+  it 'performs merge found in lookup_options in module of values declared in environment and module' do
     resources = compile_and_get_notifications('hiera_misc', 'include one::loptsm_test')
     expect(resources.size).to eq(1)
     expect(resources[0]).to eq('A, B, C, MA, MB, MC')
+  end
+
+  it "can lookup the 'lookup_options' hash as a regular value" do
+    resources = compile_and_get_notifications('hiera_misc', '$r = lookup(lookup_options, Hash[String,Hash[String,String]], hash) notify{"${r[one::lopts_test::hash][merge]}":}')
+    expect(resources.size).to eq(1)
+    expect(resources[0]).to eq('deep')
   end
 
   it 'does find unqualified keys in the environment' do


### PR DESCRIPTION
A check for qualified name in modules prevented lookup of the
'lookup_options' key in a module. This commit adds that check and
a test that verifies that lookup_options declared in environment
and module are merged and used.