### PR TITLE
(PUP-5741) Fix confusing errors when comparing values

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -73,19 +73,30 @@ module Puppet::Pops::Issues
       instance_eval &block
     end
 
-    # Returns the label provider given as a key in the hash passed to #format.
-    # If given an argument, calls #label on the label provider (caller would otherwise have to
-    # call label.label(it)
+    # Obtains the label provider given as a key `:label` in the hash passed to #format. The label provider is
+    # return if no arguments are given. If given an argument, returns the result of calling #label on the label
+    # provider.
     #
-    def label(it = nil)
-      raise "Label provider key :label must be set to produce the text of the message!" unless @data[:label]
-      it.nil? ? @data[:label] : @data[:label].label(it)
+    # @param args [Object] one object to obtain a label for or zero arguments to obtain the label provider
+    # @return [Puppet::Pops::LabelProvider,String] the label provider or label depending on if an argument is given or not
+    # @raise [Puppet::Error] if no label provider is found
+    def label(*args)
+      args.empty? ? label_provider : label_provider.label(args[0])
+    end
+
+    # Returns the label provider given as key `:label` in the hash passed to #format.
+    # @return [Puppet::Pops::LabelProvider] the label provider
+    # @raise [Puppet::Error] if no label provider is found
+    def label_provider
+      label_provider = @data[:label]
+      raise Puppet::Error, 'Label provider key :label must be set to produce the text of the message!' unless label_provider
+      label_provider
     end
 
     # Returns the label provider given as a key in the hash passed to #format.
     #
     def semantic
-      raise "Label provider key :semantic must be set to produce the text of the message!" unless @data[:semantic]
+      raise Puppet::Error, 'Label provider key :semantic must be set to produce the text of the message!' unless @data[:semantic]
       @data[:semantic]
     end
   end

--- a/spec/unit/pops/evaluator/comparison_ops_spec.rb
+++ b/spec/unit/pops/evaluator/comparison_ops_spec.rb
@@ -86,6 +86,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       it "'1.0' < 1.1 == true" do
         expect{evaluate(literal('1.0') <  literal(1.1))}.to raise_error(/String < Float/)
       end
+      it "undef < 1.1 == true" do
+        expect{evaluate(literal(nil) <  literal(1.1))}.to raise_error(/Undef Value < Float/)
+      end
     end
 
     context "of regular expressions" do


### PR DESCRIPTION
Prior to this commit, the method MessageData#label had two functions.
If called with an argument, it presented the String form for that
argument. If called without, it returned a `ModelLabelProvider`. This
made it impossible to produce a message for `nil`.

This commit splits the method in two. One `provider`method that takes
no arguments and just returns the `ModuleLabelProvider` and one that
always returns the String representation of its argument. All calls
are adjusted accordingly.