### PR TITLE
(PUP-5909) Add Serializer and Deserializer and a JSON packer/unpacker

### DIFF
--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -126,6 +126,10 @@ module Puppet
     module Migration
       require 'puppet/pops/migration/migration_checker'
     end
+
+    module Serialization
+      require 'puppet/pops/serialization'
+    end
   end
 
   require 'puppet/parser/ast/pops_bridge'

--- a/lib/puppet/pops/parser/locator.rb
+++ b/lib/puppet/pops/parser/locator.rb
@@ -262,6 +262,26 @@ class Locator
   # strings are frozen).
   #
   class Locator19 < AbstractLocator
+    include Types::PuppetObject
+
+    def self._ptype
+      @type
+    end
+
+    # The Locator is not part of the Ecore model so no ObjectType is automatically inferred. Instead the
+    # type is explicitly added here.
+    # TODO: LocatorForChars is never added. It looks like it could be removed (remnant from Ruby 1.8 compatibility?)
+    # @api private
+    def self.register_ptype(loader, ir)
+      @type = Pcore::create_object_type(loader, ir, self, 'Puppet::AST::Locator', 'Any',
+        'string' => Types::PStringType::DEFAULT,
+        'file' => Types::PStringType::DEFAULT,
+        'line_index' => {
+          Types::KEY_TYPE => Types::POptionalType.new(Types::PArrayType.new(Types::PIntegerType::DEFAULT)),
+          Types::KEY_VALUE => nil
+        }
+      ).resolve(Types::TypeParser.singleton, loader)
+    end
 
     # Returns the offset on line (first offset on a line is 0).
     # Ruby 19 is multibyte but has no character position methods, must use byteslice

--- a/lib/puppet/pops/parser/locator.rb
+++ b/lib/puppet/pops/parser/locator.rb
@@ -205,6 +205,15 @@ class Locator
       return low
     end
 
+    def hash
+      [string, file, line_index].hash
+    end
+
+    # Equal method needed by serializer to perform tabulation
+    def eql?(o)
+      self.class == o.class && string == o.string && file == o.file && line_index == o.line_index
+    end
+
     # Common impl for 18 and 19 since scanner is byte based
     def compute_line_index
       scanner = StringScanner.new(string)

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -25,6 +25,13 @@ module Pcore
     Types::TypedModelObject.register_ptypes(loader, ir)
 
     ir.register_implementation_namespace('Pcore', 'Puppet::Pops::Pcore', loader)
+    ir.register_implementation_namespace('Puppet::AST', 'Puppet::Pops::Model', loader)
+    ast_type_set = Serialization::RGen::TypeGenerator.new.generate_type_set('Puppet::AST', Puppet::Pops::Model, loader)
+
+    # Extend the Puppet::AST type set with the Locator (it's not an RGen class, but nevertheless, used in the model)
+    ast_ts_i12n = ast_type_set.i12n_hash
+    ast_ts_i12n['types'] = ast_ts_i12n['types'].merge('Locator' => Parser::Locator::Locator19.register_ptype(loader, ir))
+    add_type(Types::PTypeSetType.new(ast_ts_i12n), loader)
   end
 
   # Create and register a new `Object` type in the Puppet Type System and map it to an implementation class

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -22,11 +22,31 @@ module Pcore
     add_alias('Pcore::SimpleTypeName', TYPE_SIMPLE_TYPE_NAME, loader)
     add_alias('Pcore::TypeName', TYPE_QUALIFIED_REFERENCE, loader)
     add_alias('Pcore::QRef', TYPE_QUALIFIED_REFERENCE, loader)
+    Types::TypedModelObject.register_ptypes(loader, ir)
 
     ir.register_implementation_namespace('Pcore', 'Puppet::Pops::Pcore', loader)
   end
 
-  def self.add_object(name, body, loader)
+  # Create and register a new `Object` type in the Puppet Type System and map it to an implementation class
+  #
+  # @param loader [Loader::Loader] The loader where the new type will be registered
+  # @param ir [ImplementationRegistry] The implementation registry that maps this class to the new type
+  # @param impl_class [Class] The class that is the implementation of the type
+  # @param type_name [String] The fully qualified name of the new type
+  # @param parent_name [String,nil] The fully qualified name of the parent type
+  # @param attributes_hash [Hash{String => Object}] A hash of attribute definitions for the new type
+  # @return [PObjectType] the created type. Not yet resolved
+  #
+  # @api private
+  def self.create_object_type(loader, ir, impl_class, type_name, parent_name, attributes_hash = EMPTY_HASH)
+    i12n_hash = {}
+    i12n_hash[Types::KEY_PARENT] = Types::PTypeReferenceType.new(parent_name) unless parent_name.nil?
+    i12n_hash[Types::KEY_ATTRIBUTES] = attributes_hash unless attributes_hash.empty?
+    ir.register_implementation(type_name, impl_class, loader)
+    add_type(Types::PObjectType.new(type_name, i12n_hash), loader)
+  end
+
+  def self.add_object_type(name, body, loader)
     add_type(Types::PObjectType.new(name, Parser::EvaluatingParser.new.parse_string(body).current.body), loader)
   end
 
@@ -36,6 +56,7 @@ module Pcore
 
   def self.add_type(type, loader, name_authority = RUNTIME_NAME_AUTHORITY)
     loader.set_entry(Loader::TypedName.new(:type, type.name.downcase, name_authority), type)
+    type
   end
 
   def self.register_implementations(impls, name_authority = RUNTIME_NAME_AUTHORITY)

--- a/lib/puppet/pops/serialization.rb
+++ b/lib/puppet/pops/serialization.rb
@@ -1,0 +1,1 @@
+require_relative 'serialization/rgen'

--- a/lib/puppet/pops/serialization.rb
+++ b/lib/puppet/pops/serialization.rb
@@ -1,1 +1,17 @@
+module Puppet::Pops
+module Serialization
+  def self.not_implemented(impl, method_name)
+    raise NotImplementedError, "The class #{impl.class.name} should have implemented the method #{method_name}()"
+  end
+
+  class SerializationError < Puppet::Error
+  end
+end
+end
+
+require_relative 'serialization/serializer'
+require_relative 'serialization/deserializer'
+require_relative 'serialization/json'
+require_relative 'serialization/time_factory'
 require_relative 'serialization/rgen'
+require_relative 'serialization/object'

--- a/lib/puppet/pops/serialization/abstract_reader.rb
+++ b/lib/puppet/pops/serialization/abstract_reader.rb
@@ -1,0 +1,149 @@
+require_relative 'extension'
+require_relative 'time_factory'
+
+module Puppet::Pops
+module Serialization
+# Abstract class for protocol specific readers such as MsgPack or JSON
+# The abstract reader is capable of reading the primitive scalars:
+# - Boolean
+# - Integer
+# - Float
+# - String
+# and, by using extensions, also
+# - Array start
+# - Map start
+# - Object start
+# - Regexp
+# - Version
+# - VersionRange
+# - Timestamp
+# - Default
+#
+# @api public
+class AbstractReader
+  # @param [MessagePack::Unpacker,JSON::Unpacker] unpacker The low lever unpacker that delivers the primitive objects
+  # @param [MessagePack::Unpacker,JSON::Unpacker] extension_unpacker Optional unpacker for extensions. Defaults to the unpacker
+  # @api public
+  def initialize(unpacker, extension_unpacker = nil)
+    @read = []
+    @unpacker = unpacker
+    @extension_unpacker = extension_unpacker.nil? ? unpacker : extension_unpacker
+    register_types
+  end
+
+  # Read an object from the underlying unpacker
+  # @return [Object] the object that was read
+  # @api public
+  def read
+    obj = @unpacker.read
+    case obj
+    when Extension::InnerTabulation
+      @read[obj.index]
+    when Numeric, Symbol, Extension::NotTabulated, true, false, nil
+      # not tabulated
+      obj
+    else
+      @read << obj
+      obj
+    end
+  end
+
+  # @return [Integer] The total count of unique primitive values that has been read
+  # @api private
+  def primitive_count
+    @read.size
+  end
+
+  # @api private
+  def read_payload(data)
+    raise SerializationError, "Internal error: Class #{self.class} does not implement method 'read_payload'"
+  end
+
+  # @api private
+  def read_tpl_qname(ep)
+    Array.new(ep.read) { read_tpl(ep) }.join('::')
+  end
+
+  # @api private
+  def read_tpl(ep)
+    obj = ep.read
+    case obj
+    when Integer
+      @read[obj]
+    else
+      @read << obj
+      obj
+    end
+  end
+
+  # @api private
+  def extension_unpacker
+    @extension_unpacker
+  end
+
+  # @api private
+  def register_type(extension_number, &block)
+    @unpacker.register_type(extension_number, &block)
+  end
+
+  # @api private
+  def register_types
+    register_type(Extension::INNER_TABULATION) do |data|
+      read_payload(data) { |ep| Extension::InnerTabulation.new(ep.read) }
+    end
+
+    register_type(Extension::TABULATION) do |data|
+      read_payload(data) { |ep| Extension::Tabulation.new(ep.read) }
+    end
+
+    register_type(Extension::ARRAY_START) do |data|
+      read_payload(data) { |ep| Extension::ArrayStart.new(ep.read) }
+    end
+
+    register_type(Extension::MAP_START) do |data|
+      read_payload(data) { |ep| Extension::MapStart.new(ep.read) }
+    end
+
+    register_type(Extension::OBJECT_START) do |data|
+      read_payload(data) { |ep| type_name = read_tpl_qname(ep); Extension::ObjectStart.new(type_name, ep.read) }
+    end
+
+    register_type(Extension::DEFAULT) do |data|
+      read_payload(data) { |ep| Extension::Default::INSTANCE }
+    end
+
+    register_type(Extension::COMMENT) do |data|
+      read_payload(data) { |ep| Extension::Comment.new(ep.read) }
+    end
+
+    register_type(Extension::REGEXP) do |data|
+      read_payload(data) { |ep| Regexp.new(ep.read) }
+    end
+
+    register_type(Extension::TYPE_REFERENCE) do |data|
+      read_payload(data) { |ep| Types::PTypeReferenceType.new(read_tpl_qname(ep)) }
+    end
+
+    register_type(Extension::SYMBOL) do |data|
+      read_payload(data) { |ep| ep.read.to_sym }
+    end
+
+    register_type(Extension::TIME) do |data|
+      read_payload(data) do |ep|
+        sec = ep.read
+        nsec = ep.read
+        TimeFactory.from_sec_nsec(sec, nsec)
+      end
+    end
+
+    register_type(Extension::VERSION) do |data|
+      read_payload(data) { |ep| Semantic::Version.parse(ep.read) }
+    end
+
+    register_type(Extension::VERSION_RANGE) do |data|
+      read_payload(data) { |ep| Semantic::VersionRange.parse(ep.read) }
+    end
+  end
+end
+end
+end

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -2,6 +2,10 @@ require_relative 'extension'
 
 module Puppet::Pops
 module Serialization
