### PR TITLE
(PUP-6099) add additional autorequires for file/mount interactions

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -293,5 +293,8 @@ module Puppet
       dependencies[0..-2]
     end
 
+    # Autorequire the mount point's file resource
+    autorequire(:file) { Pathname.new(@parameters[:name].value) }
+
   end
 end

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1278,6 +1278,15 @@ describe Puppet::Type.type(:file) do
         expect(reqs[0].target).to eq(file)
       end
 
+      it "should autorequire its parent mount point" do
+        mount = Puppet::Type.type(:mount).stubs(:defaultprovider).new(:name => File.dirname(path))
+        catalog.add_resource file
+        catalog.add_resource mount
+        reqs = file.autorequire
+        expect(reqs[0].source).to eq(mount)
+        expect(reqs[0].target).to eq(file)
+      end
+
       it "should autorequire its nearest ancestor directory" do
         dir = described_class.new(:path => File.dirname(path))
         grandparent = described_class.new(:path => File.dirname(File.dirname(path)))
@@ -1287,6 +1296,18 @@ describe Puppet::Type.type(:file) do
         reqs = file.autorequire
         expect(reqs.length).to eq(1)
         expect(reqs[0].source).to eq(dir)
+        expect(reqs[0].target).to eq(file)
+      end
+
+      it "should autorequire its nearest ancestor mount point" do
+        mount = Puppet::Type.type(:mount).stubs(:defaultprovider).new(:name => File.dirname(path))
+        grandparent = Puppet::Type.type(:mount).stubs(:defaultprovider).new(:name => File.dirname(File.dirname(path)))
+        catalog.add_resource file
+        catalog.add_resource mount
+        catalog.add_resource grandparent
+        reqs = file.autorequire
+        expect(reqs.length).to eq(1)
+        expect(reqs[0].source).to eq(mount)
         expect(reqs[0].target).to eq(file)
       end
 


### PR DESCRIPTION
With this improvement, file resources will execute before their mount point is mounted and file resources will execute after their parent mount is mounted.

I need some help writing the spec tests because I am unable to fully parse how the Puppet spec API is working.  Please assist.

Also I probably could use some code criticism.  The coding style between the mount and file types and their spec tests were rather different and I tried to stick to the style within each.