### PR TITLE
(PUP-2802) Add slot support for portage package provider

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -25,12 +25,13 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     result_fields = self.eix_result_fields
 
     version_format = self.eix_version_format
+    slot_versions_format = self.eix_slot_versions_format
     begin
       eix_file = File.directory?("/var/cache/eix") ? "/var/cache/eix/portage.eix" : "/var/cache/eix"
       update_eix if !FileUtils.uptodate?(eix_file, %w{/usr/bin/eix /usr/portage/metadata/timestamp})
 
       search_output = nil
-      Puppet::Util.withenv :LASTVERSION => version_format do
+      Puppet::Util.withenv :LASTVERSION => version_format, :LASTSLOTVERSIONS => slot_versions_format do
         search_output = eix *(self.eix_search_arguments + ["--installed"])
       end
 
@@ -59,7 +60,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     name = package_name
     unless should == :present or should == :latest
       # We must install a specific version
-      name = "=#{name}-#{should}"
+      name = package_atom_with_version(should)
     end
     emerge name
   end
@@ -67,6 +68,24 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
   # The common package name format.
   def package_name
     @resource[:category] ? "#{@resource[:category]}/#{@resource[:name]}" : @resource[:name]
+  end
+
+  def package_name_without_slot
+    package_name.sub(self.class.slot_pattern, '')
+  end
+
+  def package_slot
+    if match = package_name.match(self.class.slot_pattern)
+      match[1]
+    end
+  end
+
+  def package_atom_with_version(version)
+    if slot = package_slot
+      "=#{package_name_without_slot}-#{version}:#{package_slot}"
+    else
+      "=#{package_name}-#{version}"
+    end
   end
 
   def uninstall
@@ -86,15 +105,16 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     result_fields = self.class.eix_result_fields
 
     version_format = self.class.eix_version_format
-    search_field = package_name.count('/') > 0 ? "--category-name" : "--name"
-    search_value = package_name
+    slot_versions_format = self.class.eix_slot_versions_format
+    search_field = package_name_without_slot.count('/') > 0 ? "--category-name" : "--name"
+    search_value = package_name_without_slot
 
     begin
       eix_file = File.directory?("/var/cache/eix") ? "/var/cache/eix/portage.eix" : "/var/cache/eix"
       update_eix if !FileUtils.uptodate?(eix_file, %w{/usr/bin/eix /usr/portage/metadata/timestamp})
 
       search_output = nil
-      Puppet::Util.withenv :LASTVERSION => version_format do
+      Puppet::Util.withenv :LASTVERSION => version_format, :LASTSLOTVERSIONS => slot_versions_format do
         search_output = eix *(self.class.eix_search_arguments + ["--exact",search_field,search_value])
       end
 
@@ -106,6 +126,10 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
           package = {}
           result_fields.zip(match.captures) do |field, value|
             package[field] = value unless !value or value.empty?
+          end
+          if package_slot
+            package[:version_available] = eix_get_version_for_slot(package[:slot_versions_available], package_slot)
+            package[:ensure] = eix_get_version_for_slot(package[:installed_slots], package_slot)
           end
           package[:ensure] = package[:ensure] ? package[:ensure] : :absent
           packages << package
@@ -131,20 +155,36 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
   end
 
   private
