### PR TITLE
(PUP-6133) Make struct functional as hash key

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1189,7 +1189,11 @@ class PStructElement < TypedModelObject
   end
 
   def eql?(o)
-     self.class == o.class && value_type == o.value_type && key_type == o.key_type
+    self == o
+  end
+
+  def ==(o)
+    self.class == o.class && value_type == o.value_type && key_type == o.key_type
   end
 end
 

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -185,6 +185,16 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'Struct type' do
+    context 'can be used as key in hash' do
+      it 'compacts optional in optional in optional to just optional' do
+        key1 = tf.struct({'foo' => tf.string})
+        key2 = tf.struct({'foo' => tf.string})
+        expect({key1 => 'hi'}[key2]).to eq('hi')
+      end
+    end
+  end
+
   context 'Optional type' do
     let!(:overlapping_ints) { tf.variant(tf.range(10, 20), tf.range(18, 28)) }
     let!(:optoptopt) { tf.optional(tf.optional(tf.optional(overlapping_ints))) }


### PR DESCRIPTION
It's currently not possible to use a Struct type as a Hash key. This
is because the `PStructType#eql?` method is using array == which in
turn relies on the `#==` method of its elements. The `PStructElement`
class implements `#eql?` but not `#==`. This commit changes this so
that both methods can be used.