### PR TITLE
DO NOT MERGE (PUP-5873) Contain generated resources

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -156,7 +156,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
         # Puppet::Resource object.
         children = []
         resource_table = {}
-        resource_table[resource.title] = resource
+        resource_table[resource[:path] || resource.title] = resource
 
         file.recurse_remote_metadata.each do |meta|
           # Don't create a new resource for the parent directory

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -208,6 +208,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
             end
           end
         end
+        # We're done with the parent, don't recurse again on the agent.
+        resource[:recurse] = false
       else
         metadata = file.parameter(:source).metadata
         raise "Could not get metadata for #{resource[:source]}" unless metadata

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -89,6 +89,9 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     end
   end
 
+  # Add `resources` to the catalog after `other`. WARNING: adding
+  # multiple resources will produce the reverse ordering, e.g. calling
+  # `add_resource_after(A, [B,C])` will result in `[A,C,B]`.
   def add_resource_after(other, *resources)
     resources.each do |resource|
       other_title_key = title_key_for_ref(other.ref)
@@ -97,7 +100,6 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       add_one_resource(resource, idx+1)
     end
   end
-
 
   def add_resource(*resources)
     resources.each do |resource|

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -275,30 +275,6 @@ class Puppet::Transaction
     resource_status(resource).failed_dependencies = failed.to_a
   end
 
-  # A general method for recursively generating new resources from a
-  # resource.
-  def generate_additional_resources(resource)
-    return unless resource.respond_to?(:generate)
-    begin
-      made = resource.generate
-    rescue => detail
-      resource.log_exception(detail, "Failed to generate additional resources using 'generate': #{detail}")
-    end
-    return unless made
-    made = [made] unless made.is_a?(Array)
-    made.uniq.each do |res|
-      begin
-        res.tag(*resource.tags)
-        @catalog.add_resource(res)
-        res.finish
-        add_conditional_directed_dependency(resource, res)
-        generate_additional_resources(res)
-      rescue Puppet::Resource::Catalog::DuplicateResourceError
-        res.info "Duplicate generated resource; skipping"
-      end
-    end
-  end
-
   # Should we ignore tags?
   def ignore_tags?
     ! @catalog.host_config?

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -466,7 +466,7 @@ describe Puppet::Resource::Catalog::Compiler do
       metadata
     end
 
-    def stubs_directory_metadata(checksum_type, relative_path, children)
+    def stubs_directory_metadata(relative_path)
       full_path =  File.join(Puppet[:environmentpath], 'production', relative_path)
 
       metadata = stub 'metadata'
@@ -477,9 +477,13 @@ describe Puppet::Resource::Catalog::Compiler do
 
       Puppet::Type.type(:file).attrclass(:source).any_instance.stubs(:metadata).returns(metadata)
 
+      metadata
+    end
+
+    def stubs_top_directory_metadata(children)
       Puppet::Type.type(:file).any_instance.stubs(:recurse_remote_metadata).returns(children)
 
-      metadata
+      stubs_directory_metadata('.')
     end
 
     def expects_no_source_metadata
@@ -644,7 +648,7 @@ describe Puppet::Resource::Catalog::Compiler do
             }
           MANIFEST
 
-          stubs_directory_metadata(checksum_type, '.', [])
+          stubs_top_directory_metadata([])
 
           @compiler.send(:inline_metadata, catalog, checksum_type)
 
@@ -665,7 +669,7 @@ describe Puppet::Resource::Catalog::Compiler do
           MANIFEST
 
           child_metadata = stubs_file_metadata(checksum_type, checksum_value, 'myfile.txt')
-          stubs_directory_metadata(checksum_type, '.', [child_metadata])
+          stubs_top_directory_metadata([child_metadata])
 
           @compiler.send(:inline_metadata, catalog, checksum_type)
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -675,7 +675,7 @@ describe Puppet::Resource::Catalog::Compiler do
 
           expect(catalog).to have_resource(resource_ref)
             .with_parameter(:ensure, 'directory')
-            .with_parameter(:recurse, true) # REMIND this is surprising
+            .with_parameter(:recurse, false)
             .with_parameter(:source, 'puppet:///modules/mymodule/directory')
 
           expect(catalog).to have_resource("File[#{path}/myfile.txt]")

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -286,6 +286,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
       @catalog = Puppet::Resource::Catalog.new("host")
       @one = Puppet::Type.type(:notify).new :name => "one"
       @two = Puppet::Type.type(:notify).new :name => "two"
+      @three = Puppet::Type.type(:notify).new :name => "three"
       @dupe = Puppet::Type.type(:notify).new :name => "one"
     end
 
@@ -337,6 +338,32 @@ describe Puppet::Resource::Catalog, "when compiling" do
     it "should canonize how resources are referred to during retrieval when just the title is provided" do
       @catalog.add_resource(@one)
       expect(@catalog.resource("notify[one]", nil)).to equal(@one)
+    end
+
+    it "adds resources before an existing resource" do
+      @catalog.add_resource(@one)
+      @catalog.add_resource_before(@one, @two, @three)
+
+      expect(@catalog.resources).to eq([@two, @three, @one])
+    end
+
+    it "raises if adding a resource before a resource not in the catalog" do
+      expect {
+        @catalog.add_resource_before(@one, @two)
+      }.to raise_error(ArgumentError, "Cannot add resource Notify[two] before Notify[one] because Notify[one] is not yet in the catalog")
+    end
+
+    it "adds resources after an existing resource in reverse order" do
+      @catalog.add_resource(@one)
+      @catalog.add_resource_after(@one, @two, @three)
+
+      expect(@catalog.resources).to eq([@one, @three, @two])
+    end
+
+    it "raises if adding a resource after a resource not in the catalog" do
+      expect {
+        @catalog.add_resource_after(@one, @two)
+      }.to raise_error(ArgumentError, "Cannot add resource Notify[two] after Notify[one] because Notify[one] is not yet in the catalog")
     end
 
     describe 'with a duplicate resource' do


### PR DESCRIPTION
Adding this PR to get feedback about the approach. Note this is based on PR https://github.com/puppetlabs/puppet/pull/4660, which needs to be merged first.

Previously, we copied relationship parameters as strings from the parent
directory to each generated resource. This ensured somewhat accidentally
that generated resources were contained, meaning all of the generated
resources were evaluated before any resource downstream from the parent
directory.

However, if the parent had multiple relationships, we were calling
Array#to_s, causing the catalog to contain:

    "before": "[Notify[hi]{:name=>\"hi\"}, Notify[there]{:name=>\"there\"}]"

This caused the agent run to fail, since there's no resource with that
name.

This commit ensures we copy the relationship object to the generated
resource. It can either be a String or Array depending on the number of
relationship edges.