### PR TITLE
(PUP-6508) Make tidy resources non-isomorphic

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -16,6 +16,9 @@ Puppet::Type.newtype(:tidy) do
     actual deletion.
     "
 
+  # Tidy names are not isomorphic with the objects.
+  @isomorphic = false
+
   newparam(:path) do
     desc "The path to the file or directory to manage.  Must be fully
       qualified."


### PR DESCRIPTION
Since tidy sets path as namevar, puppet tries to create aliases for it. This means multiple tidy resources with the same path (but different matches, e.g.) will fail.