### PR TITLE
(PUP-6742) Replace auto-generation of logging functions

### DIFF
--- a/lib/puppet/functions/alert.rb
+++ b/lib/puppet/functions/alert.rb
@@ -1,0 +1,11 @@
+# Log a message on the server at level alert.
+Puppet::Functions.create_function(:alert, Puppet::Functions::InternalFunction) do
+  dispatch :alert do
+    scope_param
+    repeated_param 'Any', :values
+  end
+
+  def alert(scope, *values)
+    Puppet::Util::Log.log_func(scope, :alert, values)
+  end
+end

--- a/lib/puppet/functions/crit.rb
+++ b/lib/puppet/functions/crit.rb
@@ -1,0 +1,11 @@
+# Log a message on the server at level crit.
+Puppet::Functions.create_function(:crit, Puppet::Functions::InternalFunction) do
+  dispatch :crit do
+    scope_param
+    repeated_param 'Any', :values
+  end
+
+  def crit(scope, *values)
+    Puppet::Util::Log.log_func(scope, :crit, values)
+  end
+end

--- a/lib/puppet/functions/debug.rb
+++ b/lib/puppet/functions/debug.rb
@@ -1,0 +1,11 @@
+# Log a message on the server at level debug.
+Puppet::Functions.create_function(:debug, Puppet::Functions::InternalFunction) do
+  dispatch :debug do
+    scope_param
+    repeated_param 'Any', :values
+  end
+
+  def debug(scope, *values)
+    Puppet::Util::Log.log_func(scope, :debug, values)
+  end
+end

--- a/lib/puppet/functions/emerg.rb
+++ b/lib/puppet/functions/emerg.rb
@@ -1,0 +1,11 @@
+# Log a message on the server at level emerg.
+Puppet::Functions.create_function(:emerg, Puppet::Functions::InternalFunction) do
+  dispatch :emerg do
+    scope_param
+    repeated_param 'Any', :values
+  end
+
+  def emerg(scope, *values)
+    Puppet::Util::Log.log_func(scope, :emerg, values)
+  end
+end

--- a/lib/puppet/functions/err.rb
+++ b/lib/puppet/functions/err.rb
@@ -1,0 +1,11 @@
+# Log a message on the server at level err.
+Puppet::Functions.create_function(:err, Puppet::Functions::InternalFunction) do
+  dispatch :err do
+    scope_param
+    repeated_param 'Any', :values
+  end
+
+  def err(scope, *values)
+    Puppet::Util::Log.log_func(scope, :err, values)
+  end
+end

--- a/lib/puppet/functions/info.rb
+++ b/lib/puppet/functions/info.rb
@@ -1,0 +1,11 @@
+# Log a message on the server at level info.
+Puppet::Functions.create_function(:info, Puppet::Functions::InternalFunction) do
+  dispatch :info do
+    scope_param
+    repeated_param 'Any', :values
+  end
+
+  def info(scope, *values)
+    Puppet::Util::Log.log_func(scope, :info, values)
+  end
+end

--- a/lib/puppet/functions/notice.rb
+++ b/lib/puppet/functions/notice.rb
@@ -1,0 +1,11 @@
+# Log a message on the server at level notice.
+Puppet::Functions.create_function(:notice, Puppet::Functions::InternalFunction) do
+  dispatch :notice do
+    scope_param
+    repeated_param 'Any', :values
+  end
+
+  def notice(scope, *values)
+    Puppet::Util::Log.log_func(scope, :notice, values)
+  end
+end

--- a/lib/puppet/functions/warning.rb
+++ b/lib/puppet/functions/warning.rb
@@ -1,0 +1,11 @@
+# Log a message on the server at level notice.
+Puppet::Functions.create_function(:warning, Puppet::Functions::InternalFunction) do
+  dispatch :warning do
+    scope_param
+    repeated_param 'Any', :values
+  end
+
+  def warning(scope, *values)
+    Puppet::Util::Log.log_func(scope, :warning, values)
+  end
+end

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -63,7 +63,6 @@ class StaticLoader < Loader
   attr_reader :loaded
   def initialize
     @loaded = {}
-    create_logging_functions()
     create_built_in_types()
     create_resource_type_references()
   end
@@ -97,46 +96,6 @@ class StaticLoader < Loader
 
   def load_constant(typed_name)
     @loaded[typed_name]
