### PR TITLE
(PUP-6499) Ensure Windows ADSI strings UTF-8

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -334,6 +334,10 @@ module Puppet::Util::Windows::ADSI
       user_name
     end
 
+    def self.current_user_sid
+      Puppet::Util::Windows::SID.name_to_sid_object(current_user_name)
+    end
+
     def self.exists?(name_or_sid)
       well_known = false
       if (sid = Puppet::Util::Windows::SID.name_to_sid_object(name_or_sid))

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -194,7 +194,10 @@ module Puppet::Util::Windows::ADSI
     end
 
     def [](attribute)
-      native_user.Get(attribute)
+      value = native_user.Get(attribute)
+      # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
+      return value.encode(Encoding::UTF_8) if value.is_a?(String)
+      value
     end
 
     def []=(attribute, value)
@@ -244,7 +247,8 @@ module Puppet::Util::Windows::ADSI
       # https://msdn.microsoft.com/en-us/library/aa746342.aspx
       # WIN32OLE objects aren't enumerable, so no map
       groups = []
-      native_user.Groups.each {|g| groups << g.Name} rescue nil
+      # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
+      native_user.Groups.each {|g| groups << g.Name.encode(Encoding::UTF_8)} rescue nil
       groups
     end
 
@@ -363,7 +367,8 @@ module Puppet::Util::Windows::ADSI
 
       users = []
       wql.each do |u|
-        users << new(u.name)
+        # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
+        users << new(u.name.encode(Encoding::UTF_8))
       end
 
       users.each(&block)
@@ -455,7 +460,8 @@ module Puppet::Util::Windows::ADSI
     def members
       # WIN32OLE objects aren't enumerable, so no map
       members = []
-      native_group.Members.each {|m| members << m.Name}
+      # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
+      native_group.Members.each {|m| members << m.Name.encode(Encoding::UTF_8)}
       members
     end
 
@@ -524,7 +530,8 @@ module Puppet::Util::Windows::ADSI
 
       groups = []
       wql.each do |g|
-        groups << new(g.name)
+        # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
+        groups << new(g.name.encode(Encoding::UTF_8))
       end
 
       groups.each(&block)

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -269,6 +269,11 @@ module Puppet::Util::Windows::Process
   end
   module_function :set_environment_variable
 
+  def get_system_default_ui_language
+    GetSystemDefaultUILanguage()
+  end
+  module_function :get_system_default_ui_language
+
   # Returns whether or not the OS has the ability to set elevated
   # token information.
   #
@@ -476,4 +481,9 @@ module Puppet::Util::Windows::Process
   ffi_lib :kernel32
   attach_function_private :GetVersionExW,
     [:pointer], :win32_bool
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/dd318123(v=vs.85).aspx
+  # LANGID GetSystemDefaultUILanguage(void);
+  ffi_lib :kernel32
+  attach_function_private :GetSystemDefaultUILanguage, [], :word
 end

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1393,7 +1393,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       describe "when processing SYSTEM ACEs" do
         before do
           @sids = {
-            :current_user => Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name),
+            :current_user => Puppet::Util::Windows::ADSI::User.current_user_sid.sid,
             :system => Puppet::Util::Windows::SID::LocalSystem,
             :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
             :users => Puppet::Util::Windows::SID::BuiltinUsers,

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -722,11 +722,11 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
       FileUtils.mkdir_p(srcdir)
       FileUtils.mkdir_p(dstdir)
-      
+
       srcfile = File.join(srcdir, "file.src")
       cpyfile = File.join(dstdir, "file.src")
       ignfile = File.join(srcdir, "file.ign")
-      
+
       File.open(srcfile, "w") { |f| f.puts "don't ignore me" }
       File.open(ignfile, "w") { |f| f.puts "you better ignore me" }
 
@@ -735,7 +735,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
                              :name => srcdir,
                              :ensure => 'directory',
                              :mode => '0755',)
-      
+
       catalog.add_resource described_class.new(
                              :name => dstdir,
                              :ensure => 'directory',
@@ -743,7 +743,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
                              :source => srcdir,
                              :recurse => true,
                              :ignore => '*.ign',)
