### PR TITLE
(maint) install cfpropertylist gem on all platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,9 +79,15 @@ data['gem_platform_dependencies'].each_pair do |gem_platform, info|
   next if gem_platform == 'x64-mingw32' && !x64_platform
   if bundle_deps = info['gem_runtime_dependencies']
     bundle_platform = bundle_platforms[gem_platform] or raise "Missing bundle_platform"
-    platform(bundle_platform.intern) do
+    if bundle_platform == "all"
       bundle_deps.each_pair do |name, version|
         gem(name, version, :require => false)
+      end
+    else
+      platform(bundle_platform.intern) do
+        bundle_deps.each_pair do |name, version|
+          gem(name, version, :require => false)
+        end
       end
     end
   end

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -54,7 +54,7 @@ gem_platform_dependencies:
       win32-service: '= 0.8.7'
       minitar: '~> 0.5.4'
 bundle_platforms:
-  universal-darwin: ruby
+  universal-darwin: all
   x86-mingw32: mingw
   x64-mingw32: x64_mingw
 pre_tasks:


### PR DESCRIPTION
The cfpropertylist gem is needed to run unit tests against code that
parses plist files. We've gotten around this with lots of mocking and
stubbing in the past, but it's coming up to bite us in
https://github.com/puppetlabs/puppet/pull/5119

The core issue is that Windows is not the "ruby" platform - it's
"mingw". This adds a new special "all" platform to project_data.yaml,
where we can add gems which shouldn't be platform-constrained.

Probably what we really need is more complex logic around whether
platform-specific gems are needed only at runtime or also for tests,
and around which platform-specific gems are installable on a broader
array of platforms. This unblocks the above PR, though.