### PR TITLE
(doc) (DOCUMENT-596) Fix code tags of scanf function

### DIFF
--- a/lib/puppet/parser/functions/scanf.rb
+++ b/lib/puppet/parser/functions/scanf.rb
@@ -14,17 +14,22 @@ the format string. The result of the scan is an array, with each successfully sc
 The scanning stops if a scan is unsuccessful, and the scanned result up to that point is returned. If there
 was no successful scan, the result is an empty array.
 
-   "42".scanf("%i")
+```puppet
+"42".scanf("%i")
+```
 
 You can also optionally pass a lambda to scanf, to do additional validation or processing.
 
-    "42".scanf("%i") |$x| {
-      unless $x[0] =~ Integer {
-        fail "Expected a well formed integer value, got '$x[0]'"
-      }
-      $x[0]
-    }
-- since 4.0.0
+```puppet
+"42".scanf("%i") |$x| {
+  unless $x[0] =~ Integer {
+    fail "Expected a well formed integer value, got '$x[0]'"
+  }
+  $x[0]
+}
+```
+
+- Since 4.0.0
 DOC
 ) do |args|
   data = args[0]


### PR DESCRIPTION
On this page:
https://docs.puppet.com/puppet/latest/reference/function.html#scanf

The first example is not in a code block.
The second example includes: "- since 4.0.0"
And the "since" should be capitalised to match the rest of the document.