### PR TITLE
(PUP-5768) Fix problematic usage of ENV for Windows

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -245,11 +245,11 @@ module Puppet
           be set in `[master]`, `[agent]`, or an environment config section.",
         :call_hook => :on_define_and_write,
         :hook             => proc do |value|
-          ENV["PATH"] = "" if ENV["PATH"].nil?
-          ENV["PATH"] = value unless value == "none"
-          paths = ENV["PATH"].split(File::PATH_SEPARATOR)
+          Puppet::Util.set_env('PATH', '') if Puppet::Util.get_env('PATH').nil?
+          Puppet::Util.set_env('PATH', value) unless value == 'none'
+          paths = Puppet::Util.get_env('PATH').split(File::PATH_SEPARATOR)
           Puppet::Util::Platform.default_paths.each do |path|
-            ENV["PATH"] += File::PATH_SEPARATOR + path unless paths.include?(path)
+            Puppet::Util.set_env('PATH', Puppet::Util.get_env('PATH') + File::PATH_SEPARATOR + path) unless paths.include?(path)
           end
           value
         end

--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -156,7 +156,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
     if $SAFE > 0
       tmp = @@systmpdir
     else
-      for dir in [ENV['TMPDIR'], ENV['TMP'], ENV['TEMP'], @@systmpdir, '/tmp']
+      for dir in [ Puppet::Util.get_env('TMPDIR'), Puppet::Util.get_env('TMP'), Puppet::Util.get_env('TEMP'), @@systmpdir, '/tmp']
         if dir and stat = File.stat(dir) and stat.directory? and stat.writable?
           tmp = dir
           break

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -458,8 +458,8 @@ class Puppet::Node::Environment
   private
 
   def self.extralibs()
-    if ENV["PUPPETLIB"]
-      split_path(ENV["PUPPETLIB"])
+    if Puppet::Util.get_env('PUPPETLIB')
+      split_path(Puppet::Util.get_env('PUPPETLIB'))
     else
       []
     end

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -121,7 +121,13 @@ module Puppet::Test
       end
 
       # The process environment is a shared, persistent resource.
-      $old_env = ENV.to_hash
+      # Can't use Puppet.features.microsoft_windows? as it may be mocked out in a test.  This can cause test recurring test failures
+      if (!!File::ALT_SEPARATOR)
+        mode = :windows
+      else
+        mode = :posix
+      end
+      $old_env = Puppet::Util.get_environment(mode)
 
       # So is the load_path
       $old_load_path = $LOAD_PATH.dup
@@ -171,13 +177,19 @@ module Puppet::Test
       end
       $saved_indirection_state = nil
 
+      # Can't use Puppet.features.microsoft_windows? as it may be mocked out in a test.  This can cause test recurring test failures
+      if (!!File::ALT_SEPARATOR)
+        mode = :windows
+      else
+        mode = :posix
+      end
       # Restore the global process environment.  Can't just assign because this
       # is a magic variable, sadly, and doesn't do that™.  It is sufficiently
       # faster to use the compare-then-set model to avoid excessive work that it
       # justifies the complexity.  --daniel 2012-03-15
-      unless ENV.to_hash == $old_env
-        ENV.clear
-        $old_env.each {|k, v| ENV[k] = v }
+      unless Puppet::Util.get_environment(mode) == $old_env
+        Puppet::Util.clear_environment(mode)
+        $old_env.each {|k, v| Puppet::Util.set_env(k, v, mode) }
       end
 
       # Restore the load_path late, to avoid messing with stubs from the test.

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -224,7 +224,6 @@ module Puppet::Util::Windows::Process
   end
   module_function :windows_major_version
 
-  ENVSTRINGS_TERMINATOR_WCHAR = [0,0]
   # Returns a hash of the current environment variables encoded as UTF-8
   # The memory block returned from GetEnvironmentStringsW is double-null terminated and the vars are paired as below;
   # Var1=Value1\0
@@ -237,7 +236,7 @@ module Puppet::Util::Windows::Process
   def get_environment_strings
     env_ptr = GetEnvironmentStringsW()
 
