### PR TITLE
(PUP-6608) Fix problem with inline classes not getting evaluated

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_resource_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_resource_support.rb
@@ -20,9 +20,7 @@ module Runtime3ResourceSupport
       resolved_type = CLASS_STRING
     else
       # resolve a resource type - pcore based, ruby impl, user defined, or application
-      fully_qualified_type = find_resource_type(scope, type_name)
-      type = fully_qualified_type.name if fully_qualified_type
-      resolved_type = fully_qualified_type
+      resolved_type = find_resource_type(scope, type_name)
     end
 
     # TODO: Unknown resource causes creation of Resource to fail with ArgumentError, should give
@@ -60,7 +58,7 @@ module Runtime3ResourceSupport
         scope.compiler.add_resource(scope, resource)
 
         # Classes are evaluated immediately
-        scope.compiler.evaluate_classes([resource_title], scope, false) if fully_qualified_type == CLASS_STRING
+        scope.compiler.evaluate_classes([resource_title], scope, false) if resolved_type == CLASS_STRING
 
         # Turn the resource into a PType (a reference to a resource type)
         # weed out nil's

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -196,6 +196,16 @@ describe Puppet::Parser::Resource do
       expect(edges).to include(['Class[main]', 'Notify[hello]'])
     end
 
+    it 'should evaluate class in the same file without include' do
+      Puppet[:code] = <<-MANIFEST
+        class a($myvar = 'hello') {}
+        class { 'a': myvar => 'goodbye' }
+        notify { $a::myvar: }
+      MANIFEST
+      catalog = Puppet::Parser::Compiler.compile(Puppet::Node.new 'anyone')
+      expect(catalog.resource('Notify[goodbye]')).to be_a(Puppet::Resource)
+    end
+
     it "should allow edges to propagate multiple levels down the scope hierarchy" do
       Puppet[:code] = <<-MANIFEST
         stage { before: before => Stage[main] }


### PR DESCRIPTION
Before this commit, two names `resolved_type` and `fully_qualified_type`
where used to denote the same value in the method #create_resources of
class `Runtime3ResourceSupport`. Depending on code-path, only the former
variable was initialized when the resource type was a class. The
uninitialized variable was then used to test if the resource should be
subjected to class evaluation. This commit ensures that only one name
is used for the variable.