### PR TITLE
(PUP-6336) Fix problem with diff Jruby/MRI in String#==

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -82,7 +82,7 @@ module Runtime3Support
       # Must convert :undef back to nil - this can happen when an undefined variable is used in a
       # parameter's default value expression - there nil must be :undef to work with the rest of 3x.
       # Now that the value comes back to 4x it is changed to nil.
-      return :undef == x ? nil : x
+      return :undef.equal?(x) ? nil : x
     }
     # It is always ok to reference numeric variables even if they are not assigned. They are always undef
     # if not set by a match expression.

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -9,6 +9,23 @@ describe Symbol do
     $unique_warnings.delete('symbol_comparison') if $unique_warnings
   end
 
+  it 'should have an equal? that is not true for a string with same letters' do
+    symbol = :undef
+    expect(symbol).to_not equal('undef')
+  end
+
+  it "should have an eql? that is not true for a string with same letters" do
+    pending "JRuby is incompatible with MRI - Cannot test this on JRuby" if RUBY_PLATFORM == 'java'
+    symbol = :undef
+    expect(symbol).to_not eql('undef')
+  end
+
+  it "should have an == that is not true for a string with same letters" do
+    pending "JRuby is incompatible with MRI - Cannot test this on JRuby" if RUBY_PLATFORM == 'java'
+    symbol = :undef
+    expect(symbol == 'undef').to_not be(true)
+  end
+
   it "should return self from #intern" do
     symbol = :foo
     expect(symbol).to equal symbol.intern

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -15,7 +15,6 @@ describe Symbol do
   end
 
   it "should have an eql? that is not true for a string with same letters" do
-    pending "JRuby is incompatible with MRI - Cannot test this on JRuby" if RUBY_PLATFORM == 'java'
     symbol = :undef
     expect(symbol).to_not eql('undef')
   end


### PR DESCRIPTION
Puppet has a monkey patch for `Symbol#<=>(String)` that enables
comparison. This is deprecated and slated for removal in puppet 5.0.0.

On JRuby, `String#==(other)` is implemented as `other<=>(self) == 0` which
causes the monkey patch in puppet to trigger.

In 1547756ad7caa5cb1f0add8161e51ac07f61bd67 we reversed a test from `x
== :undef` to `:undef == x`. And this caused the problem reported in
PUP-6336 as this logic now (via the MRI incompatible implementation in
JRuby) caused the monkey patch in puppet to kick in.

This commit changes the test `:undef == x` to `:undef.equal?(x)` which
avoids both the JRuby incompatibility, and the problem the change
solved in the first place (ending up in the same insane monkey patch).