### PR TITLE
(PUP-5548) Ensure systemctl is present before using it for service status

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -73,8 +73,8 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
       majversion = Facter.value(:operatingsystemmajrelease).split('.')[0].to_i
     end
 
-
-    if ((os == 'debian' && majversion >= 8) || (os == 'ubuntu' && majversion >= 15))
+    if ((os == 'debian' && majversion >= 8) || (os == 'ubuntu' && majversion >= 15)) &&
+         Puppet::Util.which('systemctl')
       # SysVInit scripts will always return '0' for status when the service is masked,
       # even if the service is actually stopped. Use the SysVInit-Systemd compatibility
       # layer to determine the actual status. This is only necessary when the SysVInit

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -147,6 +147,7 @@ describe provider_class do
         Facter.stubs(:value).with(:operatingsystem).returns('Debian')
         Facter.stubs(:value).with(:operatingsystemmajrelease).returns('8')
         @resource.stubs(:[]).with(:hasstatus).returns(:true)
+        Puppet::Util.expects(:which).with('systemctl').returns('/bin/systemctl')
         expect(@provider.statuscmd).to eq(["systemctl", "is-active", @resource[:name]])
       end
 
@@ -154,7 +155,17 @@ describe provider_class do
         Facter.stubs(:value).with(:operatingsystem).returns('Ubuntu')
         Facter.stubs(:value).with(:operatingsystemmajrelease).returns('15.04')
         @resource.stubs(:[]).with(:hasstatus).returns(:true)
+        Puppet::Util.expects(:which).with('systemctl').returns('/bin/systemctl')
         expect(@provider.statuscmd).to eq(["systemctl", "is-active", @resource[:name]])
+      end
+
+      it "should fall back to the service init script if systemctl is not present" do
+        Facter.stubs(:value).with(:operatingsystem).returns('Debian')
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('8')
+        @resource.stubs(:[]).with(:hasstatus).returns(:true)
+        Puppet::Util.expects(:which).with('systemctl').returns(nil)
+        @provider.stubs(:initscript).returns("/etc/init.d/script")
+        expect(@provider.statuscmd).to eq(["/etc/init.d/script", :status])
       end
     end
 


### PR DESCRIPTION
Currently, the Debian service provider uses systemctl to determine
service status on Debian 8 and Ubuntu 15.04, which use systemd by
default. This is necessary due to the way masked services behave
when queried with the sysvint-systemd compatibility layer.

It is possible to remove systemd from Debian 8 and Ubuntu 15.04
and only use init. In such a case, the Debian provider will error
when trying to use systemctl. This commit updates the provider to
check that systemctl exists on the system before attempting to use
it to determine service status. If it is not present, the provider
falls back to the service init script.