### PR TITLE
(PUP-6466) Pin RSpec to less than 3.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 gem "rake", "10.1.1", :require => false
 
 group(:development, :test) do
-  gem "rspec", "~> 3.1", :require => false
+  # RSpec 3.5.z is not compatible with parallel:spec.  The version pin of '< 3.5.0', be removed once PUP-6466 is resolved
+  gem "rspec", "~> 3.1", "< 3.5.0", :require => false
   gem "rspec-its", "~> 1.1", :require => false
   gem "rspec-collection_matchers", "~> 1.1", :require => false
   gem "rspec-legacy_formatters", "~> 1.0", :require => false


### PR DESCRIPTION
The RSpec gem has been upgrade to 3.5.0 however this has caused the
Parallel:Spec grouping to fail by not finding any spec files.  This
commit pins the RSpec gem to less then version 3.5.0 and can be
reverted once the grouping code is fixed.