### PR TITLE
(PUP-6459) Update win32-service to 0.8.8

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -40,7 +40,7 @@ gem_platform_dependencies:
       win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
-      win32-service: '= 0.8.7'
+      win32-service: '= 0.8.8'
       minitar: '~> 0.5.4'
   x64-mingw32:
     gem_runtime_dependencies:
@@ -51,7 +51,7 @@ gem_platform_dependencies:
       win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
-      win32-service: '= 0.8.7'
+      win32-service: '= 0.8.8'
       minitar: '~> 0.5.4'
 bundle_platforms:
   universal-darwin: ruby


### PR DESCRIPTION
 - Version 0.8.7 of the win32-service gem had a bug that prevented it
   from properly retrieving all services on Windows 10 with the
   Win32::Service.services call.

   In particular, the services pvhdparser and vhdparser don't have
   delayed start info, which would previously cause errors.

   This is fixed in the 0.8.8 version of the gem