### PR TITLE
(PUP-917) Update naming of cached catalog status in report

### DIFF
--- a/api/docs/http_report.md
+++ b/api/docs/http_report.md
@@ -110,7 +110,7 @@ example is formatted for readability)
          "change_count"=>0,
          "out_of_sync_count"=>0,
          "events"=>[]}},
-      "cached_catalog_status"=> "unused"}
+      "cached_catalog_status"=> "not_used"}
 
 Schema
 ------

--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -104,11 +104,11 @@
         },
 
         "cached_catalog_status": {
-            "description": "Whether a cached catalog was used, and if so, why it was used. Enumerator with one of the values:\n\n* `unused`, if a cached catalog was not used.\n* `use_cached_catalog`, if a cached catalog was used because the use_cached_catalog option was set.\n* `use_cache_on_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the agent failed to download a new catalog",
+            "description": "Whether a cached catalog was used, and if so, why it was used. Enumerator with one of the values:\n\n* `not_used`, if a cached catalog was not used.\n* `explicitly_requested`, if a cached catalog was used because the use_cached_catalog option was set.\n* `on_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the agent failed to download a new catalog",
             "enum": [
-              "unused",
-              "use_cached_catalog",
-              "use_cache_on_failure"
+              "not_used",
+              "explicitly_requested",
+              "on_failure"
             ]
         },
 

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -47,7 +47,7 @@ class Puppet::Configurer
   def initialize(factory = Puppet::Configurer::DownloaderFactory.new)
     @running = false
     @splayed = false
-    @cached_catalog_status = 'unused'
+    @cached_catalog_status = 'not_used'
     @environment = Puppet[:environment]
     @transaction_uuid = SecureRandom.uuid
     @handler = Puppet::Configurer::PluginHandler.new(factory)
@@ -57,7 +57,7 @@ class Puppet::Configurer
   def retrieve_catalog(query_options)
     query_options ||= {}
     if (Puppet[:use_cached_catalog] && result = retrieve_catalog_from_cache(query_options))
-      @cached_catalog_status = 'use_cached_catalog'
+      @cached_catalog_status = 'explicitly_requested'
     else
       result = retrieve_new_catalog(query_options)
 
@@ -70,7 +70,7 @@ class Puppet::Configurer
         result = retrieve_catalog_from_cache(query_options)
 
         if result
-          @cached_catalog_status = 'use_cache_on_failure'
+          @cached_catalog_status = 'on_failure'
         end
       end
     end

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -55,8 +55,8 @@ class Puppet::Transaction::Report
   attr_accessor :catalog_uuid
 
   # Whether a cached catalog was used in the run, and if so, the reason that it was used.
-  # @return [String] One of the values: 'unused', 'use_cached_catalog',
-  # or 'use_cache_on_failure'
+  # @return [String] One of the values: 'not_used', 'explicitly_requested',
+  # or 'on_failure'
   attr_accessor :cached_catalog_status
 
   # The host name for which the report is generated

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -569,12 +569,12 @@ describe Puppet::Configurer do
         expect(@agent.retrieve_catalog({})).to eq(@catalog)
       end
 
-      it "should set its cached_catalog_status to 'use_cached_catalog'" do
+      it "should set its cached_catalog_status to 'explicitly_requested'" do
         Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_terminus] == true }.returns @catalog
         Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_cache] == true }.never
 
         @agent.retrieve_catalog({})
-        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('use_cached_catalog')
+        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('explicitly_requested')
       end
 
       it "should compile a new catalog if none is found in the cache" do
@@ -584,12 +584,12 @@ describe Puppet::Configurer do
         expect(@agent.retrieve_catalog({})).to eq(@catalog)
       end
 
-      it "should set its cached_catalog_status to 'unused' if no catalog is found in the cache" do
+      it "should set its cached_catalog_status to 'not_used' if no catalog is found in the cache" do
         Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_terminus] == true }.returns nil
         Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_cache] == true }.returns @catalog
 
         @agent.retrieve_catalog({})
