### PR TITLE
Issue/pup 5898/global keys in module data

### DIFF
--- a/lib/puppet/data_providers/hiera_config.rb
+++ b/lib/puppet/data_providers/hiera_config.rb
@@ -70,6 +70,18 @@ module Puppet::DataProviders
     end
 
     def create_data_providers(lookup_invocation)
+      Puppet.deprecation_warning('Method HieraConfig#create_data_providers is deprecated. Use create_configured_data_providers instead')
+      create_configured_data_providers(lookup_invocation, nil)
+    end
+
+    # Creates the data providers for this config
+    #
+    # @param lookup_invocation [Puppet::Pops::Lookup::Invocation] Invocation data containing scope, overrides, and defaults
+    # @param parent_data_provider [Puppet::Plugins::DataProviders::DataProvider] The data provider that loaded this configuration
+    # @return [Array[DataProvider]] the created providers
+    #
+    # @api private
+    def create_configured_data_providers(lookup_invocation, parent_data_provider)
       injector = Puppet.lookup(:injector)
       service_type = Registry.hash_of_path_based_data_provider_factories
       default_datadir = @config['datadir']
@@ -92,11 +104,22 @@ module Puppet::DataProviders
         raise Puppet::DataBinding::LookupError, "#{@config_path}: No data provider is registered for backend '#{provider_name}' " unless provider_factory
 
         datadir = @config_root + (he['datadir'] || default_datadir)
-        resolved_paths = provider_factory.resolve_paths(datadir, original_paths, paths, lookup_invocation)
-        data_providers[name] = provider_factory.create(name, resolved_paths)
+        data_providers[name] = create_data_provider(parent_data_provider, provider_factory, name,
+          provider_factory.resolve_paths(datadir, original_paths, paths, lookup_invocation))
       end
       data_providers.values
     end
+
+    def create_data_provider(parent_data_provider, provider_factory, name, resolved_paths)
+      provider_factory_version = provider_factory.respond_to?(:version) ? provider_factory.version : 1
+      if provider_factory_version == 1
+        # Version 1 is not aware of the parent provider
+        provider_factory.create(name, resolved_paths)
+      else
+        provider_factory.create(name, resolved_paths, parent_data_provider)
+      end
+    end
+    private :create_data_provider
 
     def validate_config(hiera_config)
       Puppet::Pops::Types::TypeAsserter.assert_instance_of(@config_path, self.class.config_type, hiera_config)

--- a/lib/puppet/data_providers/hiera_support.rb
+++ b/lib/puppet/data_providers/hiera_support.rb
@@ -31,7 +31,7 @@ module Puppet::DataProviders::HieraSupport
 
   def data_providers(data_key, lookup_invocation)
     @hiera_config ||= Puppet::DataProviders::HieraConfig.new(provider_root(data_key, lookup_invocation.scope))
-    @data_providers ||= @hiera_config.create_data_providers(lookup_invocation)
+    @data_providers ||= @hiera_config.create_configured_data_providers(lookup_invocation, self)
   end
   private :data_providers
 end

--- a/lib/puppet/data_providers/json_data_provider_factory.rb
+++ b/lib/puppet/data_providers/json_data_provider_factory.rb
@@ -5,8 +5,8 @@ require_relative 'hiera_interpolate'
 
 module Puppet::DataProviders
   class JsonDataProviderFactory < Puppet::Plugins::DataProviders::FileBasedDataProviderFactory
-    def create(name, paths)
-      JsonDataProvider.new(name, paths)
+    def create(name, paths, parent_data_provider)
+      JsonDataProvider.new(name, paths, parent_data_provider)
     end
 
     def path_extension

--- a/lib/puppet/data_providers/yaml_data_provider_factory.rb
+++ b/lib/puppet/data_providers/yaml_data_provider_factory.rb
@@ -5,8 +5,8 @@ require_relative 'hiera_interpolate'
 
 module Puppet::DataProviders
   class YamlDataProviderFactory < Puppet::Plugins::DataProviders::FileBasedDataProviderFactory
-    def create(name, paths)
-      YamlDataProvider.new(name, paths)
+    def create(name, paths, parent_data_provider)
+      YamlDataProvider.new(name, paths, parent_data_provider)
     end
 
     def path_extension

--- a/lib/puppet/plugins/data_providers/data_provider.rb
+++ b/lib/puppet/plugins/data_providers/data_provider.rb
@@ -72,7 +72,6 @@ module Puppet::Plugins::DataProviders
     def data_key(key, lookup_invocation)
       nil
     end
-    protected :data_key
 
     # Should be reimplemented by subclass to provide the hash that corresponds to the given name.
     #
