### PR TITLE
(PUP-6445) Pin Win32 gems to explicit versions

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -34,22 +34,24 @@ gem_platform_dependencies:
     gem_runtime_dependencies:
       # Pinning versions that require native extensions
       ffi: '~> 1.9.6'
-      win32-dir: '~> 0.4.9'
-      win32-eventlog: '~> 0.6.2'
-      win32-process: '~> 0.7.4'
+      # win32-xxxx gems are pinned due to PUP-6445
+      win32-dir: '= 0.4.9'
+      win32-eventlog: '= 0.6.5'
+      win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
-      win32-security: '~> 0.2.5'
-      win32-service: '~> 0.8.6'
+      win32-security: '= 0.2.5'
+      win32-service: '= 0.8.7'
       minitar: '~> 0.5.4'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.6'
-      win32-dir: '~> 0.4.9'
-      win32-eventlog: '~> 0.6.2'
-      win32-process: '~> 0.7.4'
+      # win32-xxxx gems are pinned due to PUP-6445
+      win32-dir: '= 0.4.9'
+      win32-eventlog: '= 0.6.5'
+      win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
-      win32-security: '~> 0.2.5'
-      win32-service: '~> 0.8.6'
+      win32-security: '= 0.2.5'
+      win32-service: '= 0.8.7'
       minitar: '~> 0.5.4'
 bundle_platforms:
   universal-darwin: ruby


### PR DESCRIPTION
The Win32-Service gem was updated to 0.8.9 however the new gem pulled in a
dependant gem called ffi-win32-extensions which has a name collision on the
FFI:Pointer.read_wide_string method.  This causes Puppet to fail in mutiple
locations.  This commit pins the Win32-Service gem to a prior version without
the dependency.