### PR TITLE
(PUP-6229) Fix unclear error when dynamic expressions used in aliases

### DIFF
--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -459,6 +459,15 @@ describe 'Puppet Type System' do
       CODE
       expect(eval_and_collect_notices(code)).to eq(['true', 'true', 'false'])
     end
+
+    it 'will not allow dynamic constructs in type definition' do
+      code = <<-CODE
+      type Foo = Enum[$facts[os][family]]
+      notice(Foo)
+      CODE
+      expect{ eval_and_collect_notices(code) }.to raise_error(Puppet::Error,
+        /The expression <\$facts\[os\]\[family\]> is not a valid type specification/)
+    end
   end
 
   context 'Type mappings' do


### PR DESCRIPTION
A Puppet Type Alias expression may not contain dynamic expressions. The
error issued when it did was not very informative since the actual
source of the dynamic expression was left out. This commit ensures that
it is included in the error message.