### PR TITLE
(PUP-5903) Add local type alias to 4.x function api

### DIFF
--- a/lib/puppet/parser/e4_parser_adapter.rb
+++ b/lib/puppet/parser/e4_parser_adapter.rb
@@ -10,7 +10,7 @@ class Puppet::Parser::E4ParserAdapter
     @file = ''
     @string = ''
     @use = :unspecified
-    @@evaluating_parser ||= Puppet::Pops::Parser::EvaluatingParser.new()
+    @parser = Puppet::Pops::Parser::EvaluatingParser.singleton()
   end
 
   def file=(file)
@@ -20,15 +20,14 @@ class Puppet::Parser::E4ParserAdapter
 
   def parse(string = nil)
     self.string= string if string
-
     parse_result =
     if @use == :string
       # Parse with a source_file to set in created AST objects (it was either given, or it may be unknown
       # if caller did not set a file and the present a string.
       #
-      @@evaluating_parser.parse_string(@string, @file || "unknown-source-location")
+      @parser.parse_string(@string, @file || "unknown-source-location")
     else
-      @@evaluating_parser.parse_file(@file)
+      @parser.parse_file(@file)
     end
 
     # the parse_result may be

--- a/lib/puppet/pops/functions/dispatcher.rb
+++ b/lib/puppet/pops/functions/dispatcher.rb
@@ -49,7 +49,7 @@ class Puppet::Pops::Functions::Dispatcher
     add(Puppet::Pops::Functions::Dispatch.new(type, method_name, param_names, block_name, injections, weaving, last_captures))
   end
 
-  # Adds a dispatch directly to the set of dispathers.
+  # Adds a dispatch directly to the set of dispatchers.
   # @api private
   def add(a_dispatch)
     @dispatchers << a_dispatch

--- a/lib/puppet/pops/loader/ruby_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_function_instantiator.rb
@@ -13,10 +13,13 @@ class Puppet::Pops::Loader::RubyFunctionInstantiator
   # @return [Puppet::Pops::Functions.Function] - an instantiated function with global scope closure associated with the given loader
   #
   def self.create(loader, typed_name, source_ref, ruby_code_string)
-    unless ruby_code_string.is_a?(String) && ruby_code_string =~ /Puppet\:\:Functions\.create_function/
-      raise ArgumentError, "The code loaded from #{source_ref} does not seem to be a Puppet 4x API function - no create_function call."
+    unless ruby_code_string.is_a?(String) && ruby_code_string =~ /Puppet\:\:Functions\.create_(:?loaded_)?function/
+      raise ArgumentError, "The code loaded from #{source_ref} does not seem to be a Puppet 4x API function - no create_function or create_loaded_function call."
     end
-    created = eval(ruby_code_string, nil, source_ref, 1)
+    # make the private loader available in a binding to allow it to be passed on
+    loader_for_function = loader.private_loader
+    here = get_binding(loader_for_function)
+    created = eval(ruby_code_string, here, source_ref, 1)
     unless created.is_a?(Class)
       raise ArgumentError, "The code loaded from #{source_ref} did not produce a Function class when evaluated. Got '#{created.class}'"
     end
@@ -27,8 +30,18 @@ class Puppet::Pops::Loader::RubyFunctionInstantiator
     # when calling functions etc.
     # It should be bound to global scope
 
-    # TODO: Cheating wrt. scope - assuming it is found in the context
+    # Cheating wrt. scope - assuming it is found in the context (else an empty hash is used).
     closure_scope = Puppet.lookup(:global_scope) { {} }
-    created.new(closure_scope, loader.private_loader)
+    # If function definition used the loader from the binding to create a new loader, that loader wins
+    created.new(closure_scope, loader_for_function)
+  end
+
+  private
+
+  # Produces a binding where the given loader is bound as a local variable (loader_injected_arg). This variable can be used in loaded
+  # ruby code - e.g. to call Puppet::Function.create_loaded_function(:name, loader,...)
+  #
+  def self.get_binding(loader_injected_arg)
+    binding
   end
 end

--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -11,6 +11,10 @@ class EvaluatingParser
     @parser = Parser.new()
   end
 
+  def self.singleton
+    @instance ||= new
+  end
+
   def parse_string(s, file_source = nil)
     @file_source = file_source
     clear()

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -9,7 +9,7 @@ module Puppet::Pops
 module Types
 class TypeParser
   # @api public
