### PR TITLE
(PUP-5701) Use checksum_value instead of content if specified

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -377,7 +377,7 @@ Puppet::Type.newtype(:file) do
 
     self.fail "You cannot specify more than one of #{CREATORS.collect { |p| p.to_s}.join(", ")}" if creator_count > 1
 
-    self.fail "You cannot specify a remote recursion without a source" if !self[:source] and self[:recurse] == :remote
+    self.fail "You cannot specify a remote recursion without a source" if !self[:source] && self[:recurse] == :remote
 
     self.fail "You cannot specify source when using checksum 'none'" if self[:checksum] == :none && !self[:source].nil?
 
@@ -385,7 +385,7 @@ Puppet::Type.newtype(:file) do
       self.fail "You cannot specify content when using checksum '#{checksum_type}'" if self[:checksum] == checksum_type && !self[:content].nil?
     end
 
-    self.warning "Possible error: recurselimit is set but not recurse, no recursion will happen" if !self[:recurse] and self[:recurselimit]
+    self.warning "Possible error: recurselimit is set but not recurse, no recursion will happen" if !self[:recurse] && self[:recurselimit]
 
     if @parameters[:content] && @parameters[:content].actual_content
       # Now that we know the checksum, update content (in case it was created before checksum was known).
@@ -410,7 +410,7 @@ Puppet::Type.newtype(:file) do
 
   # Determine the user to write files as.
   def asuser
-    if self.should(:owner) and ! self.should(:owner).is_a?(Symbol)
+    if self.should(:owner) && ! self.should(:owner).is_a?(Symbol)
       writeable = Puppet::Util::SUIDManager.asuser(self.should(:owner)) {
         FileTest.writable?(::File.dirname(self[:path]))
       }

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -846,8 +846,8 @@ Puppet::Type.newtype(:file) do
     tempfile.close
 
     yield tempfile.path
-
-    tempfile.delete
+  ensure
+    tempfile.delete if tempfile
   end
 
   private

--- a/lib/puppet/type/file/checksum_value.rb
+++ b/lib/puppet/type/file/checksum_value.rb
@@ -1,74 +1,53 @@
 require 'puppet/util/checksums'
+require 'puppet/type/file/data_sync'
 
 module Puppet
   Puppet::Type.type(:file).newproperty(:checksum_value) do
     include Puppet::Util::Checksums
-    include Puppet::Util::Diff
+    include Puppet::DataSync
 
     desc "The checksum of the source contents. Only md5 and sha256 are supported when
-      specifying this parameter."
+      specifying this parameter. If this parameter is set, source_permissions will be
+      assumed to be false, and ownership and permissions will not be read from source."
 
     def insync?(is)
-      # If checksum_value is specified, only manage source.
-      # Content manages its own syncing... FOR NOW, duh duh duh
+      # If checksum_value and source are specified, manage the file contents.
+      # Otherwise the content property will manage syncing.
       if resource.parameter(:source).nil?
         return true
       end
 
-      if resource.should_be_file?
-        return false if is == :absent
-      else
-        return true
-      end
-
-      return true if ! @resource.replace?
-
-      result = super
-
-      if ! result and Puppet[:show_diff] and resource.show_diff?
-        resource.write_temporarily do |path|
-          send @resource[:loglevel], "\n" + diff(@resource[:path], path)
-        end
-      end
-      result
+      checksum_insync?(resource.parameter(:source), is, true) {|_is| super(_is)}
     end
 
     def property_matches?(current, desired)
-      time_types = [:mtime, :ctime]
-      checksum_type = resource.parameter(:checksum).value
-
-      # The inherited equality is always accepted, so use it if valid.
-      basic = super(current, desired)
-      return basic if basic || !time_types.include?(checksum_type)
-      return false unless current && desired
-      begin
-        DateTime.parse(current) >= DateTime.parse(desired)
-      rescue => detail
-        self.fail Puppet::Error, "Resource with checksum_type #{checksum_type} didn't contain a date in #{current} or #{desired}", detail.backtrace
-      end
-    end
-
-    def sync
-      # insync? only returns false if it expects to manage the file content,
-      # so instruct the resource to write its contents.
-      return_event = @resource.stat ? :file_changed : :file_created
-      @resource.write
-      return_event
+      return true if super(current, desired)
+      return date_matches?(resource.parameter(:checksum).value, current, desired)
     end
 
     def retrieve
