### PR TITLE
(PUP-5617) enable keepalive on the TCP socket opened with the master

### DIFF
--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -81,8 +81,17 @@ class Puppet::Network::HTTP::Pool
 
       Puppet.debug("Starting connection for #{site}")
       http.start
+      setsockopts(http.instance_variable_get(:@socket))
       http
     end
+  end
+
+  # Set useful socket option(s) which lack from default settings in Net:HTTP
+  #
+  # @api private
+  def setsockopts(netio)
+    socket = netio.io
+    socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
   end
 
   # Release a connection back into the pool.

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -163,6 +163,7 @@ describe Puppet::Network::HTTP::Connection do
 
       Net::HTTP.any_instance.stubs(:start)
       Net::HTTP.any_instance.stubs(:request).returns(httpok)
+      Puppet::Network::HTTP::Pool.any_instance.stubs(:setsockopts)
 
       connection.get('request')
     end

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -117,8 +117,13 @@ describe Puppet::Network::HTTP::Pool do
       # On windows, Socket.getsockopt() doesn't return exactly the same data
       # as an equivalent Socket::Option.new() statement, so we strip off the
       # unrelevant bits only on this platform.
+      #
       # To make sure we're not voiding the test case by doing this, we check
       # both with and without the keepalive bit set.
+      #
+      # This workaround can be removed once all the ruby versions we care about
+      # have the patch from https://bugs.ruby-lang.org/issues/11958 applied.
+      #
       keepalive   = Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, true).data
       nokeepalive = Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, false).data
 

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -109,6 +109,14 @@ describe Puppet::Network::HTTP::Pool do
       end rescue nil
     end
 
+    it 'sets keepalive bit on network socket' do
+      pool = create_pool
+      s = Socket.new(Socket::PF_INET, Socket::SOCK_STREAM)
+      pool.setsockopts(Net::BufferedIO.new(s))
+
+      expect(s.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE).bool).to eq(true)
+    end
+
     context 'when releasing connections' do
       it 'releases HTTP connections' do
         conn = create_connection(site)
@@ -150,6 +158,7 @@ describe Puppet::Network::HTTP::Pool do
       conn = create_connection(site)
       pool = create_pool
       pool.factory.expects(:create_connection).with(site).returns(conn)
+      pool.expects(:setsockopts)
 
       expect(pool.borrow(site, verify)).to eq(conn)
     end
@@ -169,6 +178,7 @@ describe Puppet::Network::HTTP::Pool do
 
       conn = create_connection(site)
       pool.factory.expects(:create_connection).with(site).returns(conn)
+      pool.expects(:setsockopts)
 
       expect(pool.borrow(site, verify)).to eq(conn)
     end
@@ -179,6 +189,7 @@ describe Puppet::Network::HTTP::Pool do
 
       pool = create_pool
       pool.factory.expects(:create_connection).with(site).returns(conn)
+      pool.expects(:setsockopts)
 
       expect(pool.borrow(site, verify)).to eq(conn)
     end
@@ -205,6 +216,7 @@ describe Puppet::Network::HTTP::Pool do
 
       pool = create_pool_with_expired_connections(site, conn)
       pool.factory.expects(:create_connection => stub('conn', :start => nil))
+      pool.expects(:setsockopts)
 
       pool.borrow(site, verify)
     end
@@ -217,6 +229,7 @@ describe Puppet::Network::HTTP::Pool do
 
       pool = create_pool_with_expired_connections(site, conn)
       pool.factory.expects(:create_connection => stub('open_conn', :start => nil))
+      pool.expects(:setsockopts)
 
       pool.borrow(site, verify)
     end


### PR DESCRIPTION
This will allow the socket with the master to get closed when the
network connection breaks unexpectedly, and the agent to terminate with
an error, rather than waiting forever.

According to linux's tcp(7) manpage, such zombies connections get closed
by default after a bit more than 2 hours of idleness. Configuring this
is possible but not considered portable.