### PR TITLE
(PUP-5120) Send checksum_type and static_catalog in catalog request

### DIFF
--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -40,7 +40,8 @@ doubly-escaped (it should just be singly-escaped).  To keep backward compatibili
 escaping is still used/supported.
 - `transaction_uuid`: a transaction uuid identifying the entire transaction (shows up in the report as well)
 - `static_catalog`: a boolean requesting a static catalog if available; should always be `true`
-- `checksum_type`: a checksum type supported by the agent, for use in file resources of a static catalog.
+- `checksum_type`: a dot-separated list of checksum types supported by the agent, for use in file resources of a static
+catalog. The order signifies preference, highest first.
 
 An optional parameter can be provided to the POST or GET to notify a node classifier that the client requested a specific
 environment, which might differ from what the client believes is its current environment:
@@ -53,7 +54,7 @@ environment, which might differ from what the client believes is its current env
 
     POST /puppet/v3/catalog/elmo.mydomain.com
 
-    environment=env&configured_environment=canary_env&facts_format=pson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c&static_catalog=true&checksum_type=md5
+    environment=env&configured_environment=canary_env&facts_format=pson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c&static_catalog=true&checksum_type=md5.sha256
 
     HTTP 200 OK
     Content-Type: text/pson

--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -31,7 +31,7 @@ The examples below use the POST method.
 
 ### Parameters
 
-Four parameters should be provided to the POST or GET:
+Six parameters should be provided to the POST or GET:
 
 - `environment`: the environment name
 - `facts_format`: must be `pson`
@@ -39,6 +39,8 @@ Four parameters should be provided to the POST or GET:
 doubly-escaped (it should just be singly-escaped).  To keep backward compatibility, the extraneous
 escaping is still used/supported.
 - `transaction_uuid`: a transaction uuid identifying the entire transaction (shows up in the report as well)
+- `static_catalog`: a boolean requesting a static catalog if available; should always be `true`
+- `checksum_type`: a checksum type supported by the agent, for use in file resources of a static catalog.
 
 An optional parameter can be provided to the POST or GET to notify a node classifier that the client requested a specific
 environment, which might differ from what the client believes is its current environment:
@@ -51,7 +53,7 @@ environment, which might differ from what the client believes is its current env
 
     POST /puppet/v3/catalog/elmo.mydomain.com
 
-    environment=env&configured_environment=canary_env&facts_format=pson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c
+    environment=env&configured_environment=canary_env&facts_format=pson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c&static_catalog=true&checksum_type=md5
 
     HTTP 200 OK
     Content-Type: text/pson

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -51,7 +51,7 @@ class Puppet::Configurer
     @environment = Puppet[:environment]
     @transaction_uuid = SecureRandom.uuid
     @static_catalog = true
-    @checksum_type = Puppet[:digest_algorithm]
+    @checksum_type = Puppet[:supported_checksum_types]
     @handler = Puppet::Configurer::PluginHandler.new(factory)
   end
 
@@ -115,7 +115,10 @@ class Puppet::Configurer
     options[:report].host = Puppet[:node_name_value]
     query_options[:transaction_uuid] = @transaction_uuid
     query_options[:static_catalog] = @static_catalog
-    query_options[:checksum_type] = @checksum_type
+
+    # Query params don't enforce ordered evaluation, so munge this list into a
+    # dot-separated string.
+    query_options[:checksum_type] = @checksum_type.join('.')
 
     unless catalog = (options.delete(:catalog) || retrieve_catalog(query_options))
       Puppet.err "Could not retrieve catalog; skipping run"

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -111,6 +111,7 @@ class Puppet::Configurer
   def prepare_and_retrieve_catalog(options, query_options)
     # set report host name now that we have the fact
     options[:report].host = Puppet[:node_name_value]
+    query_options[:transaction_uuid] = @transaction_uuid
 
     unless catalog = (options.delete(:catalog) || retrieve_catalog(query_options))
       Puppet.err "Could not retrieve catalog; skipping run"