-      
+
       catalog.apply
       expect(Puppet::FileSystem.exist?(srcdir)).to be_truthy
       expect(Puppet::FileSystem.exist?(dstdir)).to be_truthy
@@ -1395,7 +1395,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
           @sids = {
             :current_user => Puppet::Util::Windows::ADSI::User.current_user_sid.sid,
             :system => Puppet::Util::Windows::SID::LocalSystem,
-            :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
             :users => Puppet::Util::Windows::SID::BuiltinUsers,
             :power_users => Puppet::Util::Windows::SID::PowerUsers,
             :none => Puppet::Util::Windows::SID::Nobody
@@ -1415,8 +1414,8 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
           describe "when permissions are not insync?" do
             before :each do
-              @file[:owner] = 'None'
-              @file[:group] = 'None'
+              @file[:owner] = @sids[:none]
+              @file[:group] = @sids[:none]
             end
 
             it "preserves the inherited SYSTEM ACE for an existing file" do
@@ -1503,8 +1502,8 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
           describe "when permissions are not insync?" do
             before :each do
-              @directory[:owner] = 'None'
-              @directory[:group] = 'None'
+              @directory[:owner] = @sids[:none]
+              @directory[:group] = @sids[:none]
             end
 
             it "preserves the inherited SYSTEM ACEs for an existing directory" do
@@ -1726,7 +1725,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
         catalog.apply
         expect(Puppet::FileSystem).to be_directory(copy)
       end
-    
+
       it "should copy the link itself if :links => manage" do
         catalog.add_resource described_class.new(
           :name => target,
@@ -1746,7 +1745,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
         expect(Dir.entries(link)).to eq(Dir.entries(copy))
       end
     end
-  
+
     context "and the recurse attribute is true" do
       it "should recursively copy the directory if :links => follow" do
         catalog.add_resource described_class.new(

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util/windows'
+
+describe Puppet::Util::Windows::ADSI::User,
+  :if => Puppet.features.microsoft_windows? do
+
+  describe '.each' do
+    it 'should return a list of users with UTF-8 names' do
+      begin
+        original_codepage = Encoding.default_external
+        Encoding.default_external = Encoding::CP850 # Western Europe
+
+        Puppet::Util::Windows::ADSI::User.each do |user|
+          expect(user.name.encoding).to be(Encoding::UTF_8)
+        end
+      ensure
+        Encoding.default_external = original_codepage
+      end
+    end
+  end
+
+  describe '.[]' do
+    it 'should return string attributes as UTF-8' do
+      administrator = Puppet::Util::Windows::ADSI::User.new('Administrator')
+      expect(administrator['Description'].encoding).to eq(Encoding::UTF_8)
+    end
+  end
+
+  describe '.groups' do
+    it 'should return a list of groups with UTF-8 names' do
+      begin
+        original_codepage = Encoding.default_external
+        Encoding.default_external = Encoding::CP850 # Western Europe
+
+
+        # lookup by English name Administrator is OK on localized Windows
+        administrator = Puppet::Util::Windows::ADSI::User.new('Administrator')
+        administrator.groups.each do |name|
+          expect(name.encoding).to be(Encoding::UTF_8)
+        end
+      ensure
+        Encoding.default_external = original_codepage
+      end
+    end
+  end
+end
+
+describe Puppet::Util::Windows::ADSI::Group,
+  :if => Puppet.features.microsoft_windows? do
+
+  let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
+  let (:administrators_principal) { Puppet::Util::Windows::SID::Principal.lookup_account_sid(administrator_bytes) }
+
+  describe '.each' do
+    it 'should return a list of groups with UTF-8 names' do
+      begin
+        original_codepage = Encoding.default_external
+        Encoding.default_external = Encoding::CP850 # Western Europe
+
+
+        Puppet::Util::Windows::ADSI::Group.each do |group|
+          expect(group.name.encoding).to be(Encoding::UTF_8)
+        end
+      ensure
+        Encoding.default_external = original_codepage
+      end
+    end
+  end
+
+  describe '.members' do
+    it 'should return a list of members with UTF-8 names' do
+      begin
+        original_codepage = Encoding.default_external
+        Encoding.default_external = Encoding::CP850 # Western Europe
+
+        # lookup by English name Administrators is not OK on localized Windows
+        admins = Puppet::Util::Windows::ADSI::Group.new(administrators_principal.account)
+        admins.members.each do |name|
+          expect(name.encoding).to be(Encoding::UTF_8)
+        end
+      ensure
+        Encoding.default_external = original_codepage
+      end
+    end
+  end
+end

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -79,7 +79,10 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       principal = Puppet::Util::Windows::SID::Principal
       expect {
         principal.lookup_account_name('ConanTheBarbarian')
-      }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountNameW/)
+      }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(1332) # ERROR_NONE_MAPPED
+      end
     end
 
     it "should return a BUILTIN domain principal for empty account names" do
@@ -159,7 +162,10 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       principal = Puppet::Util::Windows::SID::Principal
       expect {
         principal.lookup_account_sid([0])
-      }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountSidW:  The parameter is incorrect/)
+      }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(87) # ERROR_INVALID_PARAMETER
+      end
     end
 
     it "should raise an error when trying to lookup a valid SID that doesn't have a matching account" do
