### PR TITLE
(maint) Fix problem with arithmetic involving TimeData on right side

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -255,6 +255,10 @@ module Issues
     "Operator '#{operator}' is not applicable to #{label.a_an(left_value)}."
   end
 
+  OPERATOR_NOT_APPLICABLE_WHEN = hard_issue :OPERATOR_NOT_APPLICABLE_WHEN, :operator, :left_value, :right_value do
+    "Operator '#{operator}' is not applicable to #{label.a_an(left_value)} when right side is #{label.a_an(right_value)}."
+  end
+
   COMPARISON_NOT_POSSIBLE = hard_issue :COMPARISON_NOT_POSSIBLE, :operator, :left_value, :right_value, :detail do
     "Comparison of: #{label(left_value)} #{operator} #{label(right_value)}, is not possible. Caused by '#{detail}'."
   end

--- a/lib/puppet/pops/time/timestamp.rb
+++ b/lib/puppet/pops/time/timestamp.rb
@@ -33,9 +33,12 @@ class Timestamp < TimeData
     end
   end
 
-  undef_method :-@, :+@, :%,:modulo,:divmod, :div, :fdiv, :abs, :abs2, :magnitude # does not make sense on a Timestamp
+  undef_method :-@, :+@, :div, :fdiv, :abs, :abs2, :magnitude # does not make sense on a Timestamp
   if method_defined?(:negative?)
     undef_method :negative?, :positive?
+  end
+  if method_defined?(:%)
+    undef_method :%, :modulo, :divmod
   end
 
   def +(o)

--- a/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
+++ b/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
@@ -114,13 +114,28 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       end
 
       it 'Timespan - Numeric = Timespan (numeric treated as seconds)' do
-        code = "notice(strftime(assert_type(Timespan, Timespan({days => 3}) + 7300.123), '%H:%M:%S.%L'))"
-        expect(eval_and_collect_notices(code)).to eql(['74:01:40.123'])
+        code = "notice(strftime(assert_type(Timespan, Timespan({days => 3}) - 7300.123), '%H:%M:%S.%L'))"
+        expect(eval_and_collect_notices(code)).to eql(['69:58:19.877'])
       end
 
       it 'Timespan * Numeric = Timespan (numeric treated as seconds)' do
-        code = "notice(strftime(assert_type(Timespan, Timespan({days => 3}) - 7300.123), '%H:%M:%S.%L'))"
-        expect(eval_and_collect_notices(code)).to eql(['69:58:19.877'])
+        code = "notice(strftime(assert_type(Timespan, Timespan({days => 3}) * 2), '%D'))"
+        expect(eval_and_collect_notices(code)).to eql(['6'])
+      end
+
+      it 'Numeric + Timespan = Timespan (numeric treated as seconds)' do
+        code = 'notice(assert_type(Timespan, 7300.0 + Timespan({days => 3})))'
+        expect(eval_and_collect_notices(code)).to eql(['3-02:01:40'])
+      end
+
+      it 'Numeric - Timespan = Timespan (numeric treated as seconds)' do
+        code = "notice(strftime(assert_type(Timespan, 300000 - Timespan({days => 3})), '%H:%M'))"
+        expect(eval_and_collect_notices(code)).to eql(['11:20'])
+      end
+
+      it 'Numeric * Timespan = Timespan (numeric treated as seconds)' do
+        code = "notice(strftime(assert_type(Timespan, 2 * Timespan({days => 3})), '%D'))"
+        expect(eval_and_collect_notices(code)).to eql(['6'])
       end
 
       it 'Timespan + Timestamp = Timestamp' do
@@ -163,6 +178,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
         expect(eval_and_collect_notices(code)).to eql(['2016-10-10T13:00:00.123 UTC'])
       end
 
+      it 'Numeric + Timestamp = Timestamp' do
+        code = "notice(assert_type(Timestamp, 3600.123 + Timestamp('2016-10-10T12:00:00.000')))"
+        expect(eval_and_collect_notices(code)).to eql(['2016-10-10T13:00:00.123 UTC'])
+      end
+
       it 'Timestamp - Timestamp = Timespan' do
         code = "notice(assert_type(Timespan, Timestamp('2016-10-10') - Timestamp('2015-10-10')))"
         expect(eval_and_collect_notices(code)).to eql(['366-00:00:00'])
@@ -176,6 +196,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       it 'Timestamp - Numeric = Timestamp' do
         code = "notice(assert_type(Timestamp, Timestamp('2016-10-10') - 3600.123))"
         expect(eval_and_collect_notices(code)).to eql(['2016-10-09T22:59:59.877 UTC'])
+      end
+
+      it 'Numeric - Timestamp = Timestamp' do
+        code = "notice(assert_type(Timestamp, 123 - Timestamp('2016-10-10')))"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '-' is not applicable.*when right side is a Timestamp/)
       end
 
       it 'Timestamp / Timestamp is an error' do
@@ -193,6 +218,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
         expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\/' is not applicable to a Timestamp/)
       end
 
+      it 'Numeric / Timestamp is an error' do
+        code = "notice(3600.123 / Timestamp('2016-10-10'))"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\/' is not applicable.*when right side is a Timestamp/)
+      end
+
       it 'Timestamp * Timestamp is an error' do
         code = "notice(Timestamp('2016-10-10') * Timestamp())"
         expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\*' is not applicable to a Timestamp/)
@@ -206,6 +236,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       it 'Timestamp * Numeric is an error' do
         code = "notice(Timestamp('2016-10-10') * 3600.123)"
         expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\*' is not applicable to a Timestamp/)
+      end
+
+      it 'Numeric * Timestamp is an error' do
+        code = "notice(3600.123 * Timestamp('2016-10-10'))"
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Operator '\*' is not applicable.*when right side is a Timestamp/)
       end
     end
   end


### PR DESCRIPTION
This commit fixes problems that occurs when a Timestamp or Timespan
is on the right hand side of an arithmetic operation and the left
hand side is an Integer or Float. The result of an addition,
subtraction, or multiplication was of the wrong type and some
nonsensical operations that really should be prohibited, were allowed.

A side effect of this fix is an improvement of the error message
when using '%' with a Float on the right hand side. The expression

1 % 1.0

would, before this commit, result in the message:

Operator '%' is not applicable to an Integer

now, the message will instead be:

Operator '%' is not applicable to an Integer when right side is a Float