@@ -211,7 +212,6 @@ class Puppet::Configurer
       Puppet.push_context({:current_environment => local_node_environment}, "Local node environment for configurer transaction")
 
       query_options = get_facts(options) unless query_options
-      query_options[:transaction_uuid] = @transaction_uuid
       query_options[:configured_environment] = configured_environment
 
       unless catalog = prepare_and_retrieve_catalog(options, query_options)
@@ -232,7 +232,6 @@ class Puppet::Configurer
         report.environment = @environment
 
         query_options = get_facts(options)
-        query_options[:transaction_uuid] = @transaction_uuid
         query_options[:configured_environment] = configured_environment
 
         return nil unless catalog = prepare_and_retrieve_catalog(options, query_options)

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -50,6 +50,8 @@ class Puppet::Configurer
     @cached_catalog_status = 'not_used'
     @environment = Puppet[:environment]
     @transaction_uuid = SecureRandom.uuid
+    @static_catalog = true
+    @checksum_type = Puppet[:digest_algorithm]
     @handler = Puppet::Configurer::PluginHandler.new(factory)
   end
 
@@ -112,6 +114,8 @@ class Puppet::Configurer
     # set report host name now that we have the fact
     options[:report].host = Puppet[:node_name_value]
     query_options[:transaction_uuid] = @transaction_uuid
+    query_options[:static_catalog] = @static_catalog
+    query_options[:checksum_type] = @checksum_type
 
     unless catalog = (options.delete(:catalog) || retrieve_catalog(query_options))
       Puppet.err "Could not retrieve catalog; skipping run"

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -786,6 +786,20 @@ EOT
         :values => ["md5", "sha256"],
         :desc     => 'Which digest algorithm to use for file resources and the filebucket.
                       Valid values are md5, sha256. Default is md5.',
+    },
+    :supported_checksum_types => {
+      :default => ['md5', 'sha256'],
+      :type    => :array,
+      :desc    => 'Checksum types supported by this agent for use in file resources of a static
+        catalog. Valid types are md5, md5lite, sha256, sha256lite, sha1, sha1lite, mtime, ctime.',
+      :hook    => proc do |value|
+        values = munge(value)
+        valid   = ['md5', 'md5lite', 'sha256', 'sha256lite', 'sha1', 'sha1lite', 'mtime', 'ctime']
+        invalid = values.reject {|alg| valid.include?(alg)}
+        if not invalid.empty?
+          raise ArgumentError, "Unrecognized checksum types #{invalid} are not supported. Valid values are #{valid}."
+        end
+      end
     }
   )
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -388,21 +388,22 @@ describe Puppet::Configurer do
       @agent.run
     end
 
-    it "sets the checksum_type query param to the default digest_algorithm in a catalog request" do
-      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:checksum_type => 'md5'))
+    it "sets the checksum_type query param to the default supported_checksum_types in a catalog request" do
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything,
+        has_entries(:checksum_type => 'md5.sha256'))
       @agent.run
     end
 
-    it "sets the checksum_type query param to the digest_algorithm setting in a catalog request" do
+    it "sets the checksum_type query param to the supported_checksum_types setting in a catalog request" do
       # Regenerate the agent to pick up the new setting
-      Puppet[:digest_algorithm] = 'sha256'
+      Puppet[:supported_checksum_types] = ['sha256']
       @agent = Puppet::Configurer.new
       @agent.stubs(:init_storage)
       @agent.stubs(:download_plugins)
       @agent.stubs(:send_report)
       @agent.stubs(:save_last_run_summary)
 
-      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:checksum_type => Puppet[:digest_algorithm]))
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:checksum_type => 'sha256'))
       @agent.run
     end
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -383,6 +383,29 @@ describe Puppet::Configurer do
       @agent.run
     end
 
