### PR TITLE
(PUP-6335) Add note explaining duplication to oids.rb

### DIFF
--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -26,6 +26,10 @@ require 'puppet/ssl'
 # @api private
 module Puppet::SSL::Oids
 
+  # Note: When updating the following OIDs make sure to also update the OID
+  # definitions here:
+  # https://github.com/puppetlabs/puppetserver/blob/master/src/clj/puppetlabs/puppetserver/certificate_authority.clj#L122-L159
+
   PUPPET_OIDS = [
     ["1.3.6.1.4.1.34380", 'puppetlabs', 'Puppet Labs'],
     ["1.3.6.1.4.1.34380.1", 'ppCertExt', 'Puppet Certificate Extension'],


### PR DESCRIPTION
The information captured in PUPPET_OIDS in oids.rb is duplicated in the
puppetserver codebase. Creating a shared oids file isn't easily
achieveable today, so instead this commit adds a comment to the oids.rb
file explaining that any changes to the oids need to be replicated in
the puppetserver codebase.