### PR TITLE
(PUP-5834) Add support for resource ext_parameters to catalog

### DIFF
--- a/api/schemas/catalog.json
+++ b/api/schemas/catalog.json
@@ -73,6 +73,14 @@
                             "^[a-z][a-z0-9_]*$": {}
                         },
                         "additionalProperties": false
+                    },
+                    "ext_parameters": {
+                        "description": "Parameters with extended type: regex is from https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html",
+                        "type": "object",
+                        "patternProperties": {
+                            "^[a-z][a-z0-9_]*$": {}
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "required": ["type", "title", "tags", "exported"],

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1926,4 +1926,24 @@ EOT
           generate manifest documentation.",
     }
   )
+
+  define_settings(
+    :main,
+    :rich_data => {
+      :default  => false,
+      :type     => :boolean,
+      :hook    => proc do |value|
+        envs = Puppet.lookup(:environments) { nil }
+        envs.clear_all unless envs.nil?
+      end,
+      :desc     => <<-'EOT'
+        Enables storage of extended data in the catalog by introducing the new Resource
+        property `ext_parameters`. When enabled, values of type Regexp, SemVer, SemVerRange,
+        Timespan, and Timestamp, will no longer be converted to strings. Instead, they will
+        be serialized using Pcore serialization which allowes them to retain their type. It
+        will also be possible to use parameters that store a Binary.
+      EOT
+    }
+  )
+
 end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1937,11 +1937,10 @@ EOT
         envs.clear_all unless envs.nil?
       end,
       :desc     => <<-'EOT'
-        Enables storage of extended data in the catalog by introducing the new Resource
-        property `ext_parameters`. When enabled, values of type Regexp, SemVer, SemVerRange,
-        Timespan, and Timestamp, will no longer be converted to strings. Instead, they will
-        be serialized using Pcore serialization which allowes them to retain their type. It
-        will also be possible to use parameters that store a Binary.
+        Enables having extended data in the catalog by adding the key `ext_parameters` to serialized
+        resources. When enabled, resource containing values of the data types `Binary`, `Regexp`,
+        `SemVer`, `SemVerRange`, `Timespan` and `Timestamp`, as well as instances of types derived
+        from `Object` retain their data type and are serialized using Pcore in `ext_parameters`.
       EOT
     }
   )

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -41,7 +41,10 @@ module Puppet::Environments
 
     def clear_all
       root = Puppet.lookup(:root_environment) { nil }
-      root.instance_variable_set(:@static_catalogs, nil) unless root.nil?
+      unless root.nil?
+        root.instance_variable_set(:@static_catalogs, nil)
+        root.instance_variable_set(:@rich_data, nil)
+      end
     end
   end
 
@@ -112,7 +115,7 @@ module Puppet::Environments
     def get_conf(name)
       env = get(name)
       if env
-        Puppet::Settings::EnvironmentConf.static_for(env, 0, Puppet[:static_catalogs])
+        Puppet::Settings::EnvironmentConf.static_for(env, 0, Puppet[:static_catalogs], Puppet[:rich_data])
       else
         nil
       end

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -218,6 +218,17 @@ class Puppet::Node::Environment
     errors
   end
 
+  # Checks if this environment permits use of rich data types in the catalog
+  # @return [Boolean] `true` if rich data is permitted.
+  # @api private
+  def rich_data?
+    if @rich_data.nil?
+      environment_conf = Puppet.lookup(:environments).get_conf(name)
+      @rich_data = (environment_conf.nil? ? Puppet[:rich_data] : environment_conf.rich_data)
+    end
+    @rich_data
+  end
+
   # Return an environment-specific Puppet setting.
   #
   # @api public

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -191,13 +191,13 @@ class Puppet::Parser::Resource < Puppet::Resource
   def to_hash
     @parameters.reduce({}) do |result, (_, param)|
       value = param.value
-      value = (value == :undef) ? nil : value
+      value = (:undef == value) ? nil : value
 
       unless value.nil?
         case param.name
         when :before, :subscribe, :notify, :require
           if value.is_a?(Array)
-            value = value.flatten.reject {|v| v.nil? || v == :undef }
+            value = value.flatten.reject {|v| v.nil? || :undef == v }
           end
           result[param.name] = value
         else

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -86,32 +86,6 @@ class Runtime3Converter
     raise Puppet::Error, 'Use of an Iterator is not supported here'
   end
 
-  def convert_Regexp(o, scope, undef_value)
-    # Puppet 3x cannot handle parameter values that are reqular expressions. Turn into regexp string in
-    # source form
-    o.inspect
-  end
-
-  def convert_SemVer(o, scope, undef_value)
-    # Puppet 3x cannot handle SemVers. Use the string form
-    o.to_s
-  end
-
-  def convert_SemVerRange(o, scope, undef_value)
-    # Puppet 3x cannot handle SemVerRanges. Use the string form
-    o.to_s
-  end
-
-  def convert_Timespan(o, scope, undef_value)
-    # Puppet 3x cannot handle Timespans. Use the string form
-    o.to_s
-  end
-
-  def convert_Timestamp(o, scope, undef_value)
-    # Puppet 3x cannot handle Timestamps. Use the string form
-    o.to_s
-  end
-
   def convert_Symbol(o, scope, undef_value)
     o == :undef && !@inner ? undef_value : o
   end
@@ -159,13 +133,47 @@ class Runtime3Converter
 
   protected
 
