### PR TITLE
(PUP-6188) Add utf-8 encoding to various calls throughout puppet

### DIFF
--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -108,7 +108,7 @@ Puppet::Face.define(:config, '0.0.1') do
     when_invoked do |name, value, options|
       path = Puppet::FileSystem.pathname(Puppet.settings.which_configuration_file)
       Puppet::FileSystem.touch(path)
-      Puppet::FileSystem.open(path, nil, 'r+') do |file|
+      Puppet::FileSystem.open(path, nil, 'r+:UTF-8') do |file|
         Puppet::Settings::IniFile.update(file) do |config|
           config.set(options[:section], name, value)
         end

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -115,7 +115,7 @@ module Puppet::FileBucketFile
     # @param files_original_path [String]
     #
     def matches(paths_file, files_original_path)
-      Puppet::FileSystem.open(paths_file, 0640, 'a+') do |f|
+      Puppet::FileSystem.open(paths_file, 0640, 'a+:UTF-8') do |f|
         path_match(f, files_original_path)
       end
     end
@@ -138,7 +138,7 @@ module Puppet::FileBucketFile
           Puppet::FileSystem.dir_mkpath(paths_file)
         end
 
-        Puppet::FileSystem.exclusive_open(paths_file, 0640, 'a+') do |f|
+        Puppet::FileSystem.exclusive_open(paths_file, 0640, 'a+:UTF-8') do |f|
           if Puppet::FileSystem.exist?(contents_file)
             verify_identical_file!(contents_file, bucket_file)
             Puppet::FileSystem.touch(contents_file)

--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -81,7 +81,7 @@ class Puppet::SSL::Base
 
   # Read content from disk appropriately.
   def read(path)
-    @content = wrapped_class.new(File.read(path))
+    @content = wrapped_class.new(Puppet::FileSystem.read(path, :encoding => 'UTF-8'))
   end
 
   # Convert our thing to pem.

--- a/lib/puppet/ssl/configuration.rb
+++ b/lib/puppet/ssl/configuration.rb
@@ -50,7 +50,7 @@ class Configuration
 
   # read_file makes testing easier.
   def read_file(path)
-    File.read(path)
+    Puppet::FileSystem.read(path, :encoding => 'UTF-8')
   end
   private :read_file
 end

--- a/lib/puppet/ssl/inventory.rb
+++ b/lib/puppet/ssl/inventory.rb
@@ -40,7 +40,7 @@ class Puppet::SSL::Inventory
   def serials(name)
     return [] unless Puppet::FileSystem.exist?(@path)
 
-    File.readlines(@path).collect do |line|
+    File.readlines(@path, :encoding => 'UTF-8').collect do |line|
       /^(\S+).+\/CN=#{name}$/.match(line)
     end.compact.map { |m| Integer(m[1]) }
   end

--- a/lib/puppet/ssl/key.rb
+++ b/lib/puppet/ssl/key.rb
@@ -38,15 +38,14 @@ DOC
   def password
     return nil unless password_file and Puppet::FileSystem.exist?(password_file)
 
-    ::File.read(password_file)
+    Puppet::FileSystem.read(password_file, :encoding => 'UTF-8')
   end
 
   # Optionally support specifying a password file.
   def read(path)
     return super unless password_file
 
-    #@content = wrapped_class.new(::File.read(path), password)
-    @content = wrapped_class.new(::File.read(path), password)
+    @content = wrapped_class.new(Puppet::FileSystem.read(path, :encoding => 'UTF-8'), password)
   end
 
   def to_s

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -105,7 +105,7 @@ class Puppet::Util::FileType
     # Read the file.
     def read
       if Puppet::FileSystem.exist?(@path)
-        File.read(@path)
+        Puppet::FileSystem.read(@path, :encoding => 'UTF-8')
       else
         return nil
       end
@@ -118,7 +118,7 @@ class Puppet::Util::FileType
 
     # Overwrite the file.
     def write(text)
-      tf = Tempfile.new("puppet")
+      tf = Tempfile.new("puppet", :encoding => 'UTF-8')
       tf.print text; tf.flush
       File.chmod(@default_mode, tf.path) if @default_mode
       FileUtils.cp(tf.path, @path)
