### PR TITLE
(PUP-5844) Add Object type to the Puppet Type system

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -932,6 +932,14 @@ class TypeCalculator
     'Struct[{' << t.elements.map {|element| string(element) }.join(', ') << '}]'
   end
 
+  # @api private
+  def string_PObjectType(t)
+    preamble = t.parent.nil? ? 'Object[{' : "Object[#{string(t.parent)},{"
+    elements_string = t.members.elements.map {|element| string(element) }.join(', ')
+    "#{preamble}#{elements_string}}]"
+  end
+
+  # @api private
   def string_PStructElement(t)
     k = t.key_type
     value_optional = t.value_type.assignable?(PUndefType::DEFAULT)

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -110,7 +110,7 @@ module TypeFactory
   # The value can be a ruby class, a String (interpreted as the name of a ruby class) or
   # a Type.
   #
-  # @param hash [Hash<Object, Object>] key => value hash
+  # @param hash [{String,PAnyType=>PAnyType}] key => value hash
   # @return [PStructType] the created Struct type
   #
   def self.struct(hash = {})
@@ -146,6 +146,18 @@ module TypeFactory
       PStructElement.new(key_type, value_type)
     end
     PStructType.new(elements)
+  end
+
+  # Produces an `Object` type with from the given inherited _parent_ and a _hash_ that represent the members
+  # of this type. The hash follows the same semantics as the hash used when creating a struct but all keys
+  # in the hash must be non-empty strings.
+  #
+  # @param parent [PAnyType] The type that the new type inherits from
+  # @param hash [{String=>PAnyType}] the members hash
+  # @return [PObjectType] the created type
+  #
+  def self.object(parent = nil, hash = {})
+    PObjectType.new(parent, struct(hash))
   end
 
   def self.tuple(types = [], size_type = nil)

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -202,6 +202,9 @@ class TypeParser
     when 'struct'
       TypeFactory.struct
 
+    when 'object'
+      TypeFactory.object
+
     when 'callable'
       # A generic callable as opposed to one that does not accept arguments
       TypeFactory.all_callables
@@ -364,6 +367,29 @@ class TypeParser
       raise_invalid_type_specification_error unless h.is_a?(Hash)
       TypeFactory.struct(h)
 
+    when 'object'
+      # 0..2 parameters. An optional parent and a literal hash describing the members
+      case parameters.size
+      when 0
+        TypeFactory.object
+      when 1
+        p = parameters[0]
+        case p
+        when Hash
+          TypeFactory.object(nil, p)
+        when PAnyType
+          TypeFactory.object(p)
+        else
+          raise_invalid_type_specification_error
+        end
+      when 2
+        p = parameters[0]
+        h = parameters[1]
+        raise_invalid_type_specification_error unless p.is_a?(PAnyType) && h.is_a?(Hash)
+        TypeFactory.object(p, h)
+      else
+        raise_invalid_parameters_error('Object', '0 to 2', parameters.size)
+      end
     when 'integer'
       if parameters.size == 1
         case parameters[0]

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2080,13 +2080,16 @@ class PObjectType < PAnyType
   #
   # @api public
   def initialize(parent, members)
-    raise Puppet::Error, "An Object can only inherit from a Type"  unless parent.nil? || parent.is_a?(PAnyType)
+    raise Puppet::Error, 'An Object can only inherit from a Type' unless parent.nil? || parent.is_a?(PAnyType)
     @parent = parent
 
     if members.nil?
       members = PStructType::DEFAULT if members.nil?
     else
-      raise Puppet::Error, "The members of an Object must be represented by a Struct" unless members.is_a?(PStructType)
+      unless members.is_a?(PStructType)
+        raise Puppet::Error, 'The members (e.g. attributes or functions) of an Object must be represented by a Struct'
+      end
+
       # Assert that each key pair is valid
       rp = resolved_parent
       parent_hash = rp.is_a?(PObjectType) ? rp.members(true).hashed_elements : {}
@@ -2095,9 +2098,9 @@ class PObjectType < PAnyType
         parent_member = parent_hash[name]
         unless parent_member.nil? || parent_member.value_type.assignable?(e.value_type)
           raise Puppet::Error,
-            "Member '#{name}' redefines member of inherited object to type that does not match"
+            "The member (e.g. attribute or function) '#{name}' redefines inherited member to a type that does not match"
         end
