### PR TITLE
(PUP-6641) Fix Service integration test for Windows 10

### DIFF
--- a/spec/integration/provider/service/windows_spec.rb
+++ b/spec/integration/provider/service/windows_spec.rb
@@ -26,11 +26,12 @@ describe Puppet::Type.type(:service).provider(:windows), '(integration)',
 
   context 'should return valid values when querying a service that does exist' do
     let(:service) do
+      # This service should be ubiquitous across all supported Windows platforms
       Puppet::Type.type(:service).new(:name => 'lmhosts')
     end
 
-    it "with a valid boolean when asked if enabled" do
-      expect([:true, :false]).to include(service.provider.enabled?)
+    it "with a valid enabled? value when asked if enabled" do
+      expect([:true, :false, :manual]).to include(service.provider.enabled?)
     end
 
     it "with a valid status when asked about status" do


### PR DESCRIPTION
Previously the integration test for the Service provider for Windows used the
lmhosts service as a test fixture.  However in Windows 10 the start type for
this service changed to Manual (Triggered) which now fails the integration test.

This commit adds `:manual` as a valid return value of `enabled?`, which now
matches the provider for service in Windows.

Note that this platform is not tested for integration tests but can easily be tested locally via VMPooler