### PR TITLE
(PUP-1476) Include puppet and ruby versions in User-Agent

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -517,6 +517,10 @@ deprecated and has been replaced by 'always_retry_plugins'."
       read after the elapsed interval then the connection will be closed. The default value is unlimited.
       #{AS_DURATION}",
     },
+    :http_user_agent => {
+      :default => "Puppet/#{Puppet.version} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})",
+      :desc    => "The HTTP User-Agent string to send when making network requests."
+    },
     :filetimeout => {
       :default    => "15s",
       :type       => :duration,

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -147,8 +147,7 @@ class Puppet::Forge
     def user_agent
       @user_agent ||= [
         @agent,
-        "Puppet/#{Puppet.version}",
-        "Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})",
+        Puppet[:http_user_agent]
       ].join(' ').freeze
     end
   end

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -197,6 +197,8 @@ module Puppet::Network::HTTP
     end
 
     def apply_options_to(request, options)
+      request["User-Agent"] = Puppet[:http_user_agent]
+
       if options[:basic_auth]
         request.basic_auth(options[:basic_auth][:user], options[:basic_auth][:password])
       end

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -296,4 +296,14 @@ describe Puppet::Network::HTTP::Connection do
       expect(request['authorization']).to match(/^Basic/)
     end.returns(httpok)
   end
+
+  it "sets HTTP User-Agent header" do
+    puppet_ua = "Puppet/#{Puppet.version} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})"
+
+    Net::HTTP.any_instance.expects(:request).with do |request|
+      expect(request['User-Agent']).to eq(puppet_ua)
+    end.returns(httpok)
+
+    subject.get('/path')
+  end
 end


### PR DESCRIPTION
Previously, puppet did not specify an HTTP User-Agent string, so ruby
would send the default "Ruby". This made it difficult to debug and
interpret server-side logs when different versions of puppet agents
connect.

This commit adds a puppet setting `http_user_agent` which includes the
puppet and ruby versions. The default value is of the form:

```
Puppet/4.7.0 Ruby/2.1.8-p440 (x86_64-darwin15.0)
```

The string is exposed as a setting for cases where puppet is being used
as a library, and the enclosing application may need to override that.

Puppet's HTTP connection code will send the User-Agent header with the
above value for all requests. The value is taken from the Puppet Module
Tool code. However, the strings are not exactly the same, because the
PMT prefixes the string with additional information:

```
PMT/1.1.1 (v3; Net::HTTP) Puppet/4.7.0 Ruby/2.1.8-p440 (x86_64-darwin15.0)
```
