### PR TITLE
(PUP-6327) better invalid path error

### DIFF
--- a/lib/puppet/module_tool/errors/installer.rb
+++ b/lib/puppet/module_tool/errors/installer.rb
@@ -81,12 +81,12 @@ Could not install module '#{@requested_module}' (#{@requested_version})
     def initialize(options)
       @entry_path = options[:entry_path]
       @directory  = options[:directory]
-      super "Attempt to install file into #{@entry_path.inspect} under #{@directory.inspect}"
+      super "Attempt to install file with an invalid path into #{@entry_path.inspect} under #{@directory.inspect}"
     end
 
     def multiline
       <<-MSG.strip
-Could not install package
+Could not install package with an invalid path.
   Package attempted to install file into
   #{@entry_path.inspect} under #{@directory.inspect}.
       MSG

--- a/spec/unit/module_tool/tar/mini_spec.rb
+++ b/spec/unit/module_tool/tar/mini_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::ModuleTool::Tar::Mini, :if => (Puppet.features.minitar? and Pup
     expect {
       minitar.unpack(sourcefile, destdir, 'uid')
     }.to raise_error(Puppet::ModuleTool::Errors::InvalidPathInPackageError,
-                     "Attempt to install file into \"/thefile\" under \"#{destdir}\"")
+                     "Attempt to install file with an invalid path into \"/thefile\" under \"#{destdir}\"")
   end
 
   it "does not allow a file to be written outside the destination directory" do
@@ -29,7 +29,7 @@ describe Puppet::ModuleTool::Tar::Mini, :if => (Puppet.features.minitar? and Pup
     expect {
       minitar.unpack(sourcefile, destdir, 'uid')
     }.to raise_error(Puppet::ModuleTool::Errors::InvalidPathInPackageError,
-                     "Attempt to install file into \"#{File.expand_path('/the/thefile')}\" under \"#{destdir}\"")
+                     "Attempt to install file with an invalid path into \"#{File.expand_path('/the/thefile')}\" under \"#{destdir}\"")
   end
 
   it "does not allow a directory to be written outside the destination directory" do
@@ -38,7 +38,7 @@ describe Puppet::ModuleTool::Tar::Mini, :if => (Puppet.features.minitar? and Pup
     expect {
       minitar.unpack(sourcefile, destdir, 'uid')
     }.to raise_error(Puppet::ModuleTool::Errors::InvalidPathInPackageError,
-                     "Attempt to install file into \"#{File.expand_path('/the/thedir')}\" under \"#{destdir}\"")
+                     "Attempt to install file with an invalid path into \"#{File.expand_path('/the/thedir')}\" under \"#{destdir}\"")
   end
 
   it "packs a tar file" do


### PR DESCRIPTION
This clarifies that the path is invalid. Prior to this, it wasn't super
clear why the PMT install failed.