### PR TITLE
(PUP-5938) Fix localized_domain test mocks

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -115,8 +115,9 @@ module Puppet::Util::Windows::ADSI
         # localized version of NT AUTHORITY (can't use S-1-5)
         # for instance AUTORITE NT on French Windows
         Puppet::Util::Windows::SID.name_to_sid_object('SYSTEM').domain.upcase
-    ]
-  end
+      ]
+    end
+
     def uri(name, host = '.')
       host = '.' if (localized_domains << Socket.gethostname.upcase).include?(host.upcase)
 

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -17,6 +17,8 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
   before :each do
     Puppet::Util::Windows::ADSI.stubs(:computer_name).returns('testcomputername')
     Puppet::Util::Windows::ADSI.stubs(:connect).returns connection
+    # this would normally query the system, but not needed for these tests
+    Puppet::Util::Windows::ADSI::Group.stubs(:localized_domains).returns([])
   end
 
   describe ".instances" do

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -18,6 +18,8 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
   before :each do
     Puppet::Util::Windows::ADSI.stubs(:computer_name).returns('testcomputername')
     Puppet::Util::Windows::ADSI.stubs(:connect).returns connection
+    # this would normally query the system, but not needed for these tests
+    Puppet::Util::Windows::ADSI::User.stubs(:localized_domains).returns([])
   end
 
   describe ".instances" do


### PR DESCRIPTION
 - A new method localized_domains was introduced in 05d1ca2 to
   Puppet::Util::Windows::ADSI::Shared to handle properly generating
   URIs when the names BUILTIN and NT AUTHORITY are localized on
   non-English versions of Windows.

   At that time, the calls should have been mocked in:

   * provider/group/windows_adsi_spec.rb
   * provider/user/windows_adsi_spec.rb

   The calls actually touch the system, and depending on test
   ordering and how calls to name_to_sid_object are mocked, the code
   execution path could produce failures.

   Fix this oversight by simply mocking the return values for
   localized_domains as they are not needed for these tests.

Paired-with: Daniel Lu <daniel.lu@puppet.com>