### PR TITLE
(ORCH-5099) Add code_id to environment catalog from request

### DIFF
--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -5,14 +5,15 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
   def call(request, response)
     env_name = request.routing_path.split('/').last
     env = Puppet.lookup(:environments).get(env_name)
+    code_id = request.params[:code_id]
 
     if env.nil?
       raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("#{env_name} is not a known environment", Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
     end
 
-    catalog = Puppet::Parser::EnvironmentCompiler.compile(env).to_resource
+    catalog = Puppet::Parser::EnvironmentCompiler.compile(env, code_id).to_resource
 
-    env_graph = {:environment => env.name, :applications => {}}
+    env_graph = {:environment => env.name, :applications => {}, :code_id => catalog.code_id}
     applications = catalog.resources.select do |res|
       type = res.resource_type
       type.is_a?(Puppet::Resource::Type) && type.application?

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -1,14 +1,14 @@
 require 'puppet/parser/compiler'
 
 class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
-  def self.compile(env)
+  def self.compile(env, code_id=nil)
     begin
       $env_module_directories = nil
       env.check_for_reparse
 
       node = Puppet::Node.new(env)
       node.environment = env
-      new(node).compile
+      new(node, :code_id => code_id).compile
     rescue => detail
       message = "#{detail} in environment #{env.name}"
       Puppet.log_exception(detail, message)

--- a/spec/unit/appmgmt_spec.rb
+++ b/spec/unit/appmgmt_spec.rb
@@ -11,10 +11,10 @@ describe "Application instantiation" do
   # no really elegant way to do this
   include ParserRspecHelper
 
-  def compile_to_env_catalog(string)
+  def compile_to_env_catalog(string, code_id=nil)
     Puppet[:code] = string
     env = Puppet::Node::Environment.create("test", ["/dev/null"])
-    Puppet::Parser::EnvironmentCompiler.compile(env).filter { |r| r.virtual? }
+    Puppet::Parser::EnvironmentCompiler.compile(env, code_id).filter { |r| r.virtual? }
   end
 
 
@@ -573,6 +573,11 @@ EOS
         catalog = compile_to_env_catalog(MANIFEST_WITH_ILLEGAL_RESOURCE).to_resource
         }.to raise_error(/Only application components can appear inside a site - Notify\[fail me\] is not allowed at line 20/)
       end
+    end
+
+    it "includes code_id if specified" do
+      catalog = compile_to_env_catalog(MANIFEST_WITH_SITE, "12345")
+      expect(catalog.code_id).to eq("12345")
     end
   end
 


### PR DESCRIPTION
This follows the model of agent catalog compilation, passing code_id
from the HTTP request to the environment compiler, which adds it to the
catalog. We then read code_id from the environment catalog and include
it in our response.

This allows environment catalogs and agent catalogs to be correlated
with one another and against a specific version of code.