### PR TITLE
(PUP-6188) Add UTF-8 support to FileSystem.open / exclusive_open

### DIFF
--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -108,6 +108,7 @@ Puppet::Face.define(:config, '0.0.1') do
     when_invoked do |name, value, options|
       path = Puppet::FileSystem.pathname(Puppet.settings.which_configuration_file)
       Puppet::FileSystem.touch(path)
+      # TODO: encoding utf8
       Puppet::FileSystem.open(path, nil, 'r+') do |file|
         Puppet::Settings::IniFile.update(file) do |config|
           config.set(options[:section], name, value)

--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -34,6 +34,7 @@ module Puppet::FileSystem
   # @api public
   #
   def self.open(path, mode, options, &block)
+    # TODO: this is a problem
     @impl.open(assert_path(path), mode, options, &block)
   end
 
@@ -107,6 +108,7 @@ module Puppet::FileSystem
   # @api public
   #
   def self.exclusive_open(path, mode, options = 'r', timeout = 300, &block)
+    # TODO: this is a problem
     @impl.exclusive_open(assert_path(path), mode, options, timeout, &block)
   end
 
@@ -115,6 +117,7 @@ module Puppet::FileSystem
   # @api public
   #
   def self.each_line(path, &block)
+    # TODO: this is a problem
     @impl.each_line(assert_path(path), &block)
   end
 
@@ -136,6 +139,7 @@ module Puppet::FileSystem
   # @api public
   #
   def self.read_preserve_line_endings(path)
+    # TODO: this is a problem
     @impl.read_preserve_line_endings(assert_path(path))
   end
 
@@ -312,6 +316,7 @@ module Puppet::FileSystem
   # @api public
   #
   def self.compare_stream(path, stream)
+    # TODO: this is a problem
     @impl.compare_stream(assert_path(path), stream)
   end
 
@@ -357,6 +362,7 @@ module Puppet::FileSystem
   # @api public
   #
   def self.exclusive_create(path, mode, &block)
+    # TODO: this is a problem
     @impl.exclusive_create(assert_path(path), mode, &block)
   end
 

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -23,6 +23,7 @@ class Puppet::FileSystem::FileImpl
   end
 
   def open(path, mode, options, &block)
+    # TODO: this is a problem
     ::File.open(path, options, mode, &block)
   end
 
@@ -39,11 +40,13 @@ class Puppet::FileSystem::FileImpl
   end
 
   def exclusive_create(path, mode, &block)
+    # TODO: this is a problem
     opt = File::CREAT | File::EXCL | File::WRONLY
     self.open(path, mode, opt, &block)
   end
 
   def exclusive_open(path, mode, options = 'r', timeout = 300, &block)
+    # TODO: this is a problem
     wait = 0.001 + (Kernel.rand / 1000)
     written = false
     while !written
@@ -64,6 +67,7 @@ class Puppet::FileSystem::FileImpl
   end
 
   def each_line(path, &block)
+    # TODO: this is a problem
     ::File.open(path) do |f|
       f.each_line do |line|
         yield line
@@ -76,6 +80,7 @@ class Puppet::FileSystem::FileImpl
   end
 
   def read_preserve_line_endings(path)
+    # TODO: this is a problem
     read(path)
   end
 
@@ -140,6 +145,7 @@ class Puppet::FileSystem::FileImpl
   end
 
   def compare_stream(path, stream)
+    # TODO: this is a problem
     open(path, 0, 'rb') { |this| FileUtils.compare_stream(this, stream) }
   end
 

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -115,6 +115,7 @@ module Puppet::FileBucketFile
     # @param files_original_path [String]
     #
     def matches(paths_file, files_original_path)
+      # TODO: a+ is read-write... need to also pass encoding utf8
       Puppet::FileSystem.open(paths_file, 0640, 'a+') do |f|
         path_match(f, files_original_path)
       end
@@ -138,6 +139,7 @@ module Puppet::FileBucketFile
           Puppet::FileSystem.dir_mkpath(paths_file)
         end
 
+        # TODO: double check this to make sure encoding isn't necessary
         Puppet::FileSystem.exclusive_open(paths_file, 0640, 'a+') do |f|
           if Puppet::FileSystem.exist?(contents_file)
             verify_identical_file!(contents_file, bucket_file)

--- a/lib/puppet/settings/directory_setting.rb
+++ b/lib/puppet/settings/directory_setting.rb
@@ -6,6 +6,7 @@ class Puppet::Settings::DirectorySetting < Puppet::Settings::FileSetting
   # @api private
   def open_file(filename, option = 'r', &block)
     controlled_access do |mode|
+      # TODO: Encoding UTF-8
       Puppet::FileSystem.open(filename, mode, option, &block)
     end
   end

--- a/lib/puppet/settings/file_or_directory_setting.rb
+++ b/lib/puppet/settings/file_or_directory_setting.rb
@@ -27,6 +27,7 @@ class Puppet::Settings::FileOrDirectorySetting < Puppet::Settings::FileSetting
       super
     else
       controlled_access do |mode|
