### PR TITLE
(PUP-6028) Treat unresolved type references as errors

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -570,6 +570,10 @@ module Puppet
           :default  => false,
           :type     => :boolean,
           :desc     => "Whether the application management feature is on or off. You must restart Puppet Server after changing this setting.",
+          :hook     => proc do |value|
+            # Statically loaded resource types differ depending on setting
+            Puppet::Pops::Loaders.clear
+          end
       }
   )
 

--- a/lib/puppet/loaders.rb
+++ b/lib/puppet/loaders.rb
@@ -10,6 +10,7 @@ module Puppet
       require 'puppet/pops/loader/dependency_loader'
       require 'puppet/pops/loader/null_loader'
       require 'puppet/pops/loader/static_loader'
+      require 'puppet/pops/loader/runtime3_type_loader'
       require 'puppet/pops/loader/ruby_function_instantiator'
       require 'puppet/pops/loader/puppet_function_instantiator'
       require 'puppet/pops/loader/type_definition_instantiator'

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -116,6 +116,14 @@ module Manager
     klass.providerloader.loadall Puppet.lookup(:current_environment)
     klass.providify unless klass.providers.empty?
 
+    if klass.is_capability?
+      # A capability type is a resource (sort of) so it must be registered with the loader
+      loader = Puppet::Pops::Loaders.loaders.public_environment_loader
+      string_name = name.to_s
+      typed_name = Puppet::Pops::Loader::Loader::TypedName.new(:type, string_name.downcase)
+      loader.set_entry(typed_name, Puppet::Pops::Types::PResourceType.new(string_name.capitalize))
+    end
+
     klass
   end
 

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -116,13 +116,8 @@ module Manager
     klass.providerloader.loadall Puppet.lookup(:current_environment)
     klass.providify unless klass.providers.empty?
 
-    if klass.is_capability?
-      # A capability type is a resource (sort of) so it must be registered with the loader
-      loader = Puppet::Pops::Loaders.loaders.public_environment_loader
-      string_name = name.to_s
-      typed_name = Puppet::Pops::Loader::Loader::TypedName.new(:type, string_name.downcase)
-      loader.set_entry(typed_name, Puppet::Pops::Types::PResourceType.new(string_name.capitalize))
-    end
+    loc = block_given? ? block.source_location : nil
+    Puppet::Pops::Loaders.register_runtime3_type(name, loc.nil? ? nil : URI("#{loc[0]}?line=#{loc[1]}"))
 
     klass
   end

--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -189,7 +189,9 @@ class Puppet::Parser::AST::PopsBridge
     end
 
     def instantiate_ResourceTypeDefinition(o, modname)
-      Puppet::Resource::Type.new(:definition, o.name, @context.merge(args_from_definition(o, modname)))
+      instance = Puppet::Resource::Type.new(:definition, o.name, @context.merge(args_from_definition(o, modname)))
+      Puppet::Pops::Loaders.register_runtime3_type(instance.name, Puppet::Pops::Adapters::SourcePosAdapter.adapt(o).to_uri)
+      instance
     end
 
     def instantiate_CapabilityMapping(o, modname)

--- a/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
@@ -28,7 +28,7 @@ class Puppet::Parser::Compiler
         end
       elsif Puppet[:strict] != :off
         # all other relationships requires the referenced resource to exist when mode is strict
-        refs = param.value.is_a?(Array) ? param.value : [param.value]
+        refs = param.value.is_a?(Array) ? param.value.flatten : [param.value]
         refs.each do |r|
           unless catalog.resource(r.to_s)
             msg = "Could not find resource '#{r.to_s}' in parameter '#{param.name.to_s}'"

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -414,6 +414,11 @@ class AccessOperator
     access(t, scope, *keys)
   end
 
+  # If a type reference is encountered here, it's an error
+  def access_PTypeReferenceType(o, scope, keys)
+    fail(Issues::UNKNOWN_RESOURCE_TYPE, @semantic, {:type_name => o.name })
+  end
+
   # A Resource can create a new more specific Resource type, and/or an array of resource types
   # If the given type has title set, it can not be specified further.
   # @example
