### PR TITLE
(PUP-2909) rubocop - meth{|my[opt]|} is no longer valid syntax in 1.9

### DIFF
--- a/ext/nagios/check_puppet.rb
+++ b/ext/nagios/check_puppet.rb
@@ -27,17 +27,17 @@ class CheckPuppet
         o.on(
           "-s", "--statefile=statefile", String, "The state file",
 
-    "Default: #{OPTIONS[:statefile]}") { |OPTIONS[:statefile]| }
+    "Default: #{OPTIONS[:statefile]}") { |op| OPTIONS[:statefile] = op }
 
       o.on(
         "-p", "--process=processname", String, "The process to check",
 
-    "Default: #{OPTIONS[:process]}")   { |OPTIONS[:process]| }
+    "Default: #{OPTIONS[:process]}")   { |op| OPTIONS[:process] = op }
 
       o.on(
         "-i", "--interval=value", Integer,
 
-    "Default: #{OPTIONS[:interval]} minutes")  { |OPTIONS[:interval]| }
+    "Default: #{OPTIONS[:interval]} minutes")  { |op| OPTIONS[:interval] = op }
 
     o.separator ""
     o.on_tail("-h", "--help", "Show this help message.") do


### PR DESCRIPTION
replace meth{|my[opt]|} with meth{|o| my[opt] = o}