### PR TITLE
(PUP-6686) Improve how Timespan parses and stringifies fractions of second (%L and %N)

### DIFF
--- a/lib/puppet/pops/time/timespan.rb
+++ b/lib/puppet/pops/time/timespan.rb
@@ -671,7 +671,7 @@ module Time
     end
 
     class Format
-      DEFAULTS = ['%D-%H:%M:%S', '%D-%H:%M', '%H:%M:%S', '%H:%M'].map { |str| FormatParser.singleton.parse_format(str) }
+      DEFAULTS = ['%D-%H:%M:%S.%-N', '%H:%M:%S.%-N', '%M:%S.%-N', '%S.%-N', '%D-%H:%M:%S', '%H:%M:%S', '%D-%H:%M', '%S'].map { |str| FormatParser.singleton.parse_format(str) }
     end
   end
 end

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -505,12 +505,10 @@ class TypeFormatter
   def string_VersionRange(t) ; @bld << "'#{t}'"  ; end
 
   # @api private
-  def string_Timestamp(t)    ; @bld << "'#{t}'"  ; end
+  def string_Timespan(t)    ; @bld << "'#{t}'"  ; end
 
   # @api private
-  def string_Timespan(o)
-    append_hash(o.to_hash, proc { |k| @bld << symbolic_key(k) })
-  end
+  def string_Timestamp(t)    ; @bld << "'#{t}'"  ; end
 
   # Debugging to_s to reduce the amount of output
   def to_s

--- a/spec/unit/functions/strftime_spec.rb
+++ b/spec/unit/functions/strftime_spec.rb
@@ -13,8 +13,6 @@ describe 'the strftime function' do
       ['hours', 'H', 2],
       ['minutes', 'M', 2],
       ['seconds', 'S', 2],
-      ['milliseconds', 'L', 3],
-      ['nanoseconds', 'N', 9],
     ].each do |field, fmt, dflt_width|
       ctor_arg = "{#{field}=>3}"
       it "%#{fmt} width defaults to #{dflt_width}" do
@@ -43,26 +41,48 @@ describe 'the strftime function' do
     end
 
     [
+      ['milliseconds', 'L', 3],
+      ['nanoseconds', 'N', 9],
       ['milliseconds', '3N', 3],
       ['microseconds', '6N', 6],
       ['nanoseconds', '9N', 9],
     ].each do |field, fmt, dflt_width|
-      ctor_arg = "{#{field}=>3}"
+      ctor_arg = "{#{field}=>3000}"
       it "%#{fmt} width defaults to #{dflt_width}" do
-        test_format(ctor_arg, "%#{fmt}", sprintf("%0#{dflt_width}d", 3))
+        test_format(ctor_arg, "%#{fmt}", sprintf("%-#{dflt_width}d", 3000))
       end
 
       it "%_#{fmt} pads with space" do
-        test_format(ctor_arg, "%_#{fmt}", sprintf("% #{dflt_width}d", 3))
+        test_format(ctor_arg, "%_#{fmt}", sprintf("%-#{dflt_width}d", 3000))
       end
 
       it "%-#{fmt} does not pad" do
-        test_format(ctor_arg, "%-#{fmt}", '3')
+        test_format(ctor_arg, "%-#{fmt}", '3000')
       end
     end
 
     it 'can use a format containing all format characters, flags, and widths' do
-      test_format("{string => '100-14:02:24.123456789', format => '%D-%H:%M:%S.%9N'}", '%_10D%%%03H:%-M:%S.%9N', '       100%014:2:24.123456789')
+      test_format("{string => '100-14:02:24.123456000', format => '%D-%H:%M:%S.%9N'}", '%_10D%%%03H:%-M:%S.%9N', '       100%014:2:24.123456000')
+    end
+
+    it 'can format and strip excess zeroes from fragment using no-padding flag' do
+      test_format("{string => '100-14:02:24.123456000', format => '%D-%H:%M:%S.%N'}", '%D-%H:%M:%S.%-N', '100-14:02:24.123456')
+    end
+
+    it 'can format and replace excess zeroes with spaces from fragment using space-padding flag and default widht' do
+      test_format("{string => '100-14:02:24.123456000', format => '%D-%H:%M:%S.%N'}", '%D-%H:%M:%S.%_N', '100-14:02:24.123456   ')
+    end
+
+    it 'can format and replace excess zeroes with spaces from fragment using space-padding flag and specified width' do
+      test_format("{string => '100-14:02:24.123400000', format => '%D-%H:%M:%S.%N'}", '%D-%H:%M:%S.%_6N', '100-14:02:24.1234  ')
+    end
+
+    it 'can format and retain excess zeroes in fragment using default width' do
+      test_format("{string => '100-14:02:24.123400000', format => '%D-%H:%M:%S.%N'}", '%D-%H:%M:%S.%N', '100-14:02:24.123400000')
+    end
+
+    it 'can format and retain excess zeroes in fragment using specified width' do
+      test_format("{string => '100-14:02:24.123400000', format => '%D-%H:%M:%S.%N'}", '%D-%H:%M:%S.%6N', '100-14:02:24.123400')
     end
   end
 end

