### PR TITLE
(maint) Bump travis matrix to ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 notifications:
   email: false
 rvm:
-  - ruby-head
+  - 2.3.0
   - 2.2.4
   - 2.1.8
   - 2.0.0
@@ -21,7 +21,7 @@ env:
 
 matrix:
   exclude:
-    - rvm: ruby-head
+    - rvm: 2.3.0
       env: "CHECK=rubocop"
     - rvm: 2.2.4
       env: "CHECK=rubocop"
@@ -29,7 +29,7 @@ matrix:
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
-    - rvm: ruby-head
+    - rvm: 2.3.0
       env: "CHECK=commits"
     - rvm: 2.2.4
       env: "CHECK=commits"


### PR DESCRIPTION
In the run up to the 2.3.0 release, .travis.yml was
configured to test against ruby-head. Now that 2.3.0 has
been released, this commit just replaces ruby-head testing
with 2.3.0 testing. (The commits in support of ruby 2.3 went
in earlier.)

Note that we won't continue to test against ruby-head for now.
Instead, next year around this time, we can enable ruby-head
again in the run up to next year's Dec 25 ruby release.