### PR TITLE
(PUP-6582) loader bound functions cannot bind scope instance

### DIFF
--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -27,7 +27,7 @@ class Closure < CallableSignature
   # Evaluates a closure in its enclosing scope after having matched given arguments with parameters (from left to right)
   # @api public
   def call(*args)
-    call_with_scope(@enclosing_scope, args)
+    call_with_scope(enclosing_scope, args)
   end
 
   # This method makes a Closure compatible with a Dispatch. This is used when the closure is wrapped in a Function
@@ -35,7 +35,7 @@ class Closure < CallableSignature
   # checks of the argument type/arity validity).
   # @api private
   def invoke(instance, calling_scope, args, &block)
-    @enclosing_scope.with_global_scope do |global_scope|
+    enclosing_scope.with_global_scope do |global_scope|
       call_with_scope(global_scope, args, &block)
     end
   end
@@ -44,7 +44,7 @@ class Closure < CallableSignature
   def call_by_name(args_hash, enforce_parameters)
     if enforce_parameters
       # Push a temporary parameter scope used while resolving the parameter defaults
-      @enclosing_scope.with_parameter_scope(closure_name, parameter_names) do |param_scope|
+      enclosing_scope.with_parameter_scope(closure_name, parameter_names) do |param_scope|
         # Assign all non-nil values, even those that represent non-existent paramaters.
         args_hash.each { |k, v| param_scope[k] = v unless v.nil? }
         parameters.each do |p|
@@ -56,7 +56,7 @@ class Closure < CallableSignature
               # No default. Assign nil if the args_hash included it
               param_scope[name] = nil if args_hash.include?(name)
             else
-              param_scope[name] = param_scope.evaluate(name, p.value, @enclosing_scope, @evaluator)
+              param_scope[name] = param_scope.evaluate(name, p.value, enclosing_scope, @evaluator)
             end
           end
         end
@@ -65,7 +65,7 @@ class Closure < CallableSignature
       Types::TypeMismatchDescriber.validate_parameters(closure_name, params_struct, args_hash)
     end
 
-    @evaluator.evaluate_block_with_bindings(@enclosing_scope, args_hash, @model.body)
+    @evaluator.evaluate_block_with_bindings(enclosing_scope, args_hash, @model.body)
   end
 
   def parameters
@@ -121,6 +121,18 @@ class Closure < CallableSignature
 
     def closure_name
       @name
+    end
+
+    # The assigned enclosing scope, or global scope if enclosing scope was initialized to nil
+    #
+    def enclosing_scope
+      # Named closures are typically used for puppet functions and they cannot be defined
+      # in an enclosing scope as they are cashed and reused. They need to bind to the
+      # global scope at time of use rather at time of definition.
+      # Unnamed closures are always a runtime construct, they are never bound by a loader
+      # and are thus garbage collected at end of a compilation.
+      #
+      super || Puppet.lookup(:global_scope) { {} }
     end
   end
 

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -42,8 +42,9 @@ class Closure < CallableSignature
   # Call closure with argument assignment by name
   def call_by_name(args_hash, enforce_parameters)
     if enforce_parameters
+      closure_scope = enclosing_scope
       # Push a temporary parameter scope used while resolving the parameter defaults
-      enclosing_scope.with_parameter_scope(closure_name, parameter_names) do |param_scope|
+      closure_scope.with_parameter_scope(closure_name, parameter_names) do |param_scope|
         # Assign all non-nil values, even those that represent non-existent paramaters.
         args_hash.each { |k, v| param_scope[k] = v unless v.nil? }
         parameters.each do |p|
@@ -55,7 +56,7 @@ class Closure < CallableSignature
               # No default. Assign nil if the args_hash included it
               param_scope[name] = nil if args_hash.include?(name)
             else
-              param_scope[name] = param_scope.evaluate(name, p.value, enclosing_scope, @evaluator)
+              param_scope[name] = param_scope.evaluate(name, p.value, closure_scope, @evaluator)
             end
           end
         end

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -42,19 +42,26 @@ class EvaluatorImpl
   Issues = Issues
 
   def initialize
+    @@initialized ||= static_initialize
+
+    # Use null migration checker unless given in context
+    @migration_checker = (Puppet.lookup(:migration_checker) { Migration::MigrationChecker.singleton() })
+  end
+
+  # @api private
+  def static_initialize
     @@eval_visitor     ||= Visitor.new(self, "eval", 1, 1)
     @@lvalue_visitor   ||= Visitor.new(self, "lvalue", 1, 1)
     @@assign_visitor   ||= Visitor.new(self, "assign", 3, 3)
     @@string_visitor   ||= Visitor.new(self, "string", 1, 1)
 
-    @@type_calculator  ||= Types::TypeCalculator.new()
+    @@type_calculator  ||= Types::TypeCalculator.singleton()
 
-    @@compare_operator     ||= CompareOperator.new()
+    @@compare_operator      ||= CompareOperator.new()
     @@relationship_operator ||= RelationshipOperator.new()
