### PR TITLE
(PUP-6135) Use present tense in type mismatch errors

### DIFF
--- a/lib/puppet/pops/types/type_asserter.rb
+++ b/lib/puppet/pops/types/type_asserter.rb
@@ -39,7 +39,7 @@ module TypeAsserter
     subject = yield(subject) if block_given?
     subject = subject[0] % subject[1..-1] if subject.is_a?(Array)
     raise TypeAssertionError.new(
-      TypeMismatchDescriber.singleton.describe_mismatch("#{subject} had wrong type,", expected_type, actual_type), expected_type, actual_type)
+      TypeMismatchDescriber.singleton.describe_mismatch("#{subject} has wrong type,", expected_type, actual_type), expected_type, actual_type)
   end
   private_class_method :report_type_mismatch
 end

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -1,5 +1,6 @@
 module Puppet::Pops
 module Types
+  # @api private
   class TypePathElement
     attr_reader :key
 
@@ -20,30 +21,35 @@ module Types
     end
    end
 
+  # @api private
   class SubjectPathElement < TypePathElement
     def to_s
       key
     end
   end
 
+  # @api private
   class EntryValuePathElement < TypePathElement
     def to_s
       "entry '#{key}'"
     end
   end
 
+  # @api private
   class EntryKeyPathElement < TypePathElement
     def to_s
       "key of entry '#{key}'"
     end
   end
 
+  # @api private
   class ParameterPathElement < TypePathElement
     def to_s
       "parameter '#{key}'"
     end
   end
 
+  # @api private
   class BlockPathElement < ParameterPathElement
     def initialize(name = 'block')
       super(name)
@@ -54,18 +60,21 @@ module Types
     end
   end
 
+  # @api private
   class ArrayPathElement < TypePathElement
     def to_s
       "index #{key}"
     end
   end
 
+  # @api private
   class VariantPathElement < TypePathElement
     def to_s
       "variant #{key}"
     end
   end
 
+  # @api private
   class SignaturePathElement < VariantPathElement
     def to_s
       "#{key+1}."
@@ -77,6 +86,7 @@ module Types
   # All method names prefixed with "it_" to avoid conflict with Mocha expectations. Adding a method
   # named 'expects' just doesn't work.
   #
+  # @api private
   module TenseVariants
     def it_expects(tense)
       case tense
@@ -115,6 +125,7 @@ module Types
     end
   end
 
+  # @api private
   class Mismatch
     include TenseVariants
     attr_reader :path
@@ -181,6 +192,7 @@ module Types
   end
 
   # @abstract
+  # @api private
   class KeyMismatch < Mismatch
     attr_reader :key
 
@@ -198,42 +210,49 @@ module Types
     end
   end
 
+  # @api private
   class MissingKey < KeyMismatch
     def message(variant, position, tense = :present)
       "#{variant}#{position} #{it_expects(tense)} a value for key '#{key}'"
     end
   end
 
+  # @api private
   class MissingParameter < KeyMismatch
     def message(variant, position, tense = :present)
       "#{variant}#{position} #{it_expects(tense)} a value for parameter '#{key}'"
     end
   end
 
+  # @api private
   class ExtraneousKey < KeyMismatch
     def message(variant, position, tense = :present)
       "#{variant}#{position} unrecognized key '#{@key}'"
     end
   end
 
+  # @api private
   class InvalidParameter < ExtraneousKey
     def message(variant, position, tense = :present)
       "#{variant}#{position} #{it_has_no(tense)} parameter named '#{@key}'"
     end
   end
 
+  # @api private
   class UnexpectedBlock < Mismatch
     def message(variant, position, tense = :present)
       "#{variant}#{position} #{it_does_not_expect(tense)} a block"
     end
   end
 
+  # @api private
   class MissingRequiredBlock < Mismatch
     def message(variant, position, tense = :present)
       "#{variant}#{position} #{it_expects(tense)} a block"
     end
   end
 
