### PR TITLE
(PUP-6724) Make strftime compatible with function in stdlib

### DIFF
--- a/lib/puppet/functions/strftime.rb
+++ b/lib/puppet/functions/strftime.rb
@@ -1,14 +1,35 @@
 # (Documentation in 3.x stub)
 #
-# @since 4.7.0
+# @since 4.8.0
 #
 Puppet::Functions.create_function(:strftime) do
-  dispatch :format do
-    param 'Variant[Timestamp,Timespan]', :time_object
+  dispatch :format_timespan do
+    param 'Timespan', :time_object
     param 'String', :format
   end
 
-  def format(time_object, format)
+  dispatch :format_timestamp do
+    param 'Timestamp', :time_object
+    param 'String', :format
+    optional_param 'String', :timezone
+  end
+
+  dispatch :legacy_strftime do
+    param 'String', :format
+    optional_param 'String', :timezone
+  end
+
+  def format_timespan(time_object, format)
     time_object.format(format)
+  end
+
+  def format_timestamp(time_object, format, timezone = nil)
+    time_object.format(format, timezone)
+  end
+
+  def legacy_strftime(format, timezone = nil)
+    Puppet.warn_once('deprecation', 'legacy#strftime',
+      'The argument signature (String format, [String timezone]) is deprecated for #strfime. See #strftime documentation and Timespan type for more info')
+    Puppet::Pops::Time::Timestamp.format_time(format, Time.now.utc, timezone)
   end
 end

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -302,11 +302,22 @@ The first argument is parsed using the format optionally passed as a string or a
 will be made to parse the string using the first entry and then with each entry in succession until parsing succeeds. If the second
 argument is omitted, an array of default formats will be used.
 
+A third optional timezone argument can be provided. The first argument will then be parsed as if it represents a local time in that
+timezone. The timezone can be any timezone that is recognized when using the '%z' or '%Z' formats, or the word 'current', in which
+case the current timezone of the evaluating process will be used. The timezone argument is case insensitive.
+
+The default timezone, when no argument is provided, or when using the keyword `default`, is 'UTC'.
+
+It is illegal to provide a timezone argument other than `default` in combination with a format that contains '%z' or '%Z' since that
+would introduce an ambiguity as to which timezone to use. The one extracted from the string, or the one provided as an argument.
+
 An exception is raised when no format was able to parse the given string.
 
 ```puppet
 function Timestamp.new(
-  String $string, Variant[String[2],Array[String[2]], 1] $format = <default format>)
+  String $string,
+  Variant[String[2],Array[String[2]], 1] $format = <default format>,
+  String $timezone = default)
 )
 ```
 
@@ -316,7 +327,8 @@ the arguments may also be passed as a `Hash`:
 function Timestamp.new(
   Struct[{
     string => String[1],
-    Optional[format] => Variant[String[2],Array[String[2]], 1]
+    Optional[format] => Variant[String[2],Array[String[2]], 1],
+    Optional[timezone] => String[1]
   }] $hash
 )
 ```
@@ -439,6 +451,11 @@ or %W). The days in the year before the first week are in week 0.
 
 The default array contains the following patterns:
 
+When a timezone argument (other than `default`) is exclicitly provided:
+```
+['%FT%T.L', '%FT%T', '%F']
+```
+otherwise:
 ```
 ['%FT%T.%L %Z', '%FT%T %Z', '%F %Z', '%FT%T.L', '%FT%T', '%F']
 ```
@@ -450,6 +467,9 @@ $ts = Timestamp(1473150899)                              # 2016-09-06 08:34:59 U
 $ts = Timestamp({string=>'2015', format=>'%Y'})          # 2015-01-01 00:00:00.000 UTC
 $ts = Timestamp('Wed Aug 24 12:13:14 2016', '%c')        # 2016-08-24 12:13:14 UTC
 $ts = Timestamp('Wed Aug 24 12:13:14 2016 PDT', '%c %Z') # 2016-08-24 19:13:14.000 UTC
+$ts = Timestamp('2016-08-24 12:13:14', '%F %T', 'PST')   # 2016-08-24 20:13:14.000 UTC
+$ts = Timestamp('2016-08-24T12:13:14', default, 'PST')   # 2016-08-24 20:13:14.000 UTC
+
 ```
 
 Conversion to String
