### PR TITLE
(PUP-5583) Bump to beaker-hostgenerator 0.3.1

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -13,7 +13,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.28')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3.1")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -13,7 +13,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.28')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3.1")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -124,7 +124,7 @@ EOS
   if agent_target
     master_target = ENV['MASTER_TEST_TARGET'] || 'redhat7-64m'
     targets = "#{master_target}-#{agent_target}"
-    cli = BeakerHostGenerator::CLI.new([targets, '--disable-default-role'])
+    cli = BeakerHostGenerator::CLI.new([targets, '--disable-default-role', '--osinfo-version', '1'])
     ENV['CONFIG'] = "tmp/#{targets}-#{SecureRandom.uuid}.yaml"
     FileUtils.mkdir_p('tmp')
     File.open(config, 'w') do |fh|


### PR DESCRIPTION
The puppet-agent components need the osinfo version 1 of b-hg,
so that centos4 is correctly specified as a platform name, so
that puppet-agent can be installed on centos4.

This commit moves to b-hg 0.3.1, the first version implementing
that, and specifies the osinfo version when invoking b-hg.