### PR TITLE
(PUP-6467) Fix Parallel Spec grouping for RSpec 3.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,7 @@ gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 gem "rake", "10.1.1", :require => false
 
 group(:development, :test) do
-  # RSpec 3.5.z is not compatible with parallel:spec.  The version pin of '< 3.5.0', be removed once PUP-6466 is resolved
-  gem "rspec", "~> 3.1", "< 3.5.0", :require => false
+  gem "rspec", "~> 3.1", :require => false
   gem "rspec-its", "~> 1.1", :require => false
   gem "rspec-collection_matchers", "~> 1.1", :require => false
   gem "rspec-legacy_formatters", "~> 1.0", :require => false

--- a/spec/unit/version_spec.rb
+++ b/spec/unit/version_spec.rb
@@ -4,11 +4,16 @@ require 'pathname'
 
 describe "Puppet.version Public API" do
   before :each do
+    @current_ver = Puppet.version
     Puppet.instance_eval do
       if @puppet_version
         @puppet_version = nil
       end
     end
+  end
+
+  after :each do
+    Puppet.version = @current_ver
   end
 
   context "without a VERSION file" do
@@ -39,4 +44,14 @@ describe "Puppet.version Public API" do
       expect(Puppet.version).to eq('1.2.3')
     end
   end
+
+  context "Using version setter" do
+    it "does not read VERSION file if using set version" do
+      Puppet.expects(:read_version_file).never
+      Puppet.version = '1.2.3'
+      expect(Puppet.version).to eq('1.2.3')
+    end
+  end
 end
+
+

--- a/util/rspec_grouper
+++ b/util/rspec_grouper
@@ -28,7 +28,7 @@ module Parallel
 
         # Populate a map of spec file => example count, sorted ascending by count
         # NOTE: this uses a private API of RSpec and is may break if the gem is updated
-        @files = ::RSpec::Core::ExampleGroup.children.inject({}) do |files, group|
+        @files = ::RSpec.world.example_groups.inject({}) do |files, group|
           file = group.metadata[:example_group_block].source_location[0]
           count = count_examples(group)
           files[file] = (files[file] || 0) + count


### PR DESCRIPTION
Rspec_grouper currently tries to access an array of example groups
through a private function children() in RSpec::Core::ExampleGroups
in order to calculate example counts per spec file. With the RSpec
3.5.0 release, the example groups are no longer accessible through
children(). So, rspec_grouper cannot find example groups and is
reporting that no examples can be found.

This commit uses RSpec.world.example_groups instead to access the
array.

Also, version_spec fix.