### PR TITLE
(maint) Unwrap arrayification of config_version from execute call

### DIFF
--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -187,7 +187,7 @@ class Puppet::Resource::TypeCollection
       if environment.config_version.nil? || environment.config_version == ""
         @version = Time.now.to_i
       else
-        @version = Puppet::Util::Execution.execute([environment.config_version]).strip
+        @version = Puppet::Util::Execution.execute(environment.config_version).strip
       end
     end
 

--- a/spec/unit/resource/type_collection_spec.rb
+++ b/spec/unit/resource/type_collection_spec.rb
@@ -320,7 +320,7 @@ describe Puppet::Resource::TypeCollection do
       let(:environment) { Puppet::Node::Environment.create(:testing, [], '', '/my/foo') }
 
       it "should use the output of the environment's config_version setting if one is provided" do
-        Puppet::Util::Execution.expects(:execute).with(["/my/foo"]).returns "output\n"
+        Puppet::Util::Execution.expects(:execute).with("/my/foo").returns "output\n"
         expect(@code.version).to eq("output")
       end
 


### PR DESCRIPTION
Previously, the config_version was wrapped in an array for the
Puppet::Util::Execution.execute call because an older instance of the
method (when it was Puppet::Util.execute), would raise an exception if
the argument to it was not an array. The current implementation accepts
both string and array, so the wrapping of it in an array is no longer
required.