+  # @api private
   class UnresolvedTypeReference < Mismatch
     attr_reader :unresolved
 
@@ -255,6 +274,7 @@ module Types
     end
   end
 
+  # @api private
   class ExpectedActualMismatch < Mismatch
     attr_reader :expected, :actual
 
@@ -279,6 +299,7 @@ module Types
     end
   end
 
+  # @api private
   class TypeMismatch < ExpectedActualMismatch
     include LabelProvider
 
@@ -424,6 +445,7 @@ module Types
     end
   end
 
+  # @api private
   class PatternMismatch < TypeMismatch
     def message(variant, position, tense = :present)
       "#{variant}#{position} #{it_expects(tense)} a match for #{expected.to_alias_expanded_s}, got #{actual_string}"
@@ -435,6 +457,7 @@ module Types
     end
   end
 
+  # @api private
   class SizeMismatch < ExpectedActualMismatch
     def from
       @expected.from || 0
@@ -469,6 +492,7 @@ module Types
     end
   end
 
+  # @api private
   class CountMismatch < SizeMismatch
     def initialize(path, expected, actual)
       super(path, expected, actual)
@@ -482,6 +506,7 @@ module Types
     end
   end
 
+  # @api private
   class TypeMismatchDescriber
     include TenseVariants
 

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -22,7 +22,7 @@ describe 'the assert_type function' do
   it 'asserts non compliant type by raising an error' do
     expect do
       func.call({}, type(Integer), 'hello world')
-    end.to raise_error(Puppet::Pops::Types::TypeAssertionError, /expected an Integer value, got String/)
+    end.to raise_error(Puppet::Pops::Types::TypeAssertionError, /expects an Integer value, got String/)
   end
 
   it 'checks that first argument is a type' do
@@ -84,7 +84,7 @@ describe 'the assert_type function' do
       assert_type(UnprivilegedPort, 345)
       notice('ok')
     CODE
-    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expected an UnprivilegedPort = Integer\[1024, 65537\] value, got Integer\[345, 345\]/)
+    expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /expects an UnprivilegedPort = Integer\[1024, 65537\] value, got Integer\[345, 345\]/)
   end
 
   it 'will use infer_set to report detailed information about complex mismatches' do
@@ -92,6 +92,6 @@ describe 'the assert_type function' do
       assert_type(Struct[{a=>Integer,b=>Boolean}], {a=>hej,x=>s})
     CODE
     expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error,
-      /entry 'a' expected an Integer value, got String.*expected a value for key 'b'.*unrecognized key 'x'/m)
+      /entry 'a' expects an Integer value, got String.*expects a value for key 'b'.*unrecognized key 'x'/m)
   end
 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -170,7 +170,7 @@ describe "when performing lookup" do
     it 'will not accept a succesful lookup of an undef value when the type rejects it' do
       expect do
         assemble_and_compile('${r}', "'abc::n'", 'String')
-      end.to raise_error(Puppet::ParseError, /Found value had wrong type, expected a String value, got Undef/)
+      end.to raise_error(Puppet::ParseError, /Found value has wrong type, expects a String value, got Undef/)
     end
 
     it 'will raise an exception when value is not found for array key and no default is provided' do
@@ -249,7 +249,7 @@ describe "when performing lookup" do
         expect do
           assemble_and_compile('${r[a]}_${r[b]}', "'abc::x'", 'Hash[String,String]', 'undef', "{'a' => 'dflt_x', 'b' => 32}")
         end.to raise_error(Puppet::ParseError,
-          /Default value had wrong type, entry 'b' expected a String value, got Integer/)
+          /Default value has wrong type, entry 'b' expects a String value, got Integer/)
       end
     end
 
