### PR TITLE
(PUP-5735) Remove requirement of Win32-Security gem from Puppet

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -35,6 +35,7 @@ gem_platform_dependencies:
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.2'
       win32-process: '~> 0.7.4'
+      # Use of win32-security is deprecated
       win32-security: '~> 0.2.5'
       win32-service: '~> 0.8.6'
       minitar: '~> 0.5.4'
@@ -44,6 +45,7 @@ gem_platform_dependencies:
       win32-dir: '~> 0.4.9'
       win32-eventlog: '~> 0.6.2'
       win32-process: '~> 0.7.4'
+      # Use of win32-security is deprecated
       win32-security: '~> 0.2.5'
       win32-service: '~> 0.8.6'
       minitar: '~> 0.5.4'

--- a/lib/puppet/util/windows/access_control_list.rb
+++ b/lib/puppet/util/windows/access_control_list.rb
@@ -76,7 +76,7 @@ class Puppet::Util::Windows::AccessControlList
         else
           new_ace.sid = new_sid
 
-          prepend_needed = old_sid == Win32::Security::SID::LocalSystem
+          prepend_needed = old_sid == Puppet::Util::Windows::SID::LocalSystem
         end
       end
       new_aces << new_ace
@@ -87,7 +87,7 @@ class Puppet::Util::Windows::AccessControlList
     if prepend_needed
       mask = Puppet::Util::Windows::File::STANDARD_RIGHTS_ALL | Puppet::Util::Windows::File::SPECIFIC_RIGHTS_ALL
       ace = Puppet::Util::Windows::AccessControlEntry.new(
-              Win32::Security::SID::LocalSystem,
+              Puppet::Util::Windows::SID::LocalSystem,
               mask)
       @aces << ace
     end

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -65,8 +65,6 @@ require 'puppet/util/windows'
 require 'pathname'
 require 'ffi'
 
-require 'win32/security'
-
 module Puppet::Util::Windows::Security
   include Puppet::Util::Windows::String
 
@@ -199,9 +197,9 @@ module Puppet::Util::Windows::Security
   def get_mode(path)
     return unless supports_acl?(path)
 
-    well_known_world_sid = Win32::Security::SID::Everyone
-    well_known_nobody_sid = Win32::Security::SID::Nobody
-    well_known_system_sid = Win32::Security::SID::LocalSystem
+    well_known_world_sid = Puppet::Util::Windows::SID::Everyone
+    well_known_nobody_sid = Puppet::Util::Windows::SID::Nobody
+    well_known_system_sid = Puppet::Util::Windows::SID::LocalSystem
 
     mode = S_ISYSTEM_MISSING
 
@@ -278,9 +276,9 @@ module Puppet::Util::Windows::Security
   # that they do not have read and write access to.
   def set_mode(mode, path, protected = true)
     sd = get_security_descriptor(path)
-    well_known_world_sid = Win32::Security::SID::Everyone
-    well_known_nobody_sid = Win32::Security::SID::Nobody
-    well_known_system_sid = Win32::Security::SID::LocalSystem
+    well_known_world_sid = Puppet::Util::Windows::SID::Everyone
+    well_known_nobody_sid = Puppet::Util::Windows::SID::Nobody
+    well_known_system_sid = Puppet::Util::Windows::SID::LocalSystem
 
     owner_allow = FILE::STANDARD_RIGHTS_ALL  |
       FILE::FILE_READ_ATTRIBUTES |
@@ -361,12 +359,12 @@ module Puppet::Util::Windows::Security
     inherit_only = Puppet::Util::Windows::AccessControlEntry::INHERIT_ONLY_ACE
     if isdir
       inherit = inherit_only | Puppet::Util::Windows::AccessControlEntry::CONTAINER_INHERIT_ACE
-      dacl.allow(Win32::Security::SID::CreatorOwner, owner_allow, inherit)
-      dacl.allow(Win32::Security::SID::CreatorGroup, group_allow, inherit)
+      dacl.allow(Puppet::Util::Windows::SID::CreatorOwner, owner_allow, inherit)
+      dacl.allow(Puppet::Util::Windows::SID::CreatorGroup, group_allow, inherit)
 
       inherit = inherit_only | Puppet::Util::Windows::AccessControlEntry::OBJECT_INHERIT_ACE
