### PR TITLE
(PUP-6413) Use https when talking to pypi

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -66,7 +66,7 @@ Puppet::Type.type(:package).provide :pip,
       proxy = http_proxy_host
     end
 
-    client = XMLRPC::Client.new2("http://pypi.python.org/pypi", proxy)
+    client = XMLRPC::Client.new2("https://pypi.python.org/pypi", proxy)
     client.http_header_extra = {"Content-Type" => "text/xml"}
     client.timeout = 10
     result = client.call("package_releases", @resource[:name])

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -120,7 +120,7 @@ describe provider_class do
     context "connecting directly" do
 
       before :each do
-        XMLRPC::Client.expects(:new2).with("http://pypi.python.org/pypi", nil).returns(@client)
+        XMLRPC::Client.expects(:new2).with("https://pypi.python.org/pypi", nil).returns(@client)
       end
 
       it "should find a version number for real_package" do
@@ -145,7 +145,7 @@ describe provider_class do
       before :each do
         Puppet::Util::HttpProxy.expects(:http_proxy_host).returns 'some_host'
         Puppet::Util::HttpProxy.expects(:http_proxy_port).returns 'some_port'
-        XMLRPC::Client.expects(:new2).with("http://pypi.python.org/pypi", "some_host:some_port").returns(@client)
+        XMLRPC::Client.expects(:new2).with("https://pypi.python.org/pypi", "some_host:some_port").returns(@client)
       end
 
       it "should find a version number for real_package" do


### PR DESCRIPTION
We really shouldn't use this code any more. But we are using it.
Pypi changed behaviour today because of vulnerabilities in urrlib, which
is used by pip.

http://blog.blindspotsecurity.com/2016/06/advisory-http-header-injection-in.html

Pypi changed to denying http requests entirely instead of redirecting to
https. (I guess? I don't really understand)

Without this patch:

root@derpderp:~# cat foo.pp
    package { 'diskimage-builder':
      ensure   => latest,
      provider => pip,
   }

root@derpderp:~# puppet apply foo.pp
Warning: Setting templatedir is deprecated. See http://links.puppetlabs.com/env-settings-deprecations
   (at /usr/lib/ruby/vendor_ruby/puppet/settings.rb:1139:in `issue_deprecation_warning')
Notice: Compiled catalog for derpderp in environment production in 0.14 seconds
Error: Could not get latest version: HTTP-Error: 403 Must access using HTTPS instead of HTTP
Error: /Stage[main]/Main/Package[diskimage-builder]/ensure: change from 1.17.0 to latest failed: Could not get latest version: HTTP-Error: 403 Must access using HTTPS instead of HTTP
Notice: Finished catalog run in 0.67 seconds

So this breaks any puppet 3.x using the default pip provider.

With this patch, it just works.