### PR TITLE
(PUP-6819) Use packaged cert when attempting to contact rubygems

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -134,7 +134,11 @@ module Puppet
       def gem_command(host, type='aio')
         if type == 'aio'
           if host['platform'] =~ /windows/
-            "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+            if host['platform'] =~ /-64$/ && host['ruby_arch'] != 'x64'
+              "env SSL_CERT_FILE=\"C:/Program Files (x86)/Puppet Labs/Puppet/puppet/ssl/cert.pem\" PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+            else
+              "env SSL_CERT_FILE=\"C:/Program Files/Puppet Labs/Puppet/puppet/ssl/cert.pem\" PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+            end
           else
             "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
           end


### PR DESCRIPTION
Since the rubygems certificate update, Windows boxes provisioned by
beaker-hostgenerator have been unable to connect to rubygems due to a
bad cert. This adds a valid cert to the environment when calling out to
rubygems.