@@ -167,7 +173,10 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect {
         # S-1-1-1 which is not a valid account
         principal.lookup_account_sid([1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0])
-      }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountSidW:  No mapping between account names and security IDs was done/)
+      }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(1332) # ERROR_NONE_MAPPED
+      end
     end
 
     it "should return a domain principal for BUILTIN SID S-1-5-32" do

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -6,34 +6,40 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
 
   let (:current_user_sid) { Puppet::Util::Windows::ADSI::User.current_user_sid }
   let (:system_bytes) { [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] }
+  let (:null_sid_bytes) { bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
   let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
+  let (:computer_sid) { Puppet::Util::Windows::SID.name_to_sid_object(Socket.gethostname) }
+  # BUILTIN is localized on German Windows, but not French
+  # looking this up like this dilutes the values of the tests as we're comparing two mechanisms
+  # for returning the same values, rather than to a known good
+  let (:builtin_localized) { Puppet::Util::Windows::SID.sid_to_name('S-1-5-32') }
 
   describe ".lookup_account_name" do
     it "should create an instance from a well-known account name" do
-      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('SYSTEM')
-      expect(principal.account).to eq('SYSTEM')
-      expect(principal.sid_bytes).to eq(system_bytes)
-      expect(principal.sid).to eq('S-1-5-18')
-      expect(principal.domain).to eq('NT AUTHORITY')
-      expect(principal.domain_account).to eq('NT AUTHORITY\\SYSTEM')
-
-      # Windows API LookupAccountSid behaves differently if current user is SYSTEM
-      if current_user_sid.sid_bytes != system_bytes
-        account_type = :SidTypeWellKnownGroup
-      else
-        account_type = :SidTypeUser
-      end
-
-      expect(principal.account_type).to eq(account_type)
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('NULL SID')
+      expect(principal.account).to eq('NULL SID')
+      expect(principal.sid_bytes).to eq(null_sid_bytes)
+      expect(principal.sid).to eq('S-1-0-0')
+      expect(principal.domain).to eq('')
+      expect(principal.domain_account).to eq('NULL SID')
+      expect(principal.account_type).to eq(:SidTypeWellKnownGroup)
     end
 
     it "should create an instance from a well-known account prefixed with NT AUTHORITY" do
+      # a special case that can be used to lookup an account on a localized Windows
       principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('NT AUTHORITY\\SYSTEM')
-      expect(principal.account).to eq('SYSTEM')
       expect(principal.sid_bytes).to eq(system_bytes)
       expect(principal.sid).to eq('S-1-5-18')
-      expect(principal.domain).to eq('NT AUTHORITY')
-      expect(principal.domain_account).to eq('NT AUTHORITY\\SYSTEM')
+
+      # guard these 3 checks on a US Windows with 1033 - primary language id of 9
+      primary_language_id = 9
+      # even though lookup in English, returned values may be localized
+      # French Windows returns AUTORITE NT\\Syst\u00E8me, German Windows returns NT-AUTORIT\u00C4T\\SYSTEM
+      if (Puppet::Util::Windows::Process.get_system_default_ui_language & primary_language_id == primary_language_id)
+        expect(principal.account).to eq('SYSTEM')
+        expect(principal.domain).to eq('NT AUTHORITY')
+        expect(principal.domain_account).to eq('NT AUTHORITY\\SYSTEM')
+      end
 
       # Windows API LookupAccountSid behaves differently if current user is SYSTEM
       if current_user_sid.sid_bytes != system_bytes
@@ -47,7 +53,10 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
 
     it "should create an instance from a local account prefixed with hostname" do
       running_as_system = (current_user_sid.sid_bytes == system_bytes)
-      username = running_as_system ? 'Administrator' : current_user_sid.account
+      username = running_as_system ?
+        # need to return localized name of Administrator account
+        Puppet::Util::Windows::SID.sid_to_name(computer_sid.sid + '-500').split('\\').last :
+        current_user_sid.account
 
       user_exists = Puppet::Util::Windows::ADSI::User.exists?(".\\#{username}")
 
@@ -65,13 +74,18 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.account_type).to eq(:SidTypeUser)
     end
 
