### PR TITLE
(maint) Remove comment referencing trac

### DIFF
--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -1,4 +1,3 @@
-# This doesn't get stored in trac, since it changes every time.
 providers = Puppet::Util::Reference.newreference :providers, :title => "Provider Suitability Report", :depth => 1, :dynamic => true, :doc => "Which providers are valid for this machine" do
   types = []
   Puppet::Type.loadall


### PR DESCRIPTION
The comment at the start of lib/puppet/reference/providers.rb was added in https://github.com/puppetlabs/puppet/commit/7835d2927ef360216612f1a782e88a6606a79d6b in 2007.
As we no longer use trac, this commit removes that comment.