### PR TITLE
(PUP-1607) Acceptance - no master in symbolic_modes

### DIFF
--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -1,5 +1,8 @@
 test_name "file resource: symbolic modes"
 confine :except, :platform => /^eos-/ # See ARISTA-37
+confine :except, :platform => /^solaris-10/
+confine :except, :platform => /^windows/
+confine :to, {}, hosts.select { |host| ! host[:roles].include?('master') }
 
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
@@ -176,14 +179,6 @@ end
 #     permissions locked while a program is accessing that file.
 #
 agents.each do |agent|
-  if agent['platform'].include?('windows')
-    Log.warn("Pending: this does not currently work on Windows")
-    next
-  end
-  if agent['platform'] =~ /solaris-10/
-    Log.warn("Pending: this does not currently work on Solaris 10")
-    next
-  end
   is_solaris = agent['platform'].include?('solaris')
 
   on(agent, puppet("resource user symuser ensure=present"))


### PR DESCRIPTION
This commit confines hosts eligible to be included in the execution
of the `resource/file/symbolic_modes` test.

It removes the master from the hosts list.
It also moves the logic to exclude windows and solaris-10 from
the body of the test and places them as confine statements at
the beginning.