### PR TITLE
(PUP-6682) Clean $settings values from implementation runtime types

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -868,10 +868,10 @@ class Puppet::Parser::Compiler
     settings_hash = {}
     Puppet.settings.each do |name, setting|
       next if name == :name
-      name = name.to_s
+      s_name = name.to_s
       # Construct a hash (in anticipation it will be set in top scope under a name like $settings)
-      settings_hash[name] = transform_setting(env[name])
-      scope[name.to_s] = settings_hash[name]
+      settings_hash[s_name] = transform_setting(env[name])
+      scope[s_name] = settings_hash[s_name]
     end
   end
 
@@ -884,7 +884,9 @@ class Puppet::Parser::Compiler
     when Array
       val.map {|entry| transform_setting(entry) }
     when Hash
-      Hash[val.map {|k,v| [transform_setting(k), transform_setting(v)] }]
+      result = {}
+      val.each {|k,v| result[transform_setting(k)] = transform_setting(v) }
+      result
     else
       # not ideal, but required as there are settings values that are special
       val.to_s

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -153,6 +153,17 @@ describe Puppet::Parser::Compiler do
     end
   end
 
+  context 'when working with $settings name space' do
+    include PuppetSpec::Compiler
+    it 'makes $settings::strict available as string' do
+      node = Puppet::Node.new("testing")
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+          notify { 'test': message => $settings::strict == 'warning' }
+      MANIFEST
+      expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
+    end
+  end
+
   context 'when working with $server_facts' do
     include PuppetSpec::Compiler
     context 'and have opted in to trusted_server_facts' do


### PR DESCRIPTION
Before this, symbols (and most likely other data values) leaked into the
puppet language and caused problems (a Symbol is not equal to a String
value).

This commit cleans all values and turns them into Integer, Float,
String, Array or Hash (containing clean values recursively).