### PR TITLE
(PUP-6131) Make NotUndef.new be transparent

### DIFF
--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -47,6 +47,14 @@ describe 'the new function' do
       MANIFEST
       )).to have_resource('Notify[Integer, 42]')
     end
+
+    it 'produces the given value when there is no type specified' do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = NotUndef.new(42)
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Integer, 42]')
+    end
   end
 
   context 'when invoked on an Integer' do


### PR DESCRIPTION
Before this, and attempt to create a new `NotUndef` resulted in
an error unless its type was narrowed.
NotUndef[Integer](42) worked but not
NotUndef(42)

This commit adds a new function to the Unit type. This is used by
NotUndef if it does not have a narrowed type.