### PR TITLE
(PUP-5525) Fix pseudo variable assignment that happens too late

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -352,6 +352,11 @@ class Puppet::Resource::Type
   # @api private
   def set_resource_parameters(resource, scope)
     # Inject parameters from using external lookup
+    modname = resource[:module_name] || module_name
+    scope[MODULE_NAME] = modname unless modname.nil?
+    caller_name = resource[:caller_module_name] || scope.parent_module_name
+    scope[CALLER_MODULE_NAME] = caller_name unless caller_name.nil?
+
     resource.add_parameters_from_consume
     inject_external_parameters(resource, scope)
 
@@ -365,11 +370,6 @@ class Puppet::Resource::Type
       scope[TITLE] = resource.title
       scope[NAME] =  resource.name
     end
-
-    modname = resource_hash[MODULE_NAME] || module_name
-    scope[MODULE_NAME] = modname unless modname.nil?
-    caller_name = resource_hash[CALLER_MODULE_NAME] || scope.parent_module_name
-    scope[CALLER_MODULE_NAME] = caller_name unless caller_name.nil?
 
     scope.class_set(self.name,scope) if hostclass? || node?
 


### PR DESCRIPTION
The pseudo variable for calling_module was assigned too late when
a resource was evaluated which resulted in that a hiera interpolation
used when finding default values didn't interpolate the value
correctly.
This commit ensures that the value is assigned before the external
values are resolved which means that hiera will find the right
values.

I suggest the addition of an acceptance test to verify this behavior.