### PR TITLE
(maint) Return PuppetSpec::File paths as UTF-8

### DIFF
--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -28,7 +28,7 @@ module PuppetSpec::Files
   def self.tmpfile(name, dir = nil)
     # Generate a temporary file, just for the name...
     source = dir ? Tempfile.new(name, dir) : Tempfile.new(name)
-    path = source.path
+    path = source.path.encode(Encoding::UTF_8)
     source.close!
 
     record_tmp(File.expand_path(path))
@@ -59,7 +59,7 @@ module PuppetSpec::Files
 
   def tmpdir(name) PuppetSpec::Files.tmpdir(name) end
   def self.tmpdir(name)
-    dir = Dir.mktmpdir(name)
+    dir = Dir.mktmpdir(name).encode!(Encoding::UTF_8)
 
     record_tmp(dir)
 


### PR DESCRIPTION
 - Re-encode string returned by PuppetSpec::Files.tmpfile and
   PuppetSpec::Files.tmpdir so that they can be concatenated with other
   UTF-8 strings used in tests.

   While Ruby internally will always return these strings intially in
   the current local codepage on Windows (which may be fixed in later
   Ruby versions), this primarily impacts testing scenarios where it is
   useful to create temporary files that have UTF-8 names.