### PR TITLE
(PUP-5278) Include global data binding in explain output

### DIFF
--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -238,6 +238,30 @@ module Puppet::Pops::Lookup
     end
   end
 
+  class ExplainGlobal < ExplainTreeNode
+    def initialize(parent, binding_terminus)
+      super(parent)
+      @binding_terminus = binding_terminus
+    end
+
+    def dump_on(io, indent, first_indent)
+      io << first_indent << 'Data Binding "' << @binding_terminus << "\"\n"
+      indent = increase_indent(indent)
+      branches.each {|b| b.dump_on(io, indent, indent)}
+      dump_outcome(io, indent)
+    end
+
+    def to_hash
+      hash = super
+      hash[:name] = @binding_terminus
+      hash
+    end
+
+    def type
+      :global
+    end
+  end
+
   class ExplainDataProvider < ExplainTreeNode
     def initialize(parent, provider)
       super(parent)
@@ -314,6 +338,8 @@ module Puppet::Pops::Lookup
 
     def push(qualifier_type, qualifier)
       node = case (qualifier_type)
+        when :global
+         ExplainGlobal.new(@current, qualifier)
         when :path
           ExplainPath.new(@current, qualifier)
         when :module

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -44,6 +44,7 @@ module Puppet::Pops::Lookup
     end
 
     # The qualifier_type can be one of:
+    # :global - qualifier is the data binding terminus name
     # :data_provider - qualifier a DataProvider instance
     # :path - qualifier is a ResolvedPath instance
     # :merge - qualifier is a MergeStrategy instance

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -161,15 +161,19 @@ describe "when using a hiera data provider" do
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(compiler.topscope, {}, {}, true)
         value = Puppet::Pops::Lookup.lookup('km_scope', nil, nil, nil, nil, lookup_invocation)
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
-Data Provider "Hiera Data Provider, version 4"
-  ConfigurationPath "#{environmentpath}/hiera_misc/hiera.yaml"
-  Data Provider "common"
-    Path "#{environmentpath}/hiera_misc/data/common.yaml"
-      Original path: common
-      Interpolation on "Value from interpolation %{scope("target_scope")}"
-        Global Scope"
-          Found key: "target_scope" value: "with scope"
-      Found key: "km_scope" value: "Value from interpolation with scope"
+Merge strategy first
+  Data Binding "hiera"
+    No such key: "km_scope"
+  Data Provider "Hiera Data Provider, version 4"
+    ConfigurationPath "#{environmentpath}/hiera_misc/hiera.yaml"
+    Data Provider "common"
+      Path "#{environmentpath}/hiera_misc/data/common.yaml"
+        Original path: common
+        Interpolation on "Value from interpolation %{scope("target_scope")}"
+          Global Scope"
+            Found key: "target_scope" value: "with scope"
+        Found key: "km_scope" value: "Value from interpolation with scope"
+  Merged result: "Value from interpolation with scope"
 EOS
       end
     end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -455,6 +455,7 @@ EOS
 
     it 'will explain deep merge results with options' do
       assemble_and_compile('${r}', "'abc::a'") do |scope|
+        Hiera.any_instance.expects(:lookup).with(any_parameters).returns({'k1' => 'global_g1'})
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
         Puppet::Pops::Lookup.lookup('abc::e', Puppet::Pops::Types::TypeParser.new.parse('Hash[String,String]'), nil, false, {'strategy' => 'deep', 'merge_hash_arrays' => true}, lookup_invocation)
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
@@ -463,7 +464,9 @@ Merge strategy deep
     "merge_hash_arrays" => true
   }
   Data Binding "hiera"
-    No such key: "abc::e"
+    Found key: "abc::e" value: {
+      "k1" => "global_g1"
+    }
   Data Provider "FunctionEnvDataProvider"
     Found key: "abc::e" value: {
       "k1" => "env_e1",
@@ -475,7 +478,7 @@ Merge strategy deep
       "k2" => "module_e2"
     }
   Merged result: {
-    "k1" => "env_e1",
+    "k1" => "global_g1",
     "k2" => "module_e2",
     "k3" => "env_e3"
   }

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -397,6 +397,8 @@ describe "when performing lookup" do
         end
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
 Merge strategy first
+  Data Binding "hiera"
+    No such key: "ppx::e"
   Data Provider "FunctionEnvDataProvider"
     No such key: "ppx::e"
   Module "ppx"
@@ -414,6 +416,8 @@ EOS
         end
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
 Merge strategy first
+  Data Binding "hiera"
+    No such key: "abc::x"
   Data Provider "FunctionEnvDataProvider"
     No such key: "abc::x"
   Module "abc" using Data Provider "FunctionModuleDataProvider"
@@ -428,6 +432,8 @@ EOS
         Puppet::Pops::Lookup.lookup('abc::e', Puppet::Pops::Types::TypeParser.new.parse('Hash[String,String]'), nil, false, 'deep', lookup_invocation)
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
 Merge strategy deep
+  Data Binding "hiera"
+    No such key: "abc::e"
   Data Provider "FunctionEnvDataProvider"
     Found key: "abc::e" value: {
       "k1" => "env_e1",
@@ -456,6 +462,8 @@ Merge strategy deep
   Options: {
     "merge_hash_arrays" => true
   }
+  Data Binding "hiera"
+    No such key: "abc::e"
   Data Provider "FunctionEnvDataProvider"
     Found key: "abc::e" value: {
       "k1" => "env_e1",
@@ -484,6 +492,8 @@ EOS
         end
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
 Merge strategy first
+  Data Binding "hiera"
+    No such key: "hieraprovider::test::not_found"
   Data Provider "FunctionEnvDataProvider"
     No such key: "hieraprovider::test::not_found"
   Module "hieraprovider" using Data Provider "Hiera Data Provider, version 4"
@@ -507,6 +517,12 @@ EOS
         expect(lookup_invocation.explainer.to_hash).to eq(
             {
               :branches => [
+              {
+                :key => 'abc::e',
+                :event => :not_found,
+                :type => :global,
+                :name => :hiera
+              },
               {
                 :key => 'abc::e',
                 :value => { 'k1' => 'env_e1', 'k3' => 'env_e3' },


### PR DESCRIPTION
The global data binding was forgotten in the explain support. This
commit adds the needed output and alters all test to accomodate its
presence.