-      dacl.allow(Win32::Security::SID::CreatorOwner, owner_allow & ~FILE::FILE_EXECUTE, inherit)
-      dacl.allow(Win32::Security::SID::CreatorGroup, group_allow & ~FILE::FILE_EXECUTE, inherit)
+      dacl.allow(Puppet::Util::Windows::SID::CreatorOwner, owner_allow & ~FILE::FILE_EXECUTE, inherit)
+      dacl.allow(Puppet::Util::Windows::SID::CreatorGroup, group_allow & ~FILE::FILE_EXECUTE, inherit)
     end
 
     new_sd = Puppet::Util::Windows::SecurityDescriptor.new(sd.owner, sd.group, dacl, protected)

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -9,6 +9,44 @@ module Puppet::Util::Windows
     ERROR_NONE_MAPPED           = 1332
     ERROR_INVALID_SID_STRUCTURE = 1337
 
+    # Well Known SIDs
+    Null                        = 'S-1-0'
+    Nobody                      = 'S-1-0-0'
+    World                       = 'S-1-1'
+    Everyone                    = 'S-1-1-0'
+    Local                       = 'S-1-2'
+    Creator                     = 'S-1-3'
+    CreatorOwner                = 'S-1-3-0'
+    CreatorGroup                = 'S-1-3-1'
+    CreatorOwnerServer          = 'S-1-3-2'
+    CreatorGroupServer          = 'S-1-3-3'
+    NonUnique                   = 'S-1-4'
+    Nt                          = 'S-1-5'
+    Dialup                      = 'S-1-5-1'
+    Network                     = 'S-1-5-2'
+    Batch                       = 'S-1-5-3'
+    Interactive                 = 'S-1-5-4'
+    Service                     = 'S-1-5-6'
+    Anonymous                   = 'S-1-5-7'
+    Proxy                       = 'S-1-5-8'
+    EnterpriseDomainControllers = 'S-1-5-9'
+    PrincipalSelf               = 'S-1-5-10'
+    AuthenticatedUsers          = 'S-1-5-11'
+    RestrictedCode              = 'S-1-5-12'
+    TerminalServerUsers         = 'S-1-5-13'
+    LocalSystem                 = 'S-1-5-18'
+    NtLocal                     = 'S-1-5-19'
+    NtNetwork                   = 'S-1-5-20'
+    BuiltinAdministrators       = 'S-1-5-32-544'
+    BuiltinUsers                = 'S-1-5-32-545'
+    Guests                      = 'S-1-5-32-546'
+    PowerUsers                  = 'S-1-5-32-547'
+    AccountOperators            = 'S-1-5-32-548'
+    ServerOperators             = 'S-1-5-32-549'
+    PrintOperators              = 'S-1-5-32-550'
+    BackupOperators             = 'S-1-5-32-551'
+    Replicators                 = 'S-1-5-32-552'
+
     # Convert an account name, e.g. 'Administrators' into a SID string,
     # e.g. 'S-1-5-32-544'. The name can be specified as 'Administrators',
     # 'BUILTIN\Administrators', or 'S-1-5-32-544', and will return the

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1394,11 +1394,11 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
         before do
           @sids = {
             :current_user => Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name),
-            :system => Win32::Security::SID::LocalSystem,
+            :system => Puppet::Util::Windows::SID::LocalSystem,
             :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
-            :users => Win32::Security::SID::BuiltinUsers,
-            :power_users => Win32::Security::SID::PowerUsers,
-            :none => Win32::Security::SID::Nobody
+            :users => Puppet::Util::Windows::SID::BuiltinUsers,
+            :power_users => Puppet::Util::Windows::SID::PowerUsers,
+            :none => Puppet::Util::Windows::SID::Nobody
           }
         end
 

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -14,13 +14,13 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
   before :all do
     @sids = {
       :current_user => Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name),
-      :system => Win32::Security::SID::LocalSystem,
-      :administrators => Win32::Security::SID::BuiltinAdministrators,
+      :system => Puppet::Util::Windows::SID::LocalSystem,
+      :administrators => Puppet::Util::Windows::SID::BuiltinAdministrators,
       :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
