### PR TITLE
(WIP)(PUP-5359) scheduled_task can't use 'last'

### DIFF
--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -420,6 +420,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
 
     days = [days] unless days.is_a?(Array)
     days.each do |day|
+      # TODO: it appears that 'last' doesn't work with v1 tasks (easy to repro in the MMC task UI)
       # The special "day" of 'last' is represented by day "number"
       # 32. 'last' has the special meaning of "the last day of the
       # month", no matter how many days there are in the month.


### PR DESCRIPTION
- TODO: add some docs / notices about usage of 'last'

Note the following manifest works with 28, but uncomment the line that
uses 'last' in the schedule and watch it explode.

```puppet
 scheduled_task { 'Test-Task':
   ensure  => 'present',
   command => "C:\windows\system32\notepad.exe",
   enabled => true,
   trigger => {
     schedule => monthly,
     on => [1,3,17,28],
     start_time => '08:00',
     months => [1, 3, 5]
   }
 }
```

The returned HRESULT for the SetTrigger call is -2147024809.:  The parameter is incorrect
