### PR TITLE
(PUP-6125) log to console if verbose/debug enabled, and logdest is unset

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -357,13 +357,16 @@ class Application
   end
 
   def setup_logs
-    if options[:debug] || options[:verbose]
-      Puppet::Util::Log.newdestination(:console)
+    unless options[:setdest]
+      if options[:debug] || options[:verbose]
+        Puppet::Util::Log.newdestination(:console)
+      else
+        Puppet::Util::Log.setup_default
+      end
     end
 
     set_log_level
 
-    Puppet::Util::Log.setup_default unless options[:setdest]
   end
 
   def set_log_level(opts = nil)

--- a/spec/integration/agent/logging_spec.rb
+++ b/spec/integration/agent/logging_spec.rb
@@ -122,21 +122,23 @@ describe 'agent logging' do
   # @return Set<Symbol> of expected loggers
   def self.expected_loggers(argv)
     loggers = Set.new
-    loggers << CONSOLE if verbose_or_debug_set_in_argv(argv)
     loggers << 'console' if log_dest_is_set_to(argv, LOGDEST_CONSOLE)
     loggers << '/dev/null/foo' if log_dest_is_set_to(argv, LOGDEST_FILE)
-    if Puppet.features.microsoft_windows?
-      # an explicit call to --logdest syslog on windows is swallowed silently with no
-      # logger created (see #suitable() of the syslog Puppet::Util::Log::Destination subclass)
-      # however Puppet::Util::Log.newdestination('syslog') does get called...so we have
-      # to set an expectation
-      loggers << 'syslog' if log_dest_is_set_to(argv, LOGDEST_SYSLOG)
-
-      loggers << EVENTLOG if no_log_dest_set_in(argv)
+    if no_log_dest_set_in(argv) and verbose_or_debug_set_in_argv(argv)
+        loggers << CONSOLE
     else
-      # posix
-      loggers << 'syslog' if log_dest_is_set_to(argv, LOGDEST_SYSLOG)
-      loggers << SYSLOG if no_log_dest_set_in(argv)
+      if Puppet.features.microsoft_windows?
+        # an explicit call to --logdest syslog on windows is swallowed silently with no
+        # logger created (see #suitable() of the syslog Puppet::Util::Log::Destination subclass)
+        # however Puppet::Util::Log.newdestination('syslog') does get called...so we have
+        # to set an expectation
+        loggers << 'syslog' if log_dest_is_set_to(argv, LOGDEST_SYSLOG)
+        loggers << EVENTLOG if no_log_dest_set_in(argv)
+      else
+        # posix
+        loggers << 'syslog' if log_dest_is_set_to(argv, LOGDEST_SYSLOG)
+        loggers << SYSLOG if no_log_dest_set_in(argv)
+      end
     end
     return loggers
   end

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -253,7 +253,6 @@ describe Puppet::Application::Agent do
         it "should set console as the log destination with level #{level}" do
           @puppetd.options[level] = true
 
-          Puppet::Util::Log.expects(:newdestination).at_least_once
           Puppet::Util::Log.expects(:newdestination).with(:console).once
 
           @puppetd.setup_logs


### PR DESCRIPTION
If the verbose or debug options are used, the console is added as a logging destination. However, the `Puppet::Util::Log.setup_default` method is also called. This results in output being sent to both the console and syslog on linux or eventlog on windows. Additionally, output would still go to the console even the logdest option was set.

The documentation states

> * --logdest:
  Where to send log messages. Choose between 'syslog' (the POSIX syslog
  service), 'eventlog' (the Windows Event Log), 'console', or the path to a log
  file. If debugging or verbosity is enabled, this defaults to 'console'.
  Otherwise, it defaults to 'syslog' on POSIX systems and 'eventlog' on Windows.

With this PR the following happens:
  * logs are sent to sources defined by logdest
  * logs are sent to the console when verbose or debug options are used
  * logs are sent to the default source when logdest is unspecified and verbose/debug option are not used