### PR TITLE
(PUP-6137) Change Object Type from anonymous to named

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -308,8 +308,7 @@ module Puppet::Functions
       # Add the loaded types to the builder
       aliases.local_types.each do |type_alias_expr|
         # Bind the type alias to the local_loader using the alias
-        typed_name, t = Puppet::Pops::Loader::TypeDefinitionInstantiator.create_from_model(type_alias_expr, aliases.loader)
-        aliases.loader.set_entry(typed_name, t, Puppet::Pops::Adapters::SourcePosAdapter.adapt(type_alias_expr).to_uri)
+        t = Puppet::Pops::Loader::TypeDefinitionInstantiator.create_from_model(type_alias_expr, aliases.loader)
 
         # Also define a method for convenient access to the defined type alias.
         # Since initial capital letter in Ruby means a Constant these names use a prefix of 

--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -264,8 +264,7 @@ class Puppet::Parser::AST::PopsBridge
       loader = Puppet::Pops::Loaders.find_loader(modname)
 
       # Bind the type alias to the loader using the alias
-      typed_name, t = Puppet::Pops::Loader::TypeDefinitionInstantiator.create_from_model(type_alias, loader)
-      loader.set_entry(typed_name, t, Puppet::Pops::Adapters::SourcePosAdapter.adapt(type_alias).to_uri)
+      Puppet::Pops::Loader::TypeDefinitionInstantiator.create_from_model(type_alias, loader)
 
       nil # do not want the type alias to inadvertently leak into 3x
     end

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -260,6 +260,15 @@ class AccessOperator
     end
   end
 
+  def access_PObjectType(o, scope, keys)
+    keys.flatten!
+    if keys.size == 1
+      Types::TypeFactory.object(keys[0])
+    else
+      fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic, {:base_type => 'Object-Type', :min => 1, :actual => keys.size})
+    end
+  end
+
   def access_PNotUndefType(o, scope, keys)
     keys.flatten!
     case keys.size

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -11,6 +11,7 @@ class PObjectType < PAnyType
   KEY_FINAL = 'final'.freeze
   KEY_FUNCTIONS = 'functions'.freeze
   KEY_KIND = 'kind'.freeze
+  KEY_NAME = 'name'.freeze
   KEY_OVERRIDE = 'override'.freeze
   KEY_PARENT = 'parent'.freeze
   KEY_TYPE = 'type'.freeze
@@ -25,6 +26,7 @@ class PObjectType < PAnyType
   TYPE_ANNOTATION_VALUE_TYPE = PStructType::DEFAULT #TBD
   TYPE_ANNOTATIONS = PHashType.new(TYPE_ANNOTATION_KEY_TYPE, TYPE_ANNOTATION_VALUE_TYPE)
 
