### PR TITLE
(PUP-5879) Use FileSystem.read where applicable to read JSON, settings and other files as UTF-8

### DIFF
--- a/lib/puppet/data_providers/json_data_provider_factory.rb
+++ b/lib/puppet/data_providers/json_data_provider_factory.rb
@@ -18,7 +18,7 @@ module Puppet::DataProviders
     include HieraInterpolate
 
     def initialize_data(path, lookup_invocation)
-      JSON.parse(File.read(path))
+      JSON.parse(Puppet::FileSystem.read(path, :encoding => 'utf-8'))
     rescue JSON::ParserError => ex
       # Filename not included in message, so we add it here.
       raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"

--- a/lib/puppet/indirector/msgpack.rb
+++ b/lib/puppet/indirector/msgpack.rb
@@ -58,7 +58,7 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
     msgpack = nil
 
     begin
-      msgpack = File.read(file)
+      msgpack = Puppet::FileSystem.read(file, :encoding => 'utf-8')
     rescue Errno::ENOENT
       return nil
     rescue => detail

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -48,7 +48,7 @@ class Puppet::Module
 
   def self.is_module_namespaced_name?(name)
     # it must match the full module name according to forge validator
-    return true if name =~ /^[a-zA-Z0-9]+[-][a-z][a-z0-9_]*$/   
+    return true if name =~ /^[a-zA-Z0-9]+[-][a-z][a-z0-9_]*$/
     return false
   end
 
@@ -90,7 +90,7 @@ class Puppet::Module
     return false unless Puppet::FileSystem.exist?(metadata_file)
 
     begin
-      metadata =  JSON.parse(File.read(metadata_file))
+      metadata =  JSON.parse(File.read(metadata_file, :encoding => 'utf-8'))
     rescue JSON::JSONError => e
       Puppet.debug("#{name} has an invalid and unparsable metadata.json file.  The parse error: #{e.message}")
       return false
@@ -145,7 +145,7 @@ class Puppet::Module
   end
 
   def load_metadata
-    @metadata = data = JSON.parse(File.read(metadata_file))
+    @metadata = data = JSON.parse(File.read(metadata_file, :encoding => 'utf-8'))
     @forge_name = data['name'].gsub('-', '/') if data['name']
 
     [:source, :author, :version, :license, :dependencies].each do |attr|

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -65,9 +65,9 @@ module Puppet::ModuleTool
           gitignore = File.join(@path, '.gitignore')
 
           if File.file? pmtignore
-            @ignored_files = PathSpec.new File.read(pmtignore)
+            @ignored_files = PathSpec.new Puppet::FileSystem.read(pmtignore, :encoding => 'utf-8')
           elsif File.file? gitignore
-            @ignored_files = PathSpec.new File.read(gitignore)
+            @ignored_files = PathSpec.new Puppet::FileSystem.read(gitignore, :encoding => 'utf-8')
           else
             @ignored_files = PathSpec.new
           end

--- a/lib/puppet/network/auth_config_parser.rb
+++ b/lib/puppet/network/auth_config_parser.rb
@@ -4,7 +4,7 @@ module Puppet::Network
 class AuthConfigParser
 
   def self.new_from_file(file)
-    self.new(File.read(file))
+    self.new(Puppet::FileSystem.read(file, :encoding => 'utf-8'))
   end
 
   def initialize(string)

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1189,7 +1189,7 @@ Generated on #{Time.now}.
   # Read the file in.
   # @api private
   def read_file(file)
-    return Puppet::FileSystem.read(file)
+    return Puppet::FileSystem.read(file, :encoding => 'utf-8')
   end
 
   # Private method for internal test use only; allows to do a comprehensive clear of all settings between tests.

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/third_utf8.json
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/third_utf8.json
@@ -1,0 +1,3 @@
+{
+    "test::param_json_utf8": "env data param_json_utf8 is ᚠᛇᚻ"
+}

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/utf8.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/utf8.yaml
@@ -1,0 +1,3 @@
+---
+test::param_yaml_utf8: env data param_yaml_utf8 is ᛫ᛒᛦ
+

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/hiera.yaml
@@ -6,11 +6,15 @@
   - :name: "one path"
     :backend: yaml
     :path: "single"