@@ -541,6 +546,8 @@ class AccessOperator
                  c.type_name
                elsif c.is_a?(String)
                  c.downcase
+               elsif c.is_a?(Types::PTypeReferenceType)
+                 c.name.downcase
                else
                  fail(Issues::ILLEGAL_HOSTCLASS_NAME, @semantic.keys[i], {:name => c})
                end

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -442,7 +442,7 @@ class AccessOperator
     when Types::PResourceType
       type_name.type_name
     when String
-      type_name.downcase
+      type_name
     else
       # blame given left expression if it defined the type, else the first given key expression
       blame = o.type_name.nil? ? @semantic.keys[0] : @semantic.left_expr
@@ -450,7 +450,7 @@ class AccessOperator
     end
 
     # type name must conform
-    if type_name !~ Patterns::CLASSREF
+    if type_name.downcase !~ Patterns::CLASSREF
       fail(Issues::ILLEGAL_CLASSREF, blamed, {:name=>type_name})
     end
 

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -494,7 +494,7 @@ module Issues
   end
 
   UNKNOWN_RESOURCE_TYPE = issue :UNKNOWN_RESOURCE_TYPE, :type_name do
-    "Resource type not found: #{type_name.capitalize}"
+    "Resource type not found: #{type_name}"
   end
 
   ILLEGAL_RESOURCE_TYPE = hard_issue :ILLEGAL_RESOURCE_TYPE, :actual do

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -1,0 +1,34 @@
+module Puppet::Pops
+module Loader
+
+# Runtime3TypeLoader
+# ===
+# Loads a resource type using the 3.x type loader
+#
+# @api private
+class Runtime3TypeLoader < BaseLoader
+  def initialize(parent_loader, environment)
+    super(parent_loader, environment.name)
+    @environment = environment
+  end
+
+  def to_s()
+    "(Runtime3TypeLoader '#{loader_name()}')"
+  end
+
+  # Finds typed/named entity in this module
+  # @param typed_name [TypedName] the type/name to find
+  # @return [Loader::NamedEntry, nil found/created entry, or nil if not found
+  #
+  def find(typed_name)
+    if typed_name.type == :type
+      name = typed_name.name
+      value = @environment.known_resource_types.find_definition(name)
+      set_entry(typed_name, Types::TypeFactory.resource(name.capitalize)) unless value.nil?
+    else
+      nil
+    end
+  end
+end
+end
+end

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -32,13 +32,12 @@ class StaticLoader < Loader
   def to_s()
     "(StaticLoader)"
   end
+
   private
 
   def load_constant(typed_name)
     @loaded[typed_name]
   end
-
-  private
 
   # Creates a function for each of the specified log levels
   #

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -136,11 +136,17 @@ class StaticLoader < Loader
       Zfs
       Zone
       Zpool
-    }.each do |name |
-      typed_name = TypedName.new(:type, name.downcase)
-      type = Puppet::Pops::Types::TypeFactory.resource(name)
-      @loaded[ typed_name ] = NamedEntry.new(typed_name, type, __FILE__)
+    }.each { |name| create_resource_type_reference(name) }
+
+    if Puppet[:app_management]
+      create_resource_type_reference('Node')
     end
+  end
+
+  def create_resource_type_reference(name)
+    typed_name = TypedName.new(:type, name.downcase)
+    type = Puppet::Pops::Types::TypeFactory.resource(name)
+    @loaded[ typed_name ] = NamedEntry.new(typed_name, type, __FILE__)
   end
 end
 end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -36,18 +36,26 @@ class Loaders
     @puppet_system_loader = nil
   end
 
-  # Finds the `Loaders` instance by looking up the :loaders in the global Puppet context and then uses it to
-  # find the appropriate loader for the given `module_name`, or for the environment in case `module_name`
-  # is `nil` or empty.
+  # Calls {#loaders} to obtain the {{Loaders}} instance and then uses it to find the appropriate loader
+  # for the given `module_name`, or for the environment in case `module_name` is `nil` or empty.
   #
   # @param module_name [String,nil] the name of the module
   # @return [Loader::Loader] the found loader
   # @raise [Puppet::ParseError] if no loader can be found
   # @api private
   def self.find_loader(module_name)
