### PR TITLE
(PUP-6067) Add features to Pip3 provider

### DIFF
--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -12,6 +12,8 @@ Puppet::Type.type(:package).provide :pip3,
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
+
   def self.cmd
     ["pip3"]
   end

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -15,6 +15,14 @@ describe provider_class do
     XMLRPC::Client.stubs(:new2).returns(@client)
   end
 
+  describe 'provider features' do
+    it { is_expected.to be_installable }
+    it { is_expected.to be_uninstallable }
+    it { is_expected.to be_upgradeable }
+    it { is_expected.to be_versionable }
+    it { is_expected.to be_install_options }
+  end
+
   describe "parse" do
 
     it "should return a hash on valid input" do

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -14,6 +14,14 @@ describe provider_class do
     @client.stubs(:call).with('package_releases', 'fake_package').returns([])
   end
 
+  describe 'provider features' do
+    it { is_expected.to be_installable }
+    it { is_expected.to be_uninstallable }
+    it { is_expected.to be_upgradeable }
+    it { is_expected.to be_versionable }
+    it { is_expected.to be_install_options }
+  end
+
   describe "parse" do
 
     it "should return a hash on valid input" do


### PR DESCRIPTION
Features are not inherited from the parent provider. Without this the
Pip3 provider is pretty limited. Specify features provided by Pip as
also provided by Pip3. Also add spec tests for Pip and Pip3 verifying
their features.