-      # Intentionally mirrors content#retrieve. Eventually content will be a
-      # parameter, and content syncing will be managed by checksum_value.
-      return :absent unless stat = @resource.stat
-      ftype = stat.ftype
-      # Don't even try to manage the content on directories or links
-      return nil if ["directory","link"].include?(ftype)
-
-      begin
-        sumdata(resource.parameter(:checksum).sum_file(resource[:path]))
-      rescue => detail
-        raise Puppet::Error, "Could not read #{ftype} #{@resource.title}: #{detail}", detail.backtrace
+      # If checksum_value and source are specified, manage the file contents.
+      # Otherwise the content property will manage syncing. Don't compute the checksum twice.
+      if resource.parameter(:source).nil?
+        return nil
       end
+
+      result = retrieve_checksum(resource)
+      # If the returned type matches the util/checksums format (prefixed with the type),
+      # strip the checksum type.
+      result = sumdata(result) if checksum?(result)
+      result
     end
+
+    def sync
+      if resource.parameter(:source).nil?
+        devfail "checksum_value#sync should not be called without a source parameter"
+      end
+
+      # insync? only returns false if it expects to manage the file content,
+      # so instruct the resource to write its contents.
+      contents_sync(resource.parameter(:source))
+    end
+
   end
 end

--- a/lib/puppet/type/file/checksum_value.rb
+++ b/lib/puppet/type/file/checksum_value.rb
@@ -1,0 +1,74 @@
+require 'puppet/util/checksums'
+
+module Puppet
+  Puppet::Type.type(:file).newproperty(:checksum_value) do
+    include Puppet::Util::Checksums
+    include Puppet::Util::Diff
+
+    desc "The checksum of the source contents. Only md5 and sha256 are supported when
+      specifying this parameter."
+
+    def insync?(is)
+      # If checksum_value is specified, only manage source.
+      # Content manages its own syncing... FOR NOW, duh duh duh
+      if resource.parameter(:source).nil?
+        return true
+      end
+
+      if resource.should_be_file?
+        return false if is == :absent
+      else
+        return true
+      end
+
+      return true if ! @resource.replace?
+
+      result = super
+
+      if ! result and Puppet[:show_diff] and resource.show_diff?
+        resource.write_temporarily do |path|
+          send @resource[:loglevel], "\n" + diff(@resource[:path], path)
+        end
+      end
+      result
+    end
+
+    def property_matches?(current, desired)
+      time_types = [:mtime, :ctime]
+      checksum_type = resource.parameter(:checksum).value
+
+      # The inherited equality is always accepted, so use it if valid.
+      basic = super(current, desired)
+      return basic if basic || !time_types.include?(checksum_type)
+      return false unless current && desired
+      begin
+        DateTime.parse(current) >= DateTime.parse(desired)
+      rescue => detail
+        self.fail Puppet::Error, "Resource with checksum_type #{checksum_type} didn't contain a date in #{current} or #{desired}", detail.backtrace
+      end
+    end
+
+    def sync
+      # insync? only returns false if it expects to manage the file content,
+      # so instruct the resource to write its contents.
+      return_event = @resource.stat ? :file_changed : :file_created
+      @resource.write
+      return_event
+    end
+
+    def retrieve
+      # Intentionally mirrors content#retrieve. Eventually content will be a
+      # parameter, and content syncing will be managed by checksum_value.
+      return :absent unless stat = @resource.stat
+      ftype = stat.ftype
+      # Don't even try to manage the content on directories or links
+      return nil if ["directory","link"].include?(ftype)
+
+      begin
+        sumdata(resource.parameter(:checksum).sum_file(resource[:path]))
+      rescue => detail
+        raise Puppet::Error, "Could not read #{ftype} #{@resource.title}: #{detail}", detail.backtrace
+      end
+    end
+  end
+end

