### PR TITLE
(maint) Remove support for ruby < 1.9.3

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -467,14 +467,7 @@ module Util
   module_function :deterministic_rand
 
   def deterministic_rand_int(seed,max)
-    if defined?(Random) == 'constant' && Random.class == Class
-      Random.new(seed).rand(max)
-    else
-      srand(seed)
-      result = rand(max)
-      srand()
-      result
-    end
+    Random.new(seed).rand(max)
   end
   module_function :deterministic_rand_int
 end


### PR DESCRIPTION
In commit 292233cea202a4989eaf0fd9a7cf3cb499d66a2c, support was added for ruby
< 1.9.3. Puppet no longer supports ruby versions that old, so this code can be
removed.