### PR TITLE
(PUP-6840) Add revert policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,30 @@ a ticket number.
 * After feedback has been given we expect responses within two weeks. After two
   weeks we may close the pull request if it isn't showing any activity.
 
+## Revert Policy
+By running tests in advance and by engaging with peer review for prospective
+changes, your contributions have a high probability of becoming long lived
+parts of the the project. After being merged, the code will run through a
+series of testing pipelines on a large number of operating system
+environments. These pipelines can reveal incompatibilities that are difficult
+to detect in advance.
+
+If the code change results in a test failure, we will make our best effort to
+correct the error. If a fix cannot be determined and committed within 24 hours
+of its discovery, the commit(s) responsible _may_ be reverted, at the
+discretion of the committer and Puppet maintainers. This action would be taken
+to help maintain passing states in our testing pipelines.
+
+The original contributor will be notified of the revert in the Jira ticket
+associated with the change. A reference to the test(s) and operating system(s)
+that failed as a result of the code change will also be added to the Jira
+ticket. This test(s) should be used to check future submissions of the code to
+ensure the issue has been resolved.
+
+### Summary
+* Changes resulting in test pipeline failures will be reverted if they cannot
+  be resolved within one business day.
+
 # Additional Resources
 
 * [Puppet community guidelines](https://docs.puppet.com/community/community_guidelines.html)


### PR DESCRIPTION
This commit outlines the revert policy for code changes that result
in test pipeline failures. The purpose of this is to establish a
clear protocol for when a revert should take place and how it should
be communicated to the original contributor.