+  TYPE_OBJECT_NAME = PPatternType.new([PRegexpType.new(Patterns::CLASSREF_EXT)])
   TYPE_MEMBER_NAME = PPatternType.new([PRegexpType.new(Patterns::PARAM_NAME)])
 
   TYPE_ATTRIBUTE = TypeFactory.struct({
@@ -52,6 +54,7 @@ class PObjectType < PAnyType
   TYPE_CHECKS = PAnyType::DEFAULT # TBD
 
   TYPE_OBJECT_I12N = TypeFactory.struct({
+    KEY_NAME => TypeFactory.optional(TYPE_OBJECT_NAME),
     KEY_PARENT => TypeFactory.optional(PType::DEFAULT),
     KEY_ATTRIBUTES => TypeFactory.optional(TYPE_ATTRIBUTES),
     KEY_FUNCTIONS => TypeFactory.optional(TYPE_FUNCTIONS),
@@ -273,6 +276,7 @@ class PObjectType < PAnyType
     end
   end
 
+  attr_reader :name
   attr_reader :parent
   attr_reader :attributes
   attr_reader :functions
@@ -280,19 +284,74 @@ class PObjectType < PAnyType
   attr_reader :checks
   attr_reader :annotations
 
-  # @param i12n_hash [Hash{String=>Object}] The hash describing the Object features
+  # Initialize an Object Type instance. The initialization will use either a name and an initialization
+  # hash expression, or a fully resolved initialization hash.
   #
-  # @api public
-  def initialize(i12n_hash)
-    TypeAsserter.assert_instance_of('object initializer', TYPE_OBJECT_I12N, i12n_hash)
-
+  # @overload initialize(name, i12n_hash_expression)
+  #   Used when the Object type is loaded using a type alias expression. When that happens, it is important that
+  #   the actual resolution of the expression is deferred until all definitions have been made known to the current
+  #   loader. The object will then be resolved when it is loaded by the {TypeParser}. "resolved" here, means that
+  #   the hash expression is fully resolved, and then passed to the {#initialize_from_hash} method.
+  #   @param name [String] The name of the object
+  #   @param i12n_hash_expression [Model::LiteralHash] The hash describing the Object features or the name of the Object
+  #
+  # @overload initialize(i12n_hash)
+  #   Used when the object is created by the {TypeFactory}. The i12n_hash must be fully resolved.
+  #   @param i12n_hash [Hash{String=>Object}] The hash describing the Object features or the name of the Object
+  #
+  # @api private
+  def initialize(name_or_i12n_hash, i12n_hash_expression = nil)
     @attributes = EMPTY_HASH
     @functions = EMPTY_HASH
+
+    if name_or_i12n_hash.is_a?(Hash)
+      initialize_from_hash(name_or_i12n_hash)
+    else
+      @name = TypeAsserter.assert_instance_of('object name', TYPE_OBJECT_NAME, name_or_i12n_hash)
+      @i12n_hash_expression = i12n_hash_expression
+    end
+  end
+
+  # Called from the TypeParser once it has found a type using the Loader. The TypeParser will
+  # interpret the contained expression and the resolved type is remembered. This method also
+  # checks and remembers if the resolve type contains self recursion.
+  #
+  # @param type_parser [TypeParser] type parser that will interpret the type expression
+  # @param loader [Loader::Loader] loader to use when loading type aliases
+  # @return [PTypeAliasType] the receiver of the call, i.e. `self`
+  # @api private
+  def resolve(type_parser, loader)
+    unless @i12n_hash_expression.nil?
+      @self_recursion = true # assumed while it being found out below
+
+      i12n_hash_expression = @i12n_hash_expression
+      @i12n_hash_expression = nil
+      initialize_from_hash(type_parser.interpret_LiteralHash(i12n_hash_expression, loader))
+
+      # Find out if this type is recursive. A recursive type has performance implications
+      # on several methods and this knowledge is used to avoid that for non-recursive
+      # types.
+      guard = RecursionGuard.new
+      accept(NoopTypeAcceptor::INSTANCE, guard)
+      @self_recursion = guard.recursive_this?(self)
+    end
+    self
+  end
+
+  # @api private
+  def initialize_from_hash(i12n_hash)
+    TypeAsserter.assert_instance_of('object initializer', TYPE_OBJECT_I12N, i12n_hash)
+
+    # Name given to the loader have higher precedence than a name declared in the type
+    @name ||= i12n_hash[KEY_NAME]
+    @name.freeze unless @name.nil?
+
     @parent = i12n_hash[KEY_PARENT]
 
     parent_members = EMPTY_HASH
     parent_object_type = nil
     unless @parent.nil?
+      check_self_recursion(self)
       rp = resolved_parent
       if rp.is_a?(PObjectType)
         parent_object_type = rp
@@ -355,8 +414,6 @@ class PObjectType < PAnyType
 
     @annotations = i12n_hash[KEY_ANNOTATIONS]
     @annotations.freeze unless @annotations.nil?
-
-    @hash = [parent, @attributes, @functions, @equality, @checks].hash
   end
 
   def [](name)
@@ -364,11 +421,13 @@ class PObjectType < PAnyType
   end
 
   def accept(visitor, guard)
-    super
-    @parent.accept(visitor, guard) unless parent.nil?
-    @attributes.values.each { |a| a.accept(visitor, guard) }
-    @functions.values.each { |f| f.accept(visitor, guard) }
-    @annotations.each_key { |key| key.accept(visitor, guard) } unless @annotations.nil?
+    guarded_recursion(guard, nil) do |g|
+      super(visitor, g)
+      @parent.accept(visitor, g) unless parent.nil?
+      @attributes.values.each { |a| a.accept(visitor, g) }
+      @functions.values.each { |f| f.accept(visitor, g) }
+      @annotations.each_key { |key| key.accept(visitor, g) } unless @annotations.nil?
+    end
   end
 
   def callable_args?(callable, guard)
@@ -382,6 +441,7 @@ class PObjectType < PAnyType
   # @api public
   def i12n_hash
     result = {}
+    result[KEY_NAME] = @name unless @name.nil?
     result[KEY_PARENT] = @parent unless @parent.nil?
     result[KEY_ATTRIBUTES] = compressed_members_hash(@attributes) unless @attributes.empty?
     result[KEY_FUNCTIONS] = compressed_members_hash(@functions) unless @functions.empty?
@@ -393,6 +453,7 @@ class PObjectType < PAnyType
 
   def eql?(o)
     self.class == o.class &&
+      @name == o.name &&
       @parent == o.parent &&
       @attributes == o.attributes &&
       @functions == o.functions &&
@@ -401,7 +462,7 @@ class PObjectType < PAnyType
   end
 
   def hash
-    @hash
+    @name.nil? ? [@parent, @attributes, @functions].hash : @name.hash
   end
 
   def kind_of_callable?(optional=true, guard = nil)
@@ -471,9 +532,22 @@ class PObjectType < PAnyType
   # @api private
   def check_self_recursion(originator)
     unless @parent.nil?
-      raise Puppet::Error, "The Object type aliased by '#{originator}' inherits from itself" if @parent.equal?(originator)
+      raise Puppet::Error, "The Object type '#{originator.label}' inherits from itself" if @parent.equal?(originator)
       @parent.check_self_recursion(originator)
     end
+  end
+
+  # Returns the expanded string the form of the alias, e.g. <alias name> = <resolved type>
+  #
+  # @return [String] the expanded form of this alias
+  # @api public
+  def to_s
+    TypeFormatter.singleton.alias_expanded_string(self)
+  end
+
+  # @api private
+  def label
+    @name || '<anonymous object type>'
   end
 
   protected
@@ -521,11 +595,6 @@ class PObjectType < PAnyType
     nil
   end
 
-  # @api private
-  def label
-    'object'
-  end
-
   private
 
   def compressed_members_hash(features)
@@ -537,6 +606,15 @@ class PObjectType < PAnyType
       end
       [feature.name, fh]
     end]
+  end
+
+  def guarded_recursion(guard, dflt)
+    if @self_recursion
+      guard ||= RecursionGuard.new
+      (guard.add_this(self) & RecursionGuard::SELF_RECURSION_IN_THIS) == 0 ? yield(guard) : dflt
+    else
+      yield(guard)
+    end
   end
 
   def resolved_parent

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -423,9 +423,13 @@ class PObjectType < PAnyType
             end
           end
 
-          raise Puppet::ParseError, "#{label} equality is referencing non existent attribute '#{attr_name}'" if attr.nil?
-          raise Puppet::ParseError, "#{label} equality is referencing #{attr.label}" unless attr.is_a?(PAttribute)
-          raise Puppet::ParseError, "#{label} equality is referencing constant #{attr.label}" if attr.kind == ATTRIBUTE_KIND_CONSTANT
+          unless attr.is_a?(PAttribute)
+            raise Puppet::ParseError, "#{label} equality is referencing non existent attribute '#{attr_name}'" if attr.nil?
+            raise Puppet::ParseError, "#{label} equality is referencing #{attr.label}. Only attribute references are allowed"
+          end
+          if attr.kind == ATTRIBUTE_KIND_CONSTANT
+            raise Puppet::ParseError, "#{label} equality is referencing constant #{attr.label}. Reference to constant is not allowed in equality"
+          end
         end
       end
       equality.freeze

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -214,7 +214,7 @@ module Types
 
   class ExtraneousKey < KeyMismatch
     def message(variant, position, tense = :present)
-      "#{variant}#{position} extraneous key '#{@key}'"
+      "#{variant}#{position} unrecognized key '#{@key}'"
     end
   end
 

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2747,6 +2747,9 @@ class PTypeAliasType < PAnyType
         @resolved_type = nil
         raise
       end
+    else
+      # An alias may appoint an Object type that isn't resolved yet.
+      @resolved_type.resolve(type_parser, loader)
     end
     self
   end
@@ -2757,7 +2760,7 @@ class PTypeAliasType < PAnyType
 
   def accept(visitor, guard)
     guarded_recursion(guard, nil) do |g|
-      super
+      super(visitor, g)
       resolved_type.accept(visitor, g)
     end
   end

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -1564,7 +1564,7 @@ describe Puppet::Parser::Compiler do
             define foo(Struct[{b => Integer, d=>String}] $a) { }
             foo{ bar: a => {b => 5, c => 'stuff'}}
           MANIFEST
-        end.to raise_error(/Foo\[bar\]:\s+parameter 'a' expects a value for key 'd'\s+parameter 'a' extraneous key 'c'/m)
+        end.to raise_error(/Foo\[bar\]:\s+parameter 'a' expects a value for key 'd'\s+parameter 'a' unrecognized key 'c'/m)
       end
     end
 

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -92,6 +92,6 @@ describe 'the assert_type function' do
       assert_type(Struct[{a=>Integer,b=>Boolean}], {a=>hej,x=>s})
     CODE
     expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error,
-      /entry 'a' expected an Integer value, got String.*expected a value for key 'b'.*extraneous key 'x'/m)
+      /entry 'a' expected an Integer value, got String.*expected a value for key 'b'.*unrecognized key 'x'/m)
   end
 end

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -28,7 +28,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /attribute 'a' had wrong type, expected a Type value, got Integer/)
+        /attribute MyObject\[a\] had wrong type, expected a Type value, got Integer/)
     end
 
     it 'raises an error if the type is missing' do
