### PR TITLE
(PUP-5737) Backport test fix from a pe-puppet fork

### DIFF
--- a/acceptance/setup/common/pre-suite/100_SetParser.rb
+++ b/acceptance/setup/common/pre-suite/100_SetParser.rb
@@ -11,7 +11,18 @@ test_name "add parser=#{ENV['PARSER']} to all puppet.conf (only if $PARSER is se
       # otherwise the setting is created outside of any section
       # which makes it appear future parser is not enabled.
       puppet_conf = host.puppet['config']
-      on(host, "echo \"[main]\nparser=future\n\" >> '#{puppet_conf}'")
+      on(host, "grep '[main]' #{puppet_conf}", :acceptable_exit_codes => [0,1,2]) do |result|
+        case result.exit_code
+        when 0
+          # there is an assumption here that if a [main] section is present, it
+          # has settings otherwise PUP-4755 comes back into play, though
+          # 'global' settings should still end up in main when Puppet parses
+          on(host, puppet("config set --section main parser #{parser}"))
+        else
+          # not found (1), or file not present (2)
+          on(host, "echo \"[main]\nparser=future\n\" >> '#{puppet_conf}'")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Merge pull request #187 from jpartlow/issue/3.8.x/pe-13723-ensure-a-single-main-section-in-puppet-conf

(PE-13723) Ensure single main section in puppet.conf