### PR TITLE
(maint) Downgrade TravisCI Ruby 2.1.8 to 2.1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: "bundle exec rake \"parallel:spec[2]\""
 notifications:
   email: false
 rvm:
-  - 2.1.8
+  - 2.1.7
   - 2.0.0
   - 1.9.3
   - 1.8.7-p374


### PR DESCRIPTION
 - There have been intermittent failures occurring on Ruby 2.1.8 in
   TravisCI when attempting to build / install native gems:

   Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

   This is currently affecting JSON 1.8.3 and msgpack 0.7.4.  This
   appears to be fixed by downgrading to Ruby 2.1.7