### PR TITLE
(PUP-5212) Pip package honors HTTP proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 bundler_args: --without development
 script: "bundle exec rake \"parallel:spec[2]\""
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 sudo: false
+before_install:
+  - gem install bundler -v 1.10
 bundler_args: --without development
 script: "bundle exec rake \"parallel:spec[2]\""
 notifications:

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -3,6 +3,7 @@
 
 require 'puppet/provider/package'
 require 'xmlrpc/client'
+require 'puppet/util/http_proxy'
 
 Puppet::Type.type(:package).provide :pip,
   :parent => ::Puppet::Provider::Package do
@@ -56,7 +57,16 @@ Puppet::Type.type(:package).provide :pip,
   # cache of PyPI's package list so this operation will always have to
   # ask the web service.
   def latest
-    client = XMLRPC::Client.new2("http://pypi.python.org/pypi")
+    http_proxy_host = Puppet::Util::HttpProxy.http_proxy_host
+    http_proxy_port = Puppet::Util::HttpProxy.http_proxy_port
+    if http_proxy_host && http_proxy_port
+      proxy = "#{http_proxy_host}:#{http_proxy_port}"
+    else
+      # nil is acceptable
+      proxy = http_proxy_host
+    end
+
+    client = XMLRPC::Client.new2("http://pypi.python.org/pypi", proxy)
     client.http_header_extra = {"Content-Type" => "text/xml"}
     client.timeout = 10
     result = client.call("package_releases", @resource[:name])


### PR DESCRIPTION
The pip package provider previously did not work behind a http proxy. It
will now honor system proxy settings for querying latest packages from
`pypi.python.org`.