### PR TITLE
(PUP-6151) Output Iterator value as Iterator-Value

### DIFF
--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -210,7 +210,7 @@ module Puppet::Pops::Types
 
     def to_s
       et = element_type
-      et.nil? ? 'Iterator value' : "Iterator[#{et.generalize}] value"
+      et.nil? ? 'Iterator-Value' : "Iterator[#{et.generalize}]-Value"
     end
 
     def unbounded?

--- a/spec/unit/pops/types/iterable_spec.rb
+++ b/spec/unit/pops/types/iterable_spec.rb
@@ -256,7 +256,7 @@ describe 'The iterable support' do
   end
 
   it 'will produce the string Iterator[T] on to_s on an iterator instance with element type T' do
-    expect(Iterable.on(18).to_s).to eq('Iterator[Integer] value')
+    expect(Iterable.on(18).to_s).to eq('Iterator[Integer]-Value')
   end
 end
 end


### PR DESCRIPTION
Use dash between the type and the text 'value' and capitalize
'value' to make the output of an iterator type more readable.