### PR TITLE
(PUP-5903) Add local type aliases to 4.x function API

### DIFF
--- a/lib/puppet/parser/e4_parser_adapter.rb
+++ b/lib/puppet/parser/e4_parser_adapter.rb
@@ -11,7 +11,6 @@ class E4ParserAdapter
     @file = ''
     @string = ''
     @use = :unspecified
-    @@evaluating_parser ||= Pops::Parser::EvaluatingParser.new()
   end
 
   def file=(file)
@@ -21,15 +20,15 @@ class E4ParserAdapter
 
   def parse(string = nil)
     self.string= string if string
-
+    parser = Pops::Parser::EvaluatingParser.singleton
     parse_result =
     if @use == :string
       # Parse with a source_file to set in created AST objects (it was either given, or it may be unknown
       # if caller did not set a file and the present a string.
       #
-      @@evaluating_parser.parse_string(@string, @file || "unknown-source-location")
+      parser.parse_string(@string, @file || "unknown-source-location")
     else
-      @@evaluating_parser.parse_file(@file)
+      parser.parse_file(@file)
     end
 
     # the parse_result may be

--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -11,6 +11,10 @@ class EvaluatingParser
     @parser = Parser.new()
   end
 
+  def self.singleton
+    @instance ||= new
+  end
+
   def parse_string(s, file_source = nil)
     @file_source = file_source
     clear()


### PR DESCRIPTION
This PR adds a new feature that makes it possible to define local type aliases in a 4.x Ruby function. These type aliases are only available inside the function.

Aliases are defined inside a block given to `local_types` by calling `type` with a puppet source string on the form `AliasT = T`.
```
Puppet::Functions.create_function(:example) do
  local_types do
    type 'MyType = Array[Integer]'
    type ...
  end
  dispatch :example do
    param 'MyType', :x
  end
end
```

This PR supersedes [PR-4732](/puppetlabs/puppet/pull/4732)