### PR TITLE
(PUP-5703) Handle cached catalog and pluginsync inconsistencies

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -41,7 +41,7 @@ class Puppet::Agent
       result = run_in_fork(should_fork) do
         with_client do |client|
           begin
-            client_args = client_options.merge(:pluginsync => Puppet[:pluginsync])
+            client_args = client_options.merge(:pluginsync => Puppet::Configurer.should_pluginsync?)
             lock { client.run(client_args) }
           rescue Puppet::LockError
             Puppet.notice "Run of #{client_class} already in progress; skipping  (#{lockfile_path} exists)"

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -199,7 +199,7 @@ Licensed under the Apache 2.0 License
 
         require 'puppet/configurer'
         configurer = Puppet::Configurer.new
-        configurer.run(:network_device => true, :pluginsync => Puppet[:pluginsync])
+        configurer.run(:network_device => true, :pluginsync => Puppet::Configurer.should_pluginsync?)
       rescue => detail
         Puppet.log_exception(detail)
         # If we rescued an error, then we return 1 as the exit code

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/agent'
+require 'puppet/configurer'
 
 class AgentTestClient
   def run


### PR DESCRIPTION
Prior to this commit, when attempting to use a cached catalog
the client would always make a node request and pluginsync,
even if there was a cached catalog available. This could cause
inconsistencies where the set of plugins used by the agent is
different than the set that was used when the catalog was
originally compiled.

This commit updates the client to first try to retrieve a cached
catalog if requested, skipping the node request and pluginsync.

In addition, if the agent's current environment differs from that
of the cached catalog, we now immediately switch to the cached
catalog's environment rather than going through the environment
convergence loop.