### PR TITLE
(maint) Pin Hiera to 1.3.4 in git tests

### DIFF
--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -1,7 +1,7 @@
 {
   :install => [
     'facter#2.x',
-    'hiera#stable',
+    'hiera#1.3.4',
     'puppet',
   ],
   :pre_suite => [


### PR DESCRIPTION
Hiera stable is being shipped with puppet-agent. For puppet 3.x we
should be testing agsint the version of hiera we still ship as
standalone pacakges