### PR TITLE
(PUP-6349) Don't quote mailalias recipients with +

### DIFF
--- a/lib/puppet/provider/mailalias/aliases.rb
+++ b/lib/puppet/provider/mailalias/aliases.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:mailalias).provide(
       if record[:recipient]
 	dest = record[:recipient].collect do |d|
 	  # Quote aliases that have non-alpha chars
-	  if d =~ /[^-\w@.]/
+	  if d =~ /[^-+\w@.]/
 	    '"%s"' % d
 	  else
 	    d


### PR DESCRIPTION
mailalias aliases povider double-quotes recipient address
if it contains non-alphanumeric and few selected characters (- . @).
This list can be extended with plus ("+") character as it's very
common in e-mail addresses and it's not necessary to quote such e-mail
address. Current behavior doesn't break anything (it's not bug),
on the other hand if Puppet works on same file with other tools,
Puppet keeps changing these recipients, although not necessary.

This simple patch adds plus character into list of accepted
characters for NOT quoting the recipient.