### PR TITLE
(PUP-5898) Make :undef be inferred as Undef (aka. bring back the undead)

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -614,6 +614,8 @@ class Puppet::Pops::Types::TypeCalculator
     case o
     when :default
       Types::PDefaultType::DEFAULT
+    when :undef
+      Types::PUndefType::DEFAULT
     else
       infer_Object(o)
     end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -238,8 +238,8 @@ describe 'The type calculator' do
       expect(calculator.infer(nil).class).to eq(Puppet::Pops::Types::PUndefType)
     end
 
-    it ':undef translates to PRuntimeType' do
-      expect(calculator.infer(:undef).class).to eq(Puppet::Pops::Types::PRuntimeType)
+    it ':undef translates to PUndefType' do
+      expect(calculator.infer(:undef).class).to eq(Puppet::Pops::Types::PUndefType)
     end
 
     it 'an instance of class Foo translates to PRuntimeType[ruby, Foo]' do
@@ -1340,8 +1340,16 @@ describe 'The type calculator' do
       end
     end
 
-    it "should consider :undef to be instance of Runtime['ruby', 'Symbol]" do
-      expect(calculator.instance?(Puppet::Pops::Types::PRuntimeType.new(:ruby, 'Symbol'), :undef)).to eq(true)
+    it "should infer :undef to be Undef" do
+      expect(calculator.infer(:undef)).to be_assignable_to(undef_t)
+    end
+
+    it "should not consider :default to be instance of Runtime['ruby', 'Symbol]" do
+      expect(calculator.instance?(Puppet::Pops::Types::PRuntimeType.new(:ruby, 'Symbol'), :default)).to eq(false)
+    end
+
+    it "should not consider :undef to be instance of Runtime['ruby', 'Symbol]" do
+      expect(calculator.instance?(Puppet::Pops::Types::PRuntimeType.new(:ruby, 'Symbol'), :undef)).to eq(false)
     end
 
     it 'should consider :undef to be instance of an Optional type' do


### PR DESCRIPTION
Before this, if :undef was found in data coming from 3.x API into 4.x it
was inferred as Runtime[ruby, 'Symbol'] causing type mismatches to
occur.

This is now changed so that it is inferrd to be an Undef.

Unfortunately we had to revert the change that made :undef be treated as
an alien Ruby Symbol. It was intended to catch :undef leaking, but all
we achived was to catch ourselves in the act - and it is difficult to do
anything about this as some resurces do need 3.x call semantics and
others don't. It is not known a priori which ones.