### PR TITLE
(PUP-6397) mount remove autorequire and fix autobefore

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -14,8 +14,7 @@ module Puppet
 
       **Autorequires:** If Puppet is managing any parents of a mount resource ---
       that is, other mount points higher up in the filesystem --- the child
-      mount will autorequire them. If Puppet is managing the file path of a
-      mount point, the mount resource will autorequire it.
+      mount will autorequire them.
 
       **Autobefores:**  If Puppet is managing any child file paths of a mount
       point, the mount resource will autobefore them."
@@ -296,9 +295,6 @@ module Puppet
       end
       dependencies[0..-2]
     end
-
-    # Autorequire the mount point's file resource
-    autorequire(:file) { Pathname.new(self[:name]) }
 
     # Autobefore the mount point's child file paths
     autobefore(:file) do

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -300,7 +300,7 @@ module Puppet
     autobefore(:file) do
       dependencies = []
       file_resources = catalog.resources.select { |resource| resource.type == :file }
-      children_file_resources = file_resources.select { |resource| File.expand_path(resource[:path]) =~ %r(#{self[:name]}/.) }
+      children_file_resources = file_resources.select { |resource| File.expand_path(resource[:path]) =~ %r(^#{self[:name]}/.) }
       children_file_resources.each do |child|
         dependencies.push Pathname.new(child[:path])
       end

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -588,32 +588,24 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
 
     it "adds the parent autorequire and the file autorequire for a mount with one parent" do
       parent_relationship = var_mount.autorequire[0]
-      file_relationship = var_mount.autorequire[1]
 
-      expect(var_mount.autorequire).to have_exactly(2).items
+      expect(var_mount.autorequire).to have_exactly(1).item
 
       expect(parent_relationship.source).to eq root_mount
       expect(parent_relationship.target).to eq var_mount
-
-      expect(file_relationship.source).to eq var_file
-      expect(file_relationship.target).to eq var_mount
     end
 
     it "adds both parent autorequires and the file autorequire for a mount with two parents" do
       grandparent_relationship = log_mount.autorequire[0]
       parent_relationship = log_mount.autorequire[1]
-      file_relationship = log_mount.autorequire[2]
 
-      expect(log_mount.autorequire).to have_exactly(3).items
+      expect(log_mount.autorequire).to have_exactly(2).items
 
       expect(grandparent_relationship.source).to eq root_mount
       expect(grandparent_relationship.target).to eq log_mount
 
       expect(parent_relationship.source).to eq var_mount
       expect(parent_relationship.target).to eq log_mount
-
-      expect(file_relationship.source).to eq log_file
-      expect(file_relationship.target).to eq log_mount
     end
 
     it "adds the child autobefore for a mount with one file child" do

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -577,9 +577,10 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
     let(:var_file) { create_file_resource('/var') }
     let(:log_file) { create_file_resource('/var/log') }
     let(:puppet_file) { create_file_resource('/var/log/puppet') }
+    let(:opt_file) { create_file_resource('/opt/var/puppet') }
 
     before do
-      create_catalog(root_mount, var_mount, log_mount, var_file, log_file, puppet_file)
+      create_catalog(root_mount, var_mount, log_mount, var_file, log_file, puppet_file, opt_file)
     end
 
     it "adds no autorequires for the root mount" do
@@ -617,7 +618,7 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
       expect(child_relationship.target).to eq puppet_file
     end
 
-    it "adds both child autobefores for a mount with two file childs" do
+    it "adds both child autobefores for a mount with two file children" do
       child_relationship = var_mount.autobefore[0]
       grandchild_relationship = var_mount.autobefore[1]
 


### PR DESCRIPTION
Removes the mount autorequire on mountpoint file resources to avoid circular dependencies. Future new feature will resolve the File[mountpoint] --> Mount[dir] --> File[permissions] issue that people currently hack around with an exec.

Tightens the regexp on the mount autobefore on nested file resources to ensure only correct file resources are captured. Adds a test to ensure false autobefores are not being captured.