### PR TITLE
(PUP-6689) Change Timespan and Timestamp inheritance. Numeric => Scalar

### DIFF
--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -1,6 +1,6 @@
 module Puppet::Pops
 module Types
-  class PAbstractTimeDataType < PNumericType
+  class PAbstractTimeDataType < PAbstractRangeType
     # @param [AbstractTime] min lower bound for this type. Nil or :default means unbounded
     # @param [AbstractTime] max upper bound for this type. Nil or :default means unbounded
     def initialize(min = nil, max = nil)
@@ -50,7 +50,10 @@ module Types
 
   class PTimespanType < PAbstractTimeDataType
     def self.register_ptype(loader, ir)
-      create_ptype(loader, ir, 'NumericType')
+      create_ptype(loader, ir, 'ScalarType',
+        'from' => { KEY_TYPE => PTimespanType::DEFAULT, KEY_VALUE => :default },
+        'to' => { KEY_TYPE => PTimespanType::DEFAULT, KEY_VALUE => :default }
+      )
     end
 
     def self.new_function(_, loader)

--- a/lib/puppet/pops/types/p_timestamp_type.rb
+++ b/lib/puppet/pops/types/p_timestamp_type.rb
@@ -2,7 +2,10 @@ module Puppet::Pops
 module Types
   class PTimestampType < PAbstractTimeDataType
     def self.register_ptype(loader, ir)
-      create_ptype(loader, ir, 'NumericType')
+      create_ptype(loader, ir, 'ScalarType',
+        'from' => { KEY_TYPE => PTimestampType::DEFAULT, KEY_VALUE => :default },
+        'to' => { KEY_TYPE => PTimestampType::DEFAULT, KEY_VALUE => :default }
+      )
     end
 
     def self.new_function(_, loader)

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -53,6 +53,8 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PEnumType,
       Puppet::Pops::Types::PSemVerType,
       Puppet::Pops::Types::PSemVerRangeType,
+      Puppet::Pops::Types::PTimespanType,
+      Puppet::Pops::Types::PTimestampType,
     ]
   end
 
@@ -62,8 +64,6 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PNumericType,
       Puppet::Pops::Types::PIntegerType,
       Puppet::Pops::Types::PFloatType,
-      Puppet::Pops::Types::PTimespanType,
-      Puppet::Pops::Types::PTimestampType,
     ]
   end
 


### PR DESCRIPTION
The Timespan and Timestamp was implemented as Numeric types. This was
not correct as they break the Numeric contract. This commit alters the
type inheritance so that Timespan and Timestamp inherits directly from
Scalar.