### PR TITLE
(PUP-6417) improve regex for line matching in ssh_authorized_keys resource type

### DIFF
--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -145,7 +145,7 @@ module Puppet
     end
 
     # regular expression suitable for use by a ParsedFile based provider
-    REGEX = /^(?:(.+) )?(ssh-dss|ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521) ([^ ]+) ?(.*)$/
+    REGEX = /^(?:(.+)\s+)?(ssh-dss|ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521)\s+([^ ]+)\s*(.*)$/
     def self.keyline_regex
       REGEX
     end


### PR DESCRIPTION
Lines in ssh authorized_keys file may have mulitple space as filed
separator. We need to use \s+ in REGEX instead of plain space.

The regex in type ssh_authorized_keys is:

```ruby
REGEX = /^(?:(.+) )?(ssh-dss|ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521) ([^ ]+) ?(.*)$/
```

This regext can't match lines with multi spaces as field separator like:

```
$ cat ~/.ssh/authorized_keys
ssh-rsa    PUBLIC_KEY_CONTENT    COMMENT    # This line is separated by multi spaces
```