### PR TITLE
(PUP-6295) Acceptance tests for the corrective_change flag

### DIFF
--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -15,16 +15,16 @@ extend Puppet::Acceptance::EnvironmentUtils
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-       if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
-        on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
-      end 
-     end
+        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
+          on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
+        end 
+      end
     end
   end
 
   step 'create file resource - site.pp to verify corrective change flag' do
-  file_contents     = 'this is a test'   
-manifest = <<MANIFEST
+    file_contents     = 'this is a test'   
+    manifest = <<MANIFEST
 file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
   ensure => file,
   content => '
@@ -47,14 +47,14 @@ MANIFEST
 
         #Run agent once to create new File resource
         step 'Run agent once to create new File resource' do
-         on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
         end
 
         #Verify the file resource is created
         step 'Verify the file resource is created' do
-         on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
-           assert_equal(file_contents, file_result, 'file contents did not match accepted')
-         end
+          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
+            assert_equal(file_contents, file_result, 'file contents did not match accepted')
+          end
         end
       end
     end
@@ -62,30 +62,29 @@ MANIFEST
 
   # Open last_run_report.yaml
   step 'Check report' do
-     agents.each do |agent|
-       on(agent, puppet('config print statedir')) do |command_result|
-         report_path = command_result.stdout.chomp + '/last_run_report.yaml'
-         on(agent, "cat #{report_path}").stdout do |report_contents|
+    agents.each do |agent|
+      on(agent, puppet('config print statedir')) do |command_result|
+        report_path = command_result.stdout.chomp + '/last_run_report.yaml'
+        on(agent, "cat #{report_path}").stdout do |report_contents|
 
-           yaml_data = YAML::parse(report_contents)
-           # Remove any Ruby class tags from the yaml
-           yaml_data.root.each do |o|
-             if o.respond_to?(:tag=) and
-                o.tag != nil and
-                o.tag.start_with?("!ruby")
-               o.tag = nil
-             end
-           end
-           report_yaml = yaml_data.to_ruby
+          yaml_data = YAML::parse(report_contents)
+          # Remove any Ruby class tags from the yaml
+          yaml_data.root.each do |o|
+            if o.respond_to?(:tag=) and
+               o.tag != nil and
+               o.tag.start_with?("!ruby")
+              o.tag = nil
+            end
+          end
+          report_yaml = yaml_data.to_ruby
 
-           file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
-           assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
-           corrective_change_value =  file_resource_details["corrective_change"]
-           assert_equal(false, corrective_change_value, 'corrective_change flag should be false') 
-         end
-       end
-     end
+          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
+          assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
+          corrective_change_value =  file_resource_details["corrective_change"]
+          assert_equal(false, corrective_change_value, 'corrective_change flag should be false')
+        end
+      end
+    end
   end
-
 
 end

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -65,11 +65,19 @@ MANIFEST
      agents.each do |agent|
        on(agent, puppet('config print statedir')) do |command_result|
          report_path = command_result.stdout.chomp + '/last_run_report.yaml'
-         on(agent, "cat #{report_path}") do |report_yaml|
+         on(agent, "cat #{report_path}").stdout do |report_contents|
 
-           #stripping out ruby class definitions from the report yaml
-           report_yaml = YAML.load(report_yaml.stdout.gsub(/\!ruby[^\n]*/, ''))
-           report_yaml.inspect
+           yaml_data = YAML::parse(report_contents)
+           # Remove any Ruby class tags from the yaml
+           yaml_data.root.each do |o|
+             if o.respond_to?(:tag=) and
+                o.tag != nil and
+                o.tag.start_with?("!ruby")
+               o.tag = nil
+             end
+           end
+           report_yaml = yaml_data.to_ruby
+
            file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
            assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
            corrective_change_value =  file_resource_details["corrective_change"]

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-test_name "C98092: corrective change new resource" do
+test_name "C98092 - a new resource should not be reported as a corrective change" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
@@ -56,23 +56,6 @@ MANIFEST
            assert_equal(file_contents, file_result, 'file contents did not match accepted')
          end
         end
-
-        #Delete the file
-        step 'Delete the file' do
-         on(agent, "rm #{tmp_file[fqdn]}", :accept_all_exit_codes => true)
-        end
-
-        #Run agent to correct the file's absence
-        step 'Run agent to correct the files absence' do
-         on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
-        end
- 
-        #Verify the file resource is created
-        step 'Verify the file resource is created' do
-         on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
-           assert_equal(file_contents, file_result, 'file contents did not match accepted')
-         end
-        end
       end
     end
   end
@@ -90,7 +73,7 @@ MANIFEST
            file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
            assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
            corrective_change_value =  file_resource_details["corrective_change"]
