### PR TITLE
(PUP-6723) collector_transformer: negation query for array type properties is broken

### DIFF
--- a/lib/puppet/pops/evaluator/collector_transformer.rb
+++ b/lib/puppet/pops/evaluator/collector_transformer.rb
@@ -123,7 +123,11 @@ protected
       end
     when :'!='
       proc do |resource|
-        !@@compare_operator.equals(resource[left_code], right_code)
+        if (tmp = resource[left_code]).is_a?(Array)
+          !@@compare_operator.include?(tmp, right_code, scope)
+        else
+          !@@compare_operator.equals(tmp, right_code)
+        end
       end
     end
   end

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -122,16 +122,6 @@ describe 'collectors' do
       MANIFEST
     end
 
-    it "allows criteria to be combined with 'or'" do
-      expect_the_message_to_be(["the message", "other message"], <<-MANIFEST)
-        @notify { "testing": message => "the message" }
-        @notify { "other": message => "other message" }
-        @notify { "yet another": message => "different message" }
-
-        Notify <| title == "testing" or message == "other message" |>
-      MANIFEST
-    end
-
     it "allows criteria to be grouped with parens" do
       expect_the_message_to_be(["the message", "different message"], <<-MANIFEST)
         @notify { "testing":     message => "different message", withpath => true }
@@ -159,8 +149,8 @@ describe 'collectors' do
       MANIFEST
     end
 
-    it "does not exclude resources with unequal arrays" do
-      expect_the_message_to_be(["message", ["not this message", "or this one"]], <<-MANIFEST)
+    it "excludes resources with unequal arrays" do
+      expect_the_message_to_be(["message"], <<-MANIFEST)
         @notify { "testing": message => "message" }
         @notify { "the wrong one": message => ["not this message", "or this one"] }
 
@@ -168,12 +158,53 @@ describe 'collectors' do
       MANIFEST
     end
 
-    it "does not exclude tags with inequalities" do
-      expect_the_message_to_be(["wanted message", "the way it works"], <<-MANIFEST)
+    it "excludes tags with inequalities" do
+      expect_the_message_to_be(["wanted message"], <<-MANIFEST)
         @notify { "testing": tag => ["wanted"], message => "wanted message" }
         @notify { "other": tag => ["why"], message => "the way it works" }
 
         Notify <| tag != "why" |>
+      MANIFEST
+    end
+
+    it "allows criteria to be excluded with 'and'" do
+      expect_the_message_to_be(["the message"], <<-MANIFEST)
+        @notify { "testing": message => "not the message" }
+        @notify { "other": message => "the message" }
+
+        Notify <| title != "testing" and message != "not the message" |>
+      MANIFEST
+    end
+
+    it "allows criteria to be excluded with 'or'" do
+      expect_the_message_to_be(["different message"], <<-MANIFEST)
+        @notify { "testing": message => "the message" }
+        @notify { "other": message => "other message" }
+        @notify { "yet another": message => "different message" }
+
+        Notify <| title != "testing" or message != "other message" |>
+      MANIFEST
+    end
+
+    it "allows arrays to be excluded with 'and'" do
+      expect_the_message_to_be(["3rd message"], <<-MANIFEST)
+        @notify { "first": message => "1st message", tag => ['one','another'] }
+        @notify { "second": message => "2nd message", tag => ['two','another'] }
+        @notify { "third": message => "3rd message", tag => ['three','another'] }
+        @notify { "fourth": message => "4th message", tag => ['one','two','another'] }
+
+        Notify <| tag != "one" and tag != "two" |>
+      MANIFEST
+    end
+
+    it "allows arrays to be excluded with 'or'" do
+      expect_the_message_to_be(["3rd message"], <<-MANIFEST)
+        @notify { "first": message => "1st message", tag => ['one','another'] }
+        @notify { "second": message => "2nd message", tag => ['two','another'] }
+        @notify { "third": message => "3rd message", tag => ['three','another'] }
+        @notify { "fourth": message => "4th message", tag => ['one','two','another'] }
+
+        Notify <| tag != "one" or tag != "two" |>
       MANIFEST
     end
 


