### PR TITLE
(maint) Update catalog format api document for version

### DIFF
--- a/api/schemas/catalog.json
+++ b/api/schemas/catalog.json
@@ -16,7 +16,7 @@
             "type": "string"
         },
         "version": {
-            "type": "integer"
+            "type": ["string", "integer"]
         },
         "code_id": {
             "type": ["string", "null"]


### PR DESCRIPTION
Previously, version was specified to be an integer. However, version is often
overridden by using a custom config_version script, which will return a
string. This commit updates the schema to include string for the
version type.