### PR TITLE
(PUP-6876) Fix INI parsing for UTF-8 keys / values / sections and `config set`

### DIFF
--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -108,7 +108,7 @@ Puppet::Face.define(:config, '0.0.1') do
     when_invoked do |name, value, options|
       path = Puppet::FileSystem.pathname(Puppet.settings.which_configuration_file)
       Puppet::FileSystem.touch(path)
-      Puppet::FileSystem.open(path, nil, 'r+') do |file|
+      Puppet::FileSystem.open(path, nil, 'r+:UTF-8') do |file|
         Puppet::Settings::IniFile.update(file) do |config|
           config.set(options[:section], name, value)
         end

--- a/lib/puppet/settings/ini_file.rb
+++ b/lib/puppet/settings/ini_file.rb
@@ -15,7 +15,7 @@ class Puppet::Settings::IniFile
       case line
       when /^(\s*)\[(\w+)\](\s*)$/
         config.append(SectionLine.new($1, $2, $3))
-      when /^(\s*)(\w+)(\s*=\s*)(.*?)(\s*)$/
+      when /^(\s*)([[:word:]]+)(\s*=\s*)(.*?)(\s*)$/
         config.append(SettingLine.new($1, $2, $3, $4, $5))
       else
         config.append(Line.new(line))

--- a/lib/puppet/settings/ini_file.rb
+++ b/lib/puppet/settings/ini_file.rb
@@ -13,7 +13,7 @@ class Puppet::Settings::IniFile
     config = new([DefaultSection.new])
     config_fh.each_line do |line|
       case line
-      when /^(\s*)\[(\w+)\](\s*)$/
+      when /^(\s*)\[([[:word:]]+)\](\s*)$/
         config.append(SectionLine.new($1, $2, $3))
       when /^(\s*)([[:word:]]+)(\s*=\s*)(.*?)(\s*)$/
         config.append(SettingLine.new($1, $2, $3, $4, $5))

--- a/spec/integration/faces/config_spec.rb
+++ b/spec/integration/faces/config_spec.rb
@@ -1,0 +1,80 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/face'
+
+describe Puppet::Face[:config, '0.0.1'] do
+  include PuppetSpec::Files
+
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  MIXED_UTF8 = "A\u06FF\u16A0\u{2070E}" # Aۿᚠ𠜎
+  let (:tmp_environment_path) { tmpdir('envpath') }
+  let (:tmp_config) { tmpfile('puppet.conf') }
+
+  def load_settings(path)
+    test_settings = Puppet::Settings.new
+
+    test_settings.define_settings(:main,
+      :config => {
+        :type => :file,
+        :default => path,
+        :desc => '',
+      },
+      :environmentpath => {
+        :default => tmp_environment_path,
+        :desc => '',
+      },
+      :basemodulepath => {
+        :default => '',
+        :desc => '',
+      },
+      # definition required to use the value
+      :rando_key => {
+        :default => '',
+        :desc => ''
+      },
+      MIXED_UTF8.to_sym => {
+        :default => '',
+        :desc => ''
+      },
+    )
+
+    test_settings.initialize_global_settings
+    test_settings
+  end
+
+  before :each do
+    File.open(tmp_config, 'w', :encoding => 'UTF-8') do |file|
+      file.puts <<-EOF
+[main]
+rando_key=foobar
+#{MIXED_UTF8}=foobar
+      EOF
+    end
+  end
+
+  context 'when getting / setting UTF8 values' do
+    # key must be a defined setting
+    ['rando_key', MIXED_UTF8].each do |key|
+      it "can change '#{key}' keyed ASCII value to a UTF-8 value and read it back" do
+        key = "rando_key"
+        value = "value#{MIXED_UTF8.reverse}value"
+
+        # needed for the subject.set to write to correct file
+        Puppet.settings.stubs(:which_configuration_file).returns(tmp_config)
+        subject.set(key, value)
+
+        # make sure subject.print looks at the newly modified settings
+        test_settings = load_settings(tmp_config)
+        # instead of the default Puppet.settings (implementation detail)
+        Puppet.stubs(:settings).returns(test_settings)
+
+        expect { subject.print() }.to have_printed("#{key} = #{value}")
+        expect { subject.print(key, :section => 'main') }.to have_printed("#{value}")
+      end
+    end
+  end
+end

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -44,6 +44,48 @@ syslogfacility = file
     subject.print('all')
   end
 
