### PR TITLE
(PUP-5598) Ensure that keys starting with lookup_options fail lookup

### DIFF
--- a/lib/puppet/data_providers/lookup_adapter.rb
+++ b/lib/puppet/data_providers/lookup_adapter.rb
@@ -4,6 +4,8 @@
 class Puppet::DataProviders::LookupAdapter < Puppet::DataProviders::DataAdapter
 
   LOOKUP_OPTIONS = Puppet::Pops::Lookup::LOOKUP_OPTIONS
+  LOOKUP_OPTIONS_PREFIX = LOOKUP_OPTIONS + '.'
+  LOOKUP_OPTIONS_PREFIX.freeze
   HASH = 'hash'.freeze
   MERGE = 'merge'.freeze
 
@@ -30,7 +32,11 @@ class Puppet::DataProviders::LookupAdapter < Puppet::DataProviders::DataAdapter
   #
   def lookup(key, lookup_invocation, merge)
     # The 'lookup_options' key is reserved and not found as normal data
-    throw :no_such_key if key == LOOKUP_OPTIONS
+    if key == LOOKUP_OPTIONS || key.start_with?(LOOKUP_OPTIONS_PREFIX)
+      lookup_invocation.with(:invalid_key, LOOKUP_OPTIONS) do
+        throw :no_such_key
+      end
+    end
 
     lookup_invocation.top_key ||= key
     merge_explained = false

--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -135,8 +135,6 @@ module Puppet::Pops::Lookup
   end
 
   class ExplainTop < ExplainTreeNode
-    attr_reader :key, :type
-
     def initialize(parent, type, key)
       super(parent)
       @type = type
@@ -147,6 +145,21 @@ module Puppet::Pops::Lookup
       io << first_indent << 'Searching for "' << key << "\"\n"
       indent = increase_indent(indent)
       branches.each {|b| b.dump_on(io, indent, indent)}
+    end
+  end
+
+  class ExplainInvalidKey < ExplainTreeNode
+    def initialize(parent, key)
+      super(parent)
+      @key = key
+    end
+
+    def dump_on(io, indent, first_indent)
+      io << first_indent << "Invalid key \"" << @key << "\"\n"
+    end
+
+    def type
+      :invalid_key
     end
   end
 
@@ -395,6 +408,8 @@ module Puppet::Pops::Lookup
           ExplainScope.new(@current)
         when :meta, :data
           ExplainTop.new(@current, qualifier_type, qualifier)
+        when :invalid_key
+          ExplainInvalidKey.new(@current, qualifier)
         else
           raise ArgumentError, "Unknown Explain type #{qualifier_type}"
         end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -551,5 +551,32 @@ EOS
           )
       end
     end
+
+    it 'will explain that "lookup_options" is an invalid key' do
+      assemble_and_compile('${r}', "'abc::a'") do |scope|
+        lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
+        begin
+          Puppet::Pops::Lookup.lookup('lookup_options', nil, nil, false, nil, lookup_invocation)
+        rescue Puppet::Error
+        end
+        expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
+Invalid key "lookup_options"
+EOS
+      end
+    end
+
+    it 'will explain that "lookup_options" is an invalid key for any key starting with "lookup_options."' do
+      assemble_and_compile('${r}', "'abc::a'") do |scope|
+        lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
+        begin
+          Puppet::Pops::Lookup.lookup('lookup_options.subkey', nil, nil, false, nil, lookup_invocation)
+        rescue Puppet::Error
+        end
+        expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
+Invalid key "lookup_options"
+EOS
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The `lookup_options`special key should not be found using a normal
lookup and neither should any of its subkeys when a dotted key is
used. This commit ensures that this holds true and also adds a new
explanation of 'Invalid key' to be used when such lookup attempts are
made.