### PR TITLE
(PUP-6619) Correct acceptance test for env_windows_installdir fact

### DIFF
--- a/acceptance/tests/windows/env_windows_installdir_fact.rb
+++ b/acceptance/tests/windows/env_windows_installdir_fact.rb
@@ -5,17 +5,21 @@ test_name 'PA-466: Ensure env_windows_installdir fact is present and correct' do
 
   confine :to, :platform => 'windows'
 
+  require 'json'
+
   agents.each do |agent|
-    step "test for presence/accurance of fact on #{agent}" do
+    step "test for presence/accuracy of fact on #{agent}" do
       platform = agent[:platform]
       ruby_arch = agent[:ruby_arch] || 'x86' # ruby_arch defaults to x86 if nil
 
       install_dir = platform =~ /-64$/ && ruby_arch == 'x86' ?
-        "C:\\\\Program Files (x86)\\\\Puppet Labs\\\\Puppet" :
-        "C:\\\\Program Files\\\\Puppet Labs\\\\Puppet"
+        "C:\\Program Files (x86)\\Puppet Labs\\Puppet" :
+        "C:\\Program Files\\Puppet Labs\\Puppet"
 
-      on agent, puppet('facts') do
-        assert_match(/"env_windows_installdir": "#{install_dir}"/, stdout, "env_windows_installdir fact did not match expected output")
+      on agent, puppet('facts', '--render-as json') do |result|
+        facts = JSON.parse(result.stdout)
+        actual_value = facts["values"]["env_windows_installdir"]
+        assert_equal(install_dir, actual_value, "env_windows_installdir fact did not match expected output")
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, the env_windows_installdir_fact.rb test would fail because after all escaping was done, beaker would match a string literal path with two back slashes against a string literal path with four back slashes. The output of Beaker's assert match will have escaped backslashes '\' in facts output, so the output we match against looks like `C:\\\\Program Files...`.

This commit modifies the test to parse the fact output as JSON and perform a string comparison expecting the known correct value. No escaping necessary, so our test is more readable as well.