### PR TITLE
(PUP-5695) Add checksum_value parameter to file type

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -124,6 +124,11 @@ Puppet::Type.newtype(:file) do
     end
   end
 
+  newparam(:checksum_value) do
+    desc "The checksum of the source contents. Only md5 and sha256 are supported when
+      specifying this parameter."
+  end
+
   newparam(:recurse) do
     desc "Whether to recursively manage the _contents_ of a directory. This attribute
       is only used when `ensure => directory` is set. The allowed values are:
@@ -385,6 +390,10 @@ Puppet::Type.newtype(:file) do
     if @parameters[:content] && @parameters[:content].actual_content
       # Now that we know the checksum, update content (in case it was created before checksum was known).
       @parameters[:content].value = @parameters[:checksum].sum(@parameters[:content].actual_content)
+    end
+
+    if self[:checksum] && self[:checksum_value] && !send("#{self[:checksum]}?", self[:checksum_value])
+      self.fail "Checksum value '#{self[:checksum_value]}' is not a valid checksum type #{self[:checksum]}"
     end
 
     provider.validate if provider.respond_to?(:validate)

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -41,19 +41,11 @@ module Puppet::Util::Checksums
     Digest::SHA256.hexdigest(content)
   end
 
-  def sha256lite(content)
-    sha256(content[0..511])
-  end
-
   def sha256_file(filename, lite = false)
     require 'digest/sha2'
 
     digest = Digest::SHA256.new
     checksum_file(digest, filename,  lite)
-  end
-
-  def sha256lite_file(filename)
-    sha256_file(filename, true)
   end
 
   def sha256_stream(lite = false, &block)
@@ -64,6 +56,14 @@ module Puppet::Util::Checksums
 
   def sha256_hex_length
     64
+  end
+
+  def sha256lite(content)
+    sha256(content[0..511])
+  end
+
+  def sha256lite_file(filename)
+    sha256_file(filename, true)
   end
 
   def sha256lite_stream(&block)
@@ -79,20 +79,10 @@ module Puppet::Util::Checksums
     Digest::MD5.hexdigest(content)
   end
 
-  # Calculate a checksum of the first 500 chars of the content using Digest::MD5.
-  def md5lite(content)
-    md5(content[0..511])
-  end
-
   # Calculate a checksum of a file's content using Digest::MD5.
   def md5_file(filename, lite = false)
     digest = Digest::MD5.new
     checksum_file(digest, filename,  lite)
-  end
-
-  # Calculate a checksum of the first 500 chars of a file's content using Digest::MD5.
-  def md5lite_file(filename)
-    md5_file(filename, true)
   end
 
   def md5_stream(lite = false, &block)
@@ -104,12 +94,26 @@ module Puppet::Util::Checksums
     32
   end
 
+  # Calculate a checksum of the first 500 chars of the content using Digest::MD5.
+  def md5lite(content)
+    md5(content[0..511])
+  end
+
+  # Calculate a checksum of the first 500 chars of a file's content using Digest::MD5.
+  def md5lite_file(filename)
+    md5_file(filename, true)
+  end
+
   def md5lite_stream(&block)
     md5_stream(true, &block)
   end
 
   def md5lite_hex_length
     md5_hex_length
+  end
+
+  def mtime(content)
+    ""
   end
 
   # Return the :mtime timestamp of a file.
@@ -125,29 +129,15 @@ module Puppet::Util::Checksums
     nil
   end
 
-  def mtime(content)
-    ""
-  end
-
   # Calculate a checksum using Digest::SHA1.
   def sha1(content)
     Digest::SHA1.hexdigest(content)
-  end
-
-  # Calculate a checksum of the first 500 chars of the content using Digest::SHA1.
-  def sha1lite(content)
-    sha1(content[0..511])
   end
 
   # Calculate a checksum of a file's content using Digest::SHA1.
   def sha1_file(filename, lite = false)
     digest = Digest::SHA1.new
     checksum_file(digest, filename, lite)
