### PR TITLE
(PUP-5831) Add binary type

### DIFF
--- a/lib/puppet/functions/binary_file.rb
+++ b/lib/puppet/functions/binary_file.rb
@@ -1,0 +1,36 @@
+# Loads a binary file from a module or file system and returns its contents as a Binary.
+#
+# The argument to this function should be a `<MODULE NAME>/<FILE>`
+# reference, which will load `<FILE>` from a module's `files`
+# directory. (For example, the reference `mysql/mysqltuner.pl` will load the
+# file `<MODULES DIRECTORY>/mysql/files/mysqltuner.pl`.)
+#
+# This function also accepts an absolute file path that allows reading
+# binary file content from anywhere on disk.
+#
+# An error is raised if the given file does not exists.
+#
+# To search for the existence of files, use the `find_file()` function.
+#
+# @since 4.6.0
+#
+Puppet::Functions.create_function(:binary_file, Puppet::Functions::InternalFunction) do
+  dispatch :binary_file do
+    scope_param
+    param 'String', :path
+  end
+
+  def binary_file(scope, unresolved_path)
+    path = nil
+    found = Puppet::Parser::Files.find_file(unresolved_path, scope.compiler.environment)
+    if found && Puppet::FileSystem.exist?(found)
+      path = found
+    end
+
+    if path
+      Puppet::Pops::Types::PBinaryType::Binary.from_binary_string(Puppet::FileSystem.binread(path))
+    else
+      raise Puppet::ParseError, "binary_file(): The given file '#{path}' does not exist"
+    end
+  end
+end

--- a/lib/puppet/functions/binary_file.rb
+++ b/lib/puppet/functions/binary_file.rb
@@ -1,18 +1,7 @@
 # Loads a binary file from a module or file system and returns its contents as a Binary.
+# (Documented in 3.x stub)
 #
-# The argument to this function should be a `<MODULE NAME>/<FILE>`
-# reference, which will load `<FILE>` from a module's `files`
-# directory. (For example, the reference `mysql/mysqltuner.pl` will load the
-# file `<MODULES DIRECTORY>/mysql/files/mysqltuner.pl`.)
-#
-# This function also accepts an absolute file path that allows reading
-# binary file content from anywhere on disk.
-#
-# An error is raised if the given file does not exists.
-#
-# To search for the existence of files, use the `find_file()` function.
-#
-# @since 4.6.0
+# @since 4.8.0
 #
 Puppet::Functions.create_function(:binary_file, Puppet::Functions::InternalFunction) do
   dispatch :binary_file do

--- a/lib/puppet/functions/find_file.rb
+++ b/lib/puppet/functions/find_file.rb
@@ -1,19 +1,7 @@
 # Finds an existing file from a module and returns its path.
+# (Documented in 3.x stub)
 #
-# The argument to this function should be a String as a `<MODULE NAME>/<FILE>`
-# reference, which will search for `<FILE>` relative to a module's `files`
-# directory. (For example, the reference `mysql/mysqltuner.pl` will search for the
-# file `<MODULES DIRECTORY>/mysql/files/mysqltuner.pl`.)
-#
-# This function can also accept:
-#
-# * An absolute String path, which will check for the existence of a file from anywhere on disk.
-# * Multiple String arguments, which will return the path of the **first** file
-#   found, skipping non existing files.
-# * An array of string paths, which will return the path of the **first** file
-#   found from the given paths in the array, skipping non existing files.
-#
-# @since 4.6.0
+# @since 4.8.0
 #
 Puppet::Functions.create_function(:find_file, Puppet::Functions::InternalFunction) do
   dispatch :find_file do

--- a/lib/puppet/functions/find_file.rb
+++ b/lib/puppet/functions/find_file.rb
@@ -1,0 +1,43 @@
+# Finds an existing file from a module and returns its path.
+#
+# The argument to this function should be a String as a `<MODULE NAME>/<FILE>`
+# reference, which will search for `<FILE>` relative to a module's `files`
+# directory. (For example, the reference `mysql/mysqltuner.pl` will search for the
+# file `<MODULES DIRECTORY>/mysql/files/mysqltuner.pl`.)
+#
+# This function can also accept:
+#
+# * An absolute String path, which will check for the existence of a file from anywhere on disk.
+# * Multiple String arguments, which will return the path of the **first** file
+#   found, skipping non existing files.
+# * An array of string paths, which will return the path of the **first** file
+#   found from the given paths in the array, skipping non existing files.
+#
+# @since 4.6.0
+#
+Puppet::Functions.create_function(:find_file, Puppet::Functions::InternalFunction) do
+  dispatch :find_file do
+    scope_param
+    repeated_param 'String', :paths
+  end
+
+  dispatch :find_file_array do
+    scope_param
+    repeated_param 'Array[String]', :paths_array
+  end
+
+  def find_file_array(scope, array)
+    find_file(scope, *array)
+  end
+
+  def find_file(scope, *args)
+    path = nil
+    args.each do |file|
+      found = Puppet::Parser::Files.find_file(file, scope.compiler.environment)
+      if found && Puppet::FileSystem.exist?(found)
+        return found
+      end
+    end
+    nil
+  end
+end

--- a/lib/puppet/functions/new.rb
+++ b/lib/puppet/functions/new.rb
@@ -26,6 +26,6 @@ Puppet::Functions.create_function(:new, Puppet::Functions::InternalFunction) do
   end
 
   def assert_type(type, value)
-    Puppet::Pops::Types::TypeAsserter.assert_instance_of("Converted value from #{type.to_s}.new()", type, value)
+    Puppet::Pops::Types::TypeAsserter.assert_instance_of(['Converted value from %s.new()', type], type, value)
   end
 end

--- a/lib/puppet/functions/new.rb
+++ b/lib/puppet/functions/new.rb
@@ -26,6 +26,6 @@ Puppet::Functions.create_function(:new, Puppet::Functions::InternalFunction) do
   end
 
   def assert_type(type, value)
-    Puppet::Pops::Types::TypeAsserter.assert_instance_of('new():', type, value)
+    Puppet::Pops::Types::TypeAsserter.assert_instance_of("Converted value from #{type.to_s}.new()", type, value)
   end
 end

--- a/lib/puppet/parser/functions/binary_file.rb
+++ b/lib/puppet/parser/functions/binary_file.rb
@@ -1,0 +1,24 @@
+Puppet::Parser::Functions::newfunction(
+  :binary_file,
+  :type => :rvalue,
+  :arity => 1,
+:doc => <<-DOC
+Loads a binary file from a module or file system and returns its contents as a Binary.
+
+The argument to this function should be a `<MODULE NAME>/<FILE>`
+reference, which will load `<FILE>` from a module's `files`
+directory. (For example, the reference `mysql/mysqltuner.pl` will load the
+file `<MODULES DIRECTORY>/mysql/files/mysqltuner.pl`.)
+
+This function also accepts an absolute file path that allows reading
+binary file content from anywhere on disk.
+
+An error is raised if the given file does not exists.
+
+To search for the existence of files, use the `find_file()` function.
+
+- since 4.8.0
+DOC
+) do |args|
+  Error.is4x('binary_file')
+end

