### PR TITLE
(PUP-5964) Improve how type mismatches are asserted and reported

### DIFF
--- a/lib/puppet/data_providers/hiera_config.rb
+++ b/lib/puppet/data_providers/hiera_config.rb
@@ -124,7 +124,7 @@ module Puppet::DataProviders
     private :create_data_provider
 
     def validate_config(hiera_config)
-      Puppet::Pops::Types::TypeAsserter.assert_instance_of(@config_path, self.class.config_type, hiera_config)
+      Puppet::Pops::Types::TypeAsserter.assert_instance_of(["The Hiera Configuration at '%s'", @config_path], self.class.config_type, hiera_config)
     end
     private :validate_config
   end

--- a/lib/puppet/functions/assert_type.rb
+++ b/lib/puppet/functions/assert_type.rb
@@ -71,16 +71,14 @@ Puppet::Functions.create_function(:assert_type, Puppet::Functions::InternalFunct
     unless Puppet::Pops::Types::TypeCalculator.instance?(type,value)
       inferred_type = Puppet::Pops::Types::TypeCalculator.infer(value)
       if block_given?
-        # Give the inferred type to allow richer comparisson in the given block (if generalized
+        # Give the inferred type to allow richer comparison in the given block (if generalized
         # information is lost).
         #
         value = yield(type, inferred_type)
       else
-        # Do not give all the details - i.e. format as Integer, instead of Integer[n, n] for exact value, which
-        # is just confusing. (OTOH: may need to revisit, or provide a better "type diff" output.
-        #
-        actual = Puppet::Pops::Types::TypeCalculator.generalize(inferred_type)
-        raise Puppet::Pops::Types::TypeAssertionError.new("assert_type(): Expected type #{type} does not match actual: #{actual}", type,actual)
+        raise Puppet::Pops::Types::TypeAssertionError.new(
+          Puppet::Pops::Types::TypeMismatchDescriber.singleton.describe_mismatch('assert_type():', type, inferred_type),
+          type, inferred_type)
       end
     end
     value

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -28,9 +28,9 @@ module Lookup
     not_found = MergeStrategy::NOT_FOUND
     override_values = lookup_invocation.override_values
     result_with_name = names.reduce([nil, not_found]) do |memo, key|
-      value = override_values.include?(key) ? assert_type('override', value_type, override_values[key]) : not_found
+      value = override_values.include?(key) ? assert_type(["Value found for key '%s' in override hash", key], value_type, override_values[key]) : not_found
       catch(:no_such_key) { value = search_and_merge(key, lookup_invocation, merge) } if value.equal?(not_found)
-      break [key, assert_type('found', value_type, value)] unless value.equal?(not_found)
+      break [key, assert_type('Found value', value_type, value)] unless value.equal?(not_found)
       memo
     end
 
@@ -39,7 +39,7 @@ module Lookup
       default_values = lookup_invocation.default_values
       unless default_values.empty?
         result_with_name = names.reduce(result_with_name) do |memo, key|
-          value = default_values.include?(key) ? assert_type('default_values_hash', value_type, default_values[key]) : not_found
+          value = default_values.include?(key) ? assert_type(["Value found for key '%s' in default values hash", key], value_type, default_values[key]) : not_found
           memo = [key, value]
           break memo unless value.equal?(not_found)
           memo
@@ -50,9 +50,9 @@ module Lookup
     answer = result_with_name[1]
     if answer.equal?(not_found)
       if block_given?
-        answer = assert_type('default_block', value_type, yield(name))
+        answer = assert_type('Value returned from default block', value_type, yield(name))
       elsif has_default
-        answer = assert_type('default_value', value_type, default_value)
+        answer = assert_type('Default value', value_type, default_value)
       else
         fail_lookup(names)
       end

--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -79,7 +79,7 @@ module Puppet::Pops
     # Create a new instance of this strategy configured with the given _options_
     # @param merge_options [Hash<String,Object>] Merge options
     def initialize(options)
-      assert_type('merge_options', options_t, options)
+      assert_type('The merge options', options_t, options)
       @options = options
     end
 
@@ -92,8 +92,8 @@ module Puppet::Pops
     #
     def merge(e1, e2)
       checked_merge(
-        assert_type('e1', value_t, e1),
-        assert_type('e2', value_t, e2))
+        assert_type('The first element of the merge', value_t, e1),
+        assert_type('The second element of the merge', value_t, e2))
     end
 
     # Merges the result of yielding the given _lookup_variants_ to a given block.