-           assert_equal(true, corrective_change_value, 'corrective_change flag should be true') 
+           assert_equal(false, corrective_change_value, 'corrective_change flag should be false') 
          end
        end
      end

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -82,11 +82,19 @@ MANIFEST
      agents.each do |agent|
        on(agent, puppet('config print statedir')) do |command_result|
          report_path = command_result.stdout.chomp + '/last_run_report.yaml'
-         on(agent, "cat #{report_path}") do |report_yaml|
+         on(agent, "cat #{report_path}").stdout do |report_contents|
 
-           #stripping out ruby class definitions from the report yaml
-           report_yaml = YAML.load(report_yaml.stdout.gsub(/\!ruby[^\n]*/, ''))
-           report_yaml.inspect
+           yaml_data = YAML::parse(report_contents)
+           # Remove any Ruby class tags from the yaml
+           yaml_data.root.each do |o|
+             if o.respond_to?(:tag=) and
+                o.tag != nil and
+                o.tag.start_with?("!ruby")
+               o.tag = nil
+             end
+           end
+           report_yaml = yaml_data.to_ruby
+
            file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
            assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
            corrective_change_value =  file_resource_details["corrective_change"]

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -1,0 +1,100 @@
+require 'yaml'
+
+test_name "C98093 - a resource changed outside of Puppet will be reported as a corrective change" do
+require 'puppet/acceptance/environment_utils'
+extend Puppet::Acceptance::EnvironmentUtils
+
+  test_file_name = File.basename(__FILE__, '.*')
+  tmp_environment   = mk_tmp_environment_with_teardown(master, test_file_name)
+  tmp_file = {}
+  
+  agents.each do |agent|
+    tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
+  end
+
+  teardown do
+    step 'clean out produced resources' do
+      agents.each do |agent|
+       if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
+        on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
+      end 
+     end
+    end
+  end
+
+  step 'create file resource - site.pp to verify corrective change flag' do
+  file_contents     = 'this is a test'   
+manifest = <<MANIFEST
+file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
+  ensure => file,
+  content => '
+\$test_path = \$::fqdn ? #{tmp_file}
+file { \$test_path:
+  content => @(UTF8)
+    #{file_contents}
+    | UTF8 
+}
+  ',
+}
+MANIFEST
+    apply_manifest_on(master, manifest, :catch_failures => true)
+  end
+
+  step 'run agent(s)' do
+    with_puppet_running_on(master, {}) do
+      agents.each do |agent|
+        fqdn = agent.hostname
+
+        #Run agent once to create new File resource
+        step 'Run agent once to create new File resource' do
+         on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+        end
+
+        #Verify the file resource is created
+        step 'Verify the file resource is created' do
+         on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
+           assert_equal(file_contents, file_result, 'file contents did not match accepted')
+         end
+        end
+
+        #Delete the file
+        step 'Delete the file' do
+         on(agent, "rm #{tmp_file[fqdn]}", :accept_all_exit_codes => true)
+        end
+
+        #Run agent to correct the file's absence
+        step 'Run agent to correct the files absence' do
+         on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+        end
+ 
+        #Verify the file resource is created
+        step 'Verify the file resource is created' do
+         on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
+           assert_equal(file_contents, file_result, 'file contents did not match accepted')
+         end
+        end
+      end
+    end
+  end
+
+  # Open last_run_report.yaml
+  step 'Check report' do
+     agents.each do |agent|
+       on(agent, puppet('config print statedir')) do |command_result|
+         report_path = command_result.stdout.chomp + '/last_run_report.yaml'
+         on(agent, "cat #{report_path}") do |report_yaml|
+
+           #stripping out ruby class definitions from the report yaml
+           report_yaml = YAML.load(report_yaml.stdout.gsub(/\!ruby[^\n]*/, ''))
+           report_yaml.inspect
+           file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
+           assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
+           corrective_change_value =  file_resource_details["corrective_change"]
+           assert_equal(true, corrective_change_value, 'corrective_change flag should be true') 
+         end
+       end
+     end
+  end
+
+
+end

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -1,13 +1,13 @@
 require 'yaml'
-
-test_name "C98093 - a resource changed outside of Puppet will be reported as a corrective change" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
+
+test_name "C98093 - a resource changed outside of Puppet will be reported as a corrective change" do
 
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file = {}
-  
+
   agents.each do |agent|
     tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
   end
@@ -15,16 +15,16 @@ extend Puppet::Acceptance::EnvironmentUtils
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-       if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
-        on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
-      end 
-     end
+        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
+          on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
+        end
+      end
     end
   end
 
   step 'create file resource - site.pp to verify corrective change flag' do
