### PR TITLE
(PUP-6558) Fix problem when loading UDRTs in non-directory environment

### DIFF
--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -10,7 +10,7 @@ class Runtime3TypeLoader < BaseLoader
   def initialize(parent_loader, environment, env_path)
     super(parent_loader, environment.name)
     @environment = environment
-    @resource_3x_loader = env_path.nil? ? NullLoader.new(parent_loader) : ModuleLoaders.module_loader_from(parent_loader, self, 'environment', env_path)
+    @resource_3x_loader = env_path.nil? ? nil : ModuleLoaders.module_loader_from(parent_loader, self, 'environment', env_path)
   end
 
   def to_s()
@@ -25,20 +25,34 @@ class Runtime3TypeLoader < BaseLoader
     return nil unless typed_name.name_authority == Pcore::RUNTIME_NAME_AUTHORITY
     case typed_name.type
     when :type
-      impl_te = find_impl(TypedName.new(:resource_type_pp, typed_name.name, typed_name.name_authority))
-      if impl_te.nil? || impl_te.value.nil?
-        nil
+      value = nil
+      name = typed_name.name
+      if @resource_3x_loader.nil?
+        value = Puppet::Type.type(name) unless typed_name.qualified?
+        if value.nil?
+          # Look for a user defined type
+          value = @environment.known_resource_types.find_definition(name)
+        end
       else
-        # Loaded types doesn't have the same life cycle as this loader, so we must start by
-        # checking if the type was created. If it was, an entry will already be stored in
-        # this loader. If not, then it was created before this loader was instantiated and
-        # we must therefore add it.
-        te = get_entry(typed_name)
-        te = set_entry(typed_name, Types::TypeFactory.resource(impl_te.value.name.to_s)) if te.nil? || te.value.nil?
-        te
+        impl_te = find_impl(TypedName.new(:resource_type_pp, name, typed_name.name_authority))
+        value = impl_te.value unless impl_te.nil?
       end
+
+      if value.nil?
+        # Cache the fact that it wasn't found
+        set_entry(typed_name, nil)
+        return nil
+      end
+
+      # Loaded types doesn't have the same life cycle as this loader, so we must start by
+      # checking if the type was created. If it was, an entry will already be stored in
+      # this loader. If not, then it was created before this loader was instantiated and
+      # we must therefore add it.
+      te = get_entry(typed_name)
+      te = set_entry(typed_name, Types::TypeFactory.resource(value.name.to_s)) if te.nil? || te.value.nil?
+      te
     when :resource_type_pp
-      find_impl(typed_name)
+      @resource_3x_loader.nil? ? nil : find_impl(typed_name)
     else
       nil
     end


### PR DESCRIPTION
The PE-installer uses a non-directory environment during the install
of some modules. The Runtime3xLoader didn't handle this very well since
it then tried to cache a loaded user defined resource type in a
NullLoader instance which resulted in a `nil` return value. As a,
consequence, the loaded resource type was lost.

This commit fixes the loader so that it handles the case of not having
an environment path. It then skips the attempt to load a pcore type
definition and will always cache the value in the Runtime3Loader (as it
did before the pcore resource type definitions were introduced).