### PR TITLE
(PUP-5991) Add a failing test for [drive]:\DEV on Windows

### DIFF
--- a/spec/unit/settings/file_setting_spec.rb
+++ b/spec/unit/settings/file_setting_spec.rb
@@ -169,6 +169,12 @@ describe Puppet::Settings::FileSetting do
       expect(resource.title).to eq(@basepath)
     end
 
+    it "should have a working directory with a root directory not called dev", :if => Puppet.features.microsoft_windows? do
+      # Although C:\Dev\.... is a valid path on Windows, some other code may regard it as a path to be ignored.  e.g. /dev/null resolves to C:\dev\null on Windows.
+      path = File.expand_path('somefile')
+      expect(path =~ /^[A-Z]:\/dev/i).to eq(nil)
+    end
+
     it "should fully qualified returned files if necessary (#795)" do
       @settings.stubs(:value).with(:myfile, nil, false).returns "myfile"
       path = File.expand_path('myfile')


### PR DESCRIPTION
Although C:\Dev\.... is a valid path on Windows, some other code and test
may regard it as a path to be ignored. e.g. /dev/null resolves to
C:\dev\null on Windows.  The unit test fails are ambiguous (e.g. expected
nil) and do not convey the underlying issue.  This commit adds a test that
fails if the working directory has a root directory of 'dev'