### PR TITLE
(PUP-5937) Detect duplicate keys in hashes

### DIFF
--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -77,6 +77,7 @@ module Puppet
     end
 
     module Evaluator
+      require 'puppet/pops/evaluator/literal_evaluator'
       require 'puppet/pops/evaluator/callable_signature'
       require 'puppet/pops/evaluator/runtime3_converter'
       require 'puppet/pops/evaluator/runtime3_support'

--- a/lib/puppet/pops/evaluator/literal_evaluator.rb
+++ b/lib/puppet/pops/evaluator/literal_evaluator.rb
@@ -1,5 +1,5 @@
-require 'rgen/ecore/ecore'
-
+module Puppet::Pops
+module Evaluator
 # Literal values for
 # String (not containing interpolation)
 # Numbers
@@ -14,14 +14,13 @@ require 'rgen/ecore/ecore'
 # Not considered literal
 # QualifiedReference  # i.e. File, FooBar
 #
-class Puppet::Pops::Evaluator::LiteralEvaluator
-  #include Puppet::Pops::Utils
+class LiteralEvaluator
 
   EMPTY_STRING = ''.freeze
   COMMA_SEPARATOR = ', '.freeze
 
   def initialize
-    @@literal_visitor ||= Puppet::Pops::Visitor.new(self, "literal", 0, 0)
+    @@literal_visitor ||= Visitor.new(self, "literal", 0, 0)
   end
 
   def literal(ast)
@@ -70,7 +69,7 @@ class Puppet::Pops::Evaluator::LiteralEvaluator
 
   def literal_ConcatenatedString(o)
     # use double quoted string value if there is no interpolation
-    throw :not_literal unless o.segments.size == 1 && o.segments[0].is_a?(Puppet::Pops::Model::LiteralString)
+    throw :not_literal unless o.segments.size == 1 && o.segments[0].is_a?(Model::LiteralString)
     o.segments[0].value
   end
 
@@ -84,4 +83,6 @@ class Puppet::Pops::Evaluator::LiteralEvaluator
       result
     end
   end
+end
+end
 end

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -594,6 +594,10 @@ module Issues
     "The parameter '#{param_name}' is declared more than once in the parameter list"
   end
 
+  DUPLICATE_KEY = issue :DUPLICATE_KEY, :key do
+    "The key '#{key}' is declared more than once"
+  end
+
   RESERVED_PARAMETER = hard_issue :RESERVED_PARAMETER, :container, :param_name do
     "The parameter $#{param_name} redefines a built in parameter in #{label.the(container)}"
   end

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -27,6 +27,7 @@ class ValidatorFactory_4_0 < Factory
 
     p[Issues::FUTURE_RESERVED_WORD]          = :deprecation
 
+    p[Issues::DUPLICATE_KEY]                 = :warning
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
     p

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -34,6 +34,13 @@ describe "validating 4x" do
     expect(validate(fqn('::_aa').var())).to_not have_issue(Puppet::Pops::Issues::ILLEGAL_VAR_NAME)
   end
 
+  it 'produces a warning for duplicate keyes in a literal hash' do
+    acceptor = validate(parse('{ a => 1, a => 2 }'))
+    expect(acceptor.warning_count).to eql(1)
+    expect(acceptor.error_count).to eql(0)
+    expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+  end
+
   context 'for non productive expressions' do
     [ '1',
       '3.14',


### PR DESCRIPTION
Before this commit, duplicate keys in hashes would go undetected
This commit changes this so that a duplicate key results in a warning:

"The key 'the_key' is declared more than once"