### PR TITLE
(PUP-6046) Add functions 'dig', 'then', and 'lest'

### DIFF
--- a/lib/puppet/functions/dig.rb
+++ b/lib/puppet/functions/dig.rb
@@ -3,7 +3,7 @@
 # using a sequence of keys / indexes to access a value from which
 # the next key/index is accessed recursively.
 #
-# The first encountered `undef` value stops the "dig" and `undef` is returned.
+# The first encountered `undef` value or key stops the "dig" and `undef` is returned.
 #
 # An error is raised if an attempt is made to "dig" into
 # something other than an `undef` (which immediately returns `undef`), an Array or a Hash. 
@@ -28,7 +28,7 @@ Puppet::Functions.create_function(:dig) do
   def dig(data, *args)
     walked_path = []
     args.reduce(data) do | d, k |
-      return nil if d.nil?
+      return nil if d.nil? || k.nil?
       if !(d.is_a?(Array) || d.is_a?(Hash))
         raise ArgumentError, "The given data does not contain a Collection at #{walked_path}, got '#{d.class}'"
       end

--- a/lib/puppet/functions/dig.rb
+++ b/lib/puppet/functions/dig.rb
@@ -1,8 +1,12 @@
-# Returns a value for a sequence of given keys/indexes
-# used to "dig into" a complex data structure. The first
-# encountered undef value stops the "dig" and undef is returned.
+# Returns a value for a sequence of given keys/indexes into a structure.
+# This function is used to "dig into" a complex data structure by
+# using a sequence of keys / indexes to access a value from which
+# the next key/index is accessed recursively.
+#
+# The first encountered `undef` value stops the "dig" and `undef` is returned.
+#
 # An error is raised if an attempt is made to "dig" into
-# something other than an Array or a Hash. 
+# something other than an `undef` (which immediately returns `undef`), an Array or a Hash. 
 #
 # @example Using `dig`
 #

--- a/lib/puppet/functions/dig.rb
+++ b/lib/puppet/functions/dig.rb
@@ -1,0 +1,35 @@
+# Returns a value for a sequence of given keys/indexes
+# used to "dig into" a complex data structure. The first
+# encountered undef value stops the "dig" and undef is returned.
+# An error is raised if an attempt is made to "dig" into
+# something other than an Array or a Hash. 
+#
+# @example Using `dig`
+#
+# ~~~ puppet
+# $data = {a => { b => [{x => 10, y => 20}, {x => 100, y => 200}]}}
+# notice $data.dig(a, b, 1, x)
+# ~~~
+#
+# Would notice the value 100.
+#
+# @since 4.5.0
+#
+Puppet::Functions.create_function(:dig) do
+  dispatch :dig do
+    param 'Collection', :data
+    repeated_param 'Any', :arg
+  end
+
+  def dig(data, *args)
+    walked_path = []
+    args.reduce(data) do | d, k |
+      return nil if d.nil?
+      if !(d.is_a?(Array) || d.is_a?(Hash))
+        raise ArgumentError, "The given data does not contain a Collection at #{walked_path}, got '#{d.class}'"
+      end
+      walked_path << k
+      d[k]
+    end
+  end
+end

--- a/lib/puppet/functions/dig.rb
+++ b/lib/puppet/functions/dig.rb
@@ -21,7 +21,7 @@
 #
 Puppet::Functions.create_function(:dig) do
   dispatch :dig do
-    param 'Collection', :data
+    param 'Optional[Collection]', :data
     repeated_param 'Any', :arg
   end
 

--- a/lib/puppet/functions/lest.rb
+++ b/lib/puppet/functions/lest.rb
@@ -1,0 +1,53 @@
+# Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+# (which should accept to arguments) if the argument given to the function is undef.
+# Returns the result of calling the lambda if the argument is undef, otherwwise the
+# given argument.
+#
+# The `lest` function is useful in a chain of `then` calls, or in general
+# as a guard against `undef` values. The function can be used to call `fail`, or to
+# return a default value.
+#
+# These two expressions are equivalent:
+# ~~~puppet
+# if $x == undef { do_things() }
+# lest($x) || { do_things() }
+# ~~
+#
+# @example Using `lest`
+#
+# ~~~ puppet
+# $data = {a => [ b, c ] }
+# notice $data.dig(a, b, c)
+#  .then |$x| { $x * 2 }
+#  .lest || { fail("no value for $data[a][b][c]" }
+# ~~~
+#
+# Would fail the operation because $data[a][b][c] results in `undef`
+#
+# In contrast - this example:
+#
+# ~~~ puppet
+# $data = {a => { b => { c => 10 } } }
+# notice $data.dig(a, b, c)
+#  .then |$x| { $x * 2 }
+#  .lest || { fail("no value for $data[a][b][c]" }
+# ~~~
+#
+# Would notice the value 20
+#
+# @since 4.5.0
+#
+Puppet::Functions.create_function(:lest) do
+  dispatch :lest do
+    param 'Any', :arg
+    block_param
+  end
+
+  def lest(arg)
+    if arg.nil?
+      yield()
+    else
+      arg
+    end
+  end
+end

