### PR TITLE
(maint) Remove unused: requre 'xmlrpc/client'

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -2,7 +2,6 @@
 # <http://pip.pypa.io/>
 
 require 'puppet/provider/package'
-require 'xmlrpc/client'
 require 'puppet/util/http_proxy'
 
 Puppet::Type.type(:package).provide :pip,


### PR DESCRIPTION
In 152299cc, as part of PUP-6120, use of the xmlrpc library
was removed from the code, but the require itself was not
removed. This commit simply removes the vestigial require.

Note that this change is required to support ruby 2.4,
which no longer includes the xmlrpc library.