--- a/lib/puppet/pops/types/type_asserter.rb
+++ b/lib/puppet/pops/types/type_asserter.rb
@@ -36,13 +36,10 @@ module TypeAsserter
   end
 
   def self.report_type_mismatch(subject, expected_type, actual_type)
-    # Do not give all the details for inferred types - i.e. format as Integer, instead of Integer[n, n] for exact
-    # value, which is just confusing. (OTOH: may need to revisit, or provide a better "type diff" output).
-    #
     subject = yield(subject) if block_given?
     subject = subject[0] % subject[1..-1] if subject.is_a?(Array)
     raise TypeAssertionError.new(
-        "#{subject} value has wrong type, expected #{expected_type}, actual #{actual_type}", expected_type, actual_type)
+      TypeMismatchDescriber.singleton.describe_mismatch("#{subject} has wrong type,", expected_type, actual_type), expected_type, actual_type)
   end
   private_class_method :report_type_mismatch
 end

--- a/lib/puppet/pops/types/type_asserter.rb
+++ b/lib/puppet/pops/types/type_asserter.rb
@@ -5,13 +5,14 @@ module TypeAsserter
   # Asserts that a type_to_check is assignable to required_type and raises
   # a {Puppet::ParseError} if that's not the case
   #
-  # @param subject [String] String to be prepended to the exception message
+  # @param subject [String,Array] String to be prepended to the exception message or Array where the first element is
+  #   a format string and the rest are arguments to that format string
   # @param expected_type [PAnyType] Expected type
   # @param type_to_check [PAnyType] Type to check against the required type
   # @return The type_to_check argument
   #
   # @api public
-  def self.assert_assignable(subject, expected_type, type_to_check)
+  def self.assert_assignable(subject, expected_type, type_to_check, &block)
     report_type_mismatch(subject, expected_type, type_to_check) unless expected_type.assignable?(type_to_check)
     type_to_check
   end
@@ -19,16 +20,17 @@ module TypeAsserter
   # Asserts that a value is an instance of a given type and raises
   # a {Puppet::ParseError} if that's not the case
   #
-  # @param subject [String] String to be prepended to the exception message
+  # @param subject [String,Array] String to be prepended to the exception message or Array where the first element is
+  #                               a format string and the rest are arguments to that format string
   # @param expected_type [PAnyType] Expected type for the value
   # @param value [Object] Value to check
   # @param nil_ok [Boolean] Can be true to allow nil value. Optional and defaults to false
   # @return The value argument
   #
   # @api public
-  def self.assert_instance_of(subject, expected_type, value, nil_ok = false)
+  def self.assert_instance_of(subject, expected_type, value, nil_ok = false, &block)
     unless value.nil? && nil_ok
-      report_type_mismatch(subject, expected_type, TypeCalculator.singleton.infer_set(value).generalize) unless expected_type.instance?(value)
+      report_type_mismatch(subject, expected_type, TypeCalculator.singleton.infer_set(value).generalize, &block) unless expected_type.instance?(value)
     end
     value
   end
@@ -37,6 +39,8 @@ module TypeAsserter
     # Do not give all the details for inferred types - i.e. format as Integer, instead of Integer[n, n] for exact
     # value, which is just confusing. (OTOH: may need to revisit, or provide a better "type diff" output).
     #
+    subject = yield(subject) if block_given?
+    subject = subject[0] % subject[1..-1] if subject.is_a?(Array)
     raise TypeAssertionError.new(
         "#{subject} value has wrong type, expected #{expected_type}, actual #{actual_type}", expected_type, actual_type)
   end

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -20,6 +20,12 @@ module Types
     alias :eql? :==
   end
 
