### PR TITLE
(PUP-5651) Prevent that functions can be defined in blocks

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -151,6 +151,10 @@ module Puppet::Pops::Issues
     "Classes, definitions, and nodes may only appear at toplevel or inside other classes"
   end
 
+  NOT_ABSOLUTE_TOP_LEVEL = hard_issue :NOT_ABSOLUTE_TOP_LEVEL do
+    "#{label.a_an_uc(semantic)} may only appear at toplevel"
+  end
+
   CROSS_SCOPE_ASSIGNMENT = hard_issue :CROSS_SCOPE_ASSIGNMENT, :name do
     "Illegal attempt to assign to '#{name}'. Cannot assign to variables in other namespaces"
   end

--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -57,6 +57,7 @@ class Puppet::Pops::Model::ModelLabelProvider
   def label_ConcatenatedString o          ; "Double Quoted String"              end
   def label_HeredocExpression o           ; "'@(#{o.syntax})' expression"       end
   def label_HostClassDefinition o         ; "Host Class Definition"             end
+  def label_FunctionDefinition o          ; "Function Definition"               end
   def label_NodeDefinition o              ; "Node Definition"                   end
   def label_SiteDefinition o              ; "Site Definition"                   end
   def label_ResourceTypeDefinition o      ; "'define' expression"               end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -366,10 +366,6 @@ class Puppet::Pops::Validation::Checker4_0
   end
 
   def check_FunctionDefinition(o)
-    # TODO PUP-2080: more strict rule for top - can only be contained in Program (for now)
-    #  sticking functions in classes would create functions in the class name space
-    #  but not be special in any other way
-    #
     check_NamedDefinition(o)
   end
 
@@ -723,8 +719,13 @@ class Puppet::Pops::Validation::Checker4_0
   end
 
   def top_BlockExpression(o, definition)
-    # ok, if this is a block representing the body of a class, or is top level
-    top o.eContainer, definition
+    if definition.is_a?(Model::FunctionDefinition)
+      # not ok if the definition is a FunctionDefinition. It can never be nested in a block
+      acceptor.accept(Issues::NOT_ABSOLUTE_TOP_LEVEL, definition)
+    else
+      # ok, if this is a block representing the body of a class, or is top level
+      top o.eContainer, definition
+    end
   end
 
   def top_HostClassDefinition(o, definition)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -293,6 +293,30 @@ describe "validating 4x" do
         expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::NOT_TOP_LEVEL)
       end
     end
+
+    ['class', 'define', 'node'].each do |word|
+      it "produces an error when $#{word} is nested in an function" do
+        source = "function y() { #{word} x {} }"
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::NOT_TOP_LEVEL)
+      end
+    end
+
+    it 'produces an error when a function is nested in an function' do
+      source = 'function y() { function x() {} }'
+      expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
+    end
+
+    ['class', 'define', 'node'].each do |word|
+      it "produces an error when function is nested in a #{word}" do
+        source = "#{word} x { function y() {} }"
+        expect(validate(parse(source))).to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
+      end
+    end
+
+    it 'does not produce an error when function is at top level' do
+      source = 'function y() {}'
+      expect(validate(parse(source))).not_to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
+    end
   end
 
   context "capability annotations" do


### PR DESCRIPTION
A function many not be nested in any type of block. This commit
adds the validation necessary to assert that rule.