### PR TITLE
(PUP-5862) Only request file content when remediating drift 

### DIFF
--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -26,22 +26,22 @@ test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri
 
   step "Create a module and a file with content representing the first code_id version" do
     apply_manifest_on(master, <<MANIFEST, :catch_failures => true)
-    File {
-      ensure => directory,
-      mode => "0750",
-      owner => #{master.puppet['user']},
-      group => #{master.puppet['group']},
-    }
+File {
+  ensure => directory,
+  mode => "0750",
+  owner => #{master.puppet['user']},
+  group => #{master.puppet['group']},
+}
 
-    file {
-      '#{basedir}':;
-      '#{basedir}/environments':;
-      '#{basedir}/environments/production':;
-      '#{basedir}/environments/production/manifests':;
-      '#{module_dir}':;
-      '#{module_dir}/foo':;
-      '#{module_dir}/foo/files':;
-    }
+file {
+  '#{basedir}':;
+  '#{basedir}/environments':;
+  '#{basedir}/environments/production':;
+  '#{basedir}/environments/production/manifests':;
+  '#{module_dir}':;
+  '#{module_dir}/foo':;
+  '#{module_dir}/foo/files':;
+}
 MANIFEST
   end
 
@@ -51,41 +51,69 @@ MANIFEST
 
       step "Add test file resource to site.pp on master with agent-specific file path" do
         apply_manifest_on(master, <<MANIFEST, :catch_failures => true)
-        File {
-          owner => #{master.puppet['user']},
-          group => #{master.puppet['group']},
-        }
+File {
+  owner => #{master.puppet['user']},
+  group => #{master.puppet['group']},
+}
 
-        file { "site.pp":
-          ensure => file,
-          path => "#{basedir}/environments/production/manifests/site.pp",
-          content => "node default { file { 'foo_file': ensure => file, path => '#{agent_test_file_path}', source => 'puppet:///modules/foo/foo.txt' } }",
-          mode => "0640",
-        }
+file { "#{basedir}/environments/production/manifests/site.pp" :
+  ensure => file,
+  mode => "0640",
+  content => "node default {
+  file { '#{agent_test_file_path}' :
+    ensure => file,
+    source => 'puppet:///modules/foo/foo.txt'
+  }
+}",
+}
 
-        file { "foo_file":
-          ensure => file,
-          path => "#{module_dir}/foo/files/foo.txt",
-          content => "code_version_1",
-          mode => "0640",
-        }
+file { "#{module_dir}/foo/files/foo.txt" :
+  ensure => file,
+  content => "code_version_1",
+  mode => "0640",
+}
 MANIFEST
       end
 
       step "agent: #{agent}: Initial run: create the file with code version 1 and cache the catalog"
       on(agent, puppet("agent", "-t", "--server #{master}"), :acceptable_exit_codes => [0,2])
 
+      # When there is no drift, there should be no request made to the server
+      # for file metadata or file content.  A puppet run depending on
+      # a non-server will fail if such a request is made.  Verify the agent
+      # sends a report.
+
+      step "Remove existing reports from server reports directory"
+      on(master, "rm -rf /opt/puppetlabs/server/data/puppetserver/reports/#{agent.node_name}/*")
+      r = on(master, "ls /opt/puppetlabs/server/data/puppetserver/reports/#{agent.node_name} | wc -l").stdout.chomp
+      assert_equal(r, '0', "reports directory should be empty!")
+
+      step "Verify puppet run without drift does not make file request from server"
+      r = on(agent, puppet("agent",
+        "--use_cached_catalog",
+        "--server", "no_such_host",
+        "--report_server", master.hostname,
+        "--onetime",
+        "--no-daemonize",
+        "--detailed-exitcodes",
+        "--verbose"
+      )).stderr
+      assert_equal(r, "", "Fail: Did agent try to contact server?")
+
+      step "Verify report was delivered to server"
+      r = on(master, "ls /opt/puppetlabs/server/data/puppetserver/reports/#{agent.node_name} | wc -l").stdout.chomp
+      assert_equal(r, '1', "Reports directory should have one file")
+
       step "agent: #{agent}: Remove the test file to simulate drift"
       on(agent, "rm -rf #{agent_test_file_path}")
 
       step "Alter the source file on the master to simulate a code update"
       apply_manifest_on(master, <<MANIFEST, :catch_failures => true)
-        file { "foo_file":
-          ensure => file,
-          path => "#{module_dir}/foo/files/foo.txt",
-          content => "code_version_2",
-          mode => "0640",
-        }
+file { "#{module_dir}/foo/files/foo.txt" :
+  ensure => file,
+  mode => "0640",
+  content => "code_version_2",
+}
 MANIFEST
 
       step "Run agent again using --use_cached_catalog and ensure content from the first code_id is used"


### PR DESCRIPTION
…t only when drift is detected.

This PR adds a few test steps to an existing acceptance test,
puppet/acceptance//tests/direct_puppet/cached_catalog_remediate_local_drive.rb.
The new steps ensure that when the file has not drifted:
(1) the client does not make any requests to the server (for
file data or file metadata) and (2) the cached catalog application
results in report to the server.

It works by doing the following:
- Remove reports from server's report directory,
  verifies "ls -l <report_directory> | wc -l" returns "0".
- Start a puppet run with options given to use the cached
  catalog and to specify a non-existent server (no_such_host)
  and to specify the actual server as the report server
  destination.  If the agent issues a request to the server
  (except for report delivery), the run will fail (and the
  test will fail) because the server identified doesn't exist.
- Verify a report was delivered to the server by checking that
  "ls -l <report_directory> | wc -l" returns "1" on the server.

[skip ci]