### PR TITLE
(maint) Don't run Facter so much

### DIFF
--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -11,7 +11,7 @@ agents.each do |agent|
   # Have to use /v1 parameter for Vista and later, older versions
   # don't accept the parameter
   version = '/v1'
-  on agents, facter('kernelmajversion') do
+  on agent, facter('kernelmajversion') do
     version = '' if stdout.chomp.to_f < 6.0
   end
 


### PR DESCRIPTION
Facter was run on every agent multiple times. Also, if we had two
Windows boxes in the acceptance run we could get the incorrection
version string. Fix so we only run facter on the box we're testing.