### PR TITLE
(PUP-1526) Add environment settings for package type

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -242,6 +242,8 @@ class Puppet::Provider
       @optional = false
       @confiner = confiner
       @custom_environment = {}
+      @command_resolver = Puppet::Util
+      @command_executor = Puppet::Util::Execution
     end
 
     def is_optional
@@ -252,12 +254,20 @@ class Puppet::Provider
       @custom_environment = @custom_environment.merge(env)
     end
 
+    def resolver(res)
+      @command_resolver = res
+    end
+
+    def executor(exec)
+      @command_executor = exec
+    end
+
     def command
       if not @optional
         @confiner.confine :exists => @path, :for_binary => true
       end
 
-      Puppet::Provider::Command.new(@name, @path, Puppet::Util, Puppet::Util::Execution, { :failonfail => true, :combine => true, :custom_environment => @custom_environment })
+      Puppet::Provider::Command.new(@name, @path, @command_resolver, @command_executor, { :failonfail => true, :combine => true, :custom_environment => @custom_environment })
     end
   end
 

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -25,14 +25,6 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
   defaultfor :osfamily => :redhat
 
-  def execute(*args)
-    if @resource and @resource[:environment]
-      Puppet::Util::Execution.execute(*args, :custom_environment => @resource[:environment])
-    else
-      Puppet::Util::Execution.execute(*args)
-    end
-  end
-
   def self.prefetch(packages)
     raise Puppet::Error, "The yum provider can only be used as root" if Process.euid != 0
     super

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -33,6 +33,7 @@ describe provider_class do
     it { is_expected.to be_versionable }
     it { is_expected.to be_install_options }
     it { is_expected.to be_virtual_packages }
+    it { is_expected.to be_settable_environment }
   end
 
   # provider should repond to the following methods
@@ -242,6 +243,14 @@ describe provider_class do
       provider.install
     end
 
+    it 'should accept environment settings' do
+      resource[:ensure] = :installed
+      resource[:environment] = { 'foo' => 'bar' }
+
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, name], :custom_environment => { 'foo' => 'bar' })
+      provider.install
+    end
+
     it 'allow virtual packages' do
       resource[:ensure] = :installed
       resource[:allow_virtual] = true
@@ -271,7 +280,7 @@ describe provider_class do
       ]
       provider.stubs(:properties).returns({:ensure => '3.4.5'})
 
-      described_class.expects(:latest_package_version).with(name, ['contrib', 'centosplus'], [], [])
+      described_class.expects(:latest_package_version).with(name, ['contrib', 'centosplus'], [], [], nil)
       provider.latest
     end
 
@@ -282,7 +291,7 @@ describe provider_class do
       ]
       provider.stubs(:properties).returns({:ensure => '3.4.5'})
 
-      described_class.expects(:latest_package_version).with(name, [], ['updates', 'centosplus'], [])
+      described_class.expects(:latest_package_version).with(name, [], ['updates', 'centosplus'], [], nil)
       provider.latest
     end
 
@@ -293,13 +302,13 @@ describe provider_class do
       ]
       provider.stubs(:properties).returns({:ensure => '3.4.5'})
 
-      described_class.expects(:latest_package_version).with(name, [], [], ['main', 'centosplus'])
+      described_class.expects(:latest_package_version).with(name, [], [], ['main', 'centosplus'], nil)
       provider.latest
     end
 
     describe 'and a newer version is not available' do
       before :each do
-        described_class.stubs(:latest_package_version).with(name, [], [], []).returns nil
+        described_class.stubs(:latest_package_version).with(name, [], [], [], nil).returns nil
       end
 
       it 'raises an error the package is not installed' do
@@ -327,7 +336,7 @@ describe provider_class do
       end
 
       it 'includes the epoch in the version string' do
-        described_class.stubs(:latest_package_version).with(name, [], [], []).returns(latest_version)
+        described_class.stubs(:latest_package_version).with(name, [], [], [], nil).returns(latest_version)
         expect(provider.latest).to eq('1:2.3.4-5')
       end
     end
@@ -361,19 +370,19 @@ describe provider_class do
     let(:enabled_versions) { {name => [mypackage_newerversion]} }
 
     it "returns the version hash if the package was found" do
-      described_class.expects(:check_updates).with([], [], []).once.returns(latest_versions)
+      described_class.expects(:check_updates).with([], [], [], nil).once.returns(latest_versions)
       version = described_class.latest_package_version(name, [], [], [])
       expect(version).to eq(mypackage_version)
     end
 
     it "is nil if the package was not found in the query" do
-      described_class.expects(:check_updates).with([], [], []).once.returns(latest_versions)
+      described_class.expects(:check_updates).with([], [], [], nil).once.returns(latest_versions)
       version = described_class.latest_package_version('nopackage', [], [], [])
       expect(version).to be_nil
     end
 
     it "caches the package list and reuses that for subsequent queries" do
