### PR TITLE
(PUP-4643) Add evaluation control functions break(), next(), and return()

### DIFF
--- a/lib/puppet/functions/break.rb
+++ b/lib/puppet/functions/break.rb
@@ -1,0 +1,22 @@
+# Make iteration break as if there were no more values to process
+#
+# @since 4.7.0
+#
+Puppet::Functions.create_function(:break) do
+  dispatch :break_impl do
+  end
+
+  def break_impl()
+    stacktrace = Puppet::Pops::PuppetStack.stacktrace()
+    if stacktrace.size > 0
+      file, line = stacktrace[0]
+    else
+      file = nil
+      line = nil
+    end
+    # PuppetStopIteration contains file and line and is a StopIteration exception
+    # so it can break a Ruby Kernel#loop or enumeration
+    #
+    raise Puppet::Pops::Evaluator::PuppetStopIteration.new(file, line)
+  end
+end

--- a/lib/puppet/functions/next.rb
+++ b/lib/puppet/functions/next.rb
@@ -1,0 +1,23 @@
+# Make iteration continue with the next value optionally given a value for this iteration.
+# If a value is not given it defaults to `undef`
+#
+# @since 4.7.0
+#
+Puppet::Functions.create_function(:next) do
+  dispatch :next_impl do
+    optional_param 'Any', :value
+  end
+
+  def next_impl(value = nil)
+    stacktrace = Puppet::Pops::PuppetStack.stacktrace()
+    if stacktrace.size > 0
+      file, line = stacktrace[0]
+    else
+      file = nil
+      line = nil
+    end
+
+    exc = Puppet::Pops::Evaluator::Next.new(value, file, line)
+    raise exc
+  end
+end

--- a/lib/puppet/functions/return.rb
+++ b/lib/puppet/functions/return.rb
@@ -1,0 +1,22 @@
+# Make iteration continue with the next value optionally given a value for this iteration.
+# If a value is not given it defaults to `undef`
+#
+# @since 4.7.0
+#
+Puppet::Functions.create_function(:return, Puppet::Functions::InternalFunction) do
+  dispatch :return_impl do
+    optional_param 'Any', :value
+  end
+
+  def return_impl(value = nil)
+    stacktrace = Puppet::Pops::PuppetStack.stacktrace()
+    if stacktrace.size > 0
+      file, line = stacktrace[0]
+    else
+      file = nil
+      line = nil
+    end
+
+    raise Puppet::Pops::Evaluator::Return.new(value, file, line)
+  end
+end

--- a/lib/puppet/parser/ast.rb
+++ b/lib/puppet/parser/ast.rb
@@ -29,6 +29,11 @@ class Puppet::Parser::AST
     # is called so many times during parsing.
     begin
       return self.evaluate(scope)
+    rescue Puppet::Pops::Evaluator::PuppetStopIteration => detail
+      raise detail
+#      # Only deals with StopIteration from the break() function as a general
+#      # StopIteration is a general runtime problem
+#      raise Puppet::ParseError.new(detail.message, detail.file, detail.line, detail)
     rescue Puppet::Error => detail
       raise adderrorcontext(detail)
     rescue => detail

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -585,6 +585,11 @@ class Puppet::Parser::Compiler
         urs = unevaluated_resources.each do |resource|
          begin
             resource.evaluate
+         rescue Puppet::Pops::Evaluator::PuppetStopIteration => detail
+           # needs to be handled specifically as the error has the file/line/position where this
+           # occurred rather than the resource
+           fail(Puppet::Pops::Issues::RUNTIME_ERROR, detail, {:detail => detail.message}, detail)
+
           rescue Puppet::Error => e
             # PuppetError has the ability to wrap an exception, if so, use the wrapped exception's
             # call stack instead

--- a/lib/puppet/parser/functions/break.rb
+++ b/lib/puppet/parser/functions/break.rb
@@ -1,0 +1,39 @@
+Puppet::Parser::Functions::newfunction(
+  :break,
+  :arity => 0,
+  :doc => <<-DOC
+Breaks the innermost iteration as if it encountered an end of input.
+This function does not return to the caller.
+
+The signal produced to stop the iteration bubbles up through
+the call stack until either terminating the innermost iteration or
+raising an error if the end of the call stack is reached.
+
+The break() function does not accept an argument.
+
+**Example:** Using `break`
+
+```puppet
+$data = [1,2,3]
+notice $data.map |$x| { if $x == 3 { break() } $x*10 }
+```
+
+Would notice the value `[10, 20]`
+
+**Example:** Using a nested `break`
+
+```puppet
+function break_if_even($x) {
+  if $x % 2 == 0 { break() }
+}
+$data = [1,2,3]
+notice $data.map |$x| { break_if_even($x); $x*10 }
+```
+Would notice the value `[10]`
+
+* Also see functions `next` and `return`
+* Since 4.8.0
+DOC
+) do |args|
+  Error.is4x('break')
+end

