### PR TITLE
(PUP-5820) Improve test coverage for managed symlinks

### DIFF
--- a/acceptance/tests/resource/file/should_create_symlink.rb
+++ b/acceptance/tests/resource/file/should_create_symlink.rb
@@ -1,24 +1,16 @@
 test_name "should create symlink"
 
-message = 'hello world'
-agents.each do |agent|
-  if agent.platform.variant == 'windows'
-    # symlinks are supported only on Vista+ (version 6.0 and higher)
-    on agent, facter('kernelmajversion') do
-      skip_test "Test not supported on this platform" if stdout.chomp.to_f < 6.0
-    end
-  end
+def message
+  'hello world'
+end
 
-  link = agent.tmpfile("symlink-link")
-  target = agent.tmpfile("symlink-target")
-
+def reset_link_and_target(agent, link, target)
   step "clean up the system before we begin"
   on agent, "rm -rf #{target} #{link}"
   on agent, "echo '#{message}' > #{target}"
+end
 
-  step "verify we can create a symlink"
-  on(agent, puppet_resource("file", link, "ensure=#{target}"))
-
+def verify_symlink(agent, link, target)
   step "verify the symlink was created"
   on agent, "test -L #{link} && test -f #{link}"
   step "verify the symlink points to a file"
@@ -31,7 +23,40 @@ agents.each do |agent|
   on(agent, "cat #{target}") do
     fail_test "target missing content" unless stdout.include? message
   end
+end
+
+agents.each do |agent|
+  if agent.platform.variant == 'windows'
+    # symlinks are supported only on Vista+ (version 6.0 and higher)
+    on agent, facter('kernelmajversion') do
+      skip_test "Test not supported on this platform" if stdout.chomp.to_f < 6.0
+    end
+  end
+
+  link_file = agent.tmpfile("symlink-link")
+  target_file = agent.tmpfile("symlink-target")
+  link_dir = agent.tmpdir("dir_symlink-link")
+  target_dir = agent.tmpdir("dir-symlink-target")
+
+  reset_link_and_target(agent, link_file, target_file)
+  reset_link_and_target(agent, link_dir, target_dir)
+
+  step "verify we can create a symlink with puppet resource"
+  on(agent, puppet_resource("file", "#{link_file}", "ensure=#{target_file}"))
+  verify_symlink(agent, link_file, target_file)
+  reset_link_and_target(agent, link_file, target_file)
+
+  step "verify that 'links => manage' preserves a symlink"
+  apply_manifest_on(agent, "file { '#{link_file}': ensure => link, target => '#{target_file}', links => manage }")
+  verify_symlink(agent, link_file, target_file)
+  reset_link_and_target(agent, link_file, target_file)
+
+  step "verify that 'links => manage' and 'recurse => true' preserves links in a directory"
+  on(agent, puppet_resource("file", target_dir, "ensure=directory"))
+  reset_link_and_target(agent, link_dir, "#{target_dir}/symlink-target", )
+  apply_manifest_on(agent, "file { '#{link_dir}': ensure => directory, target => '#{target_dir}', links => manage, recurse => true }")
+  verify_symlink(agent, "#{link_dir}/symlink-target", "#{target_dir}/symlink-target")
 
   step "clean up after the test run"
-  on agent, "rm -rf #{target} #{link}"
+  on agent, "rm -rf #{target_file} #{link_file} #{target_dir} #{link_dir}"
 end


### PR DESCRIPTION
This commit adds two test cases to the existing managed
symlink acceptance test. The first ensures that flat files
created with 'links => manage' are symlinks, and the second
ensures that symlinks inside of directories are copied
correctly when using 'links => manage' and 'recurse => true'.