### PR TITLE
(PUP-6768) Add Pcore Object type Puppet::LookupContext

### DIFF
--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -47,6 +47,7 @@ module Puppet
     # (the Types module initializes itself)
     require 'puppet/pops/types/types'
     require 'puppet/pops/types/string_converter'
+    require 'puppet/pops/lookup/context'
 
     require 'puppet/pops/merge_strategy'
 

--- a/lib/puppet/pops/lookup/context.rb
+++ b/lib/puppet/pops/lookup/context.rb
@@ -24,6 +24,7 @@ module Puppet::Pops
             'cache_all' => tf.callable([tf.hash_kv(tf.scalar, tf.any)], tf.undef),
             'cached_value' => tf.callable([tf.scalar], tf.any),
             'cached_entries' => tf.variant(
+              tf.callable([0, 0, tf.callable(1,1)], tf.undef),
               tf.callable([0, 0, tf.callable(2,2)], tf.undef),
               tf.callable([0, 0], tf.iterable(tf.tuple([tf.scalar, tf.any])))
             )
@@ -55,12 +56,16 @@ module Puppet::Pops
         @cache[key]
       end
 
-      def cached_entries
+      def cached_entries(&block)
         @cache
         if block_given?
           enumerator = @cache.each_pair
           @cache.size.times do
-            yield(*enumerator.next)
+            if block.arity == 2
+              yield(*enumerator.next)
+            else
+              yield(enumerator.next)
+            end
           end
           nil
         else

--- a/lib/puppet/pops/lookup/context.rb
+++ b/lib/puppet/pops/lookup/context.rb
@@ -1,0 +1,81 @@
+module Puppet::Pops
+  module Lookup
+    class Context
+      include Types::PuppetObject
+
+      def self._ptype
+        @type
+      end
+
+      def self.register_ptype(loader, ir)
+        tf = Types::TypeFactory
+        @type = Pcore::create_object_type(loader, ir, self, 'Puppet::LookupContext', 'Any',
+          {
+            'environment_name' => Types::PStringType::NON_EMPTY,
+            'module_name' => {
+              Types::KEY_TYPE => tf.optional(Types::PStringType::NON_EMPTY),
+              Types::KEY_VALUE => nil
+            }
+          },
+          {
+            'not_found' => tf.callable([0, 0], tf.undef),
+            'explain' => tf.callable([0, 0, tf.callable(0,0)], tf.undef),
+            'cache' => tf.callable([tf.scalar, tf.any], tf.undef),
+            'cache_all' => tf.callable([tf.hash_kv(tf.scalar, tf.any)], tf.undef),
+            'cached_value' => tf.callable([tf.scalar], tf.any),
+            'cached_entries' => tf.variant(
+              tf.callable([0, 0, tf.callable(2,2)], tf.undef),
+              tf.callable([0, 0], tf.iterable(tf.tuple([tf.scalar, tf.any])))
+            )
+          }
+        ).resolve(Types::TypeParser.singleton, loader)
+      end
+
+      attr_reader :environment_name
+      attr_reader :module_name
+
+      def initialize(environment_name, module_name, lookup_invocation = Invocation.current)
+        @lookup_invocation = lookup_invocation
+        @environment_name = environment_name
+        @module_name = module_name
+        @cache = {}
+      end
+
+      def cache(key, value)
+        @cache[key] = value
+        nil
+      end
+
+      def cache_all(hash)
+        @cache.merge!(hash)
+        nil
+      end
+
+      def cached_value(key)
+        @cache[key]
+      end
+
+      def cached_entries
+        @cache
+        if block_given?
+          enumerator = @cache.each_pair
+          @cache.size.times do
+            yield(*enumerator.next)
+          end
+          nil
+        else
+          Types::Iterable.on(@cache)
+        end
+      end
+
+      def explain(&block)
+        @lookup_invocation.report_text(&block) unless @lookup_invocation.nil?
+        nil
+      end
+
+      def not_found
+        throw :no_such_key
+      end
+    end
+  end
+end

--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -34,6 +34,7 @@ module Puppet::Pops::Lookup
     def initialize(parent)
       @parent = parent
       @event = nil