--- a/lib/puppet/type/file/data_sync.rb
+++ b/lib/puppet/type/file/data_sync.rb
@@ -1,0 +1,84 @@
+require 'puppet/util/checksums'
+require 'puppet/util/diff'
+require 'date'
+require 'tempfile'
+
+module Puppet
+  module DataSync
+    include Puppet::Util::Checksums
+    include Puppet::Util::Diff
+
+    def write_temporarily(param)
+      tempfile = Tempfile.new("puppet-file")
+      tempfile.open
+
+      param.write(tempfile)
+
+      tempfile.close
+
+      yield tempfile.path
+    ensure
+      tempfile.delete if tempfile
+    end
+
+    def checksum_insync?(param, is, has_contents, &block)
+      resource = param.resource
+      if resource.should_be_file?
+        return false if is == :absent
+      else
+        if resource[:ensure] == :present && has_contents && (s = resource.stat)
+          resource.warning "Ensure set to :present but file type is #{s.ftype} so no content will be synced"
+        end
+        return true
+      end
+
+      return true if ! resource.replace?
+
+      result = yield(is)
+
+      if !result && Puppet[:show_diff] && resource.show_diff?
+        write_temporarily(param) do |path|
+          send resource[:loglevel], "\n" + diff(resource[:path], path)
+        end
+      end
+      result
+    end
+
+    def date_matches?(checksum_type, current, desired)
+      time_types = [:mtime, :ctime]
+      return false if !time_types.include?(checksum_type)
+      return false unless current && desired
+
+      begin
+        if checksum?(current) || checksum?(desired)
+          raise if !time_types.include?(sumtype(current).to_sym) || !time_types.include?(sumtype(desired).to_sym)
+          current = sumdata(current)
+          desired = sumdata(desired)
+        end
+        DateTime.parse(current) >= DateTime.parse(desired)
+      rescue => detail
+        self.fail Puppet::Error, "Resource with checksum_type #{checksum_type} didn't contain a date in #{current} or #{desired}", detail.backtrace
+      end
+    end
+
+    def retrieve_checksum(resource)
+      return :absent unless stat = resource.stat
+      ftype = stat.ftype
+      # Don't even try to manage the content on directories or links
+      return nil if ["directory","link"].include?(ftype)
+
+      begin
+        resource.parameter(:checksum).sum_file(resource[:path])
+      rescue => detail
+        raise Puppet::Error, "Could not read #{ftype} #{resource.title}: #{detail}", detail.backtrace
+      end
+    end
+
+    def contents_sync(param)
+      return_event = param.resource.stat ? :file_changed : :file_created
+      resource.write(param)
+      return_event
+    end
+
+  end
+end

--- a/lib/puppet/type/file/ensure.rb
+++ b/lib/puppet/type/file/ensure.rb
@@ -64,8 +64,10 @@ module Puppet
       # Make sure we're not managing the content some other way
       if property = @resource.property(:content)
         property.sync
+      elsif property = @resource.property(:checksum_value)
+        property.sync
       else
-        @resource.write(:ensure)
+        @resource.write
         @resource.should(:mode)
       end
     end

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -14,7 +14,6 @@ module Puppet
   # this state, during retrieval, modifies the appropriate other states
   # so that things get taken care of appropriately.
   Puppet::Type.type(:file).newparam(:source) do
-    include Puppet::Util::Diff
     include Puppet::Network::HTTP::Compression.module
 
     attr_accessor :source, :local

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -134,6 +134,7 @@ module Puppet::Util::Checksums
   end
 
   def mtime?(string)
+    return true if string.is_a? Time
     !!DateTime.parse(string)
   rescue
     false
@@ -203,6 +204,7 @@ module Puppet::Util::Checksums
   end
 
   def ctime?(string)
+    return true if string.is_a? Time
     !!DateTime.parse(string)
   rescue
     false

