### PR TITLE
(PUP-6235) Change PMT tests to examples in build test

### DIFF
--- a/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
+++ b/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
@@ -21,7 +21,7 @@ agents.each do |agent|
 
   step 'Add symlink to module' do
     on(agent, "touch #{tmpdir}/hello")
-    on(agent, "ln -s #{tmpdir}/hello #{modname}/tests/symlink")
+    on(agent, "ln -s #{tmpdir}/hello #{modname}/examples/symlink")
   end
 
   step 'Build module should fail with message about needing symlinks removed' do


### PR DESCRIPTION
The PMT skeleton has been changed to name the 'tests' directory
to 'examples' in commit 420cb9f6bb. This caused the
'build_should_not_allow_symlinks' test to fail because the test
was using the 'tests' directory.

This commit renames the 'tests' directory to 'examples' in the
'build_should_not_allow_symlinks' test.

[skip-ci]