### PR TITLE
Flag that a type could not be found

### DIFF
--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -146,16 +146,18 @@ module Manager
     # We are overwhelmingly symbols here, which usually match, so it is worth
     # having this special-case to return quickly.  Like, 25K symbols vs. 300
     # strings in this method. --daniel 2012-07-17
-    return @types[name] if @types[name]
+    return @types[name] if @types.include? name
 
     # Try mangling the name, if it is a string.
     if name.is_a? String
       name = name.downcase.intern
-      return @types[name] if @types[name]
+      return @types[name] if @types.include? name
     end
     # Try loading the type.
     if typeloader.load(name, Puppet.lookup(:current_environment))
       Puppet.warning "Loaded puppet/type/#{name} but no class was created" unless @types.include? name
+    else
+      @types[name] = nil
     end
 
     # ...and I guess that is that, eh.


### PR DESCRIPTION
If a Ruby type is not available in the file system, every time it is found by
the parser, the Autoloader will scan all over again the directories in
search_directories for it. This generates tons of stat()s that can be saved.

This patch annotates that a type could not be found so the next time it is
required during the compilation of a catalog, the file system is not hammered
again unnecessarily.

This optimization has given us a ~61% reduction in the number of stats per
compilation, as we make an extensive use of the concat module which only
provides Puppet "defined types".