### PR TITLE
(PUP-6295) New corrective_change field

### DIFF
--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -160,6 +160,11 @@
         "environment": {
             "description": "The name of the environment that was used for the puppet run (e.g. \"production\").",
             "type":        "string"
+        },
+
+        "corrective_change": {
+            "description": "True if this report suffered an unexpected change, and Puppet corrected it, or was intending to correct it if the resource or entire run was noop.",
+            "type":        "boolean"
         }
     },
 
@@ -304,7 +309,8 @@
                                     "skipped",
                                     "failed_to_restart",
                                     "restarted",
-                                    "scheduled"
+                                    "scheduled",
+                                    "corrective_change"
                                 ]
                             },
                             {
@@ -317,7 +323,8 @@
                                     "Skipped",
                                     "Failed to restart",
                                     "Restarted",
-                                    "Scheduled"
+                                    "Scheduled",
+                                    "Corrective change"
                                 ]
                             },
                             {
@@ -526,6 +533,11 @@
                     "description": "An array of strings; each element represents a container (type or class) that, together, make up the path of the resource in the catalog.",
                     "type":        "array",
                     "items":       { "type": "string" }
+                },
+
+                "corrective_change": {
+                    "description": "True if this resource suffered an unexpected change, and Puppet corrected it, or was intending to correct it if the resource was marked noop.",
+                    "type":        "boolean"
                 }
             },
 
@@ -537,7 +549,8 @@
                 "tags",
                 "events",
                 "skipped",
-                "containment_path"
+                "containment_path",
+                "corrective_change"
             ],
             "additionalProperties":   false
         },
@@ -616,6 +629,11 @@
                 "time": {
                     "description": "The time at which the property was evaluated. In ISO 8601 format with 9 characters second-fragment",
                     "type":        "string"
+                },
+
+                "corrective_change": {
+                    "description": "True if this property suffered an unexpected change, and Puppet corrected it, or was intending to correct it if the resource was marked noop.",
+                    "type":        "boolean"
                 }
             },
             "required": [
@@ -624,7 +642,8 @@
                 "message",
                 "name",
                 "status",
-                "time"
+                "time",
+                "corrective_change"
             ],
 
             "additionalProperties": false

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1347,6 +1347,14 @@ EOT
         this file reflects the state discovered through interacting
         with clients."
       },
+    :transactionstorefile => {
+      :default => "$statedir/transactionstore.yaml",
+      :type => :file,
+      :mode => "0660",
+      :desc => "Transactional storage file for persisting data between
+        transactions for the purposes of infering information (such as
+        corrective_change) on new data received."
+    },
     :clientyamldir => {
       :default => "$vardir/client_yaml",
       :type => :directory,

--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -102,6 +102,21 @@ class Puppet::Property < Puppet::Parameter
       raise ArgumentError, "Supported values for Property#array_matching are 'first' and 'all'" unless [:first, :all].include?(value)
       @array_matching = value
     end
+
+    # Used to mark a type property as having or lacking idempotency (on purpose
+    # generally). This is used to avoid marking the property as a
+    # corrective_change when there is known idempotency issues with the property
+    # rendering a corrective_change flag as useless.
+    # @return [Boolean] returns true if the property is marked as non-idempotent
+    def idempotent
+      @idempotent.nil? ? @idempotent = true : @idempotent
+    end
+
+    # Attribute setter for the idempotent attribute.
+    # @see idempotent
+    def idempotent=(value)
+      @idempotent = value
+    end
   end
 
   # Looks up a value's name among valid values, to enable option lookup with result as a key.
@@ -388,6 +403,12 @@ class Puppet::Property < Puppet::Parameter
   # @return [Boolean] whether the {array_matching} mode is set to `:all` or not
   def match_all?
     self.class.array_matching == :all
+  end
+
+  # @return [Boolean] whether the property is marked as idempotent for the purposes
+  #   of calculating corrective change.
+  def idempotent?
+    self.class.idempotent
   end
 
   # @return [Symbol] the name of the property as stated when the property was created.

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -30,7 +30,7 @@ module Puppet
       attr_accessor :evaluation_time
 
       # Boolean status types set while evaluating `@real_resource`.
-      STATES = [:skipped, :failed, :failed_to_restart, :restarted, :changed, :out_of_sync, :scheduled]
+      STATES = [:skipped, :failed, :failed_to_restart, :restarted, :changed, :out_of_sync, :scheduled, :corrective_change]
       attr_accessor *STATES
 
       # @!attribute [r] source_description
@@ -87,6 +87,14 @@ module Puppet
       #   @return [Array<Puppet::Resource>] A cache of all
       #   dependencies of this resource that failed to apply.
       attr_accessor :failed_dependencies
+
+      # @!attribute [rw] corrective_change
+      #   @return [Boolean] true if the resource contained a corrective change.
+      attr_accessor :corrective_change
+
+      # @!attribute [r] real_resource
+      #   @return [Puppet::Type] returns the real resource that this status relates to
+      attr_reader :real_resource
 
       def dependency_failed?
         failed_dependencies && !failed_dependencies.empty?
@@ -153,6 +161,7 @@ module Puppet
         @out_of_sync = false
         @skipped = false
         @failed = false
+        @corrective_change = false
 
         @file = resource.file
         @line = resource.line
@@ -181,7 +190,7 @@ module Puppet
         @changed = data['changed']
         @skipped = data['skipped']
         @failed = data['failed']
-
+        @corrective_change = data['corrective_change']
         @events = data['events'].map do |event|
           # in YAML (for reports) we serialize this as an object, but
           # in PSON it becomes a hash. Depending on where we came from
@@ -212,6 +221,7 @@ module Puppet
           'change_count' => @change_count,
           'out_of_sync_count' => @out_of_sync_count,
           'events' => @events,
+          'corrective_change' => @corrective_change,
         }
       end
 

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -11,8 +11,8 @@ class Puppet::Transaction::Event
   include Puppet::Util::Logging
   include Puppet::Network::FormatSupport
 
