### PR TITLE
(PUP-5728) Always load manifests as UTF-8

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -175,7 +175,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     if options[:catalog] == "-"
       text = $stdin.read
     else
-      text = ::File.read(options[:catalog])
+      text = Puppet::FileSystem.read(options[:catalog], :encoding => 'utf-8')
     end
     catalog = read_catalog(text)
     apply_catalog(catalog)
@@ -239,7 +239,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
             $stderr.puts "#{file} is not readable"
             exit(63)
           end
-          node.classes = ::File.read(file).split(/[\s\n]+/)
+          node.classes = Puppet::FileSystem.read(file, :encoding => 'utf-8').split(/[\s\n]+/)
         end
       end
 

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -214,7 +214,7 @@ the puppet lookup function linked to above.
 
 EXAMPLE
 -------
-  If you wanted to lookup 'key_name' within the scope of the master, you would 
+  If you wanted to lookup 'key_name' within the scope of the master, you would
   call lookup like this:
   $ puppet lookup key_name
 
@@ -335,9 +335,9 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     if fact_file
       original_facts = node.parameters
       if fact_file.end_with?("json")
-        given_facts = JSON.parse(File.read(fact_file))
+        given_facts = JSON.parse(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
-        given_facts = YAML.load(File.read(fact_file))
+        given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end
 
       unless given_facts.instance_of?(Hash)

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -172,7 +172,7 @@ Puppet::Face.define(:epp, '0.0.1') do
 
         show_filename = templates.count > 1
         dumps = templates.each do |file|
-          buffer.print dump_parse(File.read(file), file, options, show_filename)
+          buffer.print dump_parse(Puppet::FileSystem.read(file, :encoding => 'utf-8'), file, options, show_filename)
         end
 
         if !missing_files.empty?

--- a/lib/puppet/face/parser.rb
+++ b/lib/puppet/face/parser.rb
@@ -107,7 +107,7 @@ Puppet::Face.define(:parser, '0.0.1') do
         missing_files = files - available_files
 
         dumps = available_files.collect do |file|
-          dump_parse(File.read(file), file, options)
+          dump_parse(Puppet::FileSystem.read(file, :encoding => 'utf-8'), file, options)
         end.join("")
 
         if missing_files.empty?

--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -122,8 +122,8 @@ module Puppet::FileSystem
   #
   # @api public
   #
-  def self.read(path)
-    @impl.read(assert_path(path))
+  def self.read(path, opts = {})
+    @impl.read(assert_path(path), opts)
   end
 
   # Read a file keeping the original line endings intact. This

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -71,8 +71,8 @@ class Puppet::FileSystem::FileImpl
     end
   end
 
-  def read(path)
-    path.read
+  def read(path, opts = {})
+    path.read(opts)
   end
 
   def read_preserve_line_endings(path)

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -39,7 +39,7 @@ class Puppet::FileSystem::MemoryImpl
     object.path
   end
 
-  def read(path)
+  def read(path, opts = {})
     handle = assert_path(path).handle
     handle.read
   end

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -231,7 +231,7 @@ module Puppet::Pops::Loader::ModuleLoaders
     end
 
     def get_contents(effective_path)
-      Puppet::FileSystem.read(effective_path)
+      Puppet::FileSystem.read(effective_path, :encoding => 'utf-8')
     end
   end
 

--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -640,7 +640,7 @@ class Puppet::Pops::Parser::Lexer2
   #
   def lex_file(file)
     initvars
-    contents = Puppet::FileSystem.exist?(file) ? Puppet::FileSystem.read(file) : ''
+    contents = Puppet::FileSystem.exist?(file) ? Puppet::FileSystem.read(file, :encoding => 'utf-8') : ''
     @scanner = StringScanner.new(contents.freeze)
     @locator = Puppet::Pops::Parser::Locator.locator(contents, file)
   end

--- a/lib/puppet/util/resource_template.rb
+++ b/lib/puppet/util/resource_template.rb
@@ -40,7 +40,7 @@ class Puppet::Util::ResourceTemplate
 
   def evaluate
     set_resource_variables
-    ERB.new(File.read(@file), 0, "-").result(binding)
+    ERB.new(Puppet::FileSystem.read(@file, :encoding => 'utf-8'), 0, "-").result(binding)
   end
 
   def initialize(file, resource)

--- a/spec/unit/face/parser_spec.rb
+++ b/spec/unit/face/parser_spec.rb
@@ -98,6 +98,16 @@ describe Puppet::Face[:parser, :current] do
       expect(@logs[0].message).to eq("Syntax error at end of file")
       expect(@logs[0].level).to eq(:err)
     end
+
+    it "logs an error if the input begins with a UTF-8 BOM (Byte Order Mark)" do
+      utf8_bom_manifest = file_containing('utf8_bom.pp', "\uFEFFnotice hi")
+
+      output = parser.dump(utf8_bom_manifest)
+
+      expect(output).to eq("")
+      expect(@logs[1].message).to eq("Syntax error at '' at line 1:1")
+      expect(@logs[1].level).to eq(:err)
+    end
   end
 
   def from_an_interactive_terminal

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -134,6 +134,32 @@ describe "Puppet::FileSystem" do
     end
   end
 
+  context "read should allow an encoding to be specified" do
+    # First line of Rune version of Rune poem at http://www.columbia.edu/~fdc/utf8/
+    # characters chosen since they will not parse on Windows with codepage 437 or 1252
+    # Section 3.2.1.3 of Ruby spec guarantees that \u strings are encoded as UTF-8
+    let (:rune_utf8) { "\u16A0\u16C7\u16BB" } # 'ᚠᛇᚻ'
+
+    it "and should read a UTF8 file properly" do
+      temp_file = file_containing('utf8.txt', rune_utf8)
+
+      contents = Puppet::FileSystem.read(temp_file, :encoding => 'utf-8')
+
+      expect(contents.encoding).to eq(Encoding::UTF_8)
+      expect(contents).to eq(rune_utf8)
+    end
+
+    it "does not strip the UTF8 BOM (Byte Order Mark) if present in a file" do
+      bom = "\uFEFF"
+
+      temp_file = file_containing('utf8bom.txt', "#{bom}#{rune_utf8}")
+      contents = Puppet::FileSystem.read(temp_file, :encoding => 'utf-8')
+
+      expect(contents.encoding).to eq(Encoding::UTF_8)
+      expect(contents).to eq("#{bom}#{rune_utf8}")
+    end
+  end
+
   describe "symlink",
     :if => ! Puppet.features.manages_symlinks? &&
     Puppet.features.microsoft_windows? do

--- a/spec/unit/pops/loaders/dependency_loader_spec.rb
+++ b/spec/unit/pops/loaders/dependency_loader_spec.rb
@@ -53,6 +53,59 @@ describe 'dependency loader' do
       expect(function.class.name).to eq('testmodule::foo')
       expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
     end
+
+    describe "when parsing files from disk" do
+
+      # First line of Rune version of Rune poem at http://www.columbia.edu/~fdc/utf8/
+      # characters chosen since they will not parse on Windows with codepage 437 or 1252
+      # Section 3.2.1.3 of Ruby spec guarantees that \u strings are encoded as UTF-8
+      let (:node) { Puppet::Node.new('node') }
+      let (:rune_utf8) { "\u16A0\u16C7\u16BB" } # ᚠᛇᚻ
+      let (:code_utf8) do <<-CODE
+Puppet::Functions.create_function('testmodule::foo') {
+  def foo
+    return \"#{rune_utf8}\"
+  end
+}
+      CODE
+      end
+
+      context 'when loading files from disk' do
+        it 'should always read files as UTF-8' do
+          if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+            raise 'This test must be run in a codepage other than 65001 to validate behavior'
+          end
+
+          module_dir = dir_containing('testmodule', {
+          'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {
+            'foo.rb' => code_utf8
+          }}}}})
+
+          loader = loader_for('testmodule', module_dir)
+
+          function = loader.load_typed(typed_name(:function, 'testmodule::foo')).value
+          expect(function.call({})).to eq(rune_utf8)
+        end
+
+        it 'currently ignores the UTF-8 BOM (Byte Order Mark) when loading module files' do
+          bom = "\uFEFF"
+
+          if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+            raise 'This test must be run in a codepage other than 65001 to validate behavior'
+          end
+
+          module_dir = dir_containing('testmodule', {
+          'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {
+            'foo.rb' => "#{bom}#{code_utf8}"
+          }}}}})
+
+          loader = loader_for('testmodule', module_dir)
+
+          function = loader.load_typed(typed_name(:function, 'testmodule::foo')).value
+          expect(function.call({})).to eq(rune_utf8)
+        end
+      end
+    end
   end
 
   def loader_for(name, dir)

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -702,4 +702,43 @@ describe 'Lexer2' do
       expect_issue('"asd', Puppet::Pops::Issues::UNCLOSED_QUOTE)
     end
   end
