### PR TITLE
(PUP-6497) Improve error message with conflicting capability resources

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -270,7 +270,7 @@ class Puppet::Parser::Resource < Puppet::Resource
       t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
       cap = catalog.resource(t, ref.title)
       if cap.nil?
-        raise _("Resource %{ref} could not be found; it might not have been produced yet") % { ref: ref }
+        raise Puppet::Error, _("Resource %{ref} could not be found; it might not have been produced yet") % { ref: ref }
       end
 
       # Ensure that the found resource is a capability resource

--- a/spec/unit/resource/capability_finder_spec.rb
+++ b/spec/unit/resource/capability_finder_spec.rb
@@ -124,22 +124,21 @@ describe Puppet::Resource::CapabilityFinder do
           expect(result['host']).to eq('chost')
         end
 
-        it 'should return nil if no resource matches code_id' do
+        it 'should fail if no resource matches code_id' do
           Puppet::Resource::CapabilityFinder.stubs(:search).with('production', code_id, capability).returns []
 
-          result = Puppet::Resource::CapabilityFinder.find('production', code_id, capability)
-          expect(result).to be_nil
+          expect { Puppet::Resource::CapabilityFinder.find('production', code_id, capability) }.to raise_error(Puppet::Error, /expected exactly one resource but got 2/)
         end
 
         it 'should fail if multiple resources match code_id' do
           Puppet::Resource::CapabilityFinder.stubs(:search).with('production', code_id, capability).returns resources
 
-          expect { Puppet::Resource::CapabilityFinder.find('production', code_id, capability) }.to raise_error(Puppet::DevError, /expected exactly one resource/)
+          expect { Puppet::Resource::CapabilityFinder.find('production', code_id, capability) }.to raise_error(Puppet::DevError, /expected exactly one resource but got 2/)
         end
 
         it 'should fail if no code_id was specified' do
           Puppet::Resource::CapabilityFinder.stubs(:search).with('production', nil, capability).returns resources
-          expect { Puppet::Resource::CapabilityFinder.find('production', nil, capability) }.to raise_error(Puppet::DevError, /expected exactly one resource/)
+          expect { Puppet::Resource::CapabilityFinder.find('production', nil, capability) }.to raise_error(Puppet::DevError, /expected exactly one resource but got 2/)
         end
       end
     end


### PR DESCRIPTION
When a capability resource is moved from one node to another, either due
to a code change or because an application component is classified to a
different node, the database can contain multiple resource instances
matching the capability ref. This happens when the new node has run
puppet but the old node hasn't. In those cases, we try to decide which
resource to use by repeating our search but limiting it to only
resources with the same code_id as the catalog we're currently
compiling.

When the code_id search doesn't find _any_ matching resources, we were
previously returning `nil` and the Catalog#resource method was raising
an error indicating the capability couldn't be found and may not have
been produced yet. This is misleading, since the problem is actually
that there are _too many_ copies of the resources, not that it's
missing. We now instead raise an error indicating that we found a
conflict in our initial search.
