### PR TITLE
(maint) Use service helper for launchd and AIX tests

### DIFF
--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -15,38 +15,61 @@ module Puppet
         suitable == "true" ? true : false
       end
 
-      # Alter the state of a service using puppet apply.
+      # Alter the state of a service using puppet apply. Can set 'ensure' and 'enable'.
       # @param host [String] hostname.
       # @param service [String] name of the service.
-      # @param property [String] name of the attribute to be changed.
-      # @param value [String] value which the property should be set.
+      # @param status [Hash] properties to set - can include 'ensure' and 'enable' keys.
+      # @param block [Proc] optional: block to verify service state
       # @return None
-      def ensure_service_on_host(host, service, property, value)
+      def ensure_service_on_host(host, service, status, &block)
+        ensure_status = "ensure => '#{status[:ensure]}'," if status[:ensure]
+        enable_status = "enable => '#{status[:enable]}'," if status[:enable]
         manifest = %Q{
           service { '#{service}':
-            #{property} => '#{value}'
+            #{ensure_status}
+            #{enable_status}
           }
         }
+
         # the process of creating the service will also start it
         # to avoid a flickering test from the race condition, this test will ensure
         # that the exit code is either
         #   2 => something changed, or
         #   0 => no change needed
         on host, puppet_apply(['--detailed-exitcodes', '--verbose']),
