### PR TITLE
(maint) Upgrade to new signing key

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -6,7 +6,7 @@ cows: 'base-precise-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'
-gpg_key: '4BD6EC30'
+gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
 # a space separated list of mock configs
 final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64'


### PR DESCRIPTION
This commit updates the key that is used to sign packages. We are
in the process of introducing a new signing key to verify our packages.
As a part of this effort, we need to actually switch over to this new
key for our individual projects.