### PR TITLE
(PUP-6911) Do uptime comparisons as integers in var-refresh test

### DIFF
--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -47,8 +47,8 @@ extend Puppet::Acceptance::EnvironmentUtils
           assert_equal(2, result.exit_code, 'wrong exit_code')
           assert_match(/Notice: #{local_uptime_pattern}/, result.stdout, 'first uptime was not as expected')
           assert_match(/"seconds"=>\d+,/, result.stdout, 'first module uptime was not as expected')
-          uptime = result.stdout.match(/Notice: #{local_uptime_pattern}/)[0]
-          module_uptime = result.stdout.match(/"seconds"=>(\d+),/)[0]
+          uptime = Integer(result.stdout.match(/Notice: #{local_uptime_pattern}/)[1])
+          module_uptime = Integer(result.stdout.match(/"seconds"=>(\d+),/)[1])
         end
         if agent.platform =~ /solaris|aix/
           sleep 61  # See FACT-1497;
@@ -60,8 +60,8 @@ extend Puppet::Acceptance::EnvironmentUtils
           assert_equal(2, result.exit_code, 'wrong exit_code')
           assert_match(/Notice: #{local_uptime_pattern}/, result.stdout, 'second uptime was not as expected')
           assert_match(/"seconds"=>\d+,/, result.stdout, 'second module uptime was not as expected')
-          uptime2 = result.stdout.match(/Notice: #{local_uptime_pattern}/)[0]
-          module_uptime2 = result.stdout.match(/"seconds"=>(\d+),/)[0]
+          uptime2 = Integer(result.stdout.match(/Notice: #{local_uptime_pattern}/)[1])
+          module_uptime2 = Integer(result.stdout.match(/"seconds"=>(\d+),/)[1])
           assert(uptime2 > uptime, 'uptime did not change')
           assert(module_uptime2 > module_uptime, 'module based uptime did not change')
         end


### PR DESCRIPTION
Previously, the `variables_refreshed_each_compilation` acceptance test
could fail if the "earlier" uptime value that the test was comparing for
an agent run was lexicographically greater than the "later" uptime value.
For example, an earlier uptime of "9999" would be considered greater
than a later uptime of "10002" and, therefore, fail.

This commit changes the test to convert the uptimes to Integers before
comparing them so that the comparisons are done numerically rather than
as strings.