### PR TITLE
(PUP-5502) Improve error messages for faulty hiera.yaml

### DIFF
--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -23,7 +23,9 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
     throw :no_such_key if value.equal?(not_found)
     value
   rescue *DataBindingExceptions => detail
-    raise Puppet::DataBinding::LookupError.new(detail.message, detail)
+    error = Puppet::DataBinding::LookupError.new("DataBinding 'hiera': #{detail.message}")
+    error.set_backtrace(detail.backtrace)
+    raise error
   end
 
   private

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -1,7 +1,7 @@
 module Puppet::Pops::Lookup
   class Invocation
     attr_reader :scope, :override_values, :default_values, :explainer
-    attr_accessor :module_name
+    attr_accessor :module_name, :top_key
 
     # Creates a context object for a lookup invocation. The object contains the current scope, overrides, and default
     # values and may optionally contain an {ExplanationAcceptor} instance that will receive book-keeping information

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -360,9 +360,8 @@ describe Puppet::Resource do
           Puppet::DataBinding.indirection.expects(:find).with('apache::port', any_parameters).raises(Puppet::DataBinding::LookupError, 'Forgettabotit')
           expect {
             resource.set_default_parameters(scope)
-          }.to raise_error(Puppet::Error, /Error from DataBinding 'hiera' while looking up 'apache::port':.*Forgettabotit/)
+          }.to raise_error(Puppet::Error, /Lookup of key 'apache::port' failed: Forgettabotit/)
         end
-
       end
 
       context "when a value is provided" do


### PR DESCRIPTION
Errors originating from syntax errors in the hiera.yaml were nested
and the error messages were repeated, resulting in a long blob of
unhelpful text where the original stack trace was lost.

This commit ensures that no message is repeated and that the
stack backtrace is retained.