### PR TITLE
(PUP-1985) Fix correct scope for parameter default evaluation

### DIFF
--- a/benchmarks/evaluations/benchmarker.rb
+++ b/benchmarks/evaluations/benchmarker.rb
@@ -64,7 +64,7 @@ class Benchmarker
               @parser.evaluate(@scope, model)
             ensure
               # Toss the created local scope
-              @scope.unset_ephemeral_var(scope_memo)
+              @scope.pop_ephemerals(scope_memo)
             end
           end
         end

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -174,6 +174,94 @@ class Puppet::Parser::Scope
 
   end
 
+  # @api private
+  class ParameterScope < Ephemeral
+    class Access
+      attr_accessor :value
+
+      def assigned?
+        instance_variable_defined?(:@value)
+      end
+    end
+
+    # A parameter default must be evaluated using a special scope. The scope that is given to this method must
+    # have a `ParameterScope` as its last ephemeral scope. This method will then push a `MatchScope` while the
+    # given `expression` is evaluated. The method will catch any throw of `:unevaluated_parameter` and produce
+    # an error saying that the evaluated parameter X tries to access the unevaluated parameter Y.
+    #
+    # @param name [String] the name of the currently evaluated parameter
+    # @param expression [Puppet::Parser::AST] the expression to evaluate
+    # @param scope [Puppet::Parser::Scope] a scope where a `ParameterScope` has been pushed
+    # @return [Object] the result of the evaluation
+    #
+    # @api private
+    def evaluate3x(name, expression, scope)
+      scope.with_guarded_scope do
+        bad = catch(:unevaluated_parameter) do
+          scope.new_match_scope(nil)
+          return as_read_only { expression.safeevaluate(scope) }
+        end
+        raise Puppet::Error, "default expression for $#{name} tries to illegally access not yet evaluated $#{bad}"
+      end
+    end
+
+    def evaluate(name, expression, scope, evaluator)
+      scope.with_guarded_scope do
+        bad = catch(:unevaluated_parameter) do
+          scope.new_match_scope(nil)
+          return as_read_only { evaluator.evaluate(expression, scope) }
+        end
+        raise Puppet::Error, "default expression for $#{name} tries to illegally access not yet evaluated $#{bad}"
+      end
+    end
+
+    def initialize(parent, param_names)
+      super(parent)
+      @params = {}
+      param_names.each { |name| @params[name] = Access.new }
+    end
+
+    def [](name)
+      access = @params[name]
+      return super if access.nil?
+      throw(:unevaluated_parameter, name) unless access.assigned?
+      access.value
+    end
+
+    def []=(name, value)
+      raise Puppet::Error, "Attempt to assign variable #{name} to read-only parameter scope" if @read_only
+      @params[name] ||= Access.new
+      @params[name].value = value
+    end
+
+    def bound?(name)
+      @params.include?(name)
+    end
+
+    def include?(name)
+      @params.include?(name) || super
+    end
+
+    def is_local_scope?
+      true
+    end
+
+    def as_read_only
+      read_only = @read_only
+      @read_only = true
+      begin
+        yield
+      ensure
+        @read_only = read_only
+      end
+    end
+
+    def to_hash
+      Hash[@params.select {|_, access| access.assigned? }.map { |name, access| [name, access.value] }]
+    end
+  end
+
+
   # Returns true if the variable of the given name has a non nil value.
   # TODO: This has vague semantics - does the variable exist or not?
   #       use ['name'] to get nil or value, and if nil check with exist?('name')
@@ -738,15 +826,33 @@ class Puppet::Parser::Scope
 
   alias_method :inspect, :to_s
 
-  # remove ephemeral scope up to level
-  # TODO: Who uses :all ? Remove ??
+  # Pop ephemeral scopes up to level and return them
   #
+  # @deprecated use #pop_epehemeral
+  # @api private
   def unset_ephemeral_var(level=:all)
+    Puppet.deprecation_warning('Method Parser::Scope#unset_ephemeral_var() is deprecated')
     if level == :all
       @ephemeral = [ MatchScope.new(@symtable, nil)]
     else
       @ephemeral.pop(@ephemeral.size - level)
     end
+  end
+
+  # Pop ephemeral scopes up to level and return them
+  #
+  # @param level [Fixnum] a positive integer
+  # @return [Array] the removed ephemeral scopes
+  # @api private
+  def pop_ephemerals(level)
+    @ephemeral.pop(@ephemeral.size - level)
+  end
+
+  # Push ephemeral scopes onto the ephemeral scope stack
+  # @param ephemeral_scopes [Array]
+  # @api private
+  def push_ephemerals(ephemeral_scopes)
+    ephemeral_scopes.each { |ephemeral_scope| @ephemeral.push(ephemeral_scope) } unless ephemeral_scopes.nil?
   end
 
   def ephemeral_level
