### PR TITLE
(PUP-5625) Addressed some issues with the allow_dup_csrs acceptance test

### DIFF
--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -3,9 +3,15 @@ test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 agent_hostnames = agents.map {|a| a.to_s}
 
 with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true}}) do
+  agents_with_cert_name = {}
   agents.each do |agent|
-    step "Generate a certificate request for the agent"
+    step "Collect fqdn for the agent"
     fqdn = on(agent, facter("fqdn")).stdout.strip
+    agents_with_cert_name[fqdn] = agent
+  end
+
+  agents_with_cert_name.each do |fqdn, agent|
+    step "Generate a certificate request for the agent"
     on(agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}"))
   end
 
@@ -15,14 +21,16 @@ with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true}}) 
 
   old_certs = {}
   original_certs.stdout.each_line do |line|
-    if line =~ /^\+ (\S+) \((.+)\)$/
+    if line =~ /^\+ \"(\S+)\" \(?(.+)\)?$/ && agents_with_cert_name[$1]
       old_certs[$1] = $2
       puts "old cert: #{$1} #{$2}"
     end
   end
 
-  agents.each do |agent|
-    fqdn = on(agent, facter("fqdn")).stdout.strip
+  assert_equal(agents.count, old_certs.count,
+               "Expected original number of agent csrs on master to equal number of agents")
+
+  agents_with_cert_name.each do |fqdn, agent|
     step "Make another request with the same certname"
     on(agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}"))
   end
@@ -33,18 +41,19 @@ with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true}}) 
 
   new_certs = {}
   new_cert_list.stdout.each_line do |line|
-    if line =~ /^\+ (\S+) \((.+)\)$/
+    if line =~ /^\+ \"(\S+)\" \(?(.+)\)?$/ && agents_with_cert_name[$1]
       new_certs[$1] = $2
       puts "new cert: #{$1} #{$2}"
     end
   end
 
-  step "Verify the certs have changed"
+  assert_equal(agents.count, new_certs.count,
+               "Expected new number of agent csrs on master to equal number of agents")
+
   # using the agent name as the key may cause errors;
   # agent name from cfg file is likely to have short name
   # where certs might be signed with long names.
   old_certs.each_key { |key|
-    next if key.include? master # skip the masters cert, only care about agents
-    assert_not_equal(old_certs[key], new_certs[key], "Expected #{key} to have a changed key")
+    refute_equal(old_certs[key], new_certs[key], "Expected #{key} to have a changed key")
   }
 end


### PR DESCRIPTION
This commit addresses a few issues seen when running the
`ticket_3360_allow_duplicate_csr_with_option_set.rb` test in a local
beaker run:

1) Use `refute_equal` instead of `assert_not_equals` for negative
   comparisons.

2) Changed the logic a bit around the iteration of certs on the master
   to ensure that only the csrs/certs for the agents under test (and not
   unrelated files that might be on the CA) will be used.

3) Validate that the master csr can be reissued - for the case that the
   master and agent are the same node.

4) Minor changes to the regexs used to pick the list of agent csrs/certs
   from the output of the `puppet cert` command.