+    loaders.find_loader(module_name)
+  end
+
+  # Finds the `Loaders` instance by looking up the :loaders in the global Puppet context
+  #
+  # @return [Loaders] the loaders instance
+  # @raise [Puppet::ParseError] if loader has been bound to the global context
+  # @api private
+  def self.loaders
     loaders = Puppet.lookup(:loaders) { nil }
     raise Puppet::ParseError, "Internal Error: Puppet Context ':loaders' missing" if loaders.nil?
-    loaders.find_loader(module_name)
+    loaders
   end
 
   # Finds the appropriate loader for the given `module_name`, or for the environment in case `module_name`

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -652,7 +652,7 @@ class TypeCalculator
     # A mapping must be made to empty string. A nil value will result in an error later
     title = o.title
     title = '' if :undef == title
-    PType.new(PResourceType.new(o.type.to_s.downcase, title))
+    PType.new(PResourceType.new(o.type.to_s, title))
   end
 
   # @api private

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -289,9 +289,23 @@ class TypeFormatter
     '[a TypeFormatter]'
   end
 
-  private
-
   NAME_SEGMENT_SEPARATOR = '::'.freeze
+
+  # Capitalizes each segment in a name separated with the {NAME_SEPARATOR}
+  # @param qualified_name [String] the name to capitalize
+  # @return [String] the capitalized name
+  #
+  def capitalize_segments(qualified_name)
+    segments = qualified_name.split(NAME_SEGMENT_SEPARATOR)
+    if segments.size == 1
+      qualified_name.capitalize
+    else
+      segments.each(&:capitalize!)
+      segments.join(NAME_SEGMENT_SEPARATOR)
+    end
+  end
+
+  private
 
   COMMA_SEP = ', '.freeze
 
@@ -321,10 +335,6 @@ class TypeFormatter
     bld.chomp!(COMMA_SEP)
     bld << '}'
     bld
-  end
-
-  def capitalize_segments(s)
-    s.split(NAME_SEGMENT_SEPARATOR).map(&:capitalize).join(NAME_SEGMENT_SEPARATOR)
   end
 
   @singleton = new

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -17,8 +17,10 @@ module Types
       self.class == o.class && key == o.key
     end
 
-    alias :eql? :==
-  end
+    def eql?(o)
+      self == o
+    end
+   end
 
   class SubjectPathElement < TypePathElement
     def to_s
@@ -130,7 +132,9 @@ module Types
       self.class == o.class && canonical_path == o.canonical_path
     end
 
-    alias :eql? :==
+    def eql?(o)
+      self == o
+    end
 
     def hash
       canonical_path.hash

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -106,6 +106,15 @@ module Types
         'did not have a'
       end
     end
+
+    def it_references(tense)
+      case tense
+        when :present
+          'references'
+        else
+          'referenced'
+      end
+    end
   end
 
   class Mismatch
@@ -224,6 +233,27 @@ module Types
   class MissingRequiredBlock < Mismatch
     def message(variant, position, tense = :present)
       "#{variant}#{position} #{it_expects(tense)} a block"
+    end
+  end
+
+  class UnresolvedTypeReference < Mismatch
+    attr_reader :unresolved
+
+    def initialize(path, unresolved)
+      super(path)
+      @unresolved = unresolved
+    end
+
+    def ==(o)
+      super.==(o) && @unresolved == o.unresolved
+    end
+
+    def hash
+      @unresolved.hash
+    end
+
+    def message(variant, position, tense = :present)
+      "#{variant}#{position} #{it_references(tense)} an unresolved type '#{@unresolved}'"
     end
   end
 
@@ -819,26 +849,49 @@ module Types
       expected.assignable?(actual) ? EMPTY_ARRAY : [TypeMismatch.new(path, expected, actual)]
     end
 
