### PR TITLE
(PUP-3827) Return errors matching schema from indirected routes

### DIFF
--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -31,7 +31,7 @@ test_name "CVE 2013-1652 Improper query parameter validation" do
           begin
             res = JSON.parse( test.stdout )
             fail_test( "Retrieved catalog for #{master} from #{agent}" ) if
-              res['data']['name'] == master.name
+              res['data'] && res['data']['name'] == master.name
           rescue JSON::ParserError
             # good, continue
           end

--- a/spec/integration/network/http/api/indirected_routes_spec.rb
+++ b/spec/integration/network/http/api/indirected_routes_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 require 'puppet/network/http'
 require 'puppet/network/http/api/indirected_routes'
+require 'rack/mock' if Puppet.features.rack?
+require 'puppet/network/http/rack/rest'
 require 'puppet/indirector_proxy'
 require 'puppet_spec/files'
 require 'puppet_spec/network'
@@ -49,6 +51,37 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
 
           expect(file['checksum']['type']).to eq(checksum_type)
           expect(checksum_valid(checksum_type, checksum, file['checksum']['value'])).to be_truthy
+        end
+      end
+    end
+
+    describe "an error from IndirectedRoutes", :if => Puppet.features.rack? do
+      let(:handler) { Puppet::Network::HTTP::RackREST.new }
+
+      describe "returns json" do
+        it "when a standard error" do
+          response = Rack::Response.new
+          request = Rack::Request.new(
+            Rack::MockRequest.env_for("/puppet/v3/invalid-indirector"))
+
+          handler.process(request, response)
+
+          expect(response.header["Content-Type"]).to match(/json/)
+          resp = JSON.parse(response.body.first)
+          expect(resp["message"]).to match(/The indirection name must be purely alphanumeric/)
+          expect(resp["issue_kind"]).to be_a_kind_of(String)
+        end
+        it "when a server error" do
+          response = Rack::Response.new
+          request = Rack::Request.new(
+            Rack::MockRequest.env_for("/puppet/v3/unknown_indirector"))
+
+          handler.process(request, response)
+
+          expect(response.header["Content-Type"]).to match(/json/)
+          resp = JSON.parse(response.body.first)
+          expect(resp["message"]).to match(/Could not find indirection/)
+          expect(resp["issue_kind"]).to be_a_kind_of(String)
         end
       end
     end

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -5,20 +5,20 @@ require 'puppet/network/http/api/indirected_routes'
 require 'puppet/indirector_testing'
 
 module PuppetSpec::Network
-  def not_found_code
-    Puppet::Network::HTTP::Error::HTTPNotFoundError::CODE
+  def not_found_error
+    Puppet::Network::HTTP::Error::HTTPNotFoundError
   end
 
-  def not_acceptable_code
-    Puppet::Network::HTTP::Error::HTTPNotAcceptableError::CODE
+  def not_acceptable_error
+    Puppet::Network::HTTP::Error::HTTPNotAcceptableError
   end
 
-  def bad_request_code
-    Puppet::Network::HTTP::Error::HTTPBadRequestError::CODE
+  def bad_request_error
+    Puppet::Network::HTTP::Error::HTTPBadRequestError
   end
 
-  def not_authorized_code
-    Puppet::Network::HTTP::Error::HTTPNotAuthorizedError::CODE
+  def not_authorized_error
+    Puppet::Network::HTTP::Error::HTTPNotAuthorizedError
   end
 
   def params

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -21,6 +21,10 @@ module PuppetSpec::Network
     Puppet::Network::HTTP::Error::HTTPNotAuthorizedError
   end
 
+  def method_not_allowed_error
+    Puppet::Network::HTTP::Error::HTTPMethodNotAllowedError
+  end
+
   def params
     { :environment => "production" }
   end

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -39,19 +39,19 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should fail if there is no environment specified" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {}) }).to raise_error(ArgumentError)
+      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {}) }).to raise_error(bad_request_error)
     end
 
     it "should fail if the environment is not alphanumeric" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {:environment => "env ness"}) }).to raise_error(ArgumentError)
+      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {:environment => "env ness"}) }).to raise_error(bad_request_error)
     end
 
     it "should fail if the indirection does not match the prefix" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/certificate/foo", params) }).to raise_error(ArgumentError)
+      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/certificate/foo", params) }).to raise_error(bad_request_error)
     end
 
     it "should fail if the indirection does not have the correct version" do
-      expect(lambda { handler.uri2indirection("GET", "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v3/certificate/foo", params) }).to raise_error(ArgumentError)
+      expect(lambda { handler.uri2indirection("GET", "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v3/certificate/foo", params) }).to raise_error(bad_request_error)
     end
 
     it "should not pass a buck_path parameter through (See Bugs #13553, #13518, #13511)" do
@@ -75,7 +75,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should fail if the indirection name is not alphanumeric" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/foo ness/bar", params) }).to raise_error(ArgumentError)
+      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/foo ness/bar", params) }).to raise_error(bad_request_error)
     end
 
     it "should use the remainder of the URI as the indirection key" do
