### PR TITLE
(PUP-6224) Add a Ruby generator that emits code based on Object types

### DIFF
--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -1,0 +1,30 @@
+require 'uri'
+
+module Puppet::Pops
+module Pcore
+  TYPE_QUALIFIED_REFERENCE = Types::TypeFactory.pattern(Types::TypeFactory.regexp(Patterns::CLASSREF_EXT))
+
+  def self.init(loader, ir)
+    add_alias('Puppet::Pcore::QualifiedReference', TYPE_QUALIFIED_REFERENCE, loader)
+
+    ir.register_implementation_namespace('Puppet::Pcore', 'Puppet::Pops::Pcore', loader)
+  end
+
+  def self.add_alias(name, type, loader)
+    add_type(Types::PTypeAliasType.new(name, nil, type), loader)
+  end
+
+  def self.add_type(type, loader)
+    loader.set_entry(Loader::Loader::TypedName.new(:type, type.name.downcase), type)
+  end
+
+  def self.register_implementations(*impls)
+    Loaders.loaders.register_implementations(*impls)
+  end
+
+  def self.register_aliases(aliases)
+    loader = Loaders.loaders.private_environment_loader
+    aliases.each { |name, type_string| add_type(Types::PTypeAliasType.new(name, Types::TypeFactory.type_reference(type_string), nil), loader) }
+  end
+end
+end

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -465,6 +465,24 @@ class PObjectType < PAnyType
     @parent.nil? ? false : @parent.callable_args?(callable, guard)
   end
 
+  # Returns the variant of Tuple/Struct that constraints the initialization object used when creating dynamic instances
+  # of this type.
+  #
+  # @return [PStructType] the initialization type
+  def i12n_type
+    struct_elems = {}
+    attributes(true).values.each do |attr|
+      unless attr.kind == ATTRIBUTE_KIND_CONSTANT || attr.kind == ATTRIBUTE_KIND_DERIVED
+        if attr.value?
+          struct_elems[TypeFactory.optional(attr.name)] = attr.type
+        else
+          struct_elems[attr.name] = attr.type
+        end
+      end
+    end
+    TypeFactory.struct(struct_elems)
+  end
+
   # The i12n_hash is primarily intended for serialization and string representation purposes. It creates a hash
   # suitable for passing to {PObjectType#new(i12n_hash)}
   #