-      described_class.expects(:check_updates).with([], [], []).once.returns(latest_versions)
+      described_class.expects(:check_updates).with([], [], [], nil).once.returns(latest_versions)
 
       2.times {
         version = described_class.latest_package_version(name, [], [], [])
@@ -382,8 +391,8 @@ describe provider_class do
     end
 
     it "caches separate lists for each combination of 'enablerepo' and 'disablerepo' and 'disableexcludes'" do
-      described_class.expects(:check_updates).with([], [], []).once.returns(latest_versions)
-      described_class.expects(:check_updates).with(['enabled'], ['disabled'], ['disableexcludes']).once.returns(enabled_versions)
+      described_class.expects(:check_updates).with([], [], [], nil).once.returns(latest_versions)
+      described_class.expects(:check_updates).with(['enabled'], ['disabled'], ['disableexcludes'], nil).once.returns(enabled_versions)
 
       2.times {
         version = described_class.latest_package_version(name, [], [], [])

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -35,13 +35,17 @@ describe Puppet::Type.type(:package) do
     expect(Puppet::Type.type(:package).provider_feature(:package_settings).methods).to eq([:package_settings_insync?, :package_settings, :package_settings=])
   end
 
+  it "should have a :settable_environment feature" do
+    expect(Puppet::Type.type(:package).provider_feature(:settable_environment)).not_to be_nil
+  end
+
   it "should default to being installed" do
     pkg = Puppet::Type.type(:package).new(:name => "yay", :provider => :apt)
     expect(pkg.should(:ensure)).to eq(:present)
   end
 
   describe "when validating attributes" do
-    [:name, :source, :instance, :status, :adminfile, :responsefile, :configfiles, :category, :platform, :root, :vendor, :description, :allowcdrom, :allow_virtual, :reinstall_on_refresh].each do |param|
+    [:name, :source, :instance, :status, :adminfile, :responsefile, :configfiles, :category, :platform, :root, :vendor, :description, :allowcdrom, :allow_virtual, :reinstall_on_refresh, :environment].each do |param|
       it "should have a #{param} parameter" do
         expect(Puppet::Type.type(:package).attrtype(param)).to eq(:param)
       end
@@ -123,6 +127,69 @@ describe Puppet::Type.type(:package) do
         Puppet::Type.type(:package).new(:name => ["error"])
       end.to raise_error(Puppet::ResourceError, /Name must be a String/)
     end
+
+    it "should support :environment if the provider has the :settable_environment feature" do
+      @provider.expects(:satisfies?).with([:settable_environment]).returns(true)
+      expect { Puppet::Type.type(:package).new(:name => "yay", :environment => { "foo" => "bar" }) }.to_not raise_error
+    end
+
+    it "should not support :environment if the provider does not have the :settable_environment feature" do
+      @provider.expects(:satisfies?).with([:settable_environment]).returns(false)
+      expect { Puppet::Type.type(:package).new(:name => "yay", :environment => { "foo" => "bar" }) }.to raise_error(Puppet::Error)
+    end
+
+    it "should support :environment hashes of strings to strings" do
+      @provider.expects(:satisfies?).with([:settable_environment]).returns(true)
+      pkg = Puppet::Type.type(:package).new(:name => "yay", :environment => { "foo" => "bar" })
+      expect(pkg[:environment]).to eq({ "foo" => "bar" })
+    end
+
+    it "should support :environment hashes of strings to `undef`" do
+      @provider.expects(:satisfies?).with([:settable_environment]).returns(true)
+      pkg = Puppet::Type.type(:package).new(:name => "yay", :environment => { "foo" => :undef })
+      expect(pkg[:environment]).to eq({ "foo" => nil })
+    end
+
+    it "should not support :environment hashes with empty strings" do
+      samples = [
+        { "foo" => "" } ,
+        { "" => "bar" } ,
+      ]
+      samples.each do |env|
+        @provider.expects(:satisfies?).with([:settable_environment]).returns(true)
+        expect { Puppet::Type.type(:package).new(:name => "yay", :environment => env) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    it "should not support :environment hashes with undef keys" do
+      @provider.expects(:satisfies?).with([:settable_environment]).returns(true)
+      expect { Puppet::Type.type(:package).new(:name => "yay", :environment => { :undef => "bar" }) }.to raise_error(Puppet::Error)
+    end
+
+    it "should not support :environment hashes with non-string keys or values" do
+      samples = [
+        { "foo" => 2 } ,
+        { "foo" => [2] } ,
+        { "foo" => {2=>2} } ,
+        { 1 => "bar" } ,
+        { 1 => 2 } ,
+        { 1 => [2] } ,
+        { 1 => {2=>2} } ,
+        { [1] => "bar" } ,
+        { [1] => 2 } ,
+        { [1] => [2] } ,
+        { [1] => {2=>2} } ,
+        { {1=>1} => "bar" } ,
+        { {1=>1} => 2 } ,
+        { {1=>1} => [2] } ,
+        { {1=>1} => {2=>2} } ,
+      ]
+      samples.each do |env|
+        @provider.expects(:satisfies?).with([:settable_environment]).returns(true)
+        expect { Puppet::Type.type(:package).new(:name => "yay", :environment => env) }.to raise_error(Puppet::Error)
+      end
+    end
+
   end
 
   module PackageEvaluationTesting


### PR DESCRIPTION
This patch adds to the package type the `:settable_environment` feature
and the `:environment` parameter used by that feature.  `:environment`
is a hash of key=>value pairs; keys must be non-empty strings, and
values must either be `undef` or non-empty strings.  `undef` values are
translated to ruby `nil` values before being passed to the provider.

The `yum` package provider is updated to provide the
`:settable_environment` feature.

Finally, the `spec` tests for the `package` type and `yum` provider
are updated to test for the `:settable_environment` feature and the
`environment` parameter.