+    class UnresolvedTypeFinder
+      include TypeAcceptor
+
+      attr_reader :unresolved
+
+      def initialize
+        @unresolved = nil
+      end
+
+      def visit(type, guard)
+        if @unresolved.nil? && type.is_a?(PTypeReferenceType)
+          @unresolved = type
+        end
+      end
+    end
+
     def describe(expected, actual, path)
-      case expected
-      when PVariantType
-        describe_PVariantType(expected, actual, path)
-      when PStructType
-        describe_PStructType(expected, actual, path)
-      when PTupleType
-        describe_PTupleType(expected, actual, path)
-      when PCallableType
-        describe_PCallableType(expected, actual, path)
-      when POptionalType
-        describe_POptionalType(expected, actual, path)
-      when PPatternType
-        describe_PPatternType(expected, actual, path)
-      when PEnumType
-        describe_PEnumType(expected, actual, path)
-      when PTypeAliasType
-        describe_PTypeAliasType(expected, actual, path)
+      ures_finder = UnresolvedTypeFinder.new
+      expected.accept(ures_finder, nil)
+      unresolved = ures_finder.unresolved
+      if unresolved
+        [UnresolvedTypeReference.new(path, unresolved)]
       else
-        describe_PAnyType(expected, actual, path)
+        case expected
+        when PVariantType
+          describe_PVariantType(expected, actual, path)
+        when PStructType
+          describe_PStructType(expected, actual, path)
+        when PTupleType
+          describe_PTupleType(expected, actual, path)
+        when PCallableType
+          describe_PCallableType(expected, actual, path)
+        when POptionalType
+          describe_POptionalType(expected, actual, path)
+        when PPatternType
+          describe_PPatternType(expected, actual, path)
+        when PEnumType
+          describe_PEnumType(expected, actual, path)
+        when PTypeAliasType
+          describe_PTypeAliasType(expected, actual, path)
+        else
+          describe_PAnyType(expected, actual, path)
+        end
       end
     end
 

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2128,19 +2128,20 @@ end
 # @api public
 #
 class PResourceType < PCatalogEntryType
-  attr_reader :type_name, :title
+  attr_reader :type_name, :title, :downcased_name
 
   def initialize(type_name, title = nil)
     @type_name = type_name
     @title = title
-  end
-
-  def hash
-    @type_name.hash ^ @title.hash
+    @downcased_name = type_name.nil? ? nil : @type_name.downcase
   end
 
   def eql?(o)
-    self.class == o.class && @type_name == o.type_name && @title == o.title
+    self.class == o.class && @downcased_name == o.downcased_name && @title == o.title
+  end
+
+  def hash
+    @downcased_name.hash ^ @title.hash
   end
 
   DEFAULT = PResourceType.new(nil)
@@ -2149,11 +2150,7 @@ class PResourceType < PCatalogEntryType
 
   # @api private
   def _assignable?(o, guard)
-    return false unless o.is_a?(PResourceType)
-    return true if @type_name.nil?
-    return false if @type_name != o.type_name
-    return true if @title.nil?
-    @title == o.title
+    o.is_a?(PResourceType) && (@downcased_name.nil? || @downcased_name == o.downcased_name && (@title.nil? || @title == o.title))
   end
 end
 

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1531,12 +1531,12 @@ class Type
             :event => self.class.events,
             :callback => method
           }
-          self.debug("subscribes to #{related_resource.ref}")
+          self.debug { "subscribes to #{related_resource.ref}" }
         else
           # If there's no callback, there's no point in even adding
           # a label.
           subargs = nil
-          self.debug("requires #{related_resource.ref}")
+          self.debug { "subscribes to #{related_resource.ref}" }
         end
 
         Puppet::Relationship.new(source, target, subargs)

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -1548,10 +1548,10 @@ describe Puppet::Parser::Compiler do
 
       it 'accepts a Resource as a Type' do
         catalog = compile_to_catalog(<<-MANIFEST)
+          define bar($text) { }
           define foo(Type[Bar] $x) {
             notify { 'test': message => $x[text] }
           }
