### PR TITLE
(PUP-6105) Avoid comparing symbol to string in terminus

### DIFF
--- a/lib/puppet/indirector/terminus.rb
+++ b/lib/puppet/indirector/terminus.rb
@@ -66,18 +66,18 @@ class Puppet::Indirector::Terminus
       # Yay, class/instance confusion.
       subclass.terminus_type = self.name
 
-      # Our subclass is specifically associated with an indirection.
+      # This subclass is specifically associated with an indirection.
       raise("Invalid name #{longname}") unless names.length > 0
-      indirection_name = names.pop.sub(/^[A-Z]/) { |i| i.downcase }.gsub(/[A-Z]/) { |i| "_#{i.downcase}" }.intern
+      processed_name = names.pop.sub(/^[A-Z]/) { |i| i.downcase }.gsub(/[A-Z]/) { |i| "_#{i.downcase}" }
 
-      if indirection_name == "" or indirection_name.nil?
+      if processed_name == "" || processed_name.nil?
         raise Puppet::DevError, "Could not discern indirection model from class constant"
       end
 
       # This will throw an exception if the indirection instance cannot be found.
       # Do this last, because it also registers the terminus type with the indirection,
       # which needs the above information.
-      subclass.indirection = indirection_name
+      subclass.indirection = processed_name.intern
 
       # And add this instance to the instance hash.
       Puppet::Indirector::Terminus.register_terminus_class(subclass)

--- a/lib/puppet/indirector/terminus.rb
+++ b/lib/puppet/indirector/terminus.rb
@@ -70,7 +70,7 @@ class Puppet::Indirector::Terminus
       raise("Invalid name #{longname}") unless names.length > 0
       processed_name = names.pop.sub(/^[A-Z]/) { |i| i.downcase }.gsub(/[A-Z]/) { |i| "_#{i.downcase}" }
 
-      if processed_name == "" || processed_name.nil?
+      if processed_name.empty?
         raise Puppet::DevError, "Could not discern indirection model from class constant"
       end
 


### PR DESCRIPTION
Before this, there was an attempt to create a symbol from an empty
string (or worse case from nil). With the removal of monkey patching
symbol to compare equal to string and introducing warnings, it is
important to clean up odd usage of string symbol comparisons.

This is now changed to deal with the error condition of nil/empty string
before converting to symbol and using the value.

This also makes a small refactoring to the variable name as the
implementation in general uses a very confusing style where some
attributes have readers but no writers this resulting in confusion over
if the use of the attribute is a local variable or a function call to
the attribute reader.