### PR TITLE
(PUP-6087) Error when a capability mapping is redefined.

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -169,8 +169,6 @@ class Puppet::Parser::Compiler
 
       activate_binder
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated capability mappings", [:compiler, :evaluate_capability_mappings]) { evaluate_capability_mappings }
-
       Puppet::Util::Profiler.profile("Compile: Evaluated main", [:compiler, :evaluate_main]) { evaluate_main }
 
       Puppet::Util::Profiler.profile("Compile: Evaluated site", [:compiler, :evaluate_site]) { evaluate_site }
@@ -357,7 +355,7 @@ class Puppet::Parser::Compiler
     end
   end
 
-  # Evaluates each specified class in turn. If there are any classes that 
+  # Evaluates each specified class in turn. If there are any classes that
   # can't be found, an error is raised. This method really just creates resource objects
   # that point back to the classes, and then the resources are themselves
   # evaluated later in the process.
@@ -530,7 +528,6 @@ class Puppet::Parser::Compiler
         component.add_consumes(blueprint)
       end
     end
-    krt.capability_mappings.clear # No longer needed
   end
 
   # If ast nodes are enabled, then see if we can find and evaluate one.

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -215,11 +215,17 @@ class Puppet::Resource::Type
 
   def add_produces(blueprint)
     @produces ||= []
+    if @produces.any? {|bp| bp[:capability] == blueprint[:capability]}
+      raise Puppet::ParseError, "Capability mapping error: produces clause redefines mapping for #{blueprint[:capability]} #{@name}"
+    end
     @produces << blueprint
   end
 
   def add_consumes(blueprint)
     @consumes ||= []
+    if @consumes.any? {|bp| bp[:capability] == blueprint[:capability]}
+      raise Puppet::ParseError, "Capability mapping error: consumes clause redefines mapping for #{blueprint[:capability]} #{@name}"
+    end
     @consumes << blueprint
   end
 

--- a/spec/unit/capability_spec.rb
+++ b/spec/unit/capability_spec.rb
@@ -186,6 +186,27 @@ describe 'Capability types' do
         }.to raise_error(Puppet::Error,
                          /#{kw} clause references nonexistent type Test/)
       end
+
+      it "it does not allow #{kw} mappings to be redefined" do
+        manifest = <<-MANIFEST
+        define test() {
+          notify { "hello":}
+        }
+
+        Test #{kw} Cap {
+          host => $hostname
+        }
+        Test #{kw} Cap {
+          host => 'foo'
+        }
+      MANIFEST
+
+
+        expect {
+          compile_to_catalog(manifest, node)
+        }.to raise_error(Puppet::Error,
+                         /#{kw} /)
+      end
     end
   end
 


### PR DESCRIPTION
Before this commit redefining a capability mapping added both mappings to
the capability list. When producing and consuming resources only the
first mapping would be used. Now trying to add the second mapping
results in a ParseError.

In addition we previously evaluated mappings twice. Once before
evaluating main and a second time after evaluating applications. The
capability mappings were not properly cleared after the first
evaluation. As a consequence capability mappings were added twice. It
seems better if we only only evaluate them once so that they are
available for producing resources at a consistent place in compilation.