### PR TITLE
(doc) Fix/update links to environments doc.

### DIFF
--- a/ext/README.environment
+++ b/ext/README.environment
@@ -5,4 +5,4 @@ modules that are installed globally (normally in /etc/puppetlabs/code/modules) f
 puppet master.
 
 For more information see
-https://docs.puppetlabs.com/puppet/latest/reference/environments.html
+https://docs.puppet.com/puppet/latest/reference/environments.html

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -308,7 +308,7 @@ module Puppet
 
         This setting must have a value set to enable **directory environments.** The
         recommended value is `$codedir/environments`. For more details, see
-        https://docs.puppetlabs.com/puppet/latest/reference/environments.html",
+        <https://docs.puppet.com/puppet/latest/reference/environments.html>",
       :type    => :path,
     },
     :always_cache_features => {
@@ -1077,7 +1077,7 @@ EOT
         directory environments instead. If you need to use something other than the
         environment's `manifests` directory as the main manifest, you can set
         `manifest` in environment.conf. For more info, see
-        https://docs.puppetlabs.com/puppet/latest/reference/environments.html",
+        <https://docs.puppet.com/puppet/latest/reference/environments.html>",
     },
     :modulepath => {
       :default => "",
@@ -1091,7 +1091,7 @@ EOT
         directory environments instead. If you need to use something other than the
         default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
         you can set `modulepath` in environment.conf. For more info, see
-        https://docs.puppetlabs.com/puppet/latest/reference/environments.html",
+        <https://docs.puppet.com/puppet/latest/reference/environments.html>",
     },
     :config_version => {
       :default    => "",
@@ -1103,7 +1103,7 @@ EOT
       Setting a global value for config_version in puppet.conf is not allowed
       (but it can be overridden from the commandline). Please set a
       per-environment value in environment.conf instead. For more info, see
-      https://docs.puppetlabs.com/puppet/latest/reference/environments.html",
+      <https://docs.puppet.com/puppet/latest/reference/environments.html>",
     }
   )
 
@@ -1215,7 +1215,7 @@ EOT
         These are the modules that will be used by _all_ environments. Note that
         the `modules` directory of the active environment will have priority over
         any global directories. For more info, see
-        https://docs.puppetlabs.com/puppet/latest/reference/environments.html",
+        <https://docs.puppet.com/puppet/latest/reference/environments.html>",
     },
     :ssl_client_header => {
       :default    => "HTTP_X_CLIENT_DN",

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -27,7 +27,7 @@ class Puppet::Parser::Compiler
       errors.each { |e| Puppet.err(e) } if errors.size > 1
       errmsg = [
         "Compilation has been halted because: #{errors.first}",
-        "For more information, see https://docs.puppetlabs.com/puppet/latest/reference/environments.html",
+        "For more information, see https://docs.puppet.com/puppet/latest/reference/environments.html",
       ]
       raise(Puppet::Error, errmsg.join(' '))
     end

--- a/lib/puppet/settings/config_file.rb
+++ b/lib/puppet/settings/config_file.rb
@@ -82,7 +82,7 @@ private
   def unique_sections_in(ini, file, allowed_section_names)
     ini.section_lines.collect do |section|
       if !allowed_section_names.empty? && !allowed_section_names.include?(section.name)
-        raise(Puppet::Error, "Illegal section '#{section.name}' in config file #{file} at line #{section.line_number}. The only valid puppet.conf sections are: [#{allowed_section_names.join(", ")}]. Please use the directory environments feature to specify environments. (See https://docs.puppetlabs.com/puppet/latest/reference/environments.html)")
+        raise(Puppet::Error, "Illegal section '#{section.name}' in config file #{file} at line #{section.line_number}. The only valid puppet.conf sections are: [#{allowed_section_names.join(", ")}]. Please use the directory environments feature to specify environments. (See https://docs.puppet.com/puppet/latest/reference/environments.html)")
       end
       section.name
     end.uniq


### PR DESCRIPTION
-   Add link markup and update URL in `default.rb` markdown content.
-   Update URL in error messages and other locations.