### PR TITLE
(maint) Fix UniqueFile error propagation

### DIFF
--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -175,7 +175,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
       mkdir(lock)
       yield
     ensure
-      rmdir(lock) if lock
+      rmdir(lock) if Puppet::FileSystem.exist?(lock)
     end
 
     def mkdir(*args)


### PR DESCRIPTION
 - Previously, if code in Puppet::FileSystem::UniqueFile.locking
   errored, an ensure block was entered to cleanup any temporary
   .lock directories that may have been created.  This code path is
   used any time Puppet::FileSystem::UniqueFile.open_tmp is called.

   Unfortunately, if the call to mkdir(lock) failed, there would be
   no .lock directory to cleanup, and the actual error raised here
   is a red herring, generated by the failed cleanup attempt.

   On Windows, this can frequently lead to errors like
   Errno::ENOENT: No such file or directory @ dir_s_rmdir - ... .lock
   which obscure the real underlying issue, which is typically a
   permissions problem writing to disk.

   The simplest solution is to verify if the file exists prior to
   attempting to delete it.