### PR TITLE
(PUP-6117) Fix bug with type alias and recursive variant

### DIFF
--- a/lib/puppet/pops/types/recursion_guard.rb
+++ b/lib/puppet/pops/types/recursion_guard.rb
@@ -54,6 +54,16 @@ class RecursionGuard
     @state
   end
 
+  # @return the number of objects added to the `this` map
+  def this_count
+    this_map.size
+  end
+
+  # @return the number of objects added to the `that` map
+  def that_count
+    that_map.size
+  end
+
   private
 
   def map_put(map, o)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -610,7 +610,7 @@ class PNumericType < PScalarType
   # @return [Boolean] `true` if this range intersects with the other range
   # @api public
   def intersect?(o)
-    self.class == o.class && !(@to < o.from || o.to < @from)
+    self.class == o.class && !(@to < o.numeric_from || o.numeric_to < @from)
   end
 
   # Returns the lower bound of the numeric range or `nil` if no lower bound is set.
@@ -700,8 +700,8 @@ class PIntegerType < PNumericType
   # @api public
   def merge(o)
     if intersect?(o) || adjacent?(o)
-      min = @from <= o.from ? @from : o.from
-      max = @to >= o.to ? @to : o.to
+      min = @from <= o.numeric_from ? @from : o.numeric_from
+      max = @to >= o.numeric_to ? @to : o.numeric_to
       PIntegerType.new(min, max)
     else
       nil

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2271,7 +2271,7 @@ class PTypeAliasType < PAnyType
     if @self_recursion
       guard ||= RecursionGuard.new
       guard.add_that(o)
-      return true if (guard.add_this(self) & RecursionGuard::SELF_RECURSION_IN_BOTH) == RecursionGuard::SELF_RECURSION_IN_BOTH
+      return guard.that_count > 1 if guard.add_this(self) == RecursionGuard::SELF_RECURSION_IN_BOTH
     end
     resolved_type.instance?(o, guard)
   end

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -337,7 +337,15 @@ describe 'Puppet Type System' do
       CODE
       expect(eval_and_collect_notices(code)).to eq(['true'])
     end
-  end
+
+    it 'will detect a mismatch in an alias that directly references itself in a variant with other types' do
+      code = <<-CODE
+      type Foo = Variant[Foo,String]
+      notice(3 =~ Foo)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['false'])
+    end
+ end
 end
 end
 end


### PR DESCRIPTION
An alias for a variant where one of the variants was the alias itself would always yield true when asked if an object was an instance of the alias. This PR fixes that.

The PR also ensures that variants like that gets normalized so the first problem may actually never occur. I decided to keep the fix anyway. It's semantically correct and may cover some future corner case.