### PR TITLE
(PUP-1498) Fix scheduled_task acceptance test on ruby 1.9.3

### DIFF
--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -11,7 +11,7 @@ agents.each do |agent|
   # Have to use /v1 parameter for Vista and later, older versions
   # don't accept the parameter
   version = '/v1'
-  on agents, facter('kernelmajversion') do
+  on agent, facter('kernelmajversion') do
     version = '' if stdout.chomp.to_f < 6.0
   end
 
@@ -32,6 +32,9 @@ agents.each do |agent|
 
   step "verify that schtasks reports the same output"
   on agent, "schtasks.exe /query /tn #{name} /xml" do
+    # Ruby 1.9.3 has an ecoding bug in REXML.  Instead we modify the XML Encoding header returned by schtasks.exe to be UTF-8 not UTF-16
+    stdout.gsub!('UTF-16','UTF-8') if RUBY_VERSION =~ /^1\.9/
+
     xml = REXML::Document.new(stdout)
 
     command =  xml.root.elements['//Actions/Exec/Command/text()'].value


### PR DESCRIPTION
Ruby 1.9.3 has an ecoding bug in REXML, where it disregards the text encoding on a
string in preference for the XML header encoding value.  This causes an issue because
the XML file is encoded as UTF8.  In this commit we modify the XML Encoding header
returned by schtasks.exe to be UTF-8 not UTF-16 if the ruby version matches 1.9x

Additionally fixed a typo in acceptance test as it was calling facter on all agents
instead of the agent under test

The encoding gets very strange because beaker is running a command over SSH so it is hard to determine exactly what the encoding should be.  In this case the string always comes back as UTF8