### PR TITLE
(PUP-5726) Support non-english values in environment variables

### DIFF
--- a/lib/puppet/provider/exec/windows.rb
+++ b/lib/puppet/provider/exec/windows.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
     end
 
     if resource[:path]
-      Puppet::Util.withenv :PATH => resource[:path].join(File::PATH_SEPARATOR) do
+      Puppet::Util.withenv( {:PATH => resource[:path].join(File::PATH_SEPARATOR)}, :windows) do
         return if which(exe)
       end
     end

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -317,7 +317,7 @@ module Puppet::Util::Execution
     end.join(" ") if command.is_a?(Array)
 
     options[:custom_environment] ||= {}
-    Puppet::Util.withenv(options[:custom_environment]) do
+    Puppet::Util.withenv(options[:custom_environment], :windows) do
       Puppet::Util::Windows::Process.execute(command, options, stdin, stdout, stderr)
     end
   end

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -224,6 +224,50 @@ module Puppet::Util::Windows::Process
   end
   module_function :windows_major_version
 
+  ENVSTRINGS_TERMINATOR_WCHAR = [0,0]
+  # Returns a hash of the current environment variables encoded as UTF-8
+  # The memory block returned from GetEnvironmentStringsW is double-null terminated and the vars are paired as below;
+  # Var1=Value1\0
+  # Var2=Value2\0
+  # VarX=ValueX\0\0
+  # Note - Some env variable names start with '=' and are safe to ignore
+  # Note - The env_ptr MUST be freed using the FreeEnvironmentStringsW function
+  # Note - There is no technical limitation to the size of the environment block returned.
+  #   However a pracitcal limit of 64K is used as no single environment variable can exceed 32KB
+  def get_environment_strings
+    env_ptr = GetEnvironmentStringsW()
+
+    pairs = env_ptr.read_arbitrary_wide_string_up_to(65534, ENVSTRINGS_TERMINATOR_WCHAR)
+      .split(?\x00)
+      .reject { |env_str| env_str.nil? || env_str[0] == '=' }
+      .map { |env_pair| env_pair.split('=', -2) }
+    Hash[ pairs ]
+  ensure
+    if env_ptr && ! env_ptr.null?
+      if FreeEnvironmentStringsW(env_ptr) == FFI::WIN32_FALSE
+        Puppet.debug "FreeEnvironmentStringsW memory leak"
+      end
+    end
+  end
+  module_function :get_environment_strings
+
+  def set_environment_variable(name,val)
+    FFI::MemoryPointer.from_string_to_wide_string(name) do |name_ptr|
+      if (val.nil?)
+        if SetEnvironmentVariableW(name_ptr, FFI::MemoryPointer::NULL) == FFI::WIN32_FALSE
+          raise Puppet::Util::Windows::Error.new("Failed to remove environment variable: #{name}")
+        end
+      else
+        FFI::MemoryPointer.from_string_to_wide_string(val) do |val_ptr|
+          if SetEnvironmentVariableW(name_ptr, val_ptr) == FFI::WIN32_FALSE
+            raise Puppet::Util::Windows::Error.new("Failed to set environment variable: #{name}")
+          end
+        end
+      end
+    end
+  end
+  module_function :set_environment_variable
+
   # Returns whether or not the OS has the ability to set elevated
   # token information.
   #
@@ -265,6 +309,28 @@ module Puppet::Util::Windows::Process
   # HANDLE WINAPI GetCurrentProcess(void);
   ffi_lib :kernel32
   attach_function_private :GetCurrentProcess, [], :handle
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms683187(v=vs.85).aspx
+  # LPTCH GetEnvironmentStrings(void);
+  ffi_lib :kernel32
+  attach_function_private :GetEnvironmentStringsW, [], :pointer
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms683151(v=vs.85).aspx
+  # BOOL FreeEnvironmentStrings(
+  #   _In_ LPTCH lpszEnvironmentBlock
+  # );
+  ffi_lib :kernel32
+  attach_function_private :FreeEnvironmentStringsW,
+    [:pointer], :win32_bool
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms686206(v=vs.85).aspx
+  # BOOL WINAPI SetEnvironmentVariableW(
+  #     _In_     LPCTSTR lpName,
+  #     _In_opt_ LPCTSTR lpValue
+  #   );
+  ffi_lib :kernel32
+  attach_function_private :SetEnvironmentVariableW,
+    [:lpcwstr, :lpcwstr], :win32_bool
 
   # http://msdn.microsoft.com/en-us/library/windows/desktop/aa379295(v=vs.85).aspx
   # BOOL WINAPI OpenProcessToken(


### PR DESCRIPTION
The ENV class in Ruby is not able to interpret non-english values and
can corrupt the environment.  Without these changes, the process
environment for Puppet will corrupt when there are environment variables
with non-english characters and the withenv utility function is used
e.g. the windows and powershell Exec providers.

- The withenv function was extended with an additional parameter of mode.
  The default will use the existing code path, but the windows mode will
  use the Wide String aware windows environment API calls

- The execute_windows function in the Execution module was modified to
  use the windows mode for withenv

- The get_environment_strings and set_environment_variable functions
  were added to the Windows Process module.  These functions use the
  Windows Wide String API calls

- The read_arbitrary_wide_string_up_to function was extended to use a
  specified terminating character sequence.  This was required as the
  memory block from GetEnvironmentStringsW is double null terminated
  whereas the function previously only used a single null terminating
  charater