### PR TITLE
(PUP-3827) Return errors matching schema from indirected routes

### DIFF
--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -52,7 +52,6 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
   def uri2indirection(http_method, uri, params)
     # the first field is always nil because of the leading slash,
     indirection_type, version, indirection_name, key = uri.split("/", 5)[1..-1]
-
     url_prefix = "/#{indirection_type}/#{version}"
     environment = params.delete(:environment)
 

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -47,15 +47,12 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     Puppet.override(:trusted_information => trusted) do
       send("do_#{method}", indirection, key, params, request, response)
     end
-  rescue Puppet::Network::HTTP::Error::HTTPError => e
-    return do_http_control_exception(response, e)
-  rescue StandardError => e
-    return do_exception(response, e)
   end
 
   def uri2indirection(http_method, uri, params)
     # the first field is always nil because of the leading slash,
     indirection_type, version, indirection_name, key = uri.split("/", 5)[1..-1]
+
     url_prefix = "/#{indirection_type}/#{version}"
     environment = params.delete(:environment)
 
@@ -110,24 +107,6 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
   end
 
   private
-
-  def do_http_control_exception(response, exception)
-    msg = exception.message
-    Puppet.info(msg)
-    response.respond_with(exception.status, "text/plain", msg)
-  end
-
-  def do_exception(response, exception, status=400)
-    if exception.is_a?(Puppet::Network::AuthorizationError)
-      # make sure we return the correct status code
-      # for authorization issues
-      status = 403 if status == 400
-    end
-
-    Puppet.log_exception(exception)
-
-    response.respond_with(status, "text/plain", exception.to_s)
-  end
 
   # Execute our find.
   def do_find(indirection, key, params, request, response)

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -88,7 +88,11 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       params[:environment] = configured_environment
     end
 
-    check_authorization(method, "#{url_prefix}/#{indirection_name}/#{key}", params)
+    begin
+      check_authorization(method, "#{url_prefix}/#{indirection_name}/#{key}", params)
+    rescue Puppet::Network::AuthorizationError => e
+      raise Puppet::Network::HTTP::Error::HTTPNotAuthorizedError.new(e.message)
+    end
 
     if configured_environment.nil?
       raise ArgumentError, "Could not find environment '#{environment}'"

--- a/spec/integration/network/http/api/indirected_routes_spec.rb
+++ b/spec/integration/network/http/api/indirected_routes_spec.rb
@@ -54,14 +54,14 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       end
     end
 
-    describe "an error from IndirectedRoutes" do
-      require 'rack/mock'
+    describe "an error from IndirectedRoutes", :if => Puppet.features.rack? do
+      require 'rack/mock' if Puppet.features.rack?
 
       let(:handler) { Puppet::Network::HTTP::RackREST.new }
-      let(:response) { Rack::Response.new }
 
       describe "returns json" do
         it "when a standard error" do
+          response = Rack::Response.new
           request = Rack::Request.new(
             Rack::MockRequest.env_for("/puppet/v3/invalid-indirector"))
 
@@ -73,6 +73,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
           expect(resp["issue_kind"]).to be_a_kind_of(String)
         end
         it "when a server error" do
+          response = Rack::Response.new
           request = Rack::Request.new(
             Rack::MockRequest.env_for("/puppet/v3/unknown_indirector"))
 

--- a/spec/integration/network/http/api/indirected_routes_spec.rb
+++ b/spec/integration/network/http/api/indirected_routes_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 require 'puppet/network/http'
 require 'puppet/network/http/api/indirected_routes'
+require 'rack/mock' if Puppet.features.rack?
 require 'puppet/network/http/rack/rest'
 require 'puppet/indirector_proxy'
 require 'puppet_spec/files'
@@ -55,8 +56,6 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     describe "an error from IndirectedRoutes", :if => Puppet.features.rack? do
-      require 'rack/mock' if Puppet.features.rack?
-
       let(:handler) { Puppet::Network::HTTP::RackREST.new }
 
       describe "returns json" do

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -5,20 +5,20 @@ require 'puppet/network/http/api/indirected_routes'
 require 'puppet/indirector_testing'
 
 module PuppetSpec::Network
-  def not_found_code
-    Puppet::Network::HTTP::Error::HTTPNotFoundError::CODE
+  def not_found_error
+    Puppet::Network::HTTP::Error::HTTPNotFoundError
   end
 
-  def not_acceptable_code
-    Puppet::Network::HTTP::Error::HTTPNotAcceptableError::CODE
+  def not_acceptable_error
+    Puppet::Network::HTTP::Error::HTTPNotAcceptableError
   end
 