-  def initialize(inner)
+  def initialize(inner = false)
     @inner = inner
     @inner_converter = inner ? self : self.class.new(true)
     @convert_visitor = Puppet::Pops::Visitor.new(self, 'convert', 2, 2)
   end
 
-  @instance = self.new(false)
+  @instance = self.new
+end
+
+# A Ruby function written for the 3.x API cannot be expected to handle extended data types. This
+# converter ensures that they are converted to String format
+# @api private
+class Runtime3FunctionArgumentConverter < Runtime3Converter
+
+  def convert_Regexp(o, scope, undef_value)
+    # Puppet 3x cannot handle parameter values that are reqular expressions. Turn into regexp string in
+    # source form
+    o.inspect
+  end
+
+  def convert_Version(o, scope, undef_value)
+    # Puppet 3x cannot handle SemVers. Use the string form
+    o.to_s
+  end
+
+  def convert_VersionRange(o, scope, undef_value)
+    # Puppet 3x cannot handle SemVerRanges. Use the string form
+    o.to_s
+  end
+
+  def convert_Timespan(o, scope, undef_value)
+    # Puppet 3x cannot handle Timespans. Use the string form
+    o.to_s
+  end
+
+  def convert_Timestamp(o, scope, undef_value)
+    # Puppet 3x cannot handle Timestamps. Use the string form
+    o.to_s
+  end
+
+  @instance = self.new
 end
 
 end

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -163,6 +163,11 @@ class Runtime3FunctionArgumentConverter < Runtime3Converter
     o.to_s
   end
 
+  def convert_Binary(o, scope, undef_value)
+    # Puppet 3x cannot handle Binary. Use the string form
+    o.to_s
+  end
+
   def convert_Timespan(o, scope, undef_value)
     # Puppet 3x cannot handle Timespans. Use the string form
     o.to_s

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -15,7 +15,7 @@ class Runtime3Converter
   # @return [Array] The converted values
   #
   def self.map_args(args, scope, undef_value)
-    @@instance.map_args(args, scope, undef_value)
+    @instance.map_args(args, scope, undef_value)
   end
 
   # Converts 4x supported values to a 3x values. Same as calling Runtime3Converter.instance.convert(...)
@@ -26,13 +26,13 @@ class Runtime3Converter
   # @return [Object] The converted value
   #
   def self.convert(o, scope, undef_value)
-    @@instance.convert(o, scope, undef_value)
+    @instance.convert(o, scope, undef_value)
   end
 
   # Returns the singleton instance of this class.
   # @return [Runtime3Converter] The singleton instance
   def self.instance
-    @@instance
+    @instance
   end
 
   # Converts 4x supported values to a 3x values.
@@ -58,91 +58,67 @@ class Runtime3Converter
   end
 
   def convert_NilClass(o, scope, undef_value)
-    undef_value
-  end
-
-  def convert2_NilClass(o, scope, undef_value)
-    :undef
+    @inner ? :undef : undef_value
   end
 
   def convert_String(o, scope, undef_value)
     # although wasteful, needed because user code may mutate these strings in Resources
     o.frozen? ? o.dup : o
   end
-  alias convert2_String :convert_String
 
   def convert_Object(o, scope, undef_value)
     o
   end
-  alias :convert2_Object :convert_Object
 
   def convert_Array(o, scope, undef_value)
-    o.map {|x| convert2(x, scope, undef_value) }
+    ic = @inner_converter
+    o.map {|x| ic.convert(x, scope, undef_value) }
   end
-  alias :convert2_Array :convert_Array
 
   def convert_Hash(o, scope, undef_value)
     result = {}
-    o.each {|k,v| result[convert2(k, scope, undef_value)] = convert2(v, scope, undef_value) }
+    ic = @inner_converter
+    o.each {|k,v| result[ic.convert(k, scope, undef_value)] = ic.convert(v, scope, undef_value) }
     result
   end
-  alias :convert2_Hash :convert_Hash
 
   def convert_Iterator(o, scope, undef_value)
     raise Puppet::Error, 'Use of an Iterator is not supported here'
   end
-  alias :convert2_Iterator :convert_Iterator
 
   def convert_Regexp(o, scope, undef_value)
     # Puppet 3x cannot handle parameter values that are reqular expressions. Turn into regexp string in
     # source form
     o.inspect
   end
-  alias :convert2_Regexp :convert_Regexp
 
   def convert_SemVer(o, scope, undef_value)
     # Puppet 3x cannot handle SemVers. Use the string form
     o.to_s
   end
-  alias :convert2_SemVer :convert_SemVer
 
   def convert_SemVerRange(o, scope, undef_value)
     # Puppet 3x cannot handle SemVerRanges. Use the string form
     o.to_s
   end
-  alias :convert2_SemVerRange :convert_SemVerRange
 
   def convert_Timespan(o, scope, undef_value)
     # Puppet 3x cannot handle Timespans. Use the string form
     o.to_s
   end
-  alias :convert2_Timespan :convert_Timespan
 
   def convert_Timestamp(o, scope, undef_value)
     # Puppet 3x cannot handle Timestamps. Use the string form
     o.to_s
   end
-  alias :convert2_Timestamp :convert_Timestamp
 
   def convert_Symbol(o, scope, undef_value)
