### PR TITLE
PUP-6792,6793,6795-6797 Solaris Updates

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -108,9 +108,13 @@ def do_man(man, strip = 'man/')
     FileUtils.makedirs(om, {:mode => 0755, :verbose => true})
     FileUtils.chmod(0755, om)
     FileUtils.install(mf, omf, {:mode => 0644, :preserve => true, :verbose => true})
-    gzip = %x{which gzip}
-    gzip.chomp!
-    %x{#{gzip} -f #{omf}}
+    # Solaris does not support gzipped man pages. When called with
+    # --no-check-prereqs/without facter the default gzip behavior still applies
+    unless $operatingsystem == "Solaris"
+      gzip = %x{which gzip}
+      gzip.chomp!
+      %x{#{gzip} -f #{omf}}
+    end
   end
 end
 

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
 
   confine :osfamily => :solaris
 
-  defaultfor :osfamily => :solaris, :kernelrelease => '5.11'
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
 
   def self.instances
     pkg(:list, '-Hv').split("\n").map{|l| new(parse_line(l))}

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
     when :maintenance, :degraded
       [command(:adm), :clear, @resource[:name]]
     else
-      [command(:adm), :enable, "-s", @resource[:name]]
+      [command(:adm), :enable, "-rs", @resource[:name]]
     end
   end
 

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -129,14 +129,6 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
       return
     end
 
-    # Check to see if the service exists
-    cmd = Array[command(:svccfg), "select", @resource[:name]]
-    output = Puppet::Util::Execution.execute(
-        cmd, :combine => true, :failonfail => false)
-    if $CHILD_STATUS.exitstatus != 0
-      info output
-    end
-
     begin
       # get the current state and the next state, and if the next
       # state is set (i.e. not "-") use it for state comparison

--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -12,6 +12,7 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
   options :home, :flag => "-d", :method => :dir
   options :comment, :method => :gecos
   options :groups, :flag => "-G"
+  options :shell, :flag => "-s"
   options :roles, :flag => "-R"
   options :auths, :flag => "-A"
   options :profiles, :flag => "-P"
@@ -26,7 +27,21 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
     value !~ /\s/
   end
 
+  def shell=(value)
+    check_valid_shell
+    set("shell", value)
+  end
+
   has_features :manages_homedir, :allows_duplicates, :manages_solaris_rbac, :manages_passwords, :manages_password_age, :manages_shell
+
+  def check_valid_shell
+    unless File.exists?(@resource.should(:shell))
+      raise(Puppet::Error, "Shell #{@resource.should(:shell)} must exist")
+    end
+    unless File.executable?(@resource.should(:shell).to_s)
+      raise(Puppet::Error, "Shell #{@resource.should(:shell)} must be executable")
+    end
+  end
 
   #must override this to hand the keyvalue pairs
   def add_properties

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -25,6 +25,28 @@ describe Puppet::Type.type(:package).provider(:pkg) do
 
   it_should_respond_to :install, :uninstall, :update, :query, :latest
 
+  context 'default' do
+    [ 10 ].each do |ver|
+      it "should not be the default provider on Solaris #{ver}" do
+        Facter.stubs(:value).with(:osfamily).returns(:Solaris)
+        Facter.stubs(:value).with(:kernelrelease).returns("5.#{ver}")
+        Facter.stubs(:value).with(:operatingsystem).returns(:Solaris)
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+        expect(described_class).to_not be_default
+      end
+    end
+
+    [ 11, 12 ].each do |ver|
+      it "should be the default provider on Solaris #{ver}" do
+        Facter.stubs(:value).with(:osfamily).returns(:Solaris)
+        Facter.stubs(:value).with(:kernelrelease).returns("5.#{ver}")
+        Facter.stubs(:value).with(:operatingsystem).returns(:Solaris)
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+        expect(described_class).to be_default
+      end
+    end
+  end
+
   it "should be versionable" do
     expect(described_class).to be_versionable
   end

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -18,6 +18,8 @@ describe provider_class, :if => Puppet.features.posix? do
 
     FileTest.stubs(:file?).with('/usr/sbin/svcadm').returns true
     FileTest.stubs(:executable?).with('/usr/sbin/svcadm').returns true
+    FileTest.stubs(:file?).with('/usr/sbin/svccfg').returns true
+    FileTest.stubs(:executable?).with('/usr/sbin/svccfg').returns true
     FileTest.stubs(:file?).with('/usr/bin/svcs').returns true
     FileTest.stubs(:executable?).with('/usr/bin/svcs').returns true
     Facter.stubs(:value).with(:operatingsystem).returns('Solaris')

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -76,9 +76,9 @@ describe provider_class, :if => Puppet.features.posix? do
       @provider.expects(:svcs).with('-H', '-o', 'state,nstate', "/system/myservice").returns("online\t-")
       @provider.status
     end
-    it "should return stopped if svcs can't find the service" do
+    it "should return absent if svcs can't find the service" do
       @provider.stubs(:svcs).raises(Puppet::ExecutionFailure.new("no svc found"))
-      expect(@provider.status).to eq(:stopped)
+      expect(@provider.status).to eq(:absent)
     end
     it "should return running if online in svcs output" do
       @provider.stubs(:svcs).returns("online\t-")

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -107,14 +107,14 @@ describe provider_class, :if => Puppet.features.posix? do
   describe "when starting" do
     it "should enable the service if it is not enabled" do
       @provider.expects(:status).returns :stopped
-      @provider.expects(:texecute).with(:start, ['/usr/sbin/svcadm', :enable, '-s', '/system/myservice'], true)
+      @provider.expects(:texecute).with(:start, ['/usr/sbin/svcadm', :enable, '-rs', '/system/myservice'], true)
       @provider.expects(:wait).with('online')
       @provider.start
     end
 
     it "should always execute external command 'svcadm enable /system/myservice'" do
       @provider.expects(:status).returns :running
-      @provider.expects(:texecute).with(:start, ['/usr/sbin/svcadm', :enable, '-s', '/system/myservice'], true)
+      @provider.expects(:texecute).with(:start, ['/usr/sbin/svcadm', :enable, '-rs', '/system/myservice'], true)
       @provider.expects(:wait).with('online')
       @provider.start
     end
@@ -135,7 +135,7 @@ describe provider_class, :if => Puppet.features.posix? do
 
     it "should error if timeout occurs while starting the service" do
       @provider.expects(:status).returns :stopped
-      @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, "-s", "/system/myservice"], true)
+      @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, '-rs', "/system/myservice"], true)
       Timeout.expects(:timeout).with(60).raises(Timeout::Error)
       expect { @provider.start }.to raise_error Puppet::Error, ('Timed out waiting for /system/myservice to transition states')
     end
