### PR TITLE
(PUP-2695) Deprecate reopening and merging classes other than "top scope"

### DIFF
--- a/lib/puppet/pops/model/ast_transformer.rb
+++ b/lib/puppet/pops/model/ast_transformer.rb
@@ -47,8 +47,11 @@ class Puppet::Pops::Model::AstTransformer
       if source_pos
         pos[:line] = source_pos.line
         pos[:pos]  = source_pos.pos
+        pos[:file] = source_pos.locator.file
       end
-      pos[:file] = @source_file if @source_file
+      if nil_or_empty?(pos[:file]) && !nil_or_empty?(@source_file)
+        pos[:file] = @source_file
+      end
       hash = hash.merge(pos)
     end
     hash
@@ -121,5 +124,9 @@ class Puppet::Pops::Model::AstTransformer
   #
   def is_nop?(o)
     o.nil? || o.is_a?(Model::Nop)
+  end
+
+  def nil_or_empty?(x)
+    x.nil? || x == ''
   end
 end


### PR DESCRIPTION
Merge PUP-5889 before this PR as this depends on the --strict setting being present.

This PR errors or warns under the control of --strict if a user redefines/reopens a class. This is still allowed for the class named '' (a.k.a 'main'). as that is the compilers way of merging all top scope logic.
