### PR TITLE
(PUP-5837) Change reverse_each and step functions to return undef when given a block

### DIFF
--- a/lib/puppet/functions/reverse_each.rb
+++ b/lib/puppet/functions/reverse_each.rb
@@ -28,7 +28,7 @@
 # order of its first argument. This allows methods on `Iterable` to be chained.
 #
 # When a lamdba is given as the second argument, Puppet iterates the first argument in reverse
-# order and passes each value in turn to the lambda, then returns the first argument unchanged.
+# order and passes each value in turn to the lambda, then returns `undef`.
 #
 # @example Using the `reverse_each` function with an array and a one-parameter lambda
 #
@@ -77,7 +77,6 @@ Puppet::Functions.create_function(:reverse_each) do
 
   def reverse_each_block(iterable, &block)
     Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable).reverse_each(&block)
-    # produces the receiver
-    iterable
+    nil
   end
 end

--- a/lib/puppet/functions/step.rb
+++ b/lib/puppet/functions/step.rb
@@ -28,8 +28,8 @@
 # When no block is given, Puppet returns an `Iterable` that yields the first element and every nth successor
 # element, from its first argument. This allows functions on iterables to be chained.
 #
-# When a block is given, Puppet iterates the first argument and calls the block with the first element and then with
-# every nth successor element.
+# When a block is given, Puppet iterates and calls the block with the first element and then with
+# every nth successor element. It then returns `undef`.
 #
 # @example Using the `step` function with an array, a step factor, and a one-parameter block
 #
@@ -83,7 +83,6 @@ Puppet::Functions.create_function(:step) do
 
   def step_block(iterable, step, &block)
     Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable).step(step, &block)
-    # produces the receiver
-    iterable
+    nil
   end
 end

--- a/spec/unit/functions/reverse_each_spec.rb
+++ b/spec/unit/functions/reverse_each_spec.rb
@@ -55,6 +55,14 @@ describe 'the reverse_each function' do
     end.to_not raise_error
   end
 
+  it 'returns an Undef when called with a block' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+            assert_type(Undef, [1].reverse_each |$x| { $x })
+      MANIFEST
+    end.not_to raise_error
+  end
+
   it 'returns an Iterable when called without a block' do
     expect do
       compile_to_catalog(<<-MANIFEST)

--- a/spec/unit/functions/step_spec.rb
+++ b/spec/unit/functions/step_spec.rb
@@ -71,6 +71,14 @@ describe 'the step method' do
     end.to_not raise_error
   end
 
+  it 'returns Undef when called with a block' do
+    expect do
+      compile_to_catalog(<<-MANIFEST)
+          assert_type(Undef, [1].step(2) |$x| { $x })
+      MANIFEST
+    end.not_to raise_error
+  end
+
   it 'returns an Iterable when called without a block' do
     expect do
       compile_to_catalog(<<-MANIFEST)


### PR DESCRIPTION
This PR changes the `step` and `reverse_each` functions so that so that they return the undef value instead of their first argument. This change was made to avoid any confusion on if the returned value is reversed, stepped, or if it somehow contains values returned from the given block.
