### PR TITLE
(PUP-5736) Add test for Win32-Process and UTF8 filepaths

### DIFF
--- a/spec/integration/util/execution_spec.rb
+++ b/spec/integration/util/execution_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Puppet::Util::Execution do
+  include PuppetSpec::Files
+
   describe "#execpipe" do
     it "should set LANG to C avoid localized output", :if => !Puppet.features.microsoft_windows? do
       out = ""
@@ -12,6 +14,26 @@ describe Puppet::Util::Execution do
       out = ""
       Puppet::Util::Execution.execpipe('echo $LC_ALL'){ |line| out << line.read.chomp }
       expect(out).to eq("C")
+    end
+  end
+
+  describe "#execute (Windows)", :if => Puppet.features.microsoft_windows? do
+    let(:utf8text) do
+      # Japanese Lorem Ipsum snippet
+      "utf8testfile" + [227, 131, 171, 227, 131, 147, 227, 131, 179, 227, 131, 132, 227,
+                        130, 162, 227, 130, 166, 227, 130, 167, 227, 131, 150, 227, 130,
+                        162, 227, 129, 181, 227, 129, 185, 227, 129, 139, 227, 130, 137,
+                        227, 129, 154, 227, 130, 187, 227, 130, 183, 227, 131, 147, 227,
+                        131, 170, 227, 131, 134].pack('c*').force_encoding(Encoding::UTF_8)
+    end
+    let(:temputf8filename) do
+      script_containing(utf8text, :windows => "@ECHO OFF\nECHO #{utf8text}\nEXIT 100")
+    end
+
+    it "should execute with non-english characters in command line" do
+      result = Puppet::Util::Execution.execute("cmd /c \"#{temputf8filename}\"", :failonfail => false)
+      expect(temputf8filename.encoding.name).to eq('UTF-8')
+      expect(result.exitstatus).to eq(100)
     end
   end
 end


### PR DESCRIPTION
Previously there were no tests for creating processes with UTF8
characaters in the command line.  This integration test is required
to guard against regression failures whereby future changes may cause
commands in Non-English Operating Systems to fail e.g. Script files
in a user's directory where the user has non-english characters in the
username, such as Umlaut.  This commit adds a single test for running
a command with UTF8 charaters in the command line.