### PR TITLE
(PUP-6570) Remove English MCO assert

### DIFF
--- a/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
+++ b/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
@@ -52,9 +52,7 @@ end
 step 'Shutdown MCollective service on Windows agent'
 #Shutdown MCollective Service on Windows agent and make sure it successfully exits
 agents.each do |agent|
-  on agent, 'net stop mcollective' do |result|
-    assert_match(/The Marionette Collective Server service was stopped successfully/, result.stdout, "Failed to stop MCollective service")
-  end
+  on agent, 'net stop mcollective'
 end
 
 sleep 5
@@ -62,7 +60,5 @@ sleep 5
 step 'Start MCollective service on Windows agent'
 #Bring the MCllective backup
 agents.each do |agent|
-  on agent, 'net start mcollective' do |result|
-    assert_match(/The Marionette Collective Server service was started successfully/, result.stdout, "Failed to start MCollective service")
-  end
+  on agent, 'net start mcollective'
 end


### PR DESCRIPTION
This commit removes the English STDOUT assertion. Now that i18n
work is being integrated into Puppet products, English assertions
are no longer universally valid.

This test was failing when run against non-English versions of
Windows due to the localized translation of the service start/stop
messages. The test will now rely on the exit code to determine
success.

This commit duplicates commit `405e75a` from `pe_acceptance_tests`
repository.