### PR TITLE
(PUP-6898) Fix sensitive_data_type test validation of syslog output

### DIFF
--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -64,6 +64,27 @@ extend Puppet::Acceptance::PuppetTypeTestTools
   sitepp_content = generate_manifest(test_resources)
   assertion_code = generate_assertions(test_resources)
 
+  # Make a copy of the full set of 'test_resources' but filtered down to include
+  # only the assertions of type ':refute_match'.  So for example, where the
+  # 'test_resources' array might have an entry like this...
+  #
+  #  {:type => 'notify', ...
+  #   :assertions => [{:refute_match => 'sekrit1'},
+  #                   {:assert_match => "1:#{notify_redacted}"}]}
+  #
+  # ... the ':assert_match' entry would be filtered out in the new
+  # 'refutation_resources' array, producing:
+  #
+  #  {:type => 'notify', ...
+  #   :assertions => [{:refute_match => 'sekrit1'}]}
+  #
+  # This is done so that when validating the syslog output, we can refute the
+  # existence of any of the sensitive info in the syslog without having to
+  # assert that redacted info is in the syslog.  The redacted info appears in
+  # the console output from the Puppet agent run - by virtue of including a
+  # '--debug' flag on the agent command line - whereas the redacted info is not
+  # expected to be piped into the syslog.
+
   refutation_resources = test_resources.collect do |assertion_group|
     refutation_group = assertion_group.clone
     refutation_group[:assertions] = assertion_group[:assertions].select do |assertion|
@@ -87,16 +108,16 @@ extend Puppet::Acceptance::PuppetTypeTestTools
         step "assert no redacted data in syslog" do
           #sigh.  gee, thanks for the help, beaker!
           syslogfile = case agent['platform']
-                         when /fedora|centos|el|redhat|scientific/ then
+                         when /fedora|centos|el|redhat|scientific/
                            '/var/log/messages'
-                         when /ubuntu|debian|cumulus/ then
+                         when /ubuntu|debian|cumulus/
                            '/var/log/syslog'
                          else
+                           logger.warn "Could not determine syslog for #{agent['platform']}, so skipping syslog validation"
                            nil
                        end
           if syslogfile
-            result = agent.exec(Command.new("tail -n 100 #{syslogfile}"),
-                                :acceptable_exit_codes => [0, 1]).stdout.chomp
+            result = on(agent, "tail -n 100 #{syslogfile}").stdout.chomp
             run_assertions(refutation_code, result)
           end
         end


### PR DESCRIPTION
Previously, the sensitive_data_type test, when attempting to validate
the presence / absence of expected content in the syslog, performed
assertions against the full Beaker logger instead.  This would cause
assertions looking for the absence of sensitive content to fail for the
second agent run performed because the assertions themselves would
appear in the logger output.

This commit changes the syslog assertion logic to inspect just the
content of the syslog - without bringing in the rest of the current
Beaker logger.  The commit also only runs through the assertions which
confirm that sensitive data does not appear in the syslog and not the
assertions which confirm that other debug messages from the agent run
appear in the syslog.  This is done because the agent is run with a
"--debug" flag, which should cause agent log messages to go to the
console and not to the syslog anyway.