### PR TITLE
(PUP-5815) Handle cached catalogs with strict environment mode setting

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -208,7 +208,7 @@ class Puppet::Configurer
         options[:catalog] = catalog
         @cached_catalog_status = 'explicitly_requested'
 
-        if @environment != catalog.environment
+        if @environment != catalog.environment && !Puppet[:strict_environment_mode]
           Puppet.notice "Local environment: '#{@environment}' doesn't match the environment of the cached catalog '#{catalog.environment}', switching agent to '#{catalog.environment}'."
           @environment = catalog.environment
         end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -705,6 +705,28 @@ describe Puppet::Configurer do
 
         expect(@agent.run).to eq(0)
       end
+
+      describe "and a cached catalog is explicitly requested" do
+        before do
+          Puppet.settings[:use_cached_catalog] = true
+        end
+
+        it "should return nil when the cached catalog's environment doesn't match the agent specified environment" do
+          @agent.instance_variable_set(:@environment, 'second_env')
+          expects_cached_catalog_only(@catalog)
+
+          Puppet.expects(:err).with("Not using catalog because its environment 'production' does not match agent specified environment 'second_env' and strict_environment_mode is set")
+          expect(@agent.run).to be_nil
+        end
+
+        it "should proceed with the cached catalog if its environment matchs the local environment" do
+          Puppet.settings[:use_cached_catalog] = true
+          @agent.instance_variable_set(:@environment, 'production')
+          expects_cached_catalog_only(@catalog)
+
+          expect(@agent.run).to eq(0)
+        end
+      end
     end
 
     it "should use the Catalog class to get its catalog" do


### PR DESCRIPTION
This commit ensures that if a cached catalog is explicitly requested
and strict environment mode is also requested, we do *not* switch the
local environment to match the cached catalog, as we do in all other
cases. This will cause the run to fail if the cached catalog's
environment does not match the agent specified environment.