@@ -48,7 +48,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /attribute 'a' value had wrong type, expected an Integer value, got String/)
+        /attribute MyObject\[a\] value had wrong type, expected an Integer value, got String/)
     end
 
     it 'raises an error if the kind is invalid' do
@@ -98,7 +98,7 @@ describe 'The Object Type' do
           a => Integer
         }
       OBJECT
-      expect { tp['a'].value }.to raise_error(Puppet::Error, /attribute 'a' has no value/)
+      expect { tp['a'].value }.to raise_error(Puppet::Error, 'attribute MyObject[a] has no value')
     end
 
     context 'that are constants' do
@@ -125,7 +125,7 @@ describe 'The Object Type' do
           }
         OBJECT
         expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
-          /attribute 'a' of kind 'constant' requires a value/)
+          "attribute MyObject[a] of kind 'constant' requires a value")
       end
 
       it 'raises an error when final => false' do
@@ -139,7 +139,7 @@ describe 'The Object Type' do
           }
         OBJECT
         expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
-          /attribute 'a' of kind 'constant' cannot be combined with final => false/)
+          "attribute MyObject[a] of kind 'constant' cannot be combined with final => false")
       end
     end
   end
@@ -152,7 +152,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /function 'a' had wrong type, expected a Type\[Callable\] value, got Type\[String\]/)
+        /function MyObject\[a\] had wrong type, expected a Type\[Callable\] value, got Type\[String\]/)
     end
 
     it 'raises an error when a function has the same name as an attribute' do