@@ -759,6 +865,53 @@ class Puppet::Parser::Scope
       @ephemeral.push(LocalScope.new(@ephemeral.last))
     else
       @ephemeral.push(MatchScope.new(@ephemeral.last, nil))
+    end
+  end
+
+  # Execute given block in global scope with no ephemerals present
+  #
+  # @yieldparam [Scope] global_scope the global and ephemeral less scope
+  # @return [Object] the return of the block
+  #
+  # @api private
+  def with_global_scope(&block)
+    find_global_scope.without_ephemeral_scopes(&block)
+  end
+
+  # Execute given block with all ephemeral popped from the ephemeral stack
+  #
+  # @api private
+  def without_ephemeral_scopes
+    save_ephemeral = @ephemeral
+    begin
+      @ephemeral = [ @symtable ]
+      yield(self)
+    ensure
+      @ephemeral = save_ephemeral
+    end
+  end
+
+  # Nests a parameter scope
+  # @api private
+  def with_parameter_scope(param_names)
+    param_scope = ParameterScope.new(@ephemeral.last, param_names)
+    with_guarded_scope do
+      @ephemeral.push(param_scope)
+      yield(param_scope)
+    end
+  end
+
+  # Execute given block and ensure that ephemeral level is restored
+  #
+  # @return [Object] the return of the block
+  #
+  # @api private
+  def with_guarded_scope
+    elevel = ephemeral_level
+    begin
+      yield
+    ensure
+      pop_ephemerals(elevel)
     end
   end
 

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -229,7 +229,7 @@ class Puppet::Parser::Scope
     end
 
     def []=(name, value)
-      raise Puppet::Error, "Attempt to assign variable #{name} to read-only parameter scope" if @read_only
+      raise Puppet::Error, "Attempt to assign variable #{name} when evaluating parameters" if @read_only
       @params[name] ||= Access.new
       @params[name].value = value
     end

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -136,10 +136,8 @@ module Puppet::Pops::Evaluator::Runtime3Support
   end
 
   def set_scope_nesting_level(scope, level)
-    # Yup, 3x uses this method to reset the level, it also supports passing :all to destroy all 
-    # ephemeral/local scopes - which is a sure way to create havoc.
-    #
-    scope.unset_ephemeral_var(level)
+    # 3x uses this method to reset the level,
+    scope.pop_ephemerals(level)
   end
 
   # Adds a relationship between the given `source` and `target` of the given `relationship_type`

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -488,7 +488,7 @@ module Puppet::Pops::Issues
   end
 
   DUPLICATE_ATTRIBUTE = issue :DUPLICATE_ATTRIBUE, :attribute  do
-    "The attribute '#{attribute}' has already been set in this resource body"
+    "The attribute '#{attribute}' has already been set"
   end
 
   MISSING_TITLE = hard_issue :MISSING_TITLE do

--- a/spec/integration/parser/parameter_defaults_spec.rb
+++ b/spec/integration/parser/parameter_defaults_spec.rb
@@ -123,7 +123,7 @@ require 'puppet_spec/language'
         expect_fail(params, [], /default expression for \$b tries to illegally access not yet evaluated \$a/)
       end
 
-      it 'will use the referenced parameters given value' do
+      it "will use the referenced parameter's given value" do
         expect_log(params, [2], ['$a == 2', '$b == 2'])
       end
 
@@ -139,11 +139,11 @@ require 'puppet_spec/language'
       SOURCE
       }
 
-      it 'will use the referenced parameters default value when no value is given for the referenced parameter' do
+      it "will use the referenced parameter's default value when no value is given for the referenced parameter" do
         expect_log(params, [], ['$a == 10', '$b == 10'])
       end
 
-      it 'will use the referenced parameters given value' do
+      it "will use the referenced parameter's given value" do
         expect_log(params, [2], ['$a == 2', '$b == 2'])
       end
 
@@ -174,7 +174,7 @@ require 'puppet_spec/language'
     end
 
     context 'with regular expressions' do
-      it 'evaluates unset match scope parameters to undef' do
+      it "evaluates unset match scope parameter's to undef" do
         expect_log([<<-SOURCE, 2], [], ['$a == ', '$b == '])
         $a = $0,
         $b = $1
@@ -196,7 +196,7 @@ require 'puppet_spec/language'
         SOURCE
       end
 
