### PR TITLE
(PUP-6582) Remove binding of loaders to AST model elements

### DIFF
--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -13,14 +13,11 @@ class BaseLoader < Loader
   # The parent loader
   attr_reader :parent
 
-  # An internal name used for debugging and error message purposes
-  attr_reader :loader_name
-
   def initialize(parent_loader, loader_name)
+    super(loader_name)
     @parent = parent_loader # the higher priority loader to consult
     @named_values = {}      # hash name => NamedEntry
     @last_result = nil      # the value of the last name (optimization)
-    @loader_name = loader_name # the name of the loader (not the name-space it is a loader for)
   end
 
   # @api public

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -29,7 +29,7 @@ class Loader
 
   # @param [String] name the name of the loader. Must be unique among all loaders maintained by a {Loader} instance
   def initialize(loader_name)
-    @loader_name = loader_name
+    @loader_name = loader_name.freeze
   end
 
   # Produces the value associated with the given name if already loaded, or available for loading

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -22,9 +22,15 @@
 module Puppet::Pops
 module Loader
 class Loader
+  attr_reader :loader_name
 
   # Describes the kinds of things that loaders can load
   LOADABLE_KINDS = [:func_4x, :func_4xpp, :type_pp, :resource_type_pp].freeze
+
+  # @param [String] name the name of the loader. Must be unique among all loaders maintained by a {Loader} instance
+  def initialize(loader_name)
+    @loader_name = loader_name
+  end
 
   # Produces the value associated with the given name if already loaded, or available for loading
   # by this loader, one of its parents, or other loaders visible to this loader.

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -169,6 +169,10 @@ module Puppet::Pops::Loader::LoaderPaths
       RESOURCE_TYPES_PATH_PP
     end
 
+    def root_path
+      @loader.path
+    end
+
     def instantiator()
       Puppet::Pops::Loader::PuppetResourceTypeImplInstantiator
     end

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -46,6 +46,15 @@ module ModuleLoaders
                                                        )
   end
 
+  def self.pcore_resource_type_loader_from(parent_loader, loaders, environment_path)
+    ModuleLoaders::FileBased.new(parent_loader,
+      loaders,
+      nil,
+      environment_path,
+      'pcore_resource_types'
+    )
+  end
+
   class AbstractPathBasedModuleLoader < BaseLoader
 
     # The name of the module, or nil, if this is a global "component"

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -75,6 +75,7 @@ module ModuleLoaders
 
     # Initialize a kind of ModuleLoader for one module
     # @param parent_loader [Loader] loader with higher priority
+    # @param loaders [Loaders] the container for this loader
     # @param module_name [String] the name of the module (non qualified name), may be nil for a global "component"
     # @param path [String] the path to the root of the module (semantics defined by subclass)
     # @param loader_name [String] a name that is used for human identification (useful when module_name is nil)
@@ -90,6 +91,7 @@ module ModuleLoaders
       unless (loadables - LOADABLE_KINDS).empty?
         raise ArgumentError, 'given loadables are not of supported loadable kind'
       end
+      loaders.add_loader_by_name(self)
     end
 
     def loadables

--- a/lib/puppet/pops/loader/null_loader.rb
+++ b/lib/puppet/pops/loader/null_loader.rb
@@ -6,7 +6,7 @@ class Puppet::Pops::Loader::NullLoader < Puppet::Pops::Loader::Loader
   # Construct a NullLoader, optionally with a parent loader
   #
   def initialize(parent_loader=nil, loader_name = "null-loader")
-    @loader_name = loader_name
+    super(loader_name)
     @parent = parent_loader
   end
 

--- a/lib/puppet/pops/loader/puppet_function_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_function_instantiator.rb
@@ -46,7 +46,7 @@ class PuppetFunctionInstantiator
     # loader to use when making calls to the new function API. Such logic have a hard time finding the closure (where
     # the loader is known - hence this mechanism
     private_loader = loader.private_loader
-    Adapters::LoaderAdapter.adapt(the_function_definition).loader = private_loader
+    Adapters::LoaderAdapter.adapt(the_function_definition).loader_name = private_loader.loader_name
 
     # TODO: Cheating wrt. scope - assuming it is found in the context
     closure_scope = Puppet.lookup(:global_scope) { {} }

