### PR TITLE
(PUP-6774) Add test for ext_parameters containing hashes and arrays rich data

### DIFF
--- a/lib/puppet/pops/serialization/json.rb
+++ b/lib/puppet/pops/serialization/json.rb
@@ -211,7 +211,9 @@ module JSON
 
     def write_extension(ext, obj)
       @io << '[' << extension_indicator(ext).to_json << ','
+      @nested << nil
       write_extension_payload(ext, obj)
+      @nested.pop
       if obj.is_a?(Extension::SequenceStart) && obj.sequence_size > 0
         @nested << [false, obj.sequence_size]
       else

--- a/spec/unit/pops/serialization/serialization_spec.rb
+++ b/spec/unit/pops/serialization/serialization_spec.rb
@@ -203,6 +203,34 @@ module Serialization
       end
     end
 
+    it 'Array of rich data' do
+      # Sensitive omitted because it doesn't respond to ==
+      val = [
+        Time::Timespan.from_fields(false, 3, 12, 40, 31, 123),
+        Time::Timestamp.now,
+        Semantic::Version.parse('1.2.3-alpha2'),
+        Semantic::VersionRange.parse('>=1.2.3-alpha2 <1.2.4'),
+        Types::PBinaryType::Binary.from_base64('w5ZzdGVuIG1lZCByw7ZzdGVuCg==')
+      ]
+      write(val)
+      val2 = read
+      expect(val2).to eql(val)
+    end
+
+    it 'Hash of rich data' do
+      # Sensitive omitted because it doesn't respond to ==
+      val = {
+        'duration' => Time::Timespan.from_fields(false, 3, 12, 40, 31, 123),
+        'time' => Time::Timestamp.now,
+        'version' => Semantic::Version.parse('1.2.3-alpha2'),
+        'range' => Semantic::VersionRange.parse('>=1.2.3-alpha2 <1.2.4'),
+        'binary' => Types::PBinaryType::Binary.from_base64('w5ZzdGVuIG1lZCByw7ZzdGVuCg==')
+      }
+      write(val)
+      val2 = read
+      expect(val2).to eql(val)
+    end
+
     context 'an AST model' do
       it "Locator" do
         val = Parser::Locator::Locator19.new('here is some text', '/tmp/foo', [5])

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -898,6 +898,24 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
         expect(message).to be_a(Puppet::Pops::Time::Timestamp)
         expect(message).to eql(Puppet::Pops::Time::Timestamp.parse('2016-09-15T08:32:16.123 UTC'))
       end
+
+      it 'should read and convert ext_parameters containing hash with rich data from json' do
+        catalog = compile_to_catalog("notify {'foo': message => { 'version' => SemVer('1.0.0'), 'time' => Timestamp('2016-09-15T08:32:16.123 UTC') }}")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Hash)
+        expect(message['version']).to eql(Semantic::Version.parse('1.0.0'))
+        expect(message['time']).to eql(Puppet::Pops::Time::Timestamp.parse('2016-09-15T08:32:16.123 UTC'))
+      end
+
+      it 'should read and convert ext_parameters containing an array with rich data from json' do
+        catalog = compile_to_catalog("notify {'foo': message => [ SemVer('1.0.0'), Timestamp('2016-09-15T08:32:16.123 UTC') ] }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Array)
+        expect(message[0]).to eql(Semantic::Version.parse('1.0.0'))
+        expect(message[1]).to eql(Puppet::Pops::Time::Timestamp.parse('2016-09-15T08:32:16.123 UTC'))
+      end
     end
 
     context 'and rich_data is disabled' do


### PR DESCRIPTION
This PR adds a test that verifies that arrays and hashes containing rich_data can be serialized in a catalog. It also contains a maint commit to fix a problem with unbalanced brackets in the serializer that was found when the test was written.