### PR TITLE
(PUP-5965) Add 'new' call and function

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -544,7 +544,7 @@ module Puppet::Functions
     attr_reader :local_types, :parser, :loader
 
     def initialize(loader, name)
-      @loader = Puppet::Pops::Loader::BaseLoader.new(loader, :"local_function_#{name}")
+      @loader = Puppet::Pops::Loader::PredefinedLoader.new(loader, :"local_function_#{name}")
       @local_types = []
       # get the shared parser used by puppet's compiler
       @parser = Puppet::Pops::Parser::EvaluatingParser.singleton()

--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -308,8 +308,8 @@ module Puppet::Functions
       # Add the loaded types to the builder
       aliases.local_types.each do |type_alias_expr|
         # Bind the type alias to the local_loader using the alias
-        typed_name, t = Puppet::Pops::Loader::TypeDefinitionInstantiator.create_from_model(type_alias_expr, loader)
-        loader.set_entry(typed_name, t, Puppet::Pops::Adapters::SourcePosAdapter.adapt(type_alias_expr).to_uri)
+        typed_name, t = Puppet::Pops::Loader::TypeDefinitionInstantiator.create_from_model(type_alias_expr, aliases.loader)
+        aliases.loader.set_entry(typed_name, t, Puppet::Pops::Adapters::SourcePosAdapter.adapt(type_alias_expr).to_uri)
 
         # Also define a method for convenient access to the defined type alias.
         # Since initial capital letter in Ruby means a Constant these names use a prefix of 

--- a/lib/puppet/functions/new.rb
+++ b/lib/puppet/functions/new.rb
@@ -1,0 +1,422 @@
+# Creates a new instance/object of a given type.
+#
+# This functions makes it possible to create new instances of
+# concrete types. If a block is given it is called with the
+# just created instance as an argument.
+#
+# Calling this function is equivalent to directly
+# calling the type:
+#
+# @ example new and calling type directly are equivalent
+#
+# ~~~ puppet
+# $a = Integer.new("42")
+# $b = Integer("42")
+# ~~~
+#
+# This would convert the string "42" to the decimal value 42.
+#
+# @ example arguments by position or by name
+#
+# ~~~ puppet
+# $a = Integer.new("42", 8)
+# $b = Integer({from => "42", radix => 8})
+# ~~~
+#
+# This would convert the octal (radix 8) number "42" in string form
+# to the decimal value 34.
+#
+# The new function supports two ways of giving the arguments:
+#
+# * by name (using a hash with property to value mapping)
+# * by position (as regular arguments)
+#
+# Note that it is not possible to create new instances of
+# some abstract classes (e.g. `Variant`). The type Optional[T] is an
+# exception as it will create an instance of T or `undef` if the
+# value to convert is `undef`.
+#
+# The arguments that can be given to each type is
+# determined by the type.
+#
+# An assertion is always made that
+# the produced value complies with the given type constraints.
+#
+# @example type constraints are checked:
+#
+# ~~~ puppet
+#  Integer[0].new("-100")
+# ~~~
+# 
+# Would fail with an assertion error.
+#
+# The following sections show the arguments and conversion rules
+# per type built into the Puppet Type System.
+#
+# Conversion to Optional[T] and NotUndef[T]
+# -----------------------------------------
+# Conversion to these types is the same as a conversion to the type argument `T`. In the case of `Optional[T]`
+# it accepted that the result may be `undef` (i.e. not possible to convert).
+#
+# Conversion to Integer
+# ---------------------
+#
+# A new `Integer` can be created from `Integer`, `Float`, `Boolean`, and `String` values.
+# For conversion `from` String it is possible to specify the radix. 
+#
+# ~~~ puppet
+# type Radix = Variant[Default, Integer[2,2], Integer[8,8], Integer[10,10], Integer[16,16]]
+# Callable[String, Radix, 1, 2]
+# Callable[Variant[Numeric, Boolean]]
+# ~~~
+# 
+# * When converting from String the default radix is 10
+# * If radix is not specified an attempt is made to detect the radix from the start of the string:
+#   * `0b` or `0B` is taken as radix 2, 
+#   * `0x` or `0X` is taken as radix 16, 
+#   * `0` as radix 8,
+#   * all other are decimal 
+# * Conversion from String accepts an optional sign in the string.
+# * For hexadecimal (radix 16) conversion an optional leading "0x", or "0X" is accepted
+# * for octal (radix 8) an optional leading "0" is accepted
+# * for binary (radix 2) an optional leading "0b" or "0B" is accepted
+# * When `radix` is set to `default`, the conversion is based on the leading
+#   characters in the string. A leading "0" for radix 8, a leading "0x", or "0X" for
+#   radix 16, and leading "0b" or "0B" for binary.
+# * Conversion from Boolean results in 0 for `false` and 1 for `true`.
+# * Conversion from Integer, Float, and Boolean ignores the radix.
+# * Float value fractions are truncated (no rounding)
+#
+# @example Converting to Integer
+#
+# ~~~ puppet
+# $a_number = Integer("0xFF", 16)  # results in 255
+# $a_number = Numeric("010")       # results in 8
+# $a_number = Numeric("010", 10)   # results in 10
+# $a_number = Integer("true")      # results in 1
+# ~~~
+#
+# Conversion to Numeric
+# ---------------------
+#
+# A new Integer or Float can be created from Integer, Float, Boolean and
+# String values.
+#
+# ~~~ puppet
+# Callable[Variant[Numeric, Boolean, String]]
+# ~~~
+#
+# * If the value has a decimal period, or if given in scientific notation
+#   (e/E), the result is a `Float`, otherwise the value is an `Integer`. The
+#   conversion from `String` always uses a radix based on the prefix of the string.
+# * Conversion from Boolean results in 0 for `false` and 1 for `true`.
+#
+# @example Converting to Numeric
+#
+# ~~~ puppet
+# $a_number = Numeric("true")  # results in 1
+# $a_number = Numeric("0xFF")  # results in 255
+# $a_number = Numeric("010")   # results in 8
+# $a_number = Numeric("3.14")  # results in 3.14 (a float)
+# ~~~
+# 
+# Conversion to String
+# --------------------
+#
+# Conversion to String is the most comprehensive conversion as there are many
+# use cases where a String representation is wanted. The defaults for the many options
+# have been chosen with care to be the most basic "value in textual form" representation.
+#
+# A new String can be created from all other data types. The process is performed in
+# several steps - first the type of the given value is inferred, then the resulting type
+# is used to find the most significant format specified for that type. And finally,
+# the found format is used to convert the given value.
+#
+# The mapping from type to format is referred to as the format map. This map
+# allows different formatting depending on type.
+#
+# @example Positive Integers in Hexadecimal prefixed with '0x', negative in Decimal
+#
+# ~~~ puppet
+# $format_map = { Integer[default, 0] => "%d",
+#   Integer[1, default] => "%#x"
+# }
+# String("-1", $format_map)  # produces '-1'
+# String("10", $format_map)  # produces '0xa'
+# ~~~
+#
+# A format is specified on the form:
+#
+# ~~~
+# %[Flags][Width][.Precision]Format
+# ~~~
+#
+# `Width` is the number of characters into which the value should be fitted. This allocated space is
+# padded if value is shorter. By default it is space padded, and the flag 0 will cause padding with 0
+# for numerical formats.
+#
+# `Precision` is the number of fractional digits to show for floating point, and the maximum characters
+# included in a string format.
+#
+# Note that all data type supports the formats `s` and `p` with the meaning "default to string" and
+# "default programmatic string representation" (which for example means that a String is quoted in 'p' format).
+#
+# ### Signatures of String conversion
+#
+# ~~~ puppet
+# type Format = Pattern[/^%([\s\+\-#0\[\{<\(\|]*)([1-9][0-9]*)?(?:\.([0-9]+))?([a-zA-Z])/]
+# type ContainerFormat = Struct[{
+#   format         => Optional[String],
+#   separator      => Optional[String],
+#   separator2     => Optional[String],
+#   string_formats => Hash[Type, Format]
+#   }]
+# type TypeMap = Hash[Type, Variant[Format, ContainerFormat]]
+# type Formats = Variant[Default, String[1], TypeMap]
+#
+# Callable[Any, Formats]
+# ~~~
+#
+# Where:
+# * `separator` is the string used to separate entries in an array, or hash (extra space should not be included at
+#   then end), defaults to `","`
+# * `separator2` is the separator between key and value in a hash entry (space padding should be included as
+#   wanted), defaults to `" => ".
+# * `string_formats` is a type to format map for values contained in arrays and hashes - defaults to `{Any => "%p"}`. Note that
+#   these nested formats are not applicable to containers which are always formatted as per the top level format specification.
+#
+# @example Simple Conversion to String (using defaults)
+#
+# ~~~ puppet
+# $str = String(10)      # produces '10'
+# $str = String([10])    # produces '["10"]'
+# ~~~
+#
+# @example Simple Conversion to String specifying the format for the given value directly
+#
+# ~~~ puppet
+# $str = String(10, "%#x")    # produces '0x10'
+# $str = String([10], "%(a")  # produces '("10")'
+# ~~~
+#
+# @example Specifying type for values contained in an array
+#
+# ~~~ puppet
+# $formats = { Array => {format => '%(a', string_formats => { Integer => '%#x' } }
+# $str = String([1,2,3], $formats) # produces '(0x1, 0x2, 0x3)'
+# ~~~
+#
+# Given formats are merged with the default formats, and matching of values to convert against format is based on
+# the specificity of the mapped type; for example, different formats can be used for short and long arrays.
+#
+# ### Integer to String
+#
+# | Format  | Integer Formats
+# | ------  | ---------------
+# | d       | Decimal, negative values produces leading '-'
+# | x X     | Hexadecimal in lower or upper case. Uses ..f/..F for negative values unless # is also used
+# | o       | Octal. Uses ..0 for negative values unless # is also used
+# | b B     | Binary with prefix 'b' or 'B'. Uses ..1/..1 for negative values unless # is also used
+# | c       | numeric value representing a Unicode value, result is a one unicode character string, quoted if alternative flag # is used
+# | s       | same as d, or d in quotes if alternative flag # is used
+# | p       | same as d
+# | eEfgGaA | converts integer to float and formats using the floating point rules
+#
+# Defaults to `d`
+#
+# ### Float to String
+#
+# | Format  | Float formats
+# | ------  | -------------
+# | f       | floating point in non exponential notation
+# | e E     | exponential notation with 'e' or 'E'
+# | g G     | conditional exponential with 'e' or 'E' if exponent < -4 or >= the precision
+# | a A     | hexadecimal exponential form, using 'x'/'X' as prefix and 'p'/'P' before exponent
+# | s       | converted to string using format p, then applying string formatting rule, alternate form # quotes result
+# | p       | f format with minimum significant number of fractional digits, prec has no effect
+# | dxXobBc | converts float to integer and formats using the integer rules
+#
+# Defaults to `p`
+#
+# ### String to String
+#
+# | Format | String
+# | ------ | ------
+# | s      | unquoted string, verbatim output of control chars
+# | p      | programmatic representation - strings are quoted, interior quotes and control chars are escaped
+# | C      | each :: name segment capitalized, quoted if alternative flag # is used
+# | c      | capitalized string, quoted if alternative flag # is used
+# | d      | downcased string, quoted if alternative flag # is used
+# | u      | upcased string, quoted if alternative flag # is used
+# | t      | trims leading and trailing whitespace from the string, quoted if alternative flag # is used
+#
+# Defaults to `s` at top level and `p` inside array or hash.
+#
+# ### Boolean to String
+# 
+# | Format    | Boolean Formats
+# | ----      | -------------------   
+# | t T       | 'true'/'false' or 'True'/'False' , first char if alternate form is used (i.e. 't'/'f' or 'T'/'F').
+# | y Y       | 'yes'/'no', 'Yes'/'No', 'y'/'n' or 'Y'/'N' if alternative flag # is used
+# | dxXobB    | numeric value 0/1 in accordance with the given format which must be valid integer format
+# | eEfgGaA   | numeric value 0.0/1.0 in accordance with the given float format and flags
+# | s         | 'true' / 'false'
+# | p         | 'true' / 'false'
+#
+# ### Regexp to String
+#
+# | Format    | Regexp Formats (%/)
+# | ----      | ------------------
+# | s         | / / delimiters, alternate flag replaces / delimiters with quotes
+# | p         | / / delimiters
+#
+# ### Undef to String
+#
+# | Format    | Undef formats
+# | ------    | -------------
+# | s         | empty string, or quoted empty string if alternative flag # is used
+# | p         | 'undef', or quoted '"undef"' if alternative flag # is used
+# | n         | 'nil', or 'null' if alternative flag # is used
+# | dxXobB    | 'NaN'
+# | eEfgGaA   | 'NaN'
+# | v         | 'n/a'
+# | V         | 'N/A'
+# | u         | 'undef', or 'undefined' if alternative # flag is used
+#
+# ### Default value to String
+# 
+# | Format    | Default formats
+# | ------    | ---------------
+# | d D       | 'default' or 'Default', alternative form # causes value to be quoted
+# | s         | same as d
+# | p         | same as d
+#
+# ### Array & Tuple to String
+#
+# | Format    | Array/Tuple Formats
+# | ------    | -------------
+# | a         | formats with `[ ]` delimiters and `,`, alternate form `#` indents nested arrays/hashes
+# | s         | same as a
+# | p         | same as a
+#
+# See "Flags" `<[({\|` for formatting of delimiters, and "Additional parameters for containers; Array and Hash" for
+# more information about options.
+#
+# The alternate form flag `#` will cause indentation of nested array or hash containers. If width is also set
+# it is taken as the maximum allowed length of a sequence of elements (not including delimiters). If this max length
+# is exceeded, each element will be indented.
+#
+# ### Hash & Struct to String
+#
+# | Format    | Hash/Struct Formats
+# | ------    | -------------
+# | h         | formats with `{ }` delimiters, `,` element separator and ` => ` inner element separator unless overridden by flags 
+# | s         | same as h
+# | p         | same as h
+# | a         | converts the hash to an array of [k,v] tuples and formats it using array rule(s)
+# 
+# See "Flags" `<[({\|` for formatting of delimiters, and "Additional parameters for containers; Array and Hash" for
+# more information about options.
+#
+# The alternate form flag `#` will format each hash key/value entry indented on a separate line.
+#
+# ### Type to String
+# 
+# | Format    | Array/Tuple Formats
+# | ------    | -------------
+# | s         | The same as p, quoted if alternative flag # is used
+# | p         | Outputs the type in string form as specified by the Puppet Language
+#
+# ### Flags
+#
+# | Flag     | Effect 
+# | ------   | ------
+# | (space)  | space instead of + for numeric output (- is shown), for containers skips delimiters
+# | #        | alternate format; prefix 0x/0x, 0 (octal) and 0b/0B for binary, Floats force decimal '.'. For g/G keep trailing 0.
+# | +        | show sign +/- depending on value's sign, changes x,X, o,b, B format to not use 2's complement form
+# | -        | left justify the value in the given width
+# | 0        | pad with 0 instead of space for widths larger than value
+# | <[({\|   | defines an enclosing pair <> [] () {} or \| \| when used with a container type
+#
+# Conversion to Boolean
+# ---
+#
+# Accepts a single value as argument:
+# * Float 0.0 is `false`, all other float values are `true`
+# * Integer 0 is `false`, all other integer values are `true`
+# * Strings
+#   * `true` if 'true', 'yes', 'y' (case independent compare)
+#   * `false` if 'false', 'no', 'n' (case independent compare)
+# * Boolean is already boolean and is simply returned
+#
+# Conversion to Array and Tuple
+# ---
+#
+# When given a single value as argument:
+#
+# * A non empty `Hash` is converted to an array matching `Array[Tuple[Any,Any], 1]`
+# * An empty `Hash` becomes an empty array
+# * An `Array` is simply returned
+# * An `Iterable[T]` is turned into an array of `T` instances
+#
+# When given a second Boolean argument
+# * if `true`, a value that is not already an array is returned as a one element array
+# * if `false`, (the default), converts the first argument as shown above.
+#
+# @example ensuring value is array
+#
+# ~~~ puppet
+# $arr = Array($value, true)
+# ~~~
+#
+# Conversion to a `Tuple` works exactly as conversion to an `Array`, only that the constructed array is
+# asserted against the given tuple type.
+#
+# Conversion to Hash and Struct
+# ---
+# Accepts a single value as argument:
+#
+# * An empty `Array` becomes an empty hash
+# * An `Array` matching `Array[Tuple[Any,Any], 1]` is converted to a hash where each tuple describes a key/value entry
+# * An `Array` with an even number of entries is interpreted as `[key1, val1, key2, val2, ...]`
+# * An `Iterable` is turned into an `Array` and then converted to hash as per the array rules
+# * A `Hash` is simply returned
+#
+# Conversion to a `Struct` works exactly as conversion to a `Hash`, only that the constructed hash is
+# asserted against the given struct type.
+#
+# @since 4.5.0
+#
+Puppet::Functions.create_function(:new, Puppet::Functions::InternalFunction) do
+
+  dispatch :new_instance do
+    scope_param
+    param          'Type', :type
+    repeated_param 'Any',  :args
+    optional_block_param
+  end
+
+  def new_instance(scope, t, *args)
+    result = catch :undefined_value do
+      new_function_for_type(t, scope).call(scope, *args)
+    end
+    assert_type(t, result)
+    return block_given? ? yield(result) : result
+  end
+
+  def new_function_for_type(t, scope)
+    @new_function_cache ||= Hash.new() {|hsh, key| hsh[key] = key.new_function(loader).new(scope, loader) }
+    @new_function_cache[t]
+  end
+
+  def assert_type(type, value)
+    unless Puppet::Pops::Types::TypeCalculator.instance?(type,value)
+      inferred_type = Puppet::Pops::Types::TypeCalculator.infer_set(value)
+      raise Puppet::Pops::Types::TypeAssertionError.new(
+        Puppet::Pops::Types::TypeMismatchDescriber.singleton.describe_mismatch('new():', type, inferred_type),
+        type, inferred_type)
+    end
+    value
+  end
+
+end

