### PR TITLE
(PUP-6129) Add new function support to type alias

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2779,6 +2779,10 @@ class PTypeAliasType < PAnyType
     end
   end
 
+  def new_function(loader)
+    resolved_type.new_function(loader)
+  end
+
   private
 
   def guarded_recursion(guard, dflt)

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -522,4 +522,14 @@ describe 'the new function' do
     end
   end
 
+  context 'when invoked on a type alias' do
+    it 'delegates the new to the aliased type' do
+      expect(compile_to_catalog(<<-MANIFEST
+        type X = Boolean
+        $x = X.new('yes')
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Boolean, true]')
+    end
+  end
 end


### PR DESCRIPTION
Before this, it was not possible to create a new instance when using a
type alias. Now, calls to new delegate to the aliased type.