### PR TITLE
(PUP-6115) Fix Windows cert clean instructions

### DIFF
--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -218,7 +218,7 @@ On the master:
   puppet cert clean #{Puppet[:certname]}
 On the agent:
   1a. On most platforms: find #{Puppet[:ssldir]} -name #{Puppet[:certname]}.pem -delete
-  1b. On Windows: del "#{Puppet[:ssldir]}/#{Puppet[:certname]}.pem" /f
+  1b. On Windows: del "#{Puppet[:certdir].gsub('/', '\\')}\\#{Puppet[:certname]}.pem" /f
   2. puppet agent -t
 ERROR_STRING
     end


### PR DESCRIPTION
 - Previously the instructions would say something like:

 del "C:/ProgramData/PuppetLabs/puppet/etc/ssl/agent.pem" /f

 This fails in a cmd.exe prompt, and is the incorrect directory anyhow

 Updated so that it shows like:

 del "C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\agent.pem" /f