### PR TITLE
(WIP) (PUP-6476) add hocon support to puppet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 gem "rake", "10.1.1", :require => false
+gem 'hocon', '~> 1.1.2'
 
 group(:development, :test) do
   gem "rspec", "~> 3.1", :require => false

--- a/lib/puppet/data_providers/hocon_data_provider_factory.rb
+++ b/lib/puppet/data_providers/hocon_data_provider_factory.rb
@@ -1,0 +1,27 @@
+# This file is loaded by the autoloader, and it does not find the data function support unless required relative
+#
+require 'hocon'
+require 'hocon/config_error'
+require 'hocon/config_syntax'
+
+module Puppet::DataProviders
+  class HoconDataProviderFactory < Puppet::Plugins::DataProviders::FileBasedDataProviderFactory
+    def create(name, paths, parent_data_provider)
+      HoconDataProvider.new(name, paths, parent_data_provider)
+    end
+
+    def path_extension
+      '.hocon'
+    end
+  end
+
+  class HoconDataProvider < Puppet::Plugins::DataProviders::PathBasedDataProvider
+    def initialize_data(path, lookup_invocation)
+      data = Hocon.load(File.absolute_path(path), {:syntax => Hocon::ConfigSyntax::HOCON})
+    rescue Hocon::ConfigError::ConfigParseError => ex
+      # Psych errors includes the absolute path to the file, so no need to add that
+      # to the message
+      raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"
+    end
+  end
+end

--- a/lib/puppet/plugins/data_providers/registry.rb
+++ b/lib/puppet/plugins/data_providers/registry.rb
@@ -68,6 +68,12 @@ module Puppet::Plugins::DataProviders
       end
 
       default_bindings.bind do
+        name('hocon')
+        in_multibind(PATH_BASED_DATA_PROVIDER_FACTORIES_KEY)
+        to_instance('Puppet::DataProviders::HoconDataProviderFactory')
+      end
+
+      default_bindings.bind do
         name('json')
         in_multibind(PATH_BASED_DATA_PROVIDER_FACTORIES_KEY)
         to_instance('Puppet::DataProviders::JsonDataProviderFactory')

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_hocon/data/bad.hocon
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_hocon/data/bad.hocon
@@ -1,0 +1,1 @@
+"test::param_a": "env data param_a is 10":

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_hocon/environment.conf
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_hocon/environment.conf
@@ -1,0 +1,2 @@
+# Use the 'sample' env data provider (in this fixture)
+environment_data_provider=hiera

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_hocon/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_hocon/hiera.yaml
@@ -1,0 +1,5 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "bad"
+    :backend: hocon

--- a/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_hocon/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_bad_syntax_hocon/manifests/site.pp
@@ -1,0 +1,5 @@
+class test($param_a) {
+  notify { "$param_a": }
+}
+
+include test

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/hocon1.hocon
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/hocon1.hocon
@@ -1,0 +1,1 @@
+"test::param_f": "env data param_f is 60"

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/hocon_two.hocon
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data1/hocon_two.hocon
@@ -1,0 +1,1 @@
+"test::param_g": "env data param_g is 70"

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/data2/hocon_utf8.hocon
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/data2/hocon_utf8.hocon
@@ -1,0 +1,1 @@
+"test::param_hocon_utf8": "env data param_hocon_utf8 is ᚡᚣᚤ"

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/hiera.yaml
@@ -9,14 +9,27 @@
   - :name: "utf8"
     :backend: yaml
     :path: "utf8"
+
+  - :name: "hocon1"
+    :backend: hocon
+  - :name: "second hocon"
+    :backend: hocon
+    :path: "hocon_two"
+
   - :name: "three paths"
     :backend: json
     :paths:
       - "first"
       - "second"
       - "third_utf8"
+
   - :name:  'other datadir'
     :backend: yaml
     :datadir: "data2"
     :path: "single"
+
+  - :name: "other datadir hocon"
+    :backend: hocon
+    :datadir: "data2"
+    :path: "hocon_utf8"
 :datadir: "data1"

