### PR TITLE
(PUP-6752) Fix diff in catalog lookup caused by app_management flag

### DIFF
--- a/spec/unit/capability_spec.rb
+++ b/spec/unit/capability_spec.rb
@@ -391,4 +391,26 @@ test { one: hostname => "ahost", export => Cap[two] }
       end
     end
   end
+
+  context 'and aliased resources' do
+    let(:drive) { Puppet.features.microsoft_windows? ? 'C:' : '' }
+    let(:code) { <<-PUPPET }
+      $dir='#{drive}/tmp/test'
+      $same_dir='#{drive}/tmp/test/'
+
+      file {$dir:
+        ensure => directory
+      }
+
+      if !defined(File["${same_dir}"]) {
+        file { $same_dir:
+          ensure => directory
+        }
+      }
+    PUPPET
+
+    it 'fails if a resource is defined and then redefined using name that results in the same alias' do
+      expect { compile_to_ral(code) }.to raise_error(/resource \["File", "#{drive}\/tmp\/test"\] already declared/)
+    end
+  end
 end


### PR DESCRIPTION
Before this lookup, the code-paths for how a lookup was performed
differed slightly depending on the setting of the `app_management` flag.
While the setting should extend the lookup using the capability finder,
a malformed boolean expression made it have an additional and undesired
side effect.

This commit ensures that the code path is exactly the same until the
point where the decision is made to search for the capability.