### PR TITLE
(PUP-6924) Improve serialization of parameterized collection types

### DIFF
--- a/lib/puppet/pops/binder/producers.rb
+++ b/lib/puppet/pops/binder/producers.rb
@@ -722,7 +722,7 @@ module Producers
       end
 
       if uniq || flatten || conflict_resolution.to_s == 'append'
-        etype = binding.type.element_type
+        etype = binding.type.value_type
         unless etype.class == Types::PDataType || etype.is_a?(Types::PArrayType)
           detail = []
           detail << ":uniq" if uniq
@@ -818,10 +818,10 @@ module Producers
         raise ArgumentError, "Entry contributing to multibind hash with id '#{binding.id}' must have a name."
       end
 
-      unless tc.instance?(binding.type.element_type, value)
+      unless tc.instance?(binding.type.value_type, value)
         raise ArgumentError, ["Type Error: value contribution to #{binding.name}['#{key}'] ",
           "is incompatible, ",
-          type_error_detail(binding.type.element_type, value)].join()
+          type_error_detail(binding.type.value_type, value)].join()
       end
     end
   end

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -460,7 +460,7 @@ class AccessOperator
       fail(Issues::BAD_TYPE_SLICE_ARITY, @semantic,
         {:base_type => 'Collection-Type', :min => 1, :max => 2, :actual => keys.size})
     end
-    Types::PCollectionType.new(nil, size_t)
+    Types::PCollectionType.new(size_t)
   end
 
   # An Array can create a new Array type. It is not possible to create a collection of Array types.

--- a/lib/puppet/pops/parser/locator.rb
+++ b/lib/puppet/pops/parser/locator.rb
@@ -143,13 +143,13 @@ class Locator
     # Create a locator based on a content string, and a boolean indicating if ruby version support multi-byte strings
     # or not.
     #
-    def initialize(string, file, index = nil)
+    def initialize(string, file, line_index = nil)
       @string = string.freeze
       @file = file.freeze
       @prev_offset = nil
       @prev_line = nil
-      @line_index = index
-      compute_line_index if index.nil?
+      @line_index = line_index
+      compute_line_index if line_index.nil?
     end
 
     # Returns the position on line (first position on a line is 1)

--- a/lib/puppet/pops/serialization/object.rb
+++ b/lib/puppet/pops/serialization/object.rb
@@ -11,7 +11,7 @@ class ObjectReader
 
   def read(impl_class, value_count, deserializer)
     type = impl_class._ptype
-    (names, types, required_count) = type.parameter_info
+    (names, types, required_count) = type.parameter_info(impl_class)
     max = names.size
     unless value_count >= required_count && value_count <= max
       raise Serialization::SerializationError, "Feature count mismatch for #{impl_class.name}. Expected #{min} - #{max}, actual #{value_count}"
@@ -43,7 +43,7 @@ class ObjectWriter
 
   def write(type, value, serializer)
     impl_class = value.class
-    (names, types, required_count) = type.parameter_info(true)
+    (names, types, required_count) = type.parameter_info(impl_class, true)
     args = names.map { |name| value.send(name) }
 
     # Pop optional arguments that are nil

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -358,14 +358,14 @@ class PObjectType < PMetaType
   #   @param i12n_hash [Hash{String=>Object}] The hash describing the Object features
   #
   # @api private
-  def initialize(name_or_i12n_hash, i12n_hash_expression = nil)
+  def initialize(i12n_hash, i12n_hash_expression = nil)
     @attributes = EMPTY_HASH
     @functions = EMPTY_HASH
 
-    if name_or_i12n_hash.is_a?(Hash)
-      initialize_from_hash(name_or_i12n_hash)
+    if i12n_hash.is_a?(Hash)
+      initialize_from_hash(i12n_hash)
     else
-      @name = TypeAsserter.assert_instance_of('object name', TYPE_OBJECT_NAME, name_or_i12n_hash)
+      @name = TypeAsserter.assert_instance_of('object name', TYPE_OBJECT_NAME, i12n_hash)
       @i12n_hash_expression = i12n_hash_expression
     end
   end
@@ -411,7 +411,7 @@ class PObjectType < PMetaType
     impl_class = implementation_class
     class_name = impl_class.name || "Anonymous Ruby class for #{name}"
 
-    (param_names, param_types, required_param_count) = parameter_info
+    (param_names, param_types, required_param_count) = parameter_info(impl_class)
 
     # Create the callable with a size that reflects the required and optional parameters
     param_types << required_param_count
