### PR TITLE
(PUP-6188) Puppet::FileSystem and explicit Encoding changes

### DIFF
--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -32,6 +32,15 @@ module Puppet::FileSystem
 
   # Opens the given path with given mode, and options and optionally yields it to the given block.
   #
+  # @param path [String, Pathname] the path to the file to operate on
+  # @param mode [Integer] The mode to apply to the file if it is created
+  # @param options [String] Extra file operation mode information to use
+  #   This is the standard mechanism Ruby uses in the IO class, and therefore
+  #   encoding may be specified explicitly as fmode : encoding or fmode : "BOM|UTF-*"
+  #   for example, a:ASCII or w+:UTF-8
+  # @yield The file handle, in the mode given by options, else read-write mode
+  # @return [Void]
+  #
   # @api public
   #
   def self.open(path, mode, options, &block)
@@ -98,10 +107,13 @@ module Puppet::FileSystem
   #
   # @param path [Pathname] the path to the file to operate on
   # @param mode [Integer] The mode to apply to the file if it is created
-  # @param options [Integer] Extra file operation mode information to use
-  #   (defaults to read-only mode)
+  # @param options [String] Extra file operation mode information to use
+  #   (defaults to read-only mode 'r')
+  #   This is the standard mechanism Ruby uses in the IO class, and therefore
+  #   encoding may be specified explicitly as fmode : encoding or fmode : "BOM|UTF-*"
+  #   for example, a:ASCII or w+:UTF-8
   # @param timeout [Integer] Number of seconds to wait for the lock (defaults to 300)
-  # @yield The file handle, in read-write mode
+  # @yield The file handle, in the mode given by options, else read-write mode
   # @return [Void]
   # @raise [Timeout::Error] If the timeout is exceeded while waiting to acquire the lock
   #

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -115,7 +115,11 @@ module Puppet::FileBucketFile
     # @param files_original_path [String]
     #
     def matches(paths_file, files_original_path)
-      Puppet::FileSystem.open(paths_file, 0640, 'a+') do |f|
+      # Puppet will have already written the paths_file in the systems encoding
+      # given its possible that request.options[:bucket_path] or Puppet[:bucketdir]
+      # contained characters in an encoding that are not represented the
+      # same way when the bytes are decoded as UTF-8, continue using system encoding
+      Puppet::FileSystem.open(paths_file, 0640, 'a+:external') do |f|
         path_match(f, files_original_path)
       end
     end
@@ -138,7 +142,11 @@ module Puppet::FileBucketFile
           Puppet::FileSystem.dir_mkpath(paths_file)
         end
 
-        Puppet::FileSystem.exclusive_open(paths_file, 0640, 'a+') do |f|
+        # Puppet will have already written the paths_file in the systems encoding
+        # given its possible that request.options[:bucket_path] or Puppet[:bucketdir]
+        # contained characters in an encoding that are not represented the
+        # same way when the bytes are decoded as UTF-8, continue using system encoding
+        Puppet::FileSystem.exclusive_open(paths_file, 0640, 'a+:external') do |f|
           if Puppet::FileSystem.exist?(contents_file)
             verify_identical_file!(contents_file, bucket_file)
             Puppet::FileSystem.touch(contents_file)

--- a/lib/puppet/settings/config_file.rb
+++ b/lib/puppet/settings/config_file.rb
@@ -25,7 +25,8 @@ class Puppet::Settings::ConfigFile
       allowed_section_names << 'main' unless allowed_section_names.include?('main')
     end
 
-    ini = Puppet::Settings::IniFile.parse(StringIO.new(text))
+    # in Ruby 1.9.3 strings are not UTF-8 by default, so ensure text is treated properly
+    ini = Puppet::Settings::IniFile.parse(StringIO.new(text).set_encoding(Encoding::UTF_8))
     unique_sections_in(ini, file, allowed_section_names).each do |section_name|
       section = Section.new(section_name.to_sym)
       result.with_section(section)

--- a/lib/puppet/settings/directory_setting.rb
+++ b/lib/puppet/settings/directory_setting.rb
@@ -4,6 +4,12 @@ class Puppet::Settings::DirectorySetting < Puppet::Settings::FileSetting
   end
 
   # @api private
+  #
+  # @param option [String] Extra file operation mode information to use
+  #   (defaults to read-only mode 'r')
+  #   This is the standard mechanism Ruby uses in the IO class, and therefore
+  #   encoding may be explicitly like fmode : encoding or fmode : "BOM|UTF-*"
+  #   for example, a:ASCII or w+:UTF-8
   def open_file(filename, option = 'r', &block)
     controlled_access do |mode|
       Puppet::FileSystem.open(filename, mode, option, &block)

--- a/lib/puppet/settings/file_or_directory_setting.rb
+++ b/lib/puppet/settings/file_or_directory_setting.rb
@@ -22,6 +22,12 @@ class Puppet::Settings::FileOrDirectorySetting < Puppet::Settings::FileSetting
   end
 
   # @api private
+  #
+  # @param option [String] Extra file operation mode information to use
+  #   (defaults to read-only mode 'r')
+  #   This is the standard mechanism Ruby uses in the IO class, and therefore
+  #   encoding may be explicitly like fmode : encoding or fmode : "BOM|UTF-*"
+  #   for example, a:ASCII or w+:UTF-8
   def open_file(filename, option = 'r', &block)
     if type == :file
       super

