### PR TITLE
(PUP-6094) puppet --help should show help

### DIFF
--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -81,7 +81,11 @@ module Puppet
 
       def find_subcommand
         if subcommand_name.nil?
-          NilSubcommand.new(self)
+          if args.include?("--help") || args.include?("-h")
+            ApplicationSubcommand.new("help", CommandLine.new("puppet", ["help"]))
+          else
+            NilSubcommand.new(self)
+          end
         elsif Puppet::Application.available_application_names.include?(subcommand_name)
           ApplicationSubcommand.new(subcommand_name, self)
         elsif path_to_subcommand = external_subcommand

--- a/spec/unit/util/command_line_spec.rb
+++ b/spec/unit/util/command_line_spec.rb
@@ -66,6 +66,17 @@ describe Puppet::Util::CommandLine do
         end.to have_printed(/^#{Regexp.escape(Puppet.version)}$/)
       end
     end
+
+    %w{--help -h}.each do|arg|
+      it "should print help" do
+        commandline = Puppet::Util::CommandLine.new("puppet", [arg])
+        commandline.expects(:exec).never
+
+        expect {
+          commandline.execute
+        }.to have_printed(/Usage: puppet <subcommand> \[options\] <action> \[options\]/).and_exit_with(0)
+      end
+    end
   end
 
   describe "when dealing with puppet commands" do


### PR DESCRIPTION
Previously, calling `puppet --help` would generate an error, because the
absence of a subcommand meant we created a NilSubcommand with an arg
count greater than 0:

    Error: Could not parse application options: invalid option: --help

This commit alters the `find_subcommand` logic so that if a subcommand
is not specified, but --help or -h are, then we return an
ApplicationSubcommand for the `help` application. The result is the same
as if the user had typed `puppet help`, and will show global help for
all installed applications.

Since we return an ApplicationSubcommand and the subcommand is not agent
or master, we update the $LOAD_PATH allowing puppet to return help for
applications in modules. So the behavior of --help vs puppet help is the
same.