-  def initialize
+  def initialize()
     @parser = Parser::Parser.new
     @type_transformer = Visitor.new(nil, 'interpret', 1, 1)
   end
@@ -23,12 +23,12 @@ class TypeParser
   #
   # @param string [String] a string with the type expressed in stringified form as produced by the 
   #   {TypeCalculator#string TypeCalculator#string} method.
-  # @param scope [Puppet::Parser::Scope] scope to use when loading type aliases
+  # @param context [Puppet::Parser::Scope, Puppet::Pops::Loaders::Loader] scope or loader to use when loading type aliases
   # @return [PAnyType] a specialization of the PAnyType representing the type.
   #
   # @api public
   #
-  def parse(string, scope = nil)
+  def parse(string, context = nil)
     # TODO: This state (@string) can be removed since the parse result of newer future parser
     # contains a Locator in its SourcePosAdapter and the Locator keeps the string.
     # This way, there is no difference between a parsed "string" and something that has been parsed
@@ -37,85 +37,85 @@ class TypeParser
     @string = string
     model = @parser.parse_string(@string)
     if model
-      interpret(model.current, scope)
+      interpret(model.current, context)
     else
       raise_invalid_type_specification_error
     end
   end
 
   # @api private
-  def interpret(ast, scope)
-    result = @type_transformer.visit_this_1(self, ast, scope)
+  def interpret(ast, context)
+    result = @type_transformer.visit_this_1(self, ast, context)
     result = result.body if result.is_a?(Model::Program)
     raise_invalid_type_specification_error unless result.is_a?(PAnyType)
     result
   end
 
   # @api private
-  def interpret_any(ast, scope)
-    @type_transformer.visit_this_1(self, ast, scope)
+  def interpret_any(ast, context)
+    @type_transformer.visit_this_1(self, ast, context)
   end
 
   # @api private
-  def interpret_Object(o, scope)
+  def interpret_Object(o, context)
     raise_invalid_type_specification_error
   end
 
   # @api private
-  def interpret_Program(o, scope)
-    interpret(o.body, scope)
+  def interpret_Program(o, context)
+    interpret(o.body, context)
   end
 
   # @api private
-  def interpret_QualifiedName(o, scope)
+  def interpret_QualifiedName(o, context)
     o.value
   end
 
   # @api private
-  def interpret_LiteralString(o, scope)
+  def interpret_LiteralString(o, context)
     o.value
   end
 
-  def interpret_LiteralRegularExpression(o, scope)
+  def interpret_LiteralRegularExpression(o, context)
     o.value
   end
 
   # @api private
-  def interpret_String(o, scope)
+  def interpret_String(o, context)
     o
   end
 
   # @api private
-  def interpret_LiteralDefault(o, scope)
+  def interpret_LiteralDefault(o, context)
     :default
   end
 
   # @api private
-  def interpret_LiteralInteger(o, scope)
+  def interpret_LiteralInteger(o, context)
     o.value
   end
 
   # @api private
-  def interpret_UnaryMinusExpression(o, scope)
-    -@type_transformer.visit_this_1(self, o.expr, scope)
+  def interpret_UnaryMinusExpression(o, context)
+    -@type_transformer.visit_this_1(self, o.expr, context)
   end
 
   # @api private
-  def interpret_LiteralFloat(o, scope)
+  def interpret_LiteralFloat(o, context)
     o.value
   end
 
   # @api private
-  def interpret_LiteralHash(o, scope)
+  def interpret_LiteralHash(o, context)
     result = {}
     o.entries.each do |entry|
-      result[@type_transformer.visit_this_1(self, entry.key, scope)] = @type_transformer.visit_this_1(self, entry.value, scope)
+      result[@type_transformer.visit_this_1(self, entry.key, context)] = @type_transformer.visit_this_1(self, entry.value, context)
     end
     result
   end
 
   # @api private
-  def interpret_QualifiedReference(name_ast, scope)
+  def interpret_QualifiedReference(name_ast, context)
     name = name_ast.value
     case name
     when 'integer'
@@ -207,13 +207,17 @@ class TypeParser
       TypeFactory.all_callables
 
     else
-      if scope.nil?
+      if context.nil?
         TypeFactory.type_reference(name.capitalize)
       else
