### PR TITLE
(PUP-6268) Improve cert listing and add interactivity for cert signing

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -148,10 +148,10 @@ The most important actions for day-to-day use are 'list' and 'sign'.
   List outstanding certificate requests. If '--all' is specified, signed
   certificates are also listed, prefixed by '+', and revoked or invalid
   certificates are prefixed by '-' (the verification outcome is printed
-  in parenthesis). If '--human-readable' or '-H' is specified listed
+  in parenthesis). If '--human-readable' or '-H' is specified,
   certificates are formatted in a way to improve human scan-ability. If
-  '--machine-readable' or '-m' is specified output is formatted in a
-  line-wise format optimal for scripted consumption.
+  '--machine-readable' or '-m' is specified, output is formatted concisely
+  for consumption by a script.
 
 * print:
   Print the full-text version of a host's certificate.

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -79,6 +79,22 @@ class Puppet::Application::Cert < Puppet::Application
     set_log_level
   end
 
+  option("--human-readable", "-h") do |arg|
+    options[:format] = :human
+  end
+
+  option("--machine-readable", "-m") do |arg|
+    options[:format] = :machine
+  end
+
+  option("--interactive", "-i") do |arg|
+    options[:interactive] = true
+  end
+
+  option("--assume-yes", "-y") do |arg|
+    options[:yes] = true
+  end
+
   def help
     <<-'HELP'
 
@@ -132,7 +148,10 @@ The most important actions for day-to-day use are 'list' and 'sign'.
   List outstanding certificate requests. If '--all' is specified, signed
   certificates are also listed, prefixed by '+', and revoked or invalid
   certificates are prefixed by '-' (the verification outcome is printed
-  in parenthesis).
+  in parenthesis). If '--human-readable' or '-h' is specified listed
+  certificates are formatted in a way to improve human scan-ability. If
+  '--machine-readable' or '-m' is specified output is formatted in a
+  line-wise format optimal for scripted consumption.
 
 * print:
   Print the full-text version of a host's certificate.
@@ -145,7 +164,10 @@ The most important actions for day-to-day use are 'list' and 'sign'.
   needs to be restarted after revoking certificates.
 
 * sign:
-  Sign an outstanding certificate request.
+  Sign an outstanding certificate request. If '--interactive' or '-i' is
+  supplied the user will be prompted to confirm that they are signing the
+  correct certificate (recommended). If '--assume-yes' or '-y' is supplied
+  the interactive prompt will assume the answer of 'yes'.
 
 * verify:
   Verify the named certificate against the local CA certificate.
@@ -284,6 +306,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         exit
       end
     end
+
     result
   end
 

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -79,7 +79,7 @@ class Puppet::Application::Cert < Puppet::Application
     set_log_level
   end
 
-  option("--human-readable", "-h") do |arg|
+  option("--human-readable", "-H") do |arg|
     options[:format] = :human
   end
 
@@ -148,7 +148,7 @@ The most important actions for day-to-day use are 'list' and 'sign'.
   List outstanding certificate requests. If '--all' is specified, signed
   certificates are also listed, prefixed by '+', and revoked or invalid
   certificates are prefixed by '-' (the verification outcome is printed
-  in parenthesis). If '--human-readable' or '-h' is specified listed
+  in parenthesis). If '--human-readable' or '-H' is specified listed
   certificates are formatted in a way to improve human scan-ability. If
   '--machine-readable' or '-m' is specified output is formatted in a
   line-wise format optimal for scripted consumption.

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -289,7 +289,7 @@ module Puppet
 
               if !options[:yes]
                 input = STDIN.gets.chomp
-                raise ArgumentError, "NOT Signing Certificate Request" unless VALID_CONFIRMATION_VALUES.include?(input)
+                raise InterfaceError, "NOT Signing Certificate Request" unless VALID_CONFIRMATION_VALUES.include?(input)
               else
                 puts "Assuming YES from `-y' or `--assume-yes' flag"
               end

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -9,6 +9,7 @@ module Puppet
         SUBJECTLESS_METHODS = [:list, :reinventory]
 
         CERT_STATUS_GLYPHS = {:signed => '+', :request => ' ', :invalid => '-'}
+        VALID_CONFIRMATION_VALUES = %w{y Y yes Yes YES}
 
         class InterfaceError < ArgumentError; end
 
@@ -265,11 +266,35 @@ module Puppet
           end
         end
 
-        # Signs given certificates or waiting of subjects == :all
+        # Signs given certificates or all waiting if subjects == :all
         def sign(ca)
           list = subjects == :all ? ca.waiting? : subjects
           raise InterfaceError, "No waiting certificate requests to sign" if list.empty?
+
           list.each do |host|
