### PR TITLE
(maint) Restore 2.3.0 testing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
 notifications:
   email: false
 rvm:
+  - 2.3.0-dev
   - 2.2.4
   - 2.1.7
   - 2.0.0
@@ -20,12 +21,16 @@ env:
 
 matrix:
   exclude:
+    - rvm: 2.3.0-dev
+      env: "CHECK=rubocop"
     - rvm: 2.2.4
       env: "CHECK=rubocop"
     - rvm: 2.0.0
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
+    - rvm: 2.3.0-dev
+      env: "CHECK=commits"
     - rvm: 2.2.4
       env: "CHECK=commits"
     - rvm: 2.0.0


### PR DESCRIPTION
Now that https://bugs.ruby-lang.org/issues/11928 is fixed in the 2.3 ruby
branch (but not yet released), we can test against the 2.3.0-dev rvm version
in travis.

When 2.3.1 is released, we should bump to 2.3.1 as we don't really need to
track 2.3.0-dev.