### PR TITLE
Revert "(PUP-6670) Update tag validation regex to handle newlines"

### DIFF
--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -1,7 +1,7 @@
 require 'puppet/util/tag_set'
 
 module Puppet::Util::Tagging
-  ValidTagRegex = /\A[0-9A-Za-z_][0-9A-Za-z_:.-]*\Z/
+  ValidTagRegex = /^[0-9A-Za-z_][0-9A-Za-z_:.-]*$/
 
   # Add a tag to the current tag set.
   # When a tag set is used for a scope, these tags will be added to all of

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -36,10 +36,6 @@ describe Puppet::Util::Tagging do
     expect { tagger.tag("bad tag") }.to raise_error(Puppet::ParseError)
   end
 
-  it "should fail on tags containing newline characters" do
-    expect { tagger.tag("bad\ntag") }.to raise_error(Puppet::ParseError)
-  end
-
   it "should allow alpha tags" do
     expect { tagger.tag("good_tag") }.not_to raise_error
   end


### PR DESCRIPTION
This reverts commit 06c710a2b227499d7d4710d5884a0f9d218e6467.

We need to revert this in stable until after release of 4.7.0