-    case o
-      # Support :undef since it may come from a 3x structure
-      when :undef
-        undef_value  # 3x wants undef as either empty string or :undef
-      else
-        o   # :default, and all others are verbatim since they are new in future evaluator
-    end
-  end
-
-  # The :undef symbol should not be converted when nested in arrays or hashes
-  def convert2_Symbol(o, scope, undef_value)
-    o
+    o == :undef && !@inner ? undef_value : o
   end
 
   def convert_PAnyType(o, scope, undef_value)
     o
   end
-  alias :convert2_PAnyType :convert_PAnyType
 
   def convert_PCatalogEntryType(o, scope, undef_value)
     # Since 4x does not support dynamic scoping, all names are absolute and can be
@@ -154,7 +130,6 @@ class Runtime3Converter
     t = Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
     Puppet::Resource.new(t, title)
   end
-  alias :convert2_PCatalogEntryType :convert_PCatalogEntryType
 
   # Produces an array with [type, title] from a PCatalogEntryType
   # This method is used to produce the arguments for creation of reference resource instances
@@ -182,24 +157,15 @@ class Runtime3Converter
     end
   end
 
-  private
+  protected
 
-  def initialize
-    @convert_visitor  = Puppet::Pops::Visitor.new(self, 'convert', 2, 2)
-    @convert2_visitor = Puppet::Pops::Visitor.new(self, 'convert2', 2, 2)
+  def initialize(inner)
+    @inner = inner
+    @inner_converter = inner ? self : self.class.new(true)
+    @convert_visitor = Puppet::Pops::Visitor.new(self, 'convert', 2, 2)
   end
 
-  @@instance = self.new
-
-  # Converts a nested 4x supported value to a 3x value.
-  #
-  # @param o [Object]The value to convert
-  # @param scope [Puppet::Parser::Scope] The scope to use when converting
-  # @param undef_value [Object] The value that nil is converted to
-  # @return [Object] The converted value
-  #
-  def convert2(o, scope, undef_value)
-    @convert2_visitor.visit_this_2(self, o, scope, undef_value)
-  end
+  @instance = self.new(false)
 end
+
 end

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -307,7 +307,8 @@ module Runtime3Support
   end
 
   def convert(value, scope, undef_value)
-    Runtime3Converter.convert(value, scope, undef_value)
+    converter = scope.environment.rich_data? ? Runtime3Converter.instance : Runtime3FunctionArgumentConverter.instance
+    converter.convert(value, scope, undef_value)
   end
 
   def create_resources(o, scope, virtual, exported, type_name, resource_titles, evaluated_parameters)

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -269,7 +269,7 @@ module Runtime3Support
 
     # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.
     # NOTE: Passing an empty string last converts nil/:undef to empty string
-    mapped_args = Runtime3Converter.map_args(args, scope, '')
+    mapped_args = Runtime3FunctionArgumentConverter.map_args(args, scope, '')
     result = scope.send("function_#{name}", mapped_args, &block)
     # Prevent non r-value functions from leaking their result (they are not written to care about this)
     Puppet::Parser::Functions.rvalue?(name) ? result : nil
@@ -289,7 +289,7 @@ module Runtime3Support
 
     # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.
     # NOTE: Passing an empty string last converts nil/:undef to empty string
-    mapped_args = Runtime3Converter.map_args(args, scope, '')
+    mapped_args = Runtime3FunctionArgumentConverter.map_args(args, scope, '')
     result = Puppet::Pops::PuppetStack.stack(file, line, scope, "function_#{name}", [mapped_args], &block)
     # Prevent non r-value functions from leaking their result (they are not written to care about this)
     Puppet::Parser::Functions.rvalue?(name) ? result : nil

--- a/lib/puppet/pops/functions/function.rb
+++ b/lib/puppet/pops/functions/function.rb
@@ -126,7 +126,7 @@ class Puppet::Pops::Functions::Function
     # Call via 3x API
     # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.
     # NOTE: Passing an empty string last converts nil/:undef to empty string
-    result = scope.send(func_3x, Puppet::Pops::Evaluator::Runtime3Converter.map_args(args, loader_scope, ''), &block)
+    result = scope.send(func_3x, Puppet::Pops::Evaluator::Runtime3FunctionArgumentConverter.map_args(args, loader_scope, ''), &block)
 
     # Prevent non r-value functions from leaking their result (they are not written to care about this)
     Puppet::Parser::Functions.rvalue?(function_name) ? result : nil

--- a/lib/puppet/pops/serialization/deserializer.rb
+++ b/lib/puppet/pops/serialization/deserializer.rb
@@ -6,6 +6,10 @@ module Serialization
   # resolving tabulations and assembling complex objects. The type of the complex objects are resolved using a loader.
   # @api public
   class Deserializer
+    # Provides access to the reader.
+    # @api private
+    attr_reader :reader
+
     # @param [AbstractReader] reader the reader used when reading primitive objects from a stream
     # @param [Loader::Loader] loader the loader used when resolving names of types
     # @api public

--- a/lib/puppet/pops/serialization/json.rb
+++ b/lib/puppet/pops/serialization/json.rb
@@ -15,6 +15,13 @@ module JSON
       super(Packer.new(io, options), options)
     end
 
+    # Clear the underlying io stream but does not clear tabulation cache
+    # Specifically designed to enable tabulation to span more than one
+    # separately deserialized object.
+    def clear_io
+      @packer.clear_io
+    end
+
     def extension_packer
       @packer
     end
@@ -25,6 +32,10 @@ module JSON
 
     def build_payload
       yield(@packer)
