### PR TITLE
(PUP-6531) improve service provider detection on Ubuntu

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -9,13 +9,19 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   commands :systemctl => "systemctl"
 
+  Facter.add(:running_on_systemd) do
+    setcode do
+      Dir.exists? "/run/systemd/system"
+    end
+  end
+
   if Facter.value(:osfamily).downcase == 'debian'
     # With multiple init systems on Debian, it is possible to have
     # pieces of systemd around (e.g. systemctl) but not really be
     # using systemd.  We do not do this on other platforms as it can
     # cause issues when running in a chroot without /run mounted
     # (PUP-5577)
-    confine :exists => "/run/systemd/system"
+    confine :true => Facter.value(:running_on_systemd)
   end
 
   defaultfor :osfamily => [:archlinux]
@@ -23,7 +29,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => "8"
-  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10"]
+  defaultfor :operatingsystem => :ubuntu, :running_on_systemd => :true
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 
   def self.instances

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -11,14 +11,20 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   see <http://upstart.ubuntu.com/>.
   "
 
+  Facter.add(:running_on_systemd) do
+    setcode do
+      Dir.exists? "/run/systemd/system"
+    end
+  end
+
   confine :any => [
-    Facter.value(:operatingsystem) == 'Ubuntu',
+    (Facter.value(:operatingsystem) == 'Ubuntu' and Facter.value(:running_on_systemd) == :false),
     (Facter.value(:osfamily) == 'RedHat' and Facter.value(:operatingsystemrelease) =~ /^6\./),
     Facter.value(:operatingsystem) == 'Amazon',
     Facter.value(:operatingsystem) == 'LinuxMint',
   ]
 
-  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"]
+  defaultfor :operatingsystem => :ubuntu, :running_on_systemd => :false
 
   commands :start   => "/sbin/start",
            :stop    => "/sbin/stop",

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -105,20 +105,19 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     expect(described_class).to be_default
   end
 
-  it "should not be the default provider on ubuntu14.04" do
+  it "should not be the default provider if systemd is not running on
+Ubuntu" do
     Facter.stubs(:value).with(:osfamily).returns(:debian)
     Facter.stubs(:value).with(:operatingsystem).returns(:ubuntu)
-    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("14.04")
+    Facter.stubs(:value).with(:running_on_systemd).returns(:false)
     expect(described_class).not_to be_default
   end
 
-  [ '15.04', '15.10', '16.04', '16.10' ].each do |ver|
-    it "should be the default provider on ubuntu#{ver}" do
-      Facter.stubs(:value).with(:osfamily).returns(:debian)
-      Facter.stubs(:value).with(:operatingsystem).returns(:ubuntu)
-      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
-      expect(described_class).to be_default
-    end
+  it "should be the default provider if systemd is running on Ubuntu" do
+    Facter.stubs(:value).with(:osfamily).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystem).returns(:ubuntu)
+    Facter.stubs(:value).with(:running_on_systemd).returns(:true)
+    expect(described_class).to be_default
   end
 
   [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -28,9 +28,9 @@ describe Puppet::Type.type(:service).provider(:upstart) do
     provider_class.stubs(:which).with("/sbin/initctl").returns("/sbin/initctl")
   end
 
-  it "should be the default provider on Ubuntu" do
+  it "should be the default provider on Ubuntu if systemd is not running" do
     Facter.expects(:value).with(:operatingsystem).returns("Ubuntu")
-    Facter.expects(:value).with(:operatingsystemmajrelease).returns("12.04")
+    Facter.expects(:value).with(:running_on_systemd).returns(:false)
     expect(described_class.default?).to be_truthy
   end
 


### PR DESCRIPTION
Rather than relying on version strings to determine which init-system is
in use, use the fact that the presence of /run/systemd/system (on
Debian-based systems generally, but I only can confirm for Ubuntu)
implies systemd is suitable.

Additionally, do not attempt to to use upstart in that case. However, if
systemd is not in use and upstart is the init-system (as detected by the
presence of the appropriate binaries as currently), treat upstart as
suitable.

Not-signed-off-by: Nishanth Aravamudan nish.aravamudan@canonical.com
