### PR TITLE
(maint) Bump to ruby 2.3.1 in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 notifications:
   email: false
 rvm:
-  - 2.3.0-dev
+  - 2.3.1
   - 2.2.4
   - 2.1.7
   - 2.0.0
@@ -21,7 +21,7 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.3.0-dev
+    - rvm: 2.3.1
       env: "CHECK=rubocop"
     - rvm: 2.2.4
       env: "CHECK=rubocop"
@@ -29,7 +29,7 @@ matrix:
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
-    - rvm: 2.3.0-dev
+    - rvm: 2.3.1
       env: "CHECK=commits"
     - rvm: 2.2.4
       env: "CHECK=commits"


### PR DESCRIPTION
Ruby 2.3.1 has been released, which includes the fix for
https://bugs.ruby-lang.org/issues/11928, so bump travis to
use the released version of 2.3.