### PR TITLE
(maint) Move to latest Ruby 2.2 bug fix release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 notifications:
   email: false
 rvm:
-  - 2.2.2
+  - 2.2.4
   - 2.1.8
   - 2.0.0
   - 1.9.3


### PR DESCRIPTION
Move Travis testing to the latest Ruby 2.2 bug fix release, 2.2.4.