### PR TITLE
(PUP-5871) Add Timespan and Timestamp Puppet Types and implementations

### DIFF
--- a/lib/puppet/functions/strftime.rb
+++ b/lib/puppet/functions/strftime.rb
@@ -1,0 +1,14 @@
+# (Documentation in 3.x stub)
+#
+# @since 4.7.0
+#
+Puppet::Functions.create_function(:strftime) do
+  dispatch :format do
+    param 'Variant[Timestamp,Timespan]', :time_object
+    param 'String', :format
+  end
+
+  def format(time_object, format)
+    time_object.format(format)
+  end
+end

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -269,4 +269,10 @@ module Puppet::Parser::Functions
       environment_module(environment).get_function_info(name.intern) || environment_module(Puppet.lookup(:root_environment)).get_function_info(name.intern)
     end
   end
+
+  class Error
+    def self.is4x(name)
+      raise Puppet::ParseError, "#{name}() can only be called using the 4.x function API. See Scope#call_function"
+    end
+  end
 end

--- a/lib/puppet/parser/functions/assert_type.rb
+++ b/lib/puppet/parser/functions/assert_type.rb
@@ -56,5 +56,5 @@ For more information about data types, see the
 - Since 4.0.0
 DOC
 ) do |args|
-  function_fail(["assert_type() is only available when parser/evaluator future is in effect"])
+  Error.is4x('assert_type')
 end

--- a/lib/puppet/parser/functions/defined.rb
+++ b/lib/puppet/parser/functions/defined.rb
@@ -12,7 +12,7 @@ This function takes at least one string argument, which can be a class name, typ
 resource reference, or variable reference of the form `'$name'`.
 
 The `defined` function checks both native and defined types, including types
-provided by modules. Types and classes are matched by their names. The function matches 
+provided by modules. Types and classes are matched by their names. The function matches
 resource declarations by using resource references.
 
 **Examples**: Different types of `defined` function matches
@@ -103,5 +103,5 @@ defined('$tmp_file2')
 - Since 4.0.0 includes all future parser features
 DOC
 ) do |vals|
-  function_fail(["defined() is a 4.x function - an illegal call was made to this function using old API"])
+  Error.is4x('defined')
 end

--- a/lib/puppet/parser/functions/dig.rb
+++ b/lib/puppet/parser/functions/dig.rb
@@ -25,5 +25,5 @@ Would notice the value 100.
 * Since 4.5.0
 DOC
 ) do |args|
-  function_fail(["dig() is only available when parser/evaluator future is in effect"])
+  Error.is4x('dig')
 end

--- a/lib/puppet/parser/functions/each.rb
+++ b/lib/puppet/parser/functions/each.rb
@@ -100,5 +100,5 @@ documentation.
 - Since 4.0.0
 DOC
 ) do |args|
-  function_fail(["each() is only available when parser/evaluator future is in effect"])
+  Error.is4x('each')
 end

--- a/lib/puppet/parser/functions/epp.rb
+++ b/lib/puppet/parser/functions/epp.rb
@@ -32,5 +32,5 @@ function fails to pass any required parameter.
 
 - Since 4.0.0") do |args|
 
-  function_fail(["epp() is only available when parser/evaluator future is in effect"])
+  Error.is4x('epp')
 end

--- a/lib/puppet/parser/functions/filter.rb
+++ b/lib/puppet/parser/functions/filter.rb
@@ -74,5 +74,5 @@ $filtered_data = $data.filter |$keys, $values| { $keys =~ /berry$/ and $values <
 - Since 4.0.0
 DOC
 ) do |args|
-  function_fail(["filter() is only available when parser/evaluator future is in effect"])
+  Error.is4x('filter')
 end

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -34,7 +34,7 @@ throughout a hierarchy, use the `hiera_array` or `hiera_hash` functions.
 #   - common
 
 # Assuming web01.example.com.yaml:
-# users: 
+# users:
 #   - "Amy Barry"
 #   - "Carrie Douglas"
 
@@ -58,7 +58,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that 
+[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -74,7 +74,7 @@ $users = hiera('users') | $key | { "Key \'${key}\' not found" }
 # "Key 'users' not found".
 ~~~
 
-The returned value's data type depends on the types of the results. In the example 
+The returned value's data type depends on the types of the results. In the example
 above, Hiera matches the 'users' key and returns it as a hash.
 
 See
@@ -84,6 +84,6 @@ for more information about Hiera lookup functions.
 - Since 4.0.0
 DOC
   ) do |*args|
-    function_fail(["hiera() has been converted to 4x API"])
+    Error.is4x('hiera')
   end
 end

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -72,7 +72,7 @@ for more information about Hiera lookup functions.
 - Since 4.0.0
 DOC
 ) do |*args|
-    function_fail(["hiera_array() has been converted to 4x API"])
+    Error.is4x('hiera_array')
   end
 end
 

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -82,7 +82,7 @@ for more information about Hiera lookup functions.
 - Since 4.0.0
 DOC
   ) do |*args|
-    function_fail(["hiera_hash() has been converted to 4x API"])
+    Error.is4x('hiera_hash')
   end
 end
 

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -82,7 +82,7 @@ nodes.
 - Since 4.0.0
 DOC
   ) do |*args|
-    function_fail(["hiera_include() has been converted to 4x API"])
+    Error.is4x('hiera_include')
   end
 end
 

--- a/lib/puppet/parser/functions/inline_epp.rb
+++ b/lib/puppet/parser/functions/inline_epp.rb
@@ -47,5 +47,5 @@ END
 - Since 3.5
 - Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8") do |arguments|
 
-  function_fail(["inline_epp() is only available when parser/evaluator future is in effect"])
+  Error.is4x('inline_epp')
 end

--- a/lib/puppet/parser/functions/lest.rb
+++ b/lib/puppet/parser/functions/lest.rb
@@ -45,5 +45,5 @@ Would notice the value `20`
 * Since 4.5.0
 DOC
 ) do |args|
-  function_fail(["lest() is only available when parser/evaluator future is in effect"])
+  Error.is4x('lest')
 end

--- a/lib/puppet/parser/functions/lookup.rb
+++ b/lib/puppet/parser/functions/lookup.rb
@@ -1,4 +1,5 @@
-Puppet::Parser::Functions.newfunction(:lookup, :type => :rvalue, :arity => -2, :doc => <<-'ENDHEREDOC') do |args|
+module Puppet::Parser::Functions
+  newfunction(:lookup, :type => :rvalue, :arity => -2, :doc => <<-'ENDHEREDOC') do |args|
 Uses the Puppet lookup system to retrieve a value for a given key. By default,
 this returns the first value found (and fails compilation if no values are
 available), but you can configure it to merge multiple values into one, fail
@@ -126,5 +127,6 @@ remove values by prefixing them with `--`:
     })
 
 ENDHEREDOC
-  function_fail(["lookup() has been converted to 4x API"])
+  Error.is4x('lookup')
+end
 end

--- a/lib/puppet/parser/functions/map.rb
+++ b/lib/puppet/parser/functions/map.rb
@@ -72,5 +72,5 @@ $transformed_data = $data.map |$key,$value| { $value }
 - Since 4.0.0
 DOC
 ) do |args|
-  function_fail(["map() is only available when parser/evaluator future is in effect"])
+  Error.is4x('map')
 end

--- a/lib/puppet/parser/functions/match.rb
+++ b/lib/puppet/parser/functions/match.rb
@@ -39,5 +39,5 @@ $matches = ["abc123","def456"].match(/([a-z]+)([1-9]+)/)
 - Since 4.0.0
 DOC
 ) do |args|
-  function_fail(["match() is only available when parser/evaluator future is in effect"])
+  Error.is4x('match')
 end

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -125,7 +125,7 @@ function Float.new(
 * For an integer, the floating point fraction of `.0` is added to the value.
 * A `Boolean` `true` is converted to 1.0, and a `false` to 0.0
 * In `String` format, integer prefixes for hex and binary are understood (but not octal since
-  floating point in string format may start with a '0'). 
+  floating point in string format may start with a '0').
 
 Conversion to Numeric
 ---------------------
@@ -243,7 +243,7 @@ $str = String([10], "%(a")  # produces '("10")'
 **Example:** Specifying type for values contained in an array
 
 ```puppet
-$formats = { 
+$formats = {
   Array => {
     format => '%(a',
     string_formats => { Integer => '%#x' }
@@ -301,7 +301,7 @@ Defaults to `s` at top level and `p` inside array or hash.
 ### Boolean to String
 
 | Format    | Boolean Formats
-| ----      | -------------------   
+| ----      | -------------------
 | t T       | String 'true'/'false' or 'True'/'False', first char if alternate form is used (i.e. 't'/'f' or 'T'/'F').
 | y Y       | String 'yes'/'no', 'Yes'/'No', 'y'/'n' or 'Y'/'N' if alternative flag `#` is used.
 | dxXobB    | Numeric value 0/1 in accordance with the given format which must be valid integer format.
@@ -375,7 +375,7 @@ The alternate form flag `#` will format each hash key/value entry indented on a 
 
 ### Flags
 
-| Flag     | Effect 
+| Flag     | Effect
 | ------   | ------
 | (space)  | A space instead of `+` for numeric output (`-` is shown), for containers skips delimiters.
 | #        | Alternate format; prefix 0x/0x, 0 (octal) and 0b/0B for binary, Floats force decimal '.'. For g/G keep trailing 0.
@@ -476,7 +476,7 @@ function SemVer.new(SemVerHash $hash_args)
 # SemVerRange objects.
 #
 $t = SemVer[
-  SemVerRange('>=1.0.0 <2.0.0'), 
+  SemVerRange('>=1.0.0 <2.0.0'),
   SemVerRange('>=3.0.0 <4.0.0')
 ]
 notice(SemVer('1.2.3') =~ $t) # true
@@ -525,6 +525,6 @@ For examples of `SemVerRange` use see "Creating a SemVer"
 
 DOC
 ) do |args|
-  function_fail(["new() is only available when parser/evaluator future is in effect"])
+  Error.is4x('new')
 end
 

--- a/lib/puppet/parser/functions/reduce.rb
+++ b/lib/puppet/parser/functions/reduce.rb
@@ -102,5 +102,5 @@ $combine = $data.reduce( [d, 4] ) |$memo, $value| {
 - Since 4.0.0
 DOC
 ) do |args|
-  function_fail(["reduce() is only available when parser/evaluator future is in effect"])
+  Error.is4x('reduce')
 end

--- a/lib/puppet/parser/functions/regsubst.rb
+++ b/lib/puppet/parser/functions/regsubst.rb
@@ -24,7 +24,8 @@
 # other dealings in this Software without prior written authorization
 # from Thomas Bellman.
 
-Puppet::Parser::Functions::newfunction(
+module Puppet::Parser::Functions
+  newfunction(
   :regsubst, :type => :rvalue,
   :arity => -4,
 
@@ -56,5 +57,6 @@ Put angle brackets around each octet in the node's IP address:
 
     $x = regsubst($ipaddress, '([0-9]+)', '<\\1>', 'G')
 ") do |args|
-    function_fail(['regsubst() has been converted to 4x API'])
+    Error.is4x('regsubst')
+end
 end

--- a/lib/puppet/parser/functions/reverse_each.rb
+++ b/lib/puppet/parser/functions/reverse_each.rb
@@ -79,5 +79,5 @@ $transformed_data = map(reverse_each($data)) |$item| { $item * 10 }
 
 DOC
 ) do |args|
-  function_fail(["reverse_each() is only available when parser/evaluator future is in effect"])
+  Error.is4x('reverse_each')
 end

--- a/lib/puppet/parser/functions/slice.rb
+++ b/lib/puppet/parser/functions/slice.rb
@@ -35,5 +35,5 @@ to empty arrays for a hash.
 - Since 4.0.0
 DOC
 ) do |args|
-  function_fail(["slice() is only available when parser/evaluator future is in effect"])
+  Error.is4x('slice')
 end

--- a/lib/puppet/parser/functions/split.rb
+++ b/lib/puppet/parser/functions/split.rb
@@ -23,6 +23,6 @@ a regexp meta-character (.), which must be escaped.  A simple
 way to do that for a single character is to enclose it in square
 brackets; a backslash will also escape a single character.") do |args|
 
-    function_fail(['split() has been converted to 4x API'])
+    Error.is4x('split')
   end
 end

--- a/lib/puppet/parser/functions/step.rb
+++ b/lib/puppet/parser/functions/step.rb
@@ -80,5 +80,5 @@ $transformed_data contains [0,50,100,150,200]
 
 DOC
 ) do |args|
-  function_fail(["step() is only available when parser/evaluator future is in effect"])
+  Error.is4x('step')
 end

