### PR TITLE
(PUP-5618) Ensure module data provider isolation.

### DIFF
--- a/lib/puppet/data_providers/lookup_adapter.rb
+++ b/lib/puppet/data_providers/lookup_adapter.rb
@@ -216,7 +216,8 @@ class Puppet::DataProviders::LookupAdapter < Puppet::DataProviders::DataAdapter
     unless provider
       raise Puppet::Error.new("Environment '#{@env.name}', cannot find module_data_provider '#{provider_name}'")
     end
-    provider
+    # Provider is configured per module but cached using environment life cycle so it must be cloned
+    provider.clone
   end
 
   def initialize_env_provider

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/data/common.yaml
@@ -1,0 +1,4 @@
+---
+users::local:
+  bob:
+    name: Bob

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/data/specific.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/data/specific.yaml
@@ -1,0 +1,4 @@
+---
+users::local:
+  bob:
+    shell: /bin/zsh

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/hiera.yaml
@@ -1,0 +1,7 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "common"
+    :backend: yaml
+  - :name: "specific"
+    :backend: yaml

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/data/common.yaml
@@ -1,0 +1,4 @@
+---
+one::local:
+  bob:
+    name: Bob

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/data/specific.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/data/specific.yaml
@@ -1,0 +1,4 @@
+---
+one::local:
+  bob:
+    shell: /bin/zsh

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/environment.conf
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/environment.conf
@@ -1,0 +1,2 @@
+# Use the 'sample' env data provider (in this fixture)
+environment_data_provider=hiera

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/hiera.yaml
@@ -1,0 +1,7 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "common"
+    :backend: yaml
+  - :name: "specific"
+    :backend: yaml

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/manifests/site.pp
@@ -1,0 +1,1 @@
+include one::test

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/one/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/one/data/common.yaml
@@ -1,0 +1,6 @@
+---
+lookup_options:
+  one::local:
+    merge:
+       strategy: "deep"
+       merge_hash_arrays: true

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/one/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/one/hiera.yaml
@@ -1,0 +1,5 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "common"
+    :backend: yaml

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/one/manifests/init.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/one/manifests/init.pp
@@ -1,0 +1,2 @@
+class one($local={}) {
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/one/metadata.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/one/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "example/one",
+    "version": "0.0.2",
+    "source": "git@github.com/example/example-one.git",
+    "dependencies": [],
+    "author": "Bob the Builder",
+    "license": "Apache-2.0",
+    "data_provider": "hiera"
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/data/common.yaml
@@ -1,0 +1,4 @@
+---
+lookup_options:
+  roles::devco::packages:
+    merge: unique

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/hiera.yaml
@@ -1,0 +1,5 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "common"
+    :backend: yaml

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/manifests/init.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/manifests/init.pp
@@ -1,0 +1,3 @@
+class two($arg=[]) {
+  include one
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/metadata.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "example/two",
+    "version": "0.0.2",
+    "source": "git@github.com/example/example-two.git",
+    "dependencies": [],
+    "author": "Bob the Builder",
+    "license": "Apache-2.0",
+    "data_provider": "hiera"
+}

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -53,6 +53,12 @@ describe "when using a hiera data provider" do
     expect(resources).to include('module data param_a is 100, module data param_b is 200, module data param_c is 300, module data param_d is 400, module data param_e is 500')
   end
 
+  it 'keeps lookup_options in one module separate from lookup_options in another' do
+    resources1 = compile('hiera_modules', 'include one').resources.select {|r| r.ref.start_with?('Class[One]')}
+    resources2 = compile('hiera_modules', 'include two').resources.select {|r| r.ref.start_with?('Class[One]')}
+    expect(resources1).to eq(resources2)
+  end
+
   it 'does not perform merge of values declared in environment and module when resolving parameters' do
     resources = compile_and_get_notifications('hiera_misc')
     expect(resources).to include('env 1, ')


### PR DESCRIPTION
The module data provider was a singleton that was cached in the scope
of the environment lifecycle. Yet, it was configured on a per module
basis. The first configuration of the first module to be configured
was cached and subsequently used for all other modules.

This commit ensures that each module that provides data has a unique
module data provider instance.