+            cert = Puppet::SSL::CertificateRequest.indirection.find(host)
+
+            # ca.sign will also do this - and it should if it is called
+            # elsewhere - but we want to reject an attempt to sign a
+            # problematic csr as early as possible for usability concerns.
+            ca.check_internal_signing_policies(host, cert, options[:allow_dns_alt_names])
+
+            name_width = host.inspect.length
+            info = {:type => :request, :cert => cert}
+            host_string = format_host(host, info, name_width, options[:format])
+            puts "Signing Certificate Request for:\n#{host_string}"
+
+            if options[:interactive]
+              STDOUT.print "Sign Certificate Request? [y/N] "
+
+              if !options[:yes]
+                input = STDIN.gets.chomp
+                raise ArgumentError, "NOT Signing Certificate Request" unless VALID_CONFIRMATION_VALUES.include?(input)
+              else
+                puts "Assuming YES from `-y' or `--assume-yes' flag"
+              end
+            end
+
             ca.sign(host, options[:allow_dns_alt_names])
           end
         end

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -8,6 +8,8 @@ module Puppet
         DESTRUCTIVE_METHODS = [:destroy, :revoke]
         SUBJECTLESS_METHODS = [:list, :reinventory]
 
+        CERT_STATUS_GLYPHS = {:signed => '+', :request => ' ', :invalid => '-'}
+
         class InterfaceError < ArgumentError; end
 
         attr_reader :method, :subjects, :digest, :options
@@ -71,19 +73,30 @@ module Puppet
           return if hosts.empty?
 
           hosts.uniq.sort.each do |host|
+            verify_error = nil
+
             begin
               ca.verify(host) unless requests.include?(host)
             rescue Puppet::SSL::CertificateAuthority::CertificateVerificationError => details
-              verify_error = details.to_s
+              verify_error = "(#{details.to_s})"
             end
 
             if verify_error
-              certs[:invalid][host] = [ Puppet::SSL::Certificate.indirection.find(host), verify_error ]
+              type = :invalid
+              cert = Puppet::SSL::Certificate.indirection.find(host)
             elsif (signed and signed.include?(host))
-              certs[:signed][host]  = Puppet::SSL::Certificate.indirection.find(host)
+              type = :signed
+              cert = Puppet::SSL::Certificate.indirection.find(host)
             else
-              certs[:request][host] = Puppet::SSL::CertificateRequest.indirection.find(host)
+              type = :request
+              cert = Puppet::SSL::CertificateRequest.indirection.find(host)
             end
+
+            certs[type][host] = {
+              :cert         => cert,
+              :type         => type,
+              :verify_error => verify_error,
+            }
           end
 
           names = certs.values.map(&:keys).flatten
@@ -95,37 +108,133 @@ module Puppet
           output = [:request, :signed, :invalid].map do |type|
             next if certs[type].empty?
 
-            certs[type].map do |host,info|
-              format_host(ca, host, type, info, name_width)
+            certs[type].map do |host, info|
+              format_host(host, info, name_width, options[:format])
             end
           end.flatten.compact.sort.join("\n")
 
           puts output
         end
 
-        def format_host(ca, host, type, info, width)
-          cert, verify_error = info
-          alt_names = case type
-                      when :signed
-                        cert.subject_alt_names
-                      when :request
-                        cert.subject_alt_names
-                      else
-                        []
-                      end
+        def format_host(host, info, width, format)
+          case format
+          when :machine
+            machine_host_formatting(host, info)
+          when :human
+            human_host_formatting(host, info)
+          else
+            if options[:verbose]
+              machine_host_formatting(host, info)
+            else
+              legacy_host_formatting(host, info, width)
+            end
+          end
+        end
 
-          alt_names.delete(host)
+        def machine_host_formatting(host, info)
+          type         = info[:type]
+          verify_error = info[:verify_error]
+          cert         = info[:cert]
+          alt_names    = cert.subject_alt_names - [host]
+          extensions   = format_attrs_and_exts(cert)
 
-          alt_str = "(alt names: #{alt_names.map(&:inspect).join(', ')})" unless alt_names.empty?
-
-          glyph = {:signed => '+', :request => ' ', :invalid => '-'}[type]
-
-          name = host.inspect.ljust(width)
+          glyph       = CERT_STATUS_GLYPHS[type]
+          name        = host.inspect
           fingerprint = cert.digest(@digest).to_s
 
-          explanation = "(#{verify_error})" if verify_error
+          expiration  = cert.expiration.iso8601 if type == :signed
 
