### PR TITLE
(PUP-2316) Allow single element attribute array for AIX user.

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -279,6 +279,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
 
   def managed_attribute_keys(hash)
     managed_attributes ||= @resource.original_parameters[:attributes] || hash.keys.map{|k| k.to_s}
+    managed_attributes = [managed_attributes] unless managed_attributes.is_a?(Array)
     managed_attributes.map {|attr| key, value = attr.split("="); key.strip.to_sym}
   end
 

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -55,6 +55,7 @@ guest id=100 pgrp=usr groups=usr home=/home/guest
 
     describe "invoked via manifest" do
       let(:attribute_array) { ["rlogin=false", "login =true"] }
+      let(:single_attribute_array) { "rlogin=false" }
 
       it "should return only the keys of the attribute key=value pair from manifest" do
         keys = @provider.managed_attribute_keys(existing_attributes)
@@ -78,6 +79,12 @@ guest id=100 pgrp=usr groups=usr home=/home/guest
         keys = @provider.managed_attribute_keys(existing_attributes)
         all_symbols = keys.all? {|k| k.is_a? Symbol}
         all_symbols.should be_true
+      end
+
+      it "should allow a single attribute to be specified" do
+        @resource.stubs(:original_parameters).returns({ :attributes => single_attribute_array })
+        keys = @provider.managed_attribute_keys(existing_attributes)
+        keys.should be_include(:rlogin)
       end
     end
 


### PR DESCRIPTION
This is fixed in Puppet 4 due to a rewrite of the parser.

This commit updates the handling of the attributes input to make sure
they are converted to an array. The parser previously converts single
element arrays into strings, causing this bug.