-          define bar($text) { }
           bar { 'joke': text => 'knock knock' }
           foo { 'test': x => Bar[joke] }
         MANIFEST
@@ -1634,10 +1634,10 @@ describe Puppet::Parser::Compiler do
 
       it 'accepts a Resource as a Type' do
         catalog = compile_to_catalog(<<-MANIFEST)
+          define bar($text) { }
           class foo(Type[Bar] $x) {
             notify { 'test': message => $x[text] }
           }
-          define bar($text) { }
           bar { 'joke': text => 'knock knock' }
           class { 'foo': x => Bar[joke] }
         MANIFEST

--- a/spec/integration/parser/resource_expressions_spec.rb
+++ b/spec/integration/parser/resource_expressions_spec.rb
@@ -114,7 +114,7 @@ describe "Puppet resource expressions" do
 
     fails( "define a::b { notify { testing: } } 'a::b' { title: }" => /Illegal Resource Type expression.*got String/)
 
-    fails( "Does::Not::Exist { title: }" => /Invalid resource type does::not::exist/)
+    fails( "Does::Not::Exist { title: }" => /Resource type not found: Does::Not::Exist/)
   end
 
   context "local defaults" do

--- a/spec/integration/resource/type_collection_spec.rb
+++ b/spec/integration/resource/type_collection_spec.rb
@@ -12,6 +12,14 @@ describe Puppet::Resource::TypeCollection do
       @dir = tmpfile("autoload_testing")
       FileUtils.mkdir_p @dir
 
+      loader = Object.new
+      loader.stubs(:load).returns nil
+      loader.stubs(:set_entry)
+
+      loaders = Object.new
+      loaders.expects(:runtime3_type_loader).at_most_once.returns loader
+      Puppet::Pops::Loaders.expects(:loaders).at_most_once.returns loaders
+
       environment = Puppet::Node::Environment.create(:env, [@dir])
       @code = environment.known_resource_types
     end

--- a/spec/lib/puppet_spec/compiler.rb
+++ b/spec/lib/puppet_spec/compiler.rb
@@ -1,14 +1,14 @@
 module PuppetSpec::Compiler
   module_function
 
-  def compile_to_catalog(string, node = Puppet::Node.new('foonode'))
+  def compile_to_catalog(string, node = Puppet::Node.new('test'))
     Puppet[:code] = string
     # see lib/puppet/indirector/catalog/compiler.rb#filter
     Puppet::Parser::Compiler.compile(node).filter { |r| r.virtual? }
   end
 
-  def compile_to_ral(manifest)
-    catalog = compile_to_catalog(manifest)
+  def compile_to_ral(manifest, node = Puppet::Node.new('test'))
+    catalog = compile_to_catalog(manifest, node)
     ral = catalog.to_ral
     ral.finalize
     ral

--- a/spec/unit/appmgmt_spec.rb
+++ b/spec/unit/appmgmt_spec.rb
@@ -1,15 +1,10 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet_spec/compiler'
-require_relative 'pops/parser/parser_rspec_helper'
 require 'puppet/parser/environment_compiler'
 
 describe "Application instantiation" do
   include PuppetSpec::Compiler
-  # We pull this in because we need access to with_app_management; and
-  # since that has to root around in the guts of the Pops parser, there's
-  # no really elegant way to do this
-  include ParserRspecHelper
 
   def compile_to_env_catalog(string, code_id=nil)
     Puppet[:code] = string
@@ -17,18 +12,15 @@ describe "Application instantiation" do
     Puppet::Parser::EnvironmentCompiler.compile(env, code_id).filter { |r| r.virtual? }
   end
 
-
-  before :each do
-    with_app_management(true)
+  around :each do |example|
+    Puppet[:app_management] = true
     Puppet::Type.newtype :cap, :is_capability => true do
       newparam :name
       newparam :host
     end
-  end
-
-  after :each do
+    example.run
     Puppet::Type.rmtype(:cap)
