### PR TITLE
{WIP}(PUP-5591) Fix registry binary read

### DIFF
--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -213,7 +213,7 @@ module Puppet::Util::Windows
         when Win32::Registry::REG_MULTI_SZ
           result = [ type, data_ptr.read_wide_string(string_length).split(/\0/) ]
         when Win32::Registry::REG_BINARY
-          result = [ type, data.read_bytes(0, byte_length) ]
+          result = [ type, data_ptr.read_bytes(byte_length) ]
         when Win32::Registry::REG_DWORD
           result = [ type, data_ptr.read_dword ]
         when Win32::Registry::REG_DWORD_BIG_ENDIAN


### PR DESCRIPTION
Previously, the read method was using an older variable name when
reading data for binary values. It would result in errors such as the
following when reading a binary value from the registry.

~~~
Error: Could not run: undefined local variable or method `data' for
Puppet::Provider::Package::Windows::Package:Class
C:/Program Files/Puppet
Labs/Puppet/puppet/lib/puppet/util/windows/registry.rb:216:in `block in
read'
~~~

This was introduced in b46ede74f640a809b68a473ac8720b93b13d2ac3 (Puppet
v4.0.0).

Without this fix, any registry enumerations that contain a binary
value will fail.