### PR TITLE
(PUP-6085) Prevent that subkeys can do lookups in string values

### DIFF
--- a/lib/puppet/data_providers/hiera_interpolate.rb
+++ b/lib/puppet/data_providers/hiera_interpolate.rb
@@ -100,10 +100,16 @@ module Puppet::DataProviders::HieraInterpolate
       throw :no_such_key if value.nil?
       if segment =~ /^[0-9]+$/
         segment = segment.to_i
-        raise Puppet::DataBinding::LookupError, "Data provider type mismatch: Got #{value.class.name} when Array was expected to enable lookup using key '#{segment}'" unless value.instance_of?(Array)
+        unless value.instance_of?(Array)
+          raise Puppet::DataBinding::LookupError,
+                "Data provider type mismatch: Got #{value.class.name} when Array was expected to enable lookup using key '#{segment}'"
+        end
         throw :no_such_key unless segment < value.size
       else
-        raise Puppet::DataBinding::LookupError, "Data provider type mismatch: Got #{value.class.name} when a non Array object that responds to '[]' was expected to enable lookup using key '#{segment}'" unless value.respond_to?(:'[]') && !value.instance_of?(Array)
+        unless value.respond_to?(:'[]') && !(value.instance_of?(Array) || value.instance_of?(String))
+          raise Puppet::DataBinding::LookupError,
+                "Data provider type mismatch: Got #{value.class.name} when a hash-like object was expected to enable lookup using key '#{segment}'"
+        end
         throw :no_such_key unless value.include?(segment)
       end
       value = value[segment]

--- a/spec/unit/data_providers/hiera_interpolation_spec.rb
+++ b/spec/unit/data_providers/hiera_interpolation_spec.rb
@@ -118,6 +118,7 @@ describe 'Puppet::DataProviders::HieraInterpolate' do
           }
         },
         'x.1' => '(lookup) x dot 1',
+        'key' => 'subkey'
       }
     }
 
@@ -216,6 +217,11 @@ describe 'Puppet::DataProviders::HieraInterpolate' do
     it 'should not find a subkey when the dotted key is quoted with method lookup' do
       expect_lookup('a.d')
       expect(interpolator.interpolate("a dot f: %{lookup(\"'a.d'\")}", lookup_invocation, true)).to eq('a dot f: ')
+    end
+
+    it 'should not find a subkey that is matched within a string' do
+      expect_lookup('key')
+      expect{ interpolator.interpolate('%{hiera("key.subkey")}', lookup_invocation, true) }.to raise_error(/Got String when a hash-like object was expected to enable lookup using key 'subkey'/)
     end
   end
 


### PR DESCRIPTION
Before this commit, a subkey of a dotted key could be matched by a
string that contained a matching text. Hiera would require that the
value responded to :[] and that it was not an Array (arrays should use
numeric index). A string fulfills that requirement.

This commit adds the constraint that the value cannot be a String when
subjected to a lookup.