-  - :name: "two paths"
+  - :name: "utf8"
+    :backend: yaml
+    :path: "utf8"
+  - :name: "three paths"
     :backend: json
     :paths:
       - "first"
       - "second"
+      - "third_utf8"
   - :name:  'other datadir'
     :backend: yaml
     :datadir: "data2"

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/manifests/site.pp
@@ -1,5 +1,5 @@
-class test($param_a = 1, $param_b = 2, $param_c = 3, $param_d = 4, $param_e = 5) {
-  notify { "$param_a, $param_b, $param_c, $param_d, $param_e": }
+class test($param_a = 1, $param_b = 2, $param_c = 3, $param_d = 4, $param_e = 5, $param_yaml_utf8 = 'hi', $param_json_utf8 = 'hi') {
+  notify { "$param_a, $param_b, $param_c, $param_d, $param_e, $param_yaml_utf8, $param_json_utf8": }
 }
 
 include test

--- a/spec/integration/util/settings_spec.rb
+++ b/spec/integration/util/settings_spec.rb
@@ -44,6 +44,32 @@ describe Puppet::Settings do
     expect(Puppet::FileSystem.stat(settings[:maindir]).mode & 007777).to eq(0750)
   end
 
+  it "will properly parse a UTF-8 configuration file" do
+    rune_utf8 = "\u16A0\u16C7\u16BB" # ᚠᛇᚻ
+    config = tmpfile("config")
+    define_settings(:main,
+      :config => {
+        :type => :file,
+        :default => config,
+        :desc => "a"
+      },
+      :environment => {
+        :default => 'dingos',
+        :desc => 'test',
+      }
+    )
+
+    File.open(config, 'w') do |file|
+      file.puts <<-EOF
+[main]
+environment=#{rune_utf8}
+      EOF
+    end
+
+    settings.initialize_global_settings
+    expect(settings[:environment]).to eq(rune_utf8)
+  end
+
   it "reparses configuration if configuration file is touched", :if => !Puppet.features.microsoft_windows? do
     config = tmpfile("config")
     define_settings(:main,

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -45,7 +45,7 @@ describe "when using a hiera data provider" do
 
   it 'reads hiera.yaml in environment root and configures multiple json and yaml providers' do
     resources = compile_and_get_notifications('hiera_env_config')
-    expect(resources).to include('env data param_a is 10, env data param_b is 20, env data param_c is 30, env data param_d is 40, env data param_e is 50')
+    expect(resources).to include("env data param_a is 10, env data param_b is 20, env data param_c is 30, env data param_d is 40, env data param_e is 50, env data param_yaml_utf8 is \u16EB\u16D2\u16E6, env data param_json_utf8 is \u16A0\u16C7\u16BB")
   end
 
   it 'reads hiera.yaml in module root and configures multiple json and yaml providers' do

--- a/spec/unit/module_tool/applications/builder_spec.rb
+++ b/spec/unit/module_tool/applications/builder_spec.rb
@@ -56,37 +56,41 @@ describe Puppet::ModuleTool::Applications::Builder do
       Puppet::FileSystem.touch(File.join(path, 'gitdirectory/gitartifact'))
       Puppet::FileSystem.touch(File.join(path, 'gitdirectory/gitimportantfile'))
       Puppet::FileSystem.touch(File.join(path, 'gitdirectory/sub/artifact'))
+      Puppet::FileSystem.touch(File.join(path, "git\u16A0\u16C7\u16BB"))
       Puppet::FileSystem.touch(File.join(path, 'pmtignored.foo'))
       Puppet::FileSystem.mkpath(File.join(path, 'pmtdirectory/sub'))
       Puppet::FileSystem.touch(File.join(path, 'pmtdirectory/pmtimportantfile'))
       Puppet::FileSystem.touch(File.join(path, 'pmtdirectory/pmtartifact'))
       Puppet::FileSystem.touch(File.join(path, 'pmtdirectory/sub/artifact'))
+      Puppet::FileSystem.touch(File.join(path, "pmt\u16A0\u16C7\u16BB"))
     end
 
     def create_pmtignore_file
-      Puppet::FileSystem.open(File.join(path, '.pmtignore'), 0600, 'w') do |f|
+      File.open(File.join(path, '.pmtignore'), 'w', 0600, :encoding => 'utf-8') do |f|
         f << <<-PMTIGNORE
 pmtignored.*
 pmtdirectory/sub/**
 pmtdirectory/pmt*
 !pmtimportantfile
+pmt\u16A0\u16C7\u16BB
 PMTIGNORE
       end
     end
 
     def create_gitignore_file
-      Puppet::FileSystem.open(File.join(path, '.gitignore'), 0600, 'w') do |f|
+      File.open(File.join(path, '.gitignore'), 'w', 0600, :encoding => 'utf-8') do |f|
         f << <<-GITIGNORE
 gitignored.*
 gitdirectory/sub/**
 gitdirectory/git*
 !gitimportantfile
+git\u16A0\u16C7\u16BB
 GITIGNORE
       end
     end
 
     def create_symlink_gitignore_file
-      Puppet::FileSystem.open(File.join(path, '.gitignore'), 0600, 'w') do |f|
+      File.open(File.join(path, '.gitignore'), 'w', 0600, :encoding => 'utf-8') do |f|
         f << <<-GITIGNORE
 symlinkfile
     GITIGNORE
@@ -152,6 +156,10 @@ symlinkfile
         expect(target_exists?('gitignored.foo')).to eq true
       end
 
+      it "leaves UTF-8 files" do
+        expect(target_exists?("git\u16A0\u16C7\u16BB")).to eq true
+      end
+
       it "leaves directories" do
         expect(target_exists?('gitdirectory')).to eq true
       end
@@ -176,6 +184,10 @@ symlinkfile
     shared_examples "gitignored files are not present" do
       it "ignores regular files" do
         expect(target_exists?('gitignored.foo')).to eq false
+      end
+
+      it "ignores UTF-8 files" do
+        expect(target_exists?("git\u16A0\u16C7\u16BB")).to eq false
       end
 
       it "ignores directories" do
@@ -204,6 +216,10 @@ symlinkfile
         expect(target_exists?('pmtignored.foo')).to eq true
       end
 
+      it "leaves UTF-8 files" do
+        expect(target_exists?("pmt\u16A0\u16C7\u16BB")).to eq true
+      end
+
       it "leaves directories" do
         expect(target_exists?('pmtdirectory')).to eq true
       end
@@ -228,6 +244,10 @@ symlinkfile
     shared_examples "pmtignored files are not present" do
       it "ignores regular files" do
         expect(target_exists?('pmtignored.foo')).to eq false
+      end
+
+      it "ignores UTF-8 files" do
+        expect(target_exists?("pmt\u16A0\u16C7\u16BB")).to eq false
       end
 
       it "ignores directories" do

--- a/spec/unit/network/auth_config_parser_spec.rb
+++ b/spec/unit/network/auth_config_parser_spec.rb
@@ -4,6 +4,7 @@ require 'puppet/network/auth_config_parser'
 require 'puppet/network/authconfig'
 
 describe Puppet::Network::AuthConfigParser do
+  include PuppetSpec::Files
 
   let(:fake_authconfig) do
     "path ~ ^/catalog/([^/])\nmethod find\nallow *\n"
@@ -96,6 +97,21 @@ describe Puppet::Network::AuthConfigParser do
       Puppet::Network::Rights::Right.any_instance.expects(:restrict_authenticated).with('yes')
 
       described_class.new("path /certificates\nauthenticated yes").parse_rights
+    end
+  end
+
+  describe "when parsing rights from files" do
+    it "can read UTF-8" do
+      rune_path = "/\u16A0\u16C7\u16BB" # ᚠᛇᚻ
+      config = tmpfile('config')
+
+      File.open(config, 'w', :encoding => 'utf-8') do |file|
+        file.puts <<-EOF
+path #{rune_path}
+      EOF
+    end
+
+      expect(described_class.new_from_file(config).parse_rights[rune_path]).to be
     end
   end
 end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -107,7 +107,7 @@ describe 'loaders' do
     end
 
     it 'loader allows loading a function more than once' do
-      File.stubs(:read).with(user_metadata_path).returns ''
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns ''
 
       env = environment_for(File.join(dependent_modules_with_metadata, 'modules'))
       loaders = Puppet::Pops::Loaders.new(env)
@@ -166,7 +166,7 @@ describe 'loaders' do
     end
 
     it 'all dependent modules are visible' do
-      File.stubs(:read).with(user_metadata_path).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'}, { 'name' => 'test-usee2'} ]).to_pson
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'}, { 'name' => 'test-usee2'} ]).to_pson
       loaders = Puppet::Pops::Loaders.new(env)
 
       moduleb_loader = loaders.private_loader_for_module('user')
@@ -183,7 +183,7 @@ describe 'loaders' do
         {:from => from, :called => 'a ruby function', :expects => "I'm the function usee::usee_ruby()"} ].each_with_index do |desc, called_idx|
         case_number = from_idx * 3 + called_idx + 1
         it "can call #{desc[:called]} from #{desc[:from]} when dependency is present in metadata.json" do
-          File.stubs(:read).with(user_metadata_path).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
+          File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
           Puppet[:code] = "$case_number = #{case_number}\ninclude ::user"
           catalog = compiler.compile
           resource = catalog.resource('Notify', "case_#{case_number}")
@@ -201,7 +201,7 @@ describe 'loaders' do
         end
 
         it 'can not call ruby function in a dependent module from outside a function if dependency is missing in existing metadata.json' do
-          File.stubs(:read).with(user_metadata_path).returns user_metadata.merge('dependencies' => []).to_pson
+          File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => []).to_pson
           Puppet[:code] = "$case_number = #{case_number}\ninclude ::user"
           expect { catalog = compiler.compile }.to raise_error(Puppet::Error, /Unknown function/)
         end
@@ -209,7 +209,7 @@ describe 'loaders' do
     end
 
     it "a type can reference an autoloaded type alias from another module when dependency is present in metadata.json" do
-      File.stubs(:read).with(user_metadata_path).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
       expect(eval_and_collect_notices(<<-CODE, node)).to eq(['ok'])
         assert_type(Usee::Zero, 0)
         notice(ok)
@@ -225,7 +225,7 @@ describe 'loaders' do
     end
 
     it "a type can reference a type alias from another module when other module has it declared in init.pp" do
-      File.stubs(:read).with(user_metadata_path).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
       expect(eval_and_collect_notices(<<-CODE, node)).to eq(['ok'])
         include 'usee'
         assert_type(Usee::One, 1)
@@ -234,7 +234,7 @@ describe 'loaders' do
     end
 
     it "an autoloaded type can reference an autoloaded type alias from another module when dependency is present in metadata.json" do
-      File.stubs(:read).with(user_metadata_path).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
       expect(eval_and_collect_notices(<<-CODE, node)).to eq(['ok'])
         assert_type(User::WithUseeZero, [0])
         notice(ok)
@@ -242,7 +242,7 @@ describe 'loaders' do
     end
 
     it "an autoloaded type can reference an autoloaded type alias from another module when other module has it declared in init.pp" do
-      File.stubs(:read).with(user_metadata_path).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
       expect(eval_and_collect_notices(<<-CODE, node)).to eq(['ok'])
         include 'usee'
         assert_type(User::WithUseeOne, [1])

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -737,7 +737,7 @@ describe Puppet::Settings do
 
       Puppet::FileSystem.expects(:exist?).with(myfile).returns(true)
 
-      Puppet::FileSystem.expects(:read).with(myfile).returns "[main]"
+      Puppet::FileSystem.expects(:read).with(myfile, :encoding => 'utf-8').returns "[main]"
 
       @settings.send(:parse_config_files)
     end


### PR DESCRIPTION
Adds additional UTF-8 support to Puppet when reading files from disk, including:

* Settings like `puppet.conf`
* PMT ignore files - `.gitignore` and `.pmtignore`
* Hiera YAML and JSON files
* Modules `metadata.json`
* Route auth files
* MsgPack