### PR TITLE
(PUP-6527) Ignore hiera_include calls from environment compiler

### DIFF
--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -15,6 +15,16 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
     end
   end
 
+  def initialize(node, options = {})
+    super
+    add_function_overrides
+  end
+
+  def add_function_overrides
+    hiera_include = proc { Puppet.debug "Ignoring hiera_include() during environment catalog compilation" }
+    loaders.puppet_system_loader.add_entry(:function, 'hiera_include', hiera_include, nil)
+  end
+
   def add_catalog_validators
     super
     add_catalog_validator(CatalogValidator::SiteValidator)

--- a/spec/unit/parser/environment_compiler_spec.rb
+++ b/spec/unit/parser/environment_compiler_spec.rb
@@ -480,7 +480,6 @@ EOS
     end
   end
 
-
   describe "in the environment catalog" do
     it "does not fail if there is no site expression" do
       expect {
@@ -488,6 +487,18 @@ EOS
         notify { 'ignore me':}
       EOC
       }.to_not raise_error()
+    end
+
+    it "ignores usage of hiera_include() at topscope for classification" do
+      Puppet.expects(:debug).with(regexp_matches /Ignoring hiera_include/)
+
+      expect {
+        catalog = compile_to_env_catalog(<<-EOC).to_resource
+        hiera_include('classes')
+        site { }
+        EOC
+      }.to_not raise_error()
+
     end
 
     it "includes components and capability resources" do


### PR DESCRIPTION
A common pattern for hiera_include is to put it at topscope, which
causes environment compilation to fail as the behavior of hiera_include
(or hiera in general) isn't well-defined for the environment compiler.

In order to allow users to immediately start using application
management and direct change without needing to modify how they do
classification, we now simply ignore and warn if hiera_include is called
by the environment compiler.