### PR TITLE
(PUP-6277) Add conflicts to types

### DIFF
--- a/lib/puppet/graph/relationship_graph.rb
+++ b/lib/puppet/graph/relationship_graph.rb
@@ -19,8 +19,17 @@ class Puppet::Graph::RelationshipGraph < Puppet::Graph::SimpleGraph
     @providerless_types = []
   end
 
+  def check_conflicts(catalog)
+    vertices.each do |vertex|
+      vertex.conflict(catalog)
+    end
+  end
+
   def populate_from(catalog)
     add_all_resources_as_vertices(catalog)
+
+    check_conflicts(catalog)
+
     build_manual_dependencies
     build_autorelation_dependencies(catalog)
 

--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -219,6 +219,22 @@ Puppet::Type.newtype(:augeas) do
     end
 
     cons.flatten.uniq
+
+    files = []
+
+    catalog.resources.find do |r| 
+      next unless r.is_a?(Puppet::Type.type(:file))
+      next unless cons.include?(r.title)
+      next unless r.parameter(:content) || r.parameter(:source)
+      
+      if rep = r.parameter(:replace)
+        next if rep.value == false
+      end
+
+      files << r
+    end
+
+    files
   end
 
 end

--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -208,4 +208,17 @@ Puppet::Type.newtype(:augeas) do
     end
   end
 
+  conflict(:file) do
+    cons = []
+    if incl = @parameters[:incl]
+      cons << incl.value
+    end
+
+    if context = @parameters[:context]
+      cons << context.value.gsub(%r{^/files}, '')
+    end
+
+    cons.flatten.uniq
+  end
+
 end

--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -224,7 +224,13 @@ Puppet::Type.newtype(:augeas) do
 
     catalog.resources.find do |r| 
       next unless r.is_a?(Puppet::Type.type(:file))
-      next unless cons.include?(r.title)
+
+      if p = r.parameter(:path)
+        next unless cons.include?(p.value)
+      else
+        next unless cons.include?(r.title)
+      end
+
       next unless r.parameter(:content) || r.parameter(:source)
       
       if rep = r.parameter(:replace)

--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -222,7 +222,7 @@ Puppet::Type.newtype(:augeas) do
 
     files = []
 
-    catalog.resources.find do |r| 
+    catalog.resources.each do |r| 
       next unless r.is_a?(Puppet::Type.type(:file))
 
       if p = r.parameter(:path)


### PR DESCRIPTION
This PR adds a new method for types, allowing to declare conflicts between resources. It implements such conflicts between the `augeas` and `file` resources (other resource types might benefit, too). Example usage:

``` puppet
augeas { "test":
  incl    => '/tmp/toto',
  lens    => 'Xml.lns',
  changes => [],
}

file { "/tmp/toto": }
```

``` shell
$ puppet apply conflict.pp
Notice: Compiled catalog for example.com in environment production in 0.10 seconds
Error: Failed to apply catalog: Resource augeas[test] conflicts with file[/tmp/toto]
```

Ideally, this would fail during catalog compilation, but I need a catalog in order to check the conflicts.