-        TypeAsserter.assert_assignable('Member key', MEMBER_NAME_TYPE, e.key_type)
+        TypeAsserter.assert_assignable('Member (e.g. attribute or function) key', MEMBER_NAME_TYPE, e.key_type)
       end
     end
     @members = members

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -114,6 +114,14 @@ class PAnyType < TypedModelObject
     false
   end
 
+  # Called from the `PTypeAliasType` when it detects self recursion. The default is to do nothing
+  # but some self recursive constructs are illegal such as when a `PObjectType` somehow inherits itself
+  # @param originator [PTypeAliasType] the starting point for the check
+  # @raise Puppet::Error if an illegal self recursion is detected
+  # @api private
+  def check_self_recursion(originator)
+  end
+
   # Generalizes value specific types. Types that are not value specific will return `self` otherwise
   # the generalized type is returned.
   #
@@ -1968,6 +1976,10 @@ class PTypeAliasType < PAnyType
     guarded_recursion(guard, false) { |g| resolved_type.callable_args?(callable, g) }
   end
 
+  def check_self_recursion(originator)
+    resolved_type.check_self_recursion(originator) unless originator.equal?(self)
+  end
+
   def kind_of_callable?(optional=true, guard = nil)
     guarded_recursion(guard, false) { |g| resolved_type.kind_of_callable?(optional, g) }
   end
@@ -2009,6 +2021,7 @@ class PTypeAliasType < PAnyType
         guard = RecursionGuard.new
         accept(NoopTypeAcceptor::INSTANCE, guard)
         @self_recursion = guard.recursive_this?(self)
+        @resolved_type.check_self_recursion(self) if @self_recursion
       rescue
         @resolved_type = nil
         raise
@@ -2057,6 +2070,135 @@ class PTypeAliasType < PAnyType
   end
 
   DEFAULT = PTypeAliasType.new('UnresolvedAlias', nil, PTypeReferenceType::DEFAULT)
+end
+
+class PObjectType < PAnyType
+  attr_reader :parent, :members
+
+  # @param parent [String,nil] The name of the parent type
+  # @param members [PStructType,nil] The struct expression that describes the members of this type
+  #
+  # @api public
+  def initialize(parent, members)
+    raise Puppet::Error, "An Object can only inherit from a Type"  unless parent.nil? || parent.is_a?(PAnyType)
+    @parent = parent
+
+    if members.nil?
+      members = PStructType::DEFAULT if members.nil?
+    else
+      raise Puppet::Error, "The members of an Object must be represented by a Struct" unless members.is_a?(PStructType)
+      # Assert that each key pair is valid
+      rp = resolved_parent
+      parent_hash = rp.is_a?(PObjectType) ? rp.members(true).hashed_elements : {}
+      members.each do |e|
+        name = e.name
+        parent_member = parent_hash[name]
+        unless parent_member.nil? || parent_member.value_type.assignable?(e.value_type)
+          raise Puppet::Error,
+            "Member '#{name}' redefines member of inherited object to type that does not match"
+        end
+        TypeAsserter.assert_assignable('Member key', MEMBER_NAME_TYPE, e.key_type)
+      end
+    end
+    @members = members
+  end
+
+  def accept(visitor, guard)
+    super
+    @parent.accept(visitor, guard) unless parent.nil?
+    @members.accept(visitor, guard)
+  end
+
+  def callable_args?(callable, guard)
+    @parent.nil? ? false : @parent.callable_args?(optional, guard)
+  end
+
+  def ==(o)
+    self.class == o.class && @parent == o.parent && @members == o.members
+  end
+
+  def hash
+    @parent.hash * 17 + @members.hash
+  end
+
+  def kind_of_callable?(optional=true, guard = nil)
+    @parent.nil? ? false : @parent.kind_of_callable(optional, guard)
+  end
+
+  def instance?(o)
+    assignable(TypeCalculator.infer(o))
+  end
+
+  def iterable?(guard = nil)
+    @parent.nil? ? false : @parent.iterable?(optional, guard)
+  end
+
+  def iterable_type(guard = nil)
+    @parent.nil? ? false : @parent.iterable_type(guard)
+  end
+
+  # Returns the members of this `Object` type. If _include_parent_members_ is `true`, then all
+  # inherited members will be included in the returned `Struct`.
+  #
+  # @param include_parent_members [Boolean] `true` if inherited members should be included
+  # @return [PStructType] the Struct that represents the members
+  # @api public
+  def members(include_parent_members = false)
+    if include_parent_members && !@parent.nil?
+      all = {}
+      collect_members(all)
+      PStructType.new(all.values)
+    else
+      @members
+    end
+  end
+
+  MEMBER_NAME_TYPE = PPatternType.new([PRegexpType.new(Patterns::PARAM_NAME)])
+  DEFAULT = PObjectType.new(nil, nil)
+
+  # @api private
+  def collect_members(collector)
+    parent = resolved_parent
+    parent.collect_members(collector) if parent.is_a?(PObjectType)
+    collector.merge!(@members.hashed_elements)
+    nil
+  end
+
+  # Assert that this type does not inherit from itself
+  # @api private
+  def check_self_recursion(originator)
+    unless @parent.nil?
+      raise Puppet::Error, "The Object type aliased by '#{originator}' inherits from itself" if @parent.equal?(originator)
+      @parent.check_self_recursion(originator)
+    end
+  end
+
+  protected
+
+  # An Object type is only assignable from another Object type. The other type
+  # or one of its parents must be equal to this type.
+  def _assignable?(o, guard)
+    if self == o
+      true
+    else
+      if o.is_a?(PObjectType)
+        op = o.parent
+        op.nil? ? false : assignable?(op, guard)
+      else
+        false
+      end
+    end
+  end
+
+  private
+
+  def resolved_parent
+    parent = @parent
+    while(parent.is_a?(PTypeAliasType))
+      parent = parent.resolved_type
+    end
+    parent
+  end
 end
 end
 end

