### PR TITLE
(PUP-5807) Produce error in class_info_service when file does not exist.

### DIFF
--- a/lib/puppet/info_service/class_information_service.rb
+++ b/lib/puppet/info_service/class_information_service.rb
@@ -53,6 +53,8 @@ class Puppet::InfoService::ClassInformationService
   end
 
   def parse_file(f)
+    return {:error => "The file #{f} does not exist"} unless Puppet::FileSystem.exist?(f)
+
     begin
       parse_result = @parser.parse_file(f)
       parse_result.definitions.select {|d| d.is_a?(Puppet::Pops::Model::HostClassDefinition)}.map do |d|

--- a/spec/unit/info_service_spec.rb
+++ b/spec/unit/info_service_spec.rb
@@ -283,5 +283,16 @@ describe "Puppet::InfoService" do
               },
          })
     end
+
+    it "produces error when given a file that does not exist" do
+      files = ['the_tooth_fairy_does_not_exist.pp'].map {|f| File.join(code_dir, f) }
+      result = Puppet::InfoService.classes_per_environment({'production' => files })
+      expect(result).to eq({
+        "production"=>{
+          "#{code_dir}/the_tooth_fairy_does_not_exist.pp" => {:error  => "The file #{code_dir}/the_tooth_fairy_does_not_exist.pp does not exist"}
+             },
+        })
+    end
+
   end
 end


### PR DESCRIPTION
Before this, when a file did not exist it was retured as an empty set of
values.

Now, if the file does not exist it returns a mapping of:

{THEFILE.pp => {:error => "The file THEFILE.pp does not exist"}