### PR TITLE
(PUP-5898) Backport fix for :undef to 3.x from 4x.

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -886,6 +886,8 @@ class Puppet::Pops::Types::TypeCalculator
     case o
     when :default
       Types::PDefaultType.new()
+    when :undef
+      Types::PUndefType.new()
     else
       infer_Object(o)
     end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -241,8 +241,8 @@ describe 'The type calculator' do
       calculator.infer(nil).class.should == Puppet::Pops::Types::PUndefType
     end
 
-    it ':undef translates to PRuntimeType' do
-      calculator.infer(:undef).class.should == Puppet::Pops::Types::PRuntimeType
+    it ':undef translates to PUndefType' do
+      calculator.infer(:undef).class.should == Puppet::Pops::Types::PUndefType
     end
 
     it 'an instance of class Foo translates to PRuntimeType[ruby, Foo]' do
@@ -1359,8 +1359,8 @@ describe 'The type calculator' do
       end
     end
 
-    it "should consider :undef to be instance of Runtime['ruby', 'Symbol]" do
-      calculator.instance?(Puppet::Pops::Types::PRuntimeType.new(:runtime => :ruby, :runtime_type_name => 'Symbol'), :undef).should == true
+    it "should consider :undef to be instance of Undef" do
+      calculator.instance?(Puppet::Pops::Types::PUndefType.new(), :undef).should == true
     end
 
     it "should consider :undef to be instance of an Optional type" do


### PR DESCRIPTION
This makes minimal changes to fix the :undef problem described in
PUP-5898 when using parser=future on 3.x.