### PR TITLE
{WIP}(PUP-5538) User and group failures when using Unicode in Windows

### DIFF
--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -76,7 +76,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
       expect(subject.name_to_sid(sid)).to eq(sid)
     end
 
-    describe "Non english text" do
+    describe "non-ANSI text" do
 
       let(:username) {
         # Create a user with an umlaut


### PR DESCRIPTION
The win32-security gem that Puppet uses for SID conversion uses ANSI versions of APIs that can make it fail to convert Unicode group / user names to SIDs properly.