### PR TITLE
(maint) Add teardown step to direct puppet test

### DIFF
--- a/acceptance/lib/puppet/acceptance/static_catalog_utils.rb
+++ b/acceptance/lib/puppet/acceptance/static_catalog_utils.rb
@@ -38,8 +38,17 @@ EOF
 MANIFEST
 
         puppetserver_config = "#{master['puppetserver-confdir']}/puppetserver.conf"
+        on master, "cp #{puppetserver_config} #{scriptdir}/puppetserver.conf.bak"
         versioned_code_settings = {"versioned-code" => {"code-id-command" => "#{scriptdir}/code_id.sh", "code-content-command" => "#{scriptdir}/code_content.sh"}}
         modify_tk_config(master, puppetserver_config, versioned_code_settings)
+      end
+
+      def cleanup_puppetserver_code_id_scripts(master, scriptdir)
+        # These are -f so we don't bail on the teardown if for some reason they didn't get laid down
+        on master, "rm -f #{scriptdir}/code_id.sh"
+        on master, "rm -f #{scriptdir}/code_content.sh"
+        puppetserver_config = "#{master['puppetserver-confdir']}/puppetserver.conf"
+        on master, "cp #{scriptdir}/puppetserver.conf.bak #{puppetserver_config}"
       end
     end
   end

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -20,6 +20,11 @@ test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri
     setup_puppetserver_code_id_scripts(master, basedir)
   end
 
+  teardown do
+    cleanup_puppetserver_code_id_scripts(master, basedir)
+    on master, "rm -rf #{basedir}"
+  end
+
   step "Create a module and a file with content representing the first code_id version" do
     apply_manifest_on(master, <<MANIFEST, :catch_failures => true)
     File {


### PR DESCRIPTION
Previously, the `remediate_local_drift` test for direct puppet was
modifying the puppet-server configuration to enable static
compilation, but was not restoring that state. This adds a proper
teardown step which cleans up the master configuration and removes the
files for the test environment.