-    it "should create an instance from a well-known group alias" do
-      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('Administrators')
-      expect(principal.account).to eq('Administrators')
+    it "should create an instance from a well-known BUILTIN alias" do
+      # by looking up the localized name of the account, the test value is diluted
+      # this localizes Administrators AND BUILTIN
+      qualified_name = Puppet::Util::Windows::SID.sid_to_name('S-1-5-32-544')
+      domain, name = qualified_name.split('\\')
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name(name)
+
+      expect(principal.account).to eq(name)
       expect(principal.sid_bytes).to eq(administrator_bytes)
       expect(principal.sid).to eq('S-1-5-32-544')
-      expect(principal.domain).to eq('BUILTIN')
-      expect(principal.domain_account).to eq('BUILTIN\\Administrators')
+      expect(principal.domain).to eq(domain)
+      expect(principal.domain_account).to eq(qualified_name)
       expect(principal.account_type).to eq(:SidTypeAlias)
     end
 
@@ -89,48 +103,62 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('')
       expect(principal.account_type).to eq(:SidTypeDomain)
       expect(principal.sid).to eq('S-1-5-32')
-      expect(principal.account).to eq('BUILTIN')
-      expect(principal.domain).to eq('BUILTIN')
-      expect(principal.domain_account).to eq('BUILTIN')
+      expect(principal.account).to eq(builtin_localized)
+      expect(principal.domain).to eq(builtin_localized)
+      expect(principal.domain_account).to eq(builtin_localized)
     end
 
     it "should return a BUILTIN domain principal for BUILTIN account names" do
-      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name('BUILTIN')
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_name(builtin_localized)
       expect(principal.account_type).to eq(:SidTypeDomain)
       expect(principal.sid).to eq('S-1-5-32')
-      expect(principal.account).to eq('BUILTIN')
-      expect(principal.domain).to eq('BUILTIN')
-      expect(principal.domain_account).to eq('BUILTIN')
+      expect(principal.account).to eq(builtin_localized)
+      expect(principal.domain).to eq(builtin_localized)
+      expect(principal.domain_account).to eq(builtin_localized)
     end
 
   end
 
   describe ".lookup_account_sid" do
-    it "should create an instance from a well-known account SID" do
-      principal = Puppet::Util::Windows::SID::Principal.lookup_account_sid(system_bytes)
-      expect(principal.account).to eq('SYSTEM')
-      expect(principal.sid_bytes).to eq(system_bytes)
-      expect(principal.sid).to eq('S-1-5-18')
-      expect(principal.domain).to eq('NT AUTHORITY')
-      expect(principal.domain_account).to eq('NT AUTHORITY\\SYSTEM')
+    it "should create an instance from a user SID" do
+      # take the computer account bytes and append the equivalent of -501 for Guest
+      bytes = (computer_sid.sid_bytes + [245, 1, 0, 0])
+      # computer SID bytes start with [1, 4, ...] but need to be [1, 5, ...]
+      bytes[1] = 5
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_sid(bytes)
+      # use the returned SID to lookup localized Guest account name in Windows
+      guest_name = Puppet::Util::Windows::SID.sid_to_name(principal.sid)
 
