### PR TITLE
(PUP-6714) Add missing capability flag to generated Pcore resource

### DIFF
--- a/lib/puppet/generate/models/type/type.rb
+++ b/lib/puppet/generate/models/type/type.rb
@@ -24,6 +24,9 @@ module Puppet
           # Gets the isomorphic member attribute of the type
           attr_reader :isomorphic
 
+          # Gets the capability member attribute of the type
+          attr_reader :capability
+
           # Initializes a type model.
           # @param type [Puppet::Type] The Puppet type to model.
           # @return [void]
@@ -45,6 +48,7 @@ module Puppet
               ]
             end]
             @isomorphic = type.isomorphic?
+            @capability = type.is_capability?
           end
 
           def render(template)

--- a/lib/puppet/generate/templates/type/pcore.erb
+++ b/lib/puppet/generate/templates/type/pcore.erb
@@ -37,5 +37,6 @@ Puppet::Resource::ResourceType3.new(
     <%= mapping[0] %> => [<%= mapping[1].join(', ')%>]<%= "," if index + 1 < title_patterns.size %>
 <%- end -%>
   },
-  <%= isomorphic -%>
+  <%= isomorphic -%>,
+  <%= capability -%>
 )

--- a/lib/puppet/pops/resource/resource_type_impl.rb
+++ b/lib/puppet/pops/resource/resource_type_impl.rb
@@ -47,6 +47,10 @@ class ResourceTypeImpl
           Types::KEY_TYPE => Types::PBooleanType::DEFAULT,
           Types::KEY_VALUE => true
         },
+        'capability' => {
+          Types::KEY_TYPE => Types::PBooleanType::DEFAULT,
+          Types::KEY_VALUE => false
+        },
       },
       EMPTY_HASH,
       [Types::KEY_NAME]
@@ -96,14 +100,14 @@ class ResourceTypeImpl
   attr_reader :parameters
   attr_reader :title_patterns_hash
   attr_reader :title_patterns
-  attr_reader :isomorphic
 
-  def initialize(name, properties = EMPTY_ARRAY, parameters = EMPTY_ARRAY, title_patterns_hash = nil, isomorphic = true)
+  def initialize(name, properties = EMPTY_ARRAY, parameters = EMPTY_ARRAY, title_patterns_hash = nil, isomorphic = true, capability = false)
     @name = name
     @properties = properties
     @parameters = parameters
     @title_patterns_hash = title_patterns_hash
     @isomorphic = isomorphic
+    @capability = capability
 
     # Compute attributes hash
     # Compute key_names (possibly compound key if there are multiple name vars).
@@ -172,7 +176,7 @@ class ResourceTypeImpl
   end
 
   def is_capability?
-    false
+    @capability
   end
 
   # Answers if the parameter name is a parameter/attribute of this type
@@ -259,7 +263,7 @@ class ResourceTypeImpl
 
   # Answers :property, :param or :meta depending on the type of the attribute
   # According to original version, this is called millions of times
-  # and a cache is required. 
+  # and a cache is required.
   # @param name [Symbol]
   def attrtype(name)
     raise NotImplementedError, "attrtype() - returns the kind (:meta, :param, or :property) of the parameter"

--- a/lib/puppet/pops/resource/resource_type_set.pcore
+++ b/lib/puppet/pops/resource/resource_type_set.pcore
@@ -15,6 +15,7 @@ type Puppet::Resource::ResourceType3 = Object[{
     parameters     => { type => Array[Puppet::Resource::Param], value = []},
     title_patterns => { type => Optional[Hash[Regexp, Array[String[1]]], value => nil },
     isomorphic     => { type => Boolean, value => true },
+    capability     => { type => Boolean, value => false },
   },
   equality => [name],
 }]

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -252,7 +252,7 @@ class Puppet::Resource
       #   * a "classic" 3.x ruby plugin
       #   * a compatible implementation (e.g. loading from pcore metadata)
       #   * a resolved user defined type
-      # 
+      #
       # ...then, modify the parameters to the "old" (agent side compatible) way
       # of describing the type/title with string/symbols.
       #
@@ -319,7 +319,7 @@ class Puppet::Resource
   # A resource is a capability (instance) if its underlying type is a
   # capability type
   def is_capability?
-    resource_type and resource_type.is_capability?
+    !resource_type.nil? && resource_type.is_capability?
   end
 
   # Returns the value of the 'export' metaparam as an Array

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -113,7 +113,8 @@ class Type
     attr_accessor :is_capability
 
     def is_capability?
-      is_capability
+      c = is_capability
+      c.nil? ? false : c
     end
   end
 


### PR DESCRIPTION
The capability flag of a resource (initiated by passing the option
`:is_capability => true`) was not included in the generated .pp file, and
also not recognized by the Pcore Resource type. This PR ensures that
the flag is generated by the generator and then handled correctly by
the type.
