### PR TITLE
(PUP-6592) acceptance: Sensitive data

### DIFF
--- a/acceptance/lib/puppet/acceptance/puppet_type_test_tools.rb
+++ b/acceptance/lib/puppet/acceptance/puppet_type_test_tools.rb
@@ -1,0 +1,103 @@
+require 'puppet/acceptance/environment_utils'
+
+module Puppet
+  module Acceptance
+    module PuppetTypeTestTools
+      include Puppet::Acceptance::EnvironmentUtils # for now, just for #random_string
+
+      # FIXME: yardocs
+      # TODO: create resource class which contains its manifest chunk, and assertions
+      #   can be an array or singular, holds the manifest and the assertion_code
+      #   has getter for the manifest
+      #   has #run_assertions(BeakerResult or string)
+      def generate_manifest(test_resources)
+        manifest = ''
+        test_resources = [test_resources].flatten # ensure it's an array so we enumerate properly
+        test_resources.each do |resource|
+          manifest << resource[:pre_code] + "\n" if resource[:pre_code]
+          namevar = (resource[:parameters][:namevar] if resource[:parameters]) || "#{resource[:type]}_#{random_string}"
+          # ensure these are double quotes around the namevar incase users puppet-interpolate inside it
+          # FIXME: add test ^^
+          manifest << resource[:type] + '{"' + namevar + '":' if resource[:type]
+          if resource[:parameters]
+            resource[:parameters].each do |key,value|
+              next if key == :namevar
+              manifest << "#{key} => #{value},"
+            end
+          end
+          manifest << "}\n" if resource[:type]
+        end
+        return manifest
+      end
+
+      def generate_assertions(test_resources)
+        assertion_code = ''
+        test_resources = [test_resources].flatten # ensure it's an array so we enumerate properly
+        test_resources.each do |resource|
+          if resource[:assertions]
+            resource[:assertions] = [resource[:assertions]].flatten # ensure it's an array so we enumerate properly
+            resource[:assertions].each do |assertion_type|
+              expect_failure = false
+              if assertion_type[:expect_failure]
+                expect_failure = true
+                assertion_code << "expect_failure '#{assertion_type[:expect_failure][:message]}' do\n"
+                # delete the message
+                assertion_type[:expect_failure].delete(:message)
+                # promote the hash in expect_failure
+                assertion_type = assertion_type[:expect_failure]
+                assertion_type.delete(:expect_failure)
+              end
+
+              # ensure all the values are arrays
+              assertion_values = [assertion_type.values].flatten
+              assertion_values.each do |assertion_value|
+                # TODO: non matching asserts?
+                # TODO: non stdout? (support stdout, stderr, exit_code)
+                # TODO: what about checking resource state on host (non agent/apply #on use)?
+                if assertion_type.keys.first =~ /assert_match/
+                  assert_msg = 'found '
+                elsif assertion_type.keys.first =~ /refute_match/
+                  assert_msg = 'did not find '
+                else
+                  assert_msg = ''
+                end
+                if assertion_value.is_a?(String)
+                  matcher = "\"#{assertion_value}\""
+                elsif assertion_value.is_a?(Regexp)
+                  matcher = assertion_value.inspect
+                else
+                  matcher = assertion_value
+                end
+                assertion_code << "#{assertion_type.keys.first}(#{matcher}, result.stdout, '#{assert_msg}#{matcher}')\n"
+              end
+
+              assertion_code << "end\n" if expect_failure
+            end
+          end
+        end
+        return assertion_code
+      end
+
+      Result = Struct.new(:stdout)
+      def run_assertions(assertions = '', result)
+        result_struct = Result.new
+        if result.respond_to? :stdout
+          result_struct.stdout = result.stdout
+        else
+          # handle results sent in as string
+          result_struct.stdout = result
+        end
+        result = result_struct
+
+        begin
+          eval(assertions)
+        rescue RuntimeError, SyntaxError => e
+          puts e
+          puts assertions
+          raise
+        end
+      end
+
+    end
+  end
+end