-      # Windows API LookupAccountSid behaves differently if current user is SYSTEM
-      if current_user_sid.sid_bytes != system_bytes
-        account_type = :SidTypeWellKnownGroup
-      else
-        account_type = :SidTypeUser
-      end
-
-      expect(principal.account_type).to eq(account_type)
+      expect(principal.sid_bytes).to eq(bytes)
+      expect(principal.sid).to eq(computer_sid.sid + '-501')
+      expect(principal.account).to eq(guest_name.split('\\')[1])
+      expect(principal.domain).to eq(computer_sid.domain)
+      expect(principal.domain_account).to eq(guest_name)
+      expect(principal.account_type).to eq(:SidTypeUser)
     end
 
     it "should create an instance from a well-known group SID" do
+      principal = Puppet::Util::Windows::SID::Principal.lookup_account_sid(null_sid_bytes)
+      expect(principal.sid_bytes).to eq(null_sid_bytes)
+      expect(principal.sid).to eq('S-1-0-0')
+      expect(principal.account).to eq('NULL SID')
+      expect(principal.domain).to eq('')
+      expect(principal.domain_account).to eq('NULL SID')
+      expect(principal.account_type).to eq(:SidTypeWellKnownGroup)
+    end
+
+    it "should create an instance from a well-known BUILTIN Alias SID" do
       principal = Puppet::Util::Windows::SID::Principal.lookup_account_sid(administrator_bytes)
-      expect(principal.account).to eq('Administrators')
+      # by looking up the localized name of the account, the test value is diluted
+      # this localizes Administrators AND BUILTIN
+      qualified_name = Puppet::Util::Windows::SID.sid_to_name('S-1-5-32-544')
+      domain, name = qualified_name.split('\\')
+
+      expect(principal.account).to eq(name)
       expect(principal.sid_bytes).to eq(administrator_bytes)
       expect(principal.sid).to eq('S-1-5-32-544')
-      expect(principal.domain).to eq('BUILTIN')
-      expect(principal.domain_account).to eq('BUILTIN\\Administrators')
+      expect(principal.domain).to eq(domain)
+      expect(principal.domain_account).to eq(qualified_name)
       expect(principal.account_type).to eq(:SidTypeAlias)
     end
 
@@ -183,9 +211,9 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       principal = Puppet::Util::Windows::SID::Principal.lookup_account_sid([1, 1, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0])
       expect(principal.account_type).to eq(:SidTypeDomain)
       expect(principal.sid).to eq('S-1-5-32')
-      expect(principal.account).to eq('BUILTIN')
-      expect(principal.domain).to eq('BUILTIN')
-      expect(principal.domain_account).to eq('BUILTIN')
+      expect(principal.account).to eq(builtin_localized)
+      expect(principal.domain).to eq(builtin_localized)
+      expect(principal.domain_account).to eq(builtin_localized)
     end
   end
 
@@ -193,7 +221,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
     let(:builtin_sid) { [1, 1, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0] }
     let(:sid_principal) { Puppet::Util::Windows::SID::Principal.lookup_account_sid(builtin_sid) }
 
-    ['.', 'builtin', ''].each do |name|
+    ['.', ''].each do |name|
       it "when comparing the one looked up via SID S-1-5-32 to one looked up via non-canonical name #{name} for the BUILTIN domain" do
         name_principal = Puppet::Util::Windows::SID::Principal.lookup_account_name(name)
 
@@ -204,6 +232,18 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
         sid_principal.public_methods(false).reject { |m| m == :== }.each do |method|
           expect(sid_principal.send(method)).to eq(name_principal.send(method))
         end
+      end
+    end
+
+    it "when comparing the one looked up via SID S-1-5-32 to one looked up via non-canonical localized name for the BUILTIN domain" do
+      name_principal = Puppet::Util::Windows::SID::Principal.lookup_account_name(builtin_localized)
+
+      # compares canonical sid
+      expect(sid_principal).to eq(name_principal)
+
+      # compare all properties that have public accessors
+      sid_principal.public_methods(false).reject { |m| m == :== }.each do |method|
+        expect(sid_principal.send(method)).to eq(name_principal.send(method))
       end
     end
   end

