### PR TITLE
(PUP-5730) Add iterative step function

### DIFF
--- a/lib/puppet/functions/reverse_each.rb
+++ b/lib/puppet/functions/reverse_each.rb
@@ -4,7 +4,7 @@
 #
 # This function takes one to two arguments.
 #
-# 1. An iterable that the function will iterate over.
+# 1. An `Iterable` that the function will iterate over.
 # 2. An optional lambda, which the function calls for each element in the first argument. It must
 # request one parameter.
 #
@@ -27,20 +27,20 @@
 # When no second argument is present, Puppet returns an `Iterable` that represents the reverse
 # order of its first argument. This allows methods on `Iterable` to be chained.
 #
-# When a lamdba is given as the second argument, Puppet iterates the first argument in reverse order
-# and passes each value in turn to the lambda, then returns the first argument unchanged.
+# When a lamdba is given as the second argument, Puppet iterates the first argument in reverse
+# order and passes each value in turn to the lambda, then returns the first argument unchanged.
 #
 # @example Using the `reverse_each` function with an array and a one-parameter lambda
 #
 # ~~~ puppet
-# # Puppet will print a notice for each of the three items in $data in reverse order.
+# # Puppet will log a notice for each of the three items in $data in reverse order.
 # $data = [1,2,3]
 # $data.reverse_each |$item| { notice($item) }
 #
 # ~~~
 #
-# When no second argument is present, Puppet returns a new `Iterable` which allows it to be directly chained into
-# another function that takes an `Iterable` as an argument.
+# When no second argument is present, Puppet returns a new `Iterable` which allows it to
+# be directly chained into another function that takes an `Iterable` as an argument.
 #
 # @example Using the `reverse_each` function chained with a `map` function.
 #

--- a/lib/puppet/functions/reverse_each.rb
+++ b/lib/puppet/functions/reverse_each.rb
@@ -24,8 +24,8 @@
 #
 # `$reverse_data = reverse_each($data)`
 #
-# When no second argument is present, Puppet returns an iterable that represents the reverse
-# order of its first argument. This allows methods on iterables to be chained.
+# When no second argument is present, Puppet returns an `Iterable` that represents the reverse
+# order of its first argument. This allows methods on `Iterable` to be chained.
 #
 # When a lamdba is given as the second argument, Puppet iterates the first argument in reverse order
 # and passes each value in turn to the lambda, then returns the first argument unchanged.
@@ -33,26 +33,21 @@
 # @example Using the `reverse_each` function with an array and a one-parameter lambda
 #
 # ~~~ puppet
-# # For the array $data, run a lambda that creates a resource in reverse order for each item in reverse.
-# $data = ["routers", "servers", "workstations"]
-# $data.reverse_each |$item| {
-#  notify { $item:
-#    message => $item
-#  }
-# }
-# # Puppet creates one resource for each of the three items in $data in reverse order. Each resource is
-# # named after the item's value and uses the item's value in a parameter.
+# # Puppet will print a notice for each of the three items in $data in reverse order.
+# $data = [1,2,3]
+# $data.reverse_each |$item| { notice($item) }
+#
 # ~~~
 #
-# When no second argument is present, Puppet returns a new iterable so that a new function that takes
-# an iterable as an argument can use it as input.
+# When no second argument is present, Puppet returns a new `Iterable` which allows it to be directly chained into
+# another function that takes an `Iterable` as an argument.
 #
 # @example Using the `reverse_each` function chained with a `map` function.
 #
 # # For the array $data, return an array containing each value multiplied by 10 in reverse order
 # $data = [1,2,3]
 # $transformed_data = $data.reverse_each.map |$item| { $item * 10 }
-# # $transformed_data contains [30,20,10]
+# # $transformed_data is set to [30,20,10]
 # ~~~
 #
 # @example The same example using `reverse_each` function chained with a `map` in alternative syntax
@@ -60,7 +55,7 @@
 # # For the array $data, return an array containing each value multiplied by 10 in reverse order
 # $data = [1,2,3]
 # $transformed_data = map(reverse_each($data)) |$item| { $item * 10 }
-# # $transformed_data contains [30,20,10]
+# # $transformed_data is set to [30,20,10]
 # ~~~
 #
 # @since 4.4.0

