### PR TITLE
(PUP-6783) Allow notify resources on both devices and normal hosts

### DIFF
--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -6,6 +6,8 @@ module Puppet
   Type.newtype(:notify) do
     @doc = "Sends an arbitrary message to the agent run-time log."
 
+    apply_to_all
+
     newproperty(:message, :idempotent => false) do
       desc "The message to be sent to the log."
       def sync


### PR DESCRIPTION
This avoids unexpected failures from skipping notify resources, when logging
on devices.