+        # TODO: encoding UTF8
         Puppet::FileSystem.open(filename, mode, option, &block)
       end
     end

--- a/lib/puppet/settings/file_setting.rb
+++ b/lib/puppet/settings/file_setting.rb
@@ -187,6 +187,7 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
   # @api private
   def exclusive_open(option = 'r', &block)
     controlled_access do |mode|
+      # TODO: encoding UTF8
       Puppet::FileSystem.exclusive_open(file(), mode, option, &block)
     end
   end
@@ -194,6 +195,7 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
   # @api private
   def open(option = 'r', &block)
     controlled_access do |mode|
+      # TODO: encoding UTF8
       Puppet::FileSystem.open(file, mode, option, &block)
     end
   end

--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -81,7 +81,7 @@ class Puppet::SSL::Base
 
   # Read content from disk appropriately.
   def read(path)
-    @content = wrapped_class.new(File.read(path))
+    @content = wrapped_class.new(Puppet::FileSystem.read(path, :encoding => 'utf-8'))
   end
 
   # Convert our thing to pem.

--- a/lib/puppet/ssl/configuration.rb
+++ b/lib/puppet/ssl/configuration.rb
@@ -50,7 +50,7 @@ class Configuration
 
   # read_file makes testing easier.
   def read_file(path)
-    File.read(path)
+    Puppet::FileSystem.read(path, :encoding => 'utf-8')
   end
   private :read_file
 end

--- a/lib/puppet/ssl/inventory.rb
+++ b/lib/puppet/ssl/inventory.rb
@@ -40,7 +40,8 @@ class Puppet::SSL::Inventory
   def serials(name)
     return [] unless Puppet::FileSystem.exist?(@path)
 
-    File.readlines(@path).collect do |line|
+    #  TODO: add readlines support to FileSystem class?
+    File.readlines(@path, :encoding => 'utf-8').collect do |line|
       /^(\S+).+\/CN=#{name}$/.match(line)
     end.compact.map { |m| Integer(m[1]) }
   end

--- a/lib/puppet/ssl/key.rb
+++ b/lib/puppet/ssl/key.rb
@@ -38,15 +38,15 @@ DOC
   def password
     return nil unless password_file and Puppet::FileSystem.exist?(password_file)
 
-    ::File.read(password_file)
+    Puppet::FileSystem.read(password_file, :encoding => 'utf-8')
   end
 
   # Optionally support specifying a password file.
   def read(path)
     return super unless password_file
 
-    #@content = wrapped_class.new(::File.read(path), password)
-    @content = wrapped_class.new(::File.read(path), password)
+    #@content = wrapped_class.new(Puppet::FileSystem.read(path, :encoding => 'utf-8'), password)
+    @content = wrapped_class.new(Puppet::FileSystem.read(path, :encoding => 'utf-8'), password)
   end
 
   def to_s

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -105,7 +105,7 @@ class Puppet::Util::FileType
     # Read the file.
     def read
       if Puppet::FileSystem.exist?(@path)
-        File.read(@path)
+        Puppet::FileSystem.read(@path, :encoding => 'utf-8')
       else
         return nil
       end
@@ -118,7 +118,7 @@ class Puppet::Util::FileType
 
     # Overwrite the file.
     def write(text)
-      tf = Tempfile.new("puppet")
+      tf = Tempfile.new("puppet", :encoding => 'utf-8')
       tf.print text; tf.flush
       File.chmod(@default_mode, tf.path) if @default_mode
       FileUtils.cp(tf.path, @path)
@@ -197,7 +197,7 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      IO.popen("#{cmdbase()} -", "w") { |p|
+      IO.popen("#{cmdbase()} -", "w", :encoding => 'utf-8') { |p|
         p.print text
       }
     end
@@ -242,7 +242,7 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      output_file = Tempfile.new("puppet_suntab")
+      output_file = Tempfile.new("puppet_suntab", :encoding => 'utf-8')
       begin
         output_file.print text
         output_file.close
@@ -284,7 +284,7 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      output_file = Tempfile.new("puppet_aixtab")
+      output_file = Tempfile.new("puppet_aixtab", :encoding => 'utf-8')
 
       begin
         output_file.print text

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -60,7 +60,7 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should be able to read requests from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my request")
+      Puppet::FileSystem.expects(:read).with(path, {:encoding => 'utf-8'}).returns("my request")
       my_req = mock 'request'
       OpenSSL::X509::Request.expects(:new).with("my request").returns(my_req)
       expect(request.read(path)).to equal(my_req)

--- a/spec/unit/ssl/certificate_spec.rb
+++ b/spec/unit/ssl/certificate_spec.rb
@@ -162,7 +162,7 @@ describe Puppet::SSL::Certificate do
 
     it "should be able to read certificates from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my certificate")
