### PR TITLE
(PUP-5025) Fix epoch and architecture handling for RPM systems

### DIFF
--- a/acceptance/lib/puppet/acceptance/rpm_util.rb
+++ b/acceptance/lib/puppet/acceptance/rpm_util.rb
@@ -70,6 +70,7 @@ Summary: A very simple toy bin rpm package
 Name: #{o[:pkg]}
 Version: #{o[:version]}
 Release: 1
+Epoch: #{o[:epoch] || 0}
 License: GPL+
 Group: Development/Tools
 SOURCE0 : %{name}-%{version}.tar.gz

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -6,12 +6,14 @@ confine :except, :platform => /centos-4|el-4/ # PUP-5227
 require 'puppet/acceptance/rpm_util'
 extend Puppet::Acceptance::RpmUtils
 
-rpm_options = {:pkg => 'guid', :version => '1.0'}
+epoch_rpm_options    = {:pkg => 'epoch', :version => '1.1', :epoch => '1'}
+no_epoch_rpm_options = {:pkg => 'guid', :version => '1.0'}
 
 teardown do
   step "cleanup"
   agents.each do |agent|
-    clean_rpm agent, rpm_options
+    clean_rpm agent, epoch_rpm_options
+    clean_rpm agent, no_epoch_rpm_options
   end
 end
 
@@ -33,58 +35,153 @@ def verify_absent(hosts, pkg)
   verify_state(hosts, pkg, '(?:purged|absent)', :assert_no_match)
 end
 
-step 'Setup repo and package'
+step "Managing a package which does not include an epoch in its version" do
+  step 'Setup repo and package'
+  agents.each do |agent|
+    clean_rpm agent, no_epoch_rpm_options
+    setup_rpm agent, no_epoch_rpm_options
+    send_rpm agent, no_epoch_rpm_options
+  end
+
+  step 'Installing a known package succeeds' do
+    verify_absent agents, 'guid'
+    apply_manifest_on(agents, 'package {"guid": ensure => installed}') do |result|
+      assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
+    end
+  end
+
+  step 'Removing a known package succeeds' do
+    verify_present agents, 'guid'
+    apply_manifest_on(agents, 'package {"guid": ensure => absent}') do |result|
+      assert_match('Package[guid]/ensure: removed', "#{result.host}: #{result.stdout}")
+    end
+  end
+
+  step 'Installing a specific version of a known package succeeds' do
+    verify_absent agents, 'guid'
+    apply_manifest_on(agents, 'package {"guid": ensure => "1.0"}') do |result|
+      assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
+    end
+  end
+
+  step 'Removing a specific version of a known package succeeds' do
+    verify_present agents, 'guid'
+    apply_manifest_on(agents, 'package {"guid": ensure => absent}') do |result|
+      assert_match('Package[guid]/ensure: removed', "#{result.host}: #{result.stdout}")
+    end
+  end
+
+  step 'Installing a non-existent version of a known package fails' do
+    verify_absent agents, 'guid'
+    apply_manifest_on(agents, 'package {"guid": ensure => "1.1"}') do |result|
+      assert_not_match(/Package\[guid\]\/ensure: created/, "#{result.host}: #{result.stdout}")
+      assert_match('Package[guid]/ensure: change from purged to 1.1 failed', "#{result.host}: #{result.stderr}")
+    end
+    verify_absent agents, 'guid'
+  end
+
+  step 'Installing a non-existent package fails' do
+    verify_absent agents, 'not_a_package'
+    apply_manifest_on(agents, 'package {"not_a_package": ensure => present}') do |result|
+      assert_not_match(/Package\[not_a_package\]\/ensure: created/, "#{result.host}: #{result.stdout}")
+      assert_match('Package[not_a_package]/ensure: change from purged to present failed', "#{result.host}: #{result.stderr}")
+    end
+    verify_absent agents, 'not_a_package'
+  end
+
+  step 'Removing a non-existent package succeeds' do
+    verify_absent agents, 'not_a_package'
+    apply_manifest_on(agents, 'package {"not_a_package": ensure => absent}') do |result|
+      assert_not_match(/Package\[not_a_package\]\/ensure/, "#{result.host}: #{result.stdout}")
+      assert_match('Applied catalog', "#{result.host}: #{result.stdout}")
+    end
+    verify_absent agents, 'not_a_package'
+  end
+end
+
+### Epoch tests ###
 agents.each do |agent|