-    with_app_management(false)
+    Puppet[:app_management] = false
   end
 
   MANIFEST = <<-EOS

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -495,7 +495,7 @@ describe 'the 4x function api' do
         expect(parser.evaluate({}, program)).to eql(10)
       end
 
-      it 'distinguish between a Type alias and a Resource type' do
+      it 'reports a reference to an unresolved type' do
         the_loader = loader()
         here = get_binding(the_loader)
         fc = eval(<<-CODE, here)
@@ -511,7 +511,7 @@ describe 'the 4x function api' do
         the_loader.add_function('testing::test', fc.new({}, the_loader))
         program = parser.parse_string('testing::test(10)', __FILE__)
         Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
-        expect { parser.evaluate({}, program) }.to raise_error(Puppet::Error, /parameter 'x' expects a Resource value, got Integer/)
+        expect { parser.evaluate({}, program) }.to raise_error(Puppet::Error, /parameter 'x' references an unresolved type 'Myalias'/)
       end
 
       it 'create local Type aliases' do

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -428,6 +428,16 @@ describe Puppet::Node::Environment do
     end
 
     describe "when performing initial import" do
+      let(:loaders) { Puppet::Pops::Loaders.new(env) }
+
+      around :each do |example|
+        Puppet::Parser::Compiler.any_instance.stubs(:loaders).returns(loaders)
+        Puppet.override(:loaders => loaders, :current_environment => env) do
+          example.run
+          Puppet::Pops::Loaders.clear
+        end
+      end
+
       it "loads from Puppet[:code]" do
         Puppet[:code] = "define foo {}"
         krt = env.known_resource_types

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -103,7 +103,7 @@ describe 'function for dynamically creating resources' do
 
           create_resources('foocreateresource', {'blah'=>{}})
         MANIFEST
-      }.to raise_error(Puppet::Error, /Foocreateresource\[blah\]: expects a value for parameter 'one' on node foonode/)
+      }.to raise_error(Puppet::Error, /Foocreateresource\[blah\]: expects a value for parameter 'one' on node test/)
     end
 
     it 'should be able to add multiple defines' do
@@ -169,7 +169,7 @@ describe 'function for dynamically creating resources' do
         compile_to_catalog(<<-MANIFEST)
           create_resources('class', {'blah'=>{'one'=>'two'}})
         MANIFEST
-      end.to raise_error(/Could not find declared class blah at line 1:11 on node foonode/)
+      end.to raise_error(/Could not find declared class blah at line 1:11 on node test/)
     end
 
     it 'should be able to add edges' do

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -556,7 +556,7 @@ describe Puppet::Parser::Resource do
 
   # part of #629 -- the undef keyword.  Make sure 'undef' params get skipped.
   it "should not include 'undef' parameters when converting itself to a hash" do
-    resource = Puppet::Parser::Resource.new "file", "/tmp/testing", :source => mock("source"), :scope => mock("scope")
+    resource = Puppet::Parser::Resource.new "file", "/tmp/testing", :source => mock("source"), :scope => @scope
     resource[:owner] = :undef
     resource[:mode] = "755"
     expect(resource.to_hash[:owner]).to be_nil

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -57,7 +57,15 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
         it "should parse and evaluate the expression '#{source}' to #{result}" do
           expect(parser.evaluate_string(scope, source, __FILE__)).to eq(result)
         end
-      end
+    end
+
+    it 'should error when it encounters an unknown resource' do
+      expect {parser.evaluate_string(scope, '$a = SantaClause', __FILE__)}.to raise_error(/Resource type not found: Santaclause/)
+    end
+
+    it 'should error when it encounters an unknown resource with a parameter' do
+      expect {parser.evaluate_string(scope, '$b = ToothFairy[emea]', __FILE__)}.to raise_error(/Resource type not found: Toothfairy/)
+    end
   end
 
   context "When the evaluator evaluates Lists and Hashes" do
@@ -253,9 +261,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "xxx in bananas"                => false,
       "/ana/ in bananas"              => true,
       "/xxx/ in bananas"              => false,
