### PR TITLE
(maint) acceptance-fix with() function usage

### DIFF
--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -100,7 +100,7 @@ agents.each do |agent|
     {:name => :reduce,           :args => '[4,5,6]',                           :lambda => '|$sum, $n| { $sum+$n }', :expected => '15', :rvalue => true},
     #         :reuse,:recycle
     {:name => :slice,            :args => '[1,2,3,4,5,6], 2',                  :lambda => nil, :expected => '[[1, 2], [3, 4], [5, 6]]', :rvalue => true},
-    {:name => :with,             :args => '1, "Catelyn"',                      :lambda => '|$x| {notice $x}', :expected => '1', :rvalue => true},
+    {:name => :with,             :args => '1, "Catelyn"',                      :lambda => '|$x, $y| {notice [$x, $y]}', :expected => '[1, Catelyn]', :rvalue => true},
   ]
 
   module_manifest = <<PP


### PR DESCRIPTION
In the calling_all_functions test we were passing a block to with() with
the wrong number of arguments. This passed in ruby 1.9 due to...
reasons. ruby 1.8 caught this when we ported the test to 3.x.
This change fixes the with() usage.

re: PUP-5378
[skip ci]