@@ -283,7 +283,7 @@ describe "when performing lookup" do
         expect do
           assemble_and_compile_with_block('${r[a]}_${r[b]}', "{'a' => 'dflt_x', 'b' => 32}", "'abc::x'", 'Hash[String,String]')
         end.to raise_error(Puppet::ParseError,
-          /Value returned from default block had wrong type, entry 'b' expected a String value, got Integer/)
+          /Value returned from default block has wrong type, entry 'b' expects a String value, got Integer/)
       end
 
       it 'receives a single name parameter' do

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -28,7 +28,7 @@ describe 'the new function' do
       $x = Integer.new(undef)
       notify { "one${x}word": }
     MANIFEST
-    )}.to raise_error(Puppet::Error, /expected an Integer value, got Undef/)
+    )}.to raise_error(Puppet::Error, /expects an Integer value, got Undef/)
   end
 
   it 'errors if converted value is not assignable to the type' do
@@ -36,7 +36,7 @@ describe 'the new function' do
       $x = Integer[1,5].new('42')
       notify { "one${x}word": }
     MANIFEST
-    )}.to raise_error(Puppet::Error, /expected an Integer\[1, 5\] value, got Integer\[42, 42\]/)
+    )}.to raise_error(Puppet::Error, /expects an Integer\[1, 5\] value, got Integer\[42, 42\]/)
   end
 
   context 'when invoked on NotUndef' do
@@ -441,7 +441,7 @@ describe 'the new function' do
       expect{compile_to_catalog(<<-"MANIFEST"
         $x = Boolean.new(undef)
       MANIFEST
-      )}.to raise_error(Puppet::Error, /expected a Boolean value, got Undef/)
+      )}.to raise_error(Puppet::Error, /expects a Boolean value, got Undef/)
     end
   end
 
@@ -507,7 +507,7 @@ describe 'the new function' do
       expect{compile_to_catalog(<<-"MANIFEST"
         $x = Tuple[Integer,6].new(3)
       MANIFEST
-      )}.to raise_error(Puppet::Error, /expected size to be at least 6, got 3/)
+      )}.to raise_error(Puppet::Error, /expects size to be at least 6, got 3/)
     end
   end
 
@@ -558,7 +558,7 @@ describe 'the new function' do
       expect{compile_to_catalog(<<-"MANIFEST"
         $x = Struct[{a => Integer[2]}].new({a => 0})
       MANIFEST
-      )}.to raise_error(Puppet::Error, /entry 'a' expected an Integer\[2, default\]/)
+      )}.to raise_error(Puppet::Error, /entry 'a' expects an Integer\[2, default\]/)
     end
   end
 

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -500,7 +500,7 @@ describe 'the 4x function api' do
         program = parser.parse_string('testing::test(10)', __FILE__)
         Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).returns(the_loader)
         expect { parser.evaluate({}, program) }.to raise_error(Puppet::Error,
-          /value returned from function 'test' had wrong type, expected a String value, got Integer/)
+          /value returned from function 'test' has wrong type, expects a String value, got Integer/)
       end
 
       it 'resolve a referenced Type alias' do

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1044,7 +1044,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     it 'a lambda return value is checked using the return type' do
       expect(parser.evaluate_string(scope, "[1,2].map |Integer $x| >> Integer { $x }")).to eql([1,2])
       expect { parser.evaluate_string(scope, "[1,2].map |Integer $x| >> String { $x }") }.to raise_error(
-        /value returned from lambda had wrong type, expected a String value, got Integer/)
+        /value returned from lambda has wrong type, expects a String value, got Integer/)
     end
 
     context 'using the 3x function api' do

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -31,7 +31,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /attribute MyObject\[a\] had wrong type, expected a Type value, got Integer/)
+        /attribute MyObject\[a\] has wrong type, expects a Type value, got Integer/)
     end
 
     it 'raises an error if the type is missing' do
@@ -41,7 +41,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /expected a value for key 'type'/)
+        /expects a value for key 'type'/)
     end
 
     it 'raises an error when value is of incompatible type' do
@@ -51,7 +51,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /attribute MyObject\[a\] value had wrong type, expected an Integer value, got String/)
+        /attribute MyObject\[a\] value has wrong type, expects an Integer value, got String/)
     end
 
     it 'raises an error if the kind is invalid' do
