### PR TITLE
(PUP-6441) Redact event value contents

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -256,8 +256,8 @@ class Puppet::Property < Puppet::Parameter
   #   options to the created event?
   # @return [Puppet::Transaction::Event] the created event
   # @see Puppet::Type#event
-  def event
-    attrs = { :name => event_name, :desired_value => should, :property => self, :source_description => path }
+  def event(options = {})
+    attrs = { :name => event_name, :desired_value => should, :property => self, :source_description => path }.merge(options)
     if should and value = self.class.value_collection.match?(should)
       attrs[:invalidate_refreshes] = true if value.invalidate_refreshes
     end

--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -146,12 +146,20 @@ class Puppet::Transaction::ResourceHarness
   end
 
   def create_change_event(property, current_value, historical_value)
-    event = property.event
-    event.previous_value = current_value
-    event.desired_value = property.should
-    event.historical_value = historical_value
+    options = {}
+    should = property.should
 
-    event
+    if property.sensitive
+      options[:previous_value] = current_value.nil? ? nil : '[redacted]'
+      options[:desired_value] = should.nil? ? nil : '[redacted]'
+      options[:historical_value] = historical_value.nil? ? nil : '[redacted]'
+    else
+      options[:previous_value] = current_value
+      options[:desired_value] = should
+      options[:historical_value] = historical_value
+    end
+
+    property.event(options)
   end
 
   # This method is an ugly hack because, given a Time object with nanosecond

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -438,10 +438,11 @@ describe Puppet::Transaction::ResourceHarness do
         expect(sync_event.message).to eq 'changed [redacted] to [redacted]'
       end
 
-      it "redacts event messages for sensitive properties" do
+      it "redacts event contents for sensitive properties" do
         status = @harness.evaluate(resource)
         sync_event = status.events[0]
-        expect(sync_event.message).to eq 'changed [redacted] to [redacted]'
+        expect(sync_event.previous_value).to eq '[redacted]'
+        expect(sync_event.desired_value).to eq '[redacted]'
       end
 
       it "redacts event messages for sensitive properties when simulating noop changes" do
@@ -474,6 +475,13 @@ describe Puppet::Transaction::ResourceHarness do
           status = @harness.evaluate(resource)
           sync_event = status.events[0]
           expect(sync_event.message).to eq 'current_value [redacted], should be [redacted] (noop) (previously recorded value was [redacted])'
+        end
+
+        it "redacts event contents for sensitive properties" do
+          Puppet::Util::Storage.stubs(:cache).with(resource).returns({:content => "historical world"})
+          status = @harness.evaluate(resource)
+          sync_event = status.events[0]
+          expect(sync_event.historical_value).to eq '[redacted]'
         end
       end
     end


### PR DESCRIPTION
This commit redacts event value fields for sensitive properties to
ensure that sensitive information isn't inappropriately logged or
stored.