### PR TITLE
(PUP-6834) Ensure that input to MergeStrategy deep does not mutate

### DIFF
--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -309,8 +309,20 @@ module Puppet::Pops
     def checked_merge(e1, e2)
       dm_options = { :preserve_unmergeables => false }
       options.each_pair { |k,v| dm_options[k.to_sym] = v unless k == 'strategy' }
-      # e2 (the destination) is dup'ed to avoid that the passed in object mutates
-      DeepMerge.deep_merge!(e1, e2.dup, dm_options)
+      # e2 (the destination) is deep cloned to avoid that the passed in object mutates
+      DeepMerge.deep_merge!(e1, deep_clone(e2), dm_options)
+    end
+
+    def deep_clone(value)
+      if value.is_a?(Hash)
+        result = value.clone
+        value.each{ |k, v| result[k] = deep_clone(v) }
+        result
+      elsif value.is_a?(Array)
+        value.map{ |v| deep_clone(v) }
+      else
+        value
+      end
     end
 
     protected

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -246,8 +246,7 @@ Merge strategy deep
           "c" => "C",
           "m" => {
             "ma" => "MA",
-            "mc" => "MC",
-            "mb" => "MB"
+            "mc" => "MC"
           }
         }
   Merged result: {
@@ -328,8 +327,7 @@ Searching for "one::loptsm_test::hash"
             "c" => "C",
             "m" => {
               "ma" => "MA",
-              "mc" => "MC",
-              "mb" => "MB"
+              "mc" => "MC"
             }
           }
     Merged result: {

--- a/spec/unit/pops/merge_strategy_spec.rb
+++ b/spec/unit/pops/merge_strategy_spec.rb
@@ -1,0 +1,18 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/pops'
+
+module Puppet::Pops
+describe 'MergeStrategy' do
+  context 'deep merge' do
+    it 'does not mutate the source of a merge' do
+      a = { 'a' => { 'b' => 'va' }, 'c' => 2 }
+      b = { 'a' => { 'b' => 'vb' }, 'b' => 3}
+      c = MergeStrategy.strategy(:deep).merge(a, b);
+      expect(a).to eql({ 'a' => { 'b' => 'va' }, 'c' => 2 })
+      expect(b).to eql({ 'a' => { 'b' => 'vb' }, 'b' => 3 })
+      expect(c).to eql({ 'a' => { 'b' => 'va' }, 'b' => 3, 'c' => 2 })
+    end
+  end
+end
+end


### PR DESCRIPTION
Before this commit, the primary source for a deep merge was dup'ed to avoid
that the deep merge would mutate it (it mutates the primary source). A dup
is however not enough when the source is a nested hash. The dup will only
perform a shallow copy. This commit ensures that the source is deep copied
instead.