### PR TITLE
(PUP-5697) Inline file permissions to the static catalog

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -84,24 +84,31 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   end
 
   # Rewrite a given file resource with the metadata from a fileserver based file
-  def replace_metadata(resource, metadata, recurse = false)
+  def replace_metadata(resource, metadata)
+    # TODO: when we stop using to_ral, we'll have to add a case for ensure => <path>
+    # implying a link.
     if resource[:links] == "manage" && metadata.ftype == "link"
       resource.delete(:source)
-      resource[:ensure] = "link"
       resource[:target] = metadata.destination
-    elsif resource[:links] == "follow"
-      resource[:ensure] = metadata.ftype
     end
+
+    # Most of the time, ensure should match the returned metadata. Exceptions are when
+    # ensure is `present` (it could be anything), or a path (implies creating a link).
+    # `to_ral` caused the path case to munge to managing links, so we warn if there's
+    # a mismatch that's not `present`.
+    if resource[:ensure] != :present && resource[:ensure] != metadata.ftype
+      Puppet.warning "#{resource} expected to create a #{resource[:ensure]}, but its source "+
+        "is a #{metadata.ftype}. The source metadata will override the 'ensure' property."
+    end
+
+    resource[:ensure] = metadata.ftype
 
     if metadata.ftype == "file"
+      # Since we use the checksum from metadata, it makes sense to pick up the checksum type
+      # from the same source. This should never differ, but seems like the most correct
+      # expression of intent.
       resource[:checksum_value] = sumdata(metadata.checksum)
-    end
-
-    if recurse
-      resource[:source] = metadata.source
-      if metadata.ftype == "file"
-        resource[:checksum] = metadata.checksum_type
-      end
+      resource[:checksum] = metadata.checksum_type
     end
   end
 
@@ -141,8 +148,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
           # TODO: Conditionally copy owner, group, and mode when we can check if permissions are set
           child_resource = Puppet::Resource.new(:file, File.join(file[:path], meta.relative_path))
-          child_resource[:ensure] = meta.ftype
-          replace_metadata(child_resource, meta, true)
+          child_resource[:source] = meta.source
+          replace_metadata(child_resource, meta)
 
           # Copy parameters from original parent directory
           file.original_parameters.each do |param, value|

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -82,13 +82,13 @@ describe Puppet::Configurer::Downloader do
       expect(file[:source_permissions]).to eq(:ignore)
     end
 
-    it "should allow source_permissions to be overridden" do
-      file = generate_file_resource(:source_permissions => :use)
-
-      expect(file[:source_permissions]).to eq(:use)
-    end
-
     describe "on POSIX", :if => Puppet.features.posix? do
+      it "should allow source_permissions to be overridden" do
+        file = generate_file_resource(:source_permissions => :use)
+
+        expect(file[:source_permissions]).to eq(:use)
+      end
+
       it "should always set the owner to the current UID" do
         Process.expects(:uid).returns 51
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -761,7 +761,7 @@ describe Puppet::Resource::Catalog::Compiler do
         .with_parameter(:before, catalog.resource('Notify[omega]'))
     end
 
-    it "inlines windows file paths" do
+    it "inlines windows file paths", :if => Puppet.features.posix? do
       pending "Calling Puppet::Resource#to_ral on windows path is not safe on *nix master"
 
       catalog = compile_to_catalog(<<-MANIFEST, node)
@@ -775,7 +775,7 @@ describe Puppet::Resource::Catalog::Compiler do
 
       @compiler.send(:inline_metadata, catalog, checksum_type)
 
-      expect(catalog).to have_resource(resource_ref)
+      expect(catalog).to have_resource("File[c:/foo]")
         .with_parameter(:ensure, 'file')
         .with_parameter(:checksum, checksum_type)
         .with_parameter(:checksum_value, checksum_value)


### PR DESCRIPTION
Inlines `owner`, `group`, and `mode` permissions when
`source_permissions` is `use`. Not inlined when it's `ignore`, and
raises an error if `use_when_creating` is requested.

For Windows, modified how we assert that `source_permissions => use`
will not be used on Windows so it's still checked for the static
catalog. Check is done client-side, as the master usually doesn't care
what OS the client is.

Also added a maint change to always set :ensure and :checksum to prompt discussion.