### PR TITLE
PUP-6072 Make --lastrunreport be a path-style argument

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1517,8 +1517,7 @@ EOT
     },
     :lastrunreport =>  {
       :default  => "$statedir/last_run_report.yaml",
-      :type     => :file,
-      :mode     => "0640",
+      :type     => :path,
       :desc     => "Where puppet agent stores the last run report in yaml format."
     },
     :graph => {

--- a/lib/puppet/indirector/report/yaml.rb
+++ b/lib/puppet/indirector/report/yaml.rb
@@ -6,6 +6,6 @@ class Puppet::Transaction::Report::Yaml < Puppet::Indirector::Yaml
 
   # Force report to be saved there
   def path(name,ext='.yaml')
-    Puppet[:lastrunreport]
+    Puppet[:lastrunreport].split(File::PATH_SEPARATOR)
   end
 end

--- a/lib/puppet/indirector/yaml.rb
+++ b/lib/puppet/indirector/yaml.rb
@@ -19,17 +19,20 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
   def save(request)
     raise ArgumentError.new("You can only save objects that respond to :name") unless request.instance.respond_to?(:name)
 
-    file = path(request.key)
+    files = path(request.key)
+    files = [files].flatten.uniq
 
-    basedir = File.dirname(file)
+    files.each do |file|
+      basedir = File.dirname(file)
 
-    # This is quite likely a bad idea, since we're not managing ownership or modes.
-    Dir.mkdir(basedir) unless Puppet::FileSystem.exist?(basedir)
+      # This is quite likely a bad idea, since we're not managing ownership or modes.
+      Dir.mkdir(basedir) unless Puppet::FileSystem.exist?(basedir)
 
-    begin
-      Puppet::Util::Yaml.dump(request.instance, file)
-    rescue TypeError => detail
-      Puppet.err "Could not save #{self.name} #{request.key}: #{detail}"
+      begin
+        Puppet::Util::Yaml.dump(request.instance, file)
+      rescue TypeError => detail
+        Puppet.err "Could not save #{self.name} #{request.key}: #{detail}"
+      end
     end
   end
 

--- a/spec/unit/indirector/report/yaml_spec.rb
+++ b/spec/unit/indirector/report/yaml_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Transaction::Report::Yaml do
     expect(Puppet::Transaction::Report::Yaml.name).to eq(:yaml)
   end
 
-  it "should unconditionally save/load from the --lastrunreport setting" do
-    expect(subject.path(:me)).to eq(Puppet[:lastrunreport])
+  it "should unconditionally save to the --lastrunreport setting" do
+    expect(subject.path(:me)).to eq(Puppet[:lastrunreport].split(File::PATH_SEPARATOR))
   end
 end


### PR DESCRIPTION
With this change we make the `lastrunreport` option from being a simple
file-type argument to being a path-type argument.

This is to support a usage case where a user wants to run the puppet with
a known and distinct run report in addition to the typically configured
version, which looks something like:

   $ puppet apply --lastrunreport=$(puppet config print lastrunreport):/tmp/special_report.yaml -e 'notify {"Hello World":}'