### PR TITLE
PUP-4904 Correctly format output from puppet describe

### DIFF
--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -11,21 +11,21 @@ class Formatter
     work = (opts[:scrub] ? scrub(txt) : txt)
     indent = (opts[:indent] ? opts[:indent] : 0)
     textLen = @width - indent
-    patt = Regexp.new("^(.{0,#{textLen}})[ \n]")
+    patt = Regexp.new("\\A(.{0,#{textLen}}\n)")
     prefix = " " * indent
 
     res = []
 
     while work.length > textLen
       if work =~ patt
-        res << $1
+        res << $1 + prefix
         work.slice!(0, $MATCH.length)
       else
         res << work.slice!(0, textLen)
       end
     end
     res << work if work.length.nonzero?
-    prefix + res.join("\n#{prefix}")
+    prefix + res.join("")
   end
 
   def header(txt, sep = "-")


### PR DESCRIPTION
Prior to this commit, if a type has very long strings in its @doc value,
then the output becomes garbled.  This commit fixes a regular expression
so that long lines are properly are properly split into managable lengths
for output fomatting.