### PR TITLE
(PUP-3964) fix previous test commit teardown.

### DIFF
--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -11,7 +11,8 @@ extend Puppet::Acceptance::EnvironmentUtils
 
   teardown do
     step 'clean out production env' do
-      on(hosts, "rm -rf #{fq_prod_environmentpath}/modules/*", :accept_all_exit_codes => true)
+      on(master, "rm -rf #{fq_prod_environmentpath}/modules/*",         :accept_all_exit_codes => true)
+      on(master, "rm     #{fq_prod_environmentpath}/manifests/site.pp", :accept_all_exit_codes => true)
     end
     step 'clean out file resources' do
       on(hosts, "rm #{file_correct} #{file_wrong}", :accept_all_exit_codes => true)


### PR DESCRIPTION
This test was previously not cleaning out its production site.pp, which
broke subsequent tests.  This test really should be using a temp
environmentpath, to be even safer, but this is a bit slower as it
requires a server restart.  This change also only cleans out the files
on the master, saving a bit of time.