### PR TITLE
(PUP-6402) fix openbsd package provider

### DIFF
--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -152,7 +152,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
       full_name = get_full_name(latest)
     else
       e_vars = {}
-      full_name = @resource[:source]
+      full_name = get_full_name(latest)
     end
 
     cmd << install_options


### PR DESCRIPTION
OK, this is apparently not the "end-all" of this issue. 

Currently openbsd package provider differentiates between "directory-unlike sources" and stuff ending with "/" (checks on line 150 and 68).   This makes it possible to pass in a path to a package file as a source parameter.

The trouble is that it's perfectly legal to use bare hostnames as installpath value in pkg.conf, see http://man.openbsd.org/pkg.conf.

For example: installpath = ftp.aso.ee

In that case the package "source" parameter (that does not end with "/") is inserted into the pkg_add command line is the bare hostname (ftp.aso.ee in my case) and that doesn't succeed in installing the package.