### PR TITLE
(PUP-6378) Add failover information to the report

### DIFF
--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -114,6 +114,11 @@
             ]
         },
 
+        "master_used": {
+            "description": "The name of the master that was used to compile the catalog. If failover occurred, this will hold the first master successfully contacted. If this run had no master (e.g. a `puppet apply` run), this field will be blank",
+            "type": "string"
+        },
+
         "report_format": {
             "description": "The report format version documented by this schema",
             "type":        "integer",

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -210,7 +210,10 @@ class Puppet::Configurer
             server = [nil, nil]
           end
           Puppet.override(:server => server[0], :serverport => server[1]) do
-            Puppet.debug "Selected master: #{server[0]}:#{server[1]}"
+            if !server.first.nil?
+              Puppet.debug "Selected master: #{server[0]}:#{server[1]}"
+              report.master_used = "#{server[0]}:#{server[1]}"
+            end
 
             run_internal(options.merge(:node => found[:node]))
           end

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -59,6 +59,10 @@ class Puppet::Transaction::Report
   # or 'on_failure'
   attr_accessor :cached_catalog_status
 
+  # Contains the name and port of the master that was successfully contacted
+  # @return [String] a string of the format 'servername:port'
+  attr_accessor :master_used
+
   # The host name for which the report is generated
   # @return [String] the host name
   attr_accessor :host
@@ -206,6 +210,7 @@ class Puppet::Transaction::Report
     @code_id = nil
     @catalog_uuid = nil
     @cached_catalog_status = nil
+    @master_used = nil
     @environment = environment
     @status = 'failed' # assume failed until the report is finalized
     @noop = Puppet[:noop]
@@ -224,6 +229,10 @@ class Puppet::Transaction::Report
     @noop_pending = data['noop_pending']
     @host = data['host']
     @time = data['time']
+
+    if master_used = data['master_used']
+      @master_used = master_used
+    end
 
     if catalog_uuid = data['catalog_uuid']
       @catalog_uuid = catalog_uuid
@@ -278,6 +287,7 @@ class Puppet::Transaction::Report
       'noop' => @noop,
       'noop_pending' => @noop_pending,
       'environment' => @environment,
+      'master_used' => @master_used,
 
       'logs' => @logs,
       'metrics' => @metrics,

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -570,6 +570,7 @@ describe Puppet::Transaction::Report do
     report.code_id = "some code id"
     report.catalog_uuid = "some catalog uuid"
     report.cached_catalog_status = "not_used"
+    report.master_used = "test:000"
     report.add_resource_status(status)
     report.finalize_report
     report
@@ -586,6 +587,7 @@ describe Puppet::Transaction::Report do
     report.code_id = "some code id"
     report.catalog_uuid = "some catalog uuid"
     report.cached_catalog_status = "not_used"
+    report.master_used = "test:000"
     report.add_resource_status(status)
     report.finalize_report
     report


### PR DESCRIPTION
This commit adds information about which master was successfully
contacted to the report under the master field. This field will be blank
if no master was used (e.g. for `puppet apply` runs) and otherwise take
the form "servername:port".