### PR TITLE
(maint) Update ruby build for windows

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -26,8 +26,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/hiera.git'
   sys:
     ref:
-      x86: 'refs/tags/1.9.3-p551.6'
-      x64: 'refs/tags/2.0.0.9-x64'
+      x86: 'refs/tags/1.9.3-p551.7'
+      x64: 'refs/tags/2.0.0.10-x64'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
Ruby builds were linked against an updated version of openssl. Use those
for the windows builds.