-  clean_rpm agent, rpm_options
-  setup_rpm agent, rpm_options
-  send_rpm agent, rpm_options
-end
+  step "Managing a package which includes an epoch in its version" do
+    arch = on(agent, facter('os.architecture')).stdout.chomp
+    if arch == 'i386'
+      arch = 'i686'
+    end
 
-step 'Installing a known package succeeds'
-verify_absent agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => installed}') do |result|
-  assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
-end
+    step "Setup repo and package" do
+      clean_rpm agent, no_epoch_rpm_options
+      setup_rpm agent, epoch_rpm_options
+      send_rpm agent, epoch_rpm_options
+    end
 
-step 'Removing a known package succeeds'
-verify_present agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => absent}') do |result|
-  assert_match('Package[guid]/ensure: removed', "#{result.host}: #{result.stdout}")
-end
+    step 'Installing a known package with an epoch succeeds' do
+      verify_absent [agent], 'epoch'
+      apply_manifest_on(agent, 'package {"epoch": ensure => installed}') do |result|
+        assert_match('Package[epoch]/ensure: created', "#{result.host}: #{result.stdout}")
+      end
+    end
 
-step 'Installing a specific version of a known package succeeds'
-verify_absent agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => "1.0"}') do |result|
-  assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
-end
+    step 'Removing a known package with an epoch succeeds' do
+      verify_present [agent], 'epoch'
+      apply_manifest_on(agent, 'package {"epoch": ensure => absent}') do |result|
+        assert_match('Package[epoch]/ensure: removed', "#{result.host}: #{result.stdout}")
+      end
+    end
 
-step 'Removing a specific version of a known package succeeds'
-verify_present agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => absent}') do |result|
-  assert_match('Package[guid]/ensure: removed', "#{result.host}: #{result.stdout}")
-end
+    step "Installing a specific version of a known package with an epoch succeeds when epoch and arch are specified" do
+      verify_absent [agent], 'epoch'
+      apply_manifest_on(agent, "package {'epoch': ensure => '1:1.1-1.#{arch}'}") do |result|
+        assert_match('Package[epoch]/ensure: created', "#{result.host}: #{result.stdout}")
+      end
 
-step 'Installing a non-existant version of a known package fails'
-verify_absent agents, 'guid'
-apply_manifest_on(agents, 'package {"guid": ensure => "1.1"}') do |result|
-  assert_not_match(/Package\[guid\]\/ensure: created/, "#{result.host}: #{result.stdout}")
-  assert_match('Package[guid]/ensure: change from purged to 1.1 failed', "#{result.host}: #{result.stderr}")
-end
-verify_absent agents, 'guid'
+      apply_manifest_on(agent, "package {'epoch': ensure => '1:1.1-1.#{arch}'}") do |result|
+        assert_no_match(/epoch/, result.stdout)
+      end
+    end
 
-step 'Installing a non-existant package fails'
-verify_absent agents, 'not_a_package'
-apply_manifest_on(agents, 'package {"not_a_package": ensure => present}') do |result|
-  assert_not_match(/Package\[not_a_package\]\/ensure: created/, "#{result.host}: #{result.stdout}")
-  assert_match('Package[not_a_package]/ensure: change from purged to present failed', "#{result.host}: #{result.stderr}")
-end
-verify_absent agents, 'not_a_package'
+    if rpm_provider(agent) == 'dnf'
+      # Yum requires the arch to be specified whenever epoch is specified. This step is only
+      # expected to work in DNF.
+      step "Installing a specific version of a known package with an epoch succeeds when epoch is specified and arch is not" do
+        step "Remove the package" do
+          apply_manifest_on(agent, 'package {"epoch": ensure => absent}')
+          verify_absent [agent], 'epoch'
+        end
 
