### PR TITLE
(maint) acceptance: fix calling all functions-split regex

### DIFF
--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -72,7 +72,7 @@ agents.each do |agent|
     {:name => :sha1,             :args => '"Sansa"',                           :lambda => nil, :expected => '4337ce5e4095e565d51e0ef4c80df1fecf238b29', :rvalue => true},
     {:name => :shellquote,       :args => '["-1", "--two"]',                   :lambda => nil, :expected => '-1 --two', :rvalue => true},
     # 4x output contains brackets around split output and commas btwn values
-    {:name => :split,            :args => '"9,8,7",","',                       :lambda => nil, :expected => /Split: Scope\(Class\[main\]\): \[?9,? 8,? 7\]?/, :rvalue => true},
+    {:name => :split,            :args => '"9,8,7",","',                       :lambda => nil, :expected => /Split: Scope\(Class\[main\]\): \[?9,?\s?8,?\s?7\]?/, :rvalue => true},
     {:name => :sprintf,          :args => '"%b","123"',                        :lambda => nil, :expected => '1111011', :rvalue => true},
     # explicitly called in call_em_all
     #{:name => :tag,              :args => '[4,5,6]',                          :lambda => nil, :expected => '', :rvalue => true},
@@ -85,9 +85,6 @@ agents.each do |agent|
   ]
 
   puppet_version = on(agent, puppet('--version')).stdout.chomp
-  if puppet_version =~ /\A3\./
-    functions_3x.find{|x| x[:name] == :split}[:expected] = '987'
-  end
 
   functions_4x = [
     {:name => :assert_type,      :args => '"String[1]", "Valar morghulis"',    :lambda => nil, :expected => 'Valar morghulis', :rvalue => true},


### PR DESCRIPTION
Previous versions of this test overrode the expectation for the split()
function when puppet_version was deemed to be 3.x. This failed in the
3.x job with future parser turned on.  The override has been removed as
it was confusing and the single regex now works for both 3.x jobs and
4.x jobs.

[skip ci]