### PR TITLE
(PUP-6345) In config reference, override default value of hiera_config

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -32,6 +32,8 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
       val = 'Unix/Linux: /var/run/puppetlabs -- Windows: C:\ProgramData\PuppetLabs\puppet\var\run -- Non-root user: ~/.puppetlabs/var/run'
     elsif name.to_s == 'logdir'
       val = 'Unix/Linux: /var/log/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\var\log -- Non-root user: ~/.puppetlabs/var/log'
+    elsif name.to_s == 'hiera.yaml'
+      val = '$confdir/hiera.yaml. However, if a file exists at $codedir/hiera.yaml, Puppet uses that instead.'
     end
 
     # Leave out the section information; it was apparently confusing people.


### PR DESCRIPTION
This setting's default value is now complicated, and the config reference gives up
and reports the literal location for the current local user. So like with the special
directories, we should override the default with a description.