### PR TITLE
(PUP-6178) Look for hiera.yaml in codedir first, then confdir

### DIFF
--- a/lib/hiera_puppet.rb
+++ b/lib/hiera_puppet.rb
@@ -67,21 +67,13 @@ module HieraPuppet
   end
 
   def hiera_config_file
-    config_file = nil
-
-    if Puppet.settings[:hiera_config].is_a?(String)
-      expanded_config_file = File.expand_path(Puppet.settings[:hiera_config])
-      if Puppet::FileSystem.exist?(expanded_config_file)
-        config_file = expanded_config_file
-      end
-    elsif Puppet.settings[:confdir].is_a?(String)
-      expanded_config_file = File.expand_path(File.join(Puppet.settings[:confdir], '/hiera.yaml'))
-      if Puppet::FileSystem.exist?(expanded_config_file)
-        config_file = expanded_config_file
-      end
+    hiera_config = Puppet.settings[:hiera_config]
+    if Puppet::FileSystem.exist?(hiera_config)
+      hiera_config
+    else
+      Puppet.warning "Config file #{hiera_config} not found, using Hiera defaults"
+      nil
     end
-
-    config_file
   end
 end
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -421,7 +421,16 @@ deprecated and has been replaced by 'always_retry_plugins'."
       :desc    => "Where to retrive information about data.",
     },
     :hiera_config => {
-      :default => "$codedir/hiera.yaml",
+      :default => lambda do
+        config = nil
+        codedir = Puppet.settings[:codedir]
+        if codedir.is_a?(String)
+          config = File.expand_path(File.join(codedir, 'hiera.yaml'))
+          config = nil unless Puppet::FileSystem.exist?(config)
+        end
+        config = File.expand_path(File.join(Puppet.settings[:confdir], 'hiera.yaml')) if config.nil?
+        config
+      end,
       :desc    => "The hiera configuration file. Puppet only reads this file on startup, so you must restart the puppet master every time you edit it.",
       :type    => :file,
     },

--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -95,10 +95,16 @@ class Puppet::Settings::BaseSetting
 
   def default(check_application_defaults_first = false)
     if @default.is_a? Proc
-      @default = @default.call
+      # Give unit tests a chance to reevaluate the call by removing the instance variable
+      unless instance_variable_defined?(:@evaluated_default)
+        @evaluated_default = @default.call
+      end
+      default_value = @evaluated_default
+    else
+      default_value = @default
     end
-    return @default unless check_application_defaults_first
-    return @settings.value(name, :application_defaults, true) || @default
+    return default_value unless check_application_defaults_first
+    return @settings.value(name, :application_defaults, true) || default_value
   end
 
   # Convert the object to a config statement.


### PR DESCRIPTION
This commit ensures that when Puppet is initialized, it will first check
if a Hiera config file is specified using the `hiera_config` setting. If
it is, then that setting will be used (and an warning is issued if it
doesn't exist). When`hiera_config` is not set, Puppet will first look
`hiera.yaml` in the codedir and if no such file exists, it will default
to `hiera.yaml` in confdir.