### PR TITLE
(PUP-5699) Inline symlink metadata in static catalog

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -85,6 +85,14 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
   # Rewrite a given file resource with the metadata from a fileserver based file
   def replace_metadata(resource, metadata)
+    if resource[:links] == "manage" && metadata.ftype == "link"
+      resource.delete(:source)
+      resource[:ensure] = "link"
+      resource[:target] = metadata.destination
+    elsif resource[:links] == "follow"
+      resource[:ensure] = metadata.ftype
+    end
+
     if metadata.ftype == "file"
       resource[:checksum_value] = sumdata(metadata.checksum)
     end


### PR DESCRIPTION
This commit updates the static compilation inlining logic to
handle symlinks which have their `links` parameter set to manage.
The `source` parameter of such a resource references one of two
items: a link or a regular file.

When `source` references a link, the destination of that link is
inlined directly into the `target` parameter of the new resource.

If `source` references a regular file, the existing logic holds
and file content is copied into the new resource.

When `links` is set to `follow`, we fall back to the regular
content inlining behavior, which sets the `checksum_value` of
the new resource.