### PR TITLE
(PUP-5892) Alias types are presented with the wrong name in type mismatches

### DIFF
--- a/lib/puppet/pops/loader/type_definition_instantiator.rb
+++ b/lib/puppet/pops/loader/type_definition_instantiator.rb
@@ -5,7 +5,7 @@ module Loader
 class TypeDefinitionInstantiator
   def self.create(loader, typed_name, source_ref, pp_code_string)
     # parse and validate
-    parser = Puppet::Pops::Parser::EvaluatingParser.new()
+    parser = Parser::EvaluatingParser.new()
     model = parser.parse_string(pp_code_string, source_ref).model
     # Only one type is allowed (and no other definitions)
 
@@ -41,14 +41,14 @@ class TypeDefinitionInstantiator
     # loader to use when resolving contained aliases API. Such logic have a hard time finding the closure (where
     # the loader is known - hence this mechanism
     private_loader = loader.private_loader
-    Puppet::Pops::Adapters::LoaderAdapter.adapt(type_definition).loader = private_loader
+    Adapters::LoaderAdapter.adapt(type_definition).loader = private_loader
 
-    Puppet::Pops::Types::PTypeAlias.new(name, type_definition.type_expr)
+    Types::PTypeAlias.new(name, type_definition.type_expr)
   end
 
   def self.create_from_model(type_definition, loader)
     name = type_definition.name
-    [Loader::TypedName.new(:type, name.downcase), Puppet::Pops::Types::PTypeAlias.new(name, type_definition.type_expr)]
+    [Loader::TypedName.new(:type, name.downcase), Types::PTypeAlias.new(name, type_definition.type_expr)]
   end
 end
 end

--- a/lib/puppet/pops/loader/type_definition_instantiator.rb
+++ b/lib/puppet/pops/loader/type_definition_instantiator.rb
@@ -43,12 +43,12 @@ class TypeDefinitionInstantiator
     private_loader = loader.private_loader
     Adapters::LoaderAdapter.adapt(type_definition).loader = private_loader
 
-    Types::PTypeAlias.new(name, type_definition.type_expr)
+    Types::PTypeAliasType.new(name, type_definition.type_expr)
   end
 
   def self.create_from_model(type_definition, loader)
     name = type_definition.name
-    [Loader::TypedName.new(:type, name.downcase), Types::PTypeAlias.new(name, type_definition.type_expr)]
+    [Loader::TypedName.new(:type, name.downcase), Types::PTypeAliasType.new(name, type_definition.type_expr)]
   end
 end
 end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -1048,7 +1048,7 @@ class TypeCalculator
   end
 
   # @api private
-  def string_PTypeReference(t)
+  def string_PTypeReferenceType(t)
     if t.parameters.empty?
       t.name
     else

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -1043,7 +1043,7 @@ class TypeCalculator
   end
 
   # @api private
-  def string_PTypeAlias(t)
+  def string_PTypeAliasType(t)
     t.name
   end
 

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -442,9 +442,9 @@ module TypeFactory
   # parameters.
   # @param name [String] the name of the type
   # @param parameters [Array] the parameters
-  # @return [PTypeReference] the type reference
+  # @return [PTypeReferenceType] the type reference
   def self.type_reference(name, parameters = nil)
-    PTypeReference.new(name, parameters)
+    PTypeReferenceType.new(name, parameters)
   end
 
   # Returns true if the given type t is of valid range parameter type (integer

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -433,9 +433,9 @@ module TypeFactory
   # Returns the type alias for the given expression
   # @param name [String] the name of the unresolved type
   # @param expression [Model::Expression] an expression that will evaluate to a type
-  # @return [PTypeAlias] the type alias
+  # @return [PTypeAliasType] the type alias
   def self.type_alias(name, expression)
-    PTypeAlias.new(name, expression)
+    PTypeAliasType.new(name, expression)
   end
 
   # Returns the type that represents a type reference with a given name and optional

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -214,7 +214,7 @@ module Types
         # Use simple names when classes differ, or in other words, only include details
         # when the classes are equal.
         #
