### PR TITLE
(maint) Support multi-agent acceptance configurations

### DIFF
--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -11,7 +11,8 @@ test_name "Puppet Lookup Command"
 @confdir = "#{@testroot}/puppet"
 
 @mastername = on(master, facter('fqdn')).stdout.chomp
-@agentname = on(agent, facter('fqdn')).stdout.chomp
+host = agents.find { |host| host != master }
+@agentname = on(host, facter('fqdn')).stdout.chomp
 
 @master_opts = {
   'main' => {
@@ -2121,7 +2122,7 @@ MANI4
 file { '#{@coderoot}/enc.rb' :
   ensure => file,
   mode => "0755",
-  content => "#! /bin/ruby
+  content => "#!#{master['privatebindir']}/ruby
 nodename = ARGV.shift
 node2env = {
   '#{@mastername}' => \\\"---\\\\n  environment: env2\\\\n\\\",
@@ -2539,4 +2540,4 @@ with_puppet_running_on master, @master_opts, @coderoot do
     "enc specified environment env2 environment_key lookup failed"
   )
 
-end 
+end


### PR DESCRIPTION
Previously the test assumed there was a single agent, but when run with
multiple agents, beaker's `agent` method returns an array. And since
`on` accepts an array of hosts, and returns an array of results, we were
trying to call Array#stdout and failing.

This commit updates the test to use the first non-master agent. The test
then runs `puppet lookup --node <agent>` on the master. Since the test
is exercising lookup functionality on the master, we don't need to
repeat it for every agent.

The test also failed on master platforms that didn't have system ruby
installed in /bin/ruby, e.g. debian8. Instead we use privatebindir to
resolve ruby, which works for aio and git.