### PR TITLE
(PUP-6461) Fix latest package version check in pip package provider

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -153,8 +153,10 @@ Puppet::Type.type(:package).provide :pip,
       process.collect do |line|
         # PIP OUTPUT: Could not find a version that satisfies the requirement Django==versionplease (from versions: 1.1.3, 1.8rc1)
         if line =~ /from versions: /
-          textAfterLastMatch = $'
-          versionList = textAfterLastMatch.chomp(")\n").split(', ')
+          textAfterLastMatch = $'.chomp(")\n")
+          versionList = textAfterLastMatch.split(', ').sort do |x,y|
+            Puppet::Util::Package.versioncmp(x, y)
+          end
           return versionList.last
         end
       end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -209,6 +209,20 @@ describe provider_class do
         @resource[:name] = "fake_package"
         expect(@provider.latest).to eq(nil)
       end
+
+      it "should handle out-of-order version numbers for real_package" do
+        p = StringIO.new(
+          <<-EOS
+          Collecting real-package==versionplease
+            Could not find a version that satisfies the requirement real-package==versionplease (from versions: 1.11, 13.0.3, 1.6, 1.9, 1.3.2, 14.0.1, 12.0.7, 13.0.3, 1.7.2, 1.8.4, 1.6.1, 0.9.2, 1.3, 1.8.3, 12.1.1, 1.1, 1.11.6, 1.4.8, 1.6.3, 1.10.1, 14.0.2, 1.11.3, 14.0.3, 1.4rc1, 0.8.4, 1.0, 12.0.5, 14.0.6, 1.11.5, 1.7.1.1, 1.11.4, 13.0.1, 13.1.2, 1.3.3, 0.8.2, 14.0.0, 12.0, 1.8, 1.3.4, 12.0, 1.2, 12.0.6, 0.9.1, 13.1.1, 14.0.5, 15.0.2, 15.0.0, 1.4.5, 1.4.3, 13.1.1, 1.11.2, 13.1.2, 1.3.1, 13.1.0, 12.0.2, 1.11.1, 12.0.1, 12.1.0, 0.9, 1.4.4, 13.0.0, 1.4.9, 12.1.0, 1.7.1, 1.4.2, 14.0.5, 0.8.1, 1.4.6, 0.8.3, 1.11.3, 1.5.1, 1.4.7, 13.0.2, 12.0.7, 13.0.0, 1.9.1, 1.8.2, 14.0.1, 14.0.0, 14.0.4, 1.6.2, 15.0.1, 13.1.0, 0.8, 1.7, 15.0.2, 12.0.5, 13.0.1, 1.8.1, 1.11.6, 15.0.1, 12.0.4, 12.1.1, 13.0.2, 1.11.4, 1.10, 14.0.4, 14.0.6, 1.4.1, 1.4, 1.5.2, 12.0.2, 12.0.1, 14.0.3, 14.0.2, 1.11.1, 1.7.1.2, 15.0.0, 12.0.4, 1.6.4, 1.11.2, 1.5)
+          No distributions matching the version for real-package==versionplease
+          EOS
+        )
+        Puppet::Util::Execution.expects(:execpipe).with(["/fake/bin/pip", "install", "real_package==versionplease"]).yields(p).once
+        @resource[:name] = "real_package"
+        latest = @provider.latest
+        expect(latest).to eq('15.0.2')
+      end
     end
 
   end


### PR DESCRIPTION
Output from "pip install [PACKAGE]==versionplease" must be sorted to
determine latest version