### PR TITLE
(PUP-5802) Make the Yum package provider correctly parse epochs

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -211,9 +211,14 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       e = s[0,ei]
       s = s[ei+1,s.length]
     else
-      e = nil
+      e = '0'
     end
-    e = String(Bignum(e)) rescue '0'
+    begin
+      e = String(Integer(e))
+    rescue ArgumentError
+      # If there are non-digits in the epoch field, default to 0
+      e = '0'
+    end
     ri = s.index('-')
     if ri
       v = s[0,ri]

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -51,6 +51,13 @@ describe provider_class do
       expect(v[:release]).to eq('4.el5')
     end
 
+    it 'should parse evr with non-zero epoch' do
+      v = provider.yum_parse_evr('1:1.2.3-4.el5')
+      expect(v[:epoch]).to eq('1')
+      expect(v[:version]).to eq('1.2.3')
+      expect(v[:release]).to eq('4.el5')
+    end
+
     it 'should parse version only' do
       v = provider.yum_parse_evr('1.2.3')
       expect(v[:epoch]).to eq('0')


### PR DESCRIPTION
Without this patch applied, the Yum package provider assumes all version
epochs are "0", i.e. a package with version "1:1.2.3-4.el5" will be
interpreted as having epoch "0" not "1". This causes version comparisons
made by puppet to be incorrect when comparing packages of different
epoch's.

This bug is caused by the line:

```
e = String(Bignum(e)) rescue '0'
```
Bignum is not a function, so the line always throws an exception and the
rescue is always invoked.

This patch uses Integer instead of Bignum, rescues the specific
exception needed (this is so that an epoch like "foo" is coerced into
"0"), and provides a test for non-zero epochs