-      it 'can have nexted match expressions' do
+      it 'can have nested match expressions' do
         expect_log([<<-SOURCE, 2], [], ['$a == [true, h, oo, h, i]', '$b == '] )
         $a = ['hi' =~ /(h)(.*)/, $1, if'foo' =~ /f(oo)/ { $1 }, $1, $2],
         $b = $0
@@ -266,7 +266,7 @@ require 'puppet_spec/language'
         SOURCE
       end
 
-      it 'will not make match scope available to function body' do
+      it "will not make match scope available to #{call_type} body" do
         expect_log([<<-SOURCE, call_type == 'Function' ? <<-BODY : <<-EPP_BODY], [], ['Yes'])
         $a = "hello" =~ /.*/
         SOURCE

--- a/spec/integration/parser/parameter_defaults_spec.rb
+++ b/spec/integration/parser/parameter_defaults_spec.rb
@@ -1,0 +1,336 @@
+require 'spec_helper'
+require 'puppet_spec/language'
+
+['Function', 'EPP'].each do |call_type|
+  describe "#{call_type} parameter default expressions" do
+    let! (:func_bodies) {
+      [
+        '{}',
+        '{ notice("\$a == ${a}") }',
+        '{ notice("\$a == ${a}") notice("\$b == ${b}") }',
+        '{ notice("\$a == ${a}") notice("\$b == ${b}")  notice("\$c == ${c}") }'
+      ]
+    }
+
+    let! (:epp_bodies) {
+      [
+        '',
+        '<% notice("\$a == ${a}") %>',
+        '<% notice("\$a == ${a}") notice("\$b == ${b}") %>',
+        '<% notice("\$a == ${a}") notice("\$b == ${b}")  notice("\$c == ${c}") %>'
+      ]
+    }
+    let! (:param_names) {  ('a'..'c').to_a }
+
+    let (:call_type) { call_type }
+
+    let (:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new('specification')) }
+
+    def collect_notices(code)
+      logs = []
+      Puppet[:code] = code
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        compiler.compile
+        yield
+      end
+      logs.select { |log| log.level == :notice }.map { |log| log.message }
+    end
+
+    # @param arg_list [String] comma separated parameter declarations. Not enclosed in parenthesis
+    # @param body [String,Integer] verbatim body or index of an entry in func_bodies
+    # @param call_params [Array[#to_s]] array of call parameters
+    # @return [Array] array of notice output entries
+    #
+    def eval_collect_notices(arg_list, body, call_params)
+      call = call_params.is_a?(String) ? call_params : "example(#{call_params.join(',')})"
+      body = func_bodies[body] if body.is_a?(Integer)
+      evaluator = Puppet::Pops::Parser::EvaluatingParser.new()
+      collect_notices("function example(#{arg_list}) #{body}") do
+        evaluator.evaluate_string(compiler.topscope, call)
+      end
+    end
+
+    # @param arg_list [String] comma separated parameter declarations. Not enclosed in parenthesis
+    # @param body [String,Integer] verbatim body or index of an entry in bodies
+    # @param call_params [Array] array of call parameters
+    # @param code [String] code to evaluate
+    # @return [Array] array of notice output entries
+    #
+    def epp_eval_collect_notices(arg_list, body, call_params, code, inline_epp)
+      body = body.is_a?(Integer) ? epp_bodies[body] : body.strip
+      source = "<%| #{arg_list} |%>#{body}"
+      named_params = call_params.reduce({}) {|h, v| h[param_names[h.size]] = v; h }
+      collect_notices(code) do
+        if inline_epp
+          Puppet::Pops::Evaluator::EppEvaluator.inline_epp(compiler.topscope, source, named_params)
+        else
+          file = Tempfile.new(['epp-script', '.epp'])
+          begin
+            file.write(source)
+            file.close
+            Puppet::Pops::Evaluator::EppEvaluator.epp(compiler.topscope, file.path, 'test', named_params)
+          ensure
+            file.unlink
+          end
+        end
+      end
+    end
+
+
+    # evaluates a function or EPP call, collects notice output in a log and compares log to expected result
+    #
+    # @param decl [Array[]] two element array with argument list declaration and body. Body can a verbatim string
+    #   or an integer index of an entry in bodies
+    # @param call_params [Array[#to_s]] array of call parameters
+    # @param code [String] code to evaluate. Only applicable when call_type == 'EPP'
+    # @param inline_epp [Boolean] true for inline_epp, false for file based epp, Only applicable when call_type == 'EPP'
+    # @return [Array] array of notice output entries
+    #
+    def expect_log(decl, call_params, result, code = 'undef', inline_epp = true)
+      if call_type == 'Function'
+        expect(eval_collect_notices(decl[0], decl[1], call_params)).to include(*result)
+      else
+        expect(epp_eval_collect_notices(decl[0], decl[1], call_params, code, inline_epp)).to include(*result)
+      end
+    end
+
+    # evaluates a function or EPP call and expects a failure
+    #
+    # @param decl [Array[]] two element array with argument list declaration and body. Body can a verbatim string
+    #   or an integer index of an entry in bodies
+    # @param call_params [Array[#to_s]] array of call parameters
+    # @param text [String,Regexp] expected error message
+    def expect_fail(decl, call, text, inline_epp = true)
+      if call_type == 'Function'
+        expect{eval_collect_notices(decl[0], decl[1], call) }.to raise_error(StandardError, text)
+      else
+        expect{epp_eval_collect_notices(decl[0], decl[1], call, 'undef', inline_epp) }.to raise_error(StandardError, text)
+      end
+    end
+
+    context 'that references a parameter to the left that has no default' do
+      let!(:params) { [ <<-SOURCE, 2 ]
+      $a,
+      $b = $a
+      SOURCE
+      }
+
+      it 'fails when no value is provided for required first parameter', :if => call_type == 'Function' do
+        expect_fail(params, [], /expects between 1 and 2 arguments, got none/)
+      end
+
+      it 'fails when no value is provided for required first parameter', :if => call_type == 'EPP' do
+        expect_fail(params, [], /default expression for \$b tries to illegally access not yet evaluated \$a/)
+      end
+
+      it 'will use the referenced parameters given value' do
+        expect_log(params, [2], ['$a == 2', '$b == 2'])
+      end
+
+      it 'will not be evaluated when a value is given' do
+        expect_log(params, [2, 5], ['$a == 2', '$b == 5'])
+      end
+    end
+
+    context 'that references a parameter to the left that has a default' do
+      let!(:params) { [ <<-SOURCE, 2 ]
+      $a = 10,
+      $b = $a
+      SOURCE
+      }
+
+      it 'will use the referenced parameters default value when no value is given for the referenced parameter' do
+        expect_log(params, [], ['$a == 10', '$b == 10'])
+      end
+
+      it 'will use the referenced parameters given value' do
+        expect_log(params, [2], ['$a == 2', '$b == 2'])
+      end
+
+      it 'will not be evaluated when a value is given' do
+        expect_log(params, [2, 5], ['$a == 2', '$b == 5'])
+      end
+    end
+
+    context 'that references a variable to the right' do
+      let!(:params) { [ <<-SOURCE, 3 ]
+      $a = 10,
+      $b = $c,
+      $c = 20
+      SOURCE
+      }
+
+      it 'fails when the reference is evaluated' do
+        expect_fail(params, [1], /default expression for \$b tries to illegally access not yet evaluated \$c/)
+      end
+
+      it 'does not fail when a value is given for the culprit parameter' do
+        expect_log(params, [1,2], ['$a == 1', '$b == 2', '$c == 20'])
+      end
+
+      it 'does not fail when all values are given' do
+        expect_log(params, [1,2,3], ['$a == 1', '$b == 2', '$c == 3'])
+      end
+    end
+
+    context 'with regular expressions' do
+      it 'evaluates unset match scope parameters to undef' do
+        expect_log([<<-SOURCE, 2], [], ['$a == ', '$b == '])
+        $a = $0,
+        $b = $1
+        SOURCE
+      end
+
+      it 'does not leak match variables from one expression to the next' do
+        expect_log([<<-SOURCE, 2], [], ['$a == [true, h, ello]', '$b == '])
+        $a = ['hello' =~ /(h)(.*)/, $1, $2],
+        $b = $1
+        SOURCE
+      end
+
+      it 'can evaluate expressions in separate match scopes' do
+        expect_log([<<-SOURCE, 3], [], ['$a == [true, h, ell, o]', '$b == [true, h, i, ]', '$c == '])
+        $a = ['hello' =~ /(h)(.*)(o)/, $1, $2, $3],
+        $b = ['hi' =~ /(h)(.*)/, $1, $2, $3],
+        $c = $1
+        SOURCE
+      end
+
+      it 'can have nexted match expressions' do
+        expect_log([<<-SOURCE, 2], [], ['$a == [true, h, oo, h, i]', '$b == '] )
+        $a = ['hi' =~ /(h)(.*)/, $1, if'foo' =~ /f(oo)/ { $1 }, $1, $2],
+        $b = $0
+        SOURCE
+      end
+
+      it 'can not see match scope from calling scope', :if => call_type == 'Function' do
+        expect_log([<<-SOURCE, <<-BODY], <<-CALL, ['$a == '])
+        $a = $0
+        SOURCE
+        {
+          notice("\\$a == ${a}")
+        }
+        function caller() {
+          example()
+        }
+        BODY
+        $tmp = 'foo' =~ /(f)(o)(o)/
+        caller()
+        CALL
+      end
+
+      context 'matches in calling scope', :if => call_type == 'EPP' do
+        it 'are available when using inlined epp' do
+          # Note that CODE is evaluated before the EPP is evaluated
+          #
+          expect_log([<<-SOURCE, <<-BODY], [], ['$ax == true', '$bx == foo'], <<-CODE, true)
+          $a = $tmp,
+          $b = $0
+          SOURCE
+          <% called_from_template($a, $b) %>
+          BODY
+          function called_from_template($ax, $bx) {
+            notice("\\$ax == $ax")
+            notice("\\$bx == $bx")
+          }
+          $tmp = 'foo' =~ /(f)(o)(o)/
+          CODE
+        end
+
+        it 'are not available when using epp file' do
+          # Note that CODE is evaluated before the EPP is evaluated
+          #
+          expect_log([<<-SOURCE, <<-BODY], [], ['$ax == true', '$bx == '], <<-CODE, false)
+          $a = $tmp,
+          $b = $0
+            SOURCE
+          <% called_from_template($a, $b) %>
+            BODY
+          function called_from_template($ax, $bx) {
+            notice("\\$ax == $ax")
+            notice("\\$bx == $bx")
+          }
+          $tmp = 'foo' =~ /(f)(o)(o)/
+          CODE
+        end
+      end
+
+
+      it 'will allow nested lambdas to access enclosing match scope' do
+        expect_log([<<-SOURCE, 1], [], ['$a == [1-ello, 2-ello, 3-ello]'])
+        $a = case "hello" {
+          /(h)(.*)/ : {
+            [1,2,3].map |$x| { "$x-$2" }
+          }
+        }
+        SOURCE
+      end
+
+      it 'will not make match scope available to function body' do
+        expect_log([<<-SOURCE, call_type == 'Function' ? <<-BODY : <<-EPP_BODY], [], ['Yes'])
+        $a = "hello" =~ /.*/
+        SOURCE
+        {
+          notice("Y${0}es")
+        }
+        BODY
+        <%
+          notice("Y${0}es")
+        %>
+        EPP_BODY
+      end
+
+      it 'can access earlier match results when produced using the match function' do
+        expect_log([<<-SOURCE, 3], [], ['$a == [hello, h, ello]', '$b == hello', '$c == h'])
+        $a = 'hello'.match(/(h)(.*)/),
+        $b = $a[0],
+        $c = $a[1]
+        SOURCE
+      end
+    end
+
+
+    context 'will not permit assignments' do
+      it 'at top level' do
+        expect_fail([<<-SOURCE, 0], [], /Syntax error at '='/)
+        $a = $x = $0
+        SOURCE
+      end
+
+      it 'in arrays' do
+        expect_fail([<<-SOURCE, 0], [], /Assignment not allowed here/)
+        $a = [$x = 3]
+        SOURCE
+      end
+
+      it 'of variable with the same name as a subsequently declared parameter' do
+        expect_fail([<<-SOURCE, 0], [], /Assignment not allowed here/)
+        $a = ($b = 3),
+        $b = 5
+        SOURCE
+      end
+
+      it 'of variable with the same name as a previously declared parameter' do
+        expect_fail([<<-SOURCE, 0], [], /Assignment not allowed here/)
+        $a = 10,
+        $b = ($a = 10)
+        SOURCE
+      end
+    end
+
+    it 'will permit assignments in nested scope' do
+      expect_log([<<-SOURCE, 3], [], ['$a == [1, 2, 3]', '$b == 0', '$c == [6, 12, 18]'])
+      $a = [1,2,3],
+      $b = 0,
+      $c = $a.map |$x| { $b = $x; $b * $a.reduce |$x, $y| {$x + $y} }
+      SOURCE
+    end
+
+    it 'will not permit duplicate parameter names' do
+      expect_fail([<<-SOURCE, 0], [], /The parameter 'a' is declared more than once/ )
+      $a = 2,
+      $a = 5
+      SOURCE
+    end
+  end
+end

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -489,17 +489,15 @@ describe Puppet::Parser::Scope do
         expect(@scope.include?("1")).to be_falsey
       end
 
