### PR TITLE
(PUP-6113) Don't fetch password_min_age on Solaris if it doen't exist

### DIFF
--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -167,10 +167,12 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
   end
 
   def password
-    shadow_entry[1] if shadow_entry
+    return :absent unless shadow_entry
+    shadow_entry[1]
   end
 
   def password_min_age
+    return :absent unless shadow_entry
     shadow_entry[3].empty? ? -1 : shadow_entry[3]
   end
 


### PR DESCRIPTION
This check was lost in a refactor back in 2014. Both the `password` and `password_max_age` getters retained their checks for absence.