### PR TITLE
(PUP-5437) Add 'lookup_options' to the lookup explainer

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -45,6 +45,8 @@ class Puppet::Application::Lookup < Puppet::Application
 
   option('--explain')
 
+  option('--explain-data')
+
   option('--default VALUE') do |arg|
     options[:default_value] = arg
   end
@@ -213,6 +215,10 @@ the puppet lookup function linked to above.
   than the value returned for the key. The explaination will describe how
   the result was obtained or why lookup failed to obtain the result.
 
+* --explain-data
+  Like --explain but will omit explanation of how lookup_options are found
+  and assembled.
+
 * --default <VALUE>
   A value produced if no value was found in the lookup.
 
@@ -297,7 +303,8 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
       end
     end
 
-    explain = !!options[:explain]
+    explain_data = !!options[:explain_data]
+    explain = !!options[:explain] || explain_data
 
     # Format defaults to text (:s) when producing an explanation and :yaml when producing the value
     format = options[:render_as] || (explain ? :s : :yaml)
@@ -307,7 +314,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     type = options.include?(:type) ? Puppet::Pops::Types::TypeParser.new.parse(options[:type]) : nil
 
     generate_scope do |scope|
-      lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, explain)
+      lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, explain ? Puppet::Pops::Lookup::Explainer.new(explain_data) : nil)
       begin
         result = Puppet::Pops::Lookup.lookup(keys, type, options[:default_value], use_default_value, merge_options, lookup_invocation)
         puts renderer.render(result) unless explain

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -59,7 +59,7 @@ module Puppet::Pops::Lookup
       if @explainer.nil?
         yield
       else
-        if is_meta
+        if is_meta && @explainer.suppress_meta?
           save_explainer = @explainer
           @explainer = nil
           begin
@@ -76,6 +76,10 @@ module Puppet::Pops::Lookup
           end
         end
       end
+    end
+
+    def force_options_lookup?
+      @explainer.nil? ? false : @explainer.force_options_lookup?
     end
 
     def report_found_in_overrides(key, value)

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -396,6 +396,12 @@ describe "when performing lookup" do
         rescue Puppet::Error
         end
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
+Searching for 'lookup_options'
+  Merge strategy hash
+    Data Binding "hiera"
+      No such key: "lookup_options"
+    Data Provider "FunctionEnvDataProvider"
+      No such key: "lookup_options"
 Merge strategy first
   Data Binding "hiera"
     No such key: "ppx::e"
@@ -415,6 +421,14 @@ EOS
         rescue Puppet::Error
         end
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
+Searching for 'lookup_options'
+  Merge strategy hash
+    Data Binding "hiera"
+      No such key: "lookup_options"
+    Data Provider "FunctionEnvDataProvider"
+      No such key: "lookup_options"
+    Data Provider "FunctionModuleDataProvider"
+      No such key: "lookup_options"
 Merge strategy first
   Data Binding "hiera"
     No such key: "abc::x"
@@ -494,6 +508,22 @@ EOS
         rescue Puppet::DataBinding::LookupError
         end
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
+Searching for 'lookup_options'
+  Merge strategy hash
+    Data Binding "hiera"
+      No such key: "lookup_options"
+    Data Provider "FunctionEnvDataProvider"
+      No such key: "lookup_options"
+    Data Provider "Hiera Data Provider, version 4"
+      ConfigurationPath "#{environmentpath}/production/modules/hieraprovider/hiera.yaml"
+      Data Provider "two paths"
+        Merge strategy hash
+          Path "#{environmentpath}/production/modules/hieraprovider/data/first.json"
+            Original path: first
+            No such key: "lookup_options"
+          Path "#{environmentpath}/production/modules/hieraprovider/data/second_not_present.json"
+            Original path: second_not_present
+            Path not found
 Merge strategy first
   Data Binding "hiera"
     No such key: "hieraprovider::test::not_found"


### PR DESCRIPTION
The explainer will currently only report the actions that lookup
performs during traversal of global data binders and providers in
order to find the data for a given key. This commit adds the lookup
of the new 'lookup_options' to the report.

Since this might make the report quite verbose, this commit also
adds an extra '--explain-data' option to the lookup CLI. This option
is mutally exclusive to '--explain' and will yield a report where the
'lookup_options' traversal is excluded.