@@ -165,7 +165,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
-        "function 'a' conflicts with attribute with the same name")
+        'function MyObject[a] conflicts with attribute with the same name')
     end
   end
 
@@ -201,7 +201,7 @@ describe 'The Object Type' do
       OBJECT
       parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
-        "function 'a' overrides inherited attribute")
+        'function MyDerivedObject[a] attempts to override attribute MyObject[a]')
     end
 
     it 'raises an error when the an function overrides an attribute' do
@@ -218,7 +218,7 @@ describe 'The Object Type' do
       OBJECT
       parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
-        "attribute 'a' overrides inherited function")
+        'attribute MyDerivedObject[a] attempts to override function MyObject[a]')
     end
 
     it 'raises an error on attempts to redefine inherited member to unassignable type' do
@@ -235,7 +235,7 @@ describe 'The Object Type' do
       OBJECT
       parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
-        "attempt to override attribute 'a' with a type that does not match")
+        'attribute MyDerivedObject[a] attempts to override attribute MyObject[a] with a type that does not match')
     end
 
     it 'raises an error when an attribute overrides a final attribute' do
@@ -252,7 +252,7 @@ describe 'The Object Type' do
       OBJECT
       parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
-        "attempt to override final attribute 'a'")
+        'attribute MyDerivedObject[a] attempts to override final attribute MyObject[a]')
     end
 
     it 'raises an error when an overriding attribute is not declared with override => true' do