--- a/lib/puppet/parser/functions/find_file.rb
+++ b/lib/puppet/parser/functions/find_file.rb
@@ -1,0 +1,28 @@
+Puppet::Parser::Functions::newfunction(
+  :find_file,
+  :type => :rvalue,
+  :arity => -2,
+:doc => <<-DOC
+Finds an existing file from a module and returns its path.
+
+The argument to this function should be a String as a `<MODULE NAME>/<FILE>`
+reference, which will search for `<FILE>` relative to a module's `files`
+directory. (For example, the reference `mysql/mysqltuner.pl` will search for the
+file `<MODULES DIRECTORY>/mysql/files/mysqltuner.pl`.)
+
+This function can also accept:
+
+* An absolute String path, which will check for the existence of a file from anywhere on disk.
+* Multiple String arguments, which will return the path of the **first** file
+  found, skipping non existing files.
+* An array of string paths, which will return the path of the **first** file
+  found from the given paths in the array, skipping non existing files.
+
+The function returns `undef` if none of the given paths were found
+
+- since 4.8.0
+DOC
+) do |args|
+  Error.is4x('find_file')
+end
+

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -709,6 +709,8 @@ When given a single value as argument:
 * An empty `Hash` becomes an empty array.
 * An `Array` is simply returned.
 * An `Iterable[T]` is turned into an array of `T` instances.
+* A `Binary` is converted to an `Array[Integer[0,255]]` of byte values
+
 
 When given a second Boolean argument:
 

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -630,7 +630,7 @@ Defaults to `s` at top level and `p` inside array or hash.
 
 | Format    | Default formats
 | ------    | ---------------
-| s         | binary as unquoted UTF-8 characters (errors if byte sequence is invalid UTF-8)
+| s         | binary as unquoted UTF-8 characters (errors if byte sequence is invalid UTF-8). Alternate form escapes non ascii bytes.
 | p         | 'Binary("<base64strict>")'
 | b         | '<base64>' - base64 string with newlines inserted
 | B         | '<base64strict>' - base64 strict string (without newlines inserted)
@@ -638,8 +638,10 @@ Defaults to `s` at top level and `p` inside array or hash.
 | t         | 'Binary' - outputs the name of the type only
 | T         | 'BINARY' - output the name of the type in all caps only
 
-The alternate form flag `#` will quote the binary or base64 text output
-The width and precision values are applied to the text part only in `%p` format.
+* The alternate form flag `#` will quote the binary or base64 text output.
+* The format `%#s` allows invalid UTF-8 characters and outputs all non ascii bytes
+  as hex escaped characters on the form `\\xHH` where `H` is a hex digit.
+* The width and precision values are applied to the text part only in `%p` format.
 
 ### Array & Tuple to String
 
@@ -864,7 +866,7 @@ The formats have the following meaning:
 | b | The data is in base64 encoding, padding as required by base64 strict is added by default
 | u | The data is in URL safe base64 encoding
 | B | The data is in base64 strict encoding
-| s | The data is a puppet string used verbatim as a binary byte sequence
+| s | The data is a puppet string seen as the verbatim byte sequence representing the string in its given encoding.
 
 The default format is `%b`.
 

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -828,6 +828,7 @@ function SemVerRange.new(
 For examples of `SemVerRange` use see "Creating a SemVer"
 
 * Since 4.5.0
+* Binary type since 4.8.0
 
 DOC
 ) do |args|

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -626,6 +626,21 @@ Defaults to `s` at top level and `p` inside array or hash.
 | s         | Same as d.
 | p         | Same as d.
 
+### Binary value to String
+
+| Format    | Default formats
+| ------    | ---------------
+| s         | binary as unquoted characters
+| p         | 'Binary("<base64strict>")'
+| b         | '<base64>' - base64 string with newlines inserted
+| B         | '<base64strict>' - base64 strict string (without newlines inserted)
+| u         | '<base64urlsafe>' - base64 urlsafe string
+| t         | 'Binary' - outputs the name of the type only
+| T         | 'BINARY' - output the name of the type in all caps only
+
+The alternate form flag `#` will quote the binary or base64 text output
+The width and precision values are applied to the text part only in `%p` format.
+
 ### Array & Tuple to String
 
 | Format    | Array/Tuple Formats

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -827,6 +827,46 @@ function SemVerRange.new(
 
 For examples of `SemVerRange` use see "Creating a SemVer"
 
+Creating a Binary
+---
+
+A `Binary` object represents a sequence of bytes and it can be created from a String in Base64 format,
+an Array containing byte values. A Binary can also be created from a Hash containing the value to convert to
+a `Binary`.
+
+The signatures are:
+
+```puppet
+type ByteInteger = Integer[0,255]
+type Base64Format = Enum["%b", "%u", "%B", "%s"]
+type StringHash = Struct[{value => String, "format" => Optional[Base64Format]}]
+type ArrayHash = Struct[{value => Array[ByteInteger]}]
+type BinaryArgsHash = Variant[StringHash, ArrayHash]
+
+function Binary.new(
+  String $base64_str, 
+  Optional[Base64Format] $format
+)
+
+
+function Binary.new(
+  Array[ByteInteger] $byte_array
+}
+
+# Same as for String, or for Array, but where arguments are given in a Hash.
+function Binary.new(BinaryArgsHash $hash_args)
+```
+
+**Examples:** Creating a Binary
+
+```puppet
+# create the binary content "abc"
+$a = Binary('YWJj')
+
+# create the binary content from content in a module's file
+$b = binary_file('mymodule/mypicture.jpg')
+```
+
 * Since 4.5.0
 * Binary type since 4.8.0
 

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -866,9 +866,12 @@ The formats have the following meaning:
 | b | The data is in base64 encoding, padding as required by base64 strict is added by default
 | u | The data is in URL safe base64 encoding
 | B | The data is in base64 strict encoding
-| s | The data is a puppet string seen as the verbatim byte sequence representing the string in its given encoding.
+| s | The data is a puppet string. The string must be valid UTF-8, or convertible to UTF-8 or an error is raised.
+| r | (Ruby Raw) the byte sequence in the given string is used verbatim irrespective of possible encoding errors
 
-The default format is `%b`.
+* The default format is `%b`.
+* Note that the format `%r` should be used sparingly, or not at all. It exists for backwards compatibility reasons when someone receiving
+  a string from some function and that string should be treated as Binary. Such code should be changed to return a Binary instead of a String.
 
 **Examples:** Creating a Binary
 

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -630,7 +630,7 @@ Defaults to `s` at top level and `p` inside array or hash.
 
 | Format    | Default formats
 | ------    | ---------------
-| s         | binary as unquoted characters
+| s         | binary as unquoted UTF-8 characters (errors if byte sequence is invalid UTF-8)
 | p         | 'Binary("<base64strict>")'
 | b         | '<base64>' - base64 string with newlines inserted
 | B         | '<base64strict>' - base64 strict string (without newlines inserted)
@@ -856,6 +856,17 @@ function Binary.new(
 # Same as for String, or for Array, but where arguments are given in a Hash.
 function Binary.new(BinaryArgsHash $hash_args)
 ```
+
+The formats have the following meaning:
+
+| format | explanation |
+| ----   | ----        |
+| b | The data is in base64 encoding, padding as required by base64 strict is added by default
+| u | The data is in URL safe base64 encoding
+| B | The data is in base64 strict encoding
+| s | The data is a puppet string used verbatim as a binary byte sequence
+
+The default format is `%b`.
 
 **Examples:** Creating a Binary
 

--- a/lib/puppet/plugins/configuration.rb
+++ b/lib/puppet/plugins/configuration.rb
@@ -65,5 +65,13 @@ module Puppet::Plugins::Configuration
       in_multibind(checkers_name)
       to_instance('Puppet::SyntaxCheckers::Json')
     end
+
+    bindings.bind do
+      name('base64')
+      instance_of(checkers_type)
+      in_multibind(checkers_name)
+      to_instance('Puppet::SyntaxCheckers::Base64')
+    end
+
     Puppet::Plugins::DataProviders::Registry.register_defaults(bindings)
 end

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -30,6 +30,10 @@ class AccessOperator
     fail(Issues::OPERATOR_NOT_APPLICABLE, @semantic.left_expr, :operator=>'[]', :left_value => o)
   end
 
+  def access_Binary(o, scope, keys)
+    Puppet::Pops::Types::PBinaryType::Binary.from_binary_string(access_String(o.binary_buffer, scope, keys))
+  end
+
   def access_String(o, scope, keys)
     keys.flatten!
     result = case keys.size

--- a/lib/puppet/pops/evaluator/compare_operator.rb
+++ b/lib/puppet/pops/evaluator/compare_operator.rb
@@ -147,6 +147,19 @@ class CompareOperator
     end
   end
 
+  def include_Binary(a, b, scope)
+    case b
+    when Puppet::Pops::Types::PBinaryType::Binary
+      a.binary_buffer.include?(b.binary_buffer)
+    when String
+      a.binary_buffer.include?(b)
+    when Numeric
+      a.binary_buffer.bytes.include?(b)
+    else
+      false
+    end
+  end
+
   def include_Array(a, b, scope)
     case b
     when Regexp

--- a/lib/puppet/pops/evaluator/json_strict_literal_evaluator.rb
+++ b/lib/puppet/pops/evaluator/json_strict_literal_evaluator.rb
@@ -16,7 +16,7 @@ require 'rgen/ecore/ecore'
 #   * Default is not accepted as being literal
 #   * Regular Expression is not accepted as being literal
 #   * Hash with non String keys
-#   * String with interpolatin
+#   * String with interpolation
 #
 class Puppet::Pops::Evaluator::JsonStrictLiteralEvaluator
   #include Puppet::Pops::Utils

--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -98,6 +98,7 @@ class ModelLabelProvider
   def label_TypeAlias o                   ; "Type Alias"                        end
   def label_TypeMapping o                 ; "Type Mapping"                      end
   def label_TypeDefinition o              ; "Type Definition"                   end
+  def label_Binary o                      ; "Binary"                            end
   def label_Application o                 ; "Application"                       end
   def label_Sensitive o                   ; "Sensitive"                         end
   def label_Timestamp o                   ; "Timestamp"                         end

--- a/lib/puppet/pops/parser/heredoc_support.rb
+++ b/lib/puppet/pops/parser/heredoc_support.rb
@@ -6,7 +6,7 @@ module HeredocSupport
   # Pattern for heredoc `@(endtag[:syntax][/escapes])
   # Produces groups for endtag (group 1), syntax (group 2), and escapes (group 3)
   #
-  PATTERN_HEREDOC = %r{@\(([^:/\r\n\)]+)(?::[:blank:]*([a-z][a-zA-Z0-9_+]+)[:blank:]*)?(?:/((?:\w|[$])*)[:blank:]*)?\)}
+  PATTERN_HEREDOC = %r{@\(([^:/\r\n\)]+)(?::[[:blank:]]*([a-z][a-zA-Z0-9_+]+)[[:blank:]]*)?(?:/((?:\w|[$])*)[[:blank:]]*)?\)}
 
 
   def heredoc
