### PR TITLE
(PUP-4818) Make class references absolute

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -304,6 +304,15 @@ module Puppet::Pops::Evaluator::Runtime3Support
     # a proper Issue. Now the result is "Error while evaluating a Resource Statement" with the message
     # from the raised exception. (It may be good enough).
 
+
+    # In 3.x scope does not resolve classes as absolute names.
+    # In 4.x it does. This comment, and the conditional logic in the if below
+    # should be removed when merged to 4.x
+    #
+    if type_name == CLASS_STRING
+      resource_titles = resource_titles.map {|s| s.index('::') != 0 ? "::#{s}" : s }
+    end
+
     # resolve in scope.
     fully_qualified_type, resource_titles = scope.resolve_type_and_titles(type_name, resource_titles)
 

--- a/spec/integration/parser/dynamic_scoping_spec.rb
+++ b/spec/integration/parser/dynamic_scoping_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet/parser/parser_factory'
+require 'puppet_spec/compiler'
+require 'puppet_spec/pops'
+require 'puppet_spec/scope'
+require 'matchers/resource'
+require 'rgen/metamodel_builder'
+
+# These tests are in a separate file since othr compiler related tests have
+# been dramatically changed between 3.x and 4.x and it is a pain to merge
+# them.
+#
+describe "Puppet::Parser::Compiler when dealing with relative naming" do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  describe "the compiler when using 4.x parser and evaluator" do
+    # this before-clause should be removed when merging to 4.x
+    before :each do
+      Puppet[:parser] = 'future'
+    end
+
+    it "should use absolute references" do
+      node = Puppet::Node.new("testnodex")
+      catalog = compile_to_catalog(<<-PP, node)
+      class foo::thing {
+        notify {"from foo::thing":}
+      }
+
+      class thing {
+        notify {"from ::thing":}
+      }
+
+      class foo {
+      #  include thing
+        class {'thing':}
+      }
+
+      include foo
+      PP
+
+      catalog = Puppet::Parser::Compiler.compile(node)
+
+      expect(catalog).to have_resource("Notify[from ::thing]")
+    end
+  end
+
+  # This entire describe should be removed when merged to 4.x
+  #
+  describe "the compiler when using 3.x parser and evaluator" do
+    # this before-clause should be removed when merging to 4.x
+    before :each do
+      Puppet[:parser] = 'current'
+    end
+
+    it "should use absolute references" do
+      node = Puppet::Node.new("testnodex")
+      catalog = compile_to_catalog(<<-PP, node)
+            class foo::thing {
+              notify {"from foo::thing":}
+            }
+
+            class thing {
+              notify {"from ::thing":}
+            }
+
+            class foo {
+            #  include thing
+              class {'thing':}
+            }
+
+            include foo
+      PP
+
+      catalog = Puppet::Parser::Compiler.compile(node)
+
+      expect(catalog).to have_resource("Notify[from foo::thing]")
+    end
+  end # End 3.x only case
+
+end


### PR DESCRIPTION
This fixes a remaining "relative namespaces" issue in 3.x with future parser. (See ticket or commits for details).

WHEN MERGING TO 4X:

Follow the instructions given in comments:
* runtime_3_support contains code that should be removed in 4.x
* the dynamic_scoping_spec.rb should be added to 4.x but edited as instructed in comments in that file.