### PR TITLE
(PUP-6468) Add acceptance tests from PE

### DIFF
--- a/acceptance/tests/face/help_test.rb
+++ b/acceptance/tests/face/help_test.rb
@@ -1,0 +1,40 @@
+test_name 'Test `puppet help` workflow'
+
+tag 'risk:medium'
+
+hosts.each do |host|
+
+  faces = {}
+  faces_array = []
+
+  # I want to see a list of faces when using `puppet help`
+  # NOTE: I'm breaking after the faces section because `puppet help not-face`
+  # seems to just cat the man page...
+  step 'Run `puppet help` and save a list of faces from it'
+  on host, puppet('help') do
+    processing_faces = false
+    stdout.each_line do |line|
+      (processing_faces = true and next) if line =~ /^Available subcommands/
+      processing_faces = false if line =~ /^\s*$/
+
+      next unless processing_faces
+      faces_array << line.match(/^\s{2,}\w+/).to_s.strip
+    end
+  end
+
+
+  # When using `puppet help {face} I want to be able to get standard info
+  # for each puppet face, including usage, options, and actions.
+  # NOTE: I believe these are the three standards?
+  faces_array.each do |face|
+    faces[face] = []
+    next if face == 'help'
+
+    step "Use `puppet help #{face}`"
+
+    on host, puppet("help #{face} | grep USAGE") do
+      assert_match /^USAGE:/, stdout,
+        "There is NO usage section for 'puppet help #{face}'"
+    end
+  end
+end

--- a/acceptance/tests/ruby_compiler_optimization.rb
+++ b/acceptance/tests/ruby_compiler_optimization.rb
@@ -1,0 +1,20 @@
+test_name 'ensure ruby compiler optimization is >= 2'
+
+tag 'risk:medium'
+
+step 'Validate ruby compiler optimization is >= 2' do
+  hosts.each do |host|
+    if host['platform'] =~ /osx/
+      skip_test "OSX is known to have incorrect optimization - see RE-3281"
+    end
+
+    on(host, "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby -r rbconfig -e 'puts RbConfig::CONFIG[\"CFLAGS\"]'") do |res|
+      o_level = -99
+      m = res.stdout.match(/-O(\d)/)
+      m = res.stdout.match(/-xO(\d)/) unless m
+      o_level = m[1].to_i if m
+
+      fail_test('ruby compiler optimization is not >=2') unless o_level >= 2
+    end
+  end
+end