--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -1,0 +1,173 @@
+Puppet::Parser::Functions::newfunction(
+  :strftime,
+  :type => :rvalue,
+  :arity => 2,
+  :doc => <<DOC
+Formats timestamp or timespan according to the directives in the given format string. The directives begins with a percent (%) character.
+Any text not listed as a directive will be passed through to the output string.
+
+The directive consists of a percent (%) character, zero or more flags, optional minimum field width and
+a conversion specifier as follows:
+```
+%[Flags][Width]Conversion
+```
+
+### Flags that controls padding
+
+| Flag  | Meaning
+| ----  | ---------------
+| -     | Don't pad numerical output
+| _     | Use spaces for padding
+| 0     | Use zeros for padding
+
+### `Timestamp` specific flags
+
+| Flag  | Meaning
+| ----  | ---------------
+| #     | Change case
+| ^     | Use uppercase
+| :     | Use colons for %z
+
+### Format directives applicable to `Timestamp` (names and padding can be altered using flags):
+
+**Date (Year, Month, Day):**
+
+| Format | Meaning |
+| ------ | ------- |
+| Y | Year with century, zero-padded to at least 4 digits |
+| C | year / 100 (rounded down such as 20 in 2009) |
+| y | year % 100 (00..99) |
+| m | Month of the year, zero-padded (01..12) |
+| B | The full month name ("January") |
+| b | The abbreviated month name ("Jan") |
+| h | Equivalent to %b |
+| d | Day of the month, zero-padded (01..31) |
+| e | Day of the month, blank-padded ( 1..31) |
+| j | Day of the year (001..366) |
+
+**Time (Hour, Minute, Second, Subsecond):**
+
+| Format | Meaning |
+| ------ | ------- |
+| H | Hour of the day, 24-hour clock, zero-padded (00..23) |
+| k | Hour of the day, 24-hour clock, blank-padded ( 0..23) |
+| I | Hour of the day, 12-hour clock, zero-padded (01..12) |
+| l | Hour of the day, 12-hour clock, blank-padded ( 1..12) |
+| P | Meridian indicator, lowercase ("am" or "pm") |
+| p | Meridian indicator, uppercase ("AM" or "PM") |
+| M | Minute of the hour (00..59) |
+| S | Second of the minute (00..60) |
+| L | Millisecond of the second (000..999). Digits under millisecond are truncated to not produce 1000 |
+| N | Fractional seconds digits, default is 9 digits (nanosecond). Digits under a specified width are truncated to avoid carry up |
+
+**Time (Hour, Minute, Second, Subsecond):**
+
+| Format | Meaning |
+| ------ | ------- |
+| z   | Time zone as hour and minute offset from UTC (e.g. +0900) |
+| :z  | hour and minute offset from UTC with a colon (e.g. +09:00) |
+| ::z | hour, minute and second offset from UTC (e.g. +09:00:00) |
+| Z   | Abbreviated time zone name or similar information.  (OS dependent) |
+
+**Weekday:**
+
+| Format | Meaning |
+| ------ | ------- |
+| A | The full weekday name ("Sunday") |
+| a | The abbreviated name ("Sun") |
+| u | Day of the week (Monday is 1, 1..7) |
+| w | Day of the week (Sunday is 0, 0..6) |
+
+**ISO 8601 week-based year and week number:**
+
+The first week of YYYY starts with a Monday and includes YYYY-01-04.
+The days in the year before the first week are in the last week of
+the previous year.
+
+| Format | Meaning |
+| ------ | ------- |
+| G | The week-based year |
+| g | The last 2 digits of the week-based year (00..99) |
+| V | Week number of the week-based year (01..53) |
+
+**Week number:**
+
+The first week of YYYY that starts with a Sunday or Monday (according to %U
+or %W). The days in the year before the first week are in week 0.
+
+| Format | Meaning |
+| ------ | ------- |
+| U | Week number of the year. The week starts with Sunday. (00..53) |
+| W | Week number of the year. The week starts with Monday. (00..53) |
+
+**Seconds since the Epoch:**
+
+| Format | Meaning |
+| s | Number of seconds since 1970-01-01 00:00:00 UTC. |
+
+**Literal string:**
+
+| Format | Meaning |
+| ------ | ------- |
+| n | Newline character (\n) |
+| t | Tab character (\t) |
+| % | Literal "%" character |
+
+**Combination:**
+
+| Format | Meaning |
+| ------ | ------- |
+| c | date and time (%a %b %e %T %Y) |
+| D | Date (%m/%d/%y) |
+| F | The ISO 8601 date format (%Y-%m-%d) |
+| v | VMS date (%e-%^b-%4Y) |
+| x | Same as %D |
+| X | Same as %T |
+| r | 12-hour time (%I:%M:%S %p) |
+| R | 24-hour time (%H:%M) |
+| T | 24-hour time (%H:%M:%S) |
+
+**Example**: Using `strftime` with a `Timestamp`:
+
+~~~ puppet
+$duration = Timestamp('2016-08-24T12:13:14')
+
+# Notice the duration using a format that notices <hours>:<minutes>:<seconds>
+notice($duration.strftime('%F')) # outputs '2016-08-24'
+
+# Notice the duration using a format that notices <minutes>:<seconds>
+notice($duration.strftime('%c')) # outputs 'Wed Aug 24 12:13:14 2016'
+~~~
+
+### Format directives applicable to `Timespan`:
+
+| Format | Meaning |
+| ------ | ------- |
+| D | Number of Days |
+| H | Hour of the day, 24-hour clock |
+| M | Minute of the hour (00..59) |
+| S | Second of the minute (00..59) |
+| L | Millisecond of the second (000..999). Digits under millisecond are truncated to not produce 1000. |
+| N | Fractional seconds digits, default is 9 digits (nanosecond). Digits under a specified length are truncated to avoid carry up |
+
+The format directive that represents the highest magnitude in the format will be allowed to overflow.
+I.e. if no "%D" is used but a "%H" is present, then the hours will be more than 23 in case the
+timespan reflects more than a day.
+
+**Example**: Using `strftime` with a Timespan and a format
+
+~~~ puppet
+$duration = Timespan({ hours => 3, minutes => 20, seconds => 30 })
+
+# Notice the duration using a format that outputs <hours>:<minutes>:<seconds>
+notice($duration.strftime('%H:%M:%S')) # outputs '03:20:30'
+
+# Notice the duration using a format that outputs <minutes>:<seconds>
+notice($duration.strftime('%M:%S')) # outputs '200:30'
+~~~
+
+- Since 4.7.0
+DOC
+) do |args|
+  function_fail(["strftime() is only available when parser/evaluator future is in effect"])
+end

--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -169,5 +169,5 @@ notice($duration.strftime('%M:%S')) # outputs '200:30'
 - Since 4.7.0
 DOC
 ) do |args|
-  function_fail(["strftime() is only available when parser/evaluator future is in effect"])
+  Error.is4x('strftime')
 end

--- a/lib/puppet/parser/functions/then.rb
+++ b/lib/puppet/parser/functions/then.rb
@@ -31,7 +31,7 @@ notice $data.dig(a, b, 1, x).then |$x| { $x * 2 }
 Which would notice `undef` since the last lookup of 'x' results in `undef` which
 is returned (without calling the lambda given to the `then` function).
 
-As a result there is no need for conditional logic or a temporary (non local) 
+As a result there is no need for conditional logic or a temporary (non local)
 variable as the result is now either the wanted value (`x`) multiplied
 by 2 or `undef`.
 
@@ -69,5 +69,5 @@ was not a String.
 
 DOC
 ) do |args|
-  function_fail(["then() is only available when parser/evaluator future is in effect"])
+  Error.is4x('then')
 end

--- a/lib/puppet/parser/functions/type.rb
+++ b/lib/puppet/parser/functions/type.rb
@@ -49,5 +49,5 @@ function type(Any $value, InferenceFidelity $fidelity = 'detailed') # returns Ty
 
 DOC
 ) do |args|
-  function_fail(["type() is only available when parser/evaluator future is in effect"])
+  Error.is4x('type')
 end

--- a/lib/puppet/parser/functions/with.rb
+++ b/lib/puppet/parser/functions/with.rb
@@ -13,8 +13,8 @@ class using variables whose values cannot be accessed outside of the lambda.
 
 ~~~ puppet
 # Concatenate three strings into a single string formatted as a list.
-$fruit = with("apples", "oranges", "bananas") |$x, $y, $z| { 
-  "${x}, ${y}, and ${z}" 
+$fruit = with("apples", "oranges", "bananas") |$x, $y, $z| {
+  "${x}, ${y}, and ${z}"
 }
 $check_var = $x
 # $fruit contains "apples, oranges, and bananas"
@@ -24,5 +24,5 @@ $check_var = $x
 - Since 4.0.0
 DOC
 ) do |args|
-  function_fail(["with() is only available when parser/evaluator future is in effect"])
+  Error.is4x('with')
 end

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -41,6 +41,9 @@ module Puppet
 
     require 'puppet/pops/model/model'
 
+    require 'puppet/pops/time/timespan'
+    require 'puppet/pops/time/timestamp'
+
     # (the Types module initializes itself)
     require 'puppet/pops/types/types'
     require 'puppet/pops/types/string_converter'

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -158,6 +158,18 @@ class AccessOperator
     Types::TypeFactory.sem_ver(*keys)
   end
 
+  def access_PTimestampType(o, scope, keys)
+    keys.flatten!
+    fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic, :base_type => o, :min=>0, :max => 2, :actual => keys.size) if keys.size > 2
+    Types::TypeFactory.timestamp(*keys)
+  end
+
+  def access_PTimespanType(o, scope, keys)
+    keys.flatten!
+    fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic, :base_type => o, :min=>0, :max => 2, :actual => keys.size) if keys.size > 2
+    Types::TypeFactory.timespan(*keys)
+  end
+
   def access_PTupleType(o, scope, keys)
     keys.flatten!
     if Types::TypeFactory.is_range_parameter?(keys[-2]) && Types::TypeFactory.is_range_parameter?(keys[-1])

--- a/lib/puppet/pops/evaluator/compare_operator.rb
+++ b/lib/puppet/pops/evaluator/compare_operator.rb
@@ -92,13 +92,23 @@ class CompareOperator
     end
   end
 
+  def cmp_Timespan(a, b)
+    raise ArgumentError.new('Timespans are only comparable to Timespans, Integers, and Floats') unless b.is_a?(Numeric)
+    a <=> b
+  end
+
+  def cmp_Timestamp(a, b)
+    raise ArgumentError.new('Timestamps are only comparable to Timestamps, Integers, and Floats') unless b.is_a?(Numeric)
+    a <=> b
+  end
+
   def cmp_Version(a, b)
     raise ArgumentError.new('Versions not comparable to non Versions') unless b.is_a?(Semantic::Version)
     a <=> b
   end
 
   def cmp_Object(a, b)
-    raise ArgumentError.new('Only Strings, Numbers, and Versions are comparable')
+    raise ArgumentError.new('Only Strings, Numbers, Timespans, Timestamps, and Versions are comparable')
   end
 
 

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -112,6 +112,18 @@ class Runtime3Converter
   end
   alias :convert2_SemVerRange :convert_SemVerRange
 
+  def convert_Timespan(o, scope, undef_value)
+    # Puppet 3x cannot handle Timespans. Use the string form
+    o.to_s
+  end
+  alias :convert2_Timespan :convert_Timespan
+
+  def convert_Timestamp(o, scope, undef_value)
+    # Puppet 3x cannot handle Timestamps. Use the string form
+    o.to_s
+  end
+  alias :convert2_Timestamp :convert_Timestamp
+
   def convert_Symbol(o, scope, undef_value)
     case o
       # Support :undef since it may come from a 3x structure

--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -100,6 +100,8 @@ class ModelLabelProvider
   def label_TypeDefinition o              ; "Type Definition"                   end
   def label_Application o                 ; "Application"                       end
   def label_Sensitive o                   ; "Sensitive"                         end
+  def label_Timestamp o                   ; "Timestamp"                         end
+  def label_Timespan o                    ; "Timespan"                          end
 
   def label_PResourceType o
     if o.title

--- a/lib/puppet/pops/serialization/abstract_reader.rb
+++ b/lib/puppet/pops/serialization/abstract_reader.rb
@@ -16,6 +16,7 @@ module Serialization
 # - Regexp
 # - Version
 # - VersionRange
+# - Timespan
 # - Timestamp
 # - Default
 #
@@ -132,7 +133,15 @@ class AbstractReader
       read_payload(data) do |ep|
         sec = ep.read
         nsec = ep.read
-        TimeFactory.from_sec_nsec(sec, nsec)
+        Time::Timestamp.new(sec * 1000000000 + nsec)
+      end
+    end
+
+    register_type(Extension::TIMESPAN) do |data|
+      read_payload(data) do |ep|
+        sec = ep.read
+        nsec = ep.read
+        Time::Timespan.new(sec * 1000000000 + nsec)
       end
     end
 

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -19,6 +19,7 @@ MIN_INTEGER = -0x8000000000000000
 # - Regexp
 # - Version
 # - VersionRange
+# - Timespan
 # - Timestamp
 # - Default
 #
