### PR TITLE
(PUP-6586) Check auth success codes for Windows logon

### DIFF
--- a/acceptance/tests/resource/user/should_not_modify_disabled.rb
+++ b/acceptance/tests/resource/user/should_not_modify_disabled.rb
@@ -1,0 +1,37 @@
+test_name 'PUP-6586 Ensure puppet does not continually reset password for disabled user' do
+
+  confine :to, :platform => 'windows'
+
+  name = "pl#{rand(99999).to_i}"
+
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet_resource('user', "#{name}", 'ensure=absent'))
+    end
+  end
+
+  manifest = <<-MANIFEST
+user {'#{name}':
+  ensure    => present,
+  password  => 'P@ssword!',
+}
+MANIFEST
+
+  agents.each do |agent|
+    step "create user #{name} with puppet" do
+      apply_manifest_on(agent, manifest, :catch_failures => true)
+    end
+
+    step "disable user #{name}" do
+      on(agent, "net user #{name} /ACTIVE:NO", :acceptable_exit_codes => 0)
+    end
+
+    step "test that password is not reset by puppet" do
+      # :catch_changes will fail the test if there were changes during
+      # run execution
+      apply_manifest_on(agent, manifest, :catch_changes => true)
+    end
+  end
+end
+
+

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -119,7 +119,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
   def password
     # avoid a LogonUserW style password check when the resource is not yet
     # populated with a password (as is the case with `puppet resource user`)
-    return nil if @resource[:password].nil? || @resource[:password] == ''
+    return nil if @resource[:password].nil?
     user.password_is?( @resource[:password] ) ? @resource[:password] : nil
   end
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -200,10 +200,6 @@ module Puppet
           well as the password.
         * Windows passwords can only be managed in cleartext, as there is no Windows API
           for setting the password hash.
-        * Windows passwords shouldn't be specified as empty (zero-length) strings, even
-          if you've configured Windows to allow blank passwords. If you do specify a
-          blank password, Puppet will report a change on every run because there is no
-          way to verify that an existing password is blank.
 
         [stdlib]: https://github.com/puppetlabs/puppetlabs-stdlib/
 

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -191,8 +191,6 @@ module Puppet::Util::Windows::ADSI
     end
 
     def self.logon(name, password)
-      # this underlying check will throw when password is nil or empty
-      # as the Windows LogonUserW API does not support that
       Puppet::Util::Windows::User.password_is?(name, password)
     end
 
@@ -238,9 +236,6 @@ module Puppet::Util::Windows::ADSI
 
     def password=(password)
       if !password.nil?
-        if password == ''
-          Puppet.warning("Blank (zero length) passwords are not recommended. Blank passwords might be allowed on your system based on policy, but Puppet cannot verify a blank password with the operating system. Because of this a password change event will be executed by Puppet on every run.")
-        end
         native_user.SetPassword(password)
         commit
       end

--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -22,6 +22,14 @@ module Puppet::Util::Windows::User
   # https://msdn.microsoft.com/en-us/library/windows/desktop/ee207397(v=vs.85).aspx
   SECURITY_MAX_SID_SIZE = 68
 
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms681385(v=vs.85).aspx
+  # These error codes indicate successful authentication but failure to
+  # logon for a separate reason
+  ERROR_ACCOUNT_RESTRICTION = 1327
+  ERROR_INVALID_LOGON_HOURS = 1328
+  ERROR_INVALID_WORKSTATION = 1329
+  ERROR_ACCOUNT_DISABLED    = 1331
+
   def check_token_membership
     is_admin = false
     FFI::MemoryPointer.new(:byte, SECURITY_MAX_SID_SIZE) do |sid_pointer|
@@ -63,8 +71,16 @@ module Puppet::Util::Windows::User
 
     begin
       logon_user(name, password) { |token| }
