### PR TITLE
(PUP-1526) Add environment settings for package type

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -239,6 +239,8 @@ class Puppet::Provider
       @optional = false
       @confiner = confiner
       @custom_environment = {}
+      @command_resolver = Puppet::Util
+      @command_executor = Puppet::Util::Execution
     end
 
     def is_optional
@@ -249,12 +251,20 @@ class Puppet::Provider
       @custom_environment = @custom_environment.merge(env)
     end
 
+    def resolver(res)
+      @command_resolver = res
+    end
+
+    def executor(exec)
+      @command_executor = exec
+    end
+
     def command
       if not @optional
         @confiner.confine :exists => @path, :for_binary => true
       end
 
-      Puppet::Provider::Command.new(@name, @path, Puppet::Util, Puppet::Util::Execution, { :failonfail => true, :combine => true, :custom_environment => @custom_environment })
+      Puppet::Provider::Command.new(@name, @path, @command_resolver, @command_executor, { :failonfail => true, :combine => true, :custom_environment => @custom_environment })
     end
   end
 

--- a/lib/puppet/provider/package.rb
+++ b/lib/puppet/provider/package.rb
@@ -30,6 +30,66 @@ class Puppet::Provider::Package < Puppet::Provider
     true
   end
 
+  # Wrap the has_command function to use this class's `execute` function
+  # @see Puppet::Provider.has_command
+  def self.has_command(name, path, &block)
+    if self.feature?(:settable_environment)
+      super(name, path) do
+        executor Puppet::Provider::Package
+        self.instance_eval(block) if block
+      end
+    else
+      super(name, path, &block)
+    end
+  end
+
+  # Wrap the Puppet::Util::Execution.execute function to automatically
+  # import the resource[:environment] hash into the execution environment,
+  # if the :settable_environment is available
+  # @see Puppet::Util::Execution.execute
+  def execute(command, options = nil)
+    if self.feature?(:settable_environment) and @resource and resource[:environment]
+      if options.nil?
+        # no options hash provided, provide our own
+        options = { :custom_environment => @resource[:environment] }
+      elsif options.has_key?(:custom_environment)
+        # make a "safe" copy of options before modifying
+        options = options.dup
+        options[:custom_environment] = options[:custom_environment].merge(@resource[:environment])
+      else
+        # merge creates a new copy of the hash before merging
+        options = options.merge( { :custom_environment => @resource[:environment] } )
+      end
+    end
+    if options.nil?
+      Puppet::Util::Execution.execute(command)
+    else
+      Puppet::Util::Execution.execute(command, options)
+    end
+  end
+
+  # Wrap the Puppet::Util::Execution.execpipe function to automatically
+  # import the resource[:environment] hash into the execution environment,
+  # if the :settable_environment is available
+  # @see Puppet::Util::Execution.execpipe
+  def self.execpipe(command, failonfail = nil)
+    execpipe_env = ENV.to_hash
+    if self.feature?(:settable_environment) and @resource and resource[:environment]
+      execpipe_env.merge!( resource[:environment] )
+    end
+    Puppet::Util.withenv(execpipe_env) do
+      if failonfail.nil?
+        Puppet::Util::Execution.execpipe(command) do |pipe|
+          yield pipe
+        end
+      else
+        Puppet::Util::Execution.execpipe(command, failonfail) do |pipe|
+          yield pipe
+        end
+      end
+    end
+  end
+
   # Turns a array of options into flags to be passed to a command.
   # The options can be passed as a string or hash. Note that passing a hash
   # should only be used in case --foo=bar must be passed,

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -16,11 +16,11 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   # @param args [Array<String>] any command line arguments to be appended to the command
   # @param block expected to be passed on to execpipe
   # @return whatever the block returns
-  # @see Puppet::Util::Execution.execpipe
+  # @see Puppet::Provider::Package.execpipe
   # @api private
   def self.dpkgquery_piped(*args, &block)
     cmd = args.unshift(command(:dpkgquery))
-    Puppet::Util::Execution.execpipe(cmd, &block)
+    execpipe(cmd, &block)
   end
 
   def self.instances

--- a/lib/puppet/provider/package/nim.rb
+++ b/lib/puppet/provider/package/nim.rb
@@ -87,7 +87,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
       version = nil
       showres_command << "'#{Regexp.escape(pkg)}'"
     end
