### PR TITLE
(PUP-6428) Preserve HOME env variable in gem provider

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     end
 
     begin
-      list = execute(gem_list_command).lines.
+      list = execute(gem_list_command, {:custom_environment => {"HOME"=>ENV["HOME"]}}).lines.
         map {|set| gemsplit(set) }.
         reject {|x| x.nil? }
     rescue Puppet::ExecutionFailure => detail
@@ -125,7 +125,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
     command += install_options if resource[:install_options]
 
-    output = execute(command)
+    output = execute(command, {:custom_environment => {"HOME"=>ENV["HOME"]}})
     # Apparently some stupid gem versions don't exit non-0 on failure
     self.fail "Could not install: #{output.chomp}" if output.include?("ERROR")
   end
@@ -149,7 +149,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
     command += uninstall_options if resource[:uninstall_options]
 
-    output = execute(command)
+    output = execute(command, {:custom_environment => {"HOME"=>ENV["HOME"]}})
 
     # Apparently some stupid gem versions don't exit non-0 on failure
     self.fail "Could not uninstall: #{output.chomp}" if output.include?("ERROR")

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     end
 
     begin
-      list = execute(gem_list_command, {:custom_environment => {"HOME"=>ENV["HOME"]}}).lines.
+      list = execute(gem_list_command, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).lines.
         map {|set| gemsplit(set) }.
         reject {|x| x.nil? }
     rescue Puppet::ExecutionFailure => detail
@@ -125,7 +125,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
     command += install_options if resource[:install_options]
 
-    output = execute(command, {:custom_environment => {"HOME"=>ENV["HOME"]}})
+    output = execute(command, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}})
     # Apparently some stupid gem versions don't exit non-0 on failure
     self.fail "Could not install: #{output.chomp}" if output.include?("ERROR")
   end
@@ -149,7 +149,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
     command += uninstall_options if resource[:uninstall_options]
 
-    output = execute(command, {:custom_environment => {"HOME"=>ENV["HOME"]}})
+    output = execute(command, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}})
 
     # Apparently some stupid gem versions don't exit non-0 on failure
     self.fail "Could not uninstall: #{output.chomp}" if output.include?("ERROR")

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -186,7 +186,7 @@ context 'installing myresource' do
     describe "listing gems" do
       describe "searching for a single package" do
         it "searches for an exact match" do
-          provider_class.expects(:execute).with(includes('^bundler$')).returns(File.read(my_fixture('gem-list-single-package')))
+          provider_class.expects(:execute).with(includes('^bundler$'), {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns(File.read(my_fixture('gem-list-single-package')))
           expected = {:name => 'bundler', :ensure => %w[1.6.2], :provider => :gem}
           expect(provider_class.gemlist({:justme => 'bundler'})).to eq(expected)
         end

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -137,12 +137,12 @@ context 'installing myresource' do
       end
 
       it "should return an empty array when no gems installed" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}).returns("\n")
+        provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns("\n")
         expect(provider_class.instances).to eq([])
       end
 
       it "should return ensure values as an array of installed versions" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}).returns <<-HEREDOC.gsub(/        /, '')
+        provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns <<-HEREDOC.gsub(/        /, '')
         systemu (1.2.0)
         vagrant (0.8.7, 0.6.9)
         HEREDOC
@@ -154,7 +154,7 @@ context 'installing myresource' do
       end
 
       it "should ignore platform specifications" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}).returns <<-HEREDOC.gsub(/        /, '')
+        provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns <<-HEREDOC.gsub(/        /, '')
         systemu (1.2.0)
         nokogiri (1.6.1 ruby java x86-mingw32 x86-mswin32-60, 1.4.4.1 x86-mswin32)
         HEREDOC
@@ -166,7 +166,7 @@ context 'installing myresource' do
       end
 
       it "should not fail when an unmatched line is returned" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}).
+        provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).
           returns(File.read(my_fixture('line-with-1.8.5-warning')))
 
         expect(provider_class.instances.map {|p| p.properties}).


### PR DESCRIPTION
Prior to this patch, the HOME environment variable was stripped
before the gem command was executed by the provider.  Since the
gem command uses the HOME environment variable to locate the
appropriate gemrc file to load, this was causing it to look at
/.gemrc.  Since Puppet runs as root, it is far more reasonable for
a customer to expect to find the gemrc file in /root/.gemrc.  This
patch maintains the previously existing HOME environment variable,
which forces gem to look in /root/.gemrc during puppet runs.