@@ -197,7 +197,7 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      IO.popen("#{cmdbase()} -", "w") { |p|
+      IO.popen("#{cmdbase()} -", "w", :encoding => 'UTF-8') { |p|
         p.print text
       }
     end
@@ -242,7 +242,7 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      output_file = Tempfile.new("puppet_suntab")
+      output_file = Tempfile.new("puppet_suntab", :encoding => 'UTF-8')
       begin
         output_file.print text
         output_file.close
@@ -284,7 +284,7 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      output_file = Tempfile.new("puppet_aixtab")
+      output_file = Tempfile.new("puppet_aixtab", :encoding => 'UTF-8')
 
       begin
         output_file.print text

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -64,7 +64,7 @@ syslogfacility = file
       subject.set('foo', 'bar')
     end
 
-    it "sets the supplied config/value" do
+    it "sets the supplied config/value in the default section (main)" do
       Puppet::FileSystem.stubs(:open).with(path, anything, anything).yields(StringIO.new)
       config = Puppet::Settings::IniFile.new([Puppet::Settings::IniFile::DefaultSection.new])
       manipulator = Puppet::Settings::IniFile::Manipulator.new(config)

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -44,6 +44,48 @@ syslogfacility = file
     subject.print('all')
   end
 
+  context "when setting config values" do
+    let(:config_file) { '/foo/puppet.conf' }
+    let(:path) { Pathname.new(config_file) }
+    before(:each) do
+      Puppet[:config] = '/foo/puppet.conf'
+      Puppet::FileSystem.stubs(:pathname).with(config_file).returns(path)
+      Puppet::FileSystem.stubs(:touch)
+    end
+
+    it "writes to the correct puppet config file" do
+      Puppet::FileSystem.expects(:open).with(path, anything, anything)
+      subject.set('foo', 'bar')
+    end
+
+    it "creates a config file if one does not exist" do
+      Puppet::FileSystem.stubs(:open).with(path, anything, anything).yields(StringIO.new)
+      Puppet::FileSystem.expects(:touch).with(path)
+      subject.set('foo', 'bar')
+    end
+
+    it "sets the supplied config/value" do
+      Puppet::FileSystem.stubs(:open).with(path, anything, anything).yields(StringIO.new)
+      config = Puppet::Settings::IniFile.new([Puppet::Settings::IniFile::DefaultSection.new])
+      manipulator = Puppet::Settings::IniFile::Manipulator.new(config)
+      Puppet::Settings::IniFile::Manipulator.stubs(:new).returns(manipulator)
+
+      manipulator.expects(:set).with("main", "foo", "bar")
+      subject.set('foo', 'bar')
+    end
+
+    it "sets the value in the supplied section" do
+      Puppet::FileSystem.stubs(:open).with(path, anything, anything).yields(StringIO.new)
+      config = Puppet::Settings::IniFile.new([Puppet::Settings::IniFile::DefaultSection.new])
+      manipulator = Puppet::Settings::IniFile::Manipulator.new(config)
+      Puppet::Settings::IniFile::Manipulator.stubs(:new).returns(manipulator)
+
+      manipulator.expects(:set).with("baz", "foo", "bar")
+      subject.set('foo', 'bar', {:section => "baz"})
+
+    end
+  end
+
   shared_examples_for :config_printing_a_section do |section|
 
     def add_section_option(args, section)

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -84,6 +84,11 @@ syslogfacility = file
       subject.set('foo', 'bar', {:section => "baz"})
 
     end
+
+    it "opens the file with UTF-8 encoding" do
+      Puppet::FileSystem.expects(:open).with(path, nil, 'r+:UTF-8')
+      subject.set('foo', 'bar')
+    end
   end
 
   shared_examples_for :config_printing_a_section do |section|

--- a/spec/unit/ssl/base_spec.rb
+++ b/spec/unit/ssl/base_spec.rb
@@ -45,6 +45,15 @@ describe Puppet::SSL::Certificate do
     end
   end
 
+  describe "when initializing wrapped class from a file with #read" do
+    it "should open the file with UTF-8 encoding" do
+      path = '/foo/bar/cert'
+      Puppet::SSL::Base.stubs(:valid_certname).returns(true)
+      Puppet::FileSystem.expects(:read).with(path, :encoding => 'UTF-8').returns("bar")
+      @base.read(path)
+    end
+  end
+
   describe "#digest_algorithm" do
     let(:content) { stub 'content' }
     let(:base) {

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -60,7 +60,7 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should be able to read requests from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my request")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => 'UTF-8').returns("my request")
       my_req = mock 'request'
       OpenSSL::X509::Request.expects(:new).with("my request").returns(my_req)
       expect(request.read(path)).to equal(my_req)

--- a/spec/unit/ssl/certificate_spec.rb
+++ b/spec/unit/ssl/certificate_spec.rb
@@ -162,7 +162,7 @@ describe Puppet::SSL::Certificate do
 
     it "should be able to read certificates from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my certificate")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => 'UTF-8').returns("my certificate")
       certificate = mock 'certificate'
       OpenSSL::X509::Certificate.expects(:new).with("my certificate").returns(certificate)
       expect(@certificate.read(path)).to equal(certificate)

