### PR TITLE
(PA-652) Bump Puppet version to 4.8.1

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -7,7 +7,7 @@
 
 
 module Puppet
-  PUPPETVERSION = '4.8.0'
+  PUPPETVERSION = '4.8.1'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This updates the Puppet version to 4.8.1 following the release of 4.8.0
as part of puppet-agent 1.8.0.