### PR TITLE
(PUP-6578) Use resource Type[title] for accessing system_values

### DIFF
--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -109,7 +109,10 @@ class Puppet::Transaction::Event
        !old_system_value.nil?
 
       # If the values aren't insync, we have confirmed a corrective_change
-      @corrective_change = !@property_instance.insync_values?(old_system_value, previous_value)
+      insync = @property_instance.insync_values?(old_system_value, previous_value)
+
+      # Preserve the nil state, but flip true/false
+      @corrective_change = insync.nil? ? nil : !insync
     else
       @corrective_change = false
     end

--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -107,10 +107,10 @@ class Puppet::Transaction::ResourceHarness
     end
 
     context.system_value_params.each do |pname, param|
-      @persistence.set_system_value(resource.name, pname.to_s,
+      @persistence.set_system_value(resource.ref, pname.to_s,
                                     new_system_value(param,
                                                      param_to_event[pname.to_s],
-                                                     @persistence.get_system_value(resource.name, pname.to_s)))
+                                                     @persistence.get_system_value(resource.ref, pname.to_s)))
     end
   end
 
@@ -158,7 +158,7 @@ class Puppet::Transaction::ResourceHarness
       raise
     ensure
       if event
-        event.calculate_corrective_change(@persistence.get_system_value(context.resource.name, param.name.to_s))
+        event.calculate_corrective_change(@persistence.get_system_value(context.resource.ref, param.name.to_s))
         context.record(event)
         event.send_log
         context.synced_params << param.name


### PR DESCRIPTION
We were previously just using the resource title instead of full
Type[title] syntax for looking up resources in the transactionstore.

This patch simply switches us to use the #to_s method instead of

Signed-off-by: Ken Barber <ken@bob.sh>