### PR TITLE
(PUP-6474) Incorporate gettext_setup gem into pupppet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 gem "rake", "10.1.1", :require => false
+gem "json_pure", '<=2.0.1'
+gem "gettext-setup", :require => false
 
 group(:development, :test) do
   gem "rspec", "~> 3.1", :require => false

--- a/Rakefile
+++ b/Rakefile
@@ -95,3 +95,8 @@ task(:commits) do
     end
   end
 end
+
+# Add i18n tasks (gettext:pot, gettext:po*)
+spec = Gem::Specification.find_by_name 'gettext-setup'
+load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -18,6 +18,7 @@ require 'puppet/util/run_mode'
 require 'puppet/external/pson/common'
 require 'puppet/external/pson/version'
 require 'puppet/external/pson/pure'
+require 'gettext-setup'
 
 #------------------------------------------------------------
 # the top-level module
@@ -36,6 +37,9 @@ module Puppet
   require 'puppet/environments'
 
   class << self
+    GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
+    FastGettext.locale = GettextSetup.negotiate_locale(ENV["LANG"])
+
     include Puppet::Util
     attr_reader :features
   end

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -6,22 +6,22 @@ require 'erb'
 
 Puppet::Face.define(:help, '0.0.1') do
   copyright "Puppet Labs", 2011
-  license   "Apache 2 license; see COPYING"
+  license   _("Apache 2 license; see COPYING")
 
-  summary "Display Puppet help."
+  summary _("Display Puppet help.")
 
   action(:help) do
-    summary "Display help about Puppet subcommands and their actions."
-    arguments "[<subcommand>] [<action>]"
-    returns "Short help text for the specified subcommand or action."
-    examples <<-'EOT'
+    summary _("Display help about Puppet subcommands and their actions.")
+    arguments _("[<subcommand>] [<action>]")
+    returns _("Short help text for the specified subcommand or action.")
+    examples _(<<-'EOT')
       Get help for an action:
 
       $ puppet help
     EOT
 
-    option "--version VERSION" do
-      summary "The version of the subcommand for which to show help."
+    option _("--version VERSION") do
+      summary _("The version of the subcommand for which to show help.")
     end
 
     default
@@ -47,7 +47,7 @@ Puppet::Face.define(:help, '0.0.1') do
           EOT
           353.times{i,x=i.divmod(1184);a,b=x.divmod(37);print(c[a]*b)}
         end
-        raise ArgumentError, "Puppet help only takes two (optional) arguments: a subcommand and an action"
+        raise ArgumentError, _("Puppet help only takes two (optional) arguments: a subcommand and an action")
       end
 
       version = :current
@@ -56,7 +56,7 @@ Puppet::Face.define(:help, '0.0.1') do
           version = options[:version]
         else
           if args.length == 0 then
-            raise ArgumentError, "Version only makes sense when a Faces subcommand is given"
+            raise ArgumentError, _("Version only makes sense when a Faces subcommand is given")
           end
         end
       end
@@ -66,7 +66,7 @@ Puppet::Face.define(:help, '0.0.1') do
       facename, actionname = args
       if legacy_applications.include? facename then
         if actionname then
-          raise ArgumentError, "Legacy subcommands don't take actions"
+          raise ArgumentError, _("Legacy subcommands don't take actions")
         end
         return render_application_help(facename)
       else
@@ -78,11 +78,11 @@ Puppet::Face.define(:help, '0.0.1') do
   def render_application_help(applicationname)
     return Puppet::Application[applicationname].help
   rescue StandardError, LoadError => detail
-    msg = <<-MSG
+    msg = _(<<-MSG) % {msg: detail.message}
 Could not load help for the application #{applicationname}.
 Please check the error logs for more information.
 
-Detail: "#{detail.message}"
+Detail: "%{msg}"
 MSG
     fail ArgumentError, msg, detail.backtrace
   end
@@ -91,11 +91,11 @@ MSG
     face, action = load_face_help(facename, actionname, version)
     return template_for(face, action).result(binding)
   rescue StandardError, LoadError => detail
-    msg = <<-MSG
+    msg = _(<<-MSG) % {msg: detail.message}
 Could not load help for the face #{facename}.
 Please check the error logs for more information.
 
-Detail: "#{detail.message}"
+Detail: "%{msg}"
 MSG
     fail ArgumentError, msg, detail.backtrace
   end
@@ -105,7 +105,7 @@ MSG
     if actionname
       action = face.get_action(actionname.to_sym)
       if not action