-        if e.find { |t| t.class == a.class }
+        if a.is_a?(PTypeAliasType) || e.find { |t| t.class == a.class || t.is_a?(PTypeAliasType) }
           e = e.map { |t| t.to_s }
           a = a.to_s
         else
@@ -233,7 +233,7 @@ module Types
           multi = true
         end
       else
-        if e.class != a.class
+        if e.class != a.class && !(e.is_a?(PTypeAliasType) || a.is_a?(PTypeAliasType))
           e = e.simple_name
           a = a.simple_name
         else

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -68,7 +68,7 @@ class PAnyType < TypedModelObject
       _assignable?(TypeCalculator.singleton.type(o), guard)
     when PUnitType
       true
-    when PTypeAlias
+    when PTypeAliasType
       # An alias may contain self recursive constructs.
       if o.self_recursion?
         guard ||= RecursionGuard.new
@@ -1941,7 +1941,7 @@ end
 # might contain self recursion. Whether or not that is the case is computed and remembered when the alias
 # is resolved since guarding against self recursive constructs is relatively expensive.
 #
-class PTypeAlias < PAnyType
+class PTypeAliasType < PAnyType
   attr_reader :name
 
   # @param name [String] The name of the type
@@ -1993,7 +1993,7 @@ class PTypeAlias < PAnyType
   # interpret the contained expression and the resolved type is remembered. This method also
   # checks and remembers if the resolve type contains self recursion.
   #
-  # @return [PTypeAlias] the receiver of the call, i.e. `self`
+  # @return [PTypeAliasType] the receiver of the call, i.e. `self`
   # @api private
   def resolve(type_parser, scope)
     if @resolved_type.nil?
@@ -2056,7 +2056,7 @@ class PTypeAlias < PAnyType
     end
   end
 
-  DEFAULT = PTypeAlias.new('UnresolvedAlias', nil, PTypeReference::DEFAULT)
+  DEFAULT = PTypeAliasType.new('UnresolvedAlias', nil, PTypeReference::DEFAULT)
 end
 end
 end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1901,7 +1901,7 @@ class POptionalType < PAnyType
   end
 end
 
-class PTypeReference < PAnyType
+class PTypeReferenceType < PAnyType
   attr_reader :name, :parameters
 
   def initialize(name, parameters = nil)
@@ -1932,7 +1932,7 @@ class PTypeReference < PAnyType
     o == self
   end
 
-  DEFAULT = PTypeReference.new('UnresolvedReference')
+  DEFAULT = PTypeReferenceType.new('UnresolvedReference')
 end
 
 # Describes a named alias for another Type.
@@ -1997,8 +1997,8 @@ class PTypeAliasType < PAnyType
   # @api private
   def resolve(type_parser, scope)
     if @resolved_type.nil?
-      # resolved to PTypeReference::DEFAULT during resolve to avoid endless recursion
-      @resolved_type = PTypeReference::DEFAULT
+      # resolved to PTypeReferenceType::DEFAULT during resolve to avoid endless recursion
+      @resolved_type = PTypeReferenceType::DEFAULT
       @self_recursion = true # assumed while it being found out below
       begin
         @resolved_type = type_parser.interpret(@type_expr, scope)
@@ -2056,7 +2056,7 @@ class PTypeAliasType < PAnyType
     end
   end
 
-  DEFAULT = PTypeAliasType.new('UnresolvedAlias', nil, PTypeReference::DEFAULT)
+  DEFAULT = PTypeAliasType.new('UnresolvedAlias', nil, PTypeReferenceType::DEFAULT)
 end
 end
 end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -150,7 +150,7 @@ describe 'The type calculator' do
         Puppet::Pops::Types::PType,
         Puppet::Pops::Types::POptionalType,
         Puppet::Pops::Types::PDefaultType,
