### PR TITLE
(PUP-6629) Be more careful about parsing YAML for transactionstore

### DIFF
--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -54,7 +54,7 @@ class Puppet::Transaction::Persistence
     result = nil
     Puppet::Util.benchmark(:debug, "Loaded transaction store file") do
       begin
-        result = Puppet::Util::Yaml.load_file(filename)
+        result = Puppet::Util::Yaml.load_file(filename, false, true)
       rescue Puppet::Util::Yaml::YamlLoadError => detail
         Puppet.log_exception(detail, "Transaction store file #{filename} is corrupt (#{detail}); replacing", { :level => :warning })
 

--- a/spec/unit/util/yaml_spec.rb
+++ b/spec/unit/util/yaml_spec.rb
@@ -47,6 +47,18 @@ describe Puppet::Util::Yaml do
     end
   end
 
+  it "should allow one to strip ruby tags that would otherwise not parse" do
+    write_file(filename, "---\nweirddata: !ruby/hash:Not::A::Valid::Class {}")
+
+    expect(Puppet::Util::Yaml.load_file(filename, {}, true)).to eq({"weirddata" => {}})
+  end
+
+  it "should not strip non-ruby tags" do
+    write_file(filename, "---\nweirddata: !binary |-\n          e21kNX04MTE4ZGY2NmM5MTc3OTg4ZWE4Y2JiOWEzMjMyNzFkYg==")
+
+    expect(Puppet::Util::Yaml.load_file(filename, {}, true)).to eq({"weirddata" => "{md5}8118df66c9177988ea8cbb9a323271db"})
+  end
+
   def write_file(name, contents)
     File.open(name, "w") do |fh|
       fh.write(contents)


### PR DESCRIPTION
This patch strips Ruby tags from the transactionstore before parsing, so we avoid
some deserialization issues.

Signed-off-by: Ken Barber <ken@bob.sh>