### PR TITLE
(PUP-6095) Service provider shouldn't die if an smf service is in state "degraded"

### DIFF
--- a/spec/fixtures/unit/provider/service/smf/svcs.out
+++ b/spec/fixtures/unit/provider/service/smf/svcs.out
@@ -1,3 +1,4 @@
-legacy_run     16:19:12 lrc:/etc/rcS_d/S50sk98sol
-online         16:19:08 svc:/system/svc/restarter:default
-maintenance    16:19:13 svc:/network/cswrsyncd:default
+legacy_run    lrc:/etc/rcS_d/S50sk98sol
+online        svc:/system/svc/restarter:default
+maintenance   svc:/network/cswrsyncd:default
+degraded      svc:/network/dns/client:default


### PR DESCRIPTION
(PUP-6095) Service provider shouldn't die if an smf service is in state "degraded"

Without this patch attempts to view or manage smf services fail when any service
is in a degraded state. After patching, services in a degraded state are treated in an
identical manner to those in a maintenance state. 
