### PR TITLE
(PUP-5982) acceptance: add test case for parser validate

### DIFF
--- a/acceptance/fixtures/manifest_large_exported_classes_node.pp
+++ b/acceptance/fixtures/manifest_large_exported_classes_node.pp
@@ -1,0 +1,65 @@
+class foo ($bar) {
+  @@notify { 'foo': }
+}
+@@file { "somedir/${name}_${munin_port_real}":
+  ensure => present,
+  content => template("munin/defaultclient.erb"),
+}
+# Collect all exported files
+File <<||>>
+
+# Compile the munin.conf with a local header
+concatenated_file { "/etc/munin/munin.conf":
+    dir => somedir,
+    header => "/etc/munin/munin.conf.header",
+}
+hosting_vserver_configuration {
+    "davids":
+        domain => "black.co.at",
+        type => "friend",
+        context => 13,
+        ip => "83.64.231.75", prefix => 27,
+        admin_user => "david", admin_user_name => "David Schmitt",
+        admin_user_email => "david@black.co.at",
+        customer => "David Schmitt",
+        admin_password => file("/etc/puppet/secrets/hosting/davids_admin_password"),
+}
+class davids_black_co_at {
+    ## Create users for my parents and my grandmother
+    hosting::user {
+        rztt: realname => "Gerhard Schmitt",
+            uid => 2001, admin => true;
+        conny: realname => "Conny Schmitt",
+            uid => 2002;
+        oma: realname => "Oma Schmitt",
+            uid => 2003;
+    }
+
+    # Install git.black.co.at
+    include git::daemon
+    include git::web
+    git::web::export { [manifests, "puppet-trunk"]: }
+
+    # Provision an additional mysql database on the database server
+    hosting::database { "fogbugz": type => mysql }
+    # Create another VirtualHost
+    apache2::site { "local-fogbugz":
+        source => "puppet://$servername/files/hosting/davids/sites/local-fogbugz"
+    }
+}
+node backuppc {
+        # only use the smarthost
+        $mta = ssmtp
+        # this is a vserver on this host, so register correctly in nagios
+        $nagios_parent = "ic.black.co.at"
+        # I'm sharing an IP here, so those things have to have their own ports
+        $apache2_port = 8080
+        $munin_port = 5008
+        $munin_stats_port = 8667
+
+        # default configuration
+        include dbp
+
+        # configure the backuppc server
+        include backuppc::server
+}

--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -397,6 +397,13 @@ module Puppet
       end
       module_function :mk_tmp_environment_with_teardown
 
+      # create sitepp in a tmp_environment as created by mk_tmp_environment_with_teardown
+      def create_sitepp(host, tmp_environment, file_content)
+        file_path = File.join('','tmp',tmp_environment,'manifests','site.pp')
+        create_remote_file(host, file_path, file_content)
+        on host, "chmod -R 755 #{file_path}"
+      end
+
     end
   end
 end

--- a/acceptance/lib/puppet/acceptance/temp_file_utils.rb
+++ b/acceptance/lib/puppet/acceptance/temp_file_utils.rb
@@ -77,6 +77,8 @@ module Puppet
       # Given a relative path, returns an absolute path for a test file.  Basically, this just prepends the
       # a unique temp dir path (specific to the current test execution) to your relative path.
       def get_test_file_path(host, file_rel_path)
+        initialize_temp_dirs unless @host_test_tmp_dirs
+
         File.join(@host_test_tmp_dirs[host.name], file_rel_path)
       end
 

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
   app_type = File.basename(__FILE__, '.*')
-  tmp_environment   = mk_tmp_environment_with_teardown(app_type)
+  tmp_environment   = mk_tmp_environment_with_teardown(master, app_type)
 
   tmp_file = {}
   agents.each do |agent|

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
   app_type        = File.basename(__FILE__, '.*')