@@ -161,8 +162,12 @@ class AbstractWriter
       build_payload { |ep| ep.write(o.to_s) }
     end
 
-    register_type(Extension::TIME, Time) do |o|
-      build_payload { |ep| ep.write(o.tv_sec); ep.write(o.tv_nsec) }
+    register_type(Extension::TIME, Time::Timestamp) do |o|
+      build_payload { |ep| nsecs = o.nsecs; ep.write(nsecs / 1000000000); ep.write(nsecs % 1000000000) }
+    end
+
+    register_type(Extension::TIMESPAN, Time::Timespan) do |o|
+      build_payload { |ep| nsecs = o.nsecs; ep.write(nsecs / 1000000000); ep.write(nsecs % 1000000000) }
     end
 
     register_type(Extension::VERSION, Semantic::Version) do |o|

--- a/lib/puppet/pops/serialization/serializer.rb
+++ b/lib/puppet/pops/serialization/serializer.rb
@@ -67,7 +67,7 @@ module Serialization
     def write_tabulated_first_time(value)
       @written[value.object_id] = @written.size
       case value
-      when Symbol, Regexp, Semantic::Version, Semantic::VersionRange
+      when Symbol, Regexp, Semantic::Version, Semantic::VersionRange, Time::Timestamp, Time::Timespan
         @writer.write(value)
       when Array
         start_array(value.size)

--- a/lib/puppet/pops/serialization/time_factory.rb
+++ b/lib/puppet/pops/serialization/time_factory.rb
@@ -4,7 +4,8 @@ module Serialization
   # the created Time object can be serialized and deserialized using its
   # seconds and nanoseconds without loss of precision.
   #
-  # @api public
+  # @deprecated No longer in use. Functionality replaced by Timestamp
+  # @api private
   class TimeFactory
 
     NANO_DENOMINATOR = 10**9

