### PR TITLE
(PUP-6513) Log lookup explainer info at debug level

### DIFF
--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -54,10 +54,22 @@ module Lookup
       elsif has_default
         answer = assert_type('Default value', value_type, default_value)
       else
+        lookup_invocation.emit_debug_info(debug_preamble(names)) if Puppet[:debug]
         fail_lookup(names)
       end
     end
+    lookup_invocation.emit_debug_info(debug_preamble(names)) if Puppet[:debug]
     answer
+  end
+
+  # @api private
+  def self.debug_preamble(names)
+    if names.size == 1
+      names = "'#{names[0]}'"
+    else
+      names = names.map { |n| "'#{n}'" }.join(', ')
+    end
+    "Lookup of #{names}"
   end
 
   # @api private

--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -506,4 +506,28 @@ module Puppet::Pops::Lookup
       branches.size == 1 ? branches[0].to_hash : super
     end
   end
+
+  class DebugExplainer < Explainer
+    attr_reader :wrapped_explainer
+
+    def initialize(wrapped_explainer)
+      @wrapped_explainer = wrapped_explainer
+      if wrapped_explainer.nil?
+        @current = self
+        @explain_options = false
+        @only_explain_options = false
+      else
+        @current = wrapped_explainer
+        @explain_options = wrapped_explainer.explain_options?
+        @only_explain_options = wrapped_explainer.only_explain_options?
+      end
+    end
+
+    def emit_debug_info(preamble)
+      io = ''
+      io << preamble << "\n"
+      @current.dump_on(io, '  ', '  ')
+      Puppet.debug(io.chomp!)
+    end
+  end
 end

--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -18,9 +18,9 @@ module Puppet::Pops::Lookup
     end
 
     def to_s
-      io = StringIO.new
+      io = ''
       dump_on(io, '', '')
-      io.string
+      io
     end
 
     def dump_on(io, indent, first_indent)
@@ -218,7 +218,7 @@ module Puppet::Pops::Lookup
       # It's pointless to report a merge where there's only one branch
       return branches[0].dump_on(io, indent, first_indent) if branches.size == 1
 
-      io << first_indent << 'Merge strategy ' << @merge.class.key << "\n"
+      io << first_indent << 'Merge strategy ' << @merge.class.key.to_s << "\n"
       indent = increase_indent(indent)
       options = options_wo_strategy
       unless options.nil?
@@ -297,7 +297,7 @@ module Puppet::Pops::Lookup
     end
 
     def dump_on(io, indent, first_indent)
-      io << first_indent << 'Data Binding "' << @binding_terminus << "\"\n"
+      io << first_indent << 'Data Binding "' << @binding_terminus.to_s << "\"\n"
       indent = increase_indent(indent)
       branches.each {|b| b.dump_on(io, indent, indent)}
       dump_outcome(io, indent)
@@ -323,7 +323,7 @@ module Puppet::Pops::Lookup
     def dump_on(io, indent, first_indent)
       io << first_indent << 'Data Provider "' << @provider.name << "\"\n"
       indent = increase_indent(indent)
-      io << indent << 'ConfigurationPath "' << @provider.config_path << "\"\n" if @provider.respond_to?(:config_path)
+      io << indent << 'ConfigurationPath "' << @provider.config_path.to_s << "\"\n" if @provider.respond_to?(:config_path)
       branches.each {|b| b.dump_on(io, indent, indent)}
       dump_outcome(io, indent)
     end
@@ -347,7 +347,7 @@ module Puppet::Pops::Lookup
     end
 
     def dump_on(io, indent, first_indent)
-      io << indent << 'Path "' << @path.path << "\"\n"
+      io << indent << 'Path "' << @path.path.to_s << "\"\n"
       indent = increase_indent(indent)
       io << indent << 'Original path: "' << @path.original_path << "\"\n"
       branches.each {|b| b.dump_on(io, indent, indent)}

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -23,6 +23,7 @@ module Puppet::Pops::Lookup
       unless explainer.is_a?(Explainer)
         explainer = explainer == true ? Explainer.new : nil
       end
+      explainer = DebugExplainer.new(explainer) if Puppet[:debug] && !explainer.is_a?(DebugExplainer)
       @explainer = explainer
     end
 
@@ -41,6 +42,14 @@ module Puppet::Pops::Lookup
         raise Puppet::DataBinding::LookupError.new(detail.message, detail)
       ensure
         @name_stack.pop