-  ATTRIBUTES = [:name, :resource, :property, :previous_value, :desired_value, :historical_value, :status, :message, :file, :line, :source_description, :audited, :invalidate_refreshes, :redacted]
-  YAML_ATTRIBUTES = %w{@audited @property @previous_value @desired_value @historical_value @message @name @status @time @redacted}.map(&:to_sym)
+  ATTRIBUTES = [:name, :resource, :property, :previous_value, :desired_value, :historical_value, :status, :message, :file, :line, :source_description, :audited, :invalidate_refreshes, :redacted, :corrective_change]
+  YAML_ATTRIBUTES = %w{@audited @property @previous_value @desired_value @historical_value @message @name @status @time @redacted @corrective_change}.map(&:to_sym)
   attr_accessor *ATTRIBUTES
   attr_accessor :time
   attr_reader :default_log_level
@@ -28,6 +28,7 @@ class Puppet::Transaction::Event
   def initialize(options = {})
     @audited = false
     @redacted = false
+    @corrective_change = false
 
     set_options(options)
     @time = Time.now
@@ -45,6 +46,7 @@ class Puppet::Transaction::Event
     @time = data['time']
     @time = Time.parse(@time) if @time.is_a? String
     @redacted = data.fetch('redacted', false)
+    @corrective_change = data['corrective_change']
   end
 
   def to_data_hash
@@ -58,7 +60,8 @@ class Puppet::Transaction::Event
       'name' => @name,
       'status' => @status,
       'time' => @time.iso8601(9),
