### PR TITLE
(MAINT) Disable 'add_el_extras' for Beaker

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -34,7 +34,7 @@ module HarnessOptions
     :xml => true,
     :timesync => false,
     :repo_proxy => true,
-    :add_el_extras => true,
+    :add_el_extras => false,
     :preserve_hosts => 'onfail',
     :forge_host => 'forge-aio01-petest.puppetlabs.com',
     :'master-start-curl-retries' => 30


### PR DESCRIPTION
Prior to this commit, we install and enable
an EPEL repo config during puppet acceptance
testing. However, we don't currently appear
to install any packages from EPEL during
testing.

To reduce potential occurrence of transient
failures in CI (due to issues with repo metadata,
etc), this commit sets 'add_el_extras' to
'false' so that Beaker doesn't set up the EPEL
repos on an SUT.