### PR TITLE
(PUP-6179) Fix the `puppet ca` face

### DIFF
--- a/lib/puppet/application/ca.rb
+++ b/lib/puppet/application/ca.rb
@@ -6,5 +6,6 @@ class Puppet::Application::Ca < Puppet::Application::FaceBase
 
   def setup
     Puppet::SSL::Oids.register_puppet_oids
+    super
   end
 end


### PR DESCRIPTION
Calling setup on a face is required to initialize command-line
arguments. Without this the face silently fails to execute. Fix so when
we override setup in the CA face, we still call out to `super`.