### PR TITLE
(PUP-6318) Update install.rb to actually honor InstallOptions.batch_files

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -475,7 +475,7 @@ FileUtils.cd File.dirname(__FILE__) do
   #build_ri(ri) if InstallOptions.ri
   do_configs(configs, InstallOptions.config_dir) if InstallOptions.configs
   do_bins(bins, InstallOptions.bin_dir)
-  do_bins(windows_bins, InstallOptions.bin_dir, 'ext/windows/') if $operatingsystem == "windows"
+  do_bins(windows_bins, InstallOptions.bin_dir, 'ext/windows/') if $operatingsystem == "windows" && InstallOptions.batch_files
   do_libs(libs)
   do_man(man) unless $operatingsystem == "windows"
 end


### PR DESCRIPTION
Install.rb was just updated to add an install option to omit batch file
generation during installation. But this change was incomplete. This commit
should suffice to actually omit all batch files during install