### PR TITLE
(maint) Don't allow elcapitan to match redhat el regex

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -108,7 +108,7 @@ module Puppet
           on host, 'iptables -F'
         when /fedora|el-7/
           on host, puppet('resource', 'service', 'firewalld', 'ensure=stopped')
-        when /el|centos/
+        when /el-|centos/
           on host, puppet('resource', 'service', 'iptables', 'ensure=stopped')
         when /ubuntu/
           on host, puppet('resource', 'service', 'ufw', 'ensure=stopped')
@@ -125,7 +125,7 @@ module Puppet
         sha     = sha == 'nightly' ? nil                        :  sha
 
         case platform
-        when /^(fedora|el|centos)-(\d+)-(.+)$/
+        when /^(fedora|el-|centos)-(\d+)-(.+)$/
           variant = (($1 == 'centos') ? 'el' : $1)
           fedora_prefix = ((variant == 'fedora') ? 'f' : '')
           version = $2

--- a/acceptance/lib/puppet/acceptance/mount_utils.rb
+++ b/acceptance/lib/puppet/acceptance/mount_utils.rb
@@ -9,7 +9,7 @@ module Puppet
         case host['platform']
         when /aix/
           '/etc/filesystems'
-        when /el|centos|fedora|sles|debian|ubuntu|cumulus/
+        when /el-|centos|fedora|sles|debian|ubuntu|cumulus/
           '/etc/fstab'
         else
           # TODO: Add Solaris and OSX support, as per PUP-5201 and PUP-4823
@@ -29,7 +29,7 @@ module Puppet
           else
             'jfs'
           end
-        when /el|centos|fedora|sles|debian|ubuntu|cumulus/
+        when /el-|centos|fedora|sles|debian|ubuntu|cumulus/
           'ext3'
         else
           # TODO: Add Solaris and OSX support, as per PUP-5201 and PUP-4823
@@ -49,7 +49,7 @@ module Puppet
         when /aix/
           # Note: /dev/hd8 is the default jfs logging device on AIX.
           on(host, "echo '/#{mount_name}:\n  dev = /dev/#{mount_name}\n  vfs = #{fs_type}\n  log = /dev/hd8' >> #{fs_file}")
-        when /el|centos|fedora|sles|debian|ubuntu|cumulus/
+        when /el-|centos|fedora|sles|debian|ubuntu|cumulus/
           on(host, "echo '/tmp/#{mount_name}  /#{mount_name}  #{fs_type}  loop  0  0' >> #{fs_file}")
         else
           # TODO: Add Solaris and OSX support, as per PUP-5201 and PUP-4823
@@ -68,7 +68,7 @@ module Puppet
           volume_group = on(host, 'lsvg').stdout.split("\n")[0]
           on(host, "mklv -y #{mount_name} #{volume_group} 1M")
           on(host, "mkfs -V #{fs_type} -l #{mount_name} /dev/#{mount_name}")
-        when /el|centos|fedora|sles|debian|ubuntu|cumulus/
+        when /el-|centos|fedora|sles|debian|ubuntu|cumulus/
           on(host, "dd if=/dev/zero of=/tmp/#{mount_name} count=10240", :acceptable_exit_codes => [0,1])
           on(host, "yes | mkfs -t #{fs_type} -q /tmp/#{mount_name}", :acceptable_exit_codes => (0..254))
         else

--- a/acceptance/setup/packages/pre-suite/015_PackageHostsPresets.rb
+++ b/acceptance/setup/packages/pre-suite/015_PackageHostsPresets.rb
@@ -1,5 +1,5 @@
 if master['platform'] =~ /debian|ubuntu/
   master.uses_passenger!
-elsif master['platform'] =~ /redhat|el|centos|scientific|fedora/
+elsif master['platform'] =~ /redhat|el-|centos|scientific|fedora/
   master['use-service'] = true
 end

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -1,7 +1,7 @@
 test_name 'SysV and Systemd Service Provider Validation'
 
 
-confine :to, :platform => /el|centos|fedora|debian|sles|ubuntu-v/
+confine :to, :platform => /el-|centos|fedora|debian|sles|ubuntu-v/
 # osx covered by launchd_provider.rb
 # ubuntu-[a-u] upstart covered by ticket_14297_handle_upstart.rb
 


### PR DESCRIPTION
We were using `el` in various redhat related regexs, but `elcapitan`
unfortunately matches. This commit changes the regex to be more
specific to avoid false positives.