### PR TITLE
(PUP-5887) Fix problem with nested string interpolation

### DIFF
--- a/lib/puppet/pops/parser/slurp_support.rb
+++ b/lib/puppet/pops/parser/slurp_support.rb
@@ -11,9 +11,9 @@ module Parser
 module SlurpSupport
   include LexerSupport
 
-  SLURP_SQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*[']/
-  SLURP_DQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*(["]|[$]\{?)/
-  SLURP_UQ_PATTERN  = /(?:[^\\]|^|[^\\])(?:[\\]{2})*([$]\{?|\z)/
+  SLURP_SQ_PATTERN  = /(?:[^\\]|^)(?:[\\]{2})*[']/
+  SLURP_DQ_PATTERN  = /(?:[^\\]|^)(?:[\\]{2})*(["]|[$]\{?)/
+  SLURP_UQ_PATTERN  = /(?:[^\\]|^)(?:[\\]{2})*([$]\{?|\z)/
   # unquoted, no escapes
   SLURP_UQNE_PATTERN  = /(\$\{?|\z)/m
   SLURP_ALL_PATTERN = /.*(\z)/m

--- a/spec/unit/pops/parser/parse_basic_expressions_spec.rb
+++ b/spec/unit/pops/parser/parse_basic_expressions_spec.rb
@@ -307,5 +307,13 @@ describe "egrammar parsing basic expressions" do
       expect(dump(parse("$a = \"yo${var.foo}yo\""))).to eq("(= $a (cat 'yo' (str (call-method (. $var foo))) 'yo'))")
       expect(dump(parse("$a = \"yo${var.foo.bar}yo\""))).to eq("(= $a (cat 'yo' (str (call-method (. (call-method (. $var foo)) bar))) 'yo'))")
     end
+
+    it "should interpolate interpolated expressions with a variable, \"yo${\"$var\"}yo\"" do
+      expect(dump(parse("$a = \"yo${\"$var\"}yo\""))).to eq("(= $a (cat 'yo' (str (cat '' (str $var) '')) 'yo'))")
+    end
+
+    it "should interpolate interpolated expressions with an expression, \"yo${\"${$var+2}\"}yo\"" do
+      expect(dump(parse("$a = \"yo${\"${$var+2}\"}yo\""))).to eq("(= $a (cat 'yo' (str (cat '' (str (+ $var 2)) '')) 'yo'))")
+    end
   end
 end


### PR DESCRIPTION
This commit fixes a lexer problem that prevented nested string
interpolations. A nested expression would shift a @token_queue
and "steal" a token that was intended for the top-level interpolation
expression only. Now, tokens already on the @token_queue will be left
intact by nested interpolations.