### PR TITLE
(PUP-6376) Add failover logic to the agent

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1395,7 +1395,25 @@ EOT
     },
     :server => {
       :default => "puppet",
-      :desc => "The puppet master server to which the puppet agent should connect."
+      :desc => "The puppet master server to which the puppet agent should connect.",
+      :call_hook => :on_initialize_and_write,
+      :hook => proc { |value|
+        if Puppet.settings.set_by_config?(:server) && Puppet.settings.set_by_config?(:server_list)
+          Puppet.deprecation_warning('Attempted to set both server and server_list. Server setting will not be used.', :SERVER_DUPLICATION)
+        end
+      }
+    },
+    :server_list => {
+      :default => [],
+      :type => :server_list,
+      :desc => "The list of puppet master servers to which the puppet agent should connect,
+        in the order that they will be tried.",
+      :call_hook => :on_initialize_and_write,
+      :hook => proc { |value|
+        if Puppet.settings.set_by_config?(:server) && Puppet.settings.set_by_config?(:server_list)
+          Puppet.deprecation_warning('Attempted to set both server and server_list. Server setting will not be used.', :SERVER_DUPLICATION)
+        end
+      }
     },
     :use_srv_records => {
       :default    => false,

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -178,7 +178,7 @@ class Puppet::Indirector::Request
     return(uri ? uri : "/#{indirection_name}/#{key}")
   end
 
-  def do_request(srv_service=:puppet, default_server=Puppet.settings[:server], default_port=Puppet.settings[:masterport], &block)
+  def do_request(srv_service=:puppet, default_server=nil, default_port=nil, &block)
     # We were given a specific server to use, so just use that one.
     # This happens if someone does something like specifying a file
     # source using a puppet:// URI with a specific server.
@@ -197,9 +197,22 @@ class Puppet::Indirector::Request
     end
 
     # ... Fall back onto the default server.
-    Puppet.debug "No more servers left, falling back to #{default_server}:#{default_port}" if Puppet.settings[:use_srv_records]
-    self.server = default_server
-    self.port   = default_port
+    begin
+      bound_server = Puppet.lookup(:server)
+    rescue
+      bound_server = nil
+    end
+
+    begin
+      bound_port = Puppet.lookup(:serverport)
+    rescue
+      bound_port = nil
+    end
+    self.server = default_server || bound_server || Puppet.settings[:server]
+    self.port   = default_port || bound_port || Puppet.settings[:masterport]
+
+    Puppet.debug "No more servers left, falling back to #{self.server}:#{self.port}" if Puppet.settings[:use_srv_records]
+
     return yield(self)
   end
 

--- a/lib/puppet/settings/server_list_setting.rb
+++ b/lib/puppet/settings/server_list_setting.rb
@@ -1,0 +1,20 @@
+class Puppet::Settings::ServerListSetting < Puppet::Settings::ArraySetting
+
+  def type
+    :server_list
+  end
+
+  def munge(value)
+    servers = super 
+    servers.map! { |server| 
+      case server
+      when String
+        server.split(':')
+      when Array
+        server
+      else
+        raise ArgumentError, "Expected an Array of String, got a #{value.class}"
+      end
+    }
+  end
+end

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -104,4 +104,18 @@ describe "Defaults" do
       expect(Puppet.settings[:supported_checksum_types]).to eq(['sha256', 'md5lite', 'mtime'])
     end
   end
+  
+  describe 'server vs server_list' do
+    it 'should warn when both settings are set in code' do
+      Puppet.expects(:deprecation_warning).with('Attempted to set both server and server_list. Server setting will not be used.', :SERVER_DUPLICATION)
+      Puppet.settings[:server] = 'test_server'
+      Puppet.settings[:server_list] = ['one', 'two']
+    end
+
+    it 'should warn when both settings are set by command line' do
+      Puppet.expects(:deprecation_warning).with('Attempted to set both server and server_list. Server setting will not be used.', :SERVER_DUPLICATION)
+      Puppet.settings.handlearg("--server_list", "one,two")
+      Puppet.settings.handlearg("--server", "test_server")
+    end
+  end
 end

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -205,6 +205,45 @@ describe Puppet::Indirector::REST do
     expect(terminus_class.port).to eq(543)
   end
 
+  it "should use a failover-selected server if set" do
+    terminus_class.expects(:server_setting).returns nil
+    Puppet.override(:server => "myserver") do
+      expect(terminus_class.server).to eq("myserver")
+    end
+  end
+
+  it "should use a failover-selected port if set" do
+    terminus_class.expects(:port_setting).returns nil
+    Puppet.override(:serverport => 321) do
+      expect(terminus_class.port).to eq(321)
+    end
+  end
+
+  it "should use an explicitly specified more-speciic server when failover is active" do
+    terminus_class.expects(:server_setting).returns :ca_server
+    Puppet[:ca_server] = "myserver"
+    Puppet.override(:server => "anotherserver") do
+      expect(terminus_class.server).to eq("myserver")
+    end
+  end
+
+  it "should use an explicitly specified more-specific port when failover is active" do
+    terminus_class.expects(:port_setting).returns :ca_port
+    Puppet[:ca_port] = 321
+    Puppet.override(:serverport => 543) do
+      expect(terminus_class.port).to eq(321)
+    end
+  end
+
+  it "should use a default port when a more-specific server is set" do
+    terminus_class.expects(:server_setting).returns :ca_server
+    terminus_class.expects(:port_setting).returns :ca_port
+    Puppet[:ca_server] = "myserver"
+    Puppet.override(:server => "anotherserver", :port => 666) do
+      expect(terminus_class.port).to eq(8140)
+    end
+  end
+
   it 'should default to :puppet for the srv_service' do
     expect(Puppet::Indirector::REST.srv_service).to eq(:puppet)
   end


### PR DESCRIPTION
This adds master failover logic to the agent using the new `server_list` setting. The failover happens early in the configurer, with gating to ensure it doesn't happen when the legacy `server` setting is being used, or if the configurer is actually an `apply` run.

The use of the selected master is handled using Puppet's `lookup` system. This allows us to scope the bound server info to all logic that happens within a configuration run, without needing to refactor the entire indirector.

The changes on the indirector side are fairly simple - check if server/port have been bound with `lookup` and if not fall back to the `server` and `masterport` settings.