-        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('unused')
+        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
       end
     end
 
@@ -599,11 +599,11 @@ describe Puppet::Configurer do
       @agent.retrieve_catalog({})
     end
 
-    it "should set its cached_catalog_status to 'unused' when downloading a new catalog" do
+    it "should set its cached_catalog_status to 'not_used' when downloading a new catalog" do
       Puppet::Resource::Catalog.indirection.expects(:find).returns @catalog
 
       @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('unused')
+      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
     end
 
     it "should use its node_name_value to retrieve the catalog" do
@@ -629,12 +629,12 @@ describe Puppet::Configurer do
       expect(@agent.retrieve_catalog({})).to eq(@catalog)
     end
 
-    it "should set its cached_catalog_status to 'use_cache_on_failure' when no catalog can be retrieved from the server" do
+    it "should set its cached_catalog_status to 'on_failure' when no catalog can be retrieved from the server" do
       @agent.stubs(:retrieve_new_catalog).with({}).returns nil
       @agent.stubs(:retrieve_catalog_from_cache).with({}).returns(@catalog)
 
       @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('use_cache_on_failure')
+      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
     end
 
     it "should not look in the cache for a catalog if one is returned from the server" do
@@ -651,12 +651,12 @@ describe Puppet::Configurer do
       expect(@agent.retrieve_catalog({})).to eq(@catalog)
     end
 
-    it "should set its cached_catalog_status to 'use_cache_on_failure' when retrieving the remote catalog throws an exception" do
+    it "should set its cached_catalog_status to 'on_failure' when retrieving the remote catalog throws an exception" do
       Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_cache] == true }.raises "eh"
       Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_terminus] == true }.returns @catalog
 
       @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('use_cache_on_failure')
+      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
     end
 
     it "should log and return nil if no catalog can be retrieved from the server and :usecacheonfailure is disabled" do
@@ -668,12 +668,12 @@ describe Puppet::Configurer do
       expect(@agent.retrieve_catalog({})).to be_nil
     end
 
-    it "should set its cached_catalog_status to 'unused' if no catalog can be retrieved from the server and :usecacheonfailure is disabled or fails to retrieve a catalog" do
+    it "should set its cached_catalog_status to 'not_used' if no catalog can be retrieved from the server and :usecacheonfailure is disabled or fails to retrieve a catalog" do
       Puppet[:usecacheonfailure] = false
       Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_cache] == true }.returns nil
 
       @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('unused')
+      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
     end
 
     it "should return nil if no cached catalog is available and no catalog can be retrieved from the server" do

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -66,8 +66,8 @@ describe Puppet::Transaction::Report do
 
   it "should be able to set cached_catalog_status" do
     report = Puppet::Transaction::Report.new("inspect")
-    report.cached_catalog_status = "use_cached_catalog"
-    expect(report.cached_catalog_status).to eq("use_cached_catalog")
+    report.cached_catalog_status = "explicitly_requested"
+    expect(report.cached_catalog_status).to eq("explicitly_requested")
   end
 
   it "should take 'environment' as an argument" do
@@ -508,7 +508,7 @@ describe Puppet::Transaction::Report do
     report.add_times("timing", 4)
     report.code_id = "some code id"
     report.catalog_uuid = "some catalog uuid"
-    report.cached_catalog_status = "unused"
+    report.cached_catalog_status = "not_used"
     report.add_resource_status(status)
     report.finalize_report
     report
@@ -524,7 +524,7 @@ describe Puppet::Transaction::Report do
     report.add_times("timing", 4)
     report.code_id = "some code id"
     report.catalog_uuid = "some catalog uuid"
-    report.cached_catalog_status = "unused"
+    report.cached_catalog_status = "not_used"
     report.add_resource_status(status)
     report.finalize_report
     report


### PR DESCRIPTION
This commit renames each of the three states of the
'cached_catalog_status' key of the report in order to
better convey their meaning.

The new values are 'not_used', 'explicitly_requested',
and 'on_failure'.