### PR TITLE
(PUP-6301) Make AIX service test setup idempotent

### DIFF
--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -46,6 +46,12 @@ def lssrc_assert_status(host, service, expected_status)
   end
 end
 
+teardown do
+  agents.each do |agent|
+    on(agent, "rmssys -s sloth_daemon", :allowable_exit_codes => [0,1])
+  end
+end
+
 agents.each do |agent|
 
   ## Setup
@@ -57,11 +63,6 @@ agents.each do |agent|
 
   # Creating the service may also start it. Stop service before beginning the test.
   on(agent, puppet_resource('service', 'sloth_daemon', 'ensure=stopped', 'enable=false'))
-
-  teardown do
-    on agent, "rmssys -s sloth_daemon"
-    on agent, "rm #{sloth_daemon_path}"
-  end
 
   ## Query
   step "Verify the service exists on #{agent}"

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -55,8 +55,8 @@ agents.each do |agent|
   on agent, "chmod +x #{sloth_daemon_path}"
   on agent, "mkssys -s sloth_daemon -p #{sloth_daemon_path} -u 0 -S -n 15 -f 9"
 
-  # Creating the service also starts it. Stop it before beginning the test.
-  ensure_service_on_host(agent, 'sloth_daemon', {:ensure => 'stopped'})
+  # Creating the service may also start it. Stop service before beginning the test.
+  on(agent, puppet_resource('service', 'sloth_daemon', 'ensure=stopped', 'enable=false'))
 
   teardown do
     on agent, "rmssys -s sloth_daemon"


### PR DESCRIPTION
This commit alters the setup step for ensuring that the test service is
stopped. It removes the validation that the service changed state. This allows
the step to pass if the service was already stopped prior to running the
setup step that stops it.

Prior to this commit, if the system did not automatically start the service
upon creation the test would fail during the setup step intended to ensure
that it was stopped.