### PR TITLE
(PUP-5505) Improve performance of reading service plists

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -205,6 +205,12 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   # format.
   def self.read_plist(path)
     begin
+      return Plist::parse_xml(path)
+    rescue ArgumentError => detail
+      Puppet.debug("Error reading #{path}: #{detail}. Retrying with plutil.")
+    end
+
+    begin
       Plist::parse_xml(plutil('-convert', 'xml1', '-o', '/dev/stdout', path))
     rescue Puppet::ExecutionFailure => detail
       Puppet.warning("Cannot read file #{path}; Puppet is skipping it. \n" +

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -274,6 +274,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
         }
       end
       let(:busted_plist_path) { '/Library/LaunchAgents/org.busted.plist' }
+      let(:binary_plist_path) { '/Library/LaunchAgents/org.binary.plist' }
 
       it "[17624] should warn that the plist in question is being skipped" do
         provider.expects(:launchd_paths).returns(['/Library/LaunchAgents'])
@@ -284,12 +285,22 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       end
 
       it "[15929] should skip plists that plutil cannot read" do
+        Plist.expects(:parse_xml).with(busted_plist_path).raises(ArgumentError, 'boom')
+        Puppet.expects(:debug).with("Error reading #{busted_plist_path}: boom. Retrying with plutil.")
         provider.expects(:plutil).with('-convert', 'xml1', '-o', '/dev/stdout',
           busted_plist_path).raises(Puppet::ExecutionFailure, 'boom')
         Puppet.expects(:warning).with("Cannot read file #{busted_plist_path}; " +
                                       "Puppet is skipping it. \n" +
                                       "Details: boom")
         provider.read_plist(busted_plist_path)
+      end
+
+      it "should read binary plists with plutil" do
+        Plist.expects(:parse_xml).with(binary_plist_path).raises(ArgumentError, 'boom')
+        Puppet.expects(:debug).with("Error reading #{binary_plist_path}: boom. Retrying with plutil.")
+        provider.expects(:plutil).with('-convert', 'xml1', '-o', '/dev/stdout', binary_plist_path).returns('plist')
+        Plist.expects(:parse_xml).with('plist').returns('plist_map')
+        expect(provider.read_plist(binary_plist_path)).to eq('plist_map')
       end
     end
     it "should return the cached value when available" do


### PR DESCRIPTION
Reading text-based plist files with plutil appears to incur a lot of
overhead. Attempt to read all plists as text first, falling back to
plutil if that fails. Failing to read a binary plist appears to incur
very little overhead.

This appears to compare favorably to other approaches using
CFPropertyList, and is a much smaller change. Average times for `puppet
resource service` improved from 30 seconds to 5 seconds on a variety of
tested systems (OS X 10.9 with Ruby 1.9.3, OS X 10.10 with Ruby 2.0.0,
OS X 10.11 with Ruby 2.1.7).