### PR TITLE
(PUP-6323) Support tdnf package provider

### DIFF
--- a/lib/puppet/provider/package/tdnf.rb
+++ b/lib/puppet/provider/package/tdnf.rb
@@ -1,0 +1,28 @@
+Puppet::Type.type(:package).provide :tdnf, :parent => :dnf do
+  desc "Support via `tdnf`.
+
+  This provider supports the `install_options` attribute, which allows command-line flags to be passed to tdnf.
+  These options should be spcified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}), or an
+  array where each element is either a string or a hash."
+
+  has_feature :install_options, :versionable, :virtual_packages
+
+  commands :cmd => "tdnf", :rpm => "rpm"
+
+  # Note: this confine was borrowed from the Yum provider. The
+  # original purpose (from way back in 2007) was to make sure we
+  # never try to use RPM on a machine without it. We think this
+  # has probably become obsolete with the way `commands` work, so
+  # we should investigate removing it at some point.
+  if command('rpm')
+    confine :true => begin
+      rpm('--version')
+      rescue Puppet::ExecutionFailure
+        false
+      else
+        true
+      end
+  end
+
+  defaultfor :operatingsystem => "PhotonOS" 
+end

--- a/spec/shared_examples/rhel_package_provider.rb
+++ b/spec/shared_examples/rhel_package_provider.rb
@@ -33,12 +33,16 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
       let(:error_level) { '0' }
     when 'dnf'
       let(:error_level) { '1' }
+    when 'tdnf'
+      let(:error_level) { '1' }
     end
 
     case provider_name
     when 'yum'
       let(:upgrade_command) { 'update' }
     when 'dnf'
+      let(:upgrade_command) { 'upgrade' }
+    when 'tdnf'
       let(:upgrade_command) { 'upgrade' }
     end
 

--- a/spec/unit/provider/package/tdnf_spec.rb
+++ b/spec/unit/provider/package/tdnf_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+# Note that much of the functionality of the tdnf provider is already tested with yum provider tests,
+# as yum is the parent provider, via dnf
+
+provider_class = Puppet::Type.type(:package).provider(:tdnf)
+
+context 'default' do
+  it 'should be the default provider on PhotonOS' do
+    Facter.stubs(:value).with(:osfamily).returns(:redhat)
+    Facter.stubs(:value).with(:operatingsystem).returns("PhotonOS")
+    expect(provider_class).to be_default
+  end
+end
+
+describe provider_class do
+  it_behaves_like 'RHEL package provider', provider_class, 'tdnf'
+end


### PR DESCRIPTION
The tdnf package provider is used on PhotonOS as a smaller replacement for DNF. This commit adds support for using that package provider when running on Photon OS.