### PR TITLE
(doc) Fix minor doc string issues.

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -14,4 +14,5 @@
 --api public
 --api private
 --hide-void-return
+--exclude lib/puppet/vendor/
 lib/**/*.rb

--- a/lib/puppet/functions/regsubst.rb
+++ b/lib/puppet/functions/regsubst.rb
@@ -1,40 +1,36 @@
 # Perform regexp replacement on a string or array of strings.
 #
-# @example
-#
-# Get the third octet from the node's IP address:
-#
-#   $i3 = regsubst($ipaddress,'^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$','\\3')
-#
-# Put angle brackets around each octet in the node's IP address:
-#
-#   $x = regsubst($ipaddress, /([0-9]+)/, '<\\1>', 'G')
-#
-# @param target [Array[String]|String]
+# @param target [String, Array[String]]
 #      The string or array of strings to operate on.  If an array, the replacement will be
 #      performed on each of the elements in the array, and the return value will be an array.
-# @param regexp [String|Regexp|Type[Regexp]]
+# @param pattern [String, Regexp, Type[Regexp]]
 #      The regular expression matching the target string.  If you want it anchored at the start
 #      and or end of the string, you must do that with ^ and $ yourself.
-# @param replacement [String|Hash[String, String]]
+# @param replacement [String, Hash[String, String]]
 #      Replacement string. Can contain backreferences to what was matched using \\0 (whole match),
 #      \\1 (first set of parentheses), and so on.
 #      If the second argument is a Hash, and the matched text is one of its keys, the corresponding value is the replacement string.
-# @param flags [String]
+# @param flags [Optional[Pattern[/^[GEIM]*$/]], Pattern[/^G?$/]]
 #      Optional. String of single letter flags for how the regexp is interpreted (E, I, and M cannot be used
 #      if pattern is a precompiled regexp):
 #        - *E*         Extended regexps
 #        - *I*         Ignore case in regexps
 #        - *M*         Multiline regexps
 #        - *G*         Global replacement; all occurrences of the regexp in each target string will be replaced.  Without this, only the first occurrence will be replaced.
-# @param encoding [String]
+# @param encoding [Enum['N','E','S','U']]
 #      Optional. How to handle multibyte characters when compiling the regexp (must not be used when pattern is a
 #      precompiled regexp). A single-character string with the following values:
 #        - *N*         None
 #        - *E*         EUC
 #        - *S*         SJIS
 #        - *U*         UTF-8
-# @return [Array[String]|String] The result of the substitution. Result type is the same as for the target parameter.
+# @return [Array[String], String] The result of the substitution. Result type is the same as for the target parameter.
+#
+# @example Get the third octet from the node's IP address:
+#     $i3 = regsubst($ipaddress,'^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$','\\3')
+#
+# @example Put angle brackets around each octet in the node's IP address:
+#     $x = regsubst($ipaddress, /([0-9]+)/, '<\\1>', 'G')
 #
 Puppet::Functions.create_function(:regsubst) do
   dispatch :regsubst_string do

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -238,7 +238,7 @@ module Runtime3Support
   # @param name [String] the name of the function (without the 'function_' prefix used by scope)
   # @param args [Array] arguments, may be empty
   # @param scope [Object] the (runtime specific) scope where evaluation takes place
-  # @raise ArgumentError 'unknown function' if the function does not exist
+  # @raise [ArgumentError] 'unknown function' if the function does not exist
   #
   def external_call_function(name, args, scope, &block)
     # Call via 4x API if the function exists there

--- a/lib/puppet/pops/lookup/sub_lookup.rb
+++ b/lib/puppet/pops/lookup/sub_lookup.rb
@@ -9,7 +9,7 @@ module SubLookup
   # parameter block. The block must return an exception instance.
   #
   # @param key [String] the string to split
-  # @return Array<String> the array of segments
+  # @return [Array<String>] the array of segments
   # @yieldparam problem [String] the problem, i.e. 'Syntax error'
   # @yieldreturn [Exception] the exception to raise
   #

--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -96,8 +96,7 @@ class Puppet::Provider
   attr_accessor :resource
 
   # Convenience methods - see class method with the same name.
-  # @see execute
-  # @return (see execute)
+  # @return (see self.execute)
   def execute(*args)
     Puppet::Util::Execution.execute(*args)
   end
@@ -108,8 +107,7 @@ class Puppet::Provider
   end
 
   # Convenience methods - see class method with the same name.
-  # @see execpipe
-  # @return (see execpipe)
+  # @return (see self.execpipe)
   def execpipe(*args, &block)
     Puppet::Util::Execution.execpipe(*args, &block)
   end
@@ -120,8 +118,7 @@ class Puppet::Provider
   end
 
   # Convenience methods - see class method with the same name.
-  # @see execfail
-  # @return (see execfail)
+  # @return (see self.execfail)
   def execfail(*args)
     Puppet::Util::Execution.execfail(*args)
   end


### PR DESCRIPTION
Fixes for docstrings to assist in running `puppet strings` on the Puppet source base itself.