### PR TITLE
(PUP-6398) Executing parallel specs on Windows is not reliable

### DIFF
--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -9,7 +9,7 @@
 # in /var/db/.puppet_pkgdmg_installed_<name>
 
 require 'puppet/provider/package'
-require 'puppet/util/plist' if Puppet.features.cfpropertylist?
+require 'puppet/util/plist'
 require 'puppet/util/http_proxy'
 
 Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Package do

--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -1,4 +1,4 @@
-require 'puppet/util/plist' if Puppet.features.cfpropertylist?
+require 'puppet/util/plist'
 Puppet::Type.type(:service).provide :launchd, :parent => :base do
   desc <<-'EOT'
     This provider manages jobs with `launchd`, which is the default service

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -1,4 +1,4 @@
-require 'cfpropertylist'
+require 'cfpropertylist' if Puppet.features.cfpropertylist?
 require 'puppet/util/execution'
 
 module Puppet::Util::Plist

--- a/spec/unit/module_tool/applications/installer_spec.rb
+++ b/spec/unit/module_tool/applications/installer_spec.rb
@@ -4,6 +4,8 @@ require 'puppet_spec/module_tool/shared_functions'
 require 'puppet_spec/module_tool/stub_source'
 require 'semver'
 
+require 'tmpdir'
+
 describe Puppet::ModuleTool::Applications::Installer do
   include PuppetSpec::ModuleTool::SharedFunctions
   include PuppetSpec::Files
@@ -30,6 +32,13 @@ describe Puppet::ModuleTool::Applications::Installer do
     SemanticPuppet::Dependency.clear_sources
     installer = Puppet::ModuleTool::Applications::Installer.any_instance
     installer.stubs(:module_repository).returns(remote_source)
+  end
+
+  if Puppet.features.microsoft_windows?
+    before :each do
+      Puppet.settings.stubs(:[])
+      Puppet.settings.stubs(:[]).with(:module_working_dir).returns(Dir.mktmpdir('installertmp'))
+    end
   end
 
   def installer(modname, target_dir, options)
@@ -358,6 +367,6 @@ describe Puppet::ModuleTool::Applications::Installer do
         end
       end
     end
-
   end
+
 end

--- a/spec/unit/module_tool/applications/unpacker_spec.rb
+++ b/spec/unit/module_tool/applications/unpacker_spec.rb
@@ -14,7 +14,8 @@ describe Puppet::ModuleTool::Applications::Unpacker do
   let(:working_dir) { tmpdir("working_dir") }
 
   before :each do
-    Puppet.settings[:module_working_dir] = working_dir
+    Puppet.settings.stubs(:[])
+    Puppet.settings.stubs(:[]).with(:module_working_dir).returns(working_dir)
   end
 
   it "should attempt to untar file to temporary location" do

--- a/spec/unit/module_tool/applications/upgrader_spec.rb
+++ b/spec/unit/module_tool/applications/upgrader_spec.rb
@@ -3,6 +3,7 @@ require 'puppet/module_tool/applications'
 require 'puppet_spec/module_tool/shared_functions'
 require 'puppet_spec/module_tool/stub_source'
 require 'semver'
+require 'tmpdir'
 
 describe Puppet::ModuleTool::Applications::Upgrader do
   include PuppetSpec::ModuleTool::SharedFunctions
@@ -29,6 +30,13 @@ describe Puppet::ModuleTool::Applications::Upgrader do
     SemanticPuppet::Dependency.clear_sources
     installer = Puppet::ModuleTool::Applications::Upgrader.any_instance
     installer.stubs(:module_repository).returns(remote_source)
+  end
+
+  if Puppet.features.microsoft_windows?
+    before :each do
+      Puppet.settings.stubs(:[])
+      Puppet.settings.stubs(:[]).with(:module_working_dir).returns(Dir.mktmpdir('upgradertmp'))
+    end
   end
 
   def upgrader(name, options = {})

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -438,13 +438,13 @@ EOF
 
     it 'should raise an error on non-zero pacman exit without a filter' do
       executor.expects(:open).with('| /usr/bin/pacman -Sgg 2>&1').returns 'error!'
