### PR TITLE
(PUP-5463) Fix collector query with literal undef

### DIFF
--- a/lib/puppet/pops/evaluator/collector_transformer.rb
+++ b/lib/puppet/pops/evaluator/collector_transformer.rb
@@ -155,6 +155,10 @@ protected
     @@evaluator.evaluate(o, scope)
   end
 
+  def query_LiteralUndef(o, scope)
+    nil
+  end
+
   def query_QualifiedName(o, scope)
     @@evaluator.evaluate(o, scope)
   end
@@ -203,6 +207,10 @@ protected
 
   def match_LiteralString(o, scope)
     @@evaluator.evaluate(o, scope)
+  end
+
+  def match_LiteralUndef(o, scope)
+    nil
   end
 
   def match_ConcatenatedString(o, scope)

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -201,6 +201,16 @@ describe 'collectors' do
       end.to raise_error(/Resource type someresource doesn't exist/)
     end
 
+    it 'allows query for literal undef' do
+      expect_the_message_to_be(["foo::baz::quux"], <<-MANIFEST)
+        define foo ($x = undef, $y = undef) {
+          notify { 'testing': message => "foo::${x}::${y}" }
+        }
+        foo { 'bar': y => 'quux' }
+        Foo <| x == undef |> { x => 'baz' }
+      MANIFEST
+    end
+
     context "overrides" do
       it "modifies an existing array" do
         expect_the_message_to_be([["original message", "extra message"]], <<-MANIFEST)


### PR DESCRIPTION
Before this, a query for a literal undef value in a collector would
lead to an exception.
This was caused by the collector transformer not handling a
LiteralUndef.

The fix is to add support for LiteralUndef in the transformer.