### PR TITLE
(PUP-6174) Add multi-assign vars from class vars/params

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -228,6 +228,10 @@ module Issues
     "No value for required key '#{key}' in assignment to variables from hash"
   end
 
+  MISSING_MULTI_ASSIGNMENT_VARIABLE = hard_issue :MISSING_MULTI_ASSIGNMENT_VARIABLE, :name do
+    "No value for required variable '$#{name}' in assignment to variables from class reference"
+  end
+
   APPENDS_DELETES_NO_LONGER_SUPPORTED = hard_issue :APPENDS_DELETES_NO_LONGER_SUPPORTED, :operator do
     "The operator '#{operator}' is no longer supported. See http://links.puppetlabs.com/remove-plus-equals"
   end


### PR DESCRIPTION
Before this, when using private implementation classes and wanting to expose many variables in a public facing class, code would consist of long sequences of assigns like:
```
$a = $other::inner::thing::a
$b = $other::inner::thing::b
#... repeat ad nauseum
```
This can now be achieved with a single multi assignment:
```
[$a, $b, ...] = Class['other::inner::thing']
```
The variables must exist (variable or parameter) in the referenced class, but they may be set to `undef`.