### PR TITLE
(PUP-6662) Make Sensitive data work in user defined resources

### DIFF
--- a/lib/puppet/type/component.rb
+++ b/lib/puppet/type/component.rb
@@ -71,6 +71,10 @@ Puppet::Type.newtype(:component) do
     reference.to_s
   end
 
+  # Overrides the default implementation to do nothing
+  def set_sensitive_parameters(sensitive_parameters)
+  end
+
   private
 
   attr_reader :reference

--- a/lib/puppet/type/component.rb
+++ b/lib/puppet/type/component.rb
@@ -71,7 +71,14 @@ Puppet::Type.newtype(:component) do
     reference.to_s
   end
 
-  # Overrides the default implementation to do nothing
+  # Overrides the default implementation to do nothing.
+  # This type contains data from class/define parameters, but does
+  # not have actual parameters or properties at the Type level. We can
+  # simply ignore anything flagged as sensitive here, since any
+  # contained resources will handle that sensitivity themselves. There
+  # is no risk of this information leaking into reports, since no
+  # Component instances survive the graph transmutation.
+  #
   def set_sensitive_parameters(sensitive_parameters)
   end
 

--- a/spec/unit/pops/types/p_sensitive_type_spec.rb
+++ b/spec/unit/pops/types/p_sensitive_type_spec.rb
@@ -117,6 +117,36 @@ describe 'Sensitive Type' do
       CODE
       expect(eval_and_collect_notices(code)).to eq(['Sensitive [value redacted]'])
     end
+
+    it 'can be given to a user defined resource as a parameter' do
+      code =<<-CODE
+        define keeper_of_secrets(Sensitive $x) {
+          notice(assert_type(Sensitive[String], $x))
+        }
+        keeper_of_secrets { 'test': x => Sensitive("long toe") }
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['Sensitive [value redacted]'])
+    end
+
+    it 'can be given to a class as a parameter' do
+      code =<<-CODE
+        class keeper_of_secrets(Sensitive $x) {
+          notice(assert_type(Sensitive[String], $x))
+        }
+        class { 'keeper_of_secrets': x => Sensitive("long toe") }
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['Sensitive [value redacted]'])
+    end
+
+    it 'can be given to a function as a parameter' do
+      code =<<-CODE
+        function keeper_of_secrets(Sensitive $x) {
+          notice(assert_type(Sensitive[String], $x))
+        }
+        keeper_of_secrets(Sensitive("long toe"))
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['Sensitive [value redacted]'])
+    end
   end
 
   it "enforces wrapped type constraints" do


### PR DESCRIPTION
Before this, a Sensitive type value could only be used directly
in a native resource.

In order to fix this, there are some hoops to jump through.
* a puppet apply does not serialize the resources in the catalog which
means that the processing of sensitive data must take place in the
resources themselves.
* The early unwrapping and marking parameters as sensitive then occur
too early (finish) for classes and user defined types. For native types
there is no evaluation, and finish is only called post compile, but for
user defined resources / classes this occurs when the resource is
evaluated.