### PR TITLE
(PUP-5285) Update systemd provider to detect all unit types

### DIFF
--- a/acceptance/tests/resource/service/systemd_unit_types.rb
+++ b/acceptance/tests/resource/service/systemd_unit_types.rb
@@ -1,0 +1,23 @@
+test_name 'Systemd provider should recognize non-service unit types'
+
+confine :to, :platform => /fedora-22/
+
+# This test is intended to ensure that systemd unit types other than service are
+# also discoverable via puppet. Examples include timer and socket units.
+
+agents.each do |agent|
+  teardown do
+    on(agent, puppet_resource('package', 'dnf-automatic', 'ensure=purged'))
+    on(agent, puppet_resource('package', 'httpd', 'ensure=purged'))
+  end
+
+  step "#{agent}: Install dnf-automatic and httpd packages"
+  on(agent, puppet_resource('package', 'dnf-automatic', 'ensure=installed'))
+  on(agent, puppet_resource('package', 'httpd', 'ensure=installed'))
+
+  step "#{agent}: Ensure the dnf-automatic timer unit and httpd socket unit are known by puppet"
+  on(agent, puppet_resource('service')) do
+    assert_match(/dnf-automatic\.timer/, stdout, 'Puppet did not detect the dnf-automatic systemd timer unit')
+    assert_match(/httpd\.socket/, stdout, 'Puppet did not detect the httpd systemd socket unit')
+  end
+end

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   def self.instances
     i = []
-    output = systemctl('list-unit-files', '--type', 'service', '--full', '--all',  '--no-pager')
+    output = systemctl('list-unit-files', '--full', '--all',  '--no-pager')
     output.scan(/^(\S+)\s+(disabled|enabled|masked)\s*$/i).each do |m|
       i << new(:name => m[0])
     end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -118,7 +118,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     end
 
     it "should return only services" do
-      described_class.expects(:systemctl).with('list-unit-files', '--type', 'service', '--full', '--all', '--no-pager').returns File.read(my_fixture('list_unit_files_services'))
+      described_class.expects(:systemctl).with('list-unit-files', '--full', '--all', '--no-pager').returns File.read(my_fixture('list_unit_files_services'))
       expect(described_class.instances.map(&:name)).to match_array(%w{
         arp-ethers.service
         auditd.service


### PR DESCRIPTION
Prior to this commit, when searching for discoverable systemd
services we filtered our results down to only units of the 'service'
type. There are several other valid types, such as timer and socket
which can be managed as well. This commit updates our systemctl
invocation to allow any unit type to be returned in its output.

Note that managing systemd unit types other than the service type
requires the fully-qualified service name to be provided. For example,
to manage the unit 'foo.timer', Puppet must be provided with 'foo.timer'
rather than just 'foo'. Otherwise, the provider will default to managing
the service unit type.
