### PR TITLE
(maint) Enforce consistent behavior on numeric type ranges

### DIFF
--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -130,13 +130,13 @@ or %W). The days in the year before the first week are in week 0.
 **Example**: Using `strftime` with a `Timestamp`:
 
 ~~~ puppet
-$duration = Timestamp('2016-08-24T12:13:14')
+$timestamp = Timestamp('2016-08-24T12:13:14')
 
-# Notice the duration using a format that notices <hours>:<minutes>:<seconds>
-notice($duration.strftime('%F')) # outputs '2016-08-24'
+# Notice the timestamp using a format that notices the ISO 8601 date format
+notice($timestamp.strftime('%F')) # outputs '2016-08-24'
 
-# Notice the duration using a format that notices <minutes>:<seconds>
-notice($duration.strftime('%c')) # outputs 'Wed Aug 24 12:13:14 2016'
+# Notice the timestamp using a format that notices weekday, month, day, time, and year
+notice($$timestamp.strftime('%c')) # outputs 'Wed Aug 24 12:13:14 2016'
 ~~~
 
 ### Format directives applicable to `Timespan`:

--- a/lib/puppet/pops/time/timespan.rb
+++ b/lib/puppet/pops/time/timespan.rb
@@ -474,7 +474,7 @@ module Time
         end
 
         def multiplier
-          width = @widht || @default_width
+          width = @width || @default_width
           if width < 9
             10 ** (9 - width)
           else
@@ -484,7 +484,7 @@ module Time
 
         def append_to(bld, ts)
           ns = ts.total_nano_seconds
-          width = @widht || @default_width
+          width = @width || @default_width
           if width < 9
             # Truncate digits to the right, i.e. let %6N reflect microseconds
             ns /= 10 ** (9 - width)

--- a/lib/puppet/pops/time/timestamp.rb
+++ b/lib/puppet/pops/time/timestamp.rb
@@ -12,7 +12,7 @@ class Timestamp < TimeData
   end
 
   def self.from_hash(args_hash)
-    parse(args[KEY_STRING], args[KEY_FORMAT] || DEFAULT_FORMATS)
+    parse(args_hash[KEY_STRING], args_hash[KEY_FORMAT] || DEFAULT_FORMATS)
   end
 
   def self.parse(str, format = DEFAULT_FORMATS)

--- a/lib/puppet/pops/types/p_timestamp_type.rb
+++ b/lib/puppet/pops/types/p_timestamp_type.rb
@@ -41,7 +41,7 @@ module Types
         end
 
         def from_string_hash(args_hash)
-          Time::Timestamp.from_string_hash(args)
+          Time::Timestamp.from_hash(args_hash)
         end
 
         def from_seconds(seconds)

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -169,11 +169,25 @@ module TypeFactory
   end
 
   def self.timestamp(*args)
-    args.empty? ? PTimestampType::DEFAULT : PTimestampType.new(*args)
+    case args.size
+    when 0
+      PTimestampType::DEFAULT
+    when 1
+      PTimestampType.new(args[0], args[0])
+    else
+      PTimestampType.new(*args)
+    end
   end
 
   def self.timespan(*args)
-    args.empty? ? PTimespanType::DEFAULT : PTimespanType.new(*args)
+    case args.size
+    when 0
+      PTimespanType::DEFAULT
+    when 1
+      PTimespanType.new(args[0], args[0])
+    else
+      PTimespanType.new(*args)
+    end
   end
 
   def self.tuple(types = [], size_type = nil)

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -203,7 +203,7 @@ class TypeFormatter
     max = t.to
     append_array('Timestamp', min.nil? && max.nil?) do
       min.nil? ? append_default : append_string(min)
-      unless max.nil?
+      unless max.nil? || max == min
         @bld << COMMA_SEP
         append_string(max)
       end
@@ -216,7 +216,7 @@ class TypeFormatter
     max = t.to
     append_array('Timespan', min.nil? && max.nil?) do
       min.nil? ? append_default : append_string(min)