-  def bad_request_code
-    Puppet::Network::HTTP::Error::HTTPBadRequestError::CODE
+  def bad_request_error
+    Puppet::Network::HTTP::Error::HTTPBadRequestError
   end
 
-  def not_authorized_code
-    Puppet::Network::HTTP::Error::HTTPNotAuthorizedError::CODE
+  def not_authorized_error
+    Puppet::Network::HTTP::Error::HTTPNotAuthorizedError
   end
 
   def params

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -210,14 +210,16 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
   end
 
   describe "when processing a request" do
-    it "should perform an authorization check" do
+    it "should raise not_authorized_error when authorization fails" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_heads(data)
 
-      handler.expects(:check_authorization)
+      handler.expects(:check_authorization).raises(Puppet::Network::AuthorizationError.new("forbidden"))
 
-      handler.call(request, response)
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_authorized_error)
     end
 
     it "should raise not_found_error if the indirection does not support remote requests" do

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -16,7 +16,6 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
   before do
     Puppet::IndirectorTesting.indirection.terminus_class = :memory
     Puppet::IndirectorTesting.indirection.terminus.clear
-    handler.stubs(:check_authorization)
     handler.stubs(:warn_if_near_expiration)
   end
 
@@ -211,45 +210,34 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
   end
 
   describe "when processing a request" do
-    it "should return not_authorized_code if the request is not authorized" do
-      request = a_request_that_heads(Puppet::IndirectorTesting.new("my data"))
+    it "should perform an authorization check" do
+      data = Puppet::IndirectorTesting.new("my data")
+      indirection.save(data, "my data")
+      request = a_request_that_heads(data)
 
-      handler.expects(:check_authorization).raises(Puppet::Network::AuthorizationError.new("forbidden"))
+      handler.expects(:check_authorization)
 
       handler.call(request, response)
-
-      expect(response.code).to eq(not_authorized_code)
     end
 
-    it "should return 'not found' if the indirection does not support remote requests" do
+    it "should raise not_found_error if the indirection does not support remote requests" do
       request = a_request_that_heads(Puppet::IndirectorTesting.new("my data"))
 
       indirection.expects(:allow_remote_requests?).returns(false)
 
-      handler.call(request, response)
-
-      expect(response.code).to eq(not_found_code)
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_found_error)
     end
 
-    it "should return 'bad request' if the environment does not exist" do
+    it "should raise ArgumentError if the environment does not exist" do
       Puppet.override(:environments => Puppet::Environments::Static.new()) do
         request = a_request_that_heads(Puppet::IndirectorTesting.new("my data"))
 
-        handler.call(request, response)
-
-        expect(response.code).to eq(bad_request_code)
+        expect {
+          handler.call(request, response)
+        }.to raise_error(ArgumentError)
       end
-    end
-
-    it "should serialize a controller exception when an exception is thrown while finding the model instance" do
-      request = a_request_that_finds(Puppet::IndirectorTesting.new("key"))
-      handler.expects(:do_find).raises(ArgumentError, "The exception")
-
-      handler.call(request, response)
-
-      expect(response.code).to eq(bad_request_code)
-      expect(response.body).to eq("The exception")
-      expect(response.type).to eq("text/plain")
     end
   end
 
@@ -265,24 +253,24 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
     end
 
-    it "responds with a not_acceptable_code error when no accept header is provided" do
+    it "raises not_acceptable_error when no accept header is provided" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_finds(data, :accept_header => nil)
 
-      handler.call(request, response)
-
-      expect(response.code).to eq(not_acceptable_code)
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_acceptable_error)
     end
 
-    it "raises an error when no accepted formats are known" do
+    it "raises not_acceptable_error when no accepted formats are known" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_finds(data, :accept_header => "unknown, also/unknown")
 
-      handler.call(request, response)
-
-      expect(response.code).to eq(not_acceptable_code)
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_acceptable_error)
     end
 
     it "should pass the result through without rendering it if the result is a string" do
@@ -297,12 +285,13 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
     end
 
-    it "should return a not_found_code when no model instance can be found" do
+    it "should raise not_found_error when no model instance can be found" do
       data = Puppet::IndirectorTesting.new("my data")
       request = a_request_that_finds(data, :accept_header => "unknown, text/pson")
 
-      handler.call(request, response)
-      expect(response.code).to eq(not_found_code)
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_found_error)
     end
   end
 
@@ -327,13 +316,13 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
     end
 
