### PR TITLE
(PUP-6827) fix test to meet password complexity reqs

### DIFF
--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -28,14 +28,14 @@ end
 adduser_manifest = <<MANIFEST
 user { '#{username}':
   ensure   => 'present',
-  password => 'apassword',
+  password => 'Apassw0rd!',
 }
 MANIFEST
 
 changepass_manifest = <<MANIFEST
 user { '#{username}':
   ensure   => 'present',
-  password => 'newpassword',
+  password => 'Anewpassw0rd!',
   noop     => true,
 }
 MANIFEST


### PR DESCRIPTION
Prior to this commit, the test '#6857: redact password hashes when applying in
noop mode' would fail on a host that had 'Password must meet complexity
requirements' set to true, because puppet was applying user management
manifests containing passwords that did not meet said requirements. This commit
updates the test to meet the complexity requirements (documented here:
https://technet.microsoft.com/en-us/library/hh994562(v=ws.11).aspx), allowing tests to pass.

Assumedly prior hosts in the acceptance testing systems were either
pre-configured with this requirement disabled or it was disabled at test time
for other tests (the latter of which seems unlikely).

Signed-off-by: Moses Mendoza <moses@puppet.com>