--- a/lib/puppet/pops/time/timespan.rb
+++ b/lib/puppet/pops/time/timespan.rb
@@ -1,0 +1,686 @@
+module Puppet::Pops
+module Time
+  NSECS_PER_USEC = 1000
+  NSECS_PER_MSEC = NSECS_PER_USEC * 1000
+  NSECS_PER_SEC  = NSECS_PER_MSEC * 1000
+  NSECS_PER_MIN  = NSECS_PER_SEC  * 60
+  NSECS_PER_HOUR = NSECS_PER_MIN  * 60
+  NSECS_PER_DAY  = NSECS_PER_HOUR * 24
+
+  KEY_STRING = 'string'.freeze
+  KEY_FORMAT = 'format'.freeze
+  KEY_NEGATIVE = 'negative'.freeze
+  KEY_DAYS = 'days'.freeze
+  KEY_HOURS = 'hours'.freeze
+  KEY_MINUTES = 'minutes'.freeze
+  KEY_SECONDS = 'seconds'.freeze
+  KEY_MILLI_SECONDS = 'milli_seconds'.freeze
+  KEY_MICRO_SECONDS = 'micro_seconds'.freeze
+  KEY_NANO_SECONDS = 'nano_seconds'.freeze
+
+  # TimeData is a Numeric that stores its value internally as nano-seconds but will be considered to be seconds and fractions of
+  # seconds when used in arithmetic or comparison with other Numeric types.
+  #
+  class TimeData < Numeric
+    include LabelProvider
+
+    attr_reader :nsecs
+
+    def initialize(nano_seconds)
+      @nsecs = nano_seconds
+    end
+
+    def eql?(o)
+      o.class == self.class && @nsecs.eql?(o.nsecs)
+    end
+
+    def ==(o)
+      eql?(o)
+    end
+
+    def <=>(o)
+      case o
+      when self.class
+        @nsecs <=> o.nsecs
+      when Integer
+        to_int <=> o
+      when Float
+        to_f <=> o
+      else
+        nil
+      end
+    end
+
+    def label(o)
+      Utils.name_to_segments(o.class.name).last
+    end
+
+    # @return [Float] the number of seconds
+    def to_f
+      @nsecs.fdiv(NSECS_PER_SEC)
+    end
+
+    # @return [Integer] the number of seconds with fraction part truncated
+    def to_int
+      @nsecs / NSECS_PER_SEC
+    end
+
+    def to_i
+      to_int
+    end
+
+    # @return [Complex] short for `#to_f.to_c`
+    def to_c
+      to_f.to_c
+    end
+
+    # @return [Rational] initial numerator is nano-seconds and denominator is nano-seconds per second
+    def to_r
+      Rational(@nsecs, NSECS_PER_SEC)
+    end
+
+    undef_method :phase, :polar, :rect, :rectangular
+  end
+
+  class Timespan < TimeData
+    def self.from_fields(negative, days, hours, minutes, seconds, milli_seconds = 0, micro_seconds = 0, nano_seconds = 0)
+      ns = (((((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000 + milli_seconds) * 1000 + micro_seconds) * 1000 + nano_seconds
+      new(negative ? -ns : ns)
+    end
+
+    def self.from_hash(hash)
+      hash.include?('string') ? from_string_hash(hash) : from_fields_hash(hash)
+    end
+
+    def self.from_string_hash(hash)
+      parse(hash[KEY_STRING], hash[KEY_FORMAT] || Format::DEFAULTS)
+    end
+
+    def self.from_fields_hash(hash)
+      from_fields(
+        hash[KEY_NEGATIVE] || false,
+        hash[KEY_DAYS] || 0,
+        hash[KEY_HOURS] || 0,
+        hash[KEY_MINUTES] || 0,
+        hash[KEY_SECONDS] || 0,
+        hash[KEY_MILLI_SECONDS] || 0,
+        hash[KEY_MICRO_SECONDS] || 0,
+        hash[KEY_NANO_SECONDS] || 0)
+    end
+
+    def self.parse(str, format = Format::DEFAULTS)
+      if format.is_a?(::Array)
+        format.each do |fmt|
+          fmt = FormatParser.singleton.parse_format(fmt) unless fmt.is_a?(Format)
+          begin
+            return fmt.parse(str)
+          rescue ArgumentError
+          end
+        end
+        raise ArgumentError, "Unable to parse '#{str}' using any of the formats #{format.join(', ')}"
+      end
+      format = FormatParser.singleton.parse_format(format) unless format.is_a?(Format)
+      format.parse(str)
+    end
+
+    # @return [true] if the stored value is negative
+    def negative?
+      @nsecs < 0
+    end
+
+    def +(o)
+      case o
+      when Timestamp
+        Timestamp.new(@nsecs + o.nsecs)
+      when Timespan
+        Timespan.new(@nsecs + o.nsecs)
+      when Integer, Float
+        # Add seconds
+        Timespan.new(@nsecs + (o * NSECS_PER_SEC).to_i)
+      else
+        raise ArgumentError, "#{a_an_uc(o)} cannot be added to a Timespan" unless o.is_a?(Timespan)
+      end
+    end
+
+    def -(o)
+      case o
+      when Timespan
+        Timespan.new(@nsecs - o.nsecs)
+      when Integer, Float
+        # Subtract seconds
+        Timespan.new(@nsecs - (o * NSECS_PER_SEC).to_i)
+      else
+        raise ArgumentError, "#{a_an_uc(o)} cannot be subtracted from a Timespan"
+      end
+    end
+
+    def -@
+      Timespan.new(-@nsecs)
+    end
+
+    def *(o)
+      case o
+      when Integer, Float
+        Timespan.new((@nsecs * o).to_i)
+      else
+        raise ArgumentError, "A Timestamp cannot be multiplied by #{a_an(o)}"
+      end
+    end
+
+    def divmod(o)
+      case o
+      when Integer
+        to_i.divmod(o)
+      when Float
+        to_f.divmod(o)
+      else
+        raise ArgumentError, "Can not do modulus on a Timestamp using a #{a_an(o)}"
+      end
+    end
+
+    def modulo(o)
+      divmod(o)[1]
+    end
+
+    def %(o)
+      modulo(o)
+    end
+
+    def div(o)
+      case o
+      when Timespan
+        # Timespan/Timespan yields a Float
+        @nsecs.fdiv(o.nsecs)
+      when Integer, Float
+        Timespan.new(@nsecs.div(o))
+      else
+        raise ArgumentError, "A Timespan cannot be divided by #{a_an(o)}"
+      end
+    end
+
+    def /(o)
+      div(o)
+    end
+
+    # @return [Integer] a positive integer denoting the number of days
+    def days
+      total_days
+    end
+
+    # @return [Integer] a positive integer, 0 - 23 denoting hours of day
+    def hours
+      total_hours % 24
+    end
+
+    # @return [Integer] a positive integer, 0 - 59 denoting minutes of hour
+    def minutes
+      total_minutes % 60
+    end
+
+    # @return [Integer] a positive integer, 0 - 59 denoting seconds of minute
+    def seconds
+      total_seconds % 60
+    end
+
+    # @return [Integer] a positive integer, 0 - 999 denoting milliseconds of second
+    def milli_seconds
+      total_milli_seconds % 1000
+    end
+
+    # @return [Integer] a positive integer, 0 - 999.999.999 denoting nanoseconds of second
+    def nano_seconds
+      total_nano_seconds % NSECS_PER_SEC
+    end
+
+    # Formats this timestamp into a string according to the given `format`
+    #
+    # @param [String,Format] format The format to use when producing the string
+    # @return [String] the string representing the formatted timestamp
+    # @raise [ArgumentError] if the format is a string with illegal format characters
+    # @api public
+    def format(format)
+      format = FormatParser.singleton.parse_format(format) unless format.is_a?(Format)
+      format.format(self)
+    end
+
+    # Formats this timestamp into a string according to {Format::DEFAULTS[0]}
+    #
+    # @return [String] the string representing the formatted timestamp
+    # @api public
+    def to_s
+      format(Format::DEFAULTS[0])
+    end
+
+    def to_hash(compact = false)
+      result = {}
+      n = nano_seconds
+      if compact
+        s = total_seconds
+        result[KEY_SECONDS] = negative? ? -s : s
+        result[KEY_NANO_SECONDS] = negative? ? -n : n unless n == 0
+      else
+        add_unless_zero(result, KEY_DAYS, days)
+        add_unless_zero(result, KEY_HOURS, hours)
+        add_unless_zero(result, KEY_MINUTES, minutes)
+        add_unless_zero(result, KEY_SECONDS, seconds)
+        unless n == 0
+          add_unless_zero(result, KEY_NANO_SECONDS, n % 1000)
+          n /= 1000
+          add_unless_zero(result, KEY_MICRO_SECONDS, n % 1000)
+          add_unless_zero(result, KEY_MILLI_SECONDS, n /= 1000)
+        end
+        result[KEY_NEGATIVE] = true if negative?
+      end
+      result
+    end
+
+    def add_unless_zero(result, key, value)
+      result[key] = value unless value == 0
+    end
+    private :add_unless_zero
+
+    # @api private
+    def total_days
+      total_nano_seconds / NSECS_PER_DAY
+    end
+
+    # @api private
+    def total_hours
+      total_nano_seconds / NSECS_PER_HOUR
+    end
+
+    # @api private
+    def total_minutes
+      total_nano_seconds / NSECS_PER_MIN
+    end
+
+    # @api private
+    def total_seconds
+      total_nano_seconds / NSECS_PER_SEC
+    end
+
+    # @api private
+    def total_milli_seconds
+      total_nano_seconds / NSECS_PER_MSEC
+    end
+
+    # @api private
+    def total_micro_seconds
+      total_nano_seconds / NSECS_PER_USEC
+    end
+
+    # @api private
+    def total_nano_seconds
+      @nsecs.abs
+    end
+
+    # Represents a compiled Timestamp format. The format is used both when parsing a timestamp
+    # in string format and when producing a string from a timestamp instance.
+    #
+    class Format
+      # A segment is either a string that will be represented literally in the formatted timestamp
+      # or a value that corresponds to one of the possible format characters.
+      class Segment
+        def append_to(bld, ts)
+          raise NotImplementedError, "'#{self.class.name}' should implement #append_to"
+        end
+
+        def append_regexp(bld, ts)
+          raise NotImplementedError, "'#{self.class.name}' should implement #append_regexp"
+        end
+
+        def multiplier
+          raise NotImplementedError, "'#{self.class.name}' should implement #multiplier"
+        end
+      end
+
+      class LiteralSegment < Segment
+        def append_regexp(bld)
+          bld << "(#{Regexp.escape(@literal)})"
+        end
+
+        def initialize(literal)
+          @literal = literal
+        end
+
+        def append_to(bld, ts)
+          bld << @literal
+        end
+
+        def concat(codepoint)
+          @literal.concat(codepoint)
+        end
+
+        def multiplier
+          0
+        end
+      end
+
+      class ValueSegment < Segment
+        def initialize(padchar, width, default_width)
+          @use_total = false
+          @format = case padchar
+          when nil
+            '%d'
+          when ' '
+            "%#{width || default_width}d"
+          else
+            "%#{padchar}#{width || default_width}d"
+          end
+          @width = width
+          @default_width = default_width
+        end
+
+        def append_regexp(bld)
+          if @width.nil?
+            case @padchar
+            when nil
+              bld << (use_total? ? '([0-9]+)' : "([0-9]{1,#{@default_width}})")
+            when '0'
+              bld << (use_total? ? '([0-9]+)' : "([0-9]{#{@default_width}})")
+            else
+              bld << (use_total? ? '\s*([0-9]+)' : "([0-9\\s]{#{@default_width}})")
+            end
+          else
+            case @padchar
+            when nil
+              bld << "([0-9]{1,#{@width}})"
+            when '0'
+              bld << "([0-9]{#{@width}})"
+            else
+              bld << "([0-9\\s]{#{@width}})"
+            end
+          end
+        end
+
+        def set_use_total
+          @use_total = true
+        end
+
+        def use_total?
+          @use_total
+        end
+
+        def append_value(bld, n)
+          bld << sprintf(@format, n)
+        end
+      end
+
+      class DaySegment < ValueSegment
+        def initialize(padchar, width)
+          super(padchar, width, 1)
+        end
+
+        def multiplier
+          NSECS_PER_DAY
+        end
+
+        def append_to(bld, ts)
+          append_value(bld, ts.days)
+        end
+      end
+
+      class HourSegment < ValueSegment
+        def initialize(padchar, width)
+          super(padchar, width, 2)
+        end
+
+        def multiplier
+          NSECS_PER_HOUR
+        end
+
+        def append_to(bld, ts)
+          append_value(bld, use_total? ? ts.total_hours : ts.hours)
+        end
+      end
+
+      class MinuteSegment < ValueSegment
+        def initialize(padchar, width)
+          super(padchar, width, 2)
+        end
+
+        def multiplier
+          NSECS_PER_MIN
+        end
+
+        def append_to(bld, ts)
+          append_value(bld, use_total? ? ts.total_minutes : ts.minutes)
+        end
+      end
+
+      class SecondSegment < ValueSegment
+        def initialize(padchar, width)
+          super(padchar, width, 2)
+        end
+
+        def multiplier
+          NSECS_PER_SEC
+        end
+
+        def append_to(bld, ts)
+          append_value(bld, use_total? ? ts.total_seconds : ts.seconds)
+        end
+      end
+
+      class MilliSecondSegment < ValueSegment
+        def initialize(padchar, width)
+          super(padchar, width, 3)
+        end
+
+        def multiplier
+          NSECS_PER_MSEC
+        end
+
+        def append_to(bld, ts)
+          append_value(bld, use_total? ? ts.total_milli_seconds : ts.milli_seconds)
+        end
+      end
+
+      class NanoSecondSegment < ValueSegment
+        def initialize(padchar, width)
+          super(padchar, width, 9)
+        end
+
+        def multiplier
+          width = @widht || @default_width
+          if width < 9
+            10 ** (9 - width)
+          else
+            1
+          end
+        end
+
+        def append_to(bld, ts)
+          ns = ts.total_nano_seconds
+          width = @widht || @default_width
+          if width < 9
+            # Truncate digits to the right, i.e. let %6N reflect microseconds
+            ns /= 10 ** (9 - width)
+            ns %= 10 ** width unless use_total?
+          else
+            ns %= NSECS_PER_SEC unless use_total?
+          end
+          append_value(bld, ns)
+        end
+      end
+
+      def initialize(format, segments)
+        @format = format.freeze
+        @segments = segments.freeze
+      end
+
+      def format(timespan)
+        bld = timespan.negative? ? '-' : ''
+        @segments.each { |segment| segment.append_to(bld, timespan) }
+        bld
+      end
+
+      def parse(timespan)
+        md = regexp.match(timespan)
+        raise ArgumentError, "Unable to parse '#{timespan}' using format '#{@format}'" if md.nil?
+        nano_seconds = 0
+        md.captures.each_with_index do |group, index|
+          segment = @segments[index]
+          next if segment.is_a?(LiteralSegment)
+          group.lstrip!
+          raise ArgumentError, "Unable to parse '#{timespan}' using format '#{@format}'" unless group =~ /\A[0-9]+\z/
+          nano_seconds += group.to_i * segment.multiplier
+        end
+        Timespan.new(timespan.start_with?('-') ? -nano_seconds : nano_seconds)
+      end
+
+      def to_s
+        @format
+      end
+
+      private
+
+      def regexp
+        @regexp ||= build_regexp
+      end
+
+      def build_regexp
+        bld = '\A-?'
+        @segments.each { |segment| segment.append_regexp(bld) }
+        bld << '\z'
+        Regexp.new(bld)
+      end
+    end
+
+    # Parses a string into a Timestamp::Format instance
+    class FormatParser
+      def self.singleton
+        @singleton
+      end
+
+      def initialize
+        @formats = Hash.new { |hash, str| hash[str] = internal_parse(str) }
+      end
+
+      def parse_format(format)
+        @formats[format]
+      end
+
+      private
+
+      NSEC_MAX = 0
+      MSEC_MAX = 1
+      SEC_MAX = 2
+      MIN_MAX = 3
+      HOUR_MAX = 4
+      DAY_MAX = 5
+
+      SEGMENT_CLASS_BY_ORDINAL = [
+        Format::NanoSecondSegment, Format::MilliSecondSegment, Format::SecondSegment, Format::MinuteSegment, Format::HourSegment, Format::DaySegment
+      ]
+
+      def bad_format_specifier(format, start, position)
+        "Bad format specifier '#{format[start,position-start]}' in '#{format}', at position #{position}"
+      end
+
+      def append_literal(bld, codepoint)
+        if bld.empty? || !bld.last.is_a?(Format::LiteralSegment)
+          bld << Format::LiteralSegment.new(''.concat(codepoint))
+        else
+          bld.last.concat(codepoint)
+        end
+      end
+
+      # States used by the #internal_parser function
+      STATE_LITERAL = 0 # expects literal or '%'
+      STATE_PAD  = 1 # expects pad, width, or format character
+      STATE_WIDTH = 2 # expects width, or format character
+
+      def internal_parse(str)
+        bld = []
+        raise ArgumentError, 'Format must be a String' unless str.is_a?(String)
+        highest = -1
+        state = STATE_LITERAL
+        padchar = '0'
+        width = nil
+        position = -1
+        fstart = 0
+
+        str.codepoints do |codepoint|
+          position += 1
+          if state == STATE_LITERAL
+            if codepoint == 0x25 # '%'
+              state = STATE_PAD
+              fstart = position
+              padchar = '0'
+              width = nil
+            else
+              append_literal(bld, codepoint)
+            end
+            next
+          end
+
+          case codepoint
+          when 0x25 # '%'
+            append_literal(bld, codepoint)
+            state = STATE_LITERAL
+          when 0x2D # '-'
+            raise ArgumentError, bad_format_specifier(str, fstart, position) unless state == STATE_PAD
+            padchar = nil
+            state = STATE_WIDTH
+          when 0x5F # '_'
+            raise ArgumentError, bad_format_specifier(str, fstart, position) unless state == STATE_PAD
+            padchar = ' '
+            state = STATE_WIDTH
+          when 0x44 # 'D'
+            highest = DAY_MAX
+            bld << Format::DaySegment.new(padchar, width)
+            state = STATE_LITERAL
+          when 0x48 # 'H'
+            highest = HOUR_MAX unless highest > HOUR_MAX
+            bld << Format::HourSegment.new(padchar, width)
+            state = STATE_LITERAL
+          when 0x4D # 'M'
+            highest = MIN_MAX unless highest > MIN_MAX
+            bld << Format::MinuteSegment.new(padchar, width)
+            state = STATE_LITERAL
+          when 0x53 # 'S'
+            highest = SEC_MAX unless highest > SEC_MAX
+            bld << Format::SecondSegment.new(padchar, width)
+            state = STATE_LITERAL
+          when 0x4C # 'L'
+            highest = MSEC_MAX unless highest > MSEC_MAX
+            bld << Format::MilliSecondSegment.new(padchar, width)
+            state = STATE_LITERAL
+          when 0x4E # 'N'
+            highest = NSEC_MAX unless highest > NSEC_MAX
+            bld << Format::NanoSecondSegment.new(padchar, width)
+            state = STATE_LITERAL
+          else # only digits allowed at this point
+            raise ArgumentError, bad_format_specifier(str, fstart, position) unless codepoint >= 0x30 && codepoint <= 0x39
+            if state == STATE_PAD && codepoint == 0x30
+              padchar = '0'
+            else
+              n = codepoint - 0x30
+              if width.nil?
+                width = n
+              else
+                width = width * 10 + n
+              end
+            end
+            state = STATE_WIDTH
+          end
+        end
+
+        raise ArgumentError, bad_format_specifier(str, fstart, position)  unless state == STATE_LITERAL
+        unless highest == -1
+          hc = SEGMENT_CLASS_BY_ORDINAL[highest]
+          bld.find { |s| s.instance_of?(hc) }.set_use_total
+        end
+        Format.new(str, bld)
+      end
+
+      @singleton = FormatParser.new
+    end
+
+    class Format
+      DEFAULTS = ['%D-%H:%M:%S', '%D-%H:%M', '%H:%M:%S', '%H:%M'].map { |str| FormatParser.singleton.parse_format(str) }
+    end
+  end
+end
+end

--- a/lib/puppet/pops/time/timestamp.rb
+++ b/lib/puppet/pops/time/timestamp.rb
@@ -1,0 +1,80 @@
+module Puppet::Pops
+module Time
+class Timestamp < TimeData
+  DEFAULT_FORMATS = ['%FT%T.%L %Z', '%FT%T %Z', '%F %Z', '%FT%T.L', '%FT%T', '%F']
+
+  def self.now
+    from_time(::Time.now)
+  end
+
+  def self.from_time(t)
+    new(t.tv_sec * NSECS_PER_SEC + t.tv_nsec)
+  end
+
+  def self.from_hash(args_hash)
+    parse(args[KEY_STRING], args[KEY_FORMAT] || DEFAULT_FORMATS)
+  end
+
+  def self.parse(str, format = DEFAULT_FORMATS)
+    if format.is_a?(Array)
+      format.each do |fmt|
+        begin
+          return from_time(DateTime.strptime(str, fmt).to_time)
+        rescue ArgumentError
+        end
+      end
+      raise ArgumentError, "Unable to parse '#{str}' using any of the formats #{format.join(', ')}"
+    end
+
+    begin
+      from_time(DateTime.strptime(str, format).to_time)
+    rescue ArgumentError
+      raise ArgumentError, "Unable to parse '#{str}' using format '#{format}'"
+    end
+  end
+
+  undef_method :-@, :+@, :%,:modulo,:divmod, :div, :fdiv, :abs, :abs2, :magnitude # does not make sense on a Timestamp
+  if method_defined?(:negative?)
+    undef_method :negative?, :positive?
+  end
+
+  def +(o)
+    case o
+    when Timespan
+      Timestamp.new(@nsecs + o.nsecs)
+    when Integer, Float
+      Timestamp.new(@nsecs + (o * NSECS_PER_SEC).to_i)
+    else
+      raise ArgumentError, "#{a_an_uc(o)} cannot be added to a Timestamp"
+    end
+  end
+
+  def -(o)
+    case o
+    when Timestamp
+      # Diff between two timestamps is a timespan
+      Timespan.new(@nsecs - o.nsecs)
+    when Timespan
+      Timestamp.new(@nsecs - o.nsecs)
+    when Integer, Float
+      # Subtract seconds
+      Timestamp.new(@nsecs - (o * NSECS_PER_SEC).to_i)
+    else
+      raise ArgumentError, "#{a_an_uc(o)} cannot be subtracted from a Timestamp"
+    end
+  end
+
+  def format(format)
+    to_time.strftime(format)
+  end
+
+  def to_s
+    format(DEFAULT_FORMATS[0])
+  end
+
+  def to_time
+    ::Time.at(to_r).utc
+  end
+end
+end
+end

--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -1,0 +1,138 @@
+module Puppet::Pops
+module Types
+  class PAbstractTimeDataType < PNumericType
+    # @param [AbstractTime] min lower bound for this type. Nil or :default means unbounded
+    # @param [AbstractTime] max upper bound for this type. Nil or :default means unbounded
+    def initialize(min = nil, max = nil)
+      super(convert_arg(min, true), convert_arg(max, false))
+    end
+
+    def convert_arg(arg, min)
+      case arg
+      when impl_class
+        arg
+      when Hash
+        impl_class.from_hash(arg)
+      when nil, :default
+        nil
+      when String
+        impl_class.parse(arg)
+      when Integer
+        arg == impl_class.new(arg * Time::NSECS_PER_SEC)
+      when Float
+        arg == (min ? -Float::INFINITY : Float::INFINITY) ? arg : impl_class.new(arg * Time::NSECS_PER_SEC)
+      else
+        raise ArgumentError, "Unable to create a #{impl_class.name} from a #{arg.class.name}" unless arg.nil? || arg == :default
+        nil
+      end
+    end
+
+    # Concatenates this range with another range provided that the ranges intersect or
+    # are adjacent. When that's not the case, this method will return `nil`
+    #
+    # @param o [PAbstractTimeDataType] the range to concatenate with this range
+    # @return [PAbstractTimeDataType,nil] the concatenated range or `nil` when the ranges were apart
+    # @api public
+    def merge(o)
+      if intersect?(o) || adjacent?(o)
+        new_min = numeric_from <= o.numeric_from ? numeric_from : o.numeric_from
+        new_max = numeric_to >= o.numeric_to ? numeric_to : o.numeric_to
+        self.class.new(new_min, new_max)
+      else
+        nil
+      end
+    end
+
+    def _assignable?(o, guard)
+      self.class == o.class && numeric_from <= o.numeric_from && numeric_to >= o.numeric_to
+    end
+  end
+
+  class PTimespanType < PAbstractTimeDataType
+    def self.register_ptype(loader, ir)
+      create_ptype(loader, ir, 'NumericType')
+    end
+
+    def self.new_function(_, loader)
+      @new_function ||= Puppet::Functions.create_loaded_function(:new_timespan, loader) do
+        local_types do
+          type 'Formats = Variant[String[2],Array[String[2]], 1]'
+        end
+
+        dispatch :from_seconds do
+          param           'Variant[Integer,Float]', :seconds
+        end
+
+        dispatch :from_string do
+          param           'String[1]', :string
+          optional_param  'Formats', :format
+        end
+
+        dispatch :from_fields do
+          param          'Integer', :days
+          param          'Integer', :hours
+          param          'Integer', :minutes
+          param          'Integer', :seconds
+          optional_param 'Integer', :milli_seconds
+          optional_param 'Integer', :micro_seconds
+          optional_param 'Integer', :nano_seconds
+        end
+
+        dispatch :from_string_hash do
+          param <<-TYPE, :hash_arg
+            Struct[{
+              string => String[1],
+              Optional[format] => Formats
+            }]
+          TYPE
+        end
+
+        dispatch :from_fields_hash do
+          param <<-TYPE, :hash_arg
+            Struct[{
+              Optional[negative] => Boolean,
+              Optional[days] => Integer,
+              Optional[hours] => Integer,
+              Optional[minutes] => Integer,
+              Optional[seconds] => Integer,
+              Optional[milli_seconds] => Integer,
+              Optional[micro_seconds] => Integer,
+              Optional[nano_seconds] => Integer
+            }]
+          TYPE
+        end
+
+        def from_seconds(seconds)
+          Time::Timespan.new((seconds * Time::NSECS_PER_SEC).to_i)
+        end
+
+        def from_string(string, format = Time::Timespan::Format::DEFAULTS)
+          Time::Timespan.parse(string, format)
+        end
+
+        def from_fields(days, hours, minutes, seconds, milli_seconds = 0, micro_seconds = 0, nano_seconds = 0)
+          Time::Timespan.from_fields(days, hours, minutes, seconds, milli_seconds, micro_seconds, nano_seconds)
+        end
+
+        def from_string_hash(args_hash)
+          Time::Timespan.from_string_hash(args_hash)
+        end
+
+        def from_fields_hash(args_hash)
+          Time::Timespan.from_fields_hash(args_hash)
+        end
+      end
+    end
+
+    def generalize
+      DEFAULT
+    end
+
+    def impl_class
+      Time::Timespan
+    end
+
+    DEFAULT = PTimespanType.new(nil, nil)
+  end
+end
+end

--- a/lib/puppet/pops/types/p_timestamp_type.rb
+++ b/lib/puppet/pops/types/p_timestamp_type.rb
@@ -1,0 +1,64 @@
+module Puppet::Pops
+module Types
+  class PTimestampType < PAbstractTimeDataType
+    def self.register_ptype(loader, ir)
+      create_ptype(loader, ir, 'NumericType')
+    end
+
+    def self.new_function(_, loader)
+      @new_function ||= Puppet::Functions.create_loaded_function(:new_timestamp, loader) do
+        local_types do
+          type 'Formats = Variant[String[2],Array[String[2]], 1]'
+        end
+
+        dispatch :now do
+        end
+
+        dispatch :from_seconds do
+          param 'Variant[Integer,Float]', :seconds
+        end
+
+        dispatch :from_string do
+          param           'String[1]', :string
+          optional_param  'Formats', :format
+        end
+
+        dispatch :from_string_hash do
+          param <<-TYPE, :hash_arg
+            Struct[{
+              string => String[1],
+              Optional[format] => Formats
+            }]
+          TYPE
+        end
+
+        def now
+          Time::Timestamp.now
+        end
+
+        def from_string(string, format = Time::Timestamp::DEFAULT_FORMATS)
+          Time::Timestamp.parse(string, format)
+        end
+
+        def from_string_hash(args_hash)
+          Time::Timestamp.from_string_hash(args)
+        end
+
+        def from_seconds(seconds)
+          Time::Timestamp.new((seconds * Time::NSECS_PER_SEC).to_i)
+        end
+      end
+    end
+
+    def generalize
+      DEFAULT
+    end
+
+    def impl_class
+      Time::Timestamp
+    end
+
+    DEFAULT = PTimestampType.new(nil, nil)
+  end
+end
+end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -648,6 +648,16 @@ class TypeCalculator
   end
 
   # @api private
+  def infer_Timespan(o)
+    PTimespanType.new(o, o)
+  end
+
+  # @api private
+  def infer_Timestamp(o)
+    PTimestampType.new(o, o)
+  end
+
+  # @api private
   def infer_TrueClass(o)
     PBooleanType::DEFAULT
   end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -168,6 +168,14 @@ module TypeFactory
     hash.nil? || hash.empty? ? PTypeSetType::DEFAULT : PTypeSetType.new(hash)
   end
 
+  def self.timestamp(*args)
+    args.empty? ? PTimestampType::DEFAULT : PTimestampType.new(*args)
+  end
+
+  def self.timespan(*args)
+    args.empty? ? PTimespanType::DEFAULT : PTimespanType.new(*args)
+  end
+
   def self.tuple(types = [], size_type = nil)
     PTupleType.new(types.map {|elem| type_of(elem) }, size_type)
   end

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -69,6 +69,10 @@ class TypeFormatter
   end
 
 
+  def append_default
+    @bld << 'default'
+  end
+
   def append_string(t)
     if @ruby && t.is_a?(PAnyType)
       @ruby = false
@@ -191,6 +195,32 @@ class TypeFormatter
   # @api private
   def string_PSemVerRangeType(t)
     @bld << 'SemVerRange'
+  end
+
+  # @api private
+  def string_PTimestampType(t)
+    min = t.from
+    max = t.to
+    append_array('Timestamp', min.nil? && max.nil?) do
+      min.nil? ? append_default : append_string(min)
+      unless max.nil?
+        @bld << COMMA_SEP
+        append_string(max)
+      end
+    end
+  end
+
+  # @api private
+  def string_PTimespanType(t)
+    min = t.from
+    max = t.to
+    append_array('Timespan', min.nil? && max.nil?) do
+      min.nil? ? append_default : append_string(min)
+      unless max.nil?
+        @bld << COMMA_SEP
+        append_string(max)
+      end
+    end
   end
 
   # @api private
@@ -473,6 +503,14 @@ class TypeFormatter
 
   # @api private
   def string_VersionRange(t) ; @bld << "'#{t}'"  ; end
+
+  # @api private
+  def string_Timestamp(t)    ; @bld << "'#{t}'"  ; end
+
+  # @api private
+  def string_Timespan(o)
+    append_hash(o.to_hash, proc { |k| @bld << symbolic_key(k) })
+  end
 
   # Debugging to_s to reduce the amount of output
   def to_s

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -170,7 +170,9 @@ class TypeParser
       # A generic callable as opposed to one that does not accept arguments
         'callable'     => TypeFactory.all_callables,
         'semver'       => TypeFactory.sem_ver,
-        'semverrange'  => TypeFactory.sem_ver_range
+        'semverrange'  => TypeFactory.sem_ver_range,
+        'timestamp'    => TypeFactory.timestamp,
+        'timespan'     => TypeFactory.timespan
     }
   end
 
@@ -480,6 +482,14 @@ class TypeParser
     when 'runtime'
       raise_invalid_parameters_error('Runtime', '2', parameters.size) unless parameters.size == 2
       TypeFactory.runtime(*parameters)
+
+    when 'timespan'
+      raise_invalid_parameters_error('Timespan', '0 to 2', parameters.size) unless parameters.size <= 2
+      TypeFactory.timespan(*parameters)
+
+    when 'timestamp'
+      raise_invalid_parameters_error('Timestamp', '0 to 2', parameters.size) unless parameters.size <= 2
+      TypeFactory.timestamp(*parameters)
 
     when 'semver'
       raise_invalid_parameters_error('SemVer', '1 or more', parameters.size) unless parameters.size >= 1

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -34,6 +34,8 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PTypeAliasType,
       Puppet::Pops::Types::PSemVerType,
       Puppet::Pops::Types::PSemVerRangeType,
+      Puppet::Pops::Types::PTimespanType,
+      Puppet::Pops::Types::PTimestampType,
     ]
   end
 
@@ -60,6 +62,8 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PNumericType,
       Puppet::Pops::Types::PIntegerType,
       Puppet::Pops::Types::PFloatType,
+      Puppet::Pops::Types::PTimespanType,
+      Puppet::Pops::Types::PTimestampType,
     ]
   end
 