+  class SubjectPathElement < TypePathElement
+    def to_s
+      key
+    end
+  end
+
   class MemberPathElement < TypePathElement
     def to_s
       "struct member #{key}"
@@ -392,6 +398,34 @@ module Types
       else
         raise Puppet::ParseError.new("#{subject}:\n #{errors.join("\n ")}")
       end
+    end
+
+    # Describe a confirmed mismatch using present tense
+    #
+    # @param name [String] name of mismatch
+    # @param expected [PAnyType] expected type
+    # @param actual [PAnyType] actual type
+    #
+    def describe_mismatch_present(name, expected, actual)
+      errors = describe(expected, actual, [SubjectPathElement.new(name)])
+      case errors.size
+      when 0
+        ''
+      when 1
+        errors[0].to_s.strip
+      else
+        errors.join("\n ")
+      end
+    end
+
+    # Describe a confirmed mismatch using past tense
+    #
+    # @param name [String] name of mismatch
+    # @param expected [PAnyType] expected type
+    # @param actual [PAnyType] actual type
+    #
+    def describe_mismatch(name, expected, actual)
+      describe_mismatch_present(name, expected, actual).gsub(/expects/, 'expected')
     end
 
     # @param subject [String] string to be prepended to the exception message

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1504,11 +1504,9 @@ class PArrayType < PCollectionType
   def _assignable?(o, guard)
     s_entry = element_type
     if o.is_a?(PTupleType)
-
-      # Tuple of anything can not be assigned (unless array is tuple of anything) - this case
-      # was handled at the top of this method.
-      #
-      return false if s_entry.nil?
+      # If s_entry is nil, this Array type has no opinion on element types. Therefore any
+      # tuple can be assigned.
+      return true if s_entry.nil?
 
       return false unless o.types.all? {|o_element_t| s_entry.assignable?(o_element_t, guard) }
       o_regular = o.types[0..-2]

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -28,7 +28,7 @@ describe 'the assert_type function' do
   it 'checks that first argument is a type' do
     expect do
       func.call({}, 10, 10)
-    end.to raise_error(ArgumentError, "'assert_type' expected one of:
+    end.to raise_error(ArgumentError, "'assert_type' expects one of:
   (Type type, Any value, Callable[Type, Type] block?)
     rejected: parameter 'type' expects a Type value, got Integer
   (String type_string, Any value, Callable[Type, Type] block?)

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -22,7 +22,7 @@ describe 'the assert_type function' do
   it 'asserts non compliant type by raising an error' do
     expect do
       func.call({}, type(Integer), 'hello world')
-    end.to raise_error(Puppet::Pops::Types::TypeAssertionError, /does not match actual/)
+    end.to raise_error(Puppet::Pops::Types::TypeAssertionError, /expected an Integer value, got String/)
   end
 
   it 'checks that first argument is a type' do
@@ -84,6 +84,6 @@ describe 'the assert_type function' do
       assert_type(UnprivilegedPort, 345)
       notice('ok')
     CODE
-    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Expected type UnprivilegedPort does not match actual: Integer/)
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expected an UnprivilegedPort value, got Integer\[345, 345\]/)
   end
 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -170,7 +170,7 @@ describe "when performing lookup" do
     it 'will not accept a succesful lookup of an undef value when the type rejects it' do
       expect do
         assemble_and_compile('${r}', "'abc::n'", 'String')
-      end.to raise_error(Puppet::ParseError, /found value has wrong type/)
+      end.to raise_error(Puppet::ParseError, /Found value has wrong type, expected a String value, got Undef/)
     end
 
     it 'will raise an exception when value is not found for array key and no default is provided' do
@@ -248,7 +248,8 @@ describe "when performing lookup" do
       it 'fails unless default is an instance of value_type' do
         expect do
           assemble_and_compile('${r[a]}_${r[b]}', "'abc::x'", 'Hash[String,String]', 'undef', "{'a' => 'dflt_x', 'b' => 32}")
