### PR TITLE
(PUP-6150) Don't include IP address in auth error response

### DIFF
--- a/lib/puppet/network/rights.rb
+++ b/lib/puppet/network/rights.rb
@@ -53,17 +53,7 @@ class Rights
 
     # if we end up here, then that means we either didn't match or failed, in any
     # case will return an error to the outside world
-    host_description = args[:node] ? "#{args[:node]}(#{args[:ip]})" : args[:ip]
-
-    msg = "#{host_description} access to #{name} [#{args[:method]}]"
-
-    if args[:authenticated]
-      msg += " authenticated "
-    end
-
-    if right
-      msg += " at #{right.file}:#{right.line}"
-    end
+    msg = "#{name} [#{args[:method]}]"
 
     AuthorizationError.new("Forbidden request: #{msg}")
   end

--- a/spec/unit/network/rights_spec.rb
+++ b/spec/unit/network/rights_spec.rb
@@ -24,7 +24,7 @@ describe Puppet::Network::Rights do
       rights = Puppet::Network::Rights.new
       why_forbidden = rights.is_request_forbidden_and_why?(:head, "/indirection_name/key", {})
       expect(why_forbidden).to be_instance_of(Puppet::Network::AuthorizationError)
-      expect(why_forbidden.to_s).to eq("Forbidden request:  access to /indirection_name/key [find]")
+      expect(why_forbidden.to_s).to eq("Forbidden request: /indirection_name/key [find]")
     end
   end
 


### PR DESCRIPTION
Previously, an unauthenticated client could make a request to a route
protected by auth.conf and get back an error message including the IP address
and rule description. This is more information than is probably good to
provide over http, especially since it could potentially include internal IPs
of proxy servers, depending on how those are configured. This commit makes it
so that the response includes minimal information.