--- a/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
+++ b/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
@@ -80,22 +80,22 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
       it 'Timespan + Timespan = Timespan' do
         code = 'notice(assert_type(Timespan, Timespan({days => 3}) + Timespan({hours => 12})))'
-        expect(eval_and_collect_notices(code)).to eql(['3-12:00:00'])
+        expect(eval_and_collect_notices(code)).to eql(['3-12:00:00.0'])
       end
 
       it 'Timespan - Timespan = Timespan' do
         code = 'notice(assert_type(Timespan, Timespan({days => 3}) - Timespan({hours => 12})))'
-        expect(eval_and_collect_notices(code)).to eql(['2-12:00:00'])
+        expect(eval_and_collect_notices(code)).to eql(['2-12:00:00.0'])
       end
 
       it 'Timespan + -Timespan = Timespan' do
         code = 'notice(assert_type(Timespan, Timespan({days => 3}) + -Timespan({hours => 12})))'
-        expect(eval_and_collect_notices(code)).to eql(['2-12:00:00'])
+        expect(eval_and_collect_notices(code)).to eql(['2-12:00:00.0'])
       end
 
       it 'Timespan - -Timespan = Timespan' do
         code = 'notice(assert_type(Timespan, Timespan({days => 3}) - -Timespan({hours => 12})))'
-        expect(eval_and_collect_notices(code)).to eql(['3-12:00:00'])
+        expect(eval_and_collect_notices(code)).to eql(['3-12:00:00.0'])
       end
 
       it 'Timespan / Timespan = Float' do
@@ -110,12 +110,12 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
       it 'Timespan + Numeric = Timespan (numeric treated as seconds)' do
         code = 'notice(assert_type(Timespan, Timespan({days => 3}) + 7300.0))'
-        expect(eval_and_collect_notices(code)).to eql(['3-02:01:40'])
+        expect(eval_and_collect_notices(code)).to eql(['3-02:01:40.0'])
       end
 
       it 'Timespan - Numeric = Timespan (numeric treated as seconds)' do
-        code = "notice(strftime(assert_type(Timespan, Timespan({days => 3}) - 7300.123), '%H:%M:%S.%L'))"
-        expect(eval_and_collect_notices(code)).to eql(['69:58:19.877'])
+        code = "notice(assert_type(Timespan, Timespan({days => 3}) - 7300.123))"
+        expect(eval_and_collect_notices(code)).to eql(['2-21:58:19.877000000'])
       end
 
       it 'Timespan * Numeric = Timespan (numeric treated as seconds)' do
@@ -125,7 +125,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
       it 'Numeric + Timespan = Timespan (numeric treated as seconds)' do
         code = 'notice(assert_type(Timespan, 7300.0 + Timespan({days => 3})))'
-        expect(eval_and_collect_notices(code)).to eql(['3-02:01:40'])
+        expect(eval_and_collect_notices(code)).to eql(['3-02:01:40.0'])
       end
 
       it 'Numeric - Timespan = Timespan (numeric treated as seconds)' do
@@ -185,7 +185,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
       it 'Timestamp - Timestamp = Timespan' do
         code = "notice(assert_type(Timespan, Timestamp('2016-10-10') - Timestamp('2015-10-10')))"
-        expect(eval_and_collect_notices(code)).to eql(['366-00:00:00'])
+        expect(eval_and_collect_notices(code)).to eql(['366-00:00:00.0'])
       end
 
       it 'Timestamp - Timespan = Timestamp' do

