### PR TITLE
(PUP-6897) Fix for agent mishandling in pcore-gen and cor-change tests

### DIFF
--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -52,10 +52,14 @@ test_name 'C98345: ensure puppet generate assures env. isolation' do
                        'did not produce environment isolation issue as expected')
         end
       end
-      step 'generate pcore files' do
-        on(master, puppet("generate types --environment #{tmp_environment}"))
-        on(master, puppet("generate types --environment #{tmp_environment2}"))
-      end
+    end
+
+    step 'generate pcore files' do
+      on(master, puppet("generate types --environment #{tmp_environment}"))
+      on(master, puppet("generate types --environment #{tmp_environment2}"))
+    end
+
+    agents.each do |agent|
       step 'rerun agents after generate, ensure proper runs' do
         on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
            :acceptable_exit_codes => 2)

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -48,28 +48,28 @@ MANIFEST
   step 'run agent(s) to create the new resource' do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        fqdn = agent.hostname
-
         step 'Run agent once to create new File resource' do
           on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
         end
 
         step 'Verify the file resource is created' do
-          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_contents|
+          on(agent, "cat #{tmp_file[agent.hostname]}").stdout do |file_contents|
             assert_equal(original_test_data, file_contents, 'file contents did not match expected contents')
           end
         end
+      end
 
-        step 'Change the manifest for the resource' do
-          create_manifest_for_file_resource(tmp_file, modified_test_data, tmp_environment)
-        end
+      step 'Change the manifest for the resource' do
+        create_manifest_for_file_resource(tmp_file, modified_test_data, tmp_environment)
+      end
 
+      agents.each do |agent|
         step 'Run agent a 2nd time to change the File resource' do
           on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
         end
 
         step 'Verify the file resource is created' do
-          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_contents|
+          on(agent, "cat #{tmp_file[agent.hostname]}").stdout do |file_contents|
             assert_equal(modified_test_data, file_contents, 'file contents did not match expected contents')
           end
         end


### PR DESCRIPTION
Previously, the pcore_generate_env_isolation.rb and
corrective_change_via_puppet.rb tests were failing when run in a CI
configuration with more than one agent in it.  In each case, the test
changed some state after an agent was run on the first node which was
unintentionally picked up as the agent was run on the second node.  This
commit changes both tests to perform all related actions on each of the
nodes before any state changes are made.