### PR TITLE
(PUP-6151) Create Variants only when there's a need for it

### DIFF
--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -54,7 +54,7 @@ module Puppet::Pops::Types
           Iterator.new(PUnitType::DEFAULT, o.each)
         else
           tc = TypeCalculator.singleton
-          Iterator.new(tc.unwrap_single_variant(PVariantType.new(o.map {|e| tc.infer_set(e) })), o.each)
+          Iterator.new(PVariantType.maybe_create(o.map {|e| tc.infer_set(e) }), o.each)
         end
       when Hash
         # Each element is a two element [key, value] tuple.
@@ -63,8 +63,8 @@ module Puppet::Pops::Types
         else
           tc = TypeCalculator.singleton
           Iterator.new(PTupleType.new([
-            tc.unwrap_single_variant(PVariantType.new(o.keys.map {|e| tc.infer_set(e) })),
-            tc.unwrap_single_variant(PVariantType.new(o.values.map {|e| tc.infer_set(e) }))], PHashType::KEY_PAIR_TUPLE_SIZE), o.each_pair)
+            PVariantType.maybe_create(o.keys.map {|e| tc.infer_set(e) }),
+            PVariantType.maybe_create(o.values.map {|e| tc.infer_set(e) })], PHashType::KEY_PAIR_TUPLE_SIZE), o.each_pair)
         end
       when Integer
         if o == 0

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -429,7 +429,7 @@ class TypeCalculator
 
     if t1.is_a?(PVariantType) && t2.is_a?(PVariantType)
       # The common type is one that complies with either set
-      return PVariantType.new(t1.types | t2.types)
+      return PVariantType.maybe_create(t1.types | t2.types)
     end
 
     if t1.is_a?(PRegexpType) && t2.is_a?(PRegexpType)
@@ -699,8 +699,8 @@ class TypeCalculator
     elsif o.keys.all? {|k| PStringType::NON_EMPTY.instance?(k) }
       PStructType.new(o.each_pair.map { |k,v| PStructElement.new(PStringType.new(size_as_type(k), [k]), infer_set(v)) })
     else
-      ktype = PVariantType.new(o.keys.map {|k| infer_set(k) })
-      etype = PVariantType.new(o.values.map {|e| infer_set(e) })
+      ktype = PVariantType.maybe_create(o.keys.map {|k| infer_set(k) })
+      etype = PVariantType.maybe_create(o.values.map {|e| infer_set(e) })
       PHashType.new(unwrap_single_variant(ktype), unwrap_single_variant(etype), size_as_type(o))
     end
   end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -99,7 +99,7 @@ module TypeFactory
   # @api public
   #
   def self.variant(*types)
-    PVariantType.new(types.map {|v| type_of(v) })
+    PVariantType.maybe_create(types.map {|v| type_of(v) })
   end
 
   # Produces the Struct type, either a non parameterized instance representing

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -262,7 +262,7 @@ module Types
 
     def initialize(path, expected, actual)
       super(path)
-      @expected = (expected.is_a?(Array) ? PVariantType.new(expected) : expected).normalize
+      @expected = (expected.is_a?(Array) ? PVariantType.maybe_create(expected) : expected).normalize
       @actual = actual.normalize
     end
 

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1535,8 +1535,8 @@ class PStructType < PAnyType
       tc = TypeCalculator.singleton
       PIterableType.new(
         PTupleType.new([
-          tc.unwrap_single_variant(PVariantType.new(@elements.map {|se| se.key_type })),
-          tc.unwrap_single_variant(PVariantType.new(@elements.map {|se| se.value_type }))],
+          PVariantType.maybe_create(@elements.map {|se| se.key_type }),
+          PVariantType.maybe_create(@elements.map {|se| se.value_type })],
           PHashType::KEY_PAIR_TUPLE_SIZE))
     end
   end
@@ -1718,7 +1718,7 @@ class PTupleType < PAnyType
   end
 
   def iterable_type(guard = nil)
-    PIterableType.new(TypeCalculator.singleton.unwrap_single_variant(PVariantType.new(types)))
+    PIterableType.new(PVariantType.maybe_create(types))
   end
 
   # Returns the number of elements accepted [min, max] in the tuple
@@ -2197,9 +2197,21 @@ class PVariantType < PAnyType
 
   attr_reader :types
 
+  # Checks if the number of unique types in the given array is greater than one, and if so
+  # creates a Variant with those types and returns it. If only one unique type is found,
+  # that type is instead returned.
+  #
+  # @param types [Array<PAnyType>] the variants
+  # @return [PAnyType] the resulting type
+  # @api public
+  def self.maybe_create(types)
+    types = types.uniq
+    types.size == 1 ? types[0] : new(types)
+  end
+
   # @param types [Array[PAnyType]] the variants
   def initialize(types)
-    @types = types.uniq.freeze
+    @types = types.freeze
   end
 
   def accept(visitor, guard)
@@ -2219,7 +2231,7 @@ class PVariantType < PAnyType
     if self == DEFAULT || self == DATA
       self
     else
-      alter_type_array(@types, :generalize) { |altered| PVariantType.new(altered) }
+      alter_type_array(@types, :generalize) { |altered| PVariantType.maybe_create(altered) }
     end
   end
 
