### PR TITLE
(PUP-4744) Fixes `reposdir` split by whitespace (Against stable)

### DIFF
--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -74,9 +74,12 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
   def self.reposdir(conf='/etc/yum.conf', dirs=['/etc/yum.repos.d', '/etc/yum/repos.d'])
     reposdir = find_conf_value('reposdir', conf)
     # Use directories in reposdir if they are set instead of default
-    dirs = reposdir.split(",").map(&:strip) if reposdir
-    
-
+    if reposdir
+      # Follow the code from the yum/config.py
+      dirs = reposdir.gsub!("\n", ' ')
+      dirs = reposdir.gsub!(',', ' ')
+      dirs = reposdir.split
+    end
     dirs.select! { |dir| Puppet::FileSystem.exist?(dir) }
     if dirs.empty?
       Puppet.debug('No yum directories were found on the local filesystem')

--- a/spec/unit/provider/yumrepo/inifile_spec.rb
+++ b/spec/unit/provider/yumrepo/inifile_spec.rb
@@ -249,6 +249,22 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
       expect(described_class.reposdir('/etc/yum.conf')).to include("/etc/yum/extra.repos.d")
     end
 
+    it "includes the directory if the value is split by whitespace" do
+      Puppet::FileSystem.expects(:exist?).with("/etc/yum/extra.repos.d").returns(true)
+      Puppet::FileSystem.expects(:exist?).with("/etc/yum/misc.repos.d").returns(true)
+
+      described_class.expects(:find_conf_value).with('reposdir', '/etc/yum.conf').returns "/etc/yum/extra.repos.d /etc/yum/misc.repos.d"
+      expect(described_class.reposdir('/etc/yum.conf')).to include("/etc/yum/extra.repos.d", "/etc/yum/misc.repos.d")
+    end
+
+    it "includes the directory if the value is split by new lines" do
+      Puppet::FileSystem.expects(:exist?).with("/etc/yum/extra.repos.d").returns(true)
+      Puppet::FileSystem.expects(:exist?).with("/etc/yum/misc.repos.d").returns(true)
+
+      described_class.expects(:find_conf_value).with('reposdir', '/etc/yum.conf').returns "/etc/yum/extra.repos.d\n/etc/yum/misc.repos.d"
+      expect(described_class.reposdir('/etc/yum.conf')).to include("/etc/yum/extra.repos.d", "/etc/yum/misc.repos.d")
+    end
+
     it "doesn't include the directory specified by the yum.conf 'reposdir' entry when the directory is absent" do
       Puppet::FileSystem.expects(:exist?).with("/etc/yum/extra.repos.d").returns(false)
 


### PR DESCRIPTION
* `reposdir` can be split by whitespace - http://yum.baseurl.org/gitweb?p=yum.git;a=blob;f=yum/config.py;h=97e5e3d3b063294a96227a67cce43a9655cd3aa6;hb=30c993c19b8b85f44e7cec436484862ab55a6961#l171
- Puppet previously only split by commas
- Now changed to a regex of [,|\s|\n] which will catch whitespace, commas and newlines (like in the original python code)
- Added new spec for this new regex

(New PR against stable as requested :+1:)

Continued from https://github.com/puppetlabs/puppet/pull/4495