-      describe "when calling unset_ephemeral_var with a level" do
+      describe "when using a guarded scope" do
         it "should remove ephemeral scopes up to this level" do
           @scope.set_match_data({1 => :value1})
           @scope.new_ephemeral
           @scope.set_match_data({1 => :value2})
-          level = @scope.ephemeral_level()
-          @scope.new_ephemeral
-          @scope.set_match_data({1 => :value3})
-
-          @scope.unset_ephemeral_var(level)
-
+          @scope.with_guarded_scope do
+            @scope.new_ephemeral
+            @scope.set_match_data({1 => :value3})
+          end
           expect(@scope["1"]).to eq(:value2)
         end
       end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -861,7 +861,8 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
         # NOTE: these meta-esque parameters are not recognized as such
         "notify { id: message=>explicit} Notify[id][title]"   => /does not have a parameter called 'title'/,
         "notify { id: message=>explicit} Notify[id]['type']"   => /does not have a parameter called 'type'/,
-        "notify { id: message=>explicit } Notify[id]{message=>override}" => /'message' is already set on Notify\[id\]/
+        "notify { id: message=>explicit } Notify[id]{message=>override}" => /'message' is already set on Notify\[id\]/,
+        "notify { id: message => 'once', message => 'twice' }" => /'message' has already been set/
       }.each do |source, result|
         it "should parse '#{source}' and raise error matching #{result}" do
           expect { parser.evaluate_string(scope, source, __FILE__)}.to raise_error(result)

