### PR TITLE
(PUP-6110) Make `assert_type` function use `#infer_set` when reporting type mismatches

### DIFF
--- a/lib/puppet/functions/assert_type.rb
+++ b/lib/puppet/functions/assert_type.rb
@@ -69,7 +69,7 @@ Puppet::Functions.create_function(:assert_type, Puppet::Functions::InternalFunct
   #
   def assert_type(type, value)
     unless Puppet::Pops::Types::TypeCalculator.instance?(type,value)
-      inferred_type = Puppet::Pops::Types::TypeCalculator.infer(value)
+      inferred_type = Puppet::Pops::Types::TypeCalculator.infer_set(value)
       if block_given?
         # Give the inferred type to allow richer comparison in the given block (if generalized
         # information is lost).

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1300,7 +1300,7 @@ class PStructType < PAnyType
         end
       end
       if required_elements_assignable
-        size_o = o.size_type || collection_default_size_t
+        size_o = o.size_type || PCollectionType::DEFAULT_SIZE
         PIntegerType.new(required, elements.size).assignable?(size_o, guard)
       end
     else

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -86,4 +86,12 @@ describe 'the assert_type function' do
     CODE
     expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expected an UnprivilegedPort = Integer\[1024, 65537\] value, got Integer\[345, 345\]/)
   end
+
+  it 'will use infer_set to report detailed information about complex mismatches' do
+    code = <<-CODE
+      assert_type(Struct[{a=>Integer,b=>Boolean}], {a=>hej,x=>s})
+    CODE
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error,
+      /struct member 'a' expected an Integer value, got String.*expected a value for key 'b'.*did not have a 'x' key/m)
+  end
 end

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -92,6 +92,31 @@ describe 'the type mismatch describer' do
        /parameter 'evars' expects a match for EVariants = Enum\['a', 'b', 'c', 'd'\], got 'n'/))
   end
 
+  context 'when reporting a mismatch between' do
+    let(:parser) { TypeParser.new }
+    let(:subject) { TypeMismatchDescriber.singleton }
+
+    context 'hash and struct' do
+      it 'reports a size mismatch when hash has unlimited size' do
+        expected = parser.parse('Struct[{a=>Integer,b=>Integer}]')
+        actual = parser.parse('Hash[String,Integer]')
+        expect(subject.describe_mismatch('', expected, actual)).to eq('expected size to be 2, got unlimited')
+      end
+
+      it 'reports a size mismatch when hash has specified but incorrect size' do
+        expected = parser.parse('Struct[{a=>Integer,b=>Integer}]')
+        actual = parser.parse('Hash[String,Integer,1,1]')
+        expect(subject.describe_mismatch('', expected, actual)).to eq('expected size to be 2, got 1')
+      end
+
+      it 'reports a full type mismatch when size is correct but hash value type is incorrect' do
+        expected = parser.parse('Struct[{a=>Integer,b=>String}]')
+        actual = parser.parse('Hash[String,Integer,2,2]')
+        expect(subject.describe_mismatch('', expected, actual)).to eq("expected a Struct[{'a' => Integer, 'b' => String}] value, got Hash[String, Integer]")
+      end
+    end
+  end
+
   context 'when using present tense' do
     let(:parser) { TypeParser.new }
     let(:subject) { TypeMismatchDescriber.singleton }


### PR DESCRIPTION
This PR fixes a couple of minor bugs and changes the behavior of the `assert_type` function so that it uses `TypeCalculator#infer_set` instead of `TypeCalculator#infer` when reporting mismatches.