### PR TITLE
(PUP-5588) Prevent redundant cert loading

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -114,15 +114,19 @@ if Puppet::Util::Platform.windows?
   require 'openssl'
 
   class OpenSSL::X509::Store
+    @puppet_certs_loaded = false
     alias __original_set_default_paths set_default_paths
     def set_default_paths
       # This can be removed once openssl integrates with windows
       # cert store, see https://rt.openssl.org/Ticket/Display.html?id=2158
-      Puppet::Util::Windows::RootCerts.instance.to_a.uniq.each do |x509|
-        begin
-          add_cert(x509)
-        rescue OpenSSL::X509::StoreError => e
-          warn "Failed to add #{x509.subject.to_s}"
+      unless @puppet_certs_loaded
+        @puppet_certs_loaded = true
+        Puppet::Util::Windows::RootCerts.instance.to_a.uniq.each do |x509|
+          begin
+            add_cert(x509)
+          rescue OpenSSL::X509::StoreError => e
+            warn "Failed to add #{x509.subject.to_s}"
+          end
         end
       end
 

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -186,6 +186,14 @@ describe OpenSSL::X509::Store, :if => Puppet::Util::Platform.windows? do
     store.set_default_paths
   end
 
+  it "doesn't warn when calling set_default_paths multiple times" do
+    with_root_certs([cert])
+    store.expects(:warn).never
+
+    store.set_default_paths
+    store.set_default_paths
+  end
+
   it "ignores duplicate root certs" do
     with_root_certs([cert, cert])
 


### PR DESCRIPTION
We monkey patch OpenSSL::X509::Store#set_default_paths to load our own
additional certs. Sometimes one or more of our certs are already loaded,
however. Previously the code would try to load the cert and in doing so
raise, catch, and warn on the cert already being loaded. Under certain
conditions this superflous warning could print very verbosely, obscuring
the useful output.

This commit quiesces the warn, replacing it with a Puppet#debug. Such a
message at the warn level is not useful to the user and can cause
unnecessary concern or frustration regarding the product.