### PR TITLE
(PUP-6089) Do not show unit type for empty collections, and make creation of empty Array/Hash illegal

### DIFF
--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -213,7 +213,7 @@ class TypeFormatter
   # @api private
   def string_PArrayType(t)
     if t.has_empty_range?
-      'Array[0, 0]'
+      append_array('Array', ['0', '0'])
     else
       append_array('Array', t == PArrayType::DATA ? EMPTY_ARRAY : [string(t.element_type)] + range_array_part(t.size_type))
     end
@@ -222,7 +222,7 @@ class TypeFormatter
   # @api private
   def string_PHashType(t)
     if t.has_empty_range?
-      'Hash[0, 0]'
+      append_array('Hash', ['0', '0'])
     else
       append_array('Hash', t == PHashType::DATA ? EMPTY_ARRAY : [string(t.key_type), string(t.element_type)] + range_array_part(t.size_type))
     end

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -206,14 +206,26 @@ class TypeFormatter
     append_array('Runtime', [string(t.runtime), string(t.runtime_type_name)])
   end
 
+  def is_empty_range?(from, to)
+    from == 0 && to == 0
+  end
+
   # @api private
   def string_PArrayType(t)
-    append_array('Array', t == PArrayType::DATA ? EMPTY_ARRAY : [string(t.element_type)] + range_array_part(t.size_type))
+    if t.has_empty_range?
+      'Array[0, 0]'
+    else
+      append_array('Array', t == PArrayType::DATA ? EMPTY_ARRAY : [string(t.element_type)] + range_array_part(t.size_type))
+    end
   end
 
   # @api private
   def string_PHashType(t)
-    append_array('Hash', t == PHashType::DATA ? EMPTY_ARRAY : [string(t.key_type), string(t.element_type)] + range_array_part(t.size_type))
+    if t.has_empty_range?
+      'Hash[0, 0]'
+    else
+      append_array('Hash', t == PHashType::DATA ? EMPTY_ARRAY : [string(t.key_type), string(t.element_type)] + range_array_part(t.size_type))
+    end
   end
 
   # @api private

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -784,6 +784,9 @@ class PCollectionType < PAnyType
   def initialize(element_type, size_type = nil)
     @element_type = element_type
     @size_type = size_type
+    if has_empty_range? && !@element_type.is_a?(PUnitType)
+      raise ArgumentError, 'An empty collection may not specify an element type'
+    end
   end
 
   def accept(visitor, guard)
@@ -1691,6 +1694,9 @@ class PHashType < PCollectionType
   def initialize(key_type, value_type, size_type = nil)
     super(value_type, size_type)
     @key_type = key_type
+    if has_empty_range? && !@key_type.is_a?(PUnitType)
+      raise ArgumentError, 'An empty hash may not specify a key type'
+    end
   end
 
   def accept(visitor, guard)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -819,6 +819,11 @@ class PCollectionType < PAnyType
     (@size_type || DEFAULT_SIZE).range
   end
 
+  def has_empty_range?
+    from, to = size_range
+    from == 0 && to == 0
+  end
+
   def hash
     @element_type.hash ^ @size_type.hash
   end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1157,7 +1157,7 @@ describe 'The type calculator' do
 
       it 'should accept empty array when tuple allows min of 0' do
         tuple1 = constrained_tuple_t(range_t(0, 1), Integer)
-        array = array_t(Integer, range_t(0, 0))
+        array = array_t(unit_t, range_t(0, 0))
         expect(calculator.assignable?(tuple1, array)).to eq(true)
         expect(calculator.assignable?(array, tuple1)).to eq(false)
       end
@@ -1210,9 +1210,9 @@ describe 'The type calculator' do
         expect(calculator.assignable?(hsh, struct1)).to eq(true)
       end
 
-      it 'should accept empty hash with key_type undef' do
+      it 'should accept empty hash with key_type unit' do
         struct1 = struct_t({'a'=>optional_t(Integer)})
-        hsh = hash_t(undef_t, undef_t, range_t(0, 0))
+        hsh = hash_t(unit_t, unit_t, range_t(0, 0))
         expect(calculator.assignable?(struct1, hsh)).to eq(true)
       end
     end

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -175,6 +175,32 @@ describe 'The type factory' do
       expect(t.size_type.to).to eq(2)
     end
 
+    it 'it is illegal to create a typed empty array' do
+      expect {
+        Puppet::Pops::Types::TypeFactory.array_of(Puppet::Pops::Types::TypeFactory.data, Puppet::Pops::Types::TypeFactory.range(0,0))
+      }.to raise_error(/An empty collection may not specify an element type/)
+    end
+
+    it 'it is legal to create an empty array of unit element type' do
+      t = Puppet::Pops::Types::TypeFactory.array_of(Puppet::Pops::Types::PUnitType::DEFAULT, Puppet::Pops::Types::TypeFactory.range(0,0))
+      expect(t.size_type.class).to eq(Puppet::Pops::Types::PIntegerType)
+      expect(t.size_type.from).to eq(0)
+      expect(t.size_type.to).to eq(0)
+    end
+
+    it 'it is illegal to create a typed empty hash' do
+      expect {
+        Puppet::Pops::Types::TypeFactory.hash_of(Puppet::Pops::Types::TypeFactory.scalar, Puppet::Pops::Types::TypeFactory.data, Puppet::Pops::Types::TypeFactory.range(0,0))
+      }.to raise_error(/An empty collection may not specify an element type/)
+    end
+
+    it 'it is legal to create an empty hash where key and value types are of Unit type' do
+      t = Puppet::Pops::Types::TypeFactory.hash_of(Puppet::Pops::Types::PUnitType::DEFAULT, Puppet::Pops::Types::PUnitType::DEFAULT, Puppet::Pops::Types::TypeFactory.range(0,0))
+      expect(t.size_type.class).to eq(Puppet::Pops::Types::PIntegerType)
+      expect(t.size_type.from).to eq(0)
+      expect(t.size_type.to).to eq(0)
+    end
+
     context 'callable types' do
       it 'the callable methods produces a Callable' do
         t = Puppet::Pops::Types::TypeFactory.callable()

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -76,9 +76,14 @@ describe 'The type formatter' do
       expect(s.string(f.array_of_data)).to eq('Array')
     end
 
-    it "should yield 'Array[Unit, 0, 0]' for an empty array" do
+    it "should yield 'Array[0, 0]' for an empty array" do
       t = f.array_of(PUnitType::DEFAULT, f.range(0,0))
-      expect(s.string(t)).to eq('Array[Unit, 0, 0]')
+      expect(s.string(t)).to eq('Array[0, 0]')
+    end
+
+    it "should yield 'Hash[0, 0]' for an empty hash" do
+      t = f.hash_of(PUnitType::DEFAULT, PUnitType::DEFAULT, f.range(0,0))
+      expect(s.string(t)).to eq('Hash[0, 0]')
     end
 
     it "should yield 'Collection' and from/to for PCollectionType" do


### PR DESCRIPTION
This modifies string representation of empty Array and Hash to `Array[0, 0]´ and `Hash[0, 0]´ respectively.
This also makes it illegal to attempt to type an empty collection  - these are now illegal:
* `Array[Integer, 0, 0]`
* `Hash[Integer, Integer, 0, 0]`

Internally it is still allowed to create such types if the key/value types are `Unit` (since that is how the empty states are encoded).