### PR TITLE
(PUP-6159) Convert CFPropertyList binary strings to CFPropertyList::Blob's

### DIFF
--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -1,0 +1,26 @@
+test_name "should allow password, salt, and iteration attributes in OSX"
+
+confine :to, :platform => /osx/
+
+agents.each do |agent|
+  teardown do
+    puppet_resource("user", 'testuser', "ensure=absent")
+  end
+
+  step "create the test user with password and salt" do
+    # The password is 'helloworld'
+    apply_manifest_on(agent, <<-MANIFEST, :catch_failures => true)
+  user { 'testuser':
+    ensure => present,
+    home   => '/Users/testuser',
+    password => '6ce97688468f231845d9d982f1f10832ca0c6c728a77bac51c548af99ebd9b9c62bcba15112a0c7a7e34effbb2e92635650c79c51517d72b083a4eb2a513f51ad1f8ea9556cef22456159c341d8bcd382a91708afaf253c2b727d4c6cd3d29cc26011d5d511154037330ecea0263b1be8c1c13086d029c57344291bd37952b56',
+    salt       => '377e8b60e5fdfe509cad188d5b1b9e40e78b418f8c3f0127620ea69d4c32789c',
+    iterations => 40000,
+  }
+MANIFEST
+  end
+
+  step "verify the password was set correctly" do
+    on(agent, "dscl /Local/Default -authonly testuser helloworld", :acceptable_exit_codes => 0)
+  end
+end

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -553,6 +553,7 @@ Puppet::Type.type(:user).provide :directoryservice do
   # password hash (and Salt/Iterations value if the OS is 10.8 or greater)
   # into the ShadowHashData key of the user's plist.
   def set_shadow_hash_data(users_plist, binary_plist)
+    binary_plist = Puppet::Util::Plist.string_to_blob(binary_plist)
     if users_plist.has_key?('ShadowHashData')
       users_plist['ShadowHashData'][0] = binary_plist
     else
@@ -595,7 +596,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     shadow_hash_data['SALTED-SHA512-PBKDF2'] = Hash.new unless shadow_hash_data['SALTED-SHA512-PBKDF2']
     case field
     when 'salt', 'entropy'
-      shadow_hash_data['SALTED-SHA512-PBKDF2'][field] = base64_decode_string(value)
+      shadow_hash_data['SALTED-SHA512-PBKDF2'][field] = Puppet::Util::Plist.string_to_blob(base64_decode_string(value))
     when 'iterations'
       shadow_hash_data['SALTED-SHA512-PBKDF2'][field] = Integer(value)
     else

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -91,6 +91,14 @@ module Puppet::Util::Plist
       CFPropertyList.native_types(plist_obj.value)
     end
 
+    # Helper method to convert a string into a CFProperty::Blob, which is
+    # needed to properly handle binary strings
+    #
+    # @api private
+    def string_to_blob(str)
+      CFPropertyList::Blob.new(str)
+    end
+
     # Helper method to assist in reading a file with an offset value. It's its
     # own method for stubbing purposes
     #

--- a/spec/unit/provider/user/directoryservice_spec.rb
+++ b/spec/unit/provider/user/directoryservice_spec.rb
@@ -849,13 +849,14 @@ describe Puppet::Type.type(:user).provider(:directoryservice) do
     # This will also catch the edge-case where a 10.6-style user exists on
     # a 10.8 system and Puppet attempts to set a password
     it 'should not fail if shadow_hash_data is not a Hash' do
-      provider.expects(:base64_decode_string).with(pbkdf2_password_hash).returns('binary_string')
+      Puppet::Util::Plist.expects(:string_to_blob).with(provider.base64_decode_string(pbkdf2_password_hash)).returns('binary_string')
       provider.class.expects(:convert_hash_to_binary).with(entropy_shadow_hash_data).returns('binary_plist')
       provider.expects(:set_shadow_hash_data).with({'passwd' => '********'}, 'binary_plist')
       provider.set_salted_pbkdf2({}, false, 'entropy', pbkdf2_password_hash)
     end
 
     it "should set the PBKDF2 password hash when the 'entropy' field is passed with a valid password hash" do
+      Puppet::Util::Plist.expects(:string_to_blob).with(provider.base64_decode_string(pbkdf2_password_hash))
       provider.class.expects(:convert_hash_to_binary).with(pbkdf2_embedded_bplist_hash).returns(pbkdf2_embedded_plist)
       provider.expects(:set_shadow_hash_data).with(users_plist, pbkdf2_embedded_plist)
       users_plist.expects(:[]=).with('passwd', '********')
@@ -863,6 +864,7 @@ describe Puppet::Type.type(:user).provider(:directoryservice) do
     end
 
     it "should set the PBKDF2 password hash when the 'salt' field is passed with a valid password hash" do
+      Puppet::Util::Plist.expects(:string_to_blob).with(provider.base64_decode_string(pbkdf2_salt_value))
       provider.class.expects(:convert_hash_to_binary).with(pbkdf2_embedded_bplist_hash).returns(pbkdf2_embedded_plist)
       provider.expects(:set_shadow_hash_data).with(users_plist, pbkdf2_embedded_plist)
       users_plist.expects(:[]=).with('passwd', '********')


### PR DESCRIPTION
Previously, Puppet would fail to set passwords in OSX via the
directoryservice provider due to CFPropertyList encoding problems
when converting entropy and salt strings into binary.

This was due to the fact that CFPropertyList was treating these
binary fields as CFStrings, which would then fail to
convert to binary due to invalid UTF-8 byte sequences.

In order to prevent this, the 'salt' and 'entropy' fields must
be converted into CFPropertyList::Blob's, which are interpreted
as CFPropertyList::CFData objects when parsed by CFPropertyList.
This is the correct data type for binary data values. (Thanks to 
@branan  for the help tracking this down!)

In addition, when setting shadow hash data, the binary_plist
string must also be converted into a Blob for the same reasons.

The second commit adds a simple acceptance test to verify the
ability to set passwords on the system.