### PR TITLE
(PUP-917) Identify in the report why a cached catalog was use

### DIFF
--- a/api/docs/http_report.md
+++ b/api/docs/http_report.md
@@ -53,7 +53,7 @@ example is formatted for readability)
      "transaction_uuid"=>"df34516e-4050-402d-a166-05b03b940749",
      "code_id"=>null,
      "catalog_uuid"=>"827a74c8-cf98-44da-9ff7-18c5e4bee41e",
-     "report_format"=>4,
+     "report_format"=>5,
      "puppet_version"=>"3.3.0",
      "kind"=>"apply",
      "status"=>"unchanged",
@@ -109,7 +109,8 @@ example is formatted for readability)
          "skipped"=>false,
          "change_count"=>0,
          "out_of_sync_count"=>0,
-         "events"=>[]}}}
+         "events"=>[]}},
+      "cached_catalog_status"=> "unused"}
 
 Schema
 ------

--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -103,10 +103,19 @@
             "type":        "string"
         },
 
+        "cached_catalog_status": {
+            "description": "Whether a cached catalog was used, and if so, why it was used. Enumerator with one of the values:\n\n* `unused`, if a cached catalog was not used.\n* `use_cached_catalog`, if a cached catalog was used because the use_cached_catalog option was set.\n* `use_cache_on_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the agent failed to download a new catalog",
+            "enum": [
+              "unused",
+              "use_cached_catalog",
+              "use_cache_on_failure"
+            ]
+        },
+
         "report_format": {
             "description": "The report format version documented by this schema",
             "type":        "integer",
-            "enum":        ["4", 4]
+            "enum":        ["5", 5]
         },
 
         "puppet_version": {

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -54,6 +54,11 @@ class Puppet::Transaction::Report
   # A master generated catalog uuid, useful for connecting a single catalog to multiple reports.
   attr_accessor :catalog_uuid
 
+  # Whether a cached catalog was used in the run, and if so, the reason that it was used.
+  # @return [String] One of the values: 'unused', 'use_cached_catalog',
+  # or 'use_cache_on_failure'
+  attr_accessor :cached_catalog_status
+
   # The host name for which the report is generated
   # @return [String] the host name
   attr_accessor :host
@@ -178,12 +183,13 @@ class Puppet::Transaction::Report
     @host = Puppet[:node_name_value]
     @time = Time.now
     @kind = kind
-    @report_format = 4
+    @report_format = 5
     @puppet_version = Puppet.version
     @configuration_version = configuration_version
     @transaction_uuid = transaction_uuid
     @code_id = nil
     @catalog_uuid = nil
+    @cached_catalog_status = nil
     @environment = environment
     @status = 'failed' # assume failed until the report is finalized
   end
@@ -205,6 +211,10 @@ class Puppet::Transaction::Report
 
     if code_id = data['code_id']
       @code_id = code_id
+    end
+
+    if cached_catalog_status = data['cached_catalog_status']
+      @cached_catalog_status = cached_catalog_status
     end
 
     if @time.is_a? String
@@ -240,6 +250,7 @@ class Puppet::Transaction::Report
       'transaction_uuid' => @transaction_uuid,
       'catalog_uuid' => @catalog_uuid,
       'code_id' => @code_id,
+      'cached_catalog_status' => @cached_catalog_status,
       'report_format' => @report_format,
       'puppet_version' => @puppet_version,
       'kind' => @kind,

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -64,6 +64,12 @@ describe Puppet::Transaction::Report do
     expect(report.catalog_uuid).to eq("some catalog uuid")
   end
 
+  it "should be able to set cached_catalog_status" do
+    report = Puppet::Transaction::Report.new("inspect")
+    report.cached_catalog_status = "use_cached_catalog"
+    expect(report.cached_catalog_status).to eq("use_cached_catalog")
+  end
+
   it "should take 'environment' as an argument" do
     expect(Puppet::Transaction::Report.new("inspect", "some configuration version", "some environment").environment).to eq("some environment")
   end
@@ -433,6 +439,7 @@ describe Puppet::Transaction::Report do
     expect(tripped.transaction_uuid).to eq(report.transaction_uuid)
     expect(tripped.code_id).to eq(report.code_id)
     expect(tripped.catalog_uuid).to eq(report.catalog_uuid)
+    expect(tripped.cached_catalog_status).to eq(report.cached_catalog_status)
     expect(tripped.report_format).to eq(report.report_format)
     expect(tripped.puppet_version).to eq(report.puppet_version)
     expect(tripped.kind).to eq(report.kind)
@@ -501,6 +508,7 @@ describe Puppet::Transaction::Report do
     report.add_times("timing", 4)
     report.code_id = "some code id"
     report.catalog_uuid = "some catalog uuid"
+    report.cached_catalog_status = "unused"
     report.add_resource_status(status)
     report.finalize_report
     report
@@ -516,6 +524,7 @@ describe Puppet::Transaction::Report do
     report.add_times("timing", 4)
     report.code_id = "some code id"
     report.catalog_uuid = "some catalog uuid"
+    report.cached_catalog_status = "unused"
     report.add_resource_status(status)
     report.finalize_report
     report


### PR DESCRIPTION
Currently, the agent run report does not provide any information
about why a cached catalog was used. This can cause issues when
a remote catalog request unexpectedly fails, causing the agent
to fall back to a cached catalog. In such a case, the report will
indicate that the run was successful without pointing out that a
cached catalog had to be used.

There are two ways a cached catalog may be used: by running the agent
with the `--use_cached_catalog` option, or by a catalog failing to
compile on the master, causing the agent to automatically fall back to
a cached catalog as long as the `usecacheonfailing` setting is set.

This commit adds the `cached_catalog_status` field to Puppet::Transaction::Report,
with possible values 'unused', 'use_cached_catalog' and
'use_cache_on_failure'.