### PR TITLE
(RE-6205) updating ruby for CVE-2015-7551

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -26,8 +26,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/hiera.git'
   sys:
     ref:
-      x86: 'refs/tags/1.9.3-p551.7'
-      x64: 'refs/tags/2.0.0.10-x64'
+      x86: 'refs/tags/1.9.3-p551.8'
+      x64: 'refs/tags/2.0.0.11-x64'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_signing_server: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
This will update ruby 2.0.0 and 1.9.3 for windows
per CVE at: https://tickets.puppetlabs.com/browse/RE-6141