--- a/lib/puppet/pops/loader/puppet_resource_type_impl_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_resource_type_impl_instantiator.rb
@@ -71,8 +71,7 @@ class PuppetResourceTypeImplInstantiator
     # Adapt the resource type definition with loader - this is used from logic contained in it body to find the
     # loader to use when making calls to the new function API. Such logic have a hard time finding the closure (where
     # the loader is known - hence this mechanism
-    private_loader = loader.private_loader
-    Adapters::LoaderAdapter.adapt(resource_type_impl).loader = private_loader
+    Adapters::LoaderAdapter.adapt(resource_type_impl).loader_name = loader.loader_name
     resource_type_impl
   end
 

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -7,10 +7,10 @@ module Loader
 #
 # @api private
 class Runtime3TypeLoader < BaseLoader
-  def initialize(parent_loader, environment, env_path)
+  def initialize(parent_loader, loaders, environment, env_path)
     super(parent_loader, environment.name)
     @environment = environment
-    @resource_3x_loader = env_path.nil? ? nil : ModuleLoaders.module_loader_from(parent_loader, self, 'environment', env_path)
+    @resource_3x_loader = env_path.nil? ? nil : ModuleLoaders.pcore_resource_type_loader_from(parent_loader, loaders, env_path)
   end
 
   def to_s()

--- a/lib/puppet/pops/loader/type_definition_instantiator.rb
+++ b/lib/puppet/pops/loader/type_definition_instantiator.rb
@@ -41,7 +41,7 @@ class TypeDefinitionInstantiator
     # loader to use when resolving contained aliases API. Such logic have a hard time finding the closure (where
     # the loader is known - hence this mechanism
     private_loader = loader.private_loader
-    Adapters::LoaderAdapter.adapt(type_definition).loader = private_loader
+    Adapters::LoaderAdapter.adapt(type_definition).loader_name = private_loader.loader_name
     create_runtime_type(type_definition)
   end
 

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -1,4 +1,13 @@
 module Puppet::Pops
+# This is the container for all Loader instances. Each Loader instance has a `loader_name` by which it can be uniquely
+# identified within this container.
+# A Loader can be private or public. In general, code will have access to the private loader associated with the
+# location of the code. It will be parented by a loader that in turn have access to other public loaders that
+# can load only such entries that have been publicly available. The split between public and private is not
+# yet enforced in Puppet.
+#
+# The name of a private loader should always end with ' private'
+#
 class Loaders
   class LoaderError < Puppet::Error; end
 
@@ -106,6 +115,11 @@ class Loaders
     loaders
   end
 
+  # Lookup a loader by its unique name.
+  #
+  # @param [String] loader_name the name of the loader to lookup
+  # @return [Loader] the found loader
+  # @raise [Puppet::ParserError] if no loader is found
   def [](loader_name)
     loader = @loaders_by_name[loader_name]
     if loader.nil?

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -189,7 +189,7 @@ class Loaders
     env_path = env_conf.nil? || !env_conf.is_a?(Puppet::Settings::EnvironmentConf) ? nil : env_conf.path_to_env
 
     # Create the 3.x resource type loader
-    @runtime3_type_loader = Loader::Runtime3TypeLoader.new(puppet_system_loader, environment, env_conf.nil? ? nil : env_path)
+    @runtime3_type_loader = Loader::Runtime3TypeLoader.new(puppet_system_loader, self, environment, env_conf.nil? ? nil : env_path)
 
     if env_path.nil?
       # Not a real directory environment, cannot work as a module TODO: Drop when legacy env are dropped?

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -467,7 +467,7 @@ describe 'the 4x function api' do
         # evaluate a puppet call
         source = "testing::test(10) |$x| { $x+1 }"
         program = parser.parse_string(source, __FILE__)
-        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).returns(the_loader)
         expect(parser.evaluate(scope, program)).to eql(11)
       end
     end
