### PR TITLE
{WIP}(PUP-6551) Pin json_pure to 2.0.1 if on Ruby 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,10 @@ gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 gem "rake", "10.1.1", :require => false
+# Hiera has an unbound dependency on json_pure
+# json_pure 2.0.2+ requires Ruby >= 2.0
+# Ensure json_pure maximum version 2.0.1 on Ruby 1.x
+gem 'json_pure', '<= 2.0.1', :require => false if RUBY_VERSION =~ /^1\./
 
 group(:development, :test) do
   gem "rspec", "~> 3.1", :require => false

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -19,6 +19,7 @@ gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['> 2.0', '< 4']
   hiera: ['>= 2.0', '< 4']
+  # TODO: but what about this?
   json_pure:
 gem_rdoc_options:
   - --title


### PR DESCRIPTION
 - Hiera has an unbound dependency on json_pure. json_pure 2.0.2+
   requires Ruby >= 2.0.

   Pin json_pure to maximum version of 2.0.1 on Ruby 1.x.

   Without this commit, bundler will pick json_pure 2.0.2 and then
   fail to bundle install on Ruby 1.x.