--- a/lib/puppet/pops/types/puppet_object.rb
+++ b/lib/puppet/pops/types/puppet_object.rb
@@ -1,0 +1,21 @@
+module Puppet::Pops
+module Types
+
+# Marker module for implementations that are mapped to Object types
+# @api public
+module PuppetObject
+  # Returns all classes that includes this module
+  def self.descendants
+    ObjectSpace.each_object(Class).select { |klass| klass < self }
+  end
+
+  # Returns the Puppet Type for this instance. The implementing class must
+  # add the {#_ptype} as a class method.
+  #
+  # @return [PObjectType] the type
+  def _ptype
+    self.class._ptype
+  end
+end
+end
+end

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -1,0 +1,265 @@
+module Puppet::Pops
+module Types
+
+# @api private
+class RubyGenerator < TypeFormatter
+  def remove_common_namespace(namespace_segments, name)
+    segments = name.split(TypeFormatter::NAME_SEGMENT_SEPARATOR)
+    namespace_segments.size.times do |idx|
+      break if segments.empty? || namespace_segments[idx] != segments[0]
+      segments.shift
+    end
+    segments
+  end
+
+  def namespace_relative(namespace_segments, name)
+    remove_common_namespace(namespace_segments, name).join(TypeFormatter::NAME_SEGMENT_SEPARATOR)
+  end
+
+  def create_class(obj)
+    @dynamic_classes ||= Hash.new do |hash, key|
+      rp = key.resolved_parent
+      parent_class = rp.is_a?(PObjectType) ? create_class(rp) : Object
+      class_def = ''
+      class_body(key, EMPTY_ARRAY, class_def)
+      cls = Class.new(parent_class)
+      cls.class_eval(class_def)
+      cls.define_singleton_method(:_ptype) { return key }
+      hash[key] = cls
+    end
+    @dynamic_classes[obj]
+  end
+
+  def module_definition(types, comment)
+    object_types, aliased_types = types.partition { |type| type.is_a?(PObjectType) }
+    impl_names = implementation_names(object_types)
+
+    # extract common implementation module prefix
+    common_prefix = []
+    segmented_names = impl_names.map { |impl_name| impl_name.split(TypeFormatter::NAME_SEGMENT_SEPARATOR) }
+    segments = segmented_names[0]
+    segments.size.times do |idx|
+      segment = segments[idx]
+      break unless segmented_names.all? { |sn| sn[idx] == segment }
+      common_prefix << segment
+    end
+
+    # Create class definition of all contained types
+    bld = ''
+    start_module(common_prefix, comment, bld)
+    class_names = []
+    object_types.each_with_index do |type, index|
+      class_names << class_definition(type, common_prefix, bld, impl_names[index])
+      bld << "\n"
+    end
+
+    aliases = Hash[aliased_types.map { |type| [type.name, type.resolved_type] }]
+    end_module(common_prefix, aliases, class_names, bld)
+    bld
+  end
+
+  def start_module(common_prefix, comment, bld)
+    bld << '# ' << comment << "\n"
+    common_prefix.each { |cp| bld << 'module ' << cp << "\n" }
+  end
+
+  def end_module(common_prefix, aliases, class_names, bld)
+    # Emit registration of contained type aliases
+    unless aliases.empty?
+      bld << "Puppet::Pops::Pcore.register_aliases({\n"
+      aliases.each { |name, type| bld << "  '" << name << "' => " << TypeFormatter.string(type.to_s) << "\n" }
+      bld.chomp!(",\n")
+      bld << "})\n\n"
+    end
+
+    # Emit registration of contained types
+    unless class_names.empty?
+      bld << "Puppet::Pops::Pcore.register_implementations(\n"
+      class_names.each { |class_name| bld << '  ' << class_name << ",\n" }
+      bld.chomp!(",\n")
+      bld << ")\n\n"
+    end
+    bld.chomp!("\n")
+
+    common_prefix.each { |cp| bld << "end\n" }
+  end
+
+  def implementation_names(object_types)
+    object_types.map do |type|
+      ir = Loaders.implementation_registry
+      impl_name = ir.module_name_for_type(type)
+      raise Puppet::Error, "Unable to create an instance of #{type.name}. No mapping exists to runtime object" if impl_name.nil?
+      impl_name[0]
+    end
+  end
+
+  def class_definition(obj, namespace_segments, bld, class_name)
+    module_segments = remove_common_namespace(namespace_segments, class_name)
+    leaf_name = module_segments.pop
+    module_segments.each { |segment| bld << 'module ' << segment << "\n" }
+    bld << 'class ' << leaf_name
+    segments = class_name.split(TypeFormatter::NAME_SEGMENT_SEPARATOR)
+
+    unless obj.parent.nil?
+      ir = Loaders.implementation_registry
+      parent_impl = ir.module_name_for_type(obj.parent)
+      raise Puppet::Error, "Unable to create an instance of #{obj.parent.name}. No mapping exists to runtime object" if parent_impl.nil?
+      bld << ' < ' << namespace_relative(segments, parent_impl[0])
+    end
+
+    bld << "\n"
+    bld << "  def self._plocation\n"
+    bld << "    loc = Puppet::Util.path_to_uri(\"\#{__FILE__}\")\n"
+    bld << "    URI(\"#\{loc}?line=#\{__LINE__.to_i - 3}\")\n"
+    bld << "  end\n"
+
+    bld << "\n"
+    bld << "  def self._ptype\n"
+    bld << '    @_ptype ||= ' << namespace_relative(segments, obj.class.name) << ".new('" << obj.name << "', "
+    bld << TypeFormatter.new.ruby_string('ref', 2, obj.i12n_hash(false)) << ")\n"
+    bld << "  end\n"
+
+    class_body(obj, segments, bld)
+
+    bld << "end\n"
+    module_segments.size.times { bld << "end\n" }
+    module_segments << leaf_name
+    module_segments.join(TypeFormatter::NAME_SEGMENT_SEPARATOR)
+  end
+
+  def class_body(obj, segments, bld)
+    if obj.parent.nil?
+      bld << "\n  include " << namespace_relative(segments, Puppet::Pops::Types::PuppetObject.name) << "\n\n" # marker interface
+      bld << "  def self.ref(type_string)\n"
+      bld << "    " << namespace_relative(segments, Puppet::Pops::Types::PTypeReferenceType.name) << ".new(type_string)\n"
+      bld << "  end\n"
+    end
+
+    # Output constants
+    constants, others = obj.attributes(true).values.partition { |a| a.kind == PObjectType::ATTRIBUTE_KIND_CONSTANT }
+    constants = constants.select { |ca| ca.container.equal?(obj) }
+    unless constants.empty?
+      constants.each { |ca| bld << "\n  def self." << ca.name << "\n    _ptype['" << ca.name << "'].value\n  end\n" }
+      constants.each { |ca| bld << "\n  def " << ca.name << "\n    self.class." << ca.name << "\n  end\n" }
+    end
+
+    init_params = others.reject { |a| a.kind == PObjectType::ATTRIBUTE_KIND_DERIVED }
+    opt, non_opt = init_params.partition { |ip| ip.value? }
+
+    # Output type safe hash constructor
+    bld << "\n  def self.from_hash(i12n)\n"
+    bld << '    ' << namespace_relative(segments, TypeAsserter.name) << '.assert_instance_of('
+    bld << "'" << obj.label << " initializer', _ptype.i12n_type, i12n)\n"
+    non_opt.each { |ip| bld << '    ' << ip.name << " = i12n['" << ip.name << "']\n" }
+    opt.each { |ip| bld << '    ' << ip.name << " = i12n.fetch('" << ip.name << "') { _ptype['" << ip.name << "'].value }\n" }
+    bld << '    new'
+    unless init_params.empty?
+      bld << '('
+      non_opt.each { |a| bld << a.name << ', ' }
+      opt.each { |a| bld << a.name << ', ' }
+      bld.chomp!(', ')
+      bld << ')'
+    end
+    bld << "\n  end\n"
+
+    # Output type safe constructor
+    bld << "\n  def self.create"
+    if init_params.empty?
+      bld << "\n    new"
+    else
+      bld << '('
+      non_opt.each { |ip| bld << ip.name << ', ' }
+      opt.each { |ip| bld << ip.name << ' = ' << "_ptype['#{ip.name}'].value" << ', ' }
+      bld.chomp!(', ')
+      bld << ")\n"
+      bld << '    ta = ' << namespace_relative(segments, TypeAsserter.name) << "\n"
+      bld << "    attrs = _ptype.attributes(true)\n"
+      init_params.each do |a|
+        bld << "    ta.assert_instance_of('" << a.container.name << '[' << a.name << ']'
+        bld << "', attrs['" << a.name << "'].type, " << a.name << ")\n"
+      end
+      bld << '    new('
+      non_opt.each { |a| bld << a.name << ', ' }
+      opt.each { |a| bld << a.name << ', ' }
+      bld.chomp!(', ')
+      bld << ')'
+    end
+    bld << "\n  end\n"
+
+    # Output initializer
+    bld << "\n  def initialize"
+    unless init_params.empty?
+      bld << '('
+      non_opt.each { |ip| bld << ip.name << ', ' }
+      opt.each { |ip| bld << ip.name << ' = ' << "_ptype['#{ip.name}'].value" << ', ' }
+      bld.chomp!(', ')
+      bld << ')'
+      unless obj.parent.nil?
+        bld << "\n    super"
+        super_args = (non_opt + opt).select { |ip| !ip.container.equal?(obj) }
+        unless super_args.empty?
+          bld << '('
+          super_args.each { |ip| bld << ip.name << ', ' }
+          bld.chomp!(', ')
+          bld << ')'
+        end
+      end
+    end
+    bld << "\n"
+
+    init_params.each { |a| bld << '    @' << a.name << ' = ' << a.name << "\n" if a.container.equal?(obj) }
+    bld << "  end\n\n"
+
+    # Output attr_readers
+    others.each do |a|
+      next unless a.container.equal?(obj)
+      if a.kind == PObjectType::ATTRIBUTE_KIND_DERIVED || a.kind == PObjectType::ATTRIBUTE_KIND_GIVEN_OR_DERIVED
+        bld << '  def ' << a.name << "\n"
+        bld << "    raise Puppet::Error, \"no method is implemented for derived attribute #{a.label}\"\n"
+        bld << "  end\n"
+      else
+        bld << '  attr_reader :' << a.name << "\n"
+      end
+    end
+
+    # Output function placeholders
+    obj.functions(false).each_value do |func|
+      bld << "\n  def " << func.name << "(*args)\n"
+      bld << "    # Placeholder for #{func.type}\n"
+      bld << "    raise Puppet::Error, \"no method is implemented for #{func.label}\"\n"
+      bld << "  end\n"
+    end
+
+    # output hash and equality
+    include_class = obj.include_class_in_equality?
+    if obj.equality.nil?
+      eq_names = obj.attributes(false).values.select { |a| a.kind != PObjectType::ATTRIBUTE_KIND_CONSTANT }.map(&:name)
+    else
+      eq_names = obj.equality
+    end
+
+    unless eq_names.empty? && !include_class
+      bld << "\n  def hash\n    "
+      bld << 'super.hash ^ ' unless obj.parent.nil?
+      if eq_names.empty?
+        bld << "self.class.hash\n"
+      else
+        bld << '['
+        bld << 'self.class, ' if include_class
+        eq_names.each { |eqn| bld << '@' << eqn << ', ' }
+        bld.chomp!(', ')
+        bld << "].hash\n"
+      end
+      bld << "  end\n"
+
+      bld << "\n  def eql?(o)\n"
+      bld << "    super.eql?(o) &&\n" unless obj.parent.nil?
+      bld << "    self.class.eql?(o.class) &&\n" if include_class
+      eq_names.each { |eqn| bld << '    @' << eqn << '.eql?(o.' <<  eqn << ") &&\n" }
+      bld.chomp!(" &&\n")
+      bld << "\n  end\n"
+    end
+  end
+end
+end
+end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -552,10 +552,14 @@ class TypeCalculator
 
   # @api private
   def infer_Object(o)