+
+MAX_INTEGER =  0x7fffffffffffffff
+MIN_INTEGER = -0x8000000000000000
+
 # Abstract class for protocol specific writers such as MsgPack or JSON
 # The abstract write is capable of writing the primitive scalars:
 # - Boolean
@@ -45,6 +49,9 @@ class AbstractWriter
   def write(value)
     written = false
     case value
+    when Integer
+      # not tabulated, but integers larger than 64-bit cannot be allowed.
+      raise SerializationError, 'Integer out of bounds' if value > MAX_INTEGER || value < MIN_INTEGER
     when Numeric, Symbol, Extension::NotTabulated, true, false, nil
       # not tabulated
     else

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -1,0 +1,172 @@
+require_relative 'extension'
+
+module Puppet::Pops
+module Serialization
+# Abstract class for protocol specific writers such as MsgPack or JSON
+# The abstract write is capable of writing the primitive scalars:
+# - Boolean
+# - Integer
+# - Float
+# - String
+# and, by using extensions, also
+# - Array start
+# - Map start
+# - Object start
+# - Regexp
+# - Version
+# - VersionRange
+# - Timestamp
+# - Default
+#
+# @api public
+class AbstractWriter
+  # @param [MessagePack::Packer,JSON::Packer] packer the underlying packer stream
+  # @param [Hash] options
+  # @option options [Boolean] :tabulate `true` if tabulation is enabled (which is the default).
+  # @param [DebugPacker,nil] extension_packer Optional specific extension packer. Only used for debug output
+  # @api public
+  def initialize(packer, options, extension_packer = nil)
+    @tabulate = options[:tabulate]
+    @tabulate = true if @tabulate.nil?
+    @written = {}
+    @packer = packer
+    @extension_packer = extension_packer.nil? ? packer : extension_packer
+    register_types
+  end
+
+  # Tell the underlying packer to flush.
+  # @api public
+  def finish
+    @packer.flush
+  end
+
+  # Write a value on the underlying stream
+  # @api public
+  def write(value)
+    written = false
+    case value
+    when Numeric, Symbol, Extension::NotTabulated, true, false, nil
+      # not tabulated
+    else
+      if @tabulate
+        index = @written[value]
+        if index.nil?
+          @packer.write(value)
+          written = true
+          @written[value] = @written.size
+        else
+          value = Extension::InnerTabulation.new(index)
+        end
+      end
+    end
+    @packer.write(value) unless written
+  end
+
+  # Called from extension callbacks only
+  #
+  # @api private
+  def build_payload
+    raise SerializationError, "Internal error: Class #{self.class} does not implement method 'build_payload'"
+  end
+
+  # @api private
+  def extension_packer
+    @extension_packer
+  end
+
+  # Called from extension callbacks only
+  #
+  # @api private
+  def write_tpl_qname(ep, qname)
+    names = qname.split('::')
+    ep.write(names.size)
+    names.each {|n| write_tpl(ep, n)}
+  end
+
+  # Called from extension callbacks only
+  #
+  # @api private
+  def write_tpl(ep, value)
+    raise ArgumentError, 'Internal error. Integers cannot be tabulated in extension payload' if value.is_a?(Integer)
+    if @tabulate
+      index = @written[value]
+      if index.nil?
+        @written[value] = @written.size
+      else
+        value = index
+      end
+    end
+    ep.write(value)
+  end
+
+  # @api private
+  def register_type(extension_number, payload_class, &block)
+    @packer.register_type(extension_number, payload_class, &block)
+  end
+
+  # @api private
+  def register_types
+    # 0x00 - 0x0F are reserved for low-level serialization / tabulation extensions
+
+    register_type(Extension::INNER_TABULATION, Extension::InnerTabulation) do |o|
+      build_payload { |ep| ep.write(o.index) }
+    end
+
+    register_type(Extension::TABULATION, Extension::Tabulation) do |o|
+      build_payload { |ep| ep.write(o.index) }
+    end
+
+    # 0x10 - 0x1F are reserved for structural extensions
+
+    register_type(Extension::ARRAY_START, Extension::ArrayStart) do |o|
+      build_payload { |ep| ep.write(o.size) }
+    end
+
+    register_type(Extension::MAP_START, Extension::MapStart) do |o|
+      build_payload { |ep| ep.write(o.size) }
+    end
+
+    register_type(Extension::OBJECT_START, Extension::ObjectStart) do |o|
+      build_payload { |ep| write_tpl_qname(ep, o.type_name); ep.write(o.attribute_count) }
+    end
+
+    # 0x20 - 0x2f reserved for special extension objects
+
+    register_type(Extension::DEFAULT, Extension::Default) do |o|
+      build_payload { |ep| }
+    end
+
+    register_type(Extension::COMMENT, Extension::Comment) do |o|
+      build_payload { |ep| ep.write(o.comment) }
+    end
+
+    # 0x30 - 0x7f reserved for mapping of specific runtime classes
+
+    register_type(Extension::REGEXP, Regexp) do |o|
+      build_payload { |ep| ep.write(o.source) }
+    end
+
+    register_type(Extension::TYPE_REFERENCE, Types::PTypeReferenceType) do |o|
+      build_payload { |ep| write_tpl_qname(ep, o.type_string) }
+    end
+
+    register_type(Extension::SYMBOL, Symbol) do |o|
+      build_payload { |ep| ep.write(o.to_s) }
+    end
+
+    register_type(Extension::TIME, Time) do |o|
+      build_payload { |ep| ep.write(o.tv_sec); ep.write(o.tv_nsec) }
+    end
+
+    register_type(Extension::VERSION, Semantic::Version) do |o|
+      build_payload { |ep| ep.write(o.to_s) }
+    end
+
+    register_type(Extension::VERSION_RANGE, Semantic::VersionRange) do |o|
+      build_payload { |ep| ep.write(o.to_s) }
+    end
+  end
+end
+end
+end
+

--- a/lib/puppet/pops/serialization/deserializer.rb
+++ b/lib/puppet/pops/serialization/deserializer.rb
@@ -1,0 +1,60 @@
+require_relative 'extension'
+
+module Puppet::Pops
+module Serialization
+  # The deserializer is capable of reading, arrays, maps, and complex objects using an underlying protocol reader. It takes care of
+  # resolving tabulations and assembling complex objects. The type of the complex objects are resolved using a loader.
+  # @api public
+  class Deserializer
+    # @param [AbstractReader] reader the reader used when reading primitive objects from a stream
+    # @param [Loader::Loader] loader the loader used when resolving names of types
+    # @api public
+    def initialize(reader, loader)
+      @read = []
+      @reader = reader
+      @loader = loader
+    end
+
+    # Read the next value from the reader.
+    #
+    # @return [Object] the value that was read
+    # @api public
+    def read
+      val = @reader.read
+      case val
+      when Extension::Tabulation
+        @read[val.index]
+      when Extension::Default
+        :default
+      when Extension::ArrayStart
+        result = remember([])
+        val.size.times { result << read }
+        result
+      when Extension::MapStart
+        result = remember({})
+        val.size.times { key = read; result[key] = read }
+        result
+      when Extension::ObjectStart
+        type_name = val.type_name
+        type = Types::TypeParser.singleton.parse(type_name, @loader)
+        raise SerializationError, "No implementation mapping found for Puppet Type #{type_name}" if type.is_a?(Types::PTypeReferenceType)
+        type.read(val.attribute_count, self)
+      when Numeric, String, true, false, nil, Time
+        val
+      else
+        remember(val)
+      end
+    end
+
+    # Remember that a value has been read. This means that the value is given an index
+    # and that subsequent reads of a tabulation with that index should return the value.
+    # @param [Object] value The value to remember
+    # @return [Object] the argument
+    # @api private
+    def remember(value)
+      @read << value
+      value
+    end
+  end
+end
+end

