### PR TITLE
(PUP-6774) Fix incorrect call to `is_json_type` in Puppet::Resource

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -122,7 +122,7 @@ class Puppet::Resource
     when Array
       value.all? { |elem| is_json_type?(elem) }
     when Hash
-      value.all? { |key, val| key.is_a?(String) && is_json_type(val) }
+      value.all? { |key, val| key.is_a?(String) && is_json_type?(val) }
     else
       false
     end


### PR DESCRIPTION
The actual method name is `is_json_type?`