-          [glyph, name, fingerprint, alt_str, explanation].compact.join(' ')
+          if type != :invalid
+            if !alt_names.empty?
+              extensions.unshift("alt names: #{alt_names.map(&:inspect).join(', ')}")
+            end
+
+            if !extensions.empty?
+              metadata_string = "(#{extensions.join(', ')})" unless extensions.empty?
+            end
+          end
+
+          [glyph, name, fingerprint, expiration, metadata_string, verify_error].compact.join(' ')
+        end
+
+        def human_host_formatting(host, info)
+          type         = info[:type]
+          verify_error = info[:verify_error]
+          cert         = info[:cert]
+          alt_names    = cert.subject_alt_names - [host]
+          extensions   = format_attrs_and_exts(cert)
+
+          glyph       = CERT_STATUS_GLYPHS[type]
+          fingerprint = cert.digest(@digest).to_s
+
+          if type == :invalid || (extensions.empty? && alt_names.empty?)
+            extension_string = ''
+          else
+            if !alt_names.empty?
+              extensions.unshift("alt names: #{alt_names.map(&:inspect).join(', ')}")
+            end
+
+            extension_string = "\n    Extensions:\n      "
+            extension_string << extensions.join("\n      ")
+          end
+
+          if type == :signed
+            expiration_string = "\n    Expiration: #{cert.expiration.iso8601}"
+          else
+            expiration_string = ''
+          end
+
+          status = case type
+                   when :invalid then "Invalid - #{verify_error}"
+                   when :request then "Request Pending"
+                   when :signed then "Signed"
+                   end
+
+          output = "#{glyph} #{host.inspect}"
+          output << "\n  #{fingerprint}"
+          output << "\n    Status: #{status}"
+          output << expiration_string
+          output << extension_string
+          output << "\n"
+
+          output
+        end
+
+        def legacy_host_formatting(host, info, width)
+          type         = info[:type]
+          verify_error = info[:verify_error]
+          cert         = info[:cert]
+          alt_names    = cert.subject_alt_names - [host]
+          extensions   = format_attrs_and_exts(cert)
+
+          glyph       = CERT_STATUS_GLYPHS[type]
+          name        = host.inspect.ljust(width)
+          fingerprint = cert.digest(@digest).to_s
+
+          if type != :invalid
+            if alt_names.empty?
+              alt_name_string = nil
+            else
+              alt_name_string = "(alt names: #{alt_names.map(&:inspect).join(', ')})"
+            end
+
+            if extensions.empty?
+              extension_string = nil
+            else
+              extension_string = "**"
+            end
+          end
+
+          [glyph, name, fingerprint, alt_name_string, verify_error, extension_string].compact.join(' ')
+        end
+
+        def format_attrs_and_exts(cert)
+          exts = []
+          exts += cert.custom_extensions if cert.respond_to?(:custom_extensions)
+          exts += cert.custom_attributes if cert.respond_to?(:custom_attributes)
+          exts += cert.extension_requests if cert.respond_to?(:extension_requests)
+
+          exts.map {|e| "#{e['oid']}: #{e['value'].inspect}" }.sort
         end
 
         # Set the method to apply.

--- a/spec/unit/application/cert_spec.rb
+++ b/spec/unit/application/cert_spec.rb
@@ -52,6 +52,26 @@ describe Puppet::Application::Cert => true do
     expect(@cert_app.signed).to be_truthy
   end
 
+  it "should set human to true for --human-readable" do
+    @cert_app.handle_human_readable(0)
+    expect(@cert_app.options[:format]).to be :human
+  end
+
+  it "should set machine to true for --machine-readable" do
+    @cert_app.handle_machine_readable(0)
+    expect(@cert_app.options[:format]).to be :machine
+  end
+
+  it "should set interactive to true for --interactive" do
+    @cert_app.handle_interactive(0)
+    expect(@cert_app.options[:interactive]).to be_truthy
+  end
+
+  it "should set yes to true for --assume-yes" do
+    @cert_app.handle_assume_yes(0)
+    expect(@cert_app.options[:yes]).to be_truthy
+  end
+
   Puppet::SSL::CertificateAuthority::Interface::INTERFACE_METHODS.reject { |m| m == :destroy }.each do |method|
     it "should set cert_mode to #{method} with option --#{method}" do
       @cert_app.send("handle_#{method}".to_sym, nil)

--- a/spec/unit/ssl/certificate_authority/interface_spec.rb
+++ b/spec/unit/ssl/certificate_authority/interface_spec.rb
@@ -125,8 +125,8 @@ describe Puppet::SSL::CertificateAuthority::Interface do
       it "should call :generate on the CA for each host specified" do
         @applier = @class.new(:generate, :to => %w{host1 host2})
 
-        @ca.expects(:generate).with("host1", {})
-        @ca.expects(:generate).with("host2", {})
+        @ca.expects(:generate).with() {|*args| args.first == "host1" }
+        @ca.expects(:generate).with() {|*args| args.first == "host2" }
 
         @applier.apply(@ca)
       end
@@ -199,18 +199,33 @@ describe Puppet::SSL::CertificateAuthority::Interface do
     end
 
     describe ":list" do
+      let(:signed_alt_names) { [] }
+      let(:request_alt_names) { [] }
+      let(:custom_attrs) { [] }
+      let(:ext_requests) { [] }
+      let(:custom_exts) { [] }
+
       before :each do
         @cert = Puppet::SSL::Certificate.new 'foo'
         @csr = Puppet::SSL::CertificateRequest.new 'bar'
 