### PR DESCRIPTION
(PUP-6723) collector_transformer: negation query for array type properties is broken

Only in the == case is the query property getting tested to see if it is an array which then uses the compare_operator.include? method. The != case only uses compare_operator.equals which makes it so you cant do negated queries on array type properties like tags :(

With this test code:
> $ cat t.pp
@notify {'This is a test 1':
	tag => 'one'
}
@notify {'This is a test 2':
	tag => 'two'
}
@notify {'This is a test 3':
	tag => ['one', 'two']
}
@notify {'This is a test 4':
	tag => 'three'
}

Adding these at the end would all work as expected
> Notify <| tag = 'one' |>
Notify <| tag = 'two' |>
Notify <| tag = 'one' or tag = 'two' |>
Notify <| tag = 'one' and tag = 'two' |>

The negated versions would not
> Notify <| tag != 'one' |>
Notify <| tag != 'two' |>
Notify <| !tag = 'one' or !tag = 'two' |>
Notify <| !tag = 'one' and !tag = 'two' |>

The first should only return 2 and 4 but also returns 3:
> $ puppet apply t.pp 
Notice: Compiled catalog for defiant.cequintecid.com in environment production in 0.08 seconds
Notice: This is a test 2
Notice: /Stage[main]/Main/Notify[This is a test 2]/message: defined 'message' as 'This is a test 2'
Notice: This is a test 3
Notice: /Stage[main]/Main/Notify[This is a test 3]/message: defined 'message' as 'This is a test 3'
Notice: This is a test 4
Notice: /Stage[main]/Main/Notify[This is a test 4]/message: defined 'message' as 'This is a test 4'
Notice: Applied catalog in 0.03 seconds

The second should only return 1 and 4 but also returns 3:
> $ puppet apply t.pp 
Notice: Compiled catalog for defiant.cequintecid.com in environment production in 0.07 seconds
Notice: This is a test 1
Notice: /Stage[main]/Main/Notify[This is a test 1]/message: defined 'message' as 'This is a test 1'
Notice: This is a test 3
Notice: /Stage[main]/Main/Notify[This is a test 3]/message: defined 'message' as 'This is a test 3'
Notice: This is a test 4
Notice: /Stage[main]/Main/Notify[This is a test 4]/message: defined 'message' as 'This is a test 4'
Notice: Applied catalog in 0.03 seconds

The "or" case should only return 1,2, and 4. It should not return 3 but does:
> $ puppet apply t.pp 
Notice: Compiled catalog for defiant.cequintecid.com in environment production in 0.08 seconds
Notice: This is a test 1
Notice: /Stage[main]/Main/Notify[This is a test 1]/message: defined 'message' as 'This is a test 1'
Notice: This is a test 2
Notice: /Stage[main]/Main/Notify[This is a test 2]/message: defined 'message' as 'This is a test 2'
Notice: This is a test 3
Notice: /Stage[main]/Main/Notify[This is a test 3]/message: defined 'message' as 'This is a test 3'
Notice: This is a test 4
Notice: /Stage[main]/Main/Notify[This is a test 4]/message: defined 'message' as 'This is a test 4'
Notice: Applied catalog in 0.03 seconds

The "and" case should only return 4. It should not return 3 but it does:
> $ puppet apply t.pp 
Notice: Compiled catalog for defiant.cequintecid.com in environment production in 0.07 seconds
Notice: This is a test 3
Notice: /Stage[main]/Main/Notify[This is a test 3]/message: defined 'message' as 'This is a test 3'
Notice: This is a test 4
Notice: /Stage[main]/Main/Notify[This is a test 4]/message: defined 'message' as 'This is a test 4'
Notice: Applied catalog in 0.03 seconds
