### PR TITLE
(PUP-6807 nee PE-17527) Show pretty string when inspecting loaders

### DIFF
--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -150,6 +150,23 @@ class Loader
     LOADABLE_KINDS
   end
 
+  # A loader may want to implement its own version with more detailed information.
+  def to_s
+    loader_name
+  end
+
+  # Loaders may contain references to the environment they load items within.
+  # Consequently, calling Kernel#inspect may return strings that are large
+  # enough to cause OutOfMemoryErrors on some platforms.
+  #
+  # We do not call alias_method here as that would copy the content of to_s
+  # at this point to inspect (ie children would print out `loader_name`
+  # rather than their version of to_s if they chose to implement it).
+  def inspect
+    self.to_s
+  end
+
+
   # An entry for one entity loaded by the loader.
   #
   class NamedEntry

--- a/spec/unit/pops/loaders/dependency_loader_spec.rb
+++ b/spec/unit/pops/loaders/dependency_loader_spec.rb
@@ -10,6 +10,18 @@ describe 'dependency loader' do
   let(:loaders) { Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, [])) }
 
   describe 'FileBased module loader' do
+    it 'prints a pretty name for itself when inspected' do
+      module_dir = dir_containing('testmodule', {
+      'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {
+        'foo.rb' => 'Puppet::Functions.create_function("foo") { def foo; end; }'
+      }}}}})
+
+      loader = loader_for('testmodule', module_dir)
+
+      expect(loader.inspect).to eq("(DependencyLoader 'test-dep' [(ModuleLoader::FileBased 'testmodule' 'testmodule')])")
+      expect(loader.to_s).to eq("(DependencyLoader 'test-dep' [(ModuleLoader::FileBased 'testmodule' 'testmodule')])")
+    end
+
     it 'load something in global name space raises an error' do
       module_dir = dir_containing('testmodule', {
       'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {


### PR DESCRIPTION
Previously, when calling inspect on a loader we would create a string
that contained the content of calling inspect on everything that is
reachable from a loader. The string formed could be larger than a
gigabyte in memory and would cause out of memory errors in production.

This replaces the default implementation of inspect with a call to #to_s
which is implemented in a number of Loader subclasses already. It also
provides a default #to_s implementation for all loaders.