### PR TITLE
(PUP-1498) scheduled_task test fixes

### DIFF
--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -34,11 +34,11 @@ agents.each do |agent|
   on agent, "schtasks.exe /query /tn #{name} /xml" do
     xml = REXML::Document.new(stdout)
 
-    command =  xml.root.elements['//Actions/Exec/Command/text()']
-    arguments = xml.root.elements['//Actions/Exec/Arguments/text()']
+    command =  xml.root.elements['//Actions/Exec/Command/text()'].value
+    arguments = xml.root.elements['//Actions/Exec/Arguments/text()'].value
 
     assert_match('c:\\windows\\system32\\notepad2.exe', command)
-    assert_match('args-#{verylongstring}', arguments)
+    assert_match("args-#{verylongstring}", arguments)
   end
 
   step "delete the task"

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -226,6 +226,12 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   def flush
     unless resource[:ensure] == :absent
       self.fail('Parameter command is required.') unless resource[:command]
+      # HACK: even though the user may actually be insync?, for task changes to
+      # fully propagate, it is necessary to explicitly set the user for the task,
+      # even when it is SYSTEM (and has a nil password)
+      # this is a Windows security feature with the v1 COM APIs that prevent
+      # arbitrary reassignment of a task scheduler command to run as SYSTEM
+      # without the authorization to do so
       self.user = resource[:user]
       task.save
       @task = nil


### PR DESCRIPTION
 - PR #5038 was accidentally merged out of order from #5036
   and dragged in some almost, but not quite complete changes for
   PUP-1498 that were still in progress.

 - This commit adds the changes needed to make the test pass properly
   and adds some additional notes about usage of the
   Win32::TaskScheduler API