### PR TITLE
(PUP-5937) Detect duplicate keys in hashes (Merge after PUP-5889).

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -121,6 +121,27 @@ module Puppet
           raise ArgumentError, "Cannot disable unrecognized warning types #{invalid.inspect}. Valid values are #{valid.inspect}."
         end
       end
+    },
+    :strict => {
+      :default    => :warning,
+      :type       => :symbolic_enum,
+      :values     => [:ignore, :warning, :error],
+      :desc       => "The strictness level of puppet. Allowed values are:
+
+        * ignored
+        * warning
+        * error
+
+        where 'ignored' is the default. When set to 'warning' or 'error' additional
+        checks and validations are performed at runtime (e.g. when compiling
+        a catalog, or applying a catalog). When set to 'warning' a warning is logged when a
+        strictness problem is found, and when set to 'error' and error is logged and
+        the operation fails. In addition to this master switch the behavior of
+        some individual warnings may be controlled by the disable_warnings setting.",
+      :hook    => proc do |value|
+        munge(value)
+        value.to_sym
+      end
     }
   )
 

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -504,29 +504,32 @@ class Puppet::Parser::Scope
   end
 
   UNDEFINED_VARIABLES_KIND = 'undefined_variables'.freeze
+  DEPRECATION_KIND = 'deprecation'.freeze
+
+  # The exception raised when a throw is uncaught is different in different versions
+  # of ruby. In >=2.2.0 it is UncaughtThrowError (which did not exist prior to this)
+  #
+  UNCAUGHT_THROW_EXCEPTION = defined?(UncaughtThrowError) ? UncaughtThrowError : ArgumentError
 
   def variable_not_found(name, reason=nil)
-    # Built in variables always exist
-    if BUILT_IN_VARS.include?(name)
+    # Built in variables and numeric variables always exist
+    if BUILT_IN_VARS.include?(name) || name =~ Puppet::Pops::Patterns::NUMERIC_VAR_NAME
       return nil
     end
-    if Puppet[:strict_variables]
+    begin
       throw(:undefined_variable, reason)
-    else
-      # Always warn, unfortunately without location (unless given in "reason") since
-      # a location is in most cases not given to scope (operator [], and lookupvar), and
-      # would be too expensive to always give.
-      # The ideal solution would be to always throw :undefined_variable, but that has to
-      # wait until a major release. It would then force all callers of scope to deal with
-      # the case of :undefined_variable. (Should check with include? first or catch the throw).
-      # Use deprecation warning to enable turning off these warnings, and to ensure each variable
-      # is only logged once.
-      unless name =~ Puppet::Pops::Patterns::NUMERIC_VAR_NAME
+    rescue  UNCAUGHT_THROW_EXCEPTION
+      case Puppet[:strict]
+      when :ignored
+        # do nothing
+      when :warning
         Puppet.warn_once(UNDEFINED_VARIABLES_KIND, "Variable: #{name}",
-          "Undefined variable '#{name}'; #{reason}" )
+        "Undefined variable '#{name}'; #{reason}" )
+      when :error
+        raise ArgumentError, "Undefined variable '#{name}'; #{reason}"
       end
-      nil
     end
+    nil
   end
 
   # Retrieves the variable value assigned to the name given as an argument. The name must be a String,

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -77,6 +77,7 @@ module Puppet
     end
 
     module Evaluator
+      require 'puppet/pops/evaluator/literal_evaluator'
       require 'puppet/pops/evaluator/callable_signature'
       require 'puppet/pops/evaluator/runtime3_converter'
       require 'puppet/pops/evaluator/runtime3_support'

--- a/lib/puppet/pops/evaluator/literal_evaluator.rb
+++ b/lib/puppet/pops/evaluator/literal_evaluator.rb
@@ -1,5 +1,5 @@
-require 'rgen/ecore/ecore'
-
+module Puppet::Pops
+module Evaluator
 # Literal values for
 # String (not containing interpolation)
 # Numbers
@@ -14,14 +14,13 @@ require 'rgen/ecore/ecore'
 # Not considered literal
 # QualifiedReference  # i.e. File, FooBar
 #
-class Puppet::Pops::Evaluator::LiteralEvaluator
-  #include Puppet::Pops::Utils
+class LiteralEvaluator
 
   EMPTY_STRING = ''.freeze
   COMMA_SEPARATOR = ', '.freeze
 
   def initialize
-    @@literal_visitor ||= Puppet::Pops::Visitor.new(self, "literal", 0, 0)
+    @@literal_visitor ||= Visitor.new(self, "literal", 0, 0)
   end
 
   def literal(ast)
