### PR TITLE
(PUP-5582) Enforce no return in ensure blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,9 +25,8 @@ Lint/UnreachableCode:
 Lint/UselessComparison:
   Enabled: true
 
-# MAYBE useful - no return inside ensure block.
 Lint/EnsureReturn:
-  Enabled: false
+  Enabled: true
 
 # MAYBE useful - errors when rescue {} happens.
 Lint/HandleExceptions:

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -235,7 +235,7 @@ class Puppet::Configurer
       Puppet.log_exception(detail, "Failed to apply catalog: #{detail}")
       return nil
     ensure
-      execute_postrun_command or return nil
+      execute_postrun_command
     end
   ensure
     # Between Puppet runs we need to forget the cached values.  This lets us


### PR DESCRIPTION
A return in an ensure block is ignored in ruby, so a return
statement in an ensure block is meaningless. This commit
removes the one usage of that in puppet and enforces this
going forward with rubocop.