--- a/spec/integration/util/windows/process_spec.rb
+++ b/spec/integration/util/windows/process_spec.rb
@@ -27,8 +27,10 @@ describe "Puppet::Util::Windows::Process", :if => Puppet.features.microsoft_wind
     end
 
     it "should raise an error for an unknown privilege name" do
-      fail_msg = /LookupPrivilegeValue\(, foo, .*\):  A specified privilege does not exist/
-      expect { Puppet::Util::Windows::Process.lookup_privilege_value('foo') }.to raise_error(Puppet::Util::Windows::Error, fail_msg)
+      expect { Puppet::Util::Windows::Process.lookup_privilege_value('foo') }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(1313) # ERROR_NO_SUCH_PRIVILEGE
+      end
     end
   end
 

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -12,11 +12,16 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
   include PuppetSpec::Files
 
   before :all do
+
+    # necessary for localized name of guests
+    guests_name = Puppet::Util::Windows::SID.sid_to_name('S-1-5-32-546')
+    guests = Puppet::Util::Windows::ADSI::Group.new(guests_name)
+
     @sids = {
       :current_user => Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name),
       :system => Puppet::Util::Windows::SID::LocalSystem,
       :administrators => Puppet::Util::Windows::SID::BuiltinAdministrators,
-      :guest => Puppet::Util::Windows::SID.name_to_sid("Guest"),
+      :guest => Puppet::Util::Windows::SID.name_to_sid(guests.members[0]),
       :users => Puppet::Util::Windows::SID::BuiltinUsers,
       :power_users => Puppet::Util::Windows::SID::PowerUsers,
       :none => Puppet::Util::Windows::SID::Nobody,

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -132,7 +132,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           end
 
           it "should raise an exception when setting to a different user" do
-            expect { winsec.set_owner(sids[:guest], path) }.to raise_error(Puppet::Error, /This security ID may not be assigned as the owner of this object./)
+            expect { winsec.set_owner(sids[:guest], path) }.to raise_error do |error|
+              expect(error).to be_a(Puppet::Util::Windows::Error)
+              expect(error.code).to eq(1307) # ERROR_INVALID_OWNER
+            end
           end
         end
 
@@ -142,7 +145,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           end
 
           it "should raise an exception if an invalid path is provided" do
-            expect { winsec.get_owner("c:\\doesnotexist.txt") }.to raise_error(Puppet::Error, /The system cannot find the file specified./)
+            expect { winsec.get_owner("c:\\doesnotexist.txt") }.to raise_error do |error|
+              expect(error).to be_a(Puppet::Util::Windows::Error)
+              expect(error.code).to eq(2) # ERROR_FILE_NOT_FOUND
+            end
           end
         end
 
@@ -164,7 +170,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           end
 
           it "should raise an exception if an invalid path is provided" do
-            expect { winsec.get_group("c:\\doesnotexist.txt") }.to raise_error(Puppet::Error, /The system cannot find the file specified./)
+            expect { winsec.get_group("c:\\doesnotexist.txt") }.to raise_error do |error|
+              expect(error).to be_a(Puppet::Util::Windows::Error)
+              expect(error.code).to eq(2) # ERROR_FILE_NOT_FOUND
+            end
           end
         end
 
@@ -300,7 +309,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           end
 
           it "should raise an exception if an invalid path is provided" do
-            expect { winsec.set_mode(sids[:guest], "c:\\doesnotexist.txt") }.to raise_error(Puppet::Error, /The system cannot find the file specified./)
+            expect { winsec.set_mode(sids[:guest], "c:\\doesnotexist.txt") }.to raise_error do |error|
+              expect(error).to be_a(Puppet::Util::Windows::Error)
+              expect(error.code).to eq(2) # ERROR_FILE_NOT_FOUND
+            end
           end
         end
 
@@ -344,7 +356,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           end
 
           it "should raise an exception if an invalid path is provided" do
-            expect { winsec.get_mode("c:\\doesnotexist.txt") }.to raise_error(Puppet::Error, /The system cannot find the file specified./)
+            expect { winsec.get_mode("c:\\doesnotexist.txt") }.to raise_error do |error|
+              expect(error).to be_a(Puppet::Util::Windows::Error)
+              expect(error.code).to eq(2) # ERROR_FILE_NOT_FOUND
+            end
           end
         end
 