-    rescue Puppet::Util::Windows::Error
-      return false
+    rescue Puppet::Util::Windows::Error => detail
+
+      authenticated_error_codes = Set[
+        ERROR_ACCOUNT_RESTRICTION,
+        ERROR_INVALID_LOGON_HOURS,
+        ERROR_INVALID_WORKSTATION,
+        ERROR_ACCOUNT_DISABLED,
+      ]
+
+      return authenticated_error_codes.include?(detail.code)
     end
   end
   module_function :password_is?

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -106,14 +106,6 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
         expect(Puppet::Util::Windows::User.password_is?(username, bad_password)).to be_falsey
       end
 
-      it "should raise an error given a nil password" do
-        expect { Puppet::Util::Windows::User.password_is?(username, nil) }.to raise_error(Puppet::Util::Windows::Error)
-      end
-
-      it "should raise an error given an empty password" do
-        expect { Puppet::Util::Windows::User.password_is?(username, '') }.to raise_error(Puppet::Util::Windows::Error)
-      end
-
       it "should return false given a nil username and an incorrect password" do
         expect(Puppet::Util::Windows::User.password_is?(nil, bad_password)).to be_falsey
       end

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -117,6 +117,28 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
       it "should return false given a nil username and an incorrect password" do
         expect(Puppet::Util::Windows::User.password_is?(nil, bad_password)).to be_falsey
       end
+
+      context "with a correct password" do
+        it "should return true even if account restrictions are in place " do
+          Puppet::Util::Windows::User.stubs(:logon_user).raises(Puppet::Util::Windows::Error.new('', 1327))
+          expect(Puppet::Util::Windows::User.password_is?(username, 'p@ssword')).to be(true)
+        end
+
+        it "should return true even for an account outside of logon hours" do
+          Puppet::Util::Windows::User.stubs(:logon_user).raises(Puppet::Util::Windows::Error.new('', 1328))
+          expect(Puppet::Util::Windows::User.password_is?(username, 'p@ssword')).to be(true)
+        end
+
+        it "should return true even for an account not allowed to log into this workstation" do
+          Puppet::Util::Windows::User.stubs(:logon_user).raises(Puppet::Util::Windows::Error.new('', 1329))
+          expect(Puppet::Util::Windows::User.password_is?(username, 'p@ssword')).to be(true)
+        end
+
+        it "should return true even for a disabled account" do
+          Puppet::Util::Windows::User.stubs(:logon_user).raises(Puppet::Util::Windows::Error.new('', 1331))
+          expect(Puppet::Util::Windows::User.password_is?(username, 'p@ssword')).to be(true)
+        end
+      end
     end
 
     describe "check_token_membership" do

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -238,14 +238,11 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       expect(provider.password).to be_nil
     end
 
-    it "should generate a warning with an empty password" do
-      connection.expects(:SetPassword).with('')
-      connection.expects(:SetInfo).twice
-      connection.expects(:Get).with('UserFlags')
-      connection.expects(:Put).with('UserFlags', true)
+    it "should test a blank user password" do
+      resource[:password] = ''
+      provider.user.expects(:password_is?).with('').returns true
 
-      provider.password = ''
-      expect(@logs).to have_matching_log(/Puppet cannot verify a blank password with the operating system/)
+      expect(provider.password).to eq('')
     end
 
     it 'should not create a user if a group by the same name exists' do


### PR DESCRIPTION
The password getter in the Windows user provider issues a logon attempt to verify the password and determine if the value needs synchronized. Prior to this commit, any failure to logon would result in a false return from Puppet::Util::Windows::User.password_is? which would trigger a password reset. As (somewhat) documented in
https://msdn.microsoft.com/en-us/library/windows/desktop/ms681385(v=vs.85).aspx, there are several error codes that indicate logon failure for a different reason than incorrect username/password. After some investigation, it was determined that these codes could be used to indicate a successful authentication even if logon failed. This commit modifies the method to explicitly check for these error codes and return 'true' if encountered, to prevent unnecessary password resets.