### PR TITLE
(PUP-6758) Fix pkgng provider condition

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -56,7 +56,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
 
       return packages
     rescue Puppet::ExecutionFailure
-      nil
+      return []
     end
   end
 

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -65,6 +65,11 @@ describe provider_class do
       expect(nmap.properties[:version]).to eq(nmap.properties[:latest])
     end
 
+    it "should return an empty array when pkg calls raise an exception" do
+      provider_class.stubs(:get_query).raises(Puppet::ExecutionFailure, 'An error occurred.')
+      expect(provider_class.instances).to eq([])
+    end
+
     describe "version" do
       it "should retrieve the correct version of the current package" do
         zsh = provider_class.instances.find {|i| i.properties[:origin] == 'shells/zsh' }
@@ -108,6 +113,13 @@ describe provider_class do
         arg.should include('FreeBSD')
       end
       resource.provider.install
+    end
+  end
+
+  context "#prefetch" do
+    it "should fail gracefully when " do
+      provider_class.stubs(:instances).returns([])
+      expect{ provider_class.prefetch({}) }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
In cases where pkg execution fails within instances, the result returned
to prefetch is nil causing prefetch to fail poorly calling .find on a
nil object.  Here we modify the return value of instances in the event
of an exception to be an array instead of nil.  This leaves a cleaner
prefetch behavior intact, and allows the run to continue, even in the
absence of a successful package call.