### PR TITLE
(PUP-5708) Only emit deprecation warning for pluginsync if explicitly set

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1572,7 +1572,9 @@ EOT
       :type       => :boolean,
       :desc       => "Whether plugins should be synced with the central server. This setting is
         deprecated.",
-     :deprecated => :completely,
+      :hook => proc { |value|
+        Puppet.deprecation_warning "Setting 'pluginsync' is deprecated."
+      }
     },
 
     :pluginsignore => {


### PR DESCRIPTION
This commit updates the pluginsync deprecation warning to only present
itself if the setting is actually set via the commandline or by config.