### PR TITLE
(PUP-5482) Flag that a type could not be found

### DIFF
--- a/benchmarks/missing_type_caching/benchmarker.rb
+++ b/benchmarks/missing_type_caching/benchmarker.rb
@@ -1,0 +1,63 @@
+require 'erb'
+require 'ostruct'
+require 'fileutils'
+require 'json'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size
+  end
+
+  def setup
+    require 'puppet'
+    config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', config])
+    Puppet[:always_retry_plugins] = false
+  end
+
+  def run(args=nil)
+    env = Puppet.lookup(:environments).get('benchmarking')
+    node = Puppet::Node.new("testing", :environment => env)
+    Puppet::Resource::Catalog.indirection.find("testing", :use_node => node)
+  end
+
+  def generate
+    environment = File.join(@target, 'environments', 'benchmarking')
+    templates = File.join('benchmarks', 'missing_type_caching')
+    test_module_dir = File.join(environment, 'modules', 'testmodule',
+                                'manifests')
+
+    mkdir_p(File.join(environment, 'modules'))
+    @size.times.each do |i|
+      mkdir_p(File.join(environment, 'modules', "mymodule_#{i}", 'lib',
+                        'puppet', 'type'))
+      mkdir_p(File.join(environment, 'modules', "mymodule_#{i}", 'manifests'))
+    end
+    mkdir_p(File.join(environment, 'manifests'))
+
+    mkdir_p(test_module_dir)
+
+
+    render(File.join(templates, 'site.pp.erb'),
+           File.join(environment, 'manifests', 'site.pp'),
+           :size => @size)
+
+    render(File.join(templates, 'module', 'testmodule.pp.erb'),
+           File.join(test_module_dir, 'init.pp'),
+           :name => "foo")
+
+    render(File.join(templates, 'puppet.conf.erb'),
+           File.join(@target, 'puppet.conf'),
+           :location => @target)
+  end
+
+  def render(erb_file, output_file, bindings)
+    site = ERB.new(File.read(erb_file))
+    File.open(output_file, 'w') do |fh|
+      fh.write(site.result(OpenStruct.new(bindings).instance_eval { binding }))
+    end
+  end
+end

--- a/benchmarks/missing_type_caching/description
+++ b/benchmarks/missing_type_caching/description
@@ -1,0 +1,3 @@
+Benchmark scenario: heavy use of defined types found in init.pp
+Benchmark target: catalog compilation
+

--- a/benchmarks/missing_type_caching/module/testmodule.pp.erb
+++ b/benchmarks/missing_type_caching/module/testmodule.pp.erb
@@ -1,0 +1,3 @@
+define testmodule {
+  notify { "in <%= name %>: $title": }
+}

--- a/benchmarks/missing_type_caching/puppet.conf.erb
+++ b/benchmarks/missing_type_caching/puppet.conf.erb
@@ -1,0 +1,3 @@
+confdir = <%= location %>
+vardir = <%= location %>
+environmentpath = <%= File.join(location, 'environments') %>

--- a/benchmarks/missing_type_caching/site.pp.erb
+++ b/benchmarks/missing_type_caching/site.pp.erb
@@ -1,0 +1,5 @@
+if true {
+<% size.times do |i| %>
+  testmodule { "foo<%= i %>": }
+<% end %>
+}

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -316,10 +316,10 @@ module Puppet
       :default  => false,
       :hook     => proc { |value|
         Puppet.deprecation_warning "Setting 'always_cache_features' is
-deprecated and has been replaced by 'always_cache_misses'."
+deprecated and has been replaced by 'always_retry_plugins'."
       },
       :desc     => <<-'EOT'
-        This setting is deprecated and has been replaced by always_cache_misses.
+        This setting is deprecated and has been replaced by always_retry_plugins.
 
         Affects how we cache attempts to load Puppet 'features'.  If false, then
         calls to `Puppet.features.<feature>?` will always attempt to load the

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -330,6 +330,27 @@ module Puppet
         improvement for features that are checked frequently.
       EOT
     },
+    :always_cache_misses => {
+        :type     => :boolean,
+        :default  => false,
+        :desc     => <<-'EOT'
+        Affects how we cache attempts to load Puppet 'types' and 'features'.  If
+        false, then calls to `Puppet.type.<type>?` `Puppet.feature.<feature>?`
+        will always attempt to load the type or feature (which can be an
+        expensive operation) unless it has already been loaded successfully.
+        This makes it possible for a single agent run to, e.g., install a
+        package that provides the underlying capabilities for a type or feature,
+        and then later load that type or feature during the same run (even if
+        the type or feature had been tested earlier and had not been available).
+
+        If this setting is set to true, then types and features will only be
+        checked once, and if they are not available, the negative result is
+        cached and returned for all subsequent attempts to load the type or
+        feature.  This behavior is almost always appropriate for the server,
+        and can result in a significant performance improvement for types and
+        features that are checked frequently.
+      EOT
+    },
     :diff_args => {
         :default  => lambda { default_diffargs },
         :desc     => "Which arguments to pass to the diff command when printing differences between

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -340,7 +340,7 @@ deprecated and has been replaced by 'always_cache_misses'."
         :type     => :boolean,
         :default  => false,
         :desc     => <<-'EOT'
-        Affects how we cache attempts to load Puppet 'types' and 'features'.  If
+        Affects how we cache attempts to load Puppet resource types and features.  If
         false, then calls to `Puppet.type.<type>?` `Puppet.feature.<feature>?`
         will always attempt to load the type or feature (which can be an
         expensive operation) unless it has already been loaded successfully.

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -319,6 +319,8 @@ module Puppet
 deprecated and has been replaced by 'always_cache_misses'."
       },
       :desc     => <<-'EOT'