@@ -19,7 +19,6 @@ module HeredocSupport
     # find end of the heredoc spec
     str = scn.scan_until(/\)/) || lex_error(Issues::HEREDOC_UNCLOSED_PARENTHESIS, :followed_by => followed_by)
     pos_after_heredoc = scn.pos
-
     # Note: allows '+' as separator in syntax, but this needs validation as empty segments are not allowed
     md = str.match(PATTERN_HEREDOC)
     lex_error(Issues::HEREDOC_INVALID_SYNTAX) unless md

--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -145,7 +145,9 @@ class PBinaryType < PAnyType
         format ||= '%b'
         case format
         when "%b"
-          Binary.new(Base64.decode64(str))
+          # padding must be added for older rubies to avoid truncation
+          padding = '=' * (str.length % 3)
+          Binary.new(Base64.decode64(str + padding))
 
         when "%u"
           Binary.new(Base64.urlsafe_decode64(str))

--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -1,0 +1,175 @@
+require 'base64'
+module Puppet::Pops
+module Types
+
+# A Puppet Language Type that exposes the {{SemanticPuppet::Version}} and {{SemanticPuppet::VersionRange}}.
+# The version type is parameterized with version ranges.
+#
+# @api public
+class PBinaryType < PAnyType
+
+  # Represents a binary buffer
+  # @api public
+  class Binary
+    attr_reader :binary_buffer
+
+    # Constructs an instance of Binary from a base64 urlsafe encoded string (RFC 2045).
+    # @param [String] A string with RFC 2045 compliant encoded binary 
+    #
+    def self.from_base64(str)
+      new(Base64.decode64(str))
+    end
+
+    # Constructs an instance of Binary from a base64 encoded string (RFC4648 with "URL and Filename
+    # Safe Alphabet" (That is with '-' instead of '+', and '_' instead of '/').
+    #
+    def self.from_base64_urlsafe(str)
+      new(Base64.urlsafe_decode64(str))
+    end
+
+    # Constructs an instance of Binary from a base64 strict encoded string (RFC 4648)
+    # Where correct padding must be used and line breaks causes an error to be raised.
+    #
+    # @param [String] A string with RFC 4648 compliant encoded binary
+    # 
+    def self.from_base64_strict(str)
+      new(Base64.strict_decode64(str))
+    end
+
+    # Creates a new Binary from a String containing binary data. If the string's encoding
+    # is not already ASCII-8BIT, the string is transcoded to ASCII-8BIT (that is Ruby's "binary" format).
+    # This means that this binary will have the exact same content, but the string will considered
+    # to hold a sequence of bytes in the range 0 to 255.
+    #
+    # The given string will be frozen as a side effect if it is in ASCII-8BIT encoding. If this is not
+    # wanted, a copy should be given to this method.
+    #
+    # @param [String] A string with binary data
+    # @api public
+    #
+    def self.from_binary_string(bin)
+      new(bin)
+    end
+
+    # Creates a new Binary from a String containing binary data. If the string's encoding
+    # is not already ASCII-8BIT, the string is transcoded to ASCII-8BIT (that is Ruby's "binary" format).
+    # This means that this binary will have the exact same content, but the string will considered
+    # to hold a sequence of bytes in the range 0 to 255.
+    #
+    # The given string will be frozen as a side effect if it is in ASCII-8BIT encoding. If this is not
+    # wanted, a copy should be given to this method.
+    #
+    # @param [String] A string with binary data
+    # @api private
+    #
+    def initialize(bin)
+      # TODO: When Ruby 1.9.3 support is dropped change this to `bin.b` for binary encoding instead of force_encoding
+      @binary_buffer = (bin.encoding.name == "ASCII-8BIT" ? bin : bin.force_encoding("ASCII-8BIT")).freeze
+    end
+
+    # Presents the binary content as a string base64 encoded string (without line breaks).
+    #
+    def to_s
+      Base64.strict_encode64(@binary_buffer)
+    end
+
+    def eql?(o)
+      self.class == o.class && @binary_buffer == o.binary_buffer
+    end
+
+    def ==(o)
+      self.eql?(o)
+    end
+  end
+
+
+  def initialize()
+  end
+
+  # Only instances of Binary are instances of the PBinaryType
+  #
+  def instance?(o, guard = nil)
+    o.is_a?(Binary)
+  end
+
+  def eql?(o)
+    self.class == o.class
+  end
+
+  def hash?
+    super
+  end
+
+  # @api private
+  def self.new_function(_, loader)
+    @@new_function ||= Puppet::Functions.create_loaded_function(:new_Binary, loader) do
+      local_types do
+        type 'ByteInteger = Integer[0,255]'
+        type 'Base64Format = Enum["%b", "%u", "%B"]'
+        type 'StringHash = Struct[{value => String, "format" => Optional[Base64Format]}]'
+        type 'ArrayHash = Struct[{value => Array[ByteInteger]}]'
+        type 'BinaryArgsHash = Variant[StringHash, ArrayHash]'
+      end
+
+      # Creates a binary from a base64 encoded string in one of the formats %b (
+      dispatch :from_string do
+        param 'String', :str
+        optional_param 'Base64Format', :format
+      end
+
+      dispatch :from_array do
+        param 'Array[ByteInteger]', :byte_array
+      end
+
+      # Same as from_string, or from_array, but value and (for string) optional format are given in the form
+      # of a hash.
+      #
+      dispatch :from_hash do
+        param 'BinaryArgsHash', :hash_args
+      end
+
+      def from_string(str, format = nil)
+        format ||= '%b'
+        case format
+        when "%b"
+          Binary.new(Base64.decode64(str))
+
+        when "%u"
+          Binary.new(Base64.urlsafe_decode64(str))
+
+        when "%B"
+          Binary.new(Base64.strict_decode64(str))
+
+        else
+          raise ArgumentError, "Unsupported Base64 format '#{format}'"
+        end
+      end
+
+      def from_array(array)
+        # The array is already known to have bytes in the range 0-255, or it is in error
+        # Without this pack C would produce weird results
+        Binary.from_binary_string(array.pack("C*"))
+      end
+
+      def from_hash(hash)
+        case hash['value']
+        when Array
+          from_array(hash['value'])
+        when String
+          from_string(hash['value'], hash['format'])
+        end
+      end
+    end
+  end
+
+  DEFAULT = PBinaryType.new
+
+  protected
+
+  def _assignable?(o, guard)
+    o.class == self.class
+  end
+
+end
+end
+end