-        Puppet::Pops::Types::PTypeReference,
+        Puppet::Pops::Types::PTypeReferenceType,
         Puppet::Pops::Types::PTypeAliasType,
       ]
     end
@@ -709,11 +709,11 @@ describe 'The type calculator' do
 
     context "for TypeReference, such that" do
       it 'no other type is assignable' do
-        t = Puppet::Pops::Types::PTypeReference::DEFAULT
+        t = Puppet::Pops::Types::PTypeReferenceType::DEFAULT
         all_instances = (all_types - [
-          Puppet::Pops::Types::PTypeReference, # Avoid comparison with t
+          Puppet::Pops::Types::PTypeReferenceType, # Avoid comparison with t
           Puppet::Pops::Types::PVariantType,   # DEFAULT contains no variants, so assignability is never tested and always true
-          Puppet::Pops::Types::PTypeAliasType      # DEFAULT resolves to PTypeReference::DEFAULT, i.e. t
+          Puppet::Pops::Types::PTypeAliasType      # DEFAULT resolves to PTypeReferenceType::DEFAULT, i.e. t
         ]).map {|c| c::DEFAULT }
 
         # Add a non-empty variant

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1853,6 +1853,8 @@ describe 'The type calculator' do
   end
 
   context 'when representing the type as string' do
+    include_context 'types_setup'
+
     it 'should yield \'Type\' for PType' do
       expect(calculator.string(Puppet::Pops::Types::PType::DEFAULT)).to eq('Type')
     end
@@ -2117,6 +2119,14 @@ describe 'The type calculator' do
     it "should yield the name of a type alias" do
       t = type_alias_t('Alias', 'Integer')
       expect(calculator.string(t)).to eq('Alias')
+    end
+
+    it 'should present a valid simple name' do
+      (all_types - [Puppet::Pops::Types::PType]).each do |t|
+        name = t::DEFAULT.simple_name
+        expect(t.name).to match("^Puppet::Pops::Types::P#{name}Type$")
+      end
+      expect(Puppet::Pops::Types::PType::DEFAULT.simple_name).to eql('Type')
     end
   end
 

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -151,7 +151,7 @@ describe 'The type calculator' do
         Puppet::Pops::Types::POptionalType,
         Puppet::Pops::Types::PDefaultType,
         Puppet::Pops::Types::PTypeReference,
-        Puppet::Pops::Types::PTypeAlias,
+        Puppet::Pops::Types::PTypeAliasType,
       ]
     end
 
@@ -713,7 +713,7 @@ describe 'The type calculator' do
         all_instances = (all_types - [
           Puppet::Pops::Types::PTypeReference, # Avoid comparison with t
           Puppet::Pops::Types::PVariantType,   # DEFAULT contains no variants, so assignability is never tested and always true
-          Puppet::Pops::Types::PTypeAlias      # DEFAULT resolves to PTypeReference::DEFAULT, i.e. t
+          Puppet::Pops::Types::PTypeAliasType      # DEFAULT resolves to PTypeReference::DEFAULT, i.e. t
         ]).map {|c| c::DEFAULT }
 
         # Add a non-empty variant

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+
+describe 'the type mismatch describer' do
+  include PuppetSpec::Compiler
+
+  it 'will report a mismatch against an aliased type correctly' do
+    code = <<-CODE
+      type UnprivilegedPort = Integer[1024,65537]
+
+      function check_port(UnprivilegedPort $port) {
+         $port
+      }
+      check_port(34)
+    CODE
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /parameter 'port' expects an UnprivilegedPort value, got Integer\[34, 34\]/)
+  end
+end


### PR DESCRIPTION
This PR fixes three things.

1. The PTypeAlias is renamed to PTypeAliasType
2. The PTypeReference is renamed to PTypeReferenceType (didn't deserve an issue of its own)
3. The type mismatch describer reports type aliases by alias name instead of type name