-        end.to raise_error(Puppet::ParseError, /default_value value has wrong type/)
+        end.to raise_error(Puppet::ParseError,
+          /Default value has wrong type, expected a Hash\[String, String\] value, got Struct\[\{'a'=>String, 'b'=>Integer\}\]/)
       end
     end
 
@@ -281,7 +282,8 @@ describe "when performing lookup" do
       it 'fails unless block returns an instance of value_type' do
         expect do
           assemble_and_compile_with_block('${r[a]}_${r[b]}', "{'a' => 'dflt_x', 'b' => 32}", "'abc::x'", 'Hash[String,String]')
-        end.to raise_error(Puppet::ParseError, /default_block value has wrong type/)
+        end.to raise_error(Puppet::ParseError,
+          /Value returned from default block has wrong type, expected a Hash\[String, String\] value, got Struct\[\{'a'=>String, 'b'=>Integer\}\]/)
       end
 
       it 'receives a single name parameter' do

--- a/spec/unit/functions/regsubst_spec.rb
+++ b/spec/unit/functions/regsubst_spec.rb
@@ -56,7 +56,7 @@ describe 'the regsubst function' do
     end
 
     it 'should raise an Error if given a flag other thant G' do
-      expect { regsubst('foo', /bar/, 'gazonk', 'I') }.to raise_error(/expected one of/)
+      expect { regsubst('foo', /bar/, 'gazonk', 'I') }.to raise_error(/expects one of/)
     end
 
     it 'should handle global substitutions' do

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -149,7 +149,7 @@ describe 'the 4x function api' do
       expect(func.is_a?(Puppet::Functions::Function)).to be_truthy
       expect do
         func.call({}, 3, 10, 3, "4")
