### PR TITLE
(PUP-5901) Make type mismatch describer use normalized types.

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -453,7 +453,7 @@ end
 #
 class PDataType < PAnyType
   def eql?(o)
-    self.class == o.class || o.class == PVariantType && o == PVariantType::DATA
+    self.class == o.class || o == PVariantType::DATA
   end
 
   def instance?(o)
@@ -992,7 +992,7 @@ class PPatternType < PScalarType
   end
 
   def eql?(o)
-    self.class == o.class && (@patterns | o.patterns).size == @patterns.size
+    self.class == o.class && @patterns.size == o.patterns.size && (@patterns - o.patterns).empty?
   end
 
   DEFAULT = PPatternType.new(EMPTY_ARRAY)
@@ -1688,9 +1688,8 @@ class PVariantType < PAnyType
   end
 
   def eql?(o)
-    # TODO: This special case doesn't look like it belongs here
-    self.class == o.class && (@types | o.types).size == @types.size ||
-        o.class == PDataType && self == DATA
+    o = DATA if o.is_a?(PDataType)
+    self.class == o.class && @types.size == o.types.size && (@types - o.types).empty?
   end
 
   # Variant compatible with the Data type.

--- a/spec/unit/functions/type_spec.rb
+++ b/spec/unit/functions/type_spec.rb
@@ -30,6 +30,6 @@ describe 'the type function' do
   it 'errors when given a fault inference quality' do
     expect do
       compile_to_catalog("notify { type([2, 4.14], gobbledygooked): }")
