### PR TITLE
(PUP-5353) Don't try to disable static systemd services

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -73,6 +73,17 @@ module Puppet
         provider.enabled?
       end
 
+      # This only makes sense on systemd systems. Static services cannot be enabled
+      # or disabled manually.
+      def insync?(current)
+        if provider.respond_to?(:cached_enabled?) && provider.cached_enabled? == 'static'
+          Puppet.debug("Unable to enable or disable static service #{@resource[:name]}")
+          return true
+        end
+
+        super(current)
+      end
+
       validate do |value|
         if value == :manual and !Puppet.features.microsoft_windows?
           raise Puppet::Error.new("Setting enable to manual is only supported on Microsoft Windows.")

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -151,7 +151,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
 
     it "should start the service with systemctl start otherwise" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      provider.expects(:systemctl).with('unmask', 'sshd.service')
+      provider.expects(:systemctl).with(:unmask, 'sshd.service')
       provider.expects(:execute).with(['/bin/systemctl','start','sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
       provider.start
     end
@@ -206,8 +206,8 @@ describe Puppet::Type.type(:service).provider(:systemd) do
   describe "#enable" do
     it "should run systemctl enable to enable a service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      provider.expects(:systemctl).with('unmask', 'sshd.service')
-      provider.expects(:systemctl).with('enable', 'sshd.service')
+      provider.expects(:systemctl).with(:unmask, 'sshd.service')
+      provider.expects(:systemctl).with(:enable, 'sshd.service')
       provider.enable
     end
   end
@@ -227,7 +227,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
       # a string.
       # This should be made consistent in the future and all tests updated.
       provider.expects(:systemctl).with(:disable, 'sshd.service')
-      provider.expects(:systemctl).with('mask', 'sshd.service')
+      provider.expects(:systemctl).with(:mask, 'sshd.service')
       provider.mask
     end
   end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -178,6 +178,12 @@ describe Puppet::Type.type(:service).provider(:systemd) do
       expect(provider.enabled?).to eq(:true)
     end
 
+    it "should return :true if the service is static" do
+      provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      provider.expects(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).returns "static\n"
+      expect(provider.enabled?).to eq(:true)
+    end
+
     it "should return :false if the service is disabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       provider.expects(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).returns "disabled\n"

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -218,6 +218,22 @@ describe Puppet::Type.type(:service), "when changing the host" do
     @service.property(:enable).sync
   end
 
+  it "should always consider the enable state of a static service to be in sync" do
+    @service.provider.class.stubs(:supports_parameter?).returns(true)
+    @service.provider.expects(:cached_enabled?).returns('static')
+    @service[:enable] = false
+    Puppet.expects(:debug).with("Unable to enable or disable static service yay")
+    expect(@service.property(:enable).insync?(:true)).to eq(true)
+  end
+
+  it "should determine insyncness normally when the service is not static" do
+    @service.provider.class.stubs(:supports_parameter?).returns(true)
+    @service.provider.expects(:cached_enabled?).returns('true')
+    @service[:enable] = true
+    Puppet.expects(:debug).never
+    expect(@service.property(:enable).insync?(:true)).to eq(true)
+  end
+
   it "should sync the service's enable state when changing the state of :ensure if :enable is being managed" do
     @service.provider.class.stubs(:supports_parameter?).returns(true)
     @service[:enable] = false


### PR DESCRIPTION
Static systemd services are defined as services that cannot
be enabled or disabled and are usually dependencies or tasks
of other services  Previously, Puppet would erroneously attempt
to disable these services, which is a no-op on the system. Upon
doing so, Puppet was fooled into believing that the service was
being successfully disabled in every run.

This commit updates the systemd provider to not attempt to disable
static services, and log a debugging message when a manifest
attempts to.

In addition, a new 'cached_enabled?' method is added which prevents
the provider from unnecessarily shelling out to systemctl multiple
times.

Thanks to Michael Smith for the research and part of the implementation
for this fix!