-      end.to raise_error(ArgumentError, "'min' expected one of:
+      end.to raise_error(ArgumentError, "'min' expects one of:
   (Numeric x, Numeric y, Numeric a?, Numeric b?, Numeric c*)
     rejected: parameter 'b' expects a Numeric value, got String
   (String x, String y, String a+)
@@ -217,7 +217,7 @@ describe 'the 4x function api' do
       expect(func.is_a?(Puppet::Functions::Function)).to be_truthy
       expect do
         func.call({}, 10, '20')
-      end.to raise_error(ArgumentError, "'min' expected one of:
+      end.to raise_error(ArgumentError, "'min' expects one of:
   (Numeric a, Numeric b)
     rejected: parameter 'b' expects a Numeric value, got String
   (String s1, String s2)

--- a/spec/unit/pops/types/type_asserter_spec.rb
+++ b/spec/unit/pops/types/type_asserter_spec.rb
@@ -8,19 +8,19 @@ describe 'the type asserter' do
   context 'when deferring formatting of subject'
   it 'can use an array' do
     expect{ asserter.assert_instance_of(['The %s in the %s', 'gizmo', 'gadget'], PIntegerType::DEFAULT, 'lens') }.to(
-    raise_error(TypeAssertionError, 'The gizmo in the gadget value has wrong type, expected Integer, actual String'))
+    raise_error(TypeAssertionError, 'The gizmo in the gadget has wrong type, expected an Integer value, got String'))
   end
 
   it 'can use an array obtained from block' do
     expect do
       asserter.assert_instance_of('gizmo', PIntegerType::DEFAULT, 'lens') { |s| ['The %s in the %s', s, 'gadget'] }
-    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget value has wrong type, expected Integer, actual String'))
+    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget has wrong type, expected an Integer value, got String'))
   end
 
   it 'can use an subject obtained from zero argument block' do
     expect do
       asserter.assert_instance_of(nil, PIntegerType::DEFAULT, 'lens') { 'The gizmo in the gadget' }
-    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget value has wrong type, expected Integer, actual String'))
+    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget has wrong type, expected an Integer value, got String'))
   end
 
   it 'does not produce a string unless the assertion fails' do
@@ -41,4 +41,3 @@ describe 'the type asserter' do
   end
 end
 end
-

--- a/spec/unit/pops/types/type_asserter_spec.rb
+++ b/spec/unit/pops/types/type_asserter_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'puppet/pops'
+
+module Puppet::Pops::Types
+describe 'the type asserter' do
+  let!(:asserter) { TypeAsserter }
+
+  context 'when deferring formatting of subject'
+  it 'can use an array' do
+    expect{ asserter.assert_instance_of(['The %s in the %s', 'gizmo', 'gadget'], PIntegerType::DEFAULT, 'lens') }.to(
+    raise_error(TypeAssertionError, 'The gizmo in the gadget value has wrong type, expected Integer, actual String'))
+  end
+
+  it 'can use an array obtained from block' do
+    expect do
+      asserter.assert_instance_of('gizmo', PIntegerType::DEFAULT, 'lens') { |s| ['The %s in the %s', s, 'gadget'] }
+    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget value has wrong type, expected Integer, actual String'))
+  end
+
+  it 'can use an subject obtained from zero argument block' do
+    expect do
+      asserter.assert_instance_of(nil, PIntegerType::DEFAULT, 'lens') { 'The gizmo in the gadget' }
+    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget value has wrong type, expected Integer, actual String'))
+  end
+
+  it 'does not produce a string unless the assertion fails' do
+    TypeAsserter.expects(:report_type_mismatch).never
+    asserter.assert_instance_of(nil, PIntegerType::DEFAULT, 1)
+  end
+
+  it 'does not format string unless the assertion fails' do
+    fmt_string = 'The %s in the %s'
+    fmt_string.expects(:'%').never
+    asserter.assert_instance_of([fmt_string, 'gizmo', 'gadget'], PIntegerType::DEFAULT, 1)
+  end
+
+  it 'does not call block unless the assertion fails' do
+    expect do
+      asserter.assert_instance_of(nil, PIntegerType::DEFAULT, 1) { |s| raise Error }
+    end.not_to raise_error
+  end
+end
+end
+

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 require 'puppet/pops'
 require 'puppet_spec/compiler'
 
+module Puppet::Pops
+module Types
+
 describe 'the type mismatch describer' do
   include PuppetSpec::Compiler
 
@@ -25,7 +28,7 @@ describe 'the type mismatch describer' do
     expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects an Array\[String\] value, got Tuple\[String, Integer\]/)
   end
 
-  it 'will not report a mismatch between a array and struct with details' do
+  it 'will not report details for a mismatch between an array and a struct' do
     code = <<-CODE
       function f(Array[String] $h) {
          $h[0]
@@ -35,7 +38,7 @@ describe 'the type mismatch describer' do
     expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects an Array value, got Struct/)
   end
 
-  it 'will not report a mismatch between a hash and tuple with details' do
+  it 'will not report details for a mismatch between a hash and a tuple' do
     code = <<-CODE
       function f(Hash[String,String] $h) {
          $h['a']
@@ -56,4 +59,62 @@ describe 'the type mismatch describer' do
     CODE
     expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /parameter 'port' expects an UnprivilegedPort value, got Integer\[34, 34\]/)
   end
+
+  context 'when using present tense' do
+    let(:parser) { TypeParser.new }
+    let(:subject) { TypeMismatchDescriber.singleton }
+    it 'reports a missing parameter as "has no parameter"' do
+      t = parser.parse('Struct[{a=>String}]')
+      expect { subject.validate_parameters('v', t, {'a'=>'a','b'=>'b'}, false, :present) }.to raise_error(Puppet::Error, "v: has no parameter named 'b'")
+    end
+
+    it 'reports a missing value as "expects a value"' do
+      t = parser.parse('Struct[{a=>String,b=>String}]')
+      expect { subject.validate_parameters('v', t, {'a'=>'a'}, false, :present) }.to raise_error(Puppet::Error, "v: expects a value for parameter 'b'")
+    end
+
+    it 'reports a missing block as "expects a block"' do
+      callable = parser.parse('Callable[String,String,Callable]')
+      args_tuple = parser.parse('Tuple[String,String]')
+      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], 'block', nil, nil, false)
+      expect(subject.describe_signatures('function', [dispatch], args_tuple, :present)).to eq("'function' expects a block")
+    end
+
+    it 'reports an unexpected block as "does not expect a block"' do
+      callable = parser.parse('Callable[String,String]')
+      args_tuple = parser.parse('Tuple[String,String,Callable]')
+      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], nil, nil, nil, false)
+      expect(subject.describe_signatures('function', [dispatch], args_tuple, :present)).to eq("'function' does not expect a block")
+    end
+  end
+
+  context 'when using past tense' do
+    let(:parser) { TypeParser.new }
+    let(:subject) { TypeMismatchDescriber.singleton }
+    it 'reports a missing parameter as "did not have a parameter"' do
+      t = parser.parse('Struct[{a=>String}]')
+      expect { subject.validate_parameters('v', t, {'a'=>'a','b'=>'b'}, false, :past) }.to raise_error(Puppet::Error, "v: did not have a parameter named 'b'")
+    end
+
+    it 'reports a missing value as "expected a value"' do
+      t = parser.parse('Struct[{a=>String,b=>String}]')
+      expect { subject.validate_parameters('v', t, {'a'=>'a'}, false, :past) }.to raise_error(Puppet::Error, "v: expected a value for parameter 'b'")
+    end
+
+    it 'reports a missing block as "expected a block"' do
+      callable = parser.parse('Callable[String,String,Callable]')
+      args_tuple = parser.parse('Tuple[String,String]')
+      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], 'block', nil, nil, false)
+      expect(subject.describe_signatures('function', [dispatch], args_tuple, :past)).to eq("'function' expected a block")
+    end
+
+    it 'reports an unexpected block as "did not expect a block"' do
+      callable = parser.parse('Callable[String,String]')
+      args_tuple = parser.parse('Tuple[String,String,Callable]')
+      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], nil, nil, nil, false)
+      expect(subject.describe_signatures('function', [dispatch], args_tuple, :past)).to eq("'function' did not expect a block")
+    end
+  end
+end
+end
 end

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -5,6 +5,46 @@ require 'puppet_spec/compiler'
 describe 'the type mismatch describer' do
   include PuppetSpec::Compiler
 
