### PR TITLE
(PUP-6156) Implement access operator for Iterator type

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -305,6 +305,18 @@ class AccessOperator
     end
   end
 
+  def access_PIteratorType(o, scope, keys)
+    keys.flatten!
+    if keys.size == 1
+      unless keys[0].is_a?(Types::PAnyType)
+        fail(Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[0], {:base_type => 'Iterator-Type', :actual => keys[0].class})
+      end
+      Types::PIteratorType.new(keys[0])
+    else
+      fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic, {:base_type => 'Iterator-Type', :min => 1, :actual => keys.size})
+    end
+  end
+
   def access_PRuntimeType(o, scope, keys)
     keys.flatten!
     assert_keys(keys, o, 2, 2, String, String)

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -168,6 +168,8 @@ describe 'Puppet Type System' do
   end
 
   context 'Iterator type' do
+    include PuppetSpec::Compiler
+
     let!(:iterint) { tf.iterator(tf.integer) }
 
     context 'when testing instance?' do
@@ -198,6 +200,18 @@ describe 'Puppet Type System' do
       it 'a typed iterator type returns the an equally typed iterable type' do
         expect(iterint.iterable_type).to eq(tf.iterable(tf.integer))
       end
+    end
+
+    it 'can be parameterized with an element type' do
+      code = <<-CODE
+      function foo(Iterator[String] $x) {
+        $x.each |$e| {
+          notice $e
+        }
+      }
+      foo([bar, baz, cake].reverse_each)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['cake', 'baz', 'bar'])
     end
   end
 


### PR DESCRIPTION
The AccessOperator implementation for the Iterator type was missing.
This commit adds that and a test to verify that it works.