-    output = Puppet::Util::Execution.execute(showres_command)
+    output = execute(showres_command)
 
 
     if (version_specified)

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -243,7 +243,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
   end
 
   def exec_cmd(*cmd)
-    output = Puppet::Util::Execution.execute(cmd, :failonfail => false, :combine => true)
+    output = execute(cmd, :failonfail => false, :combine => true)
     {:out => output, :exit => $CHILD_STATUS.exitstatus}
   end
 end

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :install_options, :versionable, :virtual_packages
+  has_feature :install_options, :versionable, :virtual_packages, :settable_environment
 
   commands :cmd => "yum", :rpm => "rpm"
 
@@ -42,14 +42,15 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   # @param enablerepo [Array<String>] A list of repositories to enable for this query
   # @param disablerepo [Array<String>] A list of repositories to disable for this query
   # @param disableexcludes [Array<String>] A list of repository excludes to disable for this query
+  # @param environment [Hash<String,String>] A hash of environment variables to use
   # @return [Hash<Symbol, String>]
-  def self.latest_package_version(package, enablerepo, disablerepo, disableexcludes)
+  def self.latest_package_version(package, enablerepo, disablerepo, disableexcludes, environment=nil)
 
     key = [enablerepo, disablerepo, disableexcludes]
 
     @latest_versions ||= {}
     if @latest_versions[key].nil?
-      @latest_versions[key] = check_updates(enablerepo, disablerepo, disableexcludes)
+      @latest_versions[key] = check_updates(enablerepo, disablerepo, disableexcludes, environment)
     end
 
     if @latest_versions[key][package]
@@ -64,15 +65,20 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   # @param enablerepo [Array<String>] A list of repositories to enable for this query
   # @param disablerepo [Array<String>] A list of repositories to disable for this query
   # @param disableexcludes [Array<String>] A list of repository excludes to disable for this query
+  # @param environment [Hash<String,String>] An optional hash of environment variables to apply
   # @return [Hash<String, Array<Hash<String, String>>>] All packages that were
   #   found with a list of found versions for each package.
-  def self.check_updates(enablerepo, disablerepo, disableexcludes)
+  def self.check_updates(enablerepo, disablerepo, disableexcludes, environment=nil)
     args = [command(:cmd), 'check-update']
     args.concat(enablerepo.map { |repo| ["--enablerepo=#{repo}"] }.flatten)
     args.concat(disablerepo.map { |repo| ["--disablerepo=#{repo}"] }.flatten)
     args.concat(disableexcludes.map { |repo| ["--disableexcludes=#{repo}"] }.flatten)
 
-    output = Puppet::Util::Execution.execute(args, :failonfail => false, :combine => false)
+    if environment.nil?
+      output = Puppet::Util::Execution.execute(args, :failonfail => false, :combine => false)
+    else
+      output = Puppet::Util::Execution.execute(args, :failonfail => false, :combine => false, :custom_environment => environment)
+    end
 
     updates = {}
     if output.exitstatus == 100
@@ -213,7 +219,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
   # What's the latest package version available?
   def latest
-    upd = self.class.latest_package_version(@resource[:name], enablerepo, disablerepo, disableexcludes)
+    upd = self.class.latest_package_version(@resource[:name], enablerepo, disablerepo, disableexcludes, @resource[:environment])
     unless upd.nil?
       # FIXME: there could be more than one update for a package
       # because of multiarch


### PR DESCRIPTION
This patch adds to the package type the `:settable_environment` feature
and the `:environment` parameter used by that feature.  `:environment`
is either a string of the form "NAME=VALUE" or an array of such strings.

The Puppet::Provider::Package is modified to include wrapped versions
of the `execute`, `execpipe`, and `has_command` methods which include
the custom environment if the calling resource defines it.  This
includes a required modification to the `CommandDefiner` class in
Puppet::Provider to allow the executor and resolver to be overridden.

All package providers are modified to use the Puppet::Provider::Package
versions of `execute`, `execpipe`, and `has_command`.

The `yum` package provider is updated to actually support the
`environment` parameter and `:settable_environment` feature.

Finally, the `spec` tests for the `package` type and `yum` provider
are updated to test for the `:settable_environment` feature and the
`environment` parameter.
