### PR TITLE
(PUP-5835) Make node params String if they are Symbol

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -75,7 +75,7 @@ class Puppet::Node
 
     # Keep environment_name attribute and parameter in sync if they have been set
     unless @environment.nil?
-      @parameters[ENVIRONMENT] = @environment.name if @parameters.include?(ENVIRONMENT)
+      @parameters[ENVIRONMENT] = @environment.name.to_s if @parameters.include?(ENVIRONMENT)
       self.environment_name = @environment.name if instance_variable_defined?(:@environment_name)
     end
     @environment

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -834,7 +834,8 @@ class Puppet::Parser::Compiler
   # Set the node's parameters into the top-scope as variables.
   def set_node_parameters
     node.parameters.each do |param, value|
-      @topscope[param.to_s] = value
+      # Ensure node does not leak Symbol instances in general
+      @topscope[param.to_s] = value.is_a?(Symbol) ? value.to_s : value
     end
     # These might be nil.
     catalog.client_version = node.parameters["clientversion"]

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -92,7 +92,7 @@ describe Puppet::Node do
       node.environment_name = :foo
       node.environment = :bar
       expect(node.environment_name).to eq(:bar)
-      expect(node.parameters['environment']).to eq(:bar)
+      expect(node.parameters['environment']).to eq('bar')
     end
   end
 

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -258,6 +258,22 @@ describe Puppet::Parser::Compiler do
       expect(@compiler.topscope['c']).to eq("d")
     end
 
+    it "should set node parameters thar are of Symbol type as String variables in the top scope" do
+      params = {"a" => :b}
+      @node.stubs(:parameters).returns(params)
+      compile_stub(:set_node_parameters)
+      @compiler.compile
+      expect(@compiler.topscope['a']).to eq("b")
+    end
+
+    it "should set the node's environment as a string variable in top scope" do
+      compile_stub(:set_node_parameters)
+      @node.merge({'wat' => 'this is how the sausage is made'})
+      @compiler.compile
+      expect(@compiler.topscope['environment']).to eq("testing")
+      expect(@compiler.topscope['wat']).to eq('this is how the sausage is made')
+    end
+
     it "should set the client and server versions on the catalog" do
       params = {"clientversion" => "2", "serverversion" => "3"}
       @node.stubs(:parameters).returns(params)


### PR DESCRIPTION
Before this, if a node parameter had a Ruby Symbol value it would leak
to Scope, and into variables. This was especially true for the
$environment variable after at enviroment name is made into a Symbol.

This commit fixes the problem both by ensuring that when a node sets a
parameter (in itself) based on the environment's name it transformed the
symbolic name to a Strig, and in the general case, the compiler when
setting parameters for a node, will also transform a Symbol value to
Strig. The later to ensure the same kind of mistake does not leak out to
Scope.

This commit also includes unit tests that asserts that environmet name
as a symbol dos not leak, nor any other node parameter.