### PR TITLE
(PUP-6450) Fix Windows group and user authoritative membership

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -27,10 +27,13 @@ Puppet::Type.type(:group).provide :windows_adsi do
     current_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
     specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
 
+    current_sids = current_users.keys.to_a
+    specified_sids = specified_users.keys.to_a
+
     if @resource[:auth_membership]
-      current_users.keys.to_a == specified_users.keys.to_a
+      current_sids.sort == specified_sids.sort
     else
-      (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
+      (specified_sids & current_sids) == specified_sids
     end
   end
 

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -36,13 +36,16 @@ Puppet::Type.type(:user).provide :windows_adsi do
     # since the default array_matching comparison is not commutative
 
     # dupes automatically weeded out when hashes built
-    current_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
-    specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
+    current_groups = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
+    specified_groups = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
+
+    current_sids = current_groups.keys.to_a
+    specified_sids = specified_groups.keys.to_a
 
     if @resource[:membership] == :inclusive
-      current_users.keys.to_a == specified_users.keys.to_a
+      current_sids.sort == specified_sids.sort
     else
-      (specified_users.keys.to_a & current_users.keys.to_a) == specified_users.keys.to_a
+      (specified_sids & current_sids) == specified_sids
     end
   end
 

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -74,6 +74,10 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
           resource[:auth_membership] = true
         end
 
+        it "should return true when current and should contain the same users in a different order" do
+          expect(provider.members_insync?(['user1', 'user2', 'user3'], ['user3', 'user1', 'user2'])).to be_truthy
+        end
+
         it "should return false when current is nil" do
           expect(provider.members_insync?(nil, ['user2'])).to be_falsey
         end

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -99,6 +99,10 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
         resource[:membership] = :inclusive
       end
 
+      it "should return true when current and should contain the same groups in a different order" do
+        expect(provider.groups_insync?(['group1', 'group2', 'group3'], ['group3', 'group1', 'group2'])).to be_truthy
+      end
+
       it "should return false when current contains different groups than should" do
         expect(provider.groups_insync?(['group1'], ['group2'])).to be_falsey
       end


### PR DESCRIPTION
Fixes issues with:

* The implementation of `:auth_membership => true` for the Windows ADSI Group provider
* The implementation of `:membership => inclusive` for the Windows ADSI User provider