--- a/lib/puppet/pops/serialization/extension.rb
+++ b/lib/puppet/pops/serialization/extension.rb
@@ -1,0 +1,126 @@
+module Puppet::Pops
+module Serialization
+module Extension
+  # 0x00 - 0x0F are reserved for low-level serialization / tabulation extensions
+
+  # Tabulation internal to the low level protocol reader/writer
+  INNER_TABULATION = 0x00
+
+  # Tabulation managed by the serializer / deserializer
+  TABULATION = 0x01
+
+  # 0x10 - 0x1F are reserved for structural extensions
+  ARRAY_START = 0x10
+  MAP_START = 0x11
+  OBJECT_START = 0x12
+
+  # 0x20 - 0x2f reserved for special extension objects
+  DEFAULT = 0x20
+  COMMENT = 0x21
+
+  # 0x30 - 0x7f reserved for mapping of specific runtime classes
+  REGEXP = 0x30
+  TYPE_REFERENCE = 0x31
+  SYMBOL = 0x32
+  TIME   = 0x33
+  TIMESPAN = 0x34
+  VERSION = 0x35
+  VERSION_RANGE = 0x36
+
+  # Marker module indicating whether or not an instance is tabulated or not
+  module NotTabulated; end
+
+  # Marker module for objects that starts a sequence, i.e. ArrayStart, MapStart, and ObjectStart
+  module SequenceStart; end
+
+  # The class that triggers the use of the DEFAULT extension. It doesn't have any payload
+  class Default
+    include NotTabulated
+    INSTANCE = Default.new
+  end
+
+  # The class that triggers the use of the TABULATION extension. The payload is the tabulation index
+  class Tabulation
+    include NotTabulated
+    attr_reader :index
+    def initialize(index)
+      @index = index
+    end
+  end
+
+  # Tabulation internal to the protocol reader/writer
+  class InnerTabulation < Tabulation
+  end
+
+  # The class that triggers the use of the MAP_START extension. The payload is the map size (number of entries)
+  class MapStart
+    include NotTabulated
+    include SequenceStart
+    attr_reader :size
+    def initialize(size)
+      @size = size
+    end
+
+    # Sequence size is twice the map size since each entry is written as key and value
+    def sequence_size
+      @size * 2
+    end
+  end
+
+  # The class that triggers the use of the ARRAY_START extension. The payload is the array size
+  class ArrayStart
+    include NotTabulated
+    include SequenceStart
+    attr_reader :size
+    def initialize(size)
+      @size = size
+    end
+
+    def sequence_size
+      @size
+    end
+  end
+
+  # The class that triggers the use of the OBJECT_START extension. The payload is the name of the object type and the
+  # number of attributes in the instance.
+  class ObjectStart
+    include SequenceStart
+    attr_reader :type_name, :attribute_count
+    def initialize(type_name, attribute_count)
+      @type_name = type_name
+      @attribute_count = attribute_count
+    end
+
+    def hash
+      @type_name.hash * 29 + attribute_count.hash
+    end
+
+    def eql?(o)
+      o.is_a?(ObjectStart) && o.type_name == @type_name && o.attribute_count == @attribute_count
+    end
+    alias == eql?
+
+    def sequence_size
+      @attribute_count
+    end
+  end
+
+  # The class that triggers the use of the COMMENT extension. The payload is comment text
+  class Comment
+    attr_reader :comment
+    def initialize(comment)
+      @comment = comment
+    end
+
+    def hash
+      @comment.hash
+    end
+
+    def eql?(o)
+      o.is_a?(Comment) && o.comment == @comment
+    end
+    alias == eql?
+  end
+end
+end
+end

--- a/lib/puppet/pops/serialization/instance_reader.rb
+++ b/lib/puppet/pops/serialization/instance_reader.rb
@@ -1,0 +1,19 @@
+module Puppet::Pops
+module Serialization
+  # An InstanceReader is responsible for reading an instance of a complex object using a deserializer. The read involves creating the
+  # instance, register it with the deserializer (so that self references can be resolved) and then read the instance data (which normally
+  # amounts to all attribute values).
+  # Instance readers are registered with of {Types::PObjectType}s to aid the type when reading instances.
+  #
+  # @api private
+  module InstanceReader
+    # @param [Class] impl_class the class of the instance to be created and initialized
+    # @param [Integer] value_count the expected number of objects that forms the initialization data
+    # @param [Deserializer] deserializer the deserializer to read from, and to register the instance with
+    # @return [Object] the instance that has been read
+    def read(impl_class, value_count, deserializer)
+      Serialization.not_implemented(self, 'read')
+    end
+  end
+end
+end

--- a/lib/puppet/pops/serialization/instance_writer.rb
+++ b/lib/puppet/pops/serialization/instance_writer.rb
@@ -1,0 +1,14 @@
+module Puppet::Pops
+module Serialization
+  # An instance writer is responsible for writing complex objects using a {Serializer}
+  # @api private
+  module InstanceWriter
+    # @param [Types::PObjectType] type the type of instance to write
+    # @param [Object] value the instance
+    # @param [Serializer] serializer the serializer that will receive the written instance
+    def write(type, value, serializer)
+      Serialization.not_implemented(self, 'write')
+    end
+  end
+end
+end

--- a/lib/puppet/pops/serialization/json.rb
+++ b/lib/puppet/pops/serialization/json.rb
@@ -1,0 +1,242 @@
+require 'json'
+
+module Puppet::Pops
+module Serialization
+
+require_relative 'time_factory'
+require_relative 'abstract_reader'
+require_relative 'abstract_writer'
+
+module JSON
+  # A Writer that writes output in JSON format
+  # @api private
+  class Writer < AbstractWriter
+    def initialize(io, options = {})
+      super(Packer.new(io, options), options)
+    end
+
+    def extension_packer
+      @packer
+    end
+
+    def packer
+      @packer
+    end
+
+    def build_payload
+      yield(@packer)
+    end
+
+    def to_json
+      @packer.to_json
+    end
+  end
+
+  # A Reader that reads JSON formatted input
+  # @api private
+  class Reader < AbstractReader
+    def initialize(io)
+      super(Unpacker.new(io))
+    end
+
+    def read_payload(data)
+      yield(@unpacker)
+    end
+  end
+
+  # The JSON Packer. Modeled after the MessagePack::Packer
+  # @api private
+  class Packer
+    def initialize(io, options = {})
+      @io = io
+      @type_registry = {}
+      @nested = []
+      @verbose = options[:verbose]
+      @verbose = false if @verbose.nil?
+      @indent = options[:indent] || 0
+    end
+
+    def register_type(type, klass, &block)
+      @type_registry[klass] = [type, klass, block]
+    end
+
+    def empty?
+      @io.pos == 0
+    end
+
+    def flush
+      pos = @io.pos
+      case pos
+      when 1
+        # Just start marker present.
+      when 0
+        @io << '['
+      else
+        # Drop last comma
+        @io.pos = pos - 1
+      end
+      @io << ']'
+      @io.flush
+    end
+
+    def write(obj)
+      assert_started
+      case obj
+      when Array
+        write_array_header(obj.size)
+        obj.each { |x| write(x) }
+      when Hash
+        write_map_header(obj.size)
+        obj.each_pair {|k, v| write(k); write(v) }
+      when nil
+        write_nil
+      else
+        write_scalar(obj)
+      end
+    end
+    alias pack write
+
+    def write_array_header(n)
+      assert_started
+      if n < 1
+        @io << '[]'
+      else
+        @io << '['
+        @nested <<  [false, n]
+      end
+    end
+
+    def write_map_header(n)
+      assert_started
+      if n < 1
+        @io << '{}'
+      else
+        @io << '{'
+        @nested <<  [true, n * 2]
+      end
+    end
+
+    def write_nil
+      assert_started
+      @io << 'null'
+      write_delim
+    end
+
+    def to_s
+      to_json
+    end
+
+    def to_json
+      string = @io.string
+      if @indent > 0
+        options = { :indent => ' ' * @indent }
+        string = ::JSON.pretty_unparse(::JSON.parse(string), options)
+      end
+      string
+    end
+
+    # Write a payload object. Not subject to extensions
+    def write_pl(obj)
+      @io << obj.to_json << ','
+    end
+
+    def assert_started
+      @io << '[' if @io.pos == 0
+    end
+    private :assert_started
+
+    def write_delim
+      nesting = @nested.last
+      cnt = nesting.nil? ? nil : nesting[1]
+      case cnt
+      when 1
+        @io << (nesting[0] ? '}' : ']')
+        @nested.pop
+        write_delim
+      when Integer
+        if (cnt % 2) == 0 || !nesting[0]
+          @io << ','
+        else
+          @io << ':'
+        end
+        nesting[1] = cnt - 1
+      else
+        @io << ','
+      end
+    end
+    private :write_delim
+
+    def write_scalar(obj)
+      ext = @type_registry[obj.class]
+      if ext.nil?
+        @io << obj.to_json
+        write_delim
+      else
+        write_extension(ext, obj)
+      end
+    end
+    private :write_scalar
+
+    def write_extension(ext, obj)
+      @io << '[' << extension_indicator(ext).to_json << ','
+      write_extension_payload(ext, obj)
+      if obj.is_a?(Extension::SequenceStart) && obj.sequence_size > 0
+        @nested << [false, obj.sequence_size]
+      else
+        @io.pos -= 1
+        @io << ']'
+        write_delim
+      end
+    end
+    private :write_extension
+
+    def write_extension_payload(ext, obj)
+      ext[2].call(obj)
+    end
+    private :write_extension_payload
+
+    def extension_indicator(ext)
+      @verbose ? ext[1].name.sub(/^Puppet::Pops::Serialization::\w+::(.+)$/, '\1') : ext[0]
+    end
+    private :extension_indicator
+  end
+
+  class Unpacker
+    def initialize(io)
+      parsed = ::JSON.parse(io.read(nil))
+      raise SerializationError, "JSON stream is not an array" unless parsed.is_a?(Array)
+      @etor_stack = [parsed.each]
+      @type_registry = {}
+      @nested = []
+    end
+
+    def read
+      obj = nil
+      loop do
+        raise SerializationError, 'Unexpected end of input' if @etor_stack.empty?
+        etor = @etor_stack.last
+        begin
+          obj = etor.next
+          break
+        rescue StopIteration
+          @etor_stack.pop
+        end
+      end
+      if obj.is_a?(Array)
+        ext_etor = obj.each
+        @etor_stack << ext_etor
+        ext_no = ext_etor.next
+        ext_block = @type_registry[ext_no]
+        raise SerializationError, "Invalid input. #{ext_no} is not a valid extension number" if ext_block.nil?
+        obj = ext_block.call(nil)
+      end
+      obj
+    end
+
+    def register_type(extension_number, &block)
+      @type_registry[extension_number] = block
+    end
+  end
+end
+end
+end

--- a/lib/puppet/pops/serialization/json.rb
+++ b/lib/puppet/pops/serialization/json.rb
@@ -169,8 +169,13 @@ module JSON
     def write_scalar(obj)
       ext = @type_registry[obj.class]
       if ext.nil?
-        @io << obj.to_json
-        write_delim
+        case obj
+        when Numeric, String, true, false, nil
+          @io << obj.to_json
+          write_delim
+        else
+          raise SerializationError, "Unable to serialize a #{obj.class.name}"
+        end
       else
         write_extension(ext, obj)
       end