-step 'Removing a non-existant package succeeds'
-verify_absent agents, 'not_a_package'
-apply_manifest_on(agents, 'package {"not_a_package": ensure => absent}') do |result|
-  assert_not_match(/Package\[not_a_package\]\/ensure/, "#{result.host}: #{result.stdout}")
-  assert_match('Applied catalog', "#{result.host}: #{result.stdout}")
-end
-verify_absent agents, 'not_a_package'
+        apply_manifest_on(agent, 'package {"epoch": ensure => "1:1.1-1"}') do |result|
+          assert_match('Package[epoch]/ensure: created', "#{result.host}: #{result.stdout}")
+        end
 
+        apply_manifest_on(agent, 'package {"epoch": ensure => "1:1.1-1"}') do |result|
+          assert_no_match(/epoch/, result.stdout)
+        end
+
+        apply_manifest_on(agent, "package {'epoch': ensure => '1:1.1-1.#{arch}'}") do |result|
+          assert_no_match(/epoch/, result.stdout)
+        end
+      end
+    end
+
+    if rpm_provider(agent) == 'yum'
+      step "Installing a specified version of a known package with an epoch succeeds without epoch or arch provided" do
+        # Due to a bug in DNF, epoch is required. This step is only expected to work in Yum.
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1286877
+        step "Remove the package" do
+          apply_manifest_on(agent, 'package {"epoch": ensure => absent}')
+          verify_absent [agent], 'epoch'
+        end
+
+        apply_manifest_on(agent, 'package {"epoch": ensure => "1.1-1"}') do |result|
+          assert_match('Package[epoch]/ensure: created', "#{result.host}: #{result.stdout}")
+        end
+
+        apply_manifest_on(agent, 'package {"epoch": ensure => "1.1-1"}') do |result|
+          assert_no_match(/epoch/, result.stdout)
+        end
+
+        apply_manifest_on(agent, "package {'epoch': ensure => '1:1.1-1.#{arch}'}") do |result|
+          assert_no_match(/epoch/, result.stdout)
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -298,27 +298,6 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
     0 == rpm_compareEVR(rpm_parse_evr(should), rpm_parse_evr(is))
   end
 
-  private
-  # @param line [String] one line of rpm package query information
-  # @return [Hash] of NEVRA_FIELDS strings parsed from package info
-  # or an empty hash if we failed to parse
-  # @api private
-  def self.nevra_to_hash(line)
-    line.strip!
-    hash = {}
-
-    if match = self::NEVRA_REGEX.match(line)
-      self::NEVRA_FIELDS.zip(match.captures) { |f, v| hash[f] = v }
-      hash[:provider] = self.name
-      hash[:ensure] = "#{hash[:version]}-#{hash[:release]}"
-      hash[:ensure].prepend("#{hash[:epoch]}:") if hash[:epoch] != '0'
-    else
-      Puppet.debug("Failed to match rpm line #{line}")
-    end
-
-    return hash
-  end
-
   # parse a rpm "version" specification
   # this re-implements rpm's
   # rpmUtils.miscutils.stringToVersion() in ruby
@@ -397,5 +376,26 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
       return -1
     end
     return rpmvercmp(s1, s2)
+  end
+
+  private
+  # @param line [String] one line of rpm package query information
+  # @return [Hash] of NEVRA_FIELDS strings parsed from package info
+  # or an empty hash if we failed to parse
+  # @api private
+  def self.nevra_to_hash(line)
+    line.strip!
+    hash = {}
+
+    if match = self::NEVRA_REGEX.match(line)
+      self::NEVRA_FIELDS.zip(match.captures) { |f, v| hash[f] = v }
+      hash[:provider] = self.name
+      hash[:ensure] = "#{hash[:version]}-#{hash[:release]}"
+      hash[:ensure].prepend("#{hash[:epoch]}:") if hash[:epoch] != '0'
+    else
+      Puppet.debug("Failed to match rpm line #{line}")
+    end
+
+    return hash
   end
 end

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -149,8 +149,13 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     else
       # Add the package version
       wanted += "-#{should}"
