### PR TITLE
(PUP-6669) Improve error messages from TypeMismatchDescriber

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -578,7 +578,7 @@ module Types
         value = param_hash[name]
         value_type = elem.value_type
         if param_hash.include?(name)
-          result << describe(value_type, TypeCalculator.singleton.infer_set(value).generalize, [ParameterPathElement.new(name)]) unless value_type.instance?(value)
+          result << describe(value_type, TypeCalculator.singleton.infer_set(value), [ParameterPathElement.new(name)]) unless value_type.instance?(value)
         else
           result << MissingParameter.new(nil, name) unless elem.key_type.assignable?(PUndefType::DEFAULT) unless missing_ok
         end


### PR DESCRIPTION
Before this commit, the actual type in a type mismatch description was
generalized before it was included in an error message which resulted
in confusing and incomplete messages. This commit removes the
generalization.