### PR TITLE
(pup-6592) acceptance sensitive data fix

### DIFF
--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -9,7 +9,11 @@ extend Puppet::Acceptance::PuppetTypeTestTools
   tmp_filename_win = tmp_filename_else = ''
   agents.each do |agent|
     # ugh... this won't work with more than two agents of two types
-    tmp_filename_win  = "C:\\cygwin64\\tmp\\#{tmp_environment}.txt"
+    if agent.platform =~ /32$/
+      tmp_filename_win  = "C:\\cygwin\\tmp\\#{tmp_environment}.txt"
+    else
+      tmp_filename_win  = "C:\\cygwin64\\tmp\\#{tmp_environment}.txt"
+    end
     tmp_filename_else = "/tmp/#{tmp_environment}.txt"
     if agent.platform =~ /windows/
       tmp_filename = tmp_filename_win


### PR DESCRIPTION
*  the previous commit did not take into account windows32 pathing
 differences when abstracted into cygwin.  This change should allow the
 test to run in both 64/32 bit windowses.

this will need a merge-up to master