### PR TITLE
(PUP-6650) Ensure that environment compiler overrides are removed

### DIFF
--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -82,6 +82,14 @@ class BaseLoader < Loader
     set_entry(TypedName.new(type, name), value, origin)
   end
 
+  # @api private
+  #
+  def remove_entry(typed_name)
+    unless @named_values.delete(typed_name).nil?
+      @last_result = nil unless @last_result.nil? || typed_name != @last_result.typed_name
+    end
+  end
+
   # Promotes an already created entry (typically from another loader) to this loader
   #
   # @api private

--- a/spec/unit/parser/environment_compiler_spec.rb
+++ b/spec/unit/parser/environment_compiler_spec.rb
@@ -501,6 +501,17 @@ EOS
 
     end
 
+    it 'removes overriden functions after compile' do
+      expect {
+        compile_to_env_catalog(<<-EOC)
+          hiera_include('classes')
+          site { }
+        EOC
+      }.to_not raise_error()
+      func = Puppet::Pops::Loaders.loaders.puppet_system_loader.load(:function, 'hiera_include')
+      expect(func).to be_a(Puppet::Functions::Function)
+    end
+
     it "includes components and capability resources" do
       catalog = compile_to_env_catalog(MANIFEST).to_resource
       apps = catalog.resources.select do |res|


### PR DESCRIPTION
Before this commit, the EnvironmentCompiler would add function overrides
when it was instantiated (once for each compile). This approach was
fatal in a long lived environment (where a compile happens more than
once) since a loader doesn't accept a redefine.

This commit ensures that overridden functions are added at the beginning
of a compile and then subsequently removed at the end of that compile.
Overridden functions are preserved and restored in the process.