### PR TITLE
(PUP-5308) Bump beaker dependency

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 1.17"
+gem "beaker", "~> 2.23"
 gem 'rake', "~> 10.1.0"
 
 group(:test) do

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -5,7 +5,6 @@ extend Puppet::Acceptance::ModuleUtils
 module_author = "pmtacceptance"
 module_name = "java"
 module_version = "1.7.0"
-module_dependencies   = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
@@ -16,18 +15,10 @@ agents.each do |agent|
   step 'setup'
   stub_forge_on(agent)
 
-  step "  install module '#{module_author}-#{module_name}'"
-
-  opts ||= Hash.new
-  if defined? Command::DEFAULT_GIT_ENV #this constant was removed in beaker 2
-    opts['ENV']=Command::DEFAULT_GIT_ENV
-  end
-  command = agent['platform'] =~ /windows/ ?
-    Command.new("'puppet module install --version \"<#{module_version}\" #{module_author}-#{module_name}'", [], opts) :
-    puppet("module install --version \"<#{module_version}\" #{module_author}-#{module_name}")
-
-  on(agent, command) do
+  step "install module '< #{module_version}' #{module_author}-#{module_name}"
+  on(agent, puppet("module install --version '< #{module_version}' #{module_author}-#{module_name}")) do
     assert_module_installed_ui(stdout, module_author, module_name, module_version, '<')
+    assert_module_installed_on_disk(agent, module_name)
   end
-  assert_module_installed_on_disk(agent, module_name)
 end
+


### PR DESCRIPTION
We were using an old beaker version that relied on deprecated vmpooler
behavior (see BKR-572), which will be removed real soon now. So bump
beaker to the same version we're using in puppet#stable.

[skip ci]