### PR TITLE
(PUP-5744) Make class_information_service produce json-safe literals

### DIFF
--- a/lib/puppet/info_service/class_information_service.rb
+++ b/lib/puppet/info_service/class_information_service.rb
@@ -1,6 +1,6 @@
 require 'puppet'
 require 'puppet/pops'
-require 'puppet/pops/evaluator/literal_evaluator'
+require 'puppet/pops/evaluator/json_strict_literal_evaluator'
 
 class Puppet::InfoService::ClassInformationService
 
@@ -41,7 +41,7 @@ class Puppet::InfoService::ClassInformationService
   end
 
   def literal_evaluator
-    @@literal_evaluator ||= Puppet::Pops::Evaluator::LiteralEvaluator.new
+    @@literal_evaluator ||= Puppet::Pops::Evaluator::JsonStrictLiteralEvaluator.new
   end
 
   def result_of(f)

--- a/lib/puppet/pops/evaluator/json_strict_literal_evaluator.rb
+++ b/lib/puppet/pops/evaluator/json_strict_literal_evaluator.rb
@@ -1,0 +1,85 @@
+require 'rgen/ecore/ecore'
+
+# Literal values for
+#
+#   * String
+#   * Numbers
+#   * Booleans
+#   * Undef (produces nil)
+#   * Array
+#   * Hash where keys must be Strings
+#   * QualifiedName
+#
+# Not considered literal:
+#
+#   * QualifiedReference  # i.e. File, FooBar
+#   * Default is not accepted as being literal
+#   * Regular Expression is not accepted as being literal
+#   * Hash with non String keys
+#   * String with interpolatin
+#
+class Puppet::Pops::Evaluator::JsonStrictLiteralEvaluator
+  #include Puppet::Pops::Utils
+
+  EMPTY_STRING = ''.freeze
+  COMMA_SEPARATOR = ', '.freeze
+
+  def initialize
+    @@literal_visitor ||= Puppet::Pops::Visitor.new(self, "literal", 0, 0)
+  end
+
+  def literal(ast)
+    @@literal_visitor.visit_this_0(self, ast)
+  end
+
+  def literal_Object(o)
+    throw :not_literal
+  end
+
+  def literal_Factory(o)
+    literal(o.model)
+  end
+
+  def literal_Program(o)
+    literal(o.body)
+  end
+
+  def literal_LiteralString(o)
+    o.value
+  end
+
+  def literal_QualifiedName(o)
+    o.value
+  end
+
+  def literal_LiteralNumber(o)
+    o.value
+  end
+
+  def literal_LiteralBoolean(o)
+    o.value
+  end
+
+  def literal_LiteralUndef(o)
+    nil
+  end
+
+  def literal_ConcatenatedString(o)
+    # use double quoted string value if there is no interpolation
+    throw :not_literal unless o.segments.size == 1 && o.segments[0].is_a?(Puppet::Pops::Model::LiteralString)
+    o.segments[0].value
+  end
+
+  def literal_LiteralList(o)
+    o.values.map {|v| literal(v) }
+  end
+
+  def literal_LiteralHash(o)
+    o.entries.reduce({}) do |result, entry|
+      key = literal(entry.key)
+      throw :not_literal unless key.is_a?(String)
+      result[key] = literal(entry.value)
+      result
+    end
+  end
+end

--- a/spec/unit/info_service_spec.rb
+++ b/spec/unit/info_service_spec.rb
@@ -34,6 +34,9 @@ describe "Puppet::InfoService" do
         'borked.pp' => <<-CODE,
            class Borked($Herp+$Derp) {}
         CODE
+        'json_unsafe.pp' => <<-CODE,
+             class json_unsafe($arg1 = /.*/, $arg2 = default, $arg3 = {1 => 1}) {}
+          CODE
        })
     end
 
@@ -208,6 +211,25 @@ describe "Puppet::InfoService" do
                ]},
            ]} # end production env
         })
+     end
+
+     it "produces source string for literals that are not pure json" do
+       files = ['json_unsafe.pp'].map {|f| File.join(code_dir, f) }
+       result = Puppet::InfoService.classes_per_environment({'production' => files })
+       expect(result).to eq({
+         "production"=>{
+            "#{code_dir}/json_unsafe.pp" => [
+              {:name=>"json_unsafe",
+                :params => [
+                  {:name => "arg1",
+                    :default_source => "/.*/" },
+                  {:name => "arg2",
+                    :default_source => "default" },
+                  {:name => "arg3",
+                    :default_source => "{1 => 1}" }
+                ]}
+            ]} # end production env
+         })
      end
 
     it "produces no type entry if type is not given" do

