### PR TITLE
(PUP-6025) Update GetFileAttributesW calls in Windows

### DIFF
--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -4,21 +4,7 @@ require 'puppet/util/windows'
 class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
 
   def exist?(path)
-    if ! Puppet.features.manages_symlinks?
-      return ::File.exist?(path)
-    end
-
-    path = path.to_str if path.respond_to?(:to_str) # support WatchedFile
-    path = path.to_s # support String and Pathname
-
-    begin
-      if Puppet::Util::Windows::File.symlink?(path)
-        path = Puppet::Util::Windows::File.readlink(path)
-      end
-      ! Puppet::Util::Windows::File.stat(path).nil?
-    rescue # generally INVALID_HANDLE_VALUE which means 'file not found'
-      false
-    end
+    return Puppet::Util::Windows::File.exist?(path)
   end
 
   def symlink(path, dest, options = {})

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -89,12 +89,42 @@ module Puppet::Util::Windows::File
   end
   module_function :symlink
 
+
+  def exist?(path)
+    path = path.to_str if path.respond_to?(:to_str) # support WatchedFile
+    path = path.to_s # support String and Pathname
+
+    seen_paths = []
+    loop do
+      # return false if this path has been seen before.  This is protection against circular symlinks
+      return false if seen_paths.include?(path.downcase)
+
+      result = get_attributes(path,false)
+
+      # return false for path not found
+      return false if result == INVALID_FILE_ATTRIBUTES
+
+      # return true if path exists and it's not a symlink
+      # Other file attributes are ignored. https://msdn.microsoft.com/en-us/library/windows/desktop/gg258117(v=vs.85).aspx
+      return true if (result & FILE_ATTRIBUTE_REPARSE_POINT) != FILE_ATTRIBUTE_REPARSE_POINT
+
+      # walk the symlink and try again...
+      seen_paths << path.downcase
+      path = readlink(path)
+    end
+  end
+  module_function :exist?
+
+
   INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF #define INVALID_FILE_ATTRIBUTES (DWORD (-1))
 
-  def get_attributes(file_name)
+  def get_attributes(file_name, raise_on_invalid = true)
     result = GetFileAttributesW(wide_string(file_name.to_s))
-    return result unless result == INVALID_FILE_ATTRIBUTES
-    raise Puppet::Util::Windows::Error.new("GetFileAttributes(#{file_name})")
+    if raise_on_invalid && result == INVALID_FILE_ATTRIBUTES
+      raise Puppet::Util::Windows::Error.new("GetFileAttributes(#{file_name})")
+    end
+
+    result
   end
   module_function :get_attributes
 
@@ -179,13 +209,10 @@ module Puppet::Util::Windows::File
 
   FILE_ATTRIBUTE_REPARSE_POINT = 0x400
   def symlink?(file_name)
-    begin
-      attributes = get_attributes(file_name)
-      (attributes & FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT
-    rescue
-      # raised INVALID_FILE_ATTRIBUTES is equivalent to file not found
-      false
-    end
+    attributes = get_attributes(file_name, false)
+
+    return false if (attributes == INVALID_FILE_ATTRIBUTES)
+    (attributes & FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT
   end
   module_function :symlink?
 

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -243,6 +243,42 @@ describe "Puppet::FileSystem" do
       end
     end
 
+    it "should return true for exist? when resolving a symlink chain pointing to a file" do
+      # point symlink -> file
+      symlink = tmpfile("somefile_link")
+      Puppet::FileSystem.symlink(file, symlink)
+
+      # point symlink2 -> symlink
+      symlink2 = tmpfile("somefile_link2")
+      Puppet::FileSystem.symlink(symlink, symlink2)
+
+      # point symlink3 -> symlink
+      symlink3 = tmpfile("somefile_link3")
+      Puppet::FileSystem.symlink(symlink2, symlink3)
+
+      expect(Puppet::FileSystem.exist?(symlink3)).to be_truthy
+    end
+
+    it "should return false for exist? when resolving a symlink chain that dangles" do
+      # point symlink -> file
+      symlink = tmpfile("somefile_link")
+      Puppet::FileSystem.symlink(file, symlink)
+
+      # point symlink2 -> symlink
+      symlink2 = tmpfile("somefile_link2")
+      Puppet::FileSystem.symlink(symlink, symlink2)
+
+      # point symlink3 -> symlink
+      symlink3 = tmpfile("somefile_link3")
+      Puppet::FileSystem.symlink(symlink2, symlink3)
+
+      # yank file, and make symlink dangle
+      ::File.delete(file)
+
+      # symlink3 is now indirectly dangled
+      expect(Puppet::FileSystem.exist?(symlink3)).to be_falsey
+    end
+
     it "should not create a symlink when the :noop option is specified" do
       [file, dir].each do |target|
         symlink = tmpfile("#{Puppet::FileSystem.basename(target)}_link")

--- a/spec/unit/util/windows/file_spec.rb
+++ b/spec/unit/util/windows/file_spec.rb
@@ -1,0 +1,34 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util/windows'
+
+describe "Puppet::Util::Windows::File", :if => Puppet::Util::Platform.windows? do
+  include PuppetSpec::Files
+
+  let(:nonexist_file) { 'C:\somefile\that\wont\ever\exist' }
+  let (:invalid_file_attributes) { 0xFFFFFFFF } #define INVALID_FILE_ATTRIBUTES (DWORD (-1))
+
+  describe "get_attributes" do
+    it "should raise an error for files that do not exist by default" do
+      expect {
+        Puppet::Util::Windows::File.get_attributes(nonexist_file)
+      }.to raise_error(Puppet::Error, /GetFileAttributes/)
+    end
+
+    it "should raise an error for files that do not exist when specified" do
+      expect {
+        Puppet::Util::Windows::File.get_attributes(nonexist_file,true)
+      }.to raise_error(Puppet::Error, /GetFileAttributes/)
+    end
+
+    it "should not raise an error for files that do not exist when specified" do
+      expect {
+        Puppet::Util::Windows::File.get_attributes(nonexist_file,false)
+      }.not_to raise_error
+    end
+
+    it "should return INVALID_FILE_ATTRIBUTES for files that do not exist when specified" do
+      expect(Puppet::Util::Windows::File.get_attributes(nonexist_file,false)).to eq(invalid_file_attributes)
+    end
+  end
+end


### PR DESCRIPTION
The calls to GetFileAttributesW were added do detect symlinks/reparse points
in Windows files systems.  However the way these calls were implemented has
caused a large amount of Disk IO and costly error raising within ruby which is
just ignored.  This commit updates the following;

- Updates the exist? method to use the GetFileAttributesW to both detect if
  an item exists and whether it is a symlink.  This reduces Disk IO.  Also fixed
  unknown bug whereby the exist? method did not walk symlink chains greater than
  a depth of two (sym -> sym -> file)

- Updates the get_attributes helper method to optional not raise errors and pass
  back the raw result from GetFileAttributesW.  This is useful in cases like
  file existance checks as error messages are not required.

- Updates the symlink? method to not catch/raise errors if the target path
  does not exist and instead just return false