### PR TITLE
(PUP-5815) Add strict_environment_mode option

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -207,8 +207,13 @@ class Puppet::Configurer
       if catalog = prepare_and_retrieve_catalog_from_cache
         options[:catalog] = catalog
         @cached_catalog_status = 'explicitly_requested'
-        @environment = catalog.environment
-        report.environment = catalog.environment
+
+        if @environment != catalog.environment
+          Puppet.notice "Local environment: '#{@environment}' doesn't match the environment of the cached catalog '#{catalog.environment}', switching agent to '#{catalog.environment}'."
+          @environment = catalog.environment
+        end
+
+        report.environment = @environment
       else
         # Don't try to retrieve a catalog from the cache again after we've already
         # failed to do so the first time.

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -153,6 +153,12 @@ module Puppet
       :type       => :boolean,
       :desc       => "Whether to compile a static catalog."
     },
+    :strict_environment_mode => {
+      :default    => false,
+      :type       => :boolean,
+      :desc       => "Whether the agent specified environment should be considered authoritative,
+        causing the run to fail if the retrieved catalog does not match it.",
+    },
     :autoflush => {
       :default => true,
       :type       => :boolean,


### PR DESCRIPTION
This commit adds a new Puppet option: `strict_environment_mode`.
This option ensures that the agent-specified environment is considered
authoritative, and fails the run if the environment of the retrieved
catalog does not match.