### PR TITLE
(PUP-6139) Log HTTP errors at debug level

### DIFF
--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -113,7 +113,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
 
   def do_http_control_exception(response, exception)
     msg = exception.message
-    Puppet.info(msg)
+    Puppet.debug(msg)
     response.respond_with(exception.status, "text/plain", msg)
   end
 


### PR DESCRIPTION
Previously when an indirection raised an HTTPError the error was logged
at the info level. This causes a lot of noise for resources such as a
file resource with sourceselect, where several sources may 404 while
trying to find a successful source. This commit moves the message to the
debug level to avoid that problem.