@@ -61,7 +61,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /expected a match for Enum\['constant', 'derived', 'given_or_derived'\], got 'derivd'/)
+        /expects a match for Enum\['constant', 'derived', 'given_or_derived'\], got 'derivd'/)
     end
 
     it 'stores value in attribute' do
@@ -155,7 +155,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /function MyObject\[a\] had wrong type, expected a Type\[Callable\] value, got Type\[String\]/)
+        /function MyObject\[a\] has wrong type, expects a Type\[Callable\] value, got Type\[String\]/)
     end
 
     it 'raises an error when a function has the same name as an attribute' do
@@ -494,7 +494,7 @@ describe 'The Object Type' do
         a => Integer
       }
     OBJECT
-    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /object initializer had wrong type, unrecognized key 'attribrutes'/)
+    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /object initializer has wrong type, unrecognized key 'attribrutes'/)
   end
 
   it 'raises an error when attribute contains invalid keys' do
@@ -503,7 +503,7 @@ describe 'The Object Type' do
         a => { type => Integer, knid => constant }
       }
     OBJECT
-    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /initializer for attribute MyObject\[a\] had wrong type, unrecognized key 'knid'/)
+    expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError, /initializer for attribute MyObject\[a\] has wrong type, unrecognized key 'knid'/)
   end
 
   context 'when inheriting from a another Object type' do

--- a/spec/unit/pops/types/p_sensitive_type_spec.rb
+++ b/spec/unit/pops/types/p_sensitive_type_spec.rb
@@ -96,7 +96,7 @@ describe 'Sensitive Type' do
       CODE
       expect {
         eval_and_collect_notices(code)
-      }.to raise_error(Puppet::Error, /expected a Sensitive\[String\[10, 20\]\] value, got Sensitive\[String\[7, 7\]\]/)
+      }.to raise_error(Puppet::Error, /expects a Sensitive\[String\[10, 20\]\] value, got Sensitive\[String\[7, 7\]\]/)
     end
 
     it 'does not match an inappropriate parameterized type' do

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -107,7 +107,7 @@ module Puppet::Pops
             version => '1.0.0',
             OBJECT
             expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-              /expected a value for key 'pcore_version'/)
+              /expects a value for key 'pcore_version'/)
           end
 
           it 'version is missing' do
@@ -115,7 +115,7 @@ module Puppet::Pops
             pcore_version => '1.0.0',
             OBJECT
             expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-              /expected a value for key 'version'/)
+              /expects a value for key 'version'/)
           end
 
           it 'the version is an invalid semantic version' do
@@ -150,7 +150,7 @@ module Puppet::Pops
             name_authority => 'not a valid URI'
             OBJECT
             expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-              /entry 'name_authority' expected a match for Pattern\[.*\], got 'not a valid URI'/m)
+              /entry 'name_authority' expects a match for Pattern\[.*\], got 'not a valid URI'/m)
           end
 
           context 'the types map' do
@@ -161,7 +161,7 @@ module Puppet::Pops
                 types => {}
               OBJECT
               expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                /entry 'types' expected size to be at least 1, got 0/)
+                /entry 'types' expects size to be at least 1, got 0/)
             end
 
             it 'is not a map' do
@@ -171,7 +171,7 @@ module Puppet::Pops
                 types => []
               OBJECT
               expect { parse_type_set('MySet', ts) }.to raise_error(Puppet::Error,
-                /entry 'types' expected a Hash value, got Array/)
+                /entry 'types' expects a Hash value, got Array/)
             end
 
             it 'contains values that are not types' do
@@ -195,7 +195,7 @@ module Puppet::Pops
                 }
               OBJECT
               expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                /key of entry 'car' expected a match for Pattern\[\/\\A\[A-Z\]\\w\*\\z\/\], got 'car'/)
