### PR TITLE
(doc) Link to Puppet Server-specific API endpoints.

### DIFF
--- a/api/docs/http_api_index.md
+++ b/api/docs/http_api_index.md
@@ -103,6 +103,14 @@ with JSON (MIME type of `application/json`).
 * [Environments](./http_environments.md)
 * [Environment Catalog](./http_environment.md)
 
+### Puppet Server-specific endpoints
+
+When using [Puppet Server 2.3 or newer](https://docs.puppetlabs.com/puppetserver/2.3/)
+as a Puppet master, Puppet Server adds additional `/puppet/v3/` endpoints:
+
+* [Static File Content](https://docs.puppetlabs.com/puppetserver/latest/puppet-api/v3/static_file_content.md)
+* [Environment Classes](https://docs.puppetlabs.com/puppetserver/latest/puppet-api/v3/environment_classes.md)
+
 #### Error Responses
 
 The `environments` endpoint will respond to error conditions in a uniform manner

--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -33,22 +33,24 @@ The examples below use the POST method.
 
 Four parameters should be provided to the POST or GET:
 
-- `environment`: the environment name
-- `facts_format`: must be `pson`
-- `facts`: serialized pson of the facts hash.  One odd note: due to a long-ago misunderstanding in the code, this is
-doubly-escaped (it should just be singly-escaped).  To keep backward compatibility, the extraneous
+- `environment`: the environment name.
+- `facts_format`: must be `pson`.
+- `facts`: serialized pson of the facts hash. One odd note: due to a long-ago misunderstanding in the code, this is
+doubly-escaped (it should just be singly-escaped). To keep backward compatibility, the extraneous
 escaping is still used/supported.
-- `transaction_uuid`: a transaction uuid identifying the entire transaction (shows up in the report as well)
+- `transaction_uuid`: a transaction uuid identifying the entire transaction (shows up in the report as well).
 
 Two optional parameters are required for static catalogs:
-- `static_catalog`: a boolean requesting a static catalog if available; should always be `true`
+- `static_catalog`: a boolean requesting a
+[static catalog](https://docs.puppetlabs.com/puppet/latest/reference/static_catalogs.html) if available; should always
+be `true`.
 - `checksum_type`: a dot-separated list of checksum types supported by the agent, for use in file resources of a static
 catalog. The order signifies preference, highest first.
 
 An optional parameter can be provided to the POST or GET to notify a node classifier that the client requested a specific
 environment, which might differ from what the client believes is its current environment:
 
-- `configured_environment`: the environment configured on the client
+- `configured_environment`: the environment configured on the client.
 
 ### Example Response
 


### PR DESCRIPTION
Puppet Server 2.3 adds its own `/puppet/v3/` endpoints for static file content and per-environment classes. Link to the Puppet Server documentation being written for these new endpoints from the Puppet API index, and add a supporting link for static catalogs to the `http_catalog` documentation.

Supports SERVER-1108 and SERVER-1114 for the Puppet 4.4 and Server 2.3 releases.