### PR TITLE
(PUP-6765) Ensure that produce/consume uses generated pcore resource

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -176,6 +176,7 @@ class Puppet::Parser::Resource < Puppet::Resource
   # the resource tags with its value.
   def set_parameter(param, value = nil)
     if ! param.is_a?(Puppet::Parser::Resource::Param)
+      param = param.name if param.is_a?(Puppet::Pops::Resource::Param)
       param = Puppet::Parser::Resource::Param.new(
         :name => param, :value => value, :source => self.source
       )
@@ -244,7 +245,9 @@ class Puppet::Parser::Resource < Puppet::Resource
       raise Puppet::Error, "Invalid consume in #{self.ref}: #{ref} is not a resource" unless ref.is_a?(Puppet::Resource)
 
       # Resolve references
-      cap = catalog.resource(ref.type, ref.title)
+      t = ref.type
+      t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
+      cap = catalog.resource(t, ref.title)
       if cap.nil?
         raise "Resource #{ref} could not be found; it might not have been produced yet"
       end

--- a/lib/puppet/pops/resource/param.rb
+++ b/lib/puppet/pops/resource/param.rb
@@ -10,7 +10,7 @@
 # This implementation does not support
 # * setting 'strict' - strictness (must refer to an existing type) is always true
 # * does not support the indirector
-# 
+#
 #
 module Puppet::Pops
 module Resource
@@ -41,6 +41,10 @@ class Param
     @type = type
     @name = name
     @name_var = name_var
+  end
+
+  def to_s
+    name
   end
 
   def self._ptype

--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -41,6 +41,7 @@ module Puppet::Resource::CapabilityFinder
     end
 
     if resource_hash = resources.first
+      resource_hash['type'] = cap.resource_type
       instantiate_resource(resource_hash)
     else
       Puppet.debug "Could not find capability resource #{cap} in PuppetDB"
@@ -101,13 +102,8 @@ module Puppet::Resource::CapabilityFinder
   private
 
   def self.instantiate_resource(resource_hash)
-    resource = Puppet::Resource.new(resource_hash['type'],
-                                    resource_hash['title'])
-    real_type = Puppet::Type.type(resource.type)
-    if real_type.nil?
-      fail Puppet::ParseError,
-        "Could not find resource type #{resource.type} returned from PuppetDB"
-    end
+    real_type = resource_hash['type']
+    resource = Puppet::Resource.new(real_type, resource_hash['title'])
     real_type.parameters.each do |param|
       param = param.to_s
       next if param == 'name'

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -130,7 +130,9 @@ class Puppet::Resource::Type
       if blueprint.nil?
         raise Puppet::ParseError, "Resource type #{resource.type} does not produce #{ex.type}"
       end
-      produced_resource = Puppet::Parser::Resource.new(ex.type, ex.title, :scope => scope, :source => self)
+      t = ex.type
+      t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
+      produced_resource = Puppet::Parser::Resource.new(t, ex.title, :scope => scope, :source => self)
 
       produced_resource.resource_type.parameters.each do |name|
         next if name == :name


### PR DESCRIPTION
Ensures that the export/consume logic of the `Puppet::Resource::Type`
uses a generated Pcore resource type and never makes an attempt to load
the corresponding Ruby type.