+  def eix_get_version_for_slot(versions_and_slots, slot)
+    return nil if versions_and_slots.nil?
+    versions_and_slots = versions_and_slots.split(",")
+    versions_and_slots.map! { |version_and_slot| version_and_slot.split(":") }
+    version_for_slot = versions_and_slots.find { |version_and_slot| version_and_slot.last == slot }
+    version_for_slot.first if version_for_slot
+  end
+
+  def self.slot_pattern
+    /:([\w+.\/*=-]+)$/
+  end
+
   def self.eix_search_format
-    "'<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] <homepage> <description>\n'"
+    "'<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] [<installedversions:LASTSLOTVERSIONS>] [<bestslotversions:LASTSLOTVERSIONS>] <homepage> <description>\n'"
   end
 
   def self.eix_result_format
-    /^(\S+)\s+(\S+)\s+\[(\S*)\]\s+\[(\S*)\]\s+(\S+)\s+(.*)$/
+    /^(\S+)\s+(\S+)\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+(\S+)\s+(.*)$/
   end
 
   def self.eix_result_fields
-    [:category, :name, :ensure, :version_available, :vendor, :description]
+    [:category, :name, :ensure, :version_available, :installed_slots, :slot_versions_available, :vendor, :description]
   end
 
   def self.eix_version_format
     "{last}<version>{}"
+  end
+
+  def self.eix_slot_versions_format
+    "{!first},{}<version>:<slot>"
   end
 
   def self.eix_search_arguments

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -7,14 +7,30 @@ provider = Puppet::Type.type(:package).provider(:portage)
 describe provider do
   before do
     packagename="sl"
-    @resource = stub('resource', :[] => packagename,:should => true)
+    @resource = stub('resource', :should => true)
+    @resource.stubs(:[]).with(:name).returns(packagename)
+    @resource.stubs(:[]).with(:category).returns(nil)
+
+    unslotted_packagename = "dev-lang/ruby"
+    @unslotted_resource = stub('resource', :should => true)
+    @unslotted_resource.stubs(:[]).with(:name).returns(unslotted_packagename)
+    @unslotted_resource.stubs(:[]).with(:category).returns(nil)
+
+    slotted_packagename = "dev-lang/ruby:1.9"
+    @slotted_resource = stub('resource', :should => true)
+    @slotted_resource.stubs(:[]).with(:name).returns(slotted_packagename)
+    @slotted_resource.stubs(:[]).with(:category).returns(nil)
+
     @provider = provider.new(@resource)
-    
+    @unslotted_provider = provider.new(@unslotted_resource)
+    @slotted_provider = provider.new(@slotted_resource)
+
     portage   = stub(:executable => "foo",:execute => true)
     Puppet::Provider::CommandDefiner.stubs(:define).returns(portage)
 
     @nomatch_result = ""
-    @match_result   = "app-misc sl [] [] http://www.tkl.iis.u-tokyo.ac.jp/~toyoda/index_e.html http://www.izumix.org.uk/sl/ sophisticated graphical program which corrects your miss typing\n"
+    @match_result   = "app-misc sl [] [] [] [] http://www.tkl.iis.u-tokyo.ac.jp/~toyoda/index_e.html http://www.izumix.org.uk/sl/ sophisticated graphical program which corrects your miss typing\n"
+    @slot_match_result = "dev-lang ruby [2.0.0] [2.1.0] [1.8.7:1.8,1.9.2:1.9,2.0.0:2.0] [1.9.3:1.9,2.0.1:2.0,2.1.0:2.1] http://www.ruby-lang.org/ An object-oriented scripting language\n"
   end
 
   it "is versionable" do
@@ -27,20 +43,20 @@ describe provider do
 
   it "uses :emerge to install packages" do
     @provider.expects(:emerge)
-    
+
     @provider.install
   end
 
   it "uses query to find the latest package" do
     @provider.expects(:query).returns({:versions_available => "myversion"})
-    
+
     @provider.latest
   end
 
   it "uses eix to search the lastest version of a package" do
     @provider.stubs(:update_eix)
     @provider.expects(:eix).returns(StringIO.new(@match_result))
-    
+
     @provider.query
   end
 
@@ -56,14 +72,54 @@ describe provider do
     @provider.stubs(:update_eix)
     @provider.expects(:eix).returns(StringIO.new(@match_result))
     @provider.class.expects(:eix_search_arguments).returns([])
-    
+
     @provider.query
   end
 
   it "can handle search output with empty square brackets" do
     @provider.stubs(:update_eix)
     @provider.expects(:eix).returns(StringIO.new(@match_result))
-    
+
     expect(@provider.query[:name]).to eq("sl")
+  end
+
+  it "can provide the package name without slot" do
+    expect(@slotted_provider.package_name_without_slot).to eq("dev-lang/ruby")
+  end
+
+  it "can extract the slot from the package name" do
+    expect(@slotted_provider.package_slot).to eq("1.9")
+  end
+
+  it "returns nil for as the slot when no slot is specified" do
+    expect(@provider.package_slot).to be_nil
+  end
+
+  it "provides correct package atoms for unslotted packages" do
+    expect(@provider.package_atom_with_version("1.0")).to eq("=sl-1.0")
+  end
+
+  it "provides correct package atoms for slotted packages" do
+    expect(@slotted_provider.package_atom_with_version("1.9.3")).to eq("=dev-lang/ruby-1.9.3:1.9")
+  end
+
+  it "can handle search output with slots for unslotted packages" do
+    @unslotted_provider.stubs(:update_eix)
+    @unslotted_provider.expects(:eix).returns(StringIO.new(@slot_match_result))
+
+    result = @unslotted_provider.query
+    expect(result[:name]).to eq("ruby")
+    expect(result[:ensure]).to eq("2.0.0")
+    expect(result[:version_available]).to eq("2.1.0")
+  end
+
+  it "can handle search output with slots" do
+    @slotted_provider.stubs(:update_eix)
+    @slotted_provider.expects(:eix).returns(StringIO.new(@slot_match_result))
+
+    result = @slotted_provider.query
+    expect(result[:name]).to eq("ruby")
+    expect(result[:ensure]).to eq("1.9.2")
+    expect(result[:version_available]).to eq("1.9.3")
   end
 end


### PR DESCRIPTION
Portage allows installing multiple versions of a package using slots.
To support slotted packages, Puppet needs to check only the packages
installed in the specified slot, as well as install using the slot
specifier. Other package managers have the slot as part of the package
name, but portage separates this its package name syntax.
This commit adds support for checking and installing packages with slot
specifiers, allowing one to keep multiple versions of a package
up-to-date.

This was originally PR #2649, but I updated the code, tests, and commit message.
Please read the discussion on that pull request.