--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -89,6 +89,10 @@ class PBinaryType < PAnyType
     def ==(o)
       self.eql?(o)
     end
+
+    def length()
+      @binary_buffer.length
+    end
   end
 
 

--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -82,6 +82,10 @@ class PBinaryType < PAnyType
       Base64.urlsafe_encode64(@binary_buffer)
     end
 
+    def hash
+      @binary_buffer.hash
+    end
+
     def eql?(o)
       self.class == o.class && @binary_buffer == o.binary_buffer
     end
@@ -99,9 +103,6 @@ class PBinaryType < PAnyType
     create_ptype(loader, ir, 'AnyType')
   end
 
-  def initialize()
-  end
-
   # Only instances of Binary are instances of the PBinaryType
   #
   def instance?(o, guard = nil)
@@ -110,10 +111,6 @@ class PBinaryType < PAnyType
 
   def eql?(o)
     self.class == o.class
-  end
-
-  def hash?
-    super
   end
 
   # @api private

--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -70,6 +70,18 @@ class PBinaryType < PAnyType
       Base64.strict_encode64(@binary_buffer)
     end
 
+    # Returns the binary content as a "relaxed" base64 (standard) encoding where
+    # the string is broken up with new lines.
+    def relaxed_to_s
+      Base64.encode64(@binary_buffer)
+    end
+
+    # Returns the binary content as a url safe base64 string (where + and / are replaced by - and _)
+    #
+    def urlsafe_to_s
+      Base64.urlsafe_encode64(@binary_buffer)
+    end
+
     def eql?(o)
       self.class == o.class && @binary_buffer == o.binary_buffer
     end

--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -95,6 +95,9 @@ class PBinaryType < PAnyType
     end
   end
 
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType')
+  end
 
   def initialize()
   end
@@ -115,7 +118,7 @@ class PBinaryType < PAnyType
 
   # @api private
   def self.new_function(_, loader)
-    @@new_function ||= Puppet::Functions.create_loaded_function(:new_Binary, loader) do
+    @new_function ||= Puppet::Functions.create_loaded_function(:new_Binary, loader) do
       local_types do
         type 'ByteInteger = Integer[0,255]'
         type 'Base64Format = Enum["%b", "%u", "%B", "%s"]'

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -718,7 +718,19 @@ class StringConverter
     substitute = f.alt? ? 'p' : 's'
     case f.format
     when :s
-      Kernel.format(f.orig_fmt.gsub('s', substitute), val.binary_buffer)
+      val_to_convert = val.binary_buffer
+      if !f.alt?
+        # Assume it is valid UTF-8
+        val_to_convert = val_to_convert.dup.force_encoding('UTF-8')
+        # If it isn't
+        unless val_to_convert.valid_encoding?
+          # try to convert and fail with details about what is wrong
+          val_to_convert = val.binary_buffer.encode('UTF-8')
+        end
+      else
+        val_to_convert = val.binary_buffer
+      end
+      Kernel.format(f.orig_fmt.gsub('s', substitute), val_to_convert)
 
     when :p
       # width & precision applied to string, not the the name of the type

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -688,6 +688,11 @@ class TypeCalculator
   end
 
   # @api private
+  def infer_Binary(o)
+    PBinaryType::DEFAULT
+  end
+
+  # @api private
   def infer_Version(o)
     PSemVerType::DEFAULT
   end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -329,6 +329,12 @@ module TypeFactory
     PDefaultType::DEFAULT
   end
 
+  # Creates an instance of the Binary type
+  # @api public
+  def self.binary
+    PBinaryType::DEFAULT
+  end
+
   # Produces an instance of the abstract type PCatalogEntryType
   def self.catalog_entry
     PCatalogEntryType::DEFAULT

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -134,6 +134,9 @@ class TypeFormatter
   def string_PNumericType(_) ; @bld << 'Numeric' ; end
 
   # @api private