+    end
+
+    def to_a
+      @packer.to_a
     end
 
     def to_json
@@ -39,6 +50,10 @@ module JSON
       super(Unpacker.new(io))
     end
 
+    def re_initialize(io)
+      @unpacker.re_initialize(io)
+    end
+
     def read_payload(data)
       yield(@unpacker)
     end
@@ -49,6 +64,7 @@ module JSON
   class Packer
     def initialize(io, options = {})
       @io = io
+      @io << '['
       @type_registry = {}
       @nested = []
       @verbose = options[:verbose]
@@ -60,27 +76,33 @@ module JSON
       @type_registry[klass] = [type, klass, block]
     end
 
+    def clear_io
+      # Truncate everything except leading '['
+      if @io.is_a?(String)
+        @io.slice!(1..-1)
+      else
+        @io.truncate(1)
+      end
+    end
+
     def empty?
-      @io.pos == 0
+      @io.is_a?(String) ? io.length == 1 : @io.pos == 1
     end
 
     def flush
-      pos = @io.pos
-      case pos
-      when 1
-        # Just start marker present.
-      when 0
-        @io << '['
+      # Drop last comma unless just start marker present
+      if @io.is_a?(String)
+        @io.chop! unless @io.length == 1
+        @io << ']'
       else
-        # Drop last comma
-        @io.pos = pos - 1
+        pos = @io.pos
+        @io.pos = pos - 1 unless pos == 1
+        @io << ']'
+        @io.flush
       end
-      @io << ']'
-      @io.flush
     end
 
     def write(obj)
-      assert_started
       case obj
       when Array
         write_array_header(obj.size)
@@ -97,7 +119,6 @@ module JSON
     alias pack write
 
     def write_array_header(n)
-      assert_started
       if n < 1
         @io << '[]'
       else
@@ -107,7 +128,6 @@ module JSON
     end
 
     def write_map_header(n)
-      assert_started
       if n < 1
         @io << '{}'
       else
@@ -117,7 +137,6 @@ module JSON
     end
 
     def write_nil
-      assert_started
       @io << 'null'
       write_delim
     end
@@ -126,13 +145,16 @@ module JSON
       to_json
     end
 
+    def to_a
+      ::JSON.parse(io_string)
+    end
+
     def to_json
-      string = @io.string
       if @indent > 0
-        options = { :indent => ' ' * @indent }
-        string = ::JSON.pretty_unparse(::JSON.parse(string), options)
+        ::JSON.pretty_unparse(to_a, { :indent => ' ' * @indent })
+      else
+        io_string
       end
-      string
     end
 
     # Write a payload object. Not subject to extensions
@@ -140,10 +162,15 @@ module JSON
       @io << obj.to_json << ','
     end
 
-    def assert_started
-      @io << '[' if @io.pos == 0
+    def io_string
+      if @io.is_a?(String)
+        @io
+      else
+        @io.pos = 0
+        @io.read
+      end
     end
-    private :assert_started
+    private :io_string
 
     def write_delim
       nesting = @nested.last
@@ -188,7 +215,11 @@ module JSON
       if obj.is_a?(Extension::SequenceStart) && obj.sequence_size > 0
         @nested << [false, obj.sequence_size]
       else
-        @io.pos -= 1
+        if @io.is_a?(String)
+          @io.chop!
+        else
+          @io.pos -= 1
+        end
         @io << ']'
         write_delim
       end
@@ -208,11 +239,15 @@ module JSON
 
   class Unpacker
     def initialize(io)
-      parsed = ::JSON.parse(io.read(nil))
-      raise SerializationError, "JSON stream is not an array" unless parsed.is_a?(Array)
-      @etor_stack = [parsed.each]
+      re_initialize(io)
       @type_registry = {}
       @nested = []
+    end
+
+    def re_initialize(io)
+      parsed = parse_io(io)
+      raise SerializationError, "JSON stream is not an array. It is a #{io.class.name}" unless parsed.is_a?(Array)
+      @etor_stack = [parsed.each]
     end
 
     def read
@@ -240,6 +275,19 @@ module JSON
 
     def register_type(extension_number, &block)
       @type_registry[extension_number] = block
+    end
+
+    private
+
+    def parse_io(io)
+      case io
+      when IO, StringIO
+        ::JSON.parse(io.read)
+      when String
+        ::JSON.parse(io)
+      else
+        io
+      end
     end
   end
 end

--- a/lib/puppet/pops/serialization/serializer.rb
+++ b/lib/puppet/pops/serialization/serializer.rb
@@ -6,6 +6,10 @@ module Serialization
   # tabulating and disassembling complex objects.
   # @api public
   class Serializer
+    # Provides access to the writer.
+    # @api private
+    attr_reader :writer
+
     # @param [AbstractWriter] writer the writer that is used for writing primitive values
     # @api public
     def initialize(writer)

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -84,7 +84,7 @@ class Puppet::Resource
     params = {}
     self.to_hash.each_pair do |param, value|
       # Don't duplicate the title as the namevar
-      unless param == namevar and value == title
+      unless param == namevar && value == title
         value = Puppet::Resource.value_to_pson_data(value)
         if is_json_type?(value)
           params[param] = value

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -419,8 +419,10 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     end
 
     if resources = data['resources']