--- a/spec/unit/functions/strftime_spec.rb
+++ b/spec/unit/functions/strftime_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+describe 'the strftime function' do
+  include PuppetSpec::Compiler
+
+  def test_format(ctor_arg, format, expected)
+    expect(eval_and_collect_notices("notice(strftime(Timespan(#{ctor_arg}), '#{format}'))")).to eql(["#{expected}"])
+  end
+
+  context 'when applied to a Timespan' do
+    [
+      ['hours', 'H', 2, true],
+      ['minutes', 'M', 2, true],
+      ['seconds', 'S', 2, true],
+      ['milli_seconds', 'L', 3, true],
+      ['nano_seconds', 'N', 9, false],
+    ].each do |field, fmt, dflt_width, has_width|
+      ctor_arg = "{#{field}=>3}"
+      it "%#{fmt} width defaults to #{dflt_width}" do
+        test_format(ctor_arg, "%#{fmt}", sprintf("%0#{dflt_width}d", 3))
+      end
+
+      it "%_#{fmt} pads with space" do
+        test_format(ctor_arg, "%_#{fmt}", sprintf("% #{dflt_width}d", 3))
+      end
+
+      it "%-#{fmt} does not pad" do
+        test_format(ctor_arg, "%-#{fmt}", '3')
+      end
+
+      it "%10#{fmt} pads with zeroes to specified width" do
+        test_format(ctor_arg, "%10#{fmt}", sprintf("%010d", 3))
+      end
+
+      it "%_10#{fmt} pads with space to specified width" do
+        test_format(ctor_arg, "%_10#{fmt}", sprintf("% 10d", 3))
+      end
+
+      it "%-10#{fmt} does not pad even if width is specified" do
+        test_format(ctor_arg, "%-10#{fmt}", '3')
+      end
+    end
+
+    it 'can use a format containing all format characters, flags, and widths' do
+      test_format("{string => '100-14:02:24.123456789', format => '%D-%H:%M:%S.%9N'}", '%_10D%%%03H:%-M:%S.%9N', '       100%014:2:24.123456789')
+    end
+  end
+end
+

--- a/spec/unit/parser/functions/hiera_array_spec.rb
+++ b/spec/unit/parser/functions/hiera_array_spec.rb
@@ -7,6 +7,6 @@ describe 'Puppet::Parser::Functions#hiera_array' do
   let :scope do create_test_scope_for_node('foo') end
 
   it 'should raise an error since this function is converted to 4x API)' do
