### PR TITLE
(PUP-6372) Remove unused Puppet::Transaction.failed? method

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -230,10 +230,6 @@ class Puppet::Transaction
     end
   end
 
-  def failed?(resource)
-    s = resource_status(resource) and s.failed?
-  end
-
   # Does this resource have any failed dependencies?
   def failed_dependencies?(resource)
     # When we introduced the :whit into the graph, to reduce the combinatorial


### PR DESCRIPTION
The one use of Puppet::Transaction#failed? was removed in
https://github.com/puppetlabs/puppet/commit/84be695ddee004d7e358d9256f7929e1a2c400a3,
so we can now remove the method itself.

Note that the entire class is marked as api private, so no one should
be using the method.
