### PR TITLE
(PUP-6572) Codify the `site:modules:$basemodulepath` pattern as default

### DIFF
--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -99,7 +99,7 @@ class Puppet::Settings::EnvironmentConf
   end
 
   def modulepath
-    default_modulepath = [File.join(@path_to_env, "modules")] + @global_module_path
+    default_modulepath = [File.join(@path_to_env, "site")] + [File.join(@path_to_env, "modules")] + @global_module_path
     get_setting(:modulepath, default_modulepath) do |modulepath|
       path = modulepath.kind_of?(String) ?
         modulepath.split(File::PATH_SEPARATOR) :

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -20,6 +20,7 @@ describe Puppet::Environments do
       FS::MemoryFile.a_regular_file_containing("ignored_file", ''),
       FS::MemoryFile.a_directory("an_environment", [
         FS::MemoryFile.a_missing_file("environment.conf"),
+        FS::MemoryFile.a_directory("site"),
         FS::MemoryFile.a_directory("modules"),
         FS::MemoryFile.a_directory("manifests"),
       ]),
@@ -43,7 +44,8 @@ describe Puppet::Environments do
         expect(loader.list).to include_in_any_order(
           environment(:an_environment).
             with_manifest("#{FS.path_string(directory_tree)}/an_environment/manifests").
-            with_modulepath(["#{FS.path_string(directory_tree)}/an_environment/modules",
+            with_modulepath(["#{FS.path_string(directory_tree)}/an_environment/site",
+                             "#{FS.path_string(directory_tree)}/an_environment/modules",
                              global_path_1_location,
                              global_path_2_location]),
           environment(:another_environment))
@@ -178,16 +180,17 @@ static_catalogs=false
         ])
 
         manifestdir = FS::MemoryFile.a_directory(File.join(envdir, "env1", "manifests"))
+        sitemodulesdir = FS::MemoryFile.a_directory(File.join(envdir, "env1", "site"))
         modulesdir = FS::MemoryFile.a_directory(File.join(envdir, "env1", "modules"))
         global_path_location = File.expand_path("global_path")
         global_path = FS::MemoryFile.a_directory(global_path_location)
 
-        loader_from(:filesystem => [envdir, manifestdir, modulesdir, global_path].flatten,
+        loader_from(:filesystem => [envdir, manifestdir, sitemodulesdir, modulesdir, global_path].flatten,
                     :directory => envdir,
                     :modulepath => [global_path]) do |loader|
           expect(loader.get("env1")).to environment(:env1).
             with_manifest("#{FS.path_string(envdir)}/env1/manifests").
-            with_modulepath(["#{FS.path_string(envdir)}/env1/modules", global_path_location]).
+            with_modulepath(["#{FS.path_string(envdir)}/env1/site", "#{FS.path_string(envdir)}/env1/modules", global_path_location]).
             with_config_version(nil).
             with_static_catalogs(true)
         end

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/face'
 
-module PuppetFaceSpecs 
+module PuppetFaceSpecs
 describe Puppet::Face[:config, '0.0.1'] do
 
   FS = Puppet::FileSystem
@@ -63,7 +63,7 @@ syslogfacility = file
         expect { subject.print(*add_section_option(args, section)) }.to have_printed(<<-OUTPUT)
 environmentpath = #{File.expand_path("/dev/null/environments")}
 manifest = #{File.expand_path("/dev/null/environments/production/manifests")}
-modulepath = #{File.expand_path("/dev/null/environments/production/modules")}#{File::PATH_SEPARATOR}#{File.expand_path("/some/base")}
+modulepath = #{File.expand_path("/dev/null/environments/production/site")}#{File::PATH_SEPARATOR}#{File.expand_path("/dev/null/environments/production/modules")}#{File::PATH_SEPARATOR}#{File.expand_path("/some/base")}
 environment = production
 basemodulepath = #{File.expand_path("/some/base")}
         OUTPUT
@@ -104,7 +104,7 @@ basemodulepath = #{File.expand_path("/some/base")}
         expect { subject.print(*add_section_option(args, section)) }.to have_printed(<<-OUTPUT)
 environmentpath = #{File.expand_path("/dev/null/environments")}
 manifest = no_manifest
-modulepath = 
+modulepath =
 environment = doesnotexist
 basemodulepath = #{File.expand_path("/some/base")}
         OUTPUT

--- a/spec/unit/settings/environment_conf_spec.rb
+++ b/spec/unit/settings/environment_conf_spec.rb
@@ -64,7 +64,8 @@ describe Puppet::Settings::EnvironmentConf do
 
     it "returns a default modulepath when config has none, with global_module_path" do
       expect(envconf.modulepath).to eq(
-        [File.expand_path('/some/direnv/modules'),
+        [File.expand_path('/some/direnv/site'),
+        File.expand_path('/some/direnv/modules'),
         File.expand_path('/global/modulepath')].join(File::PATH_SEPARATOR)
       )
     end


### PR DESCRIPTION
For a very long time, CS has been recommending and educating the
`modulepath = site:modules:$basemodulepath` pattern via
`environment.conf`. It's now codified as a CS standard:

https://github.com/puppetlabs/cs-standards/blob/master/control_repo_contents.md#directory-structure-and-contents

It's always felt a bit weird to be explaining to people why the best
practice wasn't the Puppet default, so how about we make it the default?
This should not impact existing users unless they're currently using
`$environment/site` for other purposes, and I'd wager that percentage is
rather low.
