### PR TITLE
(PUP-5118) Manage duplicate file resources

### DIFF
--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -529,19 +529,6 @@ describe Puppet::Type.type(:file) do
 
       expect(file.remove_less_specific_files([foo, bar, baz])).to eq([baz])
     end
-  end
-
-  describe "#remove_less_specific_files" do
-    it "should remove any nested files that are already in the catalog" do
-      foo = described_class.new :path => File.join(file[:path], 'foo')
-      bar = described_class.new :path => File.join(file[:path], 'bar')
-      baz = described_class.new :path => File.join(file[:path], 'baz')
-
-      catalog.add_resource(foo)
-      catalog.add_resource(bar)
-
-      expect(file.remove_less_specific_files([foo, bar, baz])).to eq([baz])
-    end
 
   end
 


### PR DESCRIPTION
Prior to this commit, the compiler could not handle duplicate file
resources when recursively in-lining metadata. This meant that a case
where a file is explicitly managed and also covered by its parent
directory which has recurse turned on would raise an error.

Now this case is handled by using remove_less_specific_files to
prune out duplicate resources. We will always keep the explicitly
managed version of the resource over the one generated by recursion.