### PR TITLE
(PUP-6385) Make create_resources filter out undef relationships

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -58,10 +58,11 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
       Puppet::Parser::AST::ResourceInstance.new(
         :title => Puppet::Parser::AST::Leaf.new(:value => title),
         :parameters => defaults.merge(params).collect do |name, value|
+          next if (value == :undef || value.nil?)
           Puppet::Parser::AST::ResourceParam.new(
             :param => name,
             :value => Puppet::Parser::AST::Leaf.new(:value => value))
-        end)
+        end.compact)
     end)
 
   if type.start_with? '@@'

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -75,6 +75,15 @@ describe 'function for dynamically creating resources' do
       expect(rg.path_between(test,foo)).to be
     end
 
+    it 'should filter out undefined edges as they cause errors' do
+      rg = compile_to_relationship_graph("notify { test: }\n create_resources('notify', {'foo'=>{'require'=>undef}})")
+      test  = rg.vertices.find { |v| v.title == 'test' }
+      foo   = rg.vertices.find { |v| v.title == 'foo' }
+      expect(test).to be
+      expect(foo).to be
+      expect(rg.path_between(foo,nil)).to_not be
+    end
+
     it 'should account for default values' do
       catalog = compile_to_catalog("create_resources('file', {'/etc/foo'=>{'ensure'=>'present'}, '/etc/baz'=>{'group'=>'food'}}, {'group' => 'bar'})")
       expect(catalog.resource(:file, "/etc/foo")['group']).to eq('bar')


### PR DESCRIPTION
This adds logic that filters out all parameters that are undef from the
instruction built by create_resources.

This is done to prevent validation of relationships to flag
relationships to undef as an error.
This is done for all parameters since an undef parameter means that the
default value should be used. (The language evaluator does the same
thing).