### PR TITLE
(maint) Move augeas tests into puppet acceptance

### DIFF
--- a/acceptance/tests/apply/augeas/hosts.rb
+++ b/acceptance/tests/apply/augeas/hosts.rb
@@ -1,0 +1,69 @@
+test_name "Augeas hosts file" do
+
+tag 'risk:medium'
+
+  confine :except, :platform => 'windows'
+  confine :to, {}, hosts.select { |host| ! host[:roles].include?('master') }
+
+  step "Backup the hosts file" do
+    on hosts, 'cp /etc/hosts /tmp/hosts.bak'
+  end
+
+  # We have a begin/ensure block here to clean up the hosts file in case
+  # of test failure.
+  begin
+
+    step "Create an entry in the hosts file" do
+      manifest = <<EOF
+augeas { 'add_hosts_entry':
+  context => '/files/etc/hosts',
+  incl    => '/etc/hosts',
+  lens    => 'Hosts.lns',
+  changes => [
+    'set 01/ipaddr 192.168.0.1',
+    'set 01/canonical pigiron.example.com',
+    'set 01/alias[1] pigiron',
+    'set 01/alias[2] piggy'
+  ]
+}
+EOF
+      on hosts, puppet_apply('--verbose'), :stdin => manifest
+      on hosts, "fgrep '192.168.0.1\tpigiron.example.com pigiron piggy' /etc/hosts"
+    end
+
+    step "Modify an entry in the hosts file" do
+      manifest = <<EOF
+augeas { 'mod_hosts_entry':
+  context => '/files/etc/hosts',
+  incl    => '/etc/hosts',
+  lens    => 'Hosts.lns',
+  changes => [
+    'set *[canonical = "pigiron.example.com"]/alias[last()+1] oinker'
+  ]
+}
+EOF
+
+      on hosts, puppet_apply('--verbose'), :stdin => manifest
+      on hosts, "fgrep '192.168.0.1\tpigiron.example.com pigiron piggy oinker' /etc/hosts"
+    end
+
+    step "Remove an entry from the hosts file" do
+      manifest = <<EOF
+augeas { 'del_hosts_entry':
+  context => '/files/etc/hosts',
+  incl    => '/etc/hosts',
+  lens    => 'Hosts.lns',
+  changes => [
+    'rm *[canonical = "pigiron.example.com"]'
+  ]
+}
+EOF
+
+      on hosts, puppet_apply('--verbose'), :stdin => manifest
+      on hosts, "fgrep 'pigiron.example.com' /etc/hosts", :acceptable_exit_codes => [1]
+    end
+
+  ensure
+    on hosts, 'cat /tmp/hosts.bak > /etc/hosts && rm /tmp/hosts.bak'
+  end
+end

--- a/acceptance/tests/apply/augeas/puppet.rb
+++ b/acceptance/tests/apply/augeas/puppet.rb
@@ -1,0 +1,39 @@
+test_name "Augeas puppet configuration" do
+
+  tag 'risk:medium'
+
+  confine :except, :platform => 'windows'
+  confine :to, {}, hosts.select { |host| ! host[:roles].include?('master') }
+
+  teardown do
+    hosts.each do |host|
+      on host, "cat /tmp/puppet.conf.bak > #{host.puppet['confdir']}/puppet.conf && rm /tmp/puppet.conf.bak"
+    end
+  end
+
+  hosts.each do |host|
+    step "Backup the puppet config" do
+    on host, "mv #{host.puppet['confdir']}/puppet.conf /tmp/puppet.conf.bak"
+    end
+    step "Create a new puppet config that has a master and agent section" do
+      puppet_conf = <<-CONF
+      [main]
+      CONF
+    on(host, "echo \"#{puppet_conf}\" >> #{host.puppet['confdir']}/puppet.conf")
+    on(host, "puppet config set runinterval 10 --section agent")
+    end
+
+    step "Modify the puppet.conf file"
+    manifest = <<EOF
+  augeas { 'puppet agent noop mode':
+    context => "/files#{host.puppet['confdir']}/puppet.conf/agent",
+    incl    => "/etc/puppetlabs/puppet/puppet.conf",
+    lens    => 'Puppet.lns',
+    changes => 'set noop true',
+  }
+EOF
+    on host, puppet_apply('--verbose'), :stdin => manifest
+
+    on host, "grep 'noop=true' #{host.puppet['confdir']}/puppet.conf"
+  end
+end

--- a/acceptance/tests/apply/augeas/services.rb
+++ b/acceptance/tests/apply/augeas/services.rb
@@ -1,0 +1,67 @@
+test_name "Augeas services file" do
+
+  tag 'risk:medium'
+
+  confine :except, :platform => 'windows'
+  confine :except, :platform => 'osx'
+  confine :to, {}, hosts.select { |host| ! host[:roles].include?('master') }
+
+  step "Backup the services file" do
+    on hosts, "cp /etc/services /tmp/services.bak"
+  end
+
+  begin
+    step "Add an entry to the services file" do
+      manifest = <<EOF
+augeas { 'add_services_entry':
+  context => '/files/etc/services',
+  incl    => '/etc/services',
+  lens    => 'Services.lns',
+  changes => [
+    'ins service-name after service-name[last()]',
+    'set service-name[last()] "Doom"',
+    'set service-name[. = "Doom"]/port "666"',
+    'set service-name[. = "Doom"]/protocol "udp"'
+  ]
+}
+EOF
+
+      on hosts, puppet_apply('--verbose'), :stdin => manifest
+      on hosts, "fgrep 'Doom 666/udp' /etc/services"
+    end
+
+    step "Change the protocol to udp" do
+      manifest = <<EOF
+augeas { 'change_service_protocol':
+  context => '/files/etc/services',
+  incl    => '/etc/services',
+  lens    => 'Services.lns',
+  changes => [
+    'set service-name[. = "Doom"]/protocol "tcp"'
+  ]
+}
+EOF
+
+      on hosts, puppet_apply('--verbose'), :stdin => manifest
+      on hosts, "fgrep 'Doom 666/tcp' /etc/services"
+    end
+
+    step "Remove the services entry" do
+      manifest = <<EOF
+augeas { 'del_service_entry':
+  context => '/files/etc/services',
+  incl    => '/etc/services',
+  lens    => 'Services.lns',
+  changes => [
+    'rm service-name[. = "Doom"]'
+  ]
+}
+EOF
+
+      on hosts, puppet_apply('--verbose'), :stdin => manifest
+      on hosts, "fgrep 'Doom 666/tcp' /etc/services", :acceptable_exit_codes => [1]
+    end
+  ensure
+    on hosts, "mv /tmp/services.bak /etc/services"
+  end
+end


### PR DESCRIPTION
Prior to this commit the augeas tests were in PE
acceptance tests. This is a vestige of when PE
agent and puppet agent were two different items.
Now in the puppet-agent world we need to move these
tests up so they are in the proper work stream.