### PR TITLE
(maint) fixing a typo: :slize_size to :slice_size

### DIFF
--- a/lib/puppet/functions/slice.rb
+++ b/lib/puppet/functions/slice.rb
@@ -33,13 +33,13 @@
 Puppet::Functions.create_function(:slice) do
   dispatch :slice_Hash do
     param 'Hash[Any, Any]', :hash
-    param 'Integer[1, default]', :slize_size
+    param 'Integer[1, default]', :slice_size
     optional_block_param
   end
 
   dispatch :slice_Enumerable do
     param 'Iterable', :enumerable
-    param 'Integer[1, default]', :slize_size
+    param 'Integer[1, default]', :slice_size
     optional_block_param
   end
 


### PR DESCRIPTION
Fairly certain from searching the codebase and google that this is fixing a typo in the slice function.

I did not conform to the contributing guidelines on this because it was such a trivial fix, but I can cancel the PR and go through the process if need be.