@@ -94,7 +93,6 @@ module Puppet::Plugins::DataProviders
     def validate_data(data, data_key)
       data
     end
-    protected :validate_data
   end
 
   class ModuleDataProvider
@@ -112,7 +110,6 @@ module Puppet::Plugins::DataProviders
       throw :no_such_key if qual_index.nil?
       key[0..qual_index-1]
     end
-    protected :data_key
 
     # Assert that all keys in the given _data_ are prefixed with the given _module_name_. Remove entries
     # that does not follow the convention and log a warning.
@@ -136,7 +133,6 @@ module Puppet::Plugins::DataProviders
         memo
       end
     end
-    protected :validate_data
   end
 
   class EnvironmentDataProvider
@@ -145,7 +141,6 @@ module Puppet::Plugins::DataProviders
     def data_key(key, lookup_invocation)
       'environment'
     end
-    protected :data_key
   end
 
   # Class that keeps track of the original path (as it appears in the declaration, before interpolation),
@@ -194,6 +189,31 @@ module Puppet::Plugins::DataProviders
       @parent_data_provider = parent_data_provider
     end
 
+    # Gets the data from the compiler, or initializes it by calling #initialize_data if not present in the compiler.
+    # This means, that data is initialized once per compilation, and the data is cached for as long as the compiler
+    # lives (which is for one catalog production). This makes it possible to return data that is tailored for the
+    # request.
+    #
+    # If data is obtained using the #initialize_data method it will be sent to the #validate_data for validation
+    #
+    # @param path [String] The path to the data to be loaded (passed to #initialize_data)
+    # @param data_key [String] The data key such as the name of a module or the constant 'environment'
+    # @param lookup_invocation [Puppet::Pops::Lookup::Invocation] The current lookup invocation
+    # @param merge [String|Hash<String,Object>|nil] Merge strategy or hash with strategy and options
+    # @return [Hash] The data hash for the given _key_
+    #
+    # @api public
+    def load_data(path, data_key, lookup_invocation)
+      compiler = lookup_invocation.scope.compiler
+      adapter = Puppet::DataProviders::DataAdapter.get(compiler) || Puppet::DataProviders::DataAdapter.adapt(compiler)
+      adapter.data[path] ||= validate_data(initialize_data(path, lookup_invocation), data_key)
+    end
+    protected :data
+
+    def validate_data(data, module_name)
+      @parent_data_provider.nil? ? data : @parent_data_provider.validate_data(data, module_name)
+    end
+
     # Performs a lookup by searching all given paths for the given _key_. A merge will be performed if
     # the value is found in more than one location and _merge_ is not nil.
     #
@@ -203,13 +223,14 @@ module Puppet::Plugins::DataProviders
     #
     # @api public
     def unchecked_lookup(key, lookup_invocation, merge)
+      module_name = @parent_data_provider.nil? ? nil : @parent_data_provider.data_key(key, lookup_invocation)
       lookup_invocation.with(:data_provider, self) do
         merge_strategy = Puppet::Pops::MergeStrategy.strategy(merge)
         lookup_invocation.with(:merge, merge_strategy) do
           merged_result = merge_strategy.merge_lookup(@paths) do |path|
             lookup_invocation.with(:path, path) do
               if path.exists?
-                hash = data(path.path, lookup_invocation)
+                hash = load_data(path.path, module_name, lookup_invocation)
                 value = hash[key]
                 if value || hash.include?(key)
                   lookup_invocation.report_found(key, post_process(value, lookup_invocation))

--- a/lib/puppet/plugins/data_providers/data_provider.rb
+++ b/lib/puppet/plugins/data_providers/data_provider.rb
@@ -185,11 +185,13 @@ module Puppet::Plugins::DataProviders
 
     # @param name [String] The name of the data provider
     # @param paths [Array<ResolvedPath>] Paths used by this provider
+    # @param parent_data_provider [DataProvider] The data provider that is the container of this data provider
     #
     # @api public
-    def initialize(name, paths)
+    def initialize(name, paths, parent_data_provider = nil)
       @name = name
       @paths = paths
+      @parent_data_provider = parent_data_provider
     end
 
     # Performs a lookup by searching all given paths for the given _key_. A merge will be performed if
@@ -236,10 +238,11 @@ module Puppet::Plugins::DataProviders
     #
     # @param name [String] the name of the created provider (for logging and debugging)
     # @param paths [Array<String>] array of resolved paths
+    # @param parent_data_provider [DataProvider] The data provider that is the container of this data provider
     # @return [DataProvider] The created data provider
     #
     # @api public
-    def create(name, paths)
+    def create(name, paths, parent_data_provider)
       raise NotImplementedError, "Subclass of PathBasedDataProviderFactory must implement 'create' method"
     end
 
