### PR TITLE
PUP-6048: always create a basic default environment

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -184,12 +184,10 @@ module Puppet
       # in case the configured environment (used for the default sometimes)
       # doesn't exist
       default_environment = Puppet[:environment].to_sym
-      if default_environment == :production
-        loaders << Puppet::Environments::StaticPrivate.new(
-          Puppet::Node::Environment.create(default_environment,
-                                           basemodulepath,
-                                           Puppet::Node::Environment::NO_MANIFEST))
-      end
+      loaders << Puppet::Environments::StaticPrivate.new(
+        Puppet::Node::Environment.create(default_environment,
+                                         basemodulepath,
+                                         Puppet::Node::Environment::NO_MANIFEST))
     end
 
     {


### PR DESCRIPTION
At the moment puppet only creates a basic default environment, if the
environment is named: `production`. I don't see a reason why production needs a
special handling in this case. Also changing this behavior will resolve the
problem, that 'puppet facts --environment test' throws an error if the
environment doesn't exist in the file system.