-        fail ArgumentError, "Unable to load action #{actionname} from #{face}"
+        fail ArgumentError, _("Unable to load action #{actionname} from #{face}")
       end
     end
 
@@ -148,7 +148,7 @@ MSG
           face = Puppet::Face[appname, :current]
           result << [appname, face.summary]
         rescue StandardError, LoadError
-          result << [ "! #{appname}", "! Subcommand unavailable due to error. Check error logs." ]
+          result << [ "! #{appname}", _("! Subcommand unavailable due to error. Check error logs.") ]
         end
       else
         result << [appname, horribly_extract_summary_from(appname)]
@@ -169,7 +169,7 @@ MSG
         end
       end
     rescue StandardError, LoadError
-      return "! Subcommand unavailable due to error. Check error logs."
+      return _("! Subcommand unavailable due to error. Check error logs.")
     end
     return ''
   end

--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -1,0 +1,21 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: 'puppet'
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should bea little more desctiptive than
+  # <project_name>
+  package_name: Puppet
+  # The locale that the default messages in the .pot file are in
+  default_locale: en
+  # The email used for sending bug reports.
+  bugs_address: docs@puppet.com
+  # The holder of the copyright.
+  copyright_holder: Puppet, LLC.
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+    - 'lib/**/*.rb'

--- a/locales/puppet.pot
+++ b/locales/puppet.pot
@@ -1,0 +1,148 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016 Puppet, LLC.
+# This file is distributed under the same license as the Puppet package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Puppet 4.5.2-443-g0e3b44a\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: 2016-07-26 03:40+0000\n"
+"PO-Revision-Date: 2016-07-26 03:40+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: ../lib/puppet/face/help.rb:9
+msgid "Apache 2 license; see COPYING"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:11
+msgid "Display Puppet help."
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:14
+msgid "Display help about Puppet subcommands and their actions."
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:15
+msgid "[<subcommand>] [<action>]"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:16
+msgid "Short help text for the specified subcommand or action."
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:17
+msgid ""
+"      Get help for an action:\n"
+"\n"
+"      $ puppet help\n"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:23
+msgid "--version VERSION"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:24
+msgid "The version of the subcommand for which to show help."
+msgstr ""
+
+#. Check our invocation, because we want varargs and can't do defaults
+#. yet.  REVISIT: when we do option defaults, and positional options, we
+#. should rewrite this to use those. --daniel 2011-04-04
+#: ../lib/puppet/face/help.rb:50
+msgid "Puppet help only takes two (optional) arguments: a subcommand and an action"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:59
+msgid "Version only makes sense when a Faces subcommand is given"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:69
+msgid "Legacy subcommands don't take actions"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:81
+msgid ""
+"Could not load help for the application #{applicationname}.\n"
+"Please check the error logs for more information.\n"
+"\n"
+"Detail: \"%{msg}\"\n"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:94
+msgid ""
+"Could not load help for the face #{facename}.\n"
+"Please check the error logs for more information.\n"
+"\n"
+"Detail: \"%{msg}\"\n"
+msgstr ""
+
+#: ../lib/puppet/face/help.rb:108
+msgid "\"Unable to load action #{actionname} from #{face}\""
+msgstr ""
+
+#. Return a list of all applications (both legacy and Face applications), along with a summary
+#. of their functionality.
+#. @return [Array] An Array of Arrays.  The outer array contains one entry per application; each
+#. element in the outer array is a pair whose first element is a String containing the application
+#. name, and whose second element is a String containing the summary for that application.
+#. Now we find the line with our summary, extract it, and return it.  This
+#. depends on the implementation coincidence of how our pages are
+#. formatted.  If we can't match the pattern we expect we return the empty
+#. string to ensure we don't blow up in the summary. --daniel 2011-04-11
+#: ../lib/puppet/face/help.rb:151 ../lib/puppet/face/help.rb:172
+msgid "! Subcommand unavailable due to error. Check error logs."
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:112
+msgid "Any"
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:115
+msgid "Undef"
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:118
+msgid "Default"
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:121
+msgid "Boolean"
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:124
+msgid "Scalar"
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:127
+msgid "Data"
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:130
+msgid "Numeric"
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:254
+msgid "Unit"
+msgstr ""
+
+#. @api private
+#: ../lib/puppet/pops/types/type_formatter.rb:290
+msgid "CatalogEntry"
+msgstr ""


### PR DESCRIPTION
Goal is to incorporate the gettext_setup gem, externalize a single string, and produce a pot file from a rake task. Expanded modestly from original scope (now externalizing all strings in help.rb) to work through a variety of translation scenarios.