-    pairs = env_ptr.read_arbitrary_wide_string_up_to(65534, ENVSTRINGS_TERMINATOR_WCHAR)
+    pairs = env_ptr.read_arbitrary_wide_string_up_to(65534, :double_null)
       .split(?\x00)
       .reject { |env_str| env_str.nil? || env_str.empty? || env_str[0] == '=' }
       .map { |env_pair| env_pair.split('=', 2) }

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -116,11 +116,23 @@ describe "Puppet defaults" do
   end
 
   describe "on a Windows-like platform it", :if => Puppet.features.microsoft_windows? do
-    it "should not add anything" do
+    let (:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
+
+    it "path should not add anything" do
       path = "c:\\windows\\system32#{File::PATH_SEPARATOR}c:\\windows"
-      Puppet::Util.withenv("PATH" => path) do
+      Puppet::Util.withenv( {"PATH" => path }, :windows ) do
         Puppet.settings[:path] = "none" # this causes it to ignore the setting
         expect(ENV["PATH"]).to eq(path)
+      end
+    end
+
+    it "path should support UTF8 characters" do
+      path = "c:\\windows\\system32#{File::PATH_SEPARATOR}c:\\windows#{File::PATH_SEPARATOR}C:\\" + rune_utf8
+      Puppet::Util.withenv( {"PATH" => path }, :windows) do
+        Puppet.settings[:path] = "none" # this causes it to ignore the setting
+
+        envhash = Puppet::Util::Windows::Process.get_environment_strings
+        expect(envhash['Path']).to eq(path)
       end
     end
   end

--- a/spec/integration/file_system/uniquefile_spec.rb
+++ b/spec/integration/file_system/uniquefile_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Puppet::FileSystem::Uniquefile do
+
+  describe "#open_tmp on Windows", :if => Puppet.features.microsoft_windows? do
+
+    describe "with UTF8 characters" do
+      include PuppetSpec::Files
+
+      let(:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
+      let(:temp_rune_utf8) { tmpdir(rune_utf8) }
+
+      env_hash_before = {}
+
+      before { env_hash_before = Puppet::Util::Windows::Process.get_environment_strings }
+      after do
+        Puppet::Util::Windows::Process.set_environment_variable('TMPDIR', env_hash_before['TMPDIR'])
+        Puppet::Util::Windows::Process.set_environment_variable('TMP', env_hash_before['TMP'])
+        Puppet::Util::Windows::Process.set_environment_variable('TEMP', env_hash_before['TEMP'])
+      end
+
+      it "should use UTF8 characters in TMP,TEMP,TMPDIR environment variable" do
+        # Set the temporary environment variables to the UTF8 temp path
+        Puppet::Util::Windows::Process.set_environment_variable('TMPDIR', temp_rune_utf8)
+        Puppet::Util::Windows::Process.set_environment_variable('TMP', temp_rune_utf8)
+        Puppet::Util::Windows::Process.set_environment_variable('TEMP', temp_rune_utf8)
+
+        # Create a unique file
+        filename = Puppet::FileSystem::Uniquefile.open_tmp('foo') do |file|
+          File.dirname(file.path)
+        end
+
+        expect(filename).to eq(temp_rune_utf8)
+      end
+    end
+  end
+
+end

--- a/spec/integration/file_system/uniquefile_spec.rb
+++ b/spec/integration/file_system/uniquefile_spec.rb
@@ -10,15 +10,6 @@ describe Puppet::FileSystem::Uniquefile do
       let(:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
       let(:temp_rune_utf8) { tmpdir(rune_utf8) }
 
-      env_hash_before = {}
-
-      before { env_hash_before = Puppet::Util::Windows::Process.get_environment_strings }
-      after do
-        Puppet::Util::Windows::Process.set_environment_variable('TMPDIR', env_hash_before['TMPDIR'])
-        Puppet::Util::Windows::Process.set_environment_variable('TMP', env_hash_before['TMP'])
-        Puppet::Util::Windows::Process.set_environment_variable('TEMP', env_hash_before['TEMP'])
-      end
-
       it "should use UTF8 characters in TMP,TEMP,TMPDIR environment variable" do
         # Set the temporary environment variables to the UTF8 temp path
         Puppet::Util::Windows::Process.set_environment_variable('TMPDIR', temp_rune_utf8)

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -119,4 +119,18 @@ describe Puppet::Node::Environment do
       # be raised if 'b' is evaluated before 'a').
       :strict_variables => true
   end
+
+  describe "#extralibs on Windows", :if => Puppet.features.microsoft_windows? do
+
+    describe "with UTF8 characters in PUPPETLIB" do
+      let(:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
+
+      before { Puppet::Util::Windows::Process.set_environment_variable('PUPPETLIB', rune_utf8) }
+      after  { Puppet::Util::Windows::Process.set_environment_variable('PUPPETLIB', nil) }
+
+      it "should use UTF8 characters in PUPPETLIB environment variable" do
+        expect(Puppet::Node::Environment.extralibs()).to eq([rune_utf8])
+      end
+    end
+  end
 end

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -126,7 +126,6 @@ describe Puppet::Node::Environment do
       let(:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
 
       before { Puppet::Util::Windows::Process.set_environment_variable('PUPPETLIB', rune_utf8) }
-      after  { Puppet::Util::Windows::Process.set_environment_variable('PUPPETLIB', nil) }
 
       it "should use UTF8 characters in PUPPETLIB environment variable" do
         expect(Puppet::Node::Environment.extralibs()).to eq([rune_utf8])

--- a/spec/integration/test/test_helper_spec.rb
+++ b/spec/integration/test/test_helper_spec.rb
@@ -12,7 +12,6 @@ describe "Windows UTF8 environment variables", :if => Puppet.features.microsoft_
 
     Puppet::Util::Windows::Process.set_environment_variable(@varname, @rune_utf8)
   }
-  after(:all) { ENV.delete('test-helper-foo')}
 
   it "#after_each_test should preserve UTF8 environment variables" do
     envhash = Puppet::Util::Windows::Process.get_environment_strings

--- a/spec/integration/test/test_helper_spec.rb
+++ b/spec/integration/test/test_helper_spec.rb
@@ -1,0 +1,29 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe "Windows UTF8 environment variables", :if => Puppet.features.microsoft_windows? do
+  # The Puppet::Util::Windows::Process class is used to manipulate environment variables as it is known to handle UTF8 characters. Where as the implementation of ENV in ruby does not.
+  # before and end all are used to inject environment variables before the test helper 'before_each_test' function is called
+  # Do not use before and after hooks in these tests as it may have unintended consequences
+
+  before(:all) {
+    @varname = 'test-helper-foo'
+    @rune_utf8 = "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7"
+
+    Puppet::Util::Windows::Process.set_environment_variable(@varname, @rune_utf8)
+  }
+  after(:all) { ENV.delete('test-helper-foo')}
+
+  it "#after_each_test should preserve UTF8 environment variables" do
+    envhash = Puppet::Util::Windows::Process.get_environment_strings
+    expect(envhash[@varname]).to eq(@rune_utf8)
+    # Change the value in the test to force test_helper to restore the environment
+    ENV[@varname] = 'bad foo'
+
+    # Prematurely trigger the after_each_test method
+    Puppet::Test::TestHelper.after_each_test
+
+    envhash = Puppet::Util::Windows::Process.get_environment_strings
+    expect(envhash[@varname]).to eq(@rune_utf8)
+  end
+end

--- a/spec/integration/util_spec.rb
+++ b/spec/integration/util_spec.rb
@@ -27,9 +27,10 @@ describe Puppet::Util do
       expect { Puppet::Util::Execution.execute(command) }.to raise_error(Puppet::ExecutionFailure, /Execution of '#{command}' returned 43: /)
       expect($CHILD_STATUS.exitstatus).to eq(43)
     end
+  end
 
-    it "replace_file should preserve original ACEs from existing replaced file on Windows",
-      :if => Puppet.features.microsoft_windows? do
+  describe "#replace_file on Windows", :if => Puppet.features.microsoft_windows? do
+    it "replace_file should preserve original ACEs from existing replaced file on Windows" do
 
       file = tmpfile("somefile")
       FileUtils.touch(file)
@@ -54,8 +55,7 @@ describe Puppet::Util do
       expect(replaced_sd.dacl).to eq(expected_sd.dacl)
     end
 
-    it "replace_file should use reasonable default ACEs on a new file on Windows",
-      :if => Puppet.features.microsoft_windows? do
+    it "replace_file should use reasonable default ACEs on a new file on Windows" do
 
       dir = tmpdir('DACL_playground')
       protected_sd = Puppet::Util::Windows::Security.get_security_descriptor(dir)
@@ -76,37 +76,37 @@ describe Puppet::Util do
 
       expect(new_sd.dacl).to eq(expected_sd.dacl)
     end
-  end
 
-  it "replace_file should work with filenames that include - and . (PUP-1389)", :if => Puppet.features.microsoft_windows? do
-    expected_content = 'some content'
-    dir = tmpdir('ReplaceFile_playground')
-    destination_file = File.join(dir, 'some-file.xml')
+    it "replace_file should work with filenames that include - and . (PUP-1389)" do
+      expected_content = 'some content'
+      dir = tmpdir('ReplaceFile_playground')
+      destination_file = File.join(dir, 'some-file.xml')
 
-    Puppet::Util.replace_file(destination_file, nil) do |temp_file|
-        temp_file.open
-        temp_file.write(expected_content)
+      Puppet::Util.replace_file(destination_file, nil) do |temp_file|
+          temp_file.open
+          temp_file.write(expected_content)
+      end
+
+      actual_content = File.read(destination_file)
+      expect(actual_content).to eq(expected_content)
     end
 
-    actual_content = File.read(destination_file)
-    expect(actual_content).to eq(expected_content)
-  end
+    it "replace_file should work with filenames that include special characters (PUP-1389)" do
+      expected_content = 'some content'
+      dir = tmpdir('ReplaceFile_playground')
+      # http://www.fileformat.info/info/unicode/char/00e8/index.htm
+      # dest_name = "somèfile.xml"
+      dest_name = "som\u00E8file.xml"
+      destination_file = File.join(dir, dest_name)
 
-  it "replace_file should work with filenames that include special characters (PUP-1389)", :if => Puppet.features.microsoft_windows? do
-    expected_content = 'some content'
-    dir = tmpdir('ReplaceFile_playground')
-    # http://www.fileformat.info/info/unicode/char/00e8/index.htm
-    # dest_name = "somèfile.xml"
-    dest_name = "som\u00E8file.xml"
-    destination_file = File.join(dir, dest_name)
+      Puppet::Util.replace_file(destination_file, nil) do |temp_file|
+          temp_file.open
+          temp_file.write(expected_content)
+      end
 
-    Puppet::Util.replace_file(destination_file, nil) do |temp_file|
-        temp_file.open
-        temp_file.write(expected_content)
+      actual_content = File.read(destination_file)
+      expect(actual_content).to eq(expected_content)
     end
-
-    actual_content = File.read(destination_file)
-    expect(actual_content).to eq(expected_content)
   end
 
   describe "#which on Windows", :if => Puppet.features.microsoft_windows? do

--- a/spec/integration/util_spec.rb
+++ b/spec/integration/util_spec.rb
@@ -108,4 +108,26 @@ describe Puppet::Util do
     actual_content = File.read(destination_file)
     expect(actual_content).to eq(expected_content)
   end
+
+  describe "#which on Windows", :if => Puppet.features.microsoft_windows? do
+    let (:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
+    let (:filename) { 'foo.exe' }
+    let (:filepath) { File.expand_path('C:\\' + rune_utf8 + '\\' + filename) }
+
+    before :each do
+      FileTest.stubs(:file?).returns false
+      FileTest.stubs(:file?).with(filepath).returns true
+
+      FileTest.stubs(:executable?).returns false
+      FileTest.stubs(:executable?).with(filepath).returns true
+    end
+
+    it "should be able to use UTF8 characters in the path" do
+      path = "C:\\" + rune_utf8 + "#{File::PATH_SEPARATOR}c:\\windows\\system32#{File::PATH_SEPARATOR}c:\\windows"
+      Puppet::Util.withenv( { "PATH" => path } , :windows) do
+        expect(Puppet::Util.which(filename)).to eq(filepath)
+      end
+    end
+  end
+
 end

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -261,6 +261,33 @@ describe Puppet::Util::RunMode do
         end
       end
     end
+
+    describe "#without_env internal helper with UTF8 characters" do
+      let(:varname) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
+      let(:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
+
+      before do
+        Puppet::Util::Windows::Process.set_environment_variable(varname, rune_utf8)
+      end
+      after do
+        Puppet::Util::Windows::Process.set_environment_variable(varname, nil)
+      end
+
+      it "removes environment variables within the block with UTF8 name" do
+        without_env(varname) do
+          expect(ENV[varname]).to be(nil)
+        end
+      end
+
+      it "restores UTF8 characters in environment variable values" do
+        without_env(varname) do
+          Puppet::Util::Windows::Process.set_environment_variable(varname, 'bad value')
+        end
+
+        envhash = Puppet::Util::Windows::Process.get_environment_strings
+        expect(envhash[varname]).to eq(rune_utf8)
+      end
+    end
   end
 
   def as_root

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -301,11 +301,11 @@ describe Puppet::Util::RunMode do
   end
 
   def without_env(name, &block)
-    saved = ENV[name]
-    ENV.delete name
+    saved = Puppet::Util.get_env(name)
+    Puppet::Util.set_env(name, nil)
     yield
   ensure
-    ENV[name] = saved
+    Puppet::Util.set_env(name, saved)
   end
 
   def without_home(&block)

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -269,9 +269,6 @@ describe Puppet::Util::RunMode do
       before do
         Puppet::Util::Windows::Process.set_environment_variable(varname, rune_utf8)
       end
-      after do
-        Puppet::Util::Windows::Process.set_environment_variable(varname, nil)
-      end
 
       it "removes environment variables within the block with UTF8 name" do
         without_env(varname) do

--- a/spec/unit/util/windows/api_types_spec.rb
+++ b/spec/unit/util/windows/api_types_spec.rb
@@ -25,4 +25,46 @@ describe "FFI::MemoryPointer", :if => Puppet.features.microsoft_windows? do
       expect(read_string.encoding).to eq(Encoding::UTF_8)
     end
   end
+
+  context "read_arbitrary_wide_string_up_to" do
+    let (:string) { "foo_bar" }
+    let (:single_null_string) { string + "\x00" }
+    let (:double_null_string) { string + "\x00\x00" }
+
+    it "should read a short single null terminated string" do
+      read_string = nil
+      FFI::MemoryPointer.from_string_to_wide_string(single_null_string) do |ptr|
+        read_string = ptr.read_arbitrary_wide_string_up_to()
+      end
+
+      expect(read_string).to eq(string)
+    end
+
+    it "should read a short double null terminated string" do
+      read_string = nil
+      FFI::MemoryPointer.from_string_to_wide_string(double_null_string) do |ptr|
+        read_string = ptr.read_arbitrary_wide_string_up_to(512, :double_null)
+      end
+
+      expect(read_string).to eq(string)
+    end
+
+    it "should return a string of max_length characters when specified" do
+      read_string = nil
+      FFI::MemoryPointer.from_string_to_wide_string(single_null_string) do |ptr|
+        read_string = ptr.read_arbitrary_wide_string_up_to(3)
+      end
+
+      expect(read_string).to eq(string[0..2])
+    end
+
+    it "should return wide strings in UTF-8" do
+      read_string = nil
+      FFI::MemoryPointer.from_string_to_wide_string(string) do |ptr|
+        read_string = ptr.read_arbitrary_wide_string_up_to()
+      end
+
+      expect(read_string.encoding).to eq(Encoding::UTF_8)
+    end
+  end
 end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -433,7 +433,8 @@ describe Puppet::Util do
       end
 
       it "should walk the search PATH returning the first executable" do
-        ENV.stubs(:[]).with('PATH').returns(File.expand_path('/bin'))
+        Puppet::Util.stubs(:get_env).with('PATH').returns(File.expand_path('/bin'))
+        Puppet::Util.stubs(:get_env).with('PATHEXT').returns(nil)
 
         expect(Puppet::Util.which('foo')).to eq(path)
       end
@@ -449,11 +450,11 @@ describe Puppet::Util do
 
       describe "when a file extension is specified" do
         it "should walk each directory in PATH ignoring PATHEXT" do
-          ENV.stubs(:[]).with('PATH').returns(%w[/bar /bin].map{|dir| File.expand_path(dir)}.join(File::PATH_SEPARATOR))
+          Puppet::Util.stubs(:get_env).with('PATH').returns(%w[/bar /bin].map{|dir| File.expand_path(dir)}.join(File::PATH_SEPARATOR))
+          Puppet::Util.stubs(:get_env).with('PATHEXT').returns('.FOOBAR')
 
           FileTest.expects(:file?).with(File.join(File.expand_path('/bar'), 'foo.CMD')).returns false
 
-          ENV.expects(:[]).with('PATHEXT').never
           expect(Puppet::Util.which('foo.CMD')).to eq(path)
         end
       end
@@ -461,8 +462,8 @@ describe Puppet::Util do
       describe "when a file extension is not specified" do
         it "should walk each extension in PATHEXT until an executable is found" do
           bar = File.expand_path('/bar')
-          ENV.stubs(:[]).with('PATH').returns("#{bar}#{File::PATH_SEPARATOR}#{base}")
-          ENV.stubs(:[]).with('PATHEXT').returns(".EXE#{File::PATH_SEPARATOR}.CMD")
+          Puppet::Util.stubs(:get_env).with('PATH').returns("#{bar}#{File::PATH_SEPARATOR}#{base}")
+          Puppet::Util.stubs(:get_env).with('PATHEXT').returns(".EXE#{File::PATH_SEPARATOR}.CMD")
 
           exts = sequence('extensions')
           FileTest.expects(:file?).in_sequence(exts).with(File.join(bar, 'foo.EXE')).returns false
@@ -474,8 +475,8 @@ describe Puppet::Util do
         end
 
         it "should walk the default extension path if the environment variable is not defined" do
-          ENV.stubs(:[]).with('PATH').returns(base)
-          ENV.stubs(:[]).with('PATHEXT').returns(nil)
+          Puppet::Util.stubs(:get_env).with('PATH').returns(base)
+          Puppet::Util.stubs(:get_env).with('PATHEXT').returns(nil)
 
           exts = sequence('extensions')
           %w[.COM .EXE .BAT].each do |ext|
@@ -487,8 +488,8 @@ describe Puppet::Util do
         end
 
         it "should fall back if no extension matches" do
-          ENV.stubs(:[]).with('PATH').returns(base)
-          ENV.stubs(:[]).with('PATHEXT').returns(".EXE")
+          Puppet::Util.stubs(:get_env).with('PATH').returns(base)
+          Puppet::Util.stubs(:get_env).with('PATHEXT').returns(".EXE")
 
           FileTest.stubs(:file?).with(File.join(base, 'foo.EXE')).returns false
           FileTest.stubs(:file?).with(File.join(base, 'foo')).returns true


### PR DESCRIPTION
The ENV class in Ruby is known to corrupt environment variables on Windows which contain UTF8 characters in their names and values.

This PR adds an operating system safe way of accessing environment variables as part of the Puppet::Util module, modifies the places in Puppet where it could potentially corrupt environment variables and adds tests to guard against the behaviour in the future.

Supercedes #4727 - sending through as a PR for final Travis / AppVeyor validation

NOTE: we should remove the mocking for tar_spec.rb in a future commit / PR.