--- a/lib/puppet/functions/reverse_each.rb
+++ b/lib/puppet/functions/reverse_each.rb
@@ -1,0 +1,88 @@
+# Reverses the order of the elements of something that is iterable and optionally runs a
+# [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+# element.
+#
+# This function takes one to two arguments.
+#
+# 1. An iterable that the function will iterate over.
+# 2. An optional lambda, which the function calls for each element in the first argument. It must
+# request one parameter.
+#
+# @example Using the `reverse_each` function
+#
+# `$data.reverse_each |$parameter| { <PUPPET CODE BLOCK> }`
+#
+# or
+#
+# `$reverse_data = $data.reverse_each`
+#
+# or
+#
+# `reverse_each($data) |$parameter| { <PUPPET CODE BLOCK> }`
+#
+# or
+#
+# `$reverse_data = reverse_each($data)`
+#
+# When no second argument is present, Puppet returns an iterable that represents the reverse
+# order of its first argument. This allows methods on iterables to be chained.
+#
+# When a lamdba is given as the second argument, Puppet iterates the first argument in reverse order
+# and passes each value in turn to the lambda, then returns the first argument unchanged.
+#
+# @example Using the `reverse_each` function with an array and a one-parameter lambda
+#
+# ~~~ puppet
+# # For the array $data, run a lambda that creates a resource in reverse order for each item in reverse.
+# $data = ["routers", "servers", "workstations"]
+# $data.reverse_each |$item| {
+#  notify { $item:
+#    message => $item
+#  }
+# }
+# # Puppet creates one resource for each of the three items in $data in reverse order. Each resource is
+# # named after the item's value and uses the item's value in a parameter.
+# ~~~
+#
+# When no second argument is present, Puppet returns a new iterable so that a new function that takes
+# an iterable as an argument can use it as input.
+#
+# @example Using the `reverse_each` function chained with a `map` function.
+#
+# # For the array $data, return an array containing each value multiplied by 10 in reverse order
+# $data = [1,2,3]
+# $transformed_data = $data.reverse_each.map |$item| { $item * 10 }
+# # $transformed_data contains [30,20,10]
+# ~~~
+#
+# @example The same example using `reverse_each` function chained with a `map` in alternative syntax
+#
+# # For the array $data, return an array containing each value multiplied by 10 in reverse order
+# $data = [1,2,3]
+# $transformed_data = map(reverse_each($data)) |$item| { $item * 10 }
+# # $transformed_data contains [30,20,10]
+# ~~~
+#
+# @since 4.4.0
+#
+Puppet::Functions.create_function(:reverse_each) do
+  dispatch :reverse_each do
+    param 'Iterable', :iterable
+  end
+
+  dispatch :reverse_each_block do
+    param 'Iterable', :iterable
+    block_param 'Callable[1,1]', :block
+  end
+
+  def reverse_each(iterable)
+    # produces an Iterable
+    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable).reverse_each
+  end
+
+  def reverse_each_block(iterable, &block)
+    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable).reverse_each(&block)
+    # produces the receiver
+    iterable
+  end
+end

--- a/lib/puppet/functions/step.rb
+++ b/lib/puppet/functions/step.rb
@@ -25,16 +25,16 @@
 #
 # `$stepped_data = step($data, <n>)`
 #
-# When no block is given, Puppet returns an iterable that represents every nth element
-# of its first argument. This allows functions on iterables to be chained.
+# When no block is given, Puppet returns an `Iterable` that yields the first element and every nth successor
+# element, from its first argument. This allows functions on iterables to be chained.
 #
-# When a block is given, Puppet iterates the first argument and passes each nth value in turn to
-# the block, then returns the first argument unchanged.
+# When a block is given, Puppet iterates the first argument and calls the block with the first element and then with
+# every nth successor element.
 #
 # @example Using the `step` function with an array, a step factor, and a one-parameter block
 #
 # ~~~ puppet
-# # For the array $data, call a block with each 3rd element of $data
+# # For the array $data, call a block with the first element and then with each 3rd successor element
 # $data = [1,2,3,4,5,6,7,8]
 # $data.step(3) |$item| {
 #  notice($item)
@@ -42,12 +42,13 @@
 # # Puppet notices the values '1', '4', '7'.
 # ~~~
 #
