### PR TITLE
(PUP-6319) Fix error when reporting zero sized hash mismatch

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -789,6 +789,14 @@ module Types
         else
           descriptions << SizeMismatch.new(path, expected_size, actual_size)
         end
+      elsif actual.is_a?(PHashType)
+        expected_size = expected.size_type
+        actual_size = actual.size_type || PCollectionType::DEFAULT_SIZE
+        if expected_size.nil? || expected_size.assignable?(actual_size)
+          descriptions << TypeMismatch.new(path, expected, actual)
+        else
+          descriptions << SizeMismatch.new(path, expected_size, actual_size)
+        end
       else
         descriptions << TypeMismatch.new(path, expected, actual)
       end

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -58,6 +58,16 @@ describe 'the type mismatch describer' do
     expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects size to be at least 1, got 0/)
   end
 
+  it 'will report a hash size mismatch' do
+    code = <<-CODE
+      function f(Hash[String,String,1,default] $h) {
+         $h['a']
+      }
+      f({})
+    CODE
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects size to be at least 1, got 0/)
+  end
+
   it 'will include the aliased type when reporting a mismatch that involves an alias' do
     code = <<-CODE
       type UnprivilegedPort = Integer[1024,65537]


### PR DESCRIPTION
Fixes a bug in the TypeMismatchDescriber that caused the type mismatch
reported when passing a zero sized hash where a non empty hash is
required to report an element type mismatch rather than the size
mismatch.