### PR TITLE
(PUP-5718) Update puppet.bat to current standard

### DIFF
--- a/ext/windows/puppet_interactive.bat
+++ b/ext/windows/puppet_interactive.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+echo Running Puppet agent on demand ...
+cd "%~dp0"
+call puppet.bat agent --test %*
+PAUSE

--- a/ext/windows/puppet_shell.bat
+++ b/ext/windows/puppet_shell.bat
@@ -1,0 +1,9 @@
+@echo off
+SETLOCAL
+if exist "%~dp0environment.bat" (
+  call "%~dp0environment.bat" %0 %*
+) else (
+  SET "PATH=%~dp0;%PATH%"
+)
+REM Display Ruby version
+ruby.exe -v

--- a/ext/windows/run_puppet_interactive.bat
+++ b/ext/windows/run_puppet_interactive.bat
@@ -1,0 +1,9 @@
+@echo Running puppet on demand ...
+@echo off
+SETLOCAL
+if exist "%~dp0environment.bat" (
+  call "%~dp0environment.bat" %0 %*
+) else (
+  SET "PATH=%~dp0;%PATH%"
+)
+elevate.exe "%~dp0puppet_interactive.bat"

--- a/install.rb
+++ b/install.rb
@@ -406,7 +406,7 @@ def install_binfile(from, op_file, target)
 
   File.open(from) do |ip|
     File.open(tmp_file.path, "w") do |op|
-      op.puts "#!#{ruby}"
+      op.puts "#!#{ruby}" unless $operatingsystem == "windows"
       contents = ip.readlines
       contents.shift if contents[0] =~ /^#!/
       op.write contents.join
@@ -416,33 +416,35 @@ def install_binfile(from, op_file, target)
   if $operatingsystem == "windows"
     installed_wrapper = false
 
-    if File.exists?("#{from}.bat")
-      FileUtils.install("#{from}.bat", File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)
-      installed_wrapper = true
-    end
+    unless File.extname(from).match(/\.(cmd|bat)/)
+      if File.exists?("#{from}.bat")
+        FileUtils.install("#{from}.bat", File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)
+        installed_wrapper = true
+      end
 
-    if File.exists?("#{from}.cmd")
-      FileUtils.install("#{from}.cmd", File.join(target, "#{op_file}.cmd"), :mode => 0755, :preserve => true, :verbose => true)
-      installed_wrapper = true
-    end
+      if File.exists?("#{from}.cmd")
+        FileUtils.install("#{from}.cmd", File.join(target, "#{op_file}.cmd"), :mode => 0755, :preserve => true, :verbose => true)
+        installed_wrapper = true
+      end
 
-    if not installed_wrapper
-      tmp_file2 = Tempfile.new('puppet-wrapper')
-      cwv = <<-EOS
+      if not installed_wrapper
+        tmp_file2 = Tempfile.new('puppet-wrapper')
+        cwv = <<-EOS
 @echo off
 SETLOCAL
 if exist "%~dp0environment.bat" (
   call "%~dp0environment.bat" %0 %*
 ) else (
-  SET PATH=%~dp0;%PATH%
+  SET "PATH=%~dp0;%PATH%"
 )
 ruby.exe -S -- puppet %*
 EOS
-      File.open(tmp_file2.path, "w") { |cw| cw.puts cwv }
-      FileUtils.install(tmp_file2.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)
+        File.open(tmp_file2.path, "w") { |cw| cw.puts cwv }
+        FileUtils.install(tmp_file2.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)
 
-      tmp_file2.unlink
-      installed_wrapper = true
+        tmp_file2.unlink
+        installed_wrapper = true
+      end
     end
   end
   FileUtils.install(tmp_file.path, File.join(target, op_file), :mode => 0755, :preserve => true, :verbose => true)
@@ -461,10 +463,15 @@ FileUtils.cd File.dirname(__FILE__) do
 
   prepare_installation
 
+  if $operatingsystem == "windows"
+    windows_bins = glob(%w{ext/windows/*bat})
+  end
+
   #build_rdoc(rdoc) if InstallOptions.rdoc
   #build_ri(ri) if InstallOptions.ri
   do_configs(configs, InstallOptions.config_dir) if InstallOptions.configs
   do_bins(bins, InstallOptions.bin_dir)
+  do_bins(windows_bins, InstallOptions.bin_dir, 'ext/windows/') if $operatingsystem == "windows"
   do_libs(libs)
   do_man(man) unless $operatingsystem == "windows"
 end

--- a/install.rb
+++ b/install.rb
@@ -430,10 +430,13 @@ def install_binfile(from, op_file, target)
       tmp_file2 = Tempfile.new('puppet-wrapper')
       cwv = <<-EOS
 @echo off
-setlocal
-set RUBY_BIN=%~dp0
-set RUBY_BIN=%RUBY_BIN:\\=/%
-"%RUBY_BIN%ruby.exe" -x "%RUBY_BIN%puppet" %*
+SETLOCAL
+if exist "%~dp0environment.bat" (
+  call "%~dp0environment.bat" %0 %*
+) else (
+  SET PATH=%~dp0;%PATH%
+)
+ruby.exe -S -- puppet %*
 EOS
       File.open(tmp_file2.path, "w") { |cw| cw.puts cwv }
       FileUtils.install(tmp_file2.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)


### PR DESCRIPTION
With the switch over to building puppet-agent for windows with Vanagon,
we need to effectively install puppet with install.rb. This script
installs puppet.bat, which is a wrapper that lets windows handle ruby
scripts. This commit updates puppet.bat to use our environment.bat file if
we install it, and to be more in line with the puppet.bat file installed
with the puppet-agent package as built by puppet_for_the_win

This takes advantage of `environment.bat` in puppet-agent installed with https://github.com/puppetlabs/puppet-agent/pull/512