### PR TITLE
(doc) Recommend Puppet Extension add module name

### DIFF
--- a/lib/puppet_x.rb
+++ b/lib/puppet_x.rb
@@ -1,6 +1,12 @@
 # The Puppet Extensions Module.
 #
-# Submodules of this module should be named after the publisher (e.g. 'user' part of a Puppet Module name).
+# Submodules of this module should be named after the publisher (e.g.
+# 'user' part of a Puppet Module name). You should also add the module
+# name to avoid further conflicts in the same namespace. So the
+# structure should be
+# `lib/puppet_x/<namespace>/<module_name>/<extension.rb>`.
+# A Puppet Extension for 'puppetlabs-powershell' would live at
+# `lib/puppet_x/puppetlabs/powershell/<extension.rb>`.
 #
 # @api public
 #


### PR DESCRIPTION
Even with using the namespace ('user') as part of the PuppetX naming
convention, there still could be conflicts with other existing
modules in the same namespace. This could cause two files from
different modules that share the same name to overwrite each other
when they are synced to the same folder. It may not be immediately
obvious this is the reason when this occurs, and the results can
be disastrous. Due to these reasons, we should recommended that
Puppet Extensions submodules further define folder structure to
include the module name as well.


For example, a Puppet Extension for 'puppetlabs-powershell' would live at `lib/puppet_x/puppetlabs/powershell/<extension.rb>`.