-    it "should return a not_found_code when searching returns nil" do
+    it "should raise not_found_error when searching returns nil" do
       request = a_request_that_searches(Puppet::IndirectorTesting.new("nothing"), :accept_header => "unknown, text/pson")
       indirection.expects(:search).returns(nil)
 
-      handler.call(request, response)
-
-      expect(response.code).to eq(not_found_code)
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_found_error)
     end
   end
 
@@ -375,9 +364,10 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       indirection.save(data, "my data")
       request = a_request_that_destroys(data, :accept_header => "unknown, also/unknown")
 
-      handler.call(request, response)
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_acceptable_error)
 
-      expect(response.code).to eq(not_acceptable_code)
       expect(Puppet::IndirectorTesting.indirection.find("my data")).not_to be_nil
     end
   end
@@ -441,10 +431,11 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       data = Puppet::IndirectorTesting.new("my data")
       request = a_request_that_submits(data, :accept_header => "unknown, also/unknown")
 
-      handler.call(request, response)
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_acceptable_error)
 
       expect(Puppet::IndirectorTesting.indirection.find("my data")).to be_nil
-      expect(response.code).to eq(not_acceptable_code)
     end
   end
 
@@ -459,15 +450,13 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(response.code).to eq(nil)
     end
 
-    it "should return a not_found_code when the model head call returns false" do
+    it "should raise not_found_error when the model head call returns false" do
       data = Puppet::IndirectorTesting.new("my data")
       request = a_request_that_heads(data)
 
-      handler.call(request, response)
-
-      expect(response.code).to eq(not_found_code)
-      expect(response.type).to eq("text/plain")
-      expect(response.body).to eq("Not Found: Could not find indirector_testing my data")
+      expect {
+        handler.call(request, response)
+      }.to raise_error(not_found_error)
     end
   end
 end

--- a/spec/unit/network/http/api/master/v3_spec.rb
+++ b/spec/unit/network/http/api/master/v3_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 require 'puppet/network/http'
+require 'puppet_spec/network'
 
 describe Puppet::Network::HTTP::API::Master::V3 do
+  include PuppetSpec::Network
+
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
   let(:master_url_prefix) { "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3" }
   let(:master_routes) {
@@ -29,11 +32,11 @@ describe Puppet::Network::HTTP::API::Master::V3 do
     expect(response.code).to eq(200)
   end
 
-  it "responds to unknown paths with a 404" do
+  it "responds to unknown paths by raising not_found_error" do
     request = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_url_prefix}/unknown")
-    master_routes.process(request, response)
 
-    expect(response.code).to eq(404)
-    expect(response.body).to match("Not Found: Could not find indirection 'unknown'")
+    expect {
+      master_routes.process(request, response)
+    }.to raise_error(not_found_error)
   end
 end


### PR DESCRIPTION
Prior to this the indirected routes would intercept any issues that
arose in processing the request and format them into a plain text
response with the proper error code.

All other routes pass issues up to the generic route handler which will
format them according to a documented schema.

This moves the indirected routes handler from never raising to always
raising on error, similar to other route handlers. This allows the
indirected routes to share the error handling code with other routes
and provides consistently formatted errors throughout the rest api.


Running the acceptance suite locally (via `SHA=$(git rev-parse HEAD) TEST_TARGET=ubuntu1404-64a bundle exec rake ci:test:git` I get:
```
Errored Tests Cases:
            Test Case tests/direct_puppet/static_catalog_env_control.rb reported: #<Beaker::Host::CommandFailure: Host 'y383sdp13cn6x5a.delivery.puppetlabs.net' exited with 1 runn
ing:
           mv /etc/puppetserver/conf.d/puppetserver.conf.bak /etc/puppetserver/conf.d/puppetserver.conf
          Last 10 lines of output were:
                mv: cannot stat ‘/etc/puppetserver/conf.d/puppetserver.conf.bak’: No such file or directory>
            Test Case tests/language/exported_resources.rb reported: #<Beaker::Host::CommandFailure: Host 'y383sdp13cn6x5a.delivery.puppetlabs.net' exited with 1 running:
           ln -sf /tmp/exported_resources_9p4y75k3 /etc/puppetlabs/code/environments/exported_resources_9p4y75k3
          Last 10 lines of output were:
                ln: failed to create symbolic link ‘/etc/puppetlabs/code/environments/exported_resources_9p4y75k3’: No such file or directory>
```

Both failures above are during the setup phases of the tests and have to do with files, I think, would normally be managed by packages. I reran the suite against the commit in master I branched from and it also failed with the same two failures. So I think those are an issue with either the current code base, or running from git.