### PR TITLE
(PUP-3149) Add uninstall method to zypper provider

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -123,4 +123,23 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
     # zypper install can be used for update, too
     self.install
   end
+
+  def uninstall
+    #extract version numbers and convert to integers
+    major, minor, patch = zypper_version.scan(/\d+/).map{ |x| x.to_i }
+
+    if major < 1
+      super
+    else
+      options = [:remove, '--no-confirm']
+      if major == 1 && minor < 6
+          options << '--force-resolution'
+      end
+
+      options << @resource[:name]
+    	
+      zypper *options
+    end
+
+  end
 end

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -214,4 +214,18 @@ describe provider_class do
       @provider.install
     end
   end
+
+  describe 'when uninstalling' do
+    it 'should use remove to uninstall on zypper version 1.6 and above' do
+      @provider.stubs(:zypper_version).returns '1.6.308'
+      @provider.expects(:zypper).with(:remove, '--no-confirm', 'mypackage')
+      @provider.uninstall
+    end
+
+    it 'should use remove  --force-solution to uninstall on zypper versions between 1.0 and 1.6' do
+      @provider.stubs(:zypper_version).returns '1.0.2'
+      @provider.expects(:zypper).with(:remove, '--no-confirm', '--force-resolution', 'mypackage')
+      @provider.uninstall
+    end
+  end
 end


### PR DESCRIPTION
Added zypper purge to be able to remove packages using zypper instead of rpm, which in some cases could break systems due to lack of dependencies check.