@@ -87,7 +87,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should fail if no indirection key is specified" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node", params) }).to raise_error(ArgumentError)
+      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node", params) }).to raise_error(bad_request_error)
     end
 
     it "should choose 'find' as the indirection method if the http method is a GET and the indirection name is singular" do
@@ -123,7 +123,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should fail if an indirection method cannot be picked" do
-      expect(lambda { handler.uri2indirection("UPDATE", "#{master_url_prefix}/node/bar", params) }).to raise_error(ArgumentError)
+      expect(lambda { handler.uri2indirection("UPDATE", "#{master_url_prefix}/node/bar", params) }).to raise_error(method_not_allowed_error)
     end
 
     it "should not URI unescape the indirection key" do
@@ -145,7 +145,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
                                                  Not(has_entry(:environment)))
       expect(lambda { handler.uri2indirection("GET",
                                               "#{master_url_prefix}/node/bar",
-                                              {:environment => 'bogus'}) }).to raise_error(ArgumentError)
+                                              {:environment => 'bogus'}) }).to raise_error(not_found_error)
     end
 
     it "should not URI unescape the indirection key as passed through to a call to check_authorization" do
@@ -240,13 +240,13 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       }.to raise_error(not_found_error)
     end
 
-    it "should raise ArgumentError if the environment does not exist" do
+    it "should raise not_found_error if the environment does not exist" do
       Puppet.override(:environments => Puppet::Environments::Static.new()) do
         request = a_request_that_heads(Puppet::IndirectorTesting.new("my data"))
 
         expect {
           handler.call(request, response)
-        }.to raise_error(ArgumentError)
+        }.to raise_error(not_found_error)
       end
     end
   end

--- a/spec/unit/network/http/api/master/v3_spec.rb
+++ b/spec/unit/network/http/api/master/v3_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 require 'puppet/network/http'
+require 'puppet_spec/network'
 
 describe Puppet::Network::HTTP::API::Master::V3 do
+  include PuppetSpec::Network
+
   let(:response) { Puppet::Network::HTTP::MemoryResponse.new }
   let(:master_url_prefix) { "#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3" }
   let(:master_routes) {
@@ -29,11 +32,11 @@ describe Puppet::Network::HTTP::API::Master::V3 do
     expect(response.code).to eq(200)
   end
 
-  it "responds to unknown paths with a 404" do
+  it "responds to unknown paths by raising not_found_error" do
     request = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_url_prefix}/unknown")
-    master_routes.process(request, response)
 
-    expect(response.code).to eq(404)
-    expect(response.body).to match("Not Found: Could not find indirection 'unknown'")
+    expect {
+      master_routes.process(request, response)
+    }.to raise_error(not_found_error)
   end
 end


### PR DESCRIPTION
But with feeling this time....    ...so many feelings....

Originally the merged PR for PUP-3827 (#4875) had its acceptance tests ran locally with `SHA=$(git rev-parse HEAD) TEST_TARGET=ubuntu1404-64a bundle exec rake ci:test:git`

That line is crucially missing a `PUPPET_FORK=justinstoller` and instead of running code from the local git checkout will instead look for the current SHA in puppetlabs/puppet and when it doesn't find it, it happily runs code from the current HEAD of master. 

Some selected commit messages from the past month that this ticket has been in progress:
```
Prior to this the indirected routes would intercept any issues that
arose in processing the request and format them into a plain text
response with the proper error code.

All other routes pass issues up to the generic route handler which will
format them according to a documented schema.

This moves the indirected routes handler from never raising to always
raising on error, similar to other route handlers. This allows the
indirected routes to share the error handling code with other routes
and provides consistently formatted errors throughout the rest api.
```
```
In 363d36e we brought the IndirectedRoutes into consistency with
other API handlers. However, we regressed in no longer catching
Puppet::Network::AuthorizationErrors (which is handled by additional
middleware for other route handlers).

IndirectedRoutes cannot use the same middleware as other handlers
without a larger refactor because the URI supplied to the middleware
must first be coerced and validated (logic which currently lives within
IndirectedRoutes) before it can be authorized.

Therefore, this patch leaves the authorization check within
IndirectedRoutes, but ensure that it catches any
Puppet::Network::AuthorizationError and raises
Puppet::Network::HTTP::Error::HTTPNotAuthorizedError in its place.
```
```
Previously, we threw ArgumentErrors when we received a malformed request
for the IndirectedRoutes class. This conflated an error in calling a
Ruby method and an error by the consumer calling an API endpoint, and
consequently always returned 400 statuses for internal errors.

As part of PUP-3827, higher level middleware now handles the response
formatting for errors. The higher level middleware, however, makes the
distinction between ArgumentErrors to Ruby functions and BadRequests to
the API endpoint (and expects throwers to as well).

Since IndirectedRoutes did not make this distinction all invalid
environment requests were then being treated as ServerErrors, and
returning 500 statuses.

This patch updates IndirectedRoutes to throw proper HTTPErrors instead
of ArgumentErrors when a client has submitted a BadRequest, used a
MethodNotAllowed, or the environment is NotFound.
```

Plus attendant test updates.