+        This setting is deprecated and has been replaced by always_cache_misses.
+
         Affects how we cache attempts to load Puppet 'features'.  If false, then
         calls to `Puppet.features.<feature>?` will always attempt to load the
         feature (which can be an expensive operation) unless it has already been
@@ -332,8 +334,6 @@ deprecated and has been replaced by 'always_cache_misses'."
         for all subsequent attempts to load the feature.  This behavior is almost
         always appropriate for the server, and can result in a significant performance
         improvement for features that are checked frequently.
-
-        This setting is deprecated and has been replaced by always_cache_misses.
       EOT
     },
     :always_cache_misses => {

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -314,6 +314,10 @@ module Puppet
     :always_cache_features => {
       :type     => :boolean,
       :default  => false,
+      :hook     => proc { |value|
+        Puppet.deprecation_warning "Setting 'always_cache_features' is
+deprecated and has been replaced by 'always_cache_misses'."
+      },
       :desc     => <<-'EOT'
         Affects how we cache attempts to load Puppet 'features'.  If false, then
         calls to `Puppet.features.<feature>?` will always attempt to load the
@@ -328,6 +332,8 @@ module Puppet
         for all subsequent attempts to load the feature.  This behavior is almost
         always appropriate for the server, and can result in a significant performance
         improvement for features that are checked frequently.
+
+        This setting is deprecated and has been replaced by always_cache_misses.
       EOT
     },
     :always_cache_misses => {

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -336,12 +336,12 @@ deprecated and has been replaced by 'always_cache_misses'."
         improvement for features that are checked frequently.
       EOT
     },
-    :always_cache_misses => {
+    :always_retry_plugins => {
         :type     => :boolean,
-        :default  => false,
+        :default  => true,
         :desc     => <<-'EOT'
         Affects how we cache attempts to load Puppet resource types and features.  If
-        false, then calls to `Puppet.type.<type>?` `Puppet.feature.<feature>?`
+        true, then calls to `Puppet.type.<type>?` `Puppet.feature.<feature>?`
         will always attempt to load the type or feature (which can be an
         expensive operation) unless it has already been loaded successfully.
         This makes it possible for a single agent run to, e.g., install a
@@ -349,7 +349,7 @@ deprecated and has been replaced by 'always_cache_misses'."
         and then later load that type or feature during the same run (even if
         the type or feature had been tested earlier and had not been available).
 
-        If this setting is set to true, then types and features will only be
+        If this setting is set to false, then types and features will only be
         checked once, and if they are not available, the negative result is
         cached and returned for all subsequent attempts to load the type or
         feature.  This behavior is almost always appropriate for the server,

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -266,6 +266,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
         rescue Puppet::Error => detail
           Puppet.err(detail.to_s) if networked?
           raise
+        ensure
+          Puppet::Type.clear_misses if Puppet[:always_cache_misses]
         end
 
         if checksum_type && config.is_a?(model)

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -267,7 +267,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
           Puppet.err(detail.to_s) if networked?
           raise
         ensure
-          Puppet::Type.clear_misses if Puppet[:always_cache_misses]
+          Puppet::Type.clear_misses if Puppet[:always_retry_plugins]
         end
 
         if checksum_type && config.is_a?(model)

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -267,7 +267,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
           Puppet.err(detail.to_s) if networked?
           raise
         ensure
-          Puppet::Type.clear_misses if Puppet[:always_retry_plugins]
+          Puppet::Type.clear_misses unless Puppet[:always_retry_plugins]
         end
 
         if checksum_type && config.is_a?(model)

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -20,6 +20,14 @@ module Manager
     }
   end
 
+  # Clears any types that were used but absent when types were last loaded.
+  # @note Used after each catalog compile when always_cache_missing is true
+  # @api private
+  #
+  def clear_misses
+    @types.delete_if {|_, v| v.nil? }
+  end
+
   # Iterates over all already loaded Type subclasses.
   # @yield [t] a block receiving each type
   # @yieldparam t [Puppet::Type] each defined type

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -156,7 +156,8 @@ module Manager
     # Try loading the type.
     if typeloader.load(name, Puppet.lookup(:current_environment))
       Puppet.warning "Loaded puppet/type/#{name} but no class was created" unless @types.include? name
-    else
+    elsif Puppet[:always_cache_misses]
+      # PUP-5482 - Only look for a type once if miss caching is enabled
       @types[name] = nil
     end
 

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -21,7 +21,7 @@ module Manager
   end
 
   # Clears any types that were used but absent when types were last loaded.
-  # @note Used after each catalog compile when always_cache_missing is true
+  # @note Used after each catalog compile when always_retry_plugins is false
   # @api private
   #
   def clear_misses

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -25,7 +25,9 @@ module Manager
   # @api private
   #
   def clear_misses
-    @types.delete_if {|_, v| v.nil? }
+    unless @types.nil?
+      @types.delete_if {|_, v| v.nil? }
+    end
   end
 
   # Iterates over all already loaded Type subclasses.

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -146,16 +146,18 @@ module Manager
     # We are overwhelmingly symbols here, which usually match, so it is worth
     # having this special-case to return quickly.  Like, 25K symbols vs. 300
     # strings in this method. --daniel 2012-07-17
-    return @types[name] if @types[name]
+    return @types[name] if @types.include? name
 
     # Try mangling the name, if it is a string.
     if name.is_a? String
       name = name.downcase.intern
-      return @types[name] if @types[name]
+      return @types[name] if @types.include? name
     end
     # Try loading the type.
     if typeloader.load(name, Puppet.lookup(:current_environment))
       Puppet.warning "Loaded puppet/type/#{name} but no class was created" unless @types.include? name
+    else
+      @types[name] = nil
     end
 
     # ...and I guess that is that, eh.

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -164,8 +164,8 @@ module Manager
     # Try loading the type.
     if typeloader.load(name, Puppet.lookup(:current_environment))
       Puppet.warning "Loaded puppet/type/#{name} but no class was created" unless @types.include? name
-    elsif Puppet[:always_cache_misses]
-      # PUP-5482 - Only look for a type once if miss caching is enabled
+    elsif !Puppet[:always_retry_plugins]
+      # PUP-5482 - Only look for a type once if plugin retry is disabled
       @types[name] = nil
     end
 

--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -2,7 +2,7 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
   types = []
   Puppet::Type.loadall
   Puppet::Type.eachtype do |klass|
-    next unless klass and klass.providers.length > 0
+    next unless klass && klass.providers.length > 0
     types << klass
   end
   types.sort! { |a,b| a.name.to_s <=> b.name.to_s }

--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -2,7 +2,7 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
   types = []
   Puppet::Type.loadall
   Puppet::Type.eachtype do |klass|
-    next unless klass.providers.length > 0
+    next unless klass and klass.providers.length > 0
     types << klass
   end
   types.sort! { |a,b| a.name.to_s <=> b.name.to_s }

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -32,7 +32,7 @@ class Puppet::Util::Feature
       #    configured to always cache
       if block_given?     ||
           @results[name]  ||
-          (@results.has_key?(name) && (Puppet[:always_cache_features] || Puppet[:always_cache_misses]))
+          (@results.has_key?(name) && (Puppet[:always_cache_features] || !Puppet[:always_retry_plugins]))
         @results[name]
       else
         @results[name] = test(name, options)

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -32,7 +32,7 @@ class Puppet::Util::Feature
       #    configured to always cache
       if block_given?     ||
           @results[name]  ||
-          (@results.has_key?(name) and Puppet[:always_cache_features])
+          (@results.has_key?(name) && (Puppet[:always_cache_features] || Puppet[:always_cache_misses]))
         @results[name]
       else
         @results[name] = test(name, options)

--- a/spec/unit/util/feature_spec.rb
+++ b/spec/unit/util/feature_spec.rb
@@ -89,7 +89,7 @@ describe Puppet::Util::Feature do
   end
 
   it "should cache load failures when configured to do so" do
-    Puppet[:always_cache_features] = true
+    Puppet[:always_cache_misses] = true
 
     @features.add(:myfeature, :libs => %w{foo bar})
     @features.expects(:require).with("foo").raises(LoadError)

--- a/spec/unit/util/feature_spec.rb
+++ b/spec/unit/util/feature_spec.rb
@@ -89,7 +89,7 @@ describe Puppet::Util::Feature do
   end
 
   it "should cache load failures when configured to do so" do
-    Puppet[:always_cache_misses] = true
+    Puppet[:always_retry_plugins] = false
 
     @features.add(:myfeature, :libs => %w{foo bar})
     @features.expects(:require).with("foo").raises(LoadError)


### PR DESCRIPTION
If a Ruby type is not available in the file system, every time it is found by
the parser, the Autoloader will scan all over again the directories in
search_directories for it. This generates tons of stat()s that can be saved.

This patch annotates that a type could not be found so the next time it is
required during the compilation of a catalog, the file system is not hammered
again unnecessarily.

This optimization has given us a ~61% reduction in the number of stats per
compilation, as we make an extensive use of the concat module which only
provides Puppet "defined types".