--- a/spec/unit/pops/types/object_type_spec.rb
+++ b/spec/unit/pops/types/object_type_spec.rb
@@ -54,11 +54,13 @@ describe 'The Object Type' do
         expect{ |b| tp.members.each {|m| m.name.tap(&b) }}.to yield_successive_args('c', 'd')
         expect{ |b| tp.members.each {|m| m.value_type.simple_name.tap(&b) }}.to yield_successive_args('String', 'Boolean')
         expect{ |b| tp.members(true).each {|m| m.name.tap(&b) }}.to yield_successive_args('a', 'b', 'c', 'd')
-        expect{ |b| tp.members(true).each {|m| m.value_type.simple_name.tap(&b) }}.to yield_successive_args('Integer', 'Callable', 'String', 'Boolean')
+        expect{ |b| tp.members(true).each {|m| m.value_type.simple_name.tap(&b) }}.to(
+          yield_successive_args('Integer', 'Callable', 'String', 'Boolean'))
       end
 
       it 'can redefine inherited member to assignable type' do
-        loader.expects(:load).with(:type, 'myderivedobject').returns type_object_t('MyDerivedObject', 'MyObject', '{ a=> Integer[0,default], d => Boolean }')
+        loader.expects(:load).with(:type, 'myderivedobject').returns(
+          type_object_t('MyDerivedObject', 'MyObject', '{ a=> Integer[0,default], d => Boolean }'))
         tp = parser.parse('MyDerivedObject', scope)
         expect(tp).to eql(derived)
         tp = tp.resolved_type
@@ -66,12 +68,14 @@ describe 'The Object Type' do
         expect{ |b| tp.members.each {|m| m.name.tap(&b) }}.to yield_successive_args('a', 'd')
         expect{ |b| tp.members.each {|m| m.value_type.to_s.tap(&b) }}.to yield_successive_args('Integer[0, default]', 'Boolean')
         expect{ |b| tp.members(true).each {|m| m.name.tap(&b) }}.to yield_successive_args('a', 'b', 'd')
-        expect{ |b| tp.members(true).each {|m| m.value_type.to_s.tap(&b) }}.to yield_successive_args('Integer[0, default]', 'Callable', 'Boolean')
+        expect{ |b| tp.members(true).each {|m| m.value_type.to_s.tap(&b) }}.to(
+          yield_successive_args('Integer[0, default]', 'Callable', 'Boolean'))
       end
 
       it 'can not redefine inherited member to a unassignable type' do
-        loader.expects(:load).with(:type, 'myderivedobject').returns type_object_t('MyDerivedObject', 'MyObject', '{ a=> String, d => Boolean }')
-        expect { parser.parse('MyDerivedObject', scope) }.to raise_error(Puppet::Error, "Member 'a' redefines member of inherited object to type that does not match")
+        loader.expects(:load).with(:type, 'myderivedobject').returns(
+          type_object_t('MyDerivedObject', 'MyObject', '{ a=> String, d => Boolean }'))
+        expect { parser.parse('MyDerivedObject', scope) }.to raise_error(Puppet::Error, /redefines inherited member/)
       end
 
       it 'will be assignable to its inherited type' do