+      # TODO: The deserializer needs a loader in order to deserialize types defined using the puppet language.
+      json_deserializer = Puppet::Pops::Serialization::Deserializer.new(Puppet::Pops::Serialization::JSON::Reader.new([]), nil)
       result.add_resource(*resources.collect do |res|
-        Puppet::Resource.from_data_hash(res)
+        Puppet::Resource.from_data_hash(res, json_deserializer)
       end)
     end
 
@@ -472,6 +474,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       h
     end
 
+    json_serializer = Puppet::Pops::Serialization::Serializer.new(Puppet::Pops::Serialization::JSON::Writer.new(''))
     {
       'tags'      => tags,
       'name'      => name,
@@ -480,7 +483,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       'catalog_uuid' => catalog_uuid,
       'catalog_format' => catalog_format,
       'environment'  => environment.to_s,
-      'resources' => @resources.collect { |v| @resource_table[v].to_data_hash },
+      'resources' => @resources.collect { |v| @resource_table[v].to_data_hash(json_serializer) },
       'edges'     => edges.   collect { |e| e.to_data_hash },
       'classes'   => classes,
     }.merge(metadata_hash.empty? ? {} : {'metadata' => metadata_hash})

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -420,7 +420,10 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
 
     if resources = data['resources']
       # TODO: The deserializer needs a loader in order to deserialize types defined using the puppet language.
-      json_deserializer = Puppet::Pops::Serialization::Deserializer.new(Puppet::Pops::Serialization::JSON::Reader.new([]), nil)
+      json_deserializer = nil
+      if Puppet[:rich_data] || result.environment_instance && result.environment_instance.rich_data?
+        json_deserializer = Puppet::Pops::Serialization::Deserializer.new(Puppet::Pops::Serialization::JSON::Reader.new([]), nil)
+      end
       result.add_resource(*resources.collect do |res|
         Puppet::Resource.from_data_hash(res, json_deserializer)
       end)
@@ -474,7 +477,15 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       h
     end
 
-    json_serializer = Puppet::Pops::Serialization::Serializer.new(Puppet::Pops::Serialization::JSON::Writer.new(''))
+    resources = if @resources.empty?
+        []
+      elsif environment_instance.rich_data?
+        json_serializer = Puppet::Pops::Serialization::Serializer.new(Puppet::Pops::Serialization::JSON::Writer.new(''))
+        @resources.collect { |v| @resource_table[v].to_data_hash(json_serializer) }
+      else
+        @resources.collect { |v| @resource_table[v].to_data_hash }
+      end
+
     {
       'tags'      => tags,
       'name'      => name,
@@ -483,7 +494,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       'catalog_uuid' => catalog_uuid,
       'catalog_format' => catalog_format,
       'environment'  => environment.to_s,
-      'resources' => @resources.collect { |v| @resource_table[v].to_data_hash(json_serializer) },
+      'resources' => resources,
       'edges'     => edges.   collect { |e| e.to_data_hash },
       'classes'   => classes,
     }.merge(metadata_hash.empty? ? {} : {'metadata' => metadata_hash})

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1430,7 +1430,7 @@ Generated on #{Time.now}.
     end
 
     def conf
-      @conf ||= if environments = Puppet.lookup(:environments)
+      @conf ||= if environments = Puppet.lookup(:environments) { nil }
                   environments.get_conf(@environment_name)
                 end
     end

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -3,7 +3,7 @@
 class Puppet::Settings::EnvironmentConf
 
   ENVIRONMENT_CONF_ONLY_SETTINGS = [:modulepath, :manifest, :config_version].freeze
-  VALID_SETTINGS = (ENVIRONMENT_CONF_ONLY_SETTINGS + [:environment_timeout, :environment_data_provider, :static_catalogs]).freeze
+  VALID_SETTINGS = (ENVIRONMENT_CONF_ONLY_SETTINGS + [:environment_timeout, :environment_data_provider, :static_catalogs, :rich_data]).freeze
 
   # Given a path to a directory environment, attempts to load and parse an
   # environment.conf in ini format, and return an EnvironmentConf instance.
@@ -39,8 +39,8 @@ class Puppet::Settings::EnvironmentConf
   # Configuration values are exactly those returned by the environment object,
   # without interpolation.  This is a special case for the default configured
   # environment returned by the Puppet::Environments::StaticPrivate loader.
-  def self.static_for(environment, environment_timeout = 0, static_catalogs = false)
-    Static.new(environment, environment_timeout, static_catalogs)
+  def self.static_for(environment, environment_timeout = 0, static_catalogs = false, rich_data = false)
+    Static.new(environment, environment_timeout, static_catalogs, 'none', rich_data)
   end
 
   attr_reader :section, :path_to_env, :global_modulepath
@@ -108,6 +108,12 @@ class Puppet::Settings::EnvironmentConf
     end
   end
 
+  def rich_data
+    get_setting(:rich_data, Puppet.settings.value(:rich_data)) do |value|
+      value
+    end
+  end
+
   def static_catalogs
     get_setting(:static_catalogs, Puppet.settings.value(:static_catalogs)) do |value|
       value
@@ -167,13 +173,15 @@ class Puppet::Settings::EnvironmentConf
   class Static
     attr_reader :environment_timeout
     attr_reader :environment_data_provider
+    attr_reader :rich_data
     attr_reader :static_catalogs
 
-    def initialize(environment, environment_timeout, static_catalogs, environment_data_provider = 'none')
+    def initialize(environment, environment_timeout, static_catalogs, environment_data_provider = 'none', rich_data = false)
       @environment = environment
       @environment_timeout = environment_timeout
       @static_catalogs = static_catalogs
       @environment_data_provider = environment_data_provider
