### PR TITLE
(PUP-6861) Revert PUP-6457 bad mount option handling

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -176,50 +176,6 @@ module Puppet
         appear in fstab. For many platforms this is a comma delimited string.
         Consult the fstab(5) man page for system-specific details."
 
-          def insync?(is)
-
-            if @resource[:ensure] == :mounted && !provider.property_hash[:live_options].nil?
-
-              # The mount options according to /etc/fstab. It is possible for puppet to
-              # update this file to reflect new options even if the remount to update
-              # the options has actually failed
-              fstab_options = provider.property_hash[:options] || ''
-              # The mount options according to the output of the 'mount' command. These will
-              # always reflect the options of the actual mounted device
-              mount_options = provider.property_hash[:live_options] || ''
-              # The desired mount options that have been specified in the puppet manifest
-              resource_options = @resource[:options] || ''
-
-              mount_list = mount_options.split(',')
-              resource_list = resource_options.split(',')
-              # Remove the string 'defaults' from the list of resources, because when
-              # we are comparing against the mount command output 'defaults' will be
-              # expanded into the full list of default options for the OS and file system
-              resource_list.delete('defaults')
-
-              # Do the options in fstab match the options that the user has defined?
-              if fstab_options != resource_options
-                return false
-              end
-
-              # Do the options provided by the 'mount' command match the options that
-              # the user has defined? We have to check this too because fstab could provide
-              # a false positive if a remount has failed
-              #
-              # We want to see if the mount command options contain the list of user
-              # specified options from the manifest. The reason we cannot do a 1:1
-              # comparison is because the expanded list of default options may be included
-              # in the mount output. These vary between OS and file system so since we don't
-              # have a good way to find out what they are, just check for the specific options
-              # the user has specified
-              if !(resource_list - mount_list).empty?
-                return false
-              end
-            end
-
-            super
-          end
-
       validate do |value|
         raise Puppet::Error, "options must not contain whitespace: #{value}" if value =~ /\s/
         raise Puppet::Error, "options must not be an empty string" if value.empty?

--- a/spec/integration/provider/mount_spec.rb
+++ b/spec/integration/provider/mount_spec.rb
@@ -149,10 +149,9 @@ describe "mount provider (integration)", :unless => Puppet.features.microsoft_wi
       pending "Due to bug 6309"
       @mounted = true
       @current_device = "/dev/disk2s2"
-      @current_options = "local"
       create_fake_fstab(true)
       @desired_options = "local"
-      run_in_catalog(:ensure=>:mounted, :options=>'msdos,local')
+      run_in_catalog(:ensure=>:mounted, :options=>'local')
       expect(@current_device).to eq("/dev/disk1s1")
       expect(@mounted).to eq(true)
       expect(@current_options).to eq('local')

--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -115,7 +115,6 @@ FSTAB
   describe "mountinstances" do
     it "should get name from mountoutput found on Solaris" do
       Facter.stubs(:value).with(:osfamily).returns 'Solaris'