@@ -856,7 +876,7 @@ type ArrayHash = Struct[{value => Array[ByteInteger]}]
 type BinaryArgsHash = Variant[StringHash, ArrayHash]
 
 function Binary.new(
-  String $base64_str, 
+  String $base64_str,
   Optional[Base64Format] $format
 )
 

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -451,11 +451,14 @@ or %W). The days in the year before the first week are in week 0.
 
 The default array contains the following patterns:
 
-When a timezone argument (other than `default`) is exclicitly provided:
+When a timezone argument (other than `default`) is explicitly provided:
+
 ```
 ['%FT%T.L', '%FT%T', '%F']
 ```
+
 otherwise:
+
 ```
 ['%FT%T.%L %Z', '%FT%T %Z', '%F %Z', '%FT%T.L', '%FT%T', '%F']
 ```

--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -6,6 +6,12 @@ Puppet::Parser::Functions::newfunction(
 Formats timestamp or timespan according to the directives in the given format string. The directives begins with a percent (%) character.
 Any text not listed as a directive will be passed through to the output string.
 
+A third optional timezone argument can be provided. The first argument will then be formatted to represent a local time in that
+timezone. The timezone can be any timezone that is recognized when using the '%z' or '%Z' formats, or the word 'current', in which
+case the current timezone of the evaluating process will be used. The timezone argument is case insensitive.
+
+The default timezone, when no argument is provided, or when using the keyword `default`, is 'UTC'.
+
 The directive consists of a percent (%) character, zero or more flags, optional minimum field width and
 a conversion specifier as follows:
 ```
@@ -142,7 +148,7 @@ notice($timestamp.strftime('%c')) # outputs 'Wed Aug 24 12:13:14 2016'
 notice($timestamp.strftime('%F %T %z', 'PST')) # outputs '2016-08-24 04:13:14 -0800'
 
 # Notice the timestamp using timezone that is current for the evaluating process
-notice($timestamp.strftime('%F %T', 'CURRENT')) # outputs the timestamp using the timezone for the current process
+notice($timestamp.strftime('%F %T', 'current')) # outputs the timestamp using the timezone for the current process
 ~~~
 
 ### Format directives applicable to `Timespan`:

--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -1,7 +1,7 @@
 Puppet::Parser::Functions::newfunction(
   :strftime,
   :type => :rvalue,
-  :arity => 2,
+  :arity => -3,
   :doc => <<DOC
 Formats timestamp or timespan according to the directives in the given format string. The directives begins with a percent (%) character.
 Any text not listed as a directive will be passed through to the output string.
@@ -135,8 +135,14 @@ $timestamp = Timestamp('2016-08-24T12:13:14')
 # Notice the timestamp using a format that notices the ISO 8601 date format
 notice($timestamp.strftime('%F')) # outputs '2016-08-24'
 
-# Notice the timestamp using a format that notices weekday, month, day, time, and year
-notice($$timestamp.strftime('%c')) # outputs 'Wed Aug 24 12:13:14 2016'
+# Notice the timestamp using a format that notices weekday, month, day, time (as UTC), and year
+notice($timestamp.strftime('%c')) # outputs 'Wed Aug 24 12:13:14 2016'
+
+# Notice the timestamp using a specific timezone
+notice($timestamp.strftime('%F %T %z', 'PST')) # outputs '2016-08-24 04:13:14 -0800'
+
+# Notice the timestamp using timezone that is current for the evaluating process
+notice($timestamp.strftime('%F %T', 'CURRENT')) # outputs the timestamp using the timezone for the current process
 ~~~
 
 ### Format directives applicable to `Timespan`:
@@ -166,7 +172,7 @@ notice($duration.strftime('%H:%M:%S')) # outputs '03:20:30'
 notice($duration.strftime('%M:%S')) # outputs '200:30'
 ~~~
 
-- Since 4.7.0
+- Since 4.8.0
 DOC
 ) do |args|
   Error.is4x('strftime')

--- a/lib/puppet/pops/time/timestamp.rb
+++ b/lib/puppet/pops/time/timestamp.rb
@@ -1,7 +1,54 @@
 module Puppet::Pops
 module Time
 class Timestamp < TimeData
-  DEFAULT_FORMATS = ['%FT%T.%L %Z', '%FT%T %Z', '%F %Z', '%FT%T.L', '%FT%T', '%F']
+  DEFAULT_FORMATS_WO_TZ = ['%FT%T.L', '%FT%T', '%F']
+  DEFAULT_FORMATS = ['%FT%T.%L %Z', '%FT%T %Z', '%F %Z'] + DEFAULT_FORMATS_WO_TZ
+
+  CURRENT_TIMEZONE = 'current'.freeze
+  KEY_TIMEZONE = 'timezone'.freeze
+
+  # Converts a timezone that strptime can parse using '%z' into '-HH:MM' or '+HH:MM'
+  # @param [String] tz the timezone to convert
+  # @return [String] the converted timezone
+  #
+  # @api private
+  def self.convert_timezone(tz)
+    if tz =~ /\A[+-]\d\d:\d\d\z/
+      tz
+    else
+      offset = utc_offset(tz) / 60
+      if offset < 0
+        offset = offset.abs
+        sprintf('-%2.2d:%2.2d', offset / 60, offset % 60)
+      else
+        sprintf('+%2.2d:%2.2d', offset / 60, offset % 60)
+      end
+    end
+  end
+
+  # Returns the zone offset from utc for the given `timezone`
+  # @param [String] timezone the timezone to get the offset for
+  # @return [Integer] the timezone offset, in seconds
+  #
+  # @api private
+  def self.utc_offset(timezone)
+    if CURRENT_TIMEZONE.casecmp(timezone) == 0
+      ::Time.now.utc_offset
+    else
+      hash = DateTime._strptime(timezone, '%z')
+      offset = hash.nil? ? nil : hash[:offset]
+      raise ArgumentError, "Illegal timezone '#{timezone}'" if offset.nil?
+      offset
+    end
+  end
+
+  # Formats a ruby Time object using the given timezone
+  def self.format_time(format, time, timezone)
+    unless timezone.nil? || timezone.empty?
+      time = time.localtime(convert_timezone(timezone))
+    end
+    time.strftime(format)
+  end
 
   def self.now
     from_time(::Time.now)
@@ -12,24 +59,42 @@ class Timestamp < TimeData
   end
 
   def self.from_hash(args_hash)
-    parse(args_hash[KEY_STRING], args_hash[KEY_FORMAT] || DEFAULT_FORMATS)
+    parse(args_hash[KEY_STRING], args_hash[KEY_FORMAT], args_hash[KEY_TIMEZONE])
   end
 
-  def self.parse(str, format = DEFAULT_FORMATS)
+  def self.parse(str, format = :default, timezone = nil)
+    has_timezone = !(timezone.nil? || timezone.empty? || timezone == :default)
+    if format.nil? || format == :default
+      format = has_timezone ? DEFAULT_FORMATS_WO_TZ : DEFAULT_FORMATS
+    end
+
+    parsed = nil
     if format.is_a?(Array)
       format.each do |fmt|
+        assert_no_tz_extractor(fmt) if has_timezone
         begin
-          return from_time(DateTime.strptime(str, fmt).to_time)
+          parsed = DateTime.strptime(str, fmt)
+          break
         rescue ArgumentError
         end
       end
-      raise ArgumentError, "Unable to parse '#{str}' using any of the formats #{format.join(', ')}"
+      raise ArgumentError, "Unable to parse '#{str}' using any of the formats #{format.join(', ')}" if parsed.nil?
+    else
+      assert_no_tz_extractor(format) if has_timezone
+      begin
+        parsed = DateTime.strptime(str, format)
+      rescue ArgumentError
+        raise ArgumentError, "Unable to parse '#{str}' using format '#{format}'"
+      end
     end
+    parsed_time = parsed.to_time
+    parsed_time -= utc_offset(timezone) if has_timezone
+    from_time(parsed_time)
+  end
 
-    begin
-      from_time(DateTime.strptime(str, format).to_time)
-    rescue ArgumentError
-      raise ArgumentError, "Unable to parse '#{str}' using format '#{format}'"
+  def self.assert_no_tz_extractor(format)
+    if format =~ /[^%]%[zZ]/
+      raise ArgumentError, 'Using a Timezone designator in format specification is mutually exclusive to providing an explicit timezone argument'
     end
   end
 
@@ -67,8 +132,8 @@ class Timestamp < TimeData
     end
   end
 
-  def format(format)
-    to_time.strftime(format)
+  def format(format, timezone = nil)
+    self.class.format_time(format, to_time, timezone)
   end
 
   def to_s

--- a/lib/puppet/pops/types/p_timestamp_type.rb
+++ b/lib/puppet/pops/types/p_timestamp_type.rb
@@ -23,14 +23,16 @@ module Types
 
         dispatch :from_string do
           param           'String[1]', :string
-          optional_param  'Formats', :format
+          optional_param  'Formats',   :format
+          optional_param  'String[1]', :timezone
         end
 
         dispatch :from_string_hash do
           param <<-TYPE, :hash_arg
             Struct[{
               string => String[1],
-              Optional[format] => Formats
+              Optional[format] => Formats,
+              Optional[timezone] => String[1]
             }]
           TYPE
         end
@@ -39,8 +41,8 @@ module Types
           Time::Timestamp.now
         end
 
-        def from_string(string, format = Time::Timestamp::DEFAULT_FORMATS)
-          Time::Timestamp.parse(string, format)
+        def from_string(string, format = :default, timezone = nil)
+          Time::Timestamp.parse(string, format, timezone)
         end
 
         def from_string_hash(args_hash)

--- a/spec/unit/functions/strftime_spec.rb
+++ b/spec/unit/functions/strftime_spec.rb
@@ -85,5 +85,68 @@ describe 'the strftime function' do
       test_format("{string => '100-14:02:24.123400000', format => '%D-%H:%M:%S.%N'}", '%D-%H:%M:%S.%6N', '100-14:02:24.123400')
     end
   end
+
+  def test_timestamp_format(ctor_arg, format, expected)
+    expect(eval_and_collect_notices("notice(strftime(Timestamp('#{ctor_arg}'), '#{format}'))")).to eql(["#{expected}"])
+  end
+
+  def test_timestamp_format_tz(ctor_arg, format, tz, expected)
+    expect(eval_and_collect_notices("notice(strftime(Timestamp('#{ctor_arg}'), '#{format}', '#{tz}'))")).to eql(["#{expected}"])
+  end
+
+  def collect_log(code, node = Puppet::Node.new('foonode'))
+    Puppet[:code] = code
+    compiler = Puppet::Parser::Compiler.new(node)
+    node.environment.check_for_reparse
+    logs = []
+    Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+      compiler.compile
+    end
+    logs
+  end
+
+  context 'when applied to a Timestamp' do
+    it 'can format a timestamp with a format pattern' do
+      test_timestamp_format('2016-09-23T13:14:15.123 UTC', '%Y-%m-%d %H:%M:%S.%L %z', '2016-09-23 13:14:15.123 +0000')
+    end
+
+    it 'can format a timestamp using a specific timezone' do
+      test_timestamp_format_tz('2016-09-23T13:14:15.123 UTC', '%Y-%m-%d %H:%M:%S.%L %z', 'EST', '2016-09-23 08:14:15.123 -0500')
+    end
+  end
+
+  context 'when used with dispatcher covering legacy stdlib API (String format, String timeszone = undef)' do
+    it 'produces the current time when used with one argument' do
+      before_eval = Time.now
+      notices = eval_and_collect_notices("notice(strftime('%F %T'))")
+      expect(notices).not_to be_empty
+      expect(notices[0]).to match(/\A\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\z/)
+      parsed_time = DateTime.strptime(notices[0], '%F %T').to_time
+      expect(Time.now.to_i >= parsed_time.to_i && parsed_time.to_i >= before_eval.to_i).to be_truthy
+    end
+
+    it 'emits a deprecation warning when used with one argument' do
+      log = collect_log("notice(strftime('%F %T'))")
+      warnings = log.select { |log_entry| log_entry.level == :warning }.map { |log_entry| log_entry.message }
+      expect(warnings).not_to be_empty
+      expect(warnings[0]).to match(/The argument signature \(String format, \[String timezone\]\) is deprecated for #strfime/)
+    end
+
+    it 'produces the current time formatted with specific timezone when used with two arguments' do
+      before_eval = Time.now
+      notices = eval_and_collect_notices("notice(strftime('%F %T %:z', 'EST'))")
+      expect(notices).not_to be_empty
+      expect(notices[0]).to match(/\A\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} -05:00\z/)
+      parsed_time = DateTime.strptime(notices[0], '%F %T %z').to_time
+      expect(Time.now.to_i >= parsed_time.to_i && parsed_time.to_i >= before_eval.to_i).to be_truthy
+    end
+
+    it 'emits a deprecation warning when using legacy format with two arguments' do
+      log = collect_log("notice(strftime('%F %T', 'EST'))")
+      warnings = log.select { |log_entry| log_entry.level == :warning }.map { |log_entry| log_entry.message }
+      expect(warnings).not_to be_empty
+      expect(warnings[0]).to match(/The argument signature \(String format, \[String timezone\]\) is deprecated for #strfime/)
+    end
+  end
 end
 

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -68,12 +68,37 @@ describe 'Timestamp type' do
         expect(eval_and_collect_notices(code)).to eq(['2016-08-28T00:00:00.000 UTC'])
       end
 
+      it 'can be created from a string, format, and a timezone' do
+        code = <<-CODE
+            $o = Timestamp('Sunday, 28 August, 2016', '%A, %d %B, %Y', 'EST')
+            notice($o)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['2016-08-28T05:00:00.000 UTC'])
+      end
+
+      it 'can be not be created from a string, format with timezone designator, and a timezone' do
+        code = <<-CODE
+            $o = Timestamp('Sunday, 28 August, 2016 UTC', '%A, %d %B, %Y %z', 'EST')
+            notice($o)
+        CODE
+        expect { eval_and_collect_notices(code) }.to raise_error(
+          /Using a Timezone designator in format specification is mutually exclusive to providing an explicit timezone argument/)
+      end
+
       it 'can be created from a hash with string and format' do
         code = <<-CODE
             $o = Timestamp({ string => 'Sunday, 28 August, 2016', format => '%A, %d %B, %Y' })
             notice($o)
         CODE
         expect(eval_and_collect_notices(code)).to eq(['2016-08-28T00:00:00.000 UTC'])
+      end
+
+      it 'can be created from a hash with string, format, and a timezone' do
+        code = <<-CODE
+            $o = Timestamp({ string => 'Sunday, 28 August, 2016', format => '%A, %d %B, %Y', timezone => 'EST' })
+            notice($o)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['2016-08-28T05:00:00.000 UTC'])
       end
 
       it 'can be created from a string and array of formats' do
@@ -89,6 +114,21 @@ describe 'Timestamp type' do
         CODE
         expect(eval_and_collect_notices(code)).to eq(
           ['2016-08-28T12:15:00.000 UTC', '2016-07-24T01:20:00.000 UTC', '2016-06-21T18:23:15.000 UTC'])
+      end
+
+      it 'can be created from a string, array of formats, and a timezone' do
+        code = <<-CODE
+            $fmts = [
+              '%A, %d %B, %Y at %r',
+              '%b %d, %Y, %l:%M %P',
+              '%y-%m-%d %H:%M:%S'
+            ]
+            notice(Timestamp('Sunday, 28 August, 2016 at 12:15:00 PM', $fmts, 'CET'))
+            notice(Timestamp('Jul 24, 2016, 1:20 am', $fmts, 'CET'))
+            notice(Timestamp('16-06-21 18:23:15', $fmts, 'CET'))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(
+          ['2016-08-28T11:15:00.000 UTC', '2016-07-24T00:20:00.000 UTC', '2016-06-21T17:23:15.000 UTC'])
       end
 
       it 'can be created from a integer that represents seconds since epoch' do


### PR DESCRIPTION
This commit adds a new disptacher to the strftime function which is
backward compatible with the stdlib function with the same name.

The stdlib function also accepted a second `timezone` argument which
the new function did not provideand that was an oversight. It must be
provided to enable formatting of timezones other than UTC. The same
thing is true when parsing timestamps. A timezone must be provided to
parse a timestamp string that doesn't include a timezone unless a
default of UTC is acceptable in all cases (which it of course, isn't).
This commit therefore provides the timezone functionality needed to both
parse and format a timestamp.