### PR TITLE
(doc) (DOCUMENT-541) Make resource type examples pass puppet-lint checks

### DIFF
--- a/lib/puppet/provider/service/daemontools.rb
+++ b/lib/puppet/provider/service/daemontools.rb
@@ -19,9 +19,9 @@ Puppet::Type.type(:service).provide :daemontools, :parent => :base do
 
     ...or this can be overriden in the resource's attributes:
 
-        service { "myservice":
-          provider => "daemontools",
-          path     => "/path/to/daemons",
+        service { 'myservice':
+          provider => 'daemontools',
+          path     => '/path/to/daemons',
         }
 
     This provider supports out of the box:

--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -19,9 +19,9 @@ Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
 
     or this can be overriden in the service resource parameters::
 
-        service { "myservice":
-          provider => "runit",
-          path => "/path/to/daemons",
+        service { 'myservice':
+          provider => 'runit',
+          path     => '/path/to/daemons',
         }
 
     This provider supports out of the box:

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -340,15 +340,15 @@ module Puppet
         other object; it is useful for triggering an action:
 
             # Pull down the main aliases file
-            file { "/etc/aliases":
-              source => "puppet://server/module/aliases"
+            file { '/etc/aliases':
+              source => 'puppet://server/module/aliases',
             }
 
             # Rebuild the database, but only when the file changes
             exec { newaliases:
-              path        => ["/usr/bin", "/usr/sbin"],
-              subscribe   => File["/etc/aliases"],
-              refreshonly => true
+              path        => ['/usr/bin', '/usr/sbin'],
+              subscribe   => File['/etc/aliases'],
+              refreshonly => true,
             }
 
         Note that only `subscribe` and `notify` can trigger actions, not `require`,
@@ -377,10 +377,10 @@ module Puppet
         This parameter doesn't cause Puppet to create a file; it is only
         useful if **the command itself** creates a file.
 
-            exec { "tar -xf /Volumes/nfs02/important.tar":
-              cwd     => "/var/tmp",
-              creates => "/var/tmp/myfile",
-              path    => ["/usr/bin", "/usr/sbin"]
+            exec { 'tar -xf /Volumes/nfs02/important.tar':
+              cwd     => '/var/tmp',
+              creates => '/var/tmp/myfile',
+              path    => ['/usr/bin', '/usr/sbin',],
             }
 
         In this example, `myfile` is assumed to be a file inside
@@ -404,9 +404,9 @@ module Puppet
         If this parameter is set, then this `exec` will run unless
         the command has an exit code of 0.  For example:
 
-            exec { "/bin/echo root >> /usr/lib/cron/cron.allow":
-              path   => "/usr/bin:/usr/sbin:/bin",
-              unless => "grep root /usr/lib/cron/cron.allow 2>/dev/null"
+            exec { '/bin/echo root >> /usr/lib/cron/cron.allow':
+              path   => '/usr/bin:/usr/sbin:/bin',
+              unless => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
             }
 
         This would add `root` to the cron.allow file (on Solaris) unless
@@ -420,7 +420,7 @@ module Puppet
 
         Also note that unless can take an array as its value, e.g.:
 
-            unless => ["test -f /tmp/file1", "test -f /tmp/file2"]
+            unless => ['test -f /tmp/file1', 'test -f /tmp/file2'],
 
         This will only run the exec if _all_ conditions in the array return false.
       EOT
@@ -455,9 +455,9 @@ module Puppet
         If this parameter is set, then this `exec` will only run if
         the command has an exit code of 0.  For example:
 
-            exec { "logrotate":
-              path   => "/usr/bin:/usr/sbin:/bin",
-              onlyif => "test `du /var/log/messages | cut -f1` -gt 100000"
+            exec { 'logrotate':
+              path   => '/usr/bin:/usr/sbin:/bin',
+              onlyif => 'test `du /var/log/messages | cut -f1` -gt 100000',
             }
 
         This would run `logrotate` only if that test returned true.
@@ -471,7 +471,7 @@ module Puppet
 
         Also note that onlyif can take an array as its value, e.g.:
 
-            onlyif => ["test -f /tmp/file1", "test -f /tmp/file2"]
+            onlyif => ['test -f /tmp/file1', 'test -f /tmp/file2'],
 
         This will only run the exec if _all_ conditions in the array return true.
       EOT

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -23,14 +23,14 @@ module Puppet
       the manifest...
 
           define resolve(nameserver1, nameserver2, domain, search) {
-              $str = "search $search
-                  domain $domain
-                  nameserver $nameserver1
-                  nameserver $nameserver2
+              $str = "search ${search}
+                  domain ${domain}
+                  nameserver ${nameserver1}
+                  nameserver ${nameserver2}
                   "
 
-              file { "/etc/resolv.conf":
-                content => "$str",
+              file { '/etc/resolv.conf':
+                content => $str,
               }
           }
 

--- a/lib/puppet/type/file/ensure.rb
+++ b/lib/puppet/type/file/ensure.rb
@@ -36,13 +36,13 @@ module Puppet
 
           # Equivalent resources:
 
-          file { "/etc/inetd.conf":
-            ensure => "/etc/inet/inetd.conf",
+          file { '/etc/inetd.conf':
+            ensure => '/etc/inet/inetd.conf',
           }
 
-          file { "/etc/inetd.conf":
+          file { '/etc/inetd.conf':
             ensure => link,
-            target => "/etc/inet/inetd.conf",
+            target => '/etc/inet/inetd.conf',
           }
 
       However, we recommend using `link` and `target` explicitly, since this

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -52,11 +52,11 @@ module Puppet
       use the first source that exists. This can be used to serve different
       files to different system types:
 
-          file { "/etc/nfs.conf":
+          file { '/etc/nfs.conf':
             source => [
-              "puppet:///modules/nfs/conf.$host",
-              "puppet:///modules/nfs/conf.$operatingsystem",
-              "puppet:///modules/nfs/conf"
+              "puppet:///modules/nfs/conf.${host}",
+              "puppet:///modules/nfs/conf.${operatingsystem}",
+              'puppet:///modules/nfs/conf'
             ]
           }
 

--- a/lib/puppet/type/file/target.rb
+++ b/lib/puppet/type/file/target.rb
@@ -7,9 +7,9 @@ module Puppet
       Symlink targets can be relative, as well as absolute:
 
           # (Useful on Solaris)
-          file { \"/etc/inetd.conf\":
+          file { '/etc/inetd.conf':
             ensure => link,
-            target => \"inet/inetd.conf\",
+            target => 'inet/inetd.conf',
           }
 
       Directories of symlinks can be served recursively by instead using the

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -238,8 +238,8 @@ module Puppet
           }
 
           package { 'openssl':
+            ensure => installed,
             name   => $ssl,
-            ensure => installed
           }
 
           . etc. .
@@ -250,9 +250,9 @@ module Puppet
           }
 
           package { 'openssh':
-            name    => $ssh
             ensure  => installed,
-            require => Package['openssl']
+            name    => $ssh,
+            require => Package['openssl'],
           }
 
       "

--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -24,7 +24,7 @@ module Puppet
       the hours of two and 4 AM, then you would use this schedule:
 
           schedule { 'maint':
-            range  => "2 - 4",
+            range  => '2 - 4',
             period => daily,
             repeat => 1,
           }
@@ -57,10 +57,10 @@ module Puppet
 
             schedule { 'everyday':
               period => daily,
-              range  => "2 - 4",
+              range  => '2 - 4',
             }
 
-            exec { "/usr/bin/apt-get update":
+            exec { '/usr/bin/apt-get update':
               schedule => 'everyday',
             }
 
@@ -77,7 +77,7 @@ module Puppet
         separator. For instance:
 
             schedule { 'maintenance':
-              range => "1:30 - 4:30",
+              range => '1:30 - 4:30',
             }
 
         This is mostly useful for restricting certain resources to being

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -56,10 +56,10 @@ Puppet::Type.newtype(:tidy) do
 
       Example:
 
-          tidy { "/tmp":
-            age     => "1w",
+          tidy { '/tmp':
+            age     => '1w',
             recurse => 1,
-            matches => [ "[0-9]pub*.tmp", "*.temp", "tmpfile?" ]
+            matches => [ '[0-9]pub*.tmp', '*.temp', 'tmpfile?' ],
           }
 
       This removes files from `/tmp` if they are one week old or older,

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -282,11 +282,11 @@ end
 
       And then call that:
 
-          zone { myzone:
-            ip           => "bge0:192.168.0.23",
-            sysidcfg     => template("site/sysidcfg.erb"),
-            path         => "/opt/zones/myzone",
-            realhostname => "fully.qualified.domain.name"
+          zone { 'myzone':
+            ip           => 'bge0:192.168.0.23',
+            sysidcfg     => template('site/sysidcfg.erb'),
+            path         => '/opt/zones/myzone',
+            realhostname => 'fully.qualified.domain.name',
           }
 
       The `sysidcfg` only matters on the first booting of the zone,


### PR DESCRIPTION
Currently the code examples at: 
https://docs.puppet.com/puppet/latest/reference/type.html
are not all passing a puppet-lint run.

This PR fixes that.