### PR TITLE
(PUP-6839) Bump version to 4.8.0

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -7,7 +7,7 @@
 
 
 module Puppet
-  PUPPETVERSION = '4.7.1'
+  PUPPETVERSION = '4.8.0'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This updates Puppet's version to 4.8.0 in preparation for the
puppet-agent 1.8.0 release.