### PR TITLE
(PUP-6074) Remove 'unpack-arrays' options from lookup function and CLI

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -6,7 +6,7 @@ require 'puppet/parser/compiler'
 class Puppet::Application::Lookup < Puppet::Application
 
   RUN_HELP = "Run 'puppet lookup --help' for more details".freeze
-  DEEP_MERGE_OPTIONS = '--knock-out-prefix, --sort-merged-arrays, --unpack-arrays, and --merge-hash-arrays'.freeze
+  DEEP_MERGE_OPTIONS = '--knock-out-prefix, --sort-merged-arrays, and --merge-hash-arrays'.freeze
 
   run_mode :master
 
@@ -34,10 +34,6 @@ class Puppet::Application::Lookup < Puppet::Application
   end
 
   option('--sort-merge-arrays')
-
-  option('--unpack-arrays DELIMITER') do |arg|
-    options[:unpack_arrays] = arg
-  end
 
   option('--merge-hash-arrays')
 
@@ -124,7 +120,7 @@ USAGE
 -----
 puppet lookup [--help] [--type <TYPESTRING>] [--merge unique|hash|deep]
   [--knock-out-prefix <PREFIX-STRING>] [--sort-merged-arrays]
-  [--unpack-arrays <STRING-VALUE>] [--merge-hash-arrays] [--explain]
+  [--merge-hash-arrays] [--explain]
   [--default <VALUE>] [--node <NODE-NAME>] [--facts <FILE>]
   [--compile]
   [--render-as s|json|yaml|binary|msgpack] <keys>
@@ -171,10 +167,6 @@ the puppet lookup function linked to above.
 * --sort-merged-arrays
   Can be used with the 'deep' merge strategy. When this flag is used all
   merged arrays will be sorted.
-
-* --unpack-arrays <STRING-VALUE>
-  Can be used with the 'deep' merge strategy. Specify a string value used
-  as a deliminator to join all array values and then split them again.
 
 * --merge-hash-arrays
   Can be used with the 'deep' merge strategy. When this flag is used arrays
@@ -251,7 +243,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     #  raise "No node was given via the '--node' flag for the scope of the lookup.\n#{RUN_HELP}"
     #end
 
-    if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix] || options[:unpack_arrays]) && options[:merge] != 'deep'
+    if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix]) && options[:merge] != 'deep'
       raise "The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUN_HELP}"
     end
 
@@ -273,10 +265,6 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
         if options[:prefix]
           merge_options.merge!({'knockout_prefix' => options[:prefix]})
-        end
-
-        if options[:unpack_arrays]
-          merge_options.merge!({'unpack_arrays' => options[:unpack_arrays]})
         end
 
       else

--- a/lib/puppet/functions/lookup.rb
+++ b/lib/puppet/functions/lookup.rb
@@ -100,9 +100,6 @@
 #     disables this feature.
 #     * `'sort_merged_arrays'` (boolean) --- Whether to sort all arrays that are
 #     merged together. Defaults to `false`.
-#     * `'unpack_arrays'` (string or undef) --- A delimiter string; Puppet will
-#     join merged arrays with this delimiter, then split them again. Defaults to
-#     `undef`, which disables this feature.
 #     * `'merge_hash_arrays'` (boolean) --- Whether to merge hashes within arrays.
 #     Defaults to `false`.
 #

--- a/lib/puppet/parser/functions/lookup.rb
+++ b/lib/puppet/parser/functions/lookup.rb
@@ -101,9 +101,6 @@ but can adjust the merge with additional options. The available options are:
     disables this feature.
     * `'sort_merged_arrays'` (boolean) --- Whether to sort all arrays that are
     merged together. Defaults to `false`.
-    * `'unpack_arrays'` (string or undef) --- A delimiter string; Puppet will
-    join merged arrays with this delimiter, then split them again. Defaults to
-    `undef`, which disables this feature.
     * `'merge_hash_arrays'` (boolean) --- Whether to merge hashes within arrays.
     Defaults to `false`.
 

--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -279,7 +279,6 @@ module Puppet::Pops
   #   hash.deep_merge!({:x => [1,2]}, {:knockout_prefix => '--'})
   #   - 'knockout_prefix' Set to string value to signify prefix which deletes elements from existing element. Defaults is _undef_
   #   - 'sort_merged_arrays' Set to _true_ to sort all arrays that are merged together. Default is _false_
-  #   - 'unpack_arrays' Set to string value used as a deliminator to join all array values and then split them again. Default is _undef_
   #   - 'merge_hash_arrays' Set to _true_ to merge hashes within arrays. Default is _false_
   #
   # Selected Options Details:
@@ -295,14 +294,6 @@ module Puppet::Pops
   #    dest   = {:x => [1,2,3]}
   #    dest.ko_deep_merge!(source)
   #    Results: {:x => ""}
-  # :unpack_arrays => The purpose of this is to permit compound elements to be passed
-  #   in as strings and to be converted into discrete array elements
-  #   irsource = {:x => ['1,2,3', '4']}
-  #   dest   = {:x => ['5','6','7,8']}
-  #   dest.deep_merge!(source, {:unpack_arrays => ','})
-  #   Results: {:x => ['1','2','3','4','5','6','7','8']}
-  #   Why: If receiving data from an HTML form, this makes it easy for a checkbox
-  #    to pass multiple values from within a single HTML element
   #
   # :merge_hash_arrays => merge hashes within arrays
   #   source = {:x => [{:y => 1}]}
@@ -335,7 +326,6 @@ module Puppet::Pops
           'merge_debug=>Optional[Boolean],'\
           'merge_hash_arrays=>Optional[Boolean],'\
           'sort_merge_arrays=>Optional[Boolean],'\
-          'unpack_arrays=>Optional[String]'\
           '}]')
     end
 

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -30,7 +30,7 @@ describe Puppet::Application::Lookup do
       lookup.options[:merge] = 'hash'
       lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
 
-      expected_error = "The options --knock-out-prefix, --sort-merged-arrays, --unpack-arrays, and --merge-hash-arrays are only available with '--merge deep'\nRun 'puppet lookup --help' for more details"
+      expected_error = "The options --knock-out-prefix, --sort-merged-arrays, and --merge-hash-arrays are only available with '--merge deep'\nRun 'puppet lookup --help' for more details"
 
       expect { lookup.run_command }.to raise_error(RuntimeError, expected_error)
     end


### PR DESCRIPTION
The unpack-arrays option is not of any value and is now removed.