@@ -70,7 +69,7 @@ class Puppet::Pops::Evaluator::LiteralEvaluator
 
   def literal_ConcatenatedString(o)
     # use double quoted string value if there is no interpolation
-    throw :not_literal unless o.segments.size == 1 && o.segments[0].is_a?(Puppet::Pops::Model::LiteralString)
+    throw :not_literal unless o.segments.size == 1 && o.segments[0].is_a?(Model::LiteralString)
     o.segments[0].value
   end
 
@@ -84,4 +83,6 @@ class Puppet::Pops::Evaluator::LiteralEvaluator
       result
     end
   end
+end
+end
 end

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -90,7 +90,7 @@ module Runtime3Support
     unless name =~ Puppet::Pops::Patterns::NUMERIC_VAR_NAME
       optionally_fail(Puppet::Pops::Issues::UNKNOWN_VARIABLE, o, {:name => name})
     end
-    nil # in case unknown variable is configured as a warning
+    nil # in case unknown variable is configured as a warning or ignore
   end
 
   # Returns true if the variable of the given name is set in the given most nested scope. True is returned even if
@@ -497,7 +497,19 @@ module Runtime3Support
         p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
       end
 
-      p[Issues::UNKNOWN_VARIABLE]             = Puppet[:strict_variables] ? :error : :warning
+      # if strict variables are on, an error is raised
+      # if strict variables are off, the Puppet[strict] defines what is done
+      #
+      if Puppet[:strict_variables]
+        p[Issues::UNKNOWN_VARIABLE] = :error
+      elsif Puppet[:strict] == :ignore
+        p[Issues::UNKNOWN_VARIABLE] = :ignore
+      else
+        Puppet[:strict_variables] 
+        p[Issues::UNKNOWN_VARIABLE] = Puppet[:strict]
+      end
+
+#      Puppet[:strict_variables] ? :error : :warning
 
       # Store config issues, ignore or warning
       p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -594,6 +594,10 @@ module Issues
     "The parameter '#{param_name}' is declared more than once in the parameter list"
   end
 
+  DUPLICATE_KEY = issue :DUPLICATE_KEY, :key do
+    "The key '#{key}' is declared more than once"
+  end
+
   RESERVED_PARAMETER = hard_issue :RESERVED_PARAMETER, :container, :param_name do
     "The parameter $#{param_name} redefines a built in parameter in #{label.the(container)}"
   end

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -27,7 +27,7 @@ class ValidatorFactory_4_0 < Factory
 
     p[Issues::FUTURE_RESERVED_WORD]          = :deprecation
 
-    p[Issues::DUPLICATE_KEY]                 = :warning
+    p[Issues::DUPLICATE_KEY]                 = Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
     p

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -27,6 +27,7 @@ class ValidatorFactory_4_0 < Factory
 
     p[Issues::FUTURE_RESERVED_WORD]          = :deprecation
 
+    p[Issues::DUPLICATE_KEY]                 = :warning
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
     p

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -14,6 +14,7 @@ class Puppet::Settings
   require 'puppet/settings/base_setting'
   require 'puppet/settings/string_setting'
   require 'puppet/settings/enum_setting'
+  require 'puppet/settings/symbolic_enum_setting'
   require 'puppet/settings/array_setting'
   require 'puppet/settings/file_setting'
   require 'puppet/settings/directory_setting'
@@ -663,6 +664,7 @@ class Puppet::Settings
       :ttl        => TTLSetting,
       :array      => ArraySetting,
       :enum       => EnumSetting,
+      :symbolic_enum   => SymbolicEnumSetting,
       :priority   => PrioritySetting,
       :autosign   => AutosignSetting,
   }

--- a/lib/puppet/settings/symbolic_enum_setting.rb
+++ b/lib/puppet/settings/symbolic_enum_setting.rb
@@ -1,0 +1,17 @@
+class Puppet::Settings::SymbolicEnumSetting < Puppet::Settings::BaseSetting
+  attr_accessor :values
+
+  def type
+    :symbolic_enum
+  end
+
+  def munge(value)
+    sym = value.to_sym
+    if values.include?(sym)
+      sym
+    else
+      raise Puppet::Settings::ValidationError,
+        "Invalid value '#{value}' for parameter #{@name}. Allowed values are '#{values.join("', '")}'"
+    end
+  end
+end

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -72,6 +72,24 @@ describe "Defaults" do
 
   end
 
