### PR TITLE
(PUP-6128) Retain case in QualifiedReference

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -442,7 +442,7 @@ class AccessOperator
     # Must know which concrete resource type to operate on in all cases.
     # It is not allowed to specify the type in an array arg - e.g. Resource[[File, 'foo']]
     # type_name is LHS type_name if set, else the first given arg
-    type_name = o.type_name || keys.shift
+    type_name = o.type_name || Types::TypeFormatter.singleton.capitalize_segments(keys.shift)
     type_name = case type_name
     when Types::PResourceType
       type_name.type_name
@@ -455,7 +455,7 @@ class AccessOperator
     end
 
     # type name must conform
-    if type_name.downcase !~ Patterns::CLASSREF
+    if type_name !~ Patterns::CLASSREF_EXT
       fail(Issues::ILLEGAL_CLASSREF, blamed, {:name=>type_name})
     end
 

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -150,7 +150,7 @@ class Runtime3Converter
         else
           # Ensure that title is '' if nil
           # Resources with absolute name always results in error because tagging does not support leading ::
-          [type_name.nil? ? nil : type_name.sub(/^::/, ''), title.nil? ? '' : title]
+          [type_name.nil? ? nil : type_name.sub(/^::/, '').downcase, title.nil? ? '' : title]
         end
       else
         raise ArgumentError, "Cannot split the type #{catalog_type.class}, it represents neither a PHostClassType, nor a PResourceType."

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -526,7 +526,7 @@ module Issues
   end
 
   UNKNOWN_RESOURCE = issue :UNKNOWN_RESOURCE, :type_name, :title do
-    "Resource not found: #{type_name.capitalize}['#{title}']"
+    "Resource not found: #{type_name}['#{title}']"
   end
 
   UNKNOWN_RESOURCE_PARAMETER = issue :UNKNOWN_RESOURCE_PARAMETER, :type_name, :title, :param_name do

--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -266,7 +266,7 @@ class Factory
   end
 
   def build_QualifiedReference(o, name)
-    o.value = name.to_s.downcase
+    o.cased_value = name.to_s
     o
   end
 

--- a/lib/puppet/pops/model/model.rb
+++ b/lib/puppet/pops/model/model.rb
@@ -107,6 +107,14 @@ module Puppet::Pops
       end
     end
 
+    class QualifiedReference
+      module ClassModule
+        def value
+          @value ||= cased_value.downcase
+        end
+      end
+    end
+
     class Program < PopsObject
       module ClassModule
         def locator

--- a/lib/puppet/pops/model/model_meta.rb
+++ b/lib/puppet/pops/model/model_meta.rb
@@ -502,7 +502,7 @@ module Puppet::Pops::Model
   # A DSL CLASSREF (one or multiple parts separated by '::' where (at least) the first part starts with an upper case letter).
   #
   class QualifiedReference < LiteralValue
-    has_attr 'value', String, :lowerBound => 1
+    has_attr 'cased_value', String, :lowerBound => 1
   end
 
   # A Variable expression looks up value of expr (some kind of name) in scope.

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -301,15 +301,19 @@ module TypeFactory
   # name.  (There is no resource-type subtyping in Puppet (yet)).
   #
   def self.resource(type_name = nil, title = nil)
-    type_name = type_name.type_name if type_name.is_a?(PResourceType)
-    type_name = type_name.downcase unless type_name.nil?
-    unless type_name.nil? || type_name =~ Patterns::CLASSREF
-      raise ArgumentError, "Illegal type name '#{type.type_name}'"
+    case type_name
+    when PResourceType
+      PResourceType.new(type_name.type_name, title)
+    when String
+      type_name = TypeFormatter.singleton.capitalize_segments(type_name)
+      raise ArgumentError, "Illegal type name '#{type_name}'" unless type_name =~ Patterns::CLASSREF_EXT
+      PResourceType.new(type_name, title)
+    when nil
+      raise ArgumentError, 'The type name cannot be nil, if title is given' unless title.nil?
+      PResourceType::DEFAULT
+    else
+      raise ArgumentError, "The type name cannot be a #{type_name.class.name}"
     end
-    if type_name.nil? && !title.nil?
-      raise ArgumentError, 'The type name cannot be nil, if title is given'
-    end
-    PResourceType.new(type_name, title)
   end
 
   # Produces PHostClassType with a string class_name.  A PHostClassType with

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -212,7 +212,7 @@ class TypeParser
         type = loader.load(:type, name)
         type = type.resolve(self, loader) unless type.nil?
       end
