### PR TITLE
(maint) Fix bug for Semantic::Version in TypeCalculator::infer_set

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -312,6 +312,8 @@ class TypeCalculator
         infer_set_Array(o)
       when Hash
         infer_set_Hash(o)
+      when Semantic::Version
+        infer_set_Version(o)
       else
         infer_set_Object(o)
     end
@@ -724,7 +726,7 @@ class TypeCalculator
 
   # @api private
   def infer_set_Version(o)
-    PSemVerType.new(PSemVerRangeType.new(o, o))
+    PSemVerType.new(Semantic::VersionRange.new(o, o))
   end
 
   def unwrap_single_variant(possible_variant)

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -208,6 +208,25 @@ describe 'The type calculator' do
       end
     end
 
+    context 'version' do
+      it 'translates to PVersionType' do
+        expect(calculator.infer(Semantic::Version.new(1,0,0)).class).to eq(PSemVerType)
+      end
+
+      it 'range translates to PVersionRangeType' do
+        expect(calculator.infer(Semantic::VersionRange.parse('1.x')).class).to eq(PSemVerRangeType)
+      end
+
+      it 'translates to a limited PVersionType by infer_set' do
+        v = Semantic::Version.new(1,0,0)
+        t = calculator.infer_set(v)
+        expect(t.class).to eq(PSemVerType)
+        expect(t.ranges.size).to eq(1)
+        expect(t.ranges[0].min).to eq(v)
+        expect(t.ranges[0].max).to eq(v)
+      end
+    end
+
     context 'array' do
       it 'translates to PArrayType' do
         expect(calculator.infer([1,2]).class).to eq(PArrayType)


### PR DESCRIPTION
The TypeCalculator::infer_set does not use the normal dynamic dispatch
algorithm. Instead, to speed things up, it uses a case/when. When adding
the SemVer type, an infer_set_Version method was added, but it was never
called because it was not added to that case/when. This commit fixes
this oversight and adds the tests needed to verify that infer_set works
for Semantic::Version.