### PR TITLE
(PUP-6619) add tests for installdir and version

### DIFF
--- a/acceptance/tests/ensure_version_file.rb
+++ b/acceptance/tests/ensure_version_file.rb
@@ -1,0 +1,30 @@
+require 'puppet/acceptance/temp_file_utils'
+extend Puppet::Acceptance::TempFileUtils
+
+# ensure a version file is created according to the puppet-agent path specification:
+# https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
+
+test_name 'PA-466: Ensure version file is created on agent' do
+
+  skip_test 'requires version file which is created by AIO' if [:gem, :git].include?(@options[:type])
+
+  step "test for existence of version file" do
+    agents.each do |agent|
+      platform = agent[:platform]
+      ruby_arch = agent[:ruby_arch] || 'x86' # ruby_arch defaults to x86 if nil
+
+      if platform =~ /windows/
+        version_file = platform =~ /-64$/ && ruby_arch == 'x86' ?
+          "C:/Program Files (x86)/Puppet Labs/Puppet/VERSION" :
+          "C:/Program Files/Puppet Labs/Puppet/VERSION"
+      else
+        version_file = "/opt/puppetlabs/puppet/VERSION"
+      end
+
+      if !file_exists?(agent, version_file)
+        fail_test("Failed to find version file #{version_file} on agent #{agent}")
+      end
+    end
+  end
+end
+

--- a/acceptance/tests/windows/env_windows_installdir_fact.rb
+++ b/acceptance/tests/windows/env_windows_installdir_fact.rb
@@ -1,0 +1,22 @@
+# (PA-466) The env_windows_installdir fact is set as an environment variable
+# fact via environment.bat on Windows systems. Test to ensure it is both
+# present and accurate.
+test_name 'PA-466: Ensure env_windows_installdir fact is present and correct' do
+
+  confine :to, :platform => 'windows'
+
+  agents.each do |agent|
+    step "test for presence/accurance of fact on #{agent}" do
+      platform = agent[:platform]
+      ruby_arch = agent[:ruby_arch] || 'x86' # ruby_arch defaults to x86 if nil
+
+      install_dir = platform =~ /-64$/ && ruby_arch == 'x86' ?
+        "C:\\\\Program Files (x86)\\\\Puppet Labs\\\\Puppet" :
+        "C:\\\\Program Files\\\\Puppet Labs\\\\Puppet"
+
+      on agent, puppet('facts') do
+        assert_match(/"env_windows_installdir": "#{install_dir}"/, stdout, "env_windows_installdir fact did not match expected output")
+      end
+    end
+  end
+end


### PR DESCRIPTION
(PA-466) This PR adds a new test to ensure the presence of the version file as laid down by the AIO in accordance with the puppet agent path specification after a recent set of changes to packaging of the AIO impacted the VERSION file creation and a regression was discovered in associated logic. This is added as a new test (as opposed to an additional step in 'ensure_puppet-agent_paths') to take advantage of the benefits of `skip_test` since this test only applies to
packaged artifacts and not git/gem which don't create a VERSION file. 

This PR also adds a test to ensure the fact env_windows_installdir is present and set to the correct directory. This fact is set via the environment.bat file on Windows installations and recently was impacted by a regression in that file, so a test is warranted. This test is added as its own file as opposed to the 4654_facts_face.rb file because that test seemed in spirit to be testing the functionatlity of `puppet facts` rather than any specific fact, while this test is for an explicit fact. This test is confined to Windows and test runs running from AIO packages (PE/FOSS) as those
environments are expected to have sourced a functional environment.bat.