### PR TITLE
(PUP-6628) Access @should directly when calculating corrective change

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -379,10 +379,10 @@ class Puppet::Property < Puppet::Parameter
     # this kind of arbitrary comparisons into the API to remove this complexity. -ken
 
     # Backup old should, set it to the new value, then call insync? on the property.
-    old_should = self.should
+    old_should = @should
 
     begin
-      self.should = should
+      @should = should
       insync?(is)
     rescue => detail
       # Certain operations may fail, but we don't want to fail the transaction if we can
@@ -393,7 +393,7 @@ class Puppet::Property < Puppet::Parameter
       nil
     ensure
       # Always restore old should
-      self.should = old_should
+      @should = old_should
     end
   end
 


### PR DESCRIPTION
Currently, the corrective change logic uses the normal `should` and
`should=` accessors when messing with property values. This can cause
failures in property `validate` and `should=` if `unmunge` does not
put the data into a state that `munge` or `validate` is happy with.

By using a small amount of metaprogramming magic, we can access the
guts of the property value directly, bypassing those layers of logic
and creating a cleaner "transplant" of the value.