### PR TITLE
(PUP-6410) puppet/util/plist should handle malformed plist data

### DIFF
--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -33,7 +33,7 @@ module Puppet::Util::Plist
       # NOTE: We used IO.read originally to be Ruby 1.8.x compatible.
       if read_file_with_offset(file_path, binary_plist_magic_number.length) == binary_plist_magic_number
         plist_obj = new_cfpropertylist(:file => file_path)
-        convert_cfpropertylist_to_native_types(plist_obj)
+        return convert_cfpropertylist_to_native_types(plist_obj)
       else
         plist_data = open_file_with_args(file_path, "r:UTF-8")
         plist = parse_plist(plist_data, file_path)
@@ -48,6 +48,7 @@ module Puppet::Util::Plist
           Puppet.warning("Cannot read file #{file_path}; Puppet is skipping it.\n" + "Details: #{detail}")
         end
       end
+      return nil
     end
 
     # Read plist text using the CFPropertyList gem.
@@ -60,7 +61,8 @@ module Puppet::Util::Plist
 
       begin
         plist_obj = new_cfpropertylist(:data => plist_data)
-      rescue CFFormatError => e
+      # CFPropertyList library will raise NoMethodError for invalid data
+      rescue CFFormatError, NoMethodError => e
         Puppet.debug "Failed with #{e.class} on #{file_path}: #{e.inspect}"
         return nil
       end

--- a/spec/unit/util/plist_spec.rb
+++ b/spec/unit/util/plist_spec.rb
@@ -54,6 +54,12 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
     </dict>
     </plist>'
   end
+  let(:non_plist_data) do
+    "Take my love, take my land
+     Take me where I cannot stand
+     I don't care, I'm still free
+     You can't take the sky from me."
+   end
   let(:valid_xml_plist_hash) { {"LastUsedPrinters"=>[{"Network"=>"10.85.132.1", "PrinterID"=>"baskerville_corp_puppetlabs_net"}, {"Network"=>"10.14.96.1", "PrinterID"=>"Statler"}]} }
   let(:plist_path) { file_containing('sample.plist', valid_xml_plist) }
   let(:binary_plist_magic_number) { 'bplist00' }
@@ -88,6 +94,15 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
       Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '/dev/stdout', plist_path],
                                                      {:failonfail => true, :combine => true}).returns(valid_xml_plist)
       expect(subject.read_plist_file(plist_path)).to eq(valid_xml_plist_hash)
+    end
+    it "returns nil when direct parsing and plutil conversion both fail" do
+      subject.stubs(:read_file_with_offset).with(plist_path, 8).returns('notbinary')
+      subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(non_plist_data)
+      Puppet.expects(:debug).with(regexp_matches(/^Failed with NoMethodError/))
+      Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '/dev/stdout', plist_path],
+                                                     {:failonfail => true, :combine => true}).raises(Puppet::ExecutionFailure, 'boom')
+      expect(subject.read_plist_file(plist_path)).to eq(nil)
     end
   end
 


### PR DESCRIPTION
CFPropertyList::List.new() can raise "NoMethodError: undefined method `elements' for nil:NilClass" if the data to parse isn't a valid (e.g., zero-length or not a plist).
* Catch NoMethodError in parse_plist
* explicitly return convert_cfpropertylist_to_native_types()
* add a 'return nil' at the end of read_plist_file so callers won't end up with the return value of Puppet.warning(...) if things fall through.