### PR TITLE
Revert "(PUP-3827) Return errors matching schema from indirected routes"

### DIFF
--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -47,6 +47,10 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     Puppet.override(:trusted_information => trusted) do
       send("do_#{method}", indirection, key, params, request, response)
     end
+  rescue Puppet::Network::HTTP::Error::HTTPError => e
+    return do_http_control_exception(response, e)
+  rescue StandardError => e
+    return do_exception(response, e)
   end
 
   def uri2indirection(http_method, uri, params)
@@ -88,11 +92,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       params[:environment] = configured_environment
     end
 
-    begin
-      check_authorization(method, "#{url_prefix}/#{indirection_name}/#{key}", params)
-    rescue Puppet::Network::AuthorizationError => e
-      raise Puppet::Network::HTTP::Error::HTTPNotAuthorizedError.new(e.message)
-    end
+    check_authorization(method, "#{url_prefix}/#{indirection_name}/#{key}", params)
 
     if configured_environment.nil?
       raise ArgumentError, "Could not find environment '#{environment}'"
@@ -108,6 +108,24 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
   end
 
   private
+
+  def do_http_control_exception(response, exception)
+    msg = exception.message
+    Puppet.info(msg)
+    response.respond_with(exception.status, "text/plain", msg)
+  end
+
+  def do_exception(response, exception, status=400)
+    if exception.is_a?(Puppet::Network::AuthorizationError)
+      # make sure we return the correct status code
+      # for authorization issues
+      status = 403 if status == 400
+    end
+
+    Puppet.log_exception(exception)
+
+    response.respond_with(status, "text/plain", exception.to_s)
+  end
 
   # Execute our find.
   def do_find(indirection, key, params, request, response)

--- a/spec/integration/network/http/api/indirected_routes_spec.rb
+++ b/spec/integration/network/http/api/indirected_routes_spec.rb
@@ -2,8 +2,6 @@
 require 'spec_helper'
 require 'puppet/network/http'
 require 'puppet/network/http/api/indirected_routes'
-require 'rack/mock' if Puppet.features.rack?
-require 'puppet/network/http/rack/rest'
 require 'puppet/indirector_proxy'
 require 'puppet_spec/files'
 require 'puppet_spec/network'
@@ -51,37 +49,6 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
 
           expect(file['checksum']['type']).to eq(checksum_type)
           expect(checksum_valid(checksum_type, checksum, file['checksum']['value'])).to be_truthy
-        end
-      end
-    end
-
-    describe "an error from IndirectedRoutes", :if => Puppet.features.rack? do
-      let(:handler) { Puppet::Network::HTTP::RackREST.new }
-
-      describe "returns json" do
-        it "when a standard error" do
-          response = Rack::Response.new
-          request = Rack::Request.new(
-            Rack::MockRequest.env_for("/puppet/v3/invalid-indirector"))
-
-          handler.process(request, response)
-
-          expect(response.header["Content-Type"]).to match(/json/)
-          resp = JSON.parse(response.body.first)
-          expect(resp["message"]).to match(/The indirection name must be purely alphanumeric/)
-          expect(resp["issue_kind"]).to be_a_kind_of(String)
-        end
-        it "when a server error" do
-          response = Rack::Response.new
-          request = Rack::Request.new(
-            Rack::MockRequest.env_for("/puppet/v3/unknown_indirector"))
-
-          handler.process(request, response)
-
-          expect(response.header["Content-Type"]).to match(/json/)
-          resp = JSON.parse(response.body.first)
-          expect(resp["message"]).to match(/Could not find indirection/)
-          expect(resp["issue_kind"]).to be_a_kind_of(String)
         end
       end
     end

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -5,20 +5,20 @@ require 'puppet/network/http/api/indirected_routes'
 require 'puppet/indirector_testing'
 
 module PuppetSpec::Network
-  def not_found_error
-    Puppet::Network::HTTP::Error::HTTPNotFoundError
+  def not_found_code
+    Puppet::Network::HTTP::Error::HTTPNotFoundError::CODE
   end
 
-  def not_acceptable_error
-    Puppet::Network::HTTP::Error::HTTPNotAcceptableError
+  def not_acceptable_code
+    Puppet::Network::HTTP::Error::HTTPNotAcceptableError::CODE
   end
 
-  def bad_request_error
-    Puppet::Network::HTTP::Error::HTTPBadRequestError
+  def bad_request_code
+    Puppet::Network::HTTP::Error::HTTPBadRequestError::CODE
   end
 
-  def not_authorized_error
-    Puppet::Network::HTTP::Error::HTTPNotAuthorizedError
+  def not_authorized_code
+    Puppet::Network::HTTP::Error::HTTPNotAuthorizedError::CODE
   end
 
   def params

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -16,6 +16,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
   before do
     Puppet::IndirectorTesting.indirection.terminus_class = :memory
     Puppet::IndirectorTesting.indirection.terminus.clear
+    handler.stubs(:check_authorization)
     handler.stubs(:warn_if_near_expiration)
   end
 
@@ -218,36 +219,45 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
   end
 
   describe "when processing a request" do
-    it "should raise not_authorized_error when authorization fails" do
-      data = Puppet::IndirectorTesting.new("my data")
-      indirection.save(data, "my data")
-      request = a_request_that_heads(data)
+    it "should return not_authorized_code if the request is not authorized" do
+      request = a_request_that_heads(Puppet::IndirectorTesting.new("my data"))
 
       handler.expects(:check_authorization).raises(Puppet::Network::AuthorizationError.new("forbidden"))
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_authorized_error)
+      handler.call(request, response)
+
+      expect(response.code).to eq(not_authorized_code)
     end
 
