### PR TITLE
(DOCS) Expand membership description

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -324,9 +324,14 @@ module Puppet
     end
 
     newparam(:membership) do
-      desc "Whether specified groups should be considered the **complete list**
-        (`inclusive`) or the **minimum list** (`minimum`) of groups to which
-        the user belongs. Defaults to `minimum`."
+      desc "If `minimum` is specified, Puppet will ensure that the user is a
+        member of all specified groups, but will not remove any other groups
+        that the user is a part of.
+
+        If `inclusive` is specified, Puppet will ensure that the user is a
+        member of **only** specified groups.
+
+        Defaults to `minimum`."
 
       newvalues(:inclusive, :minimum)
 


### PR DESCRIPTION
Previous one sentence description was insufficient. 

cc: @branan, I changed the sentence about 'inclusive', please take a look to make sure it's still technically accurate.