### PR TITLE
(PUP-6244) Fix skipped PMT upgrade acceptance tests

### DIFF
--- a/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
+++ b/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
@@ -1,64 +1,57 @@
 test_name "puppet module upgrade (that was installed twice)"
-skip_test "This test is blocked by PUP-6244"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+require 'puppet/acceptance/environment_utils'
+extend Puppet::Acceptance::EnvironmentUtils
+
+prod_env_modulepath = "#{environmentpath}/production/modules"
+
+orig_installed_modules = get_installed_modules_for_hosts hosts
+teardown do
+  rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)
+end
 
 step 'Setup'
 
 stub_forge_on(master)
-testdir = master.tmpdir('upgrademultimods')
 
-teardown do
-  on master, "rm -rf #{master['distmoduledir']}/java"
-  on master, "rm -rf #{master['distmoduledir']}/stdlub"
-  on master, "rm -rf #{testdir}/modules/java"
-  on master, "rm -rf #{testdir}/modules/stdlub"
+on master, puppet("module install pmtacceptance-java --version 1.7.0 --modulepath #{prod_env_modulepath}")
+on master, puppet("module install pmtacceptance-java --version 1.6.0 --modulepath #{master['distmoduledir']}")
+
+on master, puppet("module list") do |result|
+  pattern = Regexp.new([
+    "#{prod_env_modulepath}",
+    "├── pmtacceptance-java \\(.*v1.7.0.*\\)",
+    "└── pmtacceptance-stdlub \\(.*v1.0.0.*\\)",
+    "#{master['distmoduledir']}",
+    "├── pmtacceptance-java \\(.*v1.6.0\e.*\\)",
+    "└── pmtacceptance-stdlub \\(.*v1.0.0.*\\)",
+  ].join("\n"))
+  assert_match(pattern, result.output)
 end
 
-master_opts = {
-  'main' => {
-    'modulepath' => "#{master['distmoduledir']}:#{testdir}/modules"
-  }
-}
+step "Try to upgrade a module that exists multiple locations in the module path"
+on master, puppet("module upgrade pmtacceptance-java"), :acceptable_exit_codes => [1] do |result|
+  pattern = Regexp.new([
+    ".*Notice: Preparing to upgrade 'pmtacceptance-java' .*",
+    ".*Error: Could not upgrade module 'pmtacceptance-java'",
+    "  Module 'pmtacceptance-java' appears multiple places in the module path",
+    "    'pmtacceptance-java' \\(v1.7.0\\) was found in #{prod_env_modulepath}",
+    "    'pmtacceptance-java' \\(v1.6.0\\) was found in #{master['distmoduledir']}",
+    "    Use the `--modulepath` option to limit the search to specific directories",
+  ].join("\n"), Regexp::MULTILINE)
+  assert_match(pattern, result.output)
+end
 
-
-
-with_puppet_running_on master, master_opts, testdir do
-  on master, puppet("module install pmtacceptance-java --version 1.6.0 --modulepath #{master['distmoduledir']}")
-  on master, puppet("module install pmtacceptance-java --version 1.7.0 --modulepath #{testdir}/modules")
-  on master, puppet("module list") do
-    pattern = Regexp.new([
-      "#{master['distmoduledir']}",
-      "├── pmtacceptance-java \\(.*v1.6.0\e.*\\)",
-      "└── pmtacceptance-stdlub \\(.*v1.0.0.*\\)",
-      "#{testdir}/modules",
-      "├── pmtacceptance-java \\(.*v1.7.0.*\\)",
-      "└── pmtacceptance-stdlub \\(.*v1.0.0.*\\)",
-    ].join("\n"))
-    assert_match(pattern, result.output)
-  end
-
-  step "Try to upgrade a module that exists multiple locations in the module path"
-  on master, puppet("module upgrade pmtacceptance-java"), :acceptable_exit_codes => [1] do
-    pattern = Regexp.new([
-      ".*Notice: Preparing to upgrade 'pmtacceptance-java' .*",
-      ".*Error: Could not upgrade module 'pmtacceptance-java'",
-      "  Module 'pmtacceptance-java' appears multiple places in the module path",
-      "    'pmtacceptance-java' \\(v1.6.0\\) was found in #{master['distmoduledir']}",
-      "    'pmtacceptance-java' \\(v1.7.0\\) was found in #{testdir}/modules",
-      "    Use the `--modulepath` option to limit the search to specific directories",
-    ].join("\n"), Regexp::MULTILINE)
-    assert_match(pattern, result.output)
-  end
-
-  step "Upgrade a module that exists multiple locations by restricting the --modulepath"
-  on master, puppet("module upgrade pmtacceptance-java --modulepath #{master['distmoduledir']}") do
-    pattern = Regexp.new([
-      ".*Notice: Preparing to upgrade 'pmtacceptance-java' .*",
-      ".*Notice: Found 'pmtacceptance-java' \\(.*v1.6.0.*\\) in #{master['distmoduledir']} .*",
-      ".*Notice: Downloading from https://forgeapi.puppet.com .*",
-      ".*Notice: Upgrading -- do not interrupt .*",
-      "#{master['distmoduledir']}",
-      "└── pmtacceptance-java \\(.*v1.6.0 -> v1.7.1.*\\)",
-    ].join("\n"), Regexp::MULTILINE)
-    assert_match(pattern, result.output)
-  end
+step "Upgrade a module that exists multiple locations by restricting the --modulepath"
+on master, puppet("module upgrade pmtacceptance-java --modulepath #{master['distmoduledir']}") do
+  pattern = Regexp.new([
+    ".*Notice: Preparing to upgrade 'pmtacceptance-java' .*",
+    ".*Notice: Found 'pmtacceptance-java' \\(.*v1.6.0.*\\) in #{master['distmoduledir']} .*",
+    ".*Notice: Downloading from https://forgeapi.puppet(labs)?.com .*",
+    ".*Notice: Upgrading -- do not interrupt .*",
+    "#{master['distmoduledir']}",
+    "└── pmtacceptance-java \\(.*v1.6.0 -> v1.7.1.*\\)",
+  ].join("\n"), Regexp::MULTILINE)
+  assert_match(pattern, result.output)
 end

