### PR TITLE
(maint) Fix incorrect non-capturing group escapes

### DIFF
--- a/lib/puppet/pops/patterns.rb
+++ b/lib/puppet/pops/patterns.rb
@@ -36,7 +36,7 @@ module Puppet::Pops::Patterns
 
   # VAR_NAME matches the name part of a variable (The $ character is not included)
   # Note, that only the final segment may start with an underscore.
-  VAR_NAME = %r{\A(:?(::)?[a-z]\w*)*(:?(::)?[a-z_]\w*)\z}
+  VAR_NAME = %r{\A(?:(::)?[a-z]\w*)*(?:(::)?[a-z_]\w*)\z}
 
   # PARAM_NAME matches the name part of a parameter (The $ character is not included)
   PARAM_NAME = %r{\A[a-z_]\w*\z}


### PR DESCRIPTION
The VAR_NAME regexp in Puppet::Pops::Patterns had ':?' instead of
'?:' to denote non-capturing groups. The problem has gone unnoticed
since a) the ':' became optional, and b) no code attempts to use
that expression and extract the groups.