--- a/lib/puppet/loaders.rb
+++ b/lib/puppet/loaders.rb
@@ -16,6 +16,7 @@ module Puppet
       require 'puppet/pops/loader/type_definition_instantiator'
       require 'puppet/pops/loader/loader_paths'
       require 'puppet/pops/loader/simple_environment_loader'
+      require 'puppet/pops/loader/predefined_loader'
     end
   end
 

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -34,6 +34,7 @@ module Puppet
 
     # (the Types module initializes itself)
     require 'puppet/pops/types/types'
+    require 'puppet/pops/types/string_converter'
 
     require 'puppet/pops/merge_strategy'
 

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -827,9 +827,20 @@ class EvaluatorImpl
   # Evaluates function call by name.
   #
   def eval_CallNamedFunctionExpression(o, scope)
+    # If LHS is a type (i.e. Integer, or Integer[...]
+    # the call is taken as an instantiation of the given type
+    #
+    functor = o.functor_expr
+    if functor.is_a?(Model::QualifiedReference) || 
+      functor.is_a?(Model::AccessExpression) && functor.left_expr.is_a?(Model::QualifiedReference)
+      # instantiation
+      type = evaluate(functor, scope)
+      return call_function_with_block('new', unfold([type], o.arguments || [], scope), o, scope)
+    end 
+
     # The functor expression is not evaluated, it is not possible to select the function to call
     # via an expression like $a()
-    case o.functor_expr
+    case functor
     when Model::QualifiedName
       # ok
     when Model::RenderStringExpression

--- a/lib/puppet/pops/loader/predefined_loader.rb
+++ b/lib/puppet/pops/loader/predefined_loader.rb
@@ -1,0 +1,21 @@
+module Puppet::Pops::Loader
+
+# A PredefinedLoader is a loader that is manually populated with loaded elements
+# before being used. It never loaders anything on its own.
+# When searching for a type, it must exist or an error is raised
+#
+class PredefinedLoader < BaseLoader
+  def find(typed_name)
+    if typed_name.type == :type
+      raise Puppet::Pops::Loaders::LoaderError, "Cannot load undefined type '#{typed_name.name.capitalize}'"
+    else
+      nil
+    end
+  end
+  def to_s()
+    "(PredefinedLoader '#{loader_name}')"
+  end
+
+end
+
+end

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -654,7 +654,7 @@ class StringConverter
       Kernel.format(f.orig_fmt, val.to_f)
 
     when :c
-      char = Kernel.format('%c', val)
+      char = [val].pack("U")
       char = f.alt? ? "\"#{char}\"" : char
       char = Kernel.format(f.orig_fmt.gsub('c','s'), char)
 

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -248,7 +248,6 @@ class StringConverter
   #
   def initialize
     @@string_visitor   ||= Visitor.new(self, "string", 3, 3)
-    @@type_calculator = TypeCalculator.singleton()
   end
 
   DEFAULT_INDENTATION = Indentation.new(0, true, false).freeze
@@ -455,7 +454,7 @@ class StringConverter
 
     if string_formats.is_a?(String)
       # add the format given for the exact type
-      t = @@type_calculator.infer_set(value)
+      t = TypeCalculator.infer_set(value)
       string_formats = { t => string_formats }
     end
 
@@ -472,7 +471,7 @@ class StringConverter
       raise ArgumentError, "string conversion expects a Default value or a Hash of type to format mappings, got a '#{string_formats.class}'"
     end
 
-    _convert(@@type_calculator.infer_set(value), value, options, DEFAULT_INDENTATION)
+    _convert(TypeCalculator.infer_set(value), value, options, DEFAULT_INDENTATION)
   end
 
 #  # A method only used for manual debugging as the default output of the formatting rules is
@@ -625,13 +624,13 @@ class StringConverter
       # Boolean in numeric form, formated by integer rule
       numeric_bool = val ? 1 : 0
       string_formats = { Puppet::Pops::Types::PIntegerType::DEFAULT => f}
-      _convert(@@type_calculator.infer_set(numeric_bool), numeric_bool, string_formats, indentation)
+      _convert(TypeCalculator.infer_set(numeric_bool), numeric_bool, string_formats, indentation)
 
     when :e, :E, :f, :g, :G, :a, :A
       # Boolean in numeric form, formated by float rule
       numeric_bool = val ? 1.0 : 0.0
       string_formats = { Puppet::Pops::Types::PFloatType::DEFAULT => f}
-      _convert(@@type_calculator.infer_set(numeric_bool), numeric_bool, string_formats, indentation)
+      _convert(TypeCalculator.infer_set(numeric_bool), numeric_bool, string_formats, indentation)
 
     when :s
       val.to_s
@@ -762,7 +761,7 @@ class StringConverter
         if children_indentation.first?
           children_indentation = children_indentation.subsequent
         end
-        val_t = @@type_calculator.infer_set(v)
+        val_t = TypeCalculator.infer_set(v)
         _convert(val_t, v, is_container?(val_t) ? format_map : string_formats, children_indentation)
       end
 
@@ -836,7 +835,7 @@ class StringConverter
   # @api private
   def string_PIteratorType(val_type, val, format_map, indentation)
     v = val.to_a
-    _convert(@@type_calculator.infer_set(v), v, format_map, indentation)
+    _convert(TypeCalculator.infer_set(v), v, format_map, indentation)
   end
 
   # @api private
@@ -856,7 +855,7 @@ class StringConverter
     when :a
       # Convert to array and use array rules
       array_hash = val.to_a
-      _convert(@@type_calculator.infer_set(array_hash), array_hash, format_map, indentation)
+      _convert(TypeCalculator.infer_set(array_hash), array_hash, format_map, indentation)
 
     when :h, :s, :p
       indentation = indentation.indenting(format.alt? || indentation.is_indenting?)
@@ -874,8 +873,8 @@ class StringConverter
       buf << delims[0]
       buf << cond_break  # break after opening delimiter if pretty printing
       buf << val.map do |k,v|
