### PR TITLE
(PUP-6025) Fix Windows FileSystem exist? symlink?

### DIFF
--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -4,21 +4,7 @@ require 'puppet/util/windows'
 class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
 
   def exist?(path)
-    if ! Puppet.features.manages_symlinks?
-      return ::File.exist?(path)
-    end
-
-    path = path.to_str if path.respond_to?(:to_str) # support WatchedFile
-    path = path.to_s # support String and Pathname
-
-    begin
-      if Puppet::Util::Windows::File.symlink?(path)
-        path = Puppet::Util::Windows::File.readlink(path)
-      end
-      ! Puppet::Util::Windows::File.stat(path).nil?
-    rescue # generally INVALID_HANDLE_VALUE which means 'file not found'
-      false
-    end
+    return Puppet::Util::Windows::File.exist?(path)
   end
 
   def symlink(path, dest, options = {})

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -4,6 +4,7 @@ module Puppet::Util::Windows
     class UserProfile; end
     class Group; end
   end
+  module File; end
   module Registry
   end
   module SID

--- a/spec/unit/util/windows/file_spec.rb
+++ b/spec/unit/util/windows/file_spec.rb
@@ -1,0 +1,34 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util/windows'
+
+describe Puppet::Util::Windows::File, :if => Puppet::Util::Platform.windows? do
+  include PuppetSpec::Files
+
+  let(:nonexist_file) { 'C:\somefile\that\wont\ever\exist' }
+  let(:invalid_file_attributes) { 0xFFFFFFFF } #define INVALID_FILE_ATTRIBUTES (DWORD (-1))
+
+  describe "get_attributes" do
+    it "should raise an error for files that do not exist by default" do
+      expect {
+        described_class.get_attributes(nonexist_file)
+      }.to raise_error(Puppet::Error, /GetFileAttributes/)
+    end
+
+    it "should raise an error for files that do not exist when specified" do
+      expect {
+        described_class.get_attributes(nonexist_file, true)
+      }.to raise_error(Puppet::Error, /GetFileAttributes/)
+    end
+
+    it "should not raise an error for files that do not exist when specified" do
+      expect {
+        described_class.get_attributes(nonexist_file, false)
+      }.not_to raise_error
+    end
+
+    it "should return INVALID_FILE_ATTRIBUTES for files that do not exist when specified" do
+      expect(described_class.get_attributes(nonexist_file, false)).to eq(invalid_file_attributes)
+    end
+  end
+end


### PR DESCRIPTION
In c64fa0749f673cc75c09b986f3e50a80c7237314 code was introduced to add
symlink support on Windows. The GetFileAttributes API is used to detect
if a given file is a Windows reparse point, which means for Puppets
purpose that the path is a symlink.  However, due to the FFI
implementation of GetFileAttributes, exceptions are thrown under fairly
typical circumstances, when checking for file existence. Puppet performs
a fair amount of Disk IO as it loads (partially exploring module
directories for source to load) -- and this can generate many thrown /
silently eaten exceptions. In a basic Puppet run on Windows, nearly 1000
exceptions are thrown, creating a performance impact. It's uncertain how
much this might affect typical user code, but it's not negligible.

This commit updates the following;

- Updates the exist? method to use the GetFileAttributesW to both detect
  if an item exists and whether it is a symlink.  This reduces Disk IO.

- Also fixed unknown bug whereby the exist? method did not walk symlink
  chains greater than a depth of two (sym -> sym -> file), making the
  Windows implementation previously inconsistent with non-Windows
  platforms.

- Updates the get_attributes helper method to optionally not raise
  errors and pass back the raw result from GetFileAttributesW.  This
  is useful in cases like file existence checks as error messages are
  not required.

- Updates the symlink? method to not catch/raise errors if the target
  path does not exist and instead just return false

- Additional tests for previously unspecified behavior for exists?