### PR TITLE
(PUP-5209) Fix so that dash can be used in module dependency

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -155,6 +155,8 @@ class Puppet::Module
 
       if attr == :dependencies
         value.each do |dep|
+          name = dep['name']
+          dep['name'] = name.tr('-', '/') unless name.nil?
           dep['version_requirement'] ||= '>= 0.0.0'
         end
       end
@@ -269,11 +271,10 @@ class Puppet::Module
 
     dependencies.each do |dependency|
       name = dependency['name']
-      forge_name = name.tr('-', '/')
       version_string = dependency['version_requirement'] || '>= 0.0.0'
 
       dep_mod = begin
-        environment.module_by_forge_name(forge_name)
+        environment.module_by_forge_name(name)
       rescue
         nil
       end

--- a/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/usee2/lib/puppet/functions/usee2/callee.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/usee2/lib/puppet/functions/usee2/callee.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:'usee2::callee') do
+  def callee(value)
+    "usee2::callee() was told '#{value}'"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/user/lib/puppet/functions/user/caller2.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/user/lib/puppet/functions/user/caller2.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:'user::caller2') do
+  def caller2()
+    call_function('usee2::callee', 'passed value') + " + I am user::caller2()"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/user/metadata.json
+++ b/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/user/metadata.json
@@ -5,5 +5,8 @@
   "license": "",
   "source": "",
   "version": "1.0.0",
-  "dependencies": [{ "name": "test/usee" }]
+  "dependencies": [
+    { "name": "test/usee" },
+    { "name": "test-usee2" }
+  ]
 }

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -123,6 +123,9 @@ describe 'loaders' do
       moduleb_loader = loaders.private_loader_for_module('user')
       function = moduleb_loader.load_typed(typed_name(:function, 'user::caller')).value
       expect(function.call({})).to eql("usee::callee() was told 'passed value' + I am user::caller()")
+
+      function = moduleb_loader.load_typed(typed_name(:function, 'user::caller2')).value
+      expect(function.call({})).to eql("usee2::callee() was told 'passed value' + I am user::caller2()")
     end
   end
 


### PR DESCRIPTION
The module loader would not find a dependent module when a dash was
used instead of a slash to separate the author and module name in a
dependency in the metadata.json file. Both constructs are allowed
in other places in the code (and on the forge). This commit makes
the loader work with both.