--- a/lib/puppet/settings/file_setting.rb
+++ b/lib/puppet/settings/file_setting.rb
@@ -185,6 +185,11 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
   end
 
   # @api private
+  # @param option [String] Extra file operation mode information to use
+  #   (defaults to read-only mode 'r')
+  #   This is the standard mechanism Ruby uses in the IO class, and therefore
+  #   encoding may be explicitly like fmode : encoding or fmode : "BOM|UTF-*"
+  #   for example, a:ASCII or w+:UTF-8
   def exclusive_open(option = 'r', &block)
     controlled_access do |mode|
       Puppet::FileSystem.exclusive_open(file(), mode, option, &block)
@@ -192,6 +197,11 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
   end
 
   # @api private
+  # @param option [String] Extra file operation mode information to use
+  #   (defaults to read-only mode 'r')
+  #   This is the standard mechanism Ruby uses in the IO class, and therefore
+  #   encoding may be explicitly like fmode : encoding or fmode : "BOM|UTF-*"
+  #   for example, a:ASCII or w+:UTF-8
   def open(option = 'r', &block)
     controlled_access do |mode|
       Puppet::FileSystem.open(file, mode, option, &block)

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -450,6 +450,7 @@ module Util
 
     begin
       file     = Puppet::FileSystem.pathname(file)
+      # encoding for Uniquefile is not important here because the caller writes to it as it sees fit
       tempfile = Puppet::FileSystem::Uniquefile.new(Puppet::FileSystem.basename_string(file), Puppet::FileSystem.dir_string(file))
 
       # Set properties of the temporary file before we write the content, because

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -78,6 +78,12 @@ module Puppet::Util::Plist
     # stubbing purposes
     #
     # @api private
+    #
+    # @param args [String] Extra file operation mode information to use
+    #   (defaults to read-only mode 'r')
+    #   This is the standard mechanism Ruby uses in the IO class, and therefore
+    #   encoding may be explicitly like fmode : encoding or fmode : "BOM|UTF-*"
+    #   for example, a:ASCII or w+:UTF-8
     def open_file_with_args(file, args)
       File.open(file, args).read
     end


### PR DESCRIPTION
Supercedes #5354 

Channeling @MosesMendoza from prior PR:

This PR builds on / supersedes #4898 from @Iristyle 

[PUP-6188](tickets.puppetlabs.com/browse/PUP-6188) tracks an effort to ensure Puppet's various file system interactions are specifying utf-8 encoding where possible/applicable, possibly in `Puppet::FileSystem.open` and `Puppet::FileSystem.exclusive_open`, but notes the problematic situation resulting from the reordering of method arguments from `Puppet::FileSystem::FileImpl#open` to [`::File.open`](https://ruby-doc.org/core-2.3.1/File.html#method-c-open):

> - Rubys `perm` in our call is renamed as `mode`, and is moved from position 2 to position 1
> - Rubys `mode` in our call is renamed as `options`, and is moved from position 1 to position 2
> - We don't support the passing in of Rubys `opt` which is where one would set ``:encoding => 'utf-8'``

This is further complicated by the fact that ruby allows specifying mode, encoding, and other options a number of different ways via these parameters. For example, encoding and mode, which can be specified
- via `opt` (ruby optional param 3) in an options hash, ie `:mode => 'r', :encoding => 'BOM|UTF-8'` 
- via a `mode` string (ruby param 2), containing one of:
  - an IO Open Mode: `"r"`, `"r+"`, `"w"`
  - an IO Open Mode _with encoding_: `"r:IBM437"`, `"w:BOM|UTF-8"`
  - a list of `|` separated File Constants: `File::CREATE|File::APPEND`

This means it's not simply a matter of extending the definition of `Puppet::FileSystem::FileImpl#open` and `Puppet::FileSystem::FileImpl#exclusive_open` to support an options hash (and thus specifying `:encoding => 'UTF-8'` because such options may collide with those already specified by a user via the `mode` string (ruby param 2). We could probably handle this somewhat gracefully (a rudimentary first pass at this is in https://github.com/MosesMendoza/puppet/commit/ccb65927b22544239adbc49a7b054cc91016bdde) but it seems like less risk of backwards-incompatibility and less complexity overall to simply update the callers of `Puppet::FileSystem` inside of puppet to leverage the ability to pass encoding in via the `mode` string.

This PR does so in several places, explicitly specifying UTF-8 as part of the mode string and updating associated tests. When updating the `puppet config` face, it was discovered that the `:set` action has no unit testing associated with it (at least not that I can find) - all testing is at the lower level of `Puppet::Settings::Inifile`, so this PR also includes a commit that adds initial basic spec coverage of `puppet config set`. Additionally, where encountered, `File.read` was replaced with `Puppet::FileSystem.read` - it seemed as if some of these places existed before `Puppet::FileSystem` was implemented.

After discussion with @Iristyle it was determined that much of the test coverage here likely deserves substantial improvement. Specifically, creating new tests that actually create files containing unicode-only characters, passing them through the code under test, and validating the fidelity of the data actually remains intact. I'm not sure if this PR should be gated on the addition of such tests, but I don't disagree that they're justified.