--- a/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
+++ b/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
@@ -115,7 +115,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
       it 'Timespan - Numeric = Timespan (numeric treated as seconds)' do
         code = "notice(assert_type(Timespan, Timespan({days => 3}) - 7300.123))"
-        expect(eval_and_collect_notices(code)).to eql(['2-21:58:19.877000000'])
+        expect(eval_and_collect_notices(code)).to eql(['2-21:58:19.877'])
       end
 
       it 'Timespan * Numeric = Timespan (numeric treated as seconds)' do

--- a/spec/unit/pops/time/timespan_spec.rb
+++ b/spec/unit/pops/time/timespan_spec.rb
@@ -36,16 +36,24 @@ describe 'Timespan' do
       expect(Timespan.parse('97811', '%S')).to eql(simple)
     end
 
-    it 'using %L as the biggest quantity' do
-      expect(Timespan.parse('97811000', '%L')).to eql(simple)
-    end
-
-    it 'using %N as the biggest quantity' do
-      expect(Timespan.parse('112211123456789', '%N')).to eql(complex)
-    end
-
     it 'where biggest quantity is not frist' do
       expect(Timespan.parse('11:1630', '%S:%M')).to eql(simple)
+    end
+
+    it 'raises an error when using %L as the biggest quantity' do
+      expect { Timespan.parse('123', '%L') }.to raise_error(ArgumentError, /denotes fractions and must be used together with a specifier of higher magnitude/)
+    end
+
+    it 'raises an error when using %N as the biggest quantity' do
+      expect { Timespan.parse('123', '%N') }.to raise_error(ArgumentError, /denotes fractions and must be used together with a specifier of higher magnitude/)
+    end
+
+    it 'where %L is treated as fractions of a second' do
+      expect(Timespan.parse('0.4', '%S.%L')).to eql(Timespan.from_fields(false, 0, 0, 0, 0, 400))
+    end
+
+    it 'where %N is treated as fractions of a second' do
+      expect(Timespan.parse('0.4', '%S.%N')).to eql(Timespan.from_fields(false, 0, 0, 0, 0, 400))
     end
   end
 
@@ -65,6 +73,22 @@ describe 'Timespan' do
 
       it 'produces a leading dash for negative instance' do
         expect((-complex).format('%D-%H:%M:%S')).to eql('-1-07:10:11')
+      end
+
+      it 'produces a string without trailing zeros for %-N' do
+        expect(Timespan.parse('2.345', '%S.%N').format('%-S.%-N')).to eql('2.345')
+      end
+
+      it 'produces a string with trailing zeros for %N' do
+        expect(Timespan.parse('2.345', '%S.%N').format('%-S.%N')).to eql('2.345000000')
+      end
+
+      it 'produces a string with trailing zeros for %0N' do
+        expect(Timespan.parse('2.345', '%S.%N').format('%-S.%0N')).to eql('2.345000000')
+      end
+
+      it 'produces a string with trailing spaces for %_N' do
+        expect(Timespan.parse('2.345', '%S.%N').format('%-S.%_N')).to eql('2.345      ')
       end
     end
   end

--- a/spec/unit/pops/time/timespan_spec.rb
+++ b/spec/unit/pops/time/timespan_spec.rb
@@ -51,7 +51,7 @@ describe 'Timespan' do
 
   context 'when presented as a String' do
     it 'uses default format for #to_s' do
-      expect(simple.to_s).to eql('1-03:10:11')
+      expect(simple.to_s).to eql('1-03:10:11.0')
     end
 
     context 'using a format' do

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -56,7 +56,7 @@ describe 'Timespan type' do
             notice($o)
             notice(type($o))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(['3-11:00:00.0', 'Timespan[{days => 3, hours => 11}]'])
+        expect(eval_and_collect_notices(code)).to eq(%w(3-11:00:00.0 Timespan['3-11:00:00.0']))
       end
 
       it 'can be created from a string and format' do

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -6,9 +6,9 @@ module Puppet::Pops
 module Types
 describe 'Timespan type' do
   it 'is normalized in a Variant' do
-    t = TypeFactory.variant(TypeFactory.timespan('10:00', '15:00'), TypeFactory.timespan('14:00', '17:00')).normalize
+    t = TypeFactory.variant(TypeFactory.timespan('10:00:00', '15:00:00'), TypeFactory.timespan('14:00:00', '17:00:00')).normalize
     expect(t).to be_a(PTimespanType)
