### PR TITLE
(PUP-6354) Make Enum values uniq

### DIFF
--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -11,7 +11,8 @@ extend Puppet::Acceptance::EnvironmentUtils
 
   teardown do
     step 'clean out production env' do
-      on(hosts, "rm -rf #{fq_prod_environmentpath}/modules/*", :accept_all_exit_codes => true)
+      on(master, "rm -rf #{fq_prod_environmentpath}/modules/*",         :accept_all_exit_codes => true)
+      on(master, "rm     #{fq_prod_environmentpath}/manifests/site.pp", :accept_all_exit_codes => true)
     end
     step 'clean out file resources' do
       on(hosts, "rm #{file_correct} #{file_wrong}", :accept_all_exit_codes => true)

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -1,0 +1,108 @@
+test_name 'C59122: ensure provider from same env as custom type' do
+require 'puppet/acceptance/environment_utils'
+extend Puppet::Acceptance::EnvironmentUtils
+
+  app_type        = File.basename(__FILE__, '.*')
+  tmp_environment = mk_tmp_environment_with_teardown(app_type)
+  file_correct    = "#{tmp_environment}-correct.txt"
+  file_wrong      = "#{tmp_environment}-wrong.txt"
+  fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
+  fq_prod_environmentpath = "#{environmentpath}/production"
+
+  teardown do
+    step 'clean out production env' do
+      on(hosts, "rm -rf #{fq_prod_environmentpath}/modules/*", :accept_all_exit_codes => true)
+    end
+    step 'clean out file resources' do
+      on(hosts, "rm #{file_correct} #{file_wrong}", :accept_all_exit_codes => true)
+    end
+  end
+
+  step "create a custom type and provider in each of production and #{tmp_environment}" do
+    type_name               = 'test_custom_type'
+    provider_name           = 'universal'
+    type_content            = <<TYPE
+      Puppet::Type.newtype(:#{type_name}) do
+        @doc = "Manage a file (the simple version)."
+        ensurable
+        newparam(:name) do
+          desc "The full path to the file."
+        end
+      end
+TYPE
+
+    def provider_content(file_file_content, type_name, provider_name)
+      return <<PROVIDER
+        Puppet::Type.type(:#{type_name}).provide(:#{provider_name}) do
+          desc "#{provider_name} file mgmt, yo"
+          def create
+            File.open(@resource[:name], "w") { |f| f.puts "#{file_file_content}!" }
+          end
+          def destroy
+            File.unlink(@resource[:name])
+          end
+          def exists?
+            File.exists?(@resource[:name])
+          end
+        end
+PROVIDER
+    end
+
+    manifest = <<MANIFEST
+File { ensure => directory }
+file {
+       '#{fq_tmp_environmentpath}/modules/simple_type':;
+       '#{fq_tmp_environmentpath}/modules/simple_type/lib':;
+       '#{fq_tmp_environmentpath}/modules/simple_type/lib/puppet':;
+       '#{fq_tmp_environmentpath}/modules/simple_type/lib/puppet/type/':;
+       '#{fq_tmp_environmentpath}/modules/simple_type/lib/puppet/provider/':;
+       '#{fq_tmp_environmentpath}/modules/simple_type/lib/puppet/provider/#{type_name}':;
+       '#{fq_prod_environmentpath}/modules/simple_type':;
+       '#{fq_prod_environmentpath}/modules/simple_type/lib':;
+       '#{fq_prod_environmentpath}/modules/simple_type/lib/puppet':;
+       '#{fq_prod_environmentpath}/modules/simple_type/lib/puppet/type/':;
+       '#{fq_prod_environmentpath}/modules/simple_type/lib/puppet/provider/':;
+       '#{fq_prod_environmentpath}/modules/simple_type/lib/puppet/provider/#{type_name}':;
+}
+file { '#{fq_tmp_environmentpath}/modules/simple_type/lib/puppet/type/#{type_name}.rb':
+  ensure => file,
+    content => '#{type_content}',
+}
+file { '#{fq_prod_environmentpath}/modules/simple_type/lib/puppet/type/#{type_name}.rb':
+  ensure => file,
+    content => '#{type_content}',
+}
+file { '#{fq_tmp_environmentpath}/modules/simple_type/lib/puppet/provider/#{type_name}/#{provider_name}.rb':
+  ensure => file,
+    content => '#{provider_content('correct', type_name, provider_name)}',
+}
+file { '#{fq_prod_environmentpath}/modules/simple_type/lib/puppet/provider/#{type_name}/#{provider_name}.rb':
+  ensure => file,
+    content => '#{provider_content('wrong', type_name, provider_name)}',
+}
+file { '#{fq_tmp_environmentpath}/manifests/site.pp':
+  ensure => file,
+    content => 'node default { #{type_name}{"#{file_correct}": ensure=>present} }',
+}
+file { '#{fq_prod_environmentpath}/manifests/site.pp':
+  ensure => file,
+    content => 'node default { #{type_name}{"#{file_wrong}": ensure=>present} }',
+}
+MANIFEST
+    apply_manifest_on(master, manifest, :catch_failures => true)
+  end
+
+  step "run agent in #{tmp_environment}, ensure it finds the correct provider" do
+    with_puppet_running_on(master,{}) do
+      agents.each do |agent|
+        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+          :accept_all_exit_codes => true) do |result|
+          assert_equal(2, result.exit_code, 'agent did not exit with the correct code of 2')
+          assert_match(/#{file_correct}/, result.stdout, 'agent did not ensure the correct file')
+          assert(agent.file_exist?(file_correct), 'puppet did not create the file')
+        end
+      end
+    end
+  end
+
+end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -592,7 +592,7 @@ class PEnumType < PScalarType
   attr_reader :values
 
   def initialize(values)
-    @values = values.sort.freeze
+    @values = values.uniq.sort.freeze
   end
 
   # Returns Enumerator if no block is given, otherwise, calls the given

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -153,6 +153,22 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'Enum type' do
+    it 'sorts its entries' do
+      code = <<-CODE
+        Enum[c,b,a].each |$e| { notice $e }
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['a', 'b', 'c'])
+    end
+
+    it 'makes entries unique' do
+      code = <<-CODE
+        Enum[a,b,c,b,a].each |$e| { notice $e }
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['a', 'b', 'c'])
+    end
+  end
+
   context 'Iterable type' do
     it 'can be parameterized with element type' do
       code = <<-CODE


### PR DESCRIPTION
Before this something like `Enum[a,b,a,b]` would keep all values. Thus, when iterating the values ´a, a, b, b´ would be produced. 
Now the values are made unique.