### PR TITLE
(PUP-3740) Require at least ruby 1.9.3 for the puppet gem

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -14,6 +14,8 @@ gem_test_files: 'spec/**/*'
 gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_forge_project: 'puppet'
+gem_required_ruby_version: '>= 1.9.3'
+gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['> 2.0', '< 4']
   hiera: ['>= 2.0', '< 4']


### PR DESCRIPTION
Puppet gems do not require at least ruby 1.9.3, even though the code
will not run on earlier versions.

Add the ruby and rubygems versions to project_data.yaml, which will be
copied by the `rake package:gem` task when building the gem.

I copied the values from the .gemspec, which is used when another
project, e.g. module, depends on a source checkout of puppet. The values
in .gemspec and ext/project_data.yaml should be kept insync.