+  describe 'strict' do
+    it 'should accept the vaid value ignore' do
+      expect {Puppet.settings[:strict] = 'ignore'}.to_not raise_exception
+    end
+
+    it 'should accept the vaid value warning' do
+      expect {Puppet.settings[:strict] = 'warning'}.to_not raise_exception
+    end
+
+    it 'should accept the vaid value error' do
+      expect {Puppet.settings[:strict] = 'error'}.to_not raise_exception
+    end
+
+    it 'should fail if given an invalid value' do
+      expect {Puppet.settings[:strict] = 'off'}.to raise_exception(/Invalid value 'off' for parameter strict\./)
+    end
+  end
+
   describe 'supported_checksum_types' do
     it 'should default to md5,sha256' do
       expect(Puppet.settings[:supported_checksum_types]).to eq(['md5', 'sha256'])

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -324,6 +324,51 @@ describe Puppet::Parser::Scope do
         expect { @scope['module_name'] }.to_not raise_error
       end
     end
+
+    context "and strict_variables is false and --strict=ignore" do
+      before(:each) do
+        Puppet[:strict_variables] = false
+        Puppet[:strict] = :ignore
+      end
+
+      it "should not error when unknown variable is looked up and produce nil" do
+        expect(@scope['john_doe']).to be_nil
+      end
+
+      it "should not error when unknown qualified variable is looked up and produce nil" do
+        expect(@scope['nowhere::john_doe']).to be_nil
+      end
+    end
+
+    context "and strict_variables is false and --strict=warning" do
+      before(:each) do
+        Puppet[:strict_variables] = false
+        Puppet[:strict] = :warning
+      end
+
+      it "should not error when unknown variable is looked up" do
+        expect(@scope['john_doe']).to be_nil
+      end
+
+      it "should not error when unknown qualified variable is looked up" do
+        expect(@scope['nowhere::john_doe']).to be_nil
+      end
+    end
+
+    context "and strict_variables is false and --strict=error" do
+      before(:each) do
+        Puppet[:strict_variables] = false
+        Puppet[:strict] = :error
+      end
+
+      it "should raise error when unknown variable is looked up" do
+        expect { @scope['john_doe'] }.to raise_error(/Undefined variable/)
+      end
+
+      it "should not throw a symbol when unknown qualified variable is looked up" do
+        expect { @scope['nowhere::john_doe'] }.to raise_error(/Undefined variable/)
+      end
+    end
   end
 
   describe "when variables are set with append=true" do

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -34,6 +34,13 @@ describe "validating 4x" do
     expect(validate(fqn('::_aa').var())).to_not have_issue(Puppet::Pops::Issues::ILLEGAL_VAR_NAME)
   end
 
+  it 'produces a warning for duplicate keyes in a literal hash' do
+    acceptor = validate(parse('{ a => 1, a => 2 }'))
+    expect(acceptor.warning_count).to eql(1)
+    expect(acceptor.error_count).to eql(0)
+    expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+  end
+
   context 'for non productive expressions' do
     [ '1',
       '3.14',

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -34,11 +34,43 @@ describe "validating 4x" do
     expect(validate(fqn('::_aa').var())).to_not have_issue(Puppet::Pops::Issues::ILLEGAL_VAR_NAME)
   end
 
-  it 'produces a warning for duplicate keyes in a literal hash' do
-    acceptor = validate(parse('{ a => 1, a => 2 }'))
-    expect(acceptor.warning_count).to eql(1)
-    expect(acceptor.error_count).to eql(0)
-    expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+  context 'with the default settings for --strict' do
+    it 'produces a warning for duplicate keyes in a literal hash' do
+      acceptor = validate(parse('{ a => 1, a => 2 }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+    end
+  end
+
+  context 'with --strict set to warning' do
+    before(:each) { Puppet[:strict] = :warning }
+    it 'produces a warning for duplicate keyes in a literal hash' do
+      acceptor = validate(parse('{ a => 1, a => 2 }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+    end
+  end
+
+  context 'with --strict set to error' do
+    before(:each) { Puppet[:strict] = :error }
+    it 'produces an error for duplicate keyes in a literal hash' do
+      acceptor = validate(parse('{ a => 1, a => 2 }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+    end
+  end
+
+  context 'with --strict set to ignore' do
+    before(:each) { Puppet[:strict] = :ignore }
+    it 'produces an error for duplicate keyes in a literal hash' do
+      acceptor = validate(parse('{ a => 1, a => 2 }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+    end
   end
 
   context 'for non productive expressions' do


### PR DESCRIPTION
This PR is rebased on top of the PR for PUP-5889 which adds the --strict flag.

Merge PUP-5889 before merging this.

Replaces #4691 