### PR TITLE
(PUP-5986) Make loader available to type parser in 4.x function dispatch

### DIFF
--- a/lib/puppet/pops/loader/ruby_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_function_instantiator.rb
@@ -16,7 +16,10 @@ class Puppet::Pops::Loader::RubyFunctionInstantiator
     unless ruby_code_string.is_a?(String) && ruby_code_string =~ /Puppet\:\:Functions\.create_function/
       raise ArgumentError, "The code loaded from #{source_ref} does not seem to be a Puppet 4x API function - no create_function call."
     end
-    created = eval(ruby_code_string, nil, source_ref, 1)
+    # make the private loader available in a binding to allow it to be passed on
+    loader_for_function = loader.private_loader
+    here = get_binding(loader_for_function)
+    created = eval(ruby_code_string, here, source_ref, 1)
     unless created.is_a?(Class)
       raise ArgumentError, "The code loaded from #{source_ref} did not produce a Function class when evaluated. Got '#{created.class}'"
     end
@@ -27,8 +30,18 @@ class Puppet::Pops::Loader::RubyFunctionInstantiator
     # when calling functions etc.
     # It should be bound to global scope
 
-    # TODO: Cheating wrt. scope - assuming it is found in the context
+    # Cheating wrt. scope - assuming it is found in the context (else an empty hash is used).
     closure_scope = Puppet.lookup(:global_scope) { {} }
-    created.new(closure_scope, loader.private_loader)
+    # If function definition used the loader from the binding to create a new loader, that loader wins
+    created.new(closure_scope, loader_for_function)
+  end
+
+  private
+
+  # Produces a binding where the given loader is bound as a local variable (loader_injected_arg). This variable can be used in loaded
+  # ruby code - e.g. to call Puppet::Function.create_loaded_function(:name, loader,...)
+  #
+  def self.get_binding(loader_injected_arg)
+    binding
   end
 end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2287,15 +2287,17 @@ class PTypeAliasType < PAnyType
   # interpret the contained expression and the resolved type is remembered. This method also
   # checks and remembers if the resolve type contains self recursion.
   #
+  # @param type_parser [TypeParser] type parser that will interpret the type expression
+  # @param loader [Loader::Loader] loader to use when loading type aliases
   # @return [PTypeAliasType] the receiver of the call, i.e. `self`
   # @api private
-  def resolve(type_parser, scope)
+  def resolve(type_parser, loader)
     if @resolved_type.nil?
       # resolved to PTypeReferenceType::DEFAULT during resolve to avoid endless recursion
       @resolved_type = PTypeReferenceType::DEFAULT
       @self_recursion = true # assumed while it being found out below
       begin
-        @resolved_type = type_parser.interpret(@type_expr, scope).normalize
+        @resolved_type = type_parser.interpret(@type_expr, loader).normalize
 
         # Find out if this type is recursive. A recursive type has performance implications
         # on several methods and this knowledge is used to avoid that for non-recursive

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -10,18 +10,24 @@ module FunctionAPISpecModule
 
   class TestFunctionLoader < Puppet::Pops::Loader::StaticLoader
     def initialize
-      @functions = {}
+      @constants = {}
     end
 
     def add_function(name, function)
       typed_name = Puppet::Pops::Loader::Loader::TypedName.new(:function, name)
       entry = Puppet::Pops::Loader::Loader::NamedEntry.new(typed_name, function, __FILE__)
-      @functions[typed_name] = entry
+      @constants[typed_name] = entry
+    end
+
+    def add_type(name, type)
+      typed_name = Puppet::Pops::Loader::Loader::TypedName.new(:type, name)
+      entry = Puppet::Pops::Loader::Loader::NamedEntry.new(typed_name, type, __FILE__)
+      @constants[typed_name] = entry
     end
 
     # override StaticLoader
     def load_constant(typed_name)
-      @functions[typed_name]
+      @constants[typed_name]
     end
   end
 end
@@ -466,6 +472,48 @@ describe 'the 4x function api' do
       end
     end
 