-    expect { scope.function_hiera_array(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
+    expect { scope.function_hiera_array(['key']) }.to raise_error(Puppet::ParseError, /can only be called using the 4.x function API/)
   end
 end

--- a/spec/unit/parser/functions/hiera_hash_spec.rb
+++ b/spec/unit/parser/functions/hiera_hash_spec.rb
@@ -7,6 +7,6 @@ describe 'Puppet::Parser::Functions#hiera_hash' do
   let :scope do create_test_scope_for_node('foo') end
 
   it 'should raise an error since this function is converted to 4x API)' do
-    expect { scope.function_hiera_hash(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
+    expect { scope.function_hiera_hash(['key']) }.to raise_error(Puppet::ParseError, /can only be called using the 4.x function API/)
   end
 end

--- a/spec/unit/parser/functions/hiera_include_spec.rb
+++ b/spec/unit/parser/functions/hiera_include_spec.rb
@@ -7,6 +7,6 @@ describe 'Puppet::Parser::Functions#hiera_include' do
   let :scope do create_test_scope_for_node('foo') end
 
   it 'should raise an error since this function is converted to 4x API)' do
-    expect { scope.function_hiera_include(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
+    expect { scope.function_hiera_include(['key']) }.to raise_error(Puppet::ParseError, /can only be called using the 4.x function API/)
   end
 end

--- a/spec/unit/parser/functions/hiera_spec.rb
+++ b/spec/unit/parser/functions/hiera_spec.rb
@@ -7,6 +7,6 @@ describe 'Puppet::Parser::Functions#hiera' do
   let :scope do create_test_scope_for_node('foo') end
 
   it 'should raise an error since this function is converted to 4x API)' do
-    expect { scope.function_hiera(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
+    expect { scope.function_hiera(['key']) }.to raise_error(Puppet::ParseError, /can only be called using the 4.x function API/)
   end
 end

--- a/spec/unit/parser/functions/lookup_spec.rb
+++ b/spec/unit/parser/functions/lookup_spec.rb
@@ -9,6 +9,6 @@ describe "lookup function" do
   let :scope do create_test_scope_for_node('foo') end
 
   it 'should raise an error since this function is converted to 4x API)' do
-    expect { scope.function_lookup(['key']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
+    expect { scope.function_lookup(['key']) }.to raise_error(Puppet::ParseError, /can only be called using the 4.x function API/)
   end
 end

--- a/spec/unit/parser/functions/regsubst_spec.rb
+++ b/spec/unit/parser/functions/regsubst_spec.rb
@@ -19,6 +19,6 @@ describe "the regsubst function" do
         'b[an]*a',
         'coconut'
       ])
-    end.to raise_error(Puppet::ParseError, /converted to 4x API/)
+    end.to raise_error(Puppet::ParseError, /can only be called using the 4.x function API/)
   end
 end

--- a/spec/unit/parser/functions/split_spec.rb
+++ b/spec/unit/parser/functions/split_spec.rb
@@ -13,6 +13,6 @@ describe "the split function" do
   end
 
   it 'should raise a ParseError' do
-    expect { @scope.function_split([ '130;236;254;10', ';']) }.to raise_error(Puppet::ParseError, /converted to 4x API/)
+    expect { @scope.function_split([ '130;236;254;10', ';']) }.to raise_error(Puppet::ParseError, /can only be called using the 4.x function API/)
   end
 end

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -235,6 +235,40 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       expect { evaluate(expr)}.to raise_error(/Array-Type\[\] arguments must be types/)
     end
 
+    # Timespan Type
+    #
+    it 'produdes a Timespan type with a lower bound' do
+      expr = fqr('Timespan')[{fqn('hours') => literal(3)}]
+      expect(evaluate(expr)).to be_the_type(types.timespan({'hours' => 3}))
+    end
+
+    it 'produdes a Timespan type with an upper bound' do
+      expr = fqr('Timespan')[literal(:default), {fqn('hours') => literal(9)}]
+      expect(evaluate(expr)).to be_the_type(types.timespan(nil, {'hours' => 9}))
+    end
+
+    it 'produdes a Timespan type with both lower and upper bounds' do
+      expr = fqr('Timespan')[{fqn('hours') => literal(3)}, {fqn('hours') => literal(9)}]
+      expect(evaluate(expr)).to be_the_type(types.timespan({'hours' => 3}, {'hours' => 9}))
+    end
+
+    # Timestamp Type
+    #
+    it 'produdes a Timestamp type with a lower bound' do
+      expr = fqr('Timestamp')[literal('2014-12-12T13:14:15 CET')]
+      expect(evaluate(expr)).to be_the_type(types.timestamp('2014-12-12T13:14:15 CET'))
+    end
+
+    it 'produdes a Timestamp type with an upper bound' do
+      expr = fqr('Timestamp')[literal(:default), literal('2016-08-23T17:50:00 CET')]
+      expect(evaluate(expr)).to be_the_type(types.timestamp(nil, '2016-08-23T17:50:00 CET'))
+    end
+
+    it 'produdes a Timestamp type with both lower and upper bounds' do
+      expr = fqr('Timestamp')[literal('2014-12-12T13:14:15 CET'), literal('2016-08-23T17:50:00 CET')]
+      expect(evaluate(expr)).to be_the_type(types.timestamp('2014-12-12T13:14:15 CET', '2016-08-23T17:50:00 CET'))
+    end
+
     # Tuple Type
     #
     it 'produces a Tuple[String] from the expression Tuple[String]' do

--- a/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
+++ b/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
+require 'puppet_spec/compiler'
 
 require 'puppet/pops'
 require 'puppet/pops/evaluator/evaluator_impl'
@@ -71,6 +72,140 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
       it "'012.3' + '010'  ==  20.3 (not error, floats can start with 0)" do
         expect(evaluate(literal('012.3') + literal('010'))).to eq(20.3)
+      end
+    end
+
+    context 'on timespans' do
+      include PuppetSpec::Compiler
+
+      it 'Timespan + Timespan = Timespan' do
+        code = 'notice(assert_type(Timespan, Timespan({days => 3}) + Timespan({hours => 12})))'
+        expect(eval_and_collect_notices(code)).to eql(['3-12:00:00'])
+      end
+
+      it 'Timespan - Timespan = Timespan' do
+        code = 'notice(assert_type(Timespan, Timespan({days => 3}) - Timespan({hours => 12})))'
+        expect(eval_and_collect_notices(code)).to eql(['2-12:00:00'])
+      end
+
+      it 'Timespan + -Timespan = Timespan' do
+        code = 'notice(assert_type(Timespan, Timespan({days => 3}) + -Timespan({hours => 12})))'
+        expect(eval_and_collect_notices(code)).to eql(['2-12:00:00'])
+      end
+
+      it 'Timespan - -Timespan = Timespan' do
+        code = 'notice(assert_type(Timespan, Timespan({days => 3}) - -Timespan({hours => 12})))'
+        expect(eval_and_collect_notices(code)).to eql(['3-12:00:00'])
+      end
+
+      it 'Timespan / Timespan = Float' do
+        code = "notice(assert_type(Float, Timespan({days => 3}) / Timespan('0-12:00:00')))"
+        expect(eval_and_collect_notices(code)).to eql(['6.0'])
+      end
+
+      it 'Timespan * Timespan is an error' do
+        code = 'notice(Timespan({days => 3}) * Timespan({hours => 12}))'
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /A Timestamp cannot be multiplied by a Timespan/)
+      end
+
+      it 'Timespan + Numeric = Timespan (numeric treated as seconds)' do
+        code = 'notice(assert_type(Timespan, Timespan({days => 3}) + 7300.0))'
+        expect(eval_and_collect_notices(code)).to eql(['3-02:01:40'])
+      end
+
+      it 'Timespan - Numeric = Timespan (numeric treated as seconds)' do
+        code = "notice(strftime(assert_type(Timespan, Timespan({days => 3}) + 7300.123), '%H:%M:%S.%L'))"
+        expect(eval_and_collect_notices(code)).to eql(['74:01:40.123'])
+      end
+
+      it 'Timespan * Numeric = Timespan (numeric treated as seconds)' do
+        code = "notice(strftime(assert_type(Timespan, Timespan({days => 3}) - 7300.123), '%H:%M:%S.%L'))"
+        expect(eval_and_collect_notices(code)).to eql(['69:58:19.877'])
+      end
+
+      it 'Timespan + Timestamp = Timestamp' do
+        code = "notice(assert_type(Timestamp, Timespan({days => 3}) + Timestamp('2016-08-27T16:44:49.999 UTC')))"
+        expect(eval_and_collect_notices(code)).to eql(['2016-08-30T16:44:49.999 UTC'])
+      end
+
+      it 'Timespan - Timestamp is an error' do
+        code = 'notice(Timespan({days => 3}) - Timestamp())'
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /A Timestamp cannot be subtracted from a Timespan/)
+      end
+
+      it 'Timespan * Timestamp is an error' do
+        code = 'notice(Timespan({days => 3}) * Timestamp())'
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /A Timestamp cannot be multiplied by a Timestamp/)
+      end
+
+      it 'Timespan / Timestamp is an error' do
+        code = 'notice(Timespan({days => 3}) / Timestamp())'
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /A Timespan cannot be divided by a Timestamp/)
+      end
+    end
+
+
+    context 'on timestamps' do
+      include PuppetSpec::Compiler
+
+      it 'Timestamp + Timestamp is an error' do
+        code = 'notice(Timestamp() + Timestamp())'
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /A Timestamp cannot be added to a Timestamp/)
+      end
+
+      it 'Timestamp + Timespan = Timestamp' do
+        code = "notice(assert_type(Timestamp, Timestamp('2016-10-10') + Timespan('0-12:00:00')))"
+        expect(eval_and_collect_notices(code)).to eql(['2016-10-10T12:00:00.000 UTC'])
+      end
+
+      it 'Timestamp + Numeric = Timestamp' do
+        code = "notice(assert_type(Timestamp, Timestamp('2016-10-10T12:00:00.000') + 3600.123))"
+        expect(eval_and_collect_notices(code)).to eql(['2016-10-10T13:00:00.123 UTC'])
+      end
+
+      it 'Timestamp - Timestamp = Timespan' do
+        code = "notice(assert_type(Timespan, Timestamp('2016-10-10') - Timestamp('2015-10-10')))"
+        expect(eval_and_collect_notices(code)).to eql(['366-00:00:00'])
+      end
+
+      it 'Timestamp - Timespan = Timestamp' do
+        code = "notice(assert_type(Timestamp, Timestamp('2016-10-10') - Timespan('0-12:00:00')))"
+        expect(eval_and_collect_notices(code)).to eql(['2016-10-09T12:00:00.000 UTC'])
+      end
+
+      it 'Timestamp - Numeric = Timestamp' do
+        code = "notice(assert_type(Timestamp, Timestamp('2016-10-10') - 3600.123))"
+        expect(eval_and_collect_notices(code)).to eql(['2016-10-09T22:59:59.877 UTC'])
+      end
+
+      it 'Timestamp / Timestamp is an error' do
+        code = "notice(Timestamp('2016-10-10') / Timestamp())"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\/' is not applicable to a Timestamp/)
+      end
+
+      it 'Timestamp / Timespan is an error' do
+        code = "notice(Timestamp('2016-10-10') / Timespan('0-12:00:00'))"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\/' is not applicable to a Timestamp/)
+      end
+
+      it 'Timestamp / Numeric is an error' do
+        code = "notice(Timestamp('2016-10-10') / 3600.123)"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\/' is not applicable to a Timestamp/)
+      end
+
+      it 'Timestamp * Timestamp is an error' do
+        code = "notice(Timestamp('2016-10-10') * Timestamp())"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\*' is not applicable to a Timestamp/)
+      end
+
+      it 'Timestamp * Timespan is an error' do
+        code = "notice(Timestamp('2016-10-10') * Timespan('0-12:00:00'))"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\*' is not applicable to a Timestamp/)
+      end
+
+      it 'Timestamp * Numeric is an error' do
+        code = "notice(Timestamp('2016-10-10') * 3600.123)"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\*' is not applicable to a Timestamp/)
       end
     end
   end

--- a/spec/unit/pops/serialization/packer_spec.rb
+++ b/spec/unit/pops/serialization/packer_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 require 'puppet/pops/serialization'
 
-module Puppet::Pops::Serialization
+module Puppet::Pops
+module Serialization
 [JSON].each do |packer_module|
 describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
   let(:io) { StringIO.new }
@@ -86,11 +87,19 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
       expect(val2).to eql(val)
     end
 
-    it 'Time created by TimeFactory' do
-      val = TimeFactory.now
+    it 'Timespan' do
+      val = Time::Timespan.from_fields(false, 3, 12, 40, 31, 123)
       write(val)
       val2 = read
-      expect(val2).to be_a(Time)
+      expect(val2).to be_a(Time::Timespan)
+      expect(val2).to eql(val)
+    end
+
+    it 'Timestamp' do
+      val = Time::Timestamp.now
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Time::Timestamp)
       expect(val2).to eql(val)
     end
 
@@ -108,23 +117,6 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
       val2 = read
       expect(val2).to be_a(Semantic::VersionRange)
       expect(val2).to eql(val)
-    end
-
-    it 'will never fail write and read of Time created by TimeFactory' do
-      val = Time.now
-      val = TimeFactory.at(val.tv_sec, val.tv_nsec / 1000 + 0.123)
-      write(val)
-      val2 = read
-      expect(val).to eq(val2)
-    end
-
-    # Windows doesn't seem ot have fine enough granularity to provoke the problem
-    it 'will fail on Time not created by TimeFactory' do
-      val = Time.now
-      val = Time.at(val.tv_sec, val.tv_nsec / 1000 + 0.123)
-      write(val)
-      val2 = read
-      expect(val).not_to eq(val2)
     end
   end
 
@@ -148,6 +140,7 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
     expect(read(2)).to eql([val, val])
     expect(@deserializer.primitive_count).to eql(1)
   end
+end
 end
 end
 end

--- a/spec/unit/pops/serialization/serialization_spec.rb
+++ b/spec/unit/pops/serialization/serialization_spec.rb
@@ -94,12 +94,19 @@ module Serialization
       expect(val2).to eql(val)
     end
 
-    it 'Time created by TimeFactory' do
-      # It does succeed on rare occasions, so we need to repeat
-      val = TimeFactory.now
+    it 'Timespan' do
+      val = Time::Timespan.from_fields(false, 3, 12, 40, 31, 123)
       write(val)
       val2 = read
-      expect(val2).to be_a(Time)
+      expect(val2).to be_a(Time::Timespan)
+      expect(val2).to eql(val)
+    end
+
+    it 'Timestamp' do
+      val = Time::Timestamp.now
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Time::Timestamp)
       expect(val2).to eql(val)
     end
 

--- a/spec/unit/pops/time/timespan_spec.rb
+++ b/spec/unit/pops/time/timespan_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+
+module Puppet::Pops
+module Time
+describe 'Timespan' do
+  include PuppetSpec::Compiler
+
+  let! (:simple) { Timespan.from_fields(false, 1, 3, 10, 11) }
+  let! (:all_fields_hash) { {'days' => 1, 'hours' => 7, 'minutes' => 10, 'seconds' => 11, 'milli_seconds' => 123, 'micro_seconds' => 456, 'nano_seconds' => 789} }
+  let! (:complex) { Timespan.from_fields_hash(all_fields_hash) }
+
+  context 'can be created from a String' do
+    it 'using default format' do
+      expect(Timespan.parse('1-03:10:11')).to eql(simple)
+    end
+
+    it 'using explicit format' do
+      expect(Timespan.parse('1-7:10:11.123456789', '%D-%H:%M:%S.%N')).to eql(complex)
+    end
+
+    it 'using leading minus and explicit format' do
+      expect(Timespan.parse('-1-7:10:11.123456789', '%D-%H:%M:%S.%N')).to eql(-complex)
+    end
+
+    it 'using %H as the biggest quantity' do
+      expect(Timespan.parse('27:10:11', '%H:%M:%S')).to eql(simple)
+    end
+
+    it 'using %M as the biggest quantity' do
+      expect(Timespan.parse('1630:11', '%M:%S')).to eql(simple)
+    end
+
+    it 'using %S as the biggest quantity' do
+      expect(Timespan.parse('97811', '%S')).to eql(simple)
+    end
+
+    it 'using %L as the biggest quantity' do
+      expect(Timespan.parse('97811000', '%L')).to eql(simple)
+    end
+
+    it 'using %N as the biggest quantity' do
+      expect(Timespan.parse('112211123456789', '%N')).to eql(complex)
+    end
+
+    it 'where biggest quantity is not frist' do
+      expect(Timespan.parse('11:1630', '%S:%M')).to eql(simple)
+    end
+  end
+
+  context 'when presented as a String' do
+    it 'uses default format for #to_s' do
+      expect(simple.to_s).to eql('1-03:10:11')
+    end
+
+    context 'using a format' do
+      it 'produces a string containing all components' do
+        expect(complex.format('%D-%H:%M:%S.%N')).to eql('1-07:10:11.123456789')
+      end
+
+      it 'produces a literal % for %%' do
+        expect(complex.format('%D%%%H:%M:%S')).to eql('1%07:10:11')
+      end
+
+      it 'produces a leading dash for negative instance' do
+        expect((-complex).format('%D-%H:%M:%S')).to eql('-1-07:10:11')
+      end
+    end
+  end
+
+  context 'when converted to a hash' do
+    it 'produces a hash with all numeric keys' do
+      hash = complex.to_hash
+      expect(hash).to eql(all_fields_hash)
+    end
+
+    it 'produces a compact hash with seconds and nanoseconds for #to_hash(true)' do
+      hash = complex.to_hash(true)
+      expect(hash).to eql({'seconds' => 112211, 'nano_seconds' => 123456789})
+    end
+
+    context 'from a negative value' do
+      it 'produces a hash with all numeric keys and negative = true' do
+        hash = (-complex).to_hash
+        expect(hash).to eql(all_fields_hash.merge('negative' => true))
+      end
+
+      it 'produces a compact hash with negative seconds and negative nanoseconds for #to_hash(true)' do
+        hash = (-complex).to_hash(true)
+        expect(hash).to eql({'seconds' => -112211, 'nano_seconds' => -123456789})
+      end
+    end
+  end
+end
+end
+end

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -1,0 +1,251 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+
+module Puppet::Pops
+module Types
+describe 'Timespan type' do
+  it 'is normalized in a Variant' do
+    t = TypeFactory.variant(TypeFactory.timespan('10:00', '15:00'), TypeFactory.timespan('14:00', '17:00')).normalize
+    expect(t).to be_a(PTimespanType)
+    expect(t).to eql(TypeFactory.timespan('10:00', '17:00'))
+  end
+
+  context 'when used in Puppet expressions' do
+    include PuppetSpec::Compiler
+    it 'is equal to itself only' do
+      code = <<-CODE
+          $t = Timespan
+          notice(Timespan =~ Type[Timespan])
+          notice(Timespan == Timespan)
+          notice(Timespan < Timespan)
+          notice(Timespan > Timespan)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(%w(true true false false))
+    end
+
+    context "when parameterized" do
+      it 'is equal other types with the same parameterization' do
+        code = <<-CODE
+            notice(Timespan['01:00:00', '13:00:00'] == Timespan['01:00:00', '13:00:00'])
+            notice(Timespan['01:00:00', '13:00:00'] != Timespan['01:12:20', '13:00:00'])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true))
+      end
+
+      it 'orders parameterized types based on range inclusion' do
+        code = <<-CODE
+            notice(Timespan['01:00:00', '13:00:00'] < Timespan['00:00:00', '14:00:00'])
+            notice(Timespan['01:00:00', '13:00:00'] > Timespan['00:00:00', '14:00:00'])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true false))
+      end
+    end
+
+    context 'a Timespan instance' do
+      it 'can be created from a string' do
+        code = <<-CODE
+            $o = Timespan('3-11:00')
+            notice($o)
+            notice(type($o))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['3-11:00:00', 'Timespan[{days => 3, hours => 11}, {days => 3, hours => 11}]'])
+      end
+
+      it 'can be created from a string and format' do
+        code = <<-CODE
+            $o = Timespan('1d11h23m', '%Dd%Hh%Mm')
+            notice($o)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(1-11:23:00))
+      end
+
+      it 'can be created from a string and array of formats' do
+        code = <<-CODE
+            $fmts = ['%Dd%Hh%Mm%Ss', '%Hh%Mm%Ss', '%Dd%Hh%Mm', '%Dd%Hh', '%Hh%Mm', '%Mm%Ss', '%Dd', '%Hh', '%Mm', '%Ss' ]
+            notice(Timespan('1d11h23m13s', $fmts))
+            notice(Timespan('11h23m13s', $fmts))
+            notice(Timespan('1d11h23m', $fmts))
+            notice(Timespan('1d11h', $fmts))
+            notice(Timespan('11h23m', $fmts))
+            notice(Timespan('23m13s', $fmts))
+            notice(Timespan('1d', $fmts))
+            notice(Timespan('11h', $fmts))
+            notice(Timespan('23m', $fmts))
+            notice(Timespan('13s', $fmts))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(
+          %w(1-11:23:13 0-11:23:13 1-11:23:00 1-11:00:00 0-11:23:00 0-00:23:13 1-00:00:00 0-11:00:00 0-00:23:00 0-00:00:13))
+      end
+
+      it 'can be created from a integer that represents seconds since epoch' do
+        code = <<-CODE
+            $o = Timespan(6800)
+            notice(Integer($o) == 6800)
+            notice($o == Timespan('01:53:20'))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true))
+      end
+
+      it 'can be created from a float that represents seconds with fraction since epoch' do
+        code = <<-CODE
+            $o = Timespan(6800.123456789)
+            notice(Float($o) == 6800.123456789)
+            notice($o == Timespan('01:53:20.123456789', '%H:%M:%S.%N'))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true))
+      end
+
+      it 'matches the appropriate parameterized type' do
+        code = <<-CODE
+            $o = Timespan('3-11:12:13')
+            notice(assert_type(Timespan['3-00:00:00', '4-00:00:00'], $o))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['3-11:12:13'])
+      end
+
+      it 'does not match an inappropriate parameterized type' do
+        code = <<-CODE
+            $o = Timespan('1-03:04:05')
+            notice(assert_type(Timespan['2-00:00:00', '3-00:00:00'], $o) |$e, $a| { 'nope' })
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['nope'])
+      end
+
+      it 'can be compared to other instances' do
+        code = <<-CODE
+            $o1 = Timespan('00:00:01')
+            $o2 = Timespan('00:00:02')
+            $o3 = Timespan('00:00:02')
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o1 == $o3)
+            notice($o1 != $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+            notice($o2 == $o3)
+            notice($o2 != $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false true false false true true true false))
+      end
+
+      it 'can be compared to integer that represents seconds' do
+        code = <<-CODE
+            $o1 = Timespan('00:00:01')
+            $o2 = Timespan('00:00:02')
+            $o3 = 2
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
+      end
+
+      it 'integer that represents seconds can be compared to it' do
+        code = <<-CODE
+            $o1 = 1
+            $o2 = 2
+            $o3 = Timespan('00:00:02')
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
+      end
+
+      it 'is not equal to integer that represents seconds' do
+        code = <<-CODE
+            $o1 = Timespan('02', '%S')
+            $o2 = 2
+            notice($o1 == $o2)
+            notice($o1 != $o2)
+            notice(Integer($o1) == $o2)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+      end
+
+      it 'integer that represents seconds is not equal to it' do
+        code = <<-CODE
+            $o1 = 2
+            $o2 = Timespan('02', '%S')
+            notice($o1 == $o2)
+            notice($o1 != $o2)
+            notice($o1 == Integer($o2))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+      end
+
+      it 'can be compared to float that represents seconds with fraction' do
+        code = <<-CODE
+            $o1 = Timespan('01.123456789', '%S.%N')
+            $o2 = Timespan('02.123456789', '%S.%N')
+            $o3 = 2.123456789
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
+      end
+
+      it 'float that represents seconds with fraction can be compared to it' do
+        code = <<-CODE
+            $o1 = 1.123456789
+            $o2 = 2.123456789
+            $o3 = Timespan('02.123456789', '%S.%N')
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
+      end
+
+      it 'is not equal to float that represents seconds with fraction' do
+        code = <<-CODE
+            $o1 = Timespan('02.123456789', '%S.%N')
+            $o2 = 2.123456789
+            notice($o1 == $o2)
+            notice($o1 != $o2)
+            notice(Float($o1) == $o2)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+      end
+
+      it 'float that represents seconds with fraction is not equal to it' do
+        code = <<-CODE
+            $o1 = 2.123456789
+            $o2 = Timespan('02.123456789', '%S.%N')
+            notice($o1 == $o2)
+            notice($o1 != $o2)
+            notice($o1 == Float($o2))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+      end
+    end
+  end
+end
+end
+end

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -1,0 +1,249 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+
+module Puppet::Pops
+module Types
+describe 'Timestamp type' do
+
+  it 'is normalized in a Variant' do
+    t = TypeFactory.variant(TypeFactory.timestamp('2015-03-01', '2016-01-01'), TypeFactory.timestamp('2015-11-03', '2016-12-24')).normalize
+    expect(t).to be_a(PTimestampType)
+    expect(t).to eql(TypeFactory.timestamp('2015-03-01', '2016-12-24'))
+  end
+
+  context 'when used in Puppet expressions' do
+    include PuppetSpec::Compiler
+    it 'is equal to itself only' do
+      code = <<-CODE
+          $t = Timestamp
+          notice(Timestamp =~ Type[Timestamp])
+          notice(Timestamp == Timestamp)
+          notice(Timestamp < Timestamp)
+          notice(Timestamp > Timestamp)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(%w(true true false false))
+    end
+
+    context "when parameterized" do
+      it 'is equal other types with the same parameterization' do
+        code = <<-CODE
+            notice(Timestamp['2015-03-01', '2016-01-01'] == Timestamp['2015-03-01', '2016-01-01'])
+            notice(Timestamp['2015-03-01', '2016-01-01'] != Timestamp['2015-11-03', '2016-12-24'])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true))
+      end
+
+      it 'orders parameterized types based on range inclusion' do
+        code = <<-CODE
+            notice(Timestamp['2015-03-01', '2015-09-30'] < Timestamp['2015-02-01', '2015-10-30'])
+            notice(Timestamp['2015-03-01', '2015-09-30'] > Timestamp['2015-02-01', '2015-10-30'])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true false))
+      end
+    end
+
+    context 'a Timestamp instance' do
+      it 'can be created from a string' do
+        code = <<-CODE
+            $o = Timestamp('2015-03-01')
+            notice($o)
+            notice(type($o))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['2015-03-01T00:00:00.000 UTC', "Timestamp['2015-03-01T00:00:00.000 UTC', '2015-03-01T00:00:00.000 UTC']"])
+      end
+
+      it 'can be created from a string and format' do
+        code = <<-CODE
+            $o = Timestamp('Sunday, 28 August, 2016', '%A, %d %B, %Y')
+            notice($o)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['2016-08-28T00:00:00.000 UTC'])
+      end
+
+      it 'can be created from a string and array of formats' do
+        code = <<-CODE
+            $fmts = [
+              '%A, %d %B, %Y at %r',
+              '%b %d, %Y, %l:%M %P',
+              '%y-%m-%d %H:%M:%S %z'
+            ]
+            notice(Timestamp('Sunday, 28 August, 2016 at 12:15:00 PM', $fmts))
+            notice(Timestamp('Jul 24, 2016, 1:20 am', $fmts))
+            notice(Timestamp('16-06-21 18:23:15 UTC', $fmts))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(
+          ['2016-08-28T12:15:00.000 UTC', '2016-07-24T01:20:00.000 UTC', '2016-06-21T18:23:15.000 UTC'])
+      end
+
+      it 'can be created from a integer that represents seconds since epoch' do
+        code = <<-CODE
+            $o = Timestamp(1433116800)
+            notice(Integer($o) == 1433116800)
+            notice($o == Timestamp('2015-06-01T00:00:00 UTC'))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true))
+      end
+
+      it 'can be created from a float that represents seconds with fraction since epoch' do
+        code = <<-CODE
+            $o = Timestamp(1433116800.123456)
+            notice(Float($o) == 1433116800.123456)
+            notice($o == Timestamp('2015-06-01T00:00:00.123456 UTC'))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true))
+      end
+
+      it 'matches the appropriate parameterized type' do
+        code = <<-CODE
+            $o = Timestamp('2015-05-01')
+            notice(assert_type(Timestamp['2015-03-01', '2015-09-30'], $o))
+         CODE
+        expect(eval_and_collect_notices(code)).to eq(['2015-05-01T00:00:00.000 UTC'])
+      end
+
+      it 'does not match an inappropriate parameterized type' do
+        code = <<-CODE
+            $o = Timestamp('2015-05-01')
+            notice(assert_type(Timestamp['2016-03-01', '2016-09-30'], $o) |$e, $a| { 'nope' })
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['nope'])
+      end
+
+      it 'can be compared to other instances' do
+        code = <<-CODE
+            $o1 = Timestamp('2015-05-01')
+            $o2 = Timestamp('2015-06-01')
+            $o3 = Timestamp('2015-06-01')
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o1 == $o3)
+            notice($o1 != $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+            notice($o2 == $o3)
+            notice($o2 != $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false true false false true true true false))
+      end
+
+      it 'can be compared to integer that represents seconds since epoch' do
+        code = <<-CODE
+            $o1 = Timestamp('2015-05-01')
+            $o2 = Timestamp('2015-06-01')
+            $o3 = 1433116800
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
+      end
+
+      it 'integer that represents seconds since epoch can be compared to it' do
+        code = <<-CODE
+            $o1 = 1430438400
+            $o2 = 1433116800
+            $o3 = Timestamp('2015-06-01')
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
+      end
+
+      it 'is not equal to integer that represents seconds since epoch' do
+        code = <<-CODE
+            $o1 = Timestamp('2015-06-01T00:00:00 UTC')
+            $o2 = 1433116800
+            notice($o1 == $o2)
+            notice($o1 != $o2)
+            notice(Integer($o1) == $o2)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+      end
+
+      it 'integer that represents seconds is not equal to it' do
+        code = <<-CODE
+            $o1 = 1433116800
+            $o2 = Timestamp('2015-06-01T00:00:00 UTC')
+            notice($o1 == $o2)
+            notice($o1 != $o2)
+            notice($o1 == Integer($o2))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+      end
+
+      it 'can be compared to float that represents seconds with fraction since epoch' do
+        code = <<-CODE
+            $o1 = Timestamp('2015-05-01T00:00:00.123456789 UTC')
+            $o2 = Timestamp('2015-06-01T00:00:00.123456789 UTC')
+            $o3 = 1433116800.123456789
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
+      end
+
+      it 'float that represents seconds with fraction since epoch can be compared to it' do
+        code = <<-CODE
+            $o1 = 1430438400.123456789
+            $o2 = 1433116800.123456789
+            $o3 = Timestamp('2015-06-01T00:00:00.123456789 UTC')
+            notice($o1 > $o3)
+            notice($o1 >= $o3)
+            notice($o1 < $o3)
+            notice($o1 <= $o3)
+            notice($o2 > $o3)
+            notice($o2 < $o3)
+            notice($o2 >= $o3)
+            notice($o2 <= $o3)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
+      end
+
+      it 'is not equal to float that represents seconds with fraction since epoch' do
+        code = <<-CODE
+            $o1 = Timestamp('2015-06-01T00:00:00.123456789 UTC')
+            $o2 = 1433116800.123456789
+            notice($o1 == $o2)
+            notice($o1 != $o2)
+            notice(Float($o1) == $o2)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+      end
+
+      it 'float that represents seconds with fraction is not equal to it' do
+        code = <<-CODE
+            $o1 = 1433116800.123456789
+            $o2 = Timestamp('2015-06-01T00:00:00.123456789 UTC')
+            notice($o1 == $o2)
+            notice($o1 != $o2)
+            notice($o1 == Float($o2))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+      end
+    end
+  end
+end
+end
+end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -233,6 +233,34 @@ describe 'The type calculator' do
       end
     end
 
