### PR TITLE
(PUP-5538) Fix SID::Principal domain_account

### DIFF
--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -6,12 +6,16 @@ module Puppet::Util::Windows::SID
     attr_reader :account, :sid_bytes, :sid, :domain, :domain_account, :account_type
 
     def initialize(account, sid_bytes, sid, domain, account_type)
-      @account = account
+      # Calling lookup_account_name like host\user is valid and therefore this
+      # value may include two components, but favor the domain value passed in
+      @account = account =~ /(.+)\\(.+)/ ? $2 : account
       @sid_bytes = sid_bytes
       @sid = sid
       @domain = domain
+      # when domain is available, combine it with parsed account
+      # otherwise use the account value directly
       @domain_account = domain && !domain.empty? ?
-        "#{domain}\\#{account}" : account
+        "#{domain}\\#{@account}" : account
 
       @account_type = account_type
     end


### PR DESCRIPTION
 - Previously, the Puppet::Util::Windows::SID::Principal initializer
   didn't understand that an account may be passed in with a domain
   prefix that should be parsed off when building the domain_account
   value.

   When calling:

   Puppet::Util::Windows::SID::Principal.lookup_account_name('NT AUTHORITY\\SYSTEM')

   account was previously set to 'NT AUTHORITY\\SYSTEM' and
   domain_account to 'NT AUTHORITY\\NT AUTHORITY\\SYSTEM'

   This commit changes account to 'SYSTEM' and
   domain_account to 'NT AUTHORITY\\SYSTEM' in the above instance