### PR TITLE
(PUP-6182) Improve validation of component mappings in applications

### DIFF
--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -13,40 +13,59 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
 
     catalog = Puppet::Parser::EnvironmentCompiler.compile(env, code_id).to_resource
 
-    # This reads code_id off the catalog rather than using the one from the
-    # request. There shouldn't really be a case where the two differ, but if
-    # they do, the one from the catalog itself is authoritative.
-    env_graph = {:environment => env.name, :applications => {}, :code_id => catalog.code_id}
+    env_graph = build_environment_graph(catalog)
+
+    response.respond_with(200, "application/json", JSON.dump(env_graph))
+  end
+
+  def build_environment_graph(catalog)
+    # This reads catalog and code_id off the catalog rather than using the one
+    # from the request. There shouldn't really be a case where the two differ,
+    # but if they do, the one from the catalog itself is authoritative.
+    env_graph = {:environment => catalog.environment, :applications => {}, :code_id => catalog.code_id}
     applications = catalog.resources.select do |res|
       type = res.resource_type
       type.is_a?(Puppet::Resource::Type) && type.application?
     end
     applications.each do |app|
-      app_components = {}
+      file, line = app.file, app.line
+      nodes = app['nodes']
+
+      required_components = catalog.direct_dependents_of(app).map {|comp| comp.ref}
+      mapped_components = nodes.values.flatten.map {|comp| comp.ref}
+
+      nonexistent_components = mapped_components - required_components
+      if nonexistent_components.any?
+        raise Puppet::ParseError.new("Application #{app} assigns nodes to non-existent components: #{nonexistent_components.join(', ')}", file, line)
+      end
+
+      missing_components = required_components - mapped_components
+      if missing_components.any?
+        raise Puppet::ParseError.new("Application #{app} has components without assigned nodes: #{missing_components.join(', ')}", file, line)
+      end
+
       # Turn the 'nodes' hash into a map component ref => node name
       node_mapping = {}
-      app['nodes'].each do |node, comps|
+      nodes.each do |node, comps|
         comps = [comps] unless comps.is_a?(Array)
         comps.each do |comp|
-          raise Puppet::ParseError, "Application #{app} maps component #{comp} to multiple nodes" if node_mapping.include?(comp.ref)
+          raise Puppet::ParseError.new("Application #{app} assigns multiple nodes to component #{comp}", file, line) if node_mapping.include?(comp.ref)
           node_mapping[comp.ref] = node.title
         end
       end
 
+      app_components = {}
       catalog.direct_dependents_of(app).each do |comp|
-        mapped_node = node_mapping[comp.ref]
-        if mapped_node.nil?
-          raise Puppet::ParseError, "Component #{comp} is not mapped to any node"
-        end
         app_components[comp.ref] = {
           :produces => comp.export.map(&:ref),
           :consumes => prerequisites(comp).map(&:ref),
-          :node => mapped_node
+          :node => node_mapping[comp.ref]
         }
       end
       env_graph[:applications][app.ref] = app_components
     end
-    response.respond_with(200, "application/json", JSON.dump(env_graph))
+
+    env_graph
   end
 
   private

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -549,7 +549,7 @@ class Puppet::Resource::Type
 
     if application?
       resource_type = type_factory.type_type(type_factory.resource)
-      members[type_factory.optional(type_factory.string(NODES))] = type_factory.hash_of(type_factory.variant(
+      members[type_factory.string(NODES)] = type_factory.hash_of(type_factory.variant(
           resource_type, type_factory.array_of(resource_type)), type_factory.type_type(type_factory.resource('node')))
     end
 


### PR DESCRIPTION
This pull request includes two improvements to how application node/component
mapping specifications are validated:
- Require `nodes` param for application declarations

Previously, the `nodes` parameter of applications was marked as optional in the
type system, but would cause a failure when processing the catalog and
attempting to iterate the nodes hash. Since this was always implicitly required
and there's no good reason for it not to always be specified, we now explicitly
require it so as to cause a clear, early failure.
- Fail when non-existent components have nodes assigned

Previously, non-existent components in the node mapping of an application would
simply be ignored. Because this frequently happens when the user incorrectly
types the component name, it can be especially confusing as the only complaint
will be that no node was mapped to the _correct_ component. We now explicitly
fail if there are non-existent components, and we do so before checking whether
there are unmapped components.
