### PR TITLE
(PUP-6125) send verbose/debug messages to console when logdest is unset

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -357,8 +357,10 @@ class Application
   end
 
   def setup_logs
-    if options[:debug] || options[:verbose]
-      Puppet::Util::Log.newdestination(:console)
+    unless options[:setdest]
+      if options[:debug] || options[:verbose]
+        Puppet::Util::Log.newdestination(:console)
+      end
     end
 
     set_log_level

--- a/spec/integration/agent/logging_spec.rb
+++ b/spec/integration/agent/logging_spec.rb
@@ -86,21 +86,22 @@ describe 'agent logging' do
       end
 
     else
+      if no_log_dest_set_in(argv)
+        it "when evoked with #{argv}, logs to #{expected[:loggers].inspect} at level #{expected[:level]}" do
+          # This logger is created by the Puppet::Settings object which creates and
+          # applies a catalog to ensure that configuration files and users are in
+          # place.
+          #
+          # It's not something we are specifically testing here since it occurs
+          # regardless of user flags.
+          Puppet::Util::Log.expects(:newdestination).with(instance_of(Puppet::Transaction::Report)).at_least_once
+          expected[:loggers].each do |logclass|
+            Puppet::Util::Log.expects(:newdestination).with(logclass).at_least_once
+          end
+          double_of_bin_puppet_agent_call(argv)
 
-      it "when evoked with #{argv}, logs to #{expected[:loggers].inspect} at level #{expected[:level]}" do
-        # This logger is created by the Puppet::Settings object which creates and
-        # applies a catalog to ensure that configuration files and users are in
-        # place.
-        #
-        # It's not something we are specifically testing here since it occurs
-        # regardless of user flags.
-        Puppet::Util::Log.expects(:newdestination).with(instance_of(Puppet::Transaction::Report)).at_least_once
-        expected[:loggers].each do |logclass|
-          Puppet::Util::Log.expects(:newdestination).with(logclass).at_least_once
+          expect(Puppet::Util::Log.level).to eq(expected[:level])
         end
-        double_of_bin_puppet_agent_call(argv)
-
-        expect(Puppet::Util::Log.level).to eq(expected[:level])
       end
 
     end


### PR DESCRIPTION
When the verbose or debug flags are used log output is sent to the
default logger (syslog/eventlog) and console regardless if logdest is
set.

Without this PR
`puppet agent --verbose` prints to syslog and console
`puppet agent --verbose --logdest=syslog` **prints to syslog and console**
`puppet agent --verbose --logdest=console` prints only to console

With this PR
`puppet agent --verbose` prints to syslog and console
`puppet agent --verbose --logdest=syslog` **only prints to syslog**
`puppet agent --verbose --logdest=console` prints only to console