### PR TITLE
(PUP-5262) Wait for services to finish state transitions in Solaris

### DIFF
--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -25,7 +25,6 @@ end
 # 1) Starting, stopping and refreshing while the service is initially stopped
 # 2) Starting, stopping and refreshing while the service is initially running
 agents.each do |agent|
-  skip_test "Skipping because of Solaris service status race condition when refreshing service: see PUP-5262." if agent['platform'] =~ /solaris/
 
   ['puppet', 'mcollective'].each do |service|
     ['stopped', 'running'].each do |status|

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -1,3 +1,5 @@
+require 'timeout'
+
 # Solaris 10 SMF-style services.
 Puppet::Type.type(:service).provide :smf, :parent => :base do
   desc <<-EOT
@@ -74,6 +76,47 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
     end
   end
 
+  # Wait for the service to transition into the specified state before returning.
+  # This is necessary due to the asynchronous nature of SMF services.
+  # desired_state should be online, offline, disabled, or uninitialized.
+  # See PUP-5474 for long-term solution to this issue.
+  def wait(desired_state)
+    desired_state = [desired_state].flatten
+
+    Timeout.timeout(60) do
+      loop do
+        states = self.service_states
+        break if desired_state.include?(states[0]) && states[1] == '-'
+        sleep(1)
+      end
+    end
+  rescue Timeout::Error
+    raise Puppet::Error.new("Timed out waiting for #{@resource[:name]} to transition states")
+  end
+
+  def start
+    # Wait for the service to actually start before returning.
+    super
+    self.wait('online')
+  end
+
+  def stop
+    # Wait for the service to actually stop before returning.
+    super
+    self.wait(['offline', 'disabled', 'uninitialized'])
+  end
+
+  def restart
+    # Wait for the service to actually start before returning.
+    super
+    self.wait('online')
+  end
+
+  # Determine the current and next states of a service.
+  def service_states
+    svcs("-H", "-o", "state,nstate", @resource[:name]).chomp.split
+  end
+
   def status
     if @resource[:status]
       super
@@ -83,7 +126,7 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
     begin
       # get the current state and the next state, and if the next
       # state is set (i.e. not "-") use it for state comparison
-      states = svcs("-H", "-o", "state,nstate", @resource[:name]).chomp.split
+      states = service_states
       state = states[1] == "-" ? states[0] : states[1]
     rescue Puppet::ExecutionFailure
       info "Could not get status on service #{self.name}"


### PR DESCRIPTION
When stopping, starting, and restarting services, SMF tracks state
transitions through through two states: `state` for the
current state, and `nstate` for the next state. Because of this,
Puppet would occasionally encounter race conditions when attempting
to act on a service that was in the middle of a state transition.

This is due to the asychronous nature of service management in Solaris,
and the fact that state transitions are not atomic.

This commit adds a 60 second timeout when stopping or starting services
to ensure that the state transition has completed before continuing
operatings.