@@ -491,7 +491,7 @@ describe 'the 4x function api' do
         CODE
         the_loader.add_function('testing::test', fc.new({}, the_loader))
         program = parser.parse_string('testing::test(10)', __FILE__)
-        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).returns(the_loader)
         expect(parser.evaluate({}, program)).to eql(10)
       end
 
@@ -510,7 +510,7 @@ describe 'the 4x function api' do
         CODE
         the_loader.add_function('testing::test', fc.new({}, the_loader))
         program = parser.parse_string('testing::test(10)', __FILE__)
-        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).returns(the_loader)
         expect { parser.evaluate({}, program) }.to raise_error(Puppet::Error, /parameter 'x' references an unresolved type 'MyAlias'/)
       end
 
@@ -532,7 +532,7 @@ describe 'the 4x function api' do
         CODE
         the_loader.add_function('testing::test', fc.new({}, the_loader))
         program = parser.parse_string('testing::test([10,20])', __FILE__)
-        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).returns(the_loader)
         expect(parser.evaluate({}, program)).to eq([10,20])
       end
 
@@ -555,7 +555,7 @@ describe 'the 4x function api' do
         CODE
         the_loader.add_function('testing::test', fc.new({}, the_loader))
         program = parser.parse_string("testing::test({'x' => [10,20]})", __FILE__)
-        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).returns(the_loader)
         expect(parser.evaluate({}, program)).to eq({'x' => [10,20]})
       end
 
@@ -577,7 +577,7 @@ describe 'the 4x function api' do
         CODE
         the_loader.add_function('testing::test', fc.new({}, the_loader))
         program = parser.parse_string("testing::test({'x' => {'y' => 'n'}})", __FILE__)
-        Puppet::Pops::Adapters::LoaderAdapter.adapt(program.model).loader = the_loader
+        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).returns(the_loader)
         expect(parser.evaluate({}, program)).to eq({'x' => {'y' => 'n'}})
       end
     end

--- a/spec/unit/pops/loaders/loader_paths_spec.rb
+++ b/spec/unit/pops/loaders/loader_paths_spec.rb
@@ -7,7 +7,7 @@ describe 'loader paths' do
   include PuppetSpec::Files
 
   let(:static_loader) { Puppet::Pops::Loader::StaticLoader.new() }
-  let(:unused_loaders) { nil }
+  let(:unused_loaders) { Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:'*test*', [])) }
 
   it 'module loader has smart-paths that prunes unavailable paths' do
     module_dir = dir_containing('testmodule', {'lib' => {'puppet' => {'functions' =>

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -87,7 +87,7 @@ describe 'loaders' do
     expect(loaders.public_environment_loader()).to be_a(Puppet::Pops::Loader::SimpleEnvironmentLoader)
     expect(loaders.public_environment_loader().to_s).to eql("(SimpleEnvironmentLoader 'environment:*test*')")
     expect(loaders.private_environment_loader()).to be_a(Puppet::Pops::Loader::DependencyLoader)
-    expect(loaders.private_environment_loader().to_s).to eql("(DependencyLoader 'environment' [])")
+    expect(loaders.private_environment_loader().to_s).to eql("(DependencyLoader 'environment private' [])")
   end
 
   context 'when loading from a module' do

--- a/spec/unit/pops/loaders/module_loaders_spec.rb
+++ b/spec/unit/pops/loaders/module_loaders_spec.rb
@@ -58,7 +58,7 @@ describe 'FileBased module loader' do
   end
 
   it 'system loader has itself as private loader' do
-    module_loader = Puppet::Pops::Loader::ModuleLoaders.system_loader_from(static_loader, loaders)
+    module_loader = loaders.puppet_system_loader
     expect(module_loader.private_loader).to be(module_loader)
   end
 


### PR DESCRIPTION
Before this commit, 4x loaders were bound to AST model elements. That
was less than ideal since an AST model element has the same life cycle
as the environment. A new compile on the same environment would hence
find the loader created and attached to the adapter during the first
compile.

This commit retains the adapter but instead of attaching the actual
loader instance, it attaches the name of the loader. The loader is
then retrieved using `scope.compiler.loaders[loader_name]`