### PR TITLE
(PUP-5724) Backport PUP-5693 Make function_loading benchmark operational

### DIFF
--- a/benchmarks/function_loading/description
+++ b/benchmarks/function_loading/description
@@ -1,3 +1,6 @@
 Benchmark scenario: many functions spread across many modules.
-Benchmark target: function loading.
+Benchmark target: function loading and call overhead
 
+A number of modules are generated. The environment, and each module holds a large number of functions (several 100s).
+Fuctions call each other and cause deep recursion (and on demand loading as they are called.
+Calls are made across modules, and to the environment.

--- a/benchmarks/function_loading/puppet.conf.erb
+++ b/benchmarks/function_loading/puppet.conf.erb
@@ -1,5 +1,5 @@
 confdir = <%= location %>
 vardir = <%= location %>
 environmentpath = <%= File.join(location, 'environments') %>
-environment_timeout = 40s
+environment_timeout = 0
 parser = future

--- a/benchmarks/function_loading/site.pp.erb
+++ b/benchmarks/function_loading/site.pp.erb
@@ -1,4 +1,4 @@
-environment::f999()
+environment::f<%= function_count() - 1 %>()
 <% size.times do |i| %>include module<%= i %>
 <% end %>
 

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -280,7 +280,6 @@ module Puppet::Pops::Evaluator::Runtime3Support
         return func.call(scope, *args, &block)
       end
     end
-
     # Call via 3x API if function exists there
     fail(Puppet::Pops::Issues::UNKNOWN_FUNCTION, o, {:name => name}) unless Puppet::Parser::Functions.function(name)
 

--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -49,7 +49,7 @@ class Puppet::Pops::Loader::BaseLoader < Puppet::Pops::Loader::Loader
   # @api private
   #
   def set_entry(typed_name, value, origin = nil)
-    if entry = @named_values[typed_name] then fail_redefined(entry); end
+    if entry = @named_values[typed_name] then fail_redefine(entry); end
     @named_values[typed_name] = Puppet::Pops::Loader::Loader::NamedEntry.new(typed_name, value, origin)
   end
 


### PR DESCRIPTION
Before this the function_loading benchmark failed with a out of stack
error. This was caused by a combination of the deep recursion set up by
the benchmark, and that the rutime needs additional stack levels per
call.

The benchmark logic also had flaws that had gone undetected in older
puppet versions. Now with stricter module visibility rules the benchmark
generated modules did not have the correct deendencies in meta data.

This changes the recursion to not go as deep and fixes the module
dependency problems. The number of runs/modules/funcions were also
lowered to reduce the running time of the benchmark as he additional
iterations does not provide more information.

One problem remains - each iteration takes about 25% longer than the
previous. There could be a natural explanatoin for this (GC), but
manually performing gc beteeen runs did not change the outcome. Newer
riibies performed better, but still with degradation of the performance.
It looks like there is either a memory leak (either real, or caused by
the benchmark's construction).

This also corrects a typo in the base_loader that would cause an
error-reporting case to fail with a method not found instead of the
actual error.