### PR TITLE
(PUP-6913) Use NetBIOS name when resolving names to SIDs in tests

### DIFF
--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
   let (:system_bytes) { [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] }
   let (:null_sid_bytes) { bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
   let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
-  let (:computer_sid) { Puppet::Util::Windows::SID.name_to_sid_object(Socket.gethostname) }
+  let (:computer_sid) { Puppet::Util::Windows::SID.name_to_sid_object(Puppet::Util::Windows::ADSI.computer_name) }
   # BUILTIN is localized on German Windows, but not French
   # looking this up like this dilutes the values of the tests as we're comparing two mechanisms
   # for returning the same values, rather than to a known good
@@ -64,7 +64,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       # otherwise running in AppVeyor there is no Administrator and a the current local user can be used
       skip if (running_as_system && !user_exists)
 
-      hostname = Socket.gethostname
+      hostname = Puppet::Util::Windows::ADSI.computer_name
 
       principal = Puppet::Util::Windows::SID::Principal.lookup_account_name("#{hostname}\\#{username}")
       expect(principal.account).to match(/^#{Regexp.quote(username)}$/i)


### PR DESCRIPTION
Previously, two tests failed when run on a Windows system whose hostname
exceeded 15 characters. In that situation, ruby's `Socket.gethostname`
returns the full name, e.g. jenkins-slave-windows2012r2-prod-1, which
causes `LookupAccountName` to fail when resolving a name into a SID.

This commit modifies the tests to use the NetBIOS name returned
via Win32 GetComputerNameW[1], which is a truncated version of the
full name, e.g. JENKINS-SLAVE-W.

[1] https://msdn.microsoft.com/en-us/library/windows/desktop/ms724295(v=vs.85).aspx