### PR TITLE
(PUP-6251) Ensure that both Array[0,0] and Hash[0,0] works.

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -357,6 +357,10 @@ class AccessOperator
   #
   def access_PHashType(o, scope, keys)
     keys.flatten!
+    if keys.size == 2 && keys[0].is_a?(Integer) && keys[1].is_a?(Integer)
+      return Types::PHashType.new(nil, nil, Types::PIntegerType.new(*keys))
+    end
+
     keys[0,2].each_with_index do |k, index|
       unless k.is_a?(Types::PAnyType)
         fail(Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[index], {:base_type => 'Hash-Type', :actual => k.class})
@@ -364,18 +368,18 @@ class AccessOperator
     end
     case keys.size
     when 2
-      Types::PHashType.new(keys[0], keys[1], nil)
+      size_t = nil
     when 3
       size_t = keys[2]
       size_t = Types::PIntegerType.new(size_t) unless size_t.is_a?(Types::PIntegerType)
-      Types::PHashType.new(keys[0], keys[1], size_t)
     when 4
-      Types::PHashType.new(keys[0], keys[1], collection_size_t(1, keys[2], keys[3]))
+      size_t = collection_size_t(2, keys[2], keys[3])
     else
       fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic, {
         :base_type => 'Hash-Type', :min => 2, :max => 4, :actual => keys.size
       })
     end
+    Types::PHashType.new(keys[0], keys[1], size_t)
   end
 
   # CollectionType is parameterized with a range
@@ -383,9 +387,9 @@ class AccessOperator
     keys.flatten!
     case keys.size
     when 1
-      size_t = collection_size_t(1, keys[0])
+      size_t = collection_size_t(0, keys[0])
     when 2
-      size_t = collection_size_t(1, keys[0], keys[1])
+      size_t = collection_size_t(0, keys[0], keys[1])
     else
       fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic,
         {:base_type => 'Collection-Type', :min => 1, :max => 2, :actual => keys.size})
@@ -399,19 +403,31 @@ class AccessOperator
     keys.flatten!
     case keys.size
     when 1
+      unless keys[0].is_a?(Types::PAnyType)
+        fail(Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[0], {:base_type => 'Array-Type', :actual => keys[0].class})
+      end
+      type = keys[0]
       size_t = nil
     when 2
-      size_t = collection_size_t(1, keys[1])
+      if keys[0].is_a?(Types::PAnyType)
+        size_t = collection_size_t(1, keys[1])
+        type = keys[0]
+      else
+        size_t = collection_size_t(0, keys[0], keys[1])
+        type = nil
+      end
     when 3
-      size_t = collection_size_t(1, keys[1], keys[2])
+      if keys[0].is_a?(Types::PAnyType)
+        size_t = collection_size_t(1, keys[1], keys[2])
+        type = keys[0]
+      else
+        fail(Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[0], {:base_type => 'Array-Type', :actual => keys[0].class})
+      end
     else
       fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic,
         {:base_type => 'Array-Type', :min => 1, :max => 3, :actual => keys.size})
     end
-    unless keys[0].is_a?(Types::PAnyType)
-      fail(Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[0], {:base_type => 'Array-Type', :actual => keys[0].class})
-    end
-    Types::PArrayType.new(keys[0], size_t)
+    Types::PArrayType.new(type, size_t)
   end
 
   # Produces an PIntegerType (range) given one or two keys.

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -236,30 +236,43 @@ class TypeParser
     when 'array'
       case parameters.size
       when 1
+        type = assert_type(parameters[0])
       when 2
-        size_type =
-          if parameters[1].is_a?(PIntegerType)
-            parameters[1]
-          else
-            assert_range_parameter(parameters[1])
-            TypeFactory.range(parameters[1], :default)
-          end
+        if parameters[0].is_a?(PAnyType)
+          type = parameters[0]
+          size_type =
+            if parameters[1].is_a?(PIntegerType)
+              size_type = parameters[1]
+            else
+              assert_range_parameter(parameters[1])
+              TypeFactory.range(parameters[1], :default)
+            end
+        else
+          type = :default
+          assert_range_parameter(parameters[0])
+          assert_range_parameter(parameters[1])
+          size_type = TypeFactory.range(parameters[0], parameters[1])
+        end
       when 3
