### PR TITLE
(PUP-5813) Prevent memory leaks due to environments that doesn't get garbage collected

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -238,11 +238,6 @@ class Puppet::Configurer
       execute_postrun_command or return nil
     end
   ensure
-    # Between Puppet runs we need to forget the cached values.  This lets us
-    # pick up on new functions installed by gems or new modules being added
-    # without the daemon being restarted.
-    $env_module_directories = nil
-
     Puppet::Util::Log.close(report)
     send_report(report)
     Puppet.pop_context

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -20,7 +20,6 @@ class Puppet::Parser::Compiler
   include Puppet::Pops::Evaluator::Runtime3Support
 
   def self.compile(node, code_id = nil)
-    $env_module_directories = nil
     node.environment.check_for_reparse
 
     errors = node.environment.validation_errors

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -3,7 +3,6 @@ require 'puppet/parser/compiler'
 class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   def self.compile(env)
     begin
-      $env_module_directories = nil
       env.check_for_reparse
 
       node = Puppet::Node.new(env)

--- a/lib/puppet/pops/adaptable.rb
+++ b/lib/puppet/pops/adaptable.rb
@@ -15,7 +15,8 @@
 #   be exploited as the implementation of _being adaptable_ may change in the future.
 # @api private
 #
-module Puppet::Pops::Adaptable
+module Puppet::Pops
+module Adaptable
   # Base class for an Adapter.
   #
   # A typical adapter just defines some accessors.
@@ -199,3 +200,5 @@ module Puppet::Pops::Adaptable
     end
   end
 end
+end
+

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -369,14 +369,6 @@ describe Puppet::Configurer do
       expect(report.environment).to eq("second_env")
     end
 
-    it "should clear the global caches" do
-      $env_module_directories = false
-
-      @agent.run
-
-      expect($env_module_directories).to eq(nil)
-    end
-
     describe "when not using a REST terminus for catalogs" do
       it "should not pass any facts when retrieving the catalog" do
         Puppet::Resource::Catalog.indirection.terminus_class = :compiler


### PR DESCRIPTION
This PR contains two commits. The first that deals with a memory leak cause by a class-level instance variable that holds on to functions (puppet functions created in Ruby) that in turn have a dynamic scope that holds on to an environment. The second deals with the global $env_module_directories, a hash that uses environments as keys. Both commits uses the same approach for solving the problem. A dedicated adapter object that is adapted to the environment for which they hold data.