### PR TITLE
(PUP-6339) Bind lookup adapter to compiler instead of environment

### DIFF
--- a/lib/puppet/data_providers.rb
+++ b/lib/puppet/data_providers.rb
@@ -25,6 +25,6 @@ module Puppet::DataProviders
 
   def self.lookup_adapter(lookup_invocation)
     assert_loaded()
-    LookupAdapter.adapt(lookup_invocation.scope.environment)
+    LookupAdapter.adapt(lookup_invocation.scope.compiler)
   end
 end

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/name.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/name.yaml
@@ -1,1 +1,2 @@
 one::test::param_b: module data param_b is 200
+one::my_var: 'In name.yaml'

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/server1.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/server1.yaml
@@ -1,0 +1,1 @@
+one::my_var: 'server1'

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/server2.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/server2.yaml
@@ -1,0 +1,1 @@
+one::my_var: 'server2'

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/hiera.yaml
@@ -1,6 +1,8 @@
 ---
 :version: 4
 :hierarchy:
+  - :name: "%{my_fact}"
+    :backend: yaml
   - :name: "name"
     :backend: yaml
   - :name: "one path"


### PR DESCRIPTION
Before this commit, the LookupAdapter used for providing environment and
module data providers, was attached to the current environment. This
caused all caches to have the same lifecycle as the environment which
is wrong. The caches should not survive between compilations.

This commit changes the LookupAdapter so that it instead attaches itself
to the compiler. This ensures that a new LookupAdapter instance (and
and hence, new caches) are created for each compilation.