--- a/lib/puppet/parser/functions/next.rb
+++ b/lib/puppet/parser/functions/next.rb
@@ -1,0 +1,38 @@
+Puppet::Parser::Functions::newfunction(
+  :next,
+  :arity => -2,
+  :doc => <<-DOC
+Immediately returns the given optional value from a block (lambda), function, class body or user defined type body.
+If a value is not given, an `undef` value is returned. This function does not return to the immediate caller.
+
+The signal produced to return a value bubbles up through
+the call stack until reaching a code block (lambda), function, class definition or
+definition of a user defined type at which point the value given to the function will
+be produced as the result of that body of code. An error is raised
+if the signal to return a value reaches the end of the call stack.
+
+**Example:** Using `next` in `each`
+
+```puppet
+$data = [1,2,3]
+$data.each |$x| { if $x == 2 { next() } notice $x }
+```
+
+Would notice the values `1` and `3`
+
+**Example:** Using `next` to produce a value
+
+If logic consists of deeply nested conditionals it may be complicated to get out of the innermost conditional.
+A call to `next` can then simplify the logic. This example however, only shows the principle.
+```puppet
+$data = [1,2,3]
+notice $data.map |$x| { if $x == 2 { next($x*100) }; $x*10 }
+```
+Would notice the value `[10, 200, 30]`
+
+* Also see functions `return` and `break`
+* Since 4.8.0
+DOC
+) do |args|
+  Error.is4x('next')
+end

--- a/lib/puppet/parser/functions/return.rb
+++ b/lib/puppet/parser/functions/return.rb
@@ -1,0 +1,71 @@
+Puppet::Parser::Functions::newfunction(
+  :return,
+  :arity => -2,
+  :doc => <<-DOC
+Immediately returns the given optional value from a function, class body or user defined type body.
+If a value is not given, an `undef` value is returned. This function does not return to the immediate caller.
+If called from within a lambda the return will return from the function evaluating the lambda.
+
+The signal produced to return a value bubbles up through
+the call stack until reaching a function, class definition or
+definition of a user defined type at which point the value given to the function will
+be produced as the result of that body of code. An error is raised
+if the signal to return a value reaches the end of the call stack.
+
+**Example:** Using `return`
+
+```puppet
+function example($x) {
+  # handle trivial cases first for better readability of
+  # what follows
+  if $x == undef or $x == [] or $x == '' {
+    return false
+  }
+  # complex logic to determine if value is true
+  true 
+}
+notice example([]) # would notice false
+notice example(42) # would notice true
+```
+
+**Example:** Using `return` in a class
+
+```puppet
+class example($x) {
+  # handle trivial cases first for better readability of
+  # what follows
+  if $x == undef or $x == [] or $x == '' {
+    # Do some default configuration of this class
+    notice 'foo'
+    return()
+  }
+  # complex logic configuring the class if something more interesting
+  # was given in $x
+  notice 'bar'
+}
+```
+
+When used like this:
+
+```puppet
+class { example: x => [] }
+```
+
+The code would notice `'foo'`, but not `'bar'`.
+
+When used like this:
+
+```puppet
+class { example: x => [some_value] }
+```
+
+The code would notice `'bar'` but not `'foo'`
+
+Note that the returned value is ignored if used in a class or user defined type.
+
+* Also see functions `return` and `break`
+* Since 4.8.0
+DOC
+) do |args|
+  Error.is4x('return')
+end

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -2,20 +2,40 @@ module Puppet::Pops
 module Evaluator
   class Jumper < Exception
     attr_reader :value
-    def initialize(value)
+    attr_reader :file
+    attr_reader :line
+    def initialize(value, file, line)
       @value = value
+      @file = file
+      @line = line
     end
   end
 
   class Next < Jumper
-    def initialize(value)
+    def initialize(value, file, line)
       super
     end
   end
 
   class Return < Jumper
-    def initialize(value)
+    def initialize(value, file, line)
       super
