### PR TITLE
(PUP-5861) Make Data matching Arrray and Hash not present type parameters

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -979,8 +979,12 @@ class TypeCalculator
 
   # @api private
   def string_PHashType(t)
-    parts = [string(t.key_type), string(t.element_type)] + range_array_part(t.size_type)
-    "Hash[#{parts.join(', ')}]"
+    if t == PHashType::DATA
+      "Hash"
+    else
+      parts = [string(t.key_type), string(t.element_type)] + range_array_part(t.size_type)
+      "Hash[#{parts.join(', ')}]"
+    end
   end
 
   # @api private

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -969,8 +969,12 @@ class TypeCalculator
 
   # @api private
   def string_PArrayType(t)
-    parts = [string(t.element_type)] + range_array_part(t.size_type)
-    "Array[#{parts.join(', ')}]"
+    if t == PArrayType::DATA
+      "Array"
+    else
+      parts = [string(t.element_type)] + range_array_part(t.size_type)
+      "Array[#{parts.join(', ')}]"
+  end
   end
 
   # @api private

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1924,6 +1924,10 @@ describe 'The type calculator' do
       expect(calculator.string(t)).to eq('Array[Integer]')
     end
 
+    it 'should yield \'Array\' for PArrayType::DATA' do
+      expect(calculator.string(Puppet::Pops::Types::PArrayType::DATA)).to eq('Array')
+    end
+
     it 'should yield \'Array[Unit, 0, 0]\' for an empty array' do
       t = empty_array_t
       expect(calculator.string(t)).to eq('Array[Unit, 0, 0]')

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1999,6 +1999,10 @@ describe 'The type calculator' do
       expect(calculator.string(hash_t(string_t, string_t, range_t(2, :default)))).to eq('Hash[String, String, 2, default]')
     end
 
+    it 'should yield \'Hash\' for PHashType::DATA' do
+      expect(calculator.string(Puppet::Pops::Types::PHashType::DATA)).to eq('Hash')
+    end
+
     it "should yield 'Class' for a PHostClassType" do
       t = Puppet::Pops::Types::PHostClassType::DEFAULT
       expect(calculator.string(t)).to eq('Class')


### PR DESCRIPTION
This removes surprising output when doing:
```
notice Array
notice Hash
```