### PR TITLE
(PUP-6604) Extend variables_refreshed sleep on Solaris

### DIFF
--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -50,7 +50,11 @@ extend Puppet::Acceptance::EnvironmentUtils
           uptime = result.stdout.match(/Notice: #{local_uptime_pattern}/)[0]
           module_uptime = result.stdout.match(/"seconds"=>(\d+),/)[0]
         end
-        sleep 1
+        if agent.platform =~ /solaris/
+          sleep 31  # See FACT-1497; the system_uptime.seconds fact on solaris only updates every 30 secs.
+        else
+          sleep 1
+        end
         on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
           assert_equal(2, result.exit_code, 'wrong exit_code')


### PR DESCRIPTION
This commit extends the `sleep` statement in the
`variables_refreshed_each_compilation` test to 31 seconds when
the platform is Solaris.

As per FACT-1497, the `system_uptime.seconds` fact only updates
every 30 seconds on Solaris. Prior to this change this test failed
on Solaris due to this issue with facter.

This is a work around and should be reverted when the underlying
facter issue is resolved.