### PR TITLE
(PUP-6483) Prevent `puppet resource user` logins

### DIFF
--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -117,6 +117,9 @@ Puppet::Type.type(:user).provide :windows_adsi do
   end
 
   def password
+    # avoid a LogonUserW style password check when the resource is not yet
+    # populated with a password (as is the case with `puppet resource user`)
+    return nil if @resource[:password].nil? || @resource[:password] == ''
     user.password_is?( @resource[:password] ) ? @resource[:password] : nil
   end
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -200,6 +200,10 @@ module Puppet
           well as the password.
         * Windows passwords can only be managed in cleartext, as there is no Windows API
           for setting the password hash.
+        * Windows passwords shouldn't be specified as empty (zero-length) strings, even
+          if you've configured Windows to allow blank passwords. If you do specify a
+          blank password, Puppet will report a change on every run because there is no
+          way to verify that an existing password is blank.
 
         [stdlib]: https://github.com/puppetlabs/puppetlabs-stdlib/
 

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -191,6 +191,8 @@ module Puppet::Util::Windows::ADSI
     end
 
     def self.logon(name, password)
+      # this underlying check will throw when password is nil or empty
+      # as the Windows LogonUserW API does not support that
       Puppet::Util::Windows::User.password_is?(name, password)
     end
 

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -238,6 +238,9 @@ module Puppet::Util::Windows::ADSI
 
     def password=(password)
       if !password.nil?
+        if password == ''
+          Puppet.warning("Blank (zero length) passwords are not recommended. Blank passwords might be allowed on your system based on policy, but Puppet cannot verify a blank password with the operating system. Because of this a password change event will be executed by Puppet on every run.")
+        end
         native_user.SetPassword(password)
         commit
       end

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -110,6 +110,10 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
         expect { Puppet::Util::Windows::User.password_is?(username, nil) }.to raise_error(Puppet::Util::Windows::Error)
       end
 
+      it "should raise an error given an empty password" do
+        expect { Puppet::Util::Windows::User.password_is?(username, '') }.to raise_error(Puppet::Util::Windows::Error)
+      end
+
       it "should return false given a nil username and an incorrect password" do
         expect(Puppet::Util::Windows::User.password_is?(nil, bad_password)).to be_falsey
       end

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -106,8 +106,8 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
         expect(Puppet::Util::Windows::User.password_is?(username, bad_password)).to be_falsey
       end
 
-      it "should return false given an incorrect username and nil password" do
-        expect(Puppet::Util::Windows::User.password_is?(username, nil)).to be_falsey
+      it "should raise an error given a nil password" do
+        expect { Puppet::Util::Windows::User.password_is?(username, nil) }.to raise_error(Puppet::Util::Windows::Error)
       end
 
       it "should return false given a nil username and an incorrect password" do

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -228,6 +228,21 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       expect(provider.password).to be_nil
     end
 
+    it "should generate a warning with an empty password" do
+      resource[:password] = ''
+
+      # expect
+    end
+
+    it "should generate a warning with a nil password" do
+      # TODO: can we use error code 1327 to identify that a user in fact has an empty password
+      # i.e. is the error code returned when logging in unsuccessfully with a valid empty password
+      # any different than trying to login with an invalid non-empty password?
+      resource[:password] = ''
+
+      # expect
+    end
+
     it 'should not create a user if a group by the same name exists' do
       Puppet::Util::Windows::ADSI::User.expects(:create).with('testuser').raises( Puppet::Error.new("Cannot create user if group 'testuser' exists.") )
       expect{ provider.create }.to raise_error( Puppet::Error,


### PR DESCRIPTION
 - `puppet resource user` will make calls to LogonUserW for each local
   user that exists when enumerating / populating the user resources.

   Unfortunately, it does so with a nil password (given the values are
   not derived from a manifest).  The Windows API, even when a user
   actually has an empty password, will return 1327 for account
   restrictions when trying to call LogonUser.

   This prevents additional calls to LogonUser with the wrong password
   (which could cause accounts to be locked out), and it also adds
   some warnings to Puppet to inform users that when users have blank
   / empty passwords, that Puppet will always set them, and will
   always generate spurious change notices as a result.