+
+end
+
+describe Puppet::Pops::Parser::Lexer2 do
+
+  include PuppetSpec::Files
+
+  # First line of Rune version of Rune poem at http://www.columbia.edu/~fdc/utf8/
+  # characters chosen since they will not parse on Windows with codepage 437 or 1252
+  # Section 3.2.1.3 of Ruby spec guarantees that \u strings are encoded as UTF-8
+  # ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ
+  let (:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
+
+  context 'when lexing files from disk' do
+    it 'should always read files as UTF-8' do
+      if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+        raise 'This test must be run in a codepage other than 65001 to validate behavior'
+      end
+
+      manifest_code = "notify { '#{rune_utf8}': }"
+      manifest = file_containing('manifest.pp', manifest_code)
+      lexed_file = described_class.new.lex_file(manifest)
+
+      expect(lexed_file.string.encoding).to eq(Encoding::UTF_8)
+      expect(lexed_file.string).to eq(manifest_code)
+    end
+
+    it 'currently preserves the UTF-8 BOM (Byte Order Mark) when lexing files' do
+      bom = "\uFEFF"
+
+      manifest_code = "#{bom}notify { '#{rune_utf8}': }"
+      manifest = file_containing('manifest.pp', manifest_code)
+      lexed_file = described_class.new.lex_file(manifest)
+
+      expect(lexed_file.string.encoding).to eq(Encoding::UTF_8)
+      expect(lexed_file.string).to eq(manifest_code)
+    end
+  end
+
 end

--- a/spec/unit/util/resource_template_spec.rb
+++ b/spec/unit/util/resource_template_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Util::ResourceTemplate do
   describe "when evaluating" do
     before do
       Puppet::FileSystem.stubs(:exist?).returns true
-      File.stubs(:read).returns "eh"
+      Puppet::FileSystem.stubs(:read).returns "eh"
 
       @template = stub 'template', :result => nil
       ERB.stubs(:new).returns @template
@@ -38,7 +38,7 @@ describe Puppet::Util::ResourceTemplate do
     end
 
     it "should create a template instance with the contents of the file" do
-      File.expects(:read).with("/my/template").returns "yay"
+      Puppet::FileSystem.expects(:read).with("/my/template", :encoding => 'utf-8').returns "yay"
       ERB.expects(:new).with("yay", 0, "-").returns(@template)
 
       @wrapper.stubs :set_resource_variables


### PR DESCRIPTION
 - In PUP-2564, documentation was changed to indicate that all manifest
   are expected to be in UTF-8 as part of Puppet 4.0.

   However, this is not actually enforced, and causes problems on Windows.



There are more details to be sorted out on this, and I haven't run tests fully yet - but this is a good starting point for looking at this problem.