### PR TITLE
(PUP-5876) Enable static catalogs by default

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -149,7 +149,7 @@ module Puppet
         :desc     => "Whether to enable experimental performance profiling",
     },
     :static_catalogs => {
-      :default    => false,
+      :default    => true,
       :type       => :boolean,
       :desc       => "Whether to compile a static catalog."
     },

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -144,13 +144,13 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
   # Compile the actual catalog.
   def compile(node, options)
-    if node.environment.static_catalogs? && options[:static_catalog]
+    if node.environment && node.environment.static_catalogs? && options[:static_catalog] && options[:code_id]
       # Check for errors before compiling the catalog
       checksum_type = common_checksum_type(options[:checksum_type])
       raise Puppet::Error, "Unable to find a common checksum type between agent '#{options[:checksum_type]}' and master '#{known_checksum_types}'." unless checksum_type
     end
 
-    str = "Compiled %s for #{node.name}" % [node.environment.static_catalogs? ? 'static catalog' : 'catalog']
+    str = "Compiled %s for #{node.name}" % [checksum_type ? 'static catalog' : 'catalog']
     str += " in environment #{node.environment}" if node.environment
     config = nil
 

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -121,7 +121,7 @@ describe Puppet::Environments do
 manifest=#{manifestdir}
 modulepath=#{modulepath.join(File::PATH_SEPARATOR)}
 config_version=/some/script
-static_catalogs=true
+static_catalogs=false
         EOF
       end
 
@@ -164,7 +164,7 @@ static_catalogs=true
             with_manifest(manifestdir.path).
             with_modulepath(modulepath.map(&:path)).
             with_config_version(File.expand_path('/some/script')).
-            with_static_catalogs(true)
+            with_static_catalogs(false)
         end
       end
 
@@ -189,7 +189,7 @@ static_catalogs=true
             with_manifest("#{FS.path_string(envdir)}/env1/manifests").
             with_modulepath(["#{FS.path_string(envdir)}/env1/modules", global_path_location]).
             with_config_version(nil).
-            with_static_catalogs(false)
+            with_static_catalogs(true)
         end
 
         expect(@logs).to be_empty
@@ -399,7 +399,7 @@ config_version=$vardir/random/scripts
       expect(conf.modulepath).to eq('')
       expect(conf.manifest).to eq(:no_manifest)
       expect(conf.config_version).to be_nil
-      expect(conf.static_catalogs).to eq(false)
+      expect(conf.static_catalogs).to eq(true)
     end
 
     it "returns nil if you request a configuration from an env that doesn't exist" do

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -149,6 +149,7 @@ describe Puppet::Resource::Catalog::Compiler do
     it "does not inline metadata when the static_catalog option is false" do
       Puppet::Node.indirection.stubs(:find).returns(@node)
       @request.options[:static_catalog] = false
+      @request.options[:code_id] = 'some_code_id'
       @node.environment.stubs(:static_catalogs?).returns true
 
       catalog = Puppet::Resource::Catalog.new(@node.name, @node.environment)
@@ -162,6 +163,7 @@ describe Puppet::Resource::Catalog::Compiler do
       Puppet::Node.indirection.stubs(:find).returns(@node)
       @request.options[:static_catalog] = true
       @request.options[:checksum_type] = 'md5'
+      @request.options[:code_id] = 'some_code_id'
       @node.environment.stubs(:static_catalogs?).returns false
 
       catalog = Puppet::Resource::Catalog.new(@node.name, @node.environment)
@@ -171,10 +173,24 @@ describe Puppet::Resource::Catalog::Compiler do
       expect(@compiler.find(@request)).to eq(catalog)
     end
 
-    it "inlines metadata when the static_catalog option is true and static_catalogs are enabled" do
+    it "does not inline metadata when code_id is not specified" do
+      Puppet::Node.indirection.stubs(:find).returns(@node)
+      @request.options[:static_catalog] = true
+      @request.options[:checksum_type] = 'md5'
+      @node.environment.stubs(:static_catalogs?).returns true
+
+      catalog = Puppet::Resource::Catalog.new(@node.name, @node.environment)
+      Puppet::Parser::Compiler.stubs(:compile).returns catalog
+
+      @compiler.expects(:inline_metadata).never
+      expect(@compiler.find(@request)).to eq(catalog)
+    end
+
+    it "inlines metadata when the static_catalog option is true, static_catalogs are enabled, and a code_id is provided" do
       Puppet::Node.indirection.stubs(:find).returns(@node)
       @request.options[:static_catalog] = true
       @request.options[:checksum_type] = 'sha256'
+      @request.options[:code_id] = 'some_code_id'
       @node.environment.stubs(:static_catalogs?).returns true
 
       catalog = Puppet::Resource::Catalog.new(@node.name, @node.environment)
@@ -188,6 +204,7 @@ describe Puppet::Resource::Catalog::Compiler do
       Puppet::Node.indirection.stubs(:find).returns(@node)
       @request.options[:static_catalog] = true
       @request.options[:checksum_type] = 'atime.md5.sha256.mtime'
+      @request.options[:code_id] = 'some_code_id'
       @node.environment.stubs(:static_catalogs?).returns true
 
       catalog = Puppet::Resource::Catalog.new(@node.name, @node.environment)
@@ -201,6 +218,7 @@ describe Puppet::Resource::Catalog::Compiler do
       Puppet::Node.indirection.stubs(:find).returns(@node)
       @request.options[:static_catalog] = true
       @request.options[:checksum_type] = 'atime.sha512'
+      @request.options[:code_id] = 'some_code_id'
       @node.environment.stubs(:static_catalogs?).returns true
 
       expect { @compiler.find(@request) }.to raise_error Puppet::Error,
@@ -211,6 +229,7 @@ describe Puppet::Resource::Catalog::Compiler do
       Puppet::Node.indirection.stubs(:find).returns(@node)
       @request.options[:static_catalog] = true
       @request.options[:checksum_type] = nil
+      @request.options[:code_id] = 'some_code_id'
       @node.environment.stubs(:static_catalogs?).returns true
 
       expect { @compiler.find(@request) }.to raise_error Puppet::Error,

--- a/spec/unit/settings/environment_conf_spec.rb
+++ b/spec/unit/settings/environment_conf_spec.rb
@@ -81,8 +81,8 @@ describe Puppet::Settings::EnvironmentConf do
       expect(envconf.environment_timeout).to eq(0)
     end
 
-    it "returns default of false for static_catalogs when config has none" do
-      expect(envconf.static_catalogs).to eq(false)
+    it "returns default of true for static_catalogs when config has none" do
+      expect(envconf.static_catalogs).to eq(true)
     end
 
     it "can still retrieve raw setting" do


### PR DESCRIPTION
They will only be generated if code_id is provided when compiling the
catalog.