### PR TITLE
(PA-212) update the version.rb for puppet

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -7,7 +7,7 @@
 
 
 module Puppet
-  PUPPETVERSION = '4.4.0'
+  PUPPETVERSION = '4.4.1'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
Puppet 4.4.0 left the building yesterday, so
we need to bump the puppetversion to 4.4.1