### PR TITLE
(PUP-6693) Add --strict control over assignment to $server_facts

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -59,10 +59,18 @@ module Runtime3Support
     # The error is not specific enough to allow catching it - need to check the actual message text.
     # TODO: Improve the messy implementation in Scope.
     #
+    if name == "server_facts"
+      if Puppet[:trusted_server_facts] || Puppet[:strict] == :error
+        fail(Issues::ILLEGAL_RESERVED_ASSIGNMENT, o, {:name => name} )
+      elsif Puppet[:strict] == :warning
+        file, line = extract_file_line(o)
+        msg = "Assignment to $server_facts is deprecated"
+        Puppet.warn_once(:deprecation, msg, msg, file, line)
+      end
+    end
+
     if scope.bound?(name)
       if Puppet::Parser::Scope::RESERVED_VARIABLE_NAMES.include?(name)
-        fail(Issues::ILLEGAL_RESERVED_ASSIGNMENT, o, {:name => name} )
-      elsif name == "server_facts" && Puppet[:trusted_server_facts]
         fail(Issues::ILLEGAL_RESERVED_ASSIGNMENT, o, {:name => name} )
       else
         fail(Issues::ILLEGAL_REASSIGNMENT, o, {:name => name} )

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -208,6 +208,15 @@ describe Puppet::Parser::Compiler do
 
         expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
       end
+      it 'should warn about assignment to $server_facts' do
+        catalog = compile_to_catalog(<<-MANIFEST)
+            $server_facts = 'changed'
+            notify { 'test': message => $server_facts == 'changed' }
+        MANIFEST
+        expect(@logs).to have_matching_log(/Assignment to \$server_facts is deprecated/)
+
+        expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
+      end
     end
   end
   describe "the compiler when using 4.x language constructs" do


### PR DESCRIPTION
Before this assignments to $server_facts would go unnoticed unless
--trusted_server_facts was turned on.
Now a warning/error (or ignore) is under the control of the --strict
option.