### PR TITLE
(packaging) (PA-25) The registered facter gem in puppet-agent is v3.x

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "puppet"
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
-  s.add_runtime_dependency(%q<facter>, [">= 1.7", "< 3"])
+  s.add_runtime_dependency(%q<facter>, [">= 1.7", "< 4"])
   s.add_runtime_dependency(%q<hiera>, [">= 2.0", "< 4"])
 end


### PR DESCRIPTION
In PA-25 we are registering puppet, facter, and hiera as gems in the
puppet agent packaging. However, the version of facter registered is in
the 3.x series, so currently any gems installed with a dependency on
puppet would end up trying to pull in facter 2.4, causing conflicts with
the puppet-agent facter. This allows dependency resolution to work
properly for the puppet-agent rubygems installation.