### PR TITLE
(PUP-5547) Prevent unnecessary environment eviction

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -387,7 +387,7 @@ class Puppet::Resource
     begin
       Puppet::DataBinding.indirection.find(
         name,
-        :environment => scope.environment.to_s,
+        :environment => scope.environment,
         :variables => scope)
     rescue Puppet::DataBinding::LookupError => e
       raise Puppet::Error.new("Error from DataBinding '#{Puppet[:data_binding_terminus]}' while looking up '#{name}': #{e.message}", e)


### PR DESCRIPTION
This commit ensures that the environment instance rather than its
name is passed to the DataBinder indirection during lookup. This
prevents that a lot of unnecessary lookups takes place when the
environment_timeout is set to zero.

Please note that there are two PRs for this fix. One for the 3.x branch that places a fix in file `lib/puppet/resource.rb` and another for 4.x that places the same fix in file `lib/puppet/data_providers/lookup_adapter.rb`. When the 3.x branch is merged to stable this PR should be considered a no-op.