-      'redacted' => @redacted
+      'redacted' => @redacted,
+      'corrective_change' => @corrective_change,
     }
   end
 

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -1,0 +1,83 @@
+require 'yaml'
+require 'puppet/util/yaml'
+
+# A persistence store implementation for storing information between
+# transaction runs for the purposes of information inference (such
+# as calculating corrective_change).
+class Puppet::Transaction::Persistence
+  def initialize
+    @filename = Puppet[:transactionstorefile]
+
+    @data = {"resources" => {}}
+  end
+
+  # Obtain the full raw data from the persistence store.
+  # @return [Hash] hash of data stored in persistence store
+  def data
+    @data
+  end
+
+  # Return just the resource specific data from the persistence store.
+  # @return [Hash] hash of resources data in persistence store
+  def resources
+    @data["resources"]
+  end
+
+  # Set the resource specific data in the persistence store.
+  # @param value [Hash] new hash to store for resources in persistence store.
+  def resources=(value)
+    @data["resources"] = value
+  end
+
+  # Retrieve the system value using the resource and parameter name
+  # @param [String] resource_name name of resource
+  # @param [String] param_name name of the parameter
+  # @return [Object,nil] the system_value
+  def get_system_value(resource_name, param_name)
+    if !@data["resources"][resource_name].nil? &&
+       !@data["resources"][resource_name]["parameters"].nil? &&
+       !@data["resources"][resource_name]["parameters"][param_name].nil?
+      @data["resources"][resource_name]["parameters"][param_name]["system_value"]
+    else
+      nil
+    end
+  end
+
+  # Load data from the persistence store on disk.
+  def load
+    unless Puppet::FileSystem.exist?(@filename)
+      return
+    end
+    unless File.file?(@filename)
+      Puppet.warning("Persistence file #{@filename} is not a file, ignoring")
+      return
+    end
+
+    result = nil
+    Puppet::Util.benchmark(:debug, "Loaded transaction") do
+      begin
+        result = Puppet::Util::Yaml.load_file(@filename)
+      rescue Puppet::Util::Yaml::YamlLoadError => detail
+        Puppet.err "Persistence file #{@filename} is corrupt (#{detail}); replacing"
+
+        begin
+          File.rename(@filename, @filename + ".bad")
+        rescue
+          raise Puppet::Error, "Could not rename corrupt #{@filename}; remove manually", detail.backtrace
+        end
+      end
+    end
+
+    unless result.is_a?(Hash)
+      Puppet.err "State got corrupted"
+      return
+    end
+
+    @data = result
+  end
+
+  # Save data from internal class to persistence store on disk.
+  def save
+    Puppet::Util::Yaml.dump(@data, @filename)
+  end
+end

--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -6,7 +6,7 @@ module Puppet
   Type.newtype(:notify) do
     @doc = "Sends an arbitrary message to the agent run-time log."
 
-    newproperty(:message) do
+    newproperty(:message, :idempotent => false) do
       desc "The message to be sent to the log."
       def sync
         case @resource["withpath"]

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
+require 'puppet_spec/files'
 
 describe Puppet::Transaction::Report do
   describe "when using the indirector" do
@@ -35,6 +36,671 @@ describe Puppet::Transaction::Report do
       report << log
 
       expect(YAML.dump(report)).to_not match('Puppet::Util::TagSet')
