### PR TITLE
(PUP-6140) Acceptance test for init.d services when systemd is default

### DIFF
--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -15,41 +15,64 @@ module Puppet
         suitable == "true" ? true : false
       end
 
-      # Alter the state of a service using puppet apply. Can set 'ensure' and 'enable'.
+      # Construct manifest ensuring service status.
+      # @param service [String] name of the service
+      # @param status [Hash] properties to set - can include 'ensure' and 'enable' keys.
+      # @return [String] a manifest
+      def service_manifest(service, status)
+        ensure_status = "ensure => '#{status[:ensure]}'," if status[:ensure]
+        enable_status = "enable => '#{status[:enable]}'," if status[:enable]
+        %Q{
+          service { '#{service}':
+            #{ensure_status}
+            #{enable_status}
+          }
+        }
+      end
+
+      # Alter the state of a service using puppet apply and assert that a change was logged.
+      # Assumes the starting state is not the desired state.
+      # @param host [String] hostname.
+      # @param service [String] name of the service.
+      # @param status [Hash] properties to set - can include 'ensure' and 'enable' keys.
+      # @return None
+      def ensure_service_change_on_host(host, service, status)
+        # the process of creating the service will also start it
+        # to avoid a flickering test from the race condition, this test will ensure
+        # that the exit code is either
+        #   2 => something changed, or
+        #   0 => no change needed
+        apply_manifest_on host, service_manifest(service, status), :acceptable_exit_codes => [0, 2] do
+          assert_match(/Service\[#{service}\]\/ensure: ensure changed '\w+' to '#{status[:ensure]}'/, stdout, 'Service status change failed') if status[:ensure]
+          assert_match(/Service\[#{service}\]\/enable: enable changed '\w+' to '#{status[:enable]}'/, stdout, 'Service enable change failed') if status[:enable]
+        end
+      end
+
+      # Ensure the state of a service using puppet apply and assert that no change was logged.
+      # Assumes the starting state is the ensured state.
+      # @param host [String] hostname.
+      # @param service [String] name of the service.
+      # @param status [Hash] properties to set - can include 'ensure' and 'enable' keys.
+      # @return None
+      def ensure_service_idempotent_on_host(host, service, status)
+        # ensure idempotency
+        apply_manifest_on host, service_manifest(service, status) do
+          assert_no_match(/Service\[#{service}\]\/ensure/, stdout, 'Service status not idempotent') if status[:ensure]
+          assert_no_match(/Service\[#{service}\]\/enable/, stdout, 'Service enable not idempotent') if status[:enable]
+        end
+      end
+
+      # Alter the state of a service using puppet apply, assert that it changed and change is idempotent.
+      # Can set 'ensure' and 'enable'. Assumes the starting state is not the desired state.
       # @param host [String] hostname.
       # @param service [String] name of the service.
       # @param status [Hash] properties to set - can include 'ensure' and 'enable' keys.
       # @param block [Proc] optional: block to verify service state
       # @return None
       def ensure_service_on_host(host, service, status, &block)
-        ensure_status = "ensure => '#{status[:ensure]}'," if status[:ensure]
-        enable_status = "enable => '#{status[:enable]}'," if status[:enable]
-        manifest = %Q{
-          service { '#{service}':
-            #{ensure_status}
-            #{enable_status}
-          }
-        }
-
-        # the process of creating the service will also start it
-        # to avoid a flickering test from the race condition, this test will ensure
-        # that the exit code is either
-        #   2 => something changed, or
-        #   0 => no change needed
-        on host, puppet_apply(['--detailed-exitcodes', '--verbose']),
-          {:stdin => manifest, :acceptable_exit_codes => [0, 2]} do
-            assert_match(/Service\[#{service}\]\/ensure: ensure changed '\w+' to '#{status[:ensure]}'/, stdout, 'Service status change failed') if status[:ensure]
-            assert_match(/Service\[#{service}\]\/enable: enable changed '\w+' to '#{status[:enable]}'/, stdout, 'Service enable change failed') if status[:enable]
-        end
-
+        ensure_service_change_on_host(host, service, status)
         assert_service_status_on_host(host, service, status, &block)
-
-        # ensure idempotency
-        apply_manifest_on host, "service { '#{service}': #{ensure_status} #{enable_status} }" do
-          assert_no_match(/Service\[#{service}\]\/ensure/, stdout, 'Service status not idempotent') if status[:ensure]
-          assert_no_match(/Service\[#{service}\]\/enable/, stdout, 'Service enable not idempotent') if status[:enable]
-        end
-
+        ensure_service_idempotent_on_host(host, service, status)
         assert_service_status_on_host(host, service, status, &block)
       end
 

--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -1,0 +1,179 @@
+test_name 'SysV on default Systemd Service Provider Validation' do
+
+  confine :to, :platform => /el-|centos|fedora/ do |h|
+    on h, 'which systemctl', :acceptable_exit_codes => [0, 1]
+    stdout =~ /systemctl/
+  end
+
+  require 'puppet/acceptance/service_utils'
+  extend Puppet::Acceptance::ServiceUtils
+
+  svc = 'puppetize'
+  initd_location = "/etc/init.d/#{svc}"
+  pidfile = "/var/run/#{svc}.pid"
+
+  # Some scripts don't have status command.
+  def initd_file(svc, pidfile, initd_location, status)
+    initd = <<INITD
+#!/bin/bash
+# #{svc} daemon
+# chkconfig: 2345 20 80
+# description: #{svc} daemon
+
+DESC="#{svc} daemon"
+PIDFILE=#{pidfile}
+SCRIPTNAME=#{initd_location}
+
+case "$1" in
+start)
+    PID=`/usr/bin/#{svc} 120 > /dev/null 2>&1 & echo $!`
+    if [ -z $PID ]; then
+        echo "Failed to start"
+    else
+        echo $PID > $PIDFILE
+        echo "Started"
+    fi
+;;
+
+#{if status then "status)" else "status-ignored)" end}
+    if [ -f $PIDFILE ]; then
+        PID=`cat $PIDFILE`
+        if [ -z "`ps axf | grep ${PID} | grep -v grep `" ]; then
+            printf "Process dead but pidfile exists"
+            exit 2
+        else
+            echo "Running"
+        fi
+    else
+        echo "Service not running"
+        exit 3
+    fi
+;;
+
+stop)
+    PID=`cat $PIDFILE`
+    if [ -f $PIDFILE ]; then
+        kill -TERM $PID
+        rm -f $PIDFILE
+    else
+        echo "pidfile not found"
+    fi
+;;
+
+restart)
+    $0 stop
+    $0 start
+;;
+
+*)
+    echo "Usage: $0 (start|stop|restart)"
+    exit 1
+esac
+
+exit 0
+INITD
+  end
+
+  def assert_service_status(agent, pidfile, expected_running)
+    on agent, "ps -p `cat #{pidfile}`", :acceptable_exit_codes => (expected_running ? [0] : [1])
+  end
+
+  agents.each do |agent|
+    on agent, 'which sleep'
+    sleep_bin = stdout.chomp
+
+    step "Create initd script with status command" do
+      create_remote_file agent, initd_location, initd_file(svc, pidfile, initd_location, true)
+      apply_manifest_on agent, <<MANIFEST
+file {'/usr/bin/#{svc}': ensure => link, target => '#{sleep_bin}', }
+file {'#{initd_location}': ensure => file, mode   => '0755', }
+MANIFEST
+      on agent, "chkconfig --add #{svc}"
+      on agent, "chkconfig #{svc}", :acceptable_exit_codes => [0]
+      on agent, "service #{svc} status", :acceptable_exit_codes => [3]
+    end
+
+    step "Verify the service exists on #{agent}" do
+      assert_service_status_on_host(agent, svc, {:ensure => 'stopped', :enable => 'true'}) do
+        assert_service_status(agent, pidfile, false)
+      end
+    end
+
+    step "Start the service on #{agent}" do
+      ensure_service_on_host(agent, svc, {:ensure => 'running'}) do
+        assert_service_status(agent, pidfile, true)
+      end
+    end
+
+    step "Disable the service on #{agent}" do
+      ensure_service_on_host(agent, svc, {:enable => 'false'}) do
+        assert_service_status(agent, pidfile, true)
+      end
+    end
+
+    step "Stop the service on #{agent}" do
+      ensure_service_on_host(agent, svc, {:ensure => 'stopped'}) do
+        assert_service_status(agent, pidfile, false)
+      end
+    end
+
+    step "Enable the service on #{agent}" do
+      ensure_service_on_host(agent, svc, {:enable => 'true'}) do
+        assert_service_status(agent, pidfile, false)
+      end
+    end
+
+    step "Create initd script without status command" do
+      create_remote_file agent, initd_location, initd_file(svc, pidfile, initd_location, false)
+      apply_manifest_on agent, <<MANIFEST
+file {'/usr/bin/#{svc}': ensure => link, target => '#{sleep_bin}', }
+file {'#{initd_location}': ensure => file, mode   => '0755', }
+MANIFEST
+      on agent, "chkconfig --add #{svc}"
+      on agent, "chkconfig #{svc}", :acceptable_exit_codes => [0]
+      on agent, "service #{svc} status", :acceptable_exit_codes => [1]
+    end
+
+    step "Verify the service exists on #{agent}" do
+      assert_service_status_on_host(agent, svc, {:ensure => 'stopped', :enable => 'true'}) do
+        assert_service_status(agent, pidfile, false)
+      end
+    end
+
+    # The following are implemented differently because currently the Redhat provider can't tell when
+    # a service is running if it doesn't implement the status command. However it can still manage it.
+    step "Start the service on #{agent}" do
+      ensure_service_change_on_host(agent, svc, {:ensure => 'running'})
+      assert_service_status(agent, pidfile, true)
+      ensure_service_idempotent_on_host(agent, svc, {:ensure => 'running'})
+      assert_service_status(agent, pidfile, true)
+    end
+
+    step "Disable the service on #{agent}" do
+      ensure_service_change_on_host(agent, svc, {:enable => 'false'})
+      assert_service_status(agent, pidfile, true)
+      ensure_service_idempotent_on_host(agent, svc, {:enable => 'false'})
+      assert_service_status(agent, pidfile, true)
+    end
+
+    step "Stop the service on #{agent}" do
+      ensure_service_change_on_host(agent, svc, {:ensure => 'stopped'})
+      assert_service_status(agent, pidfile, false)
+      ensure_service_idempotent_on_host(agent, svc, {:ensure => 'stopped'})
+      assert_service_status(agent, pidfile, false)
+    end
+
+    step "Enable the service on #{agent}" do
+      ensure_service_change_on_host(agent, svc, {:enable => 'true'})
+      assert_service_status(agent, pidfile, false)
+      ensure_service_idempotent_on_host(agent, svc, {:enable => 'true'})
+      assert_service_status(agent, pidfile, false)
+    end
+
+    teardown do
+      on agent, "service #{svc} stop", :accept_any_exit_code => true
+      on agent, "chkconfig --del #{svc}"
+      on agent, "rm /usr/bin/#{svc} #{initd_location}"
+    end
+  end
+end


### PR DESCRIPTION
An acceptance test for managing init.d services on systems where the
systemd provider is the default. This doesn't work without PUP-2744,
which ensures the fallback on RedHat systems is the RedHat provider
- which works - instead of the init provider - which doesn't on RedHat.

It also helps verify that managing SysV init scripts continues to work
after a fix for PUP-5296/PUP-5825, where enabled status was reported
incorrectly.

[skip ci]