### PR TITLE
(PUP-5936) Add test to verify that given undef removes need for default

### DIFF
--- a/spec/integration/parser/undef_param_spec.rb
+++ b/spec/integration/parser/undef_param_spec.rb
@@ -84,4 +84,12 @@ describe "Parameter passing" do
     MANIFEST
     end
   end
+
+  it "uses a given undef and do not require a default expression" do
+    expect_the_message_to_be(true) do <<-MANIFEST
+        define a(Optional[Integer] $x) { notify { 'something': message => $x == undef}}
+        a {'a': x => undef }
+    MANIFEST
+    end
+  end
 end


### PR DESCRIPTION
This commit adds an integration test that asserts that a given undef
parameter will be used when no parameter default expression exists
for resource declared with a `define` declaration.