### PR TITLE
(PUP-6551) Pin json_pure to ~> 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ end
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 1.6', '< 3'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
 gem "rake", "10.1.1", :require => false
+# Hiera has an unbound dependency on json_pure
+# json_pure 2.0.2+ officially requires Ruby >= 2.0, but should have specified that in 2.0
+gem 'json_pure', '~> 1.8', :require => false
 
 group(:development, :test) do
   gem "rspec", "~> 2.14.0", :require => false

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -17,7 +17,7 @@ gem_forge_project: 'puppet'
 gem_runtime_dependencies:
   facter: ['> 1.6', '< 3']
   hiera: '~> 1.0'
-  json_pure:
+  json_pure: '~> 1.8'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"


### PR DESCRIPTION
 - Hiera has an unbound dependency on json_pure. json_pure 2.0.2+
   explicitly requires Ruby >= 2.0, though support was dropped for
   Ruby 1.9 in json_pure 2.0.0 (though mistakently the Gemfile was
   not updated).

   Pin json_pure to a 1.8 series release everywhere.

   Without this commit, bundler will pick json_pure 2.0.2 and then
   fail to bundle install on Ruby 1.x.