+                /key of entry 'car' expects a match for Pattern\[\/\\A\[A-Z\]\\w\*\\z\/\], got 'car'/)
             end
           end
 
@@ -207,7 +207,7 @@ module Puppet::Pops
                 references => {}
               OBJECT
               expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                /entry 'references' expected size to be at least 1, got 0/)
+                /entry 'references' expects size to be at least 1, got 0/)
             end
 
             it 'is not a hash' do
@@ -217,7 +217,7 @@ module Puppet::Pops
                 references => []
               OBJECT
               expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                /entry 'references' expected a Hash value, got Array/)
+                /entry 'references' expects a Hash value, got Array/)
             end
 
             it 'contains something other than reference initialization maps' do
@@ -227,7 +227,7 @@ module Puppet::Pops
                 references => {Ref => 2}
               OBJECT
               expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                /entry 'references' entry 'Ref' expected a Struct value, got Integer/)
+                /entry 'references' entry 'Ref' expects a Struct value, got Integer/)
             end
 
             it 'contains several initialization that refers to the same TypeSet' do
@@ -266,7 +266,7 @@ module Puppet::Pops
                   references => { Ref => { name => 'X' } }
                 OBJECT
                 expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                  /entry 'references' entry 'Ref' expected a value for key 'version_range'/)
+                  /entry 'references' entry 'Ref' expects a value for key 'version_range'/)
               end
 
               it 'has no name' do
@@ -276,7 +276,7 @@ module Puppet::Pops
                   references => { Ref => { version_range => '1.x' } }
                 OBJECT
                 expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                  /entry 'references' entry 'Ref' expected a value for key 'name'/)
+                  /entry 'references' entry 'Ref' expects a value for key 'name'/)
               end
 
               it 'has a name that is not a QRef' do
@@ -286,7 +286,7 @@ module Puppet::Pops
                   references => { Ref => { name => 'cars', version_range => '1.x' } }
                 OBJECT
                 expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                  /entry 'references' entry 'Ref' entry 'name' expected a match for Pattern\[\/\\A\[A-Z\]\[\\w\]\*\(\?:::\[A-Z\]\[\\w\]\*\)\*\\z\/\], got 'cars'/)
+                  /entry 'references' entry 'Ref' entry 'name' expects a match for Pattern\[\/\\A\[A-Z\]\[\\w\]\*\(\?:::\[A-Z\]\[\\w\]\*\)\*\\z\/\], got 'cars'/)
               end
 
               it 'has a version_range that is not a valid SemVer range' do
@@ -306,7 +306,7 @@ module Puppet::Pops
                   references => { 'cars' => { name => 'X', version_range => '1.x' } }
                 OBJECT
                 expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-                  /entry 'references' key of entry 'cars' expected a match for Pattern\[\/\\A\[A-Z\]\\w\*\\z\/\], got 'cars'/)
+                  /entry 'references' key of entry 'cars' expects a match for Pattern\[\/\\A\[A-Z\]\\w\*\\z\/\], got 'cars'/)
               end
             end
           end

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -81,14 +81,14 @@ describe 'Puppet Ruby Generator' do
         it 'will perform type assertion of the arguments' do
           expect { first.create('Bob Builder', '52') }.to(
             raise_error(TypeAssertionError,
-              'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got String')
+              'MyModule::FirstGenerated[age] has wrong type, expects an Integer value, got String')
           )
         end
 
         it 'will not accept nil as given value for an optional parameter that does not accept nil' do
           expect { first.create('Bob Builder', nil) }.to(
             raise_error(TypeAssertionError,
-              'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got Undef')
+              'MyModule::FirstGenerated[age] has wrong type, expects an Integer value, got Undef')
           )
         end
 
