### PR TITLE
(PUP-5698) In-line directory metadata

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -135,7 +135,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       file = resource.to_ral
 
       if file.recurse?
-        file.recurse_remote_metadata do |meta|
+        file.recurse_remote_metadata.each do |meta|
           # Don't create a new resource for the parent directory
           next if meta.relative_path == "."
 

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -84,7 +84,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   end
 
   # Rewrite a given file resource with the metadata from a fileserver based file
-  def replace_metadata(resource, metadata)
+  def replace_metadata(resource, metadata, recurse = false)
     if resource[:links] == "manage" && metadata.ftype == "link"
       resource.delete(:source)
       resource[:ensure] = "link"
@@ -95,6 +95,13 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
     if metadata.ftype == "file"
       resource[:checksum_value] = sumdata(metadata.checksum)
+    end
+
+    if recurse
+      resource[:source] = metadata.source
+      if metadata.ftype == "file"
+        resource[:checksum] = metadata.checksum_type
+      end
     end
   end
 
@@ -128,7 +135,27 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       file = resource.to_ral
 
       if file.recurse?
-        # TODO: find and replace metadata for children recursively
+        file.recurse_remote_metadata do |meta|
+          # Don't create a new resource for the parent directory
+          next if meta.relative_path == "."
+
+          # TODO: Conditionally copy owner, group, and mode when we can check if permissions are set
+          child_resource = Puppet::Resource.new(:file, File.join(file[:path], meta.relative_path))
+          replace_metadata(child_resource, meta, true)
+
+          # Copy parameters from original parent directory
+          file.original_parameters.each do |param, value|
+            # These should never be passed to our children
+            unless [:parent, :ensure, :recurse, :recurselimit, :target, :alias, :source].include? param
+              child_resource[param] = value.to_s
+            end
+          end
+          #TODO: Add edge between `child_resource` and its nearest ancestor and
+          # add an edge between `child_resource` and all other resources that depend
+          # on `file`
+          catalog.add_resource(child_resource)
+          catalog.add_edge(file, child_resource)
+          end
       else
         metadata = file.parameter(:source).metadata
         raise "Could not get metadata for #{resource[:source]}" unless metadata

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -641,7 +641,7 @@ Puppet::Type.newtype(:file) do
 
   # Recurse against our remote file.
   def recurse_remote(children)
-    recurse_remote_metadata do |meta|
+    recurse_remote_metadata.each do |meta|
       if meta.relative_path == "."
         parameter(:source).metadata = meta
         next
@@ -654,12 +654,12 @@ Puppet::Type.newtype(:file) do
     children
   end
 
-  def recurse_remote_metadata(&block)
+  def recurse_remote_metadata
     sourceselect = self[:sourceselect]
 
     total = self[:source].collect do |source|
       next unless result = perform_recursion(source)
-      return if top = result.find { |r| r.relative_path == "." } and top.ftype != "directory"
+      return [] if top = result.find { |r| r.relative_path == "." } and top.ftype != "directory"
       result.each do |data|
         if data.relative_path == '.'
           data.source = source
@@ -682,9 +682,7 @@ Puppet::Type.newtype(:file) do
       end
     end
 
-    total.each do |meta|
-      yield meta
-    end
+    total
   end
 
   def perform_recursion(path)

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -660,7 +660,14 @@ Puppet::Type.newtype(:file) do
     total = self[:source].collect do |source|
       next unless result = perform_recursion(source)
       return if top = result.find { |r| r.relative_path == "." } and top.ftype != "directory"
-      result.each { |data| data.source = "#{source}/#{data.relative_path}" }
+      result.each do |data|
+        if data.relative_path == '.'
+          data.source = source
+        else
+          # REMIND: appending file paths to URL may not be safe, e.g. foo+bar
+          data.source = "#{source}/#{data.relative_path}"
+        end
+      end
       break result if result and ! result.empty? and sourceselect == :first
       result
     end.flatten.compact
@@ -670,7 +677,7 @@ Puppet::Type.newtype(:file) do
       found = []
       total.reject! do |data|
         result = found.include?(data.relative_path)
-        found << data.relative_path unless found.include?(data.relative_path)
+        found << data.relative_path unless result
         result
       end
     end


### PR DESCRIPTION
Update the catalog compiler so it inlines directory metadata for
static catalogs. This means that when there is a file resource
that is a directory and has recurse set to true, we will add resources
for all it's children to the catalog.

In order to support this, make a few changes to the file type as
well so that we can easily reuse functionality for static catalogs.