### PR TITLE
(PUP-5648) Add Iterable and Iterator to Puppet Type System

### DIFF
--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -106,12 +106,12 @@ Puppet::Functions.create_function(:each) do
   end
 
   dispatch :foreach_Enumerable_2 do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     block_param 'Callable[2,2]', :block
   end
 
   dispatch :foreach_Enumerable_1 do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     block_param 'Callable[1,1]', :block
   end
 
@@ -134,7 +134,7 @@ Puppet::Functions.create_function(:each) do
   end
 
   def foreach_Enumerable_1(enumerable)
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
       begin
         loop { yield(enum.next) }
       rescue StopIteration
@@ -144,7 +144,7 @@ Puppet::Functions.create_function(:each) do
   end
 
   def foreach_Enumerable_2(enumerable)
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     index = 0
     begin
       loop do
@@ -156,12 +156,4 @@ Puppet::Functions.create_function(:each) do
     # produces the receiver
     enumerable
   end
-
-  def asserted_enumerable(obj)
-    unless enum = Puppet::Pops::Types::Enumeration.enumerator(obj)
-      raise ArgumentError, ("#{self.class.name}(): wrong argument type (#{obj.class}; must be something enumerable.")
-    end
-    enum
-  end
-
 end

--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -3,7 +3,7 @@
 #
 # This function takes two mandatory arguments, in this order:
 #
-# 1. An array or hash the function will iterate over.
+# 1. An array, hash, or other iterable object that the function will iterate over.
 # 2. A lambda, which the function calls for each element in the first argument. It can
 # request one or two parameters.
 #

--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -80,12 +80,12 @@ Puppet::Functions.create_function(:filter) do
   end
 
   dispatch :filter_Enumerable_2 do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     block_param 'Callable[2,2]', :block
   end
 
   dispatch :filter_Enumerable_1 do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     block_param 'Callable[1,1]', :block
   end
 
@@ -105,8 +105,7 @@ Puppet::Functions.create_function(:filter) do
 
   def filter_Enumerable_1(enumerable)
     result = []
-    index = 0
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     begin
       loop do
         it = enum.next
@@ -122,7 +121,7 @@ Puppet::Functions.create_function(:filter) do
   def filter_Enumerable_2(enumerable)
     result = []
     index = 0
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     begin
       loop do
         it = enum.next
@@ -135,12 +134,4 @@ Puppet::Functions.create_function(:filter) do
     end
     result
   end
-
-  def asserted_enumerable(obj)
-    unless enum = Puppet::Pops::Types::Enumeration.enumerator(obj)
-      raise ArgumentError, ("#{self.class.name}(): wrong argument type (#{obj.class}; must be something enumerable.")
-    end
-    enum
-  end
-
 end

--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -4,7 +4,7 @@
 #
 # This function takes two mandatory arguments, in this order:
 #
-# 1. An array or hash the function will iterate over.
+# 1. An array, hash, or other iterable object that the function will iterate over.
 # 2. A lambda, which the function calls for each element in the first argument. It can
 # request one or two parameters.
 #

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -78,12 +78,12 @@ Puppet::Functions.create_function(:map) do
   end
 
   dispatch :map_Enumerable_2 do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     block_param 'Callable[2,2]', :block
   end
 
   dispatch :map_Enumerable_1 do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     block_param 'Callable[1,1]', :block
   end
 
@@ -98,7 +98,7 @@ Puppet::Functions.create_function(:map) do
   def map_Enumerable_1(enumerable)
     result = []
     index = 0
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     begin
       loop { result << yield(enum.next) }
     rescue StopIteration
@@ -109,7 +109,7 @@ Puppet::Functions.create_function(:map) do
   def map_Enumerable_2(enumerable)
     result = []
     index = 0
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     begin
       loop do
         result << yield(index, enum.next)
@@ -119,12 +119,4 @@ Puppet::Functions.create_function(:map) do
     end
     result
   end
-
-  def asserted_enumerable(obj)
-    unless enum = Puppet::Pops::Types::Enumeration.enumerator(obj)
-      raise ArgumentError, ("#{self.class.name}(): wrong argument type (#{obj.class}; must be something enumerable.")
-    end
-    enum
-  end
-
 end

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -3,7 +3,7 @@
 #
 # This function takes two mandatory arguments, in this order:
 #
-# 1. An array or hash the function will iterate over.
+# 1. An array, hash, or other iterable object that the function will iterate over.
 # 2. A lambda, which the function calls for each element in the first argument. It can
 # request one or two parameters.
 #

--- a/lib/puppet/functions/reduce.rb
+++ b/lib/puppet/functions/reduce.rb
@@ -6,7 +6,7 @@
 #
 # This function takes two mandatory arguments, in this order:
 #
-# 1. An array or hash the function will iterate over.
+# 1. An array, hash, or other iterable object that the function will iterate over.
 # 2. A lambda, which the function calls for each element in the first argument. It takes
 # two mandatory parameters:
 #     1. A memo value that is overwritten after each iteration with the iteration's result.

--- a/lib/puppet/functions/reduce.rb
+++ b/lib/puppet/functions/reduce.rb
@@ -99,31 +99,23 @@
 Puppet::Functions.create_function(:reduce) do
 
   dispatch :reduce_without_memo do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     block_param 'Callable[2,2]', :block
   end
 
   dispatch :reduce_with_memo do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     param 'Any', :memo
     block_param 'Callable[2,2]', :block
   end
 
   def reduce_without_memo(enumerable)
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     enum.reduce {|memo, x| yield(memo, x) }
   end
 
   def reduce_with_memo(enumerable, given_memo)
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     enum.reduce(given_memo) {|memo, x| yield(memo, x) }
   end
-
-  def asserted_enumerable(obj)
-    unless enum = Puppet::Pops::Types::Enumeration.enumerator(obj)
-      raise ArgumentError, ("#{self.class.name}(): wrong argument type (#{obj.class}; must be something enumerable.")
-    end
-    enum
-  end
-
 end

--- a/lib/puppet/functions/slice.rb
+++ b/lib/puppet/functions/slice.rb
@@ -38,7 +38,7 @@ Puppet::Functions.create_function(:slice) do
   end
 
   dispatch :slice_Enumerable do
-    param 'Any', :enumerable
+    param 'Iterable', :enumerable
     param 'Integer[1, default]', :slize_size
     optional_block_param
   end
@@ -49,7 +49,7 @@ Puppet::Functions.create_function(:slice) do
   end
 
   def slice_Enumerable(enumerable, slice_size, &pblock)
