### PR TITLE
(maint) Update teardown for aix pkg acceptance

### DIFF
--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -20,7 +20,7 @@ version2 = '1.8.6.4'
 
 teardown do
   on hosts, "rm -rf #{dir}"
-  on hosts, puppet('resource', 'package', "'#{package}' ensure=absent")
+  on hosts, "installp -u #{package}"
 end
 
 step "download packages to use for test"


### PR DESCRIPTION
This commit updates the teardown step for the
`aix_package_provider` acceptance test to not use puppet
to remove the package.

This test is intended to test the provider. So, even if there
is a bug in the provider, we want to make sure the package is
removed. This commit uses the native AIX package call to ensure
that the package is uninstalled.

[skip ci]