### PR TITLE
(PUP-5538) Rewrite SID conversions

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
     specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
 
     if @resource[:auth_membership]
-      current_users == specified_users
+      current_users.keys.to_a == specified_users.keys.to_a
     else
       (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
     end
@@ -48,7 +48,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
       else
         account = sid.account
       end
-      resource.debug("#{sid.domain}\\#{account} (#{sid.to_s})")
+      resource.debug("#{sid.domain}\\#{account} (#{sid.sid})")
       "#{sid.domain}\\#{account}"
     end
     return users.join(',')

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
     specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
 
     if @resource[:membership] == :inclusive
-      current_users == specified_users
+      current_users.keys.to_a == specified_users.keys.to_a
     else
       (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
     end
@@ -55,7 +55,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
       else
         account = sid.account
       end
-      resource.debug("#{sid.domain}\\#{account} (#{sid.to_s})")
+      resource.debug("#{sid.domain}\\#{account} (#{sid.sid})")
       "#{sid.domain}\\#{account}"
     end
     return groups.join(',')

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -6,6 +6,9 @@ module Puppet::Util::Windows
   end
   module Registry
   end
+  module SID
+    class Principal; end
+  end
 
   if Puppet::Util::Platform.windows?
     # these reference platform specific gems
@@ -14,6 +17,7 @@ module Puppet::Util::Windows
     require 'puppet/util/windows/error'
     require 'puppet/util/windows/com'
     require 'puppet/util/windows/sid'
+    require 'puppet/util/windows/principal'
     require 'puppet/util/windows/file'
     require 'puppet/util/windows/security'
     require 'puppet/util/windows/user'

--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -1,0 +1,172 @@
+require 'puppet/util/windows'
+
+module Puppet::Util::Windows::SID
+  class Principal
+    extend FFI::Library
+    attr_reader :account, :sid_bytes, :sid, :domain, :domain_account, :account_type
+
+    def initialize(account, sid_bytes, sid, domain, account_type)
+      @account = account
+      @sid_bytes = sid_bytes
+      @sid = sid
+      @domain = domain
+      @domain_account = domain && !domain.empty? ?
+        "#{domain}\\#{account}" : account
+
+      @account_type = account_type
+    end
+
+    # added for backward compatibility
+    def ==(compare)
+      compare.is_a?(Puppet::Util::Windows::SID::Principal) &&
+        @sid_bytes == compare.sid_bytes
+    end
+
+    # = 8 + max sub identifiers (15) * 4
+    MAXIMUM_SID_BYTE_LENGTH = 68
+
+    ERROR_INSUFFICIENT_BUFFER = 122
+
+    def self.lookup_account_name(system_name = nil, account_name)
+      system_name_ptr = FFI::Pointer::NULL
+      begin
+        if system_name
+          system_name_wide = Puppet::Util::Windows::String.wide_string(system_name)
+          # uchar here is synonymous with byte
+          system_name_ptr = FFI::MemoryPointer.new(:byte, system_name_wide.bytesize)
+          system_name_ptr.put_array_of_uchar(0, system_name_wide.bytes.to_a)
+        end
+
+        FFI::MemoryPointer.from_string_to_wide_string(account_name) do |account_name_ptr|
+          FFI::MemoryPointer.new(:byte, MAXIMUM_SID_BYTE_LENGTH) do |sid_ptr|
+            FFI::MemoryPointer.new(:dword, 1) do |sid_length_ptr|
+              FFI::MemoryPointer.new(:dword, 1) do |domain_length_ptr|
+                FFI::MemoryPointer.new(:uint32, 1) do |name_use_enum_ptr|
+
+                sid_length_ptr.write_dword(MAXIMUM_SID_BYTE_LENGTH)
+                success = LookupAccountNameW(system_name_ptr, account_name_ptr, sid_ptr, sid_length_ptr,
+                  FFI::Pointer::NULL, domain_length_ptr, name_use_enum_ptr)
+                last_error = FFI.errno
+
+                if (success == FFI::WIN32_FALSE && last_error != ERROR_INSUFFICIENT_BUFFER)
+                  raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountNameW', last_error)
+                end
+
+                FFI::MemoryPointer.new(:lpwstr, domain_length_ptr.read_dword) do |domain_ptr|
+                  if LookupAccountNameW(system_name_ptr, account_name_ptr,
+                      sid_ptr, sid_length_ptr,
+                      domain_ptr, domain_length_ptr, name_use_enum_ptr) == FFI::WIN32_FALSE
+                   raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountNameW')
+                  end
+
+                  return new(
+                    account_name,
+                    sid_ptr.read_bytes(sid_length_ptr.read_dword).unpack('C*'),
+                    Puppet::Util::Windows::SID.sid_ptr_to_string(sid_ptr),
+                    domain_ptr.read_wide_string(domain_length_ptr.read_dword),
+                    SID_NAME_USE[name_use_enum_ptr.read_uint32])
+                  end
+                end
+              end
+            end
+          end
+        end
+      ensure
+        system_name_ptr.free if system_name_ptr != FFI::Pointer::NULL
+      end
+    end
+
+    def self.lookup_account_sid(system_name = nil, sid_bytes)
+      system_name_ptr = FFI::Pointer::NULL
+      begin
+        if system_name
+          system_name_wide = Puppet::Util::Windows::String.wide_string(system_name)
+          # uchar here is synonymous with byte
+          system_name_ptr = FFI::MemoryPointer.new(:byte, system_name_wide.bytesize)
+          system_name_ptr.put_array_of_uchar(0, system_name_wide.bytes.to_a)
+        end
+
+        FFI::MemoryPointer.new(:byte, sid_bytes.length) do |sid_ptr|
+          FFI::MemoryPointer.new(:dword, 1) do |name_length_ptr|
+            FFI::MemoryPointer.new(:dword, 1) do |domain_length_ptr|
+              FFI::MemoryPointer.new(:uint32, 1) do |name_use_enum_ptr|
+
+                sid_ptr.write_array_of_uchar(sid_bytes)
+                success = LookupAccountSidW(system_name_ptr, sid_ptr, FFI::Pointer::NULL, name_length_ptr,
+                  FFI::Pointer::NULL, domain_length_ptr, name_use_enum_ptr)
+                last_error = FFI.errno
+
+                if (success == FFI::WIN32_FALSE && last_error != ERROR_INSUFFICIENT_BUFFER)
+                  raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountSidW', last_error)
+                end
+
+                FFI::MemoryPointer.new(:lpwstr, name_length_ptr.read_dword) do |name_ptr|
+                  FFI::MemoryPointer.new(:lpwstr, domain_length_ptr.read_dword) do |domain_ptr|
+                    if LookupAccountSidW(system_name_ptr, sid_ptr, name_ptr, name_length_ptr,
+                        domain_ptr, domain_length_ptr, name_use_enum_ptr) == FFI::WIN32_FALSE
+                     raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountSidW')
+                    end
+
+                    return new(
+                      name_ptr.read_wide_string(name_length_ptr.read_dword),
+                      sid_bytes,
+                      Puppet::Util::Windows::SID.sid_ptr_to_string(sid_ptr),
+                      domain_ptr.read_wide_string(domain_length_ptr.read_dword),
+                      SID_NAME_USE[name_use_enum_ptr.read_uint32])
+                  end
+                end
+              end
+            end
+          end
+        end
+      ensure
+        system_name_ptr.free if system_name_ptr != FFI::Pointer::NULL
+      end
+    end
+
+    ffi_convention :stdcall
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379601(v=vs.85).aspx
+    SID_NAME_USE = enum(
+      :SidTypeUser, 1,
+      :SidTypeGroup, 2,
+      :SidTypeDomain, 3,
+      :SidTypeAlias, 4,
+      :SidTypeWellKnownGroup, 5,
+      :SidTypeDeletedAccount, 6,
+      :SidTypeInvalid, 7,
+      :SidTypeUnknown, 8,
+      :SidTypeComputer, 9,
+      :SidTypeLabel, 10
+    )
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379159(v=vs.85).aspx
+    # BOOL WINAPI LookupAccountName(
+    #   _In_opt_  LPCTSTR       lpSystemName,
+    #   _In_      LPCTSTR       lpAccountName,
+    #   _Out_opt_ PSID          Sid,
+    #   _Inout_   LPDWORD       cbSid,
+    #   _Out_opt_ LPTSTR        ReferencedDomainName,
+    #   _Inout_   LPDWORD       cchReferencedDomainName,
+    #   _Out_     PSID_NAME_USE peUse
+    # );
+    ffi_lib :advapi32
+    attach_function_private :LookupAccountNameW,
+      [:lpcwstr, :lpcwstr, :pointer, :lpdword, :lpwstr, :lpdword, :pointer], :win32_bool
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379166(v=vs.85).aspx
+    # BOOL WINAPI LookupAccountSid(
+    #   _In_opt_  LPCTSTR       lpSystemName,
+    #   _In_      PSID          lpSid,
+    #   _Out_opt_ LPTSTR        lpName,
+    #   _Inout_   LPDWORD       cchName,
+    #   _Out_opt_ LPTSTR        lpReferencedDomainName,
+    #   _Inout_   LPDWORD       cchReferencedDomainName,
+    #   _Out_     PSID_NAME_USE peUse
+    # );
+    ffi_lib :advapi32
+    attach_function_private :LookupAccountSidW,
+      [:lpcwstr, :pointer, :lpwstr, :lpdword, :lpwstr, :lpdword, :pointer], :win32_bool
+  end
+end
+

--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -22,6 +22,11 @@ module Puppet::Util::Windows::SID
         @sid_bytes == compare.sid_bytes
     end
 
+    # added for backward compatibility
+    def to_s
+      @sid
+    end
+
     # = 8 + max sub identifiers (15) * 4
     MAXIMUM_SID_BYTE_LENGTH = 68
 

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util/windows'
+
+describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft_windows? do
+
+  let (:system_bytes) { [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] }
+  let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
+
+  describe ".lookup_account_name" do
+    it "should create an instance from a well-known account name" do
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('SYSTEM')
+      expect(principal.account).to eq('SYSTEM')
+      expect(principal.sid_bytes).to eq(system_bytes)
+      expect(principal.sid).to eq('S-1-5-18')
+      expect(principal.domain).to eq('NT AUTHORITY')
+      expect(principal.domain_account).to eq('NT AUTHORITY\\SYSTEM')
+      expect(principal.account_type).to eq(:SidTypeWellKnownGroup)
+    end
+
+    it "should create an instance from a well-known group alias" do
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('Administrators')
+      expect(principal.account).to eq('Administrators')
+      expect(principal.sid_bytes).to eq(administrator_bytes)
+      expect(principal.sid).to eq('S-1-5-32-544')
+      expect(principal.domain).to eq('BUILTIN')
+      expect(principal.domain_account).to eq('BUILTIN\\Administrators')
+      expect(principal.account_type).to eq(:SidTypeAlias)
+    end
+
+    it "should raise an error when trying to lookup an account that doesn't exist" do
+      principal = Puppet::Util::Windows::SID::Principal
+      expect {
+        principal.lookup_account_name('ConanTheBarbarian')
+      }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountNameW/)
+    end
+  end
+
+  describe ".lookup_account_sid" do
+    it "should create an instance from a well-known account SID" do
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_sid(system_bytes)
+      expect(principal.account).to eq('SYSTEM')
+      expect(principal.sid_bytes).to eq(system_bytes)
+      expect(principal.sid).to eq('S-1-5-18')
+      expect(principal.domain).to eq('NT AUTHORITY')
+      expect(principal.domain_account).to eq('NT AUTHORITY\\SYSTEM')
+      expect(principal.account_type).to eq(:SidTypeWellKnownGroup)
+    end
+
+    it "should create an instance from a well-known group SID" do
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_sid(administrator_bytes)
+      expect(principal.account).to eq('Administrators')
+      expect(principal.sid_bytes).to eq(administrator_bytes)
+      expect(principal.sid).to eq('S-1-5-32-544')
+      expect(principal.domain).to eq('BUILTIN')
+      expect(principal.domain_account).to eq('BUILTIN\\Administrators')
+      expect(principal.account_type).to eq(:SidTypeAlias)
+    end
+
+    it "should raise an error when trying to lookup completely invalid SID bytes" do
+      principal = Puppet::Util::Windows::SID::Principal
+      expect {
+        principal.lookup_account_sid([])
+      }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountSidW:  The parameter is incorrect/)
+    end
+
+    it "should raise an error when trying to lookup a valid SID that doesn't have a matching account" do
+      principal = Puppet::Util::Windows::SID::Principal
+      expect {
+        # S-1-1-1 which is not a valid account
+        principal.lookup_account_sid([1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0])
+      }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountSidW:  No mapping between account names and security IDs was done/)
+    end
+  end
+end

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -478,7 +478,7 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
             user = Puppet::Util::Windows::ADSI::User.create("puppet#{rand(10000)}")
             user.commit
             begin
