### PR TITLE
(PUP-6502) Reinstate dscl read for OSX user exists?

### DIFF
--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -237,7 +237,13 @@ Puppet::Type.type(:user).provide :directoryservice do
 ##                   ##
 
   def exists?
-    return @property_hash.any?
+    begin
+      dscl '.', 'read', "/Users/#{@resource.name}"
+    rescue Puppet::ExecutionFailure => e
+      Puppet.debug("User was not found, dscl returned: #{e.inspect}")
+      return false
+    end
+    true
   end
 
   # This method is called if ensure => present is passed and the exists?


### PR DESCRIPTION
This commit adds back the dscl read implementation for the `exists?`
method of the user directoryservice provider. Currently, the
`@property_hash` is not being refreshed upon a `create` event. Therefore,
the previous query to `@property_hash.any?` returned `false even
though the user had been created.