### PR TITLE
(PUP-5589) Ensure that errors from terminus filter is propagated

### DIFF
--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -207,10 +207,14 @@ class Puppet::Indirector::Indirection
         filtered = result
         if terminus.respond_to?(:filter)
           Puppet::Util::Profiler.profile("Filtered result for #{self.name} #{request.key}", [:indirector, :filter, self.name, request.key]) do
-            filtered = terminus.filter(result)
+            begin
+              filtered = terminus.filter(result)
+            rescue Puppet::Error => detail
+              Puppet.log_exception(detail)
+              raise detail
+            end
           end
         end
-
         filtered
       end
     end


### PR DESCRIPTION
Prior to this commit, the errors from the method
`Puppet::Indirector::Indirection.find` that occurred when calling
the `terminus.filter(result)` method was never logged. This caused
the puppet apply command to return 1 without any information since
the command assumes that the indirection has logged all
Puppet::Error exceptions.

This commit ensures that these particular errors are logged by
the `Indirector.find` method.