### PR TITLE
(PUP-6381) Use systemd default service provider for Cumulus 3

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   commands :invoke_rc => "/usr/sbin/invoke-rc.d"
   commands :service => "/usr/sbin/service"
 
-  defaultfor :operatingsystem => :cumuluslinux
+  defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ['1','2']
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ['5','6','7']
 
   # Remove the symlinks

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -24,6 +24,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :suse
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => "8"
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10"]
+  defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 
   def self.instances
     i = []

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -33,15 +33,18 @@ describe provider_class do
     @provider.stubs(:invoke_rc)
   end
 
-  operatingsystem = [ 'Debian', 'CumulusLinux' ]
-  operatingsystem.each do |os|
-    it "should be the default provider on #{os}" do
-      Facter.expects(:value).with(:operatingsystem).at_least_once.returns(os)
-      if os == 'Debian'
-        Facter.expects(:value).with(:operatingsystemmajrelease).returns('7')
-      end
+  ['1','2'].each do |version|
+    it "should be the default provider on CumulusLinux #{version}" do
+      Facter.expects(:value).with(:operatingsystem).at_least_once.returns('CumulusLinux')
+      Facter.expects(:value).with(:operatingsystemmajrelease).returns(version)
       expect(provider_class.default?).to be_truthy
     end
+  end
+
+  it "should be the default provider on Debian" do
+    Facter.expects(:value).with(:operatingsystem).at_least_once.returns('Debian')
+    Facter.expects(:value).with(:operatingsystemmajrelease).returns('7')
+    expect(provider_class.default?).to be_truthy
   end
 
   it "should have an enabled? method" do

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -51,6 +51,13 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     end
   end
 
+  it "should be the default provider on cumulus3" do
+    Facter.stubs(:value).with(:osfamily).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystem).returns('CumulusLinux')
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("3")
+    expect(described_class).to be_default
+  end
+
   it "should be the default provider on sles12" do
     Facter.stubs(:value).with(:osfamily).returns(:suse)
     Facter.stubs(:value).with(:operatingsystemmajrelease).returns("12")


### PR DESCRIPTION
Prior to this pull request, Cumulus Linux defaults to the debian provider which uses init as the parent.  Since Cumulus Linux 3.0 uses systemd, service resources are broken for CL 3 unless the user specifies the systemd provider.  This pull request changes the default provider for CL 3 to be systemd