### PR TITLE
(PUP-6145) Prevent self recursion in TypeAlias assignable? method

### DIFF
--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -338,6 +338,18 @@ describe 'Puppet Type System' do
       expect(eval_and_collect_notices(code)).to eq(['true'])
     end
 
+    it 'will allow an alias where a variant references an alias with a variant that references itself' do
+      code = <<-CODE
+      type X = Variant[Y, Integer]
+      type Y = Variant[X, String]
+
+      notice(X >= X)
+      notice(X >= Y)
+      notice(Y >= X)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true','true','true'])
+    end
+
     it 'will detect a mismatch in an alias that directly references itself in a variant with other types' do
       code = <<-CODE
       type Foo = Variant[Foo,String]


### PR DESCRIPTION
A `PTypeAliasType` with a resolved type that is a `PVariantType` where
one of the variants points directly the alias, would cause an endless
recursion since the recursion check resided in the `#_assignable?`
method. That method was never called due to special handling of type
alias and assignable in `PAnyType`. This commit fixes this by letting
the `PTypeAliasType` override the `#assignable?` method.

The commit also deals with a problem that occurred when calculating
whether or not a type was self recursive. If the computation involved
yet another alias that was not yet resolved, then it would yield a false
negative. Only the other type would be considered recursive (first type
was resolved when it resolves). This commit ensures that contained
aliases recompute their self-recursive state when a self recursion has
been detected.

When the above bug was fixed, it revealed a flaw in how `#instance?`
was computed for cases where self recursion was detected. Fixing that
required the addition of the API private method `#really_instance?`which
detects if a positive outcome stems from traversing a real type or just
a sequence of type aliases and variants.

NOTE!
When merging to master, since some functionality was moved, the
following call must be added at the very end of the method
`PTypeAliasType#when_self_recursion`.
```
@resolved_type.check_self_recursion(self) if @self_recursion
```