--- a/lib/puppet/pops/serialization/object.rb
+++ b/lib/puppet/pops/serialization/object.rb
@@ -1,0 +1,63 @@
+require_relative 'instance_reader'
+require_relative 'instance_writer'
+
+module Puppet::Pops
+module Serialization
+
+# Instance reader for objects that implement {Types::PuppetObject}
+# @api private
+class ObjectReader
+  include InstanceReader
+
+  def read(impl_class, value_count, deserializer)
+    type = impl_class._ptype
+    (names, types, required_count) = type.parameter_info
+    max = names.size
+    unless value_count >= required_count && value_count <= max
+      raise Serialization::SerializationError, "Feature count mismatch for #{impl_class.name}. Expected #{min} - #{max}, actual #{value_count}"
+    end
+    # Deserializer must know about this instance before we read its attributes
+    val = deserializer.remember(impl_class.allocate)
+    args = Array.new(value_count) { deserializer.read }
+    types.each_with_index do |ptype, index|
+      if index < args.size
+        arg = args[index]
+        Types::TypeAsserter.assert_instance_of(nil, ptype, arg) { "#{type.name}[#{names[index]}]" } unless arg == :default
+      else
+        attr = type[names[index]]
+        raise Serialization::SerializationError, "Missing default value for #{type.name}[#{names[index]}]" unless attr.value?
+        args << attr.value
+      end
+    end
+    val.send(:initialize, *args)
+    val
+  end
+
+  INSTANCE = ObjectReader.new
+end
+
+# Instance writer for objects that implement {Types::PuppetObject}
+# @api private
+class ObjectWriter
+  include InstanceWriter
+
+  def write(type, value, serializer)
+    impl_class = value.class
+    (names, types, required_count) = type.parameter_info(true)
+    args = names.map { |name| value.send(name) }
+
+    # Pop optional arguments that are nil
+    while args.size > required_count
+      break unless args.last.nil?
+      args.pop
+    end
+
+    serializer.start_object(type.name, args.size)
+    args.each { |arg| serializer.write(arg) }
+  end
+
+  INSTANCE = ObjectWriter.new
+end
+end
+end
+

--- a/lib/puppet/pops/serialization/rgen.rb
+++ b/lib/puppet/pops/serialization/rgen.rb
@@ -1,0 +1,105 @@
+module Puppet::Pops
+module Serialization
+
+# @api private
+module RGen
+  # A generator that produces a {Types::PTypeSetType} instance based on an ruby {Module}
+  # that represents an RGen::ECore::EPackage.
+  #
+  # The generator is not complete. In particular, it does not deal with:
+  # - references that extend beyond eCore and the given ePackage
+  # - sub packages
+  # - methods
+  # - annotations
+  #
+  class TypeGenerator
+
+    ECore = ::RGen::ECore
+
+    def generate_type_set(namespace, package, loader)
+      types = {}
+      package.constants.each do |c|
+        cls = package.const_get(c)
+        next unless cls.is_a?(Class) && cls.respond_to?(:ecore)
+        e_class = cls.ecore
+        types[e_class.name] = generate_type_hash(e_class)
+      end
+      type_set = Types::PTypeSetType.new(namespace, {
+        Pcore::KEY_PCORE_VERSION => Pcore::PCORE_VERSION,
+        Types::KEY_VERSION => '0.1.0',
+        Types::KEY_TYPES => types
+      }, Pcore::RUNTIME_NAME_AUTHORITY).resolve(Types::TypeParser.singleton, loader)
+      type_set
+    end
+
+    def generate_type_hash(e_class)
+      attributes = {}
+      e_class.eStructuralFeatures.each do |feature|
+        attr = {}
+        attributes[feature.name] = attr
+        type = feature_type(feature)
+        value = feature.defaultValue
+        if value.nil?
+          if feature.lowerBound == 0
+            if feature.upperBound == -1 || feature.upperBound > 1
+              attr[Types::KEY_VALUE] = []
+            elsif !feature.derived
+              type = Types::POptionalType.new(type)
+              attr[Types::KEY_VALUE] = nil
+            end
+          end
+        else
+          value = value.to_s if value.is_a?(Symbol)
+          attr['value'] = value
+        end
+        attr[Types::KEY_TYPE] = type
+        if feature.derived
+          attr[Types::KEY_KIND] = Types::PObjectType::ATTRIBUTE_KIND_DERIVED
+        elsif feature.unsettable
+          attr[Types::KEY_KIND] = Types::PObjectType::ATTRIBUTE_KIND_CONSTANT
+        end
+      end
+      result = { Types::KEY_ATTRIBUTES => attributes }
+      supers = e_class.eSuperTypes
+      case supers.size
+      when 0
+      when 1
+        result['parent'] = Types::PTypeReferenceType.new(supers[0].name)
+      else
+        raise SerializationError, "Multiple inheritance is not supported. #{e_class.name} has #{supers.size} super types"
+      end
+      result
+    end
+
+    def feature_type(feature)
+      eType = feature.eType
+      type = case eType
+      when ECore::EInt, ECore::ELong
+        Types::PIntegerType::DEFAULT
+      when ECore::EFloat
+        Types::PFloatType::DEFAULT
+      when ECore::EEnum
+        Types::PEnumType.new(eType.eLiterals.map { |e| e.name })
+      when ECore::EBoolean
+        Types::PBooleanType::DEFAULT
+      when ECore::EString
+        Types::PStringType::DEFAULT
+      when ECore::EClass
+        Types::PTypeReferenceType.new(eType.name)
+      else
+        Types::PAnyType::DEFAULT
+      end
+
+      case feature.upperBound
+      when 1
+        type
+      when -1
+        Types::PArrayType.new(type, Types::PIntegerType.new(feature.lowerBound))
+      else
+        Types::PArrayType.new(type, Types::PIntegerType.new(feature.lowerBound, feature.upperBound))
+      end
+    end
+  end
+end
+end
+end

--- a/lib/puppet/pops/serialization/serializer.rb
+++ b/lib/puppet/pops/serialization/serializer.rb
@@ -1,0 +1,91 @@
+require_relative 'extension'
+
+module Puppet::Pops
+module Serialization
+  # The serializer is capable of writing, arrays, maps, and complex objects using an underlying protocol writer. It takes care of
+  # tabulating and disassembling complex objects.
+  # @api public
+  class Serializer
+    # @param [AbstractWriter] writer the writer that is used for writing primitive values
+    # @api public
+    def initialize(writer)
+      @written = {}
+      @writer = writer
+    end
+
+    # Tell the underlying writer to finish
+    # @api public
+    def finish
+      @writer.finish
+    end
+
+    # Write an object
+    # @param [Object] value the object to write
+    # @api public
+    def write(value)
+      case value
+      when Integer, Float, String, true, false, nil, Time
+        @writer.write(value)
+      when :default
+        @writer.write(Extension::Default::INSTANCE)
+      else
+        index = @written[value.object_id]
+        if index.nil?
+          write_tabulated_first_time(value)
+        else
+          @writer.write(Extension::Tabulation.new(index)) unless index.nil?
+        end
+      end
+    end
+
+    # Write the start of an array.
+    # @param [Integer] size the size of the array
+    # @api private
+    def start_array(size)
+      @writer.write(Extension::ArrayStart.new(size))
+    end
+
+    # Write the start of a map (hash).
+    # @param [Integer] size the number of entries in the map
+    # @api private
+    def start_map(size)
+      @writer.write(Extension::MapStart.new(size))
+    end
+
+    # Write the start of a complex object
+    # @param [String] type_ref the name of the type
+    # @param [Integer] attr_count the number of attributes in the object
+    # @api private
+    def start_object(type_ref, attr_count)
+      @writer.write(Extension::ObjectStart.new(type_ref, attr_count))
+    end
+
+    # First time write of a tabulated object. This means that the object is written and then remembered. Subsequent writes
+    # of the same object will yield a write of a tabulation index instead.
+    # @param [Object] value the value to write
+    # @api private
+    def write_tabulated_first_time(value)
+      @written[value.object_id] = @written.size
+      case value
+      when Symbol, Regexp, Semantic::Version, Semantic::VersionRange
+        @writer.write(value)
+      when Array
+        start_array(value.size)
+        value.each { |elem| write(elem) }
+      when Hash
+        start_map(value.size)
+        value.each_pair { |key, val| write(key); write(val) }
+      when Types::PTypeReferenceType
+        @writer.write(value)
+      when Types::PuppetObject
+        value._ptype.write(value, self)
+      else
+        impl_class = value.class
+        type = Loaders.implementation_registry.type_for_module(impl_class)
+        raise SerializationError, "No Puppet Type found for #{impl_class.name}" unless type.is_a?(Types::PObjectType)
+        type.write(value, self)
+      end
+    end
+  end
+end
+end

--- a/lib/puppet/pops/serialization/time_factory.rb
+++ b/lib/puppet/pops/serialization/time_factory.rb
@@ -1,0 +1,66 @@
+module Puppet::Pops
+module Serialization
+  # Implements all the constructors found in the Time class and ensures that
+  # the created Time object can be serialized and deserialized using its
+  # seconds and nanoseconds without loss of precision.
+  #
+  # @api public
+  class TimeFactory
+
+    NANO_DENOMINATOR = 10**9
+
+    def self.at(*args)
+      sec_nsec_safe(Time.at(*args))
+    end
+
+    def self.gm(*args)
+      sec_nsec_safe(Time.gm(*args))
+    end
+
+    def self.local(*args)
+      sec_nsec_safe(Time.local(*args))
+    end
+
+    def self.mktime(*args)
+      sec_nsec_safe(Time.mktime(*args))
+    end
+
+    def self.new(*args)
+      sec_nsec_safe(Time.new(*args))
+    end
+
+    def self.now
+      sec_nsec_safe(Time.now)
+    end
+
+    def self.utc(*args)
+      sec_nsec_safe(Time.utc(*args))
+    end
+
+    # Creates a Time object from a Rational defined as:
+    #
+    # (_sec_ * #NANO_DENOMINATOR + _nsec_) / #NANO_DENOMINATOR
+    #
+    # This ensures that a Time object can be reliably serialized and using its
+    # its #tv_sec and #tv_nsec values and then recreated again (using this method)
+    # without loss of precision.
+    #
+    # @param sec [Integer] seconds since Epoch
+    # @param nsec [Integer] nano seconds
+    # @return [Time] the created object
+    #
+    def self.from_sec_nsec(sec, nsec)
+      Time.at(Rational(sec * NANO_DENOMINATOR + nsec, NANO_DENOMINATOR))
+    end
+
+    # Returns a new Time object that is adjusted to ensure that precision is not
+    # lost when it is serialized and deserialized using its seconds and nanoseconds
+    # @param t [Time] the object to adjust
+    # @return [Time] the adjusted object
+    #
+    def self.sec_nsec_safe(t)
+      from_sec_nsec(t.tv_sec, t.tv_nsec)
+    end
+  end
+end
+end

