### PR TITLE
(PUP-6148) Fix problem with Callable#assignable? and undefined method

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1598,7 +1598,9 @@ class PCallableType < PAnyType
 
     # NOTE: these tests are made in reverse as it is calling the callable that is constrained
     # (it's lower bound), not its upper bound
-    return false unless o.param_types.assignable?(@param_types, guard)
+    other_param_types = o.param_types
+
+    return false if other_param_types.nil? ||  !other_param_types.assignable?(@param_types, guard)
     # names are ignored, they are just information
     # Blocks must be compatible
     this_block_t = @block_type || PUndefType::DEFAULT

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -906,6 +906,14 @@ describe 'The type calculator' do
           Puppet::Pops::Types::PNotUndefType]
         tested_types.each {|t2| expect(t).to_not be_assignable_to(t2::DEFAULT) }
       end
+
+      it 'a callable with parameter is assignable to the default callable' do
+        expect(callable_t(string_t)).to be_assignable_to(Puppet::Pops::Types::PCallableType::DEFAULT)
+      end
+
+      it 'the default callable is not assignable to a callable with parameter' do
+        expect(Puppet::Pops::Types::PCallableType::DEFAULT).not_to be_assignable_to(callable_t(string_t))
+      end
     end
 
     it 'should recognize mapped ruby types' do


### PR DESCRIPTION
The `Callable#assignable?` would raise an undefined method when passed
a callable that didn't have any parameter definition. This commit fixes
that problem.