--- a/spec/unit/pops/evaluator/evaluator_rspec_helper.rb
+++ b/spec/unit/pops/evaluator/evaluator_rspec_helper.rb
@@ -55,10 +55,10 @@ module EvaluatorRspecHelper
     result = evaluator.evaluate(in_top_scope.current, top_scope)
     if in_local_scope
       # This is really bad in 3.x scope
-      elevel = top_scope.ephemeral_level
-      top_scope.new_ephemeral(true)
-      result = evaluator.evaluate(in_local_scope.current, top_scope)
-      top_scope.unset_ephemeral_var(elevel)
+      top_scope.with_guarded_scope do
+        top_scope.new_ephemeral(true)
+        result = evaluator.evaluate(in_local_scope.current, top_scope)
+      end
     end
     if in_top_scope_again
       result = evaluator.evaluate(in_top_scope_again.current, top_scope)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -249,7 +249,7 @@ describe "validating 4x" do
         expect(validate(parse("#{word} foo($a = 10, $b = ($a = 10)) {}"))).to have_issue(Puppet::Pops::Issues::ILLEGAL_ASSIGNMENT_CONTEXT)
       end
 
-      it "should permit assignments permit assignments in #{word} parameter default inside nested lambda expressions" do
+      it "should permit assignments in #{word} parameter default inside nested lambda expressions" do
         expect(validate(parse(
           "#{word} foo($a = [1,2,3], $b = 0, $c = $a.map |$x| { $b = $x; $b * $a.reduce |$x, $y| {$x + $y}}) {}"))).not_to(
           have_issue(Puppet::Pops::Issues::ILLEGAL_ASSIGNMENT_CONTEXT))

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -229,6 +229,34 @@ describe "validating 4x" do
     end
   end
 
