### PR TITLE
(PUP-6320) Fix error when reporting zero sized array mismatch

### DIFF
--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -806,6 +806,18 @@ describe 'The type calculator' do
         expect(empty_array_t).to be_assignable_to(array_t(string_t))
         expect(empty_array_t).to be_assignable_to(array_t(integer_t))
       end
+
+      it 'A Tuple is assignable to an array' do
+        expect(tuple_t(String)).to be_assignable_to(array_t(String))
+      end
+
+      it 'A Tuple with <n> elements is assignable to an array with min size <n>' do
+        expect(tuple_t(String,String)).to be_assignable_to(array_t(String, range_t(2, :default)))
+      end
+
+      it 'A Tuple with <n> elements where the last 2 are optional is assignable to an array with size <n> - 2' do
+        expect(constrained_tuple_t(range_t(2, :default), String,String,String,String)).to be_assignable_to(array_t(String, range_t(2, :default)))
+      end
     end
 
     context 'for Hash, such that' do

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -25,7 +25,7 @@ describe 'the type mismatch describer' do
       }
       f(['a', 23])
     CODE
-    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects an Array\[String\] value, got Tuple\[String, Integer\]/)
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /'f' parameter 'h' index 1 expects a String value, got Integer/)
   end
 
   it 'will not report details for a mismatch between an array and a struct' do
@@ -46,6 +46,16 @@ describe 'the type mismatch describer' do
       f(['a', 23])
     CODE
     expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects a Hash value, got Tuple/)
+  end
+
+  it 'will report an array size mismatch' do
+    code = <<-CODE
+      function f(Array[String,1,default] $h) {
+        $h[0]
+      }
+      f([])
+    CODE
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects size to be at least 1, got 0/)
   end
 
   it 'will include the aliased type when reporting a mismatch that involves an alias' do


### PR DESCRIPTION
Fixes a bug in the TypeMismatchDescriber that caused the type mismatch
reported when passing a zero sized array where a non empty array is
required to report an element type mismatch rather than the size
mismatch.

Also fixes so that array mismatches are reported with correct index
rather than just stating that there's a mismatch between an Array
and a Tuple where some element in the Tuple doesn't match the element
type of the Array.