--- a/lib/puppet/functions/lest.rb
+++ b/lib/puppet/functions/lest.rb
@@ -1,6 +1,6 @@
 # Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
-# (which should accept to arguments) if the argument given to the function is undef.
-# Returns the result of calling the lambda if the argument is undef, otherwwise the
+# (which should accept no arguments) if the argument given to the function is `undef`.
+# Returns the result of calling the lambda if the argument is `undef`, otherwwise the
 # given argument.
 #
 # The `lest` function is useful in a chain of `then` calls, or in general
@@ -40,7 +40,7 @@
 Puppet::Functions.create_function(:lest) do
   dispatch :lest do
     param 'Any', :arg
-    block_param
+    block_param 'Callable[0,0]', :block
   end
 
   def lest(arg)

--- a/lib/puppet/functions/lest.rb
+++ b/lib/puppet/functions/lest.rb
@@ -1,4 +1,4 @@
-# Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+# Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
 # (which should accept no arguments) if the argument given to the function is `undef`.
 # Returns the result of calling the lambda if the argument is `undef`, otherwwise the
 # given argument.

--- a/lib/puppet/functions/then.rb
+++ b/lib/puppet/functions/then.rb
@@ -1,0 +1,74 @@
+# Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+# with the given argument unless the argument is undef. Return undef if argument is
+# undef, and otherwise the result of giving the argument to the lambda.
+#
+# This is useful to process a sequence of operations where an intermediate
+# result may be undef (which makes the entire sequence undef).
+# The `then` function is especially useful with the function `dig` which
+# performs in a similar way "digging out" a value in a complex structure.
+#
+# @example Using `then`
+#
+# ~~~ puppet
+# $data = {a => { b => [{x => 10, y => 20}, {x => 100, y => 200}]}}
+# notice $data.dig(a, b, 1, x).then |$x| { $x * 2 }
+# ~~~
+#
+# Would notice the value 200
+#
+# Contrast this with:
+#
+# ~~~ puppet
+# $data = {a => { b => [{x => 10, y => 20}, {ex => 100, why => 200}]}}
+# notice $data.dig(a, b, 1, x).then |$x| { $x * 2 }
+# ~~~
+#
+# Which would notice undef since the last lookup of 'x' results in `undef` which
+# is returned (without calling the block).
+#
+# As a result there was no need for conditional logic or a temporary (non local) 
+# variable as the result is now either the wanted value (x) multiplied
+# by 2 or `undef`.
+#
+# Calls to `then` can be chained. In the next example, a structure is using an offset that
+# is using 1 as the index to the first element (instead of 0 which is used in the language).
+# We are not sure if user input actually contains an index at all, or if it is
+# outside the range of available names.
+#
+# ~~~ puppet
+# # Names to choose from
+# $names = ['Ringo', 'Paul', 'George', 'John']
+#
+# # structure where 'beatle 2' is wanted (but where the number refers
+# # to 'Paul' because input comes from a source using 1 for the first
+# # element).
+#
+# $data = [202, { beatle => 2 }]
+# $picked = assert_type(String,
+#   # the data we are interested in is the second in the array,
+#   # a hash, where we want the value of the key 'beatle'
+#   $data.dig(1, 'beatle')
+#     # and we want the index in $names before the given index
+#     .then |$x| { $names[$x-1] }
+#     # so we can construct a string with that beatle's name
+#     .then |$x| { "Picked Beatle '${x}'" }
+# )
+#
+# ~~~ puppet
+#
+# Would notice "Picked Beatle 'Paul'", and would raise an error if the result
+# was not a String.
+#
+# @since 4.5.0
+#
+Puppet::Functions.create_function(:then) do
+  dispatch :then do
+    param 'Any', :arg
+    block_param
+  end
+
+  def then(arg)
+    return nil if arg.nil?
+    yield(arg)
+  end
+end

