### PR TITLE
(maint) add provider name to 'provider must have feature' error message

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -521,7 +521,7 @@ class Puppet::Property < Puppet::Parameter
     if features = self.class.value_option(self.class.value_name(value), :required_features)
       features = Array(features)
       needed_features = features.collect { |f| f.to_s }.join(", ")
-      raise ArgumentError, "Provider must have features '#{needed_features}' to set '#{self.class.name}' to '#{value}'" unless provider.satisfies?(features)
+      raise ArgumentError, "Provider #{provider.class.name} must have features '#{needed_features}' to set '#{self.class.name}' to '#{value}'" unless provider.satisfies?(features)
     end
   end
 


### PR DESCRIPTION
knowing which provider was selected can be helpful in figuring out
why you're getting the 'Provider must have features...' message.