### PR TITLE
(PUP-5061) Alter resurrection of trusted retain 'authenticated'

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -803,14 +803,7 @@ class Puppet::Parser::Compiler
     if trusted_param
       # Blows up if it is a parameter as it will be set as $trusted by the compiler as if it was a variable
       node.parameters.delete('trusted')
-      if trusted_param.is_a?(Hash) && %w{authenticated certname extensions}.all? {|key| trusted_param.has_key?(key) }
-        # looks like a hash of trusted data - resurrect it
-        # Allow root to trust the authenticated information if option --trusted is given
-        if !Puppet.features.root?
-          # Set as not trusted - but keep the information
-          trusted_param['authenticated'] = false
-        end
-      else
+      unless trusted_param.is_a?(Hash) && %w{authenticated certname extensions}.all? {|key| trusted_param.has_key?(key) }
         # trusted is some kind of garbage, do not resurrect
         trusted_param = nil
       end

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -194,24 +194,6 @@ describe Puppet::Parser::Compiler do
       expect(sanitized.trusted_data).to_not eq({ :a => 42 })
     end
 
-    it "should report 'trusted' parameters as trusted_data but as inauthentic if running as non-root" do
-      node = Puppet::Node.new("mynode")
-      node.parameters['trusted'] = { 'authenticated' => true,
-                                     'certname'      => 'foo',
-                                     'extensions'    => 'things' }
-
-      Puppet.features.stubs(:root?).returns(false)
-
-      Puppet.ignore(:trusted_information)
-      compiler = Puppet::Parser::Compiler.new(node)
-      Puppet.restore(:trusted_information)
-
-      sanitized = compiler.node
-      expect(sanitized.trusted_data).to eq({ 'authenticated' => false,
-                                             'certname'      => 'foo',
-                                             'extensions'    => 'things' })
-    end
-
     it "should prefer trusted_data in the node above other plausible sources" do
       node = Puppet::Node.new("mynode")
       node.trusted_data = { 'authenticated' => true,


### PR DESCRIPTION
The current resurrection of the 'trusted' hash changes the
authentication to `false`. This commit removes that behavior so that
the hash is left untouched.