### PR TITLE
(PUP-5547) Prevent unnecessary environment eviction

### DIFF
--- a/lib/puppet/data_providers/lookup_adapter.rb
+++ b/lib/puppet/data_providers/lookup_adapter.rb
@@ -44,7 +44,7 @@ class Puppet::DataProviders::LookupAdapter < Puppet::DataProviders::DataAdapter
     lookup_invocation.with(:global, terminus) do
       catch(:no_such_key) do
         return lookup_invocation.report_found(name, Puppet::DataBinding.indirection.find(name,
-            { :environment => @env.to_s, :variables => lookup_invocation.scope, :merge => merge_strategy }))
+            { :environment => @env, :variables => lookup_invocation.scope, :merge => merge_strategy }))
       end
       lookup_invocation.report_not_found(name)
       throw :no_such_key


### PR DESCRIPTION
This commit ensures that the environment instance rather than its
name is passed to the DataBinder indirection during lookup. This
prevents that a lot of unnecessary lookups takes place when the
environment_timeout is set to zero.