### PR TITLE
(PUP-6629) Emit corrective change messages at info

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -367,7 +367,8 @@ class Puppet::Property < Puppet::Parameter
     rescue => detail
       # Certain operations may fail, but we don't want to fail the transaction if we can
       # avoid it
-      Puppet.log_exception(detail, "Unknown failure comparing values #{should} and #{is} using insync? on type: #{self.resource.ref} property: #{self.name}", { :level => :info })
+      msg = "Unknown failure using insync_values? on type: #{self.resource.ref} / property: #{self.name} to compare values #{should} and #{is}"
+      Puppet.info(msg)
 
       # Return nil, ie. unknown
       nil


### PR DESCRIPTION
 - The changes made in commits fc9e5b02de9c3876abaafbf879b77423c4d74173
   and b941773cf0d138a12be68bb5cb718221ed38795c introduced exception
   logging around corrective changes.  When comparison for a Puppet
   property by way of insync_values? were performed, the intent was to
   propagate this to an end user.

   However, the code was written against a code path that didn't exist.

 - Instead of refactoring the logging code to allow an info level
   exception, emit an info message instead.

   This has the downside of not carrying stack trace info in the message,
   but has the upside of not changing any existing logging behavior.  A
   stack trace at this point is not as valuable as it might seem given
   there typically won't be any additional info to glean from it, other
   than the failure point.

   To make the message more greppable in the source code, restructure the
   message slightly.

  An example of an emitted message that shows during a --trace is:

```
  Info: Unknown failure using insync_values? on type: Acl[c:/temp/REM_FI~2.TXT] / property: permissions to compare values [{}] and [
 { identity => 'NT AUTHORITY\SYSTEM', rights => ["full"], affects => 'self_only', is_inherited => 'true' },
 { identity => 'BUILTIN\Administrators', rights => ["full"], affects => 'self_only', is_inherited => 'true' },
 { identity => 'BUILTIN\Users', rights => ["read", "execute"], affects => 'self_only', is_inherited => 'true' }]
```