### PR TITLE
(PUP-6557) fix Dir.glob shenanigans

### DIFF
--- a/lib/puppet/file_system/path_pattern.rb
+++ b/lib/puppet/file_system/path_pattern.rb
@@ -31,6 +31,8 @@ module Puppet::FileSystem
     end
 
     def glob
+      # require 'pry'; binding.pry
+      # TODO: replacing / removing this is going to be too hard given usage
       Dir.glob(pathname.to_s)
     end
 

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -180,7 +180,8 @@ class Puppet::Module
 
     # (#4220) Always ensure init.pp in case class is defined there.
     init_manifest = manifest("init.pp")
-    if !init_manifest.nil? && !searched_manifests.include?(init_manifest)
+    if !init_manifest.nil? && !searched_manifests.find { |f| File.identical?(f, init_manifest) }
+
       searched_manifests.unshift(init_manifest)
     end
     searched_manifests
@@ -189,7 +190,11 @@ class Puppet::Module
   def all_manifests
     return [] unless Puppet::FileSystem.exist?(manifests)
 
-    Dir.glob(File.join(manifests, '**', '*.pp'))
+    found = []
+    Pathname(manifests).find do |p|
+      found << p if p.file? && p.extname == '.pp'
+    end
+    found
   end
 
   def metadata_file

--- a/lib/puppet/parser/type_loader.rb
+++ b/lib/puppet/parser/type_loader.rb
@@ -20,6 +20,9 @@ class Puppet::Parser::TypeLoader
       abspat = File.expand_path(pattern, dir)
       file_pattern = abspat + (File.extname(abspat).empty? ? '.pp' : '' )
 
+      # require 'pry'; binding.pry
+      # TODO: replace Dir.glob?  - need to verify what comes in for file_pattern to see if it's replaceable
+      puts "Called import with #{file_pattern}"
       files = Dir.glob(file_pattern).uniq.reject { |f| FileTest.directory?(f) }
       modname = nil
 

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -215,7 +215,9 @@ module ModuleLoaders
 
     def existing_path(effective_path)
       # Optimized, checks index instead of visiting file system
-      @path_index.include?(effective_path) ? effective_path : nil
+      # TODO: has this killed the optimization? The problem is we may be comparing 8.3 paths to expanded paths found by Dir.glob
+      # and there is no canonical form
+      @path_index.find { |f| File.identical?(f, effective_path) }
     end
 
     def meaningful_to_search?(smart_path)
@@ -227,7 +229,16 @@ module ModuleLoaders
     end
 
     def add_to_index(smart_path)
-      found = Dir.glob(File.join(smart_path.generic_path, '**', "*#{smart_path.extension}"))
+      # TODO: previous code - Dir.glob will expand 8.3 ADMINI~1 to Administrator
+      # which is a behavioral breakage
+      # found = Dir.glob(File.join(smart_path.generic_path, '**', "*#{smart_path.extension}"))
+      search_path = Pathname(smart_path.generic_path)
+      return [] if !search_path.exist?
+
+      found = []
+      search_path.find do |p|
+        found << p.to_s if p.file? && p.extname == smart_path.extension
+      end
       @path_index.merge(found)
       found
     end

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -102,9 +102,16 @@ class Puppet::Util::Autoload
 
     def files_in_dir(dir, path)
       dir = Pathname.new(File.expand_path(dir))
-      Dir.glob(File.join(dir, path, "*.rb")).collect do |file|
-        Pathname.new(file).relative_path_from(dir).to_s
+      files = []
+      search_path = Pathname(File.join(dir, path))
+      return [] if !search_path.exist?
+      search_path.find do |p|
+        files << Pathname.new(p).relative_path_from(dir).to_s if p.file? && p.extname == '.rb'
       end
+      files
+      # Dir.glob(File.join(dir, path, "*.rb")).collect do |file|
+      #   Pathname.new(file).relative_path_from(dir).to_s
+      # end
     end
 
     def module_directories(env)

--- a/spec/unit/file_system/path_pattern_spec.rb
+++ b/spec/unit/file_system/path_pattern_spec.rb
@@ -120,7 +120,8 @@ describe Puppet::FileSystem::PathPattern do
   end
 
   it "applies the pattern to the filesystem as a glob" do
-    dir = tmpdir('globtest')
+    # Dir.glob is necessary on Windows since it expand 8.3 dirs as of Ruby 2.3+
+    dir = Dir.glob(tmpdir('globtest'))[0]
     create_file_in(dir, "found_one")
     create_file_in(dir, "found_two")
     create_file_in(dir, "third_not_found")

--- a/spec/unit/parser/files_spec.rb
+++ b/spec/unit/parser/files_spec.rb
@@ -84,13 +84,19 @@ describe Puppet::Parser::Files do
     end
 
     it "returns the name of the module and the manifests from the first found module" do
-      expect(Puppet::Parser::Files.find_manifests_in_modules("mymod/init.pp", environment)
-            ).to eq(["mymod", [mymod_init_manifest]])
+      found = Puppet::Parser::Files.find_manifests_in_modules("mymod/init.pp", environment)
+      found[1] = found[1].map { |f| Dir.glob(f) }
+      expected = ["mymod", [mymod_init_manifest]]
+      expected[1] = expected[1].map { |f| Dir.glob(f) }
+      expect(found).to eq(expected)
     end
 
     it "always includes init.pp if present" do
-      expect(Puppet::Parser::Files.find_manifests_in_modules("mymod/another.pp", environment)
-            ).to eq(["mymod", [mymod_init_manifest, mymod_another_manifest]])
+      found = Puppet::Parser::Files.find_manifests_in_modules("mymod/another.pp", environment)
+      found[1] = found[1].map { |f| Dir.glob(f) }
+      expected = ["mymod", [mymod_init_manifest, mymod_another_manifest]]
+      expected[1] = expected[1].map { |f| Dir.glob(f) }
+      expect(found).to eq(expected)
     end
 
     it "does not find the module when it is a different environment" do

--- a/spec/unit/pops/loaders/loader_paths_spec.rb
+++ b/spec/unit/pops/loaders/loader_paths_spec.rb
@@ -38,6 +38,8 @@ describe 'loader paths' do
     expect(effective_paths.size).to eq(1)
     expect(module_loader.path_index.size).to eq(1)
     path_index = module_loader.path_index
-    expect(path_index).to include(File.join(module_dir, 'lib', 'puppet', 'functions', 'foo4x.rb'))
+
+    expected = File.join(module_dir, 'lib', 'puppet', 'functions', 'foo4x.rb')
+    expect(path_index.find { |f| File.identical?(f, expected) }).to be_truthy
   end
 end


### PR DESCRIPTION
Ruby 2.3 changed the behavior of `Dir.glob` as a result of https://bugs.ruby-lang.org/issues/10819 / https://github.com/ruby/ruby/commit/45df1c24d269f93a2bc1e7a6fe0ffcecc1193051

This requires test / code changes on Windows.