-        key_type = @@type_calculator.infer_set(k)
-        val_type = @@type_calculator.infer_set(v)
+        key_type = TypeCalculator.infer_set(k)
+        val_type = TypeCalculator.infer_set(v)
         key = _convert(key_type, k, is_container?(key_type) ? format_map : string_formats, children_indentation)
         val = _convert(val_type, v, is_container?(val_type) ? format_map : string_formats, children_indentation)
         "#{padding}#{key}#{assoc}#{val}"

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -1,0 +1,923 @@
+module Puppet::Pops
+module Types
+
+# Converts Puppet runtime objects to String under the control of a Format.
+# Use from Puppet Language is via the function `new`.
+#
+# @api private
+#
+class StringConverter
+
+  # @api private
+  class FormatError < ArgumentError
+    def initialize(type_string, actual, expected)
+      super "Illegal format '#{actual}' specified for value of #{type_string} type - expected one of the characters '#{expected}'"
+    end
+  end
+
+  class Indentation
+    attr_reader :level
+    attr_reader :first
+    attr_reader :is_indenting
+    alias :first? :first
+    alias :is_indenting? :is_indenting
+
+    def initialize(level, first, is_indenting)
+      @level = level
+      @first = first
+      @is_indenting = is_indenting
+    end
+
+    def subsequent
+      first? ? self.class.new(level, false, @is_indenting) : self
+    end
+
+    def indenting(indenting_flag)
+      self.class.new(level, first?, indenting_flag)
+    end
+
+    def increase(indenting_flag = false)
+      self.class.new(level + 1, true, indenting_flag)
+    end
+
+    def breaks?
+      is_indenting? && level > 0 && ! first?
+    end
+
+    def padding
+      return ' ' * 2 * level
+    end
+  end
+
+  # Format represents one format specification that is textually represented by %<flags><width>.<precision><format>
+  # Format parses and makes the individual parts available when an instance is created.
+  # 
+  # @api private
+  #
+  class Format
+    # Boolean, alternate form (varies in meaning)
+    attr_reader :alt
+    alias :alt? :alt
+
+    # Nil or Integer with width of field > 0
+    attr_reader :width
+    # Nil or Integer precisions
+    attr_reader :prec
+    # One char symbol denoting the format
+    attr_reader :format
+    # Symbol, :space, :plus, :ignore
+    attr_reader :plus
+    # Boolean, left adjust in given width or not
+    attr_reader :left
+    # Boolean left_pad with zero instead of space
+    attr_reader :zero_pad
+    # Delimiters for containers, a "left" char representing the pair <[{(
+    attr_reader :delimiters
+
+    # Map of type to format for elements contained in an object this format applies to
+    attr_accessor :container_string_formats
+
+    # Separator string inserted between elements in a container
+    attr_accessor :separator
+
+    # Separator string inserted between sub elements in a container
+    attr_accessor :separator2
+
+    attr_reader :orig_fmt
+
+    FMT_PATTERN = /^%([\s\+\-#0\[\{<\(\|]*)([1-9][0-9]*)?(?:\.([0-9]+))?([a-zA-Z])/
+    DELIMITERS  = [ '[', '{', '(', '<', '|',]
+    DELIMITER_MAP = {
+      '[' => ['[', ']'],
+      '{' => ['{', '}'],
+      '(' => ['(', ')'],
+      '<' => ['<', '>'],
+      '|' => ['|', '|'],
+      :space => ['', '']
+    }.freeze
+
+    def initialize(fmt)
+      @orig_fmt = fmt
+      match = FMT_PATTERN.match(fmt)
+      unless match
+        raise ArgumentError, "The format '#{fmt}' is not a valid format on the form '%<flags><width>.<prec><format>'"
+      end
+
+      @format = match[4]
+      unless @format.is_a?(String) && @format.length == 1
+        raise ArgumentError, "The format must be a one letter format specifier, got '#{@format}'"
+      end
+      @format = @format.to_sym
+      flags  = match[1].split('') || []
+      unless flags.uniq.size == flags.size
+        raise ArgumentError, "The same flag can only be used once, got '#{fmt}'"
+      end
+      @left  = flags.include?('-')
+      @alt   = flags.include?('#')
+      @plus  = (flags.include?(' ') ? :space : (flags.include?('+') ? :plus : :ignore))
+      @zero_pad = flags.include?('0')
+
+      @delimiters = nil
+      DELIMITERS.each do |d|
+        next unless flags.include?(d)
+          if !@delimiters.nil?
+            raise ArgumentError, "Only one of the delimiters [ { ( < | can be given in the format flags, got '#{fmt}'"
+          end
+          @delimiters = d
+      end
+
+      @width = match[2] ? match[2].to_i : nil
+      @prec  = match[3] ? match[3].to_i : nil
+    end
+
+    # Merges one format into this and returns a new `Format`. The `other` format overrides this.
+    # @param [Format] other
+    # @returns [Format] a merged format
+    #
+    def merge(other)
+      result = Format.new(other.orig_fmt)
+      result.separator = other.separator || separator
+      result.separator2 = other.separator2 || separator2
+      result.container_string_formats = Format.merge_string_formats(container_string_formats, other.container_string_formats)
+      result
+    end
+
+    # Merges two formats where the `higher` format overrides the `lower`. Produces a new `Format`
+    # @param [Format] lower
+    # @param [Format] higher
+    # @returns [Format] the merged result
+    #
+    def self.merge(lower, higher)
+      unless lower && higher
+        return lower || higher
+      end
+      lower.merge(higher)
+    end
+
+    # Merges a type => format association and returns a new merged and sorted association.
+    # @param [Format] lower
+    # @param [Format] higher
+    # @returns [Hash] the merged type => format result
+    #
+    def self.merge_string_formats(lower, higher)
+      unless lower && higher
+        return lower || higher
+      end
+      merged = (lower.keys + higher.keys).uniq.map do |k|
+        [k, merge(lower[k], higher[k])]
+      end
+      sort_formats(merged)
+    end
+
+    # Sorts format based on generality of types - most specific types before general
+    #
+    def self.sort_formats(format_map)
+      format_map = format_map.sort do |(a,_),(b,_)| 
+        ab = b.assignable?(a)
+        ba = a.assignable?(b)
+        if a == b
+          0
+        elsif ab && !ba
+          -1
+        elsif !ab && ba
+          1
+        else
+          # arbitrary order if disjunct (based on name of type)
+          rank_a = type_rank(a)
+          rank_b = type_rank(b)
+          if rank_a == 0 || rank_b == 0
+            a.to_s <=> b.to_s
+          else
+            rank_a <=> rank_b
+          end
+        end
+      end
+      format_map.to_h
+    end
+
+    # Ranks type on specificity where it matters
+    # lower number means more specific
+    def self.type_rank(t)
+      case t
+      when PStructType
+        1
+      when PHashType
+        2
+      when PTupleType
+        3
+      when PArrayType
+        4
+      when PPatternType
+        10
+      when PEnumType
+        11
+      when PStringType
+        12
+      else
+        0
+      end
+    end
+    # Returns an array with a delimiter pair derived from the format.
+    # If format does not contain a delimiter specification the given default is returned
+    # 
+    # @param [Array<String>] the default delimiters
+    # @returns [Array<String>] a tuple with left, right delimiters
+    #
+    def delimiter_pair(default = StringConverter::DEFAULT_ARRAY_DELIMITERS)
+      DELIMITER_MAP[ @delimiters || @plus ] || default
+    end
+
+    def to_s
+      "%#{@flags}#{@width}.#{@prec}#{@format}"
+    end
+  end
+
+  # @api public
+  def self.convert(value, string_formats = :default)
+    singleton.convert(value, string_formats)
+  end
+
+  # @return [TypeConverter] the singleton instance
+  #
+  # @api public
+  def self.singleton
+    @tconv_instance ||= new
+  end
+
+  # @api private
+  #
+  def initialize
+    @@string_visitor   ||= Visitor.new(self, "string", 3, 3)
+    @@type_calculator = TypeCalculator.singleton()
+  end
+
+  DEFAULT_INDENTATION = Indentation.new(0, true, false).freeze
+
+  # format used by default for values in a container
+  # (basically strings are quoted since they may contain a ','))
+  #
+  DEFAULT_CONTAINER_FORMATS = {
+    PAnyType::DEFAULT  => Format.new('%p').freeze,   # quoted string (Ruby inspect)
+  }.freeze
+
+  DEFAULT_ARRAY_FORMAT                          = Format.new('%a')
+  DEFAULT_ARRAY_FORMAT.separator                = ','.freeze
+  DEFAULT_ARRAY_FORMAT.separator2               = ','.freeze
+  DEFAULT_ARRAY_FORMAT.container_string_formats = DEFAULT_CONTAINER_FORMATS
+  DEFAULT_ARRAY_FORMAT.freeze
+
+  DEFAULT_HASH_FORMAT                           = Format.new('%h')
+  DEFAULT_HASH_FORMAT.separator                 = ','.freeze
+  DEFAULT_HASH_FORMAT.separator2                = ' => '.freeze
+  DEFAULT_HASH_FORMAT.container_string_formats  = DEFAULT_CONTAINER_FORMATS
+  DEFAULT_HASH_FORMAT.freeze
+
+  DEFAULT_HASH_DELIMITERS                       = ['{', '}'].freeze
+  DEFAULT_ARRAY_DELIMITERS                      = ['[', ']'].freeze
+
+  DEFAULT_STRING_FORMATS = {
+    PFloatType::DEFAULT    => Format.new('%f').freeze,    # float
+    PNumericType::DEFAULT  => Format.new('%d').freeze,    # decimal number
+    PArrayType::DEFAULT    => DEFAULT_ARRAY_FORMAT.freeze,
+    PHashType::DEFAULT     => DEFAULT_HASH_FORMAT.freeze,
+    PAnyType::DEFAULT      => Format.new('%s').freeze,    # unquoted string
+  }.freeze
+
+
+  # Converts the given value to a String, under the direction of formatting rules per type.
+  #
+  # When converting to string it is possible to use a set of built in conversion rules.
+  #
+  # A format is specified on the form:
+  # 
+  # ´´´
+  # %[Flags][Width][.Precision]Format
+  # ´´´
+  #
+  # `Width` is the number of characters into which the value should be fitted. This allocated space is
+  # padded if value is shorter. By default it is space padded, and the flag 0 will cause padding with 0
+  # for numerical formats.
+  #
+  # `Precision` is the number of fractional digits to show for floating point, and the maximum characters
+  # included in a string format.
+  #
+  # Note that all data type supports the formats `s` and `p` with the meaning "default to-string" and
+  # "default-programmatic to-string".
+  #
+  # ### Integer
+  #
+  # | Format  | Integer Formats
+  # | ------  | ---------------
+  # | d       | Decimal, negative values produces leading '-'
+  # | x X     | Hexadecimal in lower or upper case. Uses ..f/..F for negative values unless # is also used
+  # | o       | Octal. Uses ..0 for negative values unless # is also used
+  # | b B     | Binary with prefix 'b' or 'B'. Uses ..1/..1 for negative values unless # is also used
+  # | c       | numeric value representing a Unicode value, result is a one unicode character string, quoted if alternative flag # is used
+  # | s       | same as d, or d in quotes if alternative flag # is used
+  # | p       | same as d
+  # | eEfgGaA | converts integer to float and formats using the floating point rules
+  #
+  # Defaults to `d`
+  #
+  # ### Float
+  #
+  # | Format  | Float formats
+  # | ------  | -------------
+  # | f       | floating point in non exponential notation
+  # | e E     | exponential notation with 'e' or 'E'
+  # | g G     | conditional exponential with 'e' or 'E' if exponent < -4 or >= the precision
+  # | a A     | hexadecimal exponential form, using 'x'/'X' as prefix and 'p'/'P' before exponent
+  # | s       | converted to string using format p, then applying string formatting rule, alternate form # quotes result
+  # | p       | f format with minimum significant number of fractional digits, prec has no effect
+  # | dxXobBc | converts float to integer and formats using the integer rules
+  #
+  # Defaults to `p`
+  #
+  # ### String
+  #
+  # | Format | String
+  # | ------ | ------
+  # | s      | unquoted string, verbatim output of control chars
+  # | p      | programmatic representation - strings are quoted, interior quotes and control chars are escaped
+  # | C      | each :: name segment capitalized, quoted if alternative flag # is used
+  # | c      | capitalized string, quoted if alternative flag # is used
+  # | d      | downcased string, quoted if alternative flag # is used
+  # | u      | upcased string, quoted if alternative flag # is used
+  # | t      | trims leading and trailing whitespace from the string, quoted if alternative flag # is used
+  #
+  # Defaults to `s` at top level and `p` inside array or hash.
+  #
+  # ### Boolean
+  # 
+  # | Format    | Boolean Formats
+  # | ----      | -------------------   
+  # | t T       | 'true'/'false' or 'True'/'False' , first char if alternate form is used (i.e. 't'/'f' or 'T'/'F').
+  # | y Y       | 'yes'/'no', 'Yes'/'No', 'y'/'n' or 'Y'/'N' if alternative flag # is used
+  # | dxXobB    | numeric value 0/1 in accordance with the given format which must be valid integer format
+  # | eEfgGaA   | numeric value 0.0/1.0 in accordance with the given float format and flags
+  # | s         | 'true' / 'false'
+  # | p         | 'true' / 'false'
+  #
+  # ### Regexp
+  #
+  # | Format    | Regexp Formats (%/)
+  # | ----      | ------------------
+  # | s         | / / delimiters, alternate flag replaces / delimiters with quotes
+  # | p         | / / delimiters
+  #
+  # ### Undef
+  #
+  # | Format    | Undef formats
+  # | ------    | -------------
+  # | s         | empty string, or quoted empty string if alternative flag # is used
+  # | p         | 'undef', or quoted '"undef"' if alternative flag # is used
+  # | n         | 'nil', or 'null' if alternative flag # is used
+  # | dxXobB    | 'NaN'
+  # | eEfgGaA   | 'NaN'
+  # | v         | 'n/a'
+  # | V         | 'N/A'
+  # | u         | 'undef', or 'undefined' if alternative # flag is used
+  #
+  # ### Default (value)
+  # 
+  # | Format    | Default formats
+  # | ------    | ---------------
+  # | d D       | 'default' or 'Default', alternative form # causes value to be quoted
+  # | s         | same as d
+  # | p         | same as d
+  #
+  # ### Array & Tuple
+  #
+  # | Format    | Array/Tuple Formats
+  # | ------    | -------------
+  # | a         | formats with `[ ]` delimiters and `,`, alternate form `#` indents nested arrays/hashes
+  # | s         | same as a
+  # | p         | same as a
+  #
+  # See "Flags" `<[({\|` for formatting of delimiters, and "Additional parameters for containers; Array and Hash" for
+  # more information about options.
+  #
+  # The alternate form flag `#` will cause indentation of nested array or hash containers. If width is also set
+  # it is taken as the maximum allowed length of a sequence of elements (not including delimiters). If this max length
+  # is exceeded, each element will be indented.
+  #
+  # ### Hash & Struct
+  #
+  # | Format    | Hash/Struct Formats
+  # | ------    | -------------
+  # | h         | formats with `{ }` delimiters, `,` element separator and ` => ` inner element separator unless overridden by flags 
+  # | s         | same as h
+  # | p         | same as h
+  # | a         | converts the hash to an array of [k,v] tuples and formats it using array rule(s)
+  # 
+  # See "Flags" `<[({\|` for formatting of delimiters, and "Additional parameters for containers; Array and Hash" for
+  # more information about options.
+  #
+  # The alternate form flag `#` will format each hash key/value entry indented on a separate line.
+  #
+  # ### Type
+  # 
+  # | Format    | Array/Tuple Formats
+  # | ------    | -------------
+  # | s        | The same as p, quoted if alternative flag # is used
+  # | p        | Outputs the type in string form as specified by the Puppet Language
+  #
+  # ### Flags
+  #
+  # | Flag     | Effect 
+  # | ------   | ------
+  # | (space)  | space instead of + for numeric output (- is shown), for containers skips delimiters
+  # | #        | alternate format; prefix 0x/0x, 0 (octal) and 0b/0B for binary, Floats force decimal '.'. For g/G keep trailing 0.
+  # | +        | show sign +/- depending on value's sign, changes x,X, o,b, B format to not use 2's complement form
+  # | -        | left justify the value in the given width
+  # | 0        | pad with 0 instead of space for widths larger than value
+  # | <[({\|   | defines an enclosing pair <> [] () {} or \| \| when used with a container type
+  #
+  # 
+  # ### Additional parameters for containers; Array and Hash
+  #
+  # For containers (Array and Hash), the format is specified by a hash where the following keys can be set:
+  # * `'format'` - the format specifier for the container itself
+  # * `'separator'` - the separator string to use between elements, should not contain padding space at the end
+  # * `'separator2'` - the separator string to use between association of hash entries key/value
+  # * `'string_formats'´ - a map of type to format for elements contained in the container
+  # 
+  # Note that the top level format applies to Array and Hash objects contained/nested in an Array or a Hash.
+  #
+  # Given format mappings are merged with (default) formats and a format specified for a narrower type
+  # wins over a broader.
+  #
+  # @param mode [String, Symbol] :strict or :extended (or :default which is the same as :strict)
+  # @param string_formats [String, Hash] format tring, or a hash mapping type to a format string, and for Array and Hash types map to hash of details
+  #
+  def convert(value, string_formats = :default)
+    options = DEFAULT_STRING_FORMATS
+
+    if string_formats.is_a?(String)
+      # add the format given for the exact type
+      t = @@type_calculator.infer_set(value)
+      string_formats = { t => string_formats }
+    end
+
+    case string_formats
+    when :default
+     # do nothing, use default formats
+
+    when Hash
+      # Convert and validate user input
+      string_formats = validate_input(string_formats)
+      # Merge user given with defaults such that user options wins, merge is deep and format specific
+      options = Format.merge_string_formats(DEFAULT_STRING_FORMATS, string_formats)
+    else
+      raise ArgumentError, "string conversion expects a Default value or a Hash of type to format mappings, got a '#{string_formats.class}'"
+    end
+
+    _convert(@@type_calculator.infer_set(value), value, options, DEFAULT_INDENTATION)
+  end
+
+#  # A method only used for manual debugging as the default output of the formatting rules is
+#  # very hard to read otherwise.
+#  #
+#  # @api private
+#  def dump_string_formats(f, indent = 1)
+#     return f.to_s unless f.is_a?(Hash)
+#     "{#{f.map {|k,v| "#{k.to_s} => #{dump_string_formats(v,indent+1)}"}.join(",\n#{'  '*indent}  ")}}"
+#  end
+
+  def _convert(val_type, value, format_map, indentation)
+    @@string_visitor.visit_this_3(self, val_type, value, format_map, indentation)
+  end
+  private :_convert
+
+  def validate_input(fmt)
+    return nil if fmt.nil?
+    unless fmt.is_a?(Hash)
+      raise ArgumentError, "expected a hash with type to format mappings, got instance of '#{fmt.class}'"
+    end
+    fmt.reduce({}) do | result, entry|
+      key, value = entry
+      unless key.is_a?(Types::PAnyType)
+        raise ArgumentError, "top level keys in the format hash must be data types, got instance of '#{key.class}'"
+      end
+      if value.is_a?(Hash)
+        result[key] = validate_container_input(value)
+      else
+        result[key] = Format.new(value)
+      end
+      result
+    end
+  end
+  private :validate_input
+
+  FMT_KEYS = %w{separator separator2 format string_formats}.freeze
+
+  def validate_container_input(fmt)
+    if (fmt.keys - FMT_KEYS).size > 0
+      raise ArgumentError, "only #{FMT_KEYS}.map {|k| "'#{k}'"}.join(', ')} are allowed in a container format, got #{fmt}"
+    end
+    result                          = Format.new(fmt['format'])
+    result.separator                = fmt['separator']
+    result.separator2               = fmt['separator2']
+    result.container_string_formats = validate_input(fmt['string_formats'])
+    result
+  end
+  private :validate_container_input
+
+  def string_PRuntimeType(val_type, val, format_map)
+    case (f = get_format(val_type, format_map))
+    when :s
+      val.to_s
+    when :q
+      val.to_s.inspect
+    when :puppet
+      puppet_safe(val.to_s)
+    when :i, :d, :x, :o, :f, :puppet
+      converted = convert(o, PNumericType) # rest is default
+      "%#{f}" % converted
+    else
+      throw(:failed_conversion, [o, PStringType::DEFAULT, f])
+    end
+  end
+
+  # Given an unsafe string make it safe for puppet
+  def puppet_safe(str)
+    str = str.inspect # all specials are now quoted
+    # all $ variables must be quoted
+    str.gsub!("\$", "\\\$")
+    str
+  end
+
+  # Basically string_PAnyType converts the value to a String and then formats it according
+  # to the resulting type
+  #
+  # @api private
+  def string_PAnyType(val_type, val, format_map, _)
+    f = get_format(val_type, format_map)
+    Kernel.format(f.orig_fmt, val)
+  end
+
+  def string_PDefaultType(val_type, val, format_map, _)
+    f = get_format(val_type, format_map)
+    case f.format
+    when :d, :s, :p
+      f.alt? ? '"default"' : 'default'
+    when :D
+      f.alt? ? '"Default"' : 'Default'
+    else
+      raise FormatError.new('Default', f.format, 'dDsp')
+    end
+  end
+
+  # @api private
+  def string_PUndefType(val_type, val, format_map, _)
+    f = get_format(val_type, format_map)
+    undef_str =
+    case f.format
+    when :n
+      f.alt? ? 'null' : 'nil'
+    when :u
+      f.alt? ? 'undefined' : 'undef'
+    when :d, :x, :X, :o, :b, :B, :e, :E, :f, :g, :G, :a, :A
+      'NaN'
+    when :v
+      'n/a'
+    when :V
+      'N/A'
+    when :s
+      f.alt? ? '""' : ''
+    when :p
+      f.alt? ? '"undef"' : 'undef'
+    else
+      raise FormatError.new('Undef', f.format, 'nudxXobBeEfgGaAvVsp')
+    end
+    fmt = "%#{f.left ? '-' : ''}"
+    fmt << "#{f.width}" if f.width
+    fmt << ".#{f.prec}" if f.prec
+    fmt << "s"
+    Kernel.format(fmt,undef_str)
+  end
+
+  # @api private
+  def string_PBooleanType(val_type, val, format_map, indentation)
+    f = get_format(val_type, format_map)
+    case f.format
+    when :t
+      # 'true'/'false' or 't'/'f' if in alt mode
+      str_bool = val.to_s
+      f.alt? ? str_bool[0] : str_bool
+
+    when :T
+      # 'True'/'False' or 'T'/'F' if in alt mode
+      str_bool = val.to_s.capitalize
+      f.alt? ? str_bool[0] : str_bool
+
+    when :y
+      # 'yes'/'no' or 'y'/'n' if in alt mode
+      str_bool = val ? 'yes' : 'no'
+      f.alt? ? str_bool[0] : str_bool
+
+    when :Y
+      # 'Yes'/'No' or 'Y'/'N' if in alt mode
+      str_bool = val ? 'Yes' : 'No'
+      f.alt? ? str_bool[0] : str_bool
+
+    when :d, :x, :X, :o, :b, :B
+      # Boolean in numeric form, formated by integer rule
+      numeric_bool = val ? 1 : 0
+      string_formats = { Puppet::Pops::Types::PIntegerType::DEFAULT => f}
+      _convert(@@type_calculator.infer_set(numeric_bool), numeric_bool, string_formats, indentation)
+
+    when :e, :E, :f, :g, :G, :a, :A
+      # Boolean in numeric form, formated by float rule
+      numeric_bool = val ? 1.0 : 0.0
+      string_formats = { Puppet::Pops::Types::PFloatType::DEFAULT => f}
+      _convert(@@type_calculator.infer_set(numeric_bool), numeric_bool, string_formats, indentation)
+
+    when :s
+      val.to_s
+
+    when :p
+      val.inspect
+
+    else
+      raise FormatError.new('Boolean', f.format, 'tTyYdxXobBeEfgGaAsp')
+    end
+  end
+
+  # @api private
+  def string_PIntegerType(val_type, val, format_map, _)
+    f = get_format(val_type, format_map)
+    case f.format
+    when :d, :x, :X, :o, :b, :B, :p
+      Kernel.format(f.orig_fmt, val)
+
+    when :e, :E, :f, :g, :G, :a, :A
+      Kernel.format(f.orig_fmt, val.to_f)
+
+    when :c
+      char = Kernel.format('%c', val)
+      char = f.alt? ? "\"#{char}\"" : char
+      char = Kernel.format(f.orig_fmt.gsub('c','s'), char)
+
+    when :s
+      fmt = f.alt? ? 'p' : 's'
+      int_str = Kernel.format('%d', val)
+      Kernel.format(f.orig_fmt.gsub('s', fmt), int_str)
+
+    else
+      raise FormatError.new('Integer', f.format, 'dxXobBeEfgGaAspc')
+    end
+  end
+
+  # @api private
+  def string_PFloatType(val_type, val, format_map, _)
+    f = get_format(val_type, format_map)
+    case f.format
+    when :d, :x, :X, :o, :b, :B
+      Kernel.format(f.orig_fmt, val.to_i)
+
+    when :e, :E, :f, :g, :G, :a, :A, :p
+      Kernel.format(f.orig_fmt, val)
+
+    when :s
+      float_str = f.alt? ? "\"#{Kernel.format('%p', val)}\"" : Kernel.format('%p', val)
+      Kernel.format(f.orig_fmt, float_str)
+
+    else
+      raise FormatError.new('Float', f.format, 'dxXobBeEfgGaAsp')
+    end
+  end
+
+  # @api private
+  def string_PStringType(val_type, val, format_map, _)
+    f = get_format(val_type, format_map)
+    case f.format
+    when :s, :p
+      Kernel.format(f.orig_fmt, val)
+
+    when :c
+      c_val = val.capitalize
+      substitute = f.alt? ? 'p' : 's'
+      Kernel.format(f.orig_fmt.gsub('c', substitute), c_val)
+
+    when :C
+      c_val = val.split('::').map {|s| s.capitalize }.join('::')
+      substitute = f.alt? ? 'p' : 's'
+      Kernel.format(f.orig_fmt.gsub('C', substitute), c_val)
+
+    when :u
+      substitute = f.alt? ? 'p' : 's'
+      Kernel.format(f.orig_fmt.gsub('u', substitute), val).upcase
+
+    when :d
+      substitute = f.alt? ? 'p' : 's'
+      Kernel.format(f.orig_fmt.gsub('d', substitute), val).downcase
+
+    when :t  # trim
+      c_val = val.strip
+      substitute = f.alt? ? 'p' : 's'
+      Kernel.format(f.orig_fmt.gsub('t', substitute), c_val)
+
+    else
+      raise FormatError.new('String', f.format, 'cCudspt')
+    end
+  end
+
+  # @api private
+  def string_PRegexpType(val_type, val, format_map, _)
+    f = get_format(val_type, format_map)
+    case f.format
+    when :p
+      Kernel.format(f.orig_fmt, val)
+    when :s
+      str_regexp = val.inspect
+      str_regexp = f.alt? ? "\"#{str_regexp[1..-2]}\"" : str_regexp
+      Kernel.format(f.orig_fmt, str_regexp)
+    else
+      raise FormatError.new('Regexp', f.format, 'rsp')
+    end
+  end
+
+  def string_PArrayType(val_type, val, format_map, indentation)
+    format         = get_format(val_type, format_map)
+    sep            = format.separator || DEFAULT_ARRAY_FORMAT.separator
+    string_formats = format.container_string_formats || DEFAULT_CONTAINER_FORMATS
+    delims         = format.delimiter_pair(DEFAULT_ARRAY_DELIMITERS)
+
+    # Make indentation active, if array is in alternative format, or if nested in indenting
+    indentation = indentation.indenting(format.alt? || indentation.is_indenting?)
+
+    case format.format
+    when :a, :s, :p
+      buf = ''
+      if indentation.breaks?
+        buf << "\n"
+        buf << indentation.padding
+      end
+      buf << delims[0]
+
+      # Make a first pass to format each element
+      children_indentation = indentation.increase(format.alt?) # tell children they are expected to indent
+      mapped = val.map do |v|
+        if children_indentation.first?
+          children_indentation = children_indentation.subsequent
+        end
+        val_t = @@type_calculator.infer_set(v)
+        _convert(val_t, v, is_container?(val_t) ? format_map : string_formats, children_indentation)
+      end
+
+      # compute widest run in the array, skip nested arrays and hashes
+      # then if size > width, set flag if a break on each element should be performed
+      if format.alt? && format.width
+        widest = val.each_with_index.reduce([0]) do | memo, v_i |
+          # array or hash breaks
+          if is_a_or_h?(v_i[0])
+            memo << 0
+          else
+            memo[-1] += mapped[v_i[1]].length
+          end
+          memo
+        end
+        widest = widest.max
+        sz_break = widest > (format.width || Float::INFINITY)
+      else
+        sz_break = false
+      end
+
+      # output each element with breaks and padding
+      children_indentation = indentation.increase(format.alt?)
+      val.each_with_index do |v, i|
+        str_val = mapped[i]
+        if children_indentation.first?
+          children_indentation = children_indentation.subsequent
+          # if breaking, indent first element by one
+          if sz_break && !is_a_or_h?(v)
+            buf << ' '
+          end
+        else
+          buf << sep
+          # if break on each (and breaking will not occur because next is an array or hash)
+          # or, if indenting, and previous was an array or hash, then break and continue on next line
+          # indented.
+          if (sz_break && !is_a_or_h?(v)) || (format.alt? && i > 0 && is_a_or_h?(val[i-1]) && !is_a_or_h?(v))
+            buf << "\n"
+            buf << children_indentation.padding
+          elsif !(format.alt? && is_a_or_h?(v))
+            buf << ' '
+          end
+        end
+        buf << str_val
+      end
+      buf << delims[1]
+      buf
+    else
+      raise FormatError.new('Array', format.format, 'asp')
+    end
+  end
+
+  def is_a_or_h?(x)
+    x.is_a?(Array) || x.is_a?(Hash)
+  end
+
+  def is_container?(t)
+    case t
+    when PArrayType, PHashType, PStructType, PTupleType
+      true
+    else
+      false
+    end
+  end
+
+  # @api private
+  def string_PTupleType(val_type, val, format_map, indentation)
+    string_PArrayType(val_type, val, format_map, indentation)
+  end
+
+  # @api private
+  def string_PIteratorType(val_type, val, format_map, indentation)
+    v = val.to_a
+    _convert(@@type_calculator.infer_set(v), v, format_map, indentation)
+  end
+
+  # @api private
+  def string_PHashType(val_type, val, format_map, indentation)
+    format         = get_format(val_type, format_map)
+    sep            = format.separator  || DEFAULT_HASH_FORMAT.separator
+    assoc          = format.separator2 || DEFAULT_HASH_FORMAT.separator2
+    string_formats = format.container_string_formats || DEFAULT_CONTAINER_FORMATS
+    delims         = format.delimiter_pair(DEFAULT_HASH_DELIMITERS)
+
+    sep = format.alt? ? "#{sep}\n" : "#{sep} "
+
+    cond_break     = ''
+    padding        = ''
+
+    case format.format
+    when :a
+      # Convert to array and use array rules
+      array_hash = val.to_a
+      _convert(@@type_calculator.infer_set(array_hash), array_hash, format_map, indentation)
+
+    when :h, :s, :p
+      indentation = indentation.indenting(format.alt? || indentation.is_indenting?)
+      buf = ''
+      if indentation.breaks?
+        buf << "\n"
+        buf << indentation.padding
+      end
+
+      children_indentation = indentation.increase
+      if format.alt?
+        cond_break = "\n"
+        padding = children_indentation.padding
+      end
+      buf << delims[0]
+      buf << cond_break  # break after opening delimiter if pretty printing
+      buf << val.map do |k,v|
+        key_type = @@type_calculator.infer_set(k)
+        val_type = @@type_calculator.infer_set(v)
+        key = _convert(key_type, k, is_container?(key_type) ? format_map : string_formats, children_indentation)
+        val = _convert(val_type, v, is_container?(val_type) ? format_map : string_formats, children_indentation)
+        "#{padding}#{key}#{assoc}#{val}"
+      end.join(sep)
+      if format.alt?
+        buf << cond_break
+        buf << indentation.padding
+      end
+      buf << delims[1]
+      buf
+    else
+      raise FormatError.new('Hash', format.format, 'hasp')
+    end
+  end
+
+  # @api private
+  def string_PStructType(val_type, val, format_map, indentation)
+    string_PHashType(val_type, val, format_map, indentation)
+  end
+
+  # @api private
+  def string_PType(val_type, val, format_map, _)
+    f = get_format(val_type, format_map)
+    case f.format
+    when :s
+      str_val = f.alt? ? "\"#{val.to_s}\"" : val.to_s
+      Kernel.format(f.orig_fmt, str_val)
+    when :p
+      Kernel.format(f.orig_fmt.gsub('p', 's'), val.to_s)
+    else
+      raise FormatError.new('Type', f.format, 'sp')
+    end
+  end
+
+  # Maps the inferred type of o to a formatting rule
+  def get_format(val_t, format_options)
+    fmt = format_options.find {|k,_| k.assignable?(val_t) }
+    return fmt[1] unless fmt.nil?
+    return Format.new("%s")
+  end
+  private :get_format
+
+end
+end
+end

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -192,7 +192,7 @@ class StringConverter
           end
         end
       end
-      format_map.to_h
+      Hash[format_map]
     end
 
     # Ranks type on specificity where it matters

--- a/lib/puppet/pops/types/type_conversion_error.rb
+++ b/lib/puppet/pops/types/type_conversion_error.rb
@@ -1,0 +1,15 @@
+
+module Puppet::Pops::Types
+  # Raised when a conversion of a value to another type failed.
+  #
+  class TypeConversionError < Puppet::Error
+
+    # Creates a new instance with a given message
+    #
+    # @param message [String] The error message describing what failed
+    #
+    def initialize(message)
+      super(message)
+    end
+  end
+end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -917,7 +917,7 @@ class PFloatType < PNumericType
     end
   end
 
-  # Returns a new function that produces Integer or Float value
+  # Returns a new function that produces a Float value
   #
   def self.new_function(_, loader)
     @new_function ||= Puppet::Functions.create_loaded_function(:new_float, loader) do

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -4,6 +4,7 @@ require_relative 'recursion_guard'
 require_relative 'type_acceptor'
 require_relative 'type_asserter'
 require_relative 'type_assertion_error'
+require_relative 'type_conversion_error'
 require_relative 'type_formatter'
 require_relative 'type_calculator'
 require_relative 'type_factory'
@@ -219,6 +220,22 @@ class PAnyType < TypedModelObject
     TypeFormatter.string(self)
   end
 
+  def new_function(loader)
+    self.class.new_function(self, loader)
+  end
+
+  # This default implementation of of a new_function raises an Argument Error.
+  # Types for which creating a new instance is supported, should create and return
+  # a Puppet Function class by using Puppet:Loaders.create_loaded_function(:new, loader)
+  # and return that result.
+  #
+  # @raises ArgumentError
+  #
+  def self.new_function(instance, loader)
+    raise ArgumentError.new("Creation of new instance of type '#{instance.to_s}' is not supported")
+  end
+
+
   # The default instance of this type. Each type in the type system has this constant
   # declared.
   #
@@ -430,6 +447,10 @@ class PNotUndefType < PTypeWithContainedType
         n
        end
     end
+  end
+
+  def new_function(loader)
+    type.new_function(loader)
   end
 
   DEFAULT = PNotUndefType.new
@@ -665,6 +686,56 @@ class PNumericType < PScalarType
     @from == -Float::INFINITY && @to == Float::INFINITY
   end
 
+  def self.new_function(_, loader)
+    @new_function ||= Puppet::Functions.create_loaded_function(:new_numeric, loader) do
+      local_types do
+        type 'Convertible = Variant[Undef, Integer, Float, Boolean, String]'
+        type 'NamedArgs   = Struct[{from => Convertible}]'
+      end
+
+      dispatch :from_args do
+        param          'Convertible',  :from
+      end
+
+      dispatch :from_hash do
+        param          'NamedArgs',  :hash_args
+      end
+      def from_args(from)
+        case from
+        when NilClass
+          throw :undefined_value
+        when Float
+          from
+        when Integer
+          from
+        when TrueClass
+          1
+        when FalseClass
+          0
+        when String
+          begin
+            if from[0] == '0' && (from[1].downcase == 'b' || from[1].downcase == 'x')
+              Integer(from)
+            else
+              Puppet::Pops::Utils.to_n(from)
+            end
+          rescue TypeError => e
+            raise TypeConversionError.new(e.message)
+          rescue ArgumentError => e
+            raise TypeConversionError.new(e.message)
+          end
+        else
+          t = Puppet::Pops::Types::TypeCalculator.singleton.infer(from).generalize
+          raise TypeConversionError.new("Value of type '#{t}' cannot be converted to Numeric")
+        end
+      end
+
+      def from_hash(args_hash)
+        from_args(args_hash['from'])
+      end
+    end
+  end
+
   DEFAULT = PNumericType.new(-Float::INFINITY)
 
   protected
@@ -755,6 +826,67 @@ class PIntegerType < PNumericType
     @from >= 0 ? self : PIntegerType.new(0, @to < 0 ? 0 : @to)
   end
 
+  def new_function(loader)
+    @@new_function ||= Puppet::Functions.create_loaded_function(:new, loader) do
+      local_types do
+        type 'Radix       = Variant[Default, Integer[2,2], Integer[8,8], Integer[10,10], Integer[16,16]]'
+        type 'Convertible = Variant[Undef, Integer, Float, Boolean, String]'
+        type 'NamedArgs   = Struct[{from => Convertible, Optional[radix] => Radix}]'
+      end
+
+      dispatch :from_args do
+        param          'Convertible',  :from
+        optional_param 'Radix',   :radix
+      end
+
+      dispatch :from_hash do
+        param          'NamedArgs',  :hash_args
+      end
+
+      def from_args(from, radix = :default)
+        case from
+        when NilClass
+          throw :undefined_value
+        when Float
+          from.to_i
+        when Integer
+          from
+        when TrueClass
+          1
+        when FalseClass
+          0
+        when String
+          begin
+            radix == :default ? Integer(from) : Integer(from, assert_radix(radix))
+          rescue TypeError => e
+            raise TypeConversionError.new(e.message)
+          rescue ArgumentError => e
+            raise TypeConversionError.new(e.message)
+          end
+        else
+          t = Puppet::Pops::Types::TypeCalculator.singleton.infer(from).generalize
+          raise TypeConversionError.new("Value of type '#{t}' cannot be converted to an Integer")
+        end
+      end
+
+      def from_hash(args_hash)
+        from = args_hash['from']
+        radix = args_hash['radix'] || :default
+        from_args(from, radix)
+      end
+
+      def assert_radix(radix)
+        case radix
+        when 2, 8, 10, 16, :default
+        else
+          raise ArgumentError.new("Illegal radix: '#{radix}', expected 2, 8, 10, 16, or default")
+        end
+        radix
+      end
+
+    end
+  end
+
   DEFAULT = PIntegerType.new(-Float::INFINITY)
 end
 
@@ -782,6 +914,59 @@ class PFloatType < PNumericType
       PFloatType.new(min, max)
     else
       nil
+    end
+  end
+
+  # Returns a new function that produces Integer or Float value
+  #
+  def self.new_function(_, loader)
+    @new_function ||= Puppet::Functions.create_loaded_function(:new_float, loader) do
+      local_types do
+        type 'Convertible = Variant[Undef, Integer, Float, Boolean, String]'
+        type 'NamedArgs   = Struct[{from => Convertible}]'
+      end
+
+      dispatch :from_args do
+        param          'Convertible',  :from
+      end
+
+      dispatch :from_hash do
+        param          'NamedArgs',  :hash_args
+      end
+
+      def from_args(from)
+        case from
+        when NilClass
+          throw :undefined_value
+        when Float
+          from
+        when Integer
+          Float(from)
+        when TrueClass
+          1.0
+        when FalseClass
+          0.0
+        when String
+          begin
+            # support a binary as float
+            if from[0] == '0' && from[1].downcase == 'b'
+              from = Integer(from)
+            end 
+            Float(from)
+          rescue TypeError => e
+            raise TypeConversionError.new(e.message)
+          rescue ArgumentError => e
+            raise TypeConversionError.new(e.message)
+          end
+        else
+          t = Puppet::Pops::Types::TypeCalculator.singleton.infer(from).generalize
+          raise TypeConversionError.new("Value of type '#{t}' cannot be converted to Float")
+        end
+      end
+
+      def from_hash(args_hash)
+        from_args(args_hash['from'])
+      end
     end
   end
 
@@ -995,6 +1180,32 @@ class PStringType < PScalarType
     end
   end
 
+  def self.new_function(_, loader)
+    @new_function ||= Puppet::Functions.create_loaded_function(:new_string, loader) do
+      local_types do
+        type 'Format = Pattern[/^%([\s\+\-#0\[\{<\(\|]*)([1-9][0-9]*)?(?:\.([0-9]+))?([a-zA-Z])/]'
+        type 'ContainerFormat = Struct[{
+          Optional[format]         => String,
+          Optional[separator]      => String,
+          Optional[separator2]     => String,
+          Optional[string_formats] => Hash[Type, Format]
+        }]'
+        type 'TypeMap = Hash[Type, Variant[Format, ContainerFormat]]'
+        type 'Convertible = Any'
+        type 'Formats = Variant[Default, String[1], TypeMap]'
+      end
+
+      dispatch :from_args do
+        param           'Convertible',  :from
+        optional_param  'Formats',      :string_formats
+      end
+
+      def from_args(from, formats = :default)
+        StringConverter.singleton.convert(from, formats)
+      end
+    end
+  end
+
   DEFAULT = PStringType.new(nil)
   NON_EMPTY = PStringType.new(PIntegerType.new(1))
 
