### PR TITLE
(PUP-5520) Exclude Yocto init scripts from service init provider

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -49,6 +49,13 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     excludes += %w{wait-for-state portmap-wait}
     # these excludes were found with grep -r -L start /etc/init.d
     excludes += %w{rcS module-init-tools}
+    # Prevent puppet failing on unsafe scripts from Yocto Linux
+    if Facter.value(:osfamily) == "cisco-wrlinux"
+      excludes += %w{banner.sh bootmisc.sh checkroot.sh devpts.sh dmesg.sh
+                   hostname.sh mountall.sh mountnfs.sh populate-volatile.sh
+                   rmnologin.sh save-rtc.sh sendsigs sysfs.sh umountfs
+                   umountnfs.sh}
+    end
     # Prevent puppet failing to get status of the new service introduced
     # by the fix for this (bug https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/982889)
     # due to puppet's inability to deal with upstart services with instances.

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:service).provider(:init) do
     before :each do
       described_class.stubs(:defpath).returns('tmp')
 
-      @services = ['one', 'two', 'three', 'four']
+      @services = ['one', 'two', 'three', 'four', 'umountfs']
       Dir.stubs(:entries).with('tmp').returns @services
       FileTest.expects(:directory?).with('tmp').returns(true)
       FileTest.stubs(:executable?).returns(true)
@@ -57,6 +57,16 @@ describe Puppet::Type.type(:service).provider(:init) do
     it "should omit a single service from the exclude list" do
       exclude = 'two'
       expect(described_class.get_services(described_class.defpath, exclude).map(&:name)).to eq(@services - [exclude])
+    end
+
+    it "should omit Yocto services on cisco-wrlinux" do
+      Facter.stubs(:value).with(:osfamily).returns 'cisco-wrlinux'
+      exclude = 'umountfs'
+      expect(described_class.get_services(described_class.defpath).map(&:name)).to eq(@services - [exclude])
+    end
+
+    it "should not omit Yocto services on non cisco-wrlinux platforms" do
+      expect(described_class.get_services(described_class.defpath).map(&:name)).to eq(@services)
     end
 
     it "should use defpath" do


### PR DESCRIPTION
Yocto Linux ships a series of init scripts that are not safe to execute.  This creates unintended consequences such as sending shutdown signals to daemons.
This commit excludes the known list of unsafe scripts so that Puppet does not try to execute them via the service init provider.

https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-core/initscripts/initscripts-1.0

Replaces #4479 