### PR TITLE
(PUP-6642) Provide a way to set transaction_uuid for an agent run

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -56,12 +56,12 @@ class Puppet::Configurer
     end
   end
 
-  def initialize(factory = Puppet::Configurer::DownloaderFactory.new)
+  def initialize(factory = Puppet::Configurer::DownloaderFactory.new, transaction_uuid = nil)
     @running = false
     @splayed = false
     @cached_catalog_status = 'not_used'
     @environment = Puppet[:environment]
-    @transaction_uuid = SecureRandom.uuid
+    @transaction_uuid = transaction_uuid || SecureRandom.uuid
     @static_catalog = true
     @checksum_type = Puppet[:supported_checksum_types]
     @handler = Puppet::Configurer::PluginHandler.new(factory)

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -63,6 +63,17 @@ describe Puppet::Agent do
     @agent.run
   end
 
+  it "should initialize the client's transaction_uuid if passed as a client_option" do
+    client = mock 'client'
+    transaction_uuid = 'foo'
+    AgentTestClient.expects(:new).with(anything, transaction_uuid).returns client
+
+    client.expects(:run)
+
+    @agent.stubs(:disabled?).returns false
+    @agent.run(:transaction_uuid => transaction_uuid)
+  end
+
   it "should be considered running if the lock file is locked" do
     lockfile = mock 'lockfile'
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -424,6 +424,14 @@ describe Puppet::Configurer do
     end
   end
 
+  describe "when initialized with a transaction_uuid" do
+    it "stores it" do
+      SecureRandom.expects(:uuid).never
+      configurer = Puppet::Configurer.new(Puppet::Configurer::DownloaderFactory.new, 'foo')
+      expect(configurer.instance_variable_get(:@transaction_uuid) == 'foo')
+    end
+  end
+
   describe "when sending a report" do
     include PuppetSpec::Files
 


### PR DESCRIPTION
Without this, a report can be passed to an agent run, but the
transaction_uuid used in that report can't match the transaction_uuid
used for node requests and sending the report. Allow the
transaction_uuid to be passed as an argument to the agent run.