### PR TITLE
(PUP-5923) Fix Admin Token detection on legacy Windows OS

### DIFF
--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -43,7 +43,7 @@ module Puppet::Util::Windows::User
         end
 
         # Is administrators SID enabled in calling thread's access token?
-        is_admin = ismember_pointer.read_win32_bool != FFI::WIN32_FALSE
+        is_admin = ismember_pointer.read_win32_bool
       end
     end
 


### PR DESCRIPTION
Without this commit, the detection of administrative rights on legacy
Windows operating systems (2003/XP) is incorrect.  The helper function
read_win32_bool returns a boolean type however it is compared against
an integer which causes the detection to always succeed.  This commit
uses the helper function return value directly.