### PR TITLE
(FACT-1497) Extend variables_refreshed sleep on AIX

### DIFF
--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -50,7 +50,7 @@ extend Puppet::Acceptance::EnvironmentUtils
           uptime = result.stdout.match(/Notice: #{local_uptime_pattern}/)[0]
           module_uptime = result.stdout.match(/"seconds"=>(\d+),/)[0]
         end
-        if agent.platform =~ /solaris/
+        if agent.platform =~ /solaris|aix/
           sleep 61  # See FACT-1497;
         else
           sleep 1


### PR DESCRIPTION
This commit extends the `sleep` statement in the
`variables_refreshed_each_compilation` test to 61 seconds when
the platform is AIX.

As per FACT-1497, the `system_uptime.seconds` fact updates
less frequently on AIX. Prior to this change this test failed
on AIX due to this issue with facter.

This is a work around and should be reverted when the underlying
facter issue is resolved.

[skip-ci]