### PR TITLE
(docs) Update developer docs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ this.
 ## Ruby versions
 
 Puppet needs to work across a variety of ruby versions, including ruby
-1.9.3, 2.0.0 and 2.1.0.
+1.9.3 and up. Ruby 1.8.7 is no longer supported.
 
 Popular ways of making sure you have access to the various versions of ruby are
 to use either [rbenv](https://github.com/sstephenson/rbenv) or
@@ -47,16 +47,28 @@ To run puppet itself (for a resource lookup say):
 
     $ bundle exec puppet resource host localhost
 
+To apply a test manifest:
+
+    $ bundle exec puppet apply -e 'notify { "hello world": }'
+
 ## Running Spec Tests
 
 Puppet projects use a common convention of using Rake to run unit tests.
 The tests can be run with the following rake task:
 
-    bundle exec rake spec
+    $ bundle exec rake spec
 
 To run a single file's worth of tests (much faster!), give the filename:
 
-    bundle exec rake spec TEST=spec/unit/ssl/host_spec.rb
+    $ bundle exec rake spec TEST=spec/unit/ssl/host_spec.rb
+
+To run a single test or group of tests, give the filename and line number:
+
+    $ bundle exec rake spec TEST=spec/unit/ssl/host_spec.rb:42
+
+To run all tests in parallel:
+
+    $ bundle exec rake parallel:spec
 
 When tests fail, it is often useful to capture Puppet's log of a test
 run. The test harness pays attention to two environment variables that can

--- a/docs/rspec_tutorial.md
+++ b/docs/rspec_tutorial.md
@@ -70,14 +70,13 @@ behavior (which are done with expectations)
 ```ruby
 # This is an example; it sets the test name and defines the test to run
 specify "one equals one" do
-  # 'should' is an expectation; it adds a check to make sure that the left argument
-  # matches the right argument
-  1.should == 1
+  # add an expectation that left and right arguments are equal
+  expect(1).to eq(1)
 end
 
 # Examples can be declared with either 'it' or 'specify'
 it "one doesn't equal two" do
-  1.should_not == 2
+  expect(1).to_not eq(2)
 end
 ```
 
@@ -85,6 +84,9 @@ Good examples generally do as little setup as possible and only test one or two
 things; it makes tests easier to understand and easier to debug.
 
 More complete documentation on expectations is available at https://www.relishapp.com/rspec/rspec-expectations/docs
+
+Note Puppet supports the [RSpec 3](http://rspec.info/blog/2013/07/the-plan-for-rspec-3/)
+API, so please do not use RSpec 2 "should" syntax like `1.should == 1`.
 
 ### Example groups
 
@@ -95,15 +97,15 @@ set.
 describe "the number one" do
 
   it "is larger than zero" do
-    1.should be > 0
+    expect(1).to be > 0
   end
 
   it "is an odd number" do
-    1.odd?.should be true
+    expect(1).to be_odd # calls 1.odd?
   end
 
   it "is not nil" do
-    1.should_not be_nil
+    expect(1).to be
   end
 end
 ```
@@ -166,11 +168,11 @@ describe "a helper object" do
   end
 
   it "is an array" do
-    my_helper.should be_a_kind_of Array
+    expect(my_helper).to be_a_kind_of Array
   end
 
   it "has three elements" do
-    my_helper.should have(3).items
+    expect(my_helper.size).to eq(3)
   end
 end
 ```
@@ -198,7 +200,7 @@ describe "stubbing a method on an object" do
   end
 
   it 'has three items before being stubbed' do
-    my_helper.size.should == 3
+    expect(my_helper.size).to eq(3)
   end
 
   describe 'when stubbing the size' do
@@ -207,7 +209,7 @@ describe "stubbing a method on an object" do
     end
 
     it 'has the stubbed value for size' do
-      my_helper.size.should == 10
+      expect(my_helper.size).to eq(10)
     end
   end
 end
@@ -222,7 +224,7 @@ describe "stubbing an object" do
   end
 
   it 'has the stubbed size'
-    my_helper.size.should == 10
+    expect(my_helper.size).to eq(10)
   end
 end
 ```
@@ -327,7 +329,7 @@ describe "fixture data" do
 
     it "can be stubbed" do
       @fixture.stubs(:foo).returns :bar
-      @fixture.foo.should == :bar
+      expect(@fixture.foo).to eq(:bar)
     end
 
     it "does not keep state between tests" do
@@ -345,7 +347,7 @@ describe "fixture data" do
 
     it "can be stubbed" do
       fixture.stubs(:foo).returns :bar
-      fixture.foo.should == :bar
+      expect(fixture.foo).to eq(:bar)
     end
 
     it "does not keep state between tests" do

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,16 +1,14 @@
-# Windows #
+# Windows
 
-If you'd like to run Puppet from source on Windows platforms, the
-include `ext/envpuppet.bat` will help.
+If you'd like to run Puppet from source on Windows platforms, follow the [Quickstart](./quickstart.md) to using bundler and installing the necessary gems on Windows.
 
-To quickly run Puppet from source, assuming you already have Ruby installed
-from [rubyinstaller.org](http://rubyinstaller.org).
+You will need to install Ruby on Windows from [rubyinstaller.org](http://rubyinstaller.org).
 
     C:\> cd C:\work\puppet
-    C:\work\puppet> set PATH=%PATH%;C:\work\puppet\ext
-    C:\work\puppet> envpuppet bundle install
-    C:\work\puppet> envpuppet puppet --version
-    2.7.9
+    C:\work\puppet> gem install bundler
+    C:\work\puppet> bundle install --path .bundle
+    C:\work\puppet> bundle exec puppet --version
+    4.7.1
 
 When writing a test that cannot possibly run on Windows, e.g. there is
 no mount type on windows, do the following:
@@ -31,7 +29,7 @@ If the test doesn't currently pass on Windows, e.g. due to on going porting, the
 
 Then run the test as:
 
-    C:\work\puppet> envpuppet bundle exec rspec spec
+    C:\work\puppet> bundle exec rspec spec
 
 ## Common Issues ##
 


### PR DESCRIPTION
Mention 1.8.7 is not supported, and we support more recent versions than
2.1.

Describe executing a single test/group using line numbers and running
parallel specs.

Use rspec 3 syntax, not "should".

Update Windows section as envpuppet.bat is no longer necessary.

/cc @puppetlabs/puppet-maintainers 