### PR TITLE
(PUP-4426) backport (PUP-4386) Windows group invalid user error msgs 

### DIFF
--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -99,12 +99,20 @@ module Puppet
       def is_to_s(currentvalue)
         if provider.respond_to?(:members_to_s)
           currentvalue = '' if currentvalue.nil?
-          return provider.members_to_s(currentvalue.split(','))
+          currentvalue = currentvalue.is_a?(Array) ? currentvalue : currentvalue.split(',')
+
+          return provider.members_to_s(currentvalue)
         end
 
         super(currentvalue)
       end
       alias :should_to_s :is_to_s
+
+      validate do |value|
+        if provider.respond_to?(:member_valid?)
+          return provider.member_valid?(value)
+        end
+      end
     end
 
     newparam(:auth_membership, :boolean => true, :parent => Puppet::Parameter::Boolean) do

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -35,11 +35,13 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
     let(:user1) { stub(:account => 'user1', :domain => '.', :to_s => 'user1sid') }
     let(:user2) { stub(:account => 'user2', :domain => '.', :to_s => 'user2sid') }
     let(:user3) { stub(:account => 'user3', :domain => '.', :to_s => 'user3sid') }
+    let(:invalid_user) { SecureRandom.uuid }
 
     before :each do
       Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user1').returns(user1)
       Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user2').returns(user2)
       Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user3').returns(user3)
+      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with(invalid_user).returns(nil)
     end
 
     describe "#members_insync?" do
@@ -122,6 +124,9 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
       end
       it "should return a user string like DOMAIN\\USER,DOMAIN2\\USER2" do
         provider.members_to_s(['user1', 'user2']).should == '.\user1,.\user2'
+      end
+      it "should return the username when it cannot be resolved to a SID (for the sake of resource_harness error messages)" do
+        expect(provider.members_to_s([invalid_user])).to eq("#{invalid_user}")
       end
     end
   end


### PR DESCRIPTION
Assume that `puppet resource group guests` yields the following:

group { 'guests':
  ensure  => 'present',
  gid     => 'S-1-5-32-546',
  members => ['Guest', 'Administrator'],
}

Previously, trying to apply the following manifest with a bad user,
would trigger a bug in Puppet:

group { 'guests':
  ensure => present,
  members => ['Guest', 'Administrator', ''],
}

An error would be raised in resource_harness#sync_if_needed method, and
would lose important details about expected resource changes:

Notice: Compiled catalog for vagrant-2008r2.corp.puppetlabs.net in environment production in 0.22 seconds Error: Could not resolve username:
Error: /Group[Guests]: Could not evaluate: Puppet::Util::Log requires a message
Notice: Finished catalog run in 0.05 seconds

This change prevents both the loss of error detail, and triggering an
extraneous / misleading message about Puppet::Util::Log:

Notice: Compiled catalog for vagrant-2008r2.localdomain in environment production in 0.58 seconds
Error: Could not resolve name:
Error: /Stage[main]/Main/Group[Guests]/members: change from VAGRANT-2008R2\Guest,VAGRANT-2008R2\Administrator to VAGRANT-2008R2\Guest,VAGRANT-2008R2\Administrator, failed: Could not resolve name:
Notice: Applied catalog in 0.03 seconds