-  file_contents     = 'this is a test'   
-manifest = <<MANIFEST
+    file_contents = 'this is a test'
+    manifest = <<MANIFEST
 file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
   ensure => file,
   content => '
@@ -32,7 +32,7 @@ file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
 file { \$test_path:
   content => @(UTF8)
     #{file_contents}
-    | UTF8 
+    | UTF8
 }
   ',
 }
@@ -47,31 +47,31 @@ MANIFEST
 
         #Run agent once to create new File resource
         step 'Run agent once to create new File resource' do
-         on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
         end
 
         #Verify the file resource is created
         step 'Verify the file resource is created' do
-         on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
-           assert_equal(file_contents, file_result, 'file contents did not match accepted')
-         end
+          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
+            assert_equal(file_contents, file_result, 'file contents did not match accepted')
+          end
         end
 
         #Delete the file
         step 'Delete the file' do
-         on(agent, "rm #{tmp_file[fqdn]}", :accept_all_exit_codes => true)
+          on(agent, "rm #{tmp_file[fqdn]}", :accept_all_exit_codes => true)
         end
 
         #Run agent to correct the file's absence
         step 'Run agent to correct the files absence' do
-         on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
         end
  
         #Verify the file resource is created
         step 'Verify the file resource is created' do
-         on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
-           assert_equal(file_contents, file_result, 'file contents did not match accepted')
-         end
+          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
+            assert_equal(file_contents, file_result, 'file contents did not match accepted')
+          end
         end
       end
     end
@@ -79,30 +79,29 @@ MANIFEST
 
   # Open last_run_report.yaml
   step 'Check report' do
-     agents.each do |agent|
-       on(agent, puppet('config print statedir')) do |command_result|
-         report_path = command_result.stdout.chomp + '/last_run_report.yaml'
-         on(agent, "cat #{report_path}").stdout do |report_contents|
+    agents.each do |agent|
+      on(agent, puppet('config print statedir')) do |command_result|
+        report_path = command_result.stdout.chomp + '/last_run_report.yaml'
+        on(agent, "cat #{report_path}").stdout do |report_contents|
 
-           yaml_data = YAML::parse(report_contents)
-           # Remove any Ruby class tags from the yaml
-           yaml_data.root.each do |o|
-             if o.respond_to?(:tag=) and
-                o.tag != nil and
-                o.tag.start_with?("!ruby")
-               o.tag = nil
-             end
-           end
-           report_yaml = yaml_data.to_ruby
+          yaml_data = YAML::parse(report_contents)
+          # Remove any Ruby class tags from the yaml
+          yaml_data.root.each do |o|
+            if o.respond_to?(:tag=) and
+               o.tag != nil and
+               o.tag.start_with?("!ruby")
+              o.tag = nil
+            end
+          end
+          report_yaml = yaml_data.to_ruby
 
-           file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
-           assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
-           corrective_change_value =  file_resource_details["corrective_change"]
-           assert_equal(true, corrective_change_value, 'corrective_change flag should be true') 
-         end
-       end
-     end
+          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
+          assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
+          corrective_change_value =  file_resource_details["corrective_change"]
+          assert_equal(true, corrective_change_value, 'corrective_change flag should be true') 
+        end
+      end
+    end
   end