--- a/lib/puppet/pops/types/p_meta_type.rb
+++ b/lib/puppet/pops/types/p_meta_type.rb
@@ -10,6 +10,10 @@ KEY_VALUE = 'value'.freeze
 class PMetaType < PAnyType
   include Annotatable
 
+  def self.register_ptype(loader, ir)
+    # Abstract type. It doesn't register anything
+  end
+
   def accept(visitor, guard)
     annotatable_accept(visitor, guard)
     super

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -369,7 +369,38 @@ class PObjectType < PMetaType
     @new_function ||= create_new_function(loader)
   end
 
+  # Assign a new instance reader to this type
+  # @param [Serialization::InstanceReader] reader the reader to assign
   # @api private
+  def reader=(reader)
+    @reader = reader
+  end
+
+  # Assign a new instance write to this type
+  # @param [Serialization::InstanceWriter] the writer to assign
+  # @api private
+  def writer=(writer)
+    @writer = writer
+  end
+
+  # Read an instance of this type from a deserializer
+  # @param [Integer] value_count the number attributes needed to create the instance
+  # @param [Serialization::Deserializer] deserializer the deserializer to read from
+  # @return [Object] the created instance
+  # @api private
+  def read(value_count, deserializer)
+    reader.read(implementation_class, value_count, deserializer)
+  end
+
+  # Write an instance of this type using a serializer
+  # @param [Object] value the instance to write
+  # @param [Serialization::Serializer] the serializer to write to
+  # @api private
+  def write(value, serializer)
+    writer.write(self, value, serializer)
+  end
+
+    # @api private
   def create_new_function(loader)
     impl_class = implementation_class
     class_name = impl_class.name || "Anonymous Ruby class for #{name}"
@@ -794,6 +825,14 @@ class PObjectType < PMetaType
     else
       yield(guard)
     end
+  end
+
+  def reader
+    @reader ||= Serialization::ObjectReader::INSTANCE
+  end
+
+  def writer
+    @writer ||= Serialization::ObjectWriter::INSTANCE
   end
 end
 end

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -60,6 +60,10 @@ class PObjectType < PMetaType
     KEY_ANNOTATIONS =>  TypeFactory.optional(TYPE_ANNOTATIONS)
   })
 
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType', 'i12n_hash' => TYPE_OBJECT_I12N)
+  end
+
   # @abstract Encapsulates behavior common to {PAttribute} and {PFunction}
   # @api public
   class PAnnotatedMember

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -371,46 +371,17 @@ class PObjectType < PMetaType
 
   # @api private
   def create_new_function(loader)
-    impl_name = Loaders.implementation_registry.module_name_for_type(self)
-    if impl_name.nil?
-      # Use generator to create a default implementation
-      impl_class = RubyGenerator.new.create_class(self)
-      class_name = "Anonymous Ruby class for #{name}"
-    else
-      # Can the mapping be loaded?
-      class_name = impl_name[0]
-      impl_class = ClassLoader.provide(class_name)
+    impl_class = implementation_class
+    class_name = impl_class.name || "Anonymous Ruby class for #{name}"
 
-      raise Puppet::Error, "Unable to load class #{class_name}" if impl_class.nil?
-      unless impl_class < PuppetObject
-        raise Puppet::Error, "Unable to create an instance of #{name}. #{class_name} does not include module #{PuppetObject.name}"
-      end
-    end
-
-    i12n_t = i12n_type
-    from_hash_type = TypeFactory.callable(i12n_t, 1, 1)
-
-    # Create a types and a names array where optional entries ends up last
-    opt_types = []
-    opt_names = []
-    non_opt_types = []
-    non_opt_names = []
-    i12n_t.elements.each do |se|
-      if se.key_type.is_a?(POptionalType)
-        opt_names << se.name
-        opt_types << se.value_type
-      else
-        non_opt_names << se.name
-        non_opt_types << se.value_type
-      end
-    end
-    param_names = non_opt_names + opt_names
-    param_types = non_opt_types + opt_types
+    (param_names, param_types, required_param_count) = parameter_info
 
     # Create the callable with a size that reflects the required and optional parameters
-    param_types << non_opt_types.size
+    param_types << required_param_count
     param_types << param_names.size
+
     create_type = TypeFactory.callable(*param_types)
+    from_hash_type = TypeFactory.callable(i12n_type, 1, 1)
 
     # Create and return a #new_XXX function where the dispatchers are added programmatically.
     Puppet::Functions.create_loaded_function(:"new_#{name}", loader) do
@@ -440,6 +411,59 @@ class PObjectType < PMetaType
       def create(*args)
         self.class.impl_class.new(*args)
       end
+    end
+  end
+
+  # @api private
+  def implementation_class
+    if @implementation_class.nil?
+      impl_name = Loaders.implementation_registry.module_name_for_type(self)
+      if impl_name.nil?
+        # Use generator to create a default implementation
+        @implementation_class = RubyGenerator.new.create_class(self)
+      else
+        # Can the mapping be loaded?
+        class_name = impl_name[0]
+        @implementation_class = ClassLoader.provide(class_name)
+
+        raise Puppet::Error, "Unable to load class #{class_name}" if @implementation_class.nil?
+        unless @implementation_class < PuppetObject || @implementation_class.respond_to?(:ecore)
+          raise Puppet::Error, "Unable to create an instance of #{name}. #{class_name} does not include module #{PuppetObject.name}"
+        end
+      end
+    end
+    @implementation_class
+  end
+
+  # @api private
+  # @return [(Array<String>, Array<PAnyType>, Integer)] array of parameter names, array of parameter types, and a count reflecting the required number of parameters
+  def parameter_info(attr_readers = false)
+    # Create a types and a names array where optional entries ends up last
+    opt_types = []
+    opt_names = []
+    non_opt_types = []
+    non_opt_names = []
+    i12n_type.elements.each do |se|
+      if se.key_type.is_a?(POptionalType)
+        opt_names << (attr_readers ? attr_reader_name(se) : se.name)
+        opt_types << se.value_type
+      else
+        non_opt_names << (attr_readers ? attr_reader_name(se) : se.name)
+        non_opt_types << se.value_type
+      end
+    end
+    param_names = non_opt_names + opt_names
+    param_types = non_opt_types + opt_types
+
+    [param_names, param_types, non_opt_types.size]
+  end
+
+  # @api private
+  def attr_reader_name(se)
+    if se.value_type.is_a?(PBooleanType) || se.value_type.is_a?(POptionalType) && se.value_type.type.is_a?(PBooleanType)
+      "#{se.name}?"
+    else
+      se.name
     end
   end
 

--- a/lib/puppet/pops/types/p_runtime_type.rb
+++ b/lib/puppet/pops/types/p_runtime_type.rb
@@ -5,6 +5,19 @@ module Types
 class PRuntimeType < PAnyType
   TYPE_NAME_OR_PATTERN = PVariantType.new([PStringType::NON_EMPTY, PTupleType.new([PRegexpType::DEFAULT, PStringType::NON_EMPTY])])
 
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+      'runtime' => {
+        KEY_TYPE => POptionalType.new(PStringType::NON_EMPTY),
+        KEY_VALUE => nil
+      },
+      'name_or_pattern' => {
+        KEY_TYPE => POptionalType.new(TYPE_NAME_OR_PATTERN),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   attr_reader :runtime, :name_or_pattern
 
   # Creates a new instance of a Runtime type

--- a/lib/puppet/pops/types/p_sem_ver_range_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_range_type.rb
@@ -5,6 +5,10 @@ module Types
 #
 # @api public
 class PSemVerRangeType < PScalarType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'ScalarType')
+  end
+
   # Check if a version is included in a version range. The version can be a string or
   # a `Semantic::SemVer`
   #

--- a/lib/puppet/pops/types/p_sem_ver_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_type.rb
@@ -6,6 +6,15 @@ module Types
 #
 # @api public
 class PSemVerType < PScalarType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'ScalarType',
+       'ranges' => {
+         KEY_TYPE => PArrayType.new(PVariantType.new([PSemVerRangeType::DEFAULT,PStringType::NON_EMPTY])),
+         KEY_VALUE => []
+       }
+    )
+  end
+
   attr_reader :ranges
 
   def initialize(ranges)

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -169,12 +169,7 @@ class PTypeSetType < PMetaType
     result[KEY_NAME_AUTHORITY] = @name_authority unless @name_authority.nil?
     result[KEY_NAME] = @name
     result[KEY_VERSION] = @version.to_s
-    unless @types.empty?
-      result[KEY_TYPES] = Hash[@types.map do |key, type|
-        type = type.i12n_hash(false) if type.is_a?(PObjectType)
-        [key, type]
-      end]
-    end
+    result[KEY_TYPES] = @types unless @types.empty?
     result[KEY_REFERENCES] = Hash[@references.map { |ref_alias, ref| [ref_alias, ref.i12n_hash] }] unless @references.empty?
     result
   end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -11,6 +11,7 @@ require_relative 'type_factory'
 require_relative 'type_parser'
 require_relative 'class_loader'
 require_relative 'type_mismatch_describer'
+require_relative 'puppet_object'
 
 module Puppet::Pops
 module Types
@@ -32,14 +33,40 @@ EMPTY_HASH = {}.freeze
 #
 # TODO: See PUP-2978 for possible performance optimization
 class TypedModelObject < Object
+  include PuppetObject
   include Visitable
   include Adaptable