+  def string_PBinaryType(_)  ; @bld << 'Binary' ; end
+
+  # @api private
   def string_PIntegerType(t)
     append_array('Integer', t.unbounded?) { append_elements(range_array_part(t)) }
   end

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -134,8 +134,8 @@ class TypeParser
   # @api private
   def self.type_map
     @type_map ||= {
-       'integer'       => TypeFactory.integer,
-       'float'         => TypeFactory.float,
+        'integer'      => TypeFactory.integer,
+        'float'        => TypeFactory.float,
         'numeric'      => TypeFactory.numeric,
         'iterable'     => TypeFactory.iterable,
         'iterator'     => TypeFactory.iterator,
@@ -167,7 +167,7 @@ class TypeParser
         'typealias'    => TypeFactory.type_alias,
         'typereference' => TypeFactory.type_reference,
         'typeset'      => TypeFactory.type_set,
-      # A generic callable as opposed to one that does not accept arguments
+         # A generic callable as opposed to one that does not accept arguments
         'callable'     => TypeFactory.all_callables,
         'semver'       => TypeFactory.sem_ver,
         'semverrange'  => TypeFactory.sem_ver_range,

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -140,6 +140,7 @@ class TypeParser
         'iterable'     => TypeFactory.iterable,
         'iterator'     => TypeFactory.iterator,
         'string'       => TypeFactory.string,
+        'binary'       => TypeFactory.binary,
         'sensitive'    => TypeFactory.sensitive,
         'enum'         => TypeFactory.enum,
         'boolean'      => TypeFactory.boolean,

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -3226,6 +3226,7 @@ end
 
 require 'puppet/pops/pcore'
 
+require_relative 'puppet_object'
 require_relative 'annotatable'
 require_relative 'p_meta_type'
 require_relative 'p_object_type'
@@ -3236,5 +3237,6 @@ require_relative 'p_sensitive_type'
 require_relative 'p_type_set_type'
 require_relative 'p_timespan_type'
 require_relative 'p_timestamp_type'
+require_relative 'p_binary_type'
 require_relative 'type_set_reference'
 require_relative 'implementation_registry'

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -3230,7 +3230,6 @@ end
 
 require 'puppet/pops/pcore'
 
-require_relative 'puppet_object'
 require_relative 'annotatable'
 require_relative 'p_meta_type'
 require_relative 'p_object_type'

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2258,7 +2258,8 @@ class PArrayType < PCollectionType
           wrap ? [from] : from.to_a
 
         when PBinaryType::Binary
-          wrap ? [from] : from.binary_buffer.bytes
+          # For older rubies, the #bytes method returns an Enumerator that must be rolled out
+          wrap ? [from] : from.binary_buffer.bytes.to_a
 
         else
           if wrap

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2256,6 +2256,10 @@ class PArrayType < PCollectionType
           from
         when Hash
           wrap ? [from] : from.to_a
+
+        when PBinaryType::Binary
+          wrap ? [from] : from.binary_buffer.bytes
+
         else
           if wrap
             [from]

--- a/lib/puppet/syntax_checkers/base64.rb
+++ b/lib/puppet/syntax_checkers/base64.rb
@@ -1,0 +1,41 @@
+# A syntax checker for Base64.
+# @api public
+require 'puppet/syntax_checkers'
+require 'base64'
+class Puppet::SyntaxCheckers::Base64 < Puppet::Plugins::SyntaxCheckers::SyntaxChecker
+
+  # Checks the text for BASE64 syntax issues and reports them to the given acceptor.
+  # This checker allows the most relaxed form of Base64, including newlines and missing padding.
+  # It also accept URLsafe input.
+  #
+  # @param text [String] The text to check
+  # @param syntax [String] The syntax identifier in mime style (e.g. 'base64', 'text/xxx+base64')
+  # @param acceptor [#accept] A Diagnostic acceptor
+  # @param source_pos [Puppet::Pops::Adapters::SourcePosAdapter] A source pos adapter with location information
+  # @api public
+  #
+  def check(text, syntax, acceptor, source_pos)
+    raise ArgumentError.new("Base64 syntax checker: the text to check must be a String.") unless text.is_a?(String)
+    raise ArgumentError.new("Base64 syntax checker: the syntax identifier must be a String, e.g. json, data+json") unless syntax.is_a?(String)
+    raise ArgumentError.new("Base64 syntax checker: invalid Acceptor, got: '#{acceptor.class.name}'.") unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
+    cleaned_text = text.gsub(/[\r?\n[:blank:]]/, '')
+    begin
+      # Do a strict decode64 on text with all whitespace stripped since the non strict version
+      # simply skips all non base64 characters
+      Base64.strict_decode64(cleaned_text)
+    rescue => e
+      if (cleaned_text.bytes.size * 8) % 6 != 0
+        msg2 = "padding is not correct"
+      else
+        msg2 = "contains letters outside strict base 64 range (or whitespace)"
+      end
+      msg = "Base64 syntax checker: Cannot parse invalid Base64 string - #{msg2}"
+
+      # TODO: improve the pops API to allow simpler diagnostic creation while still maintaining capabilities
+      # and the issue code. (In this case especially, where there is only a single error message being issued).
+      #
+      issue = Puppet::Pops::Issues::issue(:ILLEGAL_BASE64) { msg }
+      acceptor.accept(Puppet::Pops::Validation::Diagnostic.new(:error, issue, source_pos.locator.file, source_pos, {}))
+    end
+  end
+end

--- a/lib/puppet/syntax_checkers/base64.rb
+++ b/lib/puppet/syntax_checkers/base64.rb
@@ -24,7 +24,7 @@ class Puppet::SyntaxCheckers::Base64 < Puppet::Plugins::SyntaxCheckers::SyntaxCh
       # simply skips all non base64 characters
       Base64.strict_decode64(cleaned_text)
     rescue => e
-      if (cleaned_text.bytes.size * 8) % 6 != 0
+      if (cleaned_text.bytes.to_a.size * 8) % 6 != 0
         msg2 = "padding is not correct"
       else
         msg2 = "contains letters outside strict base 64 range (or whitespace)"

--- a/lib/puppet/syntax_checkers/json.rb
+++ b/lib/puppet/syntax_checkers/json.rb
@@ -4,8 +4,6 @@ require 'puppet/syntax_checkers'
 class Puppet::SyntaxCheckers::Json < Puppet::Plugins::SyntaxCheckers::SyntaxChecker
 
   # Checks the text for JSON syntax issues and reports them to the given acceptor.
-  # This implementation is abstract, it raises {NotImplementedError} since a subclass should have implemented the
-  # method.
   #
   # Error messages from the checker are capped at 100 chars from the source text.
   #

--- a/lib/puppet/type/file/checksum.rb
+++ b/lib/puppet/type/file/checksum.rb
@@ -16,6 +16,7 @@ Puppet::Type.type(:file).newparam(:checksum) do
   end
 
   def sum(content)
+    content = content.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? content.binary_buffer : content
     type = digest_algorithm()
     "{#{type}}" + send(type, content)
   end

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -45,13 +45,13 @@ module Puppet
     munge do |value|
       if value == :absent
         value
-      elsif checksum?(value)
+      elsif value.is_a?(String) && checksum?(value)
         # XXX This is potentially dangerous because it means users can't write a file whose
-        # entire contents are a plain checksum
+        # entire contents are a plain checksum unless it is a Binary content.
         value
       else
-        @actual_content = value
-        resource.parameter(:checksum).sum(value)
+        @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value
+        resource.parameter(:checksum).sum(@actual_content)
       end
     end
 

--- a/spec/lib/puppet_spec/compiler.rb
+++ b/spec/lib/puppet_spec/compiler.rb
@@ -59,8 +59,12 @@ module PuppetSpec::Compiler
     logs
   end
 
-  def eval_and_collect_notices(code, node = Puppet::Node.new('foonode'))
+  def eval_and_collect_notices(code, node = Puppet::Node.new('foonode'), topscope_vars = {})
     collect_notices(code, node) do |compiler|
+      unless topscope_vars.empty?
+        scope = compiler.topscope
+        topscope_vars.each {|k,v| scope.setvar(k, v) }
+      end
       if block_given?
         compiler.compile do |catalog|
           yield(compiler.topscope, catalog)

--- a/spec/unit/functions/binary_file_spec.rb
+++ b/spec/unit/functions/binary_file_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+require 'puppet_spec/files'
+
+describe 'the binary_file function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+  include PuppetSpec::Files
+
+  def with_file_content(content)
+    path = tmpfile('find-file-function')
+    file = File.new(path, 'wb')
+    file.sync = true
+    file.print content
+    yield path
+  end
+
+  it 'reads an existing absolute file' do
+    with_file_content('one') do |one|
+      # Note that Binary to String produced Base64 encoded version of 'one' which is 'b23l'
+      expect(compile_to_catalog("notify { String(binary_file('#{one}')):}")).to have_resource("Notify[b25l]")
+    end
+  end
+
+  it 'errors on non existing files' do
+    expect do
+      with_file_content('one') do |one|
+        compile_to_catalog("notify { binary_file('#{one}/nope'):}")
+      end
+    end.to raise_error(/The given file '.*' does not exist/)
+  end
+
+  it 'reads an existing file in a module' do
+    with_file_content('binary_data') do |name|
+      mod = mock 'module'
+      mod.stubs(:file).with('myfile').returns(name)
+      Puppet[:code] = "notify { String(binary_file('mymod/myfile')):}"
+      node = Puppet::Node.new('localhost')
+      compiler = Puppet::Parser::Compiler.new(node)
+      compiler.environment.stubs(:module).with('mymod').returns(mod)
+      # Note that the Binary to string produces Base64 encoded version of 'binary_data' which is 'YmluYXJ5X2RhdGE='
+      expect(compiler.compile().filter { |r| r.virtual? }).to have_resource("Notify[YmluYXJ5X2RhdGE=]")
+    end
+  end
+end

--- a/spec/unit/functions/find_file_spec.rb
+++ b/spec/unit/functions/find_file_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+require 'puppet_spec/files'
+
+describe 'the find_file function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+  include PuppetSpec::Files
+
+  def with_file_content(content)
+    path = tmpfile('find-file-function')
+    file = File.new(path, 'wb')
+    file.sync = true
+    file.print content
+    yield path
+  end
+
+  it 'finds an existing absolute file when given arguments individually' do
+    with_file_content('one') do |one|
+      with_file_content('two') do |two|
+        expect(compile_to_catalog("notify { find_file('#{one}', '#{two}'):}")).to have_resource("Notify[#{one}]")
+      end
+    end
+  end
+
+  it 'skips non existing files' do
+    with_file_content('one') do |one|
+      with_file_content('two') do |two|
+        expect(compile_to_catalog("notify { find_file('#{one}/nope', '#{two}'):}")).to have_resource("Notify[#{two}]")
+      end
+    end
+  end
+
+  it 'accepts arguments given as an array' do
+    with_file_content('one') do |one|
+      with_file_content('two') do |two|
+        expect(compile_to_catalog("notify { find_file(['#{one}', '#{two}']):}")).to have_resource("Notify[#{one}]")
+      end
+    end
+  end
+
+  it 'finds an existing file in a module' do
+    with_file_content('file content') do |name|
+      mod = mock 'module'
+      mod.stubs(:file).with('myfile').returns(name)
+      Puppet[:code] = "notify { find_file('mymod/myfile'):}"
+      node = Puppet::Node.new('localhost')
+      compiler = Puppet::Parser::Compiler.new(node)
+      compiler.environment.stubs(:module).with('mymod').returns(mod)
+
+      expect(compiler.compile().filter { |r| r.virtual? }).to have_resource("Notify[#{name}]")
+    end
+  end
+
+  it 'returns undef when none of the paths were found' do
+    mod = mock 'module'
+    mod.stubs(:file).with('myfile').returns(nil)
+    Puppet[:code] = "notify { String(type(find_file('mymod/myfile', 'nomod/nofile'))):}"
+    node = Puppet::Node.new('localhost')
+    compiler = Puppet::Parser::Compiler.new(node)
+    # For a module that does not have the file
+    compiler.environment.stubs(:module).with('mymod').returns(mod)
+    # For a module that does not exist
+    compiler.environment.stubs(:module).with('nomod').returns(nil)
+
+    expect(compiler.compile().filter { |r| r.virtual? }).to have_resource("Notify[Undef]")
+  end
+end

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -488,6 +488,22 @@ describe 'the new function' do
         )).to have_resource(result)
       end
     end