--- a/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
+++ b/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
@@ -1,0 +1,101 @@
+test_name "Windows Exit Codes - Acceptance Tests"
+
+tag 'risk:medium'
+
+confine :to, :platform => 'windows'
+
+pass_exitcode_manifest = <<-MANIFEST
+winexitcode::execute { '0':
+	exit_code => 0
+}
+MANIFEST
+
+upper_8bit_boundary_manifest = <<-MANIFEST
+winexitcode::execute { '255':
+	exit_code => 255
+}
+MANIFEST
+
+cross_8bit_boundary_manifest = <<-MANIFEST
+winexitcode::execute { '256':
+	exit_code => 256
+}
+MANIFEST
+
+upper_32bit_boundary_manifest = <<-MANIFEST
+winexitcode::execute { '4294967295':
+	exit_code => 4294967295
+}
+MANIFEST
+
+cross_32bit_boundary_manifest = <<-MANIFEST
+winexitcode::execute { '4294967296':
+	exit_code => 0
+}
+MANIFEST
+
+negative_boundary_manifest = <<-MANIFEST
+winexitcode::execute { '-1':
+  exit_code => 4294967295
+}
+MANIFEST
+
+step "Install Custom Module for Testing"
+
+agents.each do |agent|
+  if (on(agent, puppet("--version")).stdout.split('.')[0].to_i < 4)
+    module_path_config_property = "confdir"
+  else
+    module_path_config_property = "codedir"
+  end
+
+  native_modules_path = on(agent, puppet("config print #{module_path_config_property}")).stdout.gsub('C:', '/cygdrive/c').strip
+
+  #Check to see if we are running on Windows 2003. Do a crazy hack to get around SCP issues.
+  if (on(agent, facter("find operatingsystemmajrelease")).stdout =~ /2003/)
+    on(agent, "ln -s #{native_modules_path.gsub(/ /, '\ ')} /tmp/puppet_etc")
+    modules_path = '/tmp/puppet_etc'
+  else
+    modules_path = native_modules_path
+  end
+
+  #Create the modules directory if it doesn't exist
+  if on(agent, "test ! -d #{modules_path}/modules", :acceptable_exit_codes => [0,1]).exit_code == 0
+    on(agent, "mkdir -p #{modules_path}/modules")
+  end
+
+  # copy custom module.
+  scp_to(agent, File.expand_path(File.join(File.dirname(__FILE__), "winexitcode")), "#{modules_path}/modules")
+end
+
+agents.each do |agent|
+	step "Verify '0' is a Valid Exit Code"
+
+	#Apply the manifest and verify Puppet returns success.
+	on(agent, puppet('apply', '--debug'), :stdin => pass_exitcode_manifest)
+
+	step "Verify Unsigned 8bit Upper Boundary"
+
+	#Apply the manifest and verify Puppet returns success.
+	on(agent, puppet('apply', '--debug'), :stdin => upper_8bit_boundary_manifest)
+
+	step "Verify Unsigned 8bit Cross Boundary"
+
+	#Apply the manifest and verify Puppet returns success.
+	on(agent, puppet('apply', '--debug'), :stdin => cross_8bit_boundary_manifest)
+
+	step "Verify Unsigned 32bit Upper Boundary"
+
+	#Apply the manifest and verify Puppet returns success.
+	on(agent, puppet('apply', '--debug'), :stdin => upper_32bit_boundary_manifest)
+
+	step "Verify Unsigned 32bit Cross Boundary"
+
+	#Apply the manifest and verify Puppet returns success.
+	on(agent, puppet('apply', '--debug'), :stdin => cross_32bit_boundary_manifest)
+
+  step "Verify Negative Exit Code Rollover Boundary"
+
+  #Apply the manifest and verify Puppet returns success.
+  on(agent, puppet('apply', '--debug'), :stdin => negative_boundary_manifest)
+end

--- a/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
+++ b/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
@@ -5,11 +5,51 @@ tag 'risk:medium'
 confine :to, :platform => 'windows'
 confine :to, {}, hosts.select { |host| (host[:roles].include?('aio')) }
 
+step 'Setup - create a config file'
+# this step should be deleted after MCO-727 is resolved
+config_content =<<EOS
+  main_collective = mcollective
+  collectives = mcollective
+
+  libdir = C:/ProgramData/PuppetLabs/mcollective/plugins
+
+  logfile = C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective.log
+  loglevel = debug
+  daemonize = 1
+
+  # Plugins
+  securityprovider = psk
+  plugin.psk = unset
+
+  connector = activemq
+  plugin.activemq.pool.size = 1
+  plugin.activemq.pool.1.host = stomp1
+  plugin.activemq.pool.1.port = 6163
+  plugin.activemq.pool.1.user = mcollective
+  plugin.activemq.pool.1.password = marionette
+
+  # Facts
+  factsource = yaml
+  plugin.yaml = C:/ProgramData/PuppetLabs/mcollective/facts.yaml
+EOS
+
+manifest = <<MANIFEST
+  file { 'C:/ProgramData/PuppetLabs/mcollective/etc/server.cfg':
+    ensure  => present,
+    content => '#{config_content}',
+  }
+MANIFEST
+
+agents.each do |agent|
+  apply_manifest_on(agent, manifest, :catch_failures => true)
+end
+
 step 'Setup - ensure MCollective service is running on Windows agent'
-on agent, puppet('resource service mcollective ensure=running')
+agents.each do |agent|
+  on agent, puppet('resource service mcollective ensure=running')
+end
 
 step 'Shutdown MCollective service on Windows agent'
-
 #Shutdown MCollective Service on Windows agent and make sure it successfully exits
 agents.each do |agent|
   on agent, 'net stop mcollective' do |result|
@@ -20,12 +60,9 @@ end
 sleep 5
 
 step 'Start MCollective service on Windows agent'
