### PR TITLE
(PUP-5684) Fix Windows ADSI User / Group exists?

### DIFF
--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -241,8 +241,8 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
   end
 
   it "should be able to test whether a group exists" do
-    Puppet::Util::Windows::ADSI.stubs(:sid_uri_safe).returns(nil)
-    Puppet::Util::Windows::ADSI.stubs(:connect).returns stub('connection')
+    Puppet::Util::Windows::SID.stubs(:name_to_sid_object).returns(nil)
+    Puppet::Util::Windows::ADSI.stubs(:connect).returns stub('connection', :Class => 'Group')
     expect(provider).to be_exists
 
     Puppet::Util::Windows::ADSI.stubs(:connect).returns nil

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -244,8 +244,8 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
   end
 
   it 'should be able to test whether a user exists' do
-    Puppet::Util::Windows::ADSI.stubs(:sid_uri_safe).returns(nil)
-    Puppet::Util::Windows::ADSI.stubs(:connect).returns stub('connection')
+    Puppet::Util::Windows::SID.stubs(:name_to_sid_object).returns(nil)
+    Puppet::Util::Windows::ADSI.stubs(:connect).returns stub('connection', :Class => 'User')
     expect(provider).to be_exists
 
     Puppet::Util::Windows::ADSI.stubs(:connect).returns nil


### PR DESCRIPTION
 - In #2317 / 580a1ce, a change was introduced
   to generate WinNT://<SID> style URIs.  This code was wrong.

 - The check for exists? should not only verify that the WinNT:// style
  moniker parses and resolves to a COM object, but also that the object
  is an IADsUser / IADsGroup as appropriate.  To verify this, access the
  .Class property of IADs (which IADsUser / IADsGroup inherit from) for
  "User" or "Group".  While the WinNT://<SID> will resolve, it attempts
  to resolve a domain rather than a user or group, and returns an IADs
  with .Class set to "Domain" (even though it is not an IADsDomain).

  Also ensure that sid_uri / sid_uri_safe uris are not used where they
  are not applicable.

  Note that IADsGroup::Add continues to use WinNT://<SID> style URIs for
  users per it's documentation
  https://msdn.microsoft.com/en-us/library/windows/desktop/aa706022(v=vs.85).aspx