### PR TITLE
(PUP-6233) Only use smf restart -s flag in Solaris 11.2 and above

### DIFF
--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -66,10 +66,10 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
   end
 
   def restartcmd
-    if Puppet::Util::Package.versioncmp(Facter.value(:kernelrelease), '5.11') >= 0
+    if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.2') >= 0
       [command(:adm), :restart, "-s", @resource[:name]]
     else
-      # Solaris 10 does not have synchronous restart
+      # Synchronous restart only supported in Solaris 11.2 and above
       [command(:adm), :restart, @resource[:name]]
     end
   end

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -22,7 +22,7 @@ describe provider_class, :if => Puppet.features.posix? do
     FileTest.stubs(:executable?).with('/usr/bin/svcs').returns true
     Facter.stubs(:value).with(:operatingsystem).returns('Solaris')
     Facter.stubs(:value).with(:osfamily).returns('Solaris')
-    Facter.stubs(:value).with(:kernelrelease).returns '5.11'
+    Facter.stubs(:value).with(:operatingsystemrelease).returns '11.2'
   end
 
   describe ".instances" do
@@ -184,26 +184,27 @@ describe provider_class, :if => Puppet.features.posix? do
       expect { @provider.restart }.to raise_error Puppet::Error, ('Timed out waiting for /system/myservice to transition states')
     end
 
-    context 'with :kernelrelease == 5.10' do
+    context 'with :operatingsystemrelease == 10_u10' do
       it "should call 'svcadm restart /system/myservice'" do
-        Facter.stubs(:value).with(:kernelrelease).returns '5.10'
+        Facter.stubs(:value).with(:operatingsystemrelease).returns '10_u10'
         @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, "/system/myservice"], true)
         @provider.expects(:wait).with('online')
         @provider.restart
       end
     end
 
-    context 'with :kernelrelease == 5.11' do
+    context 'with :operatingsystemrelease == 11.2' do
       it "should call 'svcadm restart -s /system/myservice'" do
+        Facter.stubs(:value).with(:operatingsystemrelease).returns '11.2'
         @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, "-s", "/system/myservice"], true)
         @provider.expects(:wait).with('online')
         @provider.restart
       end
     end
 
-    context 'with :kernelrelease > 5.11' do
+    context 'with :operatingsystemrelease > 11.2' do
       it "should call 'svcadm restart -s /system/myservice'" do
-        Facter.stubs(:value).with(:kernelrelease).returns '5.12'
+        Facter.stubs(:value).with(:operatingsystemrelease).returns '11.3'
         @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, "-s", "/system/myservice"], true)
         @provider.expects(:wait).with('online')
         @provider.restart


### PR DESCRIPTION
The synchronous `-s` flag for `smf restart` only exists in Solaris
11.2 and above. This commit ensures that we don't try to use it in
older Solaris versions.

See https://blogs.oracle.com/SolarisSMF/entry/synchronous_actions