### PR TITLE
(PUP-5889) add a strict flag

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -121,6 +121,27 @@ module Puppet
           raise ArgumentError, "Cannot disable unrecognized warning types #{invalid.inspect}. Valid values are #{valid.inspect}."
         end
       end
+    },
+    :strict => {
+      :default    => :warning,
+      :type       => :symbolic_enum,
+      :values     => [:ignore, :warning, :error],
+      :desc       => "The strictness level of puppet. Allowed values are:
+
+        * ignored
+        * warning
+        * error
+
+        where 'ignored' is the default. When set to 'warning' or 'error' additional
+        checks and validations are performed at runtime (e.g. when compiling
+        a catalog, or applying a catalog). When set to 'warning' a warning is logged when a
+        strictness problem is found, and when set to 'error' and error is logged and
+        the operation fails. In addition to this master switch the behavior of
+        some individual warnings may be controlled by the disable_warnings setting.",
+      :hook    => proc do |value|
+        munge(value)
+        value.to_sym
+      end
     }
   )
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -125,19 +125,22 @@ module Puppet
     :strict => {
       :default    => :warning,
       :type       => :symbolic_enum,
-      :values     => [:ignore, :warning, :error],
+      :values     => [:off, :warning, :error],
       :desc       => "The strictness level of puppet. Allowed values are:
 
-        * ignored
-        * warning
-        * error
+        * off     - do not perform extra validation, do not report
+        * warning - perform extra validation, report as warning (default)
+        * error   - perform extra validation, fail with error
 
-        where 'ignored' is the default. When set to 'warning' or 'error' additional
-        checks and validations are performed at runtime (e.g. when compiling
-        a catalog, or applying a catalog). When set to 'warning' a warning is logged when a
-        strictness problem is found, and when set to 'error' and error is logged and
-        the operation fails. In addition to this master switch the behavior of
-        some individual warnings may be controlled by the disable_warnings setting.",
+        The strictness level is for both language semantics and runtime
+        evaluation validation. In addition to controlling the behavior with
+        this master switch some individual warnings may also be controlled
+        by the disable_warnings setting.
+
+        No new validations will be added to a micro (x.y.z) release,
+        but may be added in minor releases (x.y.0). In major releases
+        it expected that most (if not all) strictness validation become
+        standard behavior.",
       :hook    => proc do |value|
         munge(value)
         value.to_sym

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -504,29 +504,32 @@ class Puppet::Parser::Scope
   end
 
   UNDEFINED_VARIABLES_KIND = 'undefined_variables'.freeze
+  DEPRECATION_KIND = 'deprecation'.freeze
+
+  # The exception raised when a throw is uncaught is different in different versions
+  # of ruby. In >=2.2.0 it is UncaughtThrowError (which did not exist prior to this)
+  #
+  UNCAUGHT_THROW_EXCEPTION = defined?(UncaughtThrowError) ? UncaughtThrowError : ArgumentError
 
   def variable_not_found(name, reason=nil)
-    # Built in variables always exist
-    if BUILT_IN_VARS.include?(name)
+    # Built in variables and numeric variables always exist
+    if BUILT_IN_VARS.include?(name) || name =~ Puppet::Pops::Patterns::NUMERIC_VAR_NAME
       return nil
     end
-    if Puppet[:strict_variables]
+    begin
       throw(:undefined_variable, reason)
-    else
-      # Always warn, unfortunately without location (unless given in "reason") since
-      # a location is in most cases not given to scope (operator [], and lookupvar), and
-      # would be too expensive to always give.
-      # The ideal solution would be to always throw :undefined_variable, but that has to
-      # wait until a major release. It would then force all callers of scope to deal with
-      # the case of :undefined_variable. (Should check with include? first or catch the throw).
-      # Use deprecation warning to enable turning off these warnings, and to ensure each variable
-      # is only logged once.
-      unless name =~ Puppet::Pops::Patterns::NUMERIC_VAR_NAME
+    rescue  UNCAUGHT_THROW_EXCEPTION
+      case Puppet[:strict]
+      when :ignored
+        # do nothing
+      when :warning
         Puppet.warn_once(UNDEFINED_VARIABLES_KIND, "Variable: #{name}",
-          "Undefined variable '#{name}'; #{reason}" )
+        "Undefined variable '#{name}'; #{reason}" )
+      when :error
+        raise ArgumentError, "Undefined variable '#{name}'; #{reason}"
       end
