### PR TITLE
Fix up LOAD_PATH before calling Kernel.load

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -63,7 +63,7 @@ class Puppet::Util::Autoload
       $clean_loadpath ||= $LOAD_PATH.dup
       $env_loadpath ||= {}
       $env_loadpath[env] ||= search_directories(env)
-      $current_loadpath ||= nil
+      $current_loadpath ||= $clean_loadpath
 
       loadpath = $env_loadpath[env]
       last_loadpath = $current_loadpath

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -76,7 +76,6 @@ class Puppet::Util::Autoload
       return false unless file
       begin
         mark_loaded(name, file)
-        $LOAD_PATH.push *(search_directories(env))
         Kernel.load file, @wrap
         return true
       rescue SystemExit,NoMemoryError

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -62,7 +62,11 @@ class Puppet::Util::Autoload
       # last_loadpath       - which LOAD_PATH was set when we started
       $clean_loadpath ||= $LOAD_PATH.dup
       $env_loadpath ||= {}
-      $env_loadpath[env] ||= search_directories(env)
+      unless $env_loadpath[env]
+        $LOAD_PATH.replace $clean_loadpath
+        $current_loadpath = $clean_loadpath
+        $env_loadpath[env] = search_directories(env)
+      end
       $current_loadpath ||= $clean_loadpath
 
       loadpath = $env_loadpath[env]


### PR DESCRIPTION
(PUP-4450) Sometimes, we're autoloading something that _require_s a library that lives in a directory which Puppet knows about, but the Ruby kernel doesn't.

I've compared spec results; this change makes no difference to them.

This change should be portable to Puppet 4; we've only tested it Puppet 3, though.