### PR TITLE
(maint) Fix TravisCI runs on Ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ group(:development, :test) do
 
   gem 'rdoc', "~> 4.1", :platforms => [:ruby]
 
+  # webmock requires addressable as as of 2.5.0 addressable started
+  # requiring the public_suffix gem which requires Ruby 2
+  gem 'addressable', '< 2.5.0'
   gem 'webmock', '~> 1.24'
   gem 'vcr', '~> 2.9'
 end


### PR DESCRIPTION
 - The webmock gem has always depended on the addressable gem >= 2.3.6
   and therefore it has been installed transitively.  As of 2.5.0, the
   addressable gem released on Nov 4, 2016 has added a new dependency
   on the public_suffix gem, which requires Ruby 2.

   Since jobs still run against Ruby 1.9.3, pin addressable to a prior
   version that doesn't need the public_suffix gem.

 - Note that even when using `bundle install --without development`
   this problem occurs, even though the webmock gem should be
   excluded from installation. This is a bundler behavior.