### PR TITLE
(PUP-5099) Add code_id to environment catalog from request

### DIFF
--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -1,14 +1,14 @@
 require 'puppet/parser/compiler'
 
 class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
-  def self.compile(env)
+  def self.compile(env, code_id=nil)
     begin
       $env_module_directories = nil
       env.check_for_reparse
 
       node = Puppet::Node.new(env)
       node.environment = env
-      new(node).compile
+      new(node, :code_id => code_id).compile
     rescue => detail
       message = "#{detail} in environment #{env.name}"
       Puppet.log_exception(detail, message)

--- a/spec/unit/appmgmt_spec.rb
+++ b/spec/unit/appmgmt_spec.rb
@@ -11,10 +11,10 @@ describe "Application instantiation" do
   # no really elegant way to do this
   include ParserRspecHelper
 
-  def compile_to_env_catalog(string)
+  def compile_to_env_catalog(string, code_id=nil)
     Puppet[:code] = string
     env = Puppet::Node::Environment.create("test", ["/dev/null"])
-    Puppet::Parser::EnvironmentCompiler.compile(env).filter { |r| r.virtual? }
+    Puppet::Parser::EnvironmentCompiler.compile(env, code_id).filter { |r| r.virtual? }
   end
 
 
@@ -573,6 +573,16 @@ EOS
         catalog = compile_to_env_catalog(MANIFEST_WITH_ILLEGAL_RESOURCE).to_resource
         }.to raise_error(/Only application components can appear inside a site - Notify\[fail me\] is not allowed at line 20/)
       end
+    end
+
+    it "includes code_id if specified" do
+      catalog = compile_to_env_catalog(MANIFEST_WITH_SITE, "12345")
+      expect(catalog.code_id).to eq("12345")
+    end
+
+    it "omits code_id if unspecified" do
+      catalog = compile_to_env_catalog(MANIFEST_WITH_SITE)
+      expect(catalog.code_id).to be_nil
     end
   end
 

--- a/spec/unit/network/http/api/master/v3/environment_spec.rb
+++ b/spec/unit/network/http/api/master/v3/environment_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+require 'puppet/network/http'
+
+describe Puppet::Network::HTTP::API::Master::V3::Environment do
+  let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
+
+  around :each do |example|
+    environment = Puppet::Node::Environment.create(:production, [], '/manifests')
+    loader = Puppet::Environments::Static.new(environment)
+    Puppet.override(:environments => loader) do
+      example.run
+    end
+  end
+
+  it "returns the environment catalog" do
+    request = Puppet::Network::HTTP::Request.from_hash(:headers => { 'accept' => 'application/json' }, :routing_path => "environment/production")
+
+    subject.call(request, response)
+
+    expect(response.code).to eq(200)
+
+    catalog = JSON.parse(response.body)
+    expect(catalog['environment']).to eq('production')
+    expect(catalog['applications']).to eq({})
+  end
+
+  it "returns 404 if the environment doesn't exist" do
+    request = Puppet::Network::HTTP::Request.from_hash(:routing_path => "environment/development")
+
+    expect { subject.call(request, response) }.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError, /development is not a known environment/)
+  end
+
+  it "omits code_id if unspecified" do
+    request = Puppet::Network::HTTP::Request.from_hash(:routing_path => "environment/production")
+
+    subject.call(request, response)
+
+    expect(JSON.parse(response.body)['code_id']).to be_nil
+  end
+
+  it "includes code_id if specified" do
+    request = Puppet::Network::HTTP::Request.from_hash(:params => {:code_id => '12345'}, :routing_path => "environment/production")
+
+    subject.call(request, response)
+
+    expect(JSON.parse(response.body)['code_id']).to eq('12345')
+  end
+
+  it "uses code_id from the catalog if it differs from the request" do
+    request = Puppet::Network::HTTP::Request.from_hash(:params => {:code_id => '12345'}, :routing_path => "environment/production")
+
+    Puppet::Resource::Catalog.any_instance.stubs(:code_id).returns('67890')
+
+    subject.call(request, response)
+
+    expect(JSON.parse(response.body)['code_id']).to eq('67890')
+  end
+end
+


### PR DESCRIPTION
This follows the model of agent catalog compilation, passing code_id
from the HTTP request to the environment compiler, which adds it to the
catalog. We then read code_id from the environment catalog and include
it in our response.

This allows environment catalogs and agent catalogs to be correlated
with one another and against a specific version of code.