### PR TITLE
(PUP-6102) Make it illegal to redefine any visible type

### DIFF
--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -72,8 +72,8 @@ class Puppet::Pops::Loader::BaseLoader < Puppet::Pops::Loader::Loader
   private
 
   def fail_redefine(entry)
-    origin_info = entry.origin ? " Originally set at #{origin_label(entry.origin)}." : "unknown location"
-    raise ArgumentError, "Attempt to redefine entity '#{entry.typed_name}' originally set at #{origin_info}"
+    origin_info = entry.origin ? " Originally set at #{origin_label(entry.origin)}." : "Set at unknown location"
+    raise ArgumentError, "Attempt to redefine entity '#{entry.typed_name}'. #{origin_info}"
   end
 
   # TODO: Should not really be here?? - TODO: A Label provider ? semantics for the URI?

--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -50,7 +50,9 @@ class Puppet::Pops::Loader::BaseLoader < Puppet::Pops::Loader::Loader
   #
   def set_entry(typed_name, value, origin = nil)
     if entry = @named_values[typed_name] then fail_redefine(entry); end
-    @named_values[typed_name] = Puppet::Pops::Loader::Loader::NamedEntry.new(typed_name, value, origin)
+    @last_result = Puppet::Pops::Loader::Loader::NamedEntry.new(typed_name, value, origin)
+    @last_name = typed_name
+    @named_values[typed_name] = @last_result
   end
 
   # @api private

--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -49,7 +49,10 @@ class Puppet::Pops::Loader::BaseLoader < Puppet::Pops::Loader::Loader
   # @api private
   #
   def set_entry(typed_name, value, origin = nil)
-    if entry = @named_values[typed_name] then fail_redefine(entry); end
+    if entry = @named_values[typed_name]
+      # only fail real redefines, not defines of earlier cached 'not found'
+      fail_redefine(entry) unless entry.value.nil?
+    end
     @last_result = Puppet::Pops::Loader::Loader::NamedEntry.new(typed_name, value, origin)
     @last_name = typed_name
     @named_values[typed_name] = @last_result

--- a/lib/puppet/pops/loader/dependency_loader.rb
+++ b/lib/puppet/pops/loader/dependency_loader.rb
@@ -48,11 +48,36 @@ class Puppet::Pops::Loader::DependencyLoader < Puppet::Pops::Loader::BaseLoader
     end
   end
 
+  # @api public
+  #
+  def loaded_entry(typed_name, check_dependencies = false)
+    super || (check_dependencies && loaded_entry_in_dependency(typed_name, check_dependencies))
+  end
+
   def to_s()
     "(DependencyLoader '#{@loader_name}' [" + @dependency_loaders.map {|loader| loader.to_s }.join(' ,') + "])"
   end
 
   private
+
+  def loaded_entry_in_dependency(typed_name, check_dependencies)
+    if typed_name.qualified?
+      if l = index()[typed_name.name_parts[0]]
+        l.is_loaded_typed?(typed_name)
+      else
+        # no module entered as dependency with name matching first segment of wanted name
+        false
+      end
+    else
+      # a non name-spaced name, have to search since it can be anywhere.
+      # (Note: superclass caches the result in this loader as it would have to repeat this search for every
+      # lookup otherwise).
+      @dependency_loaders.reduce(nil) do |previous, loader|
+        break previous if !previous.nil?
+        loader.loaded_entry(typed_name, check_dependencies)
+      end
+    end
+  end
 
   def index()
     @index ||= @dependency_loaders.reduce({}) { |index, loader| index[loader.module_name] = loader; index }

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -55,6 +55,18 @@ class Puppet::Pops::Loader::Loader
     raise NotImplementedError.new
   end
 
+  # Returns an already loaded entry if one exists, or nil. This does not trigger loading
+  # of the given type/name.
+  #
+  # @param typed_name [TypedName] - the type, name combination to lookup
+  # @param check_dependencies [Boolean] - if dependencies should be checked in additiona to here and parent
+  # @return [NamedEntry, nil] the entry containing the loaded value, or nil if not found
+  # @api public
+  #
+  def loaded_entry(typed_name, check_dependencies = false)
+    raise NotImplementedError.new(self.class)
+  end
+
   # Produces the value associated with the given name if defined **in this loader**, or nil if not defined.
   # This lookup does not trigger any loading, or search of the given name.
   # An implementor of this method may not search or look up in any other loader, and it may not

--- a/lib/puppet/pops/loader/predefined_loader.rb
+++ b/lib/puppet/pops/loader/predefined_loader.rb
@@ -1,7 +1,7 @@
 module Puppet::Pops::Loader
 
 # A PredefinedLoader is a loader that is manually populated with loaded elements
-# before being used. It never loaders anything on its own.
+# before being used. It never loads anything on its own.
 # When searching for a type, it must exist or an error is raised
 #
 class PredefinedLoader < BaseLoader
