### PR TITLE
(maint) Update to gettext-setup 0.4 and regenerate .pot file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 gem "rake", "10.1.1", :require => false
-gem "gettext-setup", :require => false
+gem "gettext-setup", ">= 0.4", :require => false
 # Hiera has an unbound dependency on json_pure
 # json_pure 2.0.2+ officially requires Ruby >= 2.0, but should have specified that in 2.0
 gem 'json_pure', '~> 1.8', :require => false

--- a/locales/puppet.pot
+++ b/locales/puppet.pot
@@ -6,11 +6,11 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Puppet 4.5.2-443-g0e3b44a\n"
+"Project-Id-Version: Puppet 4.5.3-435-g7943fcb\n"
 "\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
-"POT-Creation-Date: 2016-07-26 03:40+0000\n"
-"PO-Revision-Date: 2016-07-26 03:40+0000\n"
+"POT-Creation-Date: 2016-07-28 02:08+0000\n"
+"PO-Revision-Date: 2016-07-28 02:08+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -19,57 +19,45 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../lib/puppet/face/help.rb:9
 msgid "Apache 2 license; see COPYING"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:11
 msgid "Display Puppet help."
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:14
 msgid "Display help about Puppet subcommands and their actions."
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:15
 msgid "[<subcommand>] [<action>]"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:16
 msgid "Short help text for the specified subcommand or action."
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:17
 msgid ""
 "      Get help for an action:\n"
 "\n"
 "      $ puppet help\n"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:23
 msgid "--version VERSION"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:24
 msgid "The version of the subcommand for which to show help."
 msgstr ""
 
 #. Check our invocation, because we want varargs and can't do defaults
 #. yet.  REVISIT: when we do option defaults, and positional options, we
 #. should rewrite this to use those. --daniel 2011-04-04
-#: ../lib/puppet/face/help.rb:50
 msgid "Puppet help only takes two (optional) arguments: a subcommand and an action"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:59
 msgid "Version only makes sense when a Faces subcommand is given"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:69
 msgid "Legacy subcommands don't take actions"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:81
 msgid ""
 "Could not load help for the application #{applicationname}.\n"
 "Please check the error logs for more information.\n"
@@ -77,7 +65,6 @@ msgid ""
 "Detail: \"%{msg}\"\n"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:94
 msgid ""
 "Could not load help for the face #{facename}.\n"
 "Please check the error logs for more information.\n"
@@ -85,7 +72,6 @@ msgid ""
 "Detail: \"%{msg}\"\n"
 msgstr ""
 
-#: ../lib/puppet/face/help.rb:108
 msgid "\"Unable to load action #{actionname} from #{face}\""
 msgstr ""
 
@@ -98,51 +84,41 @@ msgstr ""
 #. depends on the implementation coincidence of how our pages are
 #. formatted.  If we can't match the pattern we expect we return the empty
 #. string to ensure we don't blow up in the summary. --daniel 2011-04-11
-#: ../lib/puppet/face/help.rb:151 ../lib/puppet/face/help.rb:172
 msgid "! Subcommand unavailable due to error. Check error logs."
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:112
 msgid "Any"
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:115
 msgid "Undef"
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:118
 msgid "Default"
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:121
 msgid "Boolean"
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:124
 msgid "Scalar"
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:127
 msgid "Data"
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:130
 msgid "Numeric"
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:254
 msgid "Unit"
 msgstr ""
 
 #. @api private
-#: ../lib/puppet/pops/types/type_formatter.rb:290
 msgid "CatalogEntry"
 msgstr ""


### PR DESCRIPTION
This update remove location comments from the auto-generated .pot
file to reduce source control churn.