-        @cert.stubs(:subject_alt_names).returns []
-        @csr.stubs(:subject_alt_names).returns []
+        @cert.stubs(:subject_alt_names).returns signed_alt_names
+        @cert.stubs(:custom_extensions).returns custom_exts
+
+        @csr.stubs(:subject_alt_names).returns request_alt_names
+        @csr.stubs(:custom_attributes).returns custom_attrs
+        @csr.stubs(:extension_requests).returns ext_requests
 
         Puppet::SSL::Certificate.indirection.stubs(:find).returns @cert
         Puppet::SSL::CertificateRequest.indirection.stubs(:find).returns @csr
 
         @digest = mock("digest")
         @digest.stubs(:to_s).returns("(fingerprint)")
+
+        @expiration = mock('time')
+        @expiration.stubs(:iso8601).returns("(expiration)")
+        @cert.stubs(:expiration).returns(@expiration)
+
         @ca.expects(:waiting?).returns %w{host1 host2 host3}
         @ca.expects(:list).returns(%w{host4 host5 host6}).at_most(1)
         @csr.stubs(:digest).returns @digest
@@ -291,6 +306,96 @@ describe Puppet::SSL::CertificateAuthority::Interface do
             OUTPUT
 
           applier.apply(@ca)
+        end
+      end
+
+      describe "with custom attrbutes and extensions" do
+        let(:custom_attrs) { [{'oid' => 'customAttr', 'value' => 'attrValue'}] }
+        let(:ext_requests) { [{'oid' => 'customExt', 'value' => 'reqExtValue'}] }
+        let(:custom_exts) {  [{'oid' => 'extName', 'value' => 'extValue'}] }
+        let(:signed_alt_names) { ["DNS:puppet", "DNS:puppet.example.com"] }
+
+        before do
+          @ca.unstub(:waiting?)
+          @ca.unstub(:list)
+          @ca.expects(:waiting?).returns %w{ext3}
+          @ca.expects(:list).returns(%w{ext1 ext2}).at_most(1)
+
+          @ca.stubs(:verify).with("ext2").
+            raises(Puppet::SSL::CertificateAuthority::CertificateVerificationError.new(23),
+                   "certificate revoked")
+
+          Puppet::SSL::Certificate.indirection.stubs(:find).returns @cert
+          Puppet::SSL::CertificateRequest.indirection.stubs(:find).returns @csr
+        end
+
+        describe "using legacy format" do
+          it "should append astrisks to end of line to denote additional information available" do
+            applier = @class.new(:list, :to => %w{ext1 ext2 ext3})
+
+            applier.expects(:puts).with(<<-OUTPUT.chomp)
+  "ext3" (fingerprint) **
++ "ext1" (fingerprint) (alt names: "DNS:puppet", "DNS:puppet.example.com") **
+- "ext2" (fingerprint) (certificate revoked)
+              OUTPUT
+
+            applier.apply(@ca)
+          end
+
+          it "should append attributes and extensions to end of line when running :verbose" do
+            applier = @class.new(:list, :to => %w{ext1 ext2 ext3}, :verbose => true)
+
+            applier.expects(:puts).with(<<-OUTPUT.chomp)
+  "ext3" (fingerprint) (customAttr: "attrValue", customExt: "reqExtValue")
++ "ext1" (fingerprint) (expiration) (alt names: "DNS:puppet", "DNS:puppet.example.com", extName: "extValue")
+- "ext2" (fingerprint) (certificate revoked)
+              OUTPUT
+
+            applier.apply(@ca)
+          end
+        end
+
+        describe "using line-wise format" do
+          it "use the same format as :verbose legacy format" do
+            applier = @class.new(:list, :to => %w{ext1 ext2 ext3}, :format => :machine)
+
+            applier.expects(:puts).with(<<-OUTPUT.chomp)
+  "ext3" (fingerprint) (customAttr: "attrValue", customExt: "reqExtValue")
++ "ext1" (fingerprint) (expiration) (alt names: "DNS:puppet", "DNS:puppet.example.com", extName: "extValue")
+- "ext2" (fingerprint) (certificate revoked)
+              OUTPUT
+
+            applier.apply(@ca)
+          end
+        end
+
+        describe "using human friendly format" do
+          it "should break attributes and extensions to separate lines" do
+            applier = @class.new(:list, :to => %w{ext1 ext2 ext3}, :format => :human)
+
+            applier.expects(:puts).with(<<-OUTPUT)
+  "ext3"
+  (fingerprint)
+    Status: Request Pending
+    Extensions:
+      customAttr: "attrValue"
+      customExt: "reqExtValue"
+
++ "ext1"
+  (fingerprint)
+    Status: Signed
+    Expiration: (expiration)
+    Extensions:
+      alt names: "DNS:puppet", "DNS:puppet.example.com"
+      extName: "extValue"
+
+- "ext2"
+  (fingerprint)
+    Status: Invalid - (certificate revoked)
+OUTPUT
+
+            applier.apply(@ca)
+          end
         end
       end
     end