-    enum = asserted_enumerable(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     result = slice_Common(enum, slice_size, nil, block_given? ? pblock : nil)
     block_given? ? enumerable : result
   end
@@ -108,12 +108,4 @@ Puppet::Functions.create_function(:slice) do
     end
     serving_size
   end
-
-  def asserted_enumerable(obj)
-    unless enum = Puppet::Pops::Types::Enumeration.enumerator(obj)
-      raise ArgumentError, ("#{self.class.name}(): wrong argument type (#{obj.class}; must be something enumerable.")
-    end
-    enum
-  end
-
 end

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -34,14 +34,6 @@ module Puppet
 
     # (the Types module initializes itself)
     require 'puppet/pops/types/types'
-    require 'puppet/pops/types/type_asserter'
-    require 'puppet/pops/types/type_assertion_error'
-    require 'puppet/pops/types/type_calculator'
-    require 'puppet/pops/types/type_factory'
-    require 'puppet/pops/types/type_parser'
-    require 'puppet/pops/types/class_loader'
-    require 'puppet/pops/types/enumeration'
-    require 'puppet/pops/types/type_mismatch_describer'
 
     require 'puppet/pops/merge_strategy'
 

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -88,6 +88,11 @@ class Runtime3Converter
   end
   alias :convert2_Hash :convert_Hash
 
+  def convert_Iterator(o, scope, undef_value)
+    raise Puppet::Error, 'Use of an Iterator is not supported here'
+  end
+  alias :convert2_Iterator :convert_Iterator
+
   def convert_Regexp(o, scope, undef_value)
     # Puppet 3x cannot handle parameter values that are reqular expressions. Turn into regexp string in
     # source form

--- a/lib/puppet/pops/types/enumeration.rb
+++ b/lib/puppet/pops/types/enumeration.rb
@@ -1,33 +1,16 @@
 # The Enumeration class provides default Enumerable::Enumerator creation for Puppet Programming Language
 # runtime objects that supports the concept of enumeration.
 #
-class Puppet::Pops::Types::Enumeration
-  # Produces an Enumerable::Enumerator for Array, Hash, Integer, Integer Range, and String.
-  #
-  def self.enumerator(o)
-    @@singleton ||= new
-    @@singleton.enumerator(o)
-  end
+module Puppet::Pops::Types
+  class Enumeration
+    def self.enumerator(o)
+      Puppet.deprecation_warning('Enumeration.enumerator is deprecated. Use Iterable.on instead')
+      Iterable.on(o)
+    end
 
-  # Produces an Enumerator for Array, Hash, Integer, Integer Range, and String.
-  #
-  def enumerator(o)
-    case o
-    when String
-      x = o.chars
-      # Ruby 1.9.3 returns an Enumerator, and 2.0.0 an Array
-      x.is_a?(Array) ? x.each : x
-    when Integer
-      o.times
-    when Array
-      o.each
-    when Hash
-      o.each
-    when Puppet::Pops::Types::PIntegerType
-      # Not enumerable if representing an infinite range
-      o.enumerable? ? o.each : nil
-    else
-      nil
+    def enumerator(o)
+      Puppet.deprecation_warning('Enumeration.enumerator is deprecated. Use Iterable.on instead')
+      Iterable.on(o)
     end
   end
 end

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -84,7 +84,7 @@ module Puppet::Pops::Types
         max = o.max
         if min.is_a?(Integer) && max.is_a?(Integer) && max >= min
           IntegerRangeIterator.new(PIntegerType.new(min, max))
-        elsif min.is_a?(String) && max.is_a?(String) && max > min
+        elsif min.is_a?(String) && max.is_a?(String) && max >= min
           # A generalized element type where only the size is inferred is used here since inferring the full
           # range might waste a lot of memory.
           if min.length < max.length

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -1,0 +1,291 @@
+module Puppet::Pops::Types
+  # The runtime Iterable type for an Iterable
+  module Iterable
+    # Produces an `Iterable` for one of the following types with the following characterstics:
+    #
+    # `String`       - yields each character in the string
+    # `Array`        - yields each element in the array
+    # `Hash`         - yields each key/value pair as a two element array
+    # `Integer`      - when positive, yields each value from zero to the given number
+    # `PIntegerType` - yields each element from min to max (inclusive) provided min < max and neither is unbounded.
+    # `PEnumtype`    - yields each possible value of the enum.
+    # `Range`        - yields an iterator for all elements in the range provided that the range start and end
+    #                  are both integers or both strings and start is less than end using natural ordering.
+    # `Dir`          - yields each name in the directory
+    #
+    # An `ArgumentError` is raised for all other objects.
+    #
+    # @param o [Object] The object to produce an `Iterable` for
+    # @return [Iterable,nil] The produced `Iterable` or `nil` if it couldn't be produced
+    # @raise [ArgumentError] In case an `Iterable` cannot be produced
+    # @api public
+    def self.asserted_iterable(caller, obj)
+      iter = self.on(obj)
+      raise ArgumentError, "#{caller.class}(): wrong argument type (#{obj.class}; is not Iterable." if iter.nil?
+      iter
+    end
+
+    # Produces an `Iterable` for one of the following types with the following characterstics:
+    #
+    # `String`       - yields each character in the string
+    # `Array`        - yields each element in the array
+    # `Hash`         - yields each key/value pair as a two element array
+    # `Integer`      - when positive, yields each value from zero to the given number
+    # `PIntegerType` - yields each element from min to max (inclusive) provided min < max and neither is unbounded.
+    # `PEnumtype`    - yields each possible value of the enum.
+    # `Range`        - yields an iterator for all elements in the range provided that the range start and end
+    #                  are both integers or both strings and start is less than end using natural ordering.
+    # `Dir`          - yields each name in the directory
+    #
+    # The value `nil` is returned for all other objects.
+    #
+    # @param o [Object] The object to produce an `Iterable` for
+    # @return [Iterable,nil] The produced `Iterable` or `nil` if it couldn't be produced
+    #
+    # @api public
+    def self.on(o)
+      case o
+      when Iterable
+        o
+      when String
+        Iterator.new(PStringType.new(PIntegerType.new(1, 1)), o.each_char)
+      when Array
+        tc = TypeCalculator.singleton
+        Iterator.new(tc.unwrap_single_variant(PVariantType.new(o.map {|e| tc.infer_set(e) })), o.each)
+      when Hash
+        # Each element is a two element [key, value] tuple.
+        tc = TypeCalculator.singleton
+        Iterator.new(PTupleType.new([
+          tc.unwrap_single_variant(PVariantType.new(o.keys.map {|e| tc.infer_set(e) })),
+          tc.unwrap_single_variant(PVariantType.new(o.values.map {|e| tc.infer_set(e) }))], PIntegerType.new(2,2)), o.each_pair)
+      when Integer
+        o > 0 ? IntegerRangeIterator.new(PIntegerType.new(0, o - 1)) : nil
+      when PIntegerType
+        o.enumerable? ? IntegerRangeIterator.new(o) : nil
+      when PEnumType
+        Iterator.new(o, o.values)
+      when Range
+        min = o.min
+        max = o.max
+        if min.is_a?(Integer) && max.is_a?(Integer) && max > min
+          IntegerRangeIterator.new(PIntegerType.new(min, max))
+        elsif min.is_a?(String) && max.is_a?(String) && max > min
+          # A generalized element type where only the size is inferred is used here since inferring the full
+          # range might waste a lot of memory.
+          if min.length < max.length
+            shortest = min
+            longest = max
+          else
+            shortest = max
+            longest = min
+          end
+          Iterator.new(PStringType.new(PIntegerType.new(shortest.length, longest.length)), o.each)
+        else
+          # Unsupported range. It's either descending or nonsensical for other reasons (float, mixed types, etc.)
+          nil
+        end
+      when Dir
+        # Enumerable over file names
+        Iterator.new(PStringType::NON_EMPTY, o.each)
+      else
+        # Not supported. We cannot determine the element type
+        nil
+      end
+    end
+
+    # Answers the question if there is an end to the iteration. Puppet does not currently provide any unbounded
+    # iterables.
+    #
+    # @return [Boolean] `true` if the iteration is unbounded
+    def self.unbounded?(object)
+      case object
+      when Iterable
+        object.unbounded?
+      when String,Integer,Array,Hash,Enumerator,PIntegerType,PEnumType,Dir
+        false
+      else
+        TypeAsserter.assert_instance_of('', PIterableType::DEFAULT, object, false)
+        !object.respond_to?(:size)
+      end
+    end
+
+    def each(&block)
+      step(1, &block)
+    end
+
+    def element_type
+      PAnyType::DEFAULT
+    end
+
+    def reverse_each(&block)
+      # Default implementation cannot propagate reverse_each to a new enumerator so chained
+      # calls must put reverse_each last.
+      raise ArgumentError 'Step is not implemented'
+    end
+
+    def step(step, &block)
+      # Default implementation cannot propagate step to a new enumerator so chained
+      # calls must put stepping last.
+      raise ArgumentError 'Step is not implemented'
+    end
+
+    def to_a
+      raise Puppet::Error, 'Attempt to create an Array from an unbounded Iterable' if unbounded?
+      super
+    end
+
+    def unbounded?
+      true
+    end
+  end
+
+  # @api private
+  class Iterator
+    # Note! We do not include Enumerable module here since that would make this class respond
+    # in a bad way to all enumerable methods. We want to delegate all those calls directly to
+    # the contained @enumeration
+    include Iterable
+
+    def initialize(element_type, enumeration)
+      @element_type = element_type
+      @enumeration = enumeration
+    end
+
+    def element_type
+      @element_type
+    end
+
+    def size
+      @enumeration.size
+    end
+
+    def respond_to_missing?(name, include_private)
+      @enumeration.respond_to?(name, include_private)
+    end
+
+    def method_missing(name, *arguments, &block)
+      @enumeration.send(name, *arguments, &block)
+    end
+
+    def step(step, &block)
+      raise ArgumentError if step <= 0
+      r = self
+      r = r.step_iterator(step) if step > 1
+
+      if block_given?
+        begin
+        if block.arity == 1
+          loop { yield(r.next) }
+        else
+          loop { yield(*r.next) }
+        end
+        rescue StopIteration
+        end
+        self
+      else
+        r
+      end
+    end
+
+    def reverse_each(&block)
+      r = Iterator.new(@element_type, @enumeration.reverse_each)
+      block_given? ? r.each(&block) : r
+    end
+
+    def step_iterator(step)
+      StepIterator.new(@element_type, self, step)
+    end
+
+    def unbounded?
+      Iterable.unbounded?(@enumeration)
+    end
+  end
+
+  # @api private
+  class StepIterator < Iterator
+    include Enumerable
+
+    def initialize(element_type, enumeration, step_size)
+      super(element_type, enumeration)
+      raise ArgumentError if step_size <= 0
+      @step_size = step_size
+    end
+
+    def next
+      result = @enumeration.next
+      skip = @step_size - 1
+      if skip > 0
+        begin
+          skip.times { @enumeration.next }
+        rescue StopIteration
+        end
+      end
+      result
+    end
+
+    def reverse_each(&block)
+      r = Iterator.new(@element_type, to_a.reverse_each)
+      block_given? ? r.each(&block) : r
+    end
+
+    def size
+      super / @step_size
+    end
+  end
+
+  # @api private
+  class IntegerRangeIterator < Iterator
+    include Enumerable
+
+    def initialize(range, step = 1)
+      raise ArgumentError if step == 0
+      @range = range
+      @step_size = step
+      @current = (step < 0 ? range.to : range.from) - step
+    end
+
+    def element_type
+      @range
+    end
+
+    def next
+      value = @current + @step_size
+      if @step_size < 0
+        raise StopIteration if value < @range.from
+      else
+        raise StopIteration if value > @range.to
+      end
+      @current = value
+    end
+
+    def reverse_each(&block)
+      r = IntegerRangeIterator.new(@range, -@step_size)
+      block_given? ? r.each(&block) : r
+    end
+
+    def size
+      (@range.to - @range.from) / @step_size.abs
+    end
+
+    def step_iterator(step)
+      # The step iterator must use a range that has its logical end truncated at an even step boundary. This will
+      # fulfil two objectives:
+      # 1. The element_type method should not report excessive integers as possible numbers
+      # 2. A reversed iterator must start at the correct number
+      #
+      range = @range
+      step = @step_size * step
+      mod = (range.to - range.from) % step
+      if mod < 0
+        range = PIntegerType.new(range.from - mod, range.to)
+      elsif mod > 0
+        range = PIntegerType.new(range.from, range.to - mod)
+      end
+      IntegerRangeIterator.new(range, step)
+    end
+
+    def unbounded?
+      false
+    end
+  end
+end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -533,6 +533,11 @@ class Puppet::Pops::Types::TypeCalculator
   end
 
   # @api private
+  def infer_Iterator(o)
+    Types::PIteratorType.new(o.element_type)
+  end
+
+  # @api private
   def infer_Function(o)
     o.class.dispatcher.to_type
   end
@@ -794,6 +799,24 @@ class Puppet::Pops::Types::TypeCalculator
       'Integer'
     else
       "Integer[#{range.join(', ')}]"
+    end
+  end
+
+  # @api private
+  def string_PIterableType(t)
+    if t.element_type.nil?
+      'Iterable'
+    else
+      "Iterable[#{string(t.element_type)}]"
+    end
+  end
+
+  # @api private
+  def string_PIteratorType(t)
+    if t.element_type.nil?
+      'Iterator'
+    else
+      "Iterator[#{string(t.element_type)}]"
     end
   end
 

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -147,7 +147,13 @@ class Puppet::Pops::Types::TypeCalculator
 
   # @api public
   def self.enumerable(t)
-    singleton.enumerable(t)
+    Puppet.deprecation_warning('TypeCalculator.enumerable is deprecated. Use iterable')
+    singleton.iterable(t)
+  end
+
+  # @api public
+  def self.iterable(t)
+    singleton.iterable(t)
   end
 
   # @return [TypeCalculator] the singleton instance
@@ -201,10 +207,16 @@ class Puppet::Pops::Types::TypeCalculator
     t.is_a?(Types::PAnyType) ? t.assignable?(t2) : false
  end
 
-  # Returns an enumerable if the t represents something that can be iterated
+  # Returns an iterable if the t represents something that can be iterated
   def enumerable(t)
-    # Only PIntegerTypes are enumerable and only if not representing an infinite range
-    t.is_a?(Types::PIntegerType) && t.size < Float::INFINITY ? t : nil
+    Puppet.deprecation_warning('TypeCalculator.enumerable is deprecated. Use iterable')
+    iterable(t)
+  end
+
+  # Returns an iterable if the t represents something that can be iterated
+  def iterable(t)
+    # Create an iterable on the type if possible
+    Types::Iterable.on(t)
   end
 
   # Answers, does the given callable accept the arguments given in args (an array or a tuple)

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -46,6 +46,20 @@ module Puppet::Pops::Types::TypeFactory
     Types::PNumericType::DEFAULT
   end
 
+  # Produces the Iterable type
+  # @api public
+  #
+  def self.iterable(elem_type = nil)
+    elem_type.nil? ? Types::PIterableType::DEFAULT : Types::PIterableType.new(elem_type)
+  end
+
+  # Produces the Iterator type
+  # @api public
+  #
+  def self.iterator(elem_type = nil)
+    elem_type.nil? ? Types::PIteratorType::DEFAULT : Types::PIteratorType.new(elem_type)
+  end
+
   # Produces a string representation of the type
   # @api public
   #

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -126,6 +126,12 @@ class Puppet::Pops::Types::TypeParser
     when 'numeric'
         TYPES.numeric
 
+    when 'iterable'
+      TYPES.iterable
+
+    when 'iterator'
+      TYPES.iterator
+
     when 'string'
       TYPES.string
 
@@ -361,6 +367,20 @@ class Puppet::Pops::Types::TypeParser
      else
        TYPES.range(parameters[0] == :default ? nil : parameters[0], parameters[1] == :default ? nil : parameters[1])
      end
+
+    when 'iterable'
+      if parameters.size != 1
+        raise_invalid_parameters_error('Iterable', 1, parameters.size)
+      end
+      assert_type(parameters[0])
+      TYPES.iterable(parameters[0])
+
+    when 'iterator'
+      if parameters.size != 1
+        raise_invalid_parameters_error('Iterator', 1, parameters.size)
+      end
+      assert_type(parameters[0])
+      TYPES.iterator(parameters[0])
 
     when 'float'
       if parameters.size == 1

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1,3 +1,13 @@
+require_relative 'iterable'
+require_relative 'enumeration'
+require_relative 'type_asserter'
+require_relative 'type_assertion_error'
+require_relative 'type_calculator'
+require_relative 'type_factory'
+require_relative 'type_parser'
+require_relative 'class_loader'
+require_relative 'type_mismatch_describer'
+
 require 'rgen/metamodel_builder'
 
 # The Types model is a model of Puppet Language types.
@@ -66,13 +76,7 @@ module Puppet::Pops
         false
       end
 
-      # Subclasses that are enumerable will override this method to return `true`
-      # @return [Boolean] false#
-      def enumerable?
-        is_a?(Enumerable)
-      end
-
-      # Generalizes value specific types. Types that are not value specific will return `self` otherwize
+      # Generalizes value specific types. Types that are not value specific will return `self` otherwise
       # the generalized type is returned.
       #
       # @return [PAnyType] The generalized type
@@ -88,6 +92,29 @@ module Puppet::Pops
       # @api private
       def kind_of_callable?(optional=true)
         false
+      end
+
+      # Returns `true` if an instance of this type is iterable, `false` otherwise
+      # The method #iterable_type must produce a `PIterableType` instance when this
+      # method returns `true`
+      #
+      # @return [Boolean] flag to indicate if instances of  this type is iterable.
+      def iterable?
+        false
+      end
+
+      # Returns the `PIterableType` that this type should be assignable to to, or `nil` if no such type exists.
+      # A type that returns a `PIterableType` must respond `true` to `#iterable?`.
+      #
+      # Any Collection[T] is assignable to an Iterable[T]
+      # A String is assignable to an Iterable[String] iterating over the strings characters
+      # An Integer is assignable to an Iterable[Integer] iterating over the 'times' enumerator
+      # A Type[T] is assignabel to an Iterable[Type[T]] if T is an Integer or Enum
+      #
+      # @return [PIterableType,nil] The iterable type that this type is assignable to or `nil`
+      # @api private
+      def iterable_type
+        nil
       end
 
       def hash
@@ -201,6 +228,29 @@ module Puppet::Pops
 
       def hash
         31 * @type.hash
+      end
+
+      def iterable?
+        case @type
+        when PEnumType
+          true
+        when PIntegerType
+          @type.enumerable?
+        else
+          false
+        end
+      end
+
+      def iterable_type
+        # The types PIntegerType and PEnumType are Iterable
+        case @type
+        when PEnumType
+          @type.each
+        when PIntegerType
+          @type.enumerable? ? @type.each : nil
+        else
+          nil
+        end
       end
 
       def ==(o)
@@ -368,8 +418,6 @@ module Puppet::Pops
     # @api public
     #
     class PEnumType < PScalarType
-      include Enumerable
-
       attr_reader :values
 
       def initialize(values)
@@ -378,12 +426,17 @@ module Puppet::Pops
 
       # Returns Enumerator if no block is given, otherwise, calls the given
       # block with each of the strings for this enum
-      def each
-        if block_given?
-          values.each { |x| yield x }
-        else
-          values.to_enum
-        end
+      def each(&block)
+        r = Iterable.on(self)
+        block_given? ? r.each(&block) : r
+      end
+
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        PIterableType.new(PStringType::DEFAULT)
       end
 
       def hash
@@ -483,9 +536,10 @@ module Puppet::Pops
     # @api public
     #
     class PIntegerType < PNumericType
-      # The integer type is enumerable when it defines a range
-      include Enumerable
-
+      # Answers the question, "is this instance of PIntegerType enumerable?" (as opposed to if instances described by
+      # this type is enumerable). Will respond `true` for any range that is bounded at both ends.
+      #
+      # @return [Boolean] `true` if the type is enumerable.
       def enumerable?
         @from != -Float::INFINITY && @to != Float::INFINITY
       end
@@ -496,6 +550,15 @@ module Puppet::Pops
 
       def instance?(o)
         o.is_a?(Integer) && o >= numeric_from && o <= numeric_to
+      end
+
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        # It's unknown if the iterable will be a range (min, max) or a "times" (0, max)
+        PIterableType.new(PIntegerType::DEFAULT)
       end
 
       # Returns Float.Infinity if one end of the range is unbound
@@ -512,12 +575,9 @@ module Puppet::Pops
 
       # Returns Enumerator if no block is given
       # Returns nil if size is infinity (does not yield)
-      def each
-        if block_given?
-          enumerable? ? @from.upto(@to) { |x| yield x } : nil
-        else
-          to_enum
-        end
+      def each(&block)
+        r = Iterable.on(self)
+        block_given? ? r.each(&block) : r
       end
 
       # Returns a range where both to and from are positive numbers. Negative
@@ -571,6 +631,14 @@ module Puppet::Pops
         @element_type.hash * 31 + @size_type.hash
       end
 
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        PIterableType.new(element_type)
+      end
+
       def ==(o)
         self.class == o.class && @element_type == o.element_type && @size_type == o.size_type
       end
@@ -603,6 +671,111 @@ module Puppet::Pops
       end
     end
 
+    class PIterableType < PAnyType
+      attr_reader :element_type
+
+      def initialize(type)
+        @element_type = type
+      end
+
+      def instance?(o)
+        if @element_type.nil? || @element_type.assignable?(PAnyType::DEFAULT)
+          # Any element_type will do
+          case o
+          when Iterable, String, Hash, Enumerable, Enumerator, Range, PEnumType
+            true
+          when Integer
+            o > 0
+          when PIntegerType
+            o.enumerable?
+          else
+            false
+          end
+        else
+          assignable?(TypeCalculator.infer(o))
+        end
+      end
+
+      def generalize
+        @element_type.nil? ? DEFAULT : PIterableType.new(@element_type.generalize)
+      end
+
+      def hash
+        67 * @element_type.hash
+      end
+
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        self
+      end
+
+      def ==(o)
+        self.class == o.class && @element_type == o.element_type
+      end
+
+      DEFAULT = PIterableType.new(nil)
+
+      protected
+
+      # @api private
+      def _assignable?(o)
+        if @element_type.nil? || @element_type.assignable?(PAnyType::DEFAULT)
+          # Don't request the iterable_type since it might be expensive to compute the
+          # type of its elements
+          o.iterable?
+        else
+          o = o.iterable_type
+          o.nil? || o.element_type.nil? ? false : @element_type.assignable?(o.element_type)
+        end
+      end
+    end
+
+    # @api public
+    #
+    class PIteratorType < PAnyType
+      attr_reader :element_type
+
+      def initialize(type)
+        @element_type = type
+      end
+
+      def instance?(o)
+        o.is_a?(Iterable) && (@element_type.nil? || @element_type.assignable?(o.element_type))
+      end
+
+      def generalize
+        @element_type.nil? ? DEFAULT : PIteratorType.new(@element_type.generalize)
+      end
+
+      def hash
+        71 * @element_type.hash
+      end
+
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        element_type.nil? ? PIteratbleType::DEFAULT : PIterableType.new(@element_type)
+      end
+
+      def ==(o)
+        self.class == o.class && @element_type == o.element_type
+      end
+
+      DEFAULT = PIteratorType.new(nil)
+
+      protected
+
+      # @api private
+      def _assignable?(o)
+        o.is_a?(PIteratorType) && (@element_type.nil? || @element_type.assignable?(o.element_type))
+      end
+    end
+
     # @api public
     #
     class PStringType < PScalarType
@@ -619,6 +792,14 @@ module Puppet::Pops
 
       def hash
         @size_type.hash * 31 + @values.hash
+      end
+
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        PIterableType.new(PStringType::DEFAULT)
       end
 
       def ==(o)
@@ -840,9 +1021,24 @@ module Puppet::Pops
       def hashed_elements
         @hashed ||= @elements.reduce({}) {|memo, e| memo[e.name] = e; memo }
       end
- 
+
       def hash
         @elements.hash
+      end
+
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        if self == DEFAULT
+          PIterableType.new(PTupleType.new([PAnyType::DEFAULT], PHashType::TUPLE_SIZE))
+        else
+          tc = TypeCalculator.singleton
+          key_type = tc.infer_and_reduce_type(@elements.map {|se| se.key_type })
+          value_type = tc.infer_and_reduce_type(@elements.map {|se| se.value_type })
+          PIterableType.new(PTupleType.new([key_type, value_type], PHashType::TUPLE_SIZE))
+        end
       end
 
       def ==(o)
@@ -981,6 +1177,14 @@ module Puppet::Pops
           return false unless (types[index] || types[-1]).instance?(element)
         end
         true
+      end
+
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        PIterableType.new(TypeCalculator.singleton.infer_and_reduce_type(types))
       end
 
       # Returns the number of elements accepted [min, max] in the tuple
@@ -1263,6 +1467,18 @@ module Puppet::Pops
         end
       end
 
+      def iterable?
+        true
+      end
+
+      def iterable_type
+        if self == DEFAULT || self == EMPTY
+          PIterableType.new(PTupleType.new([PAnyType::DEFAULT], TUPLE_SIZE))
+        else
+          PIterableType.new(PTupleType.new([@key_type, element_type], TUPLE_SIZE))
+        end
+      end
+
       def ==(o)
         super && @key_type == o.key_type
       end
@@ -1272,6 +1488,7 @@ module Puppet::Pops
       end
 
       DEFAULT = PHashType.new(nil, nil)
+      TUPLE_SIZE = PIntegerType.new(2,2)
       DATA = PHashType.new(PScalarType::DEFAULT, PDataType::DEFAULT, DEFAULT_SIZE)
       EMPTY = PHashType.new(PUndefType::DEFAULT, PUndefType::DEFAULT, PIntegerType.new(0, 0))
 
@@ -1307,8 +1524,9 @@ module Puppet::Pops
 
       attr_reader :types
 
+      # @param types [Array[PAnyType]] the variants
       def initialize(types)
-        @types = types.freeze
+        @types = types.uniq.freeze
       end
 
       def each
@@ -1392,6 +1610,15 @@ module Puppet::Pops
 
       def instance?(o)
         assignable?(TypeCalculator.infer(o))
+      end
+
+      def iterable?
+        c = class_from_string(@runtime_type_name)
+        c.nil? ? false : c < Enumerable || c < Iterable
+      end
+
+      def iterable_type
+        iterable? ? PIterableType.new(self) : nil
       end
 
       DEFAULT = PRuntimeType.new(nil)

--- a/spec/shared_behaviours/iterative_functions.rb
+++ b/spec/shared_behaviours/iterative_functions.rb
@@ -16,7 +16,7 @@ shared_examples_for 'all iterative functions argument checks' do |func|
       compile_to_catalog(<<-MANIFEST)
         3.14.#{func} |$k, $v| {  }
       MANIFEST
-    end.to raise_error(Puppet::Error, /must be something enumerable/)
+    end.to raise_error(Puppet::Error, /expects an Iterable value, got Float/)
   end
 
   it 'raises an error when called with any parameters besides a block' do

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -16,4 +16,10 @@ describe 'when converting to 3.x' do
     converted = Puppet::Pops::Evaluator::Runtime3Converter.instance.catalog_type_to_split_type_title(t)
     expect(converted).to eql(['class', 'kermit'])
   end
+
+  it "errors on attempts to convert an 'Iterator'" do
+    expect {
+      Puppet::Pops::Evaluator::Runtime3Converter.convert(Puppet::Pops::Types::Iterable.on((1..3)), {}, nil)
+    }.to raise_error(Puppet::Error, /Use of an Iterator is not supported here/)
+  end
 end

--- a/spec/unit/pops/types/iterable_spec.rb
+++ b/spec/unit/pops/types/iterable_spec.rb
@@ -1,0 +1,229 @@
+require 'spec_helper'
+require 'puppet/pops'
+
+module Puppet::Pops::Types
+describe 'The iterable support' do
+
+  [5, (3..10), %w(a b c), 'hello', PIntegerType.new(1, 4), PEnumType.new(%w(yes no)) ].each do |obj|
+    it "should consider instances of #{obj.class.name} to be Iterable" do
+      expect(PIterableType::DEFAULT.instance?(obj)).to eq(true)
+    end
+
+    it "should yield an Iterable instance when Iterable.on is called with a #{obj.class.name}" do
+      expect(Iterable.on(obj)).to be_a(Iterable)
+    end
+  end
+
+  { -1 => 'a negative Integer', 0 => 'the value 0', PIntegerType.new(nil, nil) => 'an unbounded Integer type' }.each_pair do |obj, desc|
+    it "does not consider #{desc} to be Iterable" do
+      expect(PIterableType::DEFAULT.instance?(obj)).to eq(false)
+    end
+
+    it "does not yield an Iterable when Iterable.on is called with #{desc}" do
+      expect(Iterable.on(obj)).to be_nil
+    end
+  end
+
+  context 'when testing assignability' do
+    iterable_types = [
+      PIntegerType::DEFAULT,
+      PStringType::DEFAULT,
+      PIterableType::DEFAULT,
+      PIteratorType::DEFAULT,
+      PCollectionType::DEFAULT,
+      PArrayType::DEFAULT,
+      PHashType::DEFAULT,
+      PTupleType::DEFAULT,
+      PStructType::DEFAULT,
+      PUnitType::DEFAULT
+    ]
+    iterable_types << PType.new(PIntegerType.new(0, 10))
+    iterable_types << PType.new(PEnumType.new(%w(yes no)))
+    iterable_types << PRuntimeType.new(:ruby, 'Dir') # Enumerable
+    iterable_types << PVariantType.new(iterable_types.clone)
+
+    not_iterable_types = [
+      PAnyType::DEFAULT,
+      PBooleanType::DEFAULT,
+      PCallableType::DEFAULT,
+      PCatalogEntryType::DEFAULT,
+      PDataType::DEFAULT,
+      PDefaultType::DEFAULT,
+      PFloatType::DEFAULT,
+      PHostClassType::DEFAULT,
+      PNotUndefType::DEFAULT,
+      PNumericType::DEFAULT,
+      POptionalType::DEFAULT,
+      PPatternType::DEFAULT,
+      PRegexpType::DEFAULT,
+      PResourceType::DEFAULT,
+      PRuntimeType::DEFAULT,
+      PScalarType::DEFAULT,
+      PType::DEFAULT,
+      PUndefType::DEFAULT
+    ]
+    not_iterable_types << PType.new(PIntegerType::DEFAULT)
+    not_iterable_types << PVariantType.new([iterable_types[0], not_iterable_types[0]])
+
+    iterable_types.each do |type|
+      it "should consider #{type} to be assignable to Iterable type" do
+        expect(PIterableType::DEFAULT.assignable?(type)).to eq(true)
+      end
+    end
+
+    not_iterable_types.each do |type|
+      it "should not consider #{type} to be assignable to Iterable type" do
+        expect(PIterableType::DEFAULT.assignable?(type)).to eq(false)
+      end
+    end
+  end
+
+  it 'does not wrap an Iterable in another Iterable' do
+    x = Iterable.on(5)
+    expect(Iterable.on(x)).to equal(x)
+  end
+
+  it 'produces a "times" iterable on integer' do
+    expect{ |b| Iterable.on(3).each(&b) }.to yield_successive_args(0,1,2)
+  end
+
+  it 'produces an iterable with element type Integer[0,X-1] for an iterable on an integer X' do
+    expect(Iterable.on(3).element_type).to eq(PIntegerType.new(0,2))
+  end
+
+  it 'produces a step iterable on an integer' do
+    expect{ |b| Iterable.on(8).step(3, &b) }.to yield_successive_args(0, 3, 6)
+  end
+
+  it 'produces a reverse iterable on an integer' do
+    expect{ |b| Iterable.on(5).reverse_each(&b) }.to yield_successive_args(4,3,2,1,0)
+  end
+
+  it 'produces an iterable on a integer range' do
+    expect{ |b| Iterable.on(2..7).each(&b) }.to yield_successive_args(2,3,4,5,6,7)
+  end
+
+  it 'produces an iterable with element type Integer[X,Y] for an iterable on an integer range (X..Y)' do
+    expect(Iterable.on(2..7).element_type).to eq(PIntegerType.new(2,7))
+  end
+
+  it 'produces an iterable on a character range' do
+    expect{ |b| Iterable.on('a'..'f').each(&b) }.to yield_successive_args('a', 'b', 'c', 'd', 'e', 'f')
+  end
+
+  it 'produces a step iterable on a range' do
+    expect{ |b| Iterable.on(1..5).step(2, &b) }.to yield_successive_args(1,3,5)
+  end
+
+  it 'produces a reverse iterable on a range' do
+    expect{ |b| Iterable.on(2..7).reverse_each(&b) }.to yield_successive_args(7,6,5,4,3,2)
+  end
+
+  it 'produces an iterable with element type String with a size constraint for an iterable on a character range' do
+    expect(Iterable.on('a'..'fe').element_type).to eq(PStringType.new(PIntegerType.new(1,2)))
+  end
+
+  it 'produces an iterable on a bounded Integer type' do
+    expect{ |b| Iterable.on(PIntegerType.new(2,7)).each(&b) }.to yield_successive_args(2,3,4,5,6,7)
+  end
+
+  it 'produces an iterable with element type Integer[X,Y] for an iterable on Integer[X,Y]' do
+    expect(Iterable.on(PIntegerType.new(2,7)).element_type).to eq(PIntegerType.new(2,7))
+  end
+
+  it 'produces an iterable on String' do
+    expect{ |b| Iterable.on('eat this').each(&b) }.to yield_successive_args('e', 'a', 't', ' ', 't', 'h', 'i', 's')
+  end
+
+  it 'produces an iterable with element type String[1,1] for an iterable created on a String' do
+    expect(Iterable.on('eat this').element_type).to eq(PStringType.new(PIntegerType.new(1,1)))
+ end
+
+  it 'produces an iterable on Array' do
+    expect{ |b| Iterable.on([1,5,9]).each(&b) }.to yield_successive_args(1,5,9)
+  end
+
+  it 'produces an iterable with element type inferred from the array elements for an iterable on Array' do
+    expect(Iterable.on([1,5,5,9,9,9]).element_type).to eq(PVariantType.new([PIntegerType.new(1,1), PIntegerType.new(5,5), PIntegerType.new(9,9)]))
+  end
+
+  it 'can chain reverse_each after step on Enumerator' do
+    expect{ |b| Iterable.on(6).step(2).reverse_each(&b) }.to yield_successive_args(4,2,0)
+  end
+
+  it 'can chain reverse_each after step on Integer range' do
+    expect{ |b| Iterable.on(PIntegerType.new(0, 5)).step(2).reverse_each(&b) }.to yield_successive_args(4,2,0)
+  end
+
+  it 'can chain step after reverse_each on Enumerator' do
+    expect{ |b| Iterable.on(6).reverse_each.step(2, &b) }.to yield_successive_args(5,3,1)
+  end
+
+  it 'can chain step after reverse_each on Integer range' do
+    expect{ |b| Iterable.on(PIntegerType.new(0, 5)).reverse_each.step(2, &b) }.to yield_successive_args(5,3,1)
+  end
+
+  it 'will produce the same result for each as for reverse_each.reverse_each' do
+    x1 = Iterable.on(5)
+    x2 = Iterable.on(5)
+    expect(x1.inject([]) { |a,i| a << i; a}).to eq(x2.reverse_each.reverse_each.inject([]) { |a,i| a << i; a})
+  end
+
+  it 'can chain many nested step/reverse_each calls' do
+    # x = Iterable.on(18).step(3) (0, 3, 6, 9, 12, 15)
+    # x = x.reverse_each (15, 12, 9, 6, 3, 0)
+    # x = x.step(2) (15, 9, 3)
+    # x = x.reverse_each(3, 9, 15)
+    expect{ |b| Iterable.on(18).step(3).reverse_each.step(2).reverse_each(&b) }.to yield_successive_args(3, 9, 15)
+  end
+
+  it 'can chain many nested step/reverse_each calls on Array iterable' do
+    expect{ |b| Iterable.on(18.times.to_a).step(3).reverse_each.step(2).reverse_each(&b) }.to yield_successive_args(3, 9, 15)
+  end
+
+  it 'produces an steppable iterable for Array' do
+    expect{ |b| Iterable.on(%w(a b c d e f g h i)).step(3, &b) }.to yield_successive_args('a', 'd', 'g')
+  end
+
+  it 'produces an reverse steppable iterable for Array' do
+    expect{ |b| Iterable.on(%w(a b c d e f g h i)).reverse_each.step(3, &b) }.to yield_successive_args('i', 'f', 'c')
+  end
+
+  it 'responds false when a bounded Iterable is passed to Iterable.unbounded?' do
+    expect(Iterable.unbounded?(Iterable.on(%w(a b c d e f g h i)))).to eq(false)
+  end
+
+  it 'can create an Array from a bounded Iterable' do
+    expect(Iterable.on(%w(a b c d e f g h i)).to_a).to eq(%w(a b c d e f g h i))
+  end
+
+  class TestUnboundedIterator
+    include Enumerable
+    include Iterable
+
+     def step(step_size)
+      if block_given?
+        begin
+          current = 0
+          loop do
+            yield(@current)
+            current = current + step_size
+          end
+        rescue StopIteration
+        end
+      end
+      self
+    end
+  end
+
+  it 'responds true when an unbounded Iterable is passed to Iterable.unbounded?' do
+    ubi = TestUnboundedIterator.new
+    expect(Iterable.unbounded?(Iterable.on(ubi))).to eq(true)
+  end
+
+  it 'can not create an Array from an unbounded Iterable' do
+    ubi = TestUnboundedIterator.new
+    expect{ Iterable.on(ubi).to_a }.to raise_error(Puppet::Error, /Attempt to create an Array from an unbounded Iterable/)
+  end
+end
+end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1978,13 +1978,13 @@ describe 'The type calculator' do
     end
   end
 
-  context 'when asking for an enumerable ' do
-    it 'should produce an enumerable for an Integer range that is not infinite' do
+  context 'when asking for an iterable ' do
+    it 'should produce an iterable for an Integer range that is finite' do
       t = Puppet::Pops::Types::PIntegerType.new(1, 10)
       expect(calculator.iterable(t).respond_to?(:each)).to eq(true)
     end
 
-    it 'should not produce an enumerable for an Integer range that has an infinite side' do
+    it 'should not produce an iterable for an Integer range that has an infinite side' do
       t = Puppet::Pops::Types::PIntegerType.new(nil, 10)
       expect(calculator.iterable(t)).to eq(nil)
 
@@ -1992,7 +1992,7 @@ describe 'The type calculator' do
       expect(calculator.iterable(t)).to eq(nil)
     end
 
-    it 'all but Integer range are not enumerable' do
+    it 'all but Integer range are not iterable' do
       [Object, Numeric, Float, String, Regexp, Array, Hash].each do |t|
         expect(calculator.iterable(calculator.type(t))).to eq(nil)
       end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1981,20 +1981,20 @@ describe 'The type calculator' do
   context 'when asking for an enumerable ' do
     it 'should produce an enumerable for an Integer range that is not infinite' do
       t = Puppet::Pops::Types::PIntegerType.new(1, 10)
-      expect(calculator.enumerable(t).respond_to?(:each)).to eq(true)
+      expect(calculator.iterable(t).respond_to?(:each)).to eq(true)
     end
 
     it 'should not produce an enumerable for an Integer range that has an infinite side' do
       t = Puppet::Pops::Types::PIntegerType.new(nil, 10)
-      expect(calculator.enumerable(t)).to eq(nil)
+      expect(calculator.iterable(t)).to eq(nil)
 
       t = Puppet::Pops::Types::PIntegerType.new(1, nil)
-      expect(calculator.enumerable(t)).to eq(nil)
+      expect(calculator.iterable(t)).to eq(nil)
     end
 
     it 'all but Integer range are not enumerable' do
       [Object, Numeric, Float, String, Regexp, Array, Hash].each do |t|
-        expect(calculator.enumerable(calculator.type(t))).to eq(nil)
+        expect(calculator.iterable(calculator.type(t))).to eq(nil)
       end
     end
   end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -123,6 +123,8 @@ describe 'The type calculator' do
         Puppet::Pops::Types::PCollectionType,
         Puppet::Pops::Types::PArrayType,
         Puppet::Pops::Types::PHashType,
+        Puppet::Pops::Types::PIterableType,
+        Puppet::Pops::Types::PIteratorType,
         Puppet::Pops::Types::PRuntimeType,
         Puppet::Pops::Types::PHostClassType,
         Puppet::Pops::Types::PResourceType,
@@ -232,6 +234,10 @@ describe 'The type calculator' do
 
     it 'regexp translates to PRegexpType' do
       expect(calculator.infer(/^a regular expression$/).class).to eq(Puppet::Pops::Types::PRegexpType)
+    end
+
+    it 'iterable translates to PIteratorType' do
+      expect(calculator.infer(Puppet::Pops::Types::Iterable.on(1))).to be_a(Puppet::Pops::Types::PIteratorType)
     end
 
     it 'nil translates to PUndefType' do
@@ -793,7 +799,11 @@ describe 'The type calculator' do
       end
 
       it 'Collection is not assignable to any disjunct type' do
-        tested_types = all_types - [Puppet::Pops::Types::PAnyType, Puppet::Pops::Types::POptionalType, Puppet::Pops::Types::PNotUndefType] - collection_types
+        tested_types = all_types - [
+          Puppet::Pops::Types::PAnyType,
+          Puppet::Pops::Types::POptionalType,
+          Puppet::Pops::Types::PNotUndefType,
+          Puppet::Pops::Types::PIterableType] - collection_types
         t = Puppet::Pops::Types::PCollectionType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
       end
@@ -815,6 +825,7 @@ describe 'The type calculator' do
           Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PNotUndefType,
+          Puppet::Pops::Types::PIterableType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PArrayType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
@@ -841,6 +852,7 @@ describe 'The type calculator' do
           Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PNotUndefType,
+          Puppet::Pops::Types::PIterableType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PHashType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
@@ -878,6 +890,7 @@ describe 'The type calculator' do
           Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PNotUndefType,
+          Puppet::Pops::Types::PIterableType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PTupleType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
@@ -899,6 +912,7 @@ describe 'The type calculator' do
           Puppet::Pops::Types::PAnyType,
           Puppet::Pops::Types::POptionalType,
           Puppet::Pops::Types::PNotUndefType,
+          Puppet::Pops::Types::PIterableType,
           Puppet::Pops::Types::PDataType] - collection_types
         t = Puppet::Pops::Types::PStructType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