+        type = assert_type(parameters[0])
         assert_range_parameter(parameters[1])
         assert_range_parameter(parameters[2])
         size_type = TypeFactory.range(parameters[1], parameters[2])
       else
         raise_invalid_parameters_error('Array', '1 to 3', parameters.size)
       end
-      assert_type(parameters[0])
-      TypeFactory.array_of(parameters[0], size_type)
+      TypeFactory.array_of(type, size_type)
 
     when 'hash'
       case parameters.size
       when 2
-        assert_type(parameters[0])
-        assert_type(parameters[1])
-        TypeFactory.hash_of(parameters[1], parameters[0])
+        if parameters[0].is_a?(PAnyType) && parameters[1].is_a?(PAnyType)
+          TypeFactory.hash_of(parameters[1], parameters[0])
+        else
+          assert_range_parameter(parameters[0])
+          assert_range_parameter(parameters[1])
+          TypeFactory.hash_of(:default, :default, TypeFactory.range(parameters[0], parameters[1]))
+        end
       when 3
         size_type =
           if parameters[2].is_a?(PIntegerType)
@@ -483,7 +496,7 @@ class TypeParser
 
   def assert_type(t)
     raise_invalid_type_specification_error unless t.is_a?(PAnyType)
-    true
+    t
   end
 
   def assert_range_parameter(t)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -792,10 +792,11 @@ class PCollectionType < PAnyType
   attr_reader :element_type, :size_type
 
   def initialize(element_type, size_type = nil)
-    @element_type = element_type
     @size_type = size_type
-    if has_empty_range? && !@element_type.is_a?(PUnitType)
-      raise ArgumentError, 'An empty collection may not specify an element type'
+    if !size_type.nil? && size_type.from == 0 && size_type.to == 0
+      @element_type = PUnitType::DEFAULT
+    else
+      @element_type = element_type
     end
   end
 
@@ -1716,9 +1717,10 @@ class PHashType < PCollectionType
 
   def initialize(key_type, value_type, size_type = nil)
     super(value_type, size_type)
-    @key_type = key_type
-    if has_empty_range? && !@key_type.is_a?(PUnitType)
-      raise ArgumentError, 'An empty hash may not specify a key type'
+    if !size_type.nil? && size_type.from == 0 && size_type.to == 0
+      @key_type = PUnitType::DEFAULT
+    else
+      @key_type = key_type
     end
   end
 

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -166,6 +166,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
 
     # Hash Type
     #
+    it 'produces a Hash[0, 0] from the expression Hash[0, 0]' do
+      expr = fqr('Hash')[0, 0]
+      expect(evaluate(expr)).to be_the_type(types.hash_of(types.default, types.default, types.range(0, 0)))
+    end
+
     it 'produces a Hash[Scalar,String] from the expression Hash[Scalar, String]' do
       expr = fqr('Hash')[fqr('Scalar'), fqr('String')]
       expect(evaluate(expr)).to be_the_type(types.hash_of(types.string, types.scalar))
@@ -192,6 +197,15 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
 
     # Array Type
     #
+    it 'produces an Array[0, 0] from the expression Array[0, 0]' do
+      expr = fqr('Array')[0, 0]
+      expect(evaluate(expr)).to be_the_type(types.array_of(types.default, types.range(0, 0)))
+
+      # arguments are flattened
+      expr = fqr('Array')[[fqr('String')]]
+      expect(evaluate(expr)).to be_the_type(types.array_of(types.string))
+    end
+
     it 'produces an Array[String] from the expression Array[String]' do
       expr = fqr('Array')[fqr('String')]
       expect(evaluate(expr)).to be_the_type(types.array_of(types.string))

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -175,30 +175,21 @@ describe 'The type factory' do
       expect(t.size_type.to).to eq(2)
     end
 
