### PR TITLE
(PUP-6435) Convert sensitive params to resource metadata

### DIFF
--- a/api/schemas/catalog.json
+++ b/api/schemas/catalog.json
@@ -51,6 +51,13 @@
                     "exported": {
                         "type": "boolean"
                     },
+                    "sensitive_parameters": {
+                        "description": "An optional list of resource parameters to be treated as sensitive.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "tags": {
                         "description": "Tags: regex is from https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html",
                         "type": "array",

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -106,6 +106,7 @@ class Puppet::Parser::Resource < Puppet::Resource
     @finished = true
     add_defaults
     add_scope_tags
+    replace_sensitive_data
     validate if do_validate
   end
 
@@ -301,6 +302,15 @@ class Puppet::Parser::Resource < Puppet::Resource
     scope_resource = scope.resource
     unless scope_resource.nil? || scope_resource.equal?(self)
       merge_tags(scope_resource)
+    end
+  end
+
+  def replace_sensitive_data
+    parameters.each_pair do |name, param|
+      if param.value.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        @sensitive_parameters << name
+        param.value = param.value.unwrap
+      end
     end
   end
 

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -254,9 +254,6 @@ describe Puppet::Parser::Resource do
 
   describe "when finishing" do
     before do
-      @class = newclass "myclass"
-      @nodedef = newnode("mynode")
-
       @resource = Puppet::Parser::Resource.new("file", "whatever", :scope => @scope, :source => @source)
     end
 
@@ -290,6 +287,13 @@ describe Puppet::Parser::Resource do
       @resource.finish
 
       expect(@resource[:owner]).to eq("other")
+    end
+
+    it "converts parameters with Sensitive values to unwrapped values and metadata" do
+      @resource[:content] = Puppet::Pops::Types::PSensitiveType::Sensitive.new("hunter2")
+      @resource.finish
+      expect(@resource[:content]).to eq "hunter2"
+      expect(@resource.sensitive_parameters).to eq [:content]
     end
   end
 

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -818,6 +818,11 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
     expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
 
+  it "should validate a single sensitive parameter resource catalog against the schema" do
+    catalog = compile_to_catalog("create_resources('file', {'/etc/foo'=>{'ensure'=>'present','content'=>Sensitive('hunter2')}})")
+    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
+  end
+
   it "should validate a two resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('notify', {'foo'=>{'message'=>'one'}, 'bar'=>{'message'=>'two'}})")
     expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')


### PR DESCRIPTION
Our current JSON based serialization format is limited in the data types
it can handle; this falls over for rich data types such as the Sensitive
type. This commit adds a sensitive field to resources to pass parameter
level sensitivity in a serializable manner.