-    name = o.class.name
-    ir = Loaders.implementation_registry
-    type = ir.nil? ? nil : ir.type_for_module(name)
-    type.nil? ? PRuntimeType.new(:ruby, name) : type
+    if o.is_a?(PuppetObject)
+      o._ptype
+    else
+      name = o.class.name
+      ir = Loaders.implementation_registry
+      type = ir.nil? ? nil : ir.type_for_module(name)
+      type.nil? ? PRuntimeType.new(:ruby, name) : type
+    end
   end
 
   # The type of all types is PType

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -56,6 +56,19 @@ class TypeFormatter
     end
   end
 
+  # @api private
+  def ruby_string(ref_ctor, indent, t)
+    @ruby = true
+    @ref_ctor = ref_ctor
+    begin
+      indented_string(t, indent)
+    ensure
+      @ruby = nil
+      @ref_ctor = nil
+    end
+  end
+
+
   def append_string(t)
     if @ruby && t.is_a?(PAnyType)
       @ruby = false
@@ -308,7 +321,7 @@ class TypeFormatter
   # method to allow override.
   # @api private
   def symbolic_key(key)
-    key
+    @ruby ? "'#{key}'" : key
   end
 
   # @api private
@@ -400,7 +413,7 @@ class TypeFormatter
   end
 
   # @api private
