### PR TITLE
(PUP-6549) fix test systemd_enabling_masked_service for Fedora 23

### DIFF
--- a/spec/fixtures/releases/jamtur01-apache/manifests/init.pp
+++ b/spec/fixtures/releases/jamtur01-apache/manifests/init.pp
@@ -11,6 +11,13 @@ class apache {
     enable    => true,
     subscribe => Package['httpd'],
   }
+  if ($::operatingsystem == 'Fedora') and ($::operatingsystemmajrelease == '23') {
+    package{'libnghttp2':
+      ensure => latest,
+      install_options => '--best',
+      before => Package['httpd'],
+    }
+  }
   #
   # May want to purge all none realize modules using the resources resource type.
   # A2mod resource type is broken.  Look into fixing it and moving it into apache.


### PR DESCRIPTION
Upstream httpd package requires an updated libnghttp2 package but is not defined as such.
https://bodhi.fedoraproject.org/updates/httpd-2.4.23-4.fc23
https://bugzilla.redhat.com/show_bug.cgi?id=1358875