### PR TITLE
(PUP-5658) Disallow numeric types with ranges where to < from

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -317,6 +317,9 @@ class Puppet::Pops::Evaluator::AccessOperator
     end
     ranged_integer = Puppet::Pops::Types::PIntegerType.new()
     from, to = keys
+    # NOTE! Do not merge the following line to 4.x. It has the same check in the initialize method
+    raise ArgumentError, "'from' must be less or equal to 'to'. Got (#{from}, #{to}" if from.is_a?(Numeric) && to.is_a?(Numeric) && from > to
+
     ranged_integer.from = from == :default ? nil : from
     ranged_integer.to = to == :default ? nil : to
     ranged_integer
@@ -333,6 +336,9 @@ class Puppet::Pops::Evaluator::AccessOperator
     end
     ranged_float = Puppet::Pops::Types::PFloatType.new()
     from, to = keys
+    # NOTE! Do not merge the following line to 4.x. It has the same check in the initialize method
+    raise ArgumentError, "'from' must be less or equal to 'to'. Got (#{from}, #{to}" if from.is_a?(Numeric) && to.is_a?(Numeric) && from > to
+
     ranged_float.from = from == :default || from.nil? ? nil : Float(from)
     ranged_float.to = to == :default || to.nil? ? nil : Float(to)
     ranged_float
@@ -428,6 +434,9 @@ class Puppet::Pops::Evaluator::AccessOperator
       end
       ranged_integer = Puppet::Pops::Types::PIntegerType.new()
       from, to = keys
+      # NOTE! Do not merge the following line to 4.x. It has the same check in the initialize method
+      raise ArgumentError, "'from' must be less or equal to 'to'. Got (#{from}, #{to}" if from.is_a?(Numeric) && to.is_a?(Numeric) && from > to
+
       ranged_integer.from = from == :default ? nil : from
       ranged_integer.to = to == :default ? nil : to
       ranged_integer

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -1069,11 +1069,7 @@ class Puppet::Pops::Types::TypeCalculator
     to = range.to
     x = from.nil? ? 1 : from
     y = to.nil? ? TheInfinity : to
-    if x < y
-      [x, y]
-    else
-      [y, x]
-    end
+    [x, y]
   end
 
   # @api private

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -17,6 +17,9 @@ module Puppet::Pops::Types::TypeFactory
   # @api public
   #
   def self.range(from, to)
+    # NOTE! Do not merge the following line to 4.x. It has the same check in the initialize method
+    raise ArgumentError, "'from' must be less or equal to 'to'. Got (#{from}, #{to}" if from.is_a?(Numeric) && to.is_a?(Numeric) && from > to
+
     t = Types::PIntegerType.new()
     # optimize eq with symbol (faster when it is left)
     t.from = from unless (:default == from || from == 'default')
@@ -28,6 +31,9 @@ module Puppet::Pops::Types::TypeFactory
   # @api public
   #
   def self.float_range(from, to)
+    # NOTE! Do not merge the following line to 4.x. It has the same check in the initialize method
+    raise ArgumentError, "'from' must be less or equal to 'to'. Got (#{from}, #{to}" if from.is_a?(Numeric) && to.is_a?(Numeric) && from > to
+
     t = Types::PFloatType.new()
     # optimize eq with symbol (faster when it is left)
     t.from = Float(from) unless :default == from || from.nil?

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -121,11 +121,7 @@ module Puppet::Pops
         def range
           f = from || NEGATIVE_INFINITY
           t = to || INFINITY
-          if f < t
-            [f, t]
-          else
-            [t,f]
-          end
+          [f, t]
         end
 
         # Returns Enumerator if no block is given
@@ -133,11 +129,7 @@ module Puppet::Pops
         def each
           return self.to_enum unless block_given?
           return nil if from.nil? || to.nil?
-          if to < from
-            from.downto(to) {|x| yield x }
-          else
-            from.upto(to) {|x| yield x }
-          end
+          from.upto(to) {|x| yield x }
         end
 
         def hash
@@ -212,11 +204,7 @@ module Puppet::Pops
           return [0, INFINITY] if size_type.nil?
           f = size_type.from || 0
           t = size_type.to || INFINITY
-          if f < t
-            [f, t]
-          else
-            [t,f]
-          end
+          [f, t]
         end
 
         def hash

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -123,9 +123,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       expect(evaluate(expr)).to eql(range(1,1))
     end
 
-    it 'produces an Integer[from, <from]' do
+    it 'gives an error for Integer[from, <from]' do
       expr = fqr('Integer')[1,0]
-      expect(evaluate(expr)).to eql(range(1,0))
+      expect{evaluate(expr)}.to raise_error(/'from' must be less or equal to 'to'/)
     end
 
     it 'produces an error for Integer[] if there are more than 2 keys' do
@@ -154,9 +154,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       expect(evaluate(expr)).to eql(float_range(1.0,1.0))
     end
 
-    it 'produces a Float[from, <from]' do
+    it 'gives an error for Float[from, <from]' do
       expr = fqr('Float')[1.0,0.0]
-      expect(evaluate(expr)).to eql(float_range(1.0,0.0))
+      expect{evaluate(expr)}.to raise_error(/'from' must be less or equal to 'to'/)
     end
 
     it 'produces an error for Float[] if there are more than 2 keys' do


### PR DESCRIPTION
Numeric types like `Integer[10,0]` was allowed. This commit ensures
that an error is raised if 'to' is less than 'from' in the range.

**Important note when merging to 4.x**
The checks for to < from (here in multiple places) should NOT be
merged. In 4.x there should be only one check and it should reside
in the `PNumericType.initialize`.