### PR TITLE
(PUP-5470) Update handle_upstart test to case out Ubuntus by version

### DIFF
--- a/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
+++ b/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
@@ -3,7 +3,7 @@ test_name 'Upstart Testing'
 # only run these on ubuntu vms
 confine :to, :platform => 'ubuntu'
 # vivid and above use systemd rather than upstart
-confine :except, :platform => /ubuntu-[v-z]/
+confine :except, :platform => /ubuntu-1?[v-z|5-9]/
 
 # pick any ubuntu agent
 agent = agents.first


### PR DESCRIPTION
This commit modifies the confine block on the handle_upstart test to
confine out the execution of the ticket_14297_handle_upstart test based
on the platform version numbers, e.g., 15.04 or greater, as opposed to
just the platform code name, e.g., Vivid or Werewolf.  This is needed
because the platform field is populated for code names on some CI
pipelines - core Puppet - but by version number on other pipelines -
e.g., Puppet Server.