@@ -1140,6 +1351,34 @@ class PBooleanType < PScalarType
     o == true || o == false
   end
 
+  def self.new_function(_, loader)
+    @new_function ||= Puppet::Functions.create_loaded_function(:new_boolean, loader) do
+      dispatch :from_args do
+        param          'Variant[Undef, Integer, Float, Boolean, String]',  :from
+      end
+
+      def from_args(from)
+        from = from.downcase if from.is_a?(String)
+        case from
+        when NilClass
+          throw :undefined_value
+        when Float
+          from != 0.0
+        when Integer
+          from != 0
+        when true, false
+          from
+        when 'false', 'no', 'n'
+          false
+        when 'true', 'yes', 'y'
+          true
+        else
+          raise TypeConversionError.new("Value '#{from}' of type '#{from.class}' cannot be converted to Boolean")
+        end
+      end
+    end
+  end
+
   DEFAULT = PBooleanType.new
 
   protected
@@ -1282,6 +1521,12 @@ class PStructType < PAnyType
         e.value_type.instance?(v, guard)
       end
     end && matched == o.size
+  end
+
+  def new_function(loader)
+    # Simply delegate to Hash type and let the higher level assertion deal with
+    # compliance with the Struct type regarding the produced result.
+    PHashType.new_function(self, loader)
   end
 
   DEFAULT = PStructType.new(EMPTY_ARRAY)
