### PR TITLE
(PUP-6653) Avoid ruby type loading and type redefine clashes

### DIFF
--- a/lib/puppet/functions/defined.rb
+++ b/lib/puppet/functions/defined.rb
@@ -126,15 +126,12 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
         end
       when Puppet::Resource
         # Find instance of given resource type and title that is in the catalog
-        scope.compiler.findresource(val.type, val.title)
+        scope.compiler.findresource(val.resource_type, val.title)
 
       when Puppet::Pops::Types::PResourceType
         raise ArgumentError, 'The given resource type is a reference to all kind of types' if val.type_name.nil?
-        if val.title.nil?
-          Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, val.type_name)
-        else
-          scope.compiler.findresource(val.type_name, val.title)
-        end
+        type = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, val.type_name)
+        val.title.nil? ? type : scope.compiler.findresource(type, val.title)
 
       when Puppet::Pops::Types::PHostClassType
         raise  ArgumentError, 'The given class type is a reference to all classes' if val.class_name.nil?

--- a/lib/puppet/pops/evaluator/collectors/exported_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/exported_collector.rb
@@ -44,7 +44,7 @@ class Puppet::Pops::Evaluator::Collectors::ExportedCollector < Puppet::Pops::Eva
       found_resources = found.map {|x| x.is_a?(Puppet::Parser::Resource) ? x : x.to_resource(@scope)}
 
       found_resources.each do |item|
-        if existing = @scope.findresource(item.type, item.title)
+        if existing = @scope.findresource(item.resource_type, item.title)
           unless existing.collector_id == item.collector_id
             raise Puppet::ParseError,
               "A duplicate resource was found while collecting exported resources, with the type and title #{item.ref}"

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -138,8 +138,9 @@ class Runtime3Converter
     # due to Puppet::Resource's idiosyncratic behavior where some references must be
     # absolute and others cannot be.
     # Thus there is no need to call scope.resolve_type_and_titles to do dynamic lookup.
-
-    Puppet::Resource.new(*catalog_type_to_split_type_title(o))
+    t, title = catalog_type_to_split_type_title(o)
+    t = Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
+    Puppet::Resource.new(t, title)
   end
   alias :convert2_PCatalogEntryType :convert_PCatalogEntryType
 

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -203,6 +203,7 @@ module Runtime3Support
     else
       # transform into the wonderful String representation in 3x
       type, title = Runtime3Converter.instance.catalog_type_to_split_type_title(source)
+      type = Runtime3ResourceSupport.find_resource_type(scope, type) unless type == 'class' || type == 'node'
       source_resource = Puppet::Resource.new(type, title)
     end
     if target.is_a?(Collectors::AbstractCollector)
@@ -211,6 +212,7 @@ module Runtime3Support
     else
       # transform into the wonderful String representation in 3x
       type, title = Runtime3Converter.instance.catalog_type_to_split_type_title(target)
+      type = Runtime3ResourceSupport.find_resource_type(scope, type) unless type == 'class' || type == 'node'
       target_resource = Puppet::Resource.new(type, title)
     end
     # Add the relationship to the compiler for later evaluation.
@@ -343,8 +345,9 @@ module Runtime3Support
       unless r.is_a?(Types::PResourceType) && r.type_name != 'class'
         fail(Issues::ILLEGAL_OVERRIDEN_TYPE, o, {:actual => r} )
       end
+      t = Runtime3ResourceSupport.find_resource_type(scope, r.type_name)
       resource = Puppet::Parser::Resource.new(
-      r.type_name, r.title,
+        t, r.title,
         :parameters => evaluated_parameters,
         :file => file,
         :line => line,

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -63,7 +63,7 @@ class Runtime3TypeLoader < BaseLoader
   #
   def find_impl(typed_name)
     name = typed_name.name
-    te = StaticLoader::BUILTIN_TYPE_NAMES_LC.include?(name) ? nil : @resource_3x_loader.find(typed_name)
+    te = StaticLoader::BUILTIN_TYPE_NAMES_LC.include?(name) ? nil : @resource_3x_loader.load_typed(typed_name)
     if te.nil? || te.value.nil?
       # Look for Puppet::Type
       value = Puppet::Type.type(name) unless typed_name.qualified?

--- a/lib/puppet/pops/resource/resource_type_impl.rb
+++ b/lib/puppet/pops/resource/resource_type_impl.rb
@@ -143,7 +143,7 @@ class ResourceTypeImpl
       when 0
         # TechDebt: The case of specifying title patterns when having no name vars is unspecified behavior in puppet
         # Here it is silently ignored.
-        []
+        nil
       when 1
         if @title_pattners_hash.nil?
           [ [ /(.*)/m, [ [@key_attributes.first] ] ] ]
@@ -168,6 +168,10 @@ class ResourceTypeImpl
 
   # Override CompilableResource inclusion
   def is_3x_ruby_plugin?
+    false
+  end
+
+  def is_capability?
     false
   end
 

--- a/spec/lib/puppet_spec/compiler.rb
+++ b/spec/lib/puppet_spec/compiler.rb
@@ -50,6 +50,7 @@ module PuppetSpec::Compiler
   def collect_notices(code, node = Puppet::Node.new('foonode'))
     Puppet[:code] = code
     compiler = Puppet::Parser::Compiler.new(node)
+    node.environment.check_for_reparse
     logs = []
     Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
       yield(compiler)


### PR DESCRIPTION
This commit ensures that Puppet::Resource instances created during
compile will not make attempts to load a Puppet::Type.