### PR TITLE
(PUP-5437) Add 'lookup_options' to the lookup explainer

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -45,6 +45,8 @@ class Puppet::Application::Lookup < Puppet::Application
 
   option('--explain')
 
+  option('--explain-options')
+
   option('--default VALUE') do |arg|
     options[:default_value] = arg
   end
@@ -214,6 +216,10 @@ the puppet lookup function linked to above.
   than the value returned for the key. The explaination will describe how
   the result was obtained or why lookup failed to obtain the result.
 
+* --explain-options
+  Explain if a lookup_options hash will be used and how it was assembled
+  when performing a lookup.
+
 * --default <VALUE>
   A value produced if no value was found in the lookup.
 
@@ -266,7 +272,6 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   def main
     keys = command_line.args
-    raise 'No keys were given to lookup.' if keys.empty?
 
     #unless options[:node]
     #  raise "No node was given via the '--node' flag for the scope of the lookup.\n#{RUN_HELP}"
@@ -298,7 +303,18 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
       end
     end
 
-    explain = !!options[:explain]
+    explain_data = !!options[:explain]
+    explain_options = !!options[:explain_options]
+    only_explain_options = explain_options && !explain_data
+    if keys.empty?
+      if only_explain_options
+        # Explain lookup_options for lookup of an unqualified value.
+        keys = Puppet::Pops::Lookup::GLOBAL
+      else
+        raise 'No keys were given to lookup.'
+      end
+    end
+    explain = explain_data || explain_options
 
     # Format defaults to text (:s) when producing an explanation and :yaml when producing the value
     format = options[:render_as] || (explain ? :s : :yaml)
@@ -308,7 +324,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     type = options.include?(:type) ? Puppet::Pops::Types::TypeParser.new.parse(options[:type]) : nil
 
     generate_scope do |scope|
-      lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, explain)
+      lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, explain ? Puppet::Pops::Lookup::Explainer.new(explain_options, only_explain_options) : nil)
       begin
         result = Puppet::Pops::Lookup.lookup(keys, type, options[:default_value], use_default_value, merge_options, lookup_invocation)
         puts renderer.render(result) unless explain

--- a/lib/puppet/plugins/data_providers/data_provider.rb
+++ b/lib/puppet/plugins/data_providers/data_provider.rb
@@ -98,6 +98,7 @@ module Puppet::Plugins::DataProviders
   end
 
   class ModuleDataProvider
+    LOOKUP_OPTIONS = Puppet::Pops::Lookup::LOOKUP_OPTIONS
     include DataProvider
 
     # Retrieve the first segment of the qualified name _key_. This method will throw
@@ -106,7 +107,7 @@ module Puppet::Plugins::DataProviders
     # @param key [String] The key
     # @return [String] The first segment of the given key
     def data_key(key, lookup_invocation)
-      return lookup_invocation.module_name if key == 'lookup_options'
+      return lookup_invocation.module_name if key == LOOKUP_OPTIONS
       qual_index = key.index('::')
       throw :no_such_key if qual_index.nil?
       key[0..qual_index-1]
@@ -121,7 +122,7 @@ module Puppet::Plugins::DataProviders
     def validate_data(data, module_name)
       module_prefix = "#{module_name}::"
       data.each_key do |k|
-        unless k.is_a?(String) && (k == 'lookup_options' || k.start_with?(module_prefix))
+        unless k.is_a?(String) && (k == LOOKUP_OPTIONS || k.start_with?(module_prefix))
           raise Puppet::DataBinding::LookupError, "Module data for module '#{module_name}' must use keys qualified with the name of the module"
         end
       end

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -2,6 +2,9 @@
 # See puppet/functions/lookup.rb for documentation.
 #
 module Puppet::Pops::Lookup
+  LOOKUP_OPTIONS = 'lookup_options'.freeze
+  GLOBAL = '__global__'.freeze
+
   # Performs a lookup in the configured scopes and optionally merges the default.
   #
   # This is a backing function and all parameters are assumed to have been type checked.

--- a/spec/fixtures/unit/application/environments/production/data/common.yaml
+++ b/spec/fixtures/unit/application/environments/production/data/common.yaml
@@ -1,3 +1,6 @@
 ---
 a: This is A
 b: This is B
