### PR TITLE
(PUP-6440) Support sensitive data tagging

### DIFF
--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -594,6 +594,11 @@
                     "type":        "string"
                 },
 
+                "redacted": {
+                  "description": "Whether this event has been redacted",
+                  "type": "boolean"
+                },
+
                 "status": {
                     "description": "One of the following strings:\n\n* `success` - property was out of sync, and was successfully changed to be in sync.\n* `failure`- property was out of sync, and couldn't be changed to be in sync due to an error.\n* `noop` - property was out of sync, and wasn't changed due to noop mode.\n* `audit` - property was in sync, and was being audited.\n\ndepending on the type of the event. Always `audit` in reports of `inspect` kind.\n",
                     "enum": [

--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -55,6 +55,10 @@ class Puppet::Property < Puppet::Parameter
   #
   attr_writer :noop
 
+  # @!attribute [rw] sensitive
+  #   @return [true, false] If this property has been tagged as sensitive.
+  attr_accessor :sensitive
+
   class << self
     # @todo Figure out what this is used for. Can not find any logic in the puppet code base that
     #   reads or writes this attribute.
@@ -230,6 +234,7 @@ class Puppet::Property < Puppet::Parameter
   # * `:property` - reference to this property
   # * `:source_description` - the _path_ (?? See todo)
   # * `:invalidate_refreshes` - if scheduled refreshes should be invalidated
+  # * `:redacted` - if the event will be redacted (due to this property being sensitive)
   #
   # @todo What is the intent of this method? What is the meaning of the :source_description passed in the
   #   options to the created event?
@@ -240,6 +245,7 @@ class Puppet::Property < Puppet::Parameter
     if should and value = self.class.value_collection.match?(should)
       attrs[:invalidate_refreshes] = true if value.invalidate_refreshes
     end
+    attrs[:redacted] = @sensitive
     resource.event attrs
   end
 

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -11,8 +11,8 @@ class Puppet::Transaction::Event
   include Puppet::Util::Logging
   include Puppet::Network::FormatSupport
 
-  ATTRIBUTES = [:name, :resource, :property, :previous_value, :desired_value, :historical_value, :status, :message, :file, :line, :source_description, :audited, :invalidate_refreshes]
-  YAML_ATTRIBUTES = %w{@audited @property @previous_value @desired_value @historical_value @message @name @status @time}.map(&:to_sym)
+  ATTRIBUTES = [:name, :resource, :property, :previous_value, :desired_value, :historical_value, :status, :message, :file, :line, :source_description, :audited, :invalidate_refreshes, :redacted]
+  YAML_ATTRIBUTES = %w{@audited @property @previous_value @desired_value @historical_value @message @name @status @time @redacted}.map(&:to_sym)
   attr_accessor *ATTRIBUTES
   attr_accessor :time
   attr_reader :default_log_level
@@ -27,6 +27,7 @@ class Puppet::Transaction::Event
 
   def initialize(options = {})
     @audited = false
+    @redacted = false
 
     set_options(options)
     @time = Time.now
@@ -43,6 +44,7 @@ class Puppet::Transaction::Event
     @status = data['status']
     @time = data['time']
     @time = Time.parse(@time) if @time.is_a? String
+    @redacted = data.fetch('redacted', false)
   end
 
   def to_data_hash
@@ -56,6 +58,7 @@ class Puppet::Transaction::Event
       'name' => @name,
       'status' => @status,
       'time' => @time.iso8601(9),
+      'redacted' => @redacted
     }
   end
 

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -146,6 +146,11 @@ describe Puppet::Property do
       property.class.stubs(:value_collection).returns(collection)
       expect(property.event.invalidate_refreshes).to be_truthy
     end
+
+    it "sets the redacted field on the event when the property is sensitive" do
+      property.sensitive = true
+      expect(property.event.redacted).to eq true
+    end
   end
 
   describe "when defining new values" do

--- a/spec/unit/transaction/event_spec.rb
+++ b/spec/unit/transaction/event_spec.rb
@@ -128,7 +128,8 @@ describe Puppet::Transaction::Event do
                                              :desired_value => 7, :historical_value => 'Brazil',
                                              :message => "Help I'm trapped in a spec test",
                                              :name => :mode_changed, :previous_value => 6, :property => :mode,
-                                             :status => 'success')
+                                             :status => 'success',
+                                             :redacted => false)
       expect(event.to_yaml_properties).to match_array(Puppet::Transaction::Event::YAML_ATTRIBUTES)
     end
   end


### PR DESCRIPTION
This commit adds a `sensitive` attribute to properties to indicate that
the `should` and `is` values of a given property are sensitive and
should be specially handled. This commit also adds a `redacted` field to
events to indicate that the data contained in this event was sensitive
and has been redacted to prevent information leakage.