### PR TITLE
(PUP-6798) Yum provider family ensuring latest

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -156,6 +156,16 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     operation = :install
 
     case should
+    when :latest
+      current_package = self.query
+      if current_package && !current_package[:ensure].to_s.empty?
+        operation = update_command
+        self.debug "Ensuring latest, so using #{operation}"
+      else
+        self.debug "Ensuring latest, but package is absent, so using #{:install}"
+        operation = :install
+      end
+      should = nil
     when true, false, Symbol
       # pass
       should = nil

--- a/spec/shared_examples/rhel_package_provider.rb
+++ b/spec/shared_examples/rhel_package_provider.rb
@@ -125,6 +125,22 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
         provider.stubs(:query).returns(:ensure => current_version).then.returns(:ensure => version)
         provider.install
       end
+      it 'should not run upgrade command if absent and ensure latest' do
+        current_version = ''
+        version = '1.2'
+        resource[:ensure] = :latest
+        Puppet::Util::Execution.expects(:execute).with(["/usr/bin/#{provider_name}", '-d', '0', '-e', error_level, '-y', :install, name])
+        provider.stubs(:query).returns(:ensure => current_version).then.returns(:ensure => version)
+        provider.install
+      end
+      it 'should run upgrade command if present and ensure latest' do
+        current_version = '1.0'
+        version = '1.2'
+        resource[:ensure] = :latest
+        Puppet::Util::Execution.expects(:execute).with(["/usr/bin/#{provider_name}", '-d', '0', '-e', error_level, '-y', upgrade_command, name])
+        provider.stubs(:query).returns(:ensure => current_version).then.returns(:ensure => version)
+        provider.install
+      end
       it 'should accept install options' do
         resource[:ensure] = :installed
         resource[:install_options] = ['-t', {'-x' => 'expackage'}]


### PR DESCRIPTION
* Previously, when ensuring latest the logic used to implement PUP-6324
didn’t take ensuring latest into account, just specifying a new version:

```
Debug: /Stage[main]/Main/Package[cockpit]/ensure: cockpit "0.55-1.fc22" is installed, latest is "0:0.67-2.fc22"
Debug: Package[cockpit](provider=dnf_update): Ensuring => latest
Debug: Executing: '/usr/bin/dnf -d 0 -e 1 -y install cockpit'
Notice: /Stage[main]/Main/Package[cockpit]/ensure: ensure changed '0.55-1.fc22' to '0:0.67-2.fc22'
Debug: /Stage[main]/Main/Package[cockpit]: The container Class[Main] will propagate my refresh event
```
* This meant the system reported that the package was updated, but it ran install rather than upgrade, which does nothing and exits zero
* Added new logic for when latest is used, add new spec, all working now!