### PR TITLE
(PUP-6549) add libnghttpd2 for fedora23 acceptance

### DIFF
--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -35,6 +35,13 @@ agents.each do |agent|
     package { '#{package_name[platform]}':
       ensure => present,
     }
+    if ($::operatingsystem == 'Fedora') and ($::operatingsystemmajrelease == '23') {
+      package{'libnghttp2':
+        ensure => latest,
+        install_options => '--best',
+        before => Package['httpd'],
+      }
+    }
   }
   manifest_service_masked = %Q{
     service { '#{package_name[platform]}':


### PR DESCRIPTION
Upstream httpd package requires an updated libnghttp2 package but is not
defined as such.
https://bodhi.fedoraproject.org/updates/httpd-2.4.23-4.fc23
https://bugzilla.redhat.com/show_bug.cgi?id=1358875