### PR TITLE
(PUP-3768) Scheduled_task keeps reapplying

### DIFF
--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -3,6 +3,8 @@ test_name "should modify a scheduled task"
 name = "pl#{rand(999999).to_i}"
 confine :to, :platform => 'windows'
 
+verylongstring = 'a' * 1024
+
 agents.each do |agent|
   # Have to use /v1 parameter for Vista and later, older versions
   # don't accept the parameter
@@ -15,12 +17,12 @@ agents.each do |agent|
   on agent, "schtasks.exe /create #{version} /tn #{name} /tr c:\\\\windows\\\\system32\\\\notepad.exe /sc daily /ru system"
 
   step "modify the task"
-  on agent, puppet_resource('scheduled_task', name, ['ensure=present', 'command=c:\\\\windows\\\\system32\\\\notepad2.exe', "arguments=args-#{name}"])
+  on agent, puppet_resource('scheduled_task', name, ['ensure=present', 'command=c:\\\\windows\\\\system32\\\\notepad2.exe', "arguments=args-#{verylongstring}"])
 
   step "verify the arguments were updated"
   on agent, puppet_resource('scheduled_task', name) do
     assert_match(/command\s*=>\s*'c:\\windows\\system32\\notepad2.exe'/, stdout)
-    assert_match(/arguments\s*=>\s*'args-#{name}'/, stdout)
+    assert_match(/arguments\s*=>\s*'args-#{verylongstring}'/, stdout)
   end
 
   step "delete the task"

--- a/lib/puppet/util/windows/taskscheduler.rb
+++ b/lib/puppet/util/windows/taskscheduler.rb
@@ -158,6 +158,11 @@ module Win32
 
     MAX_RUN_TIMES = TASK_MAX_RUN_TIMES
 
+    #260 as per Windows API MAX_PATH specification
+    APPLICATIONNAME_MAXSIZE = 260
+    PARAMETERS_MAXSIZE = 4096
+
+
     # Returns a new TaskScheduler object. If a work_item (and possibly the
     # the trigger) are passed as arguments then a new work item is created and
     # associated with that trigger, although you can still activate other tasks
@@ -374,7 +379,7 @@ module Win32
         @pITask.GetApplicationName(ptr)
 
         ptr.read_com_memory_pointer do |str_ptr|
-          app = str_ptr.read_arbitrary_wide_string_up_to(256) if ! str_ptr.null?
+          app = str_ptr.read_arbitrary_wide_string_up_to(APPLICATIONNAME_MAXSIZE) if ! str_ptr.null?
         end
       end
 
@@ -400,15 +405,13 @@ module Win32
       raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
 
       param = nil
-
       FFI::MemoryPointer.new(:pointer) do |ptr|
         @pITask.GetParameters(ptr)
 
         ptr.read_com_memory_pointer do |str_ptr|
-          param = str_ptr.read_arbitrary_wide_string_up_to(256) if ! str_ptr.null?
+          param = str_ptr.read_arbitrary_wide_string_up_to(PARAMETERS_MAXSIZE) if ! str_ptr.null?
         end
       end
-
       param
     end
 

--- a/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -3,6 +3,44 @@ require 'spec_helper'
 
 require 'puppet/util/windows/taskscheduler' if Puppet.features.microsoft_windows?
 
+describe "Puppet::Util::Windows::TaskScheduler", :if => Puppet.features.microsoft_windows? do
+
+  def dummy_time_trigger
+    now = Time.now
+    {
+        'flags'                   => 0,
+        'random_minutes_interval' => 0,
+        'end_day'                 => 0,
+        'end_year'                => 0,
+        'minutes_interval'        => 0,
+        'end_month'               => 0,
+        'minutes_duration'        => 0,
+        'start_year'              => now.year,
+        'start_month'             => now.month,
+        'start_day'               => now.day,
+        'start_hour'              => now.hour,
+        'start_minute'            => now.min,
+        'trigger_type'            => Win32::TaskScheduler::ONCE,
+    }
+  end
+
+  describe '#parameters' do
+
+    let(:resource) { Puppet::Type.type(:scheduled_task).new(:name => SecureRandom.uuid, :command => 'C:\Windows\System32\notepad.exe') }
+
+    it "should read over 300 character arguments" do
+
+      verylongstring = 'a' * 301
+
+      subject = Win32::TaskScheduler.new(resource[:name], dummy_time_trigger)
+      subject.application_name=(resource[:command])
+      subject.parameters=(verylongstring)
+
+      expect(subject.parameters).to eq(verylongstring)
+    end
+  end
+end
+
 shared_examples_for "a trigger that handles start_date and start_time" do
   let(:trigger) do
     described_class.new(


### PR DESCRIPTION
Initially, puppet would re-apply a scheduled task even though
there was no change.  The reason being, only the first 256
characters of the arguments parameter (or rather, any
parameter that accepts a string as input) were being read in
for comparison.  Therefore, the first 256 characters of the
string were being compared to the full string, resulting in
changed status.

This commit increases the comparison limit for the command
and arguments parameters to 260 and 4096, respectively.
The 260 character limit is due to Windows API MAX_PATH
limit for pathnames.  The arguments parameter doesn't appear
to have an upper bound, so 4096 was chosen as a reasonably
large limit.  An integration test was included and the
should_modify acceptance test was changed, both to exercise
scheduled_task with larger string params.