+  context "when setting config values" do
+    let(:config_file) { '/foo/puppet.conf' }
+    let(:path) { Pathname.new(config_file).expand_path }
+    before(:each) do
+      Puppet[:config] = config_file
+      Puppet::FileSystem.stubs(:pathname).with(path.to_s).returns(path)
+      Puppet::FileSystem.stubs(:touch)
+    end
+
+    it "writes to the correct puppet config file" do
+      Puppet::FileSystem.expects(:open).with(path, anything, anything)
+      subject.set('foo', 'bar')
+    end
+
+    it "creates a config file if one does not exist" do
+      Puppet::FileSystem.stubs(:open).with(path, anything, anything).yields(StringIO.new)
+      Puppet::FileSystem.expects(:touch).with(path)
+      subject.set('foo', 'bar')
+    end
+
+    it "sets the supplied config/value in the default section (main)" do
+      Puppet::FileSystem.stubs(:open).with(path, anything, anything).yields(StringIO.new)
+      config = Puppet::Settings::IniFile.new([Puppet::Settings::IniFile::DefaultSection.new])
+      manipulator = Puppet::Settings::IniFile::Manipulator.new(config)
+      Puppet::Settings::IniFile::Manipulator.stubs(:new).returns(manipulator)
+
+      manipulator.expects(:set).with("main", "foo", "bar")
+      subject.set('foo', 'bar')
+    end
+
+    it "sets the value in the supplied section" do
+      Puppet::FileSystem.stubs(:open).with(path, anything, anything).yields(StringIO.new)
+      config = Puppet::Settings::IniFile.new([Puppet::Settings::IniFile::DefaultSection.new])
+      manipulator = Puppet::Settings::IniFile::Manipulator.new(config)
+      Puppet::Settings::IniFile::Manipulator.stubs(:new).returns(manipulator)
+
+      manipulator.expects(:set).with("baz", "foo", "bar")
+      subject.set('foo', 'bar', {:section => "baz"})
+
+    end
+  end
+
   shared_examples_for :config_printing_a_section do |section|
 
     def add_section_option(args, section)

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -84,6 +84,11 @@ syslogfacility = file
       subject.set('foo', 'bar', {:section => "baz"})
 
     end
+
+    it "opens the file with UTF-8 encoding" do
+      Puppet::FileSystem.expects(:open).with(path, nil, 'r+:UTF-8')
+      subject.set('foo', 'bar')
+    end
   end
 
   shared_examples_for :config_printing_a_section do |section|

--- a/spec/unit/settings/ini_file_spec.rb
+++ b/spec/unit/settings/ini_file_spec.rb
@@ -4,6 +4,13 @@ require 'stringio'
 require 'puppet/settings/ini_file'
 
 describe Puppet::Settings::IniFile do
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ𠜎
+
   it "preserves the file when no changes are made" do
     original_config = <<-CONFIG
     # comment
@@ -25,6 +32,16 @@ describe Puppet::Settings::IniFile do
     end
 
     expect(config_fh.string).to eq "[the_section]\nname = value\n"
+  end
+
+  it "adds a UTF-8 name and value to an empty file" do
+    config_fh = a_config_file_containing("")
+
+    Puppet::Settings::IniFile.update(config_fh) do |config|
+      config.set("the_section", mixed_utf8, mixed_utf8.reverse)
+    end
+
+    expect(config_fh.string).to eq "[the_section]\n#{mixed_utf8} = #{mixed_utf8.reverse}\n"
   end
 
   it "does not add a [main] section to a file when it isn't needed" do
@@ -71,6 +88,29 @@ name = value
     # this is the preceding comment
      [section]
     name = changed value
+    # this is the trailing comment
+    CONFIG
+  end
+
+  it "updates existing UTF-8 name / values in place" do
+    config_fh = a_config_file_containing(<<-CONFIG)
+    # this is the preceding comment
+     [section]
+    ascii = foo
+    #{mixed_utf8} = bar
+    # this is the trailing comment
+    CONFIG
+
+    Puppet::Settings::IniFile.update(config_fh) do |config|
+      config.set("section", "ascii", mixed_utf8)
+      config.set("section", mixed_utf8, mixed_utf8.reverse)
+    end
+
+    expect(config_fh.string).to eq <<-CONFIG
+    # this is the preceding comment
+     [section]
+    ascii = #{mixed_utf8}
+    #{mixed_utf8} = #{mixed_utf8.reverse}
     # this is the trailing comment
     CONFIG
   end
@@ -179,6 +219,7 @@ updated = new
   end
 
   def a_config_file_containing(text)
-    StringIO.new(text)
+    # set_encoding required for Ruby 1.9.3 as ASCII is the default
+    StringIO.new(text).set_encoding(Encoding::UTF_8)
   end
 end

--- a/spec/unit/settings/ini_file_spec.rb
+++ b/spec/unit/settings/ini_file_spec.rb
@@ -62,6 +62,22 @@ name = value
     CONF
   end
 
+  it "can update values within a UTF-8 section of an existing file" do
+    config_fh = a_config_file_containing(<<-CONF)
+    [#{mixed_utf8}]
+    foo = default
+    CONF
+
+    Puppet::Settings::IniFile.update(config_fh) do |config|
+      config.set(mixed_utf8, 'foo', 'bar')
+    end
+
+    expect(config_fh.string).to eq(<<-CONF)
+    [#{mixed_utf8}]
+    foo = bar
+    CONF
+  end
+
   it "preserves comments when writing a new name and value" do
     config_fh = a_config_file_containing("# this is a comment")
 


### PR DESCRIPTION
 - Previously, INI files were using the `\w` regex character class to
   match the "key" in a INI file line like:

```ini
   key = value
```

   Unfortunately, `\w` is limited to ASCII characters `[a-zA-Z0-9_]` in
   Ruby and will fail to match properly on any Unicode word
   characters, such as:

```ini
   Aۿᚠ𠜎 = value
```

 - The \w regex character class was also used to match the section in a INI file line like:

```ini
   [Aۿᚠ𠜎]
```

   Unfortunately, due to the same limitation, an INI section like the above would not parse properly.

 - Change the `\w` character class to `[[:word]]` which Ruby describes as a:

> character in one of the following Unicode general categories Letter, Mark, Number, Connector_Punctuation

 - Supply tests demonstrating previously failing behavior

 - In addition to fixing any code paths using the INI file parser,
   this also fixes the CLI `config set` and `config print` commands
   when specifying existing keys.  Without the fix, duplicate sections
   may be written to an existing config file - which can then cause
   problems when retrieving values.