### PR TITLE
(PUP-6176) Fix error when a resource reference is appointing undef

### DIFF
--- a/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
@@ -30,6 +30,7 @@ class Puppet::Parser::Compiler
         # all other relationships requires the referenced resource to exist when mode is strict
         refs = param.value.is_a?(Array) ? param.value.flatten : [param.value]
         refs.each do |r|
+          next if r.nil?
           unless catalog.resource(r.to_s)
             msg = "Could not find resource '#{r.to_s}' in parameter '#{param.name.to_s}'"
             if Puppet[:strict] == :error

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -193,6 +193,13 @@ describe Puppet::Parser::Resource do
       expect(@compiler.catalog).to be_edge(foo_stage, resource)
     end
 
+    it 'should allow a resource reference to be undef' do
+      Puppet[:code] = "notify { 'hello': message=>'yo', notify => undef }"
+      catalog = Puppet::Parser::Compiler.compile(Puppet::Node.new 'anyone')
+      edges = catalog.edges.map {|e| [e.source.ref, e.target.ref]}
+      expect(edges).to include(['Class[main]', 'Notify[hello]'])
+    end
+
     it "should allow edges to propagate multiple levels down the scope hierarchy" do
       Puppet[:code] = <<-MANIFEST
         stage { before: before => Stage[main] }


### PR DESCRIPTION
PUP-6028 fixed a bug in how the resource type and title was extracted
where the case when both where `nil` was undetected. This revealed
another bug in the `RelationshipValidator` where it attempts to create
a resource from a parameter with the value `nil`.

This commit ensures that no attempt is made to create a resource from
`nil` during parameter validation.