### PR TITLE
(maint) Add ruby-head to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
 notifications:
   email: false
 rvm:
+  - ruby-head
   - 2.3.1
   - 2.2.4
   - 2.1.7
@@ -21,6 +22,8 @@ env:
 
 matrix:
   exclude:
+    - rvm: ruby-head
+      env: "CHECK=rubocop"
     - rvm: 2.3.1
       env: "CHECK=rubocop"
     - rvm: 2.2.4
@@ -29,6 +32,8 @@ matrix:
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
+    - rvm: ruby-head
+      env: "CHECK=commits"
     - rvm: 2.3.1
       env: "CHECK=commits"
     - rvm: 2.2.4


### PR DESCRIPTION
We might not want to include this so early in the year just because it chews up bandwidth, but I was curious to see how it behaved given that 2.4.0-preview1 was tagged: https://www.ruby-lang.org/en/news/2016/06/20/ruby-2-4-0-preview1-released/.