-      $CHILD_STATUS.stubs(:exitstatus).returns 1
+      Puppet::Util::Execution.expects(:exitstatus).returns 1
       expect { described_class.get_installed_groups(installed_packages) }.to raise_error(Puppet::ExecutionFailure, 'error!')
     end
 
     it 'should return empty groups on non-zero pacman exit with a filter' do
       executor.expects(:open).with('| /usr/bin/pacman -Sgg git 2>&1').returns ''
-      $CHILD_STATUS.stubs(:exitstatus).returns 1
+      Puppet::Util::Execution.expects(:exitstatus).returns 1
       expect(described_class.get_installed_groups(installed_packages, 'git')).to eq({})
     end
 
@@ -452,7 +452,7 @@ EOF
       pipe = stub()
       pipe.expects(:each_line)
       executor.expects(:open).with('| /usr/bin/pacman -Sgg 2>&1').yields(pipe).returns ''
-      $CHILD_STATUS.stubs(:exitstatus).returns 0
+      Puppet::Util::Execution.expects(:exitstatus).returns 0
       expect(described_class.get_installed_groups(installed_packages)).to eq({})
     end
 
@@ -460,7 +460,7 @@ EOF
       pipe = stub()
       pipe.expects(:each_line).multiple_yields(*groups)
       executor.expects(:open).with('| /usr/bin/pacman -Sgg 2>&1').yields(pipe).returns ''
-      $CHILD_STATUS.stubs(:exitstatus).returns 0
+      Puppet::Util::Execution.expects(:exitstatus).returns 0
       expect(described_class.get_installed_groups(installed_packages)).to eq({'foo' => 'package1 1.0, package2 2.0'})
     end
   end

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -5,6 +5,12 @@ describe Puppet::Type.type(:package).provider(:pkg) do
   let (:resource) { Puppet::Resource.new(:package, 'dummy', :parameters => {:name => 'dummy', :ensure => :latest}) }
   let (:provider) { described_class.new(resource) }
 
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   before :each do
     described_class.stubs(:command).with(:pkg).returns('/bin/pkg')
   end

--- a/spec/unit/provider/package/pkgdmg_spec.rb
+++ b/spec/unit/provider/package/pkgdmg_spec.rb
@@ -1,9 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-module Puppet::Util::Plist
-end
-
 describe Puppet::Type.type(:package).provider(:pkgdmg) do
   let(:resource) { Puppet::Type.type(:package).new(:name => 'foo', :provider => :pkgdmg) }
   let(:provider) { described_class.new(resource) }

--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -17,6 +17,12 @@ describe "base service provider" do
 
   subject { provider }
 
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   context "basic operations" do
     subject do
       type.new(

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -9,6 +9,12 @@ provider_class = Puppet::Type.type(:service).provider(:debian)
 
 describe provider_class do
 
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   before(:each) do
     # Create a mock resource
     @resource = stub 'resource'

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -4,6 +4,12 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:gentoo) do
 
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     FileTest.stubs(:file?).with('/sbin/rc-update').returns true

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -6,6 +6,13 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:init) do
+
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   before do
     Puppet::Type.type(:service).defaultprovider = described_class
   end

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -12,6 +12,12 @@ describe Puppet::Type.type(:service).provider(:launchd) do
   let (:launchd_overrides_10_) { '/var/db/com.apple.xpc.launchd/disabled.plist' }
   subject { resource.provider }
 
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   describe "the type interface" do
     %w{ start stop enabled? enable disable status}.each do |method|
       it { is_expected.to respond_to method.to_sym }

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -4,6 +4,12 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:openrc) do
 
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     ['/sbin/rc-service', '/bin/rc-status', '/sbin/rc-update'].each do |command|

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -9,6 +9,12 @@ provider_class = Puppet::Type.type(:service).provider(:src)
 
 describe provider_class do
 
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   before :each do
     @resource = stub 'resource'
     @resource.stubs(:[]).returns(nil)

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -5,6 +5,13 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:systemd) do
+
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     described_class.stubs(:which).with('systemctl').returns '/bin/systemctl'

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -7,6 +7,12 @@ describe Puppet::Type.type(:service).provider(:upstart) do
   let(:start_on_default_runlevels) {  "\nstart on runlevel [2,3,4,5]" }
   let(:provider_class) { Puppet::Type.type(:service).provider(:upstart) }
 
