### PR TITLE
(WIP)(PUP-6448) Indirector URIs should remain UTF-8

### DIFF
--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -243,6 +243,8 @@ class Puppet::Indirector::Request
   def set_uri_key(key)
     @uri = key
     begin
+      # calling URI.escape for UTF-8 characters will % escape them
+      # and the resulting string components of the URI are now ASCII
       uri = URI.parse(URI.escape(key))
     rescue => detail
       raise ArgumentError, "Could not understand URL #{key}: #{detail}", detail.backtrace
@@ -272,6 +274,8 @@ class Puppet::Indirector::Request
       @protocol = uri.scheme
     end
 
-    @key = URI.unescape(uri.path.sub(/^\//, ''))
+    # The unescaped bytes are correct but in ASCII and must be treated
+    # as UTF-8 for the sake of performing string comparisons later
+    @key = URI.unescape(uri.path.sub(/^\//, '')).force_encoding(Encoding::UTF_8)
   end
 end

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -140,6 +140,15 @@ describe Puppet::Indirector::Request do
         expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/stuff with spaces", nil).key).to eq("stuff with spaces")
       end
 
+      it "should set the request key to the unescaped path from the URI, in UTF-8 encoding" do
+        path = "\u4e07"
+        uri = "http://host/#{path}"
+        request = Puppet::Indirector::Request.new(:ind, :method, uri, nil)
+
+        expect(request.key).to eq(path)
+        expect(request.key.encoding).to eq(Encoding::UTF_8)
+      end
+
       it "should set the :uri attribute to the full URI" do
         expect(Puppet::Indirector::Request.new(:ind, :method, "http:///a/path/stu ff", nil).uri).to eq('http:///a/path/stu ff')
       end


### PR DESCRIPTION
- By not preserving the original Path encoding of UTF-8 used for
  incoming requests to the indirector, future string comparisons (using
  Regex for instance) are invalid and will cause exceptions.
  
  This problem is trivially reproducible with a manifest like:
  
  file { "/tmp/test":
    ensure => file,
    source => 'puppet://modules/utf_8/静的',
  }
  
  The key of the request previously was "utf_8/\xE9\x9D\x99\xE7\x9A\x84"
  instead of the appropriate "utf_8/静的"
