### PR TITLE
(PUP-2744) Always use RedHat service provider instead of init

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -17,9 +17,11 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   end
 
   # Debian and Ubuntu should use the Debian provider.
+  # RedHat systems should use the RedHat provider.
   confine :true => begin
-     os = Facter.value(:operatingsystem).downcase
-     !(os == 'debian' || os == 'ubuntu')
+      os = Facter.value(:operatingsystem).downcase
+      family = Facter.value(:osfamily).downcase
+      !(os == 'debian' || os == 'ubuntu' || family == 'redhat')
   end
 
   # We can't confine this here, because the init path can be overridden.


### PR DESCRIPTION
This commit ensures that for init-based services on RedHat
platforms, the RedHat service provider is used to properly
handle them rather than its more general parent the init provider.