### PR TITLE
(docs) Fix markup typo in the match function

### DIFF
--- a/lib/puppet/functions/match.rb
+++ b/lib/puppet/functions/match.rb
@@ -30,6 +30,7 @@
 # ~~~ ruby
 # $matches = ["abc123","def456"].match(/([a-z]+)([1-9]+)/)
 # # $matches contains [[abc123, abc, 123], [def456, def, 456]]
+# ~~~
 #
 # @since 4.0.0
 #

--- a/lib/puppet/parser/functions/match.rb
+++ b/lib/puppet/parser/functions/match.rb
@@ -34,6 +34,7 @@ $matches = "abc123".match(/([a-z]+)([1-9]+)/)
 ~~~ ruby
 $matches = ["abc123","def456"].match(/([a-z]+)([1-9]+)/)
 # $matches contains [[abc123, abc, 123], [def456, def, 456]]
+~~~
 
 - Since 4.0.0
 DOC


### PR DESCRIPTION
An unclosed code block was messing up the formatting in the function reference.