### PR TITLE
(PUP-5444) Create user and group accounts once

### DIFF
--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -82,13 +82,8 @@ class ModifiesModeTest < ActionModeTest
 
     @start_mode = start_mode
 
-    user = 'symuser'
-    group = 'symgroup'
-    agent.user_present(user)
-    agent.group_present(group)
-
-    testcase.on(agent, "touch #{@file} && chown #{user}:#{group} #{@file} && chmod #{start_mode.to_s(8)} #{@file}")
-    testcase.on(agent, "mkdir -p #{@dir} && chown #{user}:#{group} #{@dir} && chmod #{start_mode.to_s(8)} #{@dir}")
+    testcase.on(agent, "touch #{@file} && chown symuser:symgroup #{@file} && chmod #{start_mode.to_s(8)} #{@file}")
+    testcase.on(agent, "mkdir -p #{@dir} && chown symuser:symgroup #{@dir} && chmod #{start_mode.to_s(8)} #{@dir}")
   end
 
   def assert_file_mode(expected_mode)
@@ -190,6 +185,14 @@ agents.each do |agent|
     next
   end
   is_solaris = agent['platform'].include?('solaris')
+
+  on(agent, puppet("resource user symuser ensure=present"))
+  on(agent, puppet("resource group symgroup ensure=present"))
+
+  teardown do
+    on(agent, puppet("resource user symuser ensure=absent"))
+    on(agent, puppet("resource group symgroup ensure=absent"))
+  end
 
   basedir = agent.tmpdir('symbolic-modes')
   on(agent, "mkdir -p #{basedir}")


### PR DESCRIPTION
Previously, we ensured the `symuser` and `symgroup` accounts existed for
every symbolic file mode combination, of which there are over 40. Due to
BKR-628, we were updating the `PrimaryGroupID` of the `symgroup` group
everytime on OSX, leading to an apparent race condition where we would
`chmod` a file to the old gid, and then try to resolve the gid to a
name, but since the gid no longer existed, the test would fail.

This commit modifies the acceptance test to use puppet to ensure the
user and group accounts (avoiding the beaker issue), moves the ensure
check to once per agent, and adds a teardown to ensure the accounts are
removed when the test is finished.

[skip ci]