### PR TITLE
(PUP-5938) Fix localized WinNT BUILTIN monikers

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -107,8 +107,18 @@ module Puppet::Util::Windows::ADSI
   end
 
   module Shared
+    def localized_domains
+      @localized_domains ||= [
+        # localized version of BUILTIN
+        # for instance VORDEFINIERT on German Windows
+        Puppet::Util::Windows::SID.sid_to_name('S-1-5-32'),
+        # localized version of NT AUTHORITY (can't use S-1-5)
+        # for instance AUTORITE NT on French Windows
+        Puppet::Util::Windows::SID.name_to_sid_object('SYSTEM').domain
+    ]
+  end
     def uri(name, host = '.')
-      host = '.' if ['NT AUTHORITY', 'BUILTIN', Socket.gethostname].include?(host)
+      host = '.' if (localized_domains << Socket.gethostname).include?(host)
 
       # group or user
       account_type = self.name.split('::').last.downcase

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -111,14 +111,14 @@ module Puppet::Util::Windows::ADSI
       @localized_domains ||= [
         # localized version of BUILTIN
         # for instance VORDEFINIERT on German Windows
-        Puppet::Util::Windows::SID.sid_to_name('S-1-5-32'),
+        Puppet::Util::Windows::SID.sid_to_name('S-1-5-32').upcase,
         # localized version of NT AUTHORITY (can't use S-1-5)
         # for instance AUTORITE NT on French Windows
-        Puppet::Util::Windows::SID.name_to_sid_object('SYSTEM').domain
+        Puppet::Util::Windows::SID.name_to_sid_object('SYSTEM').domain.upcase
     ]
   end
     def uri(name, host = '.')
-      host = '.' if (localized_domains << Socket.gethostname).include?(host)
+      host = '.' if (localized_domains << Socket.gethostname.upcase).include?(host.upcase)
 
       # group or user
       account_type = self.name.split('::').last.downcase

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -426,8 +426,9 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
 
       it "should generate the correct URI" do
         adsi_group.expects(:objectSID).returns([0])
-        Socket.expects(:gethostname).returns('testcomputername')
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(stub(:account => groupname,:domain => 'testcomputername'))
+        Socket.expects(:gethostname).returns('TESTcomputerNAME')
+        computer_sid = stub(:account => groupname,:domain => 'testcomputername')
+        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(computer_sid)
         expect(group.uri).to eq("WinNT://./#{groupname},group")
       end
     end


### PR DESCRIPTION
(PUP-5938) Fix localized WinNT BUILTIN monikers

 - When building WinNT monikers, BUILTIN and NT AUTHORITY cannot be
   used to refer to users / groups and those names must be replaced
   with "."  For instance, SYSTEM account must use the moniker:

   WinNT://./SYSTEM,user - NOT WinNT://NT AUTHORITY/SYSTEM,user

   455834e7f21f213e9d0085510d5b47c0c3e2a1ab added the initial code for
   User moniker generation to take that into account

   Similarly, a group moniker for Administrators should use:

   WinNT://./Administrators,group - NOT WinNT://BUILTIN/Administrators,group

   bd3f3a18fa4b5ae1f1f26d8aabf74edd18598746 made sure that monikers
   for groups followed this behavior correctly as well.

   NOTE: These monikers are used only for adding / removing users to
   groups, or groups to a user - and aren't always able to be used
   with WIN32OLE.connect - this is an instrinsic behavior of the
   WinNT:// provider.

 - That code remained partially dormant, until other bugs were resolved
   for PUP-5684 in 7e176bfb3adf53d234d893f8481f576e3a2e6a0b and user
   User / Group began to more actively use the WinNT monikers in the
   exists? checks

 - On non-US versions of Windows, the "domains" BUILTIN and
   NT AUTHORITY may be localized.  For instance, on German Windows
   BUILTIN is localized as VORDEFINIERT and NT AUTHORITY is localized
   as NT-AUTORITÄ.  On French Windows, NT AUTHORITY is localized
   as AUTORITE NT, but BUILTIN remains the same.

   The moniker construction code has never taken this into account
   previously, so when trying to add a User to the Administrators
   group in German Windows, this would fail (this issue in particular
   was likely introduced in bd3f3a18fa4b5ae1f1f26d8aabf74edd18598746):

   Given a manifest:

   user { 'bla':
    ensure  => 'present',
    comment => 'bla',
    groups  => ['S-1-5-32-544',],
   }

   Would generate:

   Error: ADSI connection error: failed to parse display name of moniker `WinNT://VORDEFINIERT/Administratoren,group'
       HRESULT error code:0x80070035
         Der Netzwerkpfad wurde nicht gefunden.

 - In the same code, a performance bug was discovered in how URIs are
   generated for local accounts as well.  When the local computer name
   is used as the host, the URI code attempts to replace it with a .
   so instead of a moniker like:

   WinNT://computer/username,user

   A URI like this is preferred:

   WinNT://./username,user

   This can prevent reaching out to the network to resolve / connect
   to an external name, which incurs a performance hit.

   The code was previously not performing the check against the
   hostname in a case-insensitive manner, meaning that resoultions for
   local machine accounts could take longer than necessary.