### PR TITLE
(PUP-5968) Add deprecation warning for Symbol monkey patch

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -20,6 +20,14 @@ end
 
 class Symbol
   def <=> (other)
+    if (other.class != Symbol)
+      case Puppet[:strict]
+      when :warning
+        Puppet.warn_once('deprecation', 'symbol_comparison', 'Comparing Symbols to non-Symbol values is deprecated')
+      when :error
+        raise ArgumentError.new("Comparing Symbols to non-Symbol values is no longer allowed")
+      end
+    end
     self.to_s <=> other.to_s
   end
 


### PR DESCRIPTION
We re-introduced a monkey patch that had previously come from a
vendored dependency in order to maintain compatibility during the 4.x
series. This adds a warning that the patch is deprecated.