-      :users => Win32::Security::SID::BuiltinUsers,
-      :power_users => Win32::Security::SID::PowerUsers,
-      :none => Win32::Security::SID::Nobody,
-      :everyone => Win32::Security::SID::Everyone
+      :users => Puppet::Util::Windows::SID::BuiltinUsers,
+      :power_users => Puppet::Util::Windows::SID::PowerUsers,
+      :none => Puppet::Util::Windows::SID::Nobody,
+      :everyone => Puppet::Util::Windows::SID::Everyone
     }
     # The TCP/IP NetBIOS Helper service (aka 'lmhosts') has ended up
     # disabled on some VMs for reasons we couldn't track down. This

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -108,14 +108,14 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
     end
 
     it "should be able to confirm the existence of a user with a well-known SID" do
-      system_user = Win32::Security::SID::LocalSystem
+      system_user = Puppet::Util::Windows::SID::LocalSystem
       # ensure that the underlying OS is queried here
       Puppet::Util::Windows::ADSI.unstub(:connect)
       expect(Puppet::Util::Windows::ADSI::User.exists?(system_user)).to be_truthy
     end
 
     it "should return false with a well-known Group SID" do
-      group = Win32::Security::SID::BuiltinAdministrators
+      group = Puppet::Util::Windows::SID::BuiltinAdministrators
       # ensure that the underlying OS is queried here
       Puppet::Util::Windows::ADSI.unstub(:connect)
       expect(Puppet::Util::Windows::ADSI::User.exists?(group)).to be_falsey
@@ -446,14 +446,14 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
 
     it "should be able to confirm the existence of a group with a well-known SID" do
 
-      service_group = Win32::Security::SID::Service
+      service_group = Puppet::Util::Windows::SID::Service
       # ensure that the underlying OS is queried here
       Puppet::Util::Windows::ADSI.unstub(:connect)
       expect(Puppet::Util::Windows::ADSI::Group.exists?(service_group)).to be_truthy
     end
 
     it "will return true with a well-known User SID, as there is no way to resolve it with a WinNT:// style moniker" do
-      user = Win32::Security::SID::NtLocal
+      user = Puppet::Util::Windows::SID::NtLocal
       # ensure that the underlying OS is queried here
       Puppet::Util::Windows::ADSI.unstub(:connect)
       expect(Puppet::Util::Windows::ADSI::Group.exists?(user)).to be_truthy

--- a/spec/unit/util/windows/security_descriptor_spec.rb
+++ b/spec/unit/util/windows/security_descriptor_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 require 'puppet/util/windows'
 
 describe "Puppet::Util::Windows::SecurityDescriptor", :if => Puppet.features.microsoft_windows? do
-  let(:system_sid) { Win32::Security::SID::LocalSystem }
-  let(:admins_sid) { Win32::Security::SID::BuiltinAdministrators }
-  let(:group_sid) { Win32::Security::SID::Nobody }
+  let(:system_sid) { Puppet::Util::Windows::SID::LocalSystem }
+  let(:admins_sid) { Puppet::Util::Windows::SID::BuiltinAdministrators }
+  let(:group_sid) { Puppet::Util::Windows::SID::Nobody }
   let(:new_sid)   { 'S-1-5-32-500-1-2-3' }
 
   def empty_dacl

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -7,7 +7,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
   end
 
   let(:subject)      { Puppet::Util::Windows::SID }
-  let(:sid)          { Win32::Security::SID::LocalSystem }
+  let(:sid)          { Puppet::Util::Windows::SID::LocalSystem }
   let(:invalid_sid)  { 'bogus' }
   let(:unknown_sid)  { 'S-0-0-0' }
   let(:unknown_name) { 'chewbacca' }


### PR DESCRIPTION
The functionality of the Win32-Security gem has been merged into Puppet.
This commit moves the last of enumerations and updates the test suites to
use the newer namespace of Puppet::Util::Windows:SID.  This commit removes
Puppet's requirement of the win32-security gem, however the gem itself
still exists in the ruby gem library.  It will be removed from the library
in later commits.