+
+    it 'produces an array of byte integer values when given a Binary' do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = Array.new(Binary('ABC', '%s'))
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Array[Integer], [65, 66, 67]]')
+    end
+
+    it 'wraps a binary when given extra argument true' do
+      expect(compile_to_catalog(<<-MANIFEST
+        $x = Array[Any].new(Binary('ABC', '%s'), true)
+        notify { "${type($x, generalized)}, $x": }
+      MANIFEST
+      )).to have_resource('Notify[Array[Binary], [QUJD]]')
+    end
   end
 
   context 'when invoked on Tuple' do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1281,7 +1281,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       expect(parser.evaluate_string(scope, src)).to eq("Tex\tt\\n")
     end
 
-    it "parses syntax checked specification" do
+    it "parses json syntax checked specification" do
       src = <<-CODE
       @(END:json)
       ["foo", "bar"]
@@ -1290,13 +1290,31 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       expect(parser.evaluate_string(scope, src)).to eq('["foo", "bar"]')
     end
 
-    it "parses syntax checked specification with error and reports it" do
+    it "parses base64 syntax checked specification" do
+      src = <<-CODE
+      @(END:base64)
+        dGhlIHF1aWNrIHJlZCBmb3g=
+        |- END
+      CODE
+      expect(parser.evaluate_string(scope, src)).to eq('dGhlIHF1aWNrIHJlZCBmb3g=')
+    end
+
+    it "parses json syntax checked specification with error and reports it" do
       src = <<-CODE
       @(END:json)
       ['foo', "bar"]
       |- END
       CODE
       expect { parser.evaluate_string(scope, src)}.to raise_error(/Cannot parse invalid JSON string/)
+    end
+
+    it "parses base syntax checked specification with error and reports it" do
+      src = <<-CODE
+      @(END:base64)
+        dGhlIHF1aWNrIHJlZCBmb3g
+        |- END
+      CODE
+      expect { parser.evaluate_string(scope, src)}.to raise_error(/Cannot parse invalid Base64 string/)
     end
 
     it "parses interpolated heredoc expression" do

--- a/spec/unit/pops/types/p_binary_type_spec.rb
+++ b/spec/unit/pops/types/p_binary_type_spec.rb
@@ -13,21 +13,7 @@ describe 'Binary Type' do
       expect(t).to be_a(PBinaryType)
       expect(t).to eql(PBinaryType::DEFAULT)
     end
-
-    context 'when used in Puppet expressions' do
-
-        it 'the Binary type is equal to itself only' do
-          code = <<-CODE
-            $t = Binary
-            notice(Binary =~ Type[ Binary ])
-            notice(Binary == Binary)
-            notice(Binary < Binary)
-            notice(Binary > Binary)
-          CODE
-          expect(eval_and_collect_notices(code)).to eql(['true', 'true', 'false', 'false'])
-        end
-      end
-    end
+  end
 
   context 'a Binary instance' do
     it 'can be created from a Base64 encoded String using %s, string mode' do

--- a/spec/unit/pops/types/p_binary_type_spec.rb
+++ b/spec/unit/pops/types/p_binary_type_spec.rb
@@ -30,6 +30,15 @@ describe 'Binary Type' do
     end
 
   context 'a Binary instance' do
