### PR TITLE
(PUP-5875) Add to_s to Iterator runtime implementation

### DIFF
--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -208,6 +208,11 @@ module Puppet::Pops::Types
       StepIterator.new(@element_type, self, step)
     end
 
+    def to_s
+      et = element_type
+      et.nil? ? 'Iterator value' : "Iterator[#{et.generalize}] value"
+    end
+
     def unbounded?
       Iterable.unbounded?(@enumeration)
     end

--- a/spec/unit/pops/types/iterable_spec.rb
+++ b/spec/unit/pops/types/iterable_spec.rb
@@ -254,5 +254,9 @@ describe 'The iterable support' do
     ubi = TestUnboundedIterator.new
     expect{ Iterable.on(ubi).to_a }.to raise_error(Puppet::Error, /Attempt to create an Array from an unbounded Iterable/)
   end
+
+  it 'will produce the string Iterator[T] on to_s on an iterator instance with element type T' do
+    expect(Iterable.on(18).to_s).to eq('Iterator[Integer] value')
+  end
 end
 end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1943,6 +1943,22 @@ describe 'The type calculator' do
       expect(calculator.string(array_t(string_t, range_t(2, :default)))).to eq('Array[String, 2, default]')
     end
 
+    it 'should yield \'Iterable\' for PIterableType' do
+      expect(calculator.string(Puppet::Pops::Types::PIterableType::DEFAULT)).to eq('Iterable')
+    end
+
+    it 'should yield \'Iterable[Integer]\' for PIterableType[PIntegerType]' do
+      expect(calculator.string(Puppet::Pops::Types::PIterableType.new(Puppet::Pops::Types::PIntegerType::DEFAULT))).to eq('Iterable[Integer]')
+    end
+
+    it 'should yield \'Iterator\' for PIteratorType' do
+      expect(calculator.string(Puppet::Pops::Types::PIteratorType::DEFAULT)).to eq('Iterator')
+    end
+
+    it 'should yield \'Iterator[Integer]\' for PIteratorType[PIntegerType]' do
+      expect(calculator.string(Puppet::Pops::Types::PIteratorType.new(Puppet::Pops::Types::PIntegerType::DEFAULT))).to eq('Iterator[Integer]')
+    end
+
     it 'should yield \'Tuple[Integer]\' for PTupleType[PIntegerType]' do
       t = Puppet::Pops::Types::PTupleType.new([Puppet::Pops::Types::PIntegerType::DEFAULT])
       expect(calculator.string(t)).to eq('Tuple[Integer]')


### PR DESCRIPTION
Before this commit, the Iterator runtime implementation had no to_s
method. This commit adds that so that it prints:

"Iterator[T] value"

instead of the default and somewhat incomprehensible:

"<Puppet::Pops::Types::Iterator:0x007f93ec28f938>"

The commit also adds some missing tests for Iterable and Iterator
to_s methods.