-      unless max.nil?
+      unless max.nil? || max == min
         @bld << COMMA_SEP
         append_string(max)
       end

--- a/spec/unit/functions/strftime_spec.rb
+++ b/spec/unit/functions/strftime_spec.rb
@@ -10,12 +10,12 @@ describe 'the strftime function' do
 
   context 'when applied to a Timespan' do
     [
-      ['hours', 'H', 2, true],
-      ['minutes', 'M', 2, true],
-      ['seconds', 'S', 2, true],
-      ['milli_seconds', 'L', 3, true],
-      ['nano_seconds', 'N', 9, false],
-    ].each do |field, fmt, dflt_width, has_width|
+      ['hours', 'H', 2],
+      ['minutes', 'M', 2],
+      ['seconds', 'S', 2],
+      ['milli_seconds', 'L', 3],
+      ['nano_seconds', 'N', 9],
+    ].each do |field, fmt, dflt_width|
       ctor_arg = "{#{field}=>3}"
       it "%#{fmt} width defaults to #{dflt_width}" do
         test_format(ctor_arg, "%#{fmt}", sprintf("%0#{dflt_width}d", 3))
@@ -39,6 +39,25 @@ describe 'the strftime function' do
 
       it "%-10#{fmt} does not pad even if width is specified" do
         test_format(ctor_arg, "%-10#{fmt}", '3')
+      end
+    end
+
+    [
+      ['milli_seconds', '3N', 3],
+      ['micro_seconds', '6N', 6],
+      ['nano_seconds', '9N', 9],
+    ].each do |field, fmt, dflt_width|
+      ctor_arg = "{#{field}=>3}"
+      it "%#{fmt} width defaults to #{dflt_width}" do
+        test_format(ctor_arg, "%#{fmt}", sprintf("%0#{dflt_width}d", 3))
+      end
+
+      it "%_#{fmt} pads with space" do
+        test_format(ctor_arg, "%_#{fmt}", sprintf("% #{dflt_width}d", 3))
+      end
+
+      it "%-#{fmt} does not pad" do
+        test_format(ctor_arg, "%-#{fmt}", '3')
       end
     end
 

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -67,6 +67,14 @@ describe 'Timespan type' do
         expect(eval_and_collect_notices(code)).to eq(%w(1-11:23:00))
       end
 
+      it 'can be created from a hash with string and format' do
+        code = <<-CODE
+            $o = Timespan({string => '1d11h23m', format => '%Dd%Hh%Mm'})
+            notice($o)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(1-11:23:00))
+      end
+
       it 'can be created from a string and array of formats' do
         code = <<-CODE
             $fmts = ['%Dd%Hh%Mm%Ss', '%Hh%Mm%Ss', '%Dd%Hh%Mm', '%Dd%Hh', '%Hh%Mm', '%Mm%Ss', '%Dd', '%Hh', '%Mm', '%Ss' ]

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -33,6 +33,13 @@ describe 'Timespan type' do
         expect(eval_and_collect_notices(code)).to eq(%w(true true))
       end
 
+      it 'using just one parameter is the same as using that parameter twice' do
+        code = <<-CODE
+            notice(Timespan['01:00:00'] == Timespan['01:00:00', '01:00:00'])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true))
+      end
+
       it 'orders parameterized types based on range inclusion' do
         code = <<-CODE
             notice(Timespan['01:00:00', '13:00:00'] < Timespan['00:00:00', '14:00:00'])
@@ -49,7 +56,7 @@ describe 'Timespan type' do
             notice($o)
             notice(type($o))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(['3-11:00:00', 'Timespan[{days => 3, hours => 11}, {days => 3, hours => 11}]'])
+        expect(eval_and_collect_notices(code)).to eq(['3-11:00:00', 'Timespan[{days => 3, hours => 11}]'])
       end
 
       it 'can be created from a string and format' do

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -34,6 +34,13 @@ describe 'Timestamp type' do
         expect(eval_and_collect_notices(code)).to eq(%w(true true))
       end
 