--- a/spec/unit/ssl/configuration_spec.rb
+++ b/spec/unit/ssl/configuration_spec.rb
@@ -44,8 +44,7 @@ describe Puppet::SSL::Configuration do
     end
 
     it "#ca_auth_certificates returns an Array<OpenSSL::X509::Certificate>" do
-      subject.stubs(:read_file).returns(master_ca_pem + root_ca_pem)
-
+      Puppet::FileSystem.expects(:read).with(subject.ca_auth_file, :encoding => 'UTF-8').returns(master_ca_pem + root_ca_pem)
       certs = subject.ca_auth_certificates
       certs.each { |cert| expect(cert).to be_a_kind_of OpenSSL::X509::Certificate }
     end

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -118,7 +118,7 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
       end
 
       it "should return the all the serial numbers from the lines matching the provided name" do
-        File.expects(:readlines).with(cert_inventory).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
+        File.expects(:readlines).with(cert_inventory, :encoding => 'UTF-8').returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
 
         expect(@inventory.serials("me")).to eq([15, 2])
       end

--- a/spec/unit/ssl/key_spec.rb
+++ b/spec/unit/ssl/key_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::SSL::Key do
 
     it "should be able to read keys from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my key")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => 'UTF-8').returns("my key")
       key = mock 'key'
       OpenSSL::PKey::RSA.expects(:new).returns(key)
       expect(@key.read(path)).to equal(key)
@@ -76,9 +76,9 @@ describe Puppet::SSL::Key do
 
       path = "/my/path"
 
-      File.stubs(:read).with(path).returns("my key")
+      Puppet::FileSystem.stubs(:read).with(path, :encoding => 'UTF-8').returns("my key")
       OpenSSL::PKey::RSA.expects(:new).with("my key", nil).returns(mock('key'))
-      File.expects(:read).with("/path/to/password").never
+      Puppet::FileSystem.expects(:read).with("/path/to/password", :encoding => 'UTF-8').never
 
       @key.read(path)
     end
@@ -88,8 +88,8 @@ describe Puppet::SSL::Key do
       @key.password_file = "/path/to/password"
 
       path = "/my/path"
-      File.expects(:read).with(path).returns("my key")
-      File.expects(:read).with("/path/to/password").returns("my password")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => 'UTF-8').returns("my key")
+      Puppet::FileSystem.expects(:read).with("/path/to/password", :encoding => 'UTF-8').returns("my password")
 
       key = mock 'key'
       OpenSSL::PKey::RSA.expects(:new).with("my key", "my password").returns(key)
@@ -155,7 +155,7 @@ describe Puppet::SSL::Key do
     describe "with a password file set" do
       it "should return a nil password if the password file does not exist" do
         Puppet::FileSystem.expects(:exist?).with("/path/to/pass").returns false
-        File.expects(:read).with("/path/to/pass").never
+        Puppet::FileSystem.expects(:read).with("/path/to/pass", :encoding => 'UTF-8').never
 
         @instance.password_file = "/path/to/pass"
 
@@ -164,7 +164,7 @@ describe Puppet::SSL::Key do
 
       it "should return the contents of the password file as its password" do
         Puppet::FileSystem.expects(:exist?).with("/path/to/pass").returns true
-        File.expects(:read).with("/path/to/pass").returns "my password"
+        Puppet::FileSystem.expects(:read).with("/path/to/pass", :encoding => 'UTF-8').returns "my password"
 
         @instance.password_file = "/path/to/pass"
 