-
-    # Use null migration checker unless given in context
-    @migration_checker = (Puppet.lookup(:migration_checker) { Migration::MigrationChecker.new() })
+    true
   end
+  private :static_initialize
 
   # @api private
   def type_calculator

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -45,7 +45,7 @@ class EvaluatorImpl
     @@initialized ||= static_initialize
 
     # Use null migration checker unless given in context
-    @migration_checker = (Puppet.lookup(:migration_checker) { Migration::MigrationChecker.singleton() })
+    @migration_checker = Puppet.lookup(:migration_checker) { Migration::MigrationChecker.singleton }
   end
 
   # @api private
@@ -55,10 +55,10 @@ class EvaluatorImpl
     @@assign_visitor   ||= Visitor.new(self, "assign", 3, 3)
     @@string_visitor   ||= Visitor.new(self, "string", 1, 1)
 
-    @@type_calculator  ||= Types::TypeCalculator.singleton()
+    @@type_calculator  ||= Types::TypeCalculator.singleton
 
-    @@compare_operator      ||= CompareOperator.new()
-    @@relationship_operator ||= RelationshipOperator.new()
+    @@compare_operator      ||= CompareOperator.new
+    @@relationship_operator ||= RelationshipOperator.new
     true
   end
   private :static_initialize

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -922,7 +922,7 @@ class EvaluatorImpl
   private :call_function_with_block
 
   def proc_from_lambda(lambda, scope)
-    closure = Closure.new(self, lambda, scope)
+    closure = Closure::Dynamic.new(self, lambda, scope)
     PuppetProc.new(closure) { |*args| closure.call(*args) }
   end
   private :proc_from_lambda

--- a/lib/puppet/pops/functions/function.rb
+++ b/lib/puppet/pops/functions/function.rb
@@ -57,6 +57,11 @@ class Puppet::Pops::Functions::Function
     internal_call_function(closure_scope, function_name, args, &block)
   end
 
+  def closure_scope
+    # If closure scope is explicitly set to not nil, if there is a global scope, otherwise an empty hash
+    @closure_scope || Puppet.lookup(:global_scope) { {} }
+  end
+
   # The dispatcher for the function
   #
   # @api private

--- a/lib/puppet/pops/loader/puppet_function_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_function_instantiator.rb
@@ -48,10 +48,11 @@ class PuppetFunctionInstantiator
     private_loader = loader.private_loader
     Adapters::LoaderAdapter.adapt(the_function_definition).loader_name = private_loader.loader_name
 
-    # TODO: Cheating wrt. scope - assuming it is found in the context
-    closure_scope = Puppet.lookup(:global_scope) { {} }
+    # Cannot bind loaded functions to global scope, that must be done without binding that scope as
+    # loaders survive a compilation.
+    closure_scope = nil # Puppet.lookup(:global_scope) { {} }
 
-    created = create_function_class(the_function_definition, closure_scope)
+    created = create_function_class(the_function_definition)
     # create the function instance - it needs closure (scope), and loader (i.e. where it should start searching for things
     # when calling functions etc.
     # It should be bound to global scope
@@ -64,18 +65,19 @@ class PuppetFunctionInstantiator
   #   typed name, and an instantiated function with global scope closure associated with the given loader
   #
   def self.create_from_model(function_definition, loader)
-    closure_scope = Puppet.lookup(:global_scope) { {} }
-    created = create_function_class(function_definition, closure_scope)
+    closure_scope = nil; # Puppet.lookup(:global_scope) { {} }
+    created = create_function_class(function_definition)
     typed_name = TypedName.new(:function, function_definition.name)
     [typed_name, created.new(closure_scope, loader)]
   end
 
-  def self.create_function_class(function_definition, closure_scope)
+  def self.create_function_class(function_definition)
     # Create a 4x function wrapper around a named closure
     Puppet::Functions.create_function(function_definition.name, Puppet::Functions::PuppetFunction) do
+      # This is highly problematic - it binds both an Evaluator and closure_scope
       init_dispatch(Evaluator::Closure::Named.new(
         function_definition.name,
-        Evaluator::EvaluatorImpl.new(), function_definition, closure_scope))
+        Evaluator::EvaluatorImpl.new(), function_definition, nil))
     end
   end
 end

--- a/lib/puppet/pops/loader/puppet_function_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_function_instantiator.rb
@@ -77,7 +77,7 @@ class PuppetFunctionInstantiator
       # This is highly problematic - it binds both an Evaluator and closure_scope
       init_dispatch(Evaluator::Closure::Named.new(
         function_definition.name,
-        Evaluator::EvaluatorImpl.new(), function_definition, nil))
+        Evaluator::EvaluatorImpl.new(), function_definition))
     end
   end
 end

--- a/lib/puppet/pops/loader/puppet_function_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_function_instantiator.rb
@@ -65,16 +65,15 @@ class PuppetFunctionInstantiator
   #   typed name, and an instantiated function with global scope closure associated with the given loader
   #
   def self.create_from_model(function_definition, loader)