+      it 'using just one parameter is the same as using that parameter twice' do
+        code = <<-CODE
+            notice(Timestamp['2015-03-01'] == Timestamp['2015-03-01', '2015-03-01'])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true))
+      end
+
       it 'orders parameterized types based on range inclusion' do
         code = <<-CODE
             notice(Timestamp['2015-03-01', '2015-09-30'] < Timestamp['2015-02-01', '2015-10-30'])
@@ -50,7 +57,7 @@ describe 'Timestamp type' do
             notice($o)
             notice(type($o))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(['2015-03-01T00:00:00.000 UTC', "Timestamp['2015-03-01T00:00:00.000 UTC', '2015-03-01T00:00:00.000 UTC']"])
+        expect(eval_and_collect_notices(code)).to eq(['2015-03-01T00:00:00.000 UTC', "Timestamp['2015-03-01T00:00:00.000 UTC']"])
       end
 
       it 'can be created from a string and format' do

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -68,6 +68,14 @@ describe 'Timestamp type' do
         expect(eval_and_collect_notices(code)).to eq(['2016-08-28T00:00:00.000 UTC'])
       end
 
+      it 'can be created from a hash with string and format' do
+        code = <<-CODE
+            $o = Timestamp({ string => 'Sunday, 28 August, 2016', format => '%A, %d %B, %Y' })
+            notice($o)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['2016-08-28T00:00:00.000 UTC'])
+      end
+
       it 'can be created from a string and array of formats' do
         code = <<-CODE
             $fmts = [

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -186,12 +186,28 @@ end
       expect(s.string(f.timespan({'hours' => 1}))).to eq('Timespan[{hours => 1}]')
     end
 
-    it "should yield 'Timespan[?, {hours => 2}] for PTimespanType[nil, Timespan]" do
+    it "should yield 'Timespan[default, {hours => 2}] for PTimespanType[nil, Timespan]" do
       expect(s.string(f.timespan(nil, {'hours' => 2}))).to eq('Timespan[default, {hours => 2}]')
     end
 
     it "should yield 'Timespan[{hours => 1}, {hours => 2}] for PTimespanType[Timespan, Timespan]" do
       expect(s.string(f.timespan({'hours' => 1}, {'hours' => 2}))).to eq('Timespan[{hours => 1}, {hours => 2}]')
+    end
+
+    it "should yield 'Timestamp' for PTimestampType" do
+      expect(s.string(f.timestamp())).to eq('Timestamp')
+    end
+
+    it "should yield 'Timestamp['2016-09-05T13:00:00.000 UTC'] for PTimestampType[Timestamp]" do
+      expect(s.string(f.timestamp('2016-09-05T13:00:00.000 UTC'))).to eq("Timestamp['2016-09-05T13:00:00.000 UTC']")
+    end
+
+    it "should yield 'Timestamp[default, '2016-09-05T13:00:00.000 UTC'] for PTimestampType[nil, Timestamp]" do
+      expect(s.string(f.timestamp(nil, '2016-09-05T13:00:00.000 UTC'))).to eq("Timestamp[default, '2016-09-05T13:00:00.000 UTC']")
+    end
+
+    it "should yield 'Timestamp['2016-09-05T13:00:00.000 UTC', '2016-12-01T00:00:00.000 UTC'] for PTimestampType[Timestamp, Timestamp]" do
+      expect(s.string(f.timestamp('2016-09-05T13:00:00.000 UTC', '2016-12-01T00:00:00.000 UTC'))).to eq("Timestamp['2016-09-05T13:00:00.000 UTC', '2016-12-01T00:00:00.000 UTC']")
     end
 
     it "should yield 'Tuple[Integer]' for PTupleType[PIntegerType]" do


### PR DESCRIPTION
Before this commit, a Timespan or Timestamp type that was parameterized
with just one parameter, would interpret this as a `from` argument and
consider the `to` argument unbounded. That contradicts from the Integer
and Float ranges where one argument is considered to define both 
boundaries (i.e. a range that is limited to an exact match).

This commit ensures that the Timespan and Timestamp type behaves the
same way as the Integer and Float types when only one parameter is used.