### PR TITLE
(PUP-6463) Improved error message when accessing unassigned parameter

### DIFF
--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -44,7 +44,7 @@ class Closure < CallableSignature
   def call_by_name(args_hash, enforce_parameters)
     if enforce_parameters
       # Push a temporary parameter scope used while resolving the parameter defaults
-      @enclosing_scope.with_parameter_scope(parameter_names) do |param_scope|
+      @enclosing_scope.with_parameter_scope(closure_name, parameter_names) do |param_scope|
         # Assign all non-nil values, even those that represent non-existent paramaters.
         args_hash.each { |k, v| param_scope[k] = v unless v.nil? }
         parameters.each do |p|
@@ -146,7 +146,7 @@ class Closure < CallableSignature
   end
 
   def combine_values_with_parameters(scope, args)
-    scope.with_parameter_scope(parameter_names) do |param_scope|
+    scope.with_parameter_scope(closure_name, parameter_names) do |param_scope|
       parameters.each_with_index do |parameter, index|
         param_captures     = parameter.captures_rest
         default_expression = parameter.value

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -369,7 +369,7 @@ class Puppet::Resource::Type
     end
     scope.class_set(self.name,scope) if hostclass? || node?
 
-    param_hash = scope.with_parameter_scope(arguments.keys) do |param_scope|
+    param_hash = scope.with_parameter_scope(resource.to_s, arguments.keys) do |param_scope|
       # Assign directly to the parameter scope to avoid scope parameter validation at this point. It
       # will happen anyway when the values are assigned to the scope after the parameter scoped has
       # been popped.

--- a/spec/integration/parser/parameter_defaults_spec.rb
+++ b/spec/integration/parser/parameter_defaults_spec.rb
@@ -120,7 +120,7 @@ require 'puppet_spec/language'
       end
 
       it 'fails when no value is provided for required first parameter', :if => call_type == 'EPP' do
-        expect_fail(params, [], /default expression for \$b tries to illegally access not yet evaluated \$a/)
+        expect_fail(params, [], /expects a value for parameter \$a/)
       end
 
       it "will use the referenced parameter's given value" do

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -326,6 +326,15 @@ describe Puppet::Resource::Type do
         expect(@scope['third']).to eq('h')
       end
 
+      it 'fails when the referenced variable is unassigned' do
+        @type.set_arguments({
+          :first => nil,
+          :second => variable_expression('first'),
+        })
+        expect { @type.set_resource_parameters(@resource, @scope) }.to raise_error(
+          Puppet::Error, 'Foo[bar]: expects a value for parameter $first')
+      end
+
       it 'does not clobber a given value' do
         @type.set_arguments({
           :first => number_expression(10),
@@ -371,7 +380,7 @@ describe Puppet::Resource::Type do
 
       it 'fails when the default expression is evaluated' do
         @resource[:first] = 1
-        expect { @type.set_resource_parameters(@resource, @scope) }.to raise_error(Puppet::Error, 'default expression for $second tries to illegally access not yet evaluated $third')
+        expect { @type.set_resource_parameters(@resource, @scope) }.to raise_error(Puppet::Error, 'Foo[bar]: default expression for $second tries to illegally access not yet evaluated $third')
       end
     end
 
@@ -379,7 +388,7 @@ describe Puppet::Resource::Type do
       @type.set_arguments({
         :first => variable_expression('first')
       })
-      expect { @type.set_resource_parameters(@resource, @scope) }.to raise_error(Puppet::Error, 'default expression for $first tries to illegally access not yet evaluated $first')
+      expect { @type.set_resource_parameters(@resource, @scope) }.to raise_error(Puppet::Error, 'Foo[bar]: default expression for $first tries to illegally access not yet evaluated $first')
     end
 
     context 'when using match scope' do


### PR DESCRIPTION
A parameter default expression that made an attempt to access a
parameter to the left in the parameter list when that parameter in turn
was unassigned, resulted in an error message "$y tries to illegally
access not yet evaluated $x". That message should only be used when
accessing parameters to the right. An access to an unassigned parameter
to the left should result in the same message as when a required
parameter is unassigned. This commit fixes that.