### PR TITLE
(PUP-6427) Prevent AppVeyor password length fails

### DIFF
--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -476,6 +476,7 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           it "should retrieve the user sid" do
             sid = nil
             user = Puppet::Util::Windows::ADSI::User.create("puppet#{rand(10000)}")
+            user.password = 'PUPPET_RULeZ_123!'
             user.commit
             begin
               sid = Puppet::Util::Windows::ADSI::User.new(user.name).sid.sid

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -99,6 +99,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
         # Ruby seems to use the local codepage when making COM calls
         # if this fails, might want to use Windows API directly instead to ensure bytes
         user = Puppet::Util::Windows::ADSI.create(username, 'user')
+        user.SetPassword('PUPPET_RULeZ_123!')
         user.SetInfo()
 
         # compare the new SID to the name_to_sid result


### PR DESCRIPTION
 - When temp users are created for the sake of tests, they are not
   assigned a password, and this causes the ADSI types to create a blank
   password for the given user.  At certain times within AppVeyor,
   machines are being used to run tests that have a minimum password
   policy in place.  This causes test failures for not satisfying the
   systems password complexity policy.

   Generate random passwords in these instances, ensuring that the
   string contains 3 of 5 character classes - upper case, numeric and
   additional non-alphanumeric character.

Paired-with: Glenn Sarti <glenn.sarti@puppet.com>
             Daniel Lu   <daniel.lu@puppet.com>