-        loader = Puppet::Pops::Adapters::LoaderAdapter.loader_for_model_object(name_ast, scope)
+        if context.is_a?(Puppet::Pops::Loader::Loader)
+          loader = context
+        else
+          loader = Puppet::Pops::Adapters::LoaderAdapter.loader_for_model_object(name_ast, context)
+        end
         unless loader.nil?
           type = loader.load(:type, name)
-          type = type.resolve(self, scope) unless type.nil?
+          type = type.resolve(self, context) unless type.nil?
         end
         type || TypeFactory.resource(name)
       end
@@ -221,8 +225,8 @@ class TypeParser
   end
 
   # @api private
-  def interpret_AccessExpression(parameterized_ast, scope)
-    parameters = parameterized_ast.keys.collect { |param| interpret_any(param, scope) }
+  def interpret_AccessExpression(parameterized_ast, context)
+    parameters = parameterized_ast.keys.collect { |param| interpret_any(param, context) }
 
     unless parameterized_ast.left_expr.is_a?(Model::QualifiedReference)
       raise_invalid_type_specification_error
@@ -461,7 +465,7 @@ class TypeParser
 
     else
       type_name = parameterized_ast.left_expr.value
-      if scope.nil?
+      if context.nil?
         # Will be impossible to tell from a typed alias (when implemented) so a type reference
         # is returned here for now
         TypeFactory.type_reference(type_name.capitalize, parameters)

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -133,7 +133,7 @@ describe Puppet::Pops::Types::TypeParser do
     expect { parser.parse("Hash[Integer, Integer, 1,2,3]") }.to raise_the_parameter_error("Hash", "2 to 4", 5)
   end
 
-  context 'with scope and loader' do
+  context 'with scope context and loader' do
     let!(:scope) { {} }
 
     before :each do
@@ -156,6 +156,30 @@ describe Puppet::Pops::Types::TypeParser do
 
     it "parses a resource type with title using 'Resource[type, title]'" do
       expect(parser.parse("Resource[File, '/tmp/foo']", scope)).to be_the_type(types.resource('file', '/tmp/foo'))
+    end
+  end
+
+  context 'with loader context' do
+    let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, "type_parser_unit_test_loader") }
+    before :each do
+      loader.stubs(:load).returns nil
+      Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).never
+    end
+
+    it "interprets anything that is not a built in type to be a resource type" do
+      expect(parser.parse('File', loader)).to be_the_type(types.resource('file'))
+    end
+
+    it "parses a resource type with title" do
+      expect(parser.parse("File['/tmp/foo']", loader)).to be_the_type(types.resource('file', '/tmp/foo'))
+    end
+
+    it "parses a resource type using 'Resource[type]' form" do
+      expect(parser.parse("Resource[File]", loader)).to be_the_type(types.resource('file'))
+    end
+
+    it "parses a resource type with title using 'Resource[type, title]'" do
+      expect(parser.parse("Resource[File, '/tmp/foo']", loader)).to be_the_type(types.resource('file', '/tmp/foo'))
     end
   end
 


### PR DESCRIPTION
This adds the ability to add type aliases that are local to a function. See commit for example.

At this point, this is up for a preliminary review only and there are yet no tests of the new behavior.

1. The `TypeParser` is modified so it can operate on a `Scope` or a `Loader` (there is no scope available that would find the loader in question, so this was required).
2. The `RubyFunctionInstantiator` provides a `Binding` where loader is bound when doing the eval of the loaded function .rb file
3. The `create_function` method on `Function` picks up the loader bound in the `Binder` and delegates to a new function `create_loaded_function` (name not very good). This method is useful when unit testing, but should otherwise not be used directly by users.
4. ~~A user that wants to use type alias must use create_loaded_function instead of create_function, and must supply the loader from the Binding (i.e. just give it as an argument, see commit message).~~
5. A new builder was added to handle the `local_types` clause in the  function definition. It creates a new nested loader that the Function class remembers.
6. The Function class new operator is overloaded to set the loader from local_types instead of the user given one in case a more specialized loader should be used.

This design was favoured as it only includes one piece of magic - relaying the "loader" via divine powers. This controlling behavior from a far is not ideal, but it is used in a controlled situation.

Is it fine that if there is a local_types clause there will always be a nested loader for local types even if user did not add any local types.