@@ -269,7 +269,7 @@ describe 'The Object Type' do
       OBJECT
       parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
-        "attribute 'a' attempts to override without having override => true")
+        'attribute MyDerivedObject[a] attempts to override attribute MyObject[a] without having override => true')
     end
 
     it 'raises an error when an attribute declared with override => true does not override' do
@@ -286,7 +286,7 @@ describe 'The Object Type' do
       OBJECT
       parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
-        "expected attribute 'b' to override an inherited attribute, but no such attribute was found")
+        "expected attribute MyDerivedObject[b] to override an inherited attribute, but no such attribute was found")
     end
   end
 
@@ -432,7 +432,7 @@ describe 'The Object Type' do
       OBJECT
       parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
-        "equality is referencing attribute 'a' which is already included by parent equality")
+        "MyDerivedObject equality is referencing attribute MyObject[a] which is included in equality of MyObject")
     end
 
     it 'raises an error when equality references a constant attribute' do
@@ -444,7 +444,7 @@ describe 'The Object Type' do
         equality => [a,b]
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
-        "equality is referencing constant attribute 'b'")
+        "MyObject equality is referencing constant attribute MyObject[b]")
     end
 
     it 'raises an error when equality references a function' do
@@ -458,7 +458,7 @@ describe 'The Object Type' do
         equality => [a,b]
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
-        "equality is referencing function 'b'")
+        "MyObject equality is referencing function MyObject[b]")
     end
 
     it 'raises an error when equality references a non existent attributes' do
@@ -469,7 +469,7 @@ describe 'The Object Type' do
         equality => [a,b]
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
-        "equality is referencing non existent attribute 'b'")
+        "MyObject equality is referencing non existent attribute 'b'")
     end
 
     it 'raises an error when equality_include_type = false and attributes are provided' do
@@ -500,7 +500,7 @@ describe 'The Object Type' do
         a => { type => Integer, knid => constant }
       }
     OBJECT
-    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /initializer for attribute 'a' had wrong type, unrecognized key 'knid'/)
+    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /initializer for attribute MyObject\[a\] had wrong type, unrecognized key 'knid'/)
   end
 
   context 'when inheriting from a another Object type' do
@@ -689,7 +689,8 @@ describe 'The Object Type' do
       type MySecondObject = Object[{ parent => MyObject, attributes => { a => { type => Integer[10], override => true }}}]
       notice(MySecondObject =~ Type)
       CODE
-      expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /attempt to override final attribute 'a'/)
+      expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error,
+        /attribute MySecondObject\[a\] attempts to override final attribute MyObject\[a\]/)
     end
 
     it 'raises an error when object when circular inheritance is detected' do

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -10,17 +10,13 @@ describe 'The Object Type' do
   let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, 'type_parser_unit_test_loader') }
 
   def type_object_t(name, body_string)
-    TypeFactory.type_alias(name, pp_parser.parse_string("Object[{#{body_string}}]").current)
-  end
-
-  def expect_object(name, body_string)
-    obj = type_object_t(name, body_string)
-    loader.expects(:load).with(:type, name.downcase).at_least_once.returns obj
-    obj
+    object = PObjectType.new(name, pp_parser.parse_string("{#{body_string}}").current.body)
+    loader.set_entry(Loader::Loader::TypedName.new(:type, name.downcase), object)
+    object
   end
 
   def parse_object(name, body_string)
