### PR TITLE
(PUP-6147) Make PStructType#assignable? consider PHashType key type

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1311,6 +1311,8 @@ class PStructType < PAnyType
       if required_elements_assignable
         size_o = o.size_type || PCollectionType::DEFAULT_SIZE
         PIntegerType.new(required, elements.size).assignable?(size_o, guard)
+      else
+        false
       end
     else
       false

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1301,11 +1301,19 @@ class PStructType < PAnyType
     elsif o.is_a?(Types::PHashType)
       required = 0
       required_elements_assignable = elements.all? do |e|
-        if e.key_type.assignable?(PUndefType::DEFAULT)
+        key_type = e.key_type
+        if key_type.assignable?(PUndefType::DEFAULT)
+          # Element is optional so Hash does not need to provide it
           true
         else
           required += 1
-          e.value_type.assignable?(o.element_type, guard)
+          if e.value_type.assignable?(o.element_type, guard)
+            # Hash must have something that is assignable. We don't care about the name or size of the key though
+            # because we have no instance of a hash to compare against.
+            key_type.generalize.assignable?(o.key_type)
+          else
+            false
+          end
         end
       end
       if required_elements_assignable

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -900,6 +900,12 @@ describe 'The type calculator' do
         t2 = hash_t(string_t, string_t, range_t(2, 2))
         expect(t1.assignable?(t2)).to eql(false)
       end
+
+      it 'A hash of with integer key is not assignable to struct with string key' do
+        t1 = struct_t({'foo' => string_t, 'bar' => string_t})
+        t2 = hash_t(integer_t, string_t, range_t(2, 2))
+        expect(t1.assignable?(t2)).to eql(false)
+      end
     end
 
     context 'for Callable, such that' do

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -894,6 +894,12 @@ describe 'The type calculator' do
         t2 = struct_t({not_undef_t('other_member') => string_t})
         expect(t2).not_to be_assignable_to(t1)
       end
+
+      it 'A hash of string is not assignable to struct with integer value' do
+        t1 = struct_t({'foo' => integer_t, 'bar' => string_t})
+        t2 = hash_t(string_t, string_t, range_t(2, 2))
+        expect(t1.assignable?(t2)).to eql(false)
+      end
     end
 
     context 'for Callable, such that' do


### PR DESCRIPTION
Before this PR, the method `PStructType#assignable?` would ignore
the key type for a `PHashType` and hence, give false positives for
cases when the struct contained keys that were incompatible with the
key of the hash. This commit fixes that problem.

NOTE! This PR relies on https://github.com/puppetlabs/puppet/pull/4865 which has not yet been merged.