### PR TITLE
(PUP-6754) Allow uppercase CLI short flags

### DIFF
--- a/lib/puppet/interface/option.rb
+++ b/lib/puppet/interface/option.rb
@@ -17,7 +17,7 @@ class Puppet::Interface::Option
     dups = {}
     declaration.each do |item|
       if item.is_a? String and item.to_s =~ /^-/ then
-        unless item =~ /^-[a-z]\b/ or item =~ /^--[^-]/ then
+        unless item =~ /^-[a-zA-Z]\b/ or item =~ /^--[^-]/ then
           raise ArgumentError, "#{item.inspect}: long options need two dashes (--)"
         end
         @optparse << item
@@ -90,7 +90,7 @@ class Puppet::Interface::Option
   # @api private
   def optparse_to_name(declaration)
     name = optparse_to_optionname(declaration).tr('-', '_')
-    raise "#{name.inspect} is an invalid option name" unless name.to_s =~ /^[a-z]\w*$/
+    raise "#{name.inspect} is an invalid option name" unless name.to_s =~ /^[a-zA-Z]\w*$/
     name.to_sym
   end
 

--- a/spec/unit/interface/option_spec.rb
+++ b/spec/unit/interface/option_spec.rb
@@ -15,6 +15,11 @@ describe Puppet::Interface::Option do
       end
     end
 
+    it "should allow an uppercase short form" do
+      option = Puppet::Interface::Option.new(face, "-F json", "--format json")
+      expect(option.name).to eq(:format)
+    end
+
     [:foo, 12, nil, {}, []].each do |input|
       it "should fail sensible when given #{input.inspect}" do
         expect {


### PR DESCRIPTION
This commit changes the regex pattern that validates short CLI options so that flags like `-F` and `-V` will be allowed, rather than only `-f` and `-v`.