### PR TITLE
(PUP-5480) Windows dirs should inherit SYSTEM

### DIFF
--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -372,7 +372,10 @@ module Puppet::Util::Windows::Security
     dacl.allow(well_known_nobody_sid, nobody_allow)
 
     # TODO: system should be first?
-    dacl.allow(well_known_system_sid, system_allow)
+    flags = !isdir ? 0 :
+      Puppet::Util::Windows::AccessControlEntry::CONTAINER_INHERIT_ACE |
+      Puppet::Util::Windows::AccessControlEntry::OBJECT_INHERIT_ACE
+    dacl.allow(well_known_system_sid, system_allow, flags)
 
     # add inherit-only aces for child dirs and files that are created within the dir
     inherit_only = Puppet::Util::Windows::AccessControlEntry::INHERIT_ONLY_ACE

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -237,6 +237,24 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
             system_aces.each do |ace|
               ace.mask.should == klass::FILE_ALL_ACCESS && ! ace.inherited?
             end
+
+            if Puppet::FileSystem.directory?(path)
+              system_aces.each do |ace|
+                ace.object_inherit?.should be_true
+                ace.container_inherit?.should be_true
+              end
+
+              # it's critically important that this file be default created
+              # and that this file not have it's owner / group / mode set by winsec
+              nested_file = File.join(path, 'nested_file')
+              File.new(nested_file, 'w').close
+
+              system_aces = winsec.get_aces_for_path_by_sid(nested_file, sids[:system])
+              # even when SYSTEM is the owner (in CI), there should be an inherited SYSTEM
+              system_aces.any? do |ace|
+                ace.mask == klass::FILE_ALL_ACCESS && ace.inherited?
+              end.should be_true
+            end
           end
 
           describe "for modes that require deny aces" do


### PR DESCRIPTION
 - Previously, as part of b578ed4,
   when Puppet would manage a directory where SYSTEM was not explicitly
   set, it would re-add SYSTEM to the directory in an effort to ensure
   that Windows (and services like Puppet itself) could later access the
   directory:

   `NT AUTHORITY\SYSTEM:(F)`

   However, this approach was flawed, since files could be written to
   that directory (by Puppet or otherwise), and they would no longer be
   accessible to SYSTEM since inheritance was not set on the directory.
   Instead, the permissions should be set as:

   `NT AUTHORITY\SYSTEM:(F)(CI)(OI)`

   This allows the SYSTEM permission to propagate to any newly created
   files or directories within the parent managed directory.

 - As it turns out, Puppet itself is affected by this flaw on the first
   run that it writes an agents private key, public key and the ca cert
   when the agent is not run as SYSTEM (which is the case during
   acceptance tests).  On the next Puppet agent run, file modes are
   explicitly set via:
   https://github.com/puppetlabs/puppet/blob/master/lib/puppet/defaults.rb#L709-L759

   With debug logging on, change notifications are emitted when the
   settings catalog is applied, demonstrating the re-addition of the missing SYSTEM permissions like:

```
   [Debug: /File[C:/ProgramData/PuppetLabs/puppet/etc/ssl/private_keys/lmugyz1yds193au.delivery.puppetlabs.net.pem]/mode: mode changed '4000640' to '0640'
   [Debug: /File[C:/ProgramData/PuppetLabs/puppet/etc/ssl/public_keys/lmugyz1yds193au.delivery.puppetlabs.net.pem]/mode: mode changed '4000640' to '0644'
   [Debug: /File[C:/ProgramData/PuppetLabs/puppet/etc/ssl/certs/ca.pem]/mode: mode changed '4000640' to '0644'
```
   Also note, that the cache/client_data/catalog dir (client_datadir)
   exhibits the same behavior.

 - This commit ensures that SYSTEM is always added as inheritable to directories.