### PR TITLE
(maint) Remove skipping based on commit msg

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,4 @@
 version: 3.x.{build}
-skip_commits:
-  message: /(^\(?doc\)?.*|.*[A|a]cceptance [T|t]est.*)/
 clone_depth: 10
 init:
   - SET


### PR DESCRIPTION
Previously, appveyor skipped based on the commit message
matching the pattern for a docs commit or having the text
"acceptance test" anywhere in the commit message.

Unfortunately both these have led to some confusion in looking
at PRs and various debugging efforts to figure out what was
wrong with AppVeyor. This behavior is also inconsistent with
Travis.

So this PR removes that skipping behavior.