-  tmp_environment = mk_tmp_environment_with_teardown(app_type)
+  tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   file_correct    = "#{tmp_environment}-correct.txt"
   file_wrong      = "#{tmp_environment}-wrong.txt"
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -1,0 +1,56 @@
+test_name 'parser validate' do
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
+  require 'puppet/acceptance/temp_file_utils'
+  extend Puppet::Acceptance::TempFileUtils
+
+  app_type = File.basename(__FILE__, '.*')
+
+  agents.each do |agent|
+
+    step 'manifest with parser function call' do
+      if agent.platform !~ /windows/
+        tmp_environment   = mk_tmp_environment_with_teardown(agent, app_type)
+
+        create_sitepp(agent, tmp_environment, <<-SITE)
+function validate_this() {
+  notice('hello, puppet')
+}
+validate_this()
+        SITE
+        on(agent, puppet("parser validate --environment #{tmp_environment}"), :pty => true) # default manifest
+      end
+
+      # manifest with Type aliases
+      create_test_file(agent, "#{app_type}.pp", <<-PP)
+function validate_this() {
+  notice('hello, puppet')
+}
+validate_this()
+type MyInteger = Integer
+notice 42 =~ MyInteger
+      PP
+      tmp_manifest = get_test_file_path(agent, "#{app_type}.pp")
+      on(agent, puppet("parser validate #{tmp_manifest}"))
+    end
+
+    step 'manifest with bad syntax' do
+      create_test_file(agent, "#{app_type}_broken.pp", "notify 'hello there'")
+      tmp_manifest = get_test_file_path(agent, "#{app_type}_broken.pp")
+      on(agent, puppet("parser validate #{tmp_manifest}"), :accept_all_exit_codes => true) do |result|
+        assert_equal(result.exit_code, 1, 'parser validate did not exit with 1 upon parse failure')
+        expected = /Error: Could not parse for environment production: This Name has no effect\. A value was produced and then forgotten \(one or more preceding expressions may have the wrong form\) at .*_broken\.pp:1:1/
+        assert_match(expected, result.output, "parser validate did not output correctly: '#{result.output}'. expected: '#{expected.to_s}'")
+      end
+    end
+
+    step '(large) manifest with exported resources' do
+      fixture_path = 'fixtures/manifest_large_exported_classes_node.pp'
+      create_test_file(agent, "#{app_type}_exported.pp", File.read(fixture_path))
+      tmp_manifest = get_test_file_path(agent, "#{app_type}_exported.pp")
+      on(agent, puppet("parser validate #{tmp_manifest}"))
+    end
+
+  end
+
+end

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -6,7 +6,7 @@ extend Puppet::Acceptance::EnvironmentUtils
   skip_test if agents.any? {|agent| agent['platform'] =~ /^eos/ } # see PUP-5404, ARISTA-42
 
   app_type = File.basename(__FILE__, '.*')
-  tmp_environment   = mk_tmp_environment_with_teardown(app_type)
+  tmp_environment   = mk_tmp_environment_with_teardown(master, app_type)
   exported_username = 'er0ck'
 
   teardown do

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -3,7 +3,7 @@ test_name 'C97760: Bignum in reduce() should not cause exception' do
   extend Puppet::Acceptance::EnvironmentUtils
 
   app_type = File.basename(__FILE__, '.*')
-  tmp_environment = mk_tmp_environment_with_teardown(app_type)
+  tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   on(master, "chmod -R 666 #{File.join(environmentpath,tmp_environment)}")
 
   step 'On master, create site.pp with bignum' do


### PR DESCRIPTION
this works as-is, but has the default manifest case commented out.  
https://tickets.puppetlabs.com/browse/PUP-6431 causes parser validate to stall over SSH.

    (PUP-5982) Acceptance: test 'parser validate'

    Test parser validate with:
    * large complex manifest including exported resources (fixture)
    * expected failure with bad syntax
    * manifest with function definition and call
    * manifest with Type alias

    (PUP-5982) Acceptance: allow get_test_file_path pre-initialization.

    typically, one has to explicitly initialize the acceptance tempdirs when
    using the library facilities.  This change works around that, as
    required by the test in this ticket.
    
    (PUP-5982) Acceptance: add host selection to mk_tmp_environment

    In rare cases, we need to specify a host to create a tmp environment
    upon. This might be an agent, where one needs to use a full environment
    for non-master duties outside of agent that has been pluginsync'd.
    In the test for this ticket we use this to create an environment on the
    agents to test puppet parser validate against a default manifest.
    [skip ci]