### PR TITLE
(PUP-6376) Add `server_list` option to settings

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1395,7 +1395,26 @@ EOT
     },
     :server => {
       :default => "puppet",
-      :desc => "The puppet master server to which the puppet agent should connect."
+      :desc => "The puppet master server to which the puppet agent should connect.",
+      :call_hook => :on_initialize_and_write,
+      :hook => proc { |value|
+          if Puppet.settings.set_by_config?(:server_list)
+            Puppet.deprecation_warning('Attempted to set both server and server_list. Server setting will not be used.')
+          end        
+          value
+      }
+    },
+    :server_list => {
+      :default => [],
+      :type => :server_list,
+      :desc => "The list of puppet master servers to which the puppet agent should connect,
+        in the order that they will be tried.",
+      :call_hook => :on_initialize_and_write,
+      :hook => proc { |value| 
+            if Puppet.settings.set_by_config?(:server)  
+              Puppet.deprecation_warning('Attempted to set both server and server_list. Server setting will not be used.')
+            end
+        }
     },
     :use_srv_records => {
       :default    => false,

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -29,6 +29,7 @@ class Puppet::Settings
   require 'puppet/settings/config_file'
   require 'puppet/settings/value_translator'
   require 'puppet/settings/environment_conf'
+  require 'puppet/settings/server_list_setting'
 
   # local reference for convenience
   PuppetOptionParser = Puppet::Util::CommandLine::PuppetOptionParser
@@ -667,6 +668,7 @@ class Puppet::Settings
       :symbolic_enum   => SymbolicEnumSetting,
       :priority   => PrioritySetting,
       :autosign   => AutosignSetting,
+      :server_list => ServerListSetting
   }
 
   # Create a new setting.  The value is passed in because it's used to determine

--- a/lib/puppet/settings/server_list_setting.rb
+++ b/lib/puppet/settings/server_list_setting.rb
@@ -1,0 +1,20 @@
+class Puppet::Settings::ServerListSetting < Puppet::Settings::ArraySetting
+
+  def type
+    :server_list
+  end
+
+  def munge(value)
+    servers = super 
+    servers.map! { |server| 
+      case server
+      when String
+        server.split(':')
+      when Array
+        server
+      else
+        raise ArgumentError, "Expected an Array of String, got a #{value.class}"
+      end
+    }
+  end
+end

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -104,4 +104,18 @@ describe "Defaults" do
       expect(Puppet.settings[:supported_checksum_types]).to eq(['sha256', 'md5lite', 'mtime'])
     end
   end
+  
+  describe 'server vs server_list' do
+    it 'should warn when both settings are set in code' do
+      Puppet.expects(:deprecation_warning).with('Attempted to set both server and server_list. Server setting will not be used.')
+      Puppet.settings[:server] = 'test_server'
+      Puppet.settings[:server_list] = ['one', 'two']
+    end
+
+    it 'should warn when both settings are set by command line' do
+      Puppet.expects(:deprecation_warning).with('Attempted to set both server and server_list. Server setting will not be used.')
+      Puppet.settings.handlearg("--server_list", "one,two")
+      Puppet.settings.handlearg("--server", "test_server")
+    end
+  end
 end


### PR DESCRIPTION
This adds a server_list option to Puppet's settings. Because having both
server_list and server be set could result in ambiguous behavior, a
warning is emitted when the user sets both. The actual logic handling
the conflict is still to be determined and implemented.