+      @rich_data = rich_data
     end
 
     def manifest

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -5,21 +5,107 @@ require 'puppet/pops'
 require 'puppet/pops/types/type_factory'
 
 describe 'when converting to 3.x' do
+  let(:converter) { Puppet::Pops::Evaluator::Runtime3Converter.instance }
+
   it "converts a resource type starting with Class without confusing it with exact match on 'class'" do
     t = Puppet::Pops::Types::TypeFactory.resource('classroom', 'kermit')
-    converted = Puppet::Pops::Evaluator::Runtime3Converter.instance.catalog_type_to_split_type_title(t)
+    converted = converter.catalog_type_to_split_type_title(t)
     expect(converted).to eql(['classroom', 'kermit'])
   end
 
   it "converts a resource type of exactly 'Class'" do
     t = Puppet::Pops::Types::TypeFactory.resource('class', 'kermit')
-    converted = Puppet::Pops::Evaluator::Runtime3Converter.instance.catalog_type_to_split_type_title(t)
+    converted = converter.catalog_type_to_split_type_title(t)
     expect(converted).to eql(['class', 'kermit'])
   end
 
   it "errors on attempts to convert an 'Iterator'" do
     expect {
-      Puppet::Pops::Evaluator::Runtime3Converter.convert(Puppet::Pops::Types::Iterable.on((1..3)), {}, nil)
+      converter.convert(Puppet::Pops::Types::Iterable.on((1..3)), {}, nil)
     }.to raise_error(Puppet::Error, /Use of an Iterator is not supported here/)
+  end
+
+  it 'does not convert a SemVer instance to string' do
+    v = Semantic::Version.parse('1.0.0')
+    expect(converter.convert(v, {}, nil)).to equal(v)
+  end
+
+  it 'converts the symbol :undef to the undef value' do
+    v = Semantic::Version.parse('1.0.0')
+    expect(converter.convert(:undef, {}, 'undef value')).to eql('undef value')
+  end
+
+  it 'converts the nil to the undef value' do
+    v = Semantic::Version.parse('1.0.0')
+    expect(converter.convert(nil, {}, 'undef value')).to eql('undef value')
+  end
+
+  it 'does not convert a symbol nested in an array' do
+    v = Semantic::Version.parse('1.0.0')
+    expect(converter.convert({'foo' => :undef}, {}, 'undef value')).to eql({'foo' => :undef})
+  end
+
+  it 'converts nil to :undef when nested in an array' do
+    v = Semantic::Version.parse('1.0.0')
+    expect(converter.convert({'foo' => nil}, {}, 'undef value')).to eql({'foo' => :undef})
+  end
+
+  it 'does not convert a Regex instance to string' do
+    v = /^[A-Z]$/
+    expect(converter.convert(v, {}, nil)).to equal(v)
+  end
+
+  it 'does not convert a Version instance to string' do
+    v = Semantic::Version.parse('1.0.0')
+    expect(converter.convert(v, {}, nil)).to equal(v)
+  end
+
+  it 'does not convert a VersionRange instance to string' do
+    v = Semantic::VersionRange.parse('>=1.0.0')
+    expect(converter.convert(v, {}, nil)).to equal(v)
+  end
+
+  it 'does not convert a Timespan instance to string' do
+    v = Puppet::Pops::Time::Timespan.new(1234)
+    expect(converter.convert(v, {}, nil)).to equal(v)
+  end
+
+  it 'does not convert a Timestamp instance to string' do
+    v = Puppet::Pops::Time::Timestamp.now
+    expect(converter.convert(v, {}, nil)).to equal(v)
+  end
+
+  context 'the Runtime3FunctionArgumentConverter' do
+    let(:converter) { Puppet::Pops::Evaluator::Runtime3FunctionArgumentConverter.instance }
+
+    it 'converts a Regex instance to string' do
+      c = converter.convert(/^[A-Z]$/, {}, nil)
+      expect(c).to be_a(String)
+      expect(c).to eql('/^[A-Z]$/')
+    end
+
+    it 'converts a Version instance to string' do
+      c = converter.convert(Semantic::Version.parse('1.0.0'), {}, nil)
+      expect(c).to be_a(String)
+      expect(c).to eql('1.0.0')
+    end
+
+    it 'converts a VersionRange instance to string' do
+      c = converter.convert(Semantic::VersionRange.parse('>=1.0.0'), {}, nil)
+      expect(c).to be_a(String)
+      expect(c).to eql('>=1.0.0')
+    end
+
+    it 'converts a Timespan instance to string' do
+      c = converter.convert(Puppet::Pops::Time::Timespan.new(1234), {}, nil)
+      expect(c).to be_a(String)
+      expect(c).to eql('0-00:00:00.1234')
+    end
+
+    it 'converts a Timestamp instance to string' do
+      c = converter.convert(Puppet::Pops::Time::Timestamp.parse('2016-09-15T12:24:47.193 UTC'), {}, nil)
+      expect(c).to be_a(String)
+      expect(c).to eql('2016-09-15T12:24:47.193 UTC')
+    end
   end
 end

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -75,6 +75,16 @@ describe 'when converting to 3.x' do
     expect(converter.convert(v, {}, nil)).to equal(v)
   end
 