--- a/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
@@ -1,32 +1,24 @@
 test_name "puppet module upgrade (with scattered dependencies)"
+require 'puppet/acceptance/module_utils'
+extend Puppet::Acceptance::ModuleUtils
+require 'puppet/acceptance/environment_utils'
+extend Puppet::Acceptance::EnvironmentUtils
 
-skip_test "This test is blocked by PUP-6244"
-
-step 'Setup'
+fq_prod_env_modpath = "#{environmentpath}/production/modules"
 
 stub_forge_on(master)
-testdir = master.tmpdir('scattereddeps')
-on master, "mkdir -p #{testdir}/modules"
 
+orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
-  on master, "rm -rf #{master['distmoduledir']}/java"
-  on master, "rm -rf #{master['distmoduledir']}/postql"
+  rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)
 end
 
-master_opts = {
-  'main' => {
-    'modulepath' => "#{testdir}/modules:#{master['distmoduledir']}:#{master['sitemoduledir']}"
-  }
-}
-
-with_puppet_running_on master, master_opts, testdir do
-  on master, puppet("module install pmtacceptance-stdlub --version 0.0.2 --target-dir #{testdir}/modules")
-  on master, puppet("module install pmtacceptance-java --version 1.6.0 --target-dir #{master['distmoduledir']} --ignore-dependencies")
-  on master, puppet("module install pmtacceptance-postql --version 0.0.1 --target-dir #{master['distmoduledir']} --ignore-dependencies")
-  on master, puppet("module list") do
-    assert_match /pmtacceptance-java.*1\.6\.0/, stdout, 'Could not find pmtacceptance/java'
-    assert_match /pmtacceptance-postql.*0\.0\.1/, stdout, 'Could not find pmtacceptance/postql'
-    assert_match /pmtacceptance-stdlub.*0\.0\.2/, stdout, 'Could not find pmtacceptance/stdlub'
-  end
-
+step 'Setup'
+on master, puppet("module install pmtacceptance-stdlub --version 0.0.2 --target-dir #{fq_prod_env_modpath}")
+on master, puppet("module install pmtacceptance-java --version 1.6.0 --target-dir #{master['distmoduledir']} --ignore-dependencies")
+on master, puppet("module install pmtacceptance-postql --version 0.0.1 --target-dir #{master['distmoduledir']} --ignore-dependencies")
+on master, puppet("module list") do
+  assert_match /pmtacceptance-java.*1\.6\.0/, stdout, 'Could not find pmtacceptance/java'
+  assert_match /pmtacceptance-postql.*0\.0\.1/, stdout, 'Could not find pmtacceptance/postql'
+  assert_match /pmtacceptance-stdlub.*0\.0\.2/, stdout, 'Could not find pmtacceptance/stdlub'
 end


### PR DESCRIPTION
This commit updates the following PMT upgrade acceptance tests:

```
* tests/modules/upgrade/that_was_installed_twice.rb
* tests/modules/upgrade/with_scattered_dependencies.rb
```

Prior to this commit these tests were being skipped because they
were setting the `modulepath` via the `puppet.conf` file. This
method of managing `modulepath` has been deprecated. This commit
updates the tests to use directory based environments to install
the modules.
