### PR TITLE
(PUP-4760) Service type should not retrieve ensure status when unneeded

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1044,6 +1044,12 @@ class Type
     insync
   end
 
+  # Says if the ensure property should be retrieved if the resource is ensurable
+  # Defaults to true. Some resource type classes can override it
+  def self.needs_ensure_retrieved
+    true
+  end
+
   # Retrieves the current value of all contained properties.
   # Parameters and meta-parameters are not included in the result.
   # @todo As oposed to all non contained properties? How is this different than any of the other
@@ -1058,7 +1064,7 @@ class Type
     # Provide the name, so we know we'll always refer to a real thing
     result[:name] = self[:name] unless self[:name] == title
 
-    if ensure_prop = property(:ensure) or (self.class.validattr?(:ensure) and ensure_prop = newattr(:ensure))
+    if ensure_prop = property(:ensure) or (self.class.needs_ensure_retrieved and self.class.validattr?(:ensure) and ensure_prop = newattr(:ensure))
       result[:ensure] = ensure_state = ensure_prop.retrieve
     else
       ensure_state = nil

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -239,5 +239,9 @@ module Puppet
         debug "Skipping restart; service is not running"
       end
     end
+
+    def self.needs_ensure_retrieved
+      false
+    end
   end
 end

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -709,6 +709,20 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       @resource.property(:ensure).stubs(:retrieve).returns :absent
     end
 
+    it "should always retrieve the ensure value by default" do
+      @ensurable_resource = Puppet::Type.type(:file).new(:name => "/not/existent", :mode => "0644")
+      Puppet::Type::File::Ensure.stubs(:ensure).returns :absent
+      Puppet::Type::File::Ensure.any_instance.expects(:retrieve).once
+      @ensurable_resource.retrieve_resource
+    end
+
+    it "should not retrieve the ensure value if specified" do
+      @ensurable_resource = Puppet::Type.type(:service).new(:name => "DummyService", :enable => true)
+      @ensurable_resource.properties.each { |prop| prop.stubs(:retrieve) }
+      Puppet::Type::Service::Ensure.any_instance.expects(:retrieve).never
+      @ensurable_resource.retrieve_resource
+    end
+
     it "should fail if its provider is unsuitable" do
       @resource = Puppet::Type.type(:mount).new(:name => "foo", :fstype => "bar", :pass => 1, :ensure => :present)
       @resource.provider.class.expects(:suitable?).returns false


### PR DESCRIPTION
Before this, service type will always retrieve the ensure status even if no
ensure parameters is given.

But, because no Service Type parameter is dependant on whether the service
is running or not, we can just skip the ensure status retrieval.

Now, a service type will only retrieve the ensure status when a ensure
parameter is given.