### PR TITLE
(PUP-5465) Add missing support for Resource References in collection

### DIFF
--- a/lib/puppet/pops/evaluator/collector_transformer.rb
+++ b/lib/puppet/pops/evaluator/collector_transformer.rb
@@ -125,6 +125,14 @@ protected
     end
   end
 
+ def query_AccessExpression(o, scope)
+    pops_object = @@evaluator.evaluate(o, scope)
+
+    # Convert to Puppet 3 style objects since that is how they are represented
+    # in the catalog.
+    @@evaluator.convert(pops_object, scope, nil)
+  end
+
   def query_VariableExpression(o, scope)
     @@evaluator.evaluate(o, scope)
   end
@@ -155,6 +163,14 @@ protected
 
   def query_Object(o, scope)
     raise ArgumentError, "Cannot transform object of class #{o.class}"
+  end
+
+  def match_AccessExpression(o, scope)
+    pops_object = @@evaluator.evaluate(o, scope)
+
+    # Convert to Puppet 3 style objects since that is how they are represented
+    # in the catalog.
+    @@evaluator.convert(pops_object, scope, nil)
   end
 
   def match_AndExpression(o, scope)

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -95,6 +95,14 @@ describe 'collectors' do
       MANIFEST
     end
 
+    it "matches with resource references" do
+      expect_the_message_to_be(["wanted"], <<-MANIFEST)
+        @notify { "foobar": }
+        @notify { "testing": require => Notify["foobar"], message => "wanted" }
+        Notify <| require == Notify["foobar"] |>
+      MANIFEST
+    end
+
     it "allows criteria to be combined with 'and'" do
       expect_the_message_to_be(["the message"], <<-MANIFEST)
         @notify { "testing": message => "the message" }


### PR DESCRIPTION
The support for resource references in collector search expressions is
missing. This is a documented aspect of resource collectors and
previously worked in Puppet 3.

This PR attempts to provide a solution to this issue. Full disclosure though, I'm fairly new to the way the new parser works and it's still mostly a mystery to me. I've spent some time pulling it apart and I think I've found the most reasonable solution. If there is some other materials I should look at it to understand more, that'd be awesome.

