### PR TITLE
(PUP-6491) fix parser_validate acceptance test for puppetserver

### DIFF
--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -45,7 +45,7 @@ notice 42 =~ MyInteger
     end
 
     step '(large) manifest with exported resources' do
-      fixture_path = 'fixtures/manifest_large_exported_classes_node.pp'
+      fixture_path = File.join(File.dirname(__FILE__), '..', '..', 'fixtures/manifest_large_exported_classes_node.pp')
       create_test_file(agent, "#{app_type}_exported.pp", File.read(fixture_path))
       tmp_manifest = get_test_file_path(agent, "#{app_type}_exported.pp")
       on(agent, puppet("parser validate #{tmp_manifest}"))


### PR DESCRIPTION
puppet acceptance tests run from the root of puppetserver in a submodule
which is at `puppetserver/ruby/puppet`.  In order to use the fixutres in
this test (or any tests) we should use a path relative to the test file
itself, not where beaker thinks itself to be.

[skip ci]