### PR TITLE
(PUP-5508) Create initialize_facts helper for core Puppet facts

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -138,6 +138,23 @@ module Puppet
   end
   private_class_method :do_initialize_settings_for_run_mode
 
+  # Initialize puppet's core facts. It should not be called before initialize_settings.
+  def self.initialize_facts
+    # Add the puppetversion fact; this is done before generating the hash so it is
+    # accessible to custom facts.
+    Facter.add(:puppetversion) do
+      setcode { Puppet.version.to_s }
+    end
+
+    Facter.add(:agent_specified_environment) do
+      setcode do
+        if Puppet.settings.set_by_config?(:environment)
+          Puppet[:environment]
+        end
+      end
+    end
+  end
+
   # Create a new type.  Just proxy to the Type class.  The mirroring query
   # code was deprecated in 2008, but this is still in heavy use.  I suppose
   # this can count as a soft deprecation for the next dev. --daniel 2011-04-12

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -29,19 +29,8 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     self.class.setup_external_search_paths(request) if Puppet.features.external_facts?
     self.class.setup_search_paths(request)
 
-    # Add the puppetversion fact; this is done before generating the hash so it is
-    # accessible to custom facts.
-    Facter.add(:puppetversion) do
-      setcode { Puppet.version.to_s }
-    end
-
-    Facter.add(:agent_specified_environment) do
-      setcode do
-        if Puppet.settings.set_by_config?(:environment)
-          Puppet[:environment]
-        end
-      end
-    end
+    # Initialize core Puppet facts, such as puppetversion
+    Puppet.initialize_facts
 
     result = Puppet::Node::Facts.new(request.key, Facter.to_hash)
     result.add_local_facts


### PR DESCRIPTION
Recently several Puppet-specific facts were added to the facts
end-point. Anyone trying to use Puppet as a library, expecting all facts
to be registered with Facter, will find those facts missing. Create a
helper to initialize them as needed.