### PR TITLE
(maint) Ensure WindowsInstaller emits UTF-8

### DIFF
--- a/lib/puppet/provider/package/windows/msi_package.rb
+++ b/lib/puppet/provider/package/windows/msi_package.rb
@@ -23,7 +23,7 @@ class Puppet::Provider::Package::Windows
           MsiPackage.new(get_display_name(values),
                          values['DisplayVersion'],
                          name, # productcode
-                         inst.ProductInfo(name, 'PackageCode'))
+                         inst.ProductInfo(name, 'PackageCode').encode(Encoding::UTF_8))
         end
       end
     end


### PR DESCRIPTION
- Previously the Windows package provider would use Rubys COM support
  to retrieve values.  Unfortunately, Ruby returns strings in the
  local codepage instead of UTF-8 which can cause downstream breakages
  in Puppet when string manipulation / concatenation is performed.
