### PR TITLE
(maint) Make time data compare equal to numbers with the same magnitude

### DIFF
--- a/lib/puppet/pops/evaluator/compare_operator.rb
+++ b/lib/puppet/pops/evaluator/compare_operator.rb
@@ -93,12 +93,12 @@ class CompareOperator
   end
 
   def cmp_Timespan(a, b)
-    raise ArgumentError.new('Timespans are only comparable to Timespans, Integers, and Floats') unless b.is_a?(Numeric)
+    raise ArgumentError.new('Timespans are only comparable to Timespans, Integers, and Floats') unless b.is_a?(Time::Timespan) ||  b.is_a?(Integer) || b.is_a?(Float)
     a <=> b
   end
 
   def cmp_Timestamp(a, b)
-    raise ArgumentError.new('Timestamps are only comparable to Timestamps, Integers, and Floats') unless b.is_a?(Numeric)
+    raise ArgumentError.new('Timestamps are only comparable to Timestamps, Integers, and Floats') unless b.is_a?(Time::Timestamp) ||  b.is_a?(Integer) || b.is_a?(Float)
     a <=> b
   end
 

--- a/lib/puppet/pops/time/timespan.rb
+++ b/lib/puppet/pops/time/timespan.rb
@@ -30,14 +30,6 @@ module Time
       @nsecs = nano_seconds
     end
 
-    def eql?(o)
-      o.class == self.class && @nsecs.eql?(o.nsecs)
-    end
-
-    def ==(o)
-      eql?(o)
-    end
-
     def <=>(o)
       case o
       when self.class

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -244,6 +244,13 @@ describe 'Timespan type' do
         CODE
         expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
+
+      it 'it cannot be compared to a Timestamp' do
+        code = <<-CODE
+            notice(Timespan(3) < Timestamp())
+        CODE
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Timespans are only comparable to Timespans, Integers, and Floats/)
+      end
     end
   end
 end

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -167,7 +167,7 @@ describe 'Timespan type' do
         expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
       end
 
-      it 'is not equal to integer that represents seconds' do
+      it 'is equal to integer that represents seconds' do
         code = <<-CODE
             $o1 = Timespan('02', '%S')
             $o2 = 2
@@ -175,10 +175,10 @@ describe 'Timespan type' do
             notice($o1 != $o2)
             notice(Integer($o1) == $o2)
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
 
-      it 'integer that represents seconds is not equal to it' do
+      it 'integer that represents seconds is equal to it' do
         code = <<-CODE
             $o1 = 2
             $o2 = Timespan('02', '%S')
@@ -186,7 +186,7 @@ describe 'Timespan type' do
             notice($o1 != $o2)
             notice($o1 == Integer($o2))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
 
       it 'can be compared to float that represents seconds with fraction' do
@@ -223,7 +223,7 @@ describe 'Timespan type' do
         expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
       end
 
-      it 'is not equal to float that represents seconds with fraction' do
+      it 'is equal to float that represents seconds with fraction' do
         code = <<-CODE
             $o1 = Timespan('02.123456789', '%S.%N')
             $o2 = 2.123456789
@@ -231,10 +231,10 @@ describe 'Timespan type' do
             notice($o1 != $o2)
             notice(Float($o1) == $o2)
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
 
-      it 'float that represents seconds with fraction is not equal to it' do
+      it 'float that represents seconds with fraction is equal to it' do
         code = <<-CODE
             $o1 = 2.123456789
             $o2 = Timespan('02.123456789', '%S.%N')
@@ -242,7 +242,7 @@ describe 'Timespan type' do
             notice($o1 != $o2)
             notice($o1 == Float($o2))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
     end
   end

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -165,7 +165,7 @@ describe 'Timestamp type' do
         expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
       end
 
-      it 'is not equal to integer that represents seconds since epoch' do
+      it 'is equal to integer that represents seconds since epoch' do
         code = <<-CODE
             $o1 = Timestamp('2015-06-01T00:00:00 UTC')
             $o2 = 1433116800
@@ -173,10 +173,10 @@ describe 'Timestamp type' do
             notice($o1 != $o2)
             notice(Integer($o1) == $o2)
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
 
-      it 'integer that represents seconds is not equal to it' do
+      it 'integer that represents seconds is equal to it' do
         code = <<-CODE
             $o1 = 1433116800
             $o2 = Timestamp('2015-06-01T00:00:00 UTC')
@@ -184,7 +184,7 @@ describe 'Timestamp type' do
             notice($o1 != $o2)
             notice($o1 == Integer($o2))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
 
       it 'can be compared to float that represents seconds with fraction since epoch' do
@@ -221,7 +221,7 @@ describe 'Timestamp type' do
         expect(eval_and_collect_notices(code)).to eq(%w(false false true true false false true true))
       end
 
-      it 'is not equal to float that represents seconds with fraction since epoch' do
+      it 'is equal to float that represents seconds with fraction since epoch' do
         code = <<-CODE
             $o1 = Timestamp('2015-06-01T00:00:00.123456789 UTC')
             $o2 = 1433116800.123456789
@@ -229,10 +229,10 @@ describe 'Timestamp type' do
             notice($o1 != $o2)
             notice(Float($o1) == $o2)
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
 
-      it 'float that represents seconds with fraction is not equal to it' do
+      it 'float that represents seconds with fraction is equal to it' do
         code = <<-CODE
             $o1 = 1433116800.123456789
             $o2 = Timestamp('2015-06-01T00:00:00.123456789 UTC')
@@ -240,7 +240,7 @@ describe 'Timestamp type' do
             notice($o1 != $o2)
             notice($o1 == Float($o2))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(false true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
     end
   end

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -242,6 +242,13 @@ describe 'Timestamp type' do
         CODE
         expect(eval_and_collect_notices(code)).to eq(%w(true false true))
       end
+
+      it 'it cannot be compared to a Timespan' do
+        code = <<-CODE
+            notice(Timestamp() > Timespan(3))
+        CODE
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /Timestamps are only comparable to Timestamps, Integers, and Floats/)
+      end
     end
   end
 end


### PR DESCRIPTION
Before this commit, a `Timespan` or `Timestamp` would yield `true` when
the operator `>=` or `<=` was used to compare them with an `Integer` or
`Float` that had the same magnitude (seconds or seconds since epoch) but
yield `false` when using the operator `==` on the same operands. This
commit changes this so that the latter case also yields `true`.