### PR TITLE
(PUP-6146) Fix bug causing Struct assignable? to return nil

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1311,6 +1311,8 @@ class PStructType < PAnyType
       if required_elements_assignable
         size_o = o.size_type || PCollectionType::DEFAULT_SIZE
         PIntegerType.new(required, elements.size).assignable?(size_o, guard)
+      else
+        false
       end
     else
       false

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -894,6 +894,12 @@ describe 'The type calculator' do
         t2 = struct_t({not_undef_t('other_member') => string_t})
         expect(t2).not_to be_assignable_to(t1)
       end
+
+      it 'A hash of string is not assignable to struct with integer value' do
+        t1 = struct_t({'foo' => integer_t, 'bar' => string_t})
+        t2 = hash_t(string_t, string_t, range_t(2, 2))
+        expect(t1.assignable?(t2)).to eql(false)
+      end
     end
 
     context 'for Callable, such that' do


### PR DESCRIPTION
The `PStructType#assignable?` method would return `nil` instead of
`false` when compared to a PHashType. This commit fixes that.