### PR TITLE
(PUP-6394) Relax code id requirement when finding capabilities

### DIFF
--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -12,7 +12,11 @@ require 'json'
 # @api private
 module Puppet::Resource::CapabilityFinder
 
-  # Looks the capability resource from PuppetDB.
+  # Looks up a capability resource from PuppetDB. Capability resources are
+  # required to be unique per environment and code id. If multiple copies of a
+  # capability resource are found, the one matching the current code id is
+  # used.
+  #
   # @param environment [String] environment name
   # @param code_id [String,nil] code_id of the catalog
   # @param cap [Puppet::Type] the capability resource type instance
@@ -22,6 +26,29 @@ module Puppet::Resource::CapabilityFinder
       raise Puppet::DevError, 'PuppetDB is not available'
     end
 
+    resources = search(environment, nil, cap)
+
+    if resources.size > 1 && code_id
+      Puppet.debug "Found multiple resources when looking up capability #{cap}, filtering by code id #{code_id}"
+      resources = search(environment, code_id, cap)
+    end
+
+    if resources.size > 1
+      raise Puppet::DevError,
+        "Unexpected response from PuppetDB when looking up #{cap}:\n" \
+        "expected exactly one resource but got #{resources.size};\n" \
+        "returned data is:\n#{resources.inspect}"
+    end
+
+    if resource_hash = resources.first
+      instantiate_resource(resource_hash)
+    else
+      Puppet.debug "Could not find capability resource #{cap} in PuppetDB"
+      nil
+    end
+  end
+
+  def self.search(environment, code_id, cap)
     query_terms = [
       'and',
       ['=', 'type', cap.type.capitalize],
@@ -36,67 +63,60 @@ module Puppet::Resource::CapabilityFinder
             ['=', 'code_id', code_id]]]]
     end
 
-    Puppet.notice "Capability lookup #{cap}]: #{query_terms}"
+    Puppet.notice "Looking up capability #{cap} in PuppetDB: #{query_terms}"
 
-    data = query_puppetdb(query_terms)
-
-    # The format of the response body is documented at
-    #   http://docs.puppetlabs.com/puppetdb/3.0/api/query/v4/resources.html#response-format
-    # In a nutshell, we expect to get an array of resources back. If the
-    # array is empty, the lookup failed and we return +nil+, if it
-    # contains exactly one, we turn that resource back into a Puppet
-    # ::Resource. If the array contains more than one entry, we have a
-    # bug in the overall system, as we allowed multiple capabilities with
-    # the same type and title to be produced in this environment.
-    unless data.is_a?(Array)
-      raise Puppet::DevError,
-      "Unexpected response from PuppetDB when looking up #{cap}: " +
-        "expected an Array but got #{data.inspect}"
-    end
-    if data.size > 1
-      raise Puppet::DevError,
-      "Unexpected response from PuppetDB when looking up #{cap}:\n" +
-        "expected exactly one resource but got #{data.size};\n" +
-        "returned data is:\n#{data.inspect}"
-    end
-
-    unless data.empty?
-      resource_hash = data.first
-      resource = Puppet::Resource.new(resource_hash['type'],
-                                      resource_hash['title'])
-      real_type = Puppet::Type.type(resource.type)
-      if real_type.nil?
-        fail Puppet::ParseError,
-          "Could not find resource type #{resource.type} returned from PuppetDB"
-      end
-      real_type.parameters.each do |param|
-        param = param.to_s
-        next if param == 'name'
-        if value = resource_hash['parameters'][param]
-          resource[param] = value
-        else
-          Puppet.debug "No capability value for #{resource}->#{param}"
-        end
-      end
-      return resource
-    end
+    query_puppetdb(query_terms)
   end
 
   def self.query_puppetdb(query)
-    # If using PuppetDB >= 4, use the API method query_puppetdb()
-    if Puppet::Util::Puppetdb.respond_to?(:query_puppetdb)
-      # PuppetDB 4 uses a unified query endpoint, so we have to specify what we're querying
-      Puppet::Util::Puppetdb.query_puppetdb(["from", "resources", query])
-    # For PuppetDB < 4, use the old internal method action()
-    else
-      url = "/pdb/query/v4/resource?query=#{CGI.escape(query.to_json)}"
-      response = Puppet::Util::Puppetdb::Http.action(url) do |conn, uri|
-        conn.get(uri, { 'Accept' => 'application/json'})
+    begin
+      # If using PuppetDB >= 4, use the API method query_puppetdb()
+      result = if Puppet::Util::Puppetdb.respond_to?(:query_puppetdb)
+        # PuppetDB 4 uses a unified query endpoint, so we have to specify what we're querying
+        Puppet::Util::Puppetdb.query_puppetdb(["from", "resources", query])
+      # For PuppetDB < 4, use the old internal method action()
+      else
+        url = "/pdb/query/v4/resource?query=#{CGI.escape(query.to_json)}"
+        response = Puppet::Util::Puppetdb::Http.action(url) do |conn, uri|
+          conn.get(uri, { 'Accept' => 'application/json'})
+        end
+        JSON.parse(response.body)
       end
-      JSON.parse(response.body)
+
+      # The format of the response body is documented at
+      #   http://docs.puppetlabs.com/puppetdb/3.0/api/query/v4/resources.html#response-format
+      unless result.is_a?(Array)
+        raise Puppet::DevError,
+        "Unexpected response from PuppetDB when looking up #{cap}: " \
+          "expected an Array but got #{result.inspect}"
+      end
+
+      result
+    rescue JSON::JSONError => e
+      raise Puppet::DevError,
+        "Invalid JSON from PuppetDB when looking up #{cap}\n#{e}"
     end
-  rescue JSON::JSONError => e
-    raise Puppet::DevError,
-      "Invalid JSON from PuppetDB when looking up #{cap}\n#{e}"
+  end
+
+  private
+
+  def self.instantiate_resource(resource_hash)
+    resource = Puppet::Resource.new(resource_hash['type'],
+                                    resource_hash['title'])
+    real_type = Puppet::Type.type(resource.type)
+    if real_type.nil?
+      fail Puppet::ParseError,
+        "Could not find resource type #{resource.type} returned from PuppetDB"
+    end
+    real_type.parameters.each do |param|
+      param = param.to_s
+      next if param == 'name'
+      if value = resource_hash['parameters'][param]
+        resource[param] = value
+      else
+        Puppet.debug "No capability value for #{resource}->#{param}"
+      end
+    end
+    return resource
   end
 end


### PR DESCRIPTION
Previously when looking up capability resources, the compiler would
lookup resources resources strictly by code id. This effectively meant
that a node couldn't run against a certain code version until all of its
dependencies had run against that version.

For iterative development on changes that don't actually touch those
dependencies, this is an extremely onerous requirement. Further, it's
not sufficient for a node to only run after its dependencies; if the
capabilities it requires are changing, it needs to be run *quickly*
after its dependencies, which is a property that isn't satisfied by the
ordering requirement alone.

In order to provide more flexibility around running agents, particularly
when capabilities aren't being affected by a given change, we now use
any available version of a consumed capability resource, rather than
requiring it come from the current code id.

This creates the possibility that a capability may be moved from one
node to another node, causing two copies to exist in the database for a
time. In that case we repeat the lookup, this time using code id to
disambiguate. That disambiguation prevents the catalog from referring to
the wrong version of a capability resource, though it does reintroduce
the requirement that the producer has run against the current code id.