### PR TITLE
(PUP-5487) Remove runtime warning about storeconfig not beeing set and instead only warn on evaluation time

### DIFF
--- a/lib/puppet/pops/evaluator/collectors/exported_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/exported_collector.rb
@@ -19,7 +19,7 @@ class Puppet::Pops::Evaluator::Collectors::ExportedCollector < Puppet::Pops::Eva
   # evaluate method
   def evaluate
     if Puppet[:storeconfigs] != true
-      Puppet.warning "Not collecting exported resources without storeconfigs"
+      Puppet.warning "Not collecting exported resources without storeconfigs at " + scope.resource.to_s
       return false
     end
 

--- a/lib/puppet/pops/evaluator/collectors/exported_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/exported_collector.rb
@@ -19,7 +19,6 @@ class Puppet::Pops::Evaluator::Collectors::ExportedCollector < Puppet::Pops::Eva
   # evaluate method
   def evaluate
     if Puppet[:storeconfigs] != true
-      Puppet.warning "Not collecting exported resources without storeconfigs at " + scope.resource.to_s
       return false
     end
 

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -621,6 +621,9 @@ class Puppet::Pops::Evaluator::EvaluatorImpl
   # to the compiler to collect the resources specified by the query.
   #
   def eval_CollectExpression o, scope
+    if o.query.is_a?(Puppet::Pops::Model::ExportedQuery)
+      optionally_fail(Puppet::Pops::Issues::RT_NO_STORECONFIGS, o);
+    end
     Puppet::Pops::Evaluator::CollectorTransformer.new().transform(o,scope)
   end
 

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -287,13 +287,6 @@ class Puppet::Pops::Validation::Checker4_0
     unless o.type_expr.is_a? Model::QualifiedReference
       acceptor.accept(Issues::ILLEGAL_EXPRESSION, o.type_expr, :feature=> 'type name', :container => o)
     end
-
-    # If a collect expression tries to collect exported resources and storeconfigs is not on
-    # then it will not work... This was checked in the parser previously. This is a runtime checking
-    # thing as opposed to a language thing.
-    if acceptor.will_accept?(Issues::RT_NO_STORECONFIGS) && o.query.is_a?(Model::ExportedQuery)
-      acceptor.accept(Issues::RT_NO_STORECONFIGS, o)
-    end
   end
 
   # Only used for function names, grammar should not be able to produce something faulty, but


### PR DESCRIPTION
(PUP-5487) Remove runtime warning about storeconfig not beeing set and instead only warn on evaluation time.

Also since the evaluation time warning included less information it is changed to also include information about where the collection happened.