### PR TITLE
(maint) Remove ancient broken test involving code removed > 1 year ago

### DIFF
--- a/spec/integration/data_binding_spec.rb
+++ b/spec/integration/data_binding_spec.rb
@@ -58,27 +58,6 @@ describe "Data binding" do
     Puppet[:modulepath] = dir
   end
 
-  it "works with the puppet backend configured, although it can't use it for lookup" do
-    configure_hiera_for_puppet
-    create_manifest_in_module("testing", "binding.pp",
-                              <<-MANIFEST)
-    # lookup via the puppet backend to ensure it works
-    class testing::binding($value = hiera('variable')) {}
-    MANIFEST
-
-    create_manifest_in_module("testing", "data.pp",
-                              <<-MANIFEST)
-    class testing::data (
-    $variable = "the value"
-    ) { }
-    MANIFEST
-
-    catalog = compile_to_catalog("include testing::data")
-    resource = catalog.resource('Class[testing::data]')
-
-    expect(resource[:variable]).to eq("the value")
-  end
-
   context "with testing::binding and global data only" do
     it "looks up global data from hiera" do
       configure_hiera_for_one_tier(data)
@@ -200,19 +179,6 @@ describe "Data binding" do
       File.open(File.join(dir, "#{file}.yaml"), 'w') do |f|
         f.write(YAML.dump(contents))
       end
-    end
-
-    Puppet[:hiera_config] = hiera_config_file
-  end
-
-  def configure_hiera_for_puppet
-    hiera_config_file = tmpfile("hiera.yaml")
-
-    File.open(hiera_config_file, 'w') do |f|
-      f.write("---
-        :logger: 'noop'
-        :backends: ['puppet']
-      ")
     end
 
     Puppet[:hiera_config] = hiera_config_file


### PR DESCRIPTION
This removes testing that the "puppet_backend" for hiera (in the
puppet code base) can be loaded if configured. The result is that it
tries to load a file that was deleted over a year ago.

The reason why this problem occurs now, is because of order dependencies
among the tests. When order depending tests were fixed the now removed
test became order dependent. When it works it got an already configured
hiera, and the test assumed everything worked, since the only thing the
test did was no ensure it was possible to load a configuration
containing "puppet_backend".

When the puppet_backend freak was removed, this test became void, but
because of ordering issues it has not been seen until now.

This commit removes the broken test and the helper setup method
that configured the "puppet_backend".