@@ -258,6 +261,14 @@ module Puppet::Plugins::DataProviders
     # @api public
     def resolve_paths(datadir, declared_paths, paths, lookup_invocation)
       []
+    end
+
+    # Returns the data provider factory version.
+    #
+    # return [Integer] the version of this data provider factory
+    # @api public
+    def version
+      2
     end
   end
 

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/bad_data/lib/puppet/functions/bad_data/data.rb
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/bad_data/lib/puppet/functions/bad_data/data.rb
@@ -1,6 +1,7 @@
 Puppet::Functions.create_function(:'bad_data::data') do
   def data()
     { 'b' => 'module_b', # Intentionally bad key (no module prefix)
+      'bad_data::c' => 'module_c' # Good key. Should be OK
     }
   end
 end

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/bad_data/manifests/init.pp
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/bad_data/manifests/init.pp
@@ -1,3 +1,2 @@
 class bad_data {
-  $result = lookup(bad_data::b)
 }

--- a/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/data/first.json
+++ b/spec/fixtures/unit/functions/lookup/environments/production/modules/hieraprovider/data/first.json
@@ -1,3 +1,4 @@
 {
-    "hieraprovider::test::param_a": "module data param_a is 100"
+    "hieraprovider::test::param_a": "module data param_a is 100",
+    "test::param_b": "module data param_a is 100"
 }

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -345,11 +345,28 @@ describe "when performing lookup" do
   end
 
   context 'when accessing from outside a module' do
-    it 'will raise an exception when key in the function provided module data is not prefixed' do
-      Puppet[:code] = "include bad_data\nlookup(bad_data::b)"
-      expect do
-        compiler.compile()
-      end.to raise_error(Puppet::ParseError, /data for module 'bad_data' must use keys qualified with the name of the module/)
+    it 'will both log a warning and raise an exception when key in the function provided module data is not prefixed' do
+      logs = []
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        Puppet[:code] = "include bad_data\nlookup('bad_data::b')"
+        expect { compiler.compile }.to raise_error(Puppet::ParseError, /did not find a value for the name 'bad_data::b'/)
+      end
+      warnings = logs.select {|log| log.level == :warning }.map {|log| log.message }
+      expect(warnings).to include("Module data for module 'bad_data' must use keys qualified with the name of the module")
+    end
+
+    it 'will succeed finding prefixed keys even when a key in the function provided module data is not prefixed' do
+      logs = []
+      resources = nil
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        resources = compile_and_get_notifications(<<-END.gsub(/^ {10}/, ''))
+          include bad_data
+          notify { lookup('bad_data::c'): }
+        END
+        expect(resources).to include('module_c')
+      end
+      warnings = logs.select {|log| log.level == :warning }.map {|log| log.message }
+      expect(warnings).to include("Module data for module 'bad_data' must use keys qualified with the name of the module")
     end
 
     it 'will resolve global, environment, and module correctly' do
@@ -378,11 +395,14 @@ describe "when performing lookup" do
   end
 
   context 'when accessing bad data' do
-    it 'will raise an exception when key in the function provided module data is not prefixed' do
-      Puppet[:code] = 'include bad_data'
-      expect do
-        compiler.compile()
-      end.to raise_error(Puppet::ParseError, /data for module 'bad_data' must use keys qualified with the name of the module/)
+    it 'will log a warning when key in the function provided module data is not prefixed' do
+      Puppet[:code] = "include bad_data\nlookup('bad_data::c')"
+      logs = []
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        compiler.compile
+      end
+      warnings = logs.select {|log| log.level == :warning }.map {|log| log.message }
+      expect(warnings).to include("Module data for module 'bad_data' must use keys qualified with the name of the module")
     end
   end
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -404,6 +404,16 @@ describe "when performing lookup" do
       warnings = logs.select {|log| log.level == :warning }.map {|log| log.message }
       expect(warnings).to include("Module data for module 'bad_data' must use keys qualified with the name of the module")
     end
+
+    it 'will log a warning when key in the hiera provided module data is not prefixed' do
+      Puppet[:code] = "include bad_data\nlookup('hieraprovider::test::param_a')"
+      logs = []
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        compiler.compile
+      end
+      warnings = logs.select {|log| log.level == :warning }.map {|log| log.message }
+      expect(warnings).to include("Module data for module 'hieraprovider' must use keys qualified with the name of the module")
+    end
   end
 
 


### PR DESCRIPTION
This PR changes the behavior when validating the data of a module data provider so that:
- It is no longer considered an error if a key is unqualified. Instead a warning is logged.
- The validation works the same way for all types of module data providers (a design flaw prevented the Hiera module data provider from validating correctly).

Details can be found in the commit comments.