-    expect_object(name, body_string)
+    type_object_t(name, body_string)
     parser.parse(name, loader)
   end
 
@@ -186,7 +182,7 @@ describe 'The Object Type' do
           a => { type => Integer[0,10], override => true }
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       tp = parse_object('MyDerivedObject', obj)
       expect(tp['a'].type).to eql(PIntegerType.new(0,10))
     end
@@ -203,7 +199,7 @@ describe 'The Object Type' do
           a => { type => Callable, override => true }
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
         "function 'a' overrides inherited attribute")
     end
@@ -220,7 +216,7 @@ describe 'The Object Type' do
           a => { type => Integer, override => true }
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
         "attribute 'a' overrides inherited function")
     end
@@ -237,7 +233,7 @@ describe 'The Object Type' do
           a => { type => String, override => true }
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
         "attempt to override attribute 'a' with a type that does not match")
     end
@@ -254,7 +250,7 @@ describe 'The Object Type' do
           a => { type => Integer, override => true }
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
         "attempt to override final attribute 'a'")
     end
@@ -271,7 +267,7 @@ describe 'The Object Type' do
           a => Integer
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
         "attribute 'a' attempts to override without having override => true")
     end
@@ -288,7 +284,7 @@ describe 'The Object Type' do
           b => { type => Integer, override => true }
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
         "expected attribute 'b' to override an inherited attribute, but no such attribute was found")
     end
@@ -370,7 +366,7 @@ describe 'The Object Type' do
           d => Integer
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       tp = parse_object('MyDerivedObject', obj)
       expect(tp.equality).to be_nil
       expect(tp.equality_attributes.keys).to eq(['a','b','c','d'])
@@ -391,7 +387,7 @@ describe 'The Object Type' do
           d => Integer
         }
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       tp = parse_object('MyDerivedObject', obj)
       expect(tp.equality).to be_nil
       expect(tp.equality_attributes.keys).to eq(['a','c','d'])
@@ -413,7 +409,7 @@ describe 'The Object Type' do
         },
         equality => [b,c]
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       tp = parse_object('MyDerivedObject', obj)
       expect(tp.equality).to eq(['b','c'])
       expect(tp.equality_attributes.keys).to eq(['a','b','c'])
@@ -434,7 +430,7 @@ describe 'The Object Type' do
         },
         equality => a
       OBJECT
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       expect { parse_object('MyDerivedObject', obj) }.to raise_error(Puppet::ParseError,
         "equality is referencing attribute 'a' which is already included by parent equality")
     end
@@ -490,21 +486,21 @@ describe 'The Object Type' do
   end
 
   it 'raises an error when initialization hash contains invalid keys' do
-    expect_object('MyObject', <<-OBJECT)
+    obj = <<-OBJECT
       attribrutes => {
         a => Integer
       }
     OBJECT
-    expect { parser.parse('MyObject', loader) }.to raise_error(TypeAssertionError, /object initializer had wrong type, extraneous key 'attribrutes'/)
+    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /object initializer had wrong type, extraneous key 'attribrutes'/)
   end
 
   it 'raises an error when attribute contains invalid keys' do
-    expect_object('MyObject', <<-OBJECT)
+    obj = <<-OBJECT
       attributes => {
         a => { type => Integer, knid => constant }
       }
     OBJECT
-    expect { parser.parse('MyObject', loader) }.to raise_error(TypeAssertionError, /initializer for attribute 'a' had wrong type, extraneous key 'knid'/)
+    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /initializer for attribute 'a' had wrong type, extraneous key 'knid'/)
   end
 
   context 'when inheriting from a another Object type' do
@@ -526,7 +522,7 @@ describe 'The Object Type' do
     OBJECT
 
     it 'includes the inherited type and its members' do
-      expect_object('MyObject', parent)
+      parse_object('MyObject', parent)
       t = parse_object('MyDerivedObject', derived)
       members = t.members.values
       expect{ |b| members.each {|m| m.name.tap(&b) }}.to yield_successive_args('c', 'd')
@@ -537,23 +533,15 @@ describe 'The Object Type' do
     end
 
     it 'is assignable to its inherited type' do