+    context 'timespan' do
+      it 'translates to PTimespanType' do
+        expect(calculator.infer(Time::Timespan.from_fields_hash('days' => 2))).to be_a(PTimespanType)
+      end
+
+      it 'translates to a limited PTimespanType by infer_set' do
+        ts = Time::Timespan.from_fields_hash('days' => 2)
+        t = calculator.infer_set(ts)
+        expect(t.class).to eq(PTimespanType)
+        expect(t.from).to be(ts)
+        expect(t.to).to be(ts)
+      end
+    end
+
+    context 'timestamp' do
+      it 'translates to PTimespanType' do
+        expect(calculator.infer(Time::Timestamp.now)).to be_a(PTimestampType)
+      end
+
+      it 'translates to a limited PTimespanType by infer_set' do
+        ts = Time::Timestamp.now
+        t = calculator.infer_set(ts)
+        expect(t.class).to eq(PTimestampType)
+        expect(t.from).to be(ts)
+        expect(t.to).to be(ts)
+      end
+    end
+
     context 'array' do
       it 'translates to PArrayType' do
         expect(calculator.infer([1,2]).class).to eq(PArrayType)
@@ -879,6 +907,34 @@ describe 'The type calculator' do
 
       it 'Struct is not assignable to Hash with Enum unless all keys match' do
         expect(struct_t({'a' => integer_t, 'y' => integer_t})).not_to be_assignable_to(hash_t(enum_t('x', 'y', 'z'), factory.any))
