### PR TITLE
(PUP-5390) Audit acceptance tests for old skips and confines

### DIFF
--- a/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
+++ b/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
@@ -2,7 +2,7 @@ test_name "#17371 file metadata specified in puppet.conf needs to be applied"
 
 # when owner/group works on windows for settings, this confine should be removed.
 confine :except, :platform => 'windows'
-confine :except, :platform => /solaris-10/
+confine :except, :platform => /solaris-10/ # See PUP-5200
 
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils

--- a/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
+++ b/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
@@ -5,8 +5,6 @@
 # expect that after correcting their actions, puppet will work correctly.
 test_name "Puppet manages its own configuration in a robust manner"
 
-confine :except, :platform => 'fedora-19'
-
 skip_test "JVM Puppet cannot change its user while running." if @options[:is_puppetserver]
 
 # when owner/group works on windows for settings, this confine should be removed.

--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,9 +1,5 @@
 test_name 'puppet module changes (on a module with a modified file)'
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,9 +1,5 @@
 test_name 'puppet module changes (on a module with a removed file)'
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,9 +1,5 @@
 test_name 'puppet module changes (on an unmodified module)'
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/install/already_installed.rb
+++ b/acceptance/tests/modules/install/already_installed.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (already installed)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (already installed elsewhere)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (already installed with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -3,6 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
+confine :except, :platform => /aix/ # PUP-5501
 
 module_author = "pmtacceptance"
 module_name   = "nginx"

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -4,16 +4,6 @@ extend Puppet::Acceptance::ModuleUtils
 
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
-hosts.each do |host|
-  case host['platform']
-  when /solaris|aix/
-    # see PUP-4822, PUP-3450
-    # We now bundle the GeoTrust Global CA with our vendored openssl, so
-    # this test will run correctly in OSX.
-    skip_test "skip tests requiring forge certs"
-  end
-end
-
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/force_ignores_dependencies.rb
+++ b/acceptance/tests/modules/install/force_ignores_dependencies.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (force ignores dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "git"
 module_dependencies   = ["apache"]

--- a/acceptance/tests/modules/install/ignoring_dependencies.rb
+++ b/acceptance/tests/modules/install/ignoring_dependencies.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (ignoring dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (nonexistent directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (nonexistent module)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "nonexistent"
 module_dependencies  = []

--- a/acceptance/tests/modules/install/with_debug.rb
+++ b/acceptance/tests/modules/install/with_debug.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (with debug)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_dependencies.rb
+++ b/acceptance/tests/modules/install/with_dependencies.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (with dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -2,10 +2,6 @@ test_name 'puppet module install (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 tmpdir = master.tmpdir('module-install-with-environment')
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (with existing module directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -4,10 +4,6 @@ test_name "puppet module install (with modulepath)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 codedir = master.puppet('master')['codedir']
 module_author = "pmtacceptance"
 module_name   = "nginx"

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (with necessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (with no dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (with unnecessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -2,10 +2,6 @@ test_name "puppet module install (with unsatisfied constraints)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris|aix/
-end
-
 module_author = "pmtacceptance"
 module_name   = "git"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -3,6 +3,7 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
+confine :except, :platform => /aix/ # PUP-5501
 
 module_author = "pmtacceptance"
 module_name = "java"

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -4,16 +4,6 @@ extend Puppet::Acceptance::ModuleUtils
 
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
-hosts.each do |host|
-  case host['platform']
-  when /solaris|aix/
-    # see PUP-4822, PUP-3450
-    # We now bundle the GeoTrust Global CA with our vendored openssl, so
-    # this test will run correctly in OSX.
-    skip_test "skip tests requiring forge certs"
-  end
-end
-
 module_author = "pmtacceptance"
 module_name = "java"
 module_version = "1.7.0"

--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -2,10 +2,6 @@ test_name 'puppet module list (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 tmpdir = master.tmpdir('module-list-with-environment')
 
 step 'Setup'

--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -1,7 +1,5 @@
 test_name 'puppet module search should print a reasonable message on communication errors'
 
-confine :except, :platform => 'solaris'
-
 step 'Setup'
 stub_hosts_on(master, 'forgeapi.puppetlabs.com' => '127.0.0.2')
 

--- a/acceptance/tests/modules/search/formatting.rb
+++ b/acceptance/tests/modules/search/formatting.rb
@@ -1,9 +1,5 @@
 test_name 'puppet module search output should be well structured'
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 step 'Setup'
 stub_forge_on(master)
 

--- a/acceptance/tests/modules/search/no_results.rb
+++ b/acceptance/tests/modules/search/no_results.rb
@@ -1,9 +1,5 @@
 test_name 'puppet module search should print a reasonable message for no results'
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 module_name   = "module_not_appearing_in_this_forge"
 
 step 'Setup'

--- a/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
@@ -1,9 +1,5 @@
 test_name "puppet module uninstall (with multiple modules installed)"
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 if master.is_pe?
   skip_test
 end

--- a/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
+++ b/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (in a secondary directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (introducing new dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/not_upgradable.rb
+++ b/acceptance/tests/modules/upgrade/not_upgradable.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (not upgradable)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/to_a_specific_version.rb
+++ b/acceptance/tests/modules/upgrade/to_a_specific_version.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (to a specific version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/to_installed_version.rb
+++ b/acceptance/tests/modules/upgrade/to_installed_version.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (to installed version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (with constraints on it)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (with constraints on its dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_environment.rb
+++ b/acceptance/tests/modules/upgrade/with_environment.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (with environment)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 tmpdir = master.tmpdir('module-upgrade-withenv')
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/upgrade/with_local_changes.rb
+++ b/acceptance/tests/modules/upgrade/with_local_changes.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_update_available.rb
+++ b/acceptance/tests/modules/upgrade/with_update_available.rb
@@ -2,10 +2,6 @@ test_name "puppet module upgrade (with update available)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
-hosts.each do |host|
-  skip_test "skip tests requiring forge certs on solaris and aix" if host['platform'] =~ /solaris/
-end
-
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -1,6 +1,6 @@
 test_name "Cron: should allow changing parameters after creation"
 confine :except, :platform => 'windows'
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # See PUP-5500
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils
 

--- a/acceptance/tests/resource/cron/should_be_idempotent.rb
+++ b/acceptance/tests/resource/cron/should_be_idempotent.rb
@@ -1,6 +1,6 @@
 test_name "Cron: check idempotency"
 confine :except, :platform => 'windows'
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # See PUP-5500
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -1,6 +1,6 @@
 test_name "should create cron"
 confine :except, :platform => 'windows'
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # See PUP-5500
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_match_existing.rb
+++ b/acceptance/tests/resource/cron/should_match_existing.rb
@@ -1,6 +1,6 @@
 test_name "puppet should match existing job"
 confine :except, :platform => 'windows'
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # See PUP-5500
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -1,6 +1,6 @@
 test_name "puppet should remove a crontab entry as expected"
 confine :except, :platform => 'windows'
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # See PUP-5500
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
@@ -1,6 +1,6 @@
 test_name "(#656) leading and trailing whitespace in cron entries should should be stripped"
 confine :except, :platform => 'windows'
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # See PUP-5500
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -1,6 +1,6 @@
 test_name "puppet should remove a crontab entry based on command matching"
 confine :except, :platform => 'windows'
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # See PUP-5500
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_update_existing.rb
+++ b/acceptance/tests/resource/cron/should_update_existing.rb
@@ -1,6 +1,6 @@
 test_name "puppet should update existing crontab entry"
 confine :except, :platform => 'windows'
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # See PUP-5500
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -1,8 +1,6 @@
 test_name "tests that puppet correctly runs an exec."
 # original author: Dan Bode  --daniel 2010-12-23
 
-confine :except, :platform => /osx/ # see BKR-388
-
 def before(agent)
   step "file to be touched should not exist."
   touched = agent.tmpfile('test-exec')

--- a/acceptance/tests/resource/group/should_create.rb
+++ b/acceptance/tests/resource/group/should_create.rb
@@ -1,7 +1,5 @@
 test_name "should create a group"
 
-confine :except, :platform => /osx/ # See PUP-4824
-
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -3,7 +3,7 @@ test_name "defined should create an entry in filesystem table"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/ # See PUP-5201
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # Mount provider not supported on Arista EOS switches
 
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -3,7 +3,7 @@ test_name "should delete an entry in filesystem table and unmount it"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/ # See PUP-5201
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # Mount provider not supported on Arista EOS switches
 
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -3,7 +3,7 @@ test_name "should modify an entry in filesystem table"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/ # See PUP-5201
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # Mount provider not supported on Arista EOS switches
 
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -3,7 +3,7 @@ test_name "mounted should create an entry in filesystem table and mount it"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/ # See PUP-5201
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # Mount provider not supported on Arista EOS switches
 
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils

--- a/acceptance/tests/resource/mount/query.rb
+++ b/acceptance/tests/resource/mount/query.rb
@@ -3,7 +3,7 @@ test_name "should be able to find an existing filesystem table entry"
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823
 confine :except, :platform => /solaris/ # See PUP-5201
-confine :except, :platform => /^eos-/ # See PUP-5445
+confine :except, :platform => /^eos-/ # Mount provider not supported on Arista EOS switches
 
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -2,7 +2,7 @@ test_name "#9862: puppet runs without service user or group present"
 
 # puppet doesn't try to manage ownership on windows.
 confine :except, :platform => 'windows'
-confine :except, :platform => /solaris-10/
+confine :except, :platform => /solaris-10/ # See PUP-5200
 
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils


### PR DESCRIPTION
These commits update several acceptance tests to either un-skip for certain platforms or add better references / notes about why they're skipped.