### PR TITLE
(PUP-5616) fixes to improve error display

### DIFF
--- a/spec/unit/util/network_device/cisco/device_spec.rb
+++ b/spec/unit/util/network_device/cisco/device_spec.rb
@@ -377,7 +377,7 @@ Self Loopback: No
 Switch#
 eos
 
-        expect(@cisco.parse_trunking("FastEthernet0/1")).to eq({ :mode => :access, :access_vlan => "100" })
+        expect(@cisco.parse_trunking("FastEthernet0/1")).to eq({ :mode => :access, :access_vlan => "100", :native_vlan => "1" })
       end
 
       it "should parse auto/negotiate switchport information" do


### PR DESCRIPTION
- adds error display for device commands, which used to fail silently
- removes duplicate command input from the error output

This also removes some tests which caused never-achieve-convergence
as it was dropping device properties that could be supplied as input