### PR TITLE
(PUP-6486) Add the local lib directory to $LOAD_PATH before loading p…

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -11,12 +11,8 @@
 # repository](https://github.com/puppetlabs/packaging) for information on how
 # to build the Puppet gem package.
 
-begin
-  require 'puppet/version'
-rescue LoadError
-  $LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
-  require 'puppet/version'
-end
+$LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
+require 'puppet/version'
 
 Gem::Specification.new do |s|
   s.name = "puppet"


### PR DESCRIPTION
…uppet version.

Without this patch, previously installed mismatched versions of the puppet gem may
cause a version file from another puppet gem to be improperly loaded.

By adding the local lib directory to $LOAD_PATH before loading the puppet version,
we ensure that the proper version file is loaded.