--- a/spec/unit/type/file/checksum_value_spec.rb
+++ b/spec/unit/type/file/checksum_value_spec.rb
@@ -1,0 +1,258 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:file).attrclass(:checksum_value), :uses_checksums => true do
+  include PuppetSpec::Files
+  include_context 'with supported checksum types'
+
+  let(:path) { tmpfile('foo_bar') }
+  let(:source_file) { file_containing('temp_foo', 'nothing at all') }
+  let(:environment) { Puppet::Node::Environment.create(:testing, []) }
+  let(:catalog) { Puppet::Resource::Catalog.new(:test, environment) }
+  let(:resource) { Puppet::Type.type(:file).new(:path => path, :catalog => catalog) }
+
+  it "should be a property" do
+    expect(described_class.superclass).to eq(Puppet::Property)
+  end
+
+  describe "when retrieving the current checksum_value" do
+    let(:checksum_value) { described_class.new(:resource => resource) }
+
+    it "should return :absent if the target does not exist" do
+      resource.expects(:stat).returns nil
+
+      expect(checksum_value.retrieve).to eq(:absent)
+    end
+
+    it "should not manage content on directories" do
+      stat = mock 'stat', :ftype => "directory"
+      resource.expects(:stat).returns stat
+
+      expect(checksum_value.retrieve).to be_nil
+    end
+
+    it "should not manage content on links" do
+      stat = mock 'stat', :ftype => "link"
+      resource.expects(:stat).returns stat
+
+      expect(checksum_value.retrieve).to be_nil
+    end
+
+    it "should always return the checksum as a string" do
+      resource[:checksum] = :mtime
+
+      stat = mock 'stat', :ftype => "file"
+      resource.expects(:stat).returns stat
+
+      time = Time.now
+      resource.parameter(:checksum).expects(:mtime_file).with(resource[:path]).returns time
+
+      expect(checksum_value.retrieve).to eq(time.to_s)
+    end
+
+    with_digest_algorithms do
+      it "should return the checksum of the target if it exists and is a normal file" do
+        stat = mock 'stat', :ftype => "file"
+        resource.expects(:stat).returns stat
+        resource.parameter(:checksum).expects("#{digest_algorithm}_file".intern).with(resource[:path]).returns "mysum"
+
+        expect(checksum_value.retrieve).to eq("mysum")
+      end
+    end
+  end
+
+  describe "when testing whether the checksum_value is in sync" do
+    let(:checksum_value) { described_class.new(:resource => resource) }
+
+    before do
+      resource[:ensure] = :file
+    end
+
+    it "should return true if source is not specified" do
+      checksum_value.should = "foo"
+      expect(checksum_value).to be_safe_insync("whatever")
+    end
+
+    describe "when a source is provided" do
+      before do
+        resource[:source] = source_file
+      end
+
+      with_digest_algorithms do
+        before(:each) do
+          resource[:checksum] = digest_algorithm
+        end
+
+        it "should return true if the resource shouldn't be a regular file" do
+          resource.expects(:should_be_file?).returns false
+          checksum_value.should = "foo"
+          expect(checksum_value).to be_safe_insync("whatever")
+        end
+
+        it "should return false if the current checksum_value is :absent" do
+          checksum_value.should = "foo"
+          expect(checksum_value).not_to be_safe_insync(:absent)
+        end
+
+        it "should return false if the file should be a file but is not present" do
+          resource.expects(:should_be_file?).returns true
+          checksum_value.should = "foo"
+
+          expect(checksum_value).not_to be_safe_insync(:absent)
+        end
+
+        describe "and the file exists" do
+          before do
+            resource.stubs(:stat).returns mock("stat")
+            checksum_value.should = "somechecksum"
+          end
+
+          it "should return false if the current checksum_value is different from the desired checksum_value" do
+            expect(checksum_value).not_to be_safe_insync("otherchecksum")
+          end
+
+          it "should return true if the current checksum_value is the same as the desired checksum_value" do
+            expect(checksum_value).to be_safe_insync("somechecksum")
+          end
+
+          [true, false].product([true, false]).each do |cfg, param|
+            describe "and Puppet[:show_diff] is #{cfg} and show_diff => #{param}" do
+              before do
+                Puppet[:show_diff] = cfg
+                resource.stubs(:show_diff?).returns param
+                resource[:loglevel] = "debug"
+              end
+
+              if cfg and param
+                it "should display a diff" do
+                  checksum_value.expects(:diff).returns("my diff").once
+                  checksum_value.expects(:debug).with("\nmy diff").once
+                  expect(checksum_value).not_to be_safe_insync("otherchecksum")
+                end
+              else
+                it "should not display a diff" do
+                  checksum_value.expects(:diff).never
+                  expect(checksum_value).not_to be_safe_insync("otherchecksum")
+                end
+              end
+            end
+          end
+        end
+      end
+
+      SAVED_TIME = Time.now
+      [:ctime, :mtime].each do |time_stat|
+        [["older", SAVED_TIME-1, false], ["same", SAVED_TIME, true], ["newer", SAVED_TIME+1, true]].each do
+          |compare, target_time, success|
+          describe "with #{compare} target #{time_stat} compared to source" do
+            before do
+              resource[:checksum] = time_stat
+              checksum_value.should = SAVED_TIME.to_s
+            end
+
+            it "should return #{success}" do
+              if success
+                expect(checksum_value).to be_safe_insync(target_time.to_s)
+              else
+                expect(checksum_value).not_to be_safe_insync(target_time.to_s)
+              end
+            end
+          end
+        end
+
+        describe "with #{time_stat}" do
+          before do
+            resource[:checksum] = time_stat
+          end
+
+          it "should not be insync if trying to create it" do
+            checksum_value.should = SAVED_TIME.to_s
+            expect(checksum_value).not_to be_safe_insync(:absent)
+          end
+
+          it "should raise an error if checksum_value is not a checksum" do
+            checksum_value.should = "some content"
+            expect {
+              checksum_value.safe_insync?(SAVED_TIME.to_s)
+            }.to raise_error(/Resource with checksum_type #{time_stat} didn't contain a date in/)
+          end
+
+          it "should not be insync even if checksum_value is the absent symbol" do
+            checksum_value.should = :absent
+            expect(checksum_value).not_to be_safe_insync(:absent)
+          end
+        end
+      end
+
+      describe "and :replace is false" do
+        before do
+          resource.stubs(:replace?).returns false
+        end
+
+        it "should be insync if the file exists and the checksum_value is different" do
+          resource.stubs(:stat).returns mock('stat')
+
+          expect(checksum_value).to be_safe_insync("whatever")
+        end
+
+        it "should be insync if the file exists and the checksum_value is right" do
+          resource.stubs(:stat).returns mock('stat')
+
+          expect(checksum_value).to be_safe_insync("something")
+        end
+
+        it "should not be insync if the file does not exist" do
+          checksum_value.should = "foo"
+          expect(checksum_value).not_to be_safe_insync(:absent)
+        end
+      end
+    end
+  end
+
+  describe "when testing whether the checksum_value is initialized in the resource and in sync" do
+    CHECKSUM_TYPES_TO_TRY.each do |checksum_type, checksum|
+      describe "sync with checksum type #{checksum_type} and the file exists" do
+        before do
+          @new_resource = Puppet::Type.type(:file).new :ensure => :file, :path => path, :catalog => catalog,
+            :checksum_value => checksum, :checksum => checksum_type, :source => source_file
+          @new_resource.stubs(:stat).returns mock('stat')
+        end
+
+        it "should return false if the current checksum_value is different from the desired checksum_value" do
+          expect(@new_resource.parameters[:checksum_value]).not_to be_safe_insync("abcdef")
+        end
+
+        it "should return true if the current checksum_value is the same as the desired checksum_value" do
+          expect(@new_resource.parameters[:checksum_value]).to be_safe_insync(checksum)
+        end
+      end
+    end
+  end
+
+  describe "when changing the checksum_value" do
+    let(:checksum_value) { described_class.new(:resource => resource) }
+
+    before do
+      resource.stubs(:[]).with(:path).returns "/boo"
+      resource.stubs(:stat).returns "eh"
+    end
+
+    it "should use the file's :write method to write the checksum_value" do
+      resource.expects(:write).with(nil)
+
+      checksum_value.sync
+    end
+
+    it "should return :file_changed if the file already existed" do
+      resource.expects(:stat).returns "something"
+      resource.stubs(:write)
+      expect(checksum_value.sync).to eq(:file_changed)
+    end
+
+    it "should return :file_created if the file did not exist" do
+      resource.expects(:stat).returns nil
+      resource.stubs(:write)
+      expect(checksum_value.sync).to eq(:file_created)
+    end
+  end
+end

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -1,8 +1,5 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'puppet/network/http_pool'
-
-require 'puppet/network/resolver'
 
 describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true do
   include PuppetSpec::Files
@@ -316,7 +313,7 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
     end
 
     it "should use the file's :write method to write the content" do
-      resource.expects(:write).with(:content)
+      resource.expects(:write).with(nil)
 
       content.sync
     end
@@ -390,185 +387,35 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
       end
     end
 
-    describe "from local source" do
-      let(:source_content) { "source file content\r\n"*10 }
-      before(:each) do
-        sourcename = tmpfile('source')
-        resource[:backup] = false
-        resource[:source] = sourcename
-
-        File.open(sourcename, 'wb') {|f| f.write source_content}
-
-        # This needs to be invoked to properly initialize the content property,
-        # or attempting to write a file will fail.
-        resource.newattr(:content)
-      end
-
-      it "should copy content from the source to the file" do
-        source = resource.parameter(:source)
-        resource.write(source)
-
-        expect(Puppet::FileSystem.binread(filename)).to eq(source_content)
-      end
-
-      with_digest_algorithms do
-        it "should return the checksum computed" do
-          File.open(filename, 'wb') do |file|
-            resource[:checksum] = digest_algorithm
-            expect(content.write(file)).to eq("{#{digest_algorithm}}#{digest(source_content)}")
-          end
-        end
-      end
-    end
-
-    describe 'from remote source' do
-      let(:source_content) { "source file content\n"*10 }
-      let(:source) { resource.newattr(:source) }
-      let(:response) { stub_everything('response') }
-      let(:conn) { mock('connection') }
-
-      before(:each) do
-        resource[:backup] = false
-        # This needs to be invoked to properly initialize the content property,
-        # or attempting to write a file will fail.
-        resource.newattr(:content)
-
-        response.stubs(:read_body).multiple_yields(*source_content.lines)
-        conn.stubs(:request_get).yields(response)
-      end
-
-      it 'should use an explicit fileserver if source starts with puppet://' do
-        response.stubs(:code).returns('200')
-        source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet://somehostname/test/foo', :ftype => 'file')
-        Puppet::Network::HttpPool.expects(:http_instance).with('somehostname', anything).returns(conn)
-
-        resource.write(source)
-      end
-
-      it 'should use the default fileserver if source starts with puppet:///' do
-        response.stubs(:code).returns('200')
-        source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo', :ftype => 'file')
-        Puppet::Network::HttpPool.expects(:http_instance).with(Puppet.settings[:server], anything).returns(conn)
-
-        resource.write(source)
-      end
-
-      it 'should percent encode reserved characters' do
-        response.stubs(:code).returns('200')
-        Puppet::Network::HttpPool.stubs(:http_instance).returns(conn)
-        source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
-
-        conn.unstub(:request_get)
-        conn.expects(:request_get).with("#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3/file_content/test/foo%20bar?environment=testing&", anything).yields(response)
-
-        resource.write(source)
-      end
-
-      describe 'when handling file_content responses' do
-        before(:each) do
-          Puppet::Network::HttpPool.stubs(:http_instance).returns(conn)
-          source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo', :ftype => 'file')
-        end
-
-        it 'should not write anything if source is not found' do
-          response.stubs(:code).returns('404')
-
-          expect { resource.write(source) }.to raise_error(Net::HTTPError, /404/)
-          expect(File.read(filename)).to eq('initial file content')
-        end
-
-        it 'should raise an HTTP error in case of server error' do
-          response.stubs(:code).returns('500')
-
-          expect { resource.write(source) }.to raise_error(Net::HTTPError, /500/)
-        end
-
-        context 'and the request was successful' do
-          before(:each) { response.stubs(:code).returns '200' }
-
-          it 'should write the contents to the file' do
-            resource.write(source)
-            expect(Puppet::FileSystem.binread(filename)).to eq(source_content)
-          end
-
-          with_digest_algorithms do
-            it 'should return the checksum computed' do
-              File.open(filename, 'w') do |file|
-                resource[:checksum] = digest_algorithm
-                expect(content.write(file)).to eq("{#{digest_algorithm}}#{digest(source_content)}")
-              end
-            end
-          end
-
-        end
-
-      end
-    end
-
     # These are testing the implementation rather than the desired behaviour; while that bites, there are a whole
     # pile of other methods in the File type that depend on intimate details of this implementation and vice-versa.
     # If these blow up, you are gonna have to review the callers to make sure they don't explode! --daniel 2011-02-01
     describe "each_chunk_from should work" do
-
       it "when content is a string" do
-        content.each_chunk_from('i_am_a_string') { |chunk| expect(chunk).to eq('i_am_a_string') }
-      end
-
-      # The following manifest is a case where source and content.should are both set
-      # file { "/tmp/mydir" :
-      #   source  => '/tmp/sourcedir',
-      #   recurse => true,
-      # }
-      it "when content checksum comes from source" do
-        source_param = Puppet::Type.type(:file).attrclass(:source)
-        source = source_param.new(:resource => resource)
-        content.should = "{md5}123abcd"
-
-        content.expects(:chunk_file_from_source).returns('from_source')
-        content.each_chunk_from(source) { |chunk| expect(chunk).to eq('from_source') }
+        content.should = 'i_am_a_string'
+        content.send(:each_chunk_from) { |chunk| expect(chunk).to eq('i_am_a_string') }
       end
 
       it "when no content, source, but ensure present" do
         resource[:ensure] = :present
-        content.each_chunk_from(nil) { |chunk| expect(chunk).to eq('') }
+        content.send(:each_chunk_from) { |chunk| expect(chunk).to eq('') }
       end
 
       # you might do this if you were just auditing
       it "when no content, source, but ensure file" do
         resource[:ensure] = :file
-        content.each_chunk_from(nil) { |chunk| expect(chunk).to eq('') }
+        content.send(:each_chunk_from) { |chunk| expect(chunk).to eq('') }
       end
 
       it "when source_or_content is nil and content not a checksum" do
-        content.each_chunk_from(nil) { |chunk| expect(chunk).to eq('') }
+        content.send(:each_chunk_from) { |chunk| expect(chunk).to eq('') }
       end
 
       # the content is munged so that if it's a checksum nil gets passed in
       it "when content is a checksum it should try to read from filebucket" do
         content.should = "{md5}123abcd"
         content.expects(:read_file_from_filebucket).once.returns('im_a_filebucket')
-        content.each_chunk_from(nil) { |chunk| expect(chunk).to eq('im_a_filebucket') }
-      end
-
-      it "when running as puppet apply" do
-        Puppet[:default_file_terminus] = "file_server"
-        source_or_content = stubs('source_or_content')
-        source_or_content.expects(:content).once.returns :whoo
-        content.each_chunk_from(source_or_content) { |chunk| expect(chunk).to eq(:whoo) }
-      end
-
-      it "when running from source with a local file" do
-        source_or_content = stubs('source_or_content')
-        source_or_content.expects(:local?).returns true
-        content.expects(:chunk_file_from_disk).with(source_or_content).once.yields 'woot'
-        content.each_chunk_from(source_or_content) { |chunk| expect(chunk).to eq('woot') }
-      end
-
-      it "when running from source with a remote file" do
-        source_or_content = stubs('source_or_content')
-        source_or_content.expects(:local?).returns false
-        content.expects(:chunk_file_from_source).with(source_or_content).once.yields 'woot'
-        content.each_chunk_from(source_or_content) { |chunk| expect(chunk).to eq('woot') }
+        content.send(:each_chunk_from) { |chunk| expect(chunk).to eq('im_a_filebucket') }
       end
     end
   end

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -688,28 +688,25 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
         source = source_param.new(:resource => resource)
 
         source.expects(:chunk_file_from_source).returns('from_source')
-        source.send(:each_chunk_from, source) { |chunk| expect(chunk).to eq('from_source') }
+        source.send(:each_chunk_from) { |chunk| expect(chunk).to eq('from_source') }
       end
 
       it "when running as puppet apply" do
         Puppet[:default_file_terminus] = "file_server"
-        source_or_content = stubs('source_or_content')
-        source_or_content.expects(:content).once.returns :whoo
-        source.send(:each_chunk_from, source_or_content) { |chunk| expect(chunk).to eq(:whoo) }
+        source.expects(:content).once.returns :whoo
+        source.send(:each_chunk_from) { |chunk| expect(chunk).to eq(:whoo) }
       end
 
       it "when running from source with a local file" do
-        source_or_content = stubs('source_or_content')
-        source_or_content.expects(:local?).returns true
-        source.expects(:chunk_file_from_disk).with(source_or_content).once.yields 'woot'
-        source.send(:each_chunk_from, source_or_content) { |chunk| expect(chunk).to eq('woot') }
+        source.expects(:local?).returns true
+        source.expects(:chunk_file_from_disk).once.yields 'woot'
+        source.send(:each_chunk_from) { |chunk| expect(chunk).to eq('woot') }
       end
 
       it "when running from source with a remote file" do
-        source_or_content = stubs('source_or_content')
-        source_or_content.expects(:local?).returns false
-        source.expects(:chunk_file_from_source).with(source_or_content).once.yields 'woot'
-        source.send(:each_chunk_from, source_or_content) { |chunk| expect(chunk).to eq('woot') }
+        source.expects(:local?).returns false
+        source.expects(:chunk_file_from_source).once.yields 'woot'
+        source.send(:each_chunk_from) { |chunk| expect(chunk).to eq('woot') }
       end
     end
   end

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1070,6 +1070,7 @@ describe Puppet::Type.type(:file) do
       it "should fail if the checksum parameter and content checksums do not match" do
         checksum = stub('checksum_parameter',  :sum => 'checksum_b', :sum_file => 'checksum_b')
         file.stubs(:parameter).with(:checksum).returns(checksum)
+        file.stubs(:parameter).with(:source).returns(nil)
 
         property = stub('content_property', :actual_content => "something", :length => "something".length, :write => 'checksum_a')
         file.stubs(:property).with(:content).returns(property)
@@ -1084,6 +1085,7 @@ describe Puppet::Type.type(:file) do
       it "should not fail if the checksum property and content checksums do not match" do
         checksum = stub('checksum_parameter',  :sum => 'checksum_b')
         file.stubs(:parameter).with(:checksum).returns(checksum)
+        file.stubs(:parameter).with(:source).returns(nil)
 
         property = stub('content_property', :actual_content => "something", :length => "something".length, :write => 'checksum_a')
         file.stubs(:property).with(:content).returns(property)
@@ -1190,12 +1192,20 @@ describe Puppet::Type.type(:file) do
   end
 
   describe "#write_content" do
-    it "should delegate writing the file to the content property" do
+    it "should delegate writing the file from content to the content property" do
       io = stub('io')
       file[:content] = "some content here"
       file.property(:content).expects(:write).with(io)
 
-      file.send(:write_content, io)
+      file.send(:write_contents, io)
+    end
+
+    it "should delegate writing the file from source to the source parameter" do
+      io = stub('io')
+      file[:source] = "file:///some_source_uri"
+      file.parameter(:source).expects(:write).with(io)
+
+      file.send(:write_contents, io)
     end
   end
 

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1072,10 +1072,11 @@ describe Puppet::Type.type(:file) do
         file.stubs(:parameter).with(:checksum).returns(checksum)
         file.stubs(:parameter).with(:source).returns(nil)
 
+
         property = stub('content_property', :actual_content => "something", :length => "something".length, :write => 'checksum_a')
         file.stubs(:property).with(:content).returns(property)
 
-        expect { file.write :NOTUSED }.to raise_error(Puppet::Error)
+        expect { file.write property }.to raise_error(Puppet::Error)
       end
     end
 
@@ -1090,7 +1091,7 @@ describe Puppet::Type.type(:file) do
         property = stub('content_property', :actual_content => "something", :length => "something".length, :write => 'checksum_a')
         file.stubs(:property).with(:content).returns(property)
 
-        expect { file.write :NOTUSED }.to_not raise_error
+        expect { file.write property }.to_not raise_error
       end
     end
 
@@ -1103,13 +1104,13 @@ describe Puppet::Type.type(:file) do
         it "should convert symbolic mode to int" do
           file[:mode] = 'oga=r'
           Puppet::Util.expects(:replace_file).with(file[:path], 0444)
-          file.write :NOTUSED
+          file.write
         end
 
         it "should support int modes" do
           file[:mode] = '0444'
           Puppet::Util.expects(:replace_file).with(file[:path], 0444)
-          file.write :NOTUSED
+          file.write
         end
       end
 
@@ -1119,19 +1120,19 @@ describe Puppet::Type.type(:file) do
         it "should set a umask of 0" do
           file[:mode] = 'oga=r'
           Puppet::Util.expects(:withumask).with(0)
-          file.write :NOTUSED
+          file.write
         end
 
         it "should convert symbolic mode to int" do
           file[:mode] = 'oga=r'
           File.expects(:open).with(file[:path], anything, 0444)
-          file.write :NOTUSED
+          file.write
         end
 
         it "should support int modes" do
           file[:mode] = '0444'
           File.expects(:open).with(file[:path], anything, 0444)
-          file.write :NOTUSED
+          file.write
         end
       end
     end
@@ -1141,7 +1142,7 @@ describe Puppet::Type.type(:file) do
         it "should default to 0644 mode" do
           file = described_class.new(:path => path, :content => "file content")
 
-          file.write :NOTUSED
+          file.write file.parameter(:content)
 
           expect(File.stat(file[:path]).mode & 0777).to eq(0644)
         end
@@ -1153,7 +1154,7 @@ describe Puppet::Type.type(:file) do
 
           umask_from_the_user = 0777
           Puppet::Util.withumask(umask_from_the_user) do
-            file.write :NOTUSED
+            file.write
           end
 
           expect(File.stat(file[:path]).mode & 0777).to eq(0644)
@@ -1188,24 +1189,6 @@ describe Puppet::Type.type(:file) do
           fail_if_checksum_is_wrong(self[:path], 'anything!')
         end
       end.not_to raise_error
-    end
-  end
-
-  describe "#write_content" do
-    it "should delegate writing the file from content to the content property" do
-      io = stub('io')
-      file[:content] = "some content here"
-      file.property(:content).expects(:write).with(io)
-
-      file.send(:write_contents, io)
-    end
-
-    it "should delegate writing the file from source to the source parameter" do
-      io = stub('io')
-      file[:source] = "file:///some_source_uri"
-      file.parameter(:source).expects(:write).with(io)
-
-      file.send(:write_contents, io)
     end
   end
 


### PR DESCRIPTION
If the checksum_value property is specified, use it instead of content
for verifying whether a file is insync.

Changes checksum_value to a property, and moves implementation of
writing data from source to the source parameter, rather than delegating
through a content property (which is no longer assumed to exist).

Separates writing source from content so it can be used by
checksum_value. In some cases content still triggers the write.