### PR TITLE
(PUP-1512) Display error message if we can't display app help

### DIFF
--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -163,7 +163,7 @@ Detail: "#{detail.message}"
         end
       end
     rescue StandardError
-      result << [ "! #{appname}", "! Subcommand unavailable due to error. Check error logs." ]
+      return "! Subcommand unavailable due to error. Check error logs."
     end
     return ''
   end

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -84,6 +84,12 @@ describe Puppet::Face[:help, '0.0.1'] do
       end
     end
 
+    it "returns an 'unavailable' summary if the 'agent' application fails to generate help" do
+      Puppet::Application['agent'].class.any_instance.stubs(:help).raises(ArgumentError, "whoops")
+
+      expect(subject).to match(/agent\s+! Subcommand unavailable due to error\. Check error logs\./)
+    end
+
     context "face summaries" do
       it "can generate face summaries" do
         faces = Puppet::Face.faces


### PR DESCRIPTION
Previously `puppet help` could output nothing if one of the legacy or face-based applications raised an exception that the `help` app wasn't prepared to handle. This often could happen if you installed a module containing an app that had a gem dependency that wasn't installed, e.g. puppet-strings depends on yard, but that's not part of puppet-agent.

The behavior could occur in different ways, because the help application's exception handling wasn't consistent. When getting a listing of all apps via `puppet help`:

 * if a face app raised something other than Puppet::Error
 * if a legacy app raised a LoadError, like puppet-strings

When getting help for a particular app via `puppet help <app>`:

  * if a face app raised something other than Puppet::Error
  * if a legacy app raised anything

This commit modifies the `help` application to consistently rescue StandardError and LoadError. Since Puppet::Error and ArgumentError are both StandardErrors, we'll continue catching everything we were previously, but we don't go so far as to catch all Exceptions. See related PUP-3521 and eccd3b.