### PR TITLE
(PUP-6072) Make --lastrunreport be a path-style argument

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1517,8 +1517,7 @@ EOT
     },
     :lastrunreport =>  {
       :default  => "$statedir/last_run_report.yaml",
-      :type     => :file,
-      :mode     => "0640",
+      :type     => :path,
       :desc     => "Where puppet agent stores the last run report in yaml format."
     },
     :graph => {

--- a/lib/puppet/indirector/report/yaml.rb
+++ b/lib/puppet/indirector/report/yaml.rb
@@ -6,6 +6,28 @@ class Puppet::Transaction::Report::Yaml < Puppet::Indirector::Yaml
 
   # Force report to be saved there
   def path(name,ext='.yaml')
-    Puppet[:lastrunreport]
+    Puppet[:lastrunreport].split(File::PATH_SEPARATOR).first
   end
+
+  def save(request)
+    # Have the superclass save it
+    super
+
+    # Make copies in other locations, if needed
+    path, *copies = Puppet[:lastrunreport].split(File::PATH_SEPARATOR)
+    copies.each do |target|
+      copy_report(path, target)
+    end
+  end
+
+  private
+
+  def copy_report(src, dest)
+    basedir = File.dirname(dest)
+
+    Puppet::FileSystem.dir_mkpath(basedir) unless Puppet::FileSystem.dir_exist?(basedir)
+
+    FileUtils.copy_file(src, dest)
+  end
+
 end


### PR DESCRIPTION
With this change we make the `lastrunreport` option from being a simple
file-type argument to being a path-type argument.

This is to support a usage case where a user wants to run the puppet with
a known and distinct run report in addition to the typically configured
version, which looks something like:

   $ puppet apply --lastrunreport=$(puppet config print lastrunreport):/tmp/special_report.yaml -e 'notify {"Hello World":}'
commit fb252414284a7e31d1290fddcbec155599bc296f