+  it 'does not convert a Sensitive instance to string' do
+    v = Puppet::Pops::Types::PSensitiveType::Sensitive.new("don't reveal this")
+    expect(converter.convert(v, {}, nil)).to equal(v)
+  end
+
+  it 'does not convert a Binary instance to string' do
+    v = Puppet::Pops::Types::PBinaryType::Binary.from_base64('w5ZzdGVuIG1lZCByw7ZzdGVuCg==')
+    expect(converter.convert(v, {}, nil)).to equal(v)
+  end
+
   context 'the Runtime3FunctionArgumentConverter' do
     let(:converter) { Puppet::Pops::Evaluator::Runtime3FunctionArgumentConverter.instance }
 
@@ -106,6 +116,18 @@ describe 'when converting to 3.x' do
       c = converter.convert(Puppet::Pops::Time::Timestamp.parse('2016-09-15T12:24:47.193 UTC'), {}, nil)
       expect(c).to be_a(String)
       expect(c).to eql('2016-09-15T12:24:47.193 UTC')
+    end
+
+    it 'converts a Binary instance to string' do
+      b64 = 'w5ZzdGVuIG1lZCByw7ZzdGVuCg=='
+      c = converter.convert(Puppet::Pops::Types::PBinaryType::Binary.from_base64(b64), {}, nil)
+      expect(c).to be_a(String)
+      expect(c).to eql(b64)
+    end
+
+    it 'does not convert a Sensitive instance to string' do
+      v = Puppet::Pops::Types::PSensitiveType::Sensitive.new("don't reveal this")
+      expect(converter.convert(v, {}, nil)).to equal(v)
     end
   end
 end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -843,6 +843,57 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
     MANIFEST
     expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
   end
+
+  context 'when dealing with parameters that have non-Data values' do
+    let(:catalog_w_regexp)  { compile_to_catalog("notify {'foo': message => /[a-z]+/ }") }
+
+    it 'should generate ext_parameters for parameter values that are not Data' do
+      expect(catalog_w_regexp.to_json).to include('"ext_parameters":{"message":[48,"[a-z]+"]}')
+    end
+
+    it 'should validate ext_parameters against the schema' do
+      expect(catalog_w_regexp.to_json).to validate_against('api/schemas/catalog.json')
+    end
+
+    it 'should read and convert ext_parameters containing Regexp from json' do
+      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog_w_regexp.to_json))
+      message = catalog2.resource('notify', 'foo')['message']
+      expect(message).to be_a(Regexp)
+      expect(message).to eql(/[a-z]+/)
+    end
+
+    it 'should read and convert ext_parameters containing Version from json' do
+      catalog = compile_to_catalog("notify {'foo': message => SemVer('1.0.0') }")
+      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+      message = catalog2.resource('notify', 'foo')['message']
+      expect(message).to be_a(Semantic::Version)
+      expect(message).to eql(Semantic::Version.parse('1.0.0'))
+    end
+
+    it 'should read and convert ext_parameters containing VersionRange from json' do
+      catalog = compile_to_catalog("notify {'foo': message => SemVerRange('>=1.0.0') }")
+      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+      message = catalog2.resource('notify', 'foo')['message']
+      expect(message).to be_a(Semantic::VersionRange)
+      expect(message).to eql(Semantic::VersionRange.parse('>=1.0.0'))
+    end
+
+    it 'should read and convert ext_parameters containing Timespan from json' do
+      catalog = compile_to_catalog("notify {'foo': message => Timespan(1234) }")
+      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+      message = catalog2.resource('notify', 'foo')['message']
+      expect(message).to be_a(Puppet::Pops::Time::Timespan)
+      expect(message).to eql(Puppet::Pops::Time::Timespan.parse('1234', '%S'))
+    end
+
+    it 'should read and convert ext_parameters containing Timestamp from json' do
+      catalog = compile_to_catalog("notify {'foo': message => Timestamp('2016-09-15T08:32:16.123 UTC') }")
+      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+      message = catalog2.resource('notify', 'foo')['message']
+      expect(message).to be_a(Puppet::Pops::Time::Timestamp)
+      expect(message).to eql(Puppet::Pops::Time::Timestamp.parse('2016-09-15T08:32:16.123 UTC'))
+    end
+  end
 end
 
 describe Puppet::Resource::Catalog, "when converting to pson" do

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -845,54 +845,112 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
   end
 
   context 'when dealing with parameters that have non-Data values' do
-    let(:catalog_w_regexp)  { compile_to_catalog("notify {'foo': message => /[a-z]+/ }") }
+    context 'and rich_data is enabled' do
+      before(:each) do
+        Puppet[:rich_data] = true
+      end
 