--- a/acceptance/lib/puppet/acceptance/puppet_type_test_tools_spec.rb
+++ b/acceptance/lib/puppet/acceptance/puppet_type_test_tools_spec.rb
@@ -1,0 +1,131 @@
+require File.join(File.dirname(__FILE__),'../../acceptance_spec_helper.rb')
+require 'puppet/acceptance/puppet_type_test_tools.rb'
+require 'beaker/dsl/assertions'
+require 'beaker/result'
+
+module Puppet
+  module Acceptance
+
+    describe 'PuppetTypeTestTools' do
+      include PuppetTypeTestTools
+      include Beaker::DSL::Assertions
+      include Beaker
+
+      context '#generate_manifest' do
+        it 'takes a single hash' do
+          expect(generate_manifest({:type => 'fake'})).to match(/^fake{"fake_\w{8}":}$/)
+        end
+        it 'takes an array' do
+          expect(generate_manifest([{:type => 'fake'}])).to match(/^fake{"fake_\w{8}":}$/)
+        end
+        it 'generates empty puppet code (assertion-only instance)' do
+          expect(generate_manifest({:fake => 'fake'})).to eql('')
+        end
+        it 'puts a namevar in the right place' do
+          expect(generate_manifest({:type => 'fake', :parameters =>
+                                    {:namevar => 'blah'}})).to match(/^fake{"blah":}$/)
+        end
+        it 'retains puppet code in a namevar' do
+          expect(generate_manifest({:type => 'fake', :parameters =>
+                                    {:namevar => "half_${interpolated}_puppet_namevar"}})).
+          to match(/^fake{"half_\${interpolated}_puppet_namevar":}$/)
+        end
+        it 'places pre_code before the type' do
+          expect(generate_manifest({:type => 'fake', :pre_code => '$some = puppet_code'})).
+            to match(/^\$some = puppet_code\nfake{"fake_\w{8}":}$/m)
+        end
+        it 'places multiple, arbitrary parameters' do
+          expect(generate_manifest({:type => 'fake', :parameters =>
+                                    {:someprop => "function(call)", :namevar => "blah", :someparam => 2}})).
+          to match(/^fake{"blah":someprop => function\(call\),someparam => 2,}$/)
+        end
+      end
+
+      context '#generate_assertions' do
+        it 'takes a single hash' do
+          expect(generate_assertions({:assertions => {:fake => 'matcher'}}))
+            .to match(/^fake\("matcher", result\.stdout, '"matcher"'\)$/)
+        end
+        it 'takes an array' do
+          expect(generate_assertions([{:assertions => {:fake => 'matcher'}}]))
+            .to match(/^fake\("matcher", result\.stdout, '"matcher"'\)$/)
+        end
+        it 'generates empty assertions (puppet-code only instance)' do
+          expect(generate_assertions({:type => 'no assertions'})).to eql('')
+        end
+        it 'generates arbitrary assertions' do
+          expect(generate_assertions({:assertions => [{:fake => 'matcher'},
+                                                      {:other => 'othermatch'}]}))
+            .to match(/^fake\("matcher", result\.stdout, '"matcher"'\)\nother\("othermatch", result.stdout, '"othermatch"'\)$/m)
+        end
+        it 'can give a regex to assertions' do
+          expect(generate_assertions({:assertions => {:fake => /matcher/}}))
+            .to match(/^fake\(\/matcher\/, result\.stdout, '\/matcher\/'\)$/)
+        end
+        it 'allows multiple of one assertion type' do
+          expect(generate_assertions({:assertions => {:fake => ['matcher','othermatch']}}))
+            .to match(/^fake\("matcher", result\.stdout, '"matcher"'\)\nfake\("othermatch", result.stdout, '"othermatch"'\)$/)
+        end
+        it 'allows multiple assertion_types with multiple values' do
+          expect(generate_assertions({:assertions => [{:fake => ['matcher','othermatch']},
+                                                      {:fake2 => ['matcher2','othermatch2']}]}))
+            .to match(/^fake\("matcher", result\.stdout, '"matcher"'\)\nfake\("othermatch", result.stdout, '"othermatch"'\)\nfake2\("matcher2", result.stdout, '"matcher2"'\)\nfake2\("othermatch2", result.stdout, '"othermatch2"'\)\n$/)
+        end
+        context 'expect_failure' do
+          it 'generates arbitrary assertion' do
+            expect(generate_assertions({:assertions => {:expect_failure => {:fake => 'matcher'}}}))
+              .to match(/^expect_failure '' do\nfake\(.*\)\nend$/)
+          end
+          it 'allows multiple of one assertion type' do
+            expect(generate_assertions({:assertions => {:expect_failure => {:fake => ['matcher','othermatch']}}}))
+              .to match(/^expect_failure '' do\nfake\(.*\)\nfake\(.*\)\nend$/)
+          end
+          it 'allows multiple assertion_types' do
+            pending 'ack! requires recursion :-('
+            #expect(generate_assertions({:assertions => {:expect_failure => [{:fake => 'matcher'},{:fake2 => 'matcher2'}]}}))
+              #.to match(/^expect_failure '' do\nfake\(.*\)\nfake2\(.*\)\nend$/)
+          end
+          it 'allows multiple assertion_types with an expect_failure on one' do
+            expect(generate_assertions({:assertions => [{:expect_failure => {:fake => 'matcher'}}, {:fake2 => 'matcher2'}]}))
+              .to match(/^expect_failure '' do\nfake\(.*\)\nend\nfake2\(.*\)$/)
+          end
+          it 'allows custom expect_failure messages' do
+            expect(generate_assertions({:assertions => {:expect_failure => {:fake => 'matcher', :message => 'oh noes, this should fail but pass'}}}))
+              .to match(/^expect_failure 'oh noes, this should fail but pass' do\nfake\(.*\)\nend$/)
+          end
+        end
+        it 'allow custom assertion messages'
+      end
+
+      context 'run_assertions' do
+      #def run_assertions(assertions = '', result)
+        it 'takes a string result' do
+          expect(run_assertions('assert_match("yes please", result.stdout)', 'yes please')).to be true
+        end
+        let(:result) {Beaker::Result.new('host','command')}
+        it 'takes a beaker "type" Result' do
+          result.stdout = 'yes please'
+          expect(run_assertions('assert_match("yes please", result.stdout)', result)).to be true
+        end
+        it 'runs a bunch of assertions' do
+          result.stdout = 'yes please'
+          expect(run_assertions("assert_match('yes please', result.stdout)\nrefute_match('blah', result.stdout)", result)).to be false
+        end
+        it 'fails assertions' do
+          pending 'why doesnt this work?'
+          result.stdout = 'yes please'
+          expect(run_assertions('assert_match("blah", result.stdout)', result)).to raise_error
+        end
+        context 'exceptions' do
+          #rescue RuntimeError, SyntaxError => e
+          it 'puts the assertion code, raises error' do
+            pending 'why doesnt this work?'
+            expect(run_assertions('assert_match("blah") }', result)).to raise_error
+          end
+        end
+      end
+
+    end
+
+  end
+end

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -1,0 +1,100 @@
+test_name 'C98120, C98077: Sensitive Data is redacted on CLI, logs, reports' do
+require 'puppet/acceptance/puppet_type_test_tools.rb'
+extend Puppet::Acceptance::PuppetTypeTestTools
+
+  app_type        = File.basename(__FILE__, '.*')
+  tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
+  fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
+
+  tmp_filename_win = tmp_filename_else = ''
+  agents.each do |agent|
+    # ugh... this won't work with more than two agents of two types
+    tmp_filename_win  = "C:\\cygwin64\\tmp\\#{tmp_environment}.txt"
+    tmp_filename_else = "/tmp/#{tmp_environment}.txt"
+    if agent.platform =~ /windows/
+      tmp_filename = tmp_filename_win
+    else
+      tmp_filename = tmp_filename_else
+    end
+    on agent, "echo 'old content' > /tmp/#{tmp_environment}.txt"
+  end
+
+  # first attempts at a reasonable table driven test.  needs API work
+  # FIXME:
+  #   expand this to other resource types, make parameters arbitrary, make assertions arbitrary
+  # FIXME: add context messaging to each instance
+  notify_redacted = 'Sensitive \[value redacted\]'
+  file_redacted   = 'changed \[redacted\] to \[redacted\]'
+  test_resources = [
+    {:type => 'notify', :parameters => {:namevar => "1:${Sensitive.new('sekrit1')}"},
+       :assertions => [{:refute_match => 'sekrit1'}, {:assert_match => "1:#{notify_redacted}"}]},
+    {:type => 'notify', :parameters => {:namevar => "2:${Sensitive.new($meh2)}"}, :pre_code => '$meh2="sekrit2"',
+       :assertions => [{:refute_match => 'sekrit2'}, {:assert_match => "2:#{notify_redacted}"}]},
+    {:type => 'notify', :parameters => {:namevar => "3:meh", :message => '"3:${Sensitive.new(\'sekrit3\')}"'},
+       :assertions => [{:refute_match => 'sekrit3'}, {:assert_match => "3:#{notify_redacted}"}]},
+    {:type => 'notify', :parameters => {:namevar => "4:meh", :message => "Sensitive.new($meh4)"}, :pre_code => '$meh4="sekrit4"',
+       :assertions => {:expect_failure => {:refute_match => 'sekrit4', :message => 'you can always spill redacted data, if you want to'}}},
+    {:type => 'notify', :parameters => {:namevar => "5:meh", :message => "$meh5"}, :pre_code => '$meh5=Sensitive.new("sekrit5")',
+       :assertions => {:expect_failure => {:refute_match => 'sekrit5', :message => 'you can always spill redacted data, if you want to'}}},
+    {:type => 'notify', :parameters => {:namevar => "6:meh", :message => '"6:${meh6}"'}, :pre_code => '$meh6=Sensitive.new("sekrit6")',
+       :assertions => [{:refute_match => 'sekrit6'}, {:assert_match => "6:#{notify_redacted}"}]},
+    {:type => 'notify', :parameters => {:namevar => "7:${Sensitive('sekrit7')}"},
+       :assertions => [{:refute_match => 'sekrit7'}, {:assert_match => "7:#{notify_redacted}"}]},
+    # unwrap(), these should be en-clair
+    {:type => 'notify', :parameters => {:namevar => "8:${unwrap(Sensitive.new('sekrit8'))}"},
+       :assertions => {:assert_match => "8:sekrit8"}},
+    {:type => 'notify', :parameters => {:namevar => "9:meh", :message => '"9:${unwrap(Sensitive.new(\'sekrit9\'))}"'},
+       :assertions => {:assert_match => "9:sekrit9"}},
+    {:type => 'notify', :parameters => {:namevar => "A:meh", :message => '"A:${unwrap($mehA)}"'}, :pre_code => '$mehA=Sensitive.new("sekritA")',
+       :assertions => {:assert_match => "A:sekritA"}},
+    {:type => 'notify', :parameters => {:namevar => "B:meh", :message => '"B:${$mehB.unwrap}"'}, :pre_code => '$mehB=Sensitive.new("sekritB")',
+       :assertions => {:assert_match => "B:sekritB"}},
+    {:type => 'notify', :parameters => {:namevar => "C:meh", :message => '"C:${$mehC.unwrap |$unwrapped| { "blk_${unwrapped}_blk" } } nonblk_${mehC}_nonblk"'}, :pre_code => '$mehC=Sensitive.new("sekritC")',
+       :assertions => {:assert_match => ["C:blk_sekritC_blk", "nonblk_#{notify_redacted}_nonblk"]}},
+    # for --show_diff
+    {:type => 'file', :parameters => {:namevar => "$pup_tmp_filename", :content => "Sensitive.new('sekritD')"}, :pre_code => "$pup_tmp_filename = if $osfamily == 'windows' { '#{tmp_filename_win}' } else { '#{tmp_filename_else}' }",
+       :assertions => [{:refute_match => 'sekritD'}, {:assert_match => /#{tmp_environment}\.txt..content. #{file_redacted}/}]},
+
+  ]
+
+  sitepp_content = generate_manifest(test_resources)
+  assertion_code = generate_assertions(test_resources)
+
+  create_sitepp(master, tmp_environment, sitepp_content)
+
+  step "run agent in #{tmp_environment}, run all assertions" do
+    with_puppet_running_on(master,{}) do
+      agents.each do |agent|
+        on(agent, puppet("agent -t --debug --trace --show_diff --server #{master.hostname} --environment #{tmp_environment}"),
+           :accept_all_exit_codes => true) do |result|
+          assert(result.exit_code==2,'puppet agent run failed')
+          run_assertions(assertion_code, result)
+        end
+
+        if agent['platform'] =~ /fedora|centos|el|redhat|scientific|ubuntu|debian|cumulus/
+          step "assert no redacted data in syslog" do
+            #sigh.  gee, thanks for the help, beaker!
+            result = dump_puppet_log(agent)
+            raise if result.length < 3
+            string_io_index = 2
+            run_assertions(assertion_code, result[string_io_index].string)
+          end
+        end
+
+        # don't do this before the agent log scanning, above. it will skew the results
+        step "assert no redacted data in vardir" do
+          # no recursive grep in solaris :facepalm:
+          on(agent, "find #{agent.puppet['vardir']} -type f | xargs grep sekrit", :accept_all_exit_codes => true) do |result|
+            refute_match(/sekrit(1|2|3|6|7)/, result.stdout, 'found redacted data we should not have')
+            #TODO: if/when this is fixed, we should just be able to eval(assertion_code_ in this result block also!
+            expect_failure 'file resource contents will end up in the cached catalog en-clair' do
+              refute_match(/sekritD/, result.stdout, 'found redacted file data we should not have')
+            end
+          end
+        end
+
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
* add a test for Sensitive data type and its functions
* test employs a first pass at table driven testing
  * could be used for other tests for puppet language and resource types
  * the code generation portion could use a bit of work prior to expansion

[skip ci]