### PR TITLE
(maint) Add beaker-abs compatible with beaker 2-3

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -14,6 +14,7 @@ end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.32')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false


### PR DESCRIPTION
Add beaker-abs dependency, version 0.2.0 is compatible with beaker 2 and 3.