@@ -474,7 +474,7 @@ class PObjectType < PMetaType
 
   # @api private
   # @return [(Array<String>, Array<PAnyType>, Integer)] array of parameter names, array of parameter types, and a count reflecting the required number of parameters
-  def parameter_info(attr_readers = false)
+  def parameter_info(impl_class, attr_readers = false)
     # Create a types and a names array where optional entries ends up last
     opt_types = []
     opt_names = []
@@ -491,6 +491,35 @@ class PObjectType < PMetaType
     end
     param_names = non_opt_names + opt_names
     param_types = non_opt_types + opt_types
+    param_count = param_names.size
+
+    init = impl_class.instance_method(:initialize)
+    init_non_opt_count = 0
+    init_param_names = init.parameters.map do |p|
+      init_non_opt_count += 1 if :req == p[0]
+      p[1].to_s
+    end
+
+    if init_param_names != param_names
+      if init_param_names.size < param_count || init_non_opt_count > param_count
+        raise Serialization::SerializationError, "Initializer for class #{impl_class.name} does not match the attributes of #{name}"
+      end
+      init_param_names = init_param_names[0, param_count] if init_param_names.size > param_count
+      unless init_param_names == param_names
+        # Reorder needed to match initialize method arguments
+        new_param_types = []
+        init_param_names.each do |ip|
+          index = param_names.index(ip)
+          if index.nil?
+            raise Serialization::SerializationError,
+              "Initializer for class #{impl_class.name} parameter '#{ip}' does not match any of the the attributes of type #{name}"
+          end
+          new_param_types << param_types[index]
+        end
+        param_names = init_param_names
+        param_types = new_param_types
+      end
+    end
 
     [param_names, param_types, non_opt_types.size]
   end

--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -1,10 +1,10 @@
 module Puppet::Pops
 module Types
   class PAbstractTimeDataType < PAbstractRangeType
-    # @param [AbstractTime] min lower bound for this type. Nil or :default means unbounded
-    # @param [AbstractTime] max upper bound for this type. Nil or :default means unbounded
-    def initialize(min = nil, max = nil)
-      super(convert_arg(min, true), convert_arg(max, false))
+    # @param from [AbstractTime] lower bound for this type. Nil or :default means unbounded
+    # @param to [AbstractTime] upper bound for this type. Nil or :default means unbounded
+    def initialize(from = nil, to = nil)
+      super(convert_arg(from, true), convert_arg(to, false))
     end
 
     def convert_arg(arg, min)

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -389,8 +389,8 @@ class TypeCalculator
     # when both are hashes, return a hash with common key- and element type
     if t1.is_a?(PHashType) && t2.is_a?(PHashType)
       key_type = common_type(t1.key_type, t2.key_type)
-      element_type = common_type(t1.element_type, t2.element_type)
-      return PHashType.new(key_type, element_type)
+      value_type = common_type(t1.value_type, t2.value_type)
+      return PHashType.new(key_type, value_type)
     end
 
     # when both are host-classes, reduce to PHostClass[] (since one was not assignable to the other)

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -307,7 +307,7 @@ module TypeFactory
   # @api public
   #
   def self.collection(size_type = nil)
-    size_type.nil? ? PCollectionType::DEFAULT : PCollectionType.new(nil, size_type)
+    size_type.nil? ? PCollectionType::DEFAULT : PCollectionType.new(size_type)
   end
 
   # Produces the Data type

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -326,7 +326,7 @@ class TypeFormatter
       append_array('Hash') { append_strings([0, 0]) }
     else
       append_array('Hash', t == PHashType::DATA) do
-        append_strings([t.key_type, t.element_type], true)
+        append_strings([t.key_type, t.value_type], true)
         append_elements(range_array_part(t.size_type), true)
         chomp_list
       end

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -816,7 +816,7 @@ module Types
     def describe_PHashType(expected, actual, path)
       descriptions = []
       key_type = expected.key_type || PAnyType::DEFAULT
-      value_type = expected.element_type || PAnyType::DEFAULT
+      value_type = expected.value_type || PAnyType::DEFAULT
       if actual.is_a?(PStructType)
         elements = actual.elements
         expected_size = expected.size_type || PCollectionType::DEFAULT_SIZE

--- a/spec/unit/pops/serialization/serialization_spec.rb
+++ b/spec/unit/pops/serialization/serialization_spec.rb
@@ -186,6 +186,30 @@ module Serialization
         expect(val2).to eql(val)
       end
 
