### PR TITLE
(PUP-6784) http_proxy specs fail if proxy is defined in test env

### DIFF
--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -6,6 +6,11 @@ require 'puppet/forge/cache'
 require 'puppet/forge/errors'
 
 describe Puppet::Forge::Repository do
+  before(:all) do
+    # any local http proxy will break these tests
+    ENV['http_proxy'] = nil
+    ENV['HTTP_PROXY'] = nil
+  end
   let(:agent) { "Test/1.0" }
   let(:repository) { Puppet::Forge::Repository.new('http://fake.com', agent) }
   let(:ssl_repository) { Puppet::Forge::Repository.new('https://fake.com', agent) }

--- a/spec/unit/network/http/factory_spec.rb
+++ b/spec/unit/network/http/factory_spec.rb
@@ -4,6 +4,10 @@ require 'puppet/network/http'
 require 'puppet/util/http_proxy'
 
 describe Puppet::Network::HTTP::Factory do
+  before(:all) do
+    ENV['http_proxy'] = nil
+    ENV['HTTP_PROXY'] = nil
+  end
   before :each do
     Puppet::SSL::Key.indirection.terminus_class = :memory
     Puppet::SSL::CertificateRequest.indirection.terminus_class = :memory

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 require 'puppet/util/http_proxy'
 
 describe Puppet::Util::HttpProxy do
+  before(:all) do
+    ENV['http_proxy'] = nil
+    ENV['HTTP_PROXY'] = nil
+  end
 
   host, port, user, password = 'some.host', 1234, 'user1', 'pAssw0rd'
 


### PR DESCRIPTION
If http_proxy is defined in the test environment specs fail due to
precedence of http_proxy over HTTP_PROXY.

With this change http_proxy is explicitly set to nil before tests as
needed.
