### PR TITLE
(PA-655) Add Windows Server 2016 to the LTS agent

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.32')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.1.0')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "rake", "~> 10.1"

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -28,14 +28,14 @@ end
 adduser_manifest = <<MANIFEST
 user { '#{username}':
   ensure   => 'present',
-  password => 'apassword',
+  password => 'Apassw0rd!',
 }
 MANIFEST
 
 changepass_manifest = <<MANIFEST
 user { '#{username}':
   ensure   => 'present',
-  password => 'newpassword',
+  password => 'Anewpassw0rd!',
   noop     => true,
 }
 MANIFEST


### PR DESCRIPTION
This is a cherry-pick of several commits from master to LTS-1.7, in support of [PA-655](https://tickets.puppetlabs.com/browse/PA-655).