@@ -12,6 +12,7 @@ class PredefinedLoader < BaseLoader
       nil
     end
   end
+
   def to_s()
     "(PredefinedLoader '#{loader_name}')"
   end

--- a/lib/puppet/pops/loader/predefined_loader.rb
+++ b/lib/puppet/pops/loader/predefined_loader.rb
@@ -17,6 +17,13 @@ class PredefinedLoader < BaseLoader
     "(PredefinedLoader '#{loader_name}')"
   end
 
+  # Allows shadowing since this loader is used internally for things like function local types
+  # And they should win as there is otherwise a risk that the local types clash with built in types
+  # that were added after the function was written, or by resource types loaded by the 3x auto loader.
+  #
+  def allow_shadowing?
+    true
+  end
 end
 
 end

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -45,6 +45,15 @@ class Runtime3TypeLoader < BaseLoader
       nil
     end
   end
+
+  # Allows shadowing since this loader is populalted with all loaded resource types at time
+  # of loading. This loading will, for built in types override the aliases configured in the static
+  # loader.
+  #
+  def allow_shadowing?
+    true
+  end
+
 end
 end
 end

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -34,6 +34,10 @@ class StaticLoader < Loader
     "(StaticLoader)"
   end
 
+  def loaded_entry(typed_name, _)
+    @loaded[typed_name]
+  end
+
   private
 
   def load_constant(typed_name)
@@ -81,10 +85,11 @@ class StaticLoader < Loader
   end
 
   def create_built_in_types
+    origin_uri = URI("puppet:Puppet-Type-System/Static-Loader")
     type_map = Puppet::Pops::Types::TypeParser.type_map
     type_map.each do |name, type|
       typed_name = TypedName.new(:type, name)
-      @loaded[ typed_name ] = NamedEntry.new(typed_name, type, __FILE__)
+      @loaded[ typed_name ] = NamedEntry.new(typed_name, type, origin_uri)#__FILE__)
     end
   end
 

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -9,6 +9,7 @@ class StaticLoader < Loader
   def initialize
     @loaded = {}
     create_logging_functions()
+    create_built_in_types()
     create_resource_type_references()
   end
 
@@ -76,6 +77,14 @@ class StaticLoader < Loader
       # TODO:closure scope is fake (an empty hash) - waiting for new global scope to be available via lookup of :scopes
       func = fc.new({},self)
       @loaded[ typed_name ] = NamedEntry.new(typed_name, func, __FILE__)
+    end
+  end
+
+  def create_built_in_types
+    type_map = Puppet::Pops::Types::TypeParser.type_map
+    type_map.each do |name, type|
+      typed_name = TypedName.new(:type, name)
+      @loaded[ typed_name ] = NamedEntry.new(typed_name, type, __FILE__)
     end
   end
 

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -135,100 +135,47 @@ class TypeParser
   end
 
   # @api private
+  def type_map
+    @@type_map ||= {
+       'integer'       => TypeFactory.integer,
+       'float'         => TypeFactory.float,
+        'numeric'      => TypeFactory.numeric,
+        'iterable'     => TypeFactory.iterable,
+        'iterator'     => TypeFactory.iterator,
+        'string'       => TypeFactory.string,
+        'enum'         => TypeFactory.enum,
+        'boolean'      => TypeFactory.boolean,
+        'pattern'      => TypeFactory.pattern,
+        'regexp'       => TypeFactory.regexp,
+        'data'         => TypeFactory.data,
+        'array'        => TypeFactory.array_of_data,
+        'hash'         => TypeFactory.hash_of_data,
+        'class'        => TypeFactory.host_class,
+        'resource'     => TypeFactory.resource,
+        'collection'   => TypeFactory.collection,
+        'scalar'       => TypeFactory.scalar,
+        'catalogentry' => TypeFactory.catalog_entry,
+        'undef'        => TypeFactory.undef,
+        'notundef'     => TypeFactory.not_undef(),
+        'default'      => TypeFactory.default(),
+        'any'          => TypeFactory.any,
+        'variant'      => TypeFactory.variant,
+        'optional'     => TypeFactory.optional,
+        'runtime'      => TypeFactory.runtime,
+        'type'         => TypeFactory.type_type,
+        'tuple'        => TypeFactory.tuple,
+        'struct'       => TypeFactory.struct,
+        'object'       => TypeFactory.object,
+      # A generic callable as opposed to one that does not accept arguments
+        'callable'     => TypeFactory.all_callables
+    }
+  end
+
+  # @api private
   def interpret_QualifiedReference(name_ast, context)
     name = name_ast.value
