### PR TITLE
(PUP-5422) Setup signal trap before waiting for certs

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -322,6 +322,9 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       # waiting for certificates so that we don't block
       daemon = daemonize_process_when(Puppet[:daemonize])
 
+      # Setup signal traps immediately after daemonization so we clean up the daemon
+      daemon.set_signal_traps
+
       wait_for_certificates
 
       if Puppet[:onetime]
@@ -346,7 +349,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def onetime(daemon)
-    daemon.set_signal_traps
     begin
       exitstatus = daemon.agent.run
     rescue => detail

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -295,6 +295,9 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
     daemon.server = Puppet::Network::Server.new(Puppet[:bindaddress], Puppet[:masterport])
     daemon.daemonize if Puppet[:daemonize]
 
+    # Setup signal traps immediately after daemonization so we clean up the daemon
+    daemon.set_signal_traps
+
     announce_start_of_master
 
     daemon.start

--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -129,8 +129,6 @@ class Puppet::Daemon
   end
 
   def start
-    set_signal_traps
-
     create_pidfile
 
     raise Puppet::DevError, "Daemons must have an agent, server, or both" unless agent or server


### PR DESCRIPTION
When running the agent, waiting for certificates can sleep and wait for
a significant period of time. During that time a SIGTERM event can come
in (from Ctrl-C or service shutdown), causing an exception to be thrown
that prevents daemon cleanup.

Setup signal traps before waiting for certs so we ensure daemon cleanup
occurs. Update the master as well so all call paths only call
set_signal_traps once, and do so immediately after possibly daemonizing.