### PR TITLE
(PUP-5928) Add pattern matching to Runtime type

### DIFF
--- a/lib/puppet/pops/types/p_runtime_type.rb
+++ b/lib/puppet/pops/types/p_runtime_type.rb
@@ -47,10 +47,12 @@ class PRuntimeType < PAnyType
     iterable?(guard) ? PIterableType.new(self) : nil
   end
 
+  # @api private
   def runtime_type_name
     @name_or_pattern.is_a?(String) ? @name_or_pattern : nil
   end
 
+  # @api private
   def from_puppet_name(puppet_name)
     if @name_or_pattern.is_a?(Array)
       substituted = puppet_name.sub(*@name_or_pattern)

--- a/lib/puppet/pops/types/p_runtime_type.rb
+++ b/lib/puppet/pops/types/p_runtime_type.rb
@@ -1,0 +1,90 @@
+module Puppet::Pops
+module Types
+
+# @api public
+class PRuntimeType < PAnyType
+  TYPE_NAME_OR_PATTERN = PVariantType.new([PStringType::NON_EMPTY, PTupleType.new([PRegexpType::DEFAULT, PStringType::NON_EMPTY])])
+
+  attr_reader :runtime, :name_or_pattern
+
+  # Creates a new instance of a Runtime type
+  #
+  # @param runtime [String] the name of the runtime, e.g. 'ruby'
+  # @param name_or_pattern [String,Array(Regexp,String)] name of runtime or two patterns, mapping Puppet name => runtime name
+  # @api public
+  def initialize(runtime, name_or_pattern)
+    unless runtime.nil? || runtime.is_a?(Symbol)
+      runtime = TypeAsserter.assert_instance_of("Runtime 'runtime'", PStringType::NON_EMPTY, runtime).to_sym
+    end
+    @runtime = runtime
+    @name_or_pattern = TypeAsserter.assert_instance_of("Runtime 'name_or_pattern'", TYPE_NAME_OR_PATTERN, name_or_pattern, true)
+  end
+
+  def hash
+    @runtime.hash ^ @name_or_pattern.hash
+  end
+
+  def eql?(o)
+    self.class == o.class && @runtime == o.runtime && @name_or_pattern == o.name_or_pattern
+  end
+
+  def instance?(o, guard = nil)
+    assignable?(TypeCalculator.infer(o), guard)
+  end
+
+  def iterable?(guard = nil)
+    if @runtime == :ruby && !runtime_type_name.nil?
+      begin
+        c = ClassLoader.provide(self)
+        return c < Iterable unless c.nil?
+      rescue ArgumentError
+      end
+    end
+    false
+  end
+
+  def iterable_type(guard = nil)
+    iterable?(guard) ? PIterableType.new(self) : nil
+  end
+
+  def runtime_type_name
+    @name_or_pattern.is_a?(String) ? @name_or_pattern : nil
+  end
+
+  def from_puppet_name(puppet_name)
+    if @name_or_pattern.is_a?(Array)
+      substituted = puppet_name.sub(*@name_or_pattern)
+      substituted == puppet_name ? nil : PRuntimeType.new(@runtime, substituted)
+    else
+      nil
+    end
+  end
+
+  DEFAULT = PRuntimeType.new(nil, nil)
+
+  protected
+
+  # Assignable if o's has the same runtime and the runtime name resolves to
+  # a class that is the same or subclass of t1's resolved runtime type name
+  # @api private
+  def _assignable?(o, guard)
+    return false unless o.is_a?(PRuntimeType)
+    return false unless @runtime == o.runtime
+    return true if @name_or_pattern.nil? # t1 is wider
+
+    onp = o.name_or_pattern
+    return true if @name_or_pattern == onp
+    return false unless @name_or_pattern.is_a?(String) && onp.is_a?(String)
+
+    # NOTE: This only supports Ruby, must change when/if the set of runtimes is expanded
+    begin
+      c1 = ClassLoader.provide(self)
+      c2 = ClassLoader.provide(o)
+      c1.is_a?(Module) && c2.is_a?(Module) && !!(c2 <= c1)
+    rescue ArgumentError
+      false
+    end
+  end
+end
+end
+end

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -189,7 +189,7 @@ class TypeFormatter
 
   # @api private
   def string_PRuntimeType(t)
-    append_array('Runtime', [string(t.runtime), string(t.runtime_type_name)])
+    append_array('Runtime', [string(t.runtime), string(t.name_or_pattern)])
   end
 
   def is_empty_range?(from, to)

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -293,6 +293,21 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'Runtime type' do
+    it 'can be created with a runtime and a runtime type name' do
+      expect(tf.runtime('ruby', 'Hash').to_s).to eq("Runtime[ruby, 'Hash']")
+    end
+
+    it 'can be created with a runtime and, puppet name pattern, and runtime replacement' do
+      expect(tf.runtime('ruby', [/^MyPackage::(.*)$/, 'MyModule::\1']).to_s).to eq("Runtime[ruby, [/^MyPackage::(.*)$/, 'MyModule::\\1']]")
+    end
+
+    it 'will map a Puppet name to a runtime type' do
+      t = tf.runtime('ruby', [/^MyPackage::(.*)$/, 'MyModule::\1'])
+      expect(t.from_puppet_name('MyPackage::MyType').to_s).to eq("Runtime[ruby, 'MyModule::MyType']")
+    end
+  end
+
   context 'Type aliases' do
     include PuppetSpec::Compiler
 


### PR DESCRIPTION
This commit extends the Runtime type so that it can describe a pattern
match between a Puppet type name and a Runtime type name.