### PR DESCRIPTION
This provides a number of usability improvements triggered from the need to add meaningful certificate extension interactions.

When using `puppet cert list` this patch provides command line flags to print all pertinent information about signed and requested certs in either a machine parseable line-wise format[1] or a pretty printed human friendly format[2]. If no format options are given the current view is augmented with a double asterisk[3] to denote that further information is available through an alternate view.

When signing a cert the cert's information is now printed out before being signed. The formatting of this respects the conventions used above for cert listing. There is now an additional flag so admins can enforce an interactive prompt before signing a cert, as well as a flag to allow interactive prompts to be scripted.

It is desirable to move to defaulting to the human friendly output for listing certificate information as well forcing an interactive prompt by default (though still overridable in scripting) prior to a major version bump. Our user testing has shown that users would be in favor of making these defaults soon, though here I've implemented the more conservative take on our UX study (it is trivial to change the defaults), to a) get final sign off from UX and Product on these changes and b) ensure the client team is well aware of the implications as they will undoubtedly be asked about them.

A high level write up of our user testing is available in [confluence here](https://confluence.puppetlabs.com/display/UX/Cert+Information+Display+Research+-+June%2C+2016) the code is depoyed within our internal test infrastructure on host `vml6g3jswc3uoc9` if anyone would like to play with the code functionally. To reproduce the environment run this [script](https://gist.github.com/justinstoller/61ff070eb0f62909ab1b428e3f976bd6) with the files included in that gist all copied to puppet's acceptance directory.


/cc @nathanielksmith @KevinCorcoran @ahpook @loriland @kylog

------------------------------------

1. Example "machine" format:
```
[root@vml6g3jswc3uoc9 ~]# puppet cert list --all -m
  "pp14.delivery.puppetlabs.net" (SHA256) 9D:8B:4A:E2:C4:46:D8:65:60:5F:CA:6C:42:74:9A:FF:04:BC:0C:EE:6B:64:CC:5D:14:D1:71:3F:A3:40:38:73 (challengePassword: "fda0f2134c085648d7fae8c4f8a5f40a", pp_auth_role: "puppet infrastructure", pp_authorization: "true", pp_uuid: "d236532e-a788-4d69-8f71-b71795e4f48d")
  "pp15.delivery.puppetlabs.net" (SHA256) 9F:99:84:28:64:09:8F:13:16:18:2E:64:22:E0:9B:B5:17:F6:53:6F:FF:2B:32:9E:2F:A9:EC:DF:87:82:17:9A (challengePassword: "11111111111111111111111111111111", pp_auth_role: "infra")
  "pp16.delivery.puppetlabs.net" (SHA256) 01:B8:AB:3B:F7:3E:44:30:E1:77:3A:E8:2A:29:B1:90:A1:B1:84:4A:E0:54:C6:D0:3C:3B:D2:F5:4C:17:66:A7 (challengePassword: "a33c78b22e3491b35c2958624275d5e1", pp_auth_role: "puppet infrastructure", pp_authorization: "true", pp_uuid: "d05640da-9599-4ffd-bcee-07f71093fbc8")
  "pp17.delivery.puppetlabs.net" (SHA256) 86:72:BF:BD:A9:7D:BB:4C:F2:C0:55:FC:FF:1A:17:BC:B1:F6:38:84:53:A6:EB:61:3F:66:CD:56:0E:5C:24:2B (alt names: "DNS:pp17.delivery.puppetlabs.net", "DNS:puppet", "DNS:puppet.delivery.puppetlabs", "DNS:vml6g3jswc3uoc9.delivery.puppetlabs.net", challengePassword: "2844bffa89d5313707f6e6668d8bc293", pp_auth_role: "puppet infrastructure", pp_authorization: "true", pp_uuid: "5e47b744-3e77-44e5-9499-04f43ea4a53f")
  "pp18.delivery.puppetlabs.net" (SHA256) 98:95:E2:81:98:D2:1A:D4:FC:B2:8E:63:FF:E0:17:C6:0E:C0:FC:38:66:8D:A6:56:9E:62:90:3E:CC:FF:56:9E
  "pp19.delivery.puppetlabs.net" (SHA256) B2:14:FD:DC:41:18:38:6C:B4:85:EF:7C:D4:2C:68:5B:0A:AC:78:8D:B3:A9:6C:EC:8B:67:49:B1:40:38:AA:B1 (challengePassword: "eb845c4dad741f4326568ecc3a6dbdfe", pp_auth_role: "general infrastructure", pp_authorization: "true", pp_uuid: "91583628-d609-4ad7-90bb-a257fa16c4d9")
+ "dru2ka49hmb02gn.delivery.puppetlabs.net" (SHA256) B8:E5:DD:73:C2:F7:96:84:EE:83:0F:73:E1:80:CF:37:8A:BC:5A:41:04:C5:C0:F4:D8:8A:1F:4C:B6:B0:0D:06 2021-06-14T18:20:36Z
+ "pp10.delivery.puppetlabs.net" (SHA256) BD:31:E8:36:9E:3B:02:03:52:C3:15:ED:45:59:E7:36:32:F6:35:46:7B:AB:1D:BA:25:24:C4:A8:0D:DD:2F:F7 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Justin Stoller", pp_project: "Puppet Server", pp_role: "agent")
+ "pp11.delivery.puppetlabs.net" (SHA256) 78:3C:28:EC:32:74:50:8F:97:91:94:F3:66:86:5E:7E:6E:4A:DF:25:14:6C:07:9F:90:BE:4A:ED:31:5E:3F:F7 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Justin Stoller", pp_project: "Puppet Server", pp_role: "agent")
+ "pp12.delivery.puppetlabs.net" (SHA256) 9D:76:62:91:C5:E2:24:F5:B6:F0:BF:B2:4E:8D:85:04:26:73:4B:74:D0:C3:A3:2E:49:6D:D0:BD:25:2D:35:53 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Justin Stoller", pp_project: "Puppet Server", pp_role: "agent")
+ "pp13.delivery.puppetlabs.net" (SHA256) D3:32:95:2F:C6:1C:3E:FD:B1:06:D3:ED:A5:9A:06:53:B2:A2:32:3D:EF:19:98:EF:F4:EB:A3:C0:F2:D0:BC:EB 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Joe Q Employee", pp_project: "Puppet Server", pp_role: "app-frontend")
+ "pp4.delivery.puppetlabs.net" (SHA256) F7:0D:E2:44:D5:36:B4:99:27:06:34:58:29:F6:26:D6:D4:D8:47:96:A5:79:BA:B4:B1:CE:47:01:AC:C0:3B:E4 2021-06-14T18:21:01Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Joe Q Employee", pp_project: "Puppet Server", pp_role: "app-frontend")
+ "pp5.delivery.puppetlabs.net" (SHA256) 78:A1:02:44:EB:CD:85:42:E6:62:35:09:96:E3:6D:46:E6:7A:2A:9D:C7:9A:13:42:FA:45:6F:B2:DD:96:55:32 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Justin Stoller", pp_project: "Puppet Server", pp_role: "compile master")
+ "pp6.delivery.puppetlabs.net" (SHA256) 0D:01:2E:76:38:52:BC:F5:7D:80:CE:30:41:0A:DF:1F:0B:7E:D7:F6:A7:BB:7E:5A:4E:6F:7A:83:8D:64:5B:2B 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Justin Stoller", pp_project: "Puppet Server", pp_role: "compile master")
+ "pp7.delivery.puppetlabs.net" (SHA256) FD:9B:39:16:10:17:4E:EB:68:00:50:33:51:FB:7C:9D:FE:81:EF:38:81:1B:DE:0F:14:BC:F0:5E:DE:CA:0B:79 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Justin Stoller", pp_project: "Puppet Server", pp_role: "puppetdb")
+ "pp8.delivery.puppetlabs.net" (SHA256) 7C:52:4E:B4:A6:24:F9:8C:A4:BA:3C:F7:3D:7D:48:36:05:42:27:AF:B6:D3:80:40:90:5D:7B:3E:16:62:95:90 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Justin Stoller", pp_project: "Puppet Server", pp_role: "dashboard")
+ "pp9.delivery.puppetlabs.net" (SHA256) 0A:9C:0E:9F:26:CD:85:5C:38:B8:69:E2:67:D3:29:59:11:1E:3D:EA:28:0E:71:87:5C:7F:3C:B7:2C:93:D5:9B 2021-06-14T18:21:28Z (pl_epic: "SERVER-1305", pp_department: "Engineering", pp_employee: "Justin Stoller", pp_project: "Puppet Server", pp_role: "agent")
+ "vml6g3jswc3uoc9.delivery.puppetlabs.net" (SHA256) 00:89:2A:A8:A9:C1:07:FA:88:3E:A6:47:0A:26:9C:38:E5:20:9D:94:DF:EC:04:74:BE:82:51:35:CA:88:B5:D9 2021-06-14T18:20:32Z (alt names: "DNS:puppet", "DNS:vml6g3jswc3uoc9", "DNS:vml6g3jswc3uoc9.delivery.puppetlabs.net")
- "pp0.delivery.puppetlabs.net" (SHA256) 38:9F:73:C4:1F:80:52:5A:6D:0E:88:AE:62:D8:4C:88:5A:19:42:48:AA:D1:A6:C4:27:BF:84:99:94:04:4C:30 (certificate revoked)
- "pp1.delivery.puppetlabs.net" (SHA256) BC:A2:88:FC:31:2F:E3:6A:7B:14:59:C1:42:DB:F3:7F:5D:C8:B1:50:AC:AF:4F:BA:FC:11:65:E4:93:7B:A1:94 (certificate revoked)
- "pp2.delivery.puppetlabs.net" (SHA256) 00:A8:4D:9D:69:4F:15:06:5C:E8:54:D6:D3:8E:3B:FC:8F:76:A6:91:C1:C2:98:EF:32:4A:03:20:B5:87:E2:42 (certificate revoked)
- "pp3.delivery.puppetlabs.net" (SHA256) 9F:76:9D:CA:90:FE:63:E8:95:DC:8A:B8:CB:D1:B4:5A:20:92:2F:FA:7D:02:C4:43:2F:3C:24:C1:34:4F:DF:03 (certificate revoked)
```

2. Example human friendly output:
```
[root@vml6g3jswc3uoc9 ~]# puppet cert list --all -h
  "pp17.delivery.puppetlabs.net"
  (SHA256) 86:72:BF:BD:A9:7D:BB:4C:F2:C0:55:FC:FF:1A:17:BC:B1:F6:38:84:53:A6:EB:61:3F:66:CD:56:0E:5C:24:2B
    Status: Request Pending
    Extensions:
      alt names: "DNS:pp17.delivery.puppetlabs.net", "DNS:puppet", "DNS:puppet.delivery.puppetlabs", "DNS:vml6g3jswc3uoc9.delivery.puppetlabs.net"
      challengePassword: "2844bffa89d5313707f6e6668d8bc293"
      pp_auth_role: "puppet infrastructure"
      pp_authorization: "true"
      pp_uuid: "5e47b744-3e77-44e5-9499-04f43ea4a53f"

  "pp18.delivery.puppetlabs.net"
  (SHA256) 98:95:E2:81:98:D2:1A:D4:FC:B2:8E:63:FF:E0:17:C6:0E:C0:FC:38:66:8D:A6:56:9E:62:90:3E:CC:FF:56:9E
    Status: Request Pending

+ "pp9.delivery.puppetlabs.net"
  (SHA256) 0A:9C:0E:9F:26:CD:85:5C:38:B8:69:E2:67:D3:29:59:11:1E:3D:EA:28:0E:71:87:5C:7F:3C:B7:2C:93:D5:9B
    Status: Signed
    Expiration: 2021-06-14T18:21:28Z
    Extensions:
      pl_epic: "SERVER-1305"
      pp_department: "Engineering"
      pp_employee: "Justin Stoller"
      pp_project: "Puppet Server"
      pp_role: "agent"

+ "vml6g3jswc3uoc9.delivery.puppetlabs.net"
  (SHA256) 00:89:2A:A8:A9:C1:07:FA:88:3E:A6:47:0A:26:9C:38:E5:20:9D:94:DF:EC:04:74:BE:82:51:35:CA:88:B5:D9
    Status: Signed
    Expiration: 2021-06-14T18:20:32Z
    Extensions:
      alt names: "DNS:puppet", "DNS:vml6g3jswc3uoc9", "DNS:vml6g3jswc3uoc9.delivery.puppetlabs.net"

- "pp0.delivery.puppetlabs.net"
  (SHA256) 38:9F:73:C4:1F:80:52:5A:6D:0E:88:AE:62:D8:4C:88:5A:19:42:48:AA:D1:A6:C4:27:BF:84:99:94:04:4C:30
    Status: Invalid - (certificate revoked)

```

3. Example updated legacy output:
```
[root@vml6g3jswc3uoc9 ~]# puppet cert list --all
  "pp14.delivery.puppetlabs.net"            (SHA256) 9D:8B:4A:E2:C4:46:D8:65:60:5F:CA:6C:42:74:9A:FF:04:BC:0C:EE:6B:64:CC:5D:14:D1:71:3F:A3:40:38:73 **
  "pp15.delivery.puppetlabs.net"            (SHA256) 9F:99:84:28:64:09:8F:13:16:18:2E:64:22:E0:9B:B5:17:F6:53:6F:FF:2B:32:9E:2F:A9:EC:DF:87:82:17:9A **
  "pp16.delivery.puppetlabs.net"            (SHA256) 01:B8:AB:3B:F7:3E:44:30:E1:77:3A:E8:2A:29:B1:90:A1:B1:84:4A:E0:54:C6:D0:3C:3B:D2:F5:4C:17:66:A7 **
  "pp17.delivery.puppetlabs.net"            (SHA256) 86:72:BF:BD:A9:7D:BB:4C:F2:C0:55:FC:FF:1A:17:BC:B1:F6:38:84:53:A6:EB:61:3F:66:CD:56:0E:5C:24:2B (alt names: "DNS:pp17.delivery.puppetlabs.net", "DNS:puppet", "DNS:puppet.delivery.puppetlabs", "DNS:vml6g3jswc3uoc9.delivery.puppetlabs.net") **
  "pp18.delivery.puppetlabs.net"            (SHA256) 98:95:E2:81:98:D2:1A:D4:FC:B2:8E:63:FF:E0:17:C6:0E:C0:FC:38:66:8D:A6:56:9E:62:90:3E:CC:FF:56:9E
  "pp19.delivery.puppetlabs.net"            (SHA256) B2:14:FD:DC:41:18:38:6C:B4:85:EF:7C:D4:2C:68:5B:0A:AC:78:8D:B3:A9:6C:EC:8B:67:49:B1:40:38:AA:B1 **
+ "dru2ka49hmb02gn.delivery.puppetlabs.net" (SHA256) B8:E5:DD:73:C2:F7:96:84:EE:83:0F:73:E1:80:CF:37:8A:BC:5A:41:04:C5:C0:F4:D8:8A:1F:4C:B6:B0:0D:06
+ "pp10.delivery.puppetlabs.net"            (SHA256) BD:31:E8:36:9E:3B:02:03:52:C3:15:ED:45:59:E7:36:32:F6:35:46:7B:AB:1D:BA:25:24:C4:A8:0D:DD:2F:F7 **
+ "pp11.delivery.puppetlabs.net"            (SHA256) 78:3C:28:EC:32:74:50:8F:97:91:94:F3:66:86:5E:7E:6E:4A:DF:25:14:6C:07:9F:90:BE:4A:ED:31:5E:3F:F7 **
+ "pp12.delivery.puppetlabs.net"            (SHA256) 9D:76:62:91:C5:E2:24:F5:B6:F0:BF:B2:4E:8D:85:04:26:73:4B:74:D0:C3:A3:2E:49:6D:D0:BD:25:2D:35:53 **
+ "pp13.delivery.puppetlabs.net"            (SHA256) D3:32:95:2F:C6:1C:3E:FD:B1:06:D3:ED:A5:9A:06:53:B2:A2:32:3D:EF:19:98:EF:F4:EB:A3:C0:F2:D0:BC:EB **
+ "pp4.delivery.puppetlabs.net"             (SHA256) F7:0D:E2:44:D5:36:B4:99:27:06:34:58:29:F6:26:D6:D4:D8:47:96:A5:79:BA:B4:B1:CE:47:01:AC:C0:3B:E4 **
+ "pp5.delivery.puppetlabs.net"             (SHA256) 78:A1:02:44:EB:CD:85:42:E6:62:35:09:96:E3:6D:46:E6:7A:2A:9D:C7:9A:13:42:FA:45:6F:B2:DD:96:55:32 **
+ "pp6.delivery.puppetlabs.net"             (SHA256) 0D:01:2E:76:38:52:BC:F5:7D:80:CE:30:41:0A:DF:1F:0B:7E:D7:F6:A7:BB:7E:5A:4E:6F:7A:83:8D:64:5B:2B **
+ "pp7.delivery.puppetlabs.net"             (SHA256) FD:9B:39:16:10:17:4E:EB:68:00:50:33:51:FB:7C:9D:FE:81:EF:38:81:1B:DE:0F:14:BC:F0:5E:DE:CA:0B:79 **
+ "pp8.delivery.puppetlabs.net"             (SHA256) 7C:52:4E:B4:A6:24:F9:8C:A4:BA:3C:F7:3D:7D:48:36:05:42:27:AF:B6:D3:80:40:90:5D:7B:3E:16:62:95:90 **
+ "pp9.delivery.puppetlabs.net"             (SHA256) 0A:9C:0E:9F:26:CD:85:5C:38:B8:69:E2:67:D3:29:59:11:1E:3D:EA:28:0E:71:87:5C:7F:3C:B7:2C:93:D5:9B **
+ "vml6g3jswc3uoc9.delivery.puppetlabs.net" (SHA256) 00:89:2A:A8:A9:C1:07:FA:88:3E:A6:47:0A:26:9C:38:E5:20:9D:94:DF:EC:04:74:BE:82:51:35:CA:88:B5:D9 (alt names: "DNS:puppet", "DNS:vml6g3jswc3uoc9", "DNS:vml6g3jswc3uoc9.delivery.puppetlabs.net")
- "pp0.delivery.puppetlabs.net"             (SHA256) 38:9F:73:C4:1F:80:52:5A:6D:0E:88:AE:62:D8:4C:88:5A:19:42:48:AA:D1:A6:C4:27:BF:84:99:94:04:4C:30 (certificate revoked)
- "pp1.delivery.puppetlabs.net"             (SHA256) BC:A2:88:FC:31:2F:E3:6A:7B:14:59:C1:42:DB:F3:7F:5D:C8:B1:50:AC:AF:4F:BA:FC:11:65:E4:93:7B:A1:94 (certificate revoked)
- "pp2.delivery.puppetlabs.net"             (SHA256) 00:A8:4D:9D:69:4F:15:06:5C:E8:54:D6:D3:8E:3B:FC:8F:76:A6:91:C1:C2:98:EF:32:4A:03:20:B5:87:E2:42 (certificate revoked)
- "pp3.delivery.puppetlabs.net"             (SHA256) 9F:76:9D:CA:90:FE:63:E8:95:DC:8A:B8:CB:D1:B4:5A:20:92:2F:FA:7D:02:C4:43:2F:3C:24:C1:34:4F:DF:03 (certificate revoked)
```