+  if Puppet.features.microsoft_windows?
+    # Get a pid for $CHILD_STATUS to latch on to
+    command = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  end
+
   def given_contents_of(file, content)
     File.open(file, 'w') do |file|
       file.write(content)

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -311,7 +311,7 @@ describe Puppet::Util::Execution do
 
           Puppet::Util::Execution.stubs(:execute_windows).returns(proc_info_stub)
           stub_process_wait(real_exit_status)
-          $CHILD_STATUS.stubs(:exitstatus).returns(real_exit_status % 256) # The exitstatus is changed to be mod 256 so that ruby can fit it into 8 bits.
+          Puppet::Util::Execution.stubs(:exitstatus).returns(real_exit_status % 256) # The exitstatus is changed to be mod 256 so that ruby can fit it into 8 bits.
 
           expect(Puppet::Util::Execution.execute('test command', :failonfail => false).exitstatus).to eq(real_exit_status)
         end


### PR DESCRIPTION
Previously, executing rake parallel:spec on Windows would fail,
even when passing on other platforms.  The thought was that the
tests may improperly share state or the like on Windows.

This PR makes changes in three parts.  

One commit resolves puppet/util/plist namespace issues in a few 
spec tests by removing the require dependency on a 
Puppet.features.cfpropertylist? conditional in the corresponding 
lib/provider file.  The conditional is moved into plist.rb.  This brings 
extra code into scope, but the tests in question no longer rely on a 
separate test to bring in puppet/util/plist.  Alternatively, we could declare 
Puppet::Util::Plist namespace in each test. 

The second commit makes the following changes:

* Fixes colliding directory read/writes in installer_spec and
    upgrader_spec by stubbing Puppet.settings[:module_working_dir]
    to a new directory before each test in installer_spec and in
    upgrader_spec.

    unpacker_spec was changed to follow a similar pattern due to
    discussion about Puppet settings maybe becoming immutable after
    first load in the future.

* Guards the "when adding users and groups to the catalog" describe
    block in settings_spec on Windows.  Previously, settings_spec
    would fail on two iterations of the path_to_uri() call in
    puppet/util.rb due to the Windows platform check being
    stubbed to false. So the statement:

    path = '/' + path

    would not be executed and URI::Generic.build(params) call
    would fail to parse the path with an "Expected absolute path"
    error.

    However, there were some tests in the block that passed
    vacuously on Windows, so Windows-specific versions of those
    tests were moved into the "on Microsoft Windows" describe
    block, which already had a test related to adding users and
    groups to catalogs.

The third makes the following changes:

On Windows, $CHILD_STATUS is nil while the tests in
spec/unit/provider/service/*.rb. and pkg_spec are running.
This results in a "Can't modify frozen object"
runtime error.  However, the tests are able to pass
when run serially with the tests in capability_spec, for
example. The reason being, some tests in capability_spec
make a compile_to_catalog() call which, as a side
effect, generates a pid.  $CHILD_STATUS is able to
latch on to this pid, resolving the issue.

The bug shows up when the tests are run in isolation or in
parallel (on occasion, when the tests are grouped in
such a way and executed in such an order that
$CHILD_STATUS is not properly set by another test before
these tests run).

* Replaces $CHILD_STATUS.exitstatus calls with stubbed / mocked
    Puppet::Util::Execution.exitstatus calls in execution_spec
    and pacman_spec

* In the other specs, it generates a pid for $CHILD_STATUS by
    spinning up a process.

    The previous strategy does not work for these files because
    they call into $CHILD_STATUS in lib/provider files, not just
    in the specs. And, Puppet::Util::Execution.exitstatus is a
    private class method, so that it  is not possible to outright
    replace these $CHILD_STATUS.exitstatus calls.  This may be
    resolved with some refactoring in the future.

    Also, require 'English' does not set $CHILD_STATUS on
    Windows as it does on other platforms.  After requiring,
    $CHILD_STATUS (and $?) is still nil.