+    it 'can be created from a Base64 encoded String using %s, string mode' do
+      # the text 'binar' needs padding with '='
+      code = <<-CODE
+        $x = Binary('binary', '%s')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXJ5'])
+    end
+
     it 'can be created from a Base64 encoded String' do
       code = <<-CODE
         $x = Binary('YmluYXJ5')
@@ -38,7 +47,7 @@ describe 'Binary Type' do
       expect(eval_and_collect_notices(code)).to eql(['YmluYXJ5'])
     end
 
-    it 'can be created from a Base64 encoded String using %s, strict mode' do
+    it 'can be created from a Base64 encoded String using %B, strict mode' do
       # the text 'binar' needs padding with '='
       code = <<-CODE
         $x = Binary('YmluYXI=', '%B')

--- a/spec/unit/pops/types/p_binary_type_spec.rb
+++ b/spec/unit/pops/types/p_binary_type_spec.rb
@@ -196,6 +196,12 @@ describe 'Binary Type' do
       CODE
       expect(eval_and_collect_notices(code)).to eql(['true', 'true', 'false'])
     end
+
+    it "has a length method in ruby returning the length measured in bytes" do
+      # \u{1f452} is "woman's hat emoji - 4 bytes in UTF-8"
+      a_binary = PBinaryType::Binary.new("\u{1f452}")
+      expect(a_binary.length).to be(4)
+    end
   end
 
 end

--- a/spec/unit/pops/types/p_binary_type_spec.rb
+++ b/spec/unit/pops/types/p_binary_type_spec.rb
@@ -1,0 +1,197 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+
+module Puppet::Pops
+module Types
+describe 'Binary Type' do
+  include PuppetSpec::Compiler
+
+  context 'as a type' do
+    it 'can be created with the type factory' do
+      t = TypeFactory.binary()
+      expect(t).to be_a(PBinaryType)
+      expect(t).to eql(PBinaryType::DEFAULT)
+    end
+
+    context 'when used in Puppet expressions' do
+
+        it 'the Binary type is equal to itself only' do
+          code = <<-CODE
+            $t = Binary
+            notice(Binary =~ Type[ Binary ])
+            notice(Binary == Binary)
+            notice(Binary < Binary)
+            notice(Binary > Binary)
+          CODE
+          expect(eval_and_collect_notices(code)).to eql(['true', 'true', 'false', 'false'])
+        end
+      end
+    end
+
+  context 'a Binary instance' do
+    it 'can be created from a Base64 encoded String' do
+      code = <<-CODE
+        $x = Binary('YmluYXJ5')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXJ5'])
+    end
+
+    it 'can be created from a Base64 encoded String using %s, strict mode' do
+      # the text 'binar' needs padding with '='
+      code = <<-CODE
+        $x = Binary('YmluYXI=', '%B')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXI='])
+    end
+
+    it 'will error creation in strict mode if padding is missing' do
+      # the text 'binar' needs padding with '=' (missing here to trigger error
+      code = <<-CODE
+        $x = Binary('YmluYXI', '%B')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect{ eval_and_collect_notices(code) }.to raise_error(/invalid base64/)
+    end
+
+    it 'will not error creation in base mode if padding is missing' do
+      # the text 'binar' needs padding with '=' (missing here to trigger error
+      code = <<-CODE
+        $x = Binary('YmluYXI', '%b')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXI='])
+    end
+
+    it 'can be compared to another instance for equality' do
+      code = <<-CODE
+        $x = Binary('YmluYXJ5')
+        $y = Binary('YmluYXJ5')
+        notice($x == $y)
+        notice($x != $y)
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['true', 'false'])
+    end
+
+    it 'can be created from an array of byte values' do
+      # the text 'binar' needs padding with '='
+      code = <<-CODE
+        $x = Binary([251, 239, 255])
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['++//'])
+    end
+
+    it "can be created from an hash with value and format" do
+      # the text 'binar' needs padding with '='
+      code = <<-CODE
+        $x = Binary({value => '--__', format => '%u'})
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['++//'])
+    end
+
+    it "can be created from an hash with value and default format" do
+      # default format skips URL safe encoded chars (this is used to test that %b was selected
+      # by default.
+      code = <<-CODE
+        $x = Binary({value => '--__YmluYXJ5'})
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXJ5'])
+    end
+
+    it 'can be created from a hash with value being an array' do
+      # the text 'binar' needs padding with '='
+      code = <<-CODE
+        $x = Binary({value => [251, 239, 255]})
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['++//'])
+    end
+
+    it "can be created from an Base64 using URL safe encoding by specifying '%u' format'" do
+      # the text 'binar' needs padding with '='
+      code = <<-CODE
+        $x = Binary('--__', '%u')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['++//'])
+    end
+
+    it "when created with URL safe encoding chars in '%b' format, these are skipped" do
+      code = <<-CODE
+        $x = Binary('--__YmluYXJ5', '%b')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXJ5'])
+    end
+
+    it "will error in strict format if string contains URL safe encoded chars" do
+      code = <<-CODE
+        $x = Binary('--__YmluYXJ5', '%B')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect { eval_and_collect_notices(code) }.to raise_error(/invalid base64/)
+    end
+
+    [   '<',
+        '<=',
+        '>',
+        '>='
+    ].each do |op|
+      it "cannot be compared to another instance for magnitude using #{op}" do
+        code = <<-"CODE"
+          $x = Binary('YmluYXJ5')
+          $y = Binary('YmluYXJ5')
+          $x #{op} $y
+        CODE
+        expect { eval_and_collect_notices(code)}.to raise_error(/Comparison of: Binary #{op} Binary, is not possible/)
+      end
+    end
+
+
+
+      it 'can be matched against a Binary in case expression' do
+        code = <<-CODE
+          case Binary('YmluYXJ5') {
+            Binary('YWxpZW4='): {
+              notice('nope')
+            }
+            Binary('YmluYXJ5'): {
+              notice('yay')
+            }
+            default: {
+              notice('nope')
+            }
+          }
+        CODE
+        expect(eval_and_collect_notices(code)).to eql(['yay'])
+      end
+
+
+    it "can be matched against a Binary subsequence using 'in' expression" do
+      # finding 'one' in 'one two three'
+      code = <<-CODE
+        notice(Binary("b25l") in Binary("b25lIHR3byB0aHJlZQ=="))
+        notice(Binary("c25l") in Binary("b25lIHR3byB0aHJlZQ=="))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['true', 'false'])
+    end
+
+    it "can be matched against a byte value using 'in' expression" do
+      # finding 'e' (ascii 101) in 'one two three'
+      code = <<-CODE
+        notice(101 in Binary("b25lIHR3byB0aHJlZQ=="))
+        notice(101.0 in Binary("b25lIHR3byB0aHJlZQ=="))
+        notice(102 in Binary("b25lIHR3byB0aHJlZQ=="))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['true', 'true', 'false'])
+    end
+  end
+
+end
+end
+end

--- a/spec/unit/pops/types/p_binary_type_spec.rb
+++ b/spec/unit/pops/types/p_binary_type_spec.rb
@@ -161,25 +161,22 @@ describe 'Binary Type' do
       end
     end
 
