### PR TITLE
(PUP-5548) Use `service` in debian provider to interact with all init systems

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -15,6 +15,7 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   # http://projects.reductivelabs.com/issues/2538
   # is resolved.
   commands :invoke_rc => "/usr/sbin/invoke-rc.d"
+  commands :service => "/usr/sbin/service"
 
   defaultfor :operatingsystem => :cumuluslinux
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ['5','6','7']
@@ -65,23 +66,9 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   end
 
   def statuscmd
-    os = Facter.value(:operatingsystem).downcase
-
-    if os == 'debian'
-      majversion = Facter.value(:operatingsystemmajrelease).to_i
-    else
-      majversion = Facter.value(:operatingsystemmajrelease).split('.')[0].to_i
-    end
-
-
-    if ((os == 'debian' && majversion >= 8) || (os == 'ubuntu' && majversion >= 15))
-      # SysVInit scripts will always return '0' for status when the service is masked,
-      # even if the service is actually stopped. Use the SysVInit-Systemd compatibility
-      # layer to determine the actual status. This is only necessary when the SysVInit
-      # version of a service is queried. I.e, 'ntp' instead of 'ntp.service'.
-      (@resource[:hasstatus] == :true) && ["systemctl", "is-active", @resource[:name]]
-    else
-      super
-    end
+      # /usr/sbin/service provides an abstraction layer which is able to query services
+      # independent of the init system used.
+      # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775795
+    (@resource[:hasstatus] == :true) && [command(:service), @resource[:name], "status"]
   end
 end

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -27,6 +27,7 @@ describe provider_class do
 
     @provider.stubs(:command).with(:update_rc).returns "update_rc"
     @provider.stubs(:command).with(:invoke_rc).returns "invoke_rc"
+    @provider.stubs(:command).with(:service).returns "service"
 
     @provider.stubs(:update_rc)
     @provider.stubs(:invoke_rc)
@@ -142,30 +143,11 @@ describe provider_class do
   end
 
   describe "when checking service status" do
-    context "On systems which use the systemd-sysvinit compatibility layer" do
-      it "should call systemctl to determine running status in Debian" do
-        Facter.stubs(:value).with(:operatingsystem).returns('Debian')
-        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('8')
-        @resource.stubs(:[]).with(:hasstatus).returns(:true)
-        expect(@provider.statuscmd).to eq(["systemctl", "is-active", @resource[:name]])
-      end
-
-      it "should call systemctl to determine running status in Ubuntu" do
-        Facter.stubs(:value).with(:operatingsystem).returns('Ubuntu')
-        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('15.04')
-        @resource.stubs(:[]).with(:hasstatus).returns(:true)
-        expect(@provider.statuscmd).to eq(["systemctl", "is-active", @resource[:name]])
-      end
-    end
-
-    context "On systems which only use sysvinit" do
-      it "should use the service init script" do
-        Facter.stubs(:value).with(:operatingsystem).returns('Debian')
-        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('7')
-        @resource.stubs(:[]).with(:hasstatus).returns(:true)
-        @provider.stubs(:initscript).returns("/etc/init.d/script")
-        expect(@provider.statuscmd).to eq(["/etc/init.d/script", :status])
-      end
+    it "should use the service command" do
+      Facter.stubs(:value).with(:operatingsystem).returns('Debian')
+      Facter.stubs(:value).with(:operatingsystemmajrelease).returns('8')
+      @resource.stubs(:[]).with(:hasstatus).returns(:true)
+      expect(@provider.statuscmd).to eq(["service", @resource[:name], "status"])
     end
   end
 end


### PR DESCRIPTION
In the Debian family, the `service` command provides an
abstraction around available init systems, allowing it to be used
to properly determine service state regardless of which init system
is active on the system.

This commit updates the Debian provider's `statuscmd` method to use
`service` at all times, allowing the provider to properly query
services regardless of OS version or init system in place.