+      if wanted.scan(ARCH_REGEX)
+        self.debug "Detected Arch argument in package! - Moving arch to end of version string"
+        wanted.gsub!(/(.+)(#{ARCH_REGEX})(.+)/,'\1\3\2')
+      end
+
       is = self.query
-      if is && yum_compareEVR(yum_parse_evr(should), yum_parse_evr(is[:ensure])) < 0
+      if is && rpm_compareEVR(rpm_parse_evr(should), rpm_parse_evr(is[:ensure])) < 0
         self.debug "Downgrading package #{@resource[:name]} from version #{is[:ensure]} to #{should}"
         operation = :downgrade
       end
@@ -173,7 +178,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
       # FIXME: Should we raise an exception even if should == :latest
       # and yum updated us to a version other than @param_hash[:ensure] ?
-      vercmp_result = yum_compareEVR(yum_parse_evr(should), yum_parse_evr(is[:ensure]))
+      vercmp_result = rpm_compareEVR(rpm_parse_evr(should), rpm_parse_evr(is[:ensure]))
       raise Puppet::Error, "Failed to update to version #{should}, got version #{is[:ensure]} instead" if vercmp_result != 0
     end
   end
@@ -200,72 +205,6 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
   def purge
     execute([command(:cmd), "-y", :erase, @resource[:name]])
-  end
-
-  # parse a yum "version" specification
-  # this re-implements yum's
-  # rpmUtils.miscutils.stringToVersion() in ruby
-  def yum_parse_evr(s)
-    ei = s.index(':')
-    if ei
-      e = s[0,ei]
-      s = s[ei+1,s.length]
-    else
-      e = nil
-    end
-    e = String(Bignum(e)) rescue '0'
-    ri = s.index('-')
-    if ri
-      v = s[0,ri]
-      r = s[ri+1,s.length]
-    else
-      v = s
-      r = nil
-    end
-    return { :epoch => e, :version => v, :release => r }
-  end
-
-  # how yum compares two package versions:
-  # rpmUtils.miscutils.compareEVR(), which massages data types and then calls
-  # rpm.labelCompare(), found in rpm.git/python/header-py.c, which
-  # sets epoch to 0 if null, then compares epoch, then ver, then rel
-  # using compare_values() and returns the first non-0 result, else 0.
-  # This function combines the logic of compareEVR() and labelCompare().
-  #
-  # "version_should" can be v, v-r, or e:v-r.
-  # "version_is" will always be at least v-r, can be e:v-r
-  def yum_compareEVR(should_hash, is_hash)
-    # pass on to rpm labelCompare
-    rc = compare_values(should_hash[:epoch], is_hash[:epoch])
-    return rc unless rc == 0
-    rc = compare_values(should_hash[:version], is_hash[:version])
-    return rc unless rc == 0
-
-    # here is our special case, PUP-1244.
-    # if should_hash[:release] is nil (not specified by the user),
-    # and comparisons up to here are equal, return equal. We need to
-    # evaluate to whatever level of detail the user specified, so we
-    # don't end up upgrading or *downgrading* when not intended.
-    #
-    # This should NOT be triggered if we're trying to ensure latest.
-    return 0 if should_hash[:release].nil?
-
-    rc = compare_values(should_hash[:release], is_hash[:release])
-    return rc
-  end
-
-  # this method is a native implementation of the
-  # compare_values function in rpm's python bindings,
-  # found in python/header-py.c, as used by yum.
-  def compare_values(s1, s2)
-    if s1.nil? && s2.nil?
-      return 0
-    elsif ( not s1.nil? ) && s2.nil?
-      return 1
-    elsif s1.nil? && (not s2.nil?)
-      return -1
-    end
-    return rpmvercmp(s1, s2)
   end
 
   private


### PR DESCRIPTION
This commit updates logic in the RPM and Yum providers to
better handle the presence or absence of user specified epochs
and architecture fields. We now assert that absent epoch and
architecture values from the user are always insync with those
values as found by querying the system. This allows Puppet to
make the assumption that an unprovided epoch value can match
anything available on the system, not just the former default
of '0'.

In addition, this change also enables the detection of an
architecture in the title of a package and moves it to the
end of the version string for installation. Thanks to
Peter Souter (petems) for the work on this!

Note that there are still limitations based on the underlying
package manager when installing packages. DNF (a child of the
yum provider), for example requires the epoch to be specified
when a package includes one due to a bug. In yum, if an epoch is
specified then the architecture must also be specified.

This commit also refactors the Yum provider slightly to move
some of the more primitive version comparison methods up into
the parent RPM provider.

The second commit adds new acceptance test cases to the existing Yum
test.