--- a/spec/unit/pops/evaluator/json_strict_literal_evaluator_spec.rb
+++ b/spec/unit/pops/evaluator/json_strict_literal_evaluator_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+require 'puppet/pops'
+require 'puppet/pops/evaluator/json_strict_literal_evaluator'
+
+describe "Puppet::Pops::Evaluator::JsonStrictLiteralEvaluator" do
+  let(:parser) {  Puppet::Pops::Parser::EvaluatingParser.new }
+  let(:leval)  {  Puppet::Pops::Evaluator::JsonStrictLiteralEvaluator.new }
+
+  { "1"       => 1,
+    "3.14"    => 3.14,
+    "true"    => true,
+    "false"   => false,
+    "'1'"     => '1',
+    "'a'"     => 'a',
+    '"a"'     => 'a',
+    'a'       => 'a',
+    'a::b'    => 'a::b',
+
+    # collections
+    '[1,2,3]'     => [1,2,3],
+    '{a=>1,b=>2}' => {'a' => 1, 'b' => 2},
+
+  }.each do |source, result|
+    it "evaluates '#{source}' to #{result}" do
+      expect(leval.literal(parser.parse_string(source))).to eq(result)
+    end
+  end
+
+  it "evaluates undef to nil" do
+    expect(leval.literal(parser.parse_string('undef'))).to be_nil
+  end
+
+  [ '1+1', 
+    'File',
+    '[1,2, 1+2]',
+    '{a=>1+1}', 
+    'Integer[1]', 
+    '"x$y"', 
+    '"x${y}z"'
+  ].each do |source|
+    it "throws :not_literal for non literal expression '#{source}'" do
+      expect{leval.literal(parser.parse_string('1+1'))}.to throw_symbol(:not_literal)
+    end
+  end
+
+  [ '{1=>100}', 
+    '{"ok" => {1 => 100}}',
+    '[{1 => 100}]',
+    'default', 
+    '/.*/', 
+  ].each do |source|
+    it "throws :not_literal for values not representable as pure JSON '#{source}'" do
+      expect{leval.literal(parser.parse_string('1+1'))}.to throw_symbol(:not_literal)
+    end
+  end
+end

--- a/spec/unit/pops/evaluator/json_strict_literal_evaluator_spec.rb
+++ b/spec/unit/pops/evaluator/json_strict_literal_evaluator_spec.rb
@@ -16,19 +16,18 @@ describe "Puppet::Pops::Evaluator::JsonStrictLiteralEvaluator" do
     '"a"'     => 'a',
     'a'       => 'a',
     'a::b'    => 'a::b',
+    'undef'   => nil,
 
     # collections
     '[1,2,3]'     => [1,2,3],
     '{a=>1,b=>2}' => {'a' => 1, 'b' => 2},
+    '[undef]'     => [nil],
+    '{a=>undef}'  => { 'a' => nil }
 
   }.each do |source, result|
     it "evaluates '#{source}' to #{result}" do
       expect(leval.literal(parser.parse_string(source))).to eq(result)
     end
-  end
-
-  it "evaluates undef to nil" do
-    expect(leval.literal(parser.parse_string('undef'))).to be_nil
   end
 
   [ '1+1', 
@@ -44,11 +43,18 @@ describe "Puppet::Pops::Evaluator::JsonStrictLiteralEvaluator" do
     end
   end
 
-  [ '{1=>100}', 
-    '{"ok" => {1 => 100}}',
-    '[{1 => 100}]',
-    'default', 
+  [ 'default', 
     '/.*/', 
+    '{1=>100}', 
+    '{undef => 10}',
+    '{default => 10}',
+    '{/.*/ => 10}',
+    '{"ok" => {1 => 100}}',
+    '[default]',
+    '[[default]]',
+    '[/.*/]',
+    '[[/.*/]]',
+    '[{1 => 100}]',
   ].each do |source|
     it "throws :not_literal for values not representable as pure JSON '#{source}'" do
       expect{leval.literal(parser.parse_string('1+1'))}.to throw_symbol(:not_literal)


### PR DESCRIPTION
This PR has two commits:
* The first adds a JsonStrictLiteralEvaluator, which is similar to the LiteralEvaluator, but that only accept values as literals if they can be directly represented in JSON - i.e. no default or regexp values, or hashes with non string keys.
* The second changes the class_information_service to use the JsonSrictLiteralEvaluator instead of he LiteralEvaluator since the later accepts any puppet literal.