### PR TITLE
(PUP-5646) - pad seed fqdn_rand seed with max number

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -16,6 +16,6 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
   node. (For example, `fqdn_rand(30)`, `fqdn_rand(30, 'expensive job 1')`, and
   `fqdn_rand(30, 'expensive job 2')` will produce totally different numbers.)") do |args|
     max = args.shift.to_i
-    seed = Digest::MD5.hexdigest([self['::fqdn'],args].join(':')).hex
+    seed = Digest::MD5.hexdigest([self['::fqdn'],max,args].join(':')).hex
     Puppet::Util.deterministic_rand_int(seed,max)
 end


### PR DESCRIPTION
Currently with a default seed of the ::fqdn there is
seemingly a correlation between fqdn_rand(60) and
fqdn_rand(24) reguardless of the fqdn input.

The extra padding ensures the seed is different for the
two intentially independed fqdn calls.