### PR TITLE
(PUP-6088) Make TypeParser.interpret public API

### DIFF
--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -33,7 +33,11 @@ class TypeParser
     interpret(model.current.body, context)
   end
 
-  # @api private
+  # @param ast [Puppet::Pops::Model::PopsObject] the ast to interpret
+  # @param context [Puppet::Parser::Scope,Loader::Loader, nil] scope or loader to use when loading type aliases
+  # @return [PAnyType] a specialization of the PAnyType representing the type.
+  #
+  # @api public
   def interpret(ast, context)
     result = @type_transformer.visit_this_1(self, ast, context)
     raise_invalid_type_specification_error(ast) unless result.is_a?(PAnyType)


### PR DESCRIPTION
This makes the API for TypeParser.interpret public API (it is used by
Puppet Strings). This change is made to make Puppet aware that the API
cannot be changed without consequences.

It is a documentation change only since the method itself was not
technically Ruby private.