### PR TITLE
(PUP-2354) Do not retrieve client cert when generating new cert

### DIFF
--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -33,7 +33,7 @@ DOC
   def self.localhost
     return @localhost if @localhost
     @localhost = new
-    @localhost.generate unless @localhost.certificate
+    @localhost.generate unless @localhost.certificate(false)
     @localhost.key
     @localhost
   end
@@ -192,13 +192,14 @@ DOC
     true
   end
 
-  def certificate
+  def certificate(search_certificate = true)
     unless @certificate
       generate_key unless key
 
       # get the CA cert first, since it's required for the normal cert
       # to be of any use.
       return nil unless Certificate.indirection.find("ca", :fail_on_404 => true) unless ca?
+      return nil unless search_certificate
       return nil unless @certificate = Certificate.indirection.find(name)
 
       validate_certificate_with_key


### PR DESCRIPTION
When using `allow_duplicate_certs = true` and autosign mode on master
server, we expect that the client does not retrieve the previous signed
cert present on the master. This fix disable the search mechanism when
submitting the csr to let the server sign it, and let the agent download
the freshly signed cert instead of the previous one. It only work on the
first run with autosign enable obviously.

This is needed because we are using autoscaling group and preemptible
instances on our cloud provider. In this case the name and the certname
of the new instance is the same of the previous one.
