### PR TITLE
(PUP-6136) new-feature/pup-6136/newparam-downgrade

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -120,6 +120,8 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
 
     # RPM gets upset if you try to install an already installed package
     return if @resource.should(:ensure) == version || (@resource.should(:ensure) == :latest && version == latest)
+    # Do now downgrade the package if :dowgrade = false
+    return if @resource.should(:ensure) <= version && !@resource.downgrade?
 
     flag = ["-i"]
     flag = ["-U", "--oldpackage"] if version && (version != :absent && version != :purged)

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -147,13 +147,18 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       # pass
       should = nil
     else
-      # Add the package version
-      wanted += "-#{should}"
       is = self.query
       if is && yum_compareEVR(yum_parse_evr(should), yum_parse_evr(is[:ensure])) < 0
-        self.debug "Downgrading package #{@resource[:name]} from version #{is[:ensure]} to #{should}"
-        operation = :downgrade
+        if @resource.downgrade?
+          self.debug "Downgrading package #{@resource[:name]} from version #{is[:ensure]} to #{should}"
+          operation = :downgrade
+        else
+          self.debug "Maintaining installed package version of #{is[:ensure]}"
+          return
+        end
       end
+      # Add the package version
+      wanted += "-#{should}"
     end
 
     # Yum on el-4 and el-5 returns exit status 0 when trying to install a package it doesn't recognize;

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -501,6 +501,14 @@ module Puppet
       defaultto true
     end
 
+    newparam(:downgrade, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+      desc 'Instructs the package provider to downgrade the specified package
+      if the already installed version is greater than the version specified
+      in the package ensure parameter.'
+
+      defaultto true
+    end
+
     autorequire(:file) do
       autos = []
       [:responsefile, :adminfile].each { |param|


### PR DESCRIPTION
With this new package parameter, package downgrades can be disabled.

Tackled a couple of the easier ones. Was hoping for some preliminary feedback on whether this is the route I should be taking stylistically. I am planning on adding this for all the providers where it would not involve adding huge chunks of code.