@@ -150,7 +150,7 @@ describe provider_class, :if => Puppet.features.posix? do
 
     it "should import the manifest if service is missing" do
       @provider.expects(:svccfg).with(:import, "/tmp/myservice.xml")
-      @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, "-s", "/system/myservice"], true)
+      @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, '-rs', "/system/myservice"], true)
       @provider.expects(:wait).with('online')
       @provider.expects(:svcs).with('-H', '-o', 'state,nstate', "/system/myservice").returns("online\t-")
       @provider.start
@@ -164,13 +164,13 @@ describe provider_class, :if => Puppet.features.posix? do
 
   describe "when stopping" do
     it "should execute external command 'svcadm disable /system/myservice'" do
-      @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, "-s", "/system/myservice"], true)
+      @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, '-s', "/system/myservice"], true)
       @provider.expects(:wait).with('offline', 'disabled', 'uninitialized')
       @provider.stop
     end
 
     it "should error if timeout occurs while stopping the service" do
-      @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, "-s", "/system/myservice"], true)
+      @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, '-s', "/system/myservice"], true)
       Timeout.expects(:timeout).with(60).raises(Timeout::Error)
       expect { @provider.stop }.to raise_error Puppet::Error, ('Timed out waiting for /system/myservice to transition states')
     end
@@ -179,7 +179,7 @@ describe provider_class, :if => Puppet.features.posix? do
   describe "when restarting" do
 
     it "should error if timeout occurs while restarting the service" do
-      @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, "-s", "/system/myservice"], true)
+      @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, '-s', "/system/myservice"], true)
       Timeout.expects(:timeout).with(60).raises(Timeout::Error)
       expect { @provider.restart }.to raise_error Puppet::Error, ('Timed out waiting for /system/myservice to transition states')
     end
@@ -196,7 +196,7 @@ describe provider_class, :if => Puppet.features.posix? do
     context 'with :operatingsystemrelease == 11.2' do
       it "should call 'svcadm restart -s /system/myservice'" do
         Facter.stubs(:value).with(:operatingsystemrelease).returns '11.2'
-        @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, "-s", "/system/myservice"], true)
+        @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, '-s', "/system/myservice"], true)
         @provider.expects(:wait).with('online')
         @provider.restart
       end
@@ -205,7 +205,7 @@ describe provider_class, :if => Puppet.features.posix? do
     context 'with :operatingsystemrelease > 11.2' do
       it "should call 'svcadm restart -s /system/myservice'" do
         Facter.stubs(:value).with(:operatingsystemrelease).returns '11.3'
-        @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, "-s", "/system/myservice"], true)
+        @provider.expects(:texecute).with(:restart, ["/usr/sbin/svcadm", :restart, '-s', "/system/myservice"], true)
         @provider.expects(:wait).with('online')
         @provider.restart
       end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -438,6 +438,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     end
 
     it "should raise an error if the shell is not executable" do
+      FileTest.stubs(:executable?).with('LICENSE').returns false
       resource[:shell] = 'LICENSE'
       expect { provider.check_valid_shell }.to raise_error(Puppet::Error, /Shell LICENSE must be executable/)
     end


### PR DESCRIPTION
(PUP-6792) SMF should recursively enable services

SMF supports enabling a service and all services which that service
requires. With this patch recursive starts are the default behavior.

(PUP-6793) pkg provider should be default for Solaris 12

Puppet needs to use the pkg provider to manage packages on Solaris 12

(PUP-6795) Solaris does not support gzipped man pages

Solaris does not support gzipped man pages. Skip gzipping when
installing on Solaris.

(PUP-6796) Support setting/checking shell in user_role_add

Puppet should allow a users shell to be set in a Solaris role

(PUP-6797) service should check for smf service first

(PUP-6860) puppet on solaris 11 should support exists? for services

Attempts to manage non-existent services resulted in uninformative
errors. With this patch non-existent services return better error
messages.