@@ -128,7 +128,7 @@ describe 'Puppet Ruby Generator' do
         it 'does not accept an initializer where optional values are nil and type does not accept nil' do
           expect { first.from_hash('name' => 'Bob Builder', 'age' => nil) }.to(
             raise_error(TypeAssertionError,
-              "MyModule::FirstGenerated initializer had wrong type, entry 'age' expected an Integer value, got Undef")
+              "MyModule::FirstGenerated initializer has wrong type, entry 'age' expects an Integer value, got Undef")
           )
         end
       end
@@ -205,14 +205,14 @@ describe 'Puppet Ruby Generator' do
         it 'will perform type assertion of the arguments' do
           expect { PuppetSpec::RubyGenerator::FirstGenerated.create('Bob Builder', '52') }.to(
             raise_error(TypeAssertionError,
-              'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got String')
+              'MyModule::FirstGenerated[age] has wrong type, expects an Integer value, got String')
           )
         end
 
         it 'will not accept nil as given value for an optional parameter that does not accept nil' do
           expect { PuppetSpec::RubyGenerator::FirstGenerated.create('Bob Builder', nil) }.to(
             raise_error(TypeAssertionError,
-              'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got Undef')
+              'MyModule::FirstGenerated[age] has wrong type, expects an Integer value, got Undef')
           )
         end
 
@@ -252,7 +252,7 @@ describe 'Puppet Ruby Generator' do
         it 'does not accept an initializer where optional values are nil and type does not accept nil' do
           expect { PuppetSpec::RubyGenerator::FirstGenerated.from_hash('name' => 'Bob Builder', 'age' => nil) }.to(
             raise_error(TypeAssertionError,
-              "MyModule::FirstGenerated initializer had wrong type, entry 'age' expected an Integer value, got Undef")
+              "MyModule::FirstGenerated initializer has wrong type, entry 'age' expects an Integer value, got Undef")
           )
         end
       end
@@ -389,14 +389,14 @@ describe 'Puppet Ruby Generator' do
         it 'will perform type assertion of the arguments' do
           expect { first.create('Bob Builder', '52') }.to(
             raise_error(TypeAssertionError,
-              'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got String')
+              'MyModule::FirstGenerated[age] has wrong type, expects an Integer value, got String')
           )
         end
 
         it 'will not accept nil as given value for an optional parameter that does not accept nil' do
           expect { first.create('Bob Builder', nil) }.to(
             raise_error(TypeAssertionError,
-              'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got Undef')
+              'MyModule::FirstGenerated[age] has wrong type, expects an Integer value, got Undef')
           )
         end
 
@@ -436,7 +436,7 @@ describe 'Puppet Ruby Generator' do
         it 'does not accept an initializer where optional values are nil and type does not accept nil' do
           expect { first.from_hash('name' => 'Bob Builder', 'age' => nil) }.to(
             raise_error(TypeAssertionError,
-              "MyModule::FirstGenerated initializer had wrong type, entry 'age' expected an Integer value, got Undef")
+              "MyModule::FirstGenerated initializer has wrong type, entry 'age' expects an Integer value, got Undef")
           )
         end
       end
@@ -519,14 +519,14 @@ describe 'Puppet Ruby Generator' do
         it 'will perform type assertion of the arguments' do
           expect { PuppetSpec::RubyGenerator::My::FirstGenerated.create('Bob Builder', '52') }.to(
             raise_error(TypeAssertionError,
-              'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got String')
+              'MyModule::FirstGenerated[age] has wrong type, expects an Integer value, got String')
           )
         end
 
         it 'will not accept nil as given value for an optional parameter that does not accept nil' do
           expect { PuppetSpec::RubyGenerator::My::FirstGenerated.create('Bob Builder', nil) }.to(
             raise_error(TypeAssertionError,
-              'MyModule::FirstGenerated[age] had wrong type, expected an Integer value, got Undef')
+              'MyModule::FirstGenerated[age] has wrong type, expects an Integer value, got Undef')
           )
         end
 