@@ -2240,7 +2252,7 @@ class PVariantType < PAnyType
         types[0]
       elsif types.any? { |t| t.is_a?(PUndefType) }
         # Undef entry present. Use an OptionalType with a normalized Variant of all types that are not Undef
-        POptionalType.new(PVariantType.new(types.reject { |ot| ot.is_a?(PUndefType) }).normalize(guard)).normalize(guard)
+        POptionalType.new(PVariantType.maybe_create(types.reject { |ot| ot.is_a?(PUndefType) }).normalize(guard)).normalize(guard)
       else
         # Merge all variants into this one
         types = types.map do |t|
@@ -2264,7 +2276,7 @@ class PVariantType < PAnyType
         if types.size == 1
           types[0]
         else
-          modified || types.size != size_before_merge ? PVariantType.new(types) : self
+          modified || types.size != size_before_merge ? PVariantType.maybe_create(types) : self
         end
       end
     end
@@ -2336,7 +2348,7 @@ class PVariantType < PAnyType
       optionals = parts[0]
       if optionals.size > 1
         others = parts[1]
-        others <<  POptionalType.new(PVariantType.new(optionals.map { |optional| optional.type }).normalize)
+        others <<  POptionalType.new(PVariantType.maybe_create(optionals.map { |optional| optional.type }).normalize)
         array = others
       end
     end
@@ -2350,7 +2362,7 @@ class PVariantType < PAnyType
       not_undefs = parts[0]
       if not_undefs.size > 1
         others = parts[1]
-        others <<  PNotUndefType.new(PVariantType.new(not_undefs.map { |not_undef| not_undef.type }).normalize)
+        others <<  PNotUndefType.new(PVariantType.maybe_create(not_undefs.map { |not_undef| not_undef.type }).normalize)
         array = others
       end
     end
@@ -2816,7 +2828,7 @@ class PTypeAliasType < PAnyType
         if real_types.size == 1
           @resolved_type = real_types[0]
         else
-          @resolved_type = PVariantType.new(real_types)
+          @resolved_type = PVariantType.maybe_create(real_types)
         end
         # Drop self recursion status in case it's not self recursive anymore
         guard = RecursionGuard.new

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -472,19 +472,21 @@ describe 'The type calculator' do
       a_t1 = integer_t
       a_t2 = enum_t('b')
       v_a = variant_t(a_t1, a_t2)
-      b_t1 = enum_t('a')
-      v_b = variant_t(b_t1)
+      b_t1 = integer_t
+      b_t2 = enum_t('a')
+      v_b = variant_t(b_t1, b_t2)
       common_t = calculator.common_type(v_a, v_b)
       expect(common_t.class).to eq(PVariantType)
-      expect(Set.new(common_t.types)).to  eq(Set.new([a_t1, a_t2, b_t1]))
+      expect(Set.new(common_t.types)).to  eq(Set.new([a_t1, a_t2, b_t1, b_t2]))
     end
 
     it 'computed variant commonality to type union where added types are sub-types' do
       a_t1 = integer_t
       a_t2 = string_t
       v_a = variant_t(a_t1, a_t2)
-      b_t1 = enum_t('a')
-      v_b = variant_t(b_t1)
+      b_t1 = integer_t
+      b_t2 = enum_t('a')
+      v_b = variant_t(b_t1, b_t2)
       common_t = calculator.common_type(v_a, v_b)
       expect(common_t.class).to eq(PVariantType)
       expect(Set.new(common_t.types)).to  eq(Set.new([a_t1, a_t2]))
@@ -628,7 +630,7 @@ describe 'The type calculator' do
         ]).map {|c| c::DEFAULT }
 
         # Add a non-empty variant
-        all_instances << variant_t(PAnyType::DEFAULT)
+        all_instances << variant_t(PAnyType::DEFAULT, PUnitType::DEFAULT)
         # Add a type alias that doesn't resolve to 't'
         all_instances << type_alias_t('MyInt', 'Integer').resolve(TypeParser.new, nil)
 
@@ -656,21 +658,15 @@ describe 'The type calculator' do
         }
       end
 
-      it 'a Variant of scalar, hash, or array is assignable to Data' do
+      it 'a scalar, hash, or array is assignable to Data' do
         t = PDataType::DEFAULT
-        data_compatible_types.each { |t2| expect(variant_t(type_from_class(t2))).to be_assignable_to(t) }
+        data_compatible_types.each { |t2| expect(type_from_class(t2)).to be_assignable_to(t) }
       end
 
       it 'Data is not assignable to any of its subtypes' do
         t = PDataType::DEFAULT
         types_to_test = data_compatible_types- [PDataType]
         types_to_test.each {|t2| expect(t).not_to be_assignable_to(type_from_class(t2)) }
-      end
-
-      it 'Data is not assignable to a Variant of Data subtype' do
-        t = PDataType::DEFAULT
-        types_to_test = data_compatible_types- [PDataType]
-        types_to_test.each { |t2| expect(t).not_to be_assignable_to(variant_t(type_from_class(t2))) }
       end
 
       it 'Data is not assignable to any disjunct type' do


### PR DESCRIPTION
This commit replaces direct calls to `PVariantType#new` with calls to a
new `PVariantType#maybe_create` method. The new method checks if only
one unique entry exists among the given types. When that's the case,
that entry is returned instead of creating a variant with only one
type.