### PR TITLE
(PUP-6430) Add Fedora 24 support for DNF

### DIFF
--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
       end
   end
 
-  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => ['22', '23']
+  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => ['22', '23', '24']
 
   # The value to pass to DNF as its error output level.
   # DNF differs from Yum slightly with regards to error outputting.

--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -5,6 +5,26 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:package).provider(:dnf)
 
+context 'default' do
+  [ 19, 20, 21 ].each do |ver|
+    it "should not be the default provider on fedora#{ver}" do
+      Facter.stubs(:value).with(:osfamily).returns(:redhat)
+      Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
+      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+      expect(provider_class).to_not be_default
+    end
+  end
+
+  [ 22, 23, 24 ].each do |ver|
+    it "should be the default provider on fedora#{ver}" do
+      Facter.stubs(:value).with(:osfamily).returns(:redhat)
+      Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
+      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+      expect(provider_class).to be_default
+    end
+  end
+end
+
 describe provider_class do
   let(:name) { 'mypackage' }
   let(:resource) do


### PR DESCRIPTION
* Also add spec for default provider-ness

Closes #5052 and re-targets against stable