--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Util::FileType do
     describe "when the file already exists" do
       it "should return the file's contents when asked to read it" do
         Puppet::FileSystem.expects(:exist?).with(path).returns true
-        File.expects(:read).with(path).returns "my text"
+        Puppet::FileSystem.expects(:read).with(path, :encoding => 'UTF-8').returns "my text"
 
         expect(file.read).to eq("my text")
       end
@@ -46,7 +46,7 @@ describe Puppet::Util::FileType do
       end
 
       it "should first create a temp file and copy its contents over to the file location" do
-        Tempfile.expects(:new).with("puppet").returns tempfile
+        Tempfile.expects(:new).with("puppet", :encoding => 'UTF-8').returns tempfile
         tempfile.expects(:print).with("my text")
         tempfile.expects(:flush)
         tempfile.expects(:close)
@@ -151,7 +151,7 @@ describe Puppet::Util::FileType do
         @tmp_cron = Tempfile.new("puppet_crontab_spec")
         @tmp_cron_path = @tmp_cron.path
         Puppet::Util.stubs(:uid).with(uid).returns 9000
-        Tempfile.expects(:new).with("puppet_#{name}").returns @tmp_cron
+        Tempfile.expects(:new).with("puppet_#{name}", :encoding => 'UTF-8').returns @tmp_cron
       end
 
       after :each do


### PR DESCRIPTION
This PR builds on / supersedes #4898 from @Iristyle 

[PUP-6188](tickets.puppetlabs.com/browse/PUP-6188) tracks an effort to ensure Puppet's various file system interactions are specifying utf-8 encoding where possible/applicable, possibly in `Puppet::FileSystem.open` and `Puppet::FileSystem.exclusive_open`, but notes the problematic situation resulting from the reordering of method arguments from `Puppet::FileSystem::FileImpl#open` to [`::File.open`](https://ruby-doc.org/core-2.3.1/File.html#method-c-open):

> - Rubys `perm` in our call is renamed as `mode`, and is moved from position 2 to position 1
> - Rubys `mode` in our call is renamed as `options`, and is moved from position 1 to position 2
> - We don't support the passing in of Rubys `opt` which is where one would set ``:encoding => 'utf-8'``

This is further complicated by the fact that ruby allows specifying mode, encoding, and other options a number of different ways via these parameters. For example, encoding and mode, which can be specified
- via `opt` (ruby optional param 3) in an options hash, ie `:mode => 'r', :encoding => 'BOM|UTF-8'` 
- via a `mode` string (ruby param 2), containing one of:
  - an IO Open Mode: `"r"`, `"r+"`, `"w"`
  - an IO Open Mode _with encoding_: `"r:IBM437"`, `"w:BOM|UTF-8"`
  - a list of `|` separated File Constants: `File::CREATE|File::APPEND`

This means it's not simply a matter of extending the definition of `Puppet::FileSystem::FileImpl#open` and `Puppet::FileSystem::FileImpl#exclusive_open` to support an options hash (and thus specifying `:encoding => 'UTF-8'` because such options may collide with those already specified by a user via the `mode` string (ruby param 2). We could probably handle this somewhat gracefully (a rudimentary first pass at this is in https://github.com/MosesMendoza/puppet/commit/ccb65927b22544239adbc49a7b054cc91016bdde) but it seems like less risk of backwards-incompatibility and less complexity overall to simply update the callers of `Puppet::FileSystem` inside of puppet to leverage the ability to pass encoding in via the `mode` string.

This PR does so in several places, explicitly specifying UTF-8 as part of the mode string and updating associated tests. When updating the `puppet config` face, it was discovered that the `:set` action has no unit testing associated with it (at least not that I can find) - all testing is at the lower level of `Puppet::Settings::Inifile`, so this PR also includes a commit that adds initial basic spec coverage of `puppet config set`. Additionally, where encountered, `File.read` was replaced with `Puppet::FileSystem.read` - it seemed as if some of these places existed before `Puppet::FileSystem` was implemented.

After discussion with @Iristyle it was determined that much of the test coverage here likely deserves substantial improvement. Specifically, creating new tests that actually create files containing unicode-only characters, passing them through the code under test, and validating the fidelity of the data actually remains intact. I'm not sure if this PR should be gated on the addition of such tests, but I don't disagree that they're justified.