--- a/spec/fixtures/unit/data_providers/environments/hiera_env_config/manifests/site.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_env_config/manifests/site.pp
@@ -1,5 +1,5 @@
-class test($param_a = 1, $param_b = 2, $param_c = 3, $param_d = 4, $param_e = 5, $param_yaml_utf8 = 'hi', $param_json_utf8 = 'hi') {
-  notify { "$param_a, $param_b, $param_c, $param_d, $param_e, $param_yaml_utf8, $param_json_utf8": }
+class test($param_a = 1, $param_b = 2, $param_c = 3, $param_d = 4, $param_e = 5, $param_f = 6, $param_g = 7, $param_yaml_utf8 = 'hi', $param_json_utf8 = 'hi', $param_hocon_utf8 = 'hi') {
+  notify { "$param_a, $param_b, $param_c, $param_d, $param_e, $param_f, $param_g, $param_yaml_utf8, $param_json_utf8, $param_hocon_utf8": }
 }
 
 include test

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/hocon1.hocon
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data1/hocon1.hocon
@@ -1,0 +1,1 @@
+"one::test::param_f": "module data param_f is 600"

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data2/hocon2.hocon
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/data2/hocon2.hocon
@@ -1,0 +1,1 @@
+"one::test::param_g": "module data param_g is 700"

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/hiera.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/hiera.yaml
@@ -5,6 +5,8 @@
     :backend: yaml
   - :name: "name"
     :backend: yaml
+  - :name: "hocon1"
+    :backend: hocon
   - :name: "one path"
     :backend: yaml
     :path: "single"
@@ -17,4 +19,8 @@
     :backend: yaml
     :datadir: "data2"
     :path: "single"
+  - :name:  'hocon other datadir'
+    :backend: hocon
+    :datadir: "data2"
+    :path: "hocon2" 
 :datadir: "data1"

--- a/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/manifests/init.pp
+++ b/spec/fixtures/unit/data_providers/environments/hiera_module_config/modules/one/manifests/init.pp
@@ -1,5 +1,5 @@
 class one {
-  class test($param_a = "param default is 100", $param_b = "param default is 200", $param_c = "param default is 300", $param_d = "param default is 400", $param_e = "param default is 500") {
-    notify { "$param_a, $param_b, $param_c, $param_d, $param_e": }
+  class test($param_a = "param default is 100", $param_b = "param default is 200", $param_c = "param default is 300", $param_d = "param default is 400", $param_e = "param default is 500", $param_f = "param default is 600", $param_g = "param default is 700") {
+    notify { "$param_a, $param_b, $param_c, $param_d, $param_e, $param_f, $param_g": }
   }
 }

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -47,14 +47,19 @@ describe "when using a hiera data provider" do
     expect(resources).to include('module data param_a is 100, param default is 200, env data param_c is 300')
   end
 
-  it 'reads hiera.yaml in environment root and configures multiple json and yaml providers' do
+  it 'reads hiera.yaml in environment root and configures multiple hocon, json, and yaml providers' do
     resources = compile_and_get_notifications('hiera_env_config')
-    expect(resources).to include("env data param_a is 10, env data param_b is 20, env data param_c is 30, env data param_d is 40, env data param_e is 50, env data param_yaml_utf8 is \u16EB\u16D2\u16E6, env data param_json_utf8 is \u16A0\u16C7\u16BB")
+    expect(resources).to include("env data param_a is 10, env data param_b is 20, env data param_c is 30, env data param_d is 40, env data param_e is 50, env data param_f is 60, env data param_g is 70, env data param_yaml_utf8 is \u16EB\u16D2\u16E6, env data param_json_utf8 is \u16A0\u16C7\u16BB, env data param_hocon_utf8 is \u16A1\u16A3\u16A4")
   end
 
-  it 'reads hiera.yaml in module root and configures multiple json and yaml providers' do
+  it 'reads hiera.yaml in module root and configures multiple hocon, json, and yaml providers' do
     resources = compile_and_get_notifications('hiera_module_config')
-    expect(resources).to include('module data param_a is 100, module data param_b is 200, module data param_c is 300, module data param_d is 400, module data param_e is 500')
+    expect(resources).to include('module data param_a is 100, module data param_b is 200, module data param_c is 300, module data param_d is 400, module data param_e is 500, module data param_f is 600, module data param_g is 700')
+  end
+
+  it 'uses ' do
+    resources = compile_and_get_notifications('hiera_defaults')
+    expect(resources).to include('module data param_a is 100, param default is 200, env data param_c is 300')
   end
 
   it 'keeps lookup_options in one module separate from lookup_options in another' do
@@ -189,6 +194,12 @@ describe "when using a hiera data provider" do
     expect do
       compile_and_get_notifications('hiera_bad_syntax_yaml')
     end.to raise_error(Puppet::DataBinding::LookupError, /Unable to parse \(#{environmentpath}[^)]+\):/)
+  end
+
+  it 'reports syntax errors for HOCON files' do
+    expect do
+      compile_and_get_notifications('hiera_bad_syntax_hocon')
+    end.to raise_error(Puppet::DataBinding::LookupError, /Unable to parse #{environmentpath}/)
   end
 
   describe 'when using explain' do


### PR DESCRIPTION
This PR adds backend support of HOCON files for Puppet Lookup. 
Changes made: 
- add HOCON gem requirement
- add a HoconDataProviderFactory and include it to the registry
