### PR TITLE
(PUP-5513) Allow blank lines in ssh known hosts file

### DIFF
--- a/lib/puppet/provider/sshkey/parsed.rb
+++ b/lib/puppet/provider/sshkey/parsed.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:sshkey).provide(
   desc "Parse and generate host-wide known hosts files for SSH."
 
   text_line :comment, :match => /^#/
-  text_line :blank, :match => /^\s+/
+  text_line :blank, :match => /^\s*$/
 
   record_line :parsed, :fields => %w{name type key},
     :post_parse => proc { |hash|

--- a/spec/fixtures/unit/provider/sshkey/parsed/sample_with_blank_lines
+++ b/spec/fixtures/unit/provider/sshkey/parsed/sample_with_blank_lines
@@ -1,0 +1,8 @@
+# A comment
+
+# ... and another after a blank line. The following line includes three whitespace characters.
+   
+hosting2.planetargon.com,64.34.164.77 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEAy+f2t52cDMrYkgEKQ6juqfMf/a0nDFry3JAzl+SAWQ0gTklVxNcVbfHx2pkZk66EBGQfrK33Bx1BflZ/                   iEDyiCwmzVtNba0X9A6ELYjB9WSkWdIqZCfPlKZMu9N//aZ6+3SDVuz/BVFsAVmtqQ4Let2QjOFiSIKXrtPqWvVT/MM=
+
+will.isawesome.com,192.168.0.5 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEAw9iHuAa/wepHoUzWqsvhQvSkpE4K7agrdLOWHM9mvyRQ2X3HVq5GqzAvWu4J+f0FvcLPwA9tivpxt1oSt5MOtvDM6HoM+8m3P4daBp0nlNaYR8/vHCAmX6N3RyM8FWfp+VqWyux1SooQwxYxVFy86G78ApTqNsZ+p7cHmnBYqk0=
+will.isgreat.com,192.168.0.6 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEAw9iHuAa/wepHoUzWqsvhQvSkpE4K7agrdLOWHM9mvyRQ2X3HVq5GqzAvWu4J+f0FvcLPwA9tivpxt1oSt5MOtvDM6HoM+8m3P4daBp0nlNaYR8/vHCAmX6N3RyM8FWfp+VqWyux1SooQwxYxVFy86G78ApTqNsZ+p7cHmnBasd=

--- a/spec/unit/provider/sshkey/parsed_spec.rb
+++ b/spec/unit/provider/sshkey/parsed_spec.rb
@@ -41,30 +41,31 @@ describe "sshkey parsed provider" do
   end
 
   context "with the sample file" do
-    let :fixture do my_fixture('sample') end
-    before :each do subject.stubs(:default_target).returns(fixture) end
+    ['sample', 'sample_with_blank_lines'].each do |sample_file|
+      let :fixture do my_fixture(sample_file) end
+      before :each do subject.stubs(:default_target).returns(fixture) end
 
-    it "should parse to records on prefetch" do
-      expect(subject.target_records(fixture)).to be_empty
-      subject.prefetch
+      it "should parse to records on prefetch" do
+        expect(subject.target_records(fixture)).to be_empty
+        subject.prefetch
 
-      records = subject.target_records(fixture)
-      expect(records).to be_an Array
-      expect(records).to be_all {|x| expect(x).to be_an Hash }
-    end
+        records = subject.target_records(fixture)
+        expect(records).to be_an Array
+        expect(records).to be_all {|x| expect(x).to be_an Hash }
+      end
 
-    it "should reconstitute the file from records" do
-      subject.prefetch
-      records = subject.target_records(fixture)
+      it "should reconstitute the file from records" do
+        subject.prefetch
+        records = subject.target_records(fixture)
+        text = subject.to_file(records).gsub(/^# HEADER.+\n/, '')
 
-      text = subject.to_file(records).gsub(/^# HEADER.+\n/, '')
+        oldlines = File.readlines(fixture).map(&:chomp)
+        newlines = text.chomp.split("\n")
+        expect(oldlines.length).to eq(newlines.length)
 
-      oldlines = File.readlines(fixture).map(&:chomp)
-      newlines = text.chomp.split("\n")
-      expect(oldlines.length).to eq(newlines.length)
-
-      oldlines.zip(newlines).each do |old, new|
-        expect(old.gsub(/\s+/, '')).to eq(new.gsub(/\s+/, ''))
+        oldlines.zip(newlines).each do |old, new|
+          expect(old.gsub(/\s+/, '')).to eq(new.gsub(/\s+/, ''))
+        end
       end
     end
   end


### PR DESCRIPTION
Previously, blank lines in the default ssh_known_hosts file would
cause errors in the sshkey type due to a faulty regex. This commit
updates said regex to properly match blank lines with no whitespace
characters.