### PR TITLE
(PUP-5694) Add per environment static_catalogs setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -147,6 +147,11 @@ module Puppet
         :type     => :boolean,
         :desc     => "Whether to enable experimental performance profiling",
     },
+    :static_catalogs => {
+      :default    => false,
+      :type       => :boolean,
+      :desc       => "Whether to compile a static catalog."
+    },
     :autoflush => {
       :default => true,
       :type       => :boolean,

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -40,6 +40,8 @@ module Puppet::Environments
     end
 
     def clear_all
+      root = Puppet.lookup(:root_environment) { nil }
+      root.instance_variable_set(:@static_catalogs, nil) unless root.nil?
     end
   end
 
@@ -110,7 +112,7 @@ module Puppet::Environments
     def get_conf(name)
       env = get(name)
       if env
-        Puppet::Settings::EnvironmentConf.static_for(env)
+        Puppet::Settings::EnvironmentConf.static_for(env, 0, Puppet[:static_catalogs])
       else
         nil
       end

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -83,7 +83,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
   # Compile the actual catalog.
   def compile(node, code_id)
-    str = "Compiled catalog for #{node.name}"
+    str = "Compiled %s for #{node.name}" % [node.environment.static_catalogs? ? 'static catalog' : 'catalog']
     str += " in environment #{node.environment}" if node.environment
     config = nil
 

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -186,6 +186,15 @@ class Puppet::Node::Environment
     !original_manifest.nil? && !original_manifest.empty? && original_manifest != Puppet[:default_manifest]
   end
 
+  # @api private
+  def static_catalogs?
+    if @static_catalogs.nil?
+      environment_conf = Puppet.lookup(:environments).get_conf(name)
+      @static_catalogs = (environment_conf.nil? ? Puppet[:static_catalogs] : environment_conf.static_catalogs)
+    end
+    @static_catalogs
+  end
+
   # Return the environment configuration
   # @return [Puppet::Settings::EnvironmentConf] The configuration
   #

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -3,7 +3,7 @@
 class Puppet::Settings::EnvironmentConf
 
   ENVIRONMENT_CONF_ONLY_SETTINGS = [:modulepath, :manifest, :config_version].freeze
-  VALID_SETTINGS = (ENVIRONMENT_CONF_ONLY_SETTINGS + [:environment_timeout, :environment_data_provider]).freeze
+  VALID_SETTINGS = (ENVIRONMENT_CONF_ONLY_SETTINGS + [:environment_timeout, :environment_data_provider, :static_catalogs]).freeze
 
   # Given a path to a directory environment, attempts to load and parse an
   # environment.conf in ini format, and return an EnvironmentConf instance.
@@ -39,8 +39,8 @@ class Puppet::Settings::EnvironmentConf
   # Configuration values are exactly those returned by the environment object,
   # without interpolation.  This is a special case for the default configured
   # environment returned by the Puppet::Environments::StaticPrivate loader.
-  def self.static_for(environment, environment_timeout = 0)
-    Static.new(environment, environment_timeout)
+  def self.static_for(environment, environment_timeout = 0, static_catalogs = false)
+    Static.new(environment, environment_timeout, static_catalogs)
   end
 
   attr_reader :section, :path_to_env, :global_modulepath
@@ -108,6 +108,12 @@ class Puppet::Settings::EnvironmentConf
     end
   end
 
+  def static_catalogs
+    get_setting(:static_catalogs, Puppet.settings.value(:static_catalogs)) do |value|
+      value
+    end
+  end
+
   def config_version
     get_setting(:config_version) do |config_version|
       absolute(config_version)
@@ -161,10 +167,12 @@ class Puppet::Settings::EnvironmentConf
   class Static
     attr_reader :environment_timeout
     attr_reader :environment_data_provider
+    attr_reader :static_catalogs
 
-    def initialize(environment, environment_timeout, environment_data_provider = 'none')
+    def initialize(environment, environment_timeout, static_catalogs, environment_data_provider = 'none')
       @environment = environment
       @environment_timeout = environment_timeout
+      @static_catalogs = static_catalogs
       @environment_data_provider = environment_data_provider
     end
 

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -147,7 +147,7 @@ class Puppet::Settings::EnvironmentConf
 
   def get_setting(setting_name, default = nil)
     value = raw_setting(setting_name)
-    value ||= default
+    value = default if value.nil?
     yield value
   end
 

--- a/spec/unit/settings/environment_conf_spec.rb
+++ b/spec/unit/settings/environment_conf_spec.rb
@@ -39,6 +39,12 @@ describe Puppet::Settings::EnvironmentConf do
       expect(envconf.environment_timeout).to eq(180)
     end
 
+    it "reads a static_catalogs from config" do
+      setup_environment_conf(config, :static_catalogs => true)
+
+      expect(envconf.static_catalogs).to eq(true)
+    end
+
     it "can retrieve raw settings" do
       setup_environment_conf(config, :manifest => 'manifest.pp')
 
@@ -64,8 +70,12 @@ describe Puppet::Settings::EnvironmentConf do
       expect(envconf.config_version).to be_nil
     end
 
-    it "returns a defult of 0 for environment_timeout when config has none" do
+    it "returns a default of 0 for environment_timeout when config has none" do
       expect(envconf.environment_timeout).to eq(0)
+    end
+
+    it "returns default of false for static_catalogs when config has none" do
+      expect(envconf.static_catalogs).to eq(false)
     end
 
     it "can still retrieve raw setting" do

--- a/spec/unit/settings/environment_conf_spec.rb
+++ b/spec/unit/settings/environment_conf_spec.rb
@@ -45,6 +45,13 @@ describe Puppet::Settings::EnvironmentConf do
       expect(envconf.static_catalogs).to eq(true)
     end
 
+    it "can retrieve untruthy settings" do
+      Puppet[:static_catalogs] = true
+      setup_environment_conf(config, :static_catalogs => false)
+
+      expect(envconf.static_catalogs).to eq(false)
+    end
+
     it "can retrieve raw settings" do
       setup_environment_conf(config, :manifest => 'manifest.pp')
 


### PR DESCRIPTION
Creates a boolean `static_catalogs` puppet setting defaulting to
false. The setting can be overridden in environment.conf, similar to
how future parser worked.

Currently the `static_catalogs` setting only modifies the compiler's
message when it compiles a catalog, e.g. "Compiled static catalog". In
the future, it will control whether the compiler inlines file metadata
into the catalog.