### PR TITLE
(maint) Fix package_spec on Fedora 23

### DIFF
--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -28,7 +28,11 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
         :yum
       end
     when 'Fedora'
-      :yum
+      if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemmajrelease), '22') >= 0
+        :dnf
+      else
+        :yum
+      end
     when 'FreeBSD'
       :ports
     when 'OpenBSD'


### PR DESCRIPTION
The package_spec test was incorrect when run on Fedora 23, because the
default provider changed. Update the test to report `dnf` on Fedora 23.