### PR TITLE
(doc) Update link to pypa in comments

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -1,5 +1,5 @@
 # Puppet package provider for Python's `pip` package management frontend.
-# <http://pip.openplans.org/>
+# <http://pip.pypa.io/>
 
 require 'puppet/provider/package'
 require 'xmlrpc/client'

--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -1,5 +1,5 @@
 # Puppet package provider for Python's `pip3` package management frontend.
-# <http://pip.openplans.org/>
+# <http://pip.pypa.io/>
 
 require 'puppet/provider/package/pip'
 


### PR DESCRIPTION
The comment in the code pointed to a URL for pypa docs that was out of
date. This commit fixes the URLs.