### PR TITLE
(PUP-5584) Force ASCII-8BIT encoding for cached catalogs

### DIFF
--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -15,7 +15,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     filename = path(request.key)
     FileUtils.mkdir_p(File.dirname(filename))
 
-    Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance) }
+    Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance).force_encoding(Encoding::ASCII_8BIT) }
   rescue TypeError => detail
     Puppet.log_exception(detail, "Could not save #{self.name} #{request.key}: #{detail}")
   end
@@ -52,7 +52,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     json = nil
 
     begin
-      json = File.read(file)
+      json = Puppet::FileSystem.read(file).force_encoding(Encoding::ASCII_8BIT)
     rescue Errno::ENOENT
       return nil
     rescue => detail

--- a/spec/unit/indirector/json_spec.rb
+++ b/spec/unit/indirector/json_spec.rb
@@ -81,7 +81,7 @@ describe Puppet::Indirector::JSON do
           # I don't like this, but there isn't a credible alternative that
           # also works on Windows, so a stub it is. At least the expectation
           # will fail if the implementation changes. Sorry to the next dev.
-          File.expects(:read).with(file).raises(Errno::EPERM)
+          Puppet::FileSystem.expects(:read).with(file).raises(Errno::EPERM)
           expect { subject.find(request) }.
             to raise_error Puppet::Error, /Could not read JSON/
         end


### PR DESCRIPTION
Previously, puppet would attempt to treat JSON read from a cached
catalog as part of the system encoding. This could cause oddities with
how inlined file content is treated.

With this change, catalogs on disk will be treated as ASCII-8BIT. This
essentially tells Ruby to just treat it as a bunch of bytes,
preserving file content and avoiding any encoding issues.