### PR TITLE
(PUP-6132) Emit formatted XML when using Puppet::Util::Plist

### DIFF
--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -115,16 +115,16 @@ module Puppet::Util::Plist
       begin
         plist_to_save       = CFPropertyList::List.new
         plist_to_save.value = CFPropertyList.guess(plist)
-        plist_to_save.save(file_path, to_format(format))
+        plist_to_save.save(file_path, to_format(format), :formatted => true)
       rescue IOError => e
-        Puppet.error("Unable to write the file #{file_path}. #{e.inspect}")
+        Puppet.err("Unable to write the file #{file_path}. #{e.inspect}")
       end
     end
 
     def dump_plist(plist_data, format = :xml)
       plist_to_save       = CFPropertyList::List.new
       plist_to_save.value = CFPropertyList.guess(plist_data)
-      plist_to_save.to_str(to_format(format))
+      plist_to_save.to_str(to_format(format), :formatted => true)
     end
   end
 end


### PR DESCRIPTION
Puppet::Util::Plist's dump_plist and write_plist_file methods both emit poorly-formatted XML plists by default. Thankfully, the cfpropertylist module this depends on has a :formatted option for both .to_str and .save. Setting this to true results in properly-formatted XML.

Also fix a call of Puppet.error to Puppet.err