### PR TITLE
(PUP-4617) Display human readable cert extensions

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -246,6 +246,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
     Puppet::SSL::Oids.register_puppet_oids
+    Puppet::SSL::Oids.load_custom_oid_file(Puppet[:trusted_oid_mapping_file])
 
     Puppet::Util::Log.newdestination :console
 


### PR DESCRIPTION
Previously, `puppet cert print` would always show the OID for
custom X509v3 cert extensions:

    X509v3 extensions:
        1.3.6.1.4.1.34380.1.2.1.1:
            ..somedata

With this commit, if a `trusted_oid_mapping_file` is specified mapping
OIDs to their short and long human readable names, then the long name
will be displayed, similarly to what is displayed for puppet OIDs like
"Puppet Node UUID" and other well-known OIDs:

    $ puppet cert print <hostname> --trusted_oid_mapping_file oids.yaml
    ...
    X509v3 extensions:
        Netscape Comment:
            Puppet Ruby/OpenSSL Internal Certificate
        X509v3 Subject Key Identifier:
            47:BC:D5:14:33:F2:ED:85:B9:52:FD:A2:EA:E4:CC:00:7F:7F:19:7E
        Puppet Node UUID:
            ED803750-E3C7-44F5-BB08-41A04433FE2E
        My Long Name:
            ..somedata

If the trusted_oid_mapping_file doesn't exist (the default), then there
is no change in behavior.