### PR TITLE
(PUP-6072) Make --lastrunreport be a multi-file-style argument

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1561,9 +1561,11 @@ EOT
     },
     :lastrunreport =>  {
       :default  => "$statedir/last_run_report.yaml",
-      :type     => :file,
+      :type     => :multi_file,
       :mode     => "0640",
-      :desc     => "Where puppet agent stores the last run report in yaml format."
+      :desc     => "Where puppet agent stores the last run report in yaml format. Can be
+        provided as a '#{File::PATH_SEPARATOR}' separated list of paths to write. The
+        report will be written to all listed paths."
     },
     :graph => {
       :default  => false,

--- a/lib/puppet/indirector/report/msgpack.rb
+++ b/lib/puppet/indirector/report/msgpack.rb
@@ -6,6 +6,28 @@ class Puppet::Transaction::Report::Msgpack < Puppet::Indirector::Msgpack
 
   # Force report to be saved there
   def path(name,ext='.msgpack')
-    Puppet[:lastrunreport]
+    Puppet[:lastrunreport].first
   end
+
+  def save(request)
+    # Have the superclass save it
+    super
+
+    # Make copies in other locations, if needed
+    path, *copies = Puppet[:lastrunreport]
+    copies.each do |target|
+      copy_report(path, target)
+    end
+  end
+
+  private
+
+  def copy_report(src, dest)
+    basedir = File.dirname(dest)
+
+    Puppet::FileSystem.dir_mkpath(basedir) unless Puppet::FileSystem.dir_exist?(basedir)
+
+    FileUtils.copy_file(src, dest)
+  end
+
 end

--- a/lib/puppet/indirector/report/yaml.rb
+++ b/lib/puppet/indirector/report/yaml.rb
@@ -6,6 +6,28 @@ class Puppet::Transaction::Report::Yaml < Puppet::Indirector::Yaml
 
   # Force report to be saved there
   def path(name,ext='.yaml')
-    Puppet[:lastrunreport]
+    Puppet[:lastrunreport].first
   end
+
+  def save(request)
+    # Have the superclass save it
+    super
+
+    # Make copies in other locations, if needed
+    path, *copies = Puppet[:lastrunreport]
+    copies.each do |target|
+      copy_report(path, target)
+    end
+  end
+
+  private
+
+  def copy_report(src, dest)
+    basedir = File.dirname(dest)
+
+    Puppet::FileSystem.dir_mkpath(basedir) unless Puppet::FileSystem.dir_exist?(basedir)
+
+    FileUtils.copy_file(src, dest)
+  end
+
 end

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -17,6 +17,7 @@ class Puppet::Settings
   require 'puppet/settings/symbolic_enum_setting'
   require 'puppet/settings/array_setting'
   require 'puppet/settings/file_setting'
+  require 'puppet/settings/multi_file_setting'
   require 'puppet/settings/directory_setting'
   require 'puppet/settings/file_or_directory_setting'
   require 'puppet/settings/path_setting'
@@ -655,6 +656,7 @@ class Puppet::Settings
   SETTING_TYPES = {
       :string     => StringSetting,
       :file       => FileSetting,
+      :multi_file => MultiFileSetting,
       :directory  => DirectorySetting,
       :file_or_directory => FileOrDirectorySetting,
       :path       => PathSetting,
@@ -930,11 +932,11 @@ class Puppet::Settings
       next if file.value.nil?
       next unless (sections.nil? or sections.include?(file.section))
       next unless resource = file.to_resource
-      next if catalog.resource(resource.ref)
-
-      Puppet.debug {"Using settings: adding file resource '#{key}': '#{resource.inspect}'"}
-
-      catalog.add_resource(resource)
+      [resource].flatten.each do |res|
+        next if catalog.resource(res.ref)
+        Puppet.debug {"Using settings: adding file resource '#{key}': '#{res.inspect}'"}
+        catalog.add_resource(res)
+      end
     end
 
     add_user_resources(catalog, sections)

--- a/lib/puppet/settings/multi_file_setting.rb
+++ b/lib/puppet/settings/multi_file_setting.rb
@@ -1,0 +1,43 @@
+class Puppet::Settings::MultiFileSetting < Puppet::Settings::FileSetting
+
+  def initialize(args)
+    super
+  end
+
+  # Overrides munge to be able to read the un-munged value (the FileSetting.munge removes trailing slash)
+  #
+  def munge(value)
+    if value.is_a?(String)
+      value = value.split(File::PATH_SEPARATOR).map { |d| File.expand_path(d) }
+    end
+    value
+  end
+
+  # Turn our setting thing into a Puppet::Resource instance.
+  def to_resource
+    return nil unless type = self.type
+
+    paths = self.value
+    return nil unless paths.is_a?(Array)
+
+    paths.map {|path| create_resource(type, path)}.select {|path| path}
+  end
+
+  # @api private
+  def exclusive_open(option = 'r', &block)
+    controlled_access do |mode|
+      value.each do |file|
+        Puppet::FileSystem.exclusive_open(file, mode, option, &block)
+      end
+    end
+  end
+
+  # @api private
+  def open(option = 'r', &block)
+    controlled_access do |mode|
+      value.each do |file|
+        Puppet::FileSystem.open(file, mode, option, &block)
+      end
+    end
+  end
+end

--- a/spec/unit/indirector/report/msgpack_spec.rb
+++ b/spec/unit/indirector/report/msgpack_spec.rb
@@ -23,6 +23,6 @@ describe Puppet::Transaction::Report::Msgpack, :if => Puppet.features.msgpack? d
   end
 
   it "should unconditionally save/load from the --lastrunreport setting" do
-    expect(subject.path(:me)).to eq(Puppet[:lastrunreport])
+    expect(subject.path(:me)).to eq(Puppet[:lastrunreport].first)
   end
 end

--- a/spec/unit/indirector/report/yaml_spec.rb
+++ b/spec/unit/indirector/report/yaml_spec.rb
@@ -23,6 +23,6 @@ describe Puppet::Transaction::Report::Yaml do
   end
 
   it "should unconditionally save/load from the --lastrunreport setting" do
-    expect(subject.path(:me)).to eq(Puppet[:lastrunreport])
+    expect(subject.path(:me)).to eq(Puppet[:lastrunreport].first)
   end
 end

--- a/spec/unit/settings/multi_file_setting_spec.rb
+++ b/spec/unit/settings/multi_file_setting_spec.rb
@@ -1,0 +1,223 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/settings'
+require 'puppet/settings/multi_file_setting'
+
+describe Puppet::Settings::MultiFileSetting do
+  MultiFileSetting = Puppet::Settings::MultiFileSetting
+
+  include PuppetSpec::Files
+
+  it "should be able to be converted into a resource" do
+    expect(MultiFileSetting.new(:settings => mock("settings"), :desc => "eh")).to respond_to(:to_resource)
+  end
+
+  describe "when being converted to a resource" do
+    before do
+      @basepath1 = make_absolute("/somepath")
+      @basepath2 = make_absolute("/otherpath")
+      @settings = mock 'settings'
+      @file = Puppet::Settings::MultiFileSetting.new(:settings => @settings, :desc => "eh", :name => :myfile, :section => "mysect")
+      @file.stubs(:create_files?).returns true
+      @settings.stubs(:value).with(:myfile, nil, false).returns [@basepath1, @basepath2]
+    end
+
+    it "should return :file as its type" do
+      expect(@file.type).to eq(:file)
+    end
+
+    it "should skip non-existent files if 'create_files' is not enabled" do
+      @file.expects(:create_files?).twice.returns false
+      @file.expects(:type).returns :file
+      Puppet::FileSystem.expects(:exist?).with(@basepath1).returns false
+      Puppet::FileSystem.expects(:exist?).with(@basepath2).returns false
+      expect(@file.to_resource).to be_empty
+    end
+
+    it "should manage existent files even if 'create_files' is not enabled" do
+      @file.expects(:create_files?).twice.returns false
+      @file.expects(:type).returns :file
+      Puppet::FileSystem.stubs(:exist?)
+      Puppet::FileSystem.expects(:exist?).with(@basepath1).returns true
+      Puppet::FileSystem.expects(:exist?).with(@basepath2).returns true
+      resources = @file.to_resource
+      expect(resources).to be_instance_of(Array)
+      expect(resources.size).to eq(2)
+      expect(resources[0]).to be_instance_of(Puppet::Resource)
+    end
+
+    describe "on POSIX systems", :if => Puppet.features.posix? do
+      it "should skip files in /dev" do
+        @settings.stubs(:value).with(:myfile, nil, false).returns "/dev/file"
+        expect(@file.to_resource).to be_nil
+      end
+    end
+
+    it "should skip files whose paths are not strings" do
+      @settings.stubs(:value).with(:myfile, nil, false).returns :foo
+      expect(@file.to_resource).to be_nil
+    end
+
+    it "should return a file resource with the path set appropriately" do
+      resources = @file.to_resource
+      expect(resources[0].type).to eq("File")
+      expect(resources[0].title).to eq(@basepath1)
+      expect(resources[1].type).to eq("File")
+      expect(resources[1].title).to eq(@basepath2)
+    end
+
+    it "should fully qualified returned files if necessary (#795)" do
+      @settings.stubs(:value).with(:myfile, nil, false).returns ["myfile"]
+      path = File.expand_path('myfile')
+      expect(@file.to_resource.first.title).to eq(path)
+    end
+
+    it "should set the mode on the file if a mode is provided as an octal number" do
+      @file.mode = 0755
+
+      @file.to_resource.each {|resource| expect(resource[:mode]).to eq('755')}
+    end
+
+    it "should set the mode on the file if a mode is provided as a string" do
+      @file.mode = '0755'
+
+      @file.to_resource.each {|resource| expect(resource[:mode]).to eq('755')}
+    end
+
+    it "should not set the mode on a the file if manage_internal_file_permissions is disabled" do
+      Puppet[:manage_internal_file_permissions] = false
+
+      @file.stubs(:mode).returns(0755)
+
+      @file.to_resource.each {|resource| expect(resource[:mode]).to eq(nil)}
+    end
+
+    it "should set the owner if running as root and the owner is provided" do
+      Puppet.features.expects(:root?).twice.returns true
+      Puppet.features.stubs(:microsoft_windows?).twice.returns false
+
+      @file.stubs(:owner).returns "foo"
+      @file.to_resource.each {|resource| expect(resource[:owner]).to eq("foo")}
+    end
+
+    it "should not set the owner if manage_internal_file_permissions is disabled" do
+      Puppet[:manage_internal_file_permissions] = false
+      Puppet.features.stubs(:root?).returns true
+      @file.stubs(:owner).returns "foo"
+
+      @file.to_resource.each {|resource| expect(resource[:owner]).to eq(nil)}
+    end
+
+    it "should set the group if running as root and the group is provided" do
+      Puppet.features.expects(:root?).twice.returns true
+      Puppet.features.stubs(:microsoft_windows?).twice.returns false
+
+      @file.stubs(:group).returns "foo"
+      @file.to_resource.each {|resource| expect(resource[:group]).to eq("foo")}
+    end
+
+    it "should not set the group if manage_internal_file_permissions is disabled" do
+      Puppet[:manage_internal_file_permissions] = false
+      Puppet.features.stubs(:root?).returns true
+      @file.stubs(:group).returns "foo"
+
+      @file.to_resource.each {|resource| expect(resource[:group]).to eq(nil)}
+    end
+
+
+    it "should not set owner if not running as root" do
+      Puppet.features.expects(:root?).twice.returns false
+      Puppet.features.stubs(:microsoft_windows?).returns false
+      @file.stubs(:owner).returns "foo"
+      @file.to_resource.each {|resource| expect(resource[:owner]).to be_nil}
+    end
+
+    it "should not set group if not running as root" do
+      Puppet.features.expects(:root?).twice.returns false
+      Puppet.features.stubs(:microsoft_windows?).returns false
+      @file.stubs(:group).returns "foo"
+      @file.to_resource.each {|resource| expect(resource[:group]).to be_nil}
+    end
+
+    describe "on Microsoft Windows systems" do
+      before :each do
+        Puppet.features.stubs(:microsoft_windows?).returns true
+      end
+
+      it "should not set owner" do
+        @file.stubs(:owner).returns "foo"
+        @file.to_resource.each {|resource| expect(resource[:owner]).to be_nil}
+      end
+
+      it "should not set group" do
+        @file.stubs(:group).returns "foo"
+        @file.to_resource.each {|resource| expect(resource[:group]).to be_nil}
+      end
+    end
+
+    it "should set the loglevel to :debug" do
+      @file.to_resource.each {|resource| expect(resource[:loglevel]).to eq(:debug)}
+    end
+
+    it "should set the backup to false" do
+      @file.to_resource.each {|resource| expect(resource[:backup]).to be_falsey}
+    end
+
+    it "should tag the resource with the settings section" do
+      @file.expects(:section).twice.returns "mysect"
+      @file.to_resource.each {|resource| expect(resource).to be_tagged("mysect")}
+    end
+
+    it "should tag the resource with the setting name" do
+      @file.to_resource.each {|resource| expect(resource).to be_tagged("myfile")}
+    end
+
+    it "should tag the resource with 'settings'" do
+      @file.to_resource.each {|resource| expect(resource).to be_tagged("settings")}
+    end
+
+    it "should set links to 'follow'" do
+      @file.to_resource.each {|resource| expect(resource[:links]).to eq(:follow)}
+    end
+  end
+
+  describe "#munge" do
+    it 'splits arguments using the platform-specific path separater' do
+      filesetting = MultiFileSetting.new(:settings => mock("settings"), :desc => "eh")
+      abs_path = Puppet.features.microsoft_windows? ? ['C:/path_a', 'C:/path_b'] : ['/path_a', '/path_b']
+      expect(filesetting.munge("/path_a#{File::PATH_SEPARATOR}/path_b")).to eq(abs_path)
+    end
+  end
+
+  context "when opening", :unless => Puppet.features.microsoft_windows? do
+    let(:path) do
+      tmpfile('file_setting_spec')
+    end
+
+    let(:setting) do
+      settings = mock("settings", :value => [path])
+      MultiFileSetting.new(:name => :mysetting, :desc => "creates a file", :settings => settings)
+    end
+
+    it "creates a file with mode 0640" do
+      setting.mode = '0640'
+
+      expect(File).to_not be_exist(path)
+      setting.open('w')
+
+      expect(File).to be_exist(path)
+      expect(Puppet::FileSystem.stat(path).mode & 0777).to eq(0640)
+    end
+
+    it "preserves the mode of an existing file" do
+      setting.mode = '0640'
+
+      Puppet::FileSystem.touch(path)
+      Puppet::FileSystem.chmod(0644, path)
+      setting.open('w')
+
+      expect(Puppet::FileSystem.stat(path).mode & 0777).to eq(0644)
+    end
+  end
+end


### PR DESCRIPTION
With this change we make the `lastrunreport` option from being a simple
file-type argument to being a multi-file-type argument.

This is to support a usage case where a user wants to run the puppet with
a known and distinct run report in addition to the typically configured
version, which looks something like:

   $ puppet apply --lastrunreport=$(puppet config print lastrunreport):/tmp/special_report.yaml -e 'notify {"Hello World":}'
commit fb252414284a7e31d1290fddcbec155599bc296f