### PR TITLE
(PUP-6847) Omit whitespace from provider keyword in network_device

### DIFF
--- a/lib/puppet/util/network_device/config.rb
+++ b/lib/puppet/util/network_device/config.rb
@@ -59,7 +59,7 @@ class Puppet::Util::NetworkDevice::Config
             device.options = { :debug => false }
             Puppet.debug "found device: #{device.name} at #{device.line}"
             devices[name] = device
-          when /^\s*(type|url|debug)(\s+(.+))*$/
+          when /^\s*(type|url|debug)(\s+(.+)\s*)*$/
             parse_directive(device, $1, $3, count)
           else
             raise Puppet::Error, "Invalid line #{count}: #{line}"


### PR DESCRIPTION
Prior to this update, any trailing whitespace left in a device
configuration file will cause `puppet device` to fail with
a cryptic message because it is using the string to construct
the path for an require statement.  Since require statements
should never have spaces in them, it makes more sense to have the
regex only accept the non-whitespace characters it finds in the
confiugration file.
