### PR TITLE
(PUP-5855) Add strict error/warning for missing references to resource

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -115,7 +115,7 @@ module Puppet
         * `undefined_variables` --- disables warnings about non existing variables.",
       :hook      => proc do |value|
         values = munge(value)
-        valid   = %w[deprecations undefined_variables]
+        valid   = %w[deprecations undefined_variables undefined_resources]
         invalid = values - (values & valid)
         if not invalid.empty?
           raise ArgumentError, "Cannot disable unrecognized warning types #{invalid.inspect}. Valid values are #{valid.inspect}."

--- a/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
@@ -15,9 +15,30 @@ class Puppet::Parser::Compiler
 
     private
 
+    # A hash lookup is 6x avg times faster than find among 3 values.
+    CAPABILITY_ACCEPTED_METAPARAMS = {:require => true, :consume => true, :export => true}.freeze
+
     def validate_relationship(param)
-      unless [:require, :consume, :export].find {|pname| pname == param.name }
-        raise CatalogValidationError.new("'#{param.name}' is not a valid relationship to a capability", param.file, param.line) if has_capability?(param.value)
+      # when relationship is to a capability
+      if has_capability?(param.value)
+        unless CAPABILITY_ACCEPTED_METAPARAMS[param.name]
+          raise CatalogValidationError.new(
+            "'#{param.name}' is not a valid relationship to a capability", 
+              param.file, param.line)
+        end
+      elsif Puppet[:strict] != :off
+        # all other relationships requires the referenced resource to exist when mode is strict
+        refs = param.value.is_a?(Array) ? param.value : [param.value]
+        refs.each do |r|
+          unless catalog.resource(r.to_s)
+            msg = "Could not find resource '#{r.to_s}' in parameter '#{param.name.to_s}'"
+            if Puppet[:strict] == :error
+              raise CatalogValidationError.new(msg, param.file, param.line)
+            else
+              Puppet.warn_once(:undefined_resources, r.to_s, msg, param.file, param.line)
+            end
+          end
+        end
       end
     end
 

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -1243,6 +1243,66 @@ describe Puppet::Parser::Compiler do
       end
     end
 
+    describe "relationships to non existing resources when strict == :error" do
+      before(:each) do
+        Puppet[:strict] = :error
+      end
+
+      [ 'before',
+        'subscribe',
+        'notify',
+        'require'].each do |meta_param|
+        it "are reported as an error when formed via meta parameter #{meta_param}" do
+          expect { 
+            compile_to_catalog(<<-PP)
+              notify{ x : #{meta_param} => Notify[tooth_fairy] }
+            PP
+          }.to raise_error(/Could not find resource 'Notify\[tooth_fairy\]' in parameter '#{meta_param}'/)
+        end
+      end
+    end
+
+    describe "relationships to non existing resources when strict == :warning" do
+      before(:each) do
+        Puppet[:strict] = :warning
+      end
+
+      [ 'before',
+        'subscribe',
+        'notify',
+        'require'].each do |meta_param|
+        it "are reported as an error when formed via meta parameter #{meta_param}" do
+          expect { 
+            compile_to_catalog(<<-PP)
+              notify{ x : #{meta_param} => Notify[tooth_fairy] }
+            PP
+            expect(@logs).to have_matching_log(/Could not find resource 'Notify\[tooth_fairy\]' in parameter '#{meta_param}'/)
+
+          }.to_not raise_error()
+        end
+      end
+    end
+
+    describe "relationships to non existing resources when strict == :off" do
+      before(:each) do
+        Puppet[:strict] = :off
+      end
+
+      [ 'before',
+        'subscribe',
+        'notify',
+        'require'].each do |meta_param|
+        it "does not log an error for meta parameter #{meta_param}" do
+          expect { 
+            compile_to_catalog(<<-PP)
+              notify{ x : #{meta_param} => Notify[tooth_fairy] }
+            PP
+            expect(@logs).to_not have_matching_log(/Could not find resource 'Notify\[tooth_fairy\]' in parameter '#{meta_param}'/)
+          }.to_not raise_error()
+        end
+      end
+    end
+
     describe "relationships can be formed" do
       def extract_name(ref)
         ref.sub(/File\[(\w+)\]/, '\1')

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -1271,7 +1271,7 @@ describe Puppet::Parser::Compiler do
         'subscribe',
         'notify',
         'require'].each do |meta_param|
-        it "are reported as an error when formed via meta parameter #{meta_param}" do
+        it "are reported as a warning when formed via meta parameter #{meta_param}" do
           expect { 
             compile_to_catalog(<<-PP)
               notify{ x : #{meta_param} => Notify[tooth_fairy] }


### PR DESCRIPTION
Before this, only relationships formed with the relationship
operations <- -> <~ and ~> were validated. This validation checkes that
the referenced resource exists in the catalog and reports this.

The identical relationship formed via use of the meta parameters after,
require, subscribe, and notify were not validated. This led to that
errors in catalogs were not caught until the catalog was applied on the
agent.

This commit makes use of the recently added catalog validators and adds
validation of all relationships.

When making this change the existing code in the relationship validator
needed refactoring. It was then detected that it used an array.find and
a predicate lambda to see if a variable was one out of 3 possible
symbols. That was measured to be 6x slower that the fastest (hash
lookup= on Ruby 1.9.3. The relationship checking can be called thousands
of times and that statement alone could add several seconds to a catalog
compilation.

Note that the validation runs after the catalog is finalized. That means
that it includes all operations that could have modified the catalog.
(Overrides, queries, relationships, defaults, etc.)

Also note that this means that relationships formed with the arrow
operators are checked twice. This because there is otherwise no
information that points to that source location in case of an error. It
was measured that a mechanism that would avoid doing it twice was just
as costly as doing the check a second time. It may be possible to
instead add additional location information, but that is a greater
change, that also uses more memory.

The report of undefined_resource is controlled by the --strict flag and
`disabled_warnings` (:undefined_resources) as it turned out when first
introducing this that there are many imprecise references in use (paths
ending, or not ending with /). Too many of those showed up as hard
errors.

This is the main reason this is not a hard error by default, since that
means that it would be API breaking. Now, with --strict these warnings
can be addressed before the next major version.