### PR TITLE
(PUP-3941) Exclude yaml from the Accept header

### DIFF
--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -43,8 +43,12 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
 
   # Provide appropriate headers.
   def headers
+    # yaml is not allowed on the network
+    network_formats = model.supported_formats.reject do |format|
+      [:yaml, :b64_zlib_yaml].include?(format)
+    end
     common_headers = {
-      "Accept"                                     => model.supported_formats.join(", "),
+      "Accept"                                     => network_formats.join(", "),
       Puppet::Network::HTTP::HEADER_PUPPET_VERSION => Puppet.version
     }
 

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -190,6 +190,18 @@ describe Puppet::Indirector::REST do
     expect(Puppet::Indirector::REST.srv_service).to eq(:puppet)
   end
 
+  it 'excludes yaml from the Accept header' do
+    model.expects(:supported_formats).returns([:pson, :yaml, :binary])
+
+    expect(terminus.headers['Accept']).to eq('pson, binary')
+  end
+
+  it 'excludes b64_zlib_yaml from the Accept header' do
+    model.expects(:supported_formats).returns([:pson, :b64_zlib_yaml])
+
+    expect(terminus.headers['Accept']).to eq('pson')
+  end
+
   describe "when creating an HTTP client" do
     it "should use the class's server and port if the indirection request provides neither" do
       @request = stub 'request', :key => "foo", :server => nil, :port => nil


### PR DESCRIPTION
When making REST requests, the agent would include `yaml` in the HTTP Accept
header. However we removed network support for yaml in PUP-3272. In
particular, the Puppet::Network::HTTP::Request#assert_supported_format
method (on the server) will fail the request if it ever tries to return
yaml. Since the server should never return it (since 4.0) and 4.0 agents
can't communicate with 3.x masters (due to URL prefix changes), there's no
point in asking for it.

This commit strips `yaml` and `b64_zlib_yaml` from the HTTP Accept header
when making REST requests. It doesn't affect callers making direct
Puppet::Network::HTTP requests, e.g. providers, report processors.