--- a/spec/unit/pops/types/object_type_spec.rb
+++ b/spec/unit/pops/types/object_type_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+require 'puppet/pops'
+
+module Puppet::Pops
+module Types
+describe 'The Object Type' do
+
+  context 'when parsed by the EvaluatingParser' do
+    let(:parser) { TypeParser.new }
+    let(:pp_parser) { Puppet::Pops::Parser::EvaluatingParser.new }
+    let(:scope) { Object.new }
+    let(:loader) { Object.new }
+
+    before(:each) do
+      Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Model::QualifiedReference), scope).
+        at_least_once.returns loader
+    end
+
+    let(:object) { type_object_t('MyObject', nil, '{ a => Integer, b => Callable }') }
+
+    def type_object_t(name, inherits, body_string)
+      preamble = inherits.nil? ? '[' : "[#{inherits},"
+      TypeFactory.type_alias(name, pp_parser.parse_string("Object#{preamble}#{body_string}]").current)
+    end
+
+    before(:each) do
+      loader.expects(:load).with(:type, 'myobject').at_least_once.returns object
+    end
+
+    it 'can be loaded by the TypeParser' do
+      tp = parser.parse('MyObject', scope)
+      expect(tp).to eql(object)
+    end
+
+    it 'have members with expected name and type' do
+      tp = parser.parse('MyObject', scope).resolved_type
+      expect(tp.members).to be_a(PStructType)
+      expect{ |b| tp.members.each {|m| m.name.tap(&b) }}.to yield_successive_args('a', 'b')
+      expect{ |b| tp.members.each {|m| m.value_type.simple_name.tap(&b) }}.to yield_successive_args('Integer', 'Callable')
+    end
+
+    context 'and inheriting from a another Object type' do
+      let(:derived) { type_object_t('MyDerivedObject', 'MyObject', '{ c=> String, d => Boolean }') }
+
+      before(:each) do
+        loader.expects(:load).with(:type, 'myderivedobject').at_most_once.returns derived
+      end
+
+      it 'includes the inherited type and its members' do
+        tp = parser.parse('MyDerivedObject', scope)
+        expect(tp).to eql(derived)
+        tp = tp.resolved_type
+        expect(tp.parent).to eql(object)
+        expect{ |b| tp.members.each {|m| m.name.tap(&b) }}.to yield_successive_args('c', 'd')
+        expect{ |b| tp.members.each {|m| m.value_type.simple_name.tap(&b) }}.to yield_successive_args('String', 'Boolean')
+        expect{ |b| tp.members(true).each {|m| m.name.tap(&b) }}.to yield_successive_args('a', 'b', 'c', 'd')
+        expect{ |b| tp.members(true).each {|m| m.value_type.simple_name.tap(&b) }}.to yield_successive_args('Integer', 'Callable', 'String', 'Boolean')
+      end
+
+      it 'can redefine inherited member to assignable type' do
+        loader.expects(:load).with(:type, 'myderivedobject').returns type_object_t('MyDerivedObject', 'MyObject', '{ a=> Integer[0,default], d => Boolean }')
+        tp = parser.parse('MyDerivedObject', scope)
+        expect(tp).to eql(derived)
+        tp = tp.resolved_type
+        expect(tp.parent).to eql(object)
+        expect{ |b| tp.members.each {|m| m.name.tap(&b) }}.to yield_successive_args('a', 'd')
+        expect{ |b| tp.members.each {|m| m.value_type.to_s.tap(&b) }}.to yield_successive_args('Integer[0, default]', 'Boolean')
+        expect{ |b| tp.members(true).each {|m| m.name.tap(&b) }}.to yield_successive_args('a', 'b', 'd')
+        expect{ |b| tp.members(true).each {|m| m.value_type.to_s.tap(&b) }}.to yield_successive_args('Integer[0, default]', 'Callable', 'Boolean')
+      end
+
+      it 'can not redefine inherited member to a unassignable type' do
+        loader.expects(:load).with(:type, 'myderivedobject').returns type_object_t('MyDerivedObject', 'MyObject', '{ a=> String, d => Boolean }')
+        expect { parser.parse('MyDerivedObject', scope) }.to raise_error(Puppet::Error, "Member 'a' redefines member of inherited object to type that does not match")
+      end
+
+      it 'will be assignable to its inherited type' do
+        tp = parser.parse('MyDerivedObject', scope)
+        expect(object).to be_assignable(tp)
+      end
+
+      it 'will not consider the inherited type to be assignable' do
+        tp = parser.parse('MyDerivedObject', scope)
+        expect(tp).not_to be_assignable(object)
+      end
+
+      context 'that in turn inherits another Object type' do
+        let(:derived2) { type_object_t('MyDerivedObject2', 'MyDerivedObject', '{ e => String, f => Boolean }') }
+
+        before(:each) do
+          loader.expects(:load).with(:type, 'myderivedobject2').at_most_once.returns derived2
+        end
+
+        it 'will be assignable to all inherited types' do
+          tp = parser.parse('MyDerivedObject2', scope)
+          expect(object).to be_assignable(tp)
+          expect(derived).to be_assignable(tp)
+        end
+
+        it 'will not consider any of the inherited types to be assignable' do
+          tp = parser.parse('MyDerivedObject2', scope)
+          expect(tp).not_to be_assignable(object)
+          expect(tp).not_to be_assignable(derived)
+        end
+      end
+
+      context 'that in turn inherits itself' do
+        let(:object) { type_object_t('MyObject', 'MyDerivedObject', '{}') }
+
+        it 'will raise an error' do
+          expect { parser.parse('MyObject', scope) }.to raise_error(Puppet::Error, /inherits from itself/)
+        end
+      end
+    end
+  end
+end
+end
+end

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -59,6 +59,10 @@ describe 'The type factory' do
       expect(Puppet::Pops::Types::TypeFactory.struct().class()).to eq(Puppet::Pops::Types::PStructType)
     end
 