-  def string_NilClass(t)     ; @bld << '?' ; end
+  def string_NilClass(t)     ; @bld << (@ruby ? 'nil' : '?') ; end
 
   # @api private
   def string_Numeric(t)      ; @bld << t.to_s    ; end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2856,6 +2856,8 @@ end
 end
 end
 
+require 'puppet/pops/pcore'
+
 require_relative 'puppet_object'
 require_relative 'p_object_type'
 require_relative 'p_runtime_type'

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2856,6 +2856,7 @@ end
 end
 end
 
+require_relative 'puppet_object'
 require_relative 'p_object_type'
 require_relative 'p_runtime_type'
 require_relative 'implementation_registry'

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -822,7 +822,7 @@ describe 'The Object Type' do
           "'first_x' => Callable[Integer], "+
           "'first_y' => Callable[String]"+
           "}, "+
-          "equality => [first_a]"+
+          "equality => ['first_a']"+
           "}]",
         "Object[{"+
           "name => 'MySecondObject', "+
@@ -836,7 +836,7 @@ describe 'The Object Type' do
           "'second_x' => Callable[Integer], "+
           "'second_y' => Callable[String]"+
           "}, "+
-          "equality => [second_a]"+
+          "equality => ['second_a']"+
           "}]"
         ])
       end

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -1,0 +1,261 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+require 'puppet/pops/types/ruby_generator'
+
+def root_binding
+  return binding
+end
+
+module Puppet::Pops
+module Types
+describe 'Puppet Ruby Generator' do
+  include PuppetSpec::Compiler
+
+  def source
+    <<-CODE
+    type MyModule::FirstGenerated = Object[{
+      attributes => {
+        name => String,
+        age  => { type => Integer, value => 30 },
+        what => { type => String, value => 'what is this', kind => constant }
+      }
+    }]
+    type MyModule::SecondGenerated = Object[{
+      parent => MyModule::FirstGenerated,
+      attributes => {
+        address => String,
+        zipcode => String,
+        email => String,
+        another => { type => Optional[MyModule::FirstGenerated], value => undef },
+        number => Integer
+      }
+    }]
+    CODE
+  end
+
+  let!(:parser) { TypeParser.new }
+  let(:generator) { RubyGenerator.new }
+
+  context 'when generating anonymous classes' do
+
+    scope = nil
+
+    let(:first_type) { parser.parse('MyModule::FirstGenerated', scope) }
+    let(:second_type) { parser.parse('MyModule::SecondGenerated', scope) }
+    let(:first) { generator.create_class(first_type) }
+    let(:second) { generator.create_class(second_type) }
+
+    before(:each) do
+      eval_and_collect_notices(source) do |topscope, catalog|
+        scope = topscope
+      end
+    end
+
+    after(:each) { typeset = nil }
+
+    context 'the generated class' do
+      it 'inherits the PuppetObject module' do
+        expect(first < PuppetObject).to be_truthy
+      end
+
+      it 'is the superclass of a generated subclass' do
+        expect(second < first).to be_truthy
+      end
+    end
+
+    context 'the #create class method' do
+      it 'has an arity that reflects optional arguments' do
+        expect(first.method(:create).arity).to eql(-2)
+        expect(second.method(:create).arity).to eql(-6)
+      end
+
+      it 'creates an instance of the class' do
+        inst = first.create('Bob Builder', 52)
+        expect(inst).to be_a(first)
+        expect(inst.name).to eq('Bob Builder')
+        expect(inst.age).to eq(52)
+      end
+
+      it 'will perform type assertion of the arguments' do
+        expect { first.create('Bob Builder', '52') }.to(
+          raise_error(TypeAssertionError,
+            'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got String')
+        )
+      end
+
+      it 'will not accept nil as given value for an optional parameter that does not accept nil' do
+        expect { first.create('Bob Builder', nil) }.to(
+          raise_error(TypeAssertionError,
+            'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got Undef')
+        )
+      end
+
+      it 'reorders parameters to but the optional parameters last' do
+        inst = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+        expect(inst.name).to eq('Bob Builder')
+        expect(inst.address).to eq('42 Cool Street')
+        expect(inst.zipcode).to eq('12345')
+        expect(inst.email).to eq('bob@example.com')
+        expect(inst.number).to eq(23)
+        expect(inst.what).to eql('what is this')
+        expect(inst.age).to eql(30)
+        expect(inst.another).to be_nil
+      end
+    end
+
+    context 'the #from_hash class method' do
+      it 'has an arity of one' do
+        expect(first.method(:from_hash).arity).to eql(1)
+        expect(second.method(:from_hash).arity).to eql(1)
+      end
+
+      it 'creates an instance of the class' do
+        inst = first.from_hash('name' => 'Bob Builder', 'age' => 52)
+        expect(inst).to be_a(first)
+        expect(inst.name).to eq('Bob Builder')
+        expect(inst.age).to eq(52)
+      end
+
+      it 'accepts an initializer where optional keys are missing' do
+        inst = first.from_hash('name' => 'Bob Builder')
+        expect(inst).to be_a(first)
+        expect(inst.name).to eq('Bob Builder')
+        expect(inst.age).to eq(30)
+      end
+
+      it 'does not accept an initializer where optional values are nil and type does not accept nil' do
+        expect { first.from_hash('name' => 'Bob Builder', 'age' => nil) }.to(
+          raise_error(TypeAssertionError,
+            "MyModule::FirstGenerated initializer had wrong type, entry 'age' expected an Integer value, got Undef")
+        )
+      end
+    end
+
+    context 'creates an instance' do
+      it 'that the TypeCalculator infers to the Object type' do
+        expect(TypeCalculator.infer(first.from_hash('name' => 'Bob Builder'))).to eq(first_type)
+      end
+    end
+  end
+
+  context 'when generating static code' do
+    module_def = nil
+
+    before(:each) do
+      # Ideally, this would be in a before(:all) but that is impossible since lots of Puppet
+      # environment specific settings are configured by the spec_helper in before(:each)
+      if module_def.nil?
+        first_type = nil
+        second_type = nil
+        eval_and_collect_notices(source) do |scope, catalog|
+          first_type = parser.parse('MyModule::FirstGenerated', scope)
+          second_type = parser.parse('MyModule::SecondGenerated', scope)
+
+          loader = Loaders.find_loader(nil)
+          Loaders.implementation_registry.register_type_mapping(
+            PRuntimeType.new(:ruby, [/^PuppetSpec::RubyGenerator::(\w+)$/, 'MyModule::\1']),
+            [/^MyModule::(\w+)$/, 'PuppetSpec::RubyGenerator::\1'], loader)
+
+          module_def = generator.module_definition([first_type, second_type], 'Generated stuff')
+        end
+        Loaders.clear
+        Puppet[:code] = nil
+
+        # Create the actual classes in the PuppetSpec::RubyGenerator module
+        Puppet.override(:loaders => Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, []))) do
+          eval(module_def, root_binding)
+        end
+      end
+    end
+
+    after(:all) do
+      # Don't want generated module to leak outside this test
+      PuppetSpec.send(:remove_const, :RubyGenerator)
+    end
+
+    it 'the #_ptype class method returns a resolved Type' do
+      first_type = PuppetSpec::RubyGenerator::FirstGenerated._ptype
+      expect(first_type).to be_a(PObjectType)
+      second_type = PuppetSpec::RubyGenerator::SecondGenerated._ptype
+      expect(second_type).to be_a(PObjectType)
+      expect(second_type.parent).to eql(first_type)
+    end
+
+    it 'the #_plocation class method returns a file URI' do
+      loc = PuppetSpec::RubyGenerator::SecondGenerated._plocation
+      expect(loc).to be_a(URI)
+      expect(loc.to_s).to match(/^file:\/.*ruby_generator_spec.rb\?line=\d+$/)
+    end
+
+    context 'the #create class method' do
+      it 'has an arity that reflects optional arguments' do
+        expect(PuppetSpec::RubyGenerator::FirstGenerated.method(:create).arity).to eql(-2)
+        expect(PuppetSpec::RubyGenerator::SecondGenerated.method(:create).arity).to eql(-6)
+      end
+
+      it 'creates an instance of the class' do
+        inst = PuppetSpec::RubyGenerator::FirstGenerated.create('Bob Builder', 52)
+        expect(inst).to be_a(PuppetSpec::RubyGenerator::FirstGenerated)
+        expect(inst.name).to eq('Bob Builder')
+        expect(inst.age).to eq(52)
+      end
+
+      it 'will perform type assertion of the arguments' do
+        expect { PuppetSpec::RubyGenerator::FirstGenerated.create('Bob Builder', '52') }.to(
+          raise_error(TypeAssertionError,
+            'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got String')
+        )
+      end
+
+      it 'will not accept nil as given value for an optional parameter that does not accept nil' do
+        expect { PuppetSpec::RubyGenerator::FirstGenerated.create('Bob Builder', nil) }.to(
+          raise_error(TypeAssertionError,
+            'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got Undef')
+        )
+      end
+
+      it 'reorders parameters to but the optional parameters last' do
+        inst = PuppetSpec::RubyGenerator::SecondGenerated.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+        expect(inst.name).to eq('Bob Builder')
+        expect(inst.address).to eq('42 Cool Street')
+        expect(inst.zipcode).to eq('12345')
+        expect(inst.email).to eq('bob@example.com')
+        expect(inst.number).to eq(23)
+        expect(inst.what).to eql('what is this')
+        expect(inst.age).to eql(30)
+        expect(inst.another).to be_nil
+      end
+    end
+
+    context 'the #from_hash class method' do
+      it 'has an arity of one' do
+        expect(PuppetSpec::RubyGenerator::FirstGenerated.method(:from_hash).arity).to eql(1)
+        expect(PuppetSpec::RubyGenerator::SecondGenerated.method(:from_hash).arity).to eql(1)
+      end
+
+      it 'creates an instance of the class' do
+        inst = PuppetSpec::RubyGenerator::FirstGenerated.from_hash('name' => 'Bob Builder', 'age' => 52)
+        expect(inst).to be_a(PuppetSpec::RubyGenerator::FirstGenerated)
+        expect(inst.name).to eq('Bob Builder')
+        expect(inst.age).to eq(52)
+      end
+
+      it 'accepts an initializer where optional keys are missing' do
+        inst = PuppetSpec::RubyGenerator::FirstGenerated.from_hash('name' => 'Bob Builder')
+        expect(inst).to be_a(PuppetSpec::RubyGenerator::FirstGenerated)
+        expect(inst.name).to eq('Bob Builder')
+        expect(inst.age).to eq(30)
+      end
+
+      it 'does not accept an initializer where optional values are nil and type does not accept nil' do
+        expect { PuppetSpec::RubyGenerator::FirstGenerated.from_hash('name' => 'Bob Builder', 'age' => nil) }.to(
+          raise_error(TypeAssertionError,
+            "MyModule::FirstGenerated initializer had wrong type, entry 'age' expected an Integer value, got Undef")
+        )
+      end
+    end
+  end
+end
+end
+end

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -6,6 +6,15 @@ describe 'The type formatter' do
   let(:s) { TypeFormatter.new }
   let(:f) { TypeFactory }
 
