### PR TITLE
(maint) Fix an rspec warning re a bare raise_error

### DIFF
--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -402,7 +402,7 @@ describe Puppet::Indirector::Indirection do
 
           Puppet.expects(:log_exception)
 
-          expect { @indirection.find("/my/key") }.to raise_error
+          expect { @indirection.find("/my/key") }.to raise_error RuntimeError
         end
       end
     end


### PR DESCRIPTION
This is followup to PUP-4758, which cleaned up a ton of these.