### PR TITLE
(MAINT) Skip puppet_lookup_cmd.rb test when no non-master agents present

### DIFF
--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -2,6 +2,9 @@ test_name "Puppet Lookup Command"
 # doc:
 # https://docs.puppetlabs.com/puppet/latest/reference/lookup_quick_module.html
 
+host = agents.find { |host| host != master }
+skip_test "No agents present that are not running on a master" if host.nil?
+
 @module_name = "puppet_lookup_command_test"
 
 ### @testroot = "/etc/puppetlabs"
@@ -11,7 +14,6 @@ test_name "Puppet Lookup Command"
 @confdir = "#{@testroot}/puppet"
 
 @mastername = on(master, facter('fqdn')).stdout.chomp
-host = agents.find { |host| host != master }
 @agentname = on(host, facter('fqdn')).stdout.chomp
 
 @master_opts = {


### PR DESCRIPTION
Previously, if the host configuration for a `puppet_lookup_cmd.rb` test
run were to include a single node which has both the 'master' and 'agent'
role, the 'host' would be set to nil, causing the test to fail as it hit
the first line of code which tried to make calls on the 'host' object.

This commit causes the `puppet_lookup_cmd.rb` test to be skipped if no
agent nodes that do not have the master role are present.