+    it "sets the static_catalog query param to true in a catalog request" do
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:static_catalog => true))
+      @agent.run
+    end
+
+    it "sets the checksum_type query param to the default digest_algorithm in a catalog request" do
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:checksum_type => 'md5'))
+      @agent.run
+    end
+
+    it "sets the checksum_type query param to the digest_algorithm setting in a catalog request" do
+      # Regenerate the agent to pick up the new setting
+      Puppet[:digest_algorithm] = 'sha256'
+      @agent = Puppet::Configurer.new
+      @agent.stubs(:init_storage)
+      @agent.stubs(:download_plugins)
+      @agent.stubs(:send_report)
+      @agent.stubs(:save_last_run_summary)
+
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:checksum_type => Puppet[:digest_algorithm]))
+      @agent.run
+    end
+
     describe "when not using a REST terminus for catalogs" do
       it "should not pass any facts when retrieving the catalog" do
         Puppet::Resource::Catalog.indirection.terminus_class = :compiler

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -377,6 +377,12 @@ describe Puppet::Configurer do
       expect($env_module_directories).to eq(nil)
     end
 
+    it "sends the transaction uuid in a catalog request" do
+      @agent.instance_variable_set(:@transaction_uuid, 'aaa')
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:transaction_uuid => 'aaa'))
+      @agent.run
+    end
+
     describe "when not using a REST terminus for catalogs" do
       it "should not pass any facts when retrieving the catalog" do
         Puppet::Resource::Catalog.indirection.terminus_class = :compiler

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -71,4 +71,19 @@ describe "Defaults" do
     end
 
   end
+
+  describe 'supported_checksum_types' do
+    it 'should default to md5,sha256' do
+      expect(Puppet.settings[:supported_checksum_types]).to eq(['md5', 'sha256'])
+    end
+
+    it 'should raise an error on an unsupported checksum type' do
+      expect { Puppet.settings[:supported_checksum_types] = ['md5', 'foo'] }.to raise_exception ArgumentError, 'Unrecognized checksum types ["foo"] are not supported. Valid values are ["md5", "md5lite", "sha256", "sha256lite", "sha1", "sha1lite", "mtime", "ctime"].'
+    end
+
+    it 'should not raise an error on setting a valid list of checksum types' do
+      Puppet.settings[:supported_checksum_types] = ['sha256', 'md5lite', 'mtime']
+      expect(Puppet.settings[:supported_checksum_types]).to eq(['sha256', 'md5lite', 'mtime'])
+    end
+  end
 end

--- a/spec/unit/type/file/checksum_spec.rb
+++ b/spec/unit/type/file/checksum_spec.rb
@@ -76,4 +76,10 @@ describe checksum do
       expect(sum).to eq("something")
     end
   end
+
+  it 'should use values allowed by the supported_checksum_types setting' do
+    values = checksum.value_collection.values.reject {|v| v == :none}.map {|v| v.to_s}
+    Puppet.settings[:supported_checksum_types] = values
+    expect(Puppet.settings[:supported_checksum_types]).to eq(values)
+  end
 end


### PR DESCRIPTION
Currently, when the agent applies a catalog, it sends a `file_metadata`
request for each file resource along with the `checksum_type` that the
master should use to compute the checksum. The `checksum_type` originates
in either the manifest (and preserved in the catalog), or if none was
specified, the agent's default `Puppet[:digest_algorithm]`.

When static catalogs are enabled, the file metadata inlining process
will need to choose a digest algorithm if none is specified in the
manifest. To ensure the master chooses a checksum suitable for the
agent, the agent needs to send its desired checksum in the catalog
request as a request parameter. Add a checksum_type query param to the
catalog request with an ordered list of algorithms the agent supports,
with the value of `Puppet[:digest_algorithm]` as the first item.
Providing a list is for future proofing in the case where the agent's
default is not supported by the master.

Also, request a static catalog by sending `static_catalog=true` query
parameter. The server will decide whether to build a static catalog.