-    case name
-    when 'integer'
-      TypeFactory.integer
-
-    when 'float'
-      TypeFactory.float
-
-    when 'numeric'
-        TypeFactory.numeric
-
-    when 'iterable'
-      TypeFactory.iterable
-
-    when 'iterator'
-      TypeFactory.iterator
-
-    when 'string'
-      TypeFactory.string
-
-    when 'enum'
-      TypeFactory.enum
-
-    when 'boolean'
-      TypeFactory.boolean
-
-    when 'pattern'
-      TypeFactory.pattern
-
-    when 'regexp'
-      TypeFactory.regexp
-
-    when 'data'
-      TypeFactory.data
-
-    when 'array'
-      TypeFactory.array_of_data
-
-    when 'hash'
-      TypeFactory.hash_of_data
-
-    when 'class'
-      TypeFactory.host_class
-
-    when 'resource'
-      TypeFactory.resource
-
-    when 'collection'
-      TypeFactory.collection
-
-    when 'scalar'
-      TypeFactory.scalar
-
-    when 'catalogentry'
-      TypeFactory.catalog_entry
-
-    when 'undef'
-      TypeFactory.undef
-
-    when 'notundef'
-      TypeFactory.not_undef()
-
-    when 'default'
-      TypeFactory.default()
- 
-    when 'any'
-      TypeFactory.any
-
-    when 'variant'
-      TypeFactory.variant
-
-    when 'optional'
-      TypeFactory.optional
-
-    when 'runtime'
-      TypeFactory.runtime
-
-    when 'type'
-      TypeFactory.type_type
-
-    when 'tuple'
-      TypeFactory.tuple
-
-    when 'struct'
-      TypeFactory.struct
-
-    when 'object'
-      TypeFactory.object
-
-    when 'callable'
-      # A generic callable as opposed to one that does not accept arguments
-      TypeFactory.all_callables
-
+    if found = type_map[name]
+      found
     else
       loader = loader_from_context(name_ast, context)
       unless loader.nil?

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -135,8 +135,8 @@ class TypeParser
   end
 
   # @api private
-  def type_map
-    @@type_map ||= {
+  def self.type_map
+    @type_map ||= {
        'integer'       => TypeFactory.integer,
        'float'         => TypeFactory.float,
         'numeric'      => TypeFactory.numeric,
@@ -174,7 +174,7 @@ class TypeParser
   # @api private
   def interpret_QualifiedReference(name_ast, context)
     name = name_ast.value
-    if found = type_map[name]
+    if found = self.class.type_map[name]
       found
     else
       loader = loader_from_context(name_ast, context)

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -78,7 +78,7 @@ describe 'the type mismatch describer' do
       check_tree({ 'x' => {'y' => {32 => 'n'}}})
     CODE
     expect { eval_and_collect_notices(code) }.to(raise_error(Puppet::Error,
-      /parameter 'tree' entry 'x' entry 'y' expects a Tree = Hash\[String, Tree\] value, got Hash\[Integer\[32, 32\], String\[1, 1\]]/))
+      /parameter 'tree' entry 'x' entry 'y' expects a Tree = Hash\[String, Tree\] value, got Hash\[Integer\[32, 32\], String\[1, 1\]\]/))
   end
 
   it 'will use type normalization' do

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -388,6 +388,20 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'When attempting to redefine a built in type' do
+    include PuppetSpec::Compiler
+
+    let(:static_loader) { Puppet::Pops::Loader::StaticLoader.new("testing static loading") }
+    let(:loader) { Puppet::Pops::Loader::BaseLoader.new(static_loader, "types_unit_test_loader") }
+    it 'such as Integer, an error is raised' do
+      code = <<-CODE
+        type Integer = String
+        notice 'hello' =~ Integer
+      CODE
+      expect{ eval_and_collect_notices(code) }.to raise_error(/Attempt to redefine entity 'type\/integer'. Originally set by Puppet-Type-System\/Static-Loader/)
+    end
+  end
+
   context 'instantiation via new_function is supported by' do
     let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, "types_unit_test_loader") }
     it 'Integer' do


### PR DESCRIPTION
This makes it illegal to redefine an already defined (loaded) type. The main use case for adding this is to prevent redefinition/change of built in types like Integer or String - imagine the hilarity of doing `type Integer = String`.

This is now done by adding all types defined by the type system to the static loader (hence they are always loaded). Then, when defining a new type (data type or resource type), a check is made if this type is already loaded - and if so, an error is raised. Unfortunately it would not be backwards compatible to make it illegal to shadow what would potentially be loaded as that is legal in current puppet.

Two exceptions are made to the general rule. 4.x function (in Ruby) are allowed to shadow types - the rationale is that they may otherwise break if users add a module where a type aliases in a function happen to be the same as a resource type. There is no harm in allowing the function to use its own aliases as they never leak to the logic in general. Secondly, since the 3.x-legacy resource type loader loads types, they will shadow the statically predefined aliases for all known resource types in puppet. Hence, it was allowed that the 3.x legacy resource loader is allowed to shadow the static loader. This should probably be refactored, as it is not meaningful to add the resource types more than once.

While working on this, a number of small general problems in the domain of "loading" were fixed as (maint) commits.