### PR TITLE
(PUP-4856) Defer evaluation of 'default' node

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -556,7 +556,15 @@ class Puppet::Parser::Compiler
     # of resources.
     resource = astnode.ensure_in_catalog(topscope)
 
-    resource.evaluate
+    # Evaluate the AST node unless it is the 'default' node. The 'default' node will
+    # then be evaluated together with other ENC added classes when #eval_definitions
+    # is called, giving those classes a chance to override definitions that the
+    # default node is using.
+    #
+    # If the 'default' node is evaluated right here, then any definition that it
+    # instantiates, will be evaluated during the #eval_definitions phase and
+    # before evaluation of classes included by ENC.
+    resource.evaluate unless astnode.name == 'default'
 
     @node_scope = topscope.class_scope(astnode)
   end

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -662,5 +662,34 @@ describe "Two step scoping for variables" do
         MANIFEST
       end
     end
+
+    it 'ENC-node instantiated class overrides class instantiated by default node' do
+      enc_node = Puppet::Node.new('the_node', { :classes => ['override'], :parameters => {}})
+
+      expect_the_message_to_be('Overridden Message', enc_node) do <<-MANIFEST
+      define defined_type_test($value) {
+        notify { 'something':
+          message => $value,
+        }
+      }
+
+      class base {
+        defined_type_test { 'foo':
+          value => 'Original Message',
+        }
+      }
+
+      class override {
+        Defined_type_test <| title == 'foo' |> {
+          value => 'Overridden Message',
+        }
+      }
+
+      node default {
+        include base
+      }
+      MANIFEST
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit ensures that the evaluation of the default node is deferred
until all classes are known. This to ensure that classes included by the
ENC can override instantiations made by the 'default' node.