+    end
+  end
+
+  class PuppetStopIteration < StopIteration
+    attr_reader :file
+    attr_reader :line
+    attr_reader :pos
+
+    def initialize(file, line, pos = nil)
+      @file = file
+      @line = line
+      @pos = pos
+    end
+
+    def message
+      "break() from context where this is illegal"
     end
   end
 
@@ -150,6 +170,16 @@ class Closure < CallableSignature
 
     def enclosing_scope
       @enclosing_scope
+    end
+
+    def call(*args)
+      # A return from an unnamed closure is treated as a return from the context evaluating
+      # calling this closure - that is, as if it was the return call itself.
+      #
+      jumper = catch(:return) do
+        return call_with_scope(enclosing_scope, args)
+      end
+      raise jumper
     end
   end
 

--- a/lib/puppet/pops/functions/dispatcher.rb
+++ b/lib/puppet/pops/functions/dispatcher.rb
@@ -32,11 +32,8 @@ class Puppet::Pops::Functions::Dispatcher
     actual = tc.infer_set(block_given? ? args + [block] : args)
     found = @dispatchers.find { |d| tc.callable?(d.type, actual) }
     if found
-      # next() and return() have the same effect wrt to a dispatcher - they both return the value
       catch(:next) do
-        catch(:return) do
-          found.invoke(instance, calling_scope, args, &block)
-        end
+        found.invoke(instance, calling_scope, args, &block)
       end
     else
       raise ArgumentError, Puppet::Pops::Types::TypeMismatchDescriber.describe_signatures(instance.class.name, @dispatchers, actual)

--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -865,7 +865,10 @@ class Factory
     'err'     => true,
 
     'fail'    => true,
-    'import'  => true  # discontinued, but transform it to make it call error reporting function
+    'import'  => true,  # discontinued, but transform it to make it call error reporting function
+    'break'   => true,
+    'next'    => true,
+    'return'  => true
   }
   # Returns true if the given name is a "statement keyword" (require, include, contain,
   # error, notice, info, debug
@@ -1146,4 +1149,3 @@ class Factory
 end
 end
 end
-

--- a/lib/puppet/pops/puppet_stack.rb
+++ b/lib/puppet/pops/puppet_stack.rb
@@ -32,12 +32,12 @@ module PuppetStack
   end
 
   def self.stacktrace
-    result = caller().reduce([]) do |memo, loc|
-      if loc =~ /^(.*\.pp)?:([0-9]+):in `stack'/
+    caller().reduce([]) do |memo, loc|
+      if loc =~ /^(.*\.pp)?:([0-9]+):in (`stack'|`block in call_function')/
         memo << [$1.nil? ? 'unknown' : $1, $2.to_i]
       end
       memo
-    end.reverse
+    end
   end
 end
 end

--- a/lib/puppet/pops/validation.rb
+++ b/lib/puppet/pops/validation.rb
@@ -200,7 +200,15 @@ module Validation
       # TODO: this support is questionable, it requires knowledge that :detail is special
       arguments[:detail] ||= ''
 
-      if semantic.is_a?(Puppet::Parser::Resource)
+      # Accept an Error as semantic if it supports methods #file(), #line(), and #pos()
+      if semantic.is_a?(StandardError)
+        unless semantic.respond_to?(:file) && semantic.respond_to?(:line) && semantic.respond_to?(:pos)
+          raise Puppet::DevError("Issue #{issue.issue_code}: Cannot pass a #{semantic.class} as a semantic object when it does not support #pos(), #file() and #line()")
+        end
+        source_pos = semantic
+        file = semantic.file
+
+      elsif semantic.is_a?(Puppet::Parser::Resource)
         source_pos = semantic
         file = semantic.file
       else

