### PR TITLE
(PUP-6053) Ensure that struct member names are quoted in mismatch output

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -28,13 +28,13 @@ module Types
 
   class MemberPathElement < TypePathElement
     def to_s
-      "struct member #{key}"
+      "struct member '#{key}'"
     end
   end
 
   class MemberKeyPathElement < TypePathElement
     def to_s
-      "struct member key #{key}"
+      "struct member key '#{key}'"
     end
   end
 


### PR DESCRIPTION
Struct member names were printed without quotes which made the error
message from the type mismatch describer harder to read. This commit
adds the quotes.