### PR TITLE
(PUP-5356) check_puppet.rb does not work on CentOS 7

### DIFF
--- a/ext/nagios/check_puppet.rb
+++ b/ext/nagios/check_puppet.rb
@@ -6,83 +6,66 @@ include Sys
 
 class CheckPuppet
 
-  VERSION = '0.1'
+  VERSION = '0.2'
   script_name = File.basename($0)
 
   # default options
   OPTIONS = {
-    :statefile => "/var/lib/puppet/state/state.yaml",
-    :process   => "puppetd",
-    :interval  => 30,
+    statefile: "/var/lib/puppet/state/state.yaml",
+    process: "puppetd",
+    interval: 30
   }
 
   OptionParser.new do |o|
     o.set_summary_indent('  ')
     o.banner =    "Usage: #{script_name} [OPTIONS]"
     o.define_head "The check_puppet Nagios plug-in checks that specified Puppet process is running and the state file is no older than specified interval."
-      o.separator   ""
-      o.separator   "Mandatory arguments to long options are mandatory for short options too."
-
-
-        o.on(
-          "-s", "--statefile=statefile", String, "The state file",
-
-    "Default: #{OPTIONS[:statefile]}") { |op| OPTIONS[:statefile] = op }
-
-      o.on(
-        "-p", "--process=processname", String, "The process to check",
-
-    "Default: #{OPTIONS[:process]}")   { |op| OPTIONS[:process] = op }
-
-      o.on(
-        "-i", "--interval=value", Integer,
-
-    "Default: #{OPTIONS[:interval]} minutes")  { |op| OPTIONS[:interval] = op }
-
+    o.separator   ""
+    o.separator   "Mandatory arguments to long options are mandatory for short options too."
+    o.on('-s', '--statefile=statefile', String, 'The state file', "Default: #{OPTIONS[:statefile]}") do|tmpstatefile|
+      OPTIONS[:statefile]=tmpstatefile
+    end
+    o.on('-p', '--process=processname', String, 'The process to check', "Default: #{OPTIONS[:process]}") do|tmpprocname|
+      OPTIONS[:process]=tmpprocname
+    end
+    o.on('-i', '--interval=value', Integer, 'Interval in minutes', "Default: #{OPTIONS[:interval]} minutes") do|tmpinterval|
+      OPTIONS[:interval]=tmpinterval
+    end
     o.separator ""
     o.on_tail("-h", "--help", "Show this help message.") do
       puts o
       exit
     end
-
     o.parse!(ARGV)
   end
 
   def check_proc
-
     unless ProcTable.ps.find { |p| p.name == OPTIONS[:process]}
       @proc = 2
     else
       @proc = 0
     end
-
   end
 
   def check_state
-
     # Set variables
     curt = Time.now
     intv = OPTIONS[:interval] * 60
-
     # Check file time
     begin
       @modt = File.mtime("#{OPTIONS[:statefile]}")
     rescue
       @file = 3
     end
-
     diff = (curt - @modt).to_i
-
     if diff > intv
       @file = 2
     else
       @file = 0
     end
-
   end
 
   def output_status
-
     case @file
     when 0
       state = "state file status okay updated on " + @modt.strftime("%m/%d/%Y at %H:%M:%S")
@@ -91,14 +74,12 @@ class CheckPuppet
     when 3
       state = "state file status unknown"
     end
-
     case @proc
     when 0
       process = "process #{OPTIONS[:process]} is running"
     when 2
       process = "process #{OPTIONS[:process]} is not running"
     end
-
     case
     when (@proc == 2 or @file == 2)
       status = "CRITICAL"
@@ -110,7 +91,6 @@ class CheckPuppet
       status = "UNKNOWN"
       exitcode = 3
     end
-
     puts "PUPPET #{status}: #{process}, #{state}"
     exit(exitcode)
   end
@@ -120,4 +100,3 @@ cp = CheckPuppet.new
 cp.check_proc
 cp.check_state
 cp.output_status
-


### PR DESCRIPTION
The extension to check if puppet is running using Nagios
(with NRPE) does not work on CentOS 7 (probably on all EL7)

Refer to: https://tickets.puppetlabs.com/browse/PUP-5356