### PR TITLE
(PUP-5805) Set missing location in generated hash

### DIFF
--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -889,7 +889,7 @@ class Factory
 
   # Transforms a left expression followed by an untitled resource (in the form of attribute_operations)
   # @param left [Factory, Expression] the lhs followed what may be a hash
-  def self.transform_resource_wo_title(left, attribute_ops)
+  def self.transform_resource_wo_title(left, attribute_ops, lbrace_token, rbrace_token)
     # Returning nil means accepting the given as a potential resource expression
     return nil unless attribute_ops.is_a? Array
     return nil unless left.current.is_a?(QualifiedName)
@@ -897,7 +897,9 @@ class Factory
       return nil if ao.operator == :'+>'
       KEY_ENTRY(ao.attribute_name, ao.value_expr)
     end
-    result = block_or_expression(*transform_calls([left, HASH(keyed_entries)]))
+    a_hash = HASH(keyed_entries)
+    a_hash.record_position(lbrace_token, rbrace_token)
+    result = block_or_expression(*transform_calls([left, a_hash]))
     result
   end
 

--- a/lib/puppet/pops/parser/egrammar.ra
+++ b/lib/puppet/pops/parser/egrammar.ra
@@ -160,7 +160,7 @@ resource
         # If the attribute operations does not include +>, then the found expression
         # is actually a LEFT followed by LITERAL_HASH
         #
-        unless tmp = transform_resource_wo_title(val[0], val[2])
+        unless tmp = transform_resource_wo_title(val[0], val[2], val[1], val[4])
           error val[1], "Syntax error resource body without title or hash with +>"
         end
         tmp

--- a/lib/puppet/pops/parser/eparser.rb
+++ b/lib/puppet/pops/parser/eparser.rb
@@ -1695,7 +1695,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 156)
         # If the attribute operations does not include +>, then the found expression
         # is actually a LEFT followed by LITERAL_HASH
         #
-        unless tmp = transform_resource_wo_title(val[0], val[2])
+        unless tmp = transform_resource_wo_title(val[0], val[2], val[1], val[4])
           error val[1], "Syntax error resource body without title or hash with +>"
         end
         tmp

--- a/lib/puppet/pops/parser/parser_support.rb
+++ b/lib/puppet/pops/parser/parser_support.rb
@@ -206,8 +206,8 @@ class Parser
   end
 
   # Transforms a LEFT followed by the result of attribute_operations, this may be a call or an invalid sequence
-  def transform_resource_wo_title(left, resource)
-    Factory.transform_resource_wo_title(left, resource)
+  def transform_resource_wo_title(left, resource, lbrace_token, rbrace_token)
+    Factory.transform_resource_wo_title(left, resource, lbrace_token, rbrace_token)
   end
 
   # Creates a program with the given body.

--- a/spec/unit/pops/parser/parse_calls_spec.rb
+++ b/spec/unit/pops/parser/parse_calls_spec.rb
@@ -26,6 +26,10 @@ describe "egrammar parsing function calls" do
         expect(dump(parse("foo(bar)"))).to eq("(invoke foo bar)")
       end
 
+      it "notice {a=>2}" do
+        expect(dump(parse("notice {a => 2}"))).to eq("(invoke notice ({} ('a' 2)))")
+      end
+
       it "foo(bar,)" do
         expect(dump(parse("foo(bar,)"))).to eq("(invoke foo bar)")
       end


### PR DESCRIPTION
Before this an expression like:
```
notice {a=>2}
```
Would result in an internal error.

That was caused by the "tree rewrite" that changes that expression from
being a resource expression without title to a function call with a hash
as an argument. When the hash had no location information it lacked
offset and length of its textual representation in source text.

This is now fied by propagating the tokens for the left and right braces
to the rewrite operation that now sets them.