### PR TITLE
(maint) Remove Ruby 2.3.0 from Travis C.I. matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ script:
 notifications:
   email: false
 rvm:
-  - 2.3.0
   - 2.2.4
   - 2.1.8
   - 2.0.0
@@ -21,16 +20,12 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.3.0
-      env: "CHECK=rubocop"
     - rvm: 2.2.4
       env: "CHECK=rubocop"
     - rvm: 2.0.0
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
-    - rvm: 2.3.0
-      env: "CHECK=commits"
     - rvm: 2.2.4
       env: "CHECK=commits"
     - rvm: 2.0.0


### PR DESCRIPTION
Since we're getting a mysterious seg fault when running our spec
tests against Ruby 2.3.0, remove it from the Travis testing matrix
for now until the issue is sorted out.