### PR TITLE
(PUP-6457) Always attempt remount for out of sync options

### DIFF
--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -272,7 +272,7 @@ Puppet::Type.type(:mount).provide(
     end
     mount_output.each do |line|
       if match = regex.match(line) and name = match.captures.first
-        live_options_platforms = ["Linux"]
+        live_options_platforms = ["Linux", "Darwin"]
         if live_options_platforms.include? Facter.value(:kernel)
           options = line[/\(.*\)/].tr('()', '')
           instances << {:name => name, :mounted => :yes, :live_options => options}

--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -209,14 +209,20 @@ Puppet::Type.type(:mount).provide(
 
     # Update fstab entries that are mounted
     providers.each do |prov|
-      if mounts.delete({:name => prov.get(:name), :mounted => :yes}) then
-        prov.set(:ensure => :mounted)
+      mounts.delete_if do |mount|
+        if mount[:name] == prov.get(:name) && mount[:mounted] == :yes
+          prov.set(:ensure => :mounted)
+          prov.set(:live_options => mount[:live_options])
+          true
+        else
+          false
+        end
       end
     end
 
     # Add mounts that are not in fstab but mounted
     mounts.each do |mount|
-      providers << new(:ensure => :ghost, :name => mount[:name])
+      providers << new(:ensure => :ghost, :name => mount[:name], :live_options => mount[:live_options])
     end
     providers
   end
@@ -232,6 +238,7 @@ Puppet::Type.type(:mount).provide(
     #   to fstab we need to know if the device was mounted before)
     mountinstances.each do |hash|
       if mount = resources[hash[:name]]
+        mount.provider.set(:live_options => hash[:live_options])
         case mount.provider.get(:ensure)
         when :absent  # Mount not in fstab
           mount.provider.set(:ensure => :ghost)
@@ -254,6 +261,7 @@ Puppet::Type.type(:mount).provide(
       else
         / on (\S*)/
     end
+
     instances = []
     mount_output = mountcmd.split("\n")
     if mount_output.length >= 2 and mount_output[1] =~ /^[- \t]*$/
@@ -264,7 +272,13 @@ Puppet::Type.type(:mount).provide(
     end
     mount_output.each do |line|
       if match = regex.match(line) and name = match.captures.first
-        instances << {:name => name, :mounted => :yes} # Only :name is important here
+        live_options_platforms = ["Linux"]
+        if live_options_platforms.include? Facter.value(:kernel)
+          options = line[/\(.*\)/].tr('()', '')
+          instances << {:name => name, :mounted => :yes, :live_options => options}
+        else
+          instances << {:name => name, :mounted => :yes}
+        end
       else
         raise Puppet::Error, "Could not understand line #{line} from mount output"
       end

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -176,6 +176,30 @@ module Puppet
         appear in fstab. For many platforms this is a comma delimited string.
         Consult the fstab(5) man page for system-specific details."
 
+          def insync?(is)
+
+            if @resource[:ensure] == :mounted && !provider.property_hash[:live_options].nil?
+              fstab_options = provider.property_hash[:options] || ''
+              mount_options = provider.property_hash[:live_options] || ''
+              resource_options = @resource[:options] || ''
+
+              mount_list = mount_options.split(',')
+              resource_list = resource_options.split(',')
+              resource_list.delete('defaults')
+
+              # are the options in fstab in sync?
+              if fstab_options != resource_options
+                return false
+              elsif !(resource_list - mount_list).empty?
+                return false
+              else
+                return true
+              end
+            else
+              super
+            end
+          end
+
       validate do |value|
         raise Puppet::Error, "options must not contain whitespace: #{value}" if value =~ /\s/
         raise Puppet::Error, "options must not be an empty string" if value.empty?

--- a/spec/integration/provider/mount_spec.rb
+++ b/spec/integration/provider/mount_spec.rb
@@ -149,9 +149,10 @@ describe "mount provider (integration)", :unless => Puppet.features.microsoft_wi
       pending "Due to bug 6309"
       @mounted = true
       @current_device = "/dev/disk2s2"
+      @current_options = "local"
       create_fake_fstab(true)
       @desired_options = "local"
-      run_in_catalog(:ensure=>:mounted, :options=>'local')
+      run_in_catalog(:ensure=>:mounted, :options=>'msdos,local')
       expect(@current_device).to eq("/dev/disk1s1")
       expect(@mounted).to eq(true)
       expect(@current_options).to eq('local')

--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -152,18 +152,18 @@ FSTAB
       expect(mounts[16]).to eq({ :name => '/ghost', :mounted => :yes })
     end
 
-    it "should get name from mountoutput found on Darwin" do
+    it "should get name and mount options from mountoutput found on Darwin" do
       Facter.stubs(:value).with(:osfamily).returns 'Darwin'
       Facter.stubs(:value).with(:kernel).returns 'Darwin'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('darwin.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(6)
-      expect(mounts[0]).to eq({ :name => '/', :mounted => :yes })
-      expect(mounts[1]).to eq({ :name => '/dev', :mounted => :yes })
-      expect(mounts[2]).to eq({ :name => '/net', :mounted => :yes })
-      expect(mounts[3]).to eq({ :name => '/home', :mounted => :yes })
-      expect(mounts[4]).to eq({ :name => '/usr', :mounted => :yes })
-      expect(mounts[5]).to eq({ :name => '/ghost', :mounted => :yes })
+      expect(mounts[0]).to eq({ :name => '/', :mounted => :yes, :live_options=>"hfs, local, journaled"})
+      expect(mounts[1]).to eq({ :name => '/dev', :mounted => :yes, :live_options=>"devfs, local, nobrowse"})
+      expect(mounts[2]).to eq({ :name => '/net', :mounted => :yes, :live_options=>"autofs, nosuid, automounted, nobrowse"})
+      expect(mounts[3]).to eq({ :name => '/home', :mounted => :yes, :mounted=>:yes, :live_options=>"autofs, automounted, nobrowse"})
+      expect(mounts[4]).to eq({ :name => '/usr', :mounted => :yes, :mounted=>:yes, :live_options=>"hfs, local, journaled"})
+      expect(mounts[5]).to eq({ :name => '/ghost', :mounted => :yes, :live_options => "hfs, local, journaled"})
     end
 
     it "should get name and mount options from mountoutput found on Linux" do

--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -115,6 +115,7 @@ FSTAB
   describe "mountinstances" do
     it "should get name from mountoutput found on Solaris" do
       Facter.stubs(:value).with(:osfamily).returns 'Solaris'
+      Facter.stubs(:value).with(:kernel).returns 'SunOS'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('solaris.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(6)
@@ -128,6 +129,7 @@ FSTAB
 
     it "should get name from mountoutput found on HP-UX" do
       Facter.stubs(:value).with(:osfamily).returns 'HP-UX'
+      Facter.stubs(:value).with(:kernel).returns 'HP-UX'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('hpux.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(17)
@@ -152,6 +154,7 @@ FSTAB
 
     it "should get name from mountoutput found on Darwin" do
       Facter.stubs(:value).with(:osfamily).returns 'Darwin'
+      Facter.stubs(:value).with(:kernel).returns 'Darwin'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('darwin.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(6)
@@ -165,17 +168,19 @@ FSTAB
 
     it "should get name from mountoutput found on Linux" do
       Facter.stubs(:value).with(:osfamily).returns 'Gentoo'
+      Facter.stubs(:value).with(:kernel).returns 'Linux'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('linux.mount')))
       mounts = described_class.mountinstances
-      expect(mounts[0]).to eq({ :name => '/', :mounted => :yes })
-      expect(mounts[1]).to eq({ :name => '/lib64/rc/init.d', :mounted => :yes })
-      expect(mounts[2]).to eq({ :name => '/sys', :mounted => :yes })
-      expect(mounts[3]).to eq({ :name => '/usr/portage', :mounted => :yes })
-      expect(mounts[4]).to eq({ :name => '/ghost', :mounted => :yes })
+      expect(mounts[0]).to eq({ :name => '/', :mounted => :yes, :live_options=>"rw,noatime"})
+      expect(mounts[1]).to eq({ :name => '/lib64/rc/init.d', :mounted => :yes, :live_options => "rw,nosuid,nodev,noexec,relatime,size=1024k,mode=755" })
+      expect(mounts[2]).to eq({ :name => '/sys', :mounted => :yes, :live_options => "rw,nosuid,nodev,noexec,relatime"})
+      expect(mounts[3]).to eq({ :name => '/usr/portage', :mounted => :yes, :live_options => "rw" })
+      expect(mounts[4]).to eq({ :name => '/ghost', :mounted => :yes, :live_options => "rw" })
     end
 
     it "should get name from mountoutput found on AIX" do
       Facter.stubs(:value).with(:osfamily).returns 'AIX'
+      Facter.stubs(:value).with(:kernel).returns 'AIX'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('aix.mount')))
       mounts = described_class.mountinstances
       expect(mounts[0]).to eq({ :name => '/', :mounted => :yes })
@@ -224,29 +229,42 @@ FSTAB
           platform != 'solaris' or
             skip "We need to stub the operatingsystem fact at load time, but can't"
         end
-
-        # Stub the mount output to our fixture.
-        begin
-          mount = my_fixture(platform + '.mount')
-          described_class.stubs(:mountcmd).returns File.read(mount)
-        rescue
-          skip "is #{platform}.mount missing at this point?"
-        end
-
-        # Note: we have to stub default_target before creating resources
-        # because it is used by Puppet::Type::Mount.new to populate the
-        # :target property.
-        described_class.stubs(:default_target).returns fstab
-        @retrieve = described_class.instances.collect { |prov| {:name => prov.get(:name), :ensure => prov.get(:ensure)}}
       end
 
       # Following mountpoint are present in all fstabs/mountoutputs
       describe "on other platforms than Solaris", :if => Facter.value(:osfamily) != 'Solaris' do
-        it "should include unmounted resources" do
+        before :each do
+          # Stub the mount output to our fixture.
+          begin
+            mount = my_fixture(platform + '.mount')
+            described_class.stubs(:mountcmd).returns File.read(mount)
+          rescue
+            skip "is #{platform}.mount missing at this point?"
+          end
+
+          # Note: we have to stub default_target before creating resources
+          # because it is used by Puppet::Type::Mount.new to populate the
+          # :target property.
+          described_class.stubs(:default_target).returns fstab
+
+          platforms = {
+            'linux' => ['Gentoo', 'Linux'],
+            'freebsd' => ['BSD', 'BSD'],
+            'openbsd' => ['BSD', 'BSD'],
+            'netbsd' => ['BSd', 'BSD']
+          }
+          Facter.stubs(:value).with(:osfamily).returns(platforms[platform][0])
+          Facter.stubs(:value).with(:kernel).returns(platforms[platform][1])
+
+          @retrieve = described_class.instances.collect { |prov| {:name => prov.get(:name), :ensure => prov.get(:ensure)}}
+        end
+        
+        it "should include mounted resources" do
           expect(@retrieve).to include(:name => '/', :ensure => :mounted)
         end
 
-        it "should include mounted resources" do
+        it "should include unmounted resources" do
+        @retrieve = described_class.instances.collect { |prov| {:name => prov.get(:name), :ensure => prov.get(:ensure)}}
           expect(@retrieve).to include(:name => '/boot', :ensure => :unmounted)
         end
 

--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -166,7 +166,7 @@ FSTAB
       expect(mounts[5]).to eq({ :name => '/ghost', :mounted => :yes })
     end
 
-    it "should get name from mountoutput found on Linux" do
+    it "should get name and mount options from mountoutput found on Linux" do
       Facter.stubs(:value).with(:osfamily).returns 'Gentoo'
       Facter.stubs(:value).with(:kernel).returns 'Linux'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('linux.mount')))

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -530,6 +530,11 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
       run_in_catalog(resource)
     end
 
+    it "should detect out of sync options" do
+      resource.provider.property_hash[:live_options] = "foo";
+      expect(resource.parameters[:options].insync?('soft')).to eq(false);
+    end
+
     it "should umount before flushing changes to disk" do
       syncorder = sequence('syncorder')
 


### PR DESCRIPTION
Prior to this commit, it was possible for puppet to thing that a
mounted device was in sync with it's resource definition when it was
not. This was because if a resource had already been mounted, and a
remount was attempted with bad options, the remount would fail even
though the entry in /etc/fstab would be updated. Puppet was only
checking the resource options against etc/fstab which meant that
after this point, it would believe the mounted object to be in sync
with the puppet resource describing it, even though it was not.

Now, puppet will check the resource's options against both /etc/fstab
and the output of the mount command (on linux operating systems). This
means that it can now detect if the correct object is not mounted and
will attempt a remount.