### PR TITLE
(PUP-5501) Unblock PMT install tests on AIX

### DIFF
--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -3,7 +3,6 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
-confine :except, :platform => /aix/ # PUP-5501
 
 module_author = "pmtacceptance"
 module_name   = "nginx"

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -3,7 +3,6 @@ require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
-confine :except, :platform => /aix/ # PUP-5501
 
 module_author = "pmtacceptance"
 module_name = "java"


### PR DESCRIPTION
This commit removed the confine against AIX for PMT install tests that
were previously skipped due to a failure to override DNS resolution
for the forge on AIX.