-    it "should raise not_found_error if the indirection does not support remote requests" do
+    it "should return 'not found' if the indirection does not support remote requests" do
       request = a_request_that_heads(Puppet::IndirectorTesting.new("my data"))
 
       indirection.expects(:allow_remote_requests?).returns(false)
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_found_error)
+      handler.call(request, response)
+
+      expect(response.code).to eq(not_found_code)
     end
 
-    it "should raise ArgumentError if the environment does not exist" do
+    it "should return 'bad request' if the environment does not exist" do
       Puppet.override(:environments => Puppet::Environments::Static.new()) do
         request = a_request_that_heads(Puppet::IndirectorTesting.new("my data"))
 
-        expect {
-          handler.call(request, response)
-        }.to raise_error(ArgumentError)
+        handler.call(request, response)
+
+        expect(response.code).to eq(bad_request_code)
       end
+    end
+
+    it "should serialize a controller exception when an exception is thrown while finding the model instance" do
+      request = a_request_that_finds(Puppet::IndirectorTesting.new("key"))
+      handler.expects(:do_find).raises(ArgumentError, "The exception")
+
+      handler.call(request, response)
+
+      expect(response.code).to eq(bad_request_code)
+      expect(response.body).to eq("The exception")
+      expect(response.type).to eq("text/plain")
     end
   end
 
@@ -263,24 +273,24 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
     end
 
-    it "raises not_acceptable_error when no accept header is provided" do
+    it "responds with a not_acceptable_code error when no accept header is provided" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_finds(data, :accept_header => nil)
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_acceptable_error)
+      handler.call(request, response)
+
+      expect(response.code).to eq(not_acceptable_code)
     end
 
-    it "raises not_acceptable_error when no accepted formats are known" do
+    it "raises an error when no accepted formats are known" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_finds(data, :accept_header => "unknown, also/unknown")
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_acceptable_error)
+      handler.call(request, response)
+
+      expect(response.code).to eq(not_acceptable_code)
     end
 
     it "should pass the result through without rendering it if the result is a string" do
@@ -295,13 +305,12 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
     end
 
-    it "should raise not_found_error when no model instance can be found" do
+    it "should return a not_found_code when no model instance can be found" do
       data = Puppet::IndirectorTesting.new("my data")
       request = a_request_that_finds(data, :accept_header => "unknown, text/pson")
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_found_error)
+      handler.call(request, response)
+      expect(response.code).to eq(not_found_code)
     end
   end
 
@@ -326,13 +335,13 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
     end
 
-    it "should raise not_found_error when searching returns nil" do
+    it "should return a not_found_code when searching returns nil" do
       request = a_request_that_searches(Puppet::IndirectorTesting.new("nothing"), :accept_header => "unknown, text/pson")
       indirection.expects(:search).returns(nil)
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_found_error)
+      handler.call(request, response)
+
+      expect(response.code).to eq(not_found_code)
     end
   end
 
@@ -374,10 +383,9 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       indirection.save(data, "my data")
       request = a_request_that_destroys(data, :accept_header => "unknown, also/unknown")
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_acceptable_error)
+      handler.call(request, response)
 
+      expect(response.code).to eq(not_acceptable_code)
       expect(Puppet::IndirectorTesting.indirection.find("my data")).not_to be_nil
     end
   end
@@ -441,11 +449,10 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       data = Puppet::IndirectorTesting.new("my data")
       request = a_request_that_submits(data, :accept_header => "unknown, also/unknown")
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_acceptable_error)
+      handler.call(request, response)
 
       expect(Puppet::IndirectorTesting.indirection.find("my data")).to be_nil
+      expect(response.code).to eq(not_acceptable_code)
     end
   end
 
@@ -460,13 +467,15 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(response.code).to eq(nil)
     end
 
-    it "should raise not_found_error when the model head call returns false" do
+    it "should return a not_found_code when the model head call returns false" do
       data = Puppet::IndirectorTesting.new("my data")
       request = a_request_that_heads(data)
 
-      expect {
-        handler.call(request, response)
-      }.to raise_error(not_found_error)
+      handler.call(request, response)
+
+      expect(response.code).to eq(not_found_code)
+      expect(response.type).to eq("text/plain")
+      expect(response.body).to eq("Not Found: Could not find indirector_testing my data")
     end
   end
 end

--- a/spec/unit/network/http/api/master/v3_spec.rb
+++ b/spec/unit/network/http/api/master/v3_spec.rb
@@ -1,11 +1,8 @@
 require 'spec_helper'
 
 require 'puppet/network/http'
-require 'puppet_spec/network'
 
 describe Puppet::Network::HTTP::API::Master::V3 do
-  include PuppetSpec::Network
-
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
   let(:master_url_prefix) { "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3" }
   let(:master_routes) {
@@ -32,11 +29,11 @@ describe Puppet::Network::HTTP::API::Master::V3 do
     expect(response.code).to eq(200)
   end
 
-  it "responds to unknown paths by raising not_found_error" do
+  it "responds to unknown paths with a 404" do
     request = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_url_prefix}/unknown")
+    master_routes.process(request, response)
 
-    expect {
-      master_routes.process(request, response)
-    }.to raise_error(not_found_error)
+    expect(response.code).to eq(404)
+    expect(response.body).to match("Not Found: Could not find indirection 'unknown'")
   end
 end


### PR DESCRIPTION
Reverts puppetlabs/puppet#4875

Tests failing - PUP-6270