### PR TITLE
(maint) add Moses as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -65,6 +65,11 @@
       "github": "jtappa",
       "email": "jorie@puppet.com",
       "name": "Jorie Tappa"
+    },
+    {
+      "github": "MosesMendoza",
+      "email": "moses@puppet.com",
+      "name": "Moses Mendoza"
     }
   ]
 }


### PR DESCRIPTION
This commit adds Moses as a maintainer to the puppet MAINTAINERS file, in the
format specified by https://github.com/puppetlabs/maintainers.

Signed-off-by: Moses Mendoza <moses@puppet.com>