### PR TITLE
(PUP-6621) Log corrective_change exceptions at info instead of error level

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -387,7 +387,7 @@ class Puppet::Property < Puppet::Parameter
     rescue => detail
       # Certain operations may fail, but we don't want to fail the transaction if we can
       # avoid it
-      Puppet.log_exception(detail, "Unknown failure comparing values #{should} and #{is} using insync? on type: #{self.resource.ref} property: #{self.name}")
+      Puppet.log_exception(detail, "Unknown failure comparing values #{should} and #{is} using insync? on type: #{self.resource.ref} property: #{self.name}", :default, { :level => :info })
 
       # Return nil, ie. unknown
       nil

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -55,7 +55,7 @@ module Logging
       backtrace = []
       build_exception_trace(backtrace, exception, trace)
       Puppet::Util::Log.create({
-          :level => :err,
+          :level => options[:level] || :err,
           :source => log_source,
           :message => exception.basic_message,
           :issue_code => exception.issue_code,


### PR DESCRIPTION
Previously, when a custom type was incompatible with corrective
change, it would log any exception caught at the error level. This
causes Puppet to fail the transaction.

Instead, we should log at a lower level, so that users can look into
making their types compatible without causing catalog applications to
fails in the meantime.