@@ -1455,6 +1700,12 @@ class PTupleType < PAnyType
 
   def eql?(o)
     self.class == o.class && @types == o.types && @size_type == o.size_type
+  end
+
+  def new_function(loader)
+    # Simply delegate to Array type and let the higher level assertion deal with
+    # compliance with the Tuple type regarding the produced result.
+    PArrayType.new_function(self, loader)
   end
 
   DATA = PTupleType.new([PDataType::DEFAULT], PCollectionType::DEFAULT_SIZE)
@@ -1647,6 +1898,44 @@ class PArrayType < PCollectionType
     size_t.nil? || size_t.instance?(o.size, guard)
   end
 
+  # Returns a new function that produces an Array
+  #
+  def self.new_function(_, loader)
+    @new_function ||= Puppet::Functions.create_loaded_function(:new_array, loader) do
+
+      dispatch :from_args do
+        param           'Any',  :from
+        optional_param  'Boolean',      :wrap
+      end
+
+      def from_args(from, wrap = false)
+        case from
+        when NilClass
+          if wrap
+            [nil]
+          else
+            throw :undefined_value
+          end
+        when Array
+          from
+        when Hash
+          wrap ? [from] : from.to_a
+        else
+          if wrap
+            [from]
+          else
+            if PIterableType::DEFAULT.instance?(from)
+              Iterable.on(from).to_a
+            else
+              t = Puppet::Pops::Types::TypeCalculator.singleton.infer(from).generalize
+              raise TypeConversionError.new("Value of type '#{t}' cannot be converted to Array")
+            end
+          end
+        end
+      end
+    end
+  end
+
   DATA = PArrayType.new(PDataType::DEFAULT, DEFAULT_SIZE)
   DEFAULT = PArrayType.new(nil)
   EMPTY = PArrayType.new(PUnitType::DEFAULT, ZERO_SIZE)
@@ -1764,6 +2053,53 @@ class PHashType < PCollectionType
 
   def is_the_empty_hash?
     self == EMPTY
+  end
+
+  # Returns a new function that produces a  Hash
+  #
+  def self.new_function(_, loader)
+    @new_function ||= Puppet::Functions.create_loaded_function(:new_hash, loader) do
+      local_types do
+        type 'KeyValueArray = Array[Tuple[Any,Any],1]'
+      end
+
+      dispatch :from_tuples do
+        param           'KeyValueArray',  :from
+      end
+
+      dispatch :from_array do
+        param           'Any',  :from
+      end
+
+      def from_tuples(tuple_array)
+        Hash[tuple_array]
+      end
+
+      def from_array(from)
+        case from
+        when NilClass
+          throw :undefined_value
+        when Array
+          if from.size == 0
+            {}
+          else
+            unless from.size % 2 == 0
+              raise TypeConversionError.new("odd number of arguments for Hash")
+            end
+            Hash[*from]
+          end
+        when Hash
+          from
+        else
+          if PIterableType::DEFAULT.instance?(from)
+            Hash[*Iterable.on(from).to_a]
+          else
+            t = Puppet::Pops::Types::TypeCalculator.singleton.infer(from).generalize
+            raise TypeConversionError.new("Value of type '#{t}' cannot be converted to Hash")
+          end
+        end
+      end
+    end
   end
 
   DEFAULT = PHashType.new(nil, nil)
@@ -2187,6 +2523,10 @@ class POptionalType < PTypeWithContainedType
         n
       end
     end
+  end
+
+  def new_function(loader)
+    optional_type.new_function(loader)
   end
 
   DEFAULT = POptionalType.new(nil)

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -236,7 +236,13 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   end
 
   def check_CallNamedFunctionExpression(o)
