### PR TITLE
(maint) Update docs and license with new branding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # How to contribute
 
-Third-party patches are essential for keeping puppet great. We simply can't
+Third-party patches are essential for keeping Puppet great. We simply can't
 access the huge number of platforms and myriad configurations for running
-puppet. We want to keep it as easy as possible to contribute changes that
+Puppet. We want to keep it as easy as possible to contribute changes that
 get things working in your environment. There are a few guidelines that we
 need contributors to follow so that we can have a chance of keeping on
 top of things.
@@ -90,7 +90,7 @@ a ticket number.
 
 ## Submitting Changes
 
-* Sign the [Contributor License Agreement](http://links.puppetlabs.com/cla).
+* Sign the [Contributor License Agreement](http://links.puppet.com/cla).
 * Push your changes to a topic branch in your fork of the repository.
 * Submit a pull request to the repository in the puppetlabs organization.
 * Update your Jira ticket to mark that you have submitted code and are ready for it to be reviewed (Status: Ready for Merge).
@@ -106,9 +106,9 @@ a ticket number.
 
 # Additional Resources
 
-* [Puppet Labs community guidelines](https://docs.puppetlabs.com/community/community_guidelines.html)
+* [Puppet community guidelines](https://docs.puppet.com/community/community_guidelines.html)
 * [Bug tracker (Jira)](https://tickets.puppetlabs.com)
-* [Contributor License Agreement](http://links.puppetlabs.com/cla)
+* [Contributor License Agreement](http://links.puppet.com/cla)
 * [General GitHub documentation](https://help.github.com/)
 * [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
 * #puppet-dev IRC channel on freenode.org ([Archive](https://botbot.me/freenode/puppet-dev/))

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
    Puppet - Automating Configuration Management.
 
-   Copyright (C) 2005-2015 Puppet Labs Inc
+   Copyright (C) 2005-2016 Puppet, Inc.
 
-   Puppet Labs can be contacted at: info@puppetlabs.com
+   Puppet, Inc. can be contacted at: info@puppet.com
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,7 +49,7 @@ To run puppet itself (for a resource lookup say):
 
 ## Running Spec Tests
 
-Puppet Labs projects use a common convention of using Rake to run unit tests.
+Puppet projects use a common convention of using Rake to run unit tests.
 The tests can be run with the following rake task:
 
     bundle exec rake spec


### PR DESCRIPTION
This commit updates the CONTRIBUTING, LICENSE and quickstart markdown files
with the new branding name of Puppet and license dates

Note - There are many other instances of Puppet Labs in the codebase.  These will be addressed in later pull requests.