### PR TITLE
(PUP-6354) Make Enum values uniq

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -592,7 +592,7 @@ class PEnumType < PScalarType
   attr_reader :values
 
   def initialize(values)
-    @values = values.sort.freeze
+    @values = values.uniq.sort.freeze
   end
 
   # Returns Enumerator if no block is given, otherwise, calls the given

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -153,6 +153,22 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'Enum type' do
+    it 'sorts its entries' do
+      code = <<-CODE
+        Enum[c,b,a].each |$e| { notice $e }
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['a', 'b', 'c'])
+    end
+
+    it 'makes entries unique' do
+      code = <<-CODE
+        Enum[a,b,c,b,a].each |$e| { notice $e }
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['a', 'b', 'c'])
+    end
+  end
+
   context 'Iterable type' do
     it 'can be parameterized with element type' do
       code = <<-CODE


### PR DESCRIPTION
Before this something like `Enum[a,b,a,b]` would keep all values. Thus, when iterating the values ´a, a, b, b´ would be produced. 
Now the values are made unique.