+  context 'for parameter defaults' do
+    ['class', 'define'].each do |word|
+      it "should not permit assignments in #{word} parameter default expressions" do
+        expect { parse("#{word} foo($a = $x = 10) {}") }.to raise_error(Puppet::ParseErrorWithIssue, /Syntax error at '='/)
+      end
+    end
+
+    ['class', 'define'].each do |word|
+      it "should not permit assignments in #{word} parameter default nested expressions" do
+        expect(validate(parse("#{word} foo($a = [$x = 10]) {}"))).to have_issue(Puppet::Pops::Issues::ILLEGAL_ASSIGNMENT_CONTEXT)
+      end
+
+      it "should not permit assignments to subsequently declared parameters in #{word} parameter default nested expressions" do
+        expect(validate(parse("#{word} foo($a = ($b = 3), $b = 5) {}"))).to have_issue(Puppet::Pops::Issues::ILLEGAL_ASSIGNMENT_CONTEXT)
+      end
+
+      it "should not permit assignments to previously declared parameters in #{word} parameter default nested expressions" do
+        expect(validate(parse("#{word} foo($a = 10, $b = ($a = 10)) {}"))).to have_issue(Puppet::Pops::Issues::ILLEGAL_ASSIGNMENT_CONTEXT)
+      end
+
+      it "should permit assignments permit assignments in #{word} parameter default inside nested lambda expressions" do
+        expect(validate(parse(
+          "#{word} foo($a = [1,2,3], $b = 0, $c = $a.map |$x| { $b = $x; $b * $a.reduce |$x, $y| {$x + $y}}) {}"))).not_to(
+          have_issue(Puppet::Pops::Issues::ILLEGAL_ASSIGNMENT_CONTEXT))
+      end
+    end
+  end
+
   context 'for reserved parameter names' do
     ['name', 'title'].each do |word|
       it "produces an error when $#{word} is used as a parameter in a class" do
