### PR TITLE
(PUP-3182) Call Indirection#save with the correct arguments

### DIFF
--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -123,7 +123,7 @@ Puppet::Indirector::Face.define(:catalog, '0.0.1') do
 
       Puppet::Resource::Catalog.indirection.terminus_class = :yaml
       Puppet::Face[:catalog, "0.0.1"].save(catalog)
-      Puppet.notice "Saved catalog for #{Puppet[:certname]} to yaml"
+      Puppet.notice "Saved catalog for #{Puppet[:certname]} to #{Puppet::Resource::Catalog.indirection.terminus.path(Puppet[:certname])}"
       nil
     end
   end

--- a/lib/puppet/indirector/face.rb
+++ b/lib/puppet/indirector/face.rb
@@ -39,7 +39,12 @@ class Puppet::Indirector::Face < Puppet::Face
 
   def call_indirection_method(method, key, options)
     begin
-      result = indirection.__send__(method, key, options)
+      if method == :save
+        # key is really the instance to save
+        result = indirection.__send__(method, key, nil, options)
+      else
+        result = indirection.__send__(method, key, options)
+      end
     rescue => detail
       message = "Could not call '#{method}' on '#{indirection_name}': #{detail}"
       Puppet.log_exception(detail, message)

--- a/spec/unit/indirector/face_spec.rb
+++ b/spec/unit/indirector/face_spec.rb
@@ -40,16 +40,24 @@ describe Puppet::Indirector::Face do
   end
 
   [:find, :search, :save, :destroy].each do |method|
+    def params(method, options)
+      if method == :save
+        [nil, options]
+      else
+        [options]
+      end
+    end
+
     it "should define a '#{method}' action" do
       expect(Puppet::Indirector::Face).to be_action(method)
     end
 
     it "should call the indirection method with options when the '#{method}' action is invoked" do
-      subject.indirection.expects(method).with(:test, {})
+      subject.indirection.expects(method).with(:test, *params(method, {}))
       subject.send(method, :test)
     end
     it "should forward passed options" do
-      subject.indirection.expects(method).with(:test, {'one'=>'1'})
+      subject.indirection.expects(method).with(:test, *params(method, {'one'=>'1'}))
       subject.send(method, :test, :extra => {'one'=>'1'})
     end
   end


### PR DESCRIPTION
Previously, `puppet catalog download` failed with an obscure error:

    Instance name "<hostname>" does not match requested key {}

The problem occurred because Puppet::Indirector::Face called
Puppet::Indirector::Indirection#save(key, options) with the wrong set of
arguments. The save method expects to be called with:

    def save(instance, key = nil, options={})

Note how the instance to save should be the first argument, key is the
second, and options is optional. But Face was passing key as the instance,
and options as the key, leading to "does not match requested key".

The code originally worked in 2.7.x, but passing options never worked
correctly for any face application. During a security event, we added
validation to the Indirection methods, ensuring the instance being
passed in matched the key that the client was authorized for[1]. So for
example, you can't be authorized to send a report, but send something
else in the body of the request. This change was made in
f877cf5d63ea4b6d3bc110af6212e5187f900ee9, and released in 3.1.1, but
broke saving face-related models.

This commit modifies Puppet::Indirector::Face to call the save method
with the correct arguments. It also updates `puppet catalog download`
to output where the catalog was downloaded to:

    Notice: Saved catalog for <host> to /opt/puppetlabs/puppet/cache/client_yaml/catalog/<host>.yaml

[1] http://projects.puppetlabs.com/issues/19392