-  end
-
-  # Calculate a checksum of the first 500 chars of a file's content using Digest::SHA1.
-  def sha1lite_file(filename)
-    sha1_file(filename, true)
   end
 
   def sha1_stream(lite = false, &block)
@@ -159,12 +149,26 @@ module Puppet::Util::Checksums
     40
   end
 
+  # Calculate a checksum of the first 500 chars of the content using Digest::SHA1.
+  def sha1lite(content)
+    sha1(content[0..511])
+  end
+
+  # Calculate a checksum of the first 500 chars of a file's content using Digest::SHA1.
+  def sha1lite_file(filename)
+    sha1_file(filename, true)
+  end
+
   def sha1lite_stream(&block)
     sha1_stream(true, &block)
   end
 
   def sha1lite_hex_length
     sha1_hex_length
+  end
+
+  def ctime(content)
+    ""
   end
 
   # Return the :ctime of a file.
@@ -176,7 +180,7 @@ module Puppet::Util::Checksums
     mtime_stream(&block)
   end
 
-  def ctime(content)
+  def none(content)
     ""
   end
 
@@ -188,10 +192,6 @@ module Puppet::Util::Checksums
   def none_stream
     noop_digest = FakeChecksum.new
     yield noop_digest
-    ""
-  end
-
-  def none(content)
     ""
   end
 

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -1,5 +1,6 @@
 require 'digest/md5'
 require 'digest/sha1'
+require 'time'
 
 # A stand-alone module for calculating checksums
 # in a generic way.
@@ -41,6 +42,10 @@ module Puppet::Util::Checksums
     Digest::SHA256.hexdigest(content)
   end
 
+  def sha256?(string)
+    string =~ /^\h{64}$/
+  end
+
   def sha256_file(filename, lite = false)
     require 'digest/sha2'
 
@@ -62,6 +67,10 @@ module Puppet::Util::Checksums
     sha256(content[0..511])
   end
 
+  def sha256lite?(string)
+    sha256?(string)
+  end
+
   def sha256lite_file(filename)
     sha256_file(filename, true)
   end
@@ -77,6 +86,10 @@ module Puppet::Util::Checksums
   # Calculate a checksum using Digest::MD5.
   def md5(content)
     Digest::MD5.hexdigest(content)
+  end
+
+  def md5?(string)
+    string =~ /^\h{32}$/
   end
 
   # Calculate a checksum of a file's content using Digest::MD5.
@@ -99,6 +112,10 @@ module Puppet::Util::Checksums
     md5(content[0..511])
   end
 
+  def md5lite?(string)
+    md5?(string)
+  end
+
   # Calculate a checksum of the first 500 chars of a file's content using Digest::MD5.
   def md5lite_file(filename)
     md5_file(filename, true)
@@ -114,6 +131,12 @@ module Puppet::Util::Checksums
 
   def mtime(content)
     ""
+  end
+
+  def mtime?(string)
+    !!DateTime.parse(string)
+  rescue
+    false
   end
 
   # Return the :mtime timestamp of a file.
@@ -132,6 +155,10 @@ module Puppet::Util::Checksums
   # Calculate a checksum using Digest::SHA1.
   def sha1(content)
     Digest::SHA1.hexdigest(content)
+  end
+
+  def sha1?(string)
+    string =~ /^\h{40}$/
   end
 
   # Calculate a checksum of a file's content using Digest::SHA1.
@@ -154,6 +181,10 @@ module Puppet::Util::Checksums
     sha1(content[0..511])
   end
 
+  def sha1lite?(string)
+    sha1?(string)
+  end
+
   # Calculate a checksum of the first 500 chars of a file's content using Digest::SHA1.
   def sha1lite_file(filename)
     sha1_file(filename, true)
@@ -171,6 +202,12 @@ module Puppet::Util::Checksums
     ""
   end
 