-              sid = Puppet::Util::Windows::ADSI::User.new(user.name).sid.to_s
+              sid = Puppet::Util::Windows::ADSI::User.new(user.name).sid.sid
               winsec.set_owner(sid, path)
               winsec.set_mode(WindowsSecurityTester::S_IRWXU, path)
             ensure
@@ -494,7 +494,7 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
             group = Puppet::Util::Windows::ADSI::Group.create("puppet#{rand(10000)}")
             group.commit
             begin
-              sid = Puppet::Util::Windows::ADSI::Group.new(group.name).sid.to_s
+              sid = Puppet::Util::Windows::ADSI::Group.new(group.name).sid.sid
               winsec.set_group(sid, path)
               winsec.set_mode(WindowsSecurityTester::S_IRWXG, path)
             ensure

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -32,9 +32,9 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
   describe "group type :members property helpers" do
 
-    let(:user1) { stub(:account => 'user1', :domain => '.', :to_s => 'user1sid') }
-    let(:user2) { stub(:account => 'user2', :domain => '.', :to_s => 'user2sid') }
-    let(:user3) { stub(:account => 'user3', :domain => '.', :to_s => 'user3sid') }
+    let(:user1) { stub(:account => 'user1', :domain => '.', :sid => 'user1sid') }
+    let(:user2) { stub(:account => 'user2', :domain => '.', :sid => 'user2sid') }
+    let(:user3) { stub(:account => 'user3', :domain => '.', :sid => 'user3sid') }
     let(:invalid_user) { SecureRandom.uuid }
 
     before :each do
