### PR TITLE
(PUP-6347) Use Puppet syntax in programmatic string representation

### DIFF
--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -557,7 +557,7 @@ class StringConverter
 
   def string_PDefaultType(val_type, val, format_map, _)
     f = get_format(val_type, format_map)
-    format_literal(f, case f.format
+    apply_string_flags(f, case f.format
     when :d, :s, :p
       f.alt? ? '"default"' : 'default'
     when :D
@@ -570,7 +570,7 @@ class StringConverter
   # @api private
   def string_PUndefType(val_type, val, format_map, _)
     f = get_format(val_type, format_map)
-    format_literal(f, case f.format
+    apply_string_flags(f, case f.format
     when :n
       f.alt? ? 'null' : 'nil'
     when :u
@@ -597,22 +597,22 @@ class StringConverter
     when :t
       # 'true'/'false' or 't'/'f' if in alt mode
       str_bool = val.to_s
-      format_literal(f, f.alt? ? str_bool[0] : str_bool)
+      apply_string_flags(f, f.alt? ? str_bool[0] : str_bool)
 
     when :T
       # 'True'/'False' or 'T'/'F' if in alt mode
       str_bool = val.to_s.capitalize
-      format_literal(f, f.alt? ? str_bool[0] : str_bool)
+      apply_string_flags(f, f.alt? ? str_bool[0] : str_bool)
 
     when :y
       # 'yes'/'no' or 'y'/'n' if in alt mode
       str_bool = val ? 'yes' : 'no'
-      format_literal(f, f.alt? ? str_bool[0] : str_bool)
+      apply_string_flags(f, f.alt? ? str_bool[0] : str_bool)
 
     when :Y
       # 'Yes'/'No' or 'Y'/'N' if in alt mode
       str_bool = val ? 'Yes' : 'No'
-      format_literal(f, f.alt? ? str_bool[0] : str_bool)
+      apply_string_flags(f, f.alt? ? str_bool[0] : str_bool)
 
     when :d, :x, :X, :o, :b, :B
       # Boolean in numeric form, formated by integer rule
@@ -627,10 +627,10 @@ class StringConverter
       _convert(TypeCalculator.infer_set(numeric_bool), numeric_bool, string_formats, indentation)
 
     when :s
-      format_literal(f, val.to_s)
+      apply_string_flags(f, val.to_s)
 
     when :p
-      format_literal(f, val.inspect)
+      apply_string_flags(f, val.inspect)
 
     else
       raise FormatError.new('Boolean', f.format, 'tTyYdxXobBeEfgGaAsp')
@@ -638,7 +638,7 @@ class StringConverter
   end
 
   # Performs post-processing of literals to apply width and precision flags
-  def format_literal(f, literal_str)
+  def apply_string_flags(f, literal_str)
     if f.left || f.width || f.prec
       fmt = '%'
       fmt << '-' if f.left
@@ -650,7 +650,7 @@ class StringConverter
       literal_str
     end
   end
-  private :format_literal
+  private :apply_string_flags
 
   # @api private
   def string_PIntegerType(val_type, val, format_map, _)

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -434,8 +434,7 @@ class TypeFormatter
   # @api private
   def string_String(t)
     # Use single qoute on strings that does not contain single quotes, control characters, or backslashes.
-    # TODO: This should move to StringConverter when this formatter is changed to take advantage of it
-    @bld << (t.ascii_only? && (t =~ /^(?:'|\p{Cntrl}|\\)$/).nil? ? "'#{t}'" : t.inspect)
+    @bld << StringConverter.singleton.puppet_quote(t)
   end
 
   # @api private

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -565,7 +565,7 @@ describe 'the new function' do
   context 'when invoked on String' do
     { {}            => 'Notify[String, {}]',
       []            => 'Notify[String, []]',
-      {'a'=>true}   => 'Notify[String, {"a" => true}]',
+      {'a'=>true}   => "Notify[String, {'a' => true}]",
       [1,2,3,4]     => 'Notify[String, [1, 2, 3, 4]]',
       [[1,2],[3,4]] => 'Notify[String, [[1, 2], [3, 4]]]',
       'abcd'        => 'Notify[String, abcd]',

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -353,7 +353,7 @@ describe 'Puppet Type System' do
     end
 
     it 'can be created with a runtime and, puppet name pattern, and runtime replacement' do
-      expect(tf.runtime('ruby', [/^MyPackage::(.*)$/, 'MyModule::\1']).to_s).to eq("Runtime[ruby, [/^MyPackage::(.*)$/, 'MyModule::\\1']]")
+      expect(tf.runtime('ruby', [/^MyPackage::(.*)$/, 'MyModule::\1']).to_s).to eq("Runtime[ruby, [/^MyPackage::(.*)$/, \"MyModule::\\\\1\"]]")
     end
 
     it 'will map a Puppet name to a runtime type' do


### PR DESCRIPTION
Before this commit, the '%p' format and some alternative '#' formats
for string would output a programmatic string representation that
was using Ruby escapes. This commit changes this so that the
programmatic string representation conforms to Puppet syntax.

The following rules apply when the programmatic string representation
is created:
- The following codepoints will be escaped on output:
  * 0x0a => \n
  * 0x0d => \r
  * 0x09 => \t
  * 0x22 => \"
  * 0x24 => \$
  * 0x5c => \\
- All other characters with a codepoint < 0x20 or > 0x7f are represented
  using \u{X} syntax (where X is a hexadecimal representation of the codepoint).
- Strings that are safe to quote using single quotes will be single
  quoted.
