### PR TITLE
(PUP-5594) Fixes yum check-updates private method

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     elsif output.exitstatus == 0
       self.debug "#{command(:cmd)} check-update exited with 0; no package updates available."
     else
-      self.warn "Could not check for updates, '#{command(:cmd)} check-update' exited with #{output.exitstatus}"
+      self.warning "Could not check for updates, '#{command(:cmd)} check-update' exited with #{output.exitstatus}"
     end
     updates
   end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -448,7 +448,7 @@ describe provider_class do
 
     it "returns an empty hash if 'yum check-update' returned an exit code that was not 0 or 100" do
       Puppet::Util::Execution.expects(:execute).returns(stub(:exitstatus => 1))
-      described_class.expects(:warn)
+      described_class.expects(:warning).with('Could not check for updates, \'/usr/bin/yum check-update\' exited with 1')
       expect(described_class.check_updates([], [], [])).to eq({})
     end
   end


### PR DESCRIPTION
* Previous code was using `#warn`
* Would cause error: `private method `warn' called for Puppet::Type::Package::ProviderYum:Class`
* Changed to correct method `warning`
* Updated spec