### PR TITLE
(PUP-6142) Only warn once for missing module dependencies

### DIFF
--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -310,9 +310,10 @@ class Loaders
           msg = "ModuleLoader: module '#{from_module_data.name}' has unresolved dependencies"+
               " - it will only see those that are resolved."+
               " Use 'puppet module list --tree' to see information about modules"
-          if Puppet[:strict] == :error
-            raise LoaderError.new(msg)
-          elsif Puppet[:strict] == :warning
+          case Puppet[:strict]
+          when :error
+              raise LoaderError.new(msg)
+          when :warning
             Puppet.warn_once(:unresolved_module_dependencies,
                              "unresolved_dependencies_for_module_#{from_module_data.name}",
                              msg)

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -307,8 +307,8 @@ class Loaders
     def create_loader_with_only_dependencies_visible(from_module_data)
       if from_module_data.unmet_dependencies?
         if Puppet[:strict] != :off
-          msg = "ModuleLoader: module '#{from_module_data.name}' has unresolved dependencies"+
-              " - it will only see those that are resolved."+
+          msg = "ModuleLoader: module '#{from_module_data.name}' has unresolved dependencies" \
+              " - it will only see those that are resolved." \
               " Use 'puppet module list --tree' to see information about modules"
           case Puppet[:strict]
           when :error


### PR DESCRIPTION
This commit changes the warning for missing module dependencies
to be less verbose.  It also adds support for the `:strict`
setting.  If `:strict` is set to `:warning`, then we only log
the missing module dependency once (per ruby instance).  If `:strict`
is set to `:error`, then we raise a LoaderError.  If `:strict`
is set to `:off`, then we don't log anything.