### PR TITLE
(PUP-6705) Add Pcore serialization for Sensitive data type

### DIFF
--- a/lib/puppet/pops/serialization/abstract_reader.rb
+++ b/lib/puppet/pops/serialization/abstract_reader.rb
@@ -152,6 +152,10 @@ class AbstractReader
     register_type(Extension::VERSION_RANGE) do |data|
       read_payload(data) { |ep| Semantic::VersionRange.parse(ep.read) }
     end
+
+    register_type(Extension::SENSITIVE) do |data|
+      read_payload(data) { |ep| Types::PSensitiveType::Sensitive.new(ep.read) }
+    end
   end
 end
 end

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -53,7 +53,7 @@ class AbstractWriter
     when Integer
       # not tabulated, but integers larger than 64-bit cannot be allowed.
       raise SerializationError, 'Integer out of bounds' if value > MAX_INTEGER || value < MIN_INTEGER
-    when Numeric, Symbol, Extension::NotTabulated, true, false, nil
+    when Numeric, Symbol, Types::PSensitiveType::Sensitive, Extension::NotTabulated, true, false, nil
       # not tabulated
     else
       if @tabulate
@@ -176,6 +176,10 @@ class AbstractWriter
 
     register_type(Extension::VERSION_RANGE, Semantic::VersionRange) do |o|
       build_payload { |ep| ep.write(o.to_s) }
+    end
+
+    register_type(Extension::SENSITIVE, Types::PSensitiveType::Sensitive) do |o|
+      build_payload { |ep| ep.write(o.unwrap) }
     end
   end
 end

--- a/lib/puppet/pops/serialization/extension.rb
+++ b/lib/puppet/pops/serialization/extension.rb
@@ -26,6 +26,7 @@ module Extension
   TIMESPAN = 0x34
   VERSION = 0x35
   VERSION_RANGE = 0x36
+  SENSITIVE = 0x37
 
   # Marker module indicating whether or not an instance is tabulated or not
   module NotTabulated; end

--- a/lib/puppet/pops/serialization/serializer.rb
+++ b/lib/puppet/pops/serialization/serializer.rb
@@ -67,7 +67,7 @@ module Serialization
     def write_tabulated_first_time(value)
       @written[value.object_id] = @written.size
       case value
-      when Symbol, Regexp, Semantic::Version, Semantic::VersionRange, Time::Timestamp, Time::Timespan
+      when Symbol, Regexp, Semantic::Version, Semantic::VersionRange, Time::Timestamp, Time::Timespan, Types::PSensitiveType::Sensitive
         @writer.write(value)
       when Array
         start_array(value.size)

--- a/lib/puppet/pops/types/p_sensitive_type.rb
+++ b/lib/puppet/pops/types/p_sensitive_type.rb
@@ -6,7 +6,7 @@ module Types
 #
 #
 # @api public
-class PSensitiveType < Puppet::Pops::Types::PTypeWithContainedType
+class PSensitiveType < PTypeWithContainedType
 
   class Sensitive
     def initialize(value)
@@ -24,6 +24,10 @@ class PSensitiveType < Puppet::Pops::Types::PTypeWithContainedType
     def inspect
       "#<#{to_s}>"
     end
+  end
+
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType')
   end
 
   def initialize(type = nil)

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -36,6 +36,7 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PSemVerRangeType,
       Puppet::Pops::Types::PTimespanType,
       Puppet::Pops::Types::PTimestampType,
+      Puppet::Pops::Types::PSensitiveType,
     ]
   end
 

--- a/spec/unit/pops/serialization/packer_spec.rb
+++ b/spec/unit/pops/serialization/packer_spec.rb
@@ -22,7 +22,7 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
     count.nil? ? @deserializer.read : Array.new(count) { @deserializer.read }
   end
 
-  context 'can write and read a Scalar' do
+  context 'can write and read a' do
     it 'String' do
       val = 'the value'
       write(val)
@@ -87,6 +87,15 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
       expect(val2).to eql(val)
     end
 
+    it 'Sensitive' do
+      sval = 'the sensitive value'
+      val = Types::PSensitiveType::Sensitive.new(sval)
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Types::PSensitiveType::Sensitive)
+      expect(val2.unwrap).to eql(sval)
+    end
+
     it 'Timespan' do
       val = Time::Timespan.from_fields(false, 3, 12, 40, 31, 123)
       write(val)
@@ -117,6 +126,16 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
       val2 = read
       expect(val2).to be_a(Semantic::VersionRange)
       expect(val2).to eql(val)
+    end
+
+    it 'Sensitive with rich data' do
+      sval = Time::Timestamp.now
+      val = Types::PSensitiveType::Sensitive.new(sval)
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Types::PSensitiveType::Sensitive)
+      expect(val2.unwrap).to be_a(Time::Timestamp)
+      expect(val2.unwrap).to eql(sval)
     end
   end
 

--- a/spec/unit/pops/serialization/serialization_spec.rb
+++ b/spec/unit/pops/serialization/serialization_spec.rb
@@ -37,7 +37,7 @@ module Serialization
     parser.parse_string(string, '/home/tester/experiments/manifests/init.pp').current
   end
 
-  context 'can write and read a Scalar' do
+  context 'can write and read a' do
     it 'String' do
       val = 'the value'
       write(val)
@@ -94,6 +94,15 @@ module Serialization
       expect(val2).to eql(val)
     end
 
+    it 'Sensitive' do
+      sval = 'the sensitive value'
+      val = Types::PSensitiveType::Sensitive.new(sval)
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Types::PSensitiveType::Sensitive)
+      expect(val2.unwrap).to eql(sval)
+    end
+
     it 'Timespan' do
       val = Time::Timespan.from_fields(false, 3, 12, 40, 31, 123)
       write(val)
@@ -126,6 +135,16 @@ module Serialization
       val2 = read
       expect(val2).to be_a(Semantic::VersionRange)
       expect(val2).to eql(val)
+    end
+
+    it 'Sensitive with rich data' do
+      sval = Time::Timestamp.now
+      val = Types::PSensitiveType::Sensitive.new(sval)
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Types::PSensitiveType::Sensitive)
+      expect(val2.unwrap).to be_a(Time::Timestamp)
+      expect(val2.unwrap).to eql(sval)
     end
   end
 


### PR DESCRIPTION
This commit adds everything needed to let instances of the Sensitive
data type participate in Pcore serialization.