### PR TITLE
(PUP-6475) Use first server_list entry if failover hasn't occured

### DIFF
--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -200,13 +200,21 @@ class Puppet::Indirector::Request
     begin
       bound_server = Puppet.lookup(:server)
     rescue
-      bound_server = nil
+      if primary_server = Puppet.settings[:server_list][0]
+        bound_server = primary_server[0]
+      else
+        bound_server = nil
+      end
     end
 
     begin
       bound_port = Puppet.lookup(:serverport)
     rescue
-      bound_port = nil
+      if primary_server = Puppet.settings[:server_list][0]
+        bound_port = primary_server[1]
+      else
+        bound_port = nil
+      end
     end
     self.server = default_server || bound_server || Puppet.settings[:server]
     self.port   = default_port || bound_port || Puppet.settings[:masterport]

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -219,6 +219,34 @@ describe Puppet::Indirector::REST do
     end
   end
 
+  it "should use server_list for server when available" do
+    terminus_class.expects(:server_setting).returns nil
+    Puppet[:server_list] = [["foo", "123"]]
+    expect(terminus_class.server).to eq("foo")
+  end
+
+  it "should prefer failover-selected server from server list" do
+    terminus_class.expects(:server_setting).returns nil
+    Puppet[:server_list] = [["foo", "123"],["bar", "321"]]
+    Puppet.override(:server => "bar") do
+      expect(terminus_class.server).to eq("bar")
+    end
+  end
+
+  it "should use server_list for port when available" do
+    terminus_class.expects(:port_setting).returns nil
+    Puppet[:server_list] = [["foo", "123"]]
+    expect(terminus_class.port).to eq(123)
+  end
+
+  it "should prefer failover-selected port from server list" do
+    terminus_class.expects(:port_setting).returns nil
+    Puppet[:server_list] = [["foo", "123"],["bar", "321"]]
+    Puppet.override(:serverport => "321") do
+      expect(terminus_class.port).to eq(321)
+    end
+  end
+
   it "should use an explicitly specified more-speciic server when failover is active" do
     terminus_class.expects(:server_setting).returns :ca_server
     Puppet[:ca_server] = "myserver"


### PR DESCRIPTION
Without this change, if failover has not occured, Puppet would ignore
the server_list setting and instead use the legacy server setting.

Now, the agent will use the first entry of server_list if it's
available, and only fall back to the legacy setting if the new setting
is not in use. This will catch any requests made outside of the
"configurer" which is what handles the fallback logic