-  end
-
-  # Creates a function for each of the specified log levels
-  #
-  def create_logging_functions()
-    Puppet::Util::Log.levels.each do |level|
-
-      fc = Puppet::Functions.create_function(level) do
-        # create empty dispatcher to stop it from complaining about missing method since
-        # an override of :call is made instead of using dispatch.
-        dispatch(:log) { }
-
-        # Logs per the specified level, outputs formatted information for arrays, hashes etc.
-        # Overrides the implementation in Function that uses dispatching. This is not needed here
-        # since it accepts 0-n Object.
-        #
-        define_method(:call) do |scope, *vals|
-          # NOTE: 3x, does this: vals.join(" ")
-          # New implementation uses the evaluator to get proper formatting per type
-          # TODO: uses a fake scope (nil) - fix when :scopes are available via settings
-          mapped = vals.map {|v| Puppet::Pops::Evaluator::EvaluatorImpl.new.string(v, nil) }
-
-          # Bypass Puppet.<level> call since it picks up source from "self" which is not applicable in the 4x
-          # Function API.
-          # TODO: When a function can obtain the file, line, pos of the call merge those in (3x supports
-          #       options :file, :line. (These were never output when calling the 3x logging functions since
-          #       3x scope does not know about the calling location at that detailed level, nor do they
-          #       appear in a report to stdout/error when included). Now, the output simply uses scope (like 3x)
-          #       as this is good enough, but does not reflect the true call-stack, but is a rough estimate
-          #       of where the logging call originates from).
-          #
-          Puppet::Util::Log.create({:level => level, :source => scope, :message => mapped.join(" ")})
-        end
-      end
-
-      typed_name = TypedName.new(:function, level)
-      # TODO:closure scope is fake (an empty hash) - waiting for new global scope to be available via lookup of :scopes
-      func = fc.new({},self)
-      @loaded[ typed_name ] = NamedEntry.new(typed_name, func, __FILE__)
-    end
   end
 
   def create_built_in_types

--- a/spec/unit/functions/logging_spec.rb
+++ b/spec/unit/functions/logging_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+describe 'the log function' do
+  include PuppetSpec::Compiler
+
+  def collect_logs(code)
+    Puppet[:code] = code
+    node = Puppet::Node.new('logtest')
+    compiler = Puppet::Parser::Compiler.new(node)
+    node.environment.check_for_reparse
+    logs = []
+    Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+      compiler.compile
+    end
+    logs
+  end
+
+  def expect_log(code, log_level, message)
+    logs = collect_logs(code)
+    expect(logs.size).to eql(1)
+    expect(logs[0].level).to eql(log_level)
+    expect(logs[0].message).to eql(message)
+  end
+
+  before(:each) do
+    Puppet[:log_level] = 'debug'
+  end
+
+  Puppet::Util::Log.levels.each do |level|
+    context "for log level '#{level}'" do
+      it 'can be called' do
+        expect_log("#{level.to_s}('yay')", level, 'yay')
+      end
+
+      it 'joins multiple arguments using space' do
+        # Not using the evaluator would result in yay {"a"=>"b", "c"=>"d"}
+        expect_log("#{level.to_s}('a', 'b', 3)", level, 'a b 3')
+      end
+
+      it 'uses the evaluator to format output' do
+        # Not using the evaluator would result in yay {"a"=>"b", "c"=>"d"}
+        expect_log("#{level.to_s}('yay', {a => b, c => d})", level, 'yay {a => b, c => d}')
+      end
+    end
+  end
+end

--- a/spec/unit/pops/loaders/static_loader_spec.rb
+++ b/spec/unit/pops/loaders/static_loader_spec.rb
@@ -20,32 +20,6 @@ describe 'the static loader' do
     expect(loader.find(a_typed_name)).to be(nil)
   end
 
-  context 'provides access to logging functions' do
-    let(:loader) { loader = Puppet::Pops::Loader::StaticLoader.new() }
-    # Ensure all logging functions produce output
-    before(:each) { Puppet::Util::Log.level = :debug }
-
-    Puppet::Util::Log.levels.each do |level|
-      it "defines the function #{level.to_s}" do
-        expect(loader.load(:function, level).class.name).to eql(level.to_s)
-      end
-
-      it 'and #{level.to_s} can be called' do
-        expect(loader.load(:function, level).call({}, 'yay').to_s).to eql('yay')
-      end
-
-      it "uses the evaluator to format output" do
-        expect(loader.load(:function, level).call({}, ['yay', 'surprise']).to_s).to eql('[yay, surprise]')
-      end
-
-      it 'outputs name of source (scope) by passing it to the Log utility' do
-        the_scope = {}
-        Puppet::Util::Log.any_instance.expects(:source=).with(the_scope)
-        loader.load(:function, level).call(the_scope, 'x')
-      end
-    end
-  end
-
   context 'provides access to resource types built into puppet' do
     let(:loader) { loader = Puppet::Pops::Loader::StaticLoader.new() }
 


### PR DESCRIPTION
This commit replaces the #create_logging_functions with proper Puppet
functions so that they can be documented separately.