@@ -313,20 +341,20 @@ describe "validating 4x" do
       end
     end
 
-    it 'does not produce an error when function is at top level script' do
+    it 'does not produce an error when function is alone at top level script' do
       source = 'function y() {}'
       expect(validate(parse(source))).not_to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
     end
 
-    it 'does not produce an error when function is at top level file' do
-      source = 'function y() {}'
-
-      # We simulate a file by inserting a block between the program and the contained function
-      program = parse(source).current
-      function = program.body
-      program.body = Puppet::Pops::Model::BlockExpression.new
-      program.body.addStatements(function)
-      expect(validate(program)).not_to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
+    it 'does not produce an error when function is in a top level block' do
+      source = "function x() {}\nfunction y() {}"
+      expect(validate(parse(source))).not_to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
+      source = "$a = 10\nfunction y() {}"
+      expect(validate(parse(source))).not_to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
+      source = "function y() {}\n$a = 10"
+      expect(validate(parse(source))).not_to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
+      source = "$a = 10\nfunction y() {}\n$b = 20"
+      expect(validate(parse(source))).not_to have_issue(Puppet::Pops::Issues::NOT_ABSOLUTE_TOP_LEVEL)
     end
   end
 

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -240,9 +240,26 @@ describe Puppet::Resource::Type do
   end
 
   describe "when setting its parameters in the scope" do
+    let(:parser) { Puppet::Pops::Parser::Parser.new() }
+
+    def wrap3x(expression)
+      Puppet::Parser::AST::PopsBridge::Expression.new(:value => expression.current)
+    end
+
+    def parse_expression(expr_string)
+      wrap3x(parser.parse_string(expr_string))
+    end
+
+    def number_expression(number)
+      wrap3x(Puppet::Pops::Model::Factory.NUMBER(number))
+    end
+
     def variable_expression(name)
-      varexpr = Puppet::Pops::Model::Factory.QNAME(name).var().current
-      Puppet::Parser::AST::PopsBridge::Expression.new(:value => varexpr)
+      wrap3x(Puppet::Pops::Model::Factory.QNAME(name).var())
+    end
+
+    def matchref_expression(number)
+      wrap3x(Puppet::Pops::Model::Factory.NUMBER(number).var())
     end
 
     before do
@@ -270,6 +287,134 @@ describe Puppet::Resource::Type do
       @type.set_arguments :foo => variable_expression('name')
       @type.set_resource_parameters(@resource, @scope)
       expect(@scope['foo']).to eq('foobar')