@@ -1880,6 +1894,7 @@ describe 'The type calculator' do
       expect(calculator.infer(Puppet::Pops::Types::PCollectionType::DEFAULT).is_a?(ptype)).to eq(true)
       expect(calculator.infer(Puppet::Pops::Types::PArrayType::DEFAULT     ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(Puppet::Pops::Types::PHashType::DEFAULT      ).is_a?(ptype)).to eq(true)
+      expect(calculator.infer(Puppet::Pops::Types::PIterableType::DEFAULT  ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(Puppet::Pops::Types::PRuntimeType::DEFAULT   ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(Puppet::Pops::Types::PHostClassType::DEFAULT ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(Puppet::Pops::Types::PResourceType::DEFAULT  ).is_a?(ptype)).to eq(true)
@@ -1904,6 +1919,7 @@ describe 'The type calculator' do
       expect(calculator.string(calculator.infer(Puppet::Pops::Types::PCollectionType::DEFAULT))).to eq('Type[Collection]')
       expect(calculator.string(calculator.infer(Puppet::Pops::Types::PArrayType::DEFAULT     ))).to eq('Type[Array[?]]')
       expect(calculator.string(calculator.infer(Puppet::Pops::Types::PHashType::DEFAULT      ))).to eq('Type[Hash[?, ?]]')
+      expect(calculator.string(calculator.infer(Puppet::Pops::Types::PIterableType::DEFAULT  ))).to eq('Type[Iterable]')
       expect(calculator.string(calculator.infer(Puppet::Pops::Types::PRuntimeType::DEFAULT   ))).to eq('Type[Runtime[?, ?]]')
       expect(calculator.string(calculator.infer(Puppet::Pops::Types::PHostClassType::DEFAULT ))).to eq('Type[Class]')
       expect(calculator.string(calculator.infer(Puppet::Pops::Types::PResourceType::DEFAULT  ))).to eq('Type[Resource]')


### PR DESCRIPTION
This PR adds the new types `Iterable` and `Iterator` to the Puppet
type system together with the runtime support needed to represent an
object that has been transformed into an Iterator by a call to
`Iterable.on`. This method transforms an instance of an object that
Puppet can use in iterative functions into an Iterator. The Iterator
in turn, provides basic support for the iterative functions.

The PR also changes the iterative functions `each`, `filter`,
`map`, `reduce`, and `slice` so that the type of their declared
_enumerable_ parameter is `Iterable` instead of `Any`