-      type || TypeFactory.type_reference(TypeFormatter.singleton.capitalize_segments(name))
+      type || TypeFactory.type_reference(name_ast.cased_value)
     end
   end
 
@@ -480,7 +480,7 @@ class TypeParser
       end
 
       if type.nil?
-        TypeFactory.type_reference(TypeFormatter.singleton.capitalize_segments(type_name), parameters)
+        TypeFactory.type_reference(qref.cased_value, parameters)
       elsif type.is_a?(PResourceType)
         raise_invalid_parameters_error(type_name, 1, parameters.size) unless parameters.size == 1
         TypeFactory.resource(type.type_name, parameters[0])

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2468,9 +2468,9 @@ class PResourceType < PCatalogEntryType
   attr_reader :type_name, :title, :downcased_name
 
   def initialize(type_name, title = nil)
-    @type_name = type_name
-    @title = title
-    @downcased_name = type_name.nil? ? nil : @type_name.downcase
+    @type_name = type_name.freeze
+    @title = title.freeze
+    @downcased_name = type_name.nil? ? nil : @type_name.downcase.freeze
   end
 
   def eql?(o)

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -509,8 +509,8 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   # DOH: QualifiedReferences are created with LOWER CASE NAMES at parse time
   def check_QualifiedReference(o)
     # Is this a valid qualified name?
-    if o.value !~ Patterns::CLASSREF
-      acceptor.accept(Issues::ILLEGAL_CLASSREF, o, {:name=>o.value})
+    if o.cased_value !~ Patterns::CLASSREF_EXT
+      acceptor.accept(Issues::ILLEGAL_CLASSREF, o, {:name=>o.cased_value})
     end
   end
 

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -511,7 +511,7 @@ describe 'the 4x function api' do
         the_loader.add_function('testing::test', fc.new({}, the_loader))
         program = parser.parse_string('testing::test(10)', __FILE__)
         Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
-        expect { parser.evaluate({}, program) }.to raise_error(Puppet::Error, /parameter 'x' references an unresolved type 'Myalias'/)
+        expect { parser.evaluate({}, program) }.to raise_error(Puppet::Error, /parameter 'x' references an unresolved type 'MyAlias'/)
       end
 
       it 'create local Type aliases' do

--- a/spec/unit/parser/functions/shared.rb
+++ b/spec/unit/parser/functions/shared.rb
@@ -24,7 +24,7 @@ shared_examples_for 'all functions transforming relative to absolute names' do |
   it 'raises and error for Resource that is not of class type' do
     expect {
       @scope.send(func_method, [Puppet::Pops::Types::TypeFactory.resource('file')])
-    }.to raise_error(ArgumentError, /Cannot use a Resource\[file\] where a Resource\['class', name\] is expected/)
+    }.to raise_error(ArgumentError, /Cannot use a Resource\[File\] where a Resource\['class', name\] is expected/)
   end
 
   it 'raises and error for Resource that is unspecific' do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -60,11 +60,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     it 'should error when it encounters an unknown resource' do
-      expect {parser.evaluate_string(scope, '$a = SantaClause', __FILE__)}.to raise_error(/Resource type not found: Santaclause/)
+      expect {parser.evaluate_string(scope, '$a = SantaClause', __FILE__)}.to raise_error(/Resource type not found: SantaClause/)
     end
 
     it 'should error when it encounters an unknown resource with a parameter' do
-      expect {parser.evaluate_string(scope, '$b = ToothFairy[emea]', __FILE__)}.to raise_error(/Resource type not found: Toothfairy/)
+      expect {parser.evaluate_string(scope, '$b = ToothFairy[emea]', __FILE__)}.to raise_error(/Resource type not found: ToothFairy/)
     end
   end
 

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -108,7 +108,7 @@ describe 'The type factory' do
     it 'resource(x) creates a PResourceType[x]' do
       pr = Puppet::Pops::Types::TypeFactory.resource('x')
       expect(pr.class()).to eq(Puppet::Pops::Types::PResourceType)
-      expect(pr.type_name).to eq('x')
+      expect(pr.type_name).to eq('X')
     end
 
     it 'host_class() creates a generic PHostClassType' do


### PR DESCRIPTION
Before this commit, all qualified references were downcased immediately
in the AST model. Attempts where then made to restore the case when
reporting errors by capitalizing all segments in the name. So names
like `MyGreateResource` became `Mygreatresource`.

This commit changes the QualifiedReference so that it instead stores
the original name and will deliver the downcased name when asked to
do so. The logic is also changed in several places to avoid repeated
downcasing and capitalizing.