### PR TITLE
(PUP-6915) Fix sensitive data type test on Solaris 10

### DIFF
--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -110,7 +110,7 @@ extend Puppet::Acceptance::PuppetTypeTestTools
         end
 
         step "assert no redacted data in log" do
-          result = agent.exec(Command.new("tail -n 100 #{logfile}"),
+          result = agent.exec(Command.new("tail -100 #{logfile}"),
                                                     :acceptable_exit_codes => [0, 1]).stdout.chomp
           run_assertions(refutation_code, result)
         end


### PR DESCRIPTION
A recent refactor of the sensitive data type test to use temp files for
logging instead of default system directories allowed us to run this
test on more platforms. However, the `tail -n` command we were using is
not supported on Solaris 10. This updates the command to drop the `-n`,
which still accomplishes the same result, and works on all platforms.

I have validated this manually on Solaris 10, Fedora 24, OSX 10.9, and Windows 2012r2.