### PR TITLE
(PUP-6189) no exception in reduce() with bignums

### DIFF
--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
   app_type = File.basename(__FILE__, '.*')
-  tmp_environment   = mk_tmp_environment(app_type)
+  tmp_environment   = mk_tmp_environment_with_teardown(app_type)
 
   tmp_file = {}
   agents.each do |agent|
@@ -16,9 +16,6 @@ extend Puppet::Acceptance::EnvironmentUtils
   end
 
   teardown do
-    step 'remove the tmp environment symlink' do
-      on master, "rm -rf #{File.join(environmentpath, tmp_environment)}"
-    end
     step 'clean out produced resources' do
       agents.each do |agent|
         on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -6,7 +6,7 @@ extend Puppet::Acceptance::EnvironmentUtils
   skip_test if agents.any? {|agent| agent['platform'] =~ /^eos/ } # see PUP-5404, ARISTA-42
 
   app_type = File.basename(__FILE__, '.*')
-  tmp_environment   = mk_tmp_environment(app_type)
+  tmp_environment   = mk_tmp_environment_with_teardown(app_type)
   exported_username = 'er0ck'
 
   teardown do
@@ -19,9 +19,6 @@ extend Puppet::Acceptance::EnvironmentUtils
     end
     on(master, "mv #{File.join('','tmp','puppet.conf')} #{master.puppet['confdir']}",
        :accept_all_exit_codes => true)
-    step 'remove the tmp environment symlink' do
-      on master, "rm -rf #{File.join(environmentpath, tmp_environment)}"
-    end
     step 'clean out collected resources' do
       on(hosts, puppet_resource("user #{exported_username} ensure=absent"), :accept_all_exit_codes => true)
     end

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -1,0 +1,64 @@
+require 'puppet/acceptance/environment_utils'
+test_name 'C97760: Bignum in reduce() should not cause exception' do
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  app_type = File.basename(__FILE__, '.*')
+  tmp_environment = mk_tmp_environment_with_teardown(app_type)
+  on(master, "chmod -R 666 #{File.join(environmentpath,tmp_environment)}")
+
+  step 'On master, create site.pp with bignum' do
+    site_manifest = File.join(environmentpath, tmp_environment, 'manifests', 'site.pp')
+    create_remote_file(master, site_manifest, <<-SITEPP)
+node default {
+  $data = [
+  {
+  "certname"=>"xxxxxxxxx.some.domain",
+  "parameters"=>{
+      "admin_auth_keys"=>{
+          "keyname1"=>{
+              "key"=>"ABCDEF",
+              "options"=>["from=\"10.0.0.0/8\""]
+          },
+          "keyname2"=>{
+              "key"=>"ABCDEF",
+          },
+          "keyname3"=>{
+              "key"=>"ABCDEF",
+              "options"=>["from=\"10.0.0.0/8\""],
+              "type"=>"ssh-xxx"
+          },
+          "keyname4"=>{
+              "key"=>"ABCDEF",
+              "options"=>["from=\"10.0.0.0/8\""]
+          }
+      },
+      "admin_user"=>"ertxa",
+      "admin_hosts"=>["1.2.3.4",
+          "1.2.3.4",
+          "1.2.3.4"],
+      "admin_password"=>"ABCDEF",
+      "sshd_ports"=>[22,
+          22, 24],
+      "sudo_no_password_all"=>false,
+      "sudo_no_password_commands"=>[],
+      "sshd_config_template"=>"cfauth/sshd_config.epp",
+      "sudo_env_keep"=>[]
+  },
+  "exported"=>false},
+  ]
+  $data_reduced = $data.reduce({}) |$m, $r|{
+      $cn = $r['certname']
+      merge($m, { $cn => $r['parameters'] })
+  }
+  fail($data_reduced)
+}
+SITEPP
+  end
+
+  with_puppet_running_on(master, {}) do
+    agents.each do |agent|
+      on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"))
+    end
+  end
+
+end


### PR DESCRIPTION
This change adds a test to ensure no further regressions when using
    bignums in manifests (see: PUP-6070).

    [skip ci]