### PR TITLE
(PUP-5461) Prevent that lookup evaluates site manifest

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -27,6 +27,8 @@ class Puppet::Application::Lookup < Puppet::Application
     options[:type] = arg
   end
 
+  option('--compile', '-c')
+
   option('--knock-out-prefix PREFIX_STRING') do |arg|
     options[:prefix] = arg
   end
@@ -124,6 +126,7 @@ puppet lookup [--help] [--type <TYPESTRING>] [--merge unique|hash|deep]
   [--knock-out-prefix <PREFIX-STRING>] [--sort-merged-arrays]
   [--unpack-arrays <STRING-VALUE>] [--merge-hash-arrays] [--explain]
   [--default <VALUE>] [--node <NODE-NAME>] [--facts <FILE>]
+  [--compile]
   [--render-as s|json|yaml|binary|msgpack] <keys>
 
 DESCRIPTION
@@ -198,6 +201,11 @@ the puppet lookup function linked to above.
   Specify a .json, or .yaml file holding key => value mappings that will
   override the facts for the current node. Any facts not specified by the
   user will maintain their original value.
+
+* --compile
+  Perform a full catalog compilation prior to the lookup. This is meaningful when
+  the catalog changes global variables that are referenced in interpolated values.
+  No catalog compilation takes place unless this flag is given.
 
 * --render-as s|json|yaml|binary|msgpack
   Determines how the results will be rendered to the standard output where
@@ -339,6 +347,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
       node.parameters = original_facts.merge(given_facts)
     end
 
+    Puppet[:code] = 'undef' unless options[:compile]
     compiler = Puppet::Parser::Compiler.new(node)
     compiler.compile { |catalog| yield(compiler.topscope); catalog }
   end

--- a/spec/fixtures/unit/application/environments/production/data/common.yaml
+++ b/spec/fixtures/unit/application/environments/production/data/common.yaml
@@ -1,6 +1,7 @@
 ---
 a: This is A
 b: This is B
+c: "This is%{cx}"
 
 lookup_options:
   a: first

--- a/spec/fixtures/unit/application/environments/production/manifests/site.pp
+++ b/spec/fixtures/unit/application/environments/production/manifests/site.pp
@@ -1,0 +1,1 @@
+$cx = ' C from site.pp'

--- a/spec/fixtures/unit/application/environments/puppet_func_provider/environment.conf
+++ b/spec/fixtures/unit/application/environments/puppet_func_provider/environment.conf
@@ -1,0 +1,1 @@
+environment_data_provider = 'function'

--- a/spec/fixtures/unit/application/environments/puppet_func_provider/functions/data.pp
+++ b/spec/fixtures/unit/application/environments/puppet_func_provider/functions/data.pp
@@ -1,0 +1,10 @@
+function environment::data() {
+  {
+     a => 'This is A',
+     b => 'This is B',
+     c => "This is ${if $cx == undef { 'C from data.pp' } else { $cx }}",
+     lookup_options => {
+        a => 'first'
+     }
+  }
+}

--- a/spec/fixtures/unit/application/environments/puppet_func_provider/manifests/site.pp
+++ b/spec/fixtures/unit/application/environments/puppet_func_provider/manifests/site.pp
@@ -1,0 +1,1 @@
+$cx = 'C from site.pp'


### PR DESCRIPTION
Prior to this commit, the `lookup` application would compile a full
catalog which gave undesired side effects. This commit ensures that
this compilation does not take place unless the flag `--compile` is
given on the command line. Without this option, the lookup command will
instead compile the string `undef` to produce the scope needed
for the lookup.