+      Puppet::FileSystem.expects(:read).with(path, {:encoding => 'utf-8'}).returns("my certificate")
       certificate = mock 'certificate'
       OpenSSL::X509::Certificate.expects(:new).with("my certificate").returns(certificate)
       expect(@certificate.read(path)).to equal(certificate)

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -118,7 +118,7 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
       end
 
       it "should return the all the serial numbers from the lines matching the provided name" do
-        File.expects(:readlines).with(cert_inventory).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
+        File.expects(:readlines).with(cert_inventory, :encoding => 'utf-8').returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
 
         expect(@inventory.serials("me")).to eq([15, 2])
       end

--- a/spec/unit/ssl/key_spec.rb
+++ b/spec/unit/ssl/key_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::SSL::Key do
 
     it "should be able to read keys from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my key")
+      Puppet::FileSystem.expects(:read).with(path, {:encoding => 'utf-8'}).returns("my key")
       key = mock 'key'
       OpenSSL::PKey::RSA.expects(:new).returns(key)
       expect(@key.read(path)).to equal(key)
@@ -76,9 +76,9 @@ describe Puppet::SSL::Key do
 
       path = "/my/path"
 
-      File.stubs(:read).with(path).returns("my key")
+      Puppet::FileSystem.stubs(:read).with(path, {:encoding => 'utf-8'}).returns("my key")
       OpenSSL::PKey::RSA.expects(:new).with("my key", nil).returns(mock('key'))
-      File.expects(:read).with("/path/to/password").never
+      Puppet::FileSystem.expects(:read).with("/path/to/password", {:encoding => 'utf-8'}).never
 
       @key.read(path)
     end
@@ -88,8 +88,8 @@ describe Puppet::SSL::Key do
       @key.password_file = "/path/to/password"
 
       path = "/my/path"
-      File.expects(:read).with(path).returns("my key")
-      File.expects(:read).with("/path/to/password").returns("my password")
+      Puppet::FileSystem.expects(:read).with(path, {:encoding => 'utf-8'}).returns("my key")
+      Puppet::FileSystem.expects(:read).with("/path/to/password", {:encoding => 'utf-8'}).returns("my password")
 
       key = mock 'key'
       OpenSSL::PKey::RSA.expects(:new).with("my key", "my password").returns(key)
@@ -155,7 +155,7 @@ describe Puppet::SSL::Key do
     describe "with a password file set" do
       it "should return a nil password if the password file does not exist" do
         Puppet::FileSystem.expects(:exist?).with("/path/to/pass").returns false
-        File.expects(:read).with("/path/to/pass").never
+        Puppet::FileSystem.expects(:read).with("/path/to/pass", {:encoding => 'utf-8'}).never
 
         @instance.password_file = "/path/to/pass"
 
@@ -164,7 +164,7 @@ describe Puppet::SSL::Key do
 
       it "should return the contents of the password file as its password" do
         Puppet::FileSystem.expects(:exist?).with("/path/to/pass").returns true
-        File.expects(:read).with("/path/to/pass").returns "my password"
+        Puppet::FileSystem.expects(:read).with("/path/to/pass", {:encoding => 'utf-8'}).returns "my password"
 
         @instance.password_file = "/path/to/pass"
 

--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Util::FileType do
     describe "when the file already exists" do
       it "should return the file's contents when asked to read it" do
         Puppet::FileSystem.expects(:exist?).with(path).returns true
-        File.expects(:read).with(path).returns "my text"
+        Puppet::FileSystem.expects(:read).with(path, {:encoding => 'utf-8'}).returns "my text"
 
         expect(file.read).to eq("my text")
       end
@@ -46,7 +46,7 @@ describe Puppet::Util::FileType do
       end
 
       it "should first create a temp file and copy its contents over to the file location" do
-        Tempfile.expects(:new).with("puppet").returns tempfile
+        Tempfile.expects(:new).with("puppet", :encoding => 'utf-8').returns tempfile
         tempfile.expects(:print).with("my text")
         tempfile.expects(:flush)
         tempfile.expects(:close)
@@ -151,7 +151,7 @@ describe Puppet::Util::FileType do
         @tmp_cron = Tempfile.new("puppet_crontab_spec")
         @tmp_cron_path = @tmp_cron.path
         Puppet::Util.stubs(:uid).with(uid).returns 9000
-        Tempfile.expects(:new).with("puppet_#{name}").returns @tmp_cron
+        Tempfile.expects(:new).with("puppet_#{name}", :encoding => 'utf-8').returns @tmp_cron
       end
 
       after :each do


### PR DESCRIPTION
WIP

A couple of other things to scope out:
- Other FileSystem calls that don't specify encoding
- in `filetype.rb` for instance, `Tempfile` and `IO.open` / `IO.popen`

``` ruby
file = Tempfile.new("puppet_suntab")
file.print "text"

IO.popen("#{cmdbase()} -", "w") { |p|
```