--- a/spec/unit/functions/break_spec.rb
+++ b/spec/unit/functions/break_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the break function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  context  do
+    it 'breaks iteration as if at end of input' do
+      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[[1, 2]]')
+          function please_break() {
+            [1,2,3].map |$x| { if $x == 3 { break() } $x }
+          }
+          notify { String(please_break()): }
+        CODE
+    end
+  end
+
+  it 'does not provide early exit from a class' do
+    # A break would semantically mean that the class should not be included - as if the
+    # iteration over class names should stop. That is too magic and should
+    # be done differently by the user.
+    #
+    expect do
+      compile_to_catalog(<<-CODE)
+        class does_break {
+          notice 'a'
+          if 1 == 1 { break() } # avoid making next line statically unreachable
+          notice 'b'
+        }
+        include(does_break)
+      CODE
+    end.to raise_error(/break\(\) from context where this is illegal at unknown:3 on node.*/)
+  end
+
+    it 'does not provide early exit from a define' do
+      # A break would semantically mean that the resource should not be created - as if the
+      # iteration over resource titles should stop. That is too magic and should
+      # be done differently by the user.
+      #
+      expect do
+        compile_to_catalog(<<-CODE)
+          define does_break {
+            notice 'a'
+            if 1 == 1 { break() } # avoid making next line statically unreachable
+            notice 'b'
+          }
+            does_break { 'no_you_cannot': }
+        CODE
+      end.to raise_error(/break\(\) from context where this is illegal at unknown:3 on node.*/)
+    end
+
+  it 'can be called when nested in a function to make that function behave as a break' do
+    # This allows functions like break_when(...) to be implemented by calling break() conditionally
+    #
+    expect(eval_and_collect_notices(<<-CODE)).to eql(['[100]'])
+      function nested_break($x) {
+        if $x == 2 { break() } else { $x * 100 }
+      }
+      function example() {
+        [1,2,3].map |$x| { nested_break($x)  }
+      }
+      notice example()
+      CODE
+  end
+
+  it 'can not be called nested from top scope' do
+    expect do
+      compile_to_catalog(<<-CODE)
+        # line 1
+        # line 2
+        $result = with(1) |$x| { with($x) |$x| {break() }}
+        notice $result
+      CODE
+    end.to raise_error(/break\(\) from context where this is illegal at unknown:3 on node.*/)
+  end
+
+  it 'can not be called from top scope' do
+    expect do
+      compile_to_catalog(<<-CODE)
+        # line 1
+        # line 2
+        break()
+      CODE
+    end.to raise_error(/break\(\) from context where this is illegal at unknown:3 on node.*/)
+  end
+end

--- a/spec/unit/functions/next_spec.rb
+++ b/spec/unit/functions/next_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the next function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  context 'exits a block yielded to iteratively' do
+    it 'with a given value as result for this iteration' do
+      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[[100, 4, 6]]')
+          $result = String([1,2,3].map |$x| { if $x == 1 { next(100) } $x*2 })
+          notify { $result: }
+        CODE
+    end
+
+    it 'with undef value as result for this iteration when next is not given an argument' do
+      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[[undef, 4, 6]]')
+          $result = String([1,2,3].map |$x| { if $x == 1 { next() } $x*2 })
+          notify { $result: }
+        CODE
+    end
+  end
+
+  it 'can be called without parentheses around the argument' do
+    expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[[100, 4, 6]]')
+        $result = String([1,2,3].map |$x| { if $x == 1 { next 100 } $x*2 })
+        notify { $result: }
+      CODE
+  end
+
+  it 'has the same effect as a return when called from within a block not used in an iteration' do
+    expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[100]')
+        $result = String(with(1) |$x| { if $x == 1 { next(100) } 200 })
+        notify { $result: }
+      CODE
+  end
+
+  it 'has the same effect as a return when called from within a function' do
+    expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[[102, 200, 300]]')
+        function do_next() {
+          next(100)
+        }
+        $result = String([1,2,3].map |$x| { if $x == 1 { next do_next()+2 } $x*do_next() })
+        notify { $result: }
+      CODE
+  end
+
+  it 'provides early exit from a class and keeps the class' do
+    expect(eval_and_collect_notices(<<-CODE)).to eql(['a', 'c', 'true', 'true'])
+        class notices_c { notice 'c' }
+        class does_next {
+          notice 'a'
+          if 1 == 1 { next() } # avoid making next line statically unreachable
+          notice 'b'
+        }
+        # include two classes to check that next does not do an early return from
+        # the include function.
+        include(does_next, notices_c)
+        notice defined(does_next)
+        notice defined(notices_c)
+      CODE
+  end
+
+  it 'provides early exit from a user defined resource and keeps the resource' do
+    expect(eval_and_collect_notices(<<-CODE)).to eql(['the_doer_of_next', 'copy_cat', 'true', 'true'])
+        define does_next {
+          notice $title
+          if 1 == 1 { next() } # avoid making next line statically unreachable
+          notice 'b'
+        }
+        define checker {
+          notice defined(Does_next['the_doer_of_next'])
+          notice defined(Does_next['copy_cat'])
+        }
+        # create two instances to ensure next does not break the entire
+        # resource expression
+        does_next { ['the_doer_of_next', 'copy_cat']: }
+        checker { 'needed_because_evaluation_order': }
+      CODE
+  end
+
+  it 'can not be called from top scope' do
+    expect do
+      compile_to_catalog(<<-CODE)
+        # line 1
+        # line 2
+        next()
+      CODE
+    end.to raise_error(/next\(\) from context where this is illegal at unknown:3 on node.*/)
+  end
+end

