### PR TITLE
(PUP-6437) directoryservice user provider should handle missing Shado…

### DIFF
--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -141,7 +141,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     ################################
     # Get Password/Salt/Iterations #
     ################################
-    if attribute_hash[:shadowhashdata].empty?
+    if attribute_hash[:shadowhashdata].nil? or attribute_hash[:shadowhashdata].empty?
       attribute_hash[:password] = '*'
     else
       embedded_binary_plist = get_embedded_binary_plist(attribute_hash[:shadowhashdata])

--- a/spec/unit/provider/user/directoryservice_spec.rb
+++ b/spec/unit/provider/user/directoryservice_spec.rb
@@ -350,6 +350,33 @@ describe Puppet::Type.type(:user).provider(:directoryservice) do
     end
   end
 
+  describe 'self#generate_attribute_hash empty shadowhashdata' do
+    let(:user_plist_resource) do
+      {
+        :ensure         => :present,
+        :provider       => :directoryservice,
+        :groups         => 'testgroup,third',
+        :comment        => username,
+        :password       => '*',
+        :shadowhashdata => nil,
+        :name           => username,
+        :uid            => 1000,
+        :gid            => 22,
+        :home           => user_path
+      }
+    end
+
+    it 'should handle empty shadowhashdata' do
+      provider.class.stubs(:get_os_version).returns('10.7')
+      provider.class.stubs(:get_all_users).returns(testuser_hash)
+      provider.class.stubs(:get_attribute_from_dscl).with('Users', username, 'ShadowHashData').returns(nil)
+      provider.class.stubs(:get_list_of_groups).returns(group_plist_hash_guid)
+      provider.class.stubs(:convert_binary_to_hash).with(sha512_embedded_bplist).returns(sha512_embedded_bplist_hash)
+      provider.class.prefetch({})
+      expect(provider.class.generate_attribute_hash(user_plist_hash)).to eq(user_plist_resource)
+    end
+  end
+
   describe '#exists?' do
     # This test expects an error to be raised
     # I'm PROBABLY doing this wrong...


### PR DESCRIPTION
…wHashData

Handle if get_attribute_from_dscl returns nil when trying to fetch ShadowHashData.

This likely will only occur if other things are weird/broken on the host, but we shouldn't crash and burn in any case.