### PR TITLE
(PUP-6703) Tweak failover_master test for robustness

### DIFF
--- a/acceptance/tests/reports/failover_master.rb
+++ b/acceptance/tests/reports/failover_master.rb
@@ -33,7 +33,7 @@ test_name "The report specifies which master was contacted during failover" do
         end
 
         step "master_field should not appear when no master could be conatacted" do
-          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list=badmaster:1,badmaster:2","--http_connect_timeout=3s", "--report_server=#{master}"), :acceptable_exit_codes => [1])
+          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list=badmaster:1","--http_connect_timeout=5s", "--report_server=#{master}"), :acceptable_exit_codes => [1])
           on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do
             assert_no_match(/master_used:/, stdout, "did not expect master_used to be in the report")
           end


### PR DESCRIPTION
On 9/14 we had a failed cell (spurious failure) in the matrix run for test
acceptance/tests/reports/failover_master.rb due to a timeout sending the report
to the master for the test modified in this commit, 'master_field should not
appear when no master could be contacted'.

Prior to this commit, this test used two nonexistent servers in a server list
and specified a timeout of 3 seconds. In the beaker run noted, this led to a
test execution time of approximately 25 seconds. This commit updates the
timeout to 5 seconds, but reduces the check to only one nonexistent master as a
way to diminish the impact on overall test time of increasing the timeout.  The
fact that two masters are specified isn't actually intrinsic to the test, so
this should effectively be a no-op in terms of test effectiveness while
decreasing the likelihood of encountering a timeout during report submission.