### PR TITLE
(PUP-6255) Add new function to object type

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -266,6 +266,14 @@ module Runtime3Support
   end
 
   def call_function(name, args, o, scope, &block)
+    if args.size >= 1
+      receiver_type = Types::TypeCalculator.infer(args[0])
+      if receiver_type.is_a?(Types::PObjectType)
+        member = receiver_type[name]
+        return member.invoke(scope, args, &block) unless member.nil?
+      end
+    end
+
     loader = Adapters::LoaderAdapter.loader_for_model_object(o, scope)
     if loader && func = loader.load(:function, name)
       Puppet::Util::Profiler.profile(name, [:functions, name]) do

--- a/lib/puppet/pops/types/implementation_registry.rb
+++ b/lib/puppet/pops/types/implementation_registry.rb
@@ -26,12 +26,7 @@ module Types
       register_implementation('Pcore::AST::Locator', 'Puppet::Pops::Parser::Locator::Locator19', static_loader)
       register_implementation_namespace('Pcore::AST', 'Puppet::Pops::Model', static_loader)
 
-      # Register all known type implementations. The Type and Class does not follow the standard naming convention
-      register_implementation('Type', 'Puppet::Pops::Types::PType', static_loader)
-      register_implementation('Class', 'Puppet::Pops::Types::PHostClassType', static_loader)
-
-      # The rest of the types all follow a standard naming convention
-      register_implementation_regexp([/^([A-Z]\w*)$/, 'Puppet::Pops::Types::P\1Type'], [/^Puppet::Pops::Types::P(\w+)Type$/, '\1'], static_loader)
+      TypeParser.type_map.values.each { |type| register_implementation(type.simple_name, type.class.name, static_loader) }
     end
 
     # Register a bidirectional type mapping.

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -1,3 +1,5 @@
+require_relative 'ruby_generator'
+
 module Puppet::Pops
 module Types
 
@@ -333,6 +335,76 @@ class PObjectType < PAnyType
     end
   end
 
+  # @api private
+  def new_function(loader)
+    @new_function ||= create_new_function(loader)
+  end
+
+  # @api private
+  def create_new_function(loader)
+    impl_name = Loaders.implementation_registry.module_name_for_type(self)
+    if impl_name.nil?
+      # Use generator to create a default implementation
+      impl_class = RubyGenerator.new.create_class(self)
+      class_name = "Anonymous Ruby class for #{name}"
+    else
+      # Can the mapping be loaded?
+      class_name = impl_name[0]
+      impl_class = ClassLoader.provide(class_name)
+
+      raise Puppet::Error, "Unable to load class #{class_name}" if impl_class.nil?
+      unless impl_class < PuppetObject
+        raise Puppet::Error, "Unable to create an instance of #{name}. #{class_name} does not include module #{PuppetObject.name}"
+      end
+    end
+
+    i12n_t = i12n_type
+    from_hash_type = TypeFactory.callable(i12n_t, 1, 1)
+
+    # Create a types and a names array where optional entries ends up last
+    opt_types = []
+    opt_names = []
+    non_opt_types = []
+    non_opt_names = []
+    i12n_t.elements.each do |se|
+      if se.key_type.is_a?(POptionalType)
+        opt_names << se.name
+        opt_types << se.value_type
+      else
+        non_opt_names << se.name
+        non_opt_types << se.value_type
+      end
+    end
+    param_names = non_opt_names + opt_names
+    param_types = non_opt_types + opt_types
+
+    # Create the callable with a size that reflects the required and optional parameters
+    param_types << non_opt_types.size
+    param_types << param_names.size
+    create_type = TypeFactory.callable(*param_types)
+
+    Puppet::Functions.create_loaded_function(:"new_#{name}", loader) do
+      @impl_class = impl_class
+
+      def self.impl_class
+        @impl_class
+      end
+
+      if impl_class.respond_to?(:from_asserted_hash)
+        dispatcher.add_dispatch(from_hash_type, :from_hash, ['hash'], nil, EMPTY_ARRAY, EMPTY_ARRAY, false)
+        def from_hash(hash)
+          self.class.impl_class.from_asserted_hash(hash)
+        end
+      end
+
+      dispatcher.add_dispatch(create_type, :create, param_names, nil, EMPTY_ARRAY, EMPTY_ARRAY, false)
+      def create(*args)
+        self.class.impl_class.new(*args)
+      end
+    end
+  end
+
+  # @api private
   def include_class_in_equality?
     @equality_include_type && !(@parent.is_a?(PObjectType) && parent.include_class_in_equality?)
   end
@@ -495,11 +567,19 @@ class PObjectType < PAnyType
     @parent.nil? ? false : @parent.callable_args?(callable, guard)
   end
 
-  # Returns the variant of Tuple/Struct that constraints the initialization object used when creating dynamic instances
-  # of this type.
+  # Returns the type that a initialization hash used for creating instances of this type must conform to.
   #
-  # @return [PStructType] the initialization type
+  # @return [PStructType] the initialization hash type
+  # @api public
   def i12n_type
+    @i12n_type ||= create_i12n_type
+  end
+
+  # Creates the type that a initialization hash used for creating instances of this type must conform to.
+  #
+  # @return [PStructType] the initialization hash type
+  # @api private
+  def create_i12n_type
     struct_elems = {}
     attributes(true).values.each do |attr|
       unless attr.kind == ATTRIBUTE_KIND_CONSTANT || attr.kind == ATTRIBUTE_KIND_DERIVED


### PR DESCRIPTION
This PR adds the ability to create new instances of an Object type from the Puppet Language. It also adds the ability to call members (attributes and functions) on the object since it's difficult to test instantiations of an object if it is possible to examine the result.