--- a/lib/puppet/functions/then.rb
+++ b/lib/puppet/functions/then.rb
@@ -1,4 +1,4 @@
-# Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+# Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
 # with the given argument unless the argument is undef. Return undef if argument is
 # undef, and otherwise the result of giving the argument to the lambda.
 #

--- a/lib/puppet/functions/then.rb
+++ b/lib/puppet/functions/then.rb
@@ -64,7 +64,7 @@
 Puppet::Functions.create_function(:then) do
   dispatch :then do
     param 'Any', :arg
-    block_param
+    block_param 'Callable[1,1]', :block
   end
 
   def then(arg)

--- a/lib/puppet/functions/with.rb
+++ b/lib/puppet/functions/with.rb
@@ -1,4 +1,4 @@
-# Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+# Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
 # with the given arguments and return the result. Since a lambda's scope is
 # [local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
 # to the lambda, you can use the `with` function to create private blocks of code within a

--- a/spec/unit/functions/dig_spec.rb
+++ b/spec/unit/functions/dig_spec.rb
@@ -11,6 +11,12 @@ describe 'the dig function' do
     expect(compile_to_catalog("notify { [testing].dig(0): }")).to have_resource('Notify[testing]')
   end
 
+  it 'returns undef if given an undef key' do
+  expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[testing]')
+    notify { "test${[testing].dig(undef)}ing": }
+    SOURCE
+  end
+
   it 'returns a value from an hash key via given key' do
     expect(compile_to_catalog("notify { {key => testing}.dig(key): }")).to have_resource('Notify[testing]')
   end

--- a/spec/unit/functions/dig_spec.rb
+++ b/spec/unit/functions/dig_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the dig function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  it 'returns a value from an array index via integer index' do
+    expect(compile_to_catalog("notify { [testing].dig(0): }")).to have_resource('Notify[testing]')
+  end
+
+  it 'returns a value from an hash key via given key' do
+    expect(compile_to_catalog("notify { {key => testing}.dig(key): }")).to have_resource('Notify[testing]')
+  end
+
+  it 'continues digging if result is an array' do
+    expect(compile_to_catalog("notify { [nope, [testing]].dig(1, 0): }")).to have_resource('Notify[testing]')
+  end
+
+  it 'continues digging if result is a hash' do
+    expect(compile_to_catalog("notify { [nope, {yes => testing}].dig(1, yes): }")).to have_resource('Notify[testing]')
+  end
+
+  it 'stops digging when step is undef' do
+    expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[testing]')
+    $result = [nope, {yes => testing}].dig(1, no, 2)
+    notify { "test${result}ing": }
+    SOURCE
+  end
+
+  it 'errors if step is neither Array nor Hash' do
+    expect { compile_to_catalog(<<-SOURCE)}.to raise_error(/The given data does not contain a Collection at \[1, "yes"\], got 'String'/)
+    $result = [nope, {yes => testing}].dig(1, yes, 2)
+    notify { "test${result}ing": }
+    SOURCE
+  end
+
+  it 'errors if not given a non Collection as the starting point' do
+    expect { compile_to_catalog(<<-SOURCE)}.to raise_error(/'dig' parameter 'data' expects a Collection value, got String/)
+    "hello".dig(1, yes, 2)
+    SOURCE
+  end
+
+end

--- a/spec/unit/functions/dig_spec.rb
+++ b/spec/unit/functions/dig_spec.rb
@@ -17,6 +17,12 @@ describe 'the dig function' do
     SOURCE
   end
 
+  it 'returns undef if starting with undef' do
+  expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[testing]')
+    notify { "test${undef.dig(undef)}ing": }
+    SOURCE
+  end
+
   it 'returns a value from an hash key via given key' do
     expect(compile_to_catalog("notify { {key => testing}.dig(key): }")).to have_resource('Notify[testing]')
   end

--- a/spec/unit/functions/dig_spec.rb
+++ b/spec/unit/functions/dig_spec.rb
@@ -12,14 +12,14 @@ describe 'the dig function' do
   end
 
   it 'returns undef if given an undef key' do
-  expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[testing]')
-    notify { "test${[testing].dig(undef)}ing": }
+  expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[test-Undef-ing]')
+    notify { "test-${type([testing].dig(undef))}-ing": }
     SOURCE
   end
 
   it 'returns undef if starting with undef' do
-  expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[testing]')
-    notify { "test${undef.dig(undef)}ing": }
+  expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[test-Undef-ing]')
+    notify { "test-${type(undef.dig(undef))}-ing": }
     SOURCE
   end
 

