### PR TITLE
Patch from PUP-6365

### DIFF
--- a/lib/puppet/ssl/certificate.rb
+++ b/lib/puppet/ssl/certificate.rb
@@ -60,6 +60,8 @@ DOC
         Puppet::SSL::Oids.subtree_of?('ppPrivCertExt', ext.oid)
     end
 
-    custom_exts.map { |ext| {'oid' => ext.oid, 'value' => ext.value} }
+    extensions = []
+    custom_exts.map { |ext| extensions << {'oid' => ext.oid, 'value' => ext.value} }
+    return extensions
   end
 end


### PR DESCRIPTION
trusted facts not available when running "puppet master" webrick server

This makes the trusted facts available to $trusted.