+      end
+    end
+
+    def emit_debug_info(preamble)
+      debug_explainer = @explainer
+      if debug_explainer.is_a?(DebugExplainer)
+        @explainer = debug_explainer.wrapped_explainer
+        debug_explainer.emit_debug_info(preamble)
       end
     end
 

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -184,7 +184,47 @@ Merge strategy first
       end
     end
 
-    it '--explain produces human readable text of a hash merge when using --explain-options' do
+    it '--explain produces human readable text by default and --debug produces the same output to debug logger' do
+      lookup.options[:node] = node
+      lookup.options[:explain] = true
+      lookup.command_line.stubs(:args).returns(['a'])
+      Puppet.debug = true
+      logs = []
+      begin
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          expect { lookup.run_command }.to output(<<-EXPLANATION).to_stdout
+Merge strategy first
+  Data Binding "hiera"
+    No such key: "a"
+  Data Provider "Hiera Data Provider, version 4"
+    ConfigurationPath "#{environmentpath}/production/hiera.yaml"
+    Data Provider "common"
+      Path "#{environmentpath}/production/data/common.yaml"
+        Original path: "common"
+        Found key: "a" value: "This is A"
+  Merged result: "This is A"
+          EXPLANATION
+        end
+      rescue SystemExit => e
+        expect(e.status).to eq(0)
+      end
+      logs = logs.select { |log| log.level == :debug }.map { |log| log.message }
+      expect(logs).to include(<<-EXPLANATION.chomp)
+Lookup of 'a'
+  Merge strategy first
+    Data Binding "hiera"
+      No such key: "a"
+    Data Provider "Hiera Data Provider, version 4"
+      ConfigurationPath "#{environmentpath}/production/hiera.yaml"
+      Data Provider "common"
+        Path "#{environmentpath}/production/data/common.yaml"
+          Original path: "common"
+          Found key: "a" value: "This is A"
+    Merged result: "This is A"
+      EXPLANATION
+    end
+
+    it '--explain-options produces human readable text of a hash merge' do
       lookup.options[:node] = node
       lookup.options[:explain_options] = true
       begin
@@ -207,6 +247,53 @@ Merge strategy hash
       rescue SystemExit => e
         expect(e.status).to eq(0)
       end
+    end
+
+    it '--explain-options produces human readable text of a hash merge and --debug produces the same output to debug logger' do
+      lookup.options[:node] = node
+      lookup.options[:explain_options] = true
+      Puppet.debug = true
+      logs = []
+      begin
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          expect { lookup.run_command }.to output(<<-EXPLANATION).to_stdout
+Merge strategy hash
+  Data Binding "hiera"
+    No such key: "lookup_options"
+  Data Provider "Hiera Data Provider, version 4"
+    ConfigurationPath "#{environmentpath}/production/hiera.yaml"
+    Data Provider "common"
+      Path "#{environmentpath}/production/data/common.yaml"
+        Original path: "common"
+        Found key: "lookup_options" value: {
+          "a" => "first"
+        }
+  Merged result: {
+    "a" => "first"
+  }
+          EXPLANATION
+        end
+      rescue SystemExit => e
+        expect(e.status).to eq(0)
+      end
+      logs = logs.select { |log| log.level == :debug }.map { |log| log.message }
+      expect(logs).to include(<<-EXPLANATION.chomp)
+Lookup of '__global__'
+  Merge strategy hash
+    Data Binding "hiera"
+      No such key: "lookup_options"
+    Data Provider "Hiera Data Provider, version 4"
+      ConfigurationPath "#{environmentpath}/production/hiera.yaml"
+      Data Provider "common"
+        Path "#{environmentpath}/production/data/common.yaml"
+          Original path: "common"
+          Found key: "lookup_options" value: {
+            "a" => "first"
+          }
+    Merged result: {
+      "a" => "first"
+    }
+      EXPLANATION
     end
 
     it '--explain produces human readable text of a hash merge when using both --explain and --explain-options' do


### PR DESCRIPTION
This PR ensures that a lookup explainer is present when
`Puppet[:debug]` is `true` and that the information that it collects
is logged. For cases when `Puppet[:debug]` is `true` and an explainer is
present already (as when using the lookup command with --explain or
--explain-options), then the information from that explainer is mirrored
to the debug logger.
