### PR TITLE
(PUP-6033) Normalize source parameter when inlining metadata

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -177,6 +177,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
         source_to_metadatas = {}
         sources.each do |source|
+          source = Puppet::Type.type(:file).attrclass(:source).normalize(source)
+
           if list_of_data = Puppet::FileServing::Metadata.indirection.search(source, options)
             basedir_meta = list_of_data.find {|meta| meta.relative_path == '.'}
             devfail "FileServing::Metadata search should always return the root search path" if basedir_meta.nil?
@@ -219,6 +221,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
         metadata = nil
         sources.each do |source|
+          source = Puppet::Type.type(:file).attrclass(:source).normalize(source)
+
           if data = Puppet::FileServing::Metadata.indirection.find(source, options)
             metadata = data
             metadata.source = source

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -88,7 +88,7 @@ module Puppet
     munge do |sources|
       sources = [sources] unless sources.is_a?(Array)
       sources.map do |source|
-        source = source.sub(/[#{SEPARATOR_REGEX}]+$/, '')
+        source = self.class.normalize(source)
 
         if Puppet::Util.absolute_path?(source)
           URI.unescape(Puppet::Util.path_to_uri(source).to_s)
@@ -96,6 +96,10 @@ module Puppet
           source
         end
       end
+    end
+
+    def self.normalize(source)
+      source.sub(/[#{SEPARATOR_REGEX}]+$/, '')
     end
 
     def change_to_s(currentvalue, newvalue)


### PR DESCRIPTION
Previously, if a source parameter had a trailing slash(es), we would
inline the metadata with the trailing slash. However, the agent always
strips trailing slashes from its sources, and it was not able to lookup
the inlined recursive metadata from the catalog.

This commit normalizes the source parameter when inlining file metadata,
so that `catalog.recursive_metadata[title][source]` works as expected.

Strangely, puppet strips trailing slashes for all file resources, not
just directories, so we apply the same logic when inlining
non-recursive metadata too.