### PR TITLE
(PUP-6459) Acceptance test for 'puppet resource service'

### DIFF
--- a/acceptance/tests/resource/service/should_query_all.rb
+++ b/acceptance/tests/resource/service/should_query_all.rb
@@ -1,0 +1,9 @@
+test_name "should query all services"
+
+agents.each do |agent|
+  step "query with puppet"
+  on(agent, puppet_resource('service'), :accept_all_exit_codes => true) do
+    assert_equal(exit_code, 0, "'puppet resource service' should have an exit code of 0")
+    assert(/^service/ =~ stdout, "'puppet resource service' should present service details")
+  end
+end


### PR DESCRIPTION
Add a basic acceptance test to ensure that 'puppet resource service' does not error.

[skip ci]