-      "ANA in bananas"                => false, # ANA is a type, not a String
+      "FILE in profiler"              => false, # FILE is a type, not a String
+      "'FILE' in profiler"            => true,
       "String[1] in bananas"          => false, # Philosophically true though :-)
-      "'ANA' in bananas"              => true,
       "ana in 'BANANAS'"              => true,
       "/ana/ in 'BANANAS'"            => false,
       "/ANA/ in 'BANANAS'"            => true,
@@ -307,13 +315,13 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
     {
       'Any'  => ['NotUndef', 'Data', 'Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Collection',
-                    'Array', 'Hash', 'CatalogEntry', 'Resource', 'Class', 'Undef', 'File', 'NotYetKnownResourceType'],
+                    'Array', 'Hash', 'CatalogEntry', 'Resource', 'Class', 'Undef', 'File' ],
 
       # Note, Data > Collection is false (so not included)
       'Data'    => ['Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Array', 'Hash',],
       'Scalar' => ['Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern'],
       'Numeric' => ['Integer', 'Float'],
-      'CatalogEntry' => ['Class', 'Resource', 'File', 'NotYetKnownResourceType'],
+      'CatalogEntry' => ['Class', 'Resource', 'File'],
       'Integer[1,10]' => ['Integer[2,3]'],
     }.each do |general, specials|
       specials.each do |special |

--- a/spec/unit/pops/loaders/static_loader_spec.rb
+++ b/spec/unit/pops/loaders/static_loader_spec.rb
@@ -107,6 +107,19 @@ describe 'the static loader' do
     end
   end
 
+  context 'provides access to app-management specific resource types built into puppet' do
+    before(:each) { Puppet[:app_management] = true }
+    after(:each) { Puppet[:app_management] = false }
+
+    let(:loader) { loader = Puppet::Pops::Loader::StaticLoader.new() }
+
+    %w{Node}.each do |name|
+      it "such that #{name} is avaiable" do
+        expect(loader.load(:type, name.downcase)).to be_the_type(resource_type(name))
+      end
+    end
+  end
+
   def typed_name(type, name)
     Puppet::Pops::Loader::Loader::TypedName.new(type, name)
   end

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'matchers/match_tokens2'
 require 'puppet/pops'
 require 'puppet/pops/parser/lexer2'
-require_relative './parser_rspec_helper'
 
 module EgrammarLexer2Spec
   def tokens_scanned_from(s)
@@ -20,7 +19,6 @@ end
 
 describe 'Lexer2' do
   include EgrammarLexer2Spec
