### PR TITLE
(PUP-6261) Increase timeout for scheduled tasks deletion in test

### DIFF
--- a/acceptance/tests/resource/scheduled_task/should_destroy.rb
+++ b/acceptance/tests/resource/scheduled_task/should_destroy.rb
@@ -23,7 +23,7 @@ agents.each do |agent|
   on agent, puppet_resource('scheduled_task', name, 'ensure=absent')
 
   step "verify the task was deleted"
-  Timeout.timeout(5) do
+  Timeout.timeout(30) do
     loop do
       step "Win32::TaskScheduler#delete call seems to be asynchronous, so we my need to test multiple times"
       on agent, query_cmd, :acceptable_exit_codes => [0,1]


### PR DESCRIPTION
It is possible that due to contention in a VM that it will take longer than
5 seconds for a scheduled task to appear as deleted.  This commit increases the
timeout to a large value to give the operating system time to delete the task