### PR TITLE
(PUP-5708) Deprecate pluginsync setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1570,7 +1570,9 @@ EOT
     :pluginsync => {
       :default    => true,
       :type       => :boolean,
-      :desc       => "Whether plugins should be synced with the central server.",
+      :desc       => "Whether plugins should be synced with the central server. This setting is
+        deprecated.",
+     :deprecated => :completely,
     },
 
     :pluginsignore => {


### PR DESCRIPTION
Soon, the behavior of pluginsyncing will be based on whether or
not a cached catalog is being used. This is to prevent scenarios
where the set of plugins used by the agent is different than the
set that was used when the catalog was originally compiled.

This commit deprecates the setting. Future work will handle the
switchover to the new logic based on cached catalog usage.