### PR TITLE
(PUP-6361) Add validation error on definition names starting with '::'

### DIFF
--- a/lib/puppet/pops/patterns.rb
+++ b/lib/puppet/pops/patterns.rb
@@ -26,10 +26,18 @@ module Puppet::Pops::Patterns
   #
   CLASSREF_EXT = %r{\A((::){0,1}[A-Z][\w]*)+\z}
 
+  # Same as CLASSREF_EXT but cannot start with '::'
+  #
+  CLASSREF_EXT_DECL = %r{\A[A-Z][\w]*(?:::[A-Z][\w]*)*\z}
+
   # CLASSREF matches a class reference the way it is represented internally in the
   # model (i.e. in lower case).
   #
   CLASSREF = %r{\A((::){0,1}[a-z][\w]*)+\z}
+
+  # Same as CLASSREF but cannot start with '::'
+  #
+  CLASSREF_DECL = %r{\A[a-z][\w]*(?:::[a-z][\w]*)*\z}
 
   # DOLLAR_VAR matches a variable name including the initial $ character
   DOLLAR_VAR     = %r{\$(::)?(\w+::)*\w+}

--- a/lib/puppet/pops/patterns.rb
+++ b/lib/puppet/pops/patterns.rb
@@ -36,7 +36,7 @@ module Puppet::Pops::Patterns
 
   # VAR_NAME matches the name part of a variable (The $ character is not included)
   # Note, that only the final segment may start with an underscore.
-  VAR_NAME = %r{\A(:?(::)?[a-z]\w*)*(:?(::)?[a-z_]\w*)\z}
+  VAR_NAME = %r{\A(?:(::)?[a-z]\w*)*(?:(::)?[a-z_]\w*)\z}
 
   # PARAM_NAME matches the name part of a parameter (The $ character is not included)
   PARAM_NAME = %r{\A[a-z_]\w*\z}

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -349,7 +349,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   # for 'class', 'define', and function
   def check_NamedDefinition(o)
     top(o.eContainer, o)
-    if o.name !~ Patterns::CLASSREF
+    if o.name !~ Patterns::CLASSREF_DECL
       acceptor.accept(Issues::ILLEGAL_DEFINITION_NAME, o, {:name=>o.name})
     end
     internal_check_reserved_type_name(o, o.name)
@@ -358,6 +358,9 @@ class Checker4_0 < Evaluator::LiteralEvaluator
 
   def check_TypeAlias(o)
     top(o.eContainer, o)
+    if o.name !~ Patterns::CLASSREF_EXT_DECL
+      acceptor.accept(Issues::ILLEGAL_DEFINITION_NAME, o, {:name=>o.name})
+    end
     internal_check_reserved_type_name(o, o.name)
     internal_check_type_ref(o, o.type_expr)
   end

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -16,9 +16,26 @@ describe "validating 4x" do
     acceptor
   end
 
-  it 'should raise error for illegal names' do
+  it 'should raise error for illegal class names' do
     expect(validate(parse('class aaa::_bbb {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
     expect(validate(parse('class Aaa {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
+    expect(validate(parse('class ::aaa {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
+  end
+
+  it 'should raise error for illegal define names' do
+    expect(validate(parse('define aaa::_bbb {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
+    expect(validate(parse('define Aaa {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
+    expect(validate(parse('define ::aaa {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
+  end
+
+  it 'should raise error for illegal function names' do
+    expect(validate(parse('function aaa::_bbb() {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
+    expect(validate(parse('function Aaa() {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
+    expect(validate(parse('function ::aaa() {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
+  end
+
+  it 'should raise error for illegal type names' do
+    expect(validate(parse('type ::Aaa = Any'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
   end
 
   it 'should raise error for illegal variable names' do


### PR DESCRIPTION
A class, define, function, or type declaration that uses a name that
start with '::' is illegal. This commit ensures that such names are
trapped by the parser validator.