-# When no block is given, Puppet returns a new iterable so that a new function that takes
-# an iterable as an argument can use it as input.
+# When no block is given, Puppet returns a new `Iterable` which allows it to be directly chained into
+# another function that takes an `Iterable` as an argument.
 #
 # @example Using the `step` function chained with a `map` function.
 #
-# # For the array $data, return an array containing each 5th value in reverse order multiplied by 10
+# # For the array $data, return an array, set to the first element and each 5th successor element, in reverse
+# # order multiplied by 10
 # $data = Integer[0,20]
 # $transformed_data = $data.step(5).map |$item| { $item * 10 }
 # # $transformed_data contains [0,50,100,150,200]
@@ -55,7 +56,7 @@
 #
 # @example The same example using `step` function chained with a `map` in alternative syntax
 #
-# # For the array $data, return an array containing each 5th value in reverse order multiplied by 10
+# # For the array $data, return an array containing the first and each 5th successor, in reverse order, multiplied by 10
 # $data = Integer[0,20]
 # $transformed_data = map(step($data, 5)) |$item| { $item * 10 }
 # # $transformed_data contains [0,50,100,150,200]

--- a/lib/puppet/functions/step.rb
+++ b/lib/puppet/functions/step.rb
@@ -4,8 +4,8 @@
 #
 # This function takes two to three arguments.
 #
-# 1. An iterable that the function will iterate over.
-# 2. An integer step factor. This must be a positive integer.
+# 1. An 'Iterable' that the function will iterate over.
+# 2. An `Integer` step factor. This must be a positive integer.
 # 3. An optional lambda, which the function calls for each element in the interval. It must
 # request one parameter.
 #
@@ -56,7 +56,7 @@
 #
 # @example The same example using `step` function chained with a `map` in alternative syntax
 #
-# # For the array $data, return an array containing the first and each 5th successor, in reverse order, multiplied by 10
+# # For the array $data, return an array, set to the first and each 5th successor, in reverse order, multiplied by 10
 # $data = Integer[0,20]
 # $transformed_data = map(step($data, 5)) |$item| { $item * 10 }
 # # $transformed_data contains [0,50,100,150,200]

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -78,7 +78,7 @@ module Puppet::Pops::Types
         # a finite range will always produce at least one element since it's inclusive
         o.finite_range? ? IntegerRangeIterator.new(o) : nil
       when PEnumType
-        Iterator.new(o, o.values)
+        Iterator.new(o, o.values.each)
       when Range
         min = o.min
         max = o.max

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -217,8 +217,8 @@ module Puppet::Pops::Types
           e = e.map { |t| t.to_s }
           a = a.to_s
         else
-          sns = e.map { |t| t.simple_name }
-          e = e.map { |t| s = t.simple_name; sns.count {|x| x == s } == 1 ? s : t.to_s }
+          sns = e.map { |t| t.simple_name }.uniq
+          e = e.map { |t| s = t.simple_name; sns.count {|x| x == s } == 1 ? s : t.to_s }.uniq
           a = a.simple_name
         end
         case e.size

--- a/spec/unit/functions/defined_spec.rb
+++ b/spec/unit/functions/defined_spec.rb
@@ -268,11 +268,11 @@ describe "the 'defined' function" do
   end
 
   it 'raises error if referencing undef' do
-    expect{func.call(@scope, nil)}.to raise_error(ArgumentError, /'defined' parameter 'vals' expects a value of type String, Type\[CatalogEntry\], or Type\[Type\[CatalogEntry\]\], got Undef/)
+    expect{func.call(@scope, nil)}.to raise_error(ArgumentError, /'defined' parameter 'vals' expects a value of type String or Type, got Undef/)
   end
 
   it 'raises error if referencing a number' do
-    expect{func.call(@scope, 42)}.to raise_error(ArgumentError, /'defined' parameter 'vals' expects a value of type String, Type\[CatalogEntry\], or Type\[Type\[CatalogEntry\]\], got Integer/)
+    expect{func.call(@scope, 42)}.to raise_error(ArgumentError, /'defined' parameter 'vals' expects a value of type String or Type, got Integer/)
   end
 
   it 'is false if referencing empty string' do

