### PR TITLE
(PUP-3713) Fix zfs type volume with volsize param

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -15,7 +15,11 @@ Puppet::Type.type(:zfs).provide(:zfs) do
     Puppet::Type.type(:zfs).validproperties.each do |property|
       next if property == :ensure
       if value = @resource[property] and value != ""
-        properties << "-o" << "#{property}=#{value}"
+        if property == :volsize
+          properties << "-V" << "#{value}"
+        else
+          properties << "-o" << "#{property}=#{value}"
+        end
       end
     end
     properties


### PR DESCRIPTION
Zfs of type "volume" (not filesystem) must be created with the -V option and the volsize param is only used in this case.
So puppet should not specify -o volsize=N but -V N . 

It has already been asked the 11/26/2014 and updated twice in 2015 : https://tickets.puppetlabs.com/browse/PUP-3713

Thx
