### PR TITLE
(PUP-6167) Fix problem default Tuple having max size of zero

### DIFF
--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -833,6 +833,12 @@ describe 'The type calculator' do
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
       end
 
+      it 'A tuple with parameters is assignable to the default Tuple' do
+        t = Puppet::Pops::Types::PTupleType::DEFAULT
+        t2 = Puppet::Pops::Types::PTupleType.new([Puppet::Pops::Types::PStringType::DEFAULT])
+        expect(t2).to be_assignable_to(t)
+      end
+
       it 'Tuple is not assignable to any disjunct type' do
         tested_types = all_types - [
           Puppet::Pops::Types::PAnyType,
@@ -1111,11 +1117,11 @@ describe 'The type calculator' do
       end
 
       it 'accepts an empty tuple as assignable to a tuple with a min size of 0' do
-        tuple1 = constrained_tuple_t(range_t(0, :default), Object)
-        tuple2 = tuple_t
+        tuple1 = constrained_tuple_t(range_t(0, :default))
+        tuple2 = tuple_t()
 
         expect(calculator.assignable?(tuple1, tuple2)).to eq(true)
-        expect(calculator.assignable?(tuple2, tuple1)).to eq(false)
+        expect(calculator.assignable?(tuple2, tuple1)).to eq(true)
       end
 
       it 'should accept matching tuples' do

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -243,7 +243,7 @@ describe Puppet::Pops::Types::TypeParser do
 
   it 'parses a parameterized callable type with 0 min/max' do
     t = parser.parse("Callable[0,0]")
-    expect(t).to be_the_type(types.callable())
+    expect(t).to be_the_type(types.callable(0,0))
     expect(t.param_types.types).to be_empty
   end
 


### PR DESCRIPTION
A default tuple has no size, but when compared it creates a range based
on the size of it's contained types. The default tuple has an empty list
of types which resulted in the range 0,0.

This commit changes this so that the computed range is 0 - infinity when
there are no types.