### PR TITLE
(PUP-5308) Use puppet config set for future parser

### DIFF
--- a/acceptance/setup/common/pre-suite/100_SetParser.rb
+++ b/acceptance/setup/common/pre-suite/100_SetParser.rb
@@ -5,13 +5,7 @@ test_name "add parser=#{ENV['PARSER']} to all puppet.conf (only if $PARSER is se
 
   hosts.each do |host|
     step "adjust #{host} puppet.conf" do
-      temp = host.tmpdir('parser-set')
-      opts = {
-        'main' => {
-           'parser' => parser
-        }
-      }
-      lay_down_new_puppet_conf(host, opts, temp)
+      on(host, puppet("config set --section main parser #{parser}"))
     end
   end
 end


### PR DESCRIPTION
Previously, the future parser setup step was using Beaker's
`lay_down_new_puppet_conf` method to set the parser=future puppet
setting. When using beaker 2.x, the method calls `puppet master
--configprint config` in order to figure out the location of
puppet.conf, but since the master application isn't supported on
Windows, it was raising an error: "Puppet master is not supported on
Microsoft Windows". This issue was introduced when we bumped our
beaker dependency from ~> 1.17 to ~> 2.23 in 94d93e863 as beaker's
method behaves differently in 2.x than it did in 1.x.

This commit eliminates the call to beaker, instead just calling
`puppet config set --section main` to set the parser setting to the
value of the PARSER environment variable.