### PR TITLE
(PUP-5569) acceptance: use Set for mk_tmp_environment instead of SortedSet

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -17,7 +17,6 @@ gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] ||
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false
-gem 'rbtree', :require => false
 
 group(:test) do
   gem "rspec", "~> 2.14.0", :require => false

--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -1,5 +1,4 @@
 require 'puppet/acceptance/module_utils'
-require 'rbtree'
 
 module Puppet
   module Acceptance
@@ -373,8 +372,8 @@ module Puppet
       # create a tmpdir to hold a temporary environment bound by puppet environment naming restrictions
       # symbolically link environment into environmentpath
       def mk_tmp_environment(environment)
-        # add the tmp_environment to a sortedset so we ensure no collisions
-        @@tmp_environment_set ||= SortedSet.new
+        # add the tmp_environment to a set to ensure no collisions
+        @@tmp_environment_set ||= Set.new
         deadman = 100; loop_num = 0
         while @@tmp_environment_set.include?(tmp_environment = environment.downcase + '_' + random_string) do
           break if (loop_num = loop_num + 1) > deadman


### PR DESCRIPTION
This change uses Set instead of SortedSet which requires external gems
and could be actually slower in many cases than searching a Set which is
a valueless hash in ruby.

[skip ci]