### PR TITLE
(PUP-5584) Force ASCII_8BIT encoding when reading JSON from disk

### DIFF
--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -52,7 +52,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     json = nil
 
     begin
-      json = File.read(file)
+      json = File.read(file).force_encoding(Encoding::ASCII_8BIT)
     rescue Errno::ENOENT
       return nil
     rescue => detail


### PR DESCRIPTION
Previously, Puppet would read any JSON it got from the network as
ASCII_8BIT, but treat JSON on-disk as being part of the system
locale. Since we only read JSON from disk when reading something
cached from the network, we always want to treat those JSON files as
also ASCII_8BIT.