### PR TITLE
(PUP-6856) Catch :no_such_key during interpolation sub_lookup

### DIFF
--- a/lib/puppet/pops/lookup/interpolation.rb
+++ b/lib/puppet/pops/lookup/interpolation.rb
@@ -52,7 +52,11 @@ module Interpolation
           segments = split_key(key) { |problem| Puppet::DataBinding::LookupError.new("#{problem} in string: #{subject}") }
           root_key = segments.shift
           value = interpolate_method(method_key).call(root_key, lookup_invocation)
-          value = sub_lookup(key, lookup_invocation, segments, value) unless segments.empty?
+          unless segments.empty?
+            found = '';
+            catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
+            value = found;
+          end
           value = lookup_invocation.check(key) { interpolate(value, lookup_invocation, allow_methods) }
 
           # break gsub and return value immediately if this was an alias substitution. The value might be something other than a String

--- a/spec/unit/pops/lookup/interpolation_spec.rb
+++ b/spec/unit/pops/lookup/interpolation_spec.rb
@@ -161,6 +161,10 @@ describe 'Puppet::Pops::Lookup::Interpolation' do
       expect(interpolator.interpolate('a dot e: %{a.d}', lookup_invocation, true)).to eq('a dot e: (scope) a dot d is a hash entry')
     end
 
+    it 'should report a key missing and replace with empty string when a dotted key is used to navigate into a structure and then not found' do
+      expect(interpolator.interpolate('a dot n: %{a.n}', lookup_invocation, true)).to eq('a dot n: ')
+    end
+
     it 'should use a dotted key to navigate into a structure when when it is not quoted with method lookup' do
       expect_lookup('a')
       expect(interpolator.interpolate("a dot e: %{lookup('a.d')}", lookup_invocation, true)).to eq('a dot e: (lookup) a dot d is a hash entry')


### PR DESCRIPTION
An interpolation that uses dotted keys that in turn results in a
`:no_such_key` being thrown (because the key is missing), would not catch the
throw and hence, yield strange results. This commit ensures that the thrown
symbol `:no_such_key` is caught so that the call instead results in an empty
string.