+    end
+
+    context 'referencing a variable to the left of the default expression' do
+      it 'is possible when the referenced variable uses a default' do
+        @type.set_arguments({
+          :first => number_expression(10),
+          :second => variable_expression('first'),
+        })
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope['first']).to eq(10)
+        expect(@scope['second']).to eq(10)
+      end
+
+      it 'is possible when the referenced variable is given a value' do
+        @type.set_arguments({
+          :first => number_expression(10),
+          :second => variable_expression('first'),
+        })
+        @resource[:first] = 2
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope['first']).to eq(2)
+        expect(@scope['second']).to eq(2)
+      end
+
+      it 'is possible when the referenced variable is an array produced by match function' do
+        @type.set_arguments({
+          :first => parse_expression("'hello'.match(/(h)(.*)/)"),
+          :second => parse_expression('$first[0]'),
+          :third => parse_expression('$first[1]')
+        })
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope['first']).to eq(['hello', 'h', 'ello'])
+        expect(@scope['second']).to eq('hello')
+        expect(@scope['third']).to eq('h')
+      end
+
+      it 'does not clobber a given value' do
+        @type.set_arguments({
+          :first => number_expression(10),
+          :second => variable_expression('first'),
+        })
+        @resource[:first] = 2
+        @resource[:second] = 5
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope['first']).to eq(2)
+        expect(@scope['second']).to eq(5)
+      end
+    end
+
+    context 'referencing a variable to the right of the default expression' do
+      before :each do
+        @type.set_arguments({
+          :first => number_expression(10),
+          :second => variable_expression('third'),
+          :third => number_expression(20)
+        })
+      end
+
+      it 'no error is raised when no defaults are evaluated' do
+        @resource[:first] = 1
+        @resource[:second] = 2
+        @resource[:third] = 3
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope['first']).to eq(1)
+        expect(@scope['second']).to eq(2)
+        expect(@scope['third']).to eq(3)
+      end
+
+      it 'no error is raised unless the referencing default expression is evaluated' do
+        @resource[:second] = 2
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope['first']).to eq(10)
+        expect(@scope['second']).to eq(2)
+        expect(@scope['third']).to eq(20)
+      end
+
+      it 'fails when the default expression is evaluated' do
+        @resource[:first] = 1
+        expect { @type.set_resource_parameters(@resource, @scope) }.to raise_error(Puppet::Error, 'default expression for $second tries to illegally access not yet evaluated $third')
+      end
+    end
+
+    it 'does not allow a variable to be referenced from its own default expression' do
+      @type.set_arguments({
+        :first => variable_expression('first')
+      })
+      expect { @type.set_resource_parameters(@resource, @scope) }.to raise_error(Puppet::Error, 'default expression for $first tries to illegally access not yet evaluated $first')
+    end
+
+    context 'when using match scope' do
+      it '$n evaluates to undef at the top level' do
+        @type.set_arguments({
+          :first => matchref_expression('0'),
+          :second => matchref_expression('1'),
+        })
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope).not_to include('first')
+        expect(@scope).not_to include('second')
+      end
+
+      it 'a match scope to the left of a parameter is not visible to it' do
+        @type.set_arguments({
+          :first => parse_expression("['hello' =~ /(h)(.*)/, $1, $2]"),
+          :second => matchref_expression('1'),
+        })
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope['first']).to eq([true, 'h', 'ello'])
+        expect(@scope['second']).to be_nil
+      end
+
+      it 'match scopes nests per parameter' do
+        @type.set_arguments({
+          :first => parse_expression("['hi' =~ /(h)(.*)/, $1, if 'foo' =~ /f(oo)/ { $1 }, $1, $2]"),
+          :second => matchref_expression('0'),
+        })
+        @type.set_resource_parameters(@resource, @scope)
+
+        expect(@scope['first']).to eq([true, 'h', 'oo', 'h', 'i'])
+        expect(@scope['second']).to be_nil
+      end
     end
 
     it "should set each of the resource's parameters as variables in the scope" do
@@ -432,10 +577,9 @@ describe Puppet::Resource::Type do
       @scope.expects(:newscope).with(:source => @type, :namespace => '', :resource => @resource).returns subscope
 
       elevel = 876
-      subscope.expects(:ephemeral_level).returns elevel
+      subscope.expects(:with_guarded_scope).yields
       subscope.expects(:ephemeral_from).with(match, nil, nil).returns subscope
       code.expects(:safeevaluate).with(subscope)
-      subscope.expects(:unset_ephemeral_var).with(elevel)
 
       # Just to keep the stub quiet about intermediate calls
       @type.expects(:set_resource_parameters).with(@resource, subscope)
@@ -484,9 +628,7 @@ describe Puppet::Resource::Type do
     it "should evaluate the AST code if any is provided" do
       code = stub 'code'
       @type.stubs(:code).returns code
-      subscope = stub_everything("subscope", :compiler => @compiler)
-      @scope.stubs(:newscope).returns subscope
-      code.expects(:safeevaluate).with subscope
+      code.expects(:safeevaluate).with kind_of(Puppet::Parser::Scope)
 
       @type.evaluate_code(@resource)
     end


### PR DESCRIPTION
This commit ensures that a correct scope is used when evaluating
parameter default expressions. It impacts the parameter declarations
of functions, EPP templates, classes, and resources.

A new ephemeral scope `ParameterScope` was added to keep track of
which parameters that exists and in which order they are evaluated
and accessed. This scope is only in effect during the evaluation
of the parameter defaults. Since the parameters are evaluated left
to right, and each parameter is added to the scope, a default
expression of a parameter can use the parameters declared to the
left.

Each parameter in turn is evaluated using a private MatchScope to
ensure that the evaluation of one parameter cannot interfere with
another. No LocalScope is pushed though, since it's forbidden
to assign new variables in this context.

The commit also contain two new test suites (one for function and
epp-template parameters, and one for class and resource parameters).
They all test default parameter evaluation much in the same way but
for different targets.