### PR TITLE
(PUP-6425) Handle errors when generating legacy app help

### DIFF
--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -163,7 +163,7 @@ Detail: "#{detail.message}"
         end
       end
     rescue StandardError
-      result << [ "! #{appname}", "! Subcommand unavailable due to error. Check error logs." ]
+      return "! Subcommand unavailable due to error. Check error logs."
     end
     return ''
   end

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -84,6 +84,12 @@ describe Puppet::Face[:help, '0.0.1'] do
       end
     end
 
+    it "returns an 'unavailable' summary if the 'agent' application fails to generate help" do
+      Puppet::Application['agent'].class.any_instance.stubs(:help).raises(ArgumentError, "whoops")
+
+      expect(subject).to match(/agent\s+! Subcommand unavailable due to error\. Check error logs\./)
+    end
+
     context "face summaries" do
       it "can generate face summaries" do
         faces = Puppet::Face.faces


### PR DESCRIPTION
Previously, if a legacy app raised a StandardError when generating help,
puppet would try to append to the `results` variable that wasn't in
scope:

    Error: undefined local variable or method `result'

This commit modifies the method to return the summary message. The
caller appends the appname and summary message to the `puppet help`
output.