### PR TITLE
(PUP-6370) Honor systemd exitcodes as truth

### DIFF
--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -163,12 +163,14 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     it "should return :true if the service is enabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       provider.expects(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).returns "enabled\n"
+      $CHILD_STATUS.stubs(:exitstatus).returns(0)
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :true if the service is static" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       provider.expects(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).returns "static\n"
+      $CHILD_STATUS.stubs(:exitstatus).returns(0)
       expect(provider.enabled?).to eq(:true)
     end
 


### PR DESCRIPTION
  This commit removes the tracking of specific systemd states and
  replaces it with the exit code of the "is-enabled" subcommand.

  This needs to be done so that the systemd provider always follows the
  operating system's view of what enabled or disabled is, according to
  its documenation[1] and shipped version of the init system.

  [1] https://www.freedesktop.org/software/systemd/man/systemctl.html#is-enabled%20NAME...