### PR TITLE
(PUP-6659) Remove Stacktraces in API responses

### DIFF
--- a/api/schemas/error.json
+++ b/api/schemas/error.json
@@ -11,11 +11,6 @@
         "issue_kind": {
             "description": "A unique label to identify the error class",
             "type": "string"
-        },
-        "stacktrace": {
-            "description": "For 5xx responses only, a ruby stacktrace to where an error occurred.",
-            "type": "array",
-            "items": { "type": "string" }
         }
     },
     "required": ["message", "issue_kind"],

--- a/lib/puppet/network/http/error.rb
+++ b/lib/puppet/network/http/error.rb
@@ -63,7 +63,7 @@ module Puppet::Network::HTTP::Error
     end
 
     def to_json
-      JSON({:message => message, :issue_kind => @issue_kind, :stacktrace => self.backtrace})
+      JSON({:message => message, :issue_kind => @issue_kind})
     end
   end
 end

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -68,7 +68,8 @@ module Puppet::Network::HTTP::Handler
     new_response.respond_with(e.status, "application/json", e.to_json)
   rescue StandardError => e
     http_e = Puppet::Network::HTTP::Error::HTTPServerError.new(e)
-    Puppet.err(http_e.message)
+    log_msg = [http_e.message, *http_e.backtrace].join("\n")
+    Puppet.err(log_msg)
     new_response.respond_with(http_e.status, "application/json", http_e.to_json)
   ensure
     if profiler

--- a/spec/unit/network/http/error_spec.rb
+++ b/spec/unit/network/http/error_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Network::HTTP::Error do
   end
 
   describe Puppet::Network::HTTP::Error::HTTPServerError do
-    it "should serialize to JSON that matches the error schema and has the optional stacktrace property" do
+    it "should serialize to JSON that matches the error schema" do
       begin
         raise Exception, "a wild Exception appeared!"
       rescue Exception => e

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -81,6 +81,7 @@ describe Puppet::Network::HTTP::Handler do
       handler = PuppetSpec::Handler.new(
         Puppet::Network::HTTP::Route.path(/.*/).get(lambda { |_, _| raise error}))
 
+      # Stacktraces should be included in logs
       Puppet.expects(:err).with("Server Error: the sky is falling!\na.rb\nb.rb")
 
       req = a_request("GET", "/vtest/foo")
@@ -93,6 +94,10 @@ describe Puppet::Network::HTTP::Handler do
       expect(res[:content_type_header]).to eq("application/json")
       expect(res_body["issue_kind"]).to eq(Puppet::Network::HTTP::Issues::RUNTIME_ERROR.to_s)
       expect(res_body["message"]).to eq("Server Error: the sky is falling!")
+
+      # Stactraces may contain sensitive information, returning them to API
+      # consumers is not a best practice. See
+      # https://tickets.puppetlabs.com/browse/PUP-6659
       expect(res_body["stacktrace"]).to be_nil
       expect(res[:status]).to eq(500)
     end

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -74,9 +74,14 @@ describe Puppet::Network::HTTP::Handler do
       expect(res[:status]).to eq(404)
     end
 
-    it "returns a structured error response with a stacktrace when the server encounters an internal error" do
+    it "returns a structured error response when the server encounters an internal error" do
+      error = StandardError.new("the sky is falling!")
+      error.set_backtrace(['a.rb', 'b.rb'])
+
       handler = PuppetSpec::Handler.new(
-        Puppet::Network::HTTP::Route.path(/.*/).get(lambda { |_, _| raise StandardError.new("the sky is falling!")}))
+        Puppet::Network::HTTP::Route.path(/.*/).get(lambda { |_, _| raise error}))
+
+      Puppet.expects(:err).with("Server Error: the sky is falling!\na.rb\nb.rb")
 
       req = a_request("GET", "/vtest/foo")
       res = {}
@@ -88,8 +93,7 @@ describe Puppet::Network::HTTP::Handler do
       expect(res[:content_type_header]).to eq("application/json")
       expect(res_body["issue_kind"]).to eq(Puppet::Network::HTTP::Issues::RUNTIME_ERROR.to_s)
       expect(res_body["message"]).to eq("Server Error: the sky is falling!")
-      expect(res_body["stacktrace"].is_a?(Array) && !res_body["stacktrace"].empty?).to be_truthy
-      expect(res_body["stacktrace"][0]).to match("spec/unit/network/http/handler_spec.rb")
+      expect(res_body["stacktrace"]).to be_nil
       expect(res[:status]).to eq(500)
     end
 


### PR DESCRIPTION
Previously, Internal Server Errors would return an API response that
included a stacktrace.

This is not considered a best practice and on non-standard setups
filesystem locations disclosed in a stacktrace could be considered
sensitive information.

This commit moves to logging the stacktrace at the error level while
returning only the exception message via the HTTP API.