### PR TITLE
(maint) Fix file and line number output for certain errors

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -147,7 +147,7 @@ class Puppet::Parser::Resource < Puppet::Resource
     # Test the resource scope, to make sure the resource is even allowed
     # to override.
     unless self.source.object_id == resource.source.object_id || resource.source.child_of?(self.source)
-      raise Puppet::ParseError.new("Only subclasses can override parameters", resource.line, resource.file)
+      raise Puppet::ParseError.new("Only subclasses can override parameters", resource.file, resource.line)
     end
     # Some of these might fail, but they'll fail in the way we want.
     resource.parameters.each do |name, param|
@@ -331,7 +331,7 @@ class Puppet::Parser::Resource < Puppet::Resource
         msg += " at #{fields.join(":")}"
       end
       msg += "; cannot redefine"
-      raise Puppet::ParseError.new(msg, param.line, param.file)
+      raise Puppet::ParseError.new(msg, param.file, param.line)
     end
 
     # If we've gotten this far, we're allowed to override.

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -710,7 +710,7 @@ class Puppet::Parser::Scope
 
     params.each { |param|
       if table.include?(param.name)
-        raise Puppet::ParseError.new("Default already defined for #{type} { #{param.name} }; cannot redefine", param.line, param.file)
+        raise Puppet::ParseError.new("Default already defined for #{type} { #{param.name} }; cannot redefine", param.file, param.line)
       end
       table[param.name] = param
     }

--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -507,7 +507,7 @@ class Puppet::Property < Puppet::Parameter
       rescue Puppet::Error
         raise
       rescue => detail
-        error = Puppet::ResourceError.new("Could not set '#{value}' on #{self.class.name}: #{detail}", @resource.line, @resource.file, detail)
+        error = Puppet::ResourceError.new("Could not set '#{value}' on #{self.class.name}: #{detail}", @resource.file, @resource.line, detail)
         error.set_backtrace detail.backtrace
         Puppet.log_exception(detail, error.message)
         raise error


### PR DESCRIPTION
In a few places, we were logging errors with locations specified as
<line>:<file>. In general, we specify locations as <file>:<line>, so
these exceptions are now removed.