### PR TITLE
(PUP-6149) Fix problem in access operator for Collection type

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -366,7 +366,7 @@ class AccessOperator
       fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic,
         {:base_type => 'Collection-Type', :min => 1, :max => 2, :actual => keys.size})
     end
-    Types::PCollectionType.new(size_t)
+    Types::PCollectionType.new(nil, size_t)
   end
 
   # An Array can create a new Array type. It is not possible to create a collection of Array types.

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -185,6 +185,18 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'Collection type' do
+    include PuppetSpec::Compiler
+
+    it 'can be parameterized with a range' do
+      code = <<-CODE
+      notice(Collection[5, default] == Collection[5])
+      notice(Collection[5, 5] > Tuple[Integer, 0, 10])
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true', 'false'])
+    end
+  end
+
   context 'Struct type' do
     context 'can be used as key in hash' do
       it 'compacts optional in optional in optional to just optional' do


### PR DESCRIPTION
The AccessOperator implementation for the Collection type was flawed.
This commit fixes that and adds a test to verify that it works.