### PR TITLE
(maint) Skip updating bundler in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ init:
 install:
   - SET PATH=C:\Ruby21-x64\bin;%PATH%
   - SET LOG_SPEC_ORDER=true
-  - gem install bundler --quiet --no-ri --no-rdoc
   - bundle install --jobs 4 --retry 2 --without development extra
   - type Gemfile.lock
   - ruby -v


### PR DESCRIPTION
AppVeyor instances now come with bundler pre-installed (see
https://www.appveyor.com/docs/installed-software). Remove the step
installing bundler.