### PR TITLE
(PUP-6031) Preserve source host and port during inlining

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -103,7 +103,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     # This does that, while preserving any user-specified server or port.
     source_path = Pathname.new(metadata.full_path)
     path = source_path.relative_path_from(environment_path).to_s
-    source_as_uri = URI.parse(CGI.escape(source))
+    source_as_uri = URI.parse(URI.escape(source))
     server = source_as_uri.host
     port = ":#{source_as_uri.port}" if source_as_uri.port
     return "puppet://#{server}#{port}/#{path}"
@@ -128,7 +128,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   # for the 'modules' mount and the resolved path is of the form:
   #   $codedir/environments/$environment/*/*/files/**
   def inlineable_metadata?(metadata, source, environment_path)
-    source_as_uri = URI(URI.escape(source))
+    source_as_uri = URI.parse(URI.escape(source))
     location = Puppet::Module::FILETYPES['files']
 
     !!(source_as_uri.path =~ /^\/modules\// &&


### PR DESCRIPTION
If the puppet master's host and port are specified in the `source`
parameter, then we were not preserving the host and port when inlining
content_uri in the file metadata. As a result, the agent would either
use a host:port returned from DNS SRV records (if enabled) or the
Puppet[:server] and Puppet[:masterport] settings, which could be
different from what the manifest originally specified.

The code tried to do this, but `CGI.escape` should only be used on query
parameters, not the entire URI. And we were missing a test to verify the
behavior.

Also modifies another call site to use URI.parse(uri) instead of
URI(uri). The former should be called when parsing a String. The latter
should be called when you have either a String or a URI.