### PR TITLE
(PUP-5628) Include file name in errors from puppet function loader

### DIFF
--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -9,7 +9,7 @@ class Puppet::Pops::Parser::EvaluatingParser
     @parser = Puppet::Pops::Parser::Parser.new()
   end
 
-  def parse_string(s, file_source = 'unknown')
+  def parse_string(s, file_source = nil)
     @file_source = file_source
     clear()
     # Handling of syntax error can be much improved (in general), now it bails out of the parser
@@ -19,7 +19,7 @@ class Puppet::Pops::Parser::EvaluatingParser
     # Also a possible improvement (if the YAML parser returns positions) is to provide correct output of position.
     #
     begin
-      assert_and_report(parser.parse_string(s))
+      assert_and_report(parser.parse_string(s, file_source))
     rescue Puppet::ParseErrorWithIssue => e
       raise e
     rescue Puppet::ParseError => e
@@ -35,7 +35,7 @@ class Puppet::Pops::Parser::EvaluatingParser
     assert_and_report(parser.parse_file(file))
   end
 
-  def evaluate_string(scope, s, file_source='unknown')
+  def evaluate_string(scope, s, file_source = nil)
     evaluate(scope, parse_string(s, file_source))
   end
 

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -150,7 +150,7 @@ describe Puppet::Face[:epp, :current] do
       dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
       template = File.join(dir, template_name)
       expect(eppface.dump(template, :validate => true)).to eq("")
-      expect(@logs.join).to match(/This Literal Integer has no effect.* line 1:4/)
+      expect(@logs.join).to match(/This Literal Integer has no effect.*\/template1.epp:1:4/)
     end
 
     it "validated content by default" do
@@ -158,7 +158,7 @@ describe Puppet::Face[:epp, :current] do
       dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
       template = File.join(dir, template_name)
       expect(eppface.dump(template)).to eq("")
-      expect(@logs.join).to match(/This Literal Integer has no effect.* line 1:4/)
+      expect(@logs.join).to match(/This Literal Integer has no effect.*\/template1.epp:1:4/)
     end
 
     it "informs the user of files that don't exist" do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -960,7 +960,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       end
 
     it "provides location information on error in unparenthesized call logic" do
-    expect{parser.evaluate_string(scope, "include non_existing_class", __FILE__)}.to raise_error(Puppet::ParseError, /line 1\:1/)
+    expect{parser.evaluate_string(scope, "include non_existing_class", __FILE__)}.to raise_error(Puppet::ParseError, /:1:1/)
     end
 
     it 'defaults can be given in a lambda and used only when arg is missing' do


### PR DESCRIPTION
This commit ensures that the file name of a loaded puppet function is
propagated properly to the lexer so that errors are can be reported
including this information.