--- a/spec/unit/functions/lest_spec.rb
+++ b/spec/unit/functions/lest_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the lest function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  it 'calls a lambda passing no argument' do
+    expect(compile_to_catalog("lest(undef) || { notify { testing: } }")).to have_resource('Notify[testing]')
+  end
+
+  it 'produces what lambda returns if value is undef' do
+    expect(compile_to_catalog("notify{ lest(undef) || { testing }: }")).to have_resource('Notify[testing]')
+  end
+
+  it 'does not call lambda if argument is not undef' do
+    expect(compile_to_catalog('lest(1) || { notify { "failed": } }')).to_not have_resource('Notify[failed]')
+  end
+
+  it 'produces given argument if given not undef' do
+    expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[test_yay_ing]')
+    notify{ "test${lest('_yay_') || { '_oh_no_' }}ing": }
+    SOURCE
+  end
+
+  it 'errors when lambda wants too many args' do
+    expect do
+      compile_to_catalog('lest(1) |$x| { }')
+    end.to raise_error(/'lest' block expects no arguments, got 1/m)
+  end
+
+end

--- a/spec/unit/functions/then_spec.rb
+++ b/spec/unit/functions/then_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the then function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  it 'calls a lambda passing one argument' do
+    expect(compile_to_catalog("then(testing) |$x| { notify { $x: } }")).to have_resource('Notify[testing]')
+  end
+
+  it 'produces what lambda returns if value is not undef' do
+    expect(compile_to_catalog("notify{ then(1) |$x| { testing }: }")).to have_resource('Notify[testing]')
+  end
+
+  it 'does not call lambda if argument is undef' do
+    expect(compile_to_catalog('then(undef) |$x| { notify { "failed": } }')).to_not have_resource('Notify[failed]')
+  end
+
+  it 'produces undef if given value is undef' do
+    expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[testing]')
+    notify{ "test${then(undef) |$x| { testing }}ing": }
+    SOURCE
+  end
+
+  it 'errors when lambda wants too many args' do
+    expect do
+      compile_to_catalog('then(1) |$x, $y| { }')
+    end.to raise_error(/'then' block expects 1 argument, got 2/m)
+  end
+
+  it 'errors when lambda wants too few args' do
+    expect do
+      compile_to_catalog('then(1) || { }')
+    end.to raise_error(/'then' block expects 1 argument, got none/m)
+  end
+
+end

--- a/spec/unit/functions/then_spec.rb
+++ b/spec/unit/functions/then_spec.rb
@@ -20,8 +20,8 @@ describe 'the then function' do
   end
 
   it 'produces undef if given value is undef' do
-    expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[testing]')
-    notify{ "test${then(undef) |$x| { testing }}ing": }
+    expect(compile_to_catalog(<<-SOURCE)).to have_resource('Notify[test-Undef-ing]')
+    notify{ "test-${type(then(undef) |$x| { testing })}-ing": }
     SOURCE
   end
 


### PR DESCRIPTION
This adds three functions 'dig', 'then', and 'lest', which together with the existing `assert_type` function makes complex data access easier to perform without complex conditional logic and temporary variables.

The *dig* function performs a sequence of access operations on a complex collection similar to the 'dot-notation' used in hiera and facter.
For example:
```
$some_data.dig(somekey, 1, otherkey)
```
If, at any point, the intermediate result is `undef` the operation stops and returns `undef`. It is an error to attempt to access something in a value that is neither Array nor Hash.

The *then* function, accepts a single argument, and if it is not `undef` if calls a given block with the value. If given `undef` the block is not called and `undef` is returned.

The *lest* function is the reverse of *then*. If given `undef` it calls the given block (without arguments), and returns what the block produced. If given something that is not `undef` it returns that value.

```
$some_structure.process()
  .then |$x| { $x.process_some_more() }
  .then |$x| { $x.process_further() }
  .lest || { fail("processing of structure resulted in undef value") }
```

Or if a default value is wanted - in the middle of the chain if `undef` was the temporary result:
```
$some_structure.process()
  .then |$x| { $x. process_some_more() }
  .lest || { 42 }
  .then |$x| { $x.process_further() }
```

Naturally, for simple cases, a regular if/then/else expression or case expression is clearer - but for any chain of lookups, transformations, etc. where intermediate results are obtained and those can be undef the functional composition chain is a valuable tool as it results in more readable logic.