### PR TITLE
(maint) static catalogs cleanup

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -97,6 +97,9 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     end
   end
 
+  # Add `resources` to the catalog after `other`. WARNING: adding
+  # multiple resources will produce the reverse ordering, e.g. calling
+  # `add_resource_after(A, [B,C])` will result in `[A,C,B]`.
   def add_resource_after(other, *resources)
     resources.each do |resource|
       other_title_key = title_key_for_ref(other.ref)
@@ -105,7 +108,6 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       add_one_resource(resource, idx+1)
     end
   end
-
 
   def add_resource(*resources)
     resources.each do |resource|

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -275,30 +275,6 @@ class Puppet::Transaction
     resource_status(resource).failed_dependencies = failed.to_a
   end
 
-  # A general method for recursively generating new resources from a
-  # resource.
-  def generate_additional_resources(resource)
-    return unless resource.respond_to?(:generate)
-    begin
-      made = resource.generate
-    rescue => detail
-      resource.log_exception(detail, "Failed to generate additional resources using 'generate': #{detail}")
-    end
-    return unless made
-    made = [made] unless made.is_a?(Array)
-    made.uniq.each do |res|
-      begin
-        res.tag(*resource.tags)
-        @catalog.add_resource(res)
-        res.finish
-        add_conditional_directed_dependency(resource, res)
-        generate_additional_resources(res)
-      rescue Puppet::Resource::Catalog::DuplicateResourceError
-        res.info "Duplicate generated resource; skipping"
-      end
-    end
-  end
-
   # Should we ignore tags?
   def ignore_tags?
     ! @catalog.host_config?

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -286,6 +286,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
       @catalog = Puppet::Resource::Catalog.new("host")
       @one = Puppet::Type.type(:notify).new :name => "one"
       @two = Puppet::Type.type(:notify).new :name => "two"
+      @three = Puppet::Type.type(:notify).new :name => "three"
       @dupe = Puppet::Type.type(:notify).new :name => "one"
     end
 
@@ -337,6 +338,32 @@ describe Puppet::Resource::Catalog, "when compiling" do
     it "should canonize how resources are referred to during retrieval when just the title is provided" do
       @catalog.add_resource(@one)
       expect(@catalog.resource("notify[one]", nil)).to equal(@one)
+    end
+
+    it "adds resources before an existing resource" do
+      @catalog.add_resource(@one)
+      @catalog.add_resource_before(@one, @two, @three)
+
+      expect(@catalog.resources).to eq([@two, @three, @one])
+    end
+
+    it "raises if adding a resource before a resource not in the catalog" do
+      expect {
+        @catalog.add_resource_before(@one, @two)
+      }.to raise_error(ArgumentError, "Cannot add resource Notify[two] before Notify[one] because Notify[one] is not yet in the catalog")
+    end
+
+    it "adds resources after an existing resource in reverse order" do
+      @catalog.add_resource(@one)
+      @catalog.add_resource_after(@one, @two, @three)
+
+      expect(@catalog.resources).to eq([@one, @three, @two])
+    end
+
+    it "raises if adding a resource after a resource not in the catalog" do
+      expect {
+        @catalog.add_resource_after(@one, @two)
+      }.to raise_error(ArgumentError, "Cannot add resource Notify[two] after Notify[one] because Notify[one] is not yet in the catalog")
     end
 
     describe 'with a duplicate resource' do


### PR DESCRIPTION
These commits were part of a different PR that became obsolete once we changed how file metadata was generated. Submitting these separately as I think they're still relevant. Supercedes https://github.com/puppetlabs/puppet/pull/4698