### PR TITLE
[DNM] (PUP-6270) Update Acceptance tests for PUP-3827

### DIFF
--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -45,7 +45,7 @@ expectations = {
   },
   :puppet_agent => {
     :exit_code => 1,
-    :matches => [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
+    :matches => [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'.*},
                  %r{Could not retrieve catalog; skipping run}],
   },
 }

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -45,7 +45,7 @@ expectations = {
   },
   :puppet_agent => {
     :exit_code => 1,
-    :matches => [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
+    :matches => [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'.*},
                  %r{Could not retrieve catalog; skipping run}],
   }
 }

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -31,7 +31,7 @@ test_name "CVE 2013-1652 Improper query parameter validation" do
           begin
             res = JSON.parse( test.stdout )
             fail_test( "Retrieved catalog for #{master} from #{agent}" ) if
-              res['data']['name'] == master.name
+            res['data'] && res['data']['name'] && res['data']['name'] == master.name
           rescue JSON::ParserError
             # good, continue
           end


### PR DESCRIPTION
PUP-3827 updated the error messages from the indirector to return valid
JSON.

There are acceptance tests that parse error messages - assuming plain text -
to validate that improper behavior cannot be accomplished. This
relaxes the validation to allow for JSON formatted error messages.