### PR TITLE
(doc) (DOCUMENT-579) Fix EPP function example path

### DIFF
--- a/lib/puppet/functions/epp.rb
+++ b/lib/puppet/functions/epp.rb
@@ -18,7 +18,7 @@
 # template and pass the `docroot` and `virtual_docroot` parameters, call the `epp`
 # function like this:
 #
-# `epp('apache/templates/vhost/_docroot.epp', { 'docroot' => '/var/www/html',
+# `epp('apache/vhost/_docroot.epp', { 'docroot' => '/var/www/html',
 # 'virtual_docroot' => '/var/www/example' })`
 #
 # Puppet produces a syntax error if you pass more parameters than are declared in

--- a/lib/puppet/parser/functions/epp.rb
+++ b/lib/puppet/parser/functions/epp.rb
@@ -19,7 +19,7 @@ For example, to call the apache module's `templates/vhost/_docroot.epp`
 template and pass the `docroot` and `virtual_docroot` parameters, call the `epp`
 function like this:
 
-`epp('apache/templates/vhost/_docroot.epp', { 'docroot' => '/var/www/html',
+`epp('apache/vhost/_docroot.epp', { 'docroot' => '/var/www/html',
 'virtual_docroot' => '/var/www/example' })`
 
 Puppet produces a syntax error if you pass more parameters than are declared in


### PR DESCRIPTION
Currently the example at: https://docs.puppet.com/puppet/latest/reference/function.html#epp
uses an incorrect path in the example.

This PR fixes that.