### PR TITLE
(PUP-5487) Add ability to supress warnings about storeconfig

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -114,7 +114,7 @@ module Puppet
         * `deprecations` --- disables deprecation warnings.",
       :hook      => proc do |value|
         values = munge(value)
-        valid   = %w[deprecations]
+        valid   = %w[deprecations storeconfigs]
         invalid = values - (values & valid)
         if not invalid.empty?
           raise ArgumentError, "Cannot disable unrecognized warning types #{invalid.inspect}. Valid values are #{valid.inspect}."

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -497,8 +497,8 @@ module Puppet::Pops::Evaluator::Runtime3Support
       end
 
       # Store config issues, ignore or warning
-      p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning
-      p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
+      p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] || Puppet[:disable_warnings].include?('storeconfigs') ? :ignore : :warning
+      p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] || Puppet[:disable_warnings].include?('storeconfigs') ? :ignore : :warning
     end
   end
 

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -20,8 +20,8 @@ class Puppet::Pops::Validation::ValidatorFactory_4_0 < Puppet::Pops::Validation:
     # Configure each issue that should **not** be an error
     #
     # Validate as per the current runtime configuration
-    p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning
-    p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
+    p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] || Puppet[:disable_warnings].include?('storeconfigs') ? :ignore : :warning
+    p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] || Puppet[:disable_warnings].include?('storeconfigs') ? :ignore : :warning
 
     p[Issues::FUTURE_RESERVED_WORD]          = :deprecation
 


### PR DESCRIPTION
This patch adds the ability to disable warnings about storeconfigs
not beeing enabled with:
--disable_warnings storeconfigs