### PR TITLE
(PUP-6594) Fix incorrectly reported output path from puppet generate

### DIFF
--- a/lib/puppet/generate/type.rb
+++ b/lib/puppet/generate/type.rb
@@ -219,8 +219,8 @@ module Puppet
 
           # Write the output file
           begin
-            Puppet.notice "Generating '#{input.output_path}' using '#{input.format}' format."
             effective_output_path = input.effective_output_path(outputdir)
+            Puppet.notice "Generating '#{effective_output_path}' using '#{input.format}' format."
             FileUtils.mkdir_p(File.dirname(effective_output_path))
             File.open(effective_output_path, 'w') do |file|
               file.write(result)


### PR DESCRIPTION
This commit ensures that the output paths that are reported during
execution of `puppet generate types` correctly reflects the paths of
the generated files.