@@ -566,7 +566,7 @@ describe 'Puppet Ruby Generator' do
         it 'does not accept an initializer where optional values are nil and type does not accept nil' do
           expect { PuppetSpec::RubyGenerator::My::FirstGenerated.from_hash('name' => 'Bob Builder', 'age' => nil) }.to(
             raise_error(TypeAssertionError,
-              "MyModule::FirstGenerated initializer had wrong type, entry 'age' expected an Integer value, got Undef")
+              "MyModule::FirstGenerated initializer has wrong type, entry 'age' expects an Integer value, got Undef")
           )
         end
       end

--- a/spec/unit/pops/types/type_asserter_spec.rb
+++ b/spec/unit/pops/types/type_asserter_spec.rb
@@ -8,19 +8,19 @@ describe 'the type asserter' do
   context 'when deferring formatting of subject'
   it 'can use an array' do
     expect{ asserter.assert_instance_of(['The %s in the %s', 'gizmo', 'gadget'], PIntegerType::DEFAULT, 'lens') }.to(
-    raise_error(TypeAssertionError, 'The gizmo in the gadget had wrong type, expected an Integer value, got String'))
+    raise_error(TypeAssertionError, 'The gizmo in the gadget has wrong type, expects an Integer value, got String'))
   end
 
   it 'can use an array obtained from block' do
     expect do
       asserter.assert_instance_of('gizmo', PIntegerType::DEFAULT, 'lens') { |s| ['The %s in the %s', s, 'gadget'] }
-    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget had wrong type, expected an Integer value, got String'))
+    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget has wrong type, expects an Integer value, got String'))
   end
 
   it 'can use an subject obtained from zero argument block' do
     expect do
       asserter.assert_instance_of(nil, PIntegerType::DEFAULT, 'lens') { 'The gizmo in the gadget' }
-    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget had wrong type, expected an Integer value, got String'))
+    end.to(raise_error(TypeAssertionError, 'The gizmo in the gadget has wrong type, expects an Integer value, got String'))
   end
 
   it 'does not produce a string unless the assertion fails' do

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -149,83 +149,51 @@ describe 'the type mismatch describer' do
   end
 
   context 'when reporting a mismatch between' do
-    let(:parser) { TypeParser.new }
+    let(:parser) { TypeParser.singleton }
     let(:subject) { TypeMismatchDescriber.singleton }
 
     context 'hash and struct' do
       it 'reports a size mismatch when hash has unlimited size' do
         expected = parser.parse('Struct[{a=>Integer,b=>Integer}]')
         actual = parser.parse('Hash[String,Integer]')
-        expect(subject.describe_mismatch('', expected, actual)).to eq('expected size to be 2, got unlimited')
+        expect(subject.describe_mismatch('', expected, actual)).to eq('expects size to be 2, got unlimited')
       end
 
       it 'reports a size mismatch when hash has specified but incorrect size' do
         expected = parser.parse('Struct[{a=>Integer,b=>Integer}]')
         actual = parser.parse('Hash[String,Integer,1,1]')
-        expect(subject.describe_mismatch('', expected, actual)).to eq('expected size to be 2, got 1')
+        expect(subject.describe_mismatch('', expected, actual)).to eq('expects size to be 2, got 1')
       end
 
       it 'reports a full type mismatch when size is correct but hash value type is incorrect' do
         expected = parser.parse('Struct[{a=>Integer,b=>String}]')
         actual = parser.parse('Hash[String,Integer,2,2]')
-        expect(subject.describe_mismatch('', expected, actual)).to eq("expected a Struct[{'a' => Integer, 'b' => String}] value, got Hash[String, Integer]")
+        expect(subject.describe_mismatch('', expected, actual)).to eq("expects a Struct[{'a' => Integer, 'b' => String}] value, got Hash[String, Integer]")
       end
     end
-  end
 
-  context 'when using present tense' do
-    let(:parser) { TypeParser.singleton }
-    let(:subject) { TypeMismatchDescriber.singleton }
     it 'reports a missing parameter as "has no parameter"' do
       t = parser.parse('Struct[{a=>String}]')
