### PR TITLE
(PUP-5670) bump facter release tag

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -19,7 +19,7 @@ build_msi:
     ref: 'refs/tags/3.8.3'
     repo: 'git://github.com/puppetlabs/puppet_for_the_win.git'
   facter:
-    ref: 'refs/tags/2.4.4'
+    ref: 'refs/tags/2.4.5'
     repo: 'git://github.com/puppetlabs/facter.git'
   hiera:
     ref: 'refs/tags/1.3.4'


### PR DESCRIPTION
msi windows builds for puppet need to grab facter from the
github repo, so we need to bump the release tag to the newest
facter before releasing puppet