+  def ctime?(string)
+    !!DateTime.parse(string)
+  rescue
+    false
+  end
+
   # Return the :ctime of a file.
   def ctime_file(filename)
     Puppet::FileSystem.stat(filename).send(:ctime)
@@ -182,6 +219,10 @@ module Puppet::Util::Checksums
 
   def none(content)
     ""
+  end
+
+  def none?(string)
+    string.empty?
   end
 
   # Return a "no checksum"

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1393,6 +1393,16 @@ describe Puppet::Type.type(:file) do
   describe "when using source" do
     before do
       file[:source] = File.expand_path('/one')
+      @checksum_values = {
+        :md5 => 'd41d8cd98f00b204e9800998ecf8427e',
+        :md5lite => 'd41d8cd98f00b204e9800998ecf8427e',
+        :sha256 => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        :sha256lite => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        :sha1 => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        :sha1lite => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        :mtime => 'Jan 26 13:59:49 2016',
+        :ctime => 'Jan 26 13:59:49 2016'
+      }
     end
     Puppet::Type::File::ParameterChecksum.value_collection.values.reject {|v| v == :none}.each do |checksum_type|
       describe "with checksum '#{checksum_type}'" do
@@ -1401,7 +1411,16 @@ describe Puppet::Type.type(:file) do
         end
 
         it 'should validate' do
+          expect { file.validate }.to_not raise_error
+        end
 
+        it 'should fail on an invalid checksum_value' do
+          file[:checksum_value] = ''
+          expect { file.validate }.to raise_error(Puppet::Error, "Checksum value '' is not a valid checksum type #{checksum_type}")
+        end
+
+        it 'should validate a valid checksum_value' do
+          file[:checksum_value] = @checksum_values[checksum_type]
           expect { file.validate }.to_not raise_error
         end
       end
@@ -1421,6 +1440,14 @@ describe Puppet::Type.type(:file) do
   describe "when using content" do
     before do
       file[:content] = 'file contents'
+      @checksum_values = {
+        :md5 => 'd41d8cd98f00b204e9800998ecf8427e',
+        :md5lite => 'd41d8cd98f00b204e9800998ecf8427e',
+        :sha256 => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        :sha256lite => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        :sha1 => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        :sha1lite => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+      }
     end
 
     (Puppet::Type::File::ParameterChecksum.value_collection.values - SOURCE_ONLY_CHECKSUMS).each do |checksum_type|
@@ -1430,6 +1457,16 @@ describe Puppet::Type.type(:file) do
         end
 
         it 'should validate' do
+          expect { file.validate }.to_not raise_error
+        end
+
+        it 'should fail on an invalid checksum_value' do
+          file[:checksum_value] = ''
+          expect { file.validate }.to raise_error(Puppet::Error, "Checksum value '' is not a valid checksum type #{checksum_type}")
+        end
+
+        it 'should validate a valid checksum_value' do
+          file[:checksum_value] = @checksum_values[checksum_type]
           expect { file.validate }.to_not raise_error
         end
       end
@@ -1443,6 +1480,26 @@ describe Puppet::Type.type(:file) do
           expect { file.validate }.to raise_error(/You cannot specify content when using checksum '#{checksum_type}'/)
         end
       end
+    end
+  end
+
+  describe "when checksum is none" do
+    before do
+      file[:checksum] = :none
+    end
+
+    it 'should validate' do
+      expect { file.validate }.to_not raise_error
+    end
+
+    it 'should fail on an invalid checksum_value' do
+      file[:checksum_value] = 'boo'
+      expect { file.validate }.to raise_error(Puppet::Error, "Checksum value 'boo' is not a valid checksum type none")
+    end
+
+    it 'should validate a valid checksum_value' do
+      file[:checksum_value] = ''
+      expect { file.validate }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
Adds a checksum_value parameter to the file type. Validates that it's
format matches the specified checksum parameter.