### PR TITLE
Patch from PUP-6366

### DIFF
--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -92,7 +92,22 @@ class Puppet::Network::HTTP::RackREST
     # NOTE: The SSL_CLIENT_CERT environment variable will be the empty string
     # when Puppet agent nodes have not yet obtained a signed certificate.
     if cert.nil? || cert.empty?
-      nil
+      # When running with unicorn, the SSL_CLIENT_CERT variable is not available
+      # in the environment, therefore we have to pass a header: 'X-SSL-Client-Cert'
+      cert = request.env['HTTP_X_SSL_CLIENT_CERT']
+      if cert.nil? || cert.empty?
+        nil
+      else
+        # in contrast to the environment variable, the client cert is passed in
+        # as single string, therefore restore the certificate to a valid pem
+        # encoded certificate
+        cert.gsub!(/ /, "\n")
+        cert.gsub!(/BEGIN\nCERT/, "BEGIN CERT")
+        cert.gsub!(/END\nCERT/, "END CERT")
+        cert = Puppet::SSL::Certificate.from_instance(OpenSSL::X509::Certificate.new(cert))
+        warn_if_near_expiration(cert)
+        cert
+      end
     else
       cert = Puppet::SSL::Certificate.from_instance(OpenSSL::X509::Certificate.new(cert))
       warn_if_near_expiration(cert)


### PR DESCRIPTION
trusted facts with apache/nginx and puppetmaster unicorn

running unicorn behind nginx or apache reverse proxy, the
$trusted facts are not available to puppet.

The supported the +ExportCertData from Apache, only works
with Passenger module, but not with thin rack behind reverse
proxy, and esp. not with nginx.

Therefore I added an additionalheader that gets passed to unicorn: X-SSL-Client-Cert.
However, that header is sent as single line from Apache to unicorn,
and not as valid PEM encoded certificate. Therefore the gsub!
manipulations to restore a valid PEM certificate again.

To make use of it with Apache add this to the vhost:
RequestHeader set X-SSL-Client-Cert %{SSL_CLIENT_CERT}e

With nginx, there is a bit more trouble. Nginx has $ssl_client_cert
variable aswell, but nginx passes that variable on as multi-line header. Doh!
Unicorn doesn't like that at all.

To make it work with nginx, you need lua in nginx, then you need
something like this in your vhost:

 location / {
   set_by_lua $client_cert "return ngx.var.ssl_client_raw_cert:gsub('\\n',' ')";
   proxy_set_header X-SSL-Client-Cert $client_cert;
 }