+
+lookup_options:
+  a: first

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -104,30 +104,30 @@ describe Puppet::Application::Lookup do
       :event => :result,
       :value => 'This is A',
       :branches => [
-      { :key => 'a',
-        :event => :not_found,
-        :type => :global,
-        :name => :hiera
-      },
-      {
-        :type => :data_provider,
-        :name => 'Hiera Data Provider, version 4',
-        :configuration_path => "#{environmentpath}/production/hiera.yaml",
-        :branches => [
+        { :key => 'a',
+          :event => :not_found,
+          :type => :global,
+          :name => :hiera
+        },
         {
           :type => :data_provider,
-          :name => 'common',
+          :name => 'Hiera Data Provider, version 4',
+          :configuration_path => "#{environmentpath}/production/hiera.yaml",
           :branches => [
-          {
-            :key => 'a',
-            :value => 'This is A',
-            :event => :found,
-            :type => :path,
-            :original_path => 'common',
-            :path => "#{environmentpath}/production/data/common.yaml",
-          }]
-       }]
-      }]
+            {
+              :type => :data_provider,
+              :name => 'common',
+              :branches => [
+                {
+                  :key => 'a',
+                  :value => 'This is A',
+                  :event => :found,
+                  :type => :path,
+                  :original_path => 'common',
+                  :path => "#{environmentpath}/production/data/common.yaml",
+                }]
+            }]
+        }]
     } }
 
     around(:each) do |example|
@@ -152,9 +152,65 @@ Merge strategy first
     ConfigurationPath "#{environmentpath}/production/hiera.yaml"
     Data Provider "common"
       Path "#{environmentpath}/production/data/common.yaml"
-        Original path: common
+        Original path: "common"
         Found key: "a" value: "This is A"
   Merged result: "This is A"
+      EXPLANATION
+    end
+
+    it 'produces human readable text of a hash merge when using --explain-options' do
+      lookup.options[:node] = Puppet::Node.new("testnode", :facts => facts, :environment => 'production')
+      lookup.options[:explain_options] = true
+      expect { lookup.run_command }.to output(<<-EXPLANATION).to_stdout
+Merge strategy hash
+  Data Binding "hiera"
+    No such key: "lookup_options"
+  Data Provider "Hiera Data Provider, version 4"
+    ConfigurationPath "#{environmentpath}/production/hiera.yaml"
+    Data Provider "common"
+      Path "#{environmentpath}/production/data/common.yaml"
+        Original path: "common"
+        Found key: "lookup_options" value: {
+          "a" => "first"
+        }
+  Merged result: {
+    "a" => "first"
+  }
+      EXPLANATION
+    end
+
+    it 'produces human readable text of a hash merge when using both --explain and --explain-options' do
+      lookup.options[:node] = Puppet::Node.new("testnode", :facts => facts, :environment => 'production')
+      lookup.options[:explain] = true
+      lookup.options[:explain_options] = true
+      lookup.command_line.stubs(:args).returns(['a'])
+      expect { lookup.run_command }.to output(<<-EXPLANATION).to_stdout
+Searching for "lookup_options"
+  Merge strategy hash
+    Data Binding "hiera"
+      No such key: "lookup_options"
+    Data Provider "Hiera Data Provider, version 4"
+      ConfigurationPath "#{environmentpath}/production/hiera.yaml"
+      Data Provider "common"
+        Path "#{environmentpath}/production/data/common.yaml"
+          Original path: "common"
+          Found key: "lookup_options" value: {
+            "a" => "first"
+          }
+    Merged result: {
+      "a" => "first"
+    }
+Searching for "a"
+  Merge strategy first
+    Data Binding "hiera"
+      No such key: "a"
+    Data Provider "Hiera Data Provider, version 4"
+      ConfigurationPath "#{environmentpath}/production/hiera.yaml"
+      Data Provider "common"
+        Path "#{environmentpath}/production/data/common.yaml"
+          Original path: "common"
+          Found key: "a" value: "This is A"
+    Merged result: "This is A"
       EXPLANATION
     end
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -486,7 +486,7 @@ EOS
       end
     end
 
-    it 'will handle path merge with not found correctly' do
+    it 'will handle path merge when some entries are not found correctly' do
       assemble_and_compile('${r}', "'hieraprovider::test::param_a'") do |scope|
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
         begin
@@ -504,10 +504,10 @@ Merge strategy first
     Data Provider "two paths"
       Merge strategy first
         Path "#{environmentpath}/production/modules/hieraprovider/data/first.json"
-          Original path: first
+          Original path: "first"
           No such key: "hieraprovider::test::not_found"
         Path "#{environmentpath}/production/modules/hieraprovider/data/second_not_present.json"
-          Original path: second_not_present
+          Original path: "second_not_present"
           Path not found
 EOS
       end


### PR DESCRIPTION
The explainer will currently only report the actions that lookup
performs during traversal of global data binders and providers in
order to find the data for a given key. This commit adds an option
to include the lookup of the new 'lookup_options' hash to the report.

The '--explain-options' option takes no argument can be used alone or
in combination with the '--explain' option. When used alone, and
when no keys are passed to the lookup command, the result will be
the global lookup_options hash (merge of global data binding and
environment data provider). When keys are passed, the lookup_options
will be the full hash that includes a hash found in the data provider
of the module identified by the key.