+  def drop_indent(str)
+    ld = str.index("\n")
+    if ld.nil?
+      str
+    else
+      str.gsub(Regexp.compile("^ {#{ld - 1}}"), '')
+    end
+  end
+
   context 'when representing a literal as a string' do
     {
       'true' => true,
@@ -23,6 +32,41 @@ describe 'The type formatter' do
       end
     end
   end
+
+  context 'when using indent' do
+    it 'should put hash entries on new indented lines' do
+      expect(s.indented_string({'a' => 32,'b' => [1, 2, {'c' => 'd'}]})).to eq(<<-FORMATTED)
+{
+  'a' => 32,
+  'b' => [1, 2, {
+    'c' => 'd'
+  }]
+}
+FORMATTED
+    end
+
+    it 'should start on given indent level' do
+      expect(s.indented_string({'a' => 32,'b' => [1, 2, {'c' => 'd'}]}, 3)).to eq(<<-FORMATTED)
+      {
+        'a' => 32,
+        'b' => [1, 2, {
+          'c' => 'd'
+        }]
+      }
+FORMATTED
+    end
+
+    it 'should use given indent width' do
+      expect(s.indented_string({'a' => 32,'b' => [1, 2, {'c' => 'd'}]}, 2, 4)).to eq(<<-FORMATTED)
+        {
+            'a' => 32,
+            'b' => [1, 2, {
+                'c' => 'd'
+            }]
+        }
+    FORMATTED
+  end
+end
 
   context 'when representing the type as string' do
     include_context 'types_setup'


### PR DESCRIPTION
This PR adds a Ruby generator capable of generating a default implementation of an `Object` type. Instances of the object can be created either from a hash (validated by the `#i12n_type` of the `Object`) or by a constructor using anonymous parameters.

The generator is capable of generating both anonymous ruby classes and a static implementation intended to be written to files and then included in a code base.
