### PR TITLE
(maint) Update windows ruby builds

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -26,8 +26,8 @@ build_msi:
     repo: 'git://github.com/puppetlabs/hiera.git'
   sys:
     ref:
-      x86: 'refs/tags/1.9.3-p551.8'
-      x64: 'refs/tags/2.0.0.11-x64'
+      x86: 'refs/tags/1.9.3-p551.9'
+      x64: 'refs/tags/2.0.0.12-x64'
     repo: 'git://github.com/puppetlabs/puppet-win32-ruby.git'
 apt_signing_server: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'


### PR DESCRIPTION
Ruby for windows was rebuilt with openssl 1.0.2f to address
CVE-2016-0701. This updates to use the latest ruby build.