### PR TITLE
(PUP-5612) Detect and report resource definitions with missing title

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -536,6 +536,10 @@ module Puppet::Pops::Issues
     "This #{label.label(semantic)} has no effect. A value was produced and then forgotten (one or more preceding expressions may have the wrong form)"
   end
 
+  RESOURCE_WITHOUT_TITLE = issue :RESOURCE_WITHOUT_TITLE, :name do
+    "This expression is invalid. Did you try declaring a '#{name}' resource without a title?"
+  end
+
   IDEM_NOT_ALLOWED_LAST = hard_issue :IDEM_NOT_ALLOWED_LAST, :container do
     "This #{label.label(semantic)} has no effect. #{label.a_an_uc(container)} can not end with a value-producing expression without other effect"
   end

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -107,6 +107,46 @@ describe "validating 4x" do
         SOURCE
         expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::IDEM_NOT_ALLOWED_LAST)
       end
+
+      it "detects a resource declared without title in #{type} when it is the only declaration present" do
+        source = <<-SOURCE
+          #{type} nope {
+            notify { message => 'Nope' }
+          }
+        SOURCE
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::RESOURCE_WITHOUT_TITLE)
+      end
+
+      it "detects a resource declared without title in #{type} when it is in between other declarations" do
+        source = <<-SOURCE
+        #{type} nope {
+            notify { succ: message => 'Nope' }
+            notify { message => 'Nope' }
+            notify { pred: message => 'Nope' }
+          }
+        SOURCE
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::RESOURCE_WITHOUT_TITLE)
+      end
+
+      it "detects a resource declared without title in #{type} when it is declarated first" do
+        source = <<-SOURCE
+          #{type} nope {
+            notify { message => 'Nope' }
+            notify { pred: message => 'Nope' }
+          }
+        SOURCE
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::RESOURCE_WITHOUT_TITLE)
+      end
+
+      it "detects a resource declared without title in #{type} when it is declarated last" do
+        source = <<-SOURCE
+          #{type} nope {
+            notify { succ: message => 'Nope' }
+            notify { message => 'Nope' }
+          }
+        SOURCE
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::RESOURCE_WITHOUT_TITLE)
+      end
     end
   end
 


### PR DESCRIPTION
A resource declared without title becomes a BlockExpression with
two statments, a QualifiedName and a LiteralHash. This commit adds
validation logic that detects and reports such statements as a new
`RESOURCE_WITHOUT_TITLE` issue. It also ensures that when such a
declaration is found last in a node, define, or host class, it's
reported instead of the `IDEM_NOT_ALLOWED_LAST` since reporting both
would be confusing.