### PR TITLE
(PUP-6473) Pin FFI to 1.9.10

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -32,8 +32,9 @@ gem_platform_dependencies:
       CFPropertyList: '~> 2.2.6'
   x86-mingw32:
     gem_runtime_dependencies:
-      # Pinning versions that require native extensions
-      ffi: '~> 1.9.6'
+      # ffi is pinned due to PUP-6473.
+      # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved
+      ffi: ['~> 1.9.6', '<= 1.9.10']
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
       win32-eventlog: '= 0.6.5'
@@ -44,7 +45,9 @@ gem_platform_dependencies:
       minitar: '~> 0.5.4'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.6'
+      # ffi is pinned due to PUP-6473.
+      # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved
+      ffi: ['~> 1.9.6', '<= 1.9.10']
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
       win32-eventlog: '= 0.6.5'


### PR DESCRIPTION
An update to FFI (1.9.11) has caused downstream gems to error due to a bug
introduced in 1.9.11.  FFI Github issue 506 (https://github.com/ffi/ffi/issues/506)
shows this is affecting other users of FFI as well.  This commit pins FFI to the
latest known good working version of 1.9.10.  This change will be reverted in the
future once issue 506 is resolved.