### PR TITLE
(PUP-6036) Escape path when validating content_uri

### DIFF
--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -31,7 +31,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
 
   def content_uri=(path)
     begin
-      uri = URI.parse(path)
+      uri = URI.parse(URI.escape(path))
     rescue URI::InvalidURIError => detail
       raise(ArgumentError, "Could not understand URI #{path}: #{detail}")
     end

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -98,7 +98,13 @@ describe Puppet::FileServing::Metadata do
 
     describe "when assigning a content_uri" do
       it "should fail if uri is invalid" do
-        expect { metadata.content_uri = 'some foo' }.to raise_error ArgumentError, /Could not understand URI some foo: /
+        expect { metadata.content_uri = '://' }.to raise_error ArgumentError, /Could not understand URI :\/\//
+      end
+
+      it "should accept characters that require percent-encoding" do
+        uri = 'puppet:///modules/foo/files/ %:?#[]@!$&\'()*+,;='
+        metadata.content_uri = uri
+        expect(metadata.content_uri).to eq(uri)
       end
 
       it "should fail if uri is opaque" do


### PR DESCRIPTION
The content_uri metadata is composed from the source scheme, host, and
port, and the path of the file on disk, relative to the per-environment
directory. Since the path can contain characters that must be
percent-encoded, e.g. 'foo%bar', we need to escape the path prior to
trying to parse the URI.