@@ -424,7 +439,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           end
 
           it "should raise an exception if an invalid path is provided" do
-            expect { winsec.set_owner(sids[:guest], "c:\\doesnotexist.txt") }.to raise_error(Puppet::Error, /The system cannot find the file specified./)
+            expect { winsec.set_owner(sids[:guest], "c:\\doesnotexist.txt") }.to raise_error do |error|
+              expect(error).to be_a(Puppet::Util::Windows::Error)
+              expect(error.code).to eq(2) # ERROR_FILE_NOT_FOUND
+            end
           end
         end
 
@@ -463,7 +481,10 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           end
 
           it "should raise an exception if an invalid path is provided" do
-            expect { winsec.set_group(sids[:guest], "c:\\doesnotexist.txt") }.to raise_error(Puppet::Error, /The system cannot find the file specified./)
+            expect { winsec.set_group(sids[:guest], "c:\\doesnotexist.txt") }.to raise_error do |error|
+              expect(error).to be_a(Puppet::Util::Windows::Error)
+              expect(error.code).to eq(2) # ERROR_FILE_NOT_FOUND
+            end
           end
         end
 

--- a/spec/unit/provider/package/windows/package_spec.rb
+++ b/spec/unit/provider/package/windows/package_spec.rb
@@ -61,7 +61,10 @@ describe Puppet::Provider::Package::Windows::Package do
 
       expect {
         subject.with_key{ |key, values| }
-      }.to raise_error(Puppet::Util::Windows::Error, /Access is denied/)
+      }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(5) # ERROR_ACCESS_DENIED
+      end
     end
   end
 

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -131,7 +131,10 @@ describe Puppet::Type.type(:package).provider(:windows) do
 
       expect do
         provider.install
-      end.to raise_error(Puppet::Util::Windows::Error, /Access is denied/)
+      end.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(5) # ERROR_ACCESS_DENIED
+      end
     end
   end
 
@@ -183,7 +186,10 @@ describe Puppet::Type.type(:package).provider(:windows) do
 
       expect do
         provider.uninstall
-      end.to raise_error(Puppet::Util::Windows::Error, /Failed to uninstall.*Access is denied/)
+      end.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(5) # ERROR_ACCESS_DENIED
+      end
     end
   end
 

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -189,7 +189,10 @@ describe Puppet::Util::Storage do
       Puppet::Util::Storage.cache(:yayness)
 
       if Puppet.features.microsoft_windows?
-        expect { Puppet::Util::Storage.store }.to raise_error(Puppet::Util::Windows::Error, /Access is denied/)
+        expect { Puppet::Util::Storage.store }.to raise_error do |error|
+          expect(error).to be_a(Puppet::Util::Windows::Error)
+          expect(error.code).to eq(5) # ERROR_ACCESS_DENIED
+        end
       else
         expect { Puppet::Util::Storage.store }.to raise_error(Errno::EISDIR, /Is a directory/)
       end

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -40,14 +40,20 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
         # S-1-1-1 which is not a valid account
         valid_octet_invalid_user =[1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
         subject.octet_string_to_sid_object(valid_octet_invalid_user)
-      }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountSidW:  No mapping between account names and security IDs was done./)
+      }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(1332) # ERROR_NONE_MAPPED
+      end
     end
 
     it "should raise an error for a malformed byte array" do
       expect {
         invalid_octet = [2]
         subject.octet_string_to_sid_object(invalid_octet)
-      }.to raise_error(Puppet::Util::Windows::Error, /Failed to call LookupAccountSidW:  The parameter is incorrect./)
+      }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(87) # ERROR_INVALID_PARAMETER
+      end
     end
   end
 


### PR DESCRIPTION
- When retrieving the names of users / groups and their attributes
   through WMI, Ruby will unfortunately convert any returned strings
   into the local codepage (Default.external_encoding) instead of
   converting the values from UTF-16LE to UTF-8 for internal
   consumption.

   This then causes problems with Puppets logging when attempting to
   combine strings that are in UTF-8 and the local encoding.  This was
   observed on French Windows where the default encoding is CP850.

   Without these changes `puppet resource user` will fail to run with
   the error:

Error: Could not run: incompatible character encodings: UTF-8 and CP850