### PR TITLE
(PUP-5727) acceptance: skip supports_utf8 test on some agents

### DIFF
--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -7,6 +7,11 @@ extend Puppet::Acceptance::EnvironmentUtils
 
   tmp_file = {}
   agents.each do |agent|
+    if agent.platform =~ /^(eos-4-i386|cumulus-2\.5|osx|sles-10|)/
+      # skip_test doesn't work in with_puppet_running_on blocks (tableflip)
+      #   so we can't easily use expect_failure here
+      skip_test 'PUP-6217'
+    end
     tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
   end
 


### PR DESCRIPTION
skip due to PUP-6217. revert this change or remove skip_tests for fixed
platforms when 6217 resolves.
[skip ci]