### PR TITLE
(PUP-6121) Fix auto-loading of ruby types

### DIFF
--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -96,7 +96,10 @@ class Puppet::Pops::Loader::BaseLoader < Puppet::Pops::Loader::Loader
   #
   def internal_load(typed_name)
     # avoid calling get_entry, by looking it up
-    @named_values[typed_name] || parent.load_typed(typed_name) || find(typed_name)
+    te = @named_values[typed_name]
+    te = parent.load_typed(typed_name) if te.nil? || te.value.nil?
+    te = find(typed_name) if te.nil? || te.value.nil?
+    te
   end
 
 end

--- a/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/modules/usee/lib/puppet/type/usee_type.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/modules/usee/lib/puppet/type/usee_type.rb
@@ -1,0 +1,5 @@
+Puppet::Type.newtype(:usee_type) do
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/modules/user/manifests/init.pp
+++ b/spec/fixtures/unit/pops/loaders/loaders/dependent_modules_with_metadata/modules/user/manifests/init.pp
@@ -11,6 +11,12 @@ function puppet_init_calling_ruby() {
 }
 
 class user {
+  # Dummy resource. Added just to assert that a ruby type in another module is loaded correctly
+  # by the auto loader
+  Usee_type {
+    name => 'pelle'
+  }
+
   case $::case_number {
     1: {
       # Call a puppet function that resides in usee/functions directly from init.pp


### PR DESCRIPTION
This commit fixes a regression introduced in PUP-6028 where a Resource
Not Found error is triggered on ruby Puppet::Type declarations that
resides in a module.