### PR TITLE
(PUP-6757) Make Binary use strict base64 encoding by default

### DIFF
--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -896,13 +896,13 @@ The formats have the following meaning:
 
 | format | explanation |
 | ----   | ----        |
-| b | The data is in base64 encoding, padding as required by base64 strict is added by default
-| u | The data is in URL safe base64 encoding
 | B | The data is in base64 strict encoding
+| u | The data is in URL safe base64 encoding
+| b | The data is in base64 encoding, padding as required by base64 strict, is added by default
 | s | The data is a puppet string. The string must be valid UTF-8, or convertible to UTF-8 or an error is raised.
 | r | (Ruby Raw) the byte sequence in the given string is used verbatim irrespective of possible encoding errors
 
-* The default format is `%b`.
+* The default format is `%B`.
 * Note that the format `%r` should be used sparingly, or not at all. It exists for backwards compatibility reasons when someone receiving
   a string from some function and that string should be treated as Binary. Such code should be changed to return a Binary instead of a String.
 

--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -14,7 +14,7 @@ class PBinaryType < PAnyType
     attr_reader :binary_buffer
 
     # Constructs an instance of Binary from a base64 urlsafe encoded string (RFC 2045).
-    # @param [String] A string with RFC 2045 compliant encoded binary 
+    # @param [String] A string with RFC 2045 compliant encoded binary
     #
     def self.from_base64(str)
       new(Base64.decode64(str))
@@ -31,7 +31,7 @@ class PBinaryType < PAnyType
     # Where correct padding must be used and line breaks causes an error to be raised.
     #
     # @param [String] A string with RFC 4648 compliant encoded binary
-    # 
+    #
     def self.from_base64_strict(str)
       new(Base64.strict_decode64(str))
     end
@@ -166,7 +166,7 @@ class PBinaryType < PAnyType
       end
 
       def from_string(str, format = nil)
-        format ||= '%b'
+        format ||= '%B'
         case format
         when "%b"
           # padding must be added for older rubies to avoid truncation

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
     # Note that the factory is not aware of Binary and cannot operate on a
     # literal binary. Instead, it must create a call to Binary.new() with the base64 encoded
     # string as an argument
-    CALL_NAMED(QREF("Binary"), true, [Base64.encode64(s)])
+    CALL_NAMED(QREF("Binary"), true, [Base64.strict_encode64(s)])
   end
 
   context 'The evaluator when operating on a String' do

--- a/spec/unit/pops/types/p_binary_type_spec.rb
+++ b/spec/unit/pops/types/p_binary_type_spec.rb
@@ -57,12 +57,21 @@ describe 'Binary Type' do
       }.to raise_error(/.*"\\xF1" from ASCII-8BIT to UTF-8.*/)
     end
 
-    it 'can be created from a Base64 encoded String' do
+    it 'can be created from a strict Base64 encoded String using default format' do
       code = <<-CODE
-        $x = Binary('YmluYXJ5')
+        $x = Binary('YmluYXI=')
         notice(assert_type(Binary, $x))
       CODE
-      expect(eval_and_collect_notices(code)).to eql(['YmluYXJ5'])
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXI='])
+    end
+
+    it 'will error creation in strict mode if padding is missing when using default format' do
+      # the text 'binar' needs padding with '=' (missing here to trigger error
+      code = <<-CODE
+        $x = Binary('YmluYXI')
+        notice(assert_type(Binary, $x))
+      CODE
+      expect{ eval_and_collect_notices(code) }.to raise_error(/invalid base64/)
     end
 
     it 'can be created from a Base64 encoded String using %B, strict mode' do
@@ -130,13 +139,11 @@ describe 'Binary Type' do
     end
 
     it "can be created from an hash with value and default format" do
-      # default format skips URL safe encoded chars (this is used to test that %b was selected
-      # by default.
       code = <<-CODE
-        $x = Binary({value => '--__YmluYXJ5'})
+        $x = Binary({value => 'YmluYXI='})
         notice(assert_type(Binary, $x))
       CODE
-      expect(eval_and_collect_notices(code)).to eql(['YmluYXJ5'])
+      expect(eval_and_collect_notices(code)).to eql(['YmluYXI='])
     end
 
     it 'can be created from a hash with value being an array' do


### PR DESCRIPTION
This commit changes the default encoding used by the Binary constructor
from '%b' (relaxed base64) to '%B' (strict base64).