### PR TITLE
(PUP-5483) Update diff regex in filebucket test for AIX

### DIFF
--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -11,9 +11,9 @@ end
 
 def validate_diff_on(host, item_one, item_two, bucket_locale)
   on host, puppet("filebucket diff #{item_one} #{item_two} #{bucket_locale}"), :acceptable_exit_codes => [ 0, 2 ]
-  assert_match("-foo", result.stdout.strip)
-  assert_match('+bar', result.stdout.strip)
-  assert_match('+baz', result.stdout.strip)
+  assert_match(/[-<] ?foo/, result.stdout.strip)
+  assert_match(/[+>] ?bar/, result.stdout.strip)
+  assert_match(/[+>] ?baz/, result.stdout.strip)
 end
 
 step "Master: Start Puppet Master" do


### PR DESCRIPTION
In AIX, the output of diff varies from other platforms. This was
causing our filebucket diff test to fail due to a strict regex.
This commit updates the regexes to allow diff formats from AIX
5.3, 6.1 and 7.1.

[skip ci]