### PR TITLE
DO NOT MERGE (PUP-6708) Cache last run report even if report_server unreachable

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -401,8 +401,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     Puppet.settings.use :main, :agent, :ssl
 
     Puppet::Transaction::Report.indirection.terminus_class = :rest
-    # we want the last report to be persisted locally
-    Puppet::Transaction::Report.indirection.cache_class = :yaml
 
     if Puppet[:noop]
       Puppet::Resource::Catalog.indirection.cache_class = nil

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -388,6 +388,7 @@ class Puppet::Configurer
   def send_report(report)
     puts report.summary if Puppet[:summarize]
     save_last_run_summary(report)
+    save_last_run_report(report)
     Puppet::Transaction::Report.indirection.save(report, nil, :environment => Puppet::Node::Environment.remote(@environment)) if Puppet[:report]
   rescue => detail
     Puppet.log_exception(detail, "Could not send report: #{detail}")
@@ -397,6 +398,15 @@ class Puppet::Configurer
     mode = Puppet.settings.setting(:lastrunfile).mode
     Puppet::Util.replace_file(Puppet[:lastrunfile], mode) do |fh|
       fh.print YAML.dump(report.raw_summary)
+    end
+  rescue => detail
+    Puppet.log_exception(detail, "Could not save last run local report: #{detail}")
+  end
+
+  def save_last_run_report(report)
+    mode = Puppet.settings.setting(:lastrunreport).mode
+    Puppet::Util.replace_file(Puppet[:lastrunreport], mode) do |fh|
+      fh.print YAML.dump(report)
     end
   rescue => detail
     Puppet.log_exception(detail, "Could not save last run local report: #{detail}")

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -310,12 +310,6 @@ describe Puppet::Application::Agent do
       @puppetd.setup
     end
 
-    it "should tell the report handler to cache locally as yaml" do
-      Puppet::Transaction::Report.indirection.expects(:cache_class=).with(:yaml)
-
-      @puppetd.setup
-    end
-
     it "should default catalog_terminus setting to 'rest'" do
       @puppetd.initialize_app_defaults
       expect(Puppet[:catalog_terminus]).to eq(:rest)


### PR DESCRIPTION
Prior to this commit, when the agent could not reach its report server after an
agent run, it would not save a copy of its report locally either. This is
problematic because if an agent's report server is unreachable, there is
effectively no reporting on the agent's activities during this period of
unreachability.

This behavior existed because last run report was saved via the indirector
cache - specifically, Puppet::Indirector::Indirection#save issued the terminus
save request first, then the cache save request. If a failure to send the
report to the report_server occured, the cache save was never reached.

However, unlike the last run report, the last run summary is explicitly saved
via a configurer method, save_last_run_summary, which attempts to save the last
run summary file prior to calling Puppet::Indirector::Indirection#save.

This commit moves the saving of the last run report file to a
save_last_run_report method to configurer.rb which saves the report before
sending it, following the pattern set for save_last_run_summary.

In addition to always attempting to save the report, this has an additional
benefit of explicitly managing the mode of the last_run_summary.yaml file, as
opposed to the report handler caching yaml which did not manage file mode at
all.