### PR TITLE
(PUP-2419) Deprecate never used req_bits setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1010,7 +1010,8 @@ EOT
     },
     :req_bits => {
       :default    => 4096,
-      :desc       => "The bit length of the certificates.",
+      :desc       => "This setting has no effect and will be removed in a future Puppet version.",
+      :deprecated => :completely,
     },
     :keylength => {
       :default    => 4096,

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -238,7 +238,6 @@ module Puppet::Test
       #
       # I would make these even shorter, but OpenSSL doesn't support anything
       # below 512 bits.  Sad, really, because a 0 bit key would be just fine.
-      Puppet[:req_bits]  = 512
       Puppet[:keylength] = 512
 
       # Although we setup a testing context during initialization, some tests


### PR DESCRIPTION
The req_bits setting was added in bb4b5a54, but has only been used in
the test_helper.rb invoked by spec_helper.rb.

This commit deprecates the setting completely and removes it from the
test_helper.rb.