### PR TITLE
(PUP-5428) Add a query string with the environment when using POST

### DIFF
--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -96,7 +96,8 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       # WEBrick in Ruby 1.9.1 only supports up to 1024 character lines in an HTTP request
       # http://redmine.ruby-lang.org/issues/show/3991
       if "GET #{uri_with_query_string} HTTP/1.1\r\n".length > 1024
-        http_post(req, uri, body, headers)
+        uri_with_env = "#{uri}?environment=#{request.environment.name}"
+        http_post(req, uri_with_env, body, headers)
       else
         http_get(req, uri_with_query_string, headers)
       end


### PR DESCRIPTION
Hello, 

This PR is solving issue https://tickets.puppetlabs.com/browse/PUP-5428.

When the length of the uri is greater that 1024, the GET is converted in POST and all data (environment, facts) are stored in the body request.

Adding a query string when posting allows to loadbalance catalog compilation (for example) to specific puppetserver.

Regards

Olivier