### PR TITLE
(PUP-4929) Quote GEM_SOURCE path in puppet manifest

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -83,7 +83,7 @@ end
 
 verify_absent agents, 'guid'
 
-gem_source = if ENV['GEM_SOURCE'] then "source => #{ENV['GEM_SOURCE']}," else '' end
+gem_source = if ENV['GEM_SOURCE'] then "source => '#{ENV['GEM_SOURCE']}'," else '' end
 collide2_manifest = <<MANIFEST
   package {'guid': ensure => '0.1.0', provider => #{gem_provider}, #{gem_source}}
   package {'other-guid': name => 'guid', ensure => installed, provider => #{gem_provider}, #{gem_source}}


### PR DESCRIPTION
When using GEM_SOURCE, the initial acceptance change fails because the
URL is unquoted. Quote it.