### PR TITLE
(docs) Minor HTTP API doc fixes

### DIFF
--- a/api/docs/http_api_index.md
+++ b/api/docs/http_api_index.md
@@ -105,11 +105,11 @@ with JSON (MIME type of `application/json`).
 
 ### Puppet Server-specific endpoints
 
-When using [Puppet Server 2.3 or newer](https://docs.puppetlabs.com/puppetserver/2.3/)
+When using [Puppet Server 2.3 or newer](https://docs.puppet.com/puppetserver/2.3/)
 as a Puppet master, Puppet Server adds additional `/puppet/v3/` endpoints:
 
-* [Static File Content](https://docs.puppetlabs.com/puppetserver/latest/puppet-api/v3/static_file_content.md)
-* [Environment Classes](https://docs.puppetlabs.com/puppetserver/latest/puppet-api/v3/environment_classes.md)
+* [Static File Content](https://docs.puppet.com/puppetserver/latest/puppet-api/v3/static_file_content.md)
+* [Environment Classes](https://docs.puppet.com/puppetserver/latest/puppet-api/v3/environment_classes.md)
 
 #### Error Responses
 

--- a/api/docs/http_file_content.md
+++ b/api/docs/http_file_content.md
@@ -10,9 +10,12 @@ Get a file.
 
     GET /puppet/v3/file_content/:mount_point/:name
 
-`:mount_point` is one of mounts configured in the `fileserver.conf`.
-See [the puppet file server guide](https://docs.puppetlabs.com/guides/file_serving.html)
-for more information about how mount points work.
+The endpoint path includes a `:mount_point` which can be one of the following types:
+
+* Custom file serving mounts as specified in fileserver.conf --- see [the docs on configuring mount points](https://docs.puppet.com/puppet/latest/reference/file_serving.html).
+* `modules/<MODULE>` --- a semi-magical mount point which allows access to the `files` subdirectory of `<MODULE>` --- see [the docs on file serving](https://docs.puppet.com/puppet/latest/reference/file_serving.html).
+* `plugins` --- a highly magical mount point which merges the `lib`  directory of every module together. Used for syncing plugins; not intended for general consumption. Per-module sub-paths can not be specified.
+* `pluginfacts` --- a highly magical mount point which merges the `facts.d` directory of every module together. Used for syncing external facts; not intended for general consumption. Per-module sub-paths can not be specified.
 
 `:name` is the path to the file within the `:mount_point` that is requested.
 

--- a/api/docs/http_file_metadata.md
+++ b/api/docs/http_file_metadata.md
@@ -11,11 +11,12 @@ the following three types:
 * Directory
 * Symbolic link
 
-The endpoint path includes a `:mount` which can be one of three types:
+The endpoint path includes a `:mount` which can be one of the following types:
 
-* custom file serving mounts as specified in fileserver.conf -- see [the puppet file serving guide](https://docs.puppetlabs.com/guides/file_serving.html#serving-files-from-custom-mount-points)
-* `modules/<module>` -- a semi-magical mount point which allows access to the `files` subdirectory of `module` -- see [the puppet file serving guide](https://docs.puppetlabs.com/guides/file_serving.html#serving-module-files)
-* `plugins` -- a highly magical mount point which merges many directories together: used for plugin sync, sub-paths can not be specified, not intended for general consumption
+* Custom file serving mounts as specified in fileserver.conf --- see [the docs on configuring mount points](https://docs.puppet.com/puppet/latest/reference/file_serving.html).
+* `modules/<MODULE>` --- a semi-magical mount point which allows access to the `files` subdirectory of `<MODULE>` --- see [the docs on file serving](https://docs.puppet.com/puppet/latest/reference/file_serving.html).
+* `plugins` --- a highly magical mount point which merges the `lib`  directory of every module together. Used for syncing plugins; not intended for general consumption. Per-module sub-paths can not be specified.
+* `pluginfacts` --- a highly magical mount point which merges the `facts.d` directory of every module together. Used for syncing external facts; not intended for general consumption. Per-module sub-paths can not be specified.
 
 Note: PSON responses in the examples below are pretty-printed for readability.
 


### PR DESCRIPTION
* Update puppetlabs.com hostnames.
* Add the pluginfacts mount point, which works the same as the plugins one.