+      @texts = nil
     end
 
     def found_in_overrides(key, value)
@@ -59,6 +60,11 @@ module Puppet::Pops::Lookup
       @event = :result
     end
 
+    def text(text)
+      @texts ||= []
+      @texts << text
+    end
+
     def not_found(key)
       @key = key
       @event = :not_found
@@ -81,6 +87,7 @@ module Puppet::Pops::Lookup
       hash[:key] = @key unless @key.nil?
       hash[:value] = @value if [:found, :found_in_defaults, :found_in_overrides, :result].include?(@event)
       hash[:event] = @event unless @event.nil?
+      hash[:texts] = @texts unless @texts.nil?
       hash[:type] = type
       hash
     end
@@ -98,6 +105,11 @@ module Puppet::Pops::Lookup
         io << ' in defaults' if @event == :found_in_defaults
         io << "\n"
       end
+      dump_texts(io, indent, @texts)
+    end
+
+    def dump_texts(io, indent, texts)
+      texts.each { |text| io << indent << text << "\n" } unless texts.nil?
     end
 
     def dump_value(io, indent, value)
@@ -496,6 +508,10 @@ module Puppet::Pops::Lookup
 
     def accept_result(result)
       @current.result(result)
+    end
+
+    def accept_text(text)
+      @current.text(text)
     end
 
     def dump_on(io, indent, first_indent)

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -3,6 +3,10 @@ module Puppet::Pops::Lookup
     attr_reader :scope, :override_values, :default_values, :explainer
     attr_accessor :module_name, :top_key
 
+    def self.current
+        nil # TODO, determine how to obtain the current lookup invocation.
+    end
+
     # Creates a context object for a lookup invocation. The object contains the current scope, overrides, and default
     # values and may optionally contain an {ExplanationAcceptor} instance that will receive book-keeping information
     # about the progress of the lookup.
@@ -122,6 +126,12 @@ module Puppet::Pops::Lookup
 
     def report_module_not_found
       @explainer.accept_module_not_found unless @explainer.nil?
+    end
+
+    def report_text(&block)
+      unless @explainer.nil?
+        @explainer.accept_text(block.call)
+      end
     end
   end
 end

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -34,6 +34,7 @@ module Pcore
     add_type(Types::PTypeSetType.new(ast_ts_i12n), loader)
 
     Resource.register_ptypes(loader, ir)
+    Lookup::Context.register_ptype(loader, ir);
   end
 
   # Create and register a new `Object` type in the Puppet Type System and map it to an implementation class