-      nil
     end
+    nil
   end
 
   # Retrieves the variable value assigned to the name given as an argument. The name must be a String,

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -520,7 +520,7 @@ class Puppet::Parser::Scope
       throw(:undefined_variable, reason)
     rescue  UNCAUGHT_THROW_EXCEPTION
       case Puppet[:strict]
-      when :ignored
+      when :off
         # do nothing
       when :warning
         Puppet.warn_once(UNDEFINED_VARIABLES_KIND, "Variable: #{name}",

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -502,14 +502,12 @@ module Runtime3Support
       #
       if Puppet[:strict_variables]
         p[Issues::UNKNOWN_VARIABLE] = :error
-      elsif Puppet[:strict] == :ignore
+      elsif Puppet[:strict] == :off
         p[Issues::UNKNOWN_VARIABLE] = :ignore
       else
         Puppet[:strict_variables] 
         p[Issues::UNKNOWN_VARIABLE] = Puppet[:strict]
       end
-
-#      Puppet[:strict_variables] ? :error : :warning
 
       # Store config issues, ignore or warning
       p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -90,7 +90,7 @@ module Runtime3Support
     unless name =~ Puppet::Pops::Patterns::NUMERIC_VAR_NAME
       optionally_fail(Puppet::Pops::Issues::UNKNOWN_VARIABLE, o, {:name => name})
     end
-    nil # in case unknown variable is configured as a warning
+    nil # in case unknown variable is configured as a warning or ignore
   end
 
   # Returns true if the variable of the given name is set in the given most nested scope. True is returned even if
@@ -497,7 +497,19 @@ module Runtime3Support
         p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
       end
 
-      p[Issues::UNKNOWN_VARIABLE]             = Puppet[:strict_variables] ? :error : :warning
+      # if strict variables are on, an error is raised
+      # if strict variables are off, the Puppet[strict] defines what is done
+      #
+      if Puppet[:strict_variables]
+        p[Issues::UNKNOWN_VARIABLE] = :error
+      elsif Puppet[:strict] == :ignore
+        p[Issues::UNKNOWN_VARIABLE] = :ignore
+      else
+        Puppet[:strict_variables] 
+        p[Issues::UNKNOWN_VARIABLE] = Puppet[:strict]
+      end
+
+#      Puppet[:strict_variables] ? :error : :warning
 
       # Store config issues, ignore or warning
       p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -14,6 +14,7 @@ class Puppet::Settings
   require 'puppet/settings/base_setting'
   require 'puppet/settings/string_setting'
   require 'puppet/settings/enum_setting'
+  require 'puppet/settings/symbolic_enum_setting'
   require 'puppet/settings/array_setting'
   require 'puppet/settings/file_setting'
   require 'puppet/settings/directory_setting'
@@ -663,6 +664,7 @@ class Puppet::Settings
       :ttl        => TTLSetting,
       :array      => ArraySetting,
       :enum       => EnumSetting,
+      :symbolic_enum   => SymbolicEnumSetting,
       :priority   => PrioritySetting,
       :autosign   => AutosignSetting,
   }

--- a/lib/puppet/settings/symbolic_enum_setting.rb
+++ b/lib/puppet/settings/symbolic_enum_setting.rb
@@ -1,0 +1,17 @@
+class Puppet::Settings::SymbolicEnumSetting < Puppet::Settings::BaseSetting
+  attr_accessor :values
+
+  def type
+    :symbolic_enum
+  end
+
+  def munge(value)
+    sym = value.to_sym
+    if values.include?(sym)
+      sym
+    else
+      raise Puppet::Settings::ValidationError,
+        "Invalid value '#{value}' for parameter #{@name}. Allowed values are '#{values.join("', '")}'"
+    end
+  end
+end

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -73,20 +73,20 @@ describe "Defaults" do
   end
 
   describe 'strict' do
-    it 'should accept the vaid value ignore' do
-      expect {Puppet.settings[:strict] = 'ignore'}.to_not raise_exception
+    it 'should accept the valid value :off' do
+      expect {Puppet.settings[:strict] = 'off'}.to_not raise_exception
     end
 
-    it 'should accept the vaid value warning' do
+    it 'should accept the valid value :warning' do
       expect {Puppet.settings[:strict] = 'warning'}.to_not raise_exception
     end
 
