### PR TITLE
(PUP-5592) Ensure that undef parameter does not prevent data lookup

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -387,7 +387,8 @@ class Puppet::Resource::Type
     parameters = resource.parameters
     arguments.each do |param_name, _|
       name = param_name.to_sym
-      next if parameters.include?(name)
+      param = parameters[name]
+      next unless param.nil? || param.value.nil?
       value = lookup_external_default_for(param_name, scope)
       resource[name] = value unless value.nil?
     end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -391,6 +391,17 @@ describe Puppet::Resource do
           expect(resource.set_default_parameters(scope)).to eq([])
           expect(resource[:port]).to eq('8080')
         end
+
+        it "should use the value from the data_binding terminus when provided value is undef" do
+          Puppet::DataBinding.indirection.expects(:find).with('lookup_options', any_parameters).throws(:no_such_key)
+          Puppet::DataBinding.indirection.expects(:find).with('apache::port', any_parameters).returns('443')
+
+          rs = Puppet::Parser::Resource.new("class", "apache", :scope => scope,
+            :parameters => [Puppet::Parser::Resource::Param.new({ :name => 'port', :value => nil })])
+
+          rs.resource_type.set_resource_parameters(rs, scope)
+          expect(rs[:port]).to eq('443')
+        end
       end
     end
   end


### PR DESCRIPTION
A class parameter that is explicitly specified with an `undef` value
should not prevent that a data lookup is made for the parameter but
it did. This commit fixes that problem.