### PR TITLE
(PUP-6232) Allow module_tool to keep supporting ruby 1.8.7

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/Gemfile
+++ b/lib/puppet/module_tool/skeleton/templates/generator/Gemfile
@@ -11,4 +11,5 @@ gem 'rspec-puppet'
 # rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   gem 'rspec', '~> 2.0'
+  gem 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Rake 11 dropped support for ruby 1.8.7, so if we are using that, we need
to pin rake to v10.