### PR TITLE
(PUP-6849) remove error-prone commit check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ rvm:
 env:
   - "CHECK=parallel:spec\\[2\\]"
   - "CHECK=rubocop"
-  - "CHECK=commits"
 
 matrix:
   exclude:
@@ -29,11 +28,3 @@ matrix:
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
-    - rvm: 2.3.1
-      env: "CHECK=commits"
-    - rvm: 2.2.4
-      env: "CHECK=commits"
-    - rvm: 2.0.0
-      env: "CHECK=commits"
-    - rvm: 1.9.3
-      env: "CHECK=commits"


### PR DESCRIPTION
Prior to this PR, our travis CI would run `rake commits` as part of its suite,
the intention of which is to check for improperly formatted commits.
Unfortunately, despite a range of attempts to make this work
correctly/completely, including:

e1efdebf
4d5afd57
1ed7c7ce

...we still haven't gotten it quite right. The most challenging aspect is to
accurately get a list of commits that exist _only_ in the pull request and
check those. Failure to do so was causing consistent CI failures for many PRs,
as commits unrelated to this PR would trigger failure. This then meant lost
time investigating and spurious red in hipchat rooms.

This PR removes the check from the travis suite, so that we can have our travis
runs go green tests succeed. A second ticket, PUP-6850, has been filed to
improve the robustness of the commit check.

Signed-off-by: Moses Mendoza moses@puppet.com
