### PR TITLE
(PUP-3077) Handle cached catalog inconsistencies

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -404,7 +404,9 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # we want the last report to be persisted locally
     Puppet::Transaction::Report.indirection.cache_class = :yaml
 
-    if Puppet[:catalog_cache_terminus]
+    if Puppet[:noop]
+      Puppet::Resource::Catalog.indirection.cache_class = nil
+    elsif Puppet[:catalog_cache_terminus]
       Puppet::Resource::Catalog.indirection.cache_class = Puppet[:catalog_cache_terminus]
     end
 

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -315,7 +315,10 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     Puppet.settings.use :main, :agent, :ssl
 
-    if Puppet[:catalog_cache_terminus]
+
+    if Puppet[:noop]
+      Puppet::Resource::Catalog.indirection.cache_class = nil
+    elsif Puppet[:catalog_cache_terminus]
       Puppet::Resource::Catalog.indirection.cache_class = Puppet[:catalog_cache_terminus]
     end
 

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -72,6 +72,8 @@ class Puppet::Configurer
     query_options ||= {}
     if (Puppet[:use_cached_catalog] && result = retrieve_catalog_from_cache(query_options))
       @cached_catalog_status = 'explicitly_requested'
+
+      Puppet.info "Using cached catalog from environment '#{result.environment}'"
     else
       result = retrieve_new_catalog(query_options)
 
@@ -84,7 +86,14 @@ class Puppet::Configurer
         result = retrieve_catalog_from_cache(query_options)
 
         if result
+          # don't use use cached catalog if it doesn't match server specified environment
+          if @node_environment && result.environment != @environment
+            Puppet.err "Not using cached catalog because its environment '#{result.environment}' does not match '#{@environment}'"
+            return nil
+          end
+
           @cached_catalog_status = 'on_failure'
+          Puppet.info "Using cached catalog from environment '#{result.environment}'"
         end
       end
     end
@@ -232,6 +241,8 @@ class Puppet::Configurer
               node.environment = Puppet::Node::Environment.remote(node.environment_name)
             end
 
+            @node_environment = node.environment.to_s
+
             if node.environment.to_s != @environment
               Puppet.notice "Local environment: '#{@environment}' doesn't match server specified node environment '#{node.environment}', switching agent to '#{node.environment}'."
               @environment = node.environment.to_s
@@ -350,7 +361,6 @@ class Puppet::Configurer
       result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value],
         query_options.merge(:ignore_terminus => true, :environment => Puppet::Node::Environment.remote(@environment)))
     end
-    Puppet.notice "Using cached catalog"
     result
   rescue => detail
     Puppet.log_exception(detail, "Could not retrieve catalog from cache: #{detail}")

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -89,9 +89,7 @@ class Puppet::Configurer
       end
     end
 
-    return nil unless result
-
-    convert_catalog(result, @duration)
+    result
   end
 
   # Convert a plain resource catalog into our full host catalog.
@@ -132,11 +130,16 @@ class Puppet::Configurer
     # dot-separated string.
     query_options[:checksum_type] = @checksum_type.join('.')
 
-    unless catalog = (options.delete(:catalog) || retrieve_catalog(query_options))
-      Puppet.err "Could not retrieve catalog; skipping run"
-      return
-    end
-    catalog
+    # apply passes in ral catalog
+    catalog = options.delete(:catalog)
+    return catalog if catalog
+
+    # retrieve_catalog returns json catalog
+    catalog = retrieve_catalog(query_options)
+    return convert_catalog(catalog, @duration) if catalog
+
+    Puppet.err "Could not retrieve catalog; skipping run"
+    nil
   end
 
   def prepare_and_retrieve_catalog_from_cache

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -343,7 +343,17 @@ describe Puppet::Application::Agent do
 
     it "should not set catalog cache class if :catalog_cache_terminus is explicitly nil" do
       Puppet[:catalog_cache_terminus] = nil
+      Puppet::Resource::Catalog.indirection.unstub(:cache_class=)
       Puppet::Resource::Catalog.indirection.expects(:cache_class=).never
+
+      @puppetd.initialize_app_defaults
+      @puppetd.setup
+    end
+
+    it "should set catalog cache class to nil during a noop run" do
+      Puppet[:catalog_cache_terminus] = "json"
+      Puppet[:noop] = true
+      Puppet::Resource::Catalog.indirection.expects(:cache_class=).with(nil)
 
       @puppetd.initialize_app_defaults
       @puppetd.setup

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -478,4 +478,13 @@ describe Puppet::Application::Apply do
     @apply.initialize_app_defaults
     @apply.setup
   end
+
+  it "should set catalog cache class to nil during a noop run" do
+    Puppet[:catalog_cache_terminus] = "json"
+    Puppet[:noop] = true
+    Puppet::Resource::Catalog.indirection.expects(:cache_class=).with(nil)
+
+    @apply.initialize_app_defaults
+    @apply.setup
+  end
 end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -580,7 +580,8 @@ describe Puppet::Configurer do
       @agent.stubs(:facts_for_uploading).returns({})
       @agent.stubs(:download_plugins)
 
-      @catalog = Puppet::Resource::Catalog.new
+      # retrieve a catalog in the current environment, so we don't try to converge unexpectedly
+      @catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym))
 
       # this is the default when using a Configurer instance
       Puppet::Resource::Catalog.indirection.stubs(:terminus_class).returns :rest
@@ -608,7 +609,7 @@ describe Puppet::Configurer do
 
       it "should make a node request and pluginsync when a cached catalog cannot be retrieved" do
         Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_terminus] == true }.returns nil
-        Puppet::Resource::Catalog.indirection.expects(:find).twice.with { |name, options| options[:ignore_cache] == true }.returns @catalog
+        Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options| options[:ignore_cache] == true }.returns @catalog
         @agent.expects(:download_plugins)
 
         @agent.run

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -668,6 +668,7 @@ describe Puppet::Configurer do
       end
 
       it "should not attempt to retrieve a cached catalog again if the first attempt failed" do
+        Puppet::Node.indirection.expects(:find).returns(nil)
         expects_neither_new_or_cached_catalog
 
         @agent.run


### PR DESCRIPTION
Previously, it was possible to run an agent in noop mode in a canary environment, but during the next normal agent run, it could fall back to the previously cached catalog from the noop run, causing changes to be deployed into production there were never meant to be.
 
The short version for this PR is: Don't save cached catalogs when running in `noop` mode and only fallback to a cached catalog whose environment matches the agent's configured environment, either through the ENC or agent-specified environment.