-    it 'should accept the vaid value error' do
+    it 'should accept the valid value :error' do
       expect {Puppet.settings[:strict] = 'error'}.to_not raise_exception
     end
 
     it 'should fail if given an invalid value' do
-      expect {Puppet.settings[:strict] = 'off'}.to raise_exception(/Invalid value 'off' for parameter strict\./)
+      expect {Puppet.settings[:strict] = 'ignore'}.to raise_exception(/Invalid value 'ignore' for parameter strict\./)
     end
   end
 

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -72,6 +72,24 @@ describe "Defaults" do
 
   end
 
+  describe 'strict' do
+    it 'should accept the vaid value ignore' do
+      expect {Puppet.settings[:strict] = 'ignore'}.to_not raise_exception
+    end
+
+    it 'should accept the vaid value warning' do
+      expect {Puppet.settings[:strict] = 'warning'}.to_not raise_exception
+    end
+
+    it 'should accept the vaid value error' do
+      expect {Puppet.settings[:strict] = 'error'}.to_not raise_exception
+    end
+
+    it 'should fail if given an invalid value' do
+      expect {Puppet.settings[:strict] = 'off'}.to raise_exception(/Invalid value 'off' for parameter strict\./)
+    end
+  end
+
   describe 'supported_checksum_types' do
     it 'should default to md5,sha256' do
       expect(Puppet.settings[:supported_checksum_types]).to eq(['md5', 'sha256'])

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -325,10 +325,10 @@ describe Puppet::Parser::Scope do
       end
     end
 
-    context "and strict_variables is false and --strict=ignore" do
+    context "and strict_variables is false and --strict=off" do
       before(:each) do
         Puppet[:strict_variables] = false
-        Puppet[:strict] = :ignore
+        Puppet[:strict] = :off
       end
 
       it "should not error when unknown variable is looked up and produce nil" do

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -324,6 +324,51 @@ describe Puppet::Parser::Scope do
         expect { @scope['module_name'] }.to_not raise_error
       end
     end
+
+    context "and strict_variables is false and --strict=ignore" do
+      before(:each) do
+        Puppet[:strict_variables] = false
+        Puppet[:strict] = :ignore
+      end
+
+      it "should not error when unknown variable is looked up and produce nil" do
+        expect(@scope['john_doe']).to be_nil
+      end
+
+      it "should not error when unknown qualified variable is looked up and produce nil" do
+        expect(@scope['nowhere::john_doe']).to be_nil
+      end
+    end
+
+    context "and strict_variables is false and --strict=warning" do
+      before(:each) do
+        Puppet[:strict_variables] = false
+        Puppet[:strict] = :warning
+      end
+
+      it "should not error when unknown variable is looked up" do
+        expect(@scope['john_doe']).to be_nil
+      end
+
+      it "should not error when unknown qualified variable is looked up" do
+        expect(@scope['nowhere::john_doe']).to be_nil
+      end
+    end
+
+    context "and strict_variables is false and --strict=error" do
+      before(:each) do
+        Puppet[:strict_variables] = false
+        Puppet[:strict] = :error
+      end
+
+      it "should raise error when unknown variable is looked up" do
+        expect { @scope['john_doe'] }.to raise_error(/Undefined variable/)
+      end
+
+      it "should not throw a symbol when unknown qualified variable is looked up" do
+        expect { @scope['nowhere::john_doe'] }.to raise_error(/Undefined variable/)
+      end
+    end
   end
 
   describe "when variables are set with append=true" do


### PR DESCRIPTION
This adds a --strict flag that can be set to warning, error or ignore. In this PR this new setting is made to play nicely with the --strict_variables such that, if --strict_variables is true then it always errors (this is what users expect). If it is not set, the behavior is controlled by the --strict setting.

The default for --strict is warn. This is also what is expected for --strict_variables (by default). Users can opt out by setting --strict=off.

It is expected that the --strict flag will be used in different ways for new kinds of validations. In this PR one tricky thing is to maintain the API for those that call directly into scope (not being prepared to catch the symbol :undefined_variable. This is now done by always throwing :undefined_variable, and catching the resulting exception if there were no catcher. Earlier the trowing was conditional which led to other problems.

Now the API is - if a caller wants to handle the error/warning aspect of an undefined variable it should catch the thrown symbol. If it does not the --strict_variables/--strict flags control the behavior (like before).
