### PR TITLE
(PUP-5478) Fix tests failing in Fedora 22

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -131,11 +131,15 @@ module Puppet
       end
       module_function :ruby_command
 
-      def gem_command(host)
-        if host['platform'] =~ /windows/
-          "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+      def gem_command(host, type='aio')
+        if type == 'aio'
+          if host['platform'] =~ /windows/
+            "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+          else
+            "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
+          end
         else
-          "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
+          on(host, 'which gem').stdout.chomp
         end
       end
       module_function :gem_command

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -82,12 +82,6 @@ agents.each do |agent|
     end
   end
 
-  if platform == 'fedora' && majrelease > 21
-    # This is a reminder so we update the provider's defaultfor when new
-    # versions of Fedora are released (then update this test)
-    fail_test "Provider needs manual update to support Fedora #{majrelease}"
-  end
-
   step "installing #{package_name[platform]}"
   apply_manifest_on(agent, manifest_install_package, :catch_failures => true)
 


### PR DESCRIPTION
This commit updates two acceptance tests which were failing in Fedora
22: service_enable_linux.rb and
common_package_name_in_different_providers.rb.

The systemd provider is already the default for all versions of Fedora,
so there is no need to bump the provider.

For the common package name test, we need to use puppet-agent's private
gem binary, as rubygems is not installed on our Fedora 22 testing VMs.