### PR TITLE
(maint) Use catalog and resource matchers

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -165,8 +165,6 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
         end
       end
     end
-
-    catalog
   end
 
   # Compile the actual catalog.
@@ -197,7 +195,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       str += " in environment #{node.environment}" if node.environment
       benchmark(:notice, str) do
         Puppet::Util::Profiler.profile(str, [:compiler, :static_inline, node.environment, node.name]) do
-          config = inline_metadata(config, checksum_type)
+          inline_metadata(config, checksum_type)
         end
       end
     end

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -141,6 +141,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
           # TODO: Conditionally copy owner, group, and mode when we can check if permissions are set
           child_resource = Puppet::Resource.new(:file, File.join(file[:path], meta.relative_path))
+          child_resource[:ensure] = meta.ftype
           replace_metadata(child_resource, meta, true)
 
           # Copy parameters from original parent directory

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -656,8 +656,6 @@ describe Puppet::Resource::Catalog::Compiler do
 
       describe "when recurse is true" do
         it "inlines child metadata" do
-          pending "child resources doesn't have ensure set"
-
           catalog = compile_to_catalog(<<-MANIFEST, node)
             file { '#{path}':
               ensure  => directory,

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -156,7 +156,7 @@ describe Puppet::Resource::Catalog::Compiler do
       Puppet::Parser::Compiler.stubs(:compile).returns catalog
 
       @compiler.expects(:inline_metadata).never
-      expect(@compiler.find(@request)).to eq(catalog)
+      @compiler.find(@request)
     end
 
     it "does not inline metadata when static_catalogs are disabled" do
@@ -170,7 +170,7 @@ describe Puppet::Resource::Catalog::Compiler do
       Puppet::Parser::Compiler.stubs(:compile).returns catalog
 
       @compiler.expects(:inline_metadata).never
-      expect(@compiler.find(@request)).to eq(catalog)
+      @compiler.find(@request)
     end
 
     it "does not inline metadata when code_id is not specified" do
@@ -197,7 +197,7 @@ describe Puppet::Resource::Catalog::Compiler do
       Puppet::Parser::Compiler.stubs(:compile).returns catalog
 
       @compiler.expects(:inline_metadata).with(catalog, :sha256).returns catalog
-      expect(@compiler.find(@request)).to eq(catalog)
+      @compiler.find(@request)
     end
 
     it "inlines metadata with the first common checksum type" do
@@ -211,7 +211,7 @@ describe Puppet::Resource::Catalog::Compiler do
       Puppet::Parser::Compiler.stubs(:compile).returns catalog
 
       @compiler.expects(:inline_metadata).with(catalog, :md5).returns catalog
-      expect(@compiler.find(@request)).to eq(catalog)
+      @compiler.find(@request)
     end
 
     it "errors if checksum_type contains no shared checksum types" do
@@ -447,7 +447,7 @@ describe Puppet::Resource::Catalog::Compiler do
             ral.expects(:parameter).with(:source).returns(source)
           end
 
-          expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+          @compiler.send(:inline_metadata, catalog, checksum_type)
           expect(catalog.resources.select {|r| r[:checksum_value] == sha}.size).to eq(num_resources)
         end
       end
@@ -473,7 +473,7 @@ describe Puppet::Resource::Catalog::Compiler do
           ral.expects(:parameter).with(:source).returns(source)
         end
 
-        expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+        @compiler.send(:inline_metadata, catalog, checksum_type)
         catalog.resources.select {|r| r.type == 'File'}.each do |r|
           expect(r[:ensure]).to eq('link')
           expect(r[:target]).to eq('/tmp/some/absolute/path')
@@ -500,7 +500,7 @@ describe Puppet::Resource::Catalog::Compiler do
           ral.expects(:parameter).with(:source).returns(source)
         end
 
-        expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+        @compiler.send(:inline_metadata, catalog, checksum_type)
         catalog.resources.select {|r| r.type == 'File'}.each do |r|
           expect(r[:checksum_value]).to eq('b1946ac92492d2347c6235b4d2611184')
           expect(r[:ensure]).to eq('file')
@@ -514,7 +514,7 @@ describe Puppet::Resource::Catalog::Compiler do
       catalog.resources.select {|r| r.type == 'File'}.each do |r|
         r.expects(:to_ral).never
       end
-      expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+      @compiler.send(:inline_metadata, catalog, checksum_type)
     end
 
     it "skips resources without a source" do
@@ -522,7 +522,7 @@ describe Puppet::Resource::Catalog::Compiler do
       catalog.resources.select {|r| r.type == 'File'}.each do |r|
         r.expects(:to_ral).never
       end
-      expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+      @compiler.send(:inline_metadata, catalog, checksum_type)
     end
 
     it "skips resources with a local source" do
@@ -530,7 +530,7 @@ describe Puppet::Resource::Catalog::Compiler do
       catalog.resources.select {|r| r.type == 'File'}.each do |r|
         r.expects(:to_ral).never
       end
-      expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+      @compiler.send(:inline_metadata, catalog, checksum_type)
     end
 
     it "skips resources with a http source" do
@@ -538,7 +538,7 @@ describe Puppet::Resource::Catalog::Compiler do
       catalog.resources.select {|r| r.type == 'File'}.each do |r|
         r.expects(:to_ral).never
       end
-      expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+      @compiler.send(:inline_metadata, catalog, checksum_type)
     end
 
     it "skips resources with a source outside the environment path" do
@@ -558,7 +558,7 @@ describe Puppet::Resource::Catalog::Compiler do
         ral.expects(:parameter).with(:source).returns(source)
       end
 
-      expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+      @compiler.send(:inline_metadata, catalog, checksum_type)
       expect(catalog.resources.select {|r| r.type == 'File' && r[:checksum_value] == nil}.size).to eq(num_resources)
     end
 
@@ -584,7 +584,7 @@ describe Puppet::Resource::Catalog::Compiler do
         ral.expects(:recurse_remote_metadata).returns([parent_metadata, child_metadata])
       end
 
-      expect(@compiler.send(:inline_metadata, catalog, checksum_type)).to eq(catalog)
+      @compiler.send(:inline_metadata, catalog, checksum_type)
       expect(catalog.resources.select{ |r| r.type == 'File' }.size).to eq(2)
     end
   end

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -1,5 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
+require 'puppet_spec/compiler'
+require 'matchers/resource'
 
 require 'puppet/indirector/catalog/compiler'
 
@@ -419,173 +421,298 @@ describe Puppet::Resource::Catalog::Compiler do
   end
 
   describe "when inlining metadata" do
+    include PuppetSpec::Compiler
+    include Matchers::Resource
+
     let(:node) { Puppet::Node.new 'me' }
     let(:num_resources) { 3 }
     let(:checksum_type) { 'md5' }
+    let(:checksum_value) { 'b1946ac92492d2347c6235b4d2611184' }
+    let(:path) { File.expand_path('/foo') }
+    let(:resource_ref) { "File[#{path}]" }
+
     before :each do
       @compiler = Puppet::Resource::Catalog::Compiler.new
+    end
+
+    def stubs_file_metadata(checksum_type, sha, relative_path, full_path = nil)
+      full_path ||=  File.join(Puppet[:environmentpath], 'production', relative_path)
+
+      metadata = stub 'metadata'
+      metadata.stubs(:ftype).returns("file")
+      metadata.stubs(:full_path).returns(full_path)
+      metadata.stubs(:relative_path).returns(relative_path)
+      metadata.stubs(:source).returns("puppet:///#{relative_path}")
+      metadata.stubs(:checksum).returns("{#{checksum_type}}#{sha}")
+      metadata.stubs(:checksum_type).returns(checksum_type)
+
+      Puppet::Type.type(:file).attrclass(:source).any_instance.stubs(:metadata).returns(metadata)
+
+      metadata
+    end
+
+    def stubs_link_metadata(relative_path, destination)
+      full_path =  File.join(Puppet[:environmentpath], 'production', relative_path)
+
+      metadata = stub 'metadata'
+      metadata.stubs(:ftype).returns("link")
+      metadata.stubs(:full_path).returns(full_path)
+      metadata.stubs(:relative_path).returns(relative_path)
+      metadata.stubs(:source).returns("puppet:///#{relative_path}")
+      metadata.stubs(:destination).returns('/tmp/some/absolute/path')
+
+      Puppet::Type.type(:file).attrclass(:source).any_instance.stubs(:metadata).returns(metadata)
+
+      metadata
+    end
+
+    def stubs_directory_metadata(checksum_type, relative_path, children)
+      full_path =  File.join(Puppet[:environmentpath], 'production', relative_path)
+
+      metadata = stub 'metadata'
+      metadata.stubs(:ftype).returns("directory")
+      metadata.stubs(:full_path).returns(full_path)
+      metadata.stubs(:relative_path).returns(relative_path)
+      metadata.stubs(:source).returns("puppet:///#{relative_path}")
+
+      Puppet::Type.type(:file).attrclass(:source).any_instance.stubs(:metadata).returns(metadata)
+
+      Puppet::Type.type(:file).any_instance.stubs(:recurse_remote_metadata).returns(children)
+
+      metadata
+    end
+
+    def expects_no_source_metadata
+      Puppet::Type.type(:file).attrclass(:source).any_instance.expects(:metadata).never
     end
 
     [['md5', 'b1946ac92492d2347c6235b4d2611184'],
      ['sha256', '5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03']].each do |checksum_type, sha|
       describe "with agent requesting checksum_type #{checksum_type}" do
         it "sets checksum and checksum_value for resources with puppet:// source URIs" do
-          catalog = build_catalog(node, num_resources, ['puppet:///modules/mymodule/config_file.txt'])
-          catalog.resources.select {|r| r.type == 'File'}.each do |r|
-            source_path = File.join(Puppet[:environmentpath], catalog.environment, "modules/mymodule/files/config_file.txt")
-            ral = r.to_ral
-            r.expects(:to_ral).returns(ral)
+          catalog = compile_to_catalog(<<-MANIFEST, node)
+            file { '#{path}':
+              ensure => file,
+              source => 'puppet:///modules/mymodule/config_file.txt'
+            }
+          MANIFEST
 
-            metadata = stub 'metadata'
-            metadata.stubs(:checksum).returns("{#{checksum_type}}#{sha}")
-            metadata.stubs(:ftype).returns("file")
-            metadata.stubs(:full_path).returns(source_path)
-
-            source = stub 'source'
-            source.stubs(:metadata).returns(metadata)
-
-            ral.expects(:parameter).with(:source).returns(source)
-          end
+          stubs_file_metadata(checksum_type, sha, 'modules/mymodule/files/config_file.txt')
 
           @compiler.send(:inline_metadata, catalog, checksum_type)
-          expect(catalog.resources.select {|r| r[:checksum_value] == sha}.size).to eq(num_resources)
+
+          expect(catalog).to have_resource(resource_ref)
+            .with_parameter(:ensure, 'file')
+            .with_parameter(:checksum, checksum_type)
+            .with_parameter(:checksum_value, sha)
+            .with_parameter(:source, 'puppet:///modules/mymodule/config_file.txt')
         end
       end
     end
 
     describe "when inlining symlinks" do
       it "sets ensure and target for links which are managed" do
-        catalog = build_catalog(node, 1, ['puppet:///modules/mymodule/config_file_link.txt'], {:ensure => 'link', :links => 'manage'})
+        catalog = compile_to_catalog(<<-MANIFEST, node)
+          file { '#{path}':
+            ensure => link,
+            links  => manage,
+            source => 'puppet:///modules/mymodule/config_file_link.txt'
+          }
+        MANIFEST
 
-        catalog.resources.select {|r| r.type == 'File'}.each do |r|
-          source_path = File.join(Puppet[:environmentpath], catalog.environment, "modules/mymodule/files/config_file.txt")
-          ral = r.to_ral
-          r.expects(:to_ral).returns(ral)
-
-          metadata = stub 'metadata'
-          metadata.stubs(:ftype).returns('link')
-          metadata.stubs(:destination).returns('/tmp/some/absolute/path')
-          metadata.stubs(:full_path).returns(source_path)
-
-          source = stub 'source'
-          source.stubs(:metadata).returns(metadata)
-
-          ral.expects(:parameter).with(:source).returns(source)
-        end
+        stubs_link_metadata('modules/mymodule/files/config_file.txt', '/tmp/some/absolute/path')
 
         @compiler.send(:inline_metadata, catalog, checksum_type)
-        catalog.resources.select {|r| r.type == 'File'}.each do |r|
-          expect(r[:ensure]).to eq('link')
-          expect(r[:target]).to eq('/tmp/some/absolute/path')
-          expect(r[:source]).to be_nil
-        end
+
+        expect(catalog).to have_resource(resource_ref)
+          .with_parameter(:ensure, 'link')
+          .with_parameter(:target, '/tmp/some/absolute/path')
+          .with_parameter(:source, nil)
       end
 
       it "sets checksum and checksum_value for links which are followed" do
-        catalog = build_catalog(node, 1, ['puppet:///modules/mymodule/config_file_link.txt'], {:ensure => 'link', :links => 'follow'})
+        catalog = compile_to_catalog(<<-MANIFEST, node)
+           file { '#{path}':
+            ensure => link,
+            links  => follow,
+            source => 'puppet:///modules/mymodule/config_file_link.txt'
+          }
+        MANIFEST
 
-        catalog.resources.select {|r| r.type == 'File'}.each do |r|
-          source_path = File.join(Puppet[:environmentpath], catalog.environment, "modules/mymodule/files/config_file.txt")
-          ral = r.to_ral
-          r.expects(:to_ral).returns(ral)
-
-          metadata = stub 'metadata'
-          metadata.stubs(:ftype).returns('file')
-          metadata.stubs(:checksum).returns('{md5}b1946ac92492d2347c6235b4d2611184')
-          metadata.stubs(:full_path).returns(source_path)
-
-          source = stub 'source'
-          source.stubs(:metadata).returns(metadata)
-
-          ral.expects(:parameter).with(:source).returns(source)
-        end
+        stubs_file_metadata(checksum_type, checksum_value, 'modules/mymodule/files/config_file.txt')
 
         @compiler.send(:inline_metadata, catalog, checksum_type)
-        catalog.resources.select {|r| r.type == 'File'}.each do |r|
-          expect(r[:checksum_value]).to eq('b1946ac92492d2347c6235b4d2611184')
-          expect(r[:ensure]).to eq('file')
-        end
-      end
 
+        expect(catalog).to have_resource(resource_ref)
+          .with_parameter(:ensure, 'file')
+          .with_parameter(:checksum, checksum_type)
+          .with_parameter(:checksum_value, checksum_value)
+          .with_parameter(:source, 'puppet:///modules/mymodule/config_file_link.txt')
+      end
     end
 
     it "skips absent resources" do
-      catalog = build_catalog(node, num_resources, nil, :ensure => 'absent')
-      catalog.resources.select {|r| r.type == 'File'}.each do |r|
-        r.expects(:to_ral).never
-      end
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+        file { '#{path}':
+          ensure => absent,
+        }
+      MANIFEST
+
+      expects_no_source_metadata
+
       @compiler.send(:inline_metadata, catalog, checksum_type)
+
+      expect(catalog).to have_resource(resource_ref).with_parameter(:ensure, 'absent')
     end
 
     it "skips resources without a source" do
-      catalog = build_catalog(node, num_resources)
-      catalog.resources.select {|r| r.type == 'File'}.each do |r|
-        r.expects(:to_ral).never
-      end
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+        file { '#{path}':
+          ensure => file,
+        }
+      MANIFEST
+
+      expects_no_source_metadata
+
       @compiler.send(:inline_metadata, catalog, checksum_type)
+
+      expect(catalog).to have_resource(resource_ref).with_parameter(:ensure, 'file')
     end
 
     it "skips resources with a local source" do
-      catalog = build_catalog(node, num_resources, ['/tmp/foo_source'])
-      catalog.resources.select {|r| r.type == 'File'}.each do |r|
-        r.expects(:to_ral).never
-      end
+      local_source = File.expand_path('/tmp/source')
+
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+        file { '#{path}':
+          ensure => file,
+          source => '#{local_source}',
+        }
+      MANIFEST
+
+      expects_no_source_metadata
+
       @compiler.send(:inline_metadata, catalog, checksum_type)
+
+      expect(catalog).to have_resource(resource_ref)
+        .with_parameter(:ensure, 'file')
+        .with_parameter(:source, local_source)
     end
 
     it "skips resources with a http source" do
-      catalog = build_catalog(node, num_resources, ['http://foo.source.io', 'https://foo.source.io'])
-      catalog.resources.select {|r| r.type == 'File'}.each do |r|
-        r.expects(:to_ral).never
-      end
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+        file { '#{path}':
+          ensure => file,
+          source => ['http://foo.source.io', 'https://foo.source.io']
+        }
+      MANIFEST
+
+      expects_no_source_metadata
+
       @compiler.send(:inline_metadata, catalog, checksum_type)
+
+      expect(catalog).to have_resource(resource_ref)
+        .with_parameter(:ensure, 'file')
+        .with_parameter(:source, ['http://foo.source.io', 'https://foo.source.io'])
     end
 
     it "skips resources with a source outside the environment path" do
-      catalog = build_catalog(node, num_resources, ['puppet:///modules/mymodule/config_file.txt'])
-      catalog.resources.select {|r| r.type == 'File'}.each do |r|
-        source_path = File.join(Puppet[:codedir], "modules/mymodule/files/config_file.txt")
-        ral = r.to_ral
-        r.expects(:to_ral).returns(ral)
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+        file { '#{path}':
+          ensure => file,
+          source => 'puppet:///modules/mymodule/config_file.txt'
+        }
+      MANIFEST
 
-        metadata = stub 'metadata'
-        metadata.stubs(:ftype).returns("file")
-        metadata.stubs(:full_path).returns(source_path)
-
-        source = stub 'source'
-        source.stubs(:metadata).returns(metadata)
-
-        ral.expects(:parameter).with(:source).returns(source)
-      end
+      full_path = File.join(Puppet[:codedir], "modules/mymodule/files/config_file.txt")
+      stubs_file_metadata(checksum_type, checksum_value, 'modules/mymodule/files/config_file.txt', full_path)
 
       @compiler.send(:inline_metadata, catalog, checksum_type)
-      expect(catalog.resources.select {|r| r.type == 'File' && r[:checksum_value] == nil}.size).to eq(num_resources)
+
+      expect(catalog).to have_resource(resource_ref)
+        .with_parameter(:ensure, 'file')
+        .with_parameter(:source, 'puppet:///modules/mymodule/config_file.txt')
+        .with_parameter(:checksum_value, nil)
     end
 
-    it "inlines child metadata for directory resources where recurse is true" do
-      catalog = build_catalog(node, 1, ['puppet:///modules/mymodule/directory'], {:ensure => 'directory', :recurse => 'true'})
+    describe "when inlining directories" do
+      describe "when recurse is false" do
+        it "skips children" do
+          catalog = compile_to_catalog(<<-MANIFEST, node)
+            file { '#{path}':
+              ensure  => directory,
+              source  => 'puppet:///modules/mymodule/directory'
+            }
+          MANIFEST
 
-      catalog.resources.select {|r| r.type == 'File'}.each do |r|
-        ral = r.to_ral
-        r.expects(:to_ral).returns(ral)
+          stubs_directory_metadata(checksum_type, '.', [])
 
-        parent_metadata = stub 'parent_metadata'
-        parent_metadata.stubs(:ftype).returns('directory')
-        parent_metadata.stubs(:relative_path).returns('.')
+          @compiler.send(:inline_metadata, catalog, checksum_type)
 
-
-        child_metadata = stub 'child_metadata'
-        child_metadata.stubs(:relative_path).returns('myfile.txt')
-        child_metadata.stubs(:ftype).returns('file')
-        child_metadata.stubs(:source).returns('puppet:///modules/mymodule/directory/myfile.txt')
-        child_metadata.stubs(:checksum_type).returns(checksum_type)
-        child_metadata.stubs(:checksum).returns('{md5}b1946ac92492d2347c6235b4d2611184')
-
-        ral.expects(:recurse_remote_metadata).returns([parent_metadata, child_metadata])
+          expect(catalog).to have_resource(resource_ref)
+            .with_parameter(:ensure, 'directory')
+            .with_parameter(:source, 'puppet:///modules/mymodule/directory')
+        end
       end
 
+      describe "when recurse is true" do
+        it "inlines child metadata" do
+          pending "child resources doesn't have ensure set"
+
+          catalog = compile_to_catalog(<<-MANIFEST, node)
+            file { '#{path}':
+              ensure  => directory,
+              recurse => true,
+              source  => 'puppet:///modules/mymodule/directory'
+            }
+          MANIFEST
+
+          child_metadata = stubs_file_metadata(checksum_type, checksum_value, 'myfile.txt')
+          stubs_directory_metadata(checksum_type, '.', [child_metadata])
+
+          @compiler.send(:inline_metadata, catalog, checksum_type)
+
+          expect(catalog).to have_resource(resource_ref)
+            .with_parameter(:ensure, 'directory')
+            .with_parameter(:recurse, true) # REMIND this is surprising
+            .with_parameter(:source, 'puppet:///modules/mymodule/directory')
+
+          expect(catalog).to have_resource("File[#{path}/myfile.txt]")
+            .with_parameter(:ensure, 'file')
+            .with_parameter(:checksum, checksum_type)
+            .with_parameter(:checksum_value, checksum_value)
+        end
+      end
+    end
+
+    it "skips non-file resources" do
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+        notify { 'hi': }
+      MANIFEST
+
       @compiler.send(:inline_metadata, catalog, checksum_type)
-      expect(catalog.resources.select{ |r| r.type == 'File' }.size).to eq(2)
+
+      expect(catalog).to have_resource('Notify[hi]').with_parameter(:name, 'hi')
+    end
+
+    it "preserves relationships to other resources" do
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+        notify { 'alpha': }
+        notify { 'omega': }
+        file { '#{path}':
+          ensure  => file,
+          source  => 'puppet:///modules/mymodule/config_file.txt',
+          require => Notify[alpha],
+          before  => Notify[omega]
+        }
+      MANIFEST
+
+      stubs_file_metadata(checksum_type, checksum_value, 'modules/mymodule/files/config_file.txt')
+
+      @compiler.send(:inline_metadata, catalog, checksum_type)
+
+      expect(catalog).to have_resource(resource_ref)
+        .with_parameter(:require, catalog.resource('Notify[alpha]'))
+        .with_parameter(:before, catalog.resource('Notify[omega]'))
     end
   end
 end


### PR DESCRIPTION
Refactor the inline catalog unit tests to use `manifest_to_catalog` helper and resource matchers. I ran into an issue where generated resources didn't have an ensure value and calling `to_ral` doesn't work when you're on *nix and it's a Windows file path. The ensure value part is fixed in this PR, and I added a pending test for the second part. I recommend using `git log -p --reverse --patience 0dfeecd..` to review the changes.