+      it 'Collection' do
+        val = Types::TypeFactory.collection(Types::TypeFactory.range(0, 20))
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Types::PCollectionType)
+        expect(val2).to eql(val)
+      end
+
+      it 'Array' do
+        val = Types::TypeFactory.array_of(Types::TypeFactory.integer, Types::TypeFactory.range(0, 20))
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Types::PArrayType)
+        expect(val2).to eql(val)
+      end
+
+      it 'Hash' do
+        val = Types::TypeFactory.hash_kv(Types::TypeFactory.string, Types::TypeFactory.integer, Types::TypeFactory.range(0, 20))
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Types::PHashType)
+        expect(val2).to eql(val)
+      end
+
       it 'Variant' do
         val = Types::TypeFactory.variant(Types::TypeFactory.string, Types::TypeFactory.range(1, :default))
         write(val)

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -348,7 +348,7 @@ describe 'The type calculator' do
         expect(et.class).to eq(PArrayType)
         et = et.element_type
         expect(et.class).to eq(PHashType)
-        et = et.element_type
+        et = et.value_type
         expect(et.class).to eq(PStringType)
       end
 
@@ -357,7 +357,7 @@ describe 'The type calculator' do
         expect(et.class).to eq(PArrayType)
         et = et.element_type
         expect(et.class).to eq(PHashType)
-        et = et.element_type
+        et = et.value_type
         expect(et.class).to eq(PScalarType)
       end
     end
@@ -379,7 +379,7 @@ describe 'The type calculator' do
       end
 
       it 'with fixnum values translates to PHashType[key, PIntegerType]' do
-        expect(calculator.infer({:first => 1, :second => 2}).element_type.class).to eq(PIntegerType)
+        expect(calculator.infer({:first => 1, :second => 2}).value_type.class).to eq(PIntegerType)
       end
 
       it 'when empty infers a type that answers true to is_the_empty_hash?' do
@@ -1936,7 +1936,7 @@ describe 'The type calculator' do
       t = calculator.type(Hash)
       expect(t.class).to eq(PHashType)
       expect(t.key_type.class).to eq(PScalarType)
-      expect(t.element_type.class).to eq(PDataType)
+      expect(t.value_type.class).to eq(PDataType)
     end
   end
 
@@ -2079,12 +2079,12 @@ describe 'The type calculator' do
     it 'a generic result is created by generalize given an instance specific result for a Hash' do
       generic = calculator.infer({'a' =>1,'b' => 2})
       expect(generic.key_type.values.sort).to eq(['a', 'b'])
-      expect(generic.element_type.from).to eq(1)
-      expect(generic.element_type.to).to eq(2)
+      expect(generic.value_type.from).to eq(1)
+      expect(generic.value_type.to).to eq(2)
       generic = generic.generalize
       expect(generic.key_type.values).to eq([])
-      expect(generic.element_type.from).to eq(nil)
-      expect(generic.element_type.to).to eq(nil)
+      expect(generic.value_type.from).to eq(nil)
+      expect(generic.value_type.to).to eq(nil)
     end
 
     it 'ensures that Struct key types are not generalized' do

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -173,7 +173,7 @@ describe 'The type factory' do
       ht = TypeFactory.hash_of_data
       expect(ht.class()).to eq(PHashType)
       expect(ht.key_type.class).to eq(PScalarType)
-      expect(ht.element_type.class).to eq(PDataType)
+      expect(ht.value_type.class).to eq(PDataType)
     end
 
     it 'ruby(1) returns PRuntimeType[ruby, \'Fixnum\']' do
@@ -211,7 +211,7 @@ describe 'The type factory' do
       expect(t.size_type.from).to eq(0)
       expect(t.size_type.to).to eq(0)
       expect(t.key_type).to eq(Puppet::Pops::Types::PUnitType::DEFAULT)
-      expect(t.element_type).to eq(Puppet::Pops::Types::PUnitType::DEFAULT)
+      expect(t.value_type).to eq(Puppet::Pops::Types::PUnitType::DEFAULT)
     end
 
     context 'callable types' do


### PR DESCRIPTION
In this commit:
- The `element_type` attribute was removed from the `Collection` type and
  instead added to the `Array` type and as `value_type` to the `Hash` type.
- Serialization of registered `Object` types now uses the parameter names
  and order of the #initialize method to determine in which order the
  contained attributes are serialized.