### PR TITLE
(maint) Add a MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "issues": "https://tickets.puppet.com/browse/PUP",
+  "people": [
+    {
+      "github": "hlindberg",
+      "email": "henrik.lindberg@puppet.com",
+      "name": "Henrik Lindberg"
+    },
+    {
+      "github": "kylog",
+      "email": "kylo@puppet.com",
+      "name": "Kylo Ginsberg"
+    },
+    {
+      "github": "joshcooper",
+      "email": "josh@puppet.com",
+      "name": "Josh Cooper"
+    },
+    {
+      "github": "MikaelSmith",
+      "email": "michael.smith@puppet.com",
+      "name": "Michael Smith"
+    },
+    {
+      "github": "thallgren",
+      "name": "Thomas Hallgren"
+    },
+    {
+      "github": "branan",
+      "email": "branan@puppet.com",
+      "name": "Branan Riley"
+    },
+    {
+      "github": "whopper",
+      "email": "whopper@puppet.com",
+      "name": "Will Hopper"
+    },
+    {
+      "github": "Iristyle",
+      "name": "Ethan J. Brown"
+    },
+    {
+      "github": "HAIL9000",
+      "email": "hailee@puppet.com",
+      "name": "Hailee Kenney"
+    },
+    {
+      "github": "er0ck",
+      "email": "eric.thompson@puppet.com",
+      "name": "Eric Thompson"
+    },
+    {
+      "github": "johnduarte",
+      "email": "john.duarte@puppet.com",
+      "name": "John Duarte"
+    },
+    {
+      "github": "adrienthebo",
+      "name": "Adrien Thebo"
+    }
+  ]
+}

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -24,6 +24,7 @@
     },
     {
       "github": "thallgren",
+      "email": "thomas.hallgren@puppet.com",
       "name": "Thomas Hallgren"
     },
     {

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "file_format": "This MAINTAINERS file format is described at https://github.com/puppetlabs/maintainers",
   "issues": "https://tickets.puppet.com/browse/PUP",
   "people": [
     {

--- a/README.md
+++ b/README.md
@@ -72,9 +72,3 @@ Long-term support, including security patches and bug fixes, is available for
 commercial customers. Please see the following page for more details:
 
 [Puppet Enterprise Support Lifecycle](https://puppetlabs.com/misc/puppet-enterprise-lifecycle)
-
-Maintainers
--------
-
-* Kylo Ginsberg, kylo@puppet.com, github:kylog, jira:kylo
-* Henrik Lindberg, henrik.lindberg@puppet.com, github:hlindberg, jira:henrik.lindberg


### PR DESCRIPTION
Hi @hlindberg @joshcooper @MikaelSmith @thallgren @branan @HAIL9000 @Iristyle @whopper @adrienthebo @johnduarte @er0ck:

Anticipating some possible questions:

* This PR add a MAINTAINERS file to document who is maintaining this repo. The list of people started with the top 10 PR mergers in the last year, plus a little conversation from Michael and me here https://github.com/puppetlabs/kylo_scratchpad/pull/1/files#r76349506.
* If the list seems wrong, let's feel free to edit it.
* The format of the file is documented here: http://github.com/puppetlabs/maintainers
* And I used https://rubygems.org/gems/maintainers to construct the file
* I pushed the PR branch to the puppetlabs space (rather than mine) so that all parties can edit collaboratively as needed
* Note that this is a public repo. The email and name fields are *optional* here. As a starting point, I pre-populated them with the publicly available names/emails available for all of us on github (but took bogus or non-puppet emails as an indication that you may not want to share your puppet.com email). *Please feel free to edit your email and name fields for any reason.*
* This is just the second PR using this new MAINTAINERS format (because this repo gets more PRs than any other eng-maintained repo save ci-job-configs), and I'm sure there will be questions and prospects for improvement.

Thanks!