+    end
+  end
+
+  describe "inference checking" do
+    include PuppetSpec::Files
+    require 'puppet/configurer'
+
+    def run_catalogs(resources1, resources2, noop1 = false, noop2 = false, &block)
+      last_run_report = nil
+      Puppet::Transaction::Report.indirection.expects(:save).twice.with do |report, x|
+        last_run_report = report
+        true
+      end
+
+      Puppet[:report] = true
+      Puppet[:noop] = noop1
+
+      configurer = Puppet::Configurer.new
+      configurer.run :catalog => new_catalog(resources1)
+
+      yield block if block
+      last_report = last_run_report
+
+      Puppet[:noop] = noop2
+
+      configurer = Puppet::Configurer.new
+      configurer.run :catalog => new_catalog(resources2)
+
+      expect(last_report).not_to eq(last_run_report)
+
+      return last_run_report
+    end
+
+    def new_blank_catalog
+      Puppet::Resource::Catalog.new("testing", Puppet.lookup(:environments).get(Puppet[:environment]))
+    end
+
+    def new_catalog(resources = [])
+      new_cat = new_blank_catalog
+      [resources].flatten.each do |resource|
+        new_cat.add_resource(resource)
+      end
+      new_cat
+    end
+
+    def get_cc_count(report)
+      cc = report.metrics["resources"].values.each do |v|
+        if v[0] == "corrective_change"
+          return v[2]
+        end
+      end
+      return nil
+    end
+
+    describe "for agent runs that contain" do
+      it "notifies with catalog change" do
+        report = run_catalogs(Puppet::Type.type(:notify).new(:title => "testing",
+                                                             :message => "foo"),
+                              Puppet::Type.type(:notify).new(:title => "testing",
+                                                             :message => "foobar"))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["Notify[testing]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "notifies with no catalog change" do
+        report = run_catalogs(Puppet::Type.type(:notify).new(:title => "testing",
+                                                             :message => "foo"),
+                              Puppet::Type.type(:notify).new(:title => "testing",
+                                                             :message => "foo"))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["Notify[testing]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "new file resource" do
+        file = tmpfile("test_file")
+        report = run_catalogs([],
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "removal of a file resource" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              [])
+
+        expect(report.status).to eq("unchanged")
+        expect(report.resource_statuses["File[#{file}]"]).to eq(nil)
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with a title change" do
+        file1 = tmpfile("test_file")
+        file2 = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file1,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file2,
+                                                           :content => "mystuff"))
+
+        expect(report.status).to eq("changed")
+
+        expect(report.resource_statuses["File[#{file1}]"]).to eq(nil)
+
+        rs = report.resource_statuses["File[#{file2}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with no catalog change" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"))
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(0)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with a new parameter" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff",
+                                                           :loglevel => :debug))
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(0)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with a removed parameter" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff",
+                                                           :loglevel => :debug),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"))
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(0)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with a property no longer managed" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file))
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(0)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with no catalog change, but file changed between runs" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff")) do
+          File.open(file, 'w') do |f|
+            f.puts "some content"
+          end
+        end
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+      end
+
+      it "file with catalog change, but file changed between runs that matched catalog change" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "some content")) do
+          File.open(file, 'w') do |f|
+            f.write "some content"
+          end
+        end
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(0)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with catalog change, but file changed between runs that did not match catalog change" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff1"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff2")) do
+          File.open(file, 'w') do |file|
+            file.write "some content"
+          end
+        end
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+      end
+
+      it "file with catalog change" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff1"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff2"))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with ensure property set to present" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :present),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :present))
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(0)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with ensure property change file => absent" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :file),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :absent))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with ensure property change present => absent" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :present),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :absent))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "link with ensure property change present => absent", :unless => Puppet.features.microsoft_windows? do
+        file = tmpfile("test_file")
+        FileUtils.symlink(file, tmpfile("test_link"))
+
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :present),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :absent))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file with ensure property change absent => present" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :absent),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :ensure => :present))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "new resource in catalog" do
+        file = tmpfile("test_file")
+        report = run_catalogs([],
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff asdf"))
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "exec with idempotence issue", :unless => Puppet.features.microsoft_windows? do
+        report = run_catalogs(Puppet::Type.type(:exec).new(:title => "exec1",
+                                                           :command => "/bin/echo foo"),
+                              Puppet::Type.type(:exec).new(:title => "exec1",
+                                                           :command => "/bin/echo foo"))
+
+        expect(report.status).to eq("changed")
+
+        # Of note here, is that the main idempotence issues lives in 'returns'
+        rs = report.resource_statuses["Exec[exec1]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+      end
+
+      it "exec with no idempotence issue", :unless => Puppet.features.microsoft_windows? do
+        report = run_catalogs(Puppet::Type.type(:exec).new(:title => "exec1",
+                                                           :command => "echo foo",
+                                                           :path => "/bin",
+                                                           :unless => "ls"),
+                              Puppet::Type.type(:exec).new(:title => "exec1",
+                                                           :command => "echo foo",
+                                                           :path => "/bin",
+                                                           :unless => "ls"))
+
+        expect(report.status).to eq("unchanged")
+
+        # Of note here, is that the main idempotence issues lives in 'returns'
+        rs = report.resource_statuses["Exec[exec1]"]
+        expect(rs.events.size).to eq(0)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "noop on second run, file with no catalog change, but file changed between runs" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              false, true) do
+          File.open(file, 'w') do |f|
+            f.puts "some content"
+          end
+        end
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.events.size).to eq(1)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+      end
+
+      it "noop on all subsequent runs, file with no catalog change, but file changed between run 1 and 2" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              false, true) do
+          File.open(file, 'w') do |f|
+            f.puts "some content"
+          end
+        end
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.events.size).to eq(1)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+
+        # Simply run the catalog twice again, but this time both runs are noop to
+        # test if the corrective field is still set.
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              true, true)
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.events.size).to eq(1)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+      end
+
+      it "noop on first run, file with no catalog change, but file changed between runs" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              true, false) do
+          File.open(file, 'w') do |f|
+            f.puts "some content"
+          end
+        end
+
+        expect(report.status).to eq("changed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.events.size).to eq(1)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+      end
+
+      it "noop on both runs, file with no catalog change, but file changed between runs" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              true, true) do
+          File.open(file, 'w') do |f|
+            f.puts "some content"
+          end
+        end
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+      end
+
+      it "noop on 4 runs, file with no catalog change, but file changed between runs 1 and 2" do
+        file = tmpfile("test_file")
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              true, true) do
+          File.open(file, 'w') do |f|
+            f.puts "some content"
+          end
+        end
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "mystuff"),
+                              true, true)
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(true)
+        expect(rs.corrective_change).to eq(true)
+
+        expect(report.corrective_change).to eq(true)
+        expect(get_cc_count(report)).to eq(1)
+      end
+
+      it "noop on both runs, file already exists but with catalog change each time" do
+        file = tmpfile("test_file")
+
+        File.open(file, 'w') do |f|
+          f.puts "some content"
+        end
+
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "a"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "b"),
+                              true, true)
+
+        expect(report.status).to eq("unchanged")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file failure should not return corrective_change" do
+        # Making the path a child path (with no parent) forces a failure
+        file = tmpfile("test_file") + "/foo"
+        report = run_catalogs(Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "a"),
+                              Puppet::Type.type(:file).new(:title => file,
+                                                           :content => "b"),
+                              false, false)
+
+        expect(report.status).to eq("failed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
+
+      it "file skipped with file change between runs will not show corrective_change" do
+        # Making the path a child path (with no parent) forces a failure
+        file = tmpfile("test_file") + "/foo"
+
+        resources1 = [
+          Puppet::Type.type(:file).new(:title => file,
+                                       :content => "a",
+                                       :notify => "Notify['foo']"),
+          Puppet::Type.type(:notify).new(:title => "foo")
+        ]
+        resources2 = [
+          Puppet::Type.type(:file).new(:title => file,
+                                       :content => "a",
+                                       :notify => "Notify[foo]"),
+          Puppet::Type.type(:notify).new(:title => "foo",
+                                         :message => "foo")
+        ]
+
+        report = run_catalogs(resources1, resources2, false, false)
+
+        expect(report.status).to eq("failed")
+
+        rs = report.resource_statuses["File[#{file}]"]
+        expect(rs.events.size).to eq(1)
+        expect(rs.events[0].corrective_change).to eq(false)
+        expect(rs.corrective_change).to eq(false)
+
+        rs = report.resource_statuses["Notify[foo]"]
+        expect(rs.events.size).to eq(0)
+        expect(rs.corrective_change).to eq(false)
+
+        expect(report.corrective_change).to eq(false)
+        expect(get_cc_count(report)).to eq(0)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -152,6 +152,8 @@ RSpec.configure do |config|
     Puppet[:rundir] = "$vardir/run"
     Puppet[:hiera_config] = File.join(base, 'hiera')
 
+    FileUtils.mkdir_p Puppet[:statedir]
+
     Puppet::Test::TestHelper.before_each_test()
   end
 

--- a/spec/unit/transaction/event_spec.rb
+++ b/spec/unit/transaction/event_spec.rb
@@ -129,7 +129,8 @@ describe Puppet::Transaction::Event do
                                              :message => "Help I'm trapped in a spec test",
                                              :name => :mode_changed, :previous_value => 6, :property => :mode,
                                              :status => 'success',
-                                             :redacted => false)
+                                             :redacted => false,
+                                             :corrective_change => false)
       expect(event.to_yaml_properties).to match_array(Puppet::Transaction::Event::YAML_ATTRIBUTES)
     end
   end

