### PR TITLE
(PUP-1134) Add correct path for init scripts on AIX

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -11,6 +11,8 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
       "/sbin/init.d"
     when "Archlinux"
       "/etc/rc.d"
+    when "AIX"
+      "/etc/rc.d/init.d"
     else
       "/etc/init.d"
     end


### PR DESCRIPTION
This commit edits the init service provider to use the correct path for
init scripts on AIX.