-      expect { subject.validate_parameters('v', t, {'a'=>'a','b'=>'b'}, false, :present) }.to raise_error(Puppet::Error, "v: has no parameter named 'b'")
+      expect { subject.validate_parameters('v', t, {'a'=>'a','b'=>'b'}, false) }.to raise_error(Puppet::Error, "v: has no parameter named 'b'")
     end
 
     it 'reports a missing value as "expects a value"' do
       t = parser.parse('Struct[{a=>String,b=>String}]')
-      expect { subject.validate_parameters('v', t, {'a'=>'a'}, false, :present) }.to raise_error(Puppet::Error, "v: expects a value for parameter 'b'")
+      expect { subject.validate_parameters('v', t, {'a'=>'a'}, false) }.to raise_error(Puppet::Error, "v: expects a value for parameter 'b'")
     end
 
     it 'reports a missing block as "expects a block"' do
       callable = parser.parse('Callable[String,String,Callable]')
       args_tuple = parser.parse('Tuple[String,String]')
       dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], 'block', nil, nil, false)
-      expect(subject.describe_signatures('function', [dispatch], args_tuple, :present)).to eq("'function' expects a block")
+      expect(subject.describe_signatures('function', [dispatch], args_tuple)).to eq("'function' expects a block")
     end
 
     it 'reports an unexpected block as "does not expect a block"' do
       callable = parser.parse('Callable[String,String]')
       args_tuple = parser.parse('Tuple[String,String,Callable]')
       dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], nil, nil, nil, false)
-      expect(subject.describe_signatures('function', [dispatch], args_tuple, :present)).to eq("'function' does not expect a block")
-    end
-  end
-
-  context 'when using past tense' do
-    let(:parser) { TypeParser.singleton }
-    let(:subject) { TypeMismatchDescriber.singleton }
-    it 'reports a missing parameter as "did not have a parameter"' do
-      t = parser.parse('Struct[{a=>String}]')
-      expect { subject.validate_parameters('v', t, {'a'=>'a','b'=>'b'}, false, :past) }.to raise_error(Puppet::Error, "v: did not have a parameter named 'b'")
-    end
-
-    it 'reports a missing value as "expected a value"' do
-      t = parser.parse('Struct[{a=>String,b=>String}]')
-      expect { subject.validate_parameters('v', t, {'a'=>'a'}, false, :past) }.to raise_error(Puppet::Error, "v: expected a value for parameter 'b'")
-    end
-
-    it 'reports a missing block as "expected a block"' do
-      callable = parser.parse('Callable[String,String,Callable]')
-      args_tuple = parser.parse('Tuple[String,String]')
-      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], 'block', nil, nil, false)
-      expect(subject.describe_signatures('function', [dispatch], args_tuple, :past)).to eq("'function' expected a block")
-    end
-
-    it 'reports an unexpected block as "did not expect a block"' do
-      callable = parser.parse('Callable[String,String]')
-      args_tuple = parser.parse('Tuple[String,String,Callable]')
-      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], nil, nil, nil, false)
-      expect(subject.describe_signatures('function', [dispatch], args_tuple, :past)).to eq("'function' did not expect a block")
+      expect(subject.describe_signatures('function', [dispatch], args_tuple)).to eq("'function' does not expect a block")
     end
   end
 end

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -440,7 +440,7 @@ describe 'Puppet Type System' do
       type Foo = Variant[Foo,String,Integer]
       assert_type(Foo, /x/)
       CODE
-      expect { eval_and_collect_notices(code) }.to raise_error(/expected a value of type String or Integer, got Regexp/)
+      expect { eval_and_collect_notices(code) }.to raise_error(/expects a value of type String or Integer, got Regexp/)
     end
 
     it 'will handle a scalar correctly in combinations of nested aliased variants' do


### PR DESCRIPTION
This commit PR the ability to pass a parameter indicating present or past tense to the `TypeMismatchDescriber`. All messages are instead hard-coded to use present tense.