### PR TITLE
(PUP-5341) Emit TagSets as arrays in report YAML

### DIFF
--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -1,5 +1,6 @@
 require 'puppet/util/tagging'
 require 'puppet/util/classgen'
+require 'puppet/util/psych_support'
 require 'puppet/network/format_support'
 require 'facter'
 
@@ -9,6 +10,7 @@ require 'facter'
 class Puppet::Util::Log
   include Puppet::Util
   extend Puppet::Util::ClassGen
+  include Puppet::Util::PsychSupport
   include Puppet::Util::Tagging
   include Puppet::Network::FormatSupport
 

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -21,4 +21,20 @@ describe Puppet::Transaction::Report do
       Puppet::Transaction::Report.indirection.save(report)
     end
   end
+
+  describe "when dumping to YAML" do
+    it "should not contain TagSet objects" do
+      resource = Puppet::Resource.new(:notify, "Hello")
+      ral_resource = resource.to_ral
+      status = Puppet::Resource::Status.new(ral_resource)
+
+      log = Puppet::Util::Log.new(:level => :info, :message => "foo")
+
+      report = Puppet::Transaction::Report.new("apply")
+      report.add_resource_status(status)
+      report << log
+
+      expect(YAML.dump(report)).to_not match('Puppet::Util::TagSet')
+    end
+  end
 end


### PR DESCRIPTION
Resource::Status and Util::Log objects were not including PsychSupport
to allow them to serialize their tags member as an array.