### PR TITLE
(maint) Fix spec test on Mac OS X

### DIFF
--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -124,16 +124,14 @@ describe Puppet::Network::HTTP::Pool do
       # This workaround can be removed once all the ruby versions we care about
       # have the patch from https://bugs.ruby-lang.org/issues/11958 applied.
       #
-      keepalive   = Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, true).data
-      nokeepalive = Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, false).data
-
       if Puppet::Util::Platform.windows?
-        keepalive   = keepalive[0]
-        nokeepalive = nokeepalive[0]
+        keepalive   = Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, true).data[0]
+        nokeepalive = Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, false).data[0]
+        expect(s.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE).data).to eq(keepalive)
+        expect(s.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE).data).to_not eq(nokeepalive)
+      else
+        expect(s.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE).bool).to eq(true)
       end
-
-      expect(s.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE).data).to eq(keepalive)
-      expect(s.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE).data).to_not eq(nokeepalive)
     end
 
     context 'when releasing connections' do


### PR DESCRIPTION
The sockopt data layout is platform-specific, and on Mac the result of
creating a boolean doesn't match `getsockopt(...).data`. Comparing the
data was originally a work-around for Windows because
`getsockopt(...).bool` produced an error. Switch to using bool on all
platforms but Windows.