### PR TITLE
(PUP-6042) acceptance: test flag overrides use_cached_catalog

### DIFF
--- a/acceptance/tests/agent/should_not_use_cached_catalog_with_test_flag.rb
+++ b/acceptance/tests/agent/should_not_use_cached_catalog_with_test_flag.rb
@@ -1,0 +1,14 @@
+test_name '--test flag should override use_cached_catalog'
+
+with_puppet_running_on master, {} do
+  step "run agents once to cache the catalog" do
+    on(agents, puppet("agent -t --server #{master}"))
+  end
+  step "run agents again, verify that --test overrides cached catalog" do
+    agents.each do |agent|
+      on(agent, puppet("agent --test --use_cached_catalog --server #{master}")) do |result|
+        assert_no_match(/Using cached catalog/, result.stdout)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an acceptance test to verify that using the
`--test` flag with `puppet agent` overrides the `--use_cached_catalog`
setting. This combination should not result in the use of a cached
catalog.