### PR TITLE
(PUP-4809) Fix yumrepo boolean value handling and spec test

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -18,8 +18,8 @@ Puppet::Type.newtype(:yumrepo) do
   # Doc string for properties that can be made 'absent'
   ABSENT_DOC="Set this to `absent` to remove it from the file completely."
   # False can be false/0/no and True can be true/1/yes in yum.
-  YUM_BOOLEAN=/^(True|False|0|1|No|Yes)$/i
-  YUM_BOOLEAN_DOC="Valid values are: False/0/No or True/1/Yes."
+  YUM_BOOLEAN=/^(true|false|0|1|no|yes)$/
+  YUM_BOOLEAN_DOC="Valid values are: false/0/no or true/1/yes."
 
   # Common munge logic for YUM_BOOLEAN values. Munges for two requirements:
   # 1) Because of how regex validation works in Puppet::Parameter::Value,

--- a/spec/integration/provider/yumrepo_spec.rb
+++ b/spec/integration/provider/yumrepo_spec.rb
@@ -87,7 +87,7 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile), '(integration)',
     properties = {"bandwidth"      => "42M",
                   "baseurl"        => "http://er0ck",
                   "cost"           => "42",
-                  "enabled"        => "Yes",
+                  "enabled"        => "yes",
                   "exclude"        => "er0ckSet2.0",
                   "failovermethod" => "roundrobin",
                   "include"        => "https://er0ck",
@@ -107,6 +107,9 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile), '(integration)',
       apply_with_error_check(manifest)
       file_lines = File.read(File.join(@yumrepo_dir, super_creative + '.repo'))
       properties.each do |property_key, property_value|
+        if property_value =~ /^(true|false|no|yes)$/
+          property_value = property_value.capitalize
+        end
         expect(file_lines).to match(/^#{property_key}=#{Regexp.escape(property_value)}$/)
       end
     end

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -42,13 +42,9 @@ shared_examples_for "a yumrepo parameter that expects a natural value" do |param
 end
 
 shared_examples_for "a yumrepo parameter that expects a boolean parameter" do |param|
-  valid_values = %w[True False 0 1 No Yes]
+  valid_values = %w[true false 0 1 no yes]
 
   valid_values.each do |value|
-    it "accepts a valid value of #{value}" do
-      instance = described_class.new(:name => 'puppetlabs', param => value)
-      expect(instance[param]).to eq value
-    end
     it "accepts #{value} downcased to #{value.downcase} and capitalizes it" do
       instance = described_class.new(:name => 'puppetlabs', param => value.downcase)
       expect(instance[param]).to eq value.downcase.capitalize


### PR DESCRIPTION
Boolean value parsing is now case-sensitive and values must be specified
in all lowercase. Valid values are true|false|yes|no|1|0