-          {:stdin => manifest, :acceptable_exit_codes => [0, 2]}
+          {:stdin => manifest, :acceptable_exit_codes => [0, 2]} do
+            assert_match(/Service\[#{service}\]\/ensure: ensure changed '\w+' to '#{status[:ensure]}'/, stdout, 'Service status change failed') if status[:ensure]
+            assert_match(/Service\[#{service}\]\/enable: enable changed '\w+' to '#{status[:enable]}'/, stdout, 'Service enable change failed') if status[:enable]
+        end
+
+        assert_service_status_on_host(host, service, status, &block)
+
         # ensure idempotency
-        on host, puppet_apply(['--detailed-exitcodes', '--verbose']),
-          {:stdin => manifest, :acceptable_exit_codes => [0]}
+        apply_manifest_on host, "service { '#{service}': #{ensure_status} #{enable_status} }" do
+          assert_no_match(/Service\[#{service}\]\/ensure/, stdout, 'Service status not idempotent') if status[:ensure]
+          assert_no_match(/Service\[#{service}\]\/enable/, stdout, 'Service enable not idempotent') if status[:enable]
+        end
+
+        assert_service_status_on_host(host, service, status, &block)
       end
 
-      # Checks that the status of a service is as expected.
+      # Checks that the ensure and/or enable status of a service are as expected.
       # @param host [String] hostname.
       # @param service [String] name of the service.
-      # @param expected_status [String] expected service status.
+      # @param status [Hash] properties to set - can include 'ensure' and 'enable' keys.
+      # @param block [Proc] optional: block to verify service state
       # @return None
-      def assert_service_status_on_host(host, service, expected_status)
-        on(host, puppet_resource('service', service)) do
-          assert_match(/ensure => '#{expected_status}'/, stdout, "Expected service #{service} to have ensure => #{expected_status}")
+      def assert_service_status_on_host(host, service, status, &block)
+        ensure_status = "ensure => '#{status[:ensure]}'" if status[:ensure]
+        enable_status = "enable => '#{status[:enable]}'" if status[:enable]
+
+        on host, puppet_resource('service', service) do
+          assert_match(/'#{service}'.+#{ensure_status}.+#{enable_status}/m, stdout, "Service status does not match expectation #{status}")
+        end
+
+        # Verify service state on the system using a custom block
+        if block
+          yield block
         end
       end
 

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -2,6 +2,9 @@ test_name 'Mac OS X launchd Provider Testing'
 
 confine :to, {:platform => /osx/}, agents
 
+require 'puppet/acceptance/service_utils'
+extend Puppet::Acceptance::ServiceUtils
+
 sloth_daemon_script = <<SCRIPT
 #!/usr/bin/env sh
 while true; do sleep 1; done
@@ -10,14 +13,7 @@ SCRIPT
 svc = 'com.puppetlabs.sloth'
 launchd_script_path = "/Library/LaunchDaemons/#{svc}.plist"
 
-def assert_service_status_on(host, service, status, expect_running)
-  ensure_status = "ensure => '#{status[:ensure]}'" if status[:ensure]
-  enable_status = "enable => '#{status[:enable]}'" if status[:enable]
-
-  on host, puppet_resource('service', service) do
-    assert_match(/'#{service}'.+#{ensure_status}.+#{enable_status}/m, stdout, "Service status does not match expectation #{status}")
-  end
-
+def launchctl_assert_status(host, service, expect_running)
   on host, 'launchctl list' do
     if expect_running
       assert_match(/#{service}/, stdout, 'Service was not found in launchctl list')
@@ -25,26 +21,6 @@ def assert_service_status_on(host, service, status, expect_running)
       assert_no_match(/#{service}/, stdout, 'Service was not expected in launchctl list')
     end
   end
-end
-
-def ensure_service_on(host, service, status, expect_running)
-  ensure_status = "ensure => '#{status[:ensure]}'," if status[:ensure]
-  enable_status = "enable => '#{status[:enable]}'," if status[:enable]
-
-  apply_manifest_on host, "service { '#{service}': provider => launchd, #{ensure_status} #{enable_status} }" do
-    assert_match(/Service\[#{service}\]\/ensure: ensure changed '\w+' to '#{status[:ensure]}'/, stdout,
-                 'Service status change failed') if status[:ensure]
-    assert_match(/Service\[#{service}\]\/enable: enable changed '\w+' to '#{status[:enable]}'/, stdout,
-                 'Service enable change failed') if status[:enable]
-  end
-  assert_service_status_on host, service, status, expect_running
-
-  # Ensure idempotency
-  apply_manifest_on host, "service { '#{service}': provider => launchd, #{ensure_status} #{enable_status} }" do
-    assert_no_match(/Service\[#{service}\]\/ensure/, stdout, 'Service status not idempotent') if status[:ensure]
-    assert_no_match(/Service\[#{service}\]\/enable/, stdout, 'Service enable not idempotent') if status[:enable]
-  end
-  assert_service_status_on host, service, status, expect_running
 end
 
 agents.each do |agent|
@@ -69,22 +45,32 @@ SCRIPT
   create_remote_file(agent, launchd_script_path, launchd_script)
 
   teardown do
+    on agent, puppet_resource('service', 'com.puppetlabs.sloth', 'ensure=stopped', 'enable=true')
     on agent, "rm #{sloth_daemon_path} #{launchd_script_path}"
   end
 
   step "Verify the service exists on #{agent}"
-  assert_service_status_on(agent, svc, {:ensure => 'stopped', :enable => 'true'}, false)
+  assert_service_status_on_host(agent, svc, {:ensure => 'stopped', :enable => 'true'}) do
+    launchctl_assert_status(agent, svc, false)
+  end
 
   step "Start the service on #{agent}"
-  ensure_service_on(agent, svc, {:ensure => 'running'}, true)
+  ensure_service_on_host(agent, svc, {:ensure => 'running'}) do
+    launchctl_assert_status(agent, svc, true)
+  end
 
   step "Disable the service on #{agent}"
-  ensure_service_on(agent, svc, {:enable => 'false'}, true)
+  ensure_service_on_host(agent, svc, {:enable => 'false'}) do
+    launchctl_assert_status(agent, svc, true)
+  end
 
   step "Stop the service on #{agent}"
-  ensure_service_on(agent, svc, {:ensure => 'stopped'}, false)
+  ensure_service_on_host(agent, svc, {:ensure => 'stopped'}) do
+    launchctl_assert_status(agent, svc, false)
+  end
 
   step "Enable the service on #{agent}"
-  ensure_service_on(agent, svc, {:enable => 'true'}, false)
+  ensure_service_on_host(agent, svc, {:enable => 'true'}) do
+    launchctl_assert_status(agent, svc, false)
+  end
 end
-

--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -17,8 +17,7 @@ extend Puppet::Acceptance::ServiceUtils
 # Set service status before running other 'ensure' operations on it
 def set_service_initial_status(host, service, status)
   step "Establishing precondition: #{service}: ensure => #{status}"
-  ensure_service_on_host(host, service, 'ensure', status)
-  assert_service_status_on_host(host, service, status)
+  ensure_service_on_host(host, service, {'ensure' => status})
 end
 
 # We want to test Puppet and Mcollective in the following conditions:
@@ -27,35 +26,32 @@ end
 agents.each do |agent|
 
   ['puppet', 'mcollective'].each do |service|
+    # --- service management using `puppet apply` --- #
+    step "#{service} service management using `puppet apply`"
+    set_service_initial_status(agent, service, 'stopped')
+    step "Starting the #{service} service: it should be running"
+    ensure_service_on_host(agent, service, {'ensure' => 'running'})
+
+    step "Stopping the #{service} service: it should be stopped"
+    ensure_service_on_host(agent, service, {'ensure' => 'stopped'})
+
     ['stopped', 'running'].each do |status|
-      # --- service management using `puppet apply` --- #
-      step "#{service} service management using `puppet apply`"
-      step "Starting the #{service} service while it is #{status}: it should be running"
-      set_service_initial_status(agent, service, status)
-      ensure_service_on_host(agent, service, 'ensure', 'running')
-      assert_service_status_on_host(agent, service, 'running') # Status should always be 'running' after starting
-
-      step "Stopping the #{service} service while it is #{status}: it should be stopped"
-      set_service_initial_status(agent, service, status)
-      ensure_service_on_host(agent, service, 'ensure', 'stopped')
-      assert_service_status_on_host(agent, service, 'stopped') # Status should always be 'stopped' after stopping
-
       step "Refreshing the #{service} service while it is #{status}: it should be #{status}"
       set_service_initial_status(agent, service, status)
       refresh_service_on_host(agent, service)
-      assert_service_status_on_host(agent, service, status) # Status should not change after refresh
+      assert_service_status_on_host(agent, service, {'ensure' => status}) # Status should not change after refresh
 
       # --- service management using `puppet resource` --- #
       step "#{service} service management using `puppet resource`"
       step "Starting the #{service} service while it is #{status}: it should be running"
       set_service_initial_status(agent, service, status)
       on(agent, puppet_resource('service', service, 'ensure=running'))
-      assert_service_status_on_host(agent, service, 'running') # Status should always be 'running' after starting
+      assert_service_status_on_host(agent, service, {'ensure' => 'running'}) # Status should always be 'running' after starting
 
       step "Stopping the #{service} service while it is #{status}: it should be stopped"
       set_service_initial_status(agent, service, status)
       on(agent, puppet_resource('service', service, 'ensure=stopped'))
-      assert_service_status_on_host(agent, service, 'stopped') # Status should always be 'stopped' after stopping
+      assert_service_status_on_host(agent, service, {'ensure' => 'stopped'}) # Status should always be 'stopped' after stopping
     end
   end
 end


### PR DESCRIPTION
This commit updates the service_utils helper to more robustly
test services being started, stopped, enabled and disabled. In
addition, the launchd and AIX service tests have been updated
to use the helper rather than reimplement its methods.

[skip-ci]