### PR TITLE
(PUP-6545) Fix tests for Ruby 2.3 on Windows in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,22 @@
 version: 4.1.0.{build}
 clone_depth: 10
-init:
-  - SET
 install:
-  - SET PATH=C:\Ruby21-x64\bin;%PATH%
+build: off
+
+environment:
+  matrix:
+  - RUBY_VER: 23-x64
+  - RUBY_VER: 21-x64
+
+test_script:
+  - SET
+  - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
   - SET LOG_SPEC_ORDER=true
   - bundle install --jobs 4 --retry 2 --without development extra
   - type Gemfile.lock
   - ruby -v
-build: off
-test_script:
   - bundle exec rspec spec
+
 on_failure:
   - appveyor PushArtifact .\spec_order.txt
 notifications:


### PR DESCRIPTION
Previously only ruby 2.1.8 was used in the the Appveyor tests.  This PR adds
Ruby 2.3.0 to the test matrix.  The complete and up to date list
of installed software can be found at;
https://www.appveyor.com/docs/installed-software

Ruby bug 8822 has been partially resolved in Ruby 2.3.0.  Therefore the test in
`spec/unit/util_spec.rb:120` is now failing.  This PR guards this expected
bad behavior test, to Ruby versions prior to 2.3.