### PR TITLE
(PUP-5063) Ensure that 4x-functions are profiled

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -248,7 +248,9 @@ module Puppet::Pops::Evaluator::Runtime3Support
     # this is done from the perspective of the environment.
     loader = loaders.private_environment_loader
     if loader && func = loader.load(:function, name)
-      return func.call(scope, *args, &block)
+      Puppet::Util::Profiler.profile(name, [:functions, name]) do
+        return func.call(scope, *args, &block)
+      end
     end
 
     # Call via 3x API if function exists there
@@ -269,7 +271,9 @@ module Puppet::Pops::Evaluator::Runtime3Support
     adapter = Puppet::Pops::Utils.find_adapter(o, Puppet::Pops::Adapters::LoaderAdapter)
     loader = adapter.nil? ? loaders.private_environment_loader : adapter.loader
     if loader && func = loader.load(:function, name)
-      return func.call(scope, *args, &block)
+      Puppet::Util::Profiler.profile(name, [:functions, name]) do
+        return func.call(scope, *args, &block)
+      end
     end
 
     # Call via 3x API if function exists there

--- a/lib/puppet/pops/functions/function.rb
+++ b/lib/puppet/pops/functions/function.rb
@@ -89,7 +89,11 @@ class Puppet::Pops::Functions::Function
     raise ArgumentError, "Function #{self.class.name}(): cannot call function '#{function_name}' - no loader specified" unless the_loader
 
     func = the_loader.load(:function, function_name)
-    return func.call(scope, *args, &block) if func
+    if func
+      Puppet::Util::Profiler.profile(function_name, [:functions, function_name]) do
+        return func.call(scope, *args, &block)
+      end
+    end
 
     # Check if a 3x function is present. Raise a generic error if it's not to allow upper layers to fill in the details
     # about where in a puppet manifest this error originates. (Such information is not available here).


### PR DESCRIPTION
This commit ensures that calls to 4x functions are profiled. The
description of the profiling data is simply the method name since
I wanted to avoid unnecessary string formatting. The entry is
easy enough to understand anyway given that the metric_id is
:function.