+    context 'can use a loader when parsing types in function dispatch' do
+      let(:parser) {  Puppet::Pops::Parser::EvaluatingParser.new }
+
+      it 'and resolve a referenced Type alias' do
+        the_loader = loader()
+        the_loader.add_type('myalias', type_alias_t('MyAlias', 'Integer'))
+        here = get_binding(the_loader)
+        fc = eval(<<-CODE, here)
+          Puppet::Functions.create_function('testing::test') do
+            dispatch :test do
+              param 'MyAlias', :x
+            end
+            def test(x)
+              x
+            end
+          end
+        CODE
+        the_loader.add_function('testing::test', fc.new({}, the_loader))
+        program = parser.parse_string('testing::test(10)', __FILE__)
+        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        expect(parser.evaluate({}, program)).to eql(10)
+      end
+
+      it 'and distinguish between a Type alias and a Resource type' do
+        the_loader = loader()
+        here = get_binding(the_loader)
+        fc = eval(<<-CODE, here)
+          Puppet::Functions.create_function('testing::test') do
+            dispatch :test do
+              param 'MyAlias', :x
+            end
+            def test(x)
+              x
+            end
+          end
+        CODE
+        the_loader.add_function('testing::test', fc.new({}, the_loader))
+        program = parser.parse_string('testing::test(10)', __FILE__)
+        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        expect { parser.evaluate({}, program) }.to raise_error(Puppet::Error, /parameter 'x' expects a Resource value, got Integer/)
+      end
+    end
   end
 
   def create_noargs_function_class
@@ -801,4 +849,12 @@ describe 'the 4x function api' do
     end
   end
 
+  def type_alias_t(name, type_string)
+    type_expr = Puppet::Pops::Parser::EvaluatingParser.new.parse_string(type_string).current
+    Puppet::Pops::Types::TypeFactory.type_alias(name, type_expr)
+  end
+
+  def get_binding(loader_injected_arg)
+    binding
+  end
 end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1336,6 +1336,7 @@ describe 'The type calculator' do
         loader = mock
         loader.expects(:load).with(:type, 'tree1').returns t1
         loader.expects(:load).with(:type, 'tree2').returns t2
+        loader.expects(:is_a?).with(Puppet::Pops::Loader::Loader).returns true
 
         Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Puppet::Pops::Model::QualifiedReference), scope).at_least_once.returns loader
 
@@ -1711,6 +1712,7 @@ describe 'The type calculator' do
         loader = mock
         loader.expects(:load).with(:type, 'tree').returns t1
         loader.expects(:load).with(:type, 'othertree').returns t2
+        loader.expects(:is_a?).with(Puppet::Pops::Loader::Loader).returns true
 
         Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Puppet::Pops::Model::QualifiedReference), scope).at_least_once.returns loader
 

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -133,7 +133,7 @@ describe Puppet::Pops::Types::TypeParser do
     expect { parser.parse("Hash[Integer, Integer, 1,2,3]") }.to raise_the_parameter_error("Hash", "2 to 4", 5)
   end
 
-  context 'with scope and loader' do
+  context 'with scope context and loader' do
     let!(:scope) { {} }
 
     before :each do
@@ -156,6 +156,30 @@ describe Puppet::Pops::Types::TypeParser do
 
     it "parses a resource type with title using 'Resource[type, title]'" do
       expect(parser.parse("Resource[File, '/tmp/foo']", scope)).to be_the_type(types.resource('file', '/tmp/foo'))
+    end
+  end
+
+  context 'with loader context' do
+    let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, "type_parser_unit_test_loader") }
+    before :each do
+      loader.stubs(:load).returns nil
+      Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).never
+    end
+
+    it "interprets anything that is not a built in type to be a resource type" do
+      expect(parser.parse('File', loader)).to be_the_type(types.resource('file'))
+    end
+
+    it "parses a resource type with title" do
+      expect(parser.parse("File['/tmp/foo']", loader)).to be_the_type(types.resource('file', '/tmp/foo'))
+    end
+
+    it "parses a resource type using 'Resource[type]' form" do
+      expect(parser.parse("Resource[File]", loader)).to be_the_type(types.resource('file'))
+    end
+
+    it "parses a resource type with title using 'Resource[type, title]'" do
+      expect(parser.parse("Resource[File, '/tmp/foo']", loader)).to be_the_type(types.resource('file', '/tmp/foo'))
     end
   end
 


### PR DESCRIPTION
This PR modifies the `TypeParser` slightly so that it accepts either a loader or a scope as the optional second parameter when parsing. It also ensures that a loader is available to the type parser used when
evaluating 4x function dispatch declarations.