-    case o.functor_expr
+    functor = o.functor_expr
+    if functor.is_a?(Model::QualifiedReference) || 
+      functor.is_a?(Model::AccessExpression) && functor.left_expr.is_a?(Model::QualifiedReference)
+      # ok (a call to a type)
+      return nil
+    end
+    case functor
     when Model::QualifiedName
       # ok
       nil

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -1,0 +1,525 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the new function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  it 'yields converted value if given a block' do
+    expect(compile_to_catalog(<<-MANIFEST
+      $x = Integer.new('42') |$x| { $x+2 }
+      notify { "${type($x, generalized)}, $x": }
+    MANIFEST
+    )).to have_resource('Notify[Integer, 44]')
+  end
+
+  it 'produces undef if given an undef value and type accepts it' do
+    expect(compile_to_catalog(<<-MANIFEST
+      $x = Optional[Integer].new(undef)
+      notify { "one${x}word": }
+    MANIFEST
+    )).to have_resource('Notify[oneword]')
+  end
+
+  it 'errors if given undef and type does not accept the value' do
+    expect{compile_to_catalog(<<-MANIFEST
+      $x = Integer.new(undef)
+      notify { "one${x}word": }
+    MANIFEST
+    )}.to raise_error(Puppet::Error, /expected an Integer value, got Undef/)
+  end
+
+  it 'errors if converted value is not assignable to the type' do
+    expect{compile_to_catalog(<<-MANIFEST
+      $x = Integer[1,5].new('42')
+      notify { "one${x}word": }
+    MANIFEST
+    )}.to raise_error(Puppet::Error, /expected an Integer\[1, 5\] value, got Integer\[42, 42\]/)
+  end
+
+  context 'when invoked on NotUndef' do
+    it 'produces an instance of the NotUndef nested type' do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = NotUndef[Integer].new(42)
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Integer, 42]')
+    end
+  end
+
+  context 'when invoked on an Integer' do
+    it 'produces 42 when given the integer 42' do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = Integer.new(42)
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Integer, 42]')
+    end
+
+    it 'produces 3 when given the float 3.1415' do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = Integer.new(3.1415)
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Integer, 3]')
+    end
+
+    it 'produces 0 from false' do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = Integer.new(false)
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Integer, 0]')
+    end
+
+    it 'produces 1 from true' do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = Integer.new(true)
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Integer, 1]')
+    end
+
+    context "when radix is not set it uses default and" do
+      { "10"     => 10,
+        "010"    => 8,
+        "0x10"   => 16,
+        "0X10"   => 16,
+        '0B111'  => 7,
+        '0b111'  => 7
+      }.each do |str, result|
+        it "produces #{result} from the string '#{str}'" do
+          expect(compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}")
+            notify { "${type($x, generalized)}, $x": }
+          MANIFEST
+          )).to have_resource("Notify[Integer, #{result}]")
+        end
+      end
+    end
+
+    context "when radix is explicitly set to 'default' it" do
+      { "10"     => 10,
+        "010"    => 8,
+        "0x10"   => 16,
+        "0X10"   => 16,
+        '0B111'  => 7,
+        '0b111'  => 7
+      }.each do |str, result|
+        it "produces #{result} from the string '#{str}'" do
+          expect(compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", default)
+            notify { "${type($x, generalized)}, $x": }
+          MANIFEST
+          )).to have_resource("Notify[Integer, #{result}]")
+        end
+      end
+    end
+
+    context "when radix is explicitly set to '2' it" do
+      { "10"     => 2,
+        "010"    => 2,
+        "00010"  => 2,
+        '0B111'  => 7,
+        '0b111'  => 7
+      }.each do |str, result|
+        it "produces #{result} from the string '#{str}'" do
+          expect(compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", 2)
+            notify { "${type($x, generalized)}, $x": }
+          MANIFEST
+          )).to have_resource("Notify[Integer, #{result}]")
+        end
+      end
+
+      { "0x10"  => :error,
+        '0X10'  => :error
+      }.each do |str, result|
+        it "errors when given the non binary value compliant string '#{str}'" do
+          expect{compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", 2)
+          MANIFEST
+        )}.to raise_error(Puppet::Error, /invalid value/)
+        end
+      end
+    end
+
+    context "when radix is explicitly set to '8' it" do
+      { "10"     => 8,
+        "010"    => 8,
+        "00010"  => 8,
+      }.each do |str, result|
+        it "produces #{result} from the string '#{str}'" do
+          expect(compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", 8)
+            notify { "${type($x, generalized)}, $x": }
+          MANIFEST
+          )).to have_resource("Notify[Integer, #{result}]")
+        end
+      end
+
+      { "0x10"  => :error,
+        '0X10'  => :error,
+        '0B10'  => :error,
+        '0b10'  => :error,
+      }.each do |str, result|
+        it "errors when given the non octal value compliant string '#{str}'" do
+          expect{compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", 8)
+          MANIFEST
+        )}.to raise_error(Puppet::Error, /invalid value/)
+        end
+      end
+    end
+
+    context "when radix is explicitly set to '16' it" do
+      { "10"     => 16,
+        "010"    => 16,
+        "00010"  => 16,
+        "0x10"   => 16,
+        "0X10"   => 16,
+        "0b1"    => 16*11+1,
+        "0B1"    => 16*11+1,
+      }.each do |str, result|
+        it "produces #{result} from the string '#{str}'" do
+          expect(compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", 16)
+            notify { "${type($x, generalized)}, $x": }
+          MANIFEST
+          )).to have_resource("Notify[Integer, #{result}]")
+        end
+      end
+
+      { '0XGG'  => :error,
+      }.each do |str, result|
+        it "errors when given the non octal value compliant string '#{str}'" do
+          expect{compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", 8)
+          MANIFEST
+        )}.to raise_error(Puppet::Error, /invalid value/)
+        end
+      end
+    end
+
+    context "when radix is explicitly set to '10' it" do
+      { "10"     => 10,
+        "010"    => 10,
+        "00010"  => 10,
+      }.each do |str, result|
+        it "produces #{result} from the string '#{str}'" do
+          expect(compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", 10)
+            notify { "${type($x, generalized)}, $x": }
+          MANIFEST
+          )).to have_resource("Notify[Integer, #{result}]")
+        end
+      end
+
+      { '0X10'  => :error,
+        '0X10'  => :error,
+        '0b10'  => :error,
+        '0B10'  => :error,
+      }.each do |str, result|
+        it "errors when given the non octal value compliant string '#{str}'" do
+          expect{compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}", 10)
+          MANIFEST
+        )}.to raise_error(Puppet::Error, /invalid value/)
+        end
+      end
+    end
+
+    context "input can be given in long form " do
+      { {'from' => "10", 'radix' => 2}     => 2,
+        {'from' => "10", 'radix' => 8}     => 8,
+        {'from' => "10", 'radix' => 10}    => 10,
+        {'from' => "10", 'radix' => 16}    => 16,
+        {'from' => "10", 'radix' => :default}    => 10,
+      }.each do |options, result|
+        it "produces #{result} from the long form '#{options}'" do
+          src = <<-"MANIFEST"
+            $x = Integer.new(#{options.to_s.gsub(/:/, '')})
+            notify { "${type($x, generalized)}, $x": }
+          MANIFEST
+          expect(compile_to_catalog(src)).to have_resource("Notify[Integer, #{result}]")
+        end
+      end
+    end
+
+    context 'errors when' do
+      it 'radix is wrong and when given directly' do
+        expect{compile_to_catalog(<<-"MANIFEST"
+          $x = Integer.new('10', 3)
+        MANIFEST
+      )}.to raise_error(Puppet::Error, /rejected: parameter 'radix'/m)
+      end
+
+      it 'radix is wrong and when given in long form' do
+        expect{compile_to_catalog(<<-"MANIFEST"
+          $x = Integer.new({from =>'10', radix=>3})
+        MANIFEST
+      )}.to raise_error(Puppet::Error, /rejected: parameter 'hash_args' struct member 'radix'/m)
+      end
+
+      it 'value is not numeric and given directly' do
+        expect{compile_to_catalog(<<-"MANIFEST"
+          $x = Integer.new('eleven', 10)
+        MANIFEST
+      )}.to raise_error(Puppet::Error, /invalid value/)
+      end
+
+      it 'value is not numeric and given in long form' do
+        expect{compile_to_catalog(<<-"MANIFEST"
+      $x = Integer.new({from => 'eleven', radix => 10})
+        MANIFEST
+      )}.to raise_error(Puppet::Error, /invalid value/)
+      end
+    end
+  end
+
+  context 'when invoked on Numeric' do
+    { 42 => "Notify[Integer, 42]",
+      42.3 => "Notify[Float, 42.3]",
+      "42.0" => "Notify[Float, 42.0]",
+      "42.3" => "Notify[Float, 42.3]",
+      "0x10" => "Notify[Integer, 16]",
+      "010" => "Notify[Integer, 8]",
+      "0.10" => "Notify[Float, 0.1]",
+      "0b10" => "Notify[Integer, 2]",
+      false => "Notify[Integer, 0]",
+      true => "Notify[Integer, 1]",
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect}" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = Numeric.new(#{input.inspect})
+          notify { "${type($x, generalized)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+
+    it "produces a result when long from hash {from => val} is used" do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = Numeric.new({from=>'42'})
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Integer, 42]')
+    end
+  end
+
+  context 'when invoked on Float' do
+    { 42     => "Notify[Float, 42.0]",
+      42.3   => "Notify[Float, 42.3]",
+      "42.0" => "Notify[Float, 42.0]",
+      "42.3" => "Notify[Float, 42.3]",
+      "0x10" => "Notify[Float, 16.0]",
+      "010"  => "Notify[Float, 10.0]",
+      "0.10" => "Notify[Float, 0.1]",
+      false  => "Notify[Float, 0.0]",
+      true   => "Notify[Float, 1.0]",
+      '0b10'  => "Notify[Float, 2.0]",
+      '0B10'  => "Notify[Float, 2.0]",
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect}" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = Float.new(#{input.inspect})
+          notify { "${type($x, generalized)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+
+    it "produces a result when long from hash {from => val} is used" do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = Float.new({from=>42})
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Float, 42.0]')
+    end
+  end
+
+  context 'when invoked on Boolean' do
+    { true     => 'Notify[Boolean, true]',
+      false    => 'Notify[Boolean, false]',
+      0        => 'Notify[Boolean, false]',
+      1        => 'Notify[Boolean, true]',
+      0.0      => 'Notify[Boolean, false]',
+      1.0      => 'Notify[Boolean, true]',
+
+      'true'   => 'Notify[Boolean, true]',
+      'TrUe'   => 'Notify[Boolean, true]',
+      'yes'    => 'Notify[Boolean, true]',
+      'YeS'    => 'Notify[Boolean, true]',
+      'y'      => 'Notify[Boolean, true]',
+      'Y'      => 'Notify[Boolean, true]',
+
+      'false'  => 'Notify[Boolean, false]',
+      'no'     => 'Notify[Boolean, false]',
+      'n'      => 'Notify[Boolean, false]',
+      'FalSE'  => 'Notify[Boolean, false]',
+      'nO'     => 'Notify[Boolean, false]',
+      'N'      => 'Notify[Boolean, false]',
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect}" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = Boolean.new(#{input.inspect})
+          notify { "${type($x, generalized)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+
+    it "errors when given an non boolean representation like the string 'hello'" do
+      expect{compile_to_catalog(<<-"MANIFEST"
+        $x = Boolean.new('hello')
+      MANIFEST
+      )}.to raise_error(Puppet::Error, /cannot be converted to Boolean/)
+    end
+
+    it "does not convert an undef (as may be expected, but is handled as every other undef)" do
+      expect{compile_to_catalog(<<-"MANIFEST"
+        $x = Boolean.new(undef)
+      MANIFEST
+      )}.to raise_error(Puppet::Error, /expected a Boolean value, got Undef/)
+    end
+  end
+
+  context 'when invoked on Array' do
+    { []            => 'Notify[Array[Unit], []]',
+      [true]        => 'Notify[Array[Boolean], [true]]',
+      {'a'=>true, 'b' => false}   => 'Notify[Array[Array[Scalar]], [[a, true], [b, false]]]',
+      'abc'         => 'Notify[Array[String], [a, b, c]]',
+      3             => 'Notify[Array[Integer], [0, 1, 2]]',
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect} and wrap is not given" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = Array.new(#{input.inspect})
+          notify { "${type($x, generalized)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+
+    {
+      true          => /cannot be converted to Array/,
+      42.3          => /cannot be converted to Array/,
+    }.each do |input, error_match|
+      it "errors when given an non convertible #{input.inspect} when wrap is not given" do
+        expect{compile_to_catalog(<<-"MANIFEST"
+          $x = Array.new(#{input.inspect})
+        MANIFEST
+        )}.to raise_error(Puppet::Error, error_match)
+      end
+    end
+
+    { []            => 'Notify[Array[Unit], []]',
+      [true]        => 'Notify[Array[Boolean], [true]]',
+      {'a'=>true}   => 'Notify[Array[Hash[String, Boolean]], [{a => true}]]',
+      'hello'       => 'Notify[Array[String], [hello]]',
+      true          => 'Notify[Array[Boolean], [true]]',
+      42            => 'Notify[Array[Integer], [42]]',
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect} and wrap is given" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = Array.new(#{input.inspect}, true)
+          notify { "${type($x, generalized)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+  end
+
+  context 'when invoked on Tuple' do
+    { 'abc'         => 'Notify[Array[String], [a, b, c]]',
+      3             => 'Notify[Array[Integer], [0, 1, 2]]',
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect} and wrap is not given" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = Tuple[Any,3].new(#{input.inspect})
+          notify { "${type($x, generalized)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+
+    it "errors when tuple requirements are not met" do
+      expect{compile_to_catalog(<<-"MANIFEST"
+        $x = Tuple[Integer,6].new(3)
+      MANIFEST
+      )}.to raise_error(Puppet::Error, /expected size to be at least 6, got 3/)
+    end
+  end
+
+  context 'when invoked on Hash' do
+    { {}            => 'Notify[Hash[Unit, Unit, 0, 0], {}]',
+      []            => 'Notify[Hash[Unit, Unit, 0, 0], {}]',
+      {'a'=>true}   => 'Notify[Hash[String, Boolean], {a => true}]',
+      [1,2,3,4]     => 'Notify[Hash[Integer, Integer], {1 => 2, 3 => 4}]',
+      [[1,2],[3,4]] => 'Notify[Hash[Integer, Integer], {1 => 2, 3 => 4}]',
+      'abcd'        => 'Notify[Hash[String, String], {a => b, c => d}]',
+      4             => 'Notify[Hash[Integer, Integer], {0 => 1, 2 => 3}]',
+
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect}" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = Hash.new(#{input.inspect})
+          notify { "${type($x, generalized)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+
+    { true             => /cannot be converted to Hash/,
+      [1,2,3]          => /odd number of arguments for Hash/,
+    }.each do |input, error_match|
+      it "errors when given an non convertible #{input.inspect}" do
+        expect{compile_to_catalog(<<-"MANIFEST"
+          $x = Hash.new(#{input.inspect})
+        MANIFEST
+        )}.to raise_error(Puppet::Error, error_match)
+      end
+    end
+  end
+
+  context 'when invoked on Struct' do
+    { {'a' => 2}      => 'Notify[Struct[{\'a\' => Integer[2, 2]}], {a => 2}]',
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect}" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = Struct[{a => Integer[2]}].new(#{input.inspect})
+          notify { "${type($x)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+
+    it "errors when tuple requirements are not met" do
+      expect{compile_to_catalog(<<-"MANIFEST"
+        $x = Struct[{a => Integer[2]}].new({a => 0})
+      MANIFEST
+      )}.to raise_error(Puppet::Error, /struct member 'a' expected an Integer\[2, default\]/)
+    end
+  end
+
+  context 'when invoked on String' do
+    { {}            => 'Notify[String, {}]',
+      []            => 'Notify[String, []]',
+      {'a'=>true}   => 'Notify[String, {"a" => true}]',
+      [1,2,3,4]     => 'Notify[String, [1, 2, 3, 4]]',
+      [[1,2],[3,4]] => 'Notify[String, [[1, 2], [3, 4]]]',
+      'abcd'        => 'Notify[String, abcd]',
+      4             => 'Notify[String, 4]',
+    }.each do |input, result|
+      it "produces #{result} when given the value #{input.inspect}" do
+        expect(compile_to_catalog(<<-MANIFEST
+          $x = String.new(#{input.inspect})
+          notify { "${type($x, generalized)}, $x": }
+        MANIFEST
+        )).to have_resource(result)
+      end
+    end
+  end
+
+end

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -9,7 +9,7 @@ describe 'the new function' do
 
   it 'yields converted value if given a block' do
     expect(compile_to_catalog(<<-MANIFEST
-      $x = Integer.new('42') |$x| { $x+2 }
+      $x = Integer.new('42') |$x| { $x+2 }
       notify { "${type($x, generalized)}, $x": }
     MANIFEST
     )).to have_resource('Notify[Integer, 44]')

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -1,0 +1,904 @@
+require 'spec_helper'
+require 'puppet/pops'
+
+describe 'The string converter' do
+  let(:converter) { Puppet::Pops::Types::StringConverter.singleton }
+  let(:factory) { Puppet::Pops::Types::TypeFactory }
+  let(:format) { Puppet::Pops::Types::StringConverter::Format }
+
+  describe 'helper Format' do
+    it 'parses a single character like "%d" as a format' do
+      fmt = format.new("%d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.alt()).to be(false)
+      expect(fmt.left()).to be(false)
+      expect(fmt.width()).to be_nil
+      expect(fmt.prec()).to be_nil
+      expect(fmt.plus()).to eq(:ignore)
+    end
+
+    it 'alternative form can be given with "%#d"' do
+      fmt = format.new("%#d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.alt()).to be(true)
+    end
+
+    it 'left adjust can be given with "%-d"' do
+      fmt = format.new("%-d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.left()).to be(true)
+    end
+
+    it 'plus sign can be used to indicate how positive numbers are displayed' do
+      fmt = format.new("%+d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.plus()).to eq(:plus)
+    end
+
+    it 'a space can be used to output " " instead of "+" for positive numbers' do
+      fmt = format.new("% d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.plus()).to eq(:space)
+    end
+
+    it 'padding with zero can be specified with a "0" flag' do
+      fmt = format.new("%0d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.zero_pad()).to be(true)
+    end
+
+    it 'width can be specified as an integer >= 1' do
+      fmt = format.new("%1d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.width()).to be(1)
+      fmt = format.new("%10d")
+      expect(fmt.width()).to be(10)
+    end
+
+    it 'precision can be specified as an integer >= 0' do
+      fmt = format.new("%.0d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.prec()).to be(0)
+      fmt = format.new("%.10d")
+      expect(fmt.prec()).to be(10)
+    end
+
+    it 'width and precision can both be specified' do
+      fmt = format.new("%2.3d")
+      expect(fmt.format()).to be(:d)
+      expect(fmt.width()).to be(2)
+      expect(fmt.prec()).to be(3)
+    end
+
+    [
+      '[', '{', '(', '<', '|',
+    ].each do | delim |
+      it "a container delimiter pair can be set with '#{delim}'" do
+        fmt = format.new("%#{delim}d")
+        expect(fmt.format()).to be(:d)
+        expect(fmt.delimiters()).to eql(delim)
+      end
+    end
+
+    it "Is an error to specify different delimiters at the same time" do
+      expect do
+        fmt = format.new("%[{d")
+      end.to raise_error(/Only one of the delimiters/)
+    end
+
+    it "Is an error to specify the same flag more than once" do
+      expect do
+        fmt = format.new("%[[d")
+      end.to raise_error(/The same flag can only be used once/)
+    end
+  end
+
+  context 'when converting to string' do
+    {
+      42                   => "42",
+      3.14                 => "3.140000",
+      "hello world"        => "hello world",
+      "hello\tworld"       => "hello\tworld",
+    }.each do |from, to|
+      it "the string value of #{from} is '#{to}'" do
+        expect(converter.convert(from, :default)).to eq(to)
+      end
+    end
+
+    it 'float point value decimal digits can be specified' do
+      string_formats = { Puppet::Pops::Types::PFloatType::DEFAULT => '%.2f'}
+      expect(converter.convert(3.14, string_formats)).to eq('3.14')
+    end
+
+    it 'when specifying format for one type, other formats are not affected' do
+      string_formats = { Puppet::Pops::Types::PFloatType::DEFAULT => '%.2f'}
+      expect(converter.convert('3.1415', string_formats)).to eq('3.1415')
+    end
+
+    it 'The %p format for string produces quoted string' do
+      string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => '%p'}
+      expect(converter.convert("hello\tworld", string_formats)).to eq('"hello\\tworld"')
+    end
+
+    {
+      '%s'   => 'hello::world',
+      '%p'   => '"hello::world"',
+      '%c'   => 'Hello::world',
+      '%#c'   => '"Hello::world"',
+      '%u'   => 'HELLO::WORLD',
+      '%#u'   => '"HELLO::WORLD"',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => fmt}
+        expect(converter.convert('hello::world', string_formats)).to eq(result)
+      end
+    end
+
+    {
+      '%c'   => 'Hello::world',
+      '%#c'  => '"Hello::world"',
+      '%d'   => 'hello::world',
+      '%#d'  => '"hello::world"',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => fmt}
+        expect(converter.convert('HELLO::WORLD', string_formats)).to eq(result)
+      end
+    end
+
+    {
+      '   a b  ' => 'a b',
+      'a b  '    => 'a b',
+      '   a b'   => 'a b',
+    }.each do |input, result |
+      it "the input #{input} is trimmed to #{result} by using format '%t'" do
+        string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => '%t'}
+        expect(converter.convert(input, string_formats)).to eq(result)
+      end
+    end
+
+    {
+      '   a b  ' => '"a b"',
+      'a b  '    => '"a b"',
+      '   a b'   => '"a b"',
+    }.each do |input, result |
+      it "the input #{input} is trimmed to #{result} by using format '%#t'" do
+        string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => '%#t'}
+        expect(converter.convert(input, string_formats)).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => "%k"}
+      converter.convert('wat', string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of String type - expected one of the characters 'cCudspt'/)
+    end
+
+    it 'Width pads a string left with spaces to given width' do
+      string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => '%6s'}
+      expect(converter.convert("abcd", string_formats)).to eq('  abcd')
+    end
+
+    it 'Width pads a string right with spaces to given width and - flag' do
+      string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => '%-6s'}
+      expect(converter.convert("abcd", string_formats)).to eq('abcd  ')
+    end
+
+    it 'Precision truncates the string if precision < length' do
+      string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => '%-6.2s'}
+      expect(converter.convert("abcd", string_formats)).to eq('ab    ')
+    end
+
+    {
+      '%4.2s'   => '  he',
+      '%4.2p'   => '  "h',
+      '%4.2c'   => '  He',
+      '%#4.2c'  => '  "H',
+      '%4.2u'   => '  HE',
+      '%#4.2u'  => '  "H',
+      '%4.2c'   => '  He',
+      '%#4.2c'  => '  "H',
+      '%4.2d'   => '  he',
+      '%#4.2d'  => '  "h',
+    }.each do |fmt, result |
+      it "width and precision can be combined with #{fmt}" do
+        string_formats = { Puppet::Pops::Types::PStringType::DEFAULT => fmt}
+        expect(converter.convert('hello::world', string_formats)).to eq(result)
+      end
+    end
+
+  end
+
+  context 'when converting integer' do
+    it 'the default string representation is decimal' do
+      expect(converter.convert(42, :default)).to eq('42')
+    end
+
+    {
+      '%s'      => '18',
+      '%4.1s'   => '   1',
+      '%p'      => '18',
+      '%4.2p'   => '  18',
+      '%4.1p'   => '   1',
+      '%#s'     => '"18"',
+      '%#6.4s'  => '  "18"',
+      '%#p'     => '18',
+      '%#6.4p'  => '    18',
+      '%d'      => '18',
+      '%4.1d'   => '  18',
+      '%4.3d'   => ' 018',
+      '%x'      => '12',
+      '%4.3x'   => ' 012',
+      '%#x'     => '0x12',
+      '%#6.4x'  => '0x0012',
+      '%X'      => '12',
+      '%4.3X'   => ' 012',
+      '%#X'     => '0X12',
+      '%#6.4X'  => '0X0012',
+      '%o'      => '22',
+      '%4.2o'   => '  22',
+      '%#o'     => '022',
+      '%#6.4o'  => '  0022',
+      '%b'      => '10010',
+      '%7.6b'   => ' 010010',
+      '%#b'     => '0b10010',
+      '%#9.6b'  => ' 0b010010',
+      '%#B'     => '0B10010',
+      '%#9.6B'  => ' 0B010010',
+      # Integer to float then a float format - fully tested for float
+      '%e'      => '1.800000e+01',
+      '%E'      => '1.800000E+01',
+      '%f'      => '18.000000',
+      '%g'      => '18',
+      '%a'      => '0x1.2p+4',
+      '%A'      => '0X1.2P+4',
+      '%.1f'    => '18.0',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PIntegerType::DEFAULT => fmt}
+        expect(converter.convert(18, string_formats)).to eq(result)
+      end
+    end
+
+    it 'produces a unicode char string by using format %c' do
+      string_formats = { Puppet::Pops::Types::PIntegerType::DEFAULT => '%c'}
+      expect(converter.convert(0x1F603, string_formats)).to eq("\u{1F603}")
+    end
+
+    it 'produces a quoted unicode char string by using format %#c' do
+      string_formats = { Puppet::Pops::Types::PIntegerType::DEFAULT => '%#c'}
+      expect(converter.convert(0x1F603, string_formats)).to eq("\"\u{1F603}\"")
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PIntegerType::DEFAULT => "%k"}
+      converter.convert(18, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Integer type - expected one of the characters 'dxXobBeEfgGaAspc'/)
+    end
+  end
+
+  context 'when converting float' do
+    it 'the default string representation is decimal' do
+      expect(converter.convert(42.0, :default)).to eq('42.000000')
+    end
+
+    {
+      '%s'      => '18.0',
+      '%#s'     => '"18.0"',
+      '%5s'     => ' 18.0',
+      '%#8s'    => '  "18.0"',
+      '%05.1s'  => '    1',
+      '%p'      => '18.0',
+      '%7.2p'   => '     18',
+
+      '%e'      => '1.800000e+01',
+      '%+e'     => '+1.800000e+01',
+      '% e'     => ' 1.800000e+01',
+      '%.2e'    => '1.80e+01',
+      '%10.2e'  => '  1.80e+01',
+      '%-10.2e' => '1.80e+01  ',
+      '%010.2e' => '001.80e+01',
+
+      '%E'      => '1.800000E+01',
+      '%+E'     => '+1.800000E+01',
+      '% E'     => ' 1.800000E+01',
+      '%.2E'    => '1.80E+01',
+      '%10.2E'  => '  1.80E+01',
+      '%-10.2E' => '1.80E+01  ',
+      '%010.2E' => '001.80E+01',
+
+      '%f'      => '18.000000',
+      '%+f'     => '+18.000000',
+      '% f'     => ' 18.000000',
+      '%.2f'    => '18.00',
+      '%10.2f'  => '     18.00',
+      '%-10.2f' => '18.00     ',
+      '%010.2f' => '0000018.00',
+
+      '%g'      => '18',
+      '%5g'     => '   18',
+      '%05g'    => '00018',
+      '%-5g'    => '18   ',
+      '%5.4g'   => '   18',  # precision has no effect
+
+      '%a'      => '0x1.2p+4',
+      '%.4a'    => '0x1.2000p+4',
+      '%10a'    => '  0x1.2p+4',
+      '%010a'    => '0x001.2p+4',
+      '%-10a'   => '0x1.2p+4  ',
+      '%A'      => '0X1.2P+4',
+      '%.4A'      => '0X1.2000P+4',
+      '%10A'    => '  0X1.2P+4',
+      '%-10A'   => '0X1.2P+4  ',
+      '%010A'   => '0X001.2P+4',
+
+      # integer formats fully tested for integer
+      '%d'      => '18',
+      '%x'      => '12',
+      '%X'      => '12',
+      '%o'      => '22',
+      '%b'      => '10010',
+      '%#B'     => '0B10010',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PFloatType::DEFAULT => fmt}
+        expect(converter.convert(18.0, string_formats)).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PFloatType::DEFAULT => "%k"}
+      converter.convert(18.0, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Float type - expected one of the characters 'dxXobBeEfgGaAsp'/)
+    end
+  end
+
+  context 'when converting undef' do
+    it 'the default string representation is empty string' do
+      expect(converter.convert(nil, :default)).to eq('')
+    end
+
+    { "%u"  => "undef",
+      "%#u" => "undefined",
+      "%s"  => "",
+      "%#s"  => '""',
+      "%p"  => 'undef',
+      "%#p"  => '"undef"',
+      "%n"  => 'nil',
+      "%#n" => 'null',
+      "%v"  => 'n/a',
+      "%V"  => 'N/A',
+      "%d"  => 'NaN',
+      "%x"  => 'NaN',
+      "%o"  => 'NaN',
+      "%b"  => 'NaN',
+      "%B"  => 'NaN',
+      "%e"  => 'NaN',
+      "%E"  => 'NaN',
+      "%f"  => 'NaN',
+      "%g"  => 'NaN',
+      "%G"  => 'NaN',
+      "%a"  => 'NaN',
+      "%A"  => 'NaN',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PUndefType::DEFAULT => fmt}
+        expect(converter.convert(nil, string_formats)).to eq(result)
+      end
+    end
+
+    { "%7u"    => "  undef",
+      "%-7u"   => "undef  ",
+      "%#10u"  => " undefined",
+      "%#-10u" => "undefined ",
+      "%7.2u"  => "     un",
+      "%4s"    => "    ",
+      "%#4s"   => '  ""',
+      "%7p"    => '  undef',
+      "%7.1p"  => '      u',
+      "%#8p"   => ' "undef"',
+      "%5n"    => '  nil',
+      "%.1n"   => 'n',
+      "%-5n"   => 'nil  ',
+      "%#5n"   => ' null',
+      "%#-5n"  => 'null ',
+      "%5v"    => '  n/a',
+      "%5.2v"  => '   n/',
+      "%-5v"   => 'n/a  ',
+      "%5V"    => '  N/A',
+      "%5.1V"  => '    N',
+      "%-5V"   => 'N/A  ',
+      "%5d"    => '  NaN',
+      "%5.2d"  => '   Na',
+      "%-5d"   => 'NaN  ',
+      "%5x"    => '  NaN',
+      "%5.2x"  => '   Na',
+      "%-5x"   => 'NaN  ',
+      "%5o"    => '  NaN',
+      "%5.2o"  => '   Na',
+      "%-5o"   => 'NaN  ',
+      "%5b"    => '  NaN',
+      "%5.2b"  => '   Na',
+      "%-5b"   => 'NaN  ',
+      "%5B"    => '  NaN',
+      "%5.2B"  => '   Na',
+      "%-5B"   => 'NaN  ',
+      "%5e"    => '  NaN',
+      "%5.2e"  => '   Na',
+      "%-5e"   => 'NaN  ',
+      "%5E"    => '  NaN',
+      "%5.2E"  => '   Na',
+      "%-5E"   => 'NaN  ',
+      "%5f"    => '  NaN',
+      "%5.2f"  => '   Na',
+      "%-5f"   => 'NaN  ',
+      "%5g"    => '  NaN',
+      "%5.2g"  => '   Na',
+      "%-5g"   => 'NaN  ',
+      "%5G"    => '  NaN',
+      "%5.2G"  => '   Na',
+      "%-5G"   => 'NaN  ',
+      "%5a"    => '  NaN',
+      "%5.2a"  => '   Na',
+      "%-5a"   => 'NaN  ',
+      "%5A"    => '  NaN',
+      "%5.2A"  => '   Na',
+      "%-5A"   => 'NaN  ',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PUndefType::DEFAULT => fmt}
+        expect(converter.convert(nil, string_formats)).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PUndefType::DEFAULT => "%k"}
+      converter.convert(nil, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Undef type - expected one of the characters 'nudxXobBeEfgGaAvVsp'/)
+    end
+  end
+
+  context 'when converting default' do
+    it 'the default string representation is unquoted "default"' do
+      expect(converter.convert(:default, :default)).to eq('default')
+    end
+
+    { "%d"  => 'default',
+      "%D"  => 'Default',
+      "%#d" => '"default"',
+      "%#D" => '"Default"',
+      "%s"  => 'default',
+      "%p"  => 'default',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PDefaultType::DEFAULT => fmt}
+        expect(converter.convert(:default, string_formats)).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PDefaultType::DEFAULT => "%k"}
+      converter.convert(:default, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Default type - expected one of the characters 'dDsp'/)
+    end
+  end
+
+  context 'when converting boolean true' do
+    it 'the default string representation is unquoted "true"' do
+      expect(converter.convert(true, :default)).to eq('true')
+    end
+
+    { "%t"   => 'true',
+      "%#t"  => 't',
+      "%T"   => 'True',
+      "%#T"  => 'T',
+      "%s"   => 'true',
+      "%p"   => 'true',
+      "%d"   => '1',
+      "%x"   => '1',
+      "%#x"  => '0x1',
+      "%o"   => '1',
+      "%#o"  => '01',
+      "%b"   => '1',
+      "%#b"  => '0b1',
+      "%#B"  => '0B1',
+      "%e"   => '1.000000e+00',
+      "%f"   => '1.000000',
+      "%g"   => '1',
+      "%a"   => '0x1p+0',
+      "%A"   => '0X1P+0',
+      "%.1f" => '1.0',
+      "%y"   => 'yes',
+      "%Y"   => 'Yes',
+      "%#y"  => 'y',
+      "%#Y"  => 'Y',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PBooleanType::DEFAULT => fmt}
+        expect(converter.convert(true, string_formats)).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PBooleanType::DEFAULT => "%k"}
+      converter.convert(true, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Boolean type - expected one of the characters 'tTyYdxXobBeEfgGaAsp'/)
+    end
+
+  end
+
+  context 'when converting boolean false' do
+    it 'the default string representation is unquoted "false"' do
+      expect(converter.convert(false, :default)).to eq('false')
+    end
+
+    { "%t"   => 'false',
+      "%#t"  => 'f',
+      "%T"   => 'False',
+      "%#T"  => 'F',
+      "%s"   => 'false',
+      "%p"   => 'false',
+      "%d"   => '0',
+      "%x"   => '0',
+      "%#x"  => '0',
+      "%o"   => '0',
+      "%#o"  => '0',
+      "%b"   => '0',
+      "%#b"  => '0',
+      "%#B"  => '0',
+      "%e"   => '0.000000e+00',
+      "%E"   => '0.000000E+00',
+      "%f"   => '0.000000',
+      "%g"   => '0',
+      "%a"   => '0x0p+0',
+      "%A"   => '0X0P+0',
+      "%.1f" => '0.0',
+      "%y"   => 'no',
+      "%Y"   => 'No',
+      "%#y"  => 'n',
+      "%#Y"  => 'N',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PBooleanType::DEFAULT => fmt}
+        expect(converter.convert(false, string_formats)).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PBooleanType::DEFAULT => "%k"}
+      converter.convert(false, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Boolean type - expected one of the characters 'tTyYdxXobBeEfgGaAsp'/)
+    end
+  end
+
+  context 'when converting array' do
+    it 'the default string representation is using [] delimiters, joins with ',' and uses %p for values' do
+      expect(converter.convert(["hello", "world"], :default)).to eq('["hello", "world"]')
+    end
+
+    { "%s"  => '[1, "hello"]',
+      "%p"  => '[1, "hello"]',
+      "%a"  => '[1, "hello"]',
+      "%<a"  => '<1, "hello">',
+      "%[a"  => '[1, "hello"]',
+      "%(a"  => '(1, "hello")',
+      "%{a"  => '{1, "hello"}',
+      "% a"  => '1, "hello"',
+
+      {'format' => '%(a',
+        'separator' => ''
+      } => '(1 "hello")',
+
+      {'format' => '%|a',
+        'separator' => ''
+      } => '|1 "hello"|',
+
+      {'format' => '%(a', 
+        'separator' => '', 
+        'string_formats' => {Puppet::Pops::Types::PIntegerType::DEFAULT => '%#x'}
+      } => '(0x1 "hello")',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => fmt}
+        expect(converter.convert([1, "hello"], string_formats)).to eq(result)
+      end
+    end
+
+    it "multiple rules selects most specific" do
+      short_array_t = factory.array_of(factory.integer, factory.range(1,2))
+      long_array_t = factory.array_of(factory.integer, factory.range(3,100))
+      string_formats = { 
+        short_array_t => "%(a",
+        long_array_t  => "%[a",
+      }
+      expect(converter.convert([1, 2], string_formats)).to eq('(1, 2)')
+      expect(converter.convert([1, 2, 3], string_formats)).to eq('[1, 2, 3]')
+    end
+
+    it 'indents elements in alternate mode' do
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>"," } }
+      # formatting matters here
+      result = [
+       "[1, 2, 9, 9,",
+       "  [3, 4],",
+       "  [5,",
+       "    [6, 7]],",
+       "  8, 9]"
+       ].join("\n")
+
+     formatted = converter.convert([1, 2, 9, 9, [3, 4], [5, [6, 7]], 8, 9], string_formats)
+     expect(formatted).to eq(result)
+    end
+
+    it 'treats hashes as nested arrays wrt indentation' do
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>"," } }
+      # formatting matters here
+      result = [
+       "[1, 2, 9, 9,",
+       "  {3 => 4, 5 => 6},",
+       "  [5,",
+       "    [6, 7]],",
+       "  8, 9]"
+       ].join("\n")
+
+     formatted = converter.convert([1, 2, 9, 9, {3  => 4, 5 => 6}, [5, [6, 7]], 8, 9], string_formats)
+     expect(formatted).to eq(result)
+    end
+
+    it 'indents and breaks when a sequence > given width, in alternate mode' do
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#3a', 'separator' =>"," } }
+      # formatting matters here
+      result = [
+       "[ 1,",
+       "  2,",
+       "  90,", # this sequence has length 4 (1,2,90) which is > 3
+       "  [3, 4],",
+       "  [5,",
+       "    [6, 7]],",
+       "  8,",
+       "  9]",
+       ].join("\n")
+
+     formatted = converter.convert([1, 2, 90, [3, 4], [5, [6, 7]], 8, 9], string_formats)
+     expect(formatted).to eq(result)
+    end
+
+    it 'indents and breaks when a sequence (placed last) > given width, in alternate mode' do
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#3a', 'separator' =>"," } }
+      # formatting matters here
+      result = [
+       "[ 1,",
+       "  2,",
+       "  9,", # this sequence has length 3 (1,2,9) which does not cause breaking on each
+       "  [3, 4],",
+       "  [5,",
+       "    [6, 7]],",
+       "  8,",
+       "  900]", # this sequence has length 4 (8, 900) which causes breaking on each
+       ].join("\n")
+
+     formatted = converter.convert([1, 2, 9, [3, 4], [5, [6, 7]], 8, 900], string_formats)
+     expect(formatted).to eq(result)
+    end
+
+    it 'indents and breaks nested sequences when one is placed first' do
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>"," } }
+      # formatting matters here
+      result = [
+       "[",
+       "  [",
+       "    [1, 2,",
+       "      [3, 4]]],",
+       "  [5,",
+       "    [6, 7]],",
+       "  8, 900]",
+       ].join("\n")
+
+     formatted = converter.convert([[[1, 2, [3, 4]]], [5, [6, 7]], 8, 900], string_formats)
+     expect(formatted).to eq(result)
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => "%k"}
+      converter.convert([1,2], string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Array type - expected one of the characters 'asp'/)
+    end
+  end
+
+  context 'when converting hash' do
+    it 'the default string representation is using {} delimiters, joins with '=>' and uses %p for values' do
+      expect(converter.convert({"hello" => "world"}, :default)).to eq('{"hello" => "world"}')
+    end
+
+    { "%s"  => '{1 => "world"}',
+      "%p"  => '{1 => "world"}',
+      "%h"  => '{1 => "world"}',
+      "%a"  => '[[1, "world"]]',
+      "%<h"  => '<1 => "world">',
+      "%[h"  => '[1 => "world"]',
+      "%(h"  => '(1 => "world")',
+      "%{h"  => '{1 => "world"}',
+      "% h"  => '1 => "world"',
+
+      {'format' => '%(h',
+        'separator2' => ' '
+      } => '(1 "world")',
+
+      {'format' => '%(h', 
+        'separator2' => ' ', 
+        'string_formats' => {Puppet::Pops::Types::PIntegerType::DEFAULT => '%#x'}
+      } => '(0x1 "world")',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PHashType::DEFAULT => fmt}
+        expect(converter.convert({1 => "world"}, string_formats)).to eq(result)
+      end
+    end
+
+    {  "%s"  => '{1 => "hello", 2 => "world"}',
+
+       {'format' => '%(h',
+         'separator2' => ' '
+       } => '(1 "hello", 2 "world")',
+
+       {'format' => '%(h', 
+         'separator' => ' >>', 
+         'separator2' => ' <=> ', 
+         'string_formats' => {Puppet::Pops::Types::PIntegerType::DEFAULT => '%#x'}
+       } => '(0x1 <=> "hello" >> 0x2 <=> "world")',
+     }.each do |fmt, result |
+       it "the format #{fmt} produces #{result}" do
+         string_formats = { Puppet::Pops::Types::PHashType::DEFAULT => fmt}
+         expect(converter.convert({1 => "hello", 2 => "world"}, string_formats)).to eq(result)
+       end
+     end
+
+    it 'indents elements in alternative mode #' do
+      string_formats = {
+        Puppet::Pops::Types::PHashType::DEFAULT => {
+          'format' => '%#h',
+        }
+      }
+      # formatting matters here
+      result = [
+       "{",
+       "  1 => \"hello\",",
+       "  2 => {",
+       "    3 => \"world\"",
+       "  }",
+       "}"
+       ].join("\n")
+
+      expect(converter.convert({1 => "hello", 2 => {3=> "world"}}, string_formats)).to eq(result)
+    end
+
+    context "containing an array" do
+      it 'the hash and array renders without breaks and indentation by default' do
+        result = '{1 => [1, 2, 3]}'
+        formatted = converter.convert({ 1 => [1, 2, 3] }, :default)
+        expect(formatted).to eq(result)
+      end
+
+      it 'the array renders with breaks if so specified' do
+        string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#1a', 'separator' =>"," } }
+        result = [
+        "{1 => [ 1,",
+        "    2,", 
+        "    3]}"
+        ].join("\n")
+        formatted = converter.convert({ 1 => [1, 2, 3] }, string_formats)
+        expect(formatted).to eq(result)
+      end
+
+      it 'both hash and array renders with breaks and indentation if so specified for both' do
+        string_formats = {
+          Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#1a', 'separator' =>"," },
+          Puppet::Pops::Types::PHashType::DEFAULT => { 'format' => '%#h', 'separator' =>"," }
+        }
+        result = [
+        "{",
+        "  1 => [ 1,",
+        "    2,", 
+        "    3]",
+        "}"
+        ].join("\n")
+        formatted = converter.convert({ 1 => [1, 2, 3] }, string_formats)
+        expect(formatted).to eq(result)
+      end
+
+      it 'hash, but not array is rendered with breaks and indentation if so specified only for the hash' do
+        string_formats = {
+          Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%a', 'separator' =>"," },
+          Puppet::Pops::Types::PHashType::DEFAULT => { 'format' => '%#h', 'separator' =>"," }
+        }
+        result = [
+        "{",
+        "  1 => [1, 2, 3]",
+        "}"
+        ].join("\n")
+        formatted = converter.convert({ 1 => [1, 2, 3] }, string_formats)
+        expect(formatted).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PHashType::DEFAULT => "%k"}
+      converter.convert({1 => 2}, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Hash type - expected one of the characters 'hasp'/)
+    end
+  end
+
+  context 'when converting regexp' do
+    it 'the default string representation is /regexp/' do
+      expect(converter.convert(/.*/, :default)).to eq('/.*/')
+    end
+
+    { "%s"   => '/.*/',
+      "%6s"  => '  /.*/',
+      "%.2s" => '/.',
+      "%-6s" => '/.*/  ',
+      "%p"   => '/.*/',
+      "%6p"  => '  /.*/',
+      "%-6p" => '/.*/  ',
+      "%.2p" => '/.',
+      "%#s"  => '".*"',
+      "%#p"  => '/.*/',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => fmt}
+        expect(converter.convert(/.*/, string_formats)).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+      string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => "%k"}
+      converter.convert(/.*/, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Regexp type - expected one of the characters 'rsp'/)
+    end
+  end
+
+  context 'when converting iterator' do
+    it 'the iterator is transformed to an array and formatted using array rules' do
+      itor = Puppet::Pops::Types::Iterator.new(Puppet::Pops::Types::PIntegerType::DEFAULT, [1,2,3]).reverse_each
+      expect(converter.convert(itor, :default)).to eq('[3, 2, 1]')
+    end
+  end
+
+  context 'when converting type' do
+    it 'the default string representation of a type is its programmatic string form' do
+      expect(converter.convert(factory.integer, :default)).to eq('Integer')
+    end
+
+    { "%s"  => 'Integer',
+      "%p"  => 'Integer',
+      "%#s" => '"Integer"',
+      "%#p" => 'Integer',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PType::DEFAULT => fmt}
+        expect(converter.convert(factory.integer, string_formats)).to eq(result)
+      end
+    end
+
+    it 'errors when format is not recognized' do
+      expect do
+        string_formats = { Puppet::Pops::Types::PType::DEFAULT => "%k"}
+        converter.convert(factory.integer, string_formats)
+      end.to raise_error(/Illegal format 'k' specified for value of Type type - expected one of the characters 'sp'/)
+    end
+  end
+
+  it "allows format to be directly given (instead of as a type=> format hash)" do
+    expect(converter.convert('hello', '%5.1s')).to eq('    h')
+  end
+end

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -293,6 +293,33 @@ describe 'Puppet Type System' do
       expect(eval_and_collect_notices(code)).to eq(['true'])
     end
   end
