### PR TITLE
(PUP-6701) Make settings data type cleanup handle boolean values

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -877,7 +877,7 @@ class Puppet::Parser::Compiler
 
   def transform_setting(val)
     case val
-    when Integer, Float, String
+    when Integer, Float, String, TrueClass, FalseClass
       val
     when Symbol
       val == :undef ? nil : val.to_s

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -877,7 +877,7 @@ class Puppet::Parser::Compiler
 
   def transform_setting(val)
     case val
-    when Integer, Float, String, TrueClass, FalseClass
+    when Integer, Float, String, TrueClass, FalseClass, NilClass
       val
     when Symbol
       val == :undef ? nil : val.to_s

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -162,6 +162,14 @@ describe Puppet::Parser::Compiler do
       MANIFEST
       expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
     end
+
+    it 'can return boolean settings as Boolean' do
+      node = Puppet::Node.new("testing")
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+          notify { 'test': message => $settings::storeconfigs == false }
+      MANIFEST
+      expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
+    end
   end
 
   context 'when working with $server_facts' do


### PR DESCRIPTION
A regression was introduced in PUP-6682 as the transformation of
settings values to safe values (no symbols) omitted handling boolean
values. They ended up being transformed to string, with the unfortunate
effect that a boolean `false` turned into the string `"true"` which is
"truthy".

This commit adds the correct handling of FalseClass and TrueType so that
they are not transformed to String values.