-    expect(t).to eql(TypeFactory.timespan('10:00', '17:00'))
+    expect(t).to eql(TypeFactory.timespan('10:00:00', '17:00:00'))
   end
 
   context 'when used in Puppet expressions' do
@@ -56,7 +56,7 @@ describe 'Timespan type' do
             notice($o)
             notice(type($o))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(['3-11:00:00', 'Timespan[{days => 3, hours => 11}]'])
+        expect(eval_and_collect_notices(code)).to eq(['3-11:00:00.0', 'Timespan[{days => 3, hours => 11}]'])
       end
 
       it 'can be created from a string and format' do
@@ -64,7 +64,7 @@ describe 'Timespan type' do
             $o = Timespan('1d11h23m', '%Dd%Hh%Mm')
             notice($o)
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(1-11:23:00))
+        expect(eval_and_collect_notices(code)).to eq(%w(1-11:23:00.0))
       end
 
       it 'can be created from a hash with string and format' do
@@ -72,7 +72,7 @@ describe 'Timespan type' do
             $o = Timespan({string => '1d11h23m', format => '%Dd%Hh%Mm'})
             notice($o)
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(1-11:23:00))
+        expect(eval_and_collect_notices(code)).to eq(%w(1-11:23:00.0))
       end
 
       it 'can be created from a string and array of formats' do
@@ -90,7 +90,7 @@ describe 'Timespan type' do
             notice(Timespan('13s', $fmts))
         CODE
         expect(eval_and_collect_notices(code)).to eq(
-          %w(1-11:23:13 0-11:23:13 1-11:23:00 1-11:00:00 0-11:23:00 0-00:23:13 1-00:00:00 0-11:00:00 0-00:23:00 0-00:00:13))
+          %w(1-11:23:13.0 0-11:23:13.0 1-11:23:00.0 1-11:00:00.0 0-11:23:00.0 0-00:23:13.0 1-00:00:00.0 0-11:00:00.0 0-00:23:00.0 0-00:00:13.0))
       end
 
       it 'can be created from a integer that represents seconds since epoch' do
@@ -116,7 +116,7 @@ describe 'Timespan type' do
             $o = Timespan('3-11:12:13')
             notice(assert_type(Timespan['3-00:00:00', '4-00:00:00'], $o))
         CODE
-        expect(eval_and_collect_notices(code)).to eq(['3-11:12:13'])
+        expect(eval_and_collect_notices(code)).to eq(['3-11:12:13.0'])
       end
 
       it 'does not match an inappropriate parameterized type' do

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -183,15 +183,15 @@ end
     end
 
     it "should yield 'Timespan[{hours => 1}] for PTimespanType[Timespan]" do
-      expect(s.string(f.timespan({'hours' => 1}))).to eq('Timespan[{hours => 1}]')
+      expect(s.string(f.timespan({'hours' => 1}))).to eq("Timespan['0-01:00:00.0']")
     end
 
     it "should yield 'Timespan[default, {hours => 2}] for PTimespanType[nil, Timespan]" do
-      expect(s.string(f.timespan(nil, {'hours' => 2}))).to eq('Timespan[default, {hours => 2}]')
+      expect(s.string(f.timespan(nil, {'hours' => 2}))).to eq("Timespan[default, '0-02:00:00.0']")
     end
 
     it "should yield 'Timespan[{hours => 1}, {hours => 2}] for PTimespanType[Timespan, Timespan]" do
-      expect(s.string(f.timespan({'hours' => 1}, {'hours' => 2}))).to eq('Timespan[{hours => 1}, {hours => 2}]')
+      expect(s.string(f.timespan({'hours' => 1}, {'hours' => 2}))).to eq("Timespan['0-01:00:00.0', '0-02:00:00.0']")
     end
 
     it "should yield 'Timestamp' for PTimestampType" do


### PR DESCRIPTION
This PR aims to improve how a `Timespan` parses fractions. Instead of just treating the parsed value as milliseconds or nanoseconds, it will consistently be treated as fractions of a second. This is more intuitive and also aligned with how the Ruby implementation of `strptime()` does this (internally used as parser for `Timestamp`).

The PR also fixes the default format so that it contains fractions to avoid loss of precision when converting to and from string. Brought together, those changes made the string output more compact (default format strips trailing zeroes) and hence, more suitable to use a the default representation than the hash.