### PR TITLE
(pup-5000) acceptance test agent specified environment fact

### DIFF
--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -399,7 +399,11 @@ module Puppet
 
       # create sitepp in a tmp_environment as created by mk_tmp_environment_with_teardown
       def create_sitepp(host, tmp_environment, file_content)
-        file_path = File.join('','tmp',tmp_environment,'manifests','site.pp')
+        if tmp_environment == 'production'
+          file_path = File.join(environmentpath,tmp_environment,'manifests','site.pp')
+        else
+          file_path = File.join('','tmp',tmp_environment,'manifests','site.pp')
+        end
         create_remote_file(host, file_path, file_content)
         on host, "chmod -R 755 #{file_path}"
       end

--- a/acceptance/tests/environment/use_enc_agent_specified_environment_fact.rb
+++ b/acceptance/tests/environment/use_enc_agent_specified_environment_fact.rb
@@ -1,0 +1,56 @@
+test_name 'C70338: ENC could use agent_specified_environment fact' do
+  require 'puppet/acceptance/environment_utils'
+  extend  Puppet::Acceptance::EnvironmentUtils
+
+  test_name = File.basename(__FILE__, '.*')
+  testdir   = create_tmpdir_for_user(master, test_name)
+  tmp_environment = mk_tmp_environment_with_teardown(master, test_name)
+
+  sitepp = <<-SITEPP
+notify{"ENV${::agent_specified_environment}ENV":}
+  SITEPP
+
+  create_sitepp(master, 'production',    sitepp)
+  create_sitepp(master, tmp_environment, sitepp)
+
+  teardown do
+    # we need to tear this down because it's not in a tmp environment
+    on(master, "rm #{environmentpath}/production/manifests/site.pp")
+  end
+
+  master_opts = {}
+
+  with_puppet_running_on(master, master_opts, testdir)do
+    agents.each do |agent|
+      step 'no environment specified' do
+        run_agent_on(agent, "-t --server #{master}", :acceptable_exit_codes => 2) do |result|
+          assert_match(/: ENVENV/, result.stdout, "The file from environment 'special' was not found")
+        end
+      end
+      step 'environment specified on agent cli' do
+        run_agent_on(agent, "-t --server #{master} --environment #{tmp_environment}",
+                     :acceptable_exit_codes => 2) do |result|
+          assert_match(/: ENV#{tmp_environment}ENV/, result.stdout, "The file from environment 'special' was not found")
+        end
+      end
+    end
+  end
+
+
+  master_opts = {
+    'agent' => {
+      'environment' => 'nonesuch',
+    },
+  }
+  with_puppet_running_on(master, master_opts, testdir)do
+    agents.each do |agent|
+      step 'environment specified in puppet.conf and on agent cli' do
+        run_agent_on(agent, "-t --server #{master} --environment #{tmp_environment}",
+                     :acceptable_exit_codes => 2) do |result|
+          assert_match(/: ENV#{tmp_environment}ENV/, result.stdout, "The file from environment 'special' was not found")
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
```
(PUP-5000) acceptance: test agent specified environment fact
* test that the agent specified environment fact does the right thing
  * enc's do not receive the list of facts, so we don't have to test it
  * in there, making this test a bit more simple than first expected.
* this might be covered in unit tests
  * but there is NOT a test that ensures that we get the right
   environment from the options on the CLI and puppet.conf

(PUP-5000) acceptance: allow create_sitepp to create in production env

* previous instance of create_sitepp assumed a path to a tmp_environment
 the test in pup-5000 requires a sitepp in production.  this change
 tests if the name of the environment sent in is "production" and if
 so, creates a sitepp in stock environmentpath.  This needs to be
 torn-down manually.
```