-  include ParserRspecHelper
 
   {
     :LISTSTART => '[',
@@ -116,13 +114,8 @@ describe 'Lexer2' do
   end
 
   context 'when app_managment is (turned) on' do
-    before(:each) do
-      with_app_management(true)
-    end
-
-    after(:each) do
-      with_app_management(false)
-    end
+    before(:each) { Puppet[:app_management] = true }
+    after(:each) { Puppet[:app_management] = false }
 
     {
       "application"  => :APPLICATION,

--- a/spec/unit/pops/parser/parse_application_spec.rb
+++ b/spec/unit/pops/parser/parse_application_spec.rb
@@ -1,18 +1,13 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/pops'
-require_relative './parser_rspec_helper'
+require_relative 'parser_rspec_helper'
 
 describe "egrammar parsing of 'application'" do
   include ParserRspecHelper
 
-  before(:each) do
-    with_app_management(true)
-  end
-
-  after(:each) do
-    with_app_management(false)
-  end
+  before(:each) { Puppet[:app_management] = true }
+  after(:each) { Puppet[:app_management] = false }
 
   it "an empty body" do
     expect(dump(parse("application foo { }"))).to eq("(application foo () ())")

--- a/spec/unit/pops/parser/parse_capabilities_spec.rb
+++ b/spec/unit/pops/parser/parse_capabilities_spec.rb
@@ -1,20 +1,13 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/pops'
-
-# relative to this spec file (./) does not work as this file is loaded by rspec
-require File.join(File.dirname(__FILE__), '/parser_rspec_helper')
+require_relative 'parser_rspec_helper'
 
 describe "egrammar parsing of capability mappings" do
   include ParserRspecHelper
 
-  before(:each) do
-    with_app_management(true)
-  end
-
-  after(:each) do
-    with_app_management(false)
-  end
+  before(:each) { Puppet[:app_management] = true }
+  after(:each) { Puppet[:app_management] = false }
 
   context "when parsing 'produces'" do
     it "the ast contains produces and attributes" do

--- a/spec/unit/pops/parser/parse_site_spec.rb
+++ b/spec/unit/pops/parser/parse_site_spec.rb
@@ -1,20 +1,13 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/pops'
-
-# relative to this spec file (./) does not work as this file is loaded by rspec
-require File.join(File.dirname(__FILE__), '/parser_rspec_helper')
+require_relative 'parser_rspec_helper'
 
 describe "egrammar parsing of site expression" do
   include ParserRspecHelper
 
-  before(:each) do
-    with_app_management(true)
-  end
-
-  after(:each) do
-    with_app_management(false)
-  end
+  before(:each) { Puppet[:app_management] = true }
+  after(:each) { Puppet[:app_management] = false }
 
   context "when parsing 'site'" do
     it "an empty body is allowed" do

--- a/spec/unit/pops/parser/parser_rspec_helper.rb
+++ b/spec/unit/pops/parser/parser_rspec_helper.rb
@@ -5,10 +5,6 @@ require File.join(File.dirname(__FILE__), '/../factory_rspec_helper')
 module ParserRspecHelper
   include FactoryRspecHelper
 
-  def with_app_management(flag)
-    Puppet[:app_management] = flag
-  end
-
   def parse(code)
     parser = Puppet::Pops::Parser::Parser.new()
     parser.parse_string(code)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -2,9 +2,7 @@
 require 'spec_helper'
 require 'puppet/pops'
 require 'puppet_spec/pops'
-
-# relative to this spec file (./) does not work as this file is loaded by rspec
-require File.join(File.dirname(__FILE__), '../parser/parser_rspec_helper')
+require_relative '../parser/parser_rspec_helper'
 
 describe "validating 4x" do
   include ParserRspecHelper
@@ -427,13 +425,8 @@ describe "validating 4x" do
   end
 
   context "capability annotations" do
-    before(:each) do
-      with_app_management(true)
-    end
-
-    after(:each) do
-      with_app_management(false)
-    end
+    before(:each) { Puppet[:app_management] = true }
+    after(:each) { Puppet[:app_management] = false }
 
     ['produces', 'consumes'].each do |word|
       it "rejects illegal resource types in #{word} clauses" do

--- a/spec/unit/resource/capability_finder_spec.rb
+++ b/spec/unit/resource/capability_finder_spec.rb
@@ -20,12 +20,20 @@ describe Puppet::Resource::CapabilityFinder do
         end
       end
       begin
-        make_cap_type
-        example.run
+        Puppet::Parser::Compiler.any_instance.stubs(:loaders).returns(loaders)
+        Puppet.override(:loaders => loaders, :current_environment => env) do
+          make_cap_type
+          example.run
+        end
       ensure
         Puppet::Util.send(:remove_const, 'Puppetdb') if mock_pdb
+        Puppet::Type.rmtype(:cap)
+        Puppet::Pops::Loaders.clear
       end
     end
+
+    let(:env) { Puppet::Node::Environment.create(:testing, []) }
+    let(:loaders) { Puppet::Pops::Loaders.new(env) }
 
     let(:response_body) { [{"type"=>"Cap", "title"=>"cap", "parameters"=>{"host"=>"ahost"}}] }
     let(:response) { stub('response', :body => response_body.to_json) }


### PR DESCRIPTION
This PR changes the type parser so that it relies fully on the loader that is passed to it. If the loader cannot find a type that is well known, then it will always return a TypeReference type. The PR also contains what is needed to give the correct feedback when such unresolved references are encountered (they should never be present if the code is correct).

The details are in the commit comments.