+    it "object() returns PObjectType" do
+      expect(Puppet::Pops::Types::TypeFactory.object.class).to eq(Puppet::Pops::Types::PObjectType)
+    end
+
     it 'tuple() returns PTupleType' do
       expect(Puppet::Pops::Types::TypeFactory.tuple.class()).to eq(Puppet::Pops::Types::PTupleType)
     end
@@ -173,6 +177,20 @@ describe 'The type factory' do
       expect(t.size_type.class).to eq(Puppet::Pops::Types::PIntegerType)
       expect(t.size_type.from).to eq(1)
       expect(t.size_type.to).to eq(2)
+    end
+
+    context 'when producing object types' do
+      it "creates an Object with a members struct based on a Hash" do
+        t = Puppet::Pops::Types::TypeFactory.object(nil, {'a'=>Integer, 'b'=>String})
+        expect(t.members).to be_a(Puppet::Pops::Types::PStructType)
+      end
+
+      it "creates an Object with from a parent type and and a Hash" do
+        super_t = Puppet::Pops::Types::TypeFactory.object(nil, {'a'=>Integer, 'b'=>String})
+        t = Puppet::Pops::Types::TypeFactory.object(super_t, {'c'=>Integer, 'd'=>String})
+        expect(t.parent).to equal(super_t)
+        expect(t.members).to be_a(Puppet::Pops::Types::PStructType)
+      end
     end
 
     context 'callable types' do

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -116,6 +116,19 @@ describe Puppet::Pops::Types::TypeParser do
     expect(the_type_parsed_from(struct_t)).to be_the_type(struct_t)
   end
 
+  it "parses object type" do
+    object_t = types.object(nil, {'a'=>Integer, 'b'=>String})
+    expect(the_type_parsed_from(object_t)).to be_the_type(object_t)
+  end
+
+  it "parses object type with inheritance" do
+    super_t = types.object(nil, {'a'=>Integer, 'b'=>String})
+    object_t = types.object(super_t, {'c'=>Integer, 'd'=>String})
+    parsed_t = the_type_parsed_from(object_t)
+    expect(parsed_t).to be_the_type(object_t)
+    expect(parsed_t.parent).to be_the_type(super_t)
+  end
+
   describe "handles parsing of patterns and regexp" do
     { 'Pattern[/([a-z]+)([1-9]+)/]'        => [:pattern, [/([a-z]+)([1-9]+)/]],
       'Pattern["([a-z]+)([1-9]+)"]'        => [:pattern, [/([a-z]+)([1-9]+)/]],


### PR DESCRIPTION
This commit adds a new `Object` type to the Puppet Type system. The
type is very similar to `Struct` in that it defines a hash of named
types. There are some notable differences though:

1. The `Object` type adds inheritance.
2. An `Object` is only assignable to itself or to a parent type of itself.
3. All keys of the `Object` must be non empty strings.
4. An `Object` may redefine a parent member, but only if the type is equal or assignable to the type of that member. I.e. it may redefine it to a more special type.