-    closure_scope = nil; # Puppet.lookup(:global_scope) { {} }
     created = create_function_class(function_definition)
     typed_name = TypedName.new(:function, function_definition.name)
-    [typed_name, created.new(closure_scope, loader)]
+    [typed_name, created.new(nil, loader)]
   end
 
   def self.create_function_class(function_definition)
     # Create a 4x function wrapper around a named closure
     Puppet::Functions.create_function(function_definition.name, Puppet::Functions::PuppetFunction) do
-      # This is highly problematic - it binds both an Evaluator and closure_scope
+      # TODO: should not create a new evaluator per function
       init_dispatch(Evaluator::Closure::Named.new(
         function_definition.name,
         Evaluator::EvaluatorImpl.new(), function_definition))

--- a/lib/puppet/pops/loader/ruby_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_function_instantiator.rb
@@ -30,10 +30,9 @@ class Puppet::Pops::Loader::RubyFunctionInstantiator
     # when calling functions etc.
     # It should be bound to global scope
 
-    # Cheating wrt. scope - assuming it is found in the context (else an empty hash is used).
-    closure_scope = Puppet.lookup(:global_scope) { {} }
+    # Sets closure scope to nil, to let it be picked up at runtime from Puppet.lookup(:global_scope)
     # If function definition used the loader from the binding to create a new loader, that loader wins
-    created.new(closure_scope, loader_for_function)
+    created.new(nil, loader_for_function)
   end
 
   private

--- a/lib/puppet/pops/migration/migration_checker.rb
+++ b/lib/puppet/pops/migration/migration_checker.rb
@@ -6,6 +6,10 @@ class Puppet::Pops::Migration::MigrationChecker
   def initialize()
   end
 
+  def self.singleton
+    @@null_checker ||= self.new
+  end
+
   # Produces a hash of available migrations; a map from a symbolic name in string form to a brief description.
   # This version has no such supported migrations.
   def available_migrations()

--- a/lib/puppet/pops/migration/migration_checker.rb
+++ b/lib/puppet/pops/migration/migration_checker.rb
@@ -7,7 +7,7 @@ class Puppet::Pops::Migration::MigrationChecker
   end
 
   def self.singleton
-    @@null_checker ||= self.new
+    @null_checker ||= self.new
   end
 
   # Produces a hash of available migrations; a map from a symbolic name in string form to a brief description.

--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -55,7 +55,7 @@ class EvaluatingParser
 
   # Create a closure that can be called in the given scope
   def closure(model, scope)
-    Evaluator::Closure.new(evaluator, model, scope)
+    Evaluator::Closure::Dynamic.new(evaluator, model, scope)
   end
 
   def evaluate(scope, model)

--- a/spec/integration/parser/parameter_defaults_spec.rb
+++ b/spec/integration/parser/parameter_defaults_spec.rb
@@ -26,12 +26,16 @@ require 'puppet_spec/language'
 
     let (:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new('specification')) }
 
+    let (:topscope) { compiler.topscope }
+
     def collect_notices(code)
       logs = []
       Puppet[:code] = code
       Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-        compiler.compile
-        yield
+        Puppet.override(:global_scope => topscope) do
+          compiler.compile
+          yield
+        end
       end
       logs.select { |log| log.level == :notice }.map { |log| log.message }
     end

--- a/spec/integration/parser/parameter_defaults_spec.rb
+++ b/spec/integration/parser/parameter_defaults_spec.rb
@@ -32,10 +32,10 @@ require 'puppet_spec/language'
       logs = []
       Puppet[:code] = code
       Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-        Puppet.override(:global_scope => topscope) do
-          compiler.compile
-          yield
-        end
+          compiler.compile do |catalog|
+            yield
+            catalog
+          end
       end
       logs.select { |log| log.level == :notice }.map { |log| log.message }
     end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1721,7 +1721,7 @@ describe 'The type calculator' do
         factory = Model::Factory
         params = [factory.PARAM('a')]
         the_block = factory.LAMBDA(params,factory.literal(42))
-        the_closure = Evaluator::Closure.new(:fake_evaluator, the_block, :fake_scope)
+        the_closure = Evaluator::Closure::Dynamic.new(:fake_evaluator, the_block, :fake_scope)
         expect(calculator.instance?(all_callables_t, the_closure)).to be_truthy
         expect(calculator.instance?(callable_t(object_t), the_closure)).to be_truthy
         expect(calculator.instance?(callable_t(object_t, object_t), the_closure)).to be_falsey


### PR DESCRIPTION
This refactors Closure into two specific subclasses: Dynamic (for lambdas), and Named (static, bound by loader). This is done to ensure that all Named function closures refer to top-scope in a way that is resolved on demand rather than being bound in a member variable. The dynamic closures must bind to a scope. Such closures may never be bound in something that survives a compilation.