-    it 'should generate ext_parameters for parameter values that are not Data' do
-      expect(catalog_w_regexp.to_json).to include('"ext_parameters":{"message":[48,"[a-z]+"]}')
+      let(:catalog_w_regexp)  { compile_to_catalog("notify {'foo': message => /[a-z]+/ }") }
+
+      it 'should generate ext_parameters for parameter values that are not Data' do
+        expect(catalog_w_regexp.to_json).to include('"ext_parameters":{"message":[48,"[a-z]+"]}')
+      end
+
+      it 'should validate ext_parameters against the schema' do
+        expect(catalog_w_regexp.to_json).to validate_against('api/schemas/catalog.json')
+      end
+
+      it 'should read and convert ext_parameters containing Regexp from json' do
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog_w_regexp.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Regexp)
+        expect(message).to eql(/[a-z]+/)
+      end
+
+      it 'should read and convert ext_parameters containing Version from json' do
+        catalog = compile_to_catalog("notify {'foo': message => SemVer('1.0.0') }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Semantic::Version)
+        expect(message).to eql(Semantic::Version.parse('1.0.0'))
+      end
+
+      it 'should read and convert ext_parameters containing VersionRange from json' do
+        catalog = compile_to_catalog("notify {'foo': message => SemVerRange('>=1.0.0') }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Semantic::VersionRange)
+        expect(message).to eql(Semantic::VersionRange.parse('>=1.0.0'))
+      end
+
+      it 'should read and convert ext_parameters containing Timespan from json' do
+        catalog = compile_to_catalog("notify {'foo': message => Timespan(1234) }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Puppet::Pops::Time::Timespan)
+        expect(message).to eql(Puppet::Pops::Time::Timespan.parse('1234', '%S'))
+      end
+
+      it 'should read and convert ext_parameters containing Timestamp from json' do
+        catalog = compile_to_catalog("notify {'foo': message => Timestamp('2016-09-15T08:32:16.123 UTC') }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Puppet::Pops::Time::Timestamp)
+        expect(message).to eql(Puppet::Pops::Time::Timestamp.parse('2016-09-15T08:32:16.123 UTC'))
+      end
     end
 
-    it 'should validate ext_parameters against the schema' do
-      expect(catalog_w_regexp.to_json).to validate_against('api/schemas/catalog.json')
+    context 'and rich_data is disabled' do
+      before(:each) do
+        Puppet[:rich_data] = false
+      end
+
+      let(:catalog_w_regexp)  { compile_to_catalog("notify {'foo': message => /[a-z]+/ }") }
+
+      it 'should not generate ext_parameters for parameter values that are not Data' do
+        expect(catalog_w_regexp.to_json).not_to include('"ext_parameters":{"message":[48,"[a-z]+"]}')
+      end
+
+      it 'should convert parameter containing Regexp into strings' do
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog_w_regexp.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(String)
+        expect(message).to eql('/[a-z]+/')
+      end
+
+      it 'should convert parameter containing Version into string' do
+        catalog = compile_to_catalog("notify {'foo': message => SemVer('1.0.0') }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(String)
+        expect(message).to eql('1.0.0')
+      end
+
+      it 'should convert parameter containing VersionRange into string' do
+        catalog = compile_to_catalog("notify {'foo': message => SemVerRange('>=1.0.0') }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(String)
+        expect(message).to eql('>=1.0.0')
+      end
+
+      it 'should convert parameter containing Timespan into string' do
+        catalog = compile_to_catalog("notify {'foo': message => Timespan(1234) }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(String)
+        expect(message).to eql('0-00:20:34.0')
+      end
+
+      it 'should convert parameter containing Timestamp into string' do
+        catalog = compile_to_catalog("notify {'foo': message => Timestamp('2016-09-15T08:32:16.123 UTC') }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(String)
+        expect(message).to eql('2016-09-15T08:32:16.123 UTC')
+      end
     end
 
-    it 'should read and convert ext_parameters containing Regexp from json' do
-      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog_w_regexp.to_json))
-      message = catalog2.resource('notify', 'foo')['message']
-      expect(message).to be_a(Regexp)
-      expect(message).to eql(/[a-z]+/)
-    end
-
-    it 'should read and convert ext_parameters containing Version from json' do
-      catalog = compile_to_catalog("notify {'foo': message => SemVer('1.0.0') }")
-      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
-      message = catalog2.resource('notify', 'foo')['message']
-      expect(message).to be_a(Semantic::Version)
-      expect(message).to eql(Semantic::Version.parse('1.0.0'))
-    end
-
-    it 'should read and convert ext_parameters containing VersionRange from json' do
-      catalog = compile_to_catalog("notify {'foo': message => SemVerRange('>=1.0.0') }")
-      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
-      message = catalog2.resource('notify', 'foo')['message']
-      expect(message).to be_a(Semantic::VersionRange)
-      expect(message).to eql(Semantic::VersionRange.parse('>=1.0.0'))
-    end
-
-    it 'should read and convert ext_parameters containing Timespan from json' do
-      catalog = compile_to_catalog("notify {'foo': message => Timespan(1234) }")
-      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
-      message = catalog2.resource('notify', 'foo')['message']
-      expect(message).to be_a(Puppet::Pops::Time::Timespan)
-      expect(message).to eql(Puppet::Pops::Time::Timespan.parse('1234', '%S'))
-    end
-
-    it 'should read and convert ext_parameters containing Timestamp from json' do
-      catalog = compile_to_catalog("notify {'foo': message => Timestamp('2016-09-15T08:32:16.123 UTC') }")
-      catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
-      message = catalog2.resource('notify', 'foo')['message']
-      expect(message).to be_a(Puppet::Pops::Time::Timestamp)
-      expect(message).to eql(Puppet::Pops::Time::Timestamp.parse('2016-09-15T08:32:16.123 UTC'))
-    end
   end
 end
 


### PR DESCRIPTION
This PR adds a new `ext_parameters` entry to the JSON object that represents a `Resource`. The `ext_parameters`, like `parameters` is an object keyed by parameter names. The values are however not plain JSON types but instead an array representing an extended type created by the Puppet Serialization API.

Special hooks into the serializer enables several values to be generated, one at a time, while using the same tabulation context for all resources in the catalog.
