### PR TITLE
(maint) Performance tweaks for hash key and array looping

### DIFF
--- a/lib/puppet/provider/mcx/mcxcontent.rb
+++ b/lib/puppet/provider/mcx/mcxcontent.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:mcx).provide :mcxcontent, :parent => Puppet::Provider do
 
   def self.instances
     mcx_list = []
-    TypeMap.keys.each do |ds_type|
+    TypeMap.each_key do |ds_type|
       ds_path = "/Local/Default/#{TypeMap[ds_type]}"
       output = dscl 'localhost', '-list', ds_path
       member_list = output.split

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -110,7 +110,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
 
   def self.generate_attribute_hash(input_hash, *type_properties)
     attribute_hash = {}
-    input_hash.keys.each do |key|
+    input_hash.each_key do |key|
       ds_attribute = key.sub("dsAttrTypeStandard:", "")
       next unless (ds_to_ns_attribute_map.keys.include?(ds_attribute) and type_properties.include? ds_to_ns_attribute_map[ds_attribute])
       ds_value = input_hash[key]

--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -62,7 +62,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
 
   def self.prefetch(resources)
     packages = instances
-    resources.keys.each do |name|
+    resources.each_key do |name|
       if provider = packages.find{|p| p.name == name or p.origin == name }
         resources[name].provider = provider
       end

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -100,7 +100,7 @@ Puppet::Type.type(:user).provide :directoryservice do
   # supported by the user type.
   def self.generate_attribute_hash(input_hash)
     attribute_hash = {}
-    input_hash.keys.each do |key|
+    input_hash.each_key do |key|
       ds_attribute = key.sub("dsAttrTypeStandard:", "")
       next unless ds_to_ns_attribute_map.keys.include?(ds_attribute)
       ds_value = input_hash[key]

--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
   # @return [void]
   def self.prefetch(resources)
     repos = instances
-    resources.keys.each do |name|
+    resources.each_key do |name|
       if provider = repos.find { |repo| repo.name == name }
         resources[name].provider = provider
       end

--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:zpool).provide(:zpool) do
     tmp = []
 
     #order matters here :(
-    pool_array.reverse.each do |value|
+    pool_array.reverse_each do |value|
       sym = nil
       case value
       when "spares";


### PR DESCRIPTION
```
lib/puppet/provider/mcx/mcxcontent.rb
Hash#keys.each is slower than Hash#each_key. Occurred at lines: 39.

lib/puppet/provider/nameservice/directoryservice.rb
Hash#keys.each is slower than Hash#each_key. Occurred at lines: 113.

lib/puppet/provider/package/pkgng.rb
Hash#keys.each is slower than Hash#each_key. Occurred at lines: 65.

lib/puppet/provider/user/directoryservice.rb
Hash#keys.each is slower than Hash#each_key. Occurred at lines: 103.

lib/puppet/provider/yumrepo/inifile.rb
Hash#keys.each is slower than Hash#each_key. Occurred at lines: 61.

lib/puppet/provider/zpool/zpool.rb
Array#reverse.each is slower than Array#reverse_each. Occurred at lines: 26.
```

* See https://github.com/JuanitoFatas/fast-ruby and https://github.com/DamirSvrtan/fasterer for more details