### PR TITLE
(PUP-6369) Add noop_pending flag to puppet report

### DIFF
--- a/api/docs/http_report.md
+++ b/api/docs/http_report.md
@@ -59,6 +59,7 @@ example is formatted for readability)
      "kind"=>"apply",
      "status"=>"unchanged",
      "noop"=>false,
+     "noop_pending"=>false,
      "environment"=>"test_environment",
      "logs"=>
       [{"level"=>"warning",

--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -16,6 +16,7 @@
         "kind",
         "status",
         "noop",
+        "noop_pending",
         "environment"
     ],
 
@@ -143,6 +144,11 @@
 
         "noop": {
             "description": "Whether the puppet run was started in noop mode",
+            "type":        "boolean"
+        },
+
+        "noop_pending": {
+            "description": "Whether there are changes that we decided not to apply because of noop",
             "type":        "boolean"
         },
 


### PR DESCRIPTION
`noop_pending` flag is set to `true` when noop resource events are available