### PR TITLE
(PE-12534) Fix yumrepo param specifying false fail

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -21,6 +21,13 @@ Puppet::Type.newtype(:yumrepo) do
   YUM_BOOLEAN=/^(True|False|0|1|No|Yes)$/i
   YUM_BOOLEAN_DOC="Valid values are: False/0/No or True/1/Yes."
 
+  # Common munge logic for YUM_BOOLEAN values. Munges for two requirements:
+  # 1) In order for the default Puppet::Parameter::Value validation routines to
+  # work correctly, the @should value cannot be represented as Boolean false.
+  # 2) In order for parameter removal to work correctly, when absent is passed
+  # as a string it needs to be munged back to a symbol.
+  munge_yum_bool = Proc.new { |val| val.to_s == 'absent' ? :absent : val.to_s }
+
   VALID_SCHEMES = %w[file http https ftp]
 
   newparam(:name, :namevar => true) do
@@ -81,6 +88,7 @@ Puppet::Type.newtype(:yumrepo) do
     #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:gpgcheck) do
@@ -90,6 +98,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:repo_gpgcheck) do
@@ -98,6 +107,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:gpgkey) do
@@ -179,6 +189,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:failovermethod) do
@@ -194,6 +205,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:retries) do
@@ -231,6 +243,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:priority) do
@@ -307,6 +320,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:sslcacert) do
@@ -323,6 +337,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:sslclientcert) do
@@ -359,6 +374,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:assumeyes) do
@@ -367,6 +383,7 @@ Puppet::Type.newtype(:yumrepo) do
       #{ABSENT_DOC}"
 
     newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
   end
 
   newproperty(:deltarpm_percentage) do


### PR DESCRIPTION
Previously, there was no munge logic for YUM_BOOLEAN parameters of the yumrepo type. Boolean false is a valid value for these parameters. Due to the way Puppet::Parameter::Value default validation methods work however, if a parameter's @should value is represented as Boolean false it will effectively always be considered insync - which is wrong, in the case of how yumrepo parameters work.

This commit adds common munging logic to each parameter that accepts YUM_BOOLEAN values, converting Boolean false to string false to ensure the default validation routines work correctly and property insync is correctly detected.

While working on this problem, another issue became apparent, which is that in Puppet 4 "absent" passed to YUM_BOOLEAN parameters comes back as a string. However, the provider only knows to remove the relevant line from the config file if absent is a symbol. Therefore, the munge method also converts string absent to symbol absent.