### PR TITLE
(PUP-6588) Fixed --module-repository to use full remote URL

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -45,7 +45,7 @@ class Puppet::Forge
     # Return a Net::HTTPResponse read for this +path+.
     def make_http_request(path, io = nil)
       Puppet.debug "HTTP GET #{@host}#{path}"
-      request = get_request_object(path)
+      request = get_request_object(@uri.path.chomp('/')+path)
       return read_response(request, io)
     end
 


### PR DESCRIPTION
Instead of just host and port now user can use full path (including context path) for remote repository.
