### PR TITLE
(docs) Update password hash documentation.

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -185,25 +185,26 @@ module Puppet
     end
 
     newproperty(:password, :required_features => :manages_passwords) do
-      desc %q{The user's password, in whatever encrypted format the local
-        system requires.
+      desc %q{The user's password, in whatever encrypted format the local system
+        requires. Consult your operating system's documentation for acceptable password
+        encryption formats and requirements.
 
-        * Most modern Unix-like systems use salted SHA1 password hashes. You can use
-          Puppet's built-in `sha1` function to generate a hash from a password.
-        * Mac OS X 10.5 and 10.6 also use salted SHA1 hashes.
-        * Mac OS X 10.7 (Lion) uses salted SHA512 hashes. The Puppet Labs [stdlib][]
-          module contains a `str2saltedsha512` function which can generate password
-          hashes for Lion.
-        * Mac OS X 10.8 and higher use salted SHA512 PBKDF2 hashes. When
-          managing passwords on these systems the salt and iterations properties
-          need to be specified as well as the password.
+        * Mac OS X 10.5 and 10.6, and some older Linux distributions, use salted SHA1
+          hashes. You can use Puppet's built-in `sha1` function to generate a salted SHA1
+          hash from a password.
+        * Mac OS X 10.7 (Lion), and many recent Linux distributions, use salted SHA512
+          hashes. The Puppet Labs [stdlib][] module contains a `str2saltedsha512` function
+          which can generate password hashes for these operating systems.
+        * OS X 10.8 and higher use salted SHA512 PBKDF2 hashes. When managing passwords
+          on these systems, the `salt` and `iterations` attributes need to be specified as
+          well as the password.
         * Windows passwords can only be managed in cleartext, as there is no Windows API
           for setting the password hash.
 
         [stdlib]: https://github.com/puppetlabs/puppetlabs-stdlib/
 
-        Be sure to enclose any value that includes a dollar sign ($) in single
-        quotes (') to avoid accidental variable interpolation.}
+        Enclose any value that includes a dollar sign ($) in single quotes (') to avoid
+        accidental variable interpolation.}
 
       validate do |value|
         raise ArgumentError, "Passwords cannot include ':'" if value.is_a?(String) and value.include?(":")
@@ -584,14 +585,15 @@ module Puppet
     end
 
     newproperty(:salt, :required_features => :manages_password_salt) do
-      desc "This is the 32 byte salt used to generate the PBKDF2 password used in
+      desc "This is the 32-byte salt used to generate the PBKDF2 password used in
             OS X. This field is required for managing passwords on OS X >= 10.8."
     end
 
     newproperty(:iterations, :required_features => :manages_password_salt) do
       desc "This is the number of iterations of a chained computation of the
-            password hash (https://en.wikipedia.org/wiki/PBKDF2).  This parameter
-            is used in OS X. This field is required for managing passwords on OS X >= 10.8."
+            [PBKDF2 password hash](https://en.wikipedia.org/wiki/PBKDF2). This parameter
+            is used in OS X, and is required for managing passwords on OS X 10.8 and
+            newer."
 
       munge do |value|
         if value.is_a?(String) and value =~/^[-0-9]+$/


### PR DESCRIPTION
Per DOC-455, generalize and update references to password hashes.