### PR TITLE
(PUP-5712) Fix so that TypeParser can handle negative numbers

### DIFF
--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -96,6 +96,11 @@ class Puppet::Pops::Types::TypeParser
   end
 
   # @api private
+  def interpret_UnaryMinusExpression(o)
+    -@type_transformer.visit_this_0(self, o.expr)
+  end
+
+  # @api private
   def interpret_LiteralFloat(o)
     o.value
   end

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -163,6 +163,10 @@ describe Puppet::Pops::Types::TypeParser do
    expect(parser.parse("Integer[1,2]")).to be_the_type(types.range(1,2))
   end
 
+  it 'parses a negative integer range' do
+    expect(parser.parse("Integer[-3,-1]")).to be_the_type(types.range(-3,-1))
+  end
+
   it 'parses a float range' do
    expect(parser.parse("Float[1.0,2.0]")).to be_the_type(types.float_range(1.0,2.0))
   end


### PR DESCRIPTION
Prior to this commit, the TypeParser would not recognize an
UnaryMinusExpression and hence raise an error when one was encountered.
This commit ensures that an unary minus is handled correctly so that
types like `Integer[default, -1]` can be used in a function dispatch.