### PR TITLE
(PUP-6749) race condition smf and manifest-import

### DIFF
--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -203,10 +203,14 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     else
       command = 'update'
     end
+    args = ['--accept']
+    if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.2') >= 0
+      args.push('--sync-actuators-timeout', '900')
+    end
     unless should.is_a? Symbol
       name += "@#{should}"
     end
-    r = exec_cmd(command(:pkg), command, '--accept', name)
+    r = exec_cmd(command(:pkg), command, *args, name)
     return r if nofail
     raise Puppet::Error, "Unable to update #{r[:out]}" if r[:exit] != 0
   end


### PR DESCRIPTION
Package installs which update multiple manifests may fail later
resources because the affected services do not exist until manifest
import has completed.

Solaris 11.2 or newer pkg install and update operations will wait
for actuators to complete after this change.

23107546 race condition with smf provider and manifest-import