### PR TITLE
(PUP-6568) handle non-plist binary blobs in launchd service provider

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -135,6 +135,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     @label_to_path_map = {}
     launchd_paths.each do |path|
       return_globbed_list_of_file_paths(path).each do |filepath|
+        Puppet.debug("Reading launchd plist #{filepath}")
         job = read_plist(filepath)
         next if job.nil?
         if job.has_key?("Label")

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -54,9 +54,14 @@ module Puppet::Util::Plist
     # Read plist text using the CFPropertyList gem.
     def parse_plist(plist_data, file_path = '')
       bad_xml_doctype = /^.*<!DOCTYPE plist PUBLIC -\/\/Apple Computer.*$/
-      if plist_data =~ bad_xml_doctype
-        plist_data.gsub!( bad_xml_doctype, plist_xml_doctype )
-        Puppet.debug("Had to fix plist with incorrect DOCTYPE declaration: #{file_path}")
+      begin
+        if plist_data =~ bad_xml_doctype
+          plist_data.gsub!( bad_xml_doctype, plist_xml_doctype )
+          Puppet.debug("Had to fix plist with incorrect DOCTYPE declaration: #{file_path}")
+        end
+      rescue ArgumentError => e
+        Puppet.debug "Failed with #{e.class} on #{file_path}: #{e.inspect}"
+        return nil
       end
 
       begin

--- a/spec/unit/util/plist_spec.rb
+++ b/spec/unit/util/plist_spec.rb
@@ -57,7 +57,10 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
      Take me where I cannot stand
      I don't care, I'm still free
      You can't take the sky from me."
-   end
+  end
+  let(:binary_data) do
+    "\xCF\xFA\xED\xFE\a\u0000\u0000\u0001\u0003\u0000\u0000\x80\u0002\u0000\u0000\u0000\u0012\u0000\u0000\u0000\b"
+  end
   let(:valid_xml_plist_hash) { {"LastUsedPrinters"=>[{"Network"=>"10.85.132.1", "PrinterID"=>"baskerville_corp_puppetlabs_net"}, {"Network"=>"10.14.96.1", "PrinterID"=>"Statler"}]} }
   let(:plist_path) { file_containing('sample.plist', valid_xml_plist) }
   let(:binary_plist_magic_number) { 'bplist00' }
@@ -96,7 +99,16 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
     it "returns nil when direct parsing and plutil conversion both fail" do
       subject.stubs(:read_file_with_offset).with(plist_path, 8).returns('notbinary')
       subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(non_plist_data)
-      Puppet.expects(:debug).with(regexp_matches(/^Failed with NoMethodError/))
+      Puppet.expects(:debug).with(regexp_matches(/^Failed with (CFFormatError|NoMethodError)/))
+      Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '/dev/stdout', plist_path],
+                                                     {:failonfail => true, :combine => true}).raises(Puppet::ExecutionFailure, 'boom')
+      expect(subject.read_plist_file(plist_path)).to eq(nil)
+    end
+    it "returns nil when file is a non-plist binary blob" do
+      subject.stubs(:read_file_with_offset).with(plist_path, 8).returns('notbinary')
+      subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(binary_data)
+      Puppet.expects(:debug).with(regexp_matches(/^Failed with (CFFormatError|ArgumentError)/))
       Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
       Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '/dev/stdout', plist_path],
                                                      {:failonfail => true, :combine => true}).raises(Puppet::ExecutionFailure, 'boom')


### PR DESCRIPTION
If the launchd service provider encounters a file that's not plain text or a binary plist, it will error.

Catch the ArgumentError when trying to pattern match against bad_xml_doctype, and return nil.