### PR TITLE
(PUP-6636) Only match /environment/:env route as the whole path

### DIFF
--- a/lib/puppet/network/http/api/master/v3.rb
+++ b/lib/puppet/network/http/api/master/v3.rb
@@ -16,7 +16,7 @@ class Puppet::Network::HTTP::API::Master::V3
   end)
 
   ENVIRONMENT = Puppet::Network::HTTP::Route.
-      path(%r{/environment/[^/]+$}).get(AUTHZ.wrap do
+      path(%r{^/environment/[^/]+$}).get(AUTHZ.wrap do
     Environment.new
   end)
 

--- a/spec/unit/network/http/api/master/v3_spec.rb
+++ b/spec/unit/network/http/api/master/v3_spec.rb
@@ -22,6 +22,21 @@ describe Puppet::Network::HTTP::API::Master::V3 do
     expect(response.code).to eq(200)
   end
 
+  it "mounts the environment endpoint" do
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_url_prefix}/environment/production")
+    master_routes.process(request, response)
+
+    expect(response.code).to eq(200)
+  end
+
+  it "matches only complete routes" do
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_url_prefix}/foo/environments")
+    expect { master_routes.process(request, response) }.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError)
+
+    request = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_url_prefix}/foo/environment/production")
+    expect { master_routes.process(request, response) }.to raise_error(Puppet::Network::HTTP::Error::HTTPNotFoundError)
+  end
+
   it "mounts indirected routes" do
     request = Puppet::Network::HTTP::Request.
         from_hash(:path => "#{master_url_prefix}/node/foo",


### PR DESCRIPTION
Previously, the /environment/:env route wasn't properly anchored to the
start of the path, so routes with other prefixes would also match.
Because auth is performed separately based on the path, this allowed
requests like /status/environment/production to bypass auth checks and
retrieve environment catalogs. This also meant that other valid requests
ending in /environment/:foo, such as for files, would be handled
incorrectly.

We now properly anchor the /environment/:env regex to the beginning of
the path, so only explicit environment requests will match.

this is just a cherry-pick