-
 
 end

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -1,0 +1,98 @@
+require 'yaml'
+
+test_name "C98094 - a resource changed via Puppet manifest will not be reported as a corrective change" do
+require 'puppet/acceptance/environment_utils'
+extend Puppet::Acceptance::EnvironmentUtils
+
+  test_file_name = File.basename(__FILE__, '.*')
+  tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
+  tmp_file = {}
+  original_test_data = 'this is my original important data'
+  modified_test_data = 'this is my modified important data'
+  
+  agents.each do |agent|
+    tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
+  end
+
+  teardown do
+    step 'clean out produced resources' do
+      agents.each do |agent|
+       if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
+        on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
+      end 
+     end
+    end
+  end
+
+  def create_manifest_for_file_resource(file_resource, file_contents, environment_name)
+    manifest = <<MANIFEST
+file { '#{environmentpath}/#{environment_name}/manifests/site.pp':
+  ensure => file,
+  content => '
+\$test_path = \$::fqdn ? #{file_resource}
+file { \$test_path:
+  content => @(UTF8)
+    #{file_contents}
+    | UTF8
+}
+  ',
+}
+MANIFEST
+    apply_manifest_on(master, manifest, :catch_failures => true)
+  end
+
+  step 'create file resource in site.pp' do
+    create_manifest_for_file_resource(tmp_file, original_test_data, tmp_environment)
+  end
+
+  step 'run agent(s) to create the new resource' do
+    with_puppet_running_on(master, {}) do
+      agents.each do |agent|
+        fqdn = agent.hostname
+
+        step 'Run agent once to create new File resource' do
+          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+        end
+
+        step 'Verify the file resource is created' do
+          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_contents|
+            assert_equal(original_test_data, file_contents, 'file contents did not match expected contents')
+          end
+        end
+
+        step 'Change the manifest for the resource' do
+          create_manifest_for_file_resource(tmp_file, modified_test_data, tmp_environment)
+        end
+
+        step 'Run agent a 2nd time to change the File resource' do
+          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+        end
+
+        step 'Verify the file resource is created' do
+         on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_contents|
+           assert_equal(modified_test_data, file_contents, 'file contents did not match expected contents')
+         end
+        end
+      end
+    end
+  end
+
+  # Open last_run_report.yaml
+  step 'Check report' do
+     agents.each do |agent|
+       on(agent, puppet('config print statedir')) do |command_result|
+         report_path = command_result.stdout.chomp + '/last_run_report.yaml'
+         on(agent, "cat #{report_path}") do |report_yaml|
+
+           #stripping out ruby class definitions from the report yaml
+           report_yaml = YAML.load(report_yaml.stdout.gsub(/\!ruby[^\n]*/, ''))
+           report_yaml.inspect
+           file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
+           assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
+           corrective_change_value =  file_resource_details["corrective_change"]
+           assert_equal(false, corrective_change_value, 'corrective_change flag for the changed resource should be false') 
+         end
+       end
+     end
+  end
+end

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -1,15 +1,15 @@
 require 'yaml'
-
-test_name "C98094 - a resource changed via Puppet manifest will not be reported as a corrective change" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
+
+test_name "C98094 - a resource changed via Puppet manifest will not be reported as a corrective change" do
 
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file = {}
   original_test_data = 'this is my original important data'
   modified_test_data = 'this is my modified important data'
-  
+ 
   agents.each do |agent|
     tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
   end
@@ -17,10 +17,10 @@ extend Puppet::Acceptance::EnvironmentUtils
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-       if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
-        on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
-      end 
-     end
+        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''
+          on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
+        end
+      end
     end
   end
 
@@ -69,9 +69,9 @@ MANIFEST
         end
 
         step 'Verify the file resource is created' do
-         on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_contents|
-           assert_equal(modified_test_data, file_contents, 'file contents did not match expected contents')
-         end
+          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_contents|
+            assert_equal(modified_test_data, file_contents, 'file contents did not match expected contents')
+          end
         end
       end
     end
@@ -79,27 +79,27 @@ MANIFEST
 
   # Open last_run_report.yaml
   step 'Check report' do
-     agents.each do |agent|
-       on(agent, puppet('config print statedir')) do |command_result|
-         report_path = command_result.stdout.chomp + '/last_run_report.yaml'
-         on(agent, "cat #{report_path}").stdout do |report_contents|
+    agents.each do |agent|
+      on(agent, puppet('config print statedir')) do |command_result|
+        report_path = command_result.stdout.chomp + '/last_run_report.yaml'
+        on(agent, "cat #{report_path}").stdout do |report_contents|
 
-           yaml_data = YAML::parse(report_contents)
-           # Remove any Ruby class tags from the yaml
-           yaml_data.root.each do |o|
-             if o.respond_to?(:tag=) and
-                o.tag != nil and
-                o.tag.start_with?("!ruby")
+          yaml_data = YAML::parse(report_contents)
+          # Remove any Ruby class tags from the yaml
+          yaml_data.root.each do |o|
+            if o.respond_to?(:tag=) and
+               o.tag != nil and
+               o.tag.start_with?("!ruby")
                o.tag = nil
-             end
-           end
-           report_yaml = yaml_data.to_ruby
-           file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
-           assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
-           corrective_change_value =  file_resource_details["corrective_change"]
-           assert_equal(false, corrective_change_value, 'corrective_change flag for the changed resource should be false') 
-         end
-       end
-     end
+            end
+          end
+          report_yaml = yaml_data.to_ruby
+          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
+          assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
+          corrective_change_value =  file_resource_details["corrective_change"]
+          assert_equal(false, corrective_change_value, 'corrective_change flag for the changed resource should be false')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR contains two commits:
25c2843 - modify the existing corrective_change test (corrective_change_new_resource.rb) so that it tests precisely what its test_name suggests it will test
25a9a63 - adds two new acceptance tests. This includes the test scenario that corrective_change_new_resource.rb was previously covering, so we don't lose any test coverage.
