### PR TITLE
(PUP-6534) Use parallel specs in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ test_script:
   - bundle install --jobs 4 --retry 2 --without development extra
   - type Gemfile.lock
   - ruby -v
-  - bundle exec rspec spec
+  - bundle exec rake parallel:spec[2]
 
 on_failure:
   - appveyor PushArtifact .\spec_order.txt


### PR DESCRIPTION
Previously the AppVeyor spec tests were executed sequentially.  Now that all of
the unit tests are functioning correctly when run in parallel mode, this commit
changes the execution command for AppVeyor to use parallel spec with two
threads.