### PR TITLE
(PUP-6073) Handle launchd plists with line continuations

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -206,7 +206,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   def self.read_plist(path)
     begin
       return Plist::parse_xml(path)
-    rescue ArgumentError => detail
+    rescue ArgumentError, NoMethodError => detail
       Puppet.debug("Error reading #{path}: #{detail}. Retrying with plutil.")
     end
 


### PR DESCRIPTION
Even though line continuations in text plist files is valid XML, the plist parser in facter 2.x can't handle it. In this case, rescue `NoMethodError' and let `plutil -convert xml1' normalize it.