### PR TITLE
(PUP-6790) acceptance: dir resource with and without trailing slash

### DIFF
--- a/acceptance/tests/resource/file/should_create_directory.rb
+++ b/acceptance/tests/resource/file/should_create_directory.rb
@@ -2,16 +2,49 @@ test_name "should create directory"
 
 agents.each do |agent|
   target = agent.tmpfile("create-dir")
+  teardown do
+    step "clean up after the test run" do
+      on(agent, "rm -rf #{target}")
+    end
+  end
 
-  step "clean up the system before we begin"
-  on(agent, "rm -rf #{target}")
+  step "verify we can create a directory" do
+    on(agent, puppet_resource("file", target, 'ensure=directory'))
+  end
 
-  step "verify we can create a directory"
-  on(agent, puppet_resource("file", target, 'ensure=directory'))
+  step "verify the directory was created" do
+    on(agent, "test -d #{target}")
+  end
 
-  step "verify the directory was created"
-  on(agent, "test -d #{target}")
+  dir_manifest = agent.tmpfile("dir-resource")
+  create_remote_file(agent, dir_manifest, <<-PP)
+    $dir='#{target}'
+    $same_dir='#{target}/'
+    file {$dir:
+      ensure => directory,
+    }
+    if !defined(File["${same_dir}"]) {
+      file { $same_dir:
+        ensure => directory,
+      }
+    }
+  PP
 
-  step "clean up after the test run"
-  on(agent, "rm -rf #{target}")
+  step "verify we can't create same dir resource with a trailing slash" do
+    options = {:acceptable_exit_codes => [1]}
+    on(agent, puppet_apply("--noop #{dir_manifest}"), options) do |result|
+      assert_match('Error: Cannot alias File', result.output,
+                   'duplicate directory resources did not fail properly')
+    end
+
+    on(agent, puppet_apply("--noop --no-app_management #{dir_manifest}"), options) do |result|
+      assert_match('Error: Cannot alias File', result.output,
+                   'duplicate directory resources did not fail properly')
+    end
+
+    on(agent, puppet_apply("--noop --app_management #{dir_manifest}"), options) do |result|
+      assert_match('Error: Cannot alias File', result.output,
+                   'duplicate directory resources did not fail properly')
+    end
+  end
 end


### PR DESCRIPTION
* there was a regression recently with --app-management and duplicate
file resources with and without a trailing slash. this should prevent
that.
[skip ci]