### PR TITLE
(PUP-6275) Log profiler output at INFO level

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -328,7 +328,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     set_log_level
 
     if Puppet[:profile]
-      @profiler = Puppet::Util::Profiler.add_profiler(Puppet::Util::Profiler::Aggregate.new(Puppet.method(:debug), "apply"))
+      @profiler = Puppet::Util::Profiler.add_profiler(Puppet::Util::Profiler::Aggregate.new(Puppet.method(:info), "apply"))
     end
   end
 

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -167,7 +167,7 @@ module Puppet::Network::HTTP::Handler
 
   def configure_profiler(request_headers, request_params)
     if (request_headers.has_key?(Puppet::Network::HTTP::HEADER_ENABLE_PROFILING.downcase) or Puppet[:profile])
-      Puppet::Util::Profiler.add_profiler(Puppet::Util::Profiler::Aggregate.new(Puppet.method(:debug), request_params.object_id))
+      Puppet::Util::Profiler.add_profiler(Puppet::Util::Profiler::Aggregate.new(Puppet.method(:info), request_params.object_id))
     end
   end
 


### PR DESCRIPTION
Profiler output requires `puppet agent` or `puppet apply` to be run with
the `--profile` flag or for `profiler=true` to be set in puppet.conf.
Prior to this patch, profile output was logged at DEBUG level which meant
that the global log level for Puppet Server had to be raised, which required
hand-editing an XML file along with a  service restart before and after
profiling activities.

This patch raises Puppet Server profile output to the default INFO level since
an additional option is already required to enable the profiler. This change
allows on-demand profiling via `puppet agent -t --profile` without the need to
manually re-start the Puppet Server and edit configuration.