+      end
+    end
+
+    context 'for Timespan such that' do
+      it 'Timespan is assignable to less constrained Timespan' do
+        t1 = PTimespanType.new('00:00:10', '00:00:20')
+        t2 = PTimespanType.new('00:00:11', '00:00:19')
+        expect(t2).to be_assignable_to(t1)
+      end
+
+      it 'Timespan is not assignable to more constrained Timespan' do
+        t1 = PTimespanType.new('00:00:10', '00:00:20')
+        t2 = PTimespanType.new('00:00:11', '00:00:19')
+        expect(t1).not_to be_assignable_to(t2)
+      end
+    end
+
+    context 'for Timestamp such that' do
+      it 'Timestamp is assignable to less constrained Timestamp' do
+        t1 = PTimestampType.new('2016-01-01', '2016-12-31')
+        t2 = PTimestampType.new('2016-02-01', '2016-11-30')
+        expect(t2).to be_assignable_to(t1)
+      end
+
+      it 'Timestamp is not assignable to more constrained Timestamp' do
+        t1 = PTimestampType.new('2016-01-01', '2016-12-31')
+        t2 = PTimestampType.new('2016-02-01', '2016-11-30')
+        expect(t1).not_to be_assignable_to(t2)
       end
     end
 

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -178,6 +178,22 @@ end
       expect(s.string(f.iterator(f.integer))).to eq('Iterator[Integer]')
     end
 
+    it "should yield 'Timespan' for PTimespanType" do
+      expect(s.string(f.timespan())).to eq('Timespan')
+    end
+
+    it "should yield 'Timespan[{hours => 1}] for PTimespanType[Timespan]" do
+      expect(s.string(f.timespan({'hours' => 1}))).to eq('Timespan[{hours => 1}]')
+    end
+
+    it "should yield 'Timespan[?, {hours => 2}] for PTimespanType[nil, Timespan]" do
+      expect(s.string(f.timespan(nil, {'hours' => 2}))).to eq('Timespan[default, {hours => 2}]')
+    end
+
+    it "should yield 'Timespan[{hours => 1}, {hours => 2}] for PTimespanType[Timespan, Timespan]" do
+      expect(s.string(f.timespan({'hours' => 1}, {'hours' => 2}))).to eq('Timespan[{hours => 1}, {hours => 2}]')
+    end
+
     it "should yield 'Tuple[Integer]' for PTupleType[PIntegerType]" do
       expect(s.string(f.tuple([f.integer]))).to eq('Tuple[Integer]')
     end

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -111,6 +111,16 @@ describe TypeParser do
     expect(the_type_parsed_from(opt_t)).to be_the_type(opt_t)
   end
 
+  it "parses timespan type" do
+    timespan_t = types.timespan
+    expect(the_type_parsed_from(timespan_t)).to be_the_type(timespan_t)
+  end
+
+  it "parses timestamp type" do
+    timestamp_t = types.timestamp
+    expect(the_type_parsed_from(timestamp_t)).to be_the_type(timestamp_t)
+  end
+
   it "parses tuple type" do
     tuple_t = types.tuple([Integer, String])
     expect(the_type_parsed_from(tuple_t)).to be_the_type(tuple_t)
@@ -246,6 +256,38 @@ describe TypeParser do
 
   it 'parses a collection size range' do
    expect(parser.parse("Collection[1,2]")).to be_the_type(types.collection(types.range(1,2)))
+  end
+
+  it 'parses a timespan type' do
+    expect(parser.parse("Timespan")).to be_the_type(types.timespan)
+  end
+
+  it 'parses a timespan type with a lower bound' do
+    expect(parser.parse("Timespan[{hours => 3}]")).to be_the_type(types.timespan({'hours' => 3}))
+  end
+
+  it 'parses a timespan type with an upper bound' do
+    expect(parser.parse("Timespan[default, {hours => 9}]")).to be_the_type(types.timespan(nil, {'hours' => 9}))
+  end
+
+  it 'parses a timespan type with both lower and upper bounds' do
+    expect(parser.parse("Timespan[{hours => 3}, {hours => 9}]")).to be_the_type(types.timespan({'hours' => 3}, {'hours' => 9}))
+  end
+
+  it 'parses a timestamp type' do
+    expect(parser.parse("Timestamp")).to be_the_type(types.timestamp)
+  end
+
+  it 'parses a timestamp type with a lower bound' do
+    expect(parser.parse("Timestamp['2014-12-12T13:14:15 CET']")).to be_the_type(types.timestamp('2014-12-12T13:14:15 CET'))
+  end
+
+  it 'parses a timestamp type with an upper bound' do
+    expect(parser.parse("Timestamp[default, '2014-12-12T13:14:15 CET']")).to be_the_type(types.timestamp(nil, '2014-12-12T13:14:15 CET'))
+  end
+
+  it 'parses a timestamp type with both lower and upper bounds' do
+    expect(parser.parse("Timestamp['2014-12-12T13:14:15 CET', '2016-08-23T17:50:00 CET']")).to be_the_type(types.timestamp('2014-12-12T13:14:15 CET', '2016-08-23T17:50:00 CET'))
   end
 
   it 'parses a type type' do


### PR DESCRIPTION
This commit adds two new types. A Timespan that represents a moment
in time and a Timespan that represents a duration. Both types uses
nano-second precision and can participate in arithmetic operations.

The types have `new` functions that allow creation from a string a hash.

A strftime function is also included to provide a flexible way of
representing the instances in string form. The name was chosen since
it's well known in languages such as Ruby, C++, and Python. It's also
less likely to collide with other global functions declared in modules
than, say 'format'.

An approach of extending the String constructor and give it special
logic for Timespan and Timestamp was rejected since it would introduce
ambiguities with different formatting characters. `String(x, '%p')`
(expected to produce a programmatic representation) would print 'AM' or
'PM' in case `x` is a Timestamp.

The Timespan and Timestamp implementation share an abstract class
TimeData which in turn inherits from Numeric. This approach was selected
since it required a minimum of adjustments to make the classes work
with arithmetic and comparison operators in PL.