### PR TITLE
(PUP-5970) Add catalog format

### DIFF
--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -69,6 +69,7 @@ environment, which might differ from what the client believes is its current env
       "version": 1377473054,
       "code_id": null,
       "catalog_uuid": "827a74c8-cf98-44da-9ff7-18c5e4bee41e",
+      "catalog_format": 1,
       "environment": "production",
       "resources": [
         {

--- a/api/docs/http_report.md
+++ b/api/docs/http_report.md
@@ -53,6 +53,7 @@ example is formatted for readability)
      "transaction_uuid"=>"df34516e-4050-402d-a166-05b03b940749",
      "code_id"=>null,
      "catalog_uuid"=>"827a74c8-cf98-44da-9ff7-18c5e4bee41e",
+     "catalog_format"=>1,
      "report_format"=>5,
      "puppet_version"=>"3.3.0",
      "kind"=>"apply",

--- a/api/schemas/catalog.json
+++ b/api/schemas/catalog.json
@@ -24,6 +24,9 @@
         "catalog_uuid": {
             "type": "string"
         },
+        "catalog_format": {
+            "type": "integer"
+        },
         "environment": {
             "type": "string"
         },
@@ -122,7 +125,7 @@
             }
         }
     },
-    "required": ["tags", "name", "version", "code_id", "catalog_uuid", "environment", "resources", "edges", "classes"],
+    "required": ["tags", "name", "version", "code_id", "catalog_uuid", "catalog_format", "environment", "resources", "edges", "classes"],
     "additionalProperties": false,
 
     "definitions" : {

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -36,6 +36,11 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
   # The UUID of the catalog
   attr_accessor :catalog_uuid
 
+  # @return [Integer] catalog format version number. This value is constant
+  #  for a given version of Puppet; it is incremented when a new release of
+  #  Puppet changes the API for the various objects that make up the catalog.
+  attr_accessor :catalog_format
+
   # Inlined file metadata for non-recursive find
   # A hash of title => metadata
   attr_accessor :metadata
@@ -285,6 +290,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     super()
     @name = name
     @catalog_uuid = SecureRandom.uuid
+    @catalog_format = 1
     @metadata = {}
     @recursive_metadata = {}
     @classes = []
@@ -398,6 +404,8 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       result.catalog_uuid = catalog_uuid
     end
 
+    result.catalog_format = data['catalog_format'] || 0
+
     if environment = data['environment']
       result.environment = environment
       result.environment_instance = Puppet::Node::Environment.remote(environment.to_sym)
@@ -456,12 +464,14 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       end
       h
     end
+
     {
       'tags'      => tags,
       'name'      => name,
       'version'   => version,
       'code_id'   => code_id,
       'catalog_uuid' => catalog_uuid,
+      'catalog_format' => catalog_format,
       'environment'  => environment.to_s,
       'resources' => @resources.collect { |v| @resource_table[v].to_data_hash },
       'edges'     => edges.   collect { |e| e.to_data_hash },
@@ -580,6 +590,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     result.version = self.version
     result.code_id = self.code_id
     result.catalog_uuid = self.catalog_uuid
+    result.catalog_format = self.catalog_format
     result.metadata = self.metadata
     result.recursive_metadata = self.recursive_metadata
 

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -97,6 +97,11 @@ describe Puppet::Resource::Catalog, "when compiling" do
     expect(catalog.catalog_uuid).to eq("827a74c8-cf98-44da-9ff7-18c5e4bee41e")
   end
 
+  it "should include the current catalog_format" do
+    catalog = Puppet::Resource::Catalog.new("host")
+    expect(catalog.catalog_format).to eq(1)
+  end
+
   describe "when compiling" do
     it "should accept tags" do
       config = Puppet::Resource::Catalog.new("mynode")
@@ -278,6 +283,11 @@ describe Puppet::Resource::Catalog, "when compiling" do
     it 'copies the catalog_uuid' do
       @original.catalog_uuid = '827a74c8-cf98-44da-9ff7-18c5e4bee41e'
       expect(@original.filter.catalog_uuid).to eq(@original.catalog_uuid)
+    end
+
+    it 'copies the catalog_format' do
+      @original.catalog_format = 42
+      expect(@original.filter.catalog_format).to eq(@original.catalog_format)
     end
   end
 
@@ -811,7 +821,8 @@ describe Puppet::Resource::Catalog, "when converting to pson" do
   { :name => 'myhost',
     :version => 42,
     :code_id => 'b59e5df0578ef411f773ee6c33d8073c50e7b8fe',
-    :catalog_uuid => '827a74c8-cf98-44da-9ff7-18c5e4bee41e'
+    :catalog_uuid => '827a74c8-cf98-44da-9ff7-18c5e4bee41e',
+    :catalog_format => 42
   }.each do |param, value|
     it "emits a #{param} equal to #{value.inspect}" do
       @catalog.send(param.to_s + "=", value)
@@ -866,6 +877,7 @@ describe Puppet::Resource::Catalog, "when converting from pson" do
     @data['version'] = 50
     @data['code_id'] = 'b59e5df0578ef411f773ee6c33d8073c50e7b8fe'
     @data['catalog_uuid'] = '827a74c8-cf98-44da-9ff7-18c5e4bee41e'
+    @data['catalog_format'] = 42
     @data['tags'] = %w{one two}
     @data['classes'] = %w{one two}
     @data['edges'] = [Puppet::Relationship.new("File[/foo]", "File[/bar]",
@@ -881,6 +893,7 @@ describe Puppet::Resource::Catalog, "when converting from pson" do
     expect(catalog.version).to eq(@data['version'])
     expect(catalog.code_id).to eq(@data['code_id'])
     expect(catalog.catalog_uuid).to eq(@data['catalog_uuid'])
+    expect(catalog.catalog_format).to eq(@data['catalog_format'])
     expect(catalog).to be_tagged("one")
     expect(catalog).to be_tagged("two")
 
@@ -890,6 +903,11 @@ describe Puppet::Resource::Catalog, "when converting from pson" do
     expect(catalog.edges.collect(&:event)).to eq(["one"])
     expect(catalog.edges[0].source).to eq(catalog.resource(:file, "/foo"))
     expect(catalog.edges[0].target).to eq(catalog.resource(:file, "/bar"))
+  end
+
+  it "defaults the catalog_format to 0" do
+    catalog = Puppet::Resource::Catalog.from_data_hash PSON.parse @data.to_pson
+    expect(catalog.catalog_format).to eq(0)
   end
 
   it "should fail if the source resource cannot be found" do


### PR DESCRIPTION
Adds a `catalog_format` field to the catalog identifying the schema
version. That way future readers of the catalog can know what data
to expect. Also updates the api doc and schema to reflect the current
catalog_format version 1.