### PR TITLE
(PUP-2018) Only submit one CSR with `certificate generate`

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -197,7 +197,8 @@ module Puppet
       :http_pool => proc {
         require 'puppet/network/http'
         Puppet::Network::HTTP::NoCachePool.new
-      }
+      },
+      :ssl_host => proc { Puppet::SSL::Host.localhost },
     }
   end
 

--- a/lib/puppet/face/certificate.rb
+++ b/lib/puppet/face/certificate.rb
@@ -77,6 +77,10 @@ Puppet::Indirector::Face.define(:certificate, '0.0.1') do
       # them. Otherwise, they will default to the config file setting iff this
       # cert is for the host we're running on.
 
+      unless Puppet::FileSystem.exist?(Puppet[:hostcert])
+        Puppet.push_context({:ssl_host => host})
+      end
+
       host.generate_certificate_request(:dns_alt_names => options[:dns_alt_names])
     end
   end

--- a/lib/puppet/ssl/validator/default_validator.rb
+++ b/lib/puppet/ssl/validator/default_validator.rb
@@ -16,7 +16,7 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
   # Creates a new DefaultValidator, optionally with an SSL Configuration and SSL Host.
   #
   # @param ssl_configuration [Puppet::SSL::Configuration] (a default configuration) ssl_configuration the SSL configuration to use
-  # @param ssl_host [Puppet::SSL::Host] (Puppet::SSL::Host.localhost) the SSL host to use
+  # @param ssl_host [Puppet::SSL::Host] The SSL host to use
   #
   # @api private
   #
@@ -25,7 +25,7 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
                                         Puppet[:localcacert], {
                                           :ca_auth_file  => Puppet[:ssl_client_ca_auth]
                                         }),
-      ssl_host = Puppet::SSL::Host.localhost)
+      ssl_host = Puppet.lookup(:ssl_host))
 
     reset!
     @ssl_configuration = ssl_configuration


### PR DESCRIPTION
Puppet uses a fair amount of magic to request a CSR when using HTTPS for
the first time. While this normally works well enough when running a
Puppet agent this falls over badly with `puppet certificate generate`.
If the command is run on a node that hasn't submitted a CSR for itself
it will submit a CSR for itself before it submits a CSR for the node
requested on the CLI. If `puppet certificate generate` is used to
submit a CSR for the current node this fails badly as Puppet will try to
submit two CSRs for the same node, causing the command to fail.

The culprit behind this is `Puppet::SSL::Host.localhost`, which when
called will generate a CSR for the given node if it doesn't exist. This
function is used when setting up SSL validation and identity checking,
so by trying to validate a connection a CSR will be submitted. This code
path is brittle but since so much other code relies on this magic
initialization we can't really change this.

In order to sidestep this issue, this commit uses the Puppet context to
store the SSL::Host used for SSL validation and conditionally
substitutes another host object in when no signed certs exist.