### PR TITLE
(maint) Fixes for SSL Extension work

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -295,8 +295,6 @@ class Puppet::SSL::CertificateAuthority
       cert_type = :server
       issuer = host.certificate.content
 
-      # This allows for various bootstrapping scenarios
-      options[:allow_dns_alt_names] = true if hostname == Puppet[:certname].downcase
       # Make sure that the CSR conforms to our internal signing policies.
       # This will raise if the CSR doesn't conform, but just in case...
       check_internal_signing_policies(hostname, csr, options) or
@@ -330,6 +328,8 @@ class Puppet::SSL::CertificateAuthority
   def check_internal_signing_policies(hostname, csr, options = {})
     options[:allow_authorization_extensions] ||= false
     options[:allow_dns_alt_names] ||= false
+    # This allows for masters to bootstrap themselves in certain scenarios
+    options[:allow_dns_alt_names] = true if hostname == Puppet[:certname].downcase
 
     # Reject unknown request extensions.
     unknown_req = csr.request_extensions.reject do |x|

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -288,7 +288,6 @@ class Puppet::SSL::CertificateAuthority
       cert_type = :ca
       issuer = csr.content
     else
-      options[:allow_dns_alt_names] = true if hostname == Puppet[:certname].downcase
       unless csr = Puppet::SSL::CertificateRequest.indirection.find(hostname)
         raise ArgumentError, "Could not find certificate request for #{hostname}"
       end
@@ -296,6 +295,8 @@ class Puppet::SSL::CertificateAuthority
       cert_type = :server
       issuer = host.certificate.content
 
+      # This allows for various bootstrapping scenarios
+      options[:allow_dns_alt_names] = true if hostname == Puppet[:certname].downcase
       # Make sure that the CSR conforms to our internal signing policies.
       # This will raise if the CSR doesn't conform, but just in case...
       check_internal_signing_policies(hostname, csr, options) or

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -280,6 +280,8 @@ module Puppet
 
             raise InterfaceError, "Could not find CSR for: #{host.inspect}." unless cert
 
+            # This allows for various bootstrapping scenarios
+            options[:allow_dns_alt_names] = true if host == Puppet[:certname].downcase
             # ca.sign will also do this - and it should if it is called
             # elsewhere - but we want to reject an attempt to sign a
             # problematic csr as early as possible for usability concerns.

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -233,7 +233,7 @@ module Puppet
           exts = []
           exts += cert.custom_extensions if cert.respond_to?(:custom_extensions)
           exts += cert.custom_attributes if cert.respond_to?(:custom_attributes)
-          exts += cert.extension_requests if cert.respond_to?(:extension_requests)
+          exts += cert.request_extensions if cert.respond_to?(:request_extensions)
 
           exts.map {|e| "#{e['oid']}: #{e['value'].inspect}" }.sort
         end

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -278,6 +278,8 @@ module Puppet
           list.each do |host|
             cert = Puppet::SSL::CertificateRequest.indirection.find(host)
 
+            raise InterfaceError, "Could not find CSR for: #{host.inspect}." unless cert
+
             # ca.sign will also do this - and it should if it is called
             # elsewhere - but we want to reject an attempt to sign a
             # problematic csr as early as possible for usability concerns.

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -280,8 +280,6 @@ module Puppet
 
             raise InterfaceError, "Could not find CSR for: #{host.inspect}." unless cert
 
-            # This allows for various bootstrapping scenarios
-            options[:allow_dns_alt_names] = true if host == Puppet[:certname].downcase
             # ca.sign will also do this - and it should if it is called
             # elsewhere - but we want to reject an attempt to sign a
             # problematic csr as early as possible for usability concerns.

--- a/spec/unit/ssl/certificate_authority/interface_spec.rb
+++ b/spec/unit/ssl/certificate_authority/interface_spec.rb
@@ -156,9 +156,12 @@ describe Puppet::SSL::CertificateAuthority::Interface do
     end
 
     describe ":sign" do
+      before do
+        @csr1 = Puppet::SSL::CertificateRequest.new 'baz'
+      end
+
       describe "when run in interactive mode" do
         before do
-          @csr1 = Puppet::SSL::CertificateRequest.new 'baz'
           Puppet::SSL::CertificateRequest.indirection.stubs(:find).with("csr1").returns @csr1
 
           @ca.stubs(:waiting?).returns(%w{csr1})
@@ -199,6 +202,11 @@ describe Puppet::SSL::CertificateAuthority::Interface do
       end
 
       describe "and an array of names was provided" do
+        before do
+          Puppet::SSL::CertificateRequest.indirection.stubs(:find).with("host1").returns @csr1
+          Puppet::SSL::CertificateRequest.indirection.stubs(:find).with("host2").returns @csr1
+        end
+
         let(:applier) { @class.new(:sign, @options.merge(:to => %w{host1 host2})) }
 
         it "should sign the specified waiting certificate requests" do
@@ -229,6 +237,8 @@ describe Puppet::SSL::CertificateAuthority::Interface do
       describe "and :all was provided" do
         it "should sign all waiting certificate requests" do
           @ca.stubs(:waiting?).returns(%w{cert1 cert2})
+          Puppet::SSL::CertificateRequest.indirection.stubs(:find).with("cert1").returns @csr1
+          Puppet::SSL::CertificateRequest.indirection.stubs(:find).with("cert2").returns @csr1
           @ca.stubs(:check_internal_signing_policies).returns(true)
 
           @ca.expects(:sign).with("cert1", {})

--- a/spec/unit/ssl/certificate_authority/interface_spec.rb
+++ b/spec/unit/ssl/certificate_authority/interface_spec.rb
@@ -265,7 +265,7 @@ describe Puppet::SSL::CertificateAuthority::Interface do
 
         @csr.stubs(:subject_alt_names).returns request_alt_names
         @csr.stubs(:custom_attributes).returns custom_attrs
-        @csr.stubs(:extension_requests).returns ext_requests
+        @csr.stubs(:request_extensions).returns ext_requests
 
         Puppet::SSL::Certificate.indirection.stubs(:find).returns @cert
         Puppet::SSL::CertificateRequest.indirection.stubs(:find).returns @csr

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -575,11 +575,20 @@ describe Puppet::SSL::CertificateAuthority do
       it "should reject a subjectAltName for a non-DNS value" do
         @request.stubs(:subject_alt_names).returns ['DNS:foo', 'email:bar@example.com']
         expect {
-          @ca.check_internal_signing_policies(@name, @request, {allow_dns_alt_names:true})
+          @ca.check_internal_signing_policies(@name, @request, {allow_dns_alt_names: true})
         }.to raise_error(
           Puppet::SSL::CertificateAuthority::CertificateSigningError,
           /subjectAltName outside the DNS label space/
         )
+      end
+
+      it "should allow a subjectAltName if subject matches CA's certname" do
+        @request.stubs(:subject_alt_names).returns ['DNS:foo']
+        Puppet[:certname] = @name
+
+        expect {
+          @ca.check_internal_signing_policies(@name, @request, {allow_dns_alt_names: false})
+        }.to_not raise_error
       end
 
       it "should reject a wildcard subject" do


### PR DESCRIPTION
This fixes three important issues with the recent SSL Extension work that's landed in Puppet.