### PR TITLE
Immutable typed name 3.x

### DIFF
--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -171,10 +171,8 @@ class Puppet::Pops::Loader::Loader
     # of it cached.
     def self.new(type, name)
       @cache ||= {}
-      @cache.fetch(:"#{type}/#{name.gsub /^::/, ''}") do
-        puts "new TypedName registered: #{type}/#{name}, count: #{@cache.size}"
-        super
-      end
+      key = :"#{type}/#{name.to_s.gsub /^::/, ''}"
+      @cache.fetch(key) { @cache[key] = super }
     end
 
     # Force identity equality since this is now immutable

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -166,15 +166,23 @@ class Puppet::Pops::Loader::Loader
       @hash
     end
 
-    def ==(o)
-      o.class == self.class && type == o.type && name == o.name
+    # For all intents and purposes TypedName can be immutable,
+    # equality operations aliased to identity equality and instances
+    # of it cached.
+    def self.new(type, name)
+      @cache ||= {}
+      @cache.fetch(:"#{type}/#{name.gsub /^::/, ''}") do
+        puts "new TypedName registered: #{type}/#{name}, count: #{@cache.size}"
+        super
+      end
     end
 
-    alias eql? ==
+    # Force identity equality since this is now immutable
+    alias == equal?
+    alias eql? equal?
 
     def to_s
       "#{type}/#{name}"
     end
   end
 end
-


### PR DESCRIPTION
TypedName can be made immutable value-type and instances of it cached. Significantly improves performance.