### PR TITLE
(PUP-6155) Implement access operator for Iterable type

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -293,6 +293,18 @@ class AccessOperator
     end
   end
 
+  def access_PIterableType(o, scope, keys)
+    keys.flatten!
+    if keys.size == 1
+      unless keys[0].is_a?(Types::PAnyType)
+        fail(Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[0], {:base_type => 'Iterable-Type', :actual => keys[0].class})
+      end
+      Types::PIterableType.new(keys[0])
+    else
+      fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic, {:base_type => 'Iterable-Type', :min => 1, :actual => keys.size})
+    end
+  end
+
   def access_PRuntimeType(o, scope, keys)
     keys.flatten!
     assert_keys(keys, o, 2, 2, String, String)

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -151,6 +151,22 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'Iterable type' do
+    include PuppetSpec::Compiler
+
+    it 'can be parameterized with element type' do
+      code = <<-CODE
+      function foo(Iterable[String] $x) {
+        $x.each |$e| {
+          notice $e
+        }
+      }
+      foo([bar, baz, cake])
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['bar', 'baz', 'cake'])
+    end
+  end
+
   context 'Iterator type' do
     let!(:iterint) { tf.iterator(tf.integer) }
 


### PR DESCRIPTION
The AccessOperator implementation for the Iterable type was missing.
This commit adds that and a test to verify that it works.