### PR TITLE
(PUP-6075) Ensure known resource type registration use downcased names

### DIFF
--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -137,9 +137,9 @@ class StaticLoader < Loader
       Zone
       Zpool
     }.each do |name |
-      typed_name = TypedName.new(:type, name)
+      typed_name = TypedName.new(:type, name.downcase)
       type = Puppet::Pops::Types::TypeFactory.resource(name)
-      @loaded[ typed_name ] = NamedEntry.new(TypedName.new(:type, name), type, __FILE__)
+      @loaded[ typed_name ] = NamedEntry.new(typed_name, type, __FILE__)
     end
   end
 end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -136,6 +136,18 @@ class PAnyType < TypedModelObject
     self
   end
 
+  # Called from the TypeParser once it has found a type using the Loader to enable that this type can
+  # resolve internal type expressions using a loader. Presently, this method is a no-op for all types
+  # except the {{PTypeAliasType}}.
+  #
+  # @param type_parser [TypeParser] type parser
+  # @param loader [Loader::Loader] loader to use
+  # @return [PTypeAliasType] the receiver of the call, i.e. `self`
+  # @api private
+  def resolve(type_parser, loader)
+    self
+  end
+
   # Responds `true` for all callables, variants of callables and unless _optional_ is
   # false, all optional callables.
   # @param optional [Boolean]

--- a/spec/unit/pops/loaders/static_loader_spec.rb
+++ b/spec/unit/pops/loaders/static_loader_spec.rb
@@ -102,7 +102,7 @@ describe 'the static loader' do
       Zpool
     }.each do |name |
       it "such that #{name} is available" do
-        expect(loader.load(:type, name)).to be_the_type(resource_type(name))
+        expect(loader.load(:type, name.downcase)).to be_the_type(resource_type(name))
       end
     end
   end


### PR DESCRIPTION
Before this commit, the logic for registering known resource types in
the static loader was `TypedName`instances with capitalized names. This
resulted in that the `TypeParser` could never find these types since it
always passes a downcased name to the loader.

This commit changes the registration to instead use a downcased name
(for the registration, not for the registered resource). It also creates
a no-op '#resolve' method on the `PAnyType` so that type `TypeParser`
doesn't need to check what kind of type it is that the loader returns
before calling that method.