### PR TITLE
(PUP-6871) Fix transaction persistent unit test for non English Windows

### DIFF
--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -148,7 +148,12 @@ describe Puppet::Transaction::Persistence do
       persistence = Puppet::Transaction::Persistence.new
 
       if Puppet.features.microsoft_windows?
-        expect { persistence.save }.to raise_error(Puppet::Util::Windows::Error, /Access is denied/)
+        expect do
+          persistence.save
+        end.to raise_error do |error|
+          expect(error).to be_a(Puppet::Util::Windows::Error)
+          expect(error.code).to eq(5) # ERROR_ACCESS_DENIED
+        end
       else
         expect { persistence.save }.to raise_error(Errno::EISDIR, /Is a directory/)
       end


### PR DESCRIPTION
Previously the unit test for transaction/persistence checked whether an error
was raised with specific text.  However the text was in English and the test
would fail if used on localized versions of Windows, such as French, where the
message is French.  This commit removes the text in the expectation so that it
will behave correctly on all language versions of Windows.

example error message in French is `Accès refusé`