@@ -183,9 +183,9 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
       provider.group.stubs(:members).returns ['user1', 'user2']
 
       member_sids = [
-        stub(:account => 'user1', :domain => 'testcomputername'),
-        stub(:account => 'user2', :domain => 'testcomputername'),
-        stub(:account => 'user3', :domain => 'testcomputername'),
+        stub(:account => 'user1', :domain => 'testcomputername', :sid => 1),
+        stub(:account => 'user2', :domain => 'testcomputername', :sid => 2),
+        stub(:account => 'user3', :domain => 'testcomputername', :sid => 3),
       ]
 
       provider.group.stubs(:member_sids).returns(member_sids[0..1])

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -64,9 +64,9 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
 
   describe "#groups_insync?" do
 
-    let(:group1) { stub(:account => 'group1', :domain => '.', :to_s => 'group1sid') }
-    let(:group2) { stub(:account => 'group2', :domain => '.', :to_s => 'group2sid') }
-    let(:group3) { stub(:account => 'group3', :domain => '.', :to_s => 'group3sid') }
+    let(:group1) { stub(:account => 'group1', :domain => '.', :sid => 'group1sid') }
+    let(:group2) { stub(:account => 'group2', :domain => '.', :sid => 'group2sid') }
+    let(:group3) { stub(:account => 'group3', :domain => '.', :sid => 'group3sid') }
 
     before :each do
       Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group1').returns(group1)


### PR DESCRIPTION
* Use Windows API directly rather than consuming win32-security gem

Still left to do:

- [x] break up commits in pieces of possible to make changes clearer
- [ ] remove `Win32::Security` constants
- [ ] add manifest based acceptance test (may need to create a user with raw bytes in a PowerShell call if the manifest itself won't properly handle UTF8)
- [x] verify that codepaths are necessary / simplify any codepaths where necessary
- [x] potentially rename methods that return hashes now instead of the `SID` object and deprecate old methods
- [ ] add some better docs around API calls noting what expected inputs / outputs are
- [x] track down answers to any TODOs

The constants can be removed later.  I think we can get away without an acceptance test, unless someone wants to write one.  Docs are probably OK for now as well.