### PR TITLE
(PUP-5538) Improve SID::Principal.lookup_account_sid validation

### DIFF
--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -87,6 +87,10 @@ module Puppet::Util::Windows::SID
 
     def self.lookup_account_sid(system_name = nil, sid_bytes)
       system_name_ptr = FFI::Pointer::NULL
+      if (sid_bytes.nil? || (!sid_bytes.is_a? Array) || (sid_bytes.length == 0))
+        raise Puppet::Util::Windows::Error.new('Byte array for lookup_account_sid must not be nil and must be at least 1 byte long')
+      end
+
       begin
         if system_name
           system_name_wide = Puppet::Util::Windows::String.wide_string(system_name)

--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -12,12 +12,18 @@ module Puppet::Util::Windows::SID
       @sid_bytes = sid_bytes
       @sid = sid
       @domain = domain
-      # when domain is available, combine it with parsed account
-      # otherwise use the account value directly
-      @domain_account = domain && !domain.empty? ?
-        "#{domain}\\#{@account}" : account
-
       @account_type = account_type
+      # When domain is available and it is a Domain principal, use domain only
+      #   otherwise if domain is available then combine it with parsed account
+      #   otherwise when the domain is not available, use the account value directly
+      # WinNT naming standard https://msdn.microsoft.com/en-us/library/windows/desktop/aa746534(v=vs.85).aspx
+      if (domain && !domain.empty? && @account_type == :SidTypeDomain)
+        @domain_account = @domain
+      elsif (domain && !domain.empty?)
+        @domain_account =  "#{domain}\\#{@account}"
+      else
+        @domain_account = account
+      end
     end
 
     # added for backward compatibility

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -71,7 +71,17 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.account_type).to eq(:SidTypeDomain)
       expect(principal.sid).to eq('S-1-5-32')
       expect(principal.domain).to eq('BUILTIN')
+      expect(principal.domain_account).to eq('BUILTIN')
     end
+
+    it "should return a BUILTIN domain principal for BUILTIN account names" do
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('BUILTIN')
+      expect(principal.account_type).to eq(:SidTypeDomain)
+      expect(principal.sid).to eq('S-1-5-32')
+      expect(principal.domain).to eq('BUILTIN')
+      expect(principal.domain_account).to eq('BUILTIN')
+    end
+
   end
 
   describe ".lookup_account_sid" do
@@ -142,12 +152,13 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
         principal.lookup_account_sid([1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0])
       }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountSidW:  No mapping between account names and security IDs was done/)
     end
-    
+
     it "should return a domain principal for BUILTIN SID S-1-5-32" do
       principal = Puppet::Util::Windows::SID::Principal.lookup_account_sid([1, 1, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0])
       expect(principal.account_type).to eq(:SidTypeDomain)
       expect(principal.sid).to eq('S-1-5-32')
       expect(principal.domain).to eq('BUILTIN')
-    end    
+      expect(principal.domain_account).to eq('BUILTIN')
+    end
   end
 end


### PR DESCRIPTION
Previously the lookup_account_sid function would allow any
type of argument when calling lookup_account_sid, however this would
cause inconsistent error messages and possible memory errors when using
zero byte arrays or nils.  This commit adds validation checking to
sid_bytes before allocating memory pointers and adds tests for these
scenarios.