### PR TITLE
(PUP-6321) Handle autorequire with undef values

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -2132,8 +2132,10 @@ end
 
       # Collect the current prereqs
       list.each { |dep|
+        next if dep.nil?
+
         # Support them passing objects directly, to save some effort.
-        unless dep.is_a? Puppet::Type
+        unless dep.is_a?(Puppet::Type)
           # Skip autorelation that we aren't managing
           unless dep = rel_catalog.resource(type, dep)
             next

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -393,10 +393,46 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
         expect(relationship_graph.edges_between(src,dst).first.event).to eq(:NONE)
       end
 
+      it 'should not fail autorequire contains undef entries' do
+        type = Puppet::Type.newtype(:autorelation_two) do
+          newparam(:name) { isnamevar }
+          autorequire(:autorelation_one) { [nil, 'foo'] }
+        end
+
+        relationship_graph = compile_to_relationship_graph(<<-MANIFEST)
+          autorelation_one { 'foo': }
+          autorelation_two { 'bar': }
+        MANIFEST
+
+        src = relationship_graph.vertices.select{ |x| x.ref.to_s == 'Autorelation_one[foo]' }.first
+        dst = relationship_graph.vertices.select{ |x| x.ref.to_s == 'Autorelation_two[bar]' }.first
+
+        expect(relationship_graph.edge?(src,dst)).to be_truthy
+        expect(relationship_graph.edges_between(src,dst).first.event).to eq(:NONE)
+      end
+
       it "should be able to autosubscribe resources" do
         type = Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autosubscribe(:autorelation_one) { ['foo'] }
+        end
+
+        relationship_graph = compile_to_relationship_graph(<<-MANIFEST)
+          autorelation_one { 'foo': }
+          autorelation_two { 'bar': }
+        MANIFEST
+
+        src = relationship_graph.vertices.select{ |x| x.ref.to_s == 'Autorelation_one[foo]' }.first
+        dst = relationship_graph.vertices.select{ |x| x.ref.to_s == 'Autorelation_two[bar]' }.first
+
+        expect(relationship_graph.edge?(src,dst)).to be_truthy
+        expect(relationship_graph.edges_between(src,dst).first.event).to eq(:ALL_EVENTS)
+      end
+
+      it 'should not fail if autosubscribe contains undef entries' do
+        type = Puppet::Type.newtype(:autorelation_two) do
+          newparam(:name) { isnamevar }
+          autosubscribe(:autorelation_one) { [nil, 'foo'] }
         end
 
         relationship_graph = compile_to_relationship_graph(<<-MANIFEST)
@@ -429,10 +465,46 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
         expect(relationship_graph.edges_between(src,dst).first.event).to eq(:NONE)
       end
 
+      it "should not fail when autobefore contains undef entries" do
+        type = Puppet::Type.newtype(:autorelation_two) do
+          newparam(:name) { isnamevar }
+          autobefore(:autorelation_one) { [nil, 'foo'] }
+        end
+
+        relationship_graph = compile_to_relationship_graph(<<-MANIFEST)
+          autorelation_one { 'foo': }
+          autorelation_two { 'bar': }
+        MANIFEST
+
+        src = relationship_graph.vertices.select{ |x| x.ref.to_s == 'Autorelation_two[bar]' }.first
+        dst = relationship_graph.vertices.select{ |x| x.ref.to_s == 'Autorelation_one[foo]' }.first
+
+        expect(relationship_graph.edge?(src,dst)).to be_truthy
+        expect(relationship_graph.edges_between(src,dst).first.event).to eq(:NONE)
+      end
+
       it "should be able to autonotify resources" do
         type = Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autonotify(:autorelation_one) { ['foo'] }
+        end
+
+        relationship_graph = compile_to_relationship_graph(<<-MANIFEST)
+          autorelation_one { 'foo': }
+          autorelation_two { 'bar': }
+        MANIFEST
+
+        src = relationship_graph.vertices.select{ |x| x.ref.to_s == 'Autorelation_two[bar]' }.first
+        dst = relationship_graph.vertices.select{ |x| x.ref.to_s == 'Autorelation_one[foo]' }.first
+
+        expect(relationship_graph.edge?(src,dst)).to be_truthy
+        expect(relationship_graph.edges_between(src,dst).first.event).to eq(:ALL_EVENTS)
+      end
+
+      it 'should not fail if autonotify contains undef entries' do
+        type = Puppet::Type.newtype(:autorelation_two) do
+          newparam(:name) { isnamevar }
+          autonotify(:autorelation_one) { [nil, 'foo'] }
         end
 
         relationship_graph = compile_to_relationship_graph(<<-MANIFEST)


### PR DESCRIPTION
Prior to this commit, an autorequire that produced `undef` values would
produce an error:
```
No title provided and :xxx is not a valid resource reference
```
This commit ensures that `undef` entries provided by an autorequire are
skipped over.