### PR TITLE
(PUP-6670) Update tag validation regex to handle newlines

### DIFF
--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -1,7 +1,7 @@
 require 'puppet/util/tag_set'
 
 module Puppet::Util::Tagging
-  ValidTagRegex = /^[0-9A-Za-z_][0-9A-Za-z_:.-]*$/
+  ValidTagRegex = /\A[0-9A-Za-z_][0-9A-Za-z_:.-]*\Z/
 
   # Add a tag to the current tag set.
   # When a tag set is used for a scope, these tags will be added to all of

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -36,6 +36,10 @@ describe Puppet::Util::Tagging do
     expect { tagger.tag("bad tag") }.to raise_error(Puppet::ParseError)
   end
 
+  it "should fail on tags containing newline characters" do
+    expect { tagger.tag("bad\ntag") }.to raise_error(Puppet::ParseError)
+  end
+
   it "should allow alpha tags" do
     expect { tagger.tag("good_tag") }.not_to raise_error
   end


### PR DESCRIPTION
This patch updates the tag validation regex so that it is anchored by `\A` and
`\Z` instead of `^` and `$`. The issue with using `$` is that it will terminate
validation when a newline is encountered, which allows non-valid tags to pass
through, which causes catalogs to be rejected by PuppetDB. The updated pattern
matches the anchors PuppetDB uses to validate tags.