### PR TITLE
WIP (PUP-5609) Protect shared state with filesystem lock

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -4,8 +4,8 @@ require 'puppet/error'
 # A general class for triggering a run of another
 # class.
 class Puppet::Agent
-  require 'puppet/agent/locker'
-  include Puppet::Agent::Locker
+  require 'puppet/util/locker'
+  include Puppet::Util::Locker
 
   require 'puppet/agent/disabler'
   include Puppet::Agent::Disabler

--- a/lib/puppet/util/locker.rb
+++ b/lib/puppet/util/locker.rb
@@ -12,7 +12,7 @@ require 'puppet/error'
 #
 # For more information, please see docs on the website.
 #  http://links.puppetlabs.com/agent_lockfiles
-module Puppet::Agent::Locker
+module Puppet::Util::Locker
   # Yield if we get a lock, else raise Puppet::LockError. Return
   # value of block yielded.
   def lock
@@ -30,7 +30,7 @@ module Puppet::Agent::Locker
   # @deprecated
   def running?
     Puppet.deprecation_warning <<-ENDHEREDOC
-Puppet::Agent::Locker.running? is deprecated as it is inherently unsafe.
+Puppet::Util::Locker.running? is deprecated as it is inherently unsafe.
 The only safe way to know if the lock is locked is to try lock and perform some
 action and then handle the LockError that may result.
 ENDHEREDOC

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -18,6 +18,7 @@ describe "apply" do
       manifest = file_containing("manifest", catalog.to_pson)
 
       puppet = Puppet::Application[:apply]
+      puppet.stubs(:lock).yields
       puppet.options[:catalog] = manifest
 
       puppet.apply
@@ -34,6 +35,7 @@ describe "apply" do
     Puppet.override(:current_environment => special) do
       Puppet[:environment] = 'special'
       puppet = Puppet::Application[:apply]
+      puppet.stubs(:lock).yields
       puppet.stubs(:command_line).returns(stub('command_line', :args => [manifest]))
       expect { puppet.run_command }.to exit_with(0)
     end
@@ -46,6 +48,7 @@ describe "apply" do
     Puppet[:trusted_server_facts] = true
 
     puppet = Puppet::Application[:apply]
+    puppet.stubs(:lock).yields
     puppet.stubs(:command_line).returns(stub('command_line', :args => [manifest]))
 
     expect { puppet.run_command }.to exit_with(0)
@@ -67,6 +70,7 @@ describe "apply" do
       Puppet[:node_terminus] = 'exec'
       Puppet[:external_nodes] = enc
       puppet = Puppet::Application[:apply]
+      puppet.stubs(:lock).yields
       puppet.stubs(:command_line).returns(stub('command_line', :args => [manifest]))
       expect { puppet.run_command }.to exit_with(0)
     end
@@ -78,6 +82,7 @@ describe "apply" do
     it "logs compile errors once" do
       Puppet.initialize_settings([])
       apply = Puppet::Application.find(:apply).new(stub('command_line', :subcommand_name => :apply, :args => []))
+      apply.stubs(:lock).yields
       apply.options[:code] = '08'
 
       msg = 'valid octal'
@@ -93,6 +98,7 @@ describe "apply" do
     it "logs compile post processing errors once" do
       Puppet.initialize_settings([])
       apply = Puppet::Application.find(:apply).new(stub('command_line', :subcommand_name => :apply, :args => []))
+      apply.stubs(:lock).yields
       path = File.expand_path('/tmp/content_file_test.Q634Dlmtime')
       apply.options[:code] = "file { '#{path}':
         content => 'This is the test file content',
@@ -135,6 +141,7 @@ describe "apply" do
     def init_cli_args_and_apply_app(args, execute)
       Puppet.initialize_settings(args)
       puppet = Puppet::Application.find(:apply).new(stub('command_line', :subcommand_name => :apply, :args => args))
+      puppet.stubs(:lock).yields
       puppet.options[:code] = execute
       return puppet
     end

--- a/spec/unit/agent/disabler_spec.rb
+++ b/spec/unit/agent/disabler_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/agent'
-require 'puppet/agent/locker'
+require 'puppet/util/locker'
 
 class DisablerTester
   include Puppet::Agent::Disabler

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -49,7 +49,7 @@ describe Puppet::Agent do
   end
 
   it "should include the Locker module" do
-    expect(Puppet::Agent.ancestors).to be_include(Puppet::Agent::Locker)
+    expect(Puppet::Agent.ancestors).to be_include(Puppet::Util::Locker)
   end
 
   it "should create an instance of its client class and run it when asked to run" do

--- a/spec/unit/util/locker_spec.rb
+++ b/spec/unit/util/locker_spec.rb
@@ -1,13 +1,13 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/agent'
-require 'puppet/agent/locker'
+require 'puppet/util/locker'
 
 class LockerTester
-  include Puppet::Agent::Locker
+  include Puppet::Util::Locker
 end
 
-describe Puppet::Agent::Locker do
+describe Puppet::Util::Locker do
   before do
     @locker = LockerTester.new
   end


### PR DESCRIPTION
Use a filesytem lock when running Puppet apply. This prevents multiple
simultaneous writes to the same state files by multiple apply processes
or a mix of apply and agent processes (the same state files are shared
by apply and agent). Exits with error code 1 if lock is encountered.