### PR TITLE
(PUP-6685) Remove underscore from milli_-, micro_-, and nano_seconds

### DIFF
--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -174,13 +174,13 @@ The arguments can be passed separately in which case the first four, days, hours
 All values may overflow and/or be negative. The internal 128-bit nano-second integer is calculated as:
 
 ```
-(((((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000 + milli_seconds) * 1000 + micro_seconds) * 1000 + nano_seconds
+(((((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000 + milliseconds) * 1000 + microseconds) * 1000 + nanoseconds
 ```
 
 ```puppet
 function Timespan.new(
   Integer $days, Integer $hours, Integer $minutes, Integer $seconds,
-  Integer $milli_seconds = 0, Integer $micro_seconds = 0, Integer $nano_seconds = 0
+  Integer $milliseconds = 0, Integer $microseconds = 0, Integer $nanoseconds = 0
 )
 ```
 
@@ -194,9 +194,9 @@ function Timespan.new(
     Optional[hours] => Integer,
     Optional[minutes] => Integer,
     Optional[seconds] => Integer,
-    Optional[milli_seconds] => Integer,
-    Optional[micro_seconds] => Integer,
-    Optional[nano_seconds] => Integer
+    Optional[milliseconds] => Integer,
+    Optional[microseconds] => Integer,
+    Optional[nanoseconds] => Integer
   }] $hash
 )
 ```

--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -73,9 +73,9 @@ module Types
           param          'Integer', :hours
           param          'Integer', :minutes
           param          'Integer', :seconds
-          optional_param 'Integer', :milli_seconds
-          optional_param 'Integer', :micro_seconds
-          optional_param 'Integer', :nano_seconds
+          optional_param 'Integer', :milliseconds
+          optional_param 'Integer', :microseconds
+          optional_param 'Integer', :nanoseconds
         end
 
         dispatch :from_string_hash do
@@ -95,9 +95,9 @@ module Types
               Optional[hours] => Integer,
               Optional[minutes] => Integer,
               Optional[seconds] => Integer,
-              Optional[milli_seconds] => Integer,
-              Optional[micro_seconds] => Integer,
-              Optional[nano_seconds] => Integer
+              Optional[milliseconds] => Integer,
+              Optional[microseconds] => Integer,
+              Optional[nanoseconds] => Integer
             }]
           TYPE
         end
@@ -110,8 +110,8 @@ module Types
           Time::Timespan.parse(string, format)
         end
 
-        def from_fields(days, hours, minutes, seconds, milli_seconds = 0, micro_seconds = 0, nano_seconds = 0)
-          Time::Timespan.from_fields(days, hours, minutes, seconds, milli_seconds, micro_seconds, nano_seconds)
+        def from_fields(days, hours, minutes, seconds, milliseconds = 0, microseconds = 0, nanoseconds = 0)
+          Time::Timespan.from_fields(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
         end
 
         def from_string_hash(args_hash)

--- a/spec/unit/functions/strftime_spec.rb
+++ b/spec/unit/functions/strftime_spec.rb
@@ -13,8 +13,8 @@ describe 'the strftime function' do
       ['hours', 'H', 2],
       ['minutes', 'M', 2],
       ['seconds', 'S', 2],
-      ['milli_seconds', 'L', 3],
-      ['nano_seconds', 'N', 9],
+      ['milliseconds', 'L', 3],
+      ['nanoseconds', 'N', 9],
     ].each do |field, fmt, dflt_width|
       ctor_arg = "{#{field}=>3}"
       it "%#{fmt} width defaults to #{dflt_width}" do
@@ -43,9 +43,9 @@ describe 'the strftime function' do
     end
 
     [
-      ['milli_seconds', '3N', 3],
-      ['micro_seconds', '6N', 6],
-      ['nano_seconds', '9N', 9],
+      ['milliseconds', '3N', 3],
+      ['microseconds', '6N', 6],
+      ['nanoseconds', '9N', 9],
     ].each do |field, fmt, dflt_width|
       ctor_arg = "{#{field}=>3}"
       it "%#{fmt} width defaults to #{dflt_width}" do

--- a/spec/unit/pops/time/timespan_spec.rb
+++ b/spec/unit/pops/time/timespan_spec.rb
@@ -8,7 +8,7 @@ describe 'Timespan' do
   include PuppetSpec::Compiler
 
   let! (:simple) { Timespan.from_fields(false, 1, 3, 10, 11) }
-  let! (:all_fields_hash) { {'days' => 1, 'hours' => 7, 'minutes' => 10, 'seconds' => 11, 'milli_seconds' => 123, 'micro_seconds' => 456, 'nano_seconds' => 789} }
+  let! (:all_fields_hash) { {'days' => 1, 'hours' => 7, 'minutes' => 10, 'seconds' => 11, 'milliseconds' => 123, 'microseconds' => 456, 'nanoseconds' => 789} }
   let! (:complex) { Timespan.from_fields_hash(all_fields_hash) }
 
   context 'can be created from a String' do
@@ -77,7 +77,7 @@ describe 'Timespan' do
 
     it 'produces a compact hash with seconds and nanoseconds for #to_hash(true)' do
       hash = complex.to_hash(true)
-      expect(hash).to eql({'seconds' => 112211, 'nano_seconds' => 123456789})
+      expect(hash).to eql({'seconds' => 112211, 'nanoseconds' => 123456789})
     end
 
     context 'from a negative value' do
@@ -88,7 +88,7 @@ describe 'Timespan' do
 
       it 'produces a compact hash with negative seconds and negative nanoseconds for #to_hash(true)' do
         hash = (-complex).to_hash(true)
-        expect(hash).to eql({'seconds' => -112211, 'nano_seconds' => -123456789})
+        expect(hash).to eql({'seconds' => -112211, 'nanoseconds' => -123456789})
       end
     end
   end


### PR DESCRIPTION
The Timespan incorrectly uses an underscore in the name of the
attributes milli_seconds, micro_seconds, and nano_seconds. This commit
removes this underscore.