-
 #Bring the MCllective backup
 agents.each do |agent|
   on agent, 'net start mcollective' do |result|
     assert_match(/The Marionette Collective Server service was started successfully/, result.stdout, "Failed to start MCollective service")
   end
 end
-
-

--- a/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
+++ b/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
@@ -1,0 +1,31 @@
+test_name 'MCollective service exits on windows agent'
+
+tag 'risk:medium'
+
+confine :to, :platform => 'windows'
+confine :to, {}, hosts.select { |host| (host[:roles].include?('aio')) }
+
+step 'Setup - ensure MCollective service is running on Windows agent'
+on agent, puppet('resource service mcollective ensure=running')
+
+step 'Shutdown MCollective service on Windows agent'
+
+#Shutdown MCollective Service on Windows agent and make sure it successfully exits
+agents.each do |agent|
+  on agent, 'net stop mcollective' do |result|
+    assert_match(/The Marionette Collective Server service was stopped successfully/, result.stdout, "Failed to stop MCollective service")
+  end
+end
+
+sleep 5
+
+step 'Start MCollective service on Windows agent'
+
+#Bring the MCllective backup
+agents.each do |agent|
+  on agent, 'net start mcollective' do |result|
+    assert_match(/The Marionette Collective Server service was started successfully/, result.stdout, "Failed to start MCollective service")
+  end
+end
+
+

--- a/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
+++ b/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
@@ -1,0 +1,46 @@
+test_name "QA-760 - Windows Files Containing '-' and '.'"
+
+tag 'risk:medium'
+
+confine(:to, :platform => 'windows')
+
+temp_folder = <<-MANIFEST
+file { 'c:/temp':
+  ensure => directory
+}
+MANIFEST
+
+dash_dot_file = <<-MANIFEST
+file { 'c:/temp/dash-dot-%s.file':
+  ensure  => file,
+  content => "The file has new content: %s!",
+}
+MANIFEST
+
+step "Generate Manifest"
+
+first_run_manifest = ""
+second_run_manifest = ""
+
+for i in 1..100
+  first_run_manifest += "#{dash_dot_file}\n" % [i,i]
+  second_run_manifest += "#{dash_dot_file}\n" % [i,-i]
+end
+
+step "Create Temp Folder"
+
+agents.each do |agent|
+  on(agent, puppet('apply', '--debug'), :stdin => temp_folder)    
+end
+
+step "Create Dash Dot File 100 Times"
+
+agents.each do |agent|
+  on(agent, puppet('apply', '--debug'), :stdin => first_run_manifest)
+end
+
+step "Update Dash Dot File 100 Times"
+
+agents.each do |agent|
+  on(agent, puppet('apply', '--debug'), :stdin => second_run_manifest)
+end

--- a/acceptance/tests/windows/winexitcode/manifests/execute.pp
+++ b/acceptance/tests/windows/winexitcode/manifests/execute.pp
@@ -1,0 +1,13 @@
+define winexitcode::execute (
+	$exit_code = 0,
+) {
+
+	include winexitcode
+
+	exec { "testcommand_${exit_code}":
+		command   => "c:\\Windows\\System32\\cmd.exe /c c:\\tmp\\test.bat ${title}",
+		returns   => $exit_code,
+		logoutput => true,
+		require   => Class['winexitcode'],
+	}
+}

--- a/acceptance/tests/windows/winexitcode/manifests/init.pp
+++ b/acceptance/tests/windows/winexitcode/manifests/init.pp
@@ -1,0 +1,16 @@
+class winexitcode {
+	file { "c:\\tmp":
+		ensure  => directory,
+	  mode    => '0660',
+	  owner   => 'Administrator',
+	  group   => 'Administrators',
+	}
+	->
+	file { "c:\\tmp\\test.bat":
+  	ensure  => file,
+    mode    => '0660',
+    owner   => 'Administrator',
+    group   => 'Administrators',
+    content => 'exit /b %1',
+  }
+}


### PR DESCRIPTION
This commit adds acceptance tests that were previously tested
as part of Puppet Enterprise. These tests are universally applicable
to the puppet product and are therefore being moved here.