### PR TITLE
(PUP-6613) Fix given undef and filtering in relationships

### DIFF
--- a/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
@@ -30,7 +30,7 @@ class Puppet::Parser::Compiler
         # all other relationships requires the referenced resource to exist when mode is strict
         refs = param.value.is_a?(Array) ? param.value.flatten : [param.value]
         refs.each do |r|
-          next if r.nil?
+          next if r.nil? || r == :undef
           unless catalog.resource(r.to_s)
             msg = "Could not find resource '#{r.to_s}' in parameter '#{param.name.to_s}'"
             if Puppet[:strict] == :error

--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -85,7 +85,7 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
       type_name,
       resource_titles,
       defaults.merge(params).map do |name, value|
-        next if (value == :undef || value.nil?)
+        value = nil if value == :undef
         Puppet::Parser::Resource::Param.new(
           :name   => name,
           :value  => value, # wide open to various data types, must be correct

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -187,7 +187,9 @@ class Puppet::Parser::Resource < Puppet::Resource
       unless value.nil?
         case param.name
         when :before, :subscribe, :notify, :require
-          value = value.flatten if value.is_a?(Array)
+          if value.is_a?(Array)
+            value = value.flatten.reject {|v| v.nil? || v == :undef }
+          end
           result[param.name] = value
         else
           result[param.name] = value

--- a/spec/integration/parser/pcore_resource_spec.rb
+++ b/spec/integration/parser/pcore_resource_spec.rb
@@ -83,7 +83,6 @@ describe 'when pcore described resources types are in use' do
       Puppet[:manifest] = ''
       loader = Puppet::Environments::Directories.new(dir, [])
       Puppet.override(:environments => loader) do
-        #require 'byebug'; debugger
         Puppet.override(:current_environment => loader.get('production')) do
           example.run
         end

--- a/spec/integration/parser/resource_expressions_spec.rb
+++ b/spec/integration/parser/resource_expressions_spec.rb
@@ -164,8 +164,10 @@ describe "Puppet resource expressions" do
              path => '/somewhere',
              * => $y }"  => "File[$t][mode] == '0666' and File[$t][owner] == 'the_x' and File[$t][path] == '/somewhere'")
 
-    produces("notify{title:}; Notify[title] { * => { message => set}}" => "Notify[title][message] == 'set'")
-    produces("Notify { * => { message => set}}; notify{title:}"      => "Notify[title][message] == 'set'")
+    produces("notify{title:}; Notify[title] { * => { message => set}}"  => "Notify[title][message] == 'set'")
+    produces("Notify { * => { message => set}}; notify{title:}"         => "Notify[title][message] == 'set'")
+    produces('define foo($x) { notify { "title": message =>"aaa${x}bbb"} } foo{ test: x => undef }' => "Notify[title][message] == 'aaabbb'")
+    produces('define foo($x="xx") { notify { "title": message =>"aaa${x}bbb"} } foo{ test: x => undef }' => "Notify[title][message] == 'aaaxxbbb'")
 
     fails("notify { title: unknown => value }" => /no parameter named 'unknown'/)
 


### PR DESCRIPTION
`:undef` is the gift that keeps on giving...

The fix we added that filters out nil/undef values in create_resources proved to add too much filtering as it blocked the ability to give a parameter an explicit undef when it did not have a default value expression. OTOH, keeping the undef values meant that validation of relationships failed later. 
This PR fixes both problems and adds tests for use cases that were not earlier covered by tests.