-
-
-      it 'can be matched against a Binary in case expression' do
-        code = <<-CODE
-          case Binary('YmluYXJ5') {
-            Binary('YWxpZW4='): {
-              notice('nope')
-            }
-            Binary('YmluYXJ5'): {
-              notice('yay')
-            }
-            default: {
-              notice('nope')
-            }
+    it 'can be matched against a Binary in case expression' do
+      code = <<-CODE
+        case Binary('YmluYXJ5') {
+          Binary('YWxpZW4='): {
+            notice('nope')
           }
-        CODE
-        expect(eval_and_collect_notices(code)).to eql(['yay'])
-      end
-
+          Binary('YmluYXJ5'): {
+            notice('yay')
+          }
+          default: {
+            notice('nope')
+          }
+        }
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['yay'])
+    end
 
     it "can be matched against a Binary subsequence using 'in' expression" do
       # finding 'one' in 'one two three'

--- a/spec/unit/pops/types/p_binary_type_spec.rb
+++ b/spec/unit/pops/types/p_binary_type_spec.rb
@@ -66,12 +66,21 @@ describe 'Binary Type' do
     end
 
     it 'will not error creation in base mode if padding is missing' do
-      # the text 'binar' needs padding with '=' (missing here to trigger error
+      # the text 'binar' needs padding with '=' (missing here to trigger possible error)
       code = <<-CODE
         $x = Binary('YmluYXI', '%b')
         notice(assert_type(Binary, $x))
       CODE
       expect(eval_and_collect_notices(code)).to eql(['YmluYXI='])
+    end
+
+    it 'will not error creation in base mode if padding is not required' do
+      # the text 'binary' does not need padding with '='
+      code = <<-CODE
+        $x = Binary('YmluYXJ5', '%b')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXJ5'])
     end
 
     it 'can be compared to another instance for equality' do

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -937,7 +937,7 @@ describe 'The string converter' do
 
     it '%#s formats as quoted string with escaped non printable bytes' do
       string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => '%#s'}
-      expect(converter.convert(binary.from_base64("apa"), string_formats)).to eq("\"j\\x96\"")
+      expect(converter.convert(binary.from_base64("apa="), string_formats)).to eq("\"j\\x96\"")
     end
 
     { "%s"    => 'binary',

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -5,6 +5,7 @@ describe 'The string converter' do
   let(:converter) { Puppet::Pops::Types::StringConverter.singleton }
   let(:factory) { Puppet::Pops::Types::TypeFactory }
   let(:format) { Puppet::Pops::Types::StringConverter::Format }
+  let(:binary) { Puppet::Pops::Types::PBinaryType::Binary }
 
   describe 'helper Format' do
     it 'parses a single character like "%d" as a format' do
@@ -900,6 +901,81 @@ describe 'The string converter' do
       string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => "%k"}
       converter.convert(/.*/, string_formats)
       end.to raise_error(/Illegal format 'k' specified for value of Regexp type - expected one of the characters 'rsp'/)
+    end
+  end
+
+  context 'when converting binary' do
+    let(:sample) { binary.from_binary_string('binary') }
+
+    it 'the binary is converted to strict base64 string unquoted by default (same as %B)' do
+      expect(converter.convert(sample, :default)).to eq("YmluYXJ5")
+    end
+
+    it 'the binary is converted using %p by default when contained in an array' do
+      expect(converter.convert([sample], :default)).to eq("[Binary(\"YmluYXJ5\")]")
+    end
+
+    it '%B formats in base64 strict mode (same as default)' do
+      string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => '%B'}
+      expect(converter.convert(sample, string_formats)).to eq("YmluYXJ5")
+    end
+
+    it '%b formats in base64 relaxed mode, and adds newline' do
+      string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => '%b'}
+      expect(converter.convert(sample, string_formats)).to eq("YmluYXJ5\n")
+    end
+
+    it '%u formats in base64 urlsafe mode' do
+      string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => '%u'}
+      expect(converter.convert(binary.from_base64("++//"), string_formats)).to eq("--__")
+    end
+
+    it '%p formats with type name' do
+      string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => '%p'}
+      expect(converter.convert(sample, string_formats)).to eq("Binary(\"YmluYXJ5\")")
+    end
+
+    it '%#s formats as quoted string with escaped non printable bytes' do
+      string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => '%#s'}
+      expect(converter.convert(binary.from_base64("apa"), string_formats)).to eq("\"j\\x96\"")
+    end
+
+    { "%s"    => 'binary',
+      "%#s"   => '"binary"',
+      "%8s"   => '  binary',
+      "%.2s"  => 'bi',
+      "%-8s"  => 'binary  ',
+      "%p"    => 'Binary("YmluYXJ5")',
+      "%10p"  => 'Binary("  YmluYXJ5")',
+      "%-10p" => 'Binary("YmluYXJ5  ")',
+      "%.2p"  => 'Binary("Ym")',
+      "%b"    => "YmluYXJ5\n",
+      "%11b"  => "  YmluYXJ5\n",
+      "%-11b" => "YmluYXJ5\n  ",
+      "%.2b"  => "Ym",
+      "%B"    => "YmluYXJ5",
+      "%11B"  => "   YmluYXJ5",
+      "%-11B" => "YmluYXJ5   ",
+      "%.2B"  => "Ym",
+      "%u"    => "YmluYXJ5",
+      "%11u"  => "   YmluYXJ5",
+      "%-11u" => "YmluYXJ5   ",
+      "%.2u"  => "Ym",
+      "%t"    => 'Binary',
+      "%#t"   => '"Binary"',
+      "%8t"   => '  Binary',
+      "%-8t"  => 'Binary  ',
+      "%.3t"  => 'Bin',
+      "%T"    => 'BINARY',
+      "%#T"   => '"BINARY"',
+      "%8T"   => '  BINARY',
+      "%-8T"  => 'BINARY  ',
+      "%.3T"  => 'BIN',
+    }.each do |fmt, result |
+      it "the format #{fmt} produces #{result}" do
+        string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => fmt}
+        expect(converter.convert(sample, string_formats)).to eq(result)
+      end
     end
   end
 

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -940,6 +940,19 @@ describe 'The string converter' do
       expect(converter.convert(binary.from_base64("apa="), string_formats)).to eq("\"j\\x96\"")
     end
 
+    it '%s formats as unquoted string with valid UTF-8 chars' do
+      string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => '%s'}
+      # womans hat emoji is E318, a three byte UTF-8 char EE 8C 98
+      expect(converter.convert(binary.from_binary_string("\xEE\x8C\x98"), string_formats)).to eq("\uE318")
+    end
+
+    it '%s errors if given non UTF-8 bytes' do
+      string_formats = { Puppet::Pops::Types::PBinaryType::DEFAULT => '%s'}
+      expect {
+        converter.convert(binary.from_base64("apa="), string_formats)
+      }.to raise_error(Encoding::UndefinedConversionError)
+    end
+
     { "%s"    => 'binary',
       "%#s"   => '"binary"',
       "%8s"   => '  binary',

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -214,6 +214,12 @@ describe 'The type calculator' do
       end
     end
 
+    context 'binary' do
+      it 'translates to PBinaryType' do
+        expect(calculator.infer(PBinaryType::Binary.from_binary_string("binary")).class).to eq(PBinaryType)
+      end
+    end
+
     context 'version' do
       it 'translates to PVersionType' do
         expect(calculator.infer(Semantic::Version.new(1,0,0)).class).to eq(PSemVerType)


### PR DESCRIPTION
This adds a Binary type to the type system along with language operations. This PR also contains a function that reads a file in binary mode and returns the content as a Binary. PR also has exploratory work for setting the content of a File to be Binary, and to make this work for a puppet apply.

What remains to make the Binary type useful is the ability to include it in a catalog (i.e. basically serialization).