### PR TITLE
(PUP-5127) Fix hung process caused by unclosed multiline comments

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -632,6 +632,10 @@ module Puppet::Pops::Issues
     "Unclosed quote after #{after} followed by '#{followed_by}'"
   end
 
+  UNCLOSED_MLCOMMENT = hard_issue :UNCLOSED_MLCOMMENT do
+    'Unclosed multiline comment'
+  end
+
   EPP_INTERNAL_ERROR = hard_issue :EPP_INTERNAL_ERROR, :error do
     "Internal error: #{error}"
   end

--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -498,7 +498,7 @@ class Puppet::Pops::Parser::Lexer2
     when '/'
       case la1
       when '*'
-        scn.skip(PATTERN_MLCOMMENT)
+        lex_error(Puppet::Pops::Issues::UNCLOSED_MLCOMMENT) if scn.skip(PATTERN_MLCOMMENT).nil?
         nil
 
       else

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -329,6 +329,12 @@ describe 'Lexer2' do
     end
   end
 
+  it 'detects unterminated multiline comment' do
+    expect { tokens_scanned_from("/* not terminated\nmultiline\ncomment") }.to raise_error(Puppet::ParseErrorWithIssue) { |e|
+      expect(e.issue_code).to be(Puppet::Pops::Issues::UNCLOSED_MLCOMMENT.issue_code)
+    }
+  end
+
   { "=~" => [:MATCH, "=~ /./"],
     "!~" => [:NOMATCH, "!~ /./"],
     ","  => [:COMMA, ", /./"],


### PR DESCRIPTION
The lexer did not detect a multiline comment that wasn't closed and
returned the same parse position over and over again causing the
parser to loop forever. This commit remedies that and adds a new
issue UNCLOSED_MLCOMMENT to the set of issues reported by the parser.