### PR TITLE
(PUP-5726) Properly parse Windows env vars with =

### DIFF
--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -240,7 +240,7 @@ module Puppet::Util::Windows::Process
     pairs = env_ptr.read_arbitrary_wide_string_up_to(65534, ENVSTRINGS_TERMINATOR_WCHAR)
       .split(?\x00)
       .reject { |env_str| env_str.nil? || env_str.empty? || env_str[0] == '=' }
-      .map { |env_pair| env_pair.split('=', -2) }
+      .map { |env_pair| env_pair.split('=', 2) }
     Hash[ pairs ]
   ensure
     if env_ptr && ! env_ptr.null?

--- a/spec/integration/util/windows/process_spec.rb
+++ b/spec/integration/util/windows/process_spec.rb
@@ -31,4 +31,35 @@ describe "Puppet::Util::Windows::Process", :if => Puppet.features.microsoft_wind
       expect { Puppet::Util::Windows::Process.lookup_privilege_value('foo') }.to raise_error(Puppet::Util::Windows::Error, fail_msg)
     end
   end
+
+  describe "when setting environment variables" do
+    it "can properly handle env var values with = in them" do
+      begin
+        name = SecureRandom.uuid
+        value = 'foo=bar'
+
+        Puppet::Util::Windows::Process.set_environment_variable(name, value)
+
+        env = Puppet::Util::Windows::Process.get_environment_strings
+
+        expect(env[name]).to eq(value)
+      ensure
+        Puppet::Util::Windows::Process.set_environment_variable(name, nil)
+      end
+    end
+
+    it "can properly handle empty env var values" do
+      begin
+        name = SecureRandom.uuid
+
+        Puppet::Util::Windows::Process.set_environment_variable(name, '')
+
+        env = Puppet::Util::Windows::Process.get_environment_strings
+
+        expect(env[name]).to eq('')
+      ensure
+        Puppet::Util::Windows::Process.set_environment_variable(name, nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
 - The code introduced in 8d02eb133cb2783d976d270b7f2869140a48f0fc did
   not properly handle environment variables containing =

   This was not found in AppVeyor, local testing, or the ad-hoc
   pipeline, but was discovered in the standard Jenkins pipeline
   where the BUILD_URL env var is a URL containing = like:
   https://jenkins.puppetlabs.com/job/platform_puppet_unit-ruby-win_stable/R=ruby-2.1.5.2-x86,S=unit-win2012/44/

   Fix the parsing and add tests to verify