-    it 'it is illegal to create a typed empty array' do
-      expect {
-        Puppet::Pops::Types::TypeFactory.array_of(Puppet::Pops::Types::TypeFactory.data, Puppet::Pops::Types::TypeFactory.range(0,0))
-      }.to raise_error(/An empty collection may not specify an element type/)
-    end
-
-    it 'it is legal to create an empty array of unit element type' do
-      t = Puppet::Pops::Types::TypeFactory.array_of(Puppet::Pops::Types::PUnitType::DEFAULT, Puppet::Pops::Types::TypeFactory.range(0,0))
+    it 'a typed empty array, the resulting array erases the type' do
+      t = Puppet::Pops::Types::TypeFactory.array_of(Puppet::Pops::Types::TypeFactory.data, Puppet::Pops::Types::TypeFactory.range(0,0))
       expect(t.size_type.class).to eq(Puppet::Pops::Types::PIntegerType)
       expect(t.size_type.from).to eq(0)
       expect(t.size_type.to).to eq(0)
+      expect(t.element_type).to eq(Puppet::Pops::Types::PUnitType::DEFAULT)
     end
 
-    it 'it is illegal to create a typed empty hash' do
-      expect {
-        Puppet::Pops::Types::TypeFactory.hash_of(Puppet::Pops::Types::TypeFactory.scalar, Puppet::Pops::Types::TypeFactory.data, Puppet::Pops::Types::TypeFactory.range(0,0))
-      }.to raise_error(/An empty collection may not specify an element type/)
-    end
-
-    it 'it is legal to create an empty hash where key and value types are of Unit type' do
-      t = Puppet::Pops::Types::TypeFactory.hash_of(Puppet::Pops::Types::PUnitType::DEFAULT, Puppet::Pops::Types::PUnitType::DEFAULT, Puppet::Pops::Types::TypeFactory.range(0,0))
+    it 'a typed empty hash, the resulting hash erases the key and value type' do
+      t = Puppet::Pops::Types::TypeFactory.hash_of(Puppet::Pops::Types::TypeFactory.scalar, Puppet::Pops::Types::TypeFactory.data, Puppet::Pops::Types::TypeFactory.range(0,0))
       expect(t.size_type.class).to eq(Puppet::Pops::Types::PIntegerType)
       expect(t.size_type.from).to eq(0)
       expect(t.size_type.to).to eq(0)
+      expect(t.key_type).to eq(Puppet::Pops::Types::PUnitType::DEFAULT)
+      expect(t.element_type).to eq(Puppet::Pops::Types::PUnitType::DEFAULT)
     end
 
     context 'callable types' do

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -60,6 +60,14 @@ describe Puppet::Pops::Types::TypeParser do
     expect(parser.parse("Hash")).to be_the_type(types.hash_of_data)
   end
 
+  it "interprets a parameterized Array[0, 0] as an empty hash with no key and value type" do
+    expect(parser.parse("Array[0, 0]")).to be_the_type(types.array_of(types.default, types.range(0, 0)))
+  end
+
+  it "interprets a parameterized Hash[0, 0] as an empty hash with no key and value type" do
+    expect(parser.parse("Hash[0, 0]")).to be_the_type(types.hash_of(types.default, types.default, types.range(0, 0)))
+  end
+
   it "interprets a parameterized Hash[t] as a Hash of Scalar to t" do
     expect(parser.parse("Hash[Scalar, Integer]")).to be_the_type(types.hash_of(types.integer))
   end


### PR DESCRIPTION
This commit ensures that the following:

1. An Array type can be created with two integer arguments
2. A Hash type can be created with two integer arguments
3. An empty Array type can be created with an element type
4. An empty Hash type can be created with key and value types
5. All types of empty collection types are erased
8. A request for a type from an empty collection type returns Unit