### PR TITLE
(PUP-5727) acceptance: fix utf8 cached_catalog test for windows10 32bit

### DIFF
--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -5,14 +5,19 @@ extend Puppet::Acceptance::EnvironmentUtils
   app_type = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment(app_type)
 
-  filenames         = {'windows' => "C:/cygwin64/tmp/#{tmp_environment}_file"}
-  filenames.default = "/tmp/#{tmp_environment}_file"
+  tmp_file = {}
+  agents.each do |agent|
+    tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
+  end
+
   teardown do
     step 'remove the tmp environment symlink' do
       on master, "rm -rf #{File.join(environmentpath, tmp_environment)}"
     end
     step 'clean out produced resources' do
-      on(agents, "rm #{filenames['windows']}; rm #{filenames.default}", :accept_all_exit_codes => true)
+      agents.each do |agent|
+        on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
+      end
     end
   end
 
@@ -22,11 +27,7 @@ extend Puppet::Acceptance::EnvironmentUtils
 file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
   ensure => file,
   content => '
-\$test_path = \$::osfamily ? {
-  "Windows" => "#{filenames['windows']}",
-  default   => "#{filenames.default}",
-}
-
+\$test_path = \$::fqdn ? #{tmp_file}
 file { \$test_path:
   content => @(UTF8)
     #{file_contents}
@@ -41,25 +42,24 @@ MANIFEST
   step 'run agent(s)' do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        os_type = agent.platform =~ /windows/ ? 'windows' : 'other'
+        fqdn = agent.hostname
         config_version = ''
         config_version_matcher = /configuration version '(\d+)'/
         on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),
            :acceptable_exit_codes => 2).stdout do |agent_out|
           config_version = agent_out.match(config_version_matcher)
         end
-        on(agent, "cat #{filenames[os_type]}").stdout do |result|
+        on(agent, "cat #{tmp_file[fqdn]}").stdout do |result|
           assert_equal(file_contents, result, 'file contents did not match accepted')
         end
-        on(agent, "rm #{filenames['os_type']}", :accept_all_exit_codes => true)
+        on(agent, "rm #{tmp_file[fqdn]}", :accept_all_exit_codes => true)
         on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname} --use_cached_catalog"),
            :acceptable_exit_codes => 2).stdout do |agent_out|
           assert_match(config_version_matcher, result, 'agent did not use cached catalog')
         end
-        on(agent, "cat #{filenames[os_type]}").stdout do |result|
+        on(agent, "cat #{tmp_file[fqdn]}").stdout do |result|
           assert_equal(file_contents, result, 'file contents did not match accepted')
         end
-
       end
     end
   end


### PR DESCRIPTION
This change fixes the previous version of this test for windows10 32bit.
Tempfiles go in a different place (as addressed from cygwin) in 32bit
windows.

[skip ci]