### PR TITLE
(PUP-6629) Respect the passed log level when log_exception is passed a custom message

### DIFF
--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -67,7 +67,7 @@ module Logging
           :node => exception.node
         }.merge(log_metadata))
     else
-      err(format_exception(exception, message, trace))
+      send_log(options[:level] || :err, format_exception(exception, message, trace))
     end
   end
 

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -116,7 +116,7 @@ describe Puppet::Agent do
 
     it "should not fail if a client class instance cannot be created" do
       AgentTestClient.expects(:new).raises "eh"
-      Puppet.expects(:err)
+      Puppet::Util::Log.expects(:create).with(has_entry(:level => :err))
       @agent.run
     end
 
@@ -124,7 +124,7 @@ describe Puppet::Agent do
       client = AgentTestClient.new
       AgentTestClient.expects(:new).returns client
       client.expects(:run).raises "eh"
-      Puppet.expects(:err)
+      Puppet::Util::Log.expects(:create).with(has_entry(:level => :err))
       @agent.run
     end
 

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -400,7 +400,8 @@ EOT
       # it, but this helps us fail if that slips up and all. --daniel 2011-04-27
       Puppet::Face[:help, :current].expects(:help).never
 
-      Puppet.expects(:err).with("Could not parse application options: I don't know how to render 'interpretive-dance'")
+      Puppet::Util::Log.expects(:create).with(
+        has_entries(:message => "Could not parse application options: I don't know how to render 'interpretive-dance'", :level => :err))
 
       expect { app.run }.to exit_with(1)
     end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -33,7 +33,10 @@ describe Puppet::Application do
   describe "application defaults" do
     it "should fail if required app default values are missing" do
       @app.stubs(:app_defaults).returns({ :foo => 'bar' })
-      Puppet.expects(:err).with(regexp_matches(/missing required app default setting/))
+      Puppet::Util::Log.expects(:create).with do |value|
+        value[:level] == :err and
+          value[:message] =~ /missing required app default setting/
+      end
       expect {
         @app.run
       }.to exit_with(1)
@@ -55,10 +58,11 @@ describe Puppet::Application do
     end
 
     it "should error if it can't find a class" do
-      Puppet.expects(:err).with do |value|
-        value =~ /Unable to find application 'ThisShallNeverEverEverExist'/ and
-          value =~ /puppet\/application\/thisshallneverevereverexist/ and
-          value =~ /no such file to load|cannot load such file/
+      Puppet::Util::Log.expects(:create).with do |value|
+        value[:level] == :err and
+          value[:message] =~ /Unable to find application 'ThisShallNeverEverEverExist'/ and
+          value[:message] =~ /puppet\/application\/thisshallneverevereverexist/ and
+          value[:message] =~ /no such file to load|cannot load such file/
       end
 
       expect {
@@ -517,19 +521,19 @@ describe Puppet::Application do
     end
 
     it "should warn and exit if no command can be called" do
-      Puppet.expects(:err)
+      Puppet::Util::Log.expects(:create).with(has_entry(:level => :err))
       expect { @app.run }.to exit_with 1
     end
 
     it "should raise an error if dispatch returns no command" do
       @app.stubs(:get_command).returns(nil)
-      Puppet.expects(:err)
+      Puppet::Util::Log.expects(:create).with(has_entry(:level => :err))
       expect { @app.run }.to exit_with 1
     end
 
     it "should raise an error if dispatch returns an invalid command" do
       @app.stubs(:get_command).returns(:this_function_doesnt_exist)
-      Puppet.expects(:err)
+      Puppet::Util::Log.expects(:create).with(has_entry(:level => :err))
       expect { @app.run }.to exit_with 1
     end
   end

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -217,7 +217,8 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "should catch and log exceptions" do
-      Puppet.expects(:err)
+      Puppet::Util::Log.expects(:create).with(has_entry(:level => :err))
+      Puppet::Util::Log.expects(:create).with(has_entry(:level => :info)).at_least_once
       # The downloader creates a new catalog for each apply, and really the only object
       # that it is possible to stub for the purpose of generating a puppet error
       Puppet::Resource::Catalog.any_instance.stubs(:apply).raises(Puppet::Error, "testing")

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -546,8 +546,9 @@ describe Puppet::Property do
   end
 
   describe "#insync_values?" do
-    it "should log an exception when insync? throws one" do
+    it "should log an exception at non-error level when insync? throws one" do
       property.expects(:insync?).raises ArgumentError
+      Puppet::Util::Log.expects(:create).with(Not(has_entry(:level => :err)))
       expect(property.insync_values?("foo","bar")).to be nil
     end
   end

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -801,7 +801,7 @@ describe Puppet::SSL::Host do
       @host.stubs(:generate)
       @host.stubs(:sleep)
 
-      Puppet.expects(:err)
+      Puppet::Util::Log.expects(:create).with(has_entry(:level => :err))
 
       @host.wait_for_cert(1)
     end


### PR DESCRIPTION
The first time we tried to fix PUP-6629, we did not fix all the code
paths in log_exception - specifically, when a custom message was
passed (which insync_values? does), we still logged at error level.

This now handles that case, and also adds a test for insync_values? to
ensure it does not log at error level if insync? fails.