### PR TITLE
(PUP-5922) Add feature flag to disable inlining recursive directories

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -153,6 +153,13 @@ module Puppet
       :type       => :boolean,
       :desc       => "Whether to compile a static catalog."
     },
+    :static_catalogs_recursion => {
+      :default    => false,
+      :type       => :boolean,
+      :internal   => true,
+      :desc       => "Whether to inline metadata for recursive directory resources
+        for static catalogs."
+    },
     :strict_environment_mode => {
       :default    => false,
       :type       => :boolean,

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -157,6 +157,9 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       file = resource.to_ral
 
       if file.recurse?
+        # Skip recurse resources if the static_catalogs_recursion feature is disabled
+        next unless Puppet[:static_catalogs_recursion]
+
         child_resources = file.recurse_remote_metadata.map do |meta|
           # Don't create a new resource for the parent directory
           next if meta.relative_path == "."

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -1,6 +1,9 @@
 config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc => "A reference for all settings") do
   docs = {}
   Puppet.settings.each do |name, object|
+    # Skip documenting internal settings
+    next if object[:internal]
+
     docs[name] = object
   end
 

--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -2,7 +2,7 @@ require 'puppet/settings/errors'
 
 # The base setting type
 class Puppet::Settings::BaseSetting
-  attr_accessor :name, :desc, :section, :default, :call_hook
+  attr_accessor :name, :desc, :section, :default, :call_hook, :internal
   attr_reader :short, :deprecated
 
   def self.available_call_hook_values


### PR DESCRIPTION
Handling recursive directories is fraught with issues, and unsure we can
resolve them all by release. Add a feature flag to disable inlining
metadata for recursive directories.