### PR TITLE
(maint) Use singleton pattern for TypeParser

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -294,7 +294,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     generate_scope do |scope|
       lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, explain ? Puppet::Pops::Lookup::Explainer.new(explain_options, only_explain_options) : nil)
       begin
-        type = options.include?(:type) ? Puppet::Pops::Types::TypeParser.new.parse(options[:type], scope) : nil
+        type = options.include?(:type) ? Puppet::Pops::Types::TypeParser.singleton.parse(options[:type], scope) : nil
         result = Puppet::Pops::Lookup.lookup(keys, type, options[:default_value], use_default_value, merge_options, lookup_invocation)
         puts renderer.render(result) unless explain
       rescue Puppet::DataBinding::LookupError

--- a/lib/puppet/data_providers/hiera_config.rb
+++ b/lib/puppet/data_providers/hiera_config.rb
@@ -42,7 +42,7 @@ module Puppet::DataProviders
       hierarchy_elem_type_v2 = hierarchy_elem_type_base + ',paths=>Array[String[1]]}]'
       hierarchy_elem_type_v3 = hierarchy_elem_type_base + '}]'
 
-      Puppet::Pops::Types::TypeParser.new.parse('Struct[{'\
+      Puppet::Pops::Types::TypeParser.singleton.parse('Struct[{'\
         'version=>Integer[4],'\
         "hierarchy=>Optional[Array[Variant[#{hierarchy_elem_type_v1},#{hierarchy_elem_type_v2},#{hierarchy_elem_type_v3}]]],"\
         'datadir=>Optional[String[1]]}]')

--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -272,9 +272,8 @@ module Puppet::Functions
 
     # @api private
     def self.builder
-      @type_parser ||= Puppet::Pops::Types::TypeParser.new
       @all_callables ||= Puppet::Pops::Types::TypeFactory.all_callables
-      DispatcherBuilder.new(dispatcher, @type_parser, @all_callables, loader)
+      DispatcherBuilder.new(dispatcher, Puppet::Pops::Types::TypeParser.singleton, @all_callables, loader)
     end
 
     # Dispatch any calls that match the signature to the provided method name.
@@ -602,9 +601,8 @@ module Puppet::Functions
   class InternalFunction < Function
     # @api private
     def self.builder
-      @type_parser ||= Puppet::Pops::Types::TypeParser.new
       @all_callables ||= Puppet::Pops::Types::TypeFactory.all_callables
-      InternalDispatchBuilder.new(dispatcher, @type_parser, @all_callables, loader)
+      InternalDispatchBuilder.new(dispatcher, Puppet::Pops::Types::TypeParser.singleton, @all_callables, loader)
     end
 
     # Defines class level injected attribute with reader method

--- a/lib/puppet/functions/assert_type.rb
+++ b/lib/puppet/functions/assert_type.rb
@@ -89,7 +89,7 @@ Puppet::Functions.create_function(:assert_type, Puppet::Functions::InternalFunct
   # @param value [Object] the value to assert
   #
   def assert_type_s(scope, type_string, value, &proc)
-    t = Puppet::Pops::Types::TypeParser.new.parse(type_string, scope)
+    t = Puppet::Pops::Types::TypeParser.singleton.parse(type_string, scope)
     block_given? ? assert_type(t, value, &proc) : assert_type(t, value)
   end
 end

--- a/lib/puppet/info_service/class_information_service.rb
+++ b/lib/puppet/info_service/class_information_service.rb
@@ -36,8 +36,7 @@ class Puppet::InfoService::ClassInformationService
   private
 
   def type_parser
-    # Safe to cache this as it would otherwise constantly build up the visitor cache
-    @@type_parser ||= Puppet::Pops::Types::TypeParser.new
+    Puppet::Pops::Types::TypeParser.singleton
   end
 
   def literal_evaluator

--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -278,7 +278,7 @@ class Puppet::Parser::AST::PopsBridge
     #
     def instantiate_TypeMapping(type_mapping, modname)
       loader = Puppet::Pops::Loaders.find_loader(modname)
-      tf = Puppet::Pops::Types::TypeParser.new
+      tf = Puppet::Pops::Types::TypeParser.singleton
       lhs = tf.interpret(type_mapping.type_expr, loader)
       rhs = tf.interpret_any(type_mapping.mapping_expr, loader)
       Puppet::Pops::Loaders.implementation_registry.register_type_mapping(lhs, rhs, loader)

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -49,7 +49,6 @@ class EvaluatorImpl
     @@string_visitor   ||= Visitor.new(self, "string", 1, 1)
 
     @@type_calculator  ||= Types::TypeCalculator.new()
-    @@type_parser      ||= Types::TypeParser.new()
 
     @@compare_operator     ||= CompareOperator.new()
     @@relationship_operator ||= RelationshipOperator.new()
@@ -300,7 +299,7 @@ class EvaluatorImpl
   # A QualifiedReference (i.e. a  capitalized qualified name such as Foo, or Foo::Bar) evaluates to a PType
   #
   def eval_QualifiedReference(o, scope)
-    type = @@type_parser.interpret(o, scope)
+    type = Types::TypeParser.singleton.interpret(o, scope)
     fail(Issues::UNKNOWN_RESOURCE_TYPE, o, {:type_name => type.type_string }) if type.is_a?(Types::PTypeReferenceType)
     type
   end
@@ -451,7 +450,7 @@ class EvaluatorImpl
     keys = o.keys || []
     if left.is_a?(Types::PHostClassType)
       # Evaluate qualified references without errors no undefined types
-      keys = keys.map {|key| key.is_a?(Model::QualifiedReference) ? @@type_parser.interpret(key, scope) : evaluate(key, scope) }
+      keys = keys.map {|key| key.is_a?(Model::QualifiedReference) ? Types::TypeParser.singleton.interpret(key, scope) : evaluate(key, scope) }
     else
       keys = keys.map {|key| evaluate(key, scope) }
       # Resource[File] becomes File

--- a/lib/puppet/pops/evaluator/relationship_operator.rb
+++ b/lib/puppet/pops/evaluator/relationship_operator.rb
@@ -32,7 +32,6 @@ class RelationshipOperator
   def initialize
     @type_transformer_visitor = Visitor.new(self, "transform", 1, 1)
     @type_calculator = Types::TypeCalculator.new()
-    @type_parser = Types::TypeParser.new()
 
     tf = Types::TypeFactory
     @catalog_type = tf.variant(tf.catalog_entry, tf.type_type(tf.catalog_entry))
@@ -57,7 +56,7 @@ class RelationshipOperator
   # A string must be a type reference in string format
   # @api private
   def transform_String(o, scope)
-    assert_catalog_type(@type_parser.parse(o, scope), scope)
+    assert_catalog_type(Types::TypeParser.singleton.parse(o, scope), scope)
   end
 
   # A qualified name is short hand for a class with this name

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -70,7 +70,7 @@ class Loaders
       type
     end
     # Resolve lazy so that all types can cross reference eachother
-    parser = Types::TypeParser.new
+    parser = Types::TypeParser.singleton
     types.each { |type| type.resolve(parser, loader) }
   end
 

--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -8,7 +8,7 @@ module Puppet::Pops
 
     # The type used for validation of the _merge_ argument
     def self.merge_t
-      @@merge_t ||=  Types::TypeParser.new.parse("Variant[String[1],Runtime[ruby,'Symbol'],Hash[Variant[String[1],Runtime[ruby,'Symbol']],Scalar,1]]")
+      @@merge_t ||=  Types::TypeParser.singleton.parse("Variant[String[1],Runtime[ruby,'Symbol'],Hash[Variant[String[1],Runtime[ruby,'Symbol']],Scalar,1]]")
     end
     private_class_method :merge_t
 
@@ -149,7 +149,7 @@ module Puppet::Pops
     # @return [Types::PStructType] the puppet type
     #
     def options_t
-      @options_t ||=Types::TypeParser.new.parse("Struct[{strategy=>Optional[Pattern[#{self.class.key}]]}]")
+      @options_t ||=Types::TypeParser.singleton.parse("Struct[{strategy=>Optional[Pattern[#{self.class.key}]]}]")
     end
 
     # Returns the type used to validate the options hash
@@ -217,7 +217,7 @@ module Puppet::Pops
     protected
 
     def value_t
-      @value_t ||= Types::TypeParser.new.parse('Hash[String,Data]')
+      @value_t ||= Types::TypeParser.singleton.parse('Hash[String,Data]')
     end
 
     MergeStrategy.add_strategy(self)
@@ -249,7 +249,7 @@ module Puppet::Pops
     protected
 
     def value_t
-      @value_t ||= Types::TypeParser.new.parse('Variant[Scalar,Array[Data]]')
+      @value_t ||= Types::TypeParser.singleton.parse('Variant[Scalar,Array[Data]]')
     end
 
     MergeStrategy.add_strategy(self)
@@ -320,7 +320,7 @@ module Puppet::Pops
     #
     # @return [Types::PAnyType] the puppet type used when validating the options hash
     def options_t
-      @options_t ||= Types::TypeParser.new.parse('Struct[{'\
+      @options_t ||= Types::TypeParser.singleton.parse('Struct[{'\
           "strategy=>Optional[Pattern[#{self.class.key}]],"\
           'knockout_prefix=>Optional[String],'\
           'merge_debug=>Optional[Boolean],'\
@@ -330,7 +330,7 @@ module Puppet::Pops
     end
 
     def value_t
-      @value_t ||= Types::TypeParser.new.parse('Variant[Array[Data],Hash[String,Data]]')
+      @value_t ||= Types::TypeParser.singleton.parse('Variant[Array[Data],Hash[String,Data]]')
     end
 
     MergeStrategy.add_strategy(self)

--- a/lib/puppet/pops/types/implementation_registry.rb
+++ b/lib/puppet/pops/types/implementation_registry.rb
@@ -21,7 +21,6 @@ module Types
       @implementations_per_type_name = {}
       @type_name_substitutions = []
       @impl_name_substitutions = []
-      @type_parser = TypeParser.new
       TypeParser.type_map.values.each { |type| register_implementation(type.simple_name, type.class.name, static_loader) }
     end
 
@@ -123,7 +122,7 @@ module Types
       if name_and_loader.nil?
         nil
       else
-        @type_parser.parse(*name_and_loader)
+        TypeParser.singleton.parse(*name_and_loader)
       end
     end
 

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -8,6 +8,10 @@
 module Puppet::Pops
 module Types
 class TypeParser
+  def self.singleton
+    @singleton ||= TypeParser.new
+  end
+
   # @api public
   def initialize
     @parser = Parser::Parser.new

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -558,7 +558,7 @@ EOS
     it 'will explain deep merge results without options' do
       assemble_and_compile('${r}', "'abc::a'") do |scope|
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
-        Puppet::Pops::Lookup.lookup('abc::e', Puppet::Pops::Types::TypeParser.new.parse('Hash[String,String]'), nil, false, 'deep', lookup_invocation)
+        Puppet::Pops::Lookup.lookup('abc::e', Puppet::Pops::Types::TypeParser.singleton.parse('Hash[String,String]'), nil, false, 'deep', lookup_invocation)
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
 Merge strategy deep
   Data Binding "hiera"
@@ -586,7 +586,7 @@ EOS
       assemble_and_compile('${r}', "'abc::a'") do |scope|
         Hiera.any_instance.expects(:lookup).with(any_parameters).returns({'k1' => 'global_g1'})
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
-        Puppet::Pops::Lookup.lookup('abc::e', Puppet::Pops::Types::TypeParser.new.parse('Hash[String,String]'), nil, false, {'strategy' => 'deep', 'merge_hash_arrays' => true}, lookup_invocation)
+        Puppet::Pops::Lookup.lookup('abc::e', Puppet::Pops::Types::TypeParser.singleton.parse('Hash[String,String]'), nil, false, {'strategy' => 'deep', 'merge_hash_arrays' => true}, lookup_invocation)
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
 Merge strategy deep
   Options: {
@@ -645,7 +645,7 @@ EOS
     it 'will explain value access caused by dot notation in key' do
       assemble_and_compile('${r}', "'abc::a'") do |scope|
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
-        Puppet::Pops::Lookup.lookup('abc::f.k1.s1', Puppet::Pops::Types::TypeParser.new.parse('String'), nil, false, nil, lookup_invocation)
+        Puppet::Pops::Lookup.lookup('abc::f.k1.s1', Puppet::Pops::Types::TypeParser.singleton.parse('String'), nil, false, nil, lookup_invocation)
         expect(lookup_invocation.explainer.to_s).to eq(<<EOS)
 Merge strategy first
   Data Binding "hiera"
@@ -667,7 +667,7 @@ EOS
     it 'will provide a hash containing all explanation elements' do
       assemble_and_compile('${r}', "'abc::a'") do |scope|
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
-        Puppet::Pops::Lookup.lookup('abc::e', Puppet::Pops::Types::TypeParser.new.parse('Hash[String,String]'), nil, false, {'strategy' => 'deep', 'merge_hash_arrays' => true}, lookup_invocation)
+        Puppet::Pops::Lookup.lookup('abc::e', Puppet::Pops::Types::TypeParser.singleton.parse('Hash[String,String]'), nil, false, {'strategy' => 'deep', 'merge_hash_arrays' => true}, lookup_invocation)
         expect(lookup_invocation.explainer.to_hash).to eq(
             {
               :branches => [

--- a/spec/unit/functions/match_spec.rb
+++ b/spec/unit/functions/match_spec.rb
@@ -18,7 +18,7 @@ describe 'the match function' do
     Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'match')
   end
 
-  let(:type_parser) { Puppet::Pops::Types::TypeParser.new }
+  let(:type_parser) { Puppet::Pops::Types::TypeParser.singleton }
 
 
   it 'matches string and regular expression without captures' do
@@ -52,6 +52,6 @@ describe 'the match function' do
   end
 
   def type(s)
-    Puppet::Pops::Types::TypeParser.new.parse(s) 
+    Puppet::Pops::Types::TypeParser.singleton.parse(s)
   end
 end

--- a/spec/unit/functions/regsubst_spec.rb
+++ b/spec/unit/functions/regsubst_spec.rb
@@ -18,7 +18,7 @@ describe 'the regsubst function' do
     Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'regsubst').call({}, *args)
   end
 
-  let(:type_parser) { Puppet::Pops::Types::TypeParser.new }
+  let(:type_parser) { Puppet::Pops::Types::TypeParser.singleton }
 
   context 'when using a string pattern' do
     it 'should raise an Error if there is less than 3 arguments' do

--- a/spec/unit/functions/split_spec.rb
+++ b/spec/unit/functions/split_spec.rb
@@ -18,7 +18,7 @@ describe 'the split function' do
     Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'split').call({}, *args)
   end
 
-  let(:type_parser) { Puppet::Pops::Types::TypeParser.new }
+  let(:type_parser) { Puppet::Pops::Types::TypeParser.singleton }
 
   it 'should raise an Error if there is less than 2 arguments' do
     expect { split('a,b') }.to raise_error(/'split' expects 2 arguments, got 1/)

--- a/spec/unit/functions/versioncmp_spec.rb
+++ b/spec/unit/functions/versioncmp_spec.rb
@@ -18,7 +18,7 @@ describe "the versioncmp function" do
     Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'versioncmp').call({}, *args)
   end
 
-  let(:type_parser) { Puppet::Pops::Types::TypeParser.new }
+  let(:type_parser) { Puppet::Pops::Types::TypeParser.singleton }
 
   it 'should raise an Error if there is less than 2 arguments' do
     expect { versioncmp('a,b') }.to raise_error(/expects 2 arguments, got 1/)

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -7,7 +7,7 @@ module Types
 describe 'The Object Type' do
   include PuppetSpec::Compiler
 
-  let(:parser) { TypeParser.new }
+  let(:parser) { TypeParser.singleton }
   let(:pp_parser) { Parser::EvaluatingParser.new }
   let(:loader) { Loader::BaseLoader.new(nil, 'type_parser_unit_test_loader') }
   let(:factory) { TypeFactory }

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -286,7 +286,7 @@ module Puppet::Pops
                   references => { Ref => { name => 'cars', version_range => '1.x' } }
                 OBJECT
                 expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                  /entry 'references' entry 'Ref' entry 'name' expected a match for Pattern\[\/\\A\[A-Z\]\[\\w\]\*\(\?:::\[A-Z\]\[\\w\]\*\)\*\\z\/], got 'cars'/)
+                  /entry 'references' entry 'Ref' entry 'name' expected a match for Pattern\[\/\\A\[A-Z\]\[\\w\]\*\(\?:::\[A-Z\]\[\\w\]\*\)\*\\z\/\], got 'cars'/)
               end
 
               it 'has a version_range that is not a valid SemVer range' do

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -7,7 +7,7 @@ module Puppet::Pops
     describe 'The TypeSet Type' do
       include PuppetSpec::Compiler
 
-      let(:parser) { TypeParser.new }
+      let(:parser) { TypeParser.singleton }
       let(:pp_parser) { Parser::EvaluatingParser.new }
       let(:env) { Puppet::Node::Environment.create('test', []) }
       let(:loaders) { Loaders.new(env) }

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -12,7 +12,7 @@ module Types
 describe 'Puppet Ruby Generator' do
   include PuppetSpec::Compiler
 
-  let!(:parser) { TypeParser.new }
+  let!(:parser) { TypeParser.singleton }
   let(:generator) { RubyGenerator.new }
 
   context 'when generating from Object types' do

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -651,7 +651,7 @@ describe 'The type calculator' do
         # Add a non-empty variant
         all_instances << variant_t(PAnyType::DEFAULT, PUnitType::DEFAULT)
         # Add a type alias that doesn't resolve to 't'
-        all_instances << type_alias_t('MyInt', 'Integer').resolve(TypeParser.new, nil)
+        all_instances << type_alias_t('MyInt', 'Integer').resolve(TypeParser.singleton, nil)
 
         all_instances.each { |i| expect(i).not_to be_assignable_to(t) }
       end
@@ -1347,7 +1347,7 @@ describe 'The type calculator' do
     end
 
     context 'for TypeAlias, such that' do
-      let!(:parser) { TypeParser.new }
+      let!(:parser) { TypeParser.singleton }
 
       it 'it is assignable to the type that it is an alias for' do
         t = type_alias_t('Alias', 'Integer').resolve(parser, nil)
@@ -1740,7 +1740,7 @@ describe 'The type calculator' do
     end
 
     context 'and t is a TypeAlias' do
-      let!(:parser) { TypeParser.new }
+      let!(:parser) { TypeParser.singleton }
 
       it 'should consider x an instance of the aliased simple type' do
         t = type_alias_t('Alias', 'Integer').resolve(parser, nil)

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -138,7 +138,7 @@ describe 'the type mismatch describer' do
   end
 
   context 'when using present tense' do
-    let(:parser) { TypeParser.new }
+    let(:parser) { TypeParser.singleton }
     let(:subject) { TypeMismatchDescriber.singleton }
     it 'reports a missing parameter as "has no parameter"' do
       t = parser.parse('Struct[{a=>String}]')
@@ -166,7 +166,7 @@ describe 'the type mismatch describer' do
   end
 
   context 'when using past tense' do
-    let(:parser) { TypeParser.new }
+    let(:parser) { TypeParser.singleton }
     let(:subject) { TypeMismatchDescriber.singleton }
     it 'reports a missing parameter as "did not have a parameter"' do
       t = parser.parse('Struct[{a=>String}]')

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -6,7 +6,7 @@ module Types
 describe TypeParser do
   extend RSpec::Matchers::DSL
 
-  let(:parser) { TypeParser.new }
+  let(:parser) { TypeParser.singleton }
   let(:types)  { TypeFactory }
   it "rejects a puppet expression" do
     expect { parser.parse("1 + 1") }.to raise_error(Puppet::ParseError, /The expression <1 \+ 1> is not a valid type specification/)


### PR DESCRIPTION
A new TypeParser was created in lots of places in the code while other
places, like the evaluator, used a locally cached instance. Since using
a cached instance is quite safe, it's better to maintain such an
instance as a singleton in the class itself. This commit adds this
singleton and replaces all calls to TypeParser.new.