--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -1,0 +1,167 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'yaml'
+require 'fileutils'
+require 'puppet/transaction/persistence'
+
+describe Puppet::Transaction::Persistence do
+  include PuppetSpec::Files
+
+  before(:each) do
+    @basepath = File.expand_path("/somepath")
+  end
+
+  describe "when loading from file" do
+    before do
+      Puppet.settings.stubs(:use).returns(true)
+    end
+
+    describe "when the file/directory does not exist" do
+      before(:each) do
+        @path = tmpfile('storage_test')
+      end
+
+      it "should not fail to load" do
+        expect(Puppet::FileSystem.exist?(@path)).to be_falsey
+        Puppet[:statedir] = @path
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.load
+        Puppet[:transactionstorefile] = @path
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.load
+      end
+
+      it "should not lose its internal state when load is called" do
+        expect(Puppet::FileSystem.exist?(@path)).to be_falsey
+
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.resources = {"a"=>"b"}
+        expect(persistence.resources).to eq({"a"=>"b"})
+
+        Puppet[:transactionstorefile] = @path
+        persistence.load
+        expect(persistence.resources).to eq({"a"=>"b"})
+      end
+    end
+
+    describe "when the file/directory exists" do
+      before(:each) do
+        @tmpfile = tmpfile('storage_test')
+        FileUtils.touch(@tmpfile)
+        Puppet[:transactionstorefile] = @tmpfile
+      end
+
+      def write_state_file(contents)
+        File.open(@tmpfile, 'w') { |f| f.write(contents) }
+      end
+
+      it "should overwrite its internal state if load() is called" do
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.resources = {"a"=>"b"}
+        expect(persistence.resources).to eq({"a"=>"b"})
+
+        persistence.load
+
+        expect(persistence.resources).to eq({"a"=>"b"})
+      end
+
+      it "should restore its internal state if the file contains valid YAML" do
+        test_yaml = {"resources"=>{"a"=>"b"}}
+        write_state_file(test_yaml.to_yaml)
+
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.load
+
+        expect(persistence.data).to eq(test_yaml)
+      end
+
+      it "should initialize with a clear internal state if the file does not contain valid YAML" do
+        write_state_file('{ invalid')
+
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.load
+
+        expect(persistence.data).to eq({"resources"=>{}})
+      end
+
+      it "should initialize with a clear internal state if the file does not contain a hash of data" do
+        write_state_file("not_a_hash")
+
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.load
+
+        expect(persistence.data).to eq({"resources"=>{}})
+      end
+
+      it "should raise an error if the file does not contain valid YAML and cannot be renamed" do
+        write_state_file('{ invalid')
+
+        File.expects(:rename).raises(SystemCallError)
+
+        persistence = Puppet::Transaction::Persistence.new
+        expect { persistence.load }.to raise_error(Puppet::Error, /Could not rename/)
+      end
+
+      it "should attempt to rename the file if the file is corrupted" do
+        write_state_file('{ invalid')
+
+        File.expects(:rename).at_least_once
+
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.load
+      end
+
+      it "should fail gracefully on load() if the file is not a regular file" do
+        FileUtils.rm_f(@tmpfile)
+        Dir.mkdir(@tmpfile)
+
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.load
+      end
+    end
+  end
+
+  describe "when storing to the file" do
+    before(:each) do
+      @tmpfile = tmpfile('persistence_test')
+      @saved = Puppet[:transactionstorefile]
+      Puppet[:transactionstorefile] = @tmpfile
+    end
+
+    it "should create the file if it does not exist" do
+      expect(Puppet::FileSystem.exist?(Puppet[:transactionstorefile])).to be_falsey
+
+      persistence = Puppet::Transaction::Persistence.new
+      persistence.resources = {"a"=>"b"}
+      persistence.save
+
+      expect(Puppet::FileSystem.exist?(Puppet[:transactionstorefile])).to be_truthy
+    end
+
+    it "should raise an exception if the file is not a regular file" do
+      Dir.mkdir(Puppet[:transactionstorefile])
+      persistence = Puppet::Transaction::Persistence.new
+      persistence.resources = {"a"=>"b"}
+
+      if Puppet.features.microsoft_windows?
+        expect { persistence.save }.to raise_error(Puppet::Util::Windows::Error, /Access is denied/)
+      else
+        expect { persistence.save }.to raise_error(Errno::EISDIR, /Is a directory/)
+      end
+
+      Dir.rmdir(Puppet[:transactionstorefile])
+    end
+
+    it "should load the same information that it saves" do
+      persistence = Puppet::Transaction::Persistence.new
+      persistence.resources = {"a"=>"b"}
+      expect(persistence.resources).to eq({"a"=>"b"})
+
+      persistence.save
+      persistence.load
+
+      expect(persistence.resources).to eq({"a"=>"b"})
+    end
+  end
+end


### PR DESCRIPTION
The corrective_change field in events marks an event that was presumed to be a
manual out-of-band change from Puppet, that Puppet then corrected. In the
context of a noop or non-applying change, the same is true except that the
change was not corrected but is intended to be corrected once a real run is
applied.

This patch introduces the work necessary to calculate this change, introducing a
transaction store that stores the last known best applied value so we can
calculate that a change was indeed unexpected.

For each report, we also mark the resource that had a corrective_change plus
mark an overall report of this also so this information can be stored in
backends like PuppetDB for quick searching.

A metric has also been included, to count all resources that had
corrective_change marked true as part of the implicit metric gathering for flags
on resources.

Signed-off-by: Ken Barber <ken@bob.sh>