### PR TITLE
(PUP-5590) Detect duplicate parameter names

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -546,6 +546,10 @@ module Puppet::Pops::Issues
     "Resource Override can only operate on resources, got: #{label.label(actual)}"
   end
 
+  DUPLICATE_PARAMETER = hard_issue :DUPLICATE_PARAMETER, :param_name do
+    "The parameter '#{param_name}' is declared more than once in the parameter list"
+  end
+
   RESERVED_PARAMETER = hard_issue :RESERVED_PARAMETER, :container, :param_name do
     "The parameter $#{param_name} redefines a built in parameter in #{label.the(container)}"
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -233,6 +233,7 @@ class Puppet::Pops::Validation::Checker4_0
   def check_EppExpression(o)
     if o.eContainer.is_a?(Puppet::Pops::Model::LambdaExpression)
       internal_check_no_capture(o.eContainer, o)
+      internal_check_parameter_name_uniqueness(o.eContainer)
     end
   end
 
@@ -327,12 +328,14 @@ class Puppet::Pops::Validation::Checker4_0
   def check_HostClassDefinition(o)
     check_NamedDefinition(o)
     internal_check_no_capture(o)
+    internal_check_parameter_name_uniqueness(o)
     internal_check_reserved_params(o)
   end
 
   def check_ResourceTypeDefinition(o)
     check_NamedDefinition(o)
     internal_check_no_capture(o)
+    internal_check_parameter_name_uniqueness(o)
     internal_check_reserved_params(o)
   end
 
@@ -363,6 +366,13 @@ class Puppet::Pops::Validation::Checker4_0
       if RESERVED_PARAMETERS[p.name]
         acceptor.accept(Issues::RESERVED_PARAMETER, p, {:container => o, :param_name => p.name})
       end
+    end
+  end
+
+  def internal_check_parameter_name_uniqueness(o)
+    unique = Set.new
+    o.parameters.each do |p|
+      acceptor.accept(Issues::DUPLICATE_PARAMETER, p, {:param_name => p.name}) unless unique.add?(p.name)
     end
   end
 

--- a/spec/unit/pops/parser/parser_rspec_helper.rb
+++ b/spec/unit/pops/parser/parser_rspec_helper.rb
@@ -8,4 +8,9 @@ module ParserRspecHelper
     parser = Puppet::Pops::Parser::Parser.new()
     parser.parse_string(code)
   end
+
+  def parse_epp(code)
+    parser = Puppet::Pops::Parser::EppParser.new()
+    parser.parse_string(code)
+  end
 end

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -177,6 +177,18 @@ describe "validating 4x" do
     end
   end
 
+  context 'for parameter names' do
+    ['class', 'define'].each do |word|
+      it "should require that #{word} parameter names are unique" do
+        expect(validate(parse("#{word} foo($a = 10, $a = 20) {}"))).to have_issue(Puppet::Pops::Issues::DUPLICATE_PARAMETER)
+      end
+    end
+
+    it "should require that template parameter names are unique" do
+      expect(validate(parse_epp("<%-| $a, $a |-%><%= $a == doh %>"))).to have_issue(Puppet::Pops::Issues::DUPLICATE_PARAMETER)
+    end
+  end
+
   context 'for reserved parameter names' do
     ['name', 'title'].each do |word|
       it "produces an error when $#{word} is used as a parameter in a class" do


### PR DESCRIPTION
Adds validation logic to detect duplicate parameter names in host
class definitions, defines, and EPP templates.