### PR TITLE
(PUP-5588) Update monkey patch to detect duplicate certificates correctly

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -129,7 +129,8 @@ if Puppet::Util::Platform.windows?
       # cert store, see https://rt.openssl.org/Ticket/Display.html?id=2158
       unless @puppet_certs_loaded
         @puppet_certs_loaded = true
-        Puppet::Util::Windows::RootCerts.instance.to_a.uniq.each do |x509|
+
+        Puppet::Util::Windows::RootCerts.instance.to_a.uniq{ |h| h.to_der }.each do |x509|
           begin
             add_cert(x509)
           rescue OpenSSL::X509::StoreError => e

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -237,8 +237,9 @@ end
 
 
 describe OpenSSL::X509::Store, :if => Puppet::Util::Platform.windows? do
-  let(:store) { described_class.new }
-  let(:cert)  { OpenSSL::X509::Certificate.new(File.read(my_fixture('x509.pem'))) }
+  let(:store)    { described_class.new }
+  let(:cert)     { OpenSSL::X509::Certificate.new(File.read(my_fixture('x509.pem'))) }
+  let(:samecert) { OpenSSL::X509::Certificate.new(File.read(my_fixture('x509.pem'))) }
 
   def with_root_certs(certs)
     Puppet::Util::Windows::RootCerts.expects(:instance).returns(certs)
@@ -259,9 +260,10 @@ describe OpenSSL::X509::Store, :if => Puppet::Util::Platform.windows? do
   end
 
   it "ignores duplicate root certs" do
-    with_root_certs([cert, cert])
+    with_root_certs([cert, samecert])
 
     store.expects(:add_cert).with(cert).once
+    store.expects(:add_cert).with(samecert).never
 
     store.set_default_paths
   end


### PR DESCRIPTION
The .uniq method used to remove duplicates, was not actually removing duplicates
due to the way the .hash function works on the Certificate object. Even for
certificates with the same content, the .hash return value was different.  This
commit uses the .to_der method as the basis for comparing certificate objects.
DER was used as opposed to other methods as it generates smaller strings
(compared to PEM) and is exposed easily in the Certificate object.

Paired with Ethan Brown (@iristyle)