### PR TITLE
(maint) Skip puppet/mco service test on AIX

### DIFF
--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -26,6 +26,7 @@ end
 # 2) Starting, stopping and refreshing while the service is initially running
 agents.each do |agent|
   skip_test "Skipping because of Solaris service status race condition when refreshing service: see PUP-5262." if agent['platform'] =~ /solaris/
+  skip_test "Skipping because of Mcollective service daemonization issue: see PA-67" if agent['platform'] =~ /aix/
 
   ['puppet', 'mcollective'].each do |service|
     ['stopped', 'running'].each do |status|


### PR DESCRIPTION
This commit skips the puppet/mco service test on AIX
due to PA-67. Once Mcollective's `cmdargs` have been
updated to not daemonize in AIX, the test should be
unskipped.