### PR TITLE
(maint) Correct usage of log_exception in property.rb

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -387,7 +387,7 @@ class Puppet::Property < Puppet::Parameter
     rescue => detail
       # Certain operations may fail, but we don't want to fail the transaction if we can
       # avoid it
-      Puppet.log_exception(detail, "Unknown failure comparing values #{should} and #{is} using insync? on type: #{self.resource.ref} property: #{self.name}", :default, { :level => :info })
+      Puppet.log_exception(detail, "Unknown failure comparing values #{should} and #{is} using insync? on type: #{self.resource.ref} property: #{self.name}", { :level => :info })
 
       # Return nil, ie. unknown
       nil

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -555,4 +555,11 @@ describe Puppet::Property do
       expect(property.property_matches?(1, "1")).to be_falsey
     end
   end
+
+  describe "#insync_values?" do
+    it "should log an exception when insync? throws one" do
+      property.expects(:insync?).raises ArgumentError
+      expect(property.insync_values?("foo","bar")).to be nil
+    end
+  end
 end


### PR DESCRIPTION
We were using a four argument log_exception instead of a 3. This fixes the problem
and puts in a test for the condition.

Signed-off-by: Ken Barber <ken@bob.sh>