-      p = expect_object('MyObject', parent)
+      p = parse_object('MyObject', parent)
       t = parse_object('MyDerivedObject', derived)
       expect(p).to be_assignable(t)
     end
 
     it 'does not consider inherited type to be assignable' do
-      p = expect_object('MyObject', parent)
+      p = parse_object('MyObject', parent)
       d = parse_object('MyDerivedObject', derived)
       expect(d).not_to be_assignable(p)
-    end
-
-    it 'raises an error when object when circular inheritance is detected' do
-      obj = <<-OBJECT
-        parent => MyDerivedObject
-      OBJECT
-      expect_object('MyDerivedObject', derived)
-      expect { parse_object('MyObject', obj) }.to raise_error(Puppet::Error, /inherits from itself/)
     end
 
     context 'that in turn inherits another Object type' do
@@ -566,16 +554,16 @@ describe 'The Object Type' do
       OBJECT
 
       it 'is assignable to all inherited types' do
-        p = expect_object('MyObject', parent)
-        d1 = expect_object('MyDerivedObject', derived)
+        p = parse_object('MyObject', parent)
+        d1 = parse_object('MyDerivedObject', derived)
         d2 = parse_object('MyDerivedObject2', derived2)
         expect(p).to be_assignable(d2)
         expect(d1).to be_assignable(d2)
       end
 
       it 'does not consider any of the inherited types to be assignable' do
-        p = expect_object('MyObject', parent)
-        d1 = expect_object('MyDerivedObject', derived)
+        p = parse_object('MyObject', parent)
+        d1 = parse_object('MyDerivedObject', derived)
         d2 = parse_object('MyDerivedObject2', derived2)
         expect(d2).not_to be_assignable(p)
         expect(d2).not_to be_assignable(d1)
@@ -605,26 +593,26 @@ describe 'The Object Type' do
 
   context 'when using the initialization hash' do
     it 'produced hash that contains features using short form (type instead of detailed hash when only type is declared)' do
-      obj = t = parse_object('MyObject', <<-OBJECT).resolved_type
+      obj = t = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Integer }
         }
       OBJECT
-      expect(TypeFormatter.string(obj)).to eql("Object[{attributes => {'a' => Integer}}]")
+      expect(obj.to_s).to eql("Object[{name => 'MyObject', attributes => {'a' => Integer}}]")
     end
 
     it 'produced hash that does not include defaults' do
-      obj = t = parse_object('MyObject', <<-OBJECT).resolved_type
+      obj = t = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Integer, value => 23, kind => constant, final => true },
         },
         equality_include_type => true
       OBJECT
-      expect(TypeFormatter.string(obj)).to eql("Object[{attributes => {'a' => {type => Integer, kind => constant, value => 23}}}]")
+      expect(obj.to_s).to eql("Object[{name => 'MyObject', attributes => {'a' => {type => Integer, kind => constant, value => 23}}}]")
     end
 
     it 'can create an equal copy from produced hash' do
-      obj = t = parse_object('MyObject', <<-OBJECT).resolved_type
+      obj = t = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Struct[{x => Integer, y => Integer}], value => {x => 4, y => 9}, kind => constant },
           b => Integer
@@ -642,11 +630,11 @@ describe 'The Object Type' do
   context 'when used in Puppet expressions' do
     include PuppetSpec::Compiler
 
-    it 'two empty objects are equal' do
+    it 'two anonymous empty objects are equal' do
       code = <<-CODE
-      type MyFirstObject = Object[{}]
-      type MySecondObject = Object[{}]
-      notice(MyFirstObject == MySecondObject)
+      $x = Object[{}]
+      $y = Object[{}]
+      notice($x == $y)
       CODE
       expect(eval_and_collect_notices(code)).to eql(['true'])
     end
@@ -660,12 +648,12 @@ describe 'The Object Type' do
       expect(eval_and_collect_notices(code)).to eql(['false'])
     end
 
-    it 'two objects that inherits the same parent are equal' do
+    it 'two anonymous objects that inherits the same parent are equal' do
       code = <<-CODE
       type MyFirstObject = Object[{}]
