### PR TITLE
3.x merge to stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 gem "rake", "10.1.1", :require => false
+# Hiera has an unbound dependency on json_pure
+# json_pure 2.0.2+ officially requires Ruby >= 2.0, but should have specified that in 2.0
+gem 'json_pure', '~> 1.8', :require => false
 
 group(:development, :test) do
   gem "rspec", "~> 3.1", :require => false

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -19,7 +19,7 @@ gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['> 2.0', '< 4']
   hiera: ['>= 2.0', '< 4']
-  json_pure:
+  json_pure: '~> 1.8'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -279,6 +279,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
 
   def managed_attribute_keys(hash)
     managed_attributes ||= @resource.original_parameters[:attributes] || hash.keys.map{|k| k.to_s}
+    managed_attributes = [managed_attributes] unless managed_attributes.is_a?(Array)
     managed_attributes.map {|attr| key, value = attr.split("="); key.strip.to_sym}
   end
 

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -55,6 +55,7 @@ guest id=100 pgrp=usr groups=usr home=/home/guest
 
     describe "invoked via manifest" do
       let(:attribute_array) { ["rlogin=false", "login =true"] }
+      let(:single_attribute_array) { "rlogin=false" }
 
       it "should return only the keys of the attribute key=value pair from manifest" do
         keys = @provider.managed_attribute_keys(existing_attributes)
@@ -78,6 +79,12 @@ guest id=100 pgrp=usr groups=usr home=/home/guest
         keys = @provider.managed_attribute_keys(existing_attributes)
         all_symbols = keys.all? {|k| k.is_a? Symbol}
         expect(all_symbols).to be_truthy
+      end
+
+      it "should allow a single attribute to be specified" do
+        @resource.stubs(:original_parameters).returns({ :attributes => single_attribute_array })
+        keys = @provider.managed_attribute_keys(existing_attributes)
+        keys.should be_include(:rlogin)
       end
     end
 


### PR DESCRIPTION
This is a merge up from 3.x. Note that several of the 3.x changes amounted to noops on stable, specifically:
* the pip provider is no longer XMLRPC based, but shells out to the pip cli, see https://github.com/puppetlabs/puppet/pull/4832
* the windows gem pinning already happened in stable, see https://github.com/puppetlabs/puppet/pull/5062