### PR TITLE
(PUP-6753) Ensure that log functions return undef

### DIFF
--- a/lib/puppet/functions/alert.rb
+++ b/lib/puppet/functions/alert.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:alert, Puppet::Functions::InternalFunction) d
   dispatch :alert do
     scope_param
     repeated_param 'Any', :values
+    return_type 'Undef'
   end
 
   def alert(scope, *values)

--- a/lib/puppet/functions/crit.rb
+++ b/lib/puppet/functions/crit.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:crit, Puppet::Functions::InternalFunction) do
   dispatch :crit do
     scope_param
     repeated_param 'Any', :values
+    return_type 'Undef'
   end
 
   def crit(scope, *values)

--- a/lib/puppet/functions/debug.rb
+++ b/lib/puppet/functions/debug.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:debug, Puppet::Functions::InternalFunction) d
   dispatch :debug do
     scope_param
     repeated_param 'Any', :values
+    return_type 'Undef'
   end
 
   def debug(scope, *values)

--- a/lib/puppet/functions/emerg.rb
+++ b/lib/puppet/functions/emerg.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:emerg, Puppet::Functions::InternalFunction) d
   dispatch :emerg do
     scope_param
     repeated_param 'Any', :values
+    return_type 'Undef'
   end
 
   def emerg(scope, *values)

--- a/lib/puppet/functions/err.rb
+++ b/lib/puppet/functions/err.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:err, Puppet::Functions::InternalFunction) do
   dispatch :err do
     scope_param
     repeated_param 'Any', :values
+    return_type 'Undef'
   end
 
   def err(scope, *values)

--- a/lib/puppet/functions/info.rb
+++ b/lib/puppet/functions/info.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:info, Puppet::Functions::InternalFunction) do
   dispatch :info do
     scope_param
     repeated_param 'Any', :values
+    return_type 'Undef'
   end
 
   def info(scope, *values)

--- a/lib/puppet/functions/notice.rb
+++ b/lib/puppet/functions/notice.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:notice, Puppet::Functions::InternalFunction) 
   dispatch :notice do
     scope_param
     repeated_param 'Any', :values
+    return_type 'Undef'
   end
 
   def notice(scope, *values)

--- a/lib/puppet/functions/warning.rb
+++ b/lib/puppet/functions/warning.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:warning, Puppet::Functions::InternalFunction)
   dispatch :warning do
     scope_param
     repeated_param 'Any', :values
+    return_type 'Undef'
   end
 
   def warning(scope, *values)

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -266,6 +266,7 @@ class Puppet::Util::Log
     #       of where the logging call originates from).
     #
     Puppet::Util::Log.create({:level => level, :source => scope, :message => vals.join(" ")})
+    nil
   end
 
 

--- a/spec/unit/functions/logging_spec.rb
+++ b/spec/unit/functions/logging_spec.rb
@@ -42,6 +42,13 @@ describe 'the log function' do
         # Not using the evaluator would result in yay {"a"=>"b", "c"=>"d"}
         expect_log("#{level.to_s}('yay', {a => b, c => d})", level, 'yay {a => b, c => d}')
       end
+
+      it 'returns undef value' do
+        logs = collect_logs("notice(type(#{level.to_s}('yay')))")
+        expect(logs.size).to eql(2)
+        expect(logs[1].level).to eql(:notice)
+        expect(logs[1].message).to eql('Undef')
+      end
     end
   end
 end


### PR DESCRIPTION
This commit changes the helper method for all puppet log functions so
that it returns `nil`. A return_type of 'Undef' is also added to the
dispatcher for the log functions