--- a/spec/unit/functions/reverse_each_spec.rb
+++ b/spec/unit/functions/reverse_each_spec.rb
@@ -1,0 +1,73 @@
+require 'puppet'
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+require 'shared_behaviours/iterative_functions'
+
+describe 'the reverse_each function' do
+  include PuppetSpec::Compiler
+
+  it 'raises an error when given a type that cannot be iterated' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        3.14.reverse_each |$v| {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /expects an Iterable value, got Float/)
+  end
+
+  it 'raises an error when called with more than one argument and without a block' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].reverse_each(1)
+      MANIFEST
+    end.to raise_error(Puppet::Error, /expects 1 argument, got 2/)
+  end
+
+  it 'raises an error when called with more than one argument and a block' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].reverse_each(1) |$v| {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /expects 1 argument, got 2/)
+  end
+
+  it 'raises an error when called with a block with too many required parameters' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].reverse_each() |$v1, $v2| {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /block expects 1 argument, got 2/)
+  end
+
+  it 'raises an error when called with a block with too few parameters' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].reverse_each() | | {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /block expects 1 argument, got none/)
+  end
+
+  it 'does not raise an error when called with a block with too many but optional arguments' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].reverse_each() |$v1, $v2=extra| {  }
+      MANIFEST
+    end.to_not raise_error
+  end
+
+  it 'returns an Iterable when called without a block' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+            assert_type(Iterable, [1].reverse_each)
+      MANIFEST
+    end.not_to raise_error
+  end
+
+  it 'should produce "times" interval of integer in reverse' do
+    expect(eval_and_collect_notices('5.reverse_each |$x| { notice($x) }')).to eq(['4', '3', '2', '1', '0'])
+  end
+
+  it 'should produce range Integer[5,8] in reverse' do
+    expect(eval_and_collect_notices('Integer[5,8].reverse_each |$x| { notice($x) }')).to eq(['8', '7', '6', '5'])
+  end
+end

--- a/spec/unit/functions/reverse_each_spec.rb
+++ b/spec/unit/functions/reverse_each_spec.rb
@@ -82,4 +82,19 @@ describe 'the reverse_each function' do
   it 'should produce the choices of Enum[first,second,third] in reverse' do
     expect(eval_and_collect_notices('Enum[first,second,third].reverse_each |$x| { notice($x) }')).to eq(%w(third second first))
   end
+
+  it 'should produce nth element in reverse of range Integer[5,20] when chained after a step' do
+    expect(eval_and_collect_notices('Integer[5,20].step(4).reverse_each |$x| { notice($x) }')
+    ).to eq(['17', '13', '9', '5'])
+  end
+
+  it 'should produce nth element in reverse of times 5 when chained after a step' do
+    expect(eval_and_collect_notices('5.step(2).reverse_each |$x| { notice($x) }')).to eq(['4', '2', '0'])
+  end
+
+  it 'should produce nth element in reverse of range Integer[5,20] when chained after a step' do
+    expect(eval_and_collect_notices(
+      '[5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20].step(4).reverse_each |$x| { notice($x) }')
+    ).to eq(['17', '13', '9', '5'])
+  end
 end

--- a/spec/unit/functions/reverse_each_spec.rb
+++ b/spec/unit/functions/reverse_each_spec.rb
@@ -70,4 +70,16 @@ describe 'the reverse_each function' do
   it 'should produce range Integer[5,8] in reverse' do
     expect(eval_and_collect_notices('Integer[5,8].reverse_each |$x| { notice($x) }')).to eq(['8', '7', '6', '5'])
   end
+
+  it 'should produce the choices of [first,second,third] in reverse' do
+    expect(eval_and_collect_notices('[first,second,third].reverse_each |$x| { notice($x) }')).to eq(%w(third second first))
+  end
+
+  it 'should produce the choices of {first => 1,second => 2,third => 3} in reverse' do
+    expect(eval_and_collect_notices('{first => 1,second => 2,third => 3}.reverse_each |$t| { notice($t[0]) }')).to eq(%w(third second first))
+  end
+
+  it 'should produce the choices of Enum[first,second,third] in reverse' do
+    expect(eval_and_collect_notices('Enum[first,second,third].reverse_each |$x| { notice($x) }')).to eq(%w(third second first))
+  end
 end