--- a/spec/unit/functions/return_spec.rb
+++ b/spec/unit/functions/return_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the return function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  context 'returns from outer function when called from nested block' do
+    it 'with a given value as function result' do
+      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[100]')
+          function please_return() {
+            [1,2,3].map |$x| { if $x == 1 { return(100) } 200 }
+            300
+          }
+          notify { String(please_return()): }
+        CODE
+    end
+
+    it 'with undef value as function result when not given an argument' do
+      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[xy]')
+          function please_return() {
+            [1,2,3].map |$x| { if $x == 1 { return() } 200 }
+            300
+          }
+          notify { "x${please_return}y": }
+        CODE
+    end
+  end
+
+  it 'can be called without parentheses around the argument' do
+    expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[100]')
+        function please_return() {
+          if 1 == 1 { return 100 }
+          200
+        }
+        notify { String(please_return()): }
+      CODE
+  end
+
+  it 'provides early exit from a class and keeps the class' do
+    expect(eval_and_collect_notices(<<-CODE)).to eql(['a', 'c', 'true', 'true'])
+        class notices_c { notice 'c' }
+        class does_next {
+          notice 'a'
+          if 1 == 1 { return() } # avoid making next line statically unreachable
+          notice 'b'
+        }
+        # include two classes to check that next does not do an early return from
+        # the include function.
+        include(does_next, notices_c)
+        notice defined(does_next)
+        notice defined(notices_c)
+      CODE
+  end
+
+  it 'provides early exit from a user defined resource and keeps the resource' do
+    expect(eval_and_collect_notices(<<-CODE)).to eql(['the_doer_of_next', 'copy_cat', 'true', 'true'])
+        define does_next {
+          notice $title
+          if 1 == 1 { return() } # avoid making next line statically unreachable
+          notice 'b'
+        }
+        define checker {
+          notice defined(Does_next['the_doer_of_next'])
+          notice defined(Does_next['copy_cat'])
+        }
+        # create two instances to ensure next does not break the entire
+        # resource expression
+        does_next { ['the_doer_of_next', 'copy_cat']: }
+        checker { 'needed_because_evaluation_order': }
+      CODE
+  end
+
+  it 'can be called when nested in a function to make that function return' do
+    expect(eval_and_collect_notices(<<-CODE)).to eql(['100'])
+      function nested_return() {
+        with(1) |$x| { with($x) |$x| {return(100) }}
+      }
+      notice nested_return()
+      CODE
+  end
+
+  it 'can not be called nested from top scope' do
+    expect do
+      compile_to_catalog(<<-CODE)
+        # line 1
+        # line 2
+        $result = with(1) |$x| { with($x) |$x| {return(100) }}
+        notice $result
+      CODE
+    end.to raise_error(/return\(\) from context where this is illegal at unknown:3 on node.*/)
+  end
+
+  it 'can not be called from top scope' do
+    expect do
+      compile_to_catalog(<<-CODE)
+        # line 1
+        # line 2
+        return()
+      CODE
+    end.to raise_error(/return\(\) from context where this is illegal at unknown:3 on node.*/)
+  end
+end

--- a/spec/unit/pops/puppet_stack_spec.rb
+++ b/spec/unit/pops/puppet_stack_spec.rb
@@ -50,7 +50,7 @@ describe 'Puppet::Pops::PuppetStack' do
   end
 
   it 'returns an array from stacktrace with information about each level with oldest frame last' do
-    expect(StackTraceTest.new.two_levels).to eql([['two_levels.pp', 1237], ['level2.pp', 1240]])
+    expect(StackTraceTest.new.two_levels).to eql([['level2.pp', 1240], ['two_levels.pp', 1237]])
   end
 
   it 'accepts file to be nil' do


### PR DESCRIPTION
This adds the functions break(), next() and return() which control the order of evaluation:

* break() breaks the innermost iteration as if end of input was reached
* next() returns a value from a lambda, function, class body or define body
* return() returns a value from a function, class body or define body

When next() or return() is used to break() a class or define body, the value is ignored.