### PR TITLE
(PUP-5824) Support empty interpolation in Hiera data provider

### DIFF
--- a/spec/unit/data_providers/hiera_interpolation_spec.rb
+++ b/spec/unit/data_providers/hiera_interpolation_spec.rb
@@ -1,0 +1,48 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet'
+require 'puppet/data_providers/hiera_config'
+require 'puppet/data_providers/hiera_interpolate'
+
+describe "Puppet::DataProviders::HieraInterpolate" do
+
+  context "when there are empty interpolations %{} in data" do
+
+    let(:scope) { {} }
+    let(:lookup_invocation) {
+      Puppet::Pops::Lookup::Invocation.new(
+        scope, {}, {}, nil)
+    }
+    let(:interpolator) { Class.new { include Puppet::DataProviders::HieraInterpolate }.new }
+    let(:empty_interpolation) {'clown%{}shoe'}
+    let(:empty_interpolation_as_escape) {'clown%%{}{shoe}s'}
+    let(:only_empty_interpolation) {'%{}'}
+    let(:empty_namespace) {'%{::}'}
+    let(:whitespace1) {'%{ :: }'}
+    let(:whitespace2) {'%{   }'}
+
+    it 'should should produce an empty string for the interpolation' do
+      expect(interpolator.interpolate(empty_interpolation, lookup_invocation, true)).to eq('clownshoe')
+    end
+
+    it 'the empty interpolation can be used as an escape mechanism' do
+      expect(interpolator.interpolate(empty_interpolation_as_escape, lookup_invocation, true)).to eq('clown%{shoe}s')
+    end
+
+    it 'the value can consist of only an empty escape' do
+      expect(interpolator.interpolate(only_empty_interpolation, lookup_invocation, true)).to eq('')
+    end
+
+    it 'the value can consist of an empty namespace %{::}' do
+      expect(interpolator.interpolate(empty_namespace, lookup_invocation, true)).to eq('')
+    end
+
+    it 'the value can consist of whitespace %{ :: }' do
+      expect(interpolator.interpolate(whitespace1, lookup_invocation, true)).to eq('')
+    end
+
+    it 'the value can consist of whitespace %{  }' do
+      expect(interpolator.interpolate(whitespace2, lookup_invocation, true)).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
Before this, an empty interpolation such as `%{}` was not considered
an interpolation at all. The interpolation regexp required at least one
character between the curly braces.

This commit will allow the empty interpolation and will also ensure
that the expression between the curly braces is trimmed from whitespace
at both ends. If the result of that trim yields the empty string or
a string that only contains a name separator '::', then the interpolated
result will be the empty string.

It is still possible to have interpolated expressions where the key has
leading or trailing whitespace by using the function syntax, e.g.
%{hiera(' key ')}.