--- a/spec/unit/functions/step_spec.rb
+++ b/spec/unit/functions/step_spec.rb
@@ -87,7 +87,19 @@ describe 'the step method' do
     expect(eval_and_collect_notices('Integer[5,20].step(4) |$x| { notice($x) }')).to eq(['5', '9', '13', '17'])
   end
 
-  it 'should produce negative interval of Integer[5,20] when chained after a reverse_each' do
+  it 'should produce the elements of [a,b,c,d,e,f,g,h] according to step' do
+    expect(eval_and_collect_notices('[a,b,c,d,e,f,g,h].step(2) |$x| { notice($x) }')).to eq(%w(a c e g))
+  end
+
+  it 'should produce the elements {a=>1,b=>2,c=>3,d=>4,e=>5,f=>6,g=>7,h=>8} according to step' do
+    expect(eval_and_collect_notices('{a=>1,b=>2,c=>3,d=>4,e=>5,f=>6,g=>7,h=>8}.step(2) |$t| { notice($t[1]) }')).to eq(%w(1 3 5 7))
+  end
+
+  it 'should produce the choices of Enum[a,b,c,d,e,f,g,h] according to step' do
+    expect(eval_and_collect_notices('Enum[a,b,c,d,e,f,g,h].step(2) |$x| { notice($x) }')).to eq(%w(a c e g))
+  end
+
+  it 'should produce descending interval of Integer[5,20] when chained after a reverse_each' do
     expect(eval_and_collect_notices('Integer[5,20].reverse_each.step(4) |$x| { notice($x) }')).to eq(['20', '16', '12', '8'])
   end
 end

--- a/spec/unit/functions/step_spec.rb
+++ b/spec/unit/functions/step_spec.rb
@@ -1,0 +1,93 @@
+require 'puppet'
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+require 'shared_behaviours/iterative_functions'
+
+describe 'the step method' do
+  include PuppetSpec::Compiler
+
+  it 'raises an error when given a type that cannot be iterated' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        3.14.step(1) |$v| {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /expects an Iterable value, got Float/)
+  end
+
+  it 'raises an error when called with more than two arguments and a block' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].step(1,2) |$v| {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /expects 2 arguments, got 3/)
+  end
+
+  it 'raises an error when called with more than two arguments and without a block' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].step(1,2)
+      MANIFEST
+    end.to raise_error(Puppet::Error, /expects 2 arguments, got 3/)
+  end
+
+  it 'raises an error when called with a block with too many required parameters' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].step(1) |$v1, $v2| {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /block expects 1 argument, got 2/)
+  end
+
+  it 'raises an error when called with a block with too few parameters' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].step(1) | | {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /block expects 1 argument, got none/)
+  end
+
+  it 'raises an error when called with step == 0' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].step(0) |$x| {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /'step' expects an Integer\[1, default\] value, got Integer\[0, 0\]/)
+  end
+
+  it 'raises an error when step is not an integer' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].step('three') |$x| {  }
+      MANIFEST
+    end.to raise_error(Puppet::Error, /'step' expects an Integer value, got String/)
+  end
+
+  it 'does not raise an error when called with a block with too many but optional arguments' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+        [1].step(1) |$v1, $v2=extra| {  }
+      MANIFEST
+    end.to_not raise_error
+  end
+
+  it 'returns an Iterable when called without a block' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+          assert_type(Iterable, [1].step(2))
+      MANIFEST
+    end.not_to raise_error
+  end
+
+  it 'should produce "times" interval of integer according to step' do
+    expect(eval_and_collect_notices('10.step(2) |$x| { notice($x) }')).to eq(['0', '2', '4', '6', '8'])
+  end
+
+  it 'should produce interval of Integer[5,20] according to step' do
+    expect(eval_and_collect_notices('Integer[5,20].step(4) |$x| { notice($x) }')).to eq(['5', '9', '13', '17'])
+  end
+
+  it 'should produce negative interval of Integer[5,20] when chained after a reverse_each' do
+    expect(eval_and_collect_notices('Integer[5,20].reverse_each.step(4) |$x| { notice($x) }')).to eq(['20', '16', '12', '8'])
+  end
+end


### PR DESCRIPTION
This PR adds the new function `step(iterable, n)`. The function takes two arguments, an iterable and an integer, and an optional block.

If a block is given, it will be called with each nth element of the given argument.

Without a block, the function will return a new Iterable that will yield each nth element of the given argument.