-      type MySecondObject = Object[{ parent => MyFirstObject }]
-      type MyThirdObject = Object[{ parent => MyFirstObject }]
-      notice(MySecondObject == MyThirdObject)
+      $x = Object[{ parent => MyFirstObject }]
+      $y = Object[{ parent => MyFirstObject }]
+      notice($x == $y)
       CODE
       expect(eval_and_collect_notices(code)).to eql(['true'])
     end
@@ -685,6 +673,36 @@ describe 'The Object Type' do
       notice(MySecondObject =~ Type[MyFirstObject])
       CODE
       expect(eval_and_collect_notices(code)).to eql(['true'])
+    end
+
+    it 'a named object is not added to the loader unless a type <name> = <definition> is made' do
+      code = <<-CODE
+      $x = Object[{ name => 'MyFirstObject' }]
+      notice($x == MyFirstObject)
+      CODE
+      expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Resource type not found: MyFirstObject/)
+    end
+
+    it 'a type alias on a named object overrides the name' do
+      code = <<-CODE
+      type MyObject = Object[{ name => 'MyFirstObject', attributes => { a => { type => Integer, final => true }}}]
+      type MySecondObject = Object[{ parent => MyObject, attributes => { a => { type => Integer[10], override => true }}}]
+      notice(MySecondObject =~ Type)
+      CODE
+      expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /attempt to override final attribute 'a'/)
+    end
+
+    it 'raises an error when object when circular inheritance is detected' do
+      code = <<-CODE
+      type MyFirstObject = Object[{
+        parent => MySecondObject
+      }]
+      type MySecondObject = Object[{
+        parent => MyFirstObject
+      }]
+      notice(MySecondObject =~ Type[MyFirstObject])
+      CODE
+      expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /inherits from itself/)
     end
 
     it 'notices the expanded string form expected content' do
@@ -720,7 +738,8 @@ describe 'The Object Type' do
       notice(MySecondObject)
       CODE
       expect(eval_and_collect_notices(code)).to eql([
-        "MyFirstObject = Object[{"+
+        "Object[{"+
+          "name => 'MyFirstObject', "+
           "attributes => {"+
           "'first_a' => Integer, "+
           "'first_b' => {type => String, kind => constant, value => 'the first constant'}, "+
@@ -734,7 +753,8 @@ describe 'The Object Type' do
           "}, "+
           "equality => [first_a]"+
           "}]",
-        "MySecondObject = Object[{"+
+        "Object[{"+
+          "name => 'MySecondObject', "+
           "parent => MyFirstObject, "+
           "attributes => {"+
           "'second_a' => Integer, "+

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -491,7 +491,7 @@ describe 'The Object Type' do
         a => Integer
       }
     OBJECT
-    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /object initializer had wrong type, extraneous key 'attribrutes'/)
+    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /object initializer had wrong type, unrecognized key 'attribrutes'/)
   end
 
   it 'raises an error when attribute contains invalid keys' do
@@ -500,7 +500,7 @@ describe 'The Object Type' do
         a => { type => Integer, knid => constant }
       }
     OBJECT
-    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /initializer for attribute 'a' had wrong type, extraneous key 'knid'/)
+    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /initializer for attribute 'a' had wrong type, unrecognized key 'knid'/)
   end
 
   context 'when inheriting from a another Object type' do

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -444,7 +444,7 @@ describe 'The Object Type' do
         equality => [a,b]
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
-        "MyObject equality is referencing constant attribute MyObject[b]")
+        'MyObject equality is referencing constant attribute MyObject[b]. Reference to constant is not allowed in equality')
     end
 
     it 'raises an error when equality references a function' do
@@ -458,7 +458,7 @@ describe 'The Object Type' do
         equality => [a,b]
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
-        "MyObject equality is referencing function MyObject[b]")
+        'MyObject equality is referencing function MyObject[b]. Only attribute references are allowed')
     end
 
     it 'raises an error when equality references a non existent attributes' do


### PR DESCRIPTION
This PR adds one commit to change the Object type from being anonymous to being named, and one commit that leverages this to make feature related errors more descriptive.