+  it 'will report a mismatch between a hash and a struct with details' do
+    code = <<-CODE
+      function f(Hash[String,String] $h) {
+         $h['a']
+      }
+      f({'a' => 'a', 'b' => 23})
+    CODE
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects a Hash\[String, String\] value, got Struct\[\{'a'=>String, 'b'=>Integer\}\]/)
+  end
+
+  it 'will report a mismatch between a array and tuple with details' do
+    code = <<-CODE
+      function f(Array[String] $h) {
+         $h[0]
+      }
+      f(['a', 23])
+    CODE
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects an Array\[String\] value, got Tuple\[String, Integer\]/)
+  end
+
+  it 'will not report a mismatch between a array and struct with details' do
+    code = <<-CODE
+      function f(Array[String] $h) {
+         $h[0]
+      }
+      f({'a' => 'a string', 'b' => 23})
+    CODE
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects an Array value, got Struct/)
+  end
+
+  it 'will not report a mismatch between a hash and tuple with details' do
+    code = <<-CODE
+      function f(Hash[String,String] $h) {
+         $h['a']
+      }
+      f(['a', 23])
+    CODE
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects a Hash value, got Tuple/)
+  end
+
   it 'will report a mismatch against an aliased type correctly' do
     code = <<-CODE
       type UnprivilegedPort = Integer[1024,65537]


### PR DESCRIPTION
This PR contains several commits targeted to improve reporting of type mismatches and to make them more consistent. The details are in the commit messages.

This PR is for stable and supersedes [PR-4709](/puppetlabs/puppet/pull/4709)