-    end.to raise_error(/gobbledygooked/m)
+    end.to raise_error(/expects a match for Enum\['detailed', 'generalized', 'reduced'\], got 'gobbledygooked'/)
   end
 end

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -1,0 +1,241 @@
+require 'spec_helper'
+require 'puppet/pops'
+
+module Puppet::Pops
+module Types
+describe 'Puppet Type System' do
+  let(:tf) { TypeFactory }
+  context 'Integer type' do
+    let!(:a) { tf.range(10, 20) }
+    let!(:b) { tf.range(18, 28) }
+    let!(:c) { tf.range( 2, 12) }
+    let!(:d) { tf.range(12, 18) }
+    let!(:e) { tf.range( 8, 22) }
+    let!(:f) { tf.range( 8,  9) }
+    let!(:g) { tf.range(21, 22) }
+    let!(:h) { tf.range(30, 31) }
+    let!(:i) { tf.float_range(1.0, 30.0) }
+    let!(:j) { tf.float_range(1.0, 9.0) }
+
+    context 'when testing if ranges intersect' do
+      it 'detects an intersection when self is before its argument' do
+        expect(a.intersect?(b)).to be_truthy
+      end
+
+      it 'detects an intersection when self is after its argument' do
+        expect(a.intersect?(c)).to be_truthy
+      end
+
+      it 'detects an intersection when self covers its argument' do
+        expect(a.intersect?(d)).to be_truthy
+      end
+
+      it 'detects an intersection when self equals its argument' do
+        expect(a.intersect?(a)).to be_truthy
+      end
+
+      it 'detects an intersection when self is covered by its argument' do
+        expect(a.intersect?(e)).to be_truthy
+      end
+
+      it 'does not consider an adjacent range to be intersecting' do
+        [f, g].each {|x| expect(a.intersect?(x)).to be_falsey }
+      end
+
+      it 'does not consider an range that is apart to be intersecting' do
+        expect(a.intersect?(h)).to be_falsey
+      end
+
+      it 'does not consider an overlapping float range to be intersecting' do
+        expect(a.intersect?(i)).to be_falsey
+      end
+    end
+
+    context 'when testing if ranges are adjacent' do
+      it 'detects an adjacent type when self is after its argument' do
+        expect(a.adjacent?(f)).to be_truthy
+      end
+
+      it 'detects an adjacent type when self is before its argument' do
+        expect(a.adjacent?(g)).to be_truthy
+      end
+
+      it 'does not consider overlapping types to be adjacent' do
+        [a, b, c, d, e].each { |x| expect(a.adjacent?(x)).to be_falsey }
+      end
+
+      it 'does not consider an range that is apart to be adjacent' do
+        expect(a.adjacent?(h)).to be_falsey
+      end
+
+      it 'does not consider an adjacent float range to be adjancent' do
+        expect(a.adjacent?(j)).to be_falsey
+      end
+    end
+
+    context 'when merging ranges' do
+      it 'will merge intersecting ranges' do
+        expect(a.merge(b)).to eq(tf.range(10, 28))
+      end
+
+      it 'will merge adjacent ranges' do
+        expect(a.merge(g)).to eq(tf.range(10, 22))
+      end
+
+      it 'will not merge ranges that are apart' do
+        expect(a.merge(h)).to be_nil
+      end
+
+      it 'will not merge overlapping float ranges' do
+        expect(a.merge(i)).to be_nil
+      end
+
+      it 'will not merge adjacent float ranges' do
+        expect(a.merge(j)).to be_nil
+      end
+    end
+  end
+
+  context 'Float type' do
+    let!(:a) { tf.float_range(10.0, 20.0) }
+    let!(:b) { tf.float_range(18.0, 28.0) }
+    let!(:c) { tf.float_range( 2.0, 12.0) }
+    let!(:d) { tf.float_range(12.0, 18.0) }
+    let!(:e) { tf.float_range( 8.0, 22.0) }
+    let!(:f) { tf.float_range(30.0, 31.0) }
+    let!(:g) { tf.range(1, 30) }
+
+    context 'when testing if ranges intersect' do
+      it 'detects an intersection when self is before its argument' do
+        expect(a.intersect?(b)).to be_truthy
+      end
+
+      it 'detects an intersection when self is after its argument' do
+        expect(a.intersect?(c)).to be_truthy
+      end
+
+      it 'detects an intersection when self covers its argument' do
+        expect(a.intersect?(d)).to be_truthy
+      end
+
+      it 'detects an intersection when self equals its argument' do
+        expect(a.intersect?(a)).to be_truthy
+      end
+
+      it 'detects an intersection when self is covered by its argument' do
+        expect(a.intersect?(e)).to be_truthy
+      end
+
+      it 'does not consider an range that is apart to be intersecting' do
+        expect(a.intersect?(f)).to be_falsey
+      end
+
+      it 'does not consider an overlapping integer range to be intersecting' do
+        expect(a.intersect?(g)).to be_falsey
+      end
+    end
+
+    context 'when merging ranges' do
+      it 'will merge intersecting ranges' do
+        expect(a.merge(b)).to eq(tf.float_range(10.0, 28.0))
+      end
+
+      it 'will not merge ranges that are apart' do
+        expect(a.merge(f)).to be_nil
+      end
+
+      it 'will not merge overlapping integer ranges' do
+        expect(a.merge(g)).to be_nil
+      end
+    end
+  end
+
+  context 'Optional type' do
+    let!(:overlapping_ints) { tf.variant(tf.range(10, 20), tf.range(18, 28)) }
+    let!(:optoptopt) { tf.optional(tf.optional(tf.optional(overlapping_ints))) }
+    let!(:optnu) { tf.optional(tf.not_undef(overlapping_ints)) }
+
+    context 'when normalizing' do
+      it 'compacts optional in optional in optional to just optional' do
+        expect(optoptopt.normalize).to eq(tf.optional(tf.range(10, 28)))
+      end
+    end
+
+    it 'compacts NotUndef in Optional to just Optional' do
+      expect(optnu.normalize).to eq(tf.optional(tf.range(10, 28)))
+    end
+  end
+
+  context 'NotUndef type' do
+    let!(:nununu) { tf.not_undef(tf.not_undef(tf.not_undef(tf.any))) }
+    let!(:nuopt) { tf.not_undef(tf.optional(tf.any)) }
+
+    context 'when normalizing' do
+      it 'compacts NotUndef in NotUndef in NotUndef to just NotUndef' do
+        expect(nununu.normalize).to eq(tf.not_undef(tf.any))
+      end
+
+      it 'compacts Optional in NotUndef to just NotUndef' do
+        expect(nuopt.normalize).to eq(tf.not_undef(tf.any))
+      end
+    end
+  end
+
+  context 'Variant type' do
+    let!(:overlapping_ints) { tf.variant(tf.range(10, 20), tf.range(18, 28)) }
+    let!(:adjacent_ints) { tf.variant(tf.range(10, 20), tf.range(8, 9)) }
+    let!(:mix_ints) { tf.variant(overlapping_ints, adjacent_ints) }
+    let!(:overlapping_floats) { tf.variant(tf.float_range(10.0, 20.0), tf.float_range(18.0, 28.0)) }
+    let!(:enums) { tf.variant(tf.enum('a', 'b'), tf.enum('b', 'c')) }
+    let!(:patterns) { tf.variant(tf.pattern('a', 'b'), tf.pattern('b', 'c')) }
+    let!(:with_undef) { tf.variant(tf.undef, tf.range(1,10)) }
+    let!(:all_optional) { tf.variant(tf.optional(tf.range(1,10)), tf.optional(tf.range(11,20))) }
+    let!(:groups) { tf.variant(mix_ints, overlapping_floats, enums, patterns, with_undef, all_optional) }
+
+    context 'when normalizing contained types that' do
+      it 'are overlapping ints, the result is a range' do
+        expect(overlapping_ints.normalize).to eq(tf.range(10, 28))
+      end
+
+      it 'are adjacent ints, the result is a range' do
+        expect(adjacent_ints.normalize).to eq(tf.range(8, 20))
+      end
+
+      it 'are mixed variants with adjacent and overlapping ints, the result is a range' do
+        expect(mix_ints.normalize).to eq(tf.range(8, 28))
+      end
+
+      it 'are overlapping floats, the result is a float range' do
+        expect(overlapping_floats.normalize).to eq(tf.float_range(10.0, 28.0))
+      end
+
+      it 'are enums, the result is an enum' do
+        expect(enums.normalize).to eq(tf.enum('a', 'b', 'c'))
+      end
+
+      it 'are patterns, the result is a pattern' do
+        expect(patterns.normalize).to eq(tf.pattern('a', 'b', 'c'))
+      end
+
+      it 'contains an Undef, the result is Optional' do
+        expect(with_undef.normalize).to eq(tf.optional(tf.range(1,10)))
+      end
+
+      it 'are all Optional, the result is an Optional with normalized type' do
+        expect(all_optional.normalize).to eq(tf.optional(tf.range(1,20)))
+      end
+
+      it 'can be normalized in groups, the result is a Variant containing the resulting normalizations' do
+        expect(groups.normalize).to eq(tf.variant(
+          tf.range(8, 28),
+          tf.float_range(10.0, 28.0),
+          tf.enum('a', 'b', 'c'),
+          tf.pattern('a', 'b', 'c'),
+          tf.optional(tf.range(1,20)))
+        )
+      end
+    end
+  end
+end
+end
+end


### PR DESCRIPTION
This PR contains new functionality that enables puppet types to be normalized and then what's needed to make the TypeMismatchDescriber take advantage of that.

The details are in the commit messages.