+
+  context 'instantiation via new_function is supported by' do
+    let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, "types_unit_test_loader") }
+    it 'Integer' do
+      func_class = tf.integer.new_function(loader)
+      expect(func_class).to be_a(Class)
+      expect(func_class.superclass).to be(Puppet::Functions::Function)
+    end
+
+    it 'Optional[Integer]' do
+      func_class = tf.optional(tf.integer).new_function(loader)
+      expect(func_class).to be_a(Class)
+      expect(func_class.superclass).to be(Puppet::Functions::Function)
+    end
+  end
+
+  context 'instantiation via new_function is not supported by' do
+    let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, "types_unit_test_loader") }
+
+      it 'Any, Scalar, Collection' do
+        [tf.any, tf.scalar, tf.collection ].each do |t|
+        expect { t.new_function(loader)
+        }.to raise_error(ArgumentError, /Creation of new instance of type '#{t.to_s}' is not supported/)
+      end
+    end
+  end
+
 end
 end
 end


### PR DESCRIPTION
This adds the function 'new' which operates on a type. The same function can be called by directly calling a type e.g. `T()`.
Each type implements a `new_function` method that returns the 4.x function that acts as the initializer/instantiator function.
This is done to later enable obtaining its Puppet Signature and to allow that each type can specify a specific set of parameters.

The conversion to String is by far the most comprehensive, and it is implemented by delegating to a StringConverter utility - which is largely
modeled on Ruby's Kernel.format method, but catering to many specializations only available in the Puppet Language.

Simple conversions/instantiations are supposed to be simple. More comprehensive conversions should be seen as an interface to puppet's core to be used as
the foundation of more easy to use functions written in the puppet language. (As an example, it is now possible to implement sprintf in the puppet language,
and all conversions are fully specified by the new function.