### PR TITLE
(PUP-5284) Make test skip reasons explicit

### DIFF
--- a/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
+++ b/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
@@ -5,7 +5,7 @@
 # expect that after correcting their actions, puppet will work correctly.
 test_name "Puppet manages its own configuration in a robust manner"
 
-skip_test "JVM Puppet cannot change its user while running." if @options[:is_puppetserver]
+skip_test "JVM Puppet cannot change its user while running. PUP-6246" if @options[:is_puppetserver]
 
 # when owner/group works on windows for settings, this confine should be removed.
 confine :except, :platform => 'windows'

--- a/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
+++ b/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
@@ -1,5 +1,5 @@
 test_name "puppet module upgrade (that was installed twice)"
-skip_test "This test does not seem to properly respect the given modulepath"
+skip_test "This test is blocked by PUP-6244"
 
 step 'Setup'
 

--- a/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
@@ -1,6 +1,6 @@
 test_name "puppet module upgrade (with scattered dependencies)"
 
-skip_test 'needs triage'
+skip_test "This test is blocked by PUP-6244"
 
 step 'Setup'
 

--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -1,12 +1,10 @@
 test_name "#4123: should list all running services on Redhat/CentOS"
+confine :to, :platform => /(el|centos|oracle|redhat|scientific)-5/
+
 step "Validate services running agreement ralsh vs. OS service count"
 # This will remotely exec:
 # ticket_4123_should_list_all_running_redhat.sh
 
 hosts.each do |host|
-  if host['platform'] =~ /el-5/
-    run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4123_should_list_all_running_redhat.sh'))
-  else
-    skip_test "Test not supported on this plaform" 
-  end
+  run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4123_should_list_all_running_redhat.sh'))
 end

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -1,12 +1,10 @@
 test_name "#4124: should list all disabled services on Redhat/CentOS"
+confine :to, :platform => /(el|centos|oracle|redhat|scientific)-5/
+
 step "Validate disabled services agreement ralsh vs. OS service count"
 # This will remotely exec:
 # ticket_4124_should_list_all_disabled.sh
 
 hosts.each do |host|
-  if host['platform'] =~ /el-5/
-    run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4124_should_list_all_disabled.sh'))
-  else
-    skip_test "Test not supported on this plaform"
-  end
+  run_script_on(host, File.join(File.dirname(__FILE__), 'ticket_4124_should_list_all_disabled.sh'))
 end

--- a/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
+++ b/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
@@ -1,5 +1,6 @@
 test_name "Zone: ticket #4840 - verify that the given manifest works."
-confine :to, :platform => 'solaris:pending'
+skip_test "This test is blocked by PUP-6245"
+confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils


### PR DESCRIPTION
Update acceptance tests to make the reasons for their status as 'skipped' explicit.