### PR TITLE
(PUP-5549) Revert "(PUP-5025) RPM Epoch should be included in ensure field

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -281,7 +281,6 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
       self::NEVRA_FIELDS.zip(match.captures) { |f, v| hash[f] = v }
       hash[:provider] = self.name
       hash[:ensure] = "#{hash[:version]}-#{hash[:release]}"
-      hash[:ensure].prepend("#{hash[:epoch]}:") if hash[:epoch] != '0'
     else
       Puppet.debug("Failed to match rpm line #{line}")
     end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -12,7 +12,6 @@ describe provider_class do
     chkconfig 0 1.3.30.2 2.el5 x86_64
     myresource 0 1.2.3.4 5.el4 noarch
     mysummaryless 0 1.2.3.4 5.el4 noarch
-    tomcat 1 1.2.3.4 5.fc22 noarch
     RPM_OUTPUT
   end
 
@@ -117,18 +116,7 @@ describe provider_class do
           :ensure => "1.3.30.2-2.el5",
         }
       )
-      expect(installed_packages[3].properties).to eq(
-        {
-          :provider    => :rpm,
-          :name        => "myresource",
-          :epoch       => "0",
-          :version     => "1.2.3.4",
-          :release     => "5.el4",
-          :arch        => "noarch",
-          :ensure      => "1.2.3.4-5.el4",
-        }
-      )
-      expect(installed_packages[4].properties).to eq(
+      expect(installed_packages.last.properties).to eq(
         {
           :provider    => :rpm,
           :name        => "mysummaryless",
@@ -137,17 +125,6 @@ describe provider_class do
           :release     => "5.el4",
           :arch        => "noarch",
           :ensure      => "1.2.3.4-5.el4",
-        }
-      )
-      expect(installed_packages[5].properties).to eq(
-        {
-          :provider    => :rpm,
-          :name        => "tomcat",
-          :epoch       => "1",
-          :version     => "1.2.3.4",
-          :release     => "5.fc22",
-          :arch        => "noarch",
-          :ensure      => "1:1.2.3.4-5.fc22",
         }
       )
     end
@@ -292,7 +269,7 @@ describe provider_class do
           line.gsub(field, delimiter),
           package_hash.merge(
             field.to_sym => delimiter,
-            :ensure => 'epoch:version-release'.gsub(field, delimiter)
+            :ensure => 'version-release'.gsub(field, delimiter)
           )
         )
       end


### PR DESCRIPTION
This reverts commit 1fdaeae9fa4f18c1c96da3d6fd84613dab6024f8, which
introduced a regression when using the yum provider under certain
circumstances.

This change was originally meant to fix a DNF issue when installing RPMs
which included the epoch field in their release strings. However, it
also brought about a new issue in the yum provider when trying to
manage packages which use the epoch field. Upon every run, Puppet throws
a notice to indicate that the package version has been updated to
include the epoch. Adding the epoch into a manifest results in an error
when installing a package which isn't already on the system.

This commit reverts the original change until further investigation and
more comprehensive changes can be made.