### PR TITLE
(PUP-6617) raise exception on failure

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -29,6 +29,8 @@ module Puppet::Util::Execution
     def initialize(value,exitstatus)
       super(value)
       @exitstatus = exitstatus
+
+      raise Puppet::ExecutionFailure, "Execution returned #{exitstatus}" unless exitstatus == 0
     end
   end
 


### PR DESCRIPTION
Since the master's implementation of `Puppet::Util::Execution.execute`
does not have the same API as the Ruby implementation, the exit status
was being lost. This just raises an exception when the ProcessOutput
object is initialized with a non-zero implementation.

I don't know if this is the best way to accomplish this, and I don't
really know the best way of testing it since the code path for exposing
the regression was when the Puppetserver implementation was called.

This doesn't handle the fact that the other `.execute()` options are
effectively ignored.