### PR TITLE
(PUP-6623) Define an unwrap function

### DIFF
--- a/lib/puppet/functions/unwrap.rb
+++ b/lib/puppet/functions/unwrap.rb
@@ -1,0 +1,40 @@
+# Unwraps a Sensitive value and returns the wrapped object.
+#
+# ~~~puppet
+# $plaintext = 'hunter2'
+# $pw = Sensitive.new($plaintext)
+# notice("Wrapped object is $pw") #=> Prints "Wrapped object is Sensitive [value redacted]"
+# $unwrapped = $pw.unwrap
+# notice("Unwrapped object is $unwrapped") #=> Prints "Unwrapped object is hunter2"
+# ~~~
+#
+# You can optionally pass a block to unwrap in order to limit the scope where the
+# unwrapped value is visible.
+#
+# ~~~puppet
+# $pw = Sensitive.new('hunter2')
+# notice("Wrapped object is $pw") #=> Prints "Wrapped object is Sensitive [value redacted]"
+# $pw.unwrap |$unwrapped| {
+#   $conf = inline_template("password: ${unwrapped}\n")
+#   Sensitive.new($conf)
+# } #=> Returns a new Sensitive object containing an interpolated config file
+# # $unwrapped is now out of scope
+# ~~~
+#
+# @since 4.0.0
+#
+Puppet::Functions.create_function(:unwrap) do
+  dispatch :unwrap do
+    param 'Sensitive', :arg
+    optional_block_param
+  end
+
+  def unwrap(arg)
+    unwrapped = arg.unwrap
+    if block_given?
+      yield(unwrapped)
+    else
+      unwrapped
+    end
+  end
+end

--- a/spec/unit/functions/unwrap_spec.rb
+++ b/spec/unit/functions/unwrap_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the unwrap function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  it 'unwraps a sensitive value' do
+    code = <<-CODE
+      $sensitive = Sensitive.new("12345")
+      notice("unwrapped value is ${sensitive.unwrap}")
+    CODE
+    expect(eval_and_collect_notices(code)).to eq(['unwrapped value is 12345'])
+  end
+
+  it 'unwraps a sensitive value when given a code block' do
+    code = <<-CODE
+      $sensitive = Sensitive.new("12345")
+      $split = $sensitive.unwrap |$unwrapped| {
+        notice("unwrapped value is $unwrapped")
+        $unwrapped.split(/3/)
+      }
+      notice("split is $split")
+    CODE
+    expect(eval_and_collect_notices(code)).to eq(['unwrapped value is 12345', 'split is [12, 45]'])
+  end
+end


### PR DESCRIPTION
This commit adds an unwrap function for sensitive objects; this serves
to expose the plaintext value in case the wrapped value needs to be
operated on/interpolated/etc. While this does remove the safety measure
that the Sensitive object provides it also allows more general use of
the data type.