--- a/spec/lib/puppet_spec/unindent.rb
+++ b/spec/lib/puppet_spec/unindent.rb
@@ -1,0 +1,5 @@
+class String
+  def unindent
+    gsub(/^#{scan(/^\s*/).min_by{ |l| l.length }}/, '')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ require 'puppet_spec/files'
 require 'puppet_spec/settings'
 require 'puppet_spec/fixtures'
 require 'puppet_spec/matchers'
+require 'puppet_spec/unindent'
 require 'puppet/test/test_helper'
 
 Pathname.glob("#{dir}/shared_contexts/*.rb") do |file|

--- a/spec/unit/pops/lookup/context_spec.rb
+++ b/spec/unit/pops/lookup/context_spec.rb
@@ -1,0 +1,120 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+module Puppet::Pops
+module Lookup
+describe 'Puppet::Pops::Lookup::Context' do
+
+  context 'an instance' do
+    include PuppetSpec::Compiler
+    it 'can be created' do
+      code = "notice(type(Puppet::LookupContext.new('e', 'm')))"
+      expect(eval_and_collect_notices(code)[0]).to match(/Object\[\{name => 'Puppet::LookupContext'/)
+    end
+
+    it 'returns its environment_name' do
+      code = "notice(Puppet::LookupContext.new('e', 'm').environment_name)"
+      expect(eval_and_collect_notices(code)[0]).to eql('e')
+    end
+
+    it 'returns its module_name' do
+      code = "notice(Puppet::LookupContext.new('e', 'm').module_name)"
+      expect(eval_and_collect_notices(code)[0]).to eql('m')
+    end
+
+    it 'can use an undef module_name' do
+      code = "notice(type(Puppet::LookupContext.new('e', undef).module_name))"
+      expect(eval_and_collect_notices(code)[0]).to eql('Undef')
+    end
+
+    it 'can store and retrieve a value using the cache' do
+      code = <<-PUPPET.unindent
+        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx.cache('ze_key', 'ze_value')
+        notice($ctx.cached_value('ze_key'))
+      PUPPET
+      expect(eval_and_collect_notices(code)[0]).to eql('ze_value')
+    end
+
+    it 'can store and retrieve a hash using the cache' do
+      code = <<-PUPPET.unindent
+        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
+        $ctx.cached_entries |$key, $value| { notice($key); notice($value) }
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(%w(v1 first v2 second))
+    end
+
+    it 'can use the cache to merge hashes' do
+      code = <<-PUPPET.unindent
+        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
+        $ctx.cache_all({ 'v3' => 'third', 'v4' => 'fourth' })
+        $ctx.cached_entries |$key, $value| { notice($key); notice($value) }
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(%w(v1 first v2 second v3 third v4 fourth))
+    end
+
+    it 'can use the cache to merge hashes and individual entries' do
+      code = <<-PUPPET.unindent
+        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
+        $ctx.cache('v3', 'third')
+        $ctx.cached_entries |$key, $value| { notice($key); notice($value) }
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(%w(v1 first v2 second v3 third))
+    end
+
+    it 'cached_entries returns an Iterable when called without a block' do
+      code = <<-PUPPET.unindent
+        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
+        $iter = $ctx.cached_entries
+        notice(type($iter, generalized))
+        $iter.each |$entry| { notice($entry[0]); notice($entry[1]) }
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(['Iterator[Tuple[String, String, 2, 2]]', 'v1', 'first', 'v2', 'second'])
+    end
+
+    it 'will throw :no_such_key when not_found is called' do
+      code = <<-PUPPET.unindent
+        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx.not_found
+      PUPPET
+      expect { eval_and_collect_notices(code) }.to throw_symbol(:no_such_key)
+    end
+
+    context 'when used in an Invocation' do
+      let(:invocation) { Invocation.new({}) }
+      let(:invocation_with_explain) { Invocation.new({}, {}, {}, true) }
+
+      it 'will no call explain unless explanations are active' do
+        Invocation.expects(:current).returns(invocation)
+        code = <<-PUPPET.unindent
+          $ctx = Puppet::LookupContext.new('e', 'm')
+          $ctx.explain || { notice('stop calling'); 'bad' }
+        PUPPET
+        expect(eval_and_collect_notices(code)).to be_empty
+      end
+
+      it 'will call explain when explanations are active' do
+        Invocation.expects(:current).returns(invocation_with_explain)
+        invocation_with_explain.with(:global, 'test') do
+          code = <<-PUPPET.unindent
+            $ctx = Puppet::LookupContext.new('e', 'm')
+            $ctx.explain || { notice('called'); 'good' }
+          PUPPET
+          expect(eval_and_collect_notices(code)).to eql(['called'])
+        end
+        expect(invocation_with_explain.explainer.to_s).to eql(<<-TEXT.unindent)
+          Data Binding "test"
+            good
+        TEXT
+      end
+    end
+  end
+end
+end
+end
+

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -195,6 +195,13 @@ describe 'the type mismatch describer' do
       dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], nil, nil, nil, false)
       expect(subject.describe_signatures('function', [dispatch], args_tuple)).to eq("'function' does not expect a block")
     end
+
+    it 'reports a block return type mismatch' do
+      callable = parser.parse('Callable[[0,0,Callable[ [0,0],String]],Undef]')
+      args_tuple = parser.parse('Tuple[Callable[[0,0],Integer]]')
+      dispatch = Functions::Dispatch.new(callable, 'foo', [], 'block', nil, nil, false)
+      expect(subject.describe_signatures('function', [dispatch], args_tuple)).to eq("'function' block return expects a String value, got Integer")
+    end
   end
 end
 end


### PR DESCRIPTION
This PR adds a new Pcore Object type named `Puppet::LookupContext`
with attributes and methods.
