### PR TITLE
(maint) Default to build dmg

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -10,7 +10,7 @@ gpg_key: '4BD6EC30'
 pbuild_conf: '/etc/pbuilderrc'
 
 build_gem: TRUE
-build_dmg: FALSE
+build_dmg: TRUE
 sign_tar: FALSE
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'


### PR DESCRIPTION
In 96ba5cfae137bb81699a57241ba1c768bb8badca build_dmg was flipped
from TRUE To FALSE since we're not building dmg's any more. Reasonable.

In 307c653ac361682609b6226d861de61946c1df9e then, project_data.yaml
added a pre_tasks dependency on package:apple (to include cfpropertylist
in case someone *is* building a dmg of puppet). Also reasonable.

Unfortunately though, that package:apple rake task in the packaging
repo only appears if build_dmg is TRUE, and the pre_tasks logic in the
packaging repo fails hard if

The net effect of all the above is that, in a developer environment
where package:bootstrap has run, rake -T now fails hard since it can't
find package:apple. This disables a bunch of functionality, including
(somewhat ironically) package:implode.

We could fix this in the packaging repo in a couple different ways, but
it seems simplest that a repo (like puppet or facter#2.x) that adds the
pre_task dependency on package:apple also defaults to build_dmg=TRUE.

Whew. Are we having fun yet?