+
+  def self._ptype
+    @type
+  end
+
+  def self.create_ptype(loader, ir, parent_name, attributes_hash = EMPTY_HASH)
+    @type = Pcore::create_object_type(loader, ir, self, "Pcore::#{simple_name}Type", "Pcore::#{parent_name}", attributes_hash)
+  end
+
+  def self.register_ptypes(loader, ir)
+    types = []
+    Types.constants.each do |c|
+      cls = Types.const_get(c)
+      next unless cls.is_a?(Class) && cls < self
+      type = cls.register_ptype(loader, ir)
+      types << type unless type.nil?
+    end
+    tp = TypeParser.singleton
+    types.each { |type| type.resolve(tp, loader) }
+  end
 end
 
 # Base type for all types
 # @api public
 #
 class PAnyType < TypedModelObject
+
+  def self.register_ptype(loader, ir)
+    @type = Pcore::create_object_type(loader, ir, self, 'Pcore::AnyType', 'Any', EMPTY_HASH)
+  end
+
   # Accept a visitor that will be sent the message `visit`, once with `self` as the
   # argument. The visitor will then visit all types that this type contains.
   #
@@ -222,12 +249,19 @@ class PAnyType < TypedModelObject
     eql?(o)
   end
 
+  def simple_name
+    self.class.simple_name
+  end
+
   # Strips the class name from all module prefixes, the leading 'P' and the ending 'Type'. I.e.
   # an instance of PVariantType will return 'Variant'
   # @return [String] the simple name of this type
-  def simple_name
-    n = self.class.name
-    n[n.rindex('::')+3..n.size-5]
+  def self.simple_name
+    if @simple_name.nil?
+      n = name
+      @simple_name = n[n.rindex('::')+3..n.size-5]
+    end
+    @simple_name
   end
 
   def to_alias_expanded_s
@@ -322,6 +356,10 @@ end
 # @abstract Encapsulates common behavior for a type that contains one type
 # @api public
 class PTypeWithContainedType < PAnyType
+  def self.register_ptype(loader, ir)
+    # Abstract type. It doesn't register anything
+  end
+
   attr_reader :type
 
   def initialize(type)
@@ -364,6 +402,16 @@ end
 # @api public
 #
 class PType < PTypeWithContainedType
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+       'type' => {
+         KEY_TYPE => POptionalType.new(PType::DEFAULT),
+         KEY_VALUE => nil
+       }
+    )
+  end
+
   def instance?(o, guard = nil)
     if o.is_a?(PAnyType)
       type.nil? || type.assignable?(o, guard)
@@ -403,7 +451,7 @@ class PType < PTypeWithContainedType
     self.class == o.class && @type == o.type
   end
 
-  def simple_name
+  def self.simple_name
     # since this the class is inconsistently named PType and not PTypeType
     'Type'
   end
@@ -422,6 +470,15 @@ class PType < PTypeWithContainedType
 end
 
 class PNotUndefType < PTypeWithContainedType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+       'type' => {
+         KEY_TYPE => POptionalType.new(PType::DEFAULT),
+         KEY_VALUE => nil
+       }
+    )
+  end
+
   def initialize(type = nil)
     super(type.class == PAnyType ? nil : type)
   end
@@ -469,6 +526,10 @@ end
 # @api public
 #
 class PUndefType < PAnyType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType')
+  end
+
   def instance?(o, guard = nil)
     o.nil? || o == :undef
   end
@@ -492,6 +553,10 @@ end
 # @api private
 #
 class PUnitType < PAnyType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType')
+  end
+
   def instance?(o, guard = nil)
     true
   end
@@ -521,6 +586,10 @@ end
 # @api public
 #
 class PDefaultType < PAnyType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType')
+  end
+
   def instance?(o, guard = nil)
     o == :default
   end
@@ -539,6 +608,10 @@ end
 # @api public
 #
 class PDataType < PAnyType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType')
+  end
+
   def eql?(o)
     self.class == o.class || o == PVariantType::DATA
   end
@@ -570,6 +643,9 @@ end
 # @api public
 #
 class PScalarType < PAnyType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType')
+  end
 
   def instance?(o, guard = nil)
     assignable?(TypeCalculator.infer(o), guard)
@@ -589,6 +665,10 @@ end
 # @api public
 #
 class PEnumType < PScalarType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'ScalarType', 'values' => PArrayType.new(PStringType::NON_EMPTY))
+  end
+
   attr_reader :values
 
   def initialize(values)
@@ -645,6 +725,13 @@ end
 # @api public
 #
 class PNumericType < PScalarType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'ScalarType',
+      'from' => { KEY_TYPE => PNumericType::DEFAULT, KEY_VALUE => :default },
+      'to' => { KEY_TYPE => PNumericType::DEFAULT, KEY_VALUE => :default }
+    )
+  end
+
   def initialize(from, to = Float::INFINITY)
     from = -Float::INFINITY if from.nil? || from == :default
     to = Float::INFINITY if to.nil? || to == :default
@@ -767,6 +854,10 @@ end
 # @api public
 #
 class PIntegerType < PNumericType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'NumericType')
+  end
+
   # Will respond `true` for any range that is bounded at both ends.
   #
   # @return [Boolean] `true` if the type describes a finite range.
@@ -909,6 +1000,10 @@ end
 # @api public
 #
 class PFloatType < PNumericType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'NumericType')
+  end
+
   def generalize
     DEFAULT
   end
@@ -992,6 +1087,15 @@ end
 # @api public
 #
 class PCollectionType < PAnyType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+      'element_type' => {
+        KEY_TYPE => POptionalType.new(PType::DEFAULT),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   attr_reader :element_type, :size_type
 
   def initialize(element_type, size_type = nil)
@@ -1090,6 +1194,15 @@ class PCollectionType < PAnyType
 end
 
 class PIterableType < PTypeWithContainedType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+      'element_type' => {
+        KEY_TYPE => POptionalType.new(PType::DEFAULT),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   def element_type
     @type
   end
@@ -1139,6 +1252,15 @@ end
 # @api public
 #
 class PIteratorType < PTypeWithContainedType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+      'element_type' => {
+        KEY_TYPE => POptionalType.new(PType::DEFAULT),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   def element_type
     @type
   end
@@ -1168,6 +1290,19 @@ end
 # @api public
 #
 class PStringType < PScalarType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'ScalarType',
+      'size_type' => {
+        KEY_TYPE => POptionalType.new(PType.new(PIntegerType::DEFAULT)),
+        KEY_VALUE => nil
+      },
+      'values' => {
+        KEY_TYPE => PArrayType.new(PStringType::DEFAULT),
+        KEY_VALUE => EMPTY_ARRAY
+      }
+    )
+  end
+
   attr_reader :size_type, :values
 
   def initialize(size_type, values = EMPTY_ARRAY)
@@ -1290,6 +1425,13 @@ end
 # @api public
 #
 class PRegexpType < PScalarType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'ScalarType',
+      'pattern' => {
+        KEY_TYPE => PVariantType.new([PUndefType::DEFAULT, PStringType::DEFAULT, PRegexpType::DEFAULT]),
+        KEY_VALUE => nil
+      })
+  end
   attr_reader :pattern
 
   def initialize(pattern)
@@ -1330,6 +1472,10 @@ end
 # @api public
 #
 class PPatternType < PScalarType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'ScalarType', 'patterns' => PArrayType.new(PRegexpType::DEFAULT))
+  end
+
   attr_reader :patterns
 
   def initialize(patterns)
@@ -1380,6 +1526,9 @@ end
 # @api public
 #
 class PBooleanType < PScalarType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'ScalarType')
+  end
 
   def instance?(o, guard = nil)
     o == true || o == false
@@ -1429,6 +1578,12 @@ end
 # @api public
 #
 class PStructElement < TypedModelObject
+  def self.register_ptype(loader, ir)
+    @type = Pcore::create_object_type(loader, ir, self, 'Pcore::StructElement'.freeze, nil,
+      'key_type' => PType::DEFAULT,
+      'value_type' => PType::DEFAULT)
+  end
+
   attr_accessor :key_type, :value_type
 
   def accept(visitor, guard)
@@ -1478,6 +1633,10 @@ end
 #
 class PStructType < PAnyType
   include Enumerable
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType', 'elements' => PArrayType.new(PTypeReferenceType.new('Pcore::StructElement')))
+  end
 
   def initialize(elements)
     @elements = elements.freeze
@@ -1619,6 +1778,16 @@ end
 #
 class PTupleType < PAnyType
   include Enumerable
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+      'types' => PArrayType.new(PType::DEFAULT),
+      'size_type' => {
+        KEY_TYPE => POptionalType.new(PType.new(PIntegerType::DEFAULT)),
+        KEY_VALUE => nil
+      }
+    )
+  end
 
   # If set, describes min and max required of the given types - if max > size of
   # types, the last type entry repeats