-      Facter.stubs(:value).with(:kernel).returns 'SunOS'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('solaris.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(6)
@@ -129,7 +128,6 @@ FSTAB
 
     it "should get name from mountoutput found on HP-UX" do
       Facter.stubs(:value).with(:osfamily).returns 'HP-UX'
-      Facter.stubs(:value).with(:kernel).returns 'HP-UX'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('hpux.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(17)
@@ -152,35 +150,32 @@ FSTAB
       expect(mounts[16]).to eq({ :name => '/ghost', :mounted => :yes })
     end
 
-    it "should get name and mount options from mountoutput found on Darwin" do
+    it "should get name from mountoutput found on Darwin" do
       Facter.stubs(:value).with(:osfamily).returns 'Darwin'
-      Facter.stubs(:value).with(:kernel).returns 'Darwin'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('darwin.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(6)
-      expect(mounts[0]).to eq({ :name => '/', :mounted => :yes, :live_options=>"hfs, local, journaled"})
-      expect(mounts[1]).to eq({ :name => '/dev', :mounted => :yes, :live_options=>"devfs, local, nobrowse"})
-      expect(mounts[2]).to eq({ :name => '/net', :mounted => :yes, :live_options=>"autofs, nosuid, automounted, nobrowse"})
-      expect(mounts[3]).to eq({ :name => '/home', :mounted => :yes, :mounted=>:yes, :live_options=>"autofs, automounted, nobrowse"})
-      expect(mounts[4]).to eq({ :name => '/usr', :mounted => :yes, :mounted=>:yes, :live_options=>"hfs, local, journaled"})
-      expect(mounts[5]).to eq({ :name => '/ghost', :mounted => :yes, :live_options => "hfs, local, journaled"})
+      expect(mounts[0]).to eq({ :name => '/', :mounted => :yes })
+      expect(mounts[1]).to eq({ :name => '/dev', :mounted => :yes })
+      expect(mounts[2]).to eq({ :name => '/net', :mounted => :yes })
+      expect(mounts[3]).to eq({ :name => '/home', :mounted => :yes })
+      expect(mounts[4]).to eq({ :name => '/usr', :mounted => :yes })
+      expect(mounts[5]).to eq({ :name => '/ghost', :mounted => :yes })
     end
 
-    it "should get name and mount options from mountoutput found on Linux" do
+    it "should get name from mountoutput found on Linux" do
       Facter.stubs(:value).with(:osfamily).returns 'Gentoo'
-      Facter.stubs(:value).with(:kernel).returns 'Linux'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('linux.mount')))
       mounts = described_class.mountinstances
-      expect(mounts[0]).to eq({ :name => '/', :mounted => :yes, :live_options=>"rw,noatime"})
-      expect(mounts[1]).to eq({ :name => '/lib64/rc/init.d', :mounted => :yes, :live_options => "rw,nosuid,nodev,noexec,relatime,size=1024k,mode=755" })
-      expect(mounts[2]).to eq({ :name => '/sys', :mounted => :yes, :live_options => "rw,nosuid,nodev,noexec,relatime"})
-      expect(mounts[3]).to eq({ :name => '/usr/portage', :mounted => :yes, :live_options => "rw" })
-      expect(mounts[4]).to eq({ :name => '/ghost', :mounted => :yes, :live_options => "rw" })
+      expect(mounts[0]).to eq({ :name => '/', :mounted => :yes })
+      expect(mounts[1]).to eq({ :name => '/lib64/rc/init.d', :mounted => :yes })
+      expect(mounts[2]).to eq({ :name => '/sys', :mounted => :yes })
+      expect(mounts[3]).to eq({ :name => '/usr/portage', :mounted => :yes })
+      expect(mounts[4]).to eq({ :name => '/ghost', :mounted => :yes })
     end
 
     it "should get name from mountoutput found on AIX" do
       Facter.stubs(:value).with(:osfamily).returns 'AIX'
-      Facter.stubs(:value).with(:kernel).returns 'AIX'
       described_class.stubs(:mountcmd).returns(File.read(my_fixture('aix.mount')))
       mounts = described_class.mountinstances
       expect(mounts[0]).to eq({ :name => '/', :mounted => :yes })
@@ -229,42 +224,29 @@ FSTAB
           platform != 'solaris' or
             skip "We need to stub the operatingsystem fact at load time, but can't"
         end
+
+        # Stub the mount output to our fixture.
+        begin
+          mount = my_fixture(platform + '.mount')
+          described_class.stubs(:mountcmd).returns File.read(mount)
+        rescue
+          skip "is #{platform}.mount missing at this point?"
+        end
+
+        # Note: we have to stub default_target before creating resources
+        # because it is used by Puppet::Type::Mount.new to populate the
+        # :target property.
+        described_class.stubs(:default_target).returns fstab
+        @retrieve = described_class.instances.collect { |prov| {:name => prov.get(:name), :ensure => prov.get(:ensure)}}
       end
 
       # Following mountpoint are present in all fstabs/mountoutputs
       describe "on other platforms than Solaris", :if => Facter.value(:osfamily) != 'Solaris' do
-        before :each do
-          # Stub the mount output to our fixture.
-          begin
-            mount = my_fixture(platform + '.mount')
-            described_class.stubs(:mountcmd).returns File.read(mount)
-          rescue
-            skip "is #{platform}.mount missing at this point?"
-          end
-
-          # Note: we have to stub default_target before creating resources
-          # because it is used by Puppet::Type::Mount.new to populate the
-          # :target property.
-          described_class.stubs(:default_target).returns fstab
-
-          platforms = {
-            'linux' => ['Gentoo', 'Linux'],
-            'freebsd' => ['BSD', 'BSD'],
-            'openbsd' => ['BSD', 'BSD'],
-            'netbsd' => ['BSd', 'BSD']
-          }
-          Facter.stubs(:value).with(:osfamily).returns(platforms[platform][0])
-          Facter.stubs(:value).with(:kernel).returns(platforms[platform][1])
-
-          @retrieve = described_class.instances.collect { |prov| {:name => prov.get(:name), :ensure => prov.get(:ensure)}}
-        end
-        
-        it "should include mounted resources" do
+        it "should include unmounted resources" do
           expect(@retrieve).to include(:name => '/', :ensure => :mounted)
         end
 
-        it "should include unmounted resources" do
-        @retrieve = described_class.instances.collect { |prov| {:name => prov.get(:name), :ensure => prov.get(:ensure)}}
+        it "should include mounted resources" do
           expect(@retrieve).to include(:name => '/boot', :ensure => :unmounted)
         end
 

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -530,11 +530,6 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
       run_in_catalog(resource)
     end
 
-    it "should detect out of sync options" do
-      resource.provider.property_hash[:live_options] = "foo";
-      expect(resource.parameters[:options].insync?('soft')).to eq(false);
-    end
-
     it "should umount before flushing changes to disk" do
       syncorder = sequence('syncorder')
 


### PR DESCRIPTION
Revert "Merge pull request #5125 from HAIL9000/issue/master/PUP-6457_fail_on_bad_mount_options"

This reverts commit bcd1654afc5c2b4aa1397f7e0c1f13e02e269883, reversing
changes made to f4b86e08fa87159a84bc819458fdbe7017bcc088.

The original change relied on the idea that `/etc/mtab` would contain
an exact copy of the options specified in `/etc/fstab`. Unfortunately,
this is not correct, and causes this change to be overly-aggressive in
thinking that remounting failed.

Since there does not currently appear to be a way to check that a
mounted filesystem is in-sync with `fstab`, we unfortunately cannot
implement PUP-6457 as-described.