### PR TITLE
(PUP-6622) Fix two 4.6 performance regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ acceptance/log
 acceptance/.bundle
 # emacs backup files
 *~
+/*.samples

--- a/function_loading.samples
+++ b/function_loading.samples
@@ -1,0 +1,11 @@
+timestamp,elapsed,responsecode,success,name
+1471457716000,7100,200,true,function_loading
+1471457723000,6603,200,true,function_loading
+1471457730000,6420,200,true,function_loading
+1471457736000,6727,200,true,function_loading
+1471457743000,6624,200,true,function_loading
+1471457750000,6834,200,true,function_loading
+1471457757000,6787,200,true,function_loading
+1471457763000,6812,200,true,function_loading
+1471457770000,6431,200,true,function_loading
+1471457777000,7370,200,true,function_loading

--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -126,24 +126,24 @@ module Adapters
 
     # Finds the loader to use when loading originates from the source position of the given argument.
     #
-    # @param instance [Model::PopsObject] The model object
-    # @param scope [Puppet::Parser::Scope] The scope to use
+    # @param [Model::PopsObject] instance The model object
+    # @param [Puppet::Parser::Scope] scope The scope to use
+    # @param [String] file the file from where the model was parsed
     # @return [Loader,nil] the found loader or `nil` if it could not be found
     #
-    def self.loader_for_model_object(model, scope)
+    def self.loader_for_model_object(model, scope, file = nil)
       if scope.nil?
         loaders = Puppet.lookup(:loaders) { nil }
         loaders.nil? ? nil : loaders.private_environment_loader
       else
-        # find the loader that loaded the code, or use the private_environment_loader (sees env + all modules)
-        adapter = Utils.find_adapter(model, self)
-        if adapter.nil?
-          # Use source location to determine calling module, or use the private_environment_loader (sees env + all modules)
-          # This is necessary since not all .pp files are loaded by a Loader (see PUP-1833)
-          adapter = adapt_by_source(scope, model)
-        end
-        adapter.nil? ? scope.compiler.loaders.private_environment_loader : adapter.loader(scope)
+        loaders = scope.compiler.loaders
+        loader_name = loader_name_by_source(scope.environment, model, file)
+        loader_name.nil? ? loaders.private_environment_loader : loaders[loader_name]
       end
+    end
+
+    class PathsAndNameCacheAdapter < Puppet::Pops::Adaptable::Adapter
+      attr_accessor :cache, :paths
     end
 
     # Attempts to find the module that `instance` originates from by looking at it's {SourcePosAdapter} and
@@ -156,32 +156,29 @@ module Adapters
     #
     # @param scope
     # @param instance
-    def self.adapt_by_source(scope, instance)
-      source_pos = Utils.find_adapter(instance, SourcePosAdapter)
-      unless source_pos.nil?
-        mod = find_module_for_file(scope.environment, source_pos.locator.file)
-        adapter = LoaderAdapter.adapt(source_pos.adapted)
-        loaders = scope.compiler.loaders
-        if mod.nil?
-          adapter.loader_name = loaders.private_environment_loader.loader_name
-        else
-          adapter.loader_name = "#{mod.name} private"
-        end
-        return adapter
-      end
-      nil
-    end
-
-    def loader(scope)
-      scope.compiler.loaders[loader_name]
-    end
-
-    def self.find_module_for_file(environment, file)
+    # @api private
+    def self.loader_name_by_source(environment, instance, file)
+      file = find_file(instance) if file.nil?
       return nil if file.nil?
-      file_path = Pathname.new(file)
-      environment.modulepath.each do |path|
+      pn_adapter = PathsAndNameCacheAdapter.adapt(environment) do |a|
+        a.paths ||= environment.modulepath.map { |p| Pathname.new(p) }
+        a.cache ||= {}
+      end
+      dir = File.dirname(file)
+      pn_adapter.cache.fetch(dir) do |key|
+        mod = find_module_for_dir(environment, pn_adapter.paths, dir)
+        loader_name = mod.nil? ? nil : "#{mod.name} private"
+        pn_adapter.cache[key] = loader_name
+      end
+    end
+
+    # @api private
+    def self.find_module_for_dir(environment, paths, dir)
+      return nil if dir.nil?
+      file_path = Pathname.new(dir)
+      paths.each do |path|
         begin
-          relative_path = file_path.relative_path_from(Pathname.new(path)).to_s.split(File::SEPARATOR)
+          relative_path = file_path.relative_path_from(path).to_s.split(File::SEPARATOR)
         rescue ArgumentError
           # file_path was not relative to the module_path. That's OK.
           next
@@ -193,7 +190,12 @@ module Adapters
       end
       nil
     end
-    private_class_method :find_module_for_file
+
+    # @api private
+    def self.find_file(instance)
+      source_pos = Utils.find_closest_positioned(instance)
+      source_pos.nil? ? nil : source_pos.locator.file
+    end
   end
 end
 end

--- a/lib/puppet/pops/evaluator/external_syntax_support.rb
+++ b/lib/puppet/pops/evaluator/external_syntax_support.rb
@@ -20,7 +20,7 @@ module Puppet::Pops::Evaluator::ExternalSyntaxSupport
     # Call checker and give it the location information from the expression
     # (as opposed to where the heredoc tag is (somewhere on the line above)).
     acceptor = Puppet::Pops::Validation::Acceptor.new()
-    source_pos = find_closest_positioned(reference_expr)
+    source_pos = Puppet::Pops::Utils.find_closest_positioned(reference_expr)
     checker.check(result, syntax, acceptor, source_pos)
 
     if acceptor.error_count > 0

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -267,7 +267,7 @@ module Runtime3Support
 
   def call_function(name, args, o, scope, &block)
     file, line = extract_file_line(o)
-    loader = Adapters::LoaderAdapter.loader_for_model_object(o, scope)
+    loader = Adapters::LoaderAdapter.loader_for_model_object(o, scope, file)
     if loader && func = loader.load(:function, name)
       Puppet::Util::Profiler.profile(name, [:functions, name]) do
         # Add stack frame when calling

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -270,8 +270,8 @@ module Runtime3Support
     loader = Adapters::LoaderAdapter.loader_for_model_object(o, scope, file)
     if loader && func = loader.load(:function, name)
       Puppet::Util::Profiler.profile(name, [:functions, name]) do
-        # Add stack frame when calling
-        return Puppet::Pops::PuppetStack.stack(file, line, func, :call, [scope, *args], &block)
+        # Add stack frame when calling. See Puppet::Pops::PuppetStack
+        return Kernel.eval('func.call(scope, *args, &block)', Kernel.binding, file || '', line)
       end
     end
     # Call via 3x API if function exists there

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -433,14 +433,21 @@ module Runtime3Support
   end
 
   def extract_file_line(o)
-    source_pos = Utils.find_closest_positioned(o)
-    return [nil, -1] unless source_pos
-    [source_pos.locator.file, source_pos.line]
+    positioned = find_closest_with_offset(o)
+    unless positioned.nil?
+      locator = Adapters::SourcePosAdapter.find_locator(positioned)
+      return [locator.file, locator.line_for_offset(positioned.offset)] unless locator.nil?
+    end
+    [nil, -1]
   end
 
-  def find_closest_positioned(o)
-    return nil if o.nil? || o.is_a?(Model::Program)
-    o.offset.nil? ? find_closest_positioned(o.eContainer) : Adapters::SourcePosAdapter.adapt(o)
+  def find_closest_with_offset(o)
+    if o.offset.nil?
+      c = o.eContainer
+      c.nil? ? nil : find_closest_with_offset(c)
+    else
+      o
+    end
   end
 
   # Creates a diagnostic producer

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -236,7 +236,7 @@ describe 'loaders' do
           expect(resource['message']).to eq(desc[:expects])
         end
 
-        it 'can not call ruby function in a dependent module from outside a function if dependency is missing in existing metadata.json' do
+        it "can not call #{desc[:called]} from #{desc[:from]} if dependency is missing in existing metadata.json" do
           File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => []).to_pson
           Puppet[:code] = "$case_number = #{case_number}\ninclude ::user"
           expect { catalog = compiler.compile }.to raise_error(Puppet::Error, /Unknown function/)


### PR DESCRIPTION
This PR contains two performance improvements to remedy regressions that were introduced in 4.6.0. It makes the "function_loading" performance benchmark run more than twice as fast (but not quite as fast as in 4.5.x). The main reason that performance is not on par is that in 4.6.0 we introduce a Puppet call stack. It is expected to slow function calls slightly.