### PR TITLE
(PUP-5615) Deprecate unused options to PRC.apply

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -195,6 +195,14 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
   def apply(options = {})
     Puppet::Util::Storage.load if host_config?
 
+    # The only option still supported is report.
+    # Issue a deprecation warning for any others.
+    deprecated_options = options.keys - [:report]
+    if !deprecated_options.empty?
+      Puppet.deprecation_warning("Puppet::Resource::Catalog.apply no longer " \
+                                 "takes the #{deprecated_options} option(s)")
+    end
+
     transaction = create_transaction(options)
 
     begin

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -596,11 +596,13 @@ describe Puppet::Resource::Catalog, "when compiling" do
 
     it "should pass supplied tags on to the transaction" do
       @transaction.expects(:tags=).with(%w{one two})
+      Puppet.expects(:deprecation_warning).with(regexp_matches(/:tags/))
       @catalog.apply(:tags => %w{one two})
     end
 
     it "should set ignoreschedules on the transaction if specified in apply()" do
       @transaction.expects(:ignoreschedules=).with(true)
+      Puppet.expects(:deprecation_warning).with(regexp_matches(/:ignoreschedules/))
       @catalog.apply(:ignoreschedules => true)
     end
 


### PR DESCRIPTION
@joshcooper or @MikaelSmith: followup on the deprecation topic that we uncovered when looking into tags. Not sure what legwork we might want to do to verify that there aren't external consumers of this API who might care about this deprecation.