@@ -1797,6 +1966,19 @@ end
 # @api public
 #
 class PCallableType < PAnyType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+      'param_types' => {
+        KEY_TYPE => POptionalType.new(PTupleType::DEFAULT),
+        KEY_VALUE => nil
+      },
+      'block_type' => {
+        KEY_TYPE => POptionalType.new(PCallableType::DEFAULT),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   # Types of parameters as a Tuple with required/optional count, or an Integer with min (required), max count
   # @return [PTupleType] the tuple representing the parameter types
   attr_reader :param_types
@@ -1913,6 +2095,15 @@ end
 #
 class PArrayType < PCollectionType
 
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'CollectionType',
+      'size_type' => {
+        KEY_TYPE => POptionalType.new(PType.new(PIntegerType::DEFAULT)),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   # @api private
   def callable_args?(callable, guard = nil)
     param_t = callable.param_types
@@ -2017,7 +2208,27 @@ end
 # @api public
 #
 class PHashType < PCollectionType
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'CollectionType',
+      'key_type' => {
+        KEY_TYPE => POptionalType.new(PType::DEFAULT),
+        KEY_VALUE => nil
+      },
+      'element_type' => {
+        KEY_TYPE => POptionalType.new(PType::DEFAULT),
+        KEY_VALUE => nil,
+        KEY_OVERRIDE => true
+      },
+      'size_type' => {
+        KEY_TYPE => POptionalType.new(PType.new(PIntegerType::DEFAULT)),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   attr_accessor :key_type
+  alias value_type element_type
 
   def initialize(key_type, value_type, size_type = nil)
     super(value_type, size_type)
@@ -2176,6 +2387,10 @@ end
 #
 class PVariantType < PAnyType
   include Enumerable
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType', 'types' => PArrayType.new(PType::DEFAULT))
+  end
 
   attr_reader :types
 
@@ -2433,6 +2648,9 @@ end
 # @api public
 #
 class PCatalogEntryType < PAnyType
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType')
+  end
 
   DEFAULT = PCatalogEntryType.new
 
@@ -2453,6 +2671,15 @@ end
 class PHostClassType < PCatalogEntryType
   attr_reader :class_name
 
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'CatalogEntryType',
+      'class_name' => {
+        KEY_TYPE => POptionalType.new(PStringType::NON_EMPTY),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   NAME = 'Class'.freeze
 
   def initialize(class_name)
@@ -2466,7 +2693,7 @@ class PHostClassType < PCatalogEntryType
     self.class == o.class && @class_name == o.class_name
   end
 
-  def simple_name
+  def self.simple_name
     NAME
   end
 
@@ -2488,6 +2715,20 @@ end
 # @api public
 #
 class PResourceType < PCatalogEntryType
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'CatalogEntryType',
+      'type_name' => {
+        KEY_TYPE => POptionalType.new(PStringType::NON_EMPTY),
+        KEY_VALUE => nil
+      },
+      'title' => {
+        KEY_TYPE => POptionalType.new(PStringType::NON_EMPTY),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   attr_reader :type_name, :title, :downcased_name
 
   def initialize(type_name, title = nil)
@@ -2519,6 +2760,16 @@ end
 # @api public
 #
 class POptionalType < PTypeWithContainedType
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'CatalogEntryType',
+      'type' => {
+        KEY_TYPE => POptionalType.new(PType::DEFAULT),
+        KEY_VALUE => nil
+      }
+    )
+  end
+
   def optional_type
     @type
   end
@@ -2569,6 +2820,11 @@ class POptionalType < PTypeWithContainedType
 end
 
 class PTypeReferenceType < PAnyType
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType', 'type_string' => PStringType::NON_EMPTY)
+  end
+
   attr_reader :type_string
 
   def initialize(type_string)
@@ -2613,6 +2869,18 @@ end
 #
 # @api public
 class PTypeAliasType < PAnyType
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType',
+       'name' => PStringType::NON_EMPTY,
+       'type_expr' => PAnyType::DEFAULT,
+       'resolved_type' => {
+         KEY_TYPE => POptionalType.new(PType::DEFAULT),
+         KEY_VALUE => nil
+       }
+    )
+  end
+
   attr_reader :name
 
   # @param name [String] The name of the type
@@ -2859,7 +3127,6 @@ end
 
 require 'puppet/pops/pcore'
 
-require_relative 'puppet_object'
 require_relative 'annotatable'
 require_relative 'p_meta_type'
 require_relative 'p_object_type'

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2786,6 +2786,7 @@ class PTypeAliasType < PAnyType
 
   # Delegates to resolved type
   def method_missing(name, *arguments, &block)
+    super if @resolved_type.equal?(PTypeReferenceType::DEFAULT)
     resolved_type.send(name, *arguments, &block)
   end
 
@@ -2797,6 +2798,12 @@ class PTypeAliasType < PAnyType
       return 0 if guard.add_this(self) == RecursionGuard::SELF_RECURSION_IN_BOTH
     end
     resolved_type.really_instance?(o, guard)
+  end
+
+  # @return `nil` to prevent serialization of the type_expr used when first initializing this instance
+  # @api private
+  def type_expr
+    nil
   end
 
   protected

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1480,7 +1480,7 @@ class PStructType < PAnyType
   include Enumerable
 
   def initialize(elements)
-    @elements = elements.sort.freeze
+    @elements = elements.freeze
   end
 
   def accept(visitor, guard)

--- a/spec/unit/pops/serialization/packer_spec.rb
+++ b/spec/unit/pops/serialization/packer_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+require 'puppet/pops/serialization'
+
+module Puppet::Pops::Serialization
+[JSON].each do |packer_module|
+describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
+  let(:io) { StringIO.new }
+  let(:reader_class) { packer_module::Reader }
+  let(:writer_class) { packer_module::Writer }
+
+  def write(*values)
+    io.reopen
+    serializer = writer_class.new(io)
+    values.each { |val| serializer.write(val) }
+    serializer.finish
+    io.rewind
+  end
+
+  def read(count = nil)
+    @deserializer = reader_class.new(io)
+    count.nil? ? @deserializer.read : Array.new(count) { @deserializer.read }
+  end
+
+  context 'can write and read a Scalar' do
+    it 'String' do
+      val = 'the value'
+      write(val)
+      val2 = read
+      expect(val2).to be_a(String)
+      expect(val2).to eql(val)
+    end
+
+    it 'Integer' do
+      val = 32
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Integer)
+      expect(val2).to eql(val)
+    end
+
+    it 'Float' do
+      val = 32.45
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Float)
+      expect(val2).to eql(val)
+    end
+
+    it 'true' do
+      val = true
+      write(val)
+      val2 = read
+      expect(val2).to be_a(TrueClass)
+      expect(val2).to eql(val)
+    end
+
+    it 'false' do
+      val = false
+      write(val)
+      val2 = read
+      expect(val2).to be_a(FalseClass)
+      expect(val2).to eql(val)
+    end
+
+    it 'nil' do
+      val = nil
+      write(val)
+      val2 = read
+      expect(val2).to be_a(NilClass)
+      expect(val2).to eql(val)
+    end
+
+    it 'Regexp' do
+      val = /match me/
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Regexp)
+      expect(val2).to eql(val)
+    end
+
+    it 'Time created by TimeFactory' do
+      val = TimeFactory.now
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Time)
+      expect(val2).to eql(val)
+    end
+
+    it 'Version' do
+      val = Semantic::Version.parse('1.2.3-alpha2')
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Semantic::Version)
+      expect(val2).to eql(val)
+    end
+
+    it 'VersionRange' do
+      val = Semantic::VersionRange.parse('>=1.2.3-alpha2 <1.2.4')
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Semantic::VersionRange)
+      expect(val2).to eql(val)
+    end
+
+    it 'will never fail write and read of Time created by TimeFactory' do
+      val = Time.now
+      val = TimeFactory.at(val.tv_sec, val.tv_nsec / 1000 + 0.123)
+      write(val)
+      val2 = read
+      expect(val).to eq(val2)
+    end
+
+    # Windows doesn't seem ot have fine enough granularity to provoke the problem
+    it 'will fail on Time not created by TimeFactory' do
+      val = Time.now
+      val = Time.at(val.tv_sec, val.tv_nsec / 1000 + 0.123)
+      write(val)
+      val2 = read
+      expect(val).not_to eq(val2)
+    end
+  end
+
+  it 'should be able to write and read primitives using tabulation' do
+    val = 'the value'
+    write(val, val)
+    expect(read(2)).to eql([val, val])
+    expect(@deserializer.primitive_count).to eql(1)
+  end
+end
+end
+end

--- a/spec/unit/pops/serialization/packer_spec.rb
+++ b/spec/unit/pops/serialization/packer_spec.rb
@@ -30,8 +30,16 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
       expect(val2).to eql(val)
     end
 
-    it 'Integer' do
-      val = 32
+    it 'positive Integer' do
+      val = 2**63-1
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Integer)
+      expect(val2).to eql(val)
+    end
+
+    it 'negative Integer' do
+      val = -2**63
       write(val)
       val2 = read
       expect(val2).to be_a(Integer)
@@ -117,6 +125,20 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
       write(val)
       val2 = read
       expect(val).not_to eq(val2)
+    end
+  end
+
+  context 'will fail on attempts to write' do
+    it 'Integer larger than 2**63-1' do
+      expect { write(2**63) }.to raise_error(SerializationError, 'Integer out of bounds')
+    end
+
+    it 'Integer smaller than -2**63' do
+      expect { write(-2**63-1) }.to raise_error(SerializationError, 'Integer out of bounds')
+    end
+
+    it 'objects unknown to Puppet serialization' do
+      expect { write("".class) }.to raise_error(SerializationError, 'Unable to serialize a Class')
     end
   end
 

--- a/spec/unit/pops/serialization/rgen_spec.rb
+++ b/spec/unit/pops/serialization/rgen_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+require 'puppet/pops'
+
+module Puppet::Pops
+module Serialization
+describe 'RGen' do
+  let!(:env) { Puppet::Node::Environment.create(:testing, []) }
+  let!(:loaders) { Puppet::Pops::Loaders.new(env) }
+  let!(:loader) { loaders.find_loader(nil) }
+
+  around :each do |example|
+    Puppet.override(:loaders => loaders, :current_environment => env) do
+      example.run
+    end
+  end
+
+  def find_parent(type, parent_name)
+    p = type
+    while p.is_a?(Types::PObjectType) && p.name != parent_name
+      p = p.parent
+    end
+    expect(p).to be_a(Types::PObjectType), "did not find #{parent_name} in parent chain of #{type.name}"
+    p
+  end
+
+  context 'TypeGenerator' do
+
+    let!(:generator) { RGen::TypeGenerator.new }
+    let!(:type_set) { generator.generate_type_set('PuppetSpec::Bindings', Binder::Bindings, loader) }
+    let!(:bindings_classes) do
+      Binder::Bindings.constants.each_with_object([]) do |n, a|
+        cls = Binder::Bindings.const_get(n)
+        a << cls if cls.is_a?(Class) && cls.respond_to?(:ecore)
+      end
+    end
+
+    it 'generates TypeSet from a module that represents an ECore package' do
+      expect(type_set).to be_a(Types::PTypeSetType)
+      expect(type_set.types).not_to be_empty
+      expect(type_set.types.size).to eql(bindings_classes.size)
+    end
+
+    it 'all types are in the PuppetSpec::Bindings namespace' do
+      type_set.types.values.each {|type| expect(type.name).to start_with('PuppetSpec::Bindings::') }
+    end
+
+    it 'all types extend from PuppetSpec::Bindings::BindingsModelObject' do
+      type_set.types.values.each do |type|
+        expect(find_parent(type, 'PuppetSpec::Bindings::BindingsModelObject').name).to eq('PuppetSpec::Bindings::BindingsModelObject')
+      end
+    end
+  end
+
+  context 'AST model types' do
+    let!(:impl_repo) { Loaders.implementation_registry }
+    let!(:loader) {  Loaders.find_loader(nil) }
+    let!(:type_set) { Types::TypeParser.singleton.parse('Puppet::AST', loader) }
+    let!(:ast_classes) do
+      Model.constants.each_with_object([]) do |n, a|
+        cls = Model.const_get(n)
+        a << cls if cls.is_a?(Class) && cls.respond_to?(:ecore)
+      end
+    end
+
+    it 'can be mapped from the ecore classes found in Puppet::Pops::Model' do
+      ast_classes.each { |ast_class| expect(impl_repo.type_for_module(ast_class)).to be_a(Types::PObjectType) }
+    end
+
+    it 'are contained in a TypeSet named Puppet::AST' do
+      expect(type_set).to be_a(Types::PTypeSetType)
+      expect(type_set.name).to eq('Puppet::AST')
+      expect(type_set.types.size).to eql(ast_classes.size + 1)  # +1 because the Locator is added
+    end
+
+    it 'all reside in the Puppet::AST namespace' do
+      type_set.types.values.each {|type| expect(type.name).to start_with('Puppet::AST::') }
+    end
+
+    it 'all extend from Puppet::AST::PopsObject' do
+      type_set.types.values.each do |type|
+        next if type.name == 'Puppet::AST::Locator'
+        expect(find_parent(type, 'Puppet::AST::PopsObject').name).to eq('Puppet::AST::PopsObject')
+      end
+    end
+  end
+end
+end
+end

--- a/spec/unit/pops/serialization/serialization_spec.rb
+++ b/spec/unit/pops/serialization/serialization_spec.rb
@@ -1,0 +1,228 @@
+require 'spec_helper'
+require 'puppet/pops'
+
+module Puppet::Pops
+module Serialization
+[JSON].each do |packer_module|
+  describe "the Puppet::Pops::Serialization over #{packer_module.name}" do
+  let!(:dumper) { Model::ModelTreeDumper.new }
+  let(:io) { StringIO.new }
+  let(:parser) { Parser::EvaluatingParser.new }
+  let(:env) { Puppet::Node::Environment.create(:testing, []) }
+  let(:loaders) { Puppet::Pops::Loaders.new(env) }
+  let(:loader) { loaders.find_loader(nil) }
+  let(:reader_class) { packer_module::Reader }
+  let(:writer_class) { packer_module::Writer }
+
+  around :each do |example|
+     Puppet.override(:loaders => loaders, :current_environment => env) do
+      example.run
+    end
+  end
+
+  def write(*values)
+    io.reopen
+    serializer = Serializer.new(writer_class.new(io))
+    values.each { |val| serializer.write(val) }
+    serializer.finish
+    io.rewind
+  end
+
+  def read
+    deserializer = Deserializer.new(reader_class.new(io), loaders.find_loader(nil))
+    deserializer.read
+  end
+
+  def parse(string)
+    parser.parse_string(string, '/home/tester/experiments/manifests/init.pp').current
+  end
+
+  context 'can write and read a Scalar' do
+    it 'String' do
+      val = 'the value'
+      write(val)
+      val2 = read
+      expect(val2).to be_a(String)
+      expect(val2).to eql(val)
+    end
+
+    it 'Integer' do
+      val = 32
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Integer)
+      expect(val2).to eql(val)
+    end
+
+    it 'Float' do
+      val = 32.45
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Float)
+      expect(val2).to eql(val)
+    end
+
+    it 'true' do
+      val = true
+      write(val)
+      val2 = read
+      expect(val2).to be_a(TrueClass)
+      expect(val2).to eql(val)
+    end
+
+    it 'false' do
+      val = false
+      write(val)
+      val2 = read
+      expect(val2).to be_a(FalseClass)
+      expect(val2).to eql(val)
+    end
+
+    it 'nil' do
+      val = nil
+      write(val)
+      val2 = read
+      expect(val2).to be_a(NilClass)
+      expect(val2).to eql(val)
+    end
+
+    it 'Regexp' do
+      val = /match me/
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Regexp)
+      expect(val2).to eql(val)
+    end
+
+    it 'Time created by TimeFactory' do
+      # It does succeed on rare occasions, so we need to repeat
+      val = TimeFactory.now
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Time)
+      expect(val2).to eql(val)
+    end
+
+    it 'Version' do
+      # It does succeed on rare occasions, so we need to repeat
+      val = Semantic::Version.parse('1.2.3-alpha2')
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Semantic::Version)
+      expect(val2).to eql(val)
+    end
+
+    it 'VersionRange' do
+      # It does succeed on rare occasions, so we need to repeat
+      val = Semantic::VersionRange.parse('>=1.2.3-alpha2 <1.2.4')
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Semantic::VersionRange)
+      expect(val2).to eql(val)
+    end
+  end
+
+  context 'can write and read' do
+    include_context 'types_setup'
+
+    it 'all default types' do
+      all_types.each do |t|
+        val = t::DEFAULT
+        write(val)
+        val2 = read
+        expect(val2).to be_a(t)
+        expect(val2).to eql(val)
+      end
+    end
+
+    context 'a parameterized' do
+      it 'String' do
+        val = Types::TypeFactory.string(Types::TypeFactory.range(1, :default))
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Types::PStringType)
+        expect(val2).to eql(val)
+      end
+
+      it 'Regex' do
+        val = Types::TypeFactory.regexp(/foo/)
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Types::PRegexpType)
+        expect(val2).to eql(val)
+      end
+
+      it 'Variant' do
+        val = Types::TypeFactory.variant(Types::TypeFactory.string, Types::TypeFactory.range(1, :default))
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Types::PVariantType)
+        expect(val2).to eql(val)
+      end
+
+      it 'Object' do
+        val = Types::TypeParser.singleton.parse('Pcore::StringType', loader)
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Types::PObjectType)
+        expect(val2).to eql(val)
+      end
+    end
+
+    context 'an AST model' do
+      it "Locator" do
+        val = Parser::Locator::Locator19.new('here is some text', '/tmp/foo', [5])
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Parser::Locator::Locator19)
+        expect(val2).to eql(val)
+      end
+
+      it 'nested Expression' do
+        expr = parse(<<-CODE)
+          $rootgroup = $osfamily ? {
+              'Solaris'          => 'wheel',
+              /(Darwin|FreeBSD)/ => 'wheel',
+              default            => 'root',
+          }
+
+          file { '/etc/passwd':
+            ensure => file,
+            owner  => 'root',
+            group  => $rootgroup,
+          }
+        CODE
+        write(expr)
+        expr2 = read
+        expect(dumper.dump(expr)).to eq(dumper.dump(expr2))
+      end
+    end
+  end
+
+  context 'When debugging' do
+    let(:debug_io) { StringIO.new }
+    let(:writer) { reader_class.new(io, { :debug_io => debug_io, :tabulate => false, :verbose => true }) }
+
+    it 'can write and read an AST expression' do
+      expr = parse(<<-CODE)
+        $rootgroup = $osfamily ? {
+            'Solaris'          => 'wheel',
+            /(Darwin|FreeBSD)/ => 'wheel',
+            default            => 'root',
+        }
+
+        file { '/etc/passwd':
+          ensure => file,
+          owner  => 'root',
+          group  => $rootgroup,
+        }
+      CODE
+      write(expr)
+      expr2 = read
+      expect(dumper.dump(expr)).to eq(dumper.dump(expr2))
+    end
+  end
+end
+end
+end
+end

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -1055,6 +1055,48 @@ describe 'The Object Type' do
       end
     end
   end
+
+  context 'is assigned to all PAnyType classes such that' do
+    include_context 'types_setup'
+
+    def find_parent(tc, parent_name)
+      p = tc._ptype
+      while p.is_a?(PObjectType) && p.name != parent_name
+        p = p.parent
+      end
+      expect(p).to be_a(PObjectType), "did not find #{parent_name} in parent chain of #{tc.name}"
+      p
+    end
+
+    it 'the class has a _ptype method' do
+      all_types.each do |tc|
+        expect(tc).to respond_to(:_ptype).with(0).arguments
+      end
+    end
+
+    it 'the _ptype method returns a PObjectType instance' do
+      all_types.each do |tc|
+        expect(tc._ptype).to be_a(PObjectType)
+      end
+    end
+
+    it 'the instance returned by _ptype is a descendant from Pcore::AnyType' do
+      all_types.each { |tc| expect(find_parent(tc, 'Pcore::AnyType').name).to eq('Pcore::AnyType') }
+    end
+
+    it 'PScalarType classes _ptype returns a descendant from Pcore::ScalarType' do
+      scalar_types.each { |tc| expect(find_parent(tc, 'Pcore::ScalarType').name).to eq('Pcore::ScalarType') }
+    end
+
+    it 'PNumericType classes _ptype returns a descendant from Pcore::NumberType' do
+      numeric_types.each { |tc| expect(find_parent(tc, 'Pcore::NumericType').name).to eq('Pcore::NumericType') }
+    end
+
+    it 'PCollectionType classes _ptype returns a descendant from Pcore::CollectionType' do
+      coll_descendants = collection_types - [PTupleType, PStructType]
+      coll_descendants.each { |tc| expect(find_parent(tc, 'Pcore::CollectionType').name).to eq('Pcore::CollectionType') }
+    end
+  end
 end
 end
 end


### PR DESCRIPTION
This PR adds what's needed to perform serialization/deserialization of primitives, arrays, hashes, and complex objects that are described using the Puppet Object type. The mechanism is designed to work on differnent protocols using an underlying abstract reader/writer. A reader/writer pair for JSON is included in this PR.