### PR TITLE
(PUP-5992) Support custom status command for systemd provider

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -114,15 +114,6 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     end
   end
 
-  def status
-    begin
-      systemctl("is-active", @resource[:name])
-    rescue Puppet::ExecutionFailure
-      return :stopped
-    end
-    return :running
-  end
-
   def enable
     self.unmask
     output = systemctl("enable", @resource[:name])
@@ -158,6 +149,10 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   def stopcmd
     [command(:systemctl), "stop", @resource[:name]]
+  end
+
+  def statuscmd
+    [command(:systemctl), "is-active", @resource[:name]]
   end
 end
 


### PR DESCRIPTION
The service provider on systemd systems currently only use systemctl
command to check to service status. The patch aims to support customize
status command when using service type.