### PR TITLE
(PUP-7134) Use Puppet::FileSystem for file access / explicitly specify encodings for SSL files

### DIFF
--- a/acceptance/lib/puppet/acceptance/classifier_utils.rb
+++ b/acceptance/lib/puppet/acceptance/classifier_utils.rb
@@ -170,7 +170,8 @@ module Puppet
           Puppet::Acceptance::ClassifierUtils.tmpdirs << cert_dir
 
           @ca_cert_file = File.join(cert_dir, "cacert.pem")
-          File.open(@ca_cert_file, "w") do |f|
+          # RFC 1421 states PEM is 7-bit ASCII https://tools.ietf.org/html/rfc1421
+          File.open(@ca_cert_file, "w:ASCII") do |f|
             f.write(ca_cert)
           end
         end

--- a/lib/puppet/indirector/key/file.rb
+++ b/lib/puppet/indirector/key/file.rb
@@ -39,7 +39,8 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
     super
 
     begin
-      Puppet.settings.setting(:publickeydir).open_file(public_key_path(request.key), 'w') do |f|
+      # RFC 1421 states PEM is 7-bit ASCII https://tools.ietf.org/html/rfc1421
+      Puppet.settings.setting(:publickeydir).open_file(public_key_path(request.key), 'w:ASCII') do |f|
         f.print request.instance.content.public_key.to_pem
       end
     rescue => detail

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -173,7 +173,8 @@ class Puppet::SSL::CertificateAuthority
     20.times { pass += (rand(74) + 48).chr }
 
     begin
-      Puppet.settings.setting(:capass).open('w') { |f| f.print pass }
+      # random password is limited to ASCII characters 48 ('0') through 122 ('z')
+      Puppet.settings.setting(:capass).open('w:ASCII') { |f| f.print pass }
     rescue Errno::EACCES => detail
       raise Puppet::Error, "Could not write CA password: #{detail}", detail.backtrace
     end
@@ -216,7 +217,8 @@ class Puppet::SSL::CertificateAuthority
   # file so this one is considered used.
   def next_serial
     serial = 1
-    Puppet.settings.setting(:serial).exclusive_open('a+') do |f|
+    # the serial is 4 hex digits - limited to ASCII
+    Puppet.settings.setting(:serial).exclusive_open('a+:ASCII') do |f|
       f.rewind
       serial = f.read.chomp.hex
       if serial == 0

--- a/lib/puppet/ssl/configuration.rb
+++ b/lib/puppet/ssl/configuration.rb
@@ -50,7 +50,10 @@ class Configuration
 
   # read_file makes testing easier.
   def read_file(path)
-    File.read(path)
+    # https://www.ietf.org/rfc/rfc2459.txt defines the x509 V3 certificate format
+    # CA bundles are concatenated X509 certificates, but may also include
+    # comments, which could have UTF-8 characters
+    Puppet::FileSystem.read(path, :encoding => Encoding::UTF_8)
   end
   private :read_file
 end

--- a/lib/puppet/ssl/inventory.rb
+++ b/lib/puppet/ssl/inventory.rb
@@ -8,7 +8,10 @@ class Puppet::SSL::Inventory
   # Add a certificate to our inventory.
   def add(cert)
     cert = cert.content if cert.is_a?(Puppet::SSL::Certificate)
-    Puppet.settings.setting(:cert_inventory).open("a") do |f|
+    # RFC 5280 says the cert subject may contain UTF8 - https://www.ietf.org/rfc/rfc5280.txt
+    # Note however that Puppet generated SSL files must only contain ASCII characters
+    # based on the validate_certname method of Puppet::SSL::Base
+    Puppet.settings.setting(:cert_inventory).open('a:UTF-8') do |f|
       f.print format(cert)
     end
   end
@@ -28,7 +31,8 @@ class Puppet::SSL::Inventory
   def rebuild
     Puppet.notice "Rebuilding inventory file"
 
-    Puppet.settings.setting(:cert_inventory).open('w') do |f|
+    # RFC 5280 says the cert subject may contain UTF8 - https://www.ietf.org/rfc/rfc5280.txt
+    Puppet.settings.setting(:cert_inventory).open('w:UTF-8') do |f|
       Puppet::SSL::Certificate.indirection.search("*").each do |cert|
         f.print format(cert.content)
       end
@@ -40,7 +44,10 @@ class Puppet::SSL::Inventory
   def serials(name)
     return [] unless Puppet::FileSystem.exist?(@path)
 
-    File.readlines(@path).collect do |line|
+    # RFC 5280 says the cert subject may contain UTF8 - https://www.ietf.org/rfc/rfc5280.txt
+    # Note however that Puppet generated SSL files must only contain ASCII characters
+    # based on the validate_certname method of Puppet::SSL::Base
+    File.readlines(@path, :encoding => Encoding::UTF_8).collect do |line|
       /^(\S+).+\/CN=#{name}$/.match(line)
     end.compact.map { |m| Integer(m[1]) }
   end

--- a/lib/puppet/ssl/key.rb
+++ b/lib/puppet/ssl/key.rb
@@ -38,15 +38,19 @@ DOC
   def password
     return nil unless password_file and Puppet::FileSystem.exist?(password_file)
 
-    ::File.read(password_file)
+    # Puppet generates files at the default Puppet[:capass] using ASCII
+    # User configured :passfile could be in any encoding
+    # Use BINARY given the string is passed to an OpenSSL API accepting bytes
+    # note this is only called internally
+    Puppet::FileSystem.read(password_file, :encoding => Encoding::BINARY)
   end
 
   # Optionally support specifying a password file.
   def read(path)
     return super unless password_file
 
-    #@content = wrapped_class.new(::File.read(path), password)
-    @content = wrapped_class.new(::File.read(path), password)
+    # RFC 1421 states PEM is 7-bit ASCII https://tools.ietf.org/html/rfc1421
+    @content = wrapped_class.new(Puppet::FileSystem.read(path, :encoding => Encoding::ASCII), password)
   end
 
   def to_s

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -739,7 +739,9 @@ module Puppet
     def unknown_keys_in_file(keyfile)
       names = []
       name_index = 0
-      File.new(keyfile).each do |line|
+      # RFC 4716 specifies UTF-8 allowed in public key files per https://www.ietf.org/rfc/rfc4716.txt
+      # the authorized_keys file may contain UTF-8 comments
+      Puppet::FileSystem.open(keyfile, nil, 'r:UTF-8').each do |line|
         next unless line =~ Puppet::Type.type(:ssh_authorized_key).keyline_regex
         # the name is stored in the 4th capture of the regex
         name = $4

--- a/spec/integration/ssl/key_spec.rb
+++ b/spec/integration/ssl/key_spec.rb
@@ -1,0 +1,104 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/ssl/key'
+
+describe Puppet::SSL::Key do
+  include PuppetSpec::Files
+
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ܎
+
+  before do
+    # Get a safe temporary file
+    dir = tmpdir('key_integration_testing')
+
+    Puppet.settings[:confdir] = dir
+    Puppet.settings[:vardir] = dir
+
+    # This is necessary so the terminus instances don't lie around.
+    # and so that Puppet::SSL::Key.indirection.save may be used
+    Puppet::SSL::Key.indirection.termini.clear
+  end
+
+  describe 'with a custom user-specified passfile' do
+
+    before do
+      # write custom password file to where Puppet expects
+      password_file = tmpfile('passfile')
+      Puppet[:passfile] = password_file
+      Puppet::FileSystem.open(password_file, nil, 'w:UTF-8') { |f| f.print(mixed_utf8) }
+    end
+
+    it 'should use the configured password file if it is not the CA key' do
+      key = Puppet::SSL::Key.new('test')
+      expect(key.password_file).to eq(Puppet[:passfile])
+      expect(key.password).to eq(mixed_utf8.force_encoding(Encoding::BINARY))
+    end
+
+    it "should be able to read an existing private key given the correct password" do
+      Puppet[:keylength] = '50'
+
+      key_name = 'test'
+      # use OpenSSL APIs to generate a private key
+      private_key = OpenSSL::PKey::RSA.generate(512)
+
+      # stash it in Puppets private key directory
+      FileUtils.mkdir_p(Puppet[:privatekeydir])
+      pem_path = File.join(Puppet[:privatekeydir], "#{key_name}.pem")
+      Puppet::FileSystem.open(pem_path, nil, 'w:UTF-8') do |f|
+        # with password protection enabled
+        pem = private_key.to_pem(OpenSSL::Cipher::DES.new(:EDE3, :CBC), mixed_utf8)
+        f.print(pem)
+      end
+
+      # indirector loads existing .pem off disk instead of replacing it
+      host = Puppet::SSL::Host.new(key_name)
+      host.generate
+
+      # newly loaded host private key matches the manually created key
+      # Private-Key: (512 bit) style data
+      expect(host.key.content.to_text).to eq(private_key.to_text)
+      # -----BEGIN RSA PRIVATE KEY-----
+      expect(host.key.content.to_s).to eq(private_key.to_s)
+      expect(host.key.password).to eq(mixed_utf8.force_encoding(Encoding::BINARY))
+    end
+
+    it 'should export the private key to PEM using the password' do
+      Puppet[:keylength] = '50'
+
+      key_name = 'test'
+
+      # uses specified :passfile when writing the private key
+      key = Puppet::SSL::Key.new(key_name)
+      key.generate
+      Puppet::SSL::Key.indirection.save(key)
+
+      # indirector writes file here
+      pem_path = File.join(Puppet[:privatekeydir], "#{key_name}.pem")
+
+      # note incorrect password is an error
+      expect do
+        Puppet::FileSystem.open(pem_path, nil, 'r:ASCII') do |f|
+          reloaded_key = OpenSSL::PKey::RSA.new(f.read, 'invalid_password')
+        end
+      end.to raise_error(OpenSSL::PKey::RSAError)
+
+      # but when specifying the correct password
+      reloaded_key = nil
+      Puppet::FileSystem.open(pem_path, nil, 'r:ASCII') do |f|
+        reloaded_key = OpenSSL::PKey::RSA.new(f.read, mixed_utf8)
+      end
+
+      # the original key matches the manually reloaded key
+      # Private-Key: (512 bit) style data
+      expect(key.content.to_text).to eq(reloaded_key.to_text)
+      # -----BEGIN RSA PRIVATE KEY-----
+      expect(key.content.to_s).to eq(reloaded_key.to_s)
+    end
+  end
+end

--- a/spec/integration/type/user_spec.rb
+++ b/spec/integration/type/user_spec.rb
@@ -8,9 +8,16 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
   include PuppetSpec::Compiler
 
   context "when set to purge ssh keys from a file" do
+    # different UTF-8 widths
+    # 1-byte A
+    # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+    # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+    # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+    let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ𠜎
+
     let(:tempfile) do
       file_containing('user_spec', <<-EOF)
-        # comment
+        # comment #{mixed_utf8}
         ssh-rsa KEY-DATA key-name
         ssh-rsa KEY-DATA key name
         EOF
@@ -22,12 +29,12 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
 
     it "should purge authorized ssh keys" do
       apply_compiled_manifest(manifest)
-      expect(File.read(tempfile)).not_to match(/key-name/)
+      expect(File.read(tempfile, :encoding => Encoding::UTF_8)).not_to match(/key-name/)
     end
 
     it "should purge keys with spaces in the comment string" do
       apply_compiled_manifest(manifest)
-      expect(File.read(tempfile)).not_to match(/key name/)
+      expect(File.read(tempfile, :encoding => Encoding::UTF_8)).not_to match(/key name/)
     end
 
     context "with other prefetching resources evaluated first" do
@@ -35,14 +42,14 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
 
       it "should purge authorized ssh keys" do
         apply_compiled_manifest(manifest)
-        expect(File.read(tempfile)).not_to match(/key-name/)
+        expect(File.read(tempfile, :encoding => Encoding::UTF_8)).not_to match(/key-name/)
       end
     end
 
     context "with multiple unnamed keys" do
       let(:tempfile) do
         file_containing('user_spec', <<-EOF)
-          # comment
+          # comment #{mixed_utf8}
           ssh-rsa KEY-DATA1
           ssh-rsa KEY-DATA2
           EOF
@@ -50,7 +57,7 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
 
       it "should purge authorized ssh keys" do
         apply_compiled_manifest(manifest)
-        expect(File.read(tempfile)).not_to match(/KEY-DATA/)
+        expect(File.read(tempfile, :encoding => Encoding::UTF_8)).not_to match(/KEY-DATA/)
       end
     end
   end

--- a/spec/unit/indirector/key/file_spec.rb
+++ b/spec/unit/indirector/key/file_spec.rb
@@ -66,7 +66,7 @@ describe Puppet::SSL::Key::File do
     it "should save the public key when saving the private key" do
       fh = StringIO.new
 
-      Puppet.settings.setting(:publickeydir).expects(:open_file).with(@public_key_path, 'w').yields fh
+      Puppet.settings.setting(:publickeydir).expects(:open_file).with(@public_key_path, 'w:ASCII').yields fh
       Puppet.settings.setting(:privatekeydir).stubs(:open_file)
       @public_key.expects(:to_pem).returns "my pem"
 

--- a/spec/unit/indirector/ssl_file_spec.rb
+++ b/spec/unit/indirector/ssl_file_spec.rb
@@ -221,7 +221,7 @@ describe Puppet::Indirector::SslFile do
           @searcher.class.store_in @setting
           fh = mock 'filehandle'
           fh.stubs :print
-          Puppet.settings.setting(@setting).expects(:open_file).with(@certpath, 'w').yields fh
+          Puppet.settings.setting(@setting).expects(:open_file).with(@certpath, 'w:ASCII').yields fh
 
           @searcher.save(@request)
         end
@@ -233,7 +233,7 @@ describe Puppet::Indirector::SslFile do
 
           fh = mock 'filehandle'
           fh.stubs :print
-          Puppet.settings.setting(@setting).expects(:open).with('w').yields fh
+          Puppet.settings.setting(@setting).expects(:open).with('w:ASCII').yields fh
           @searcher.save(@request)
         end
       end
@@ -246,7 +246,7 @@ describe Puppet::Indirector::SslFile do
 
           fh = mock 'filehandle'
           fh.stubs :print
-          Puppet.settings.setting(:cakey).expects(:open).with('w').yields fh
+          Puppet.settings.setting(:cakey).expects(:open).with('w:ASCII').yields fh
           @searcher.stubs(:ca?).returns true
           @searcher.save(@request)
         end

--- a/spec/unit/ssl/base_spec.rb
+++ b/spec/unit/ssl/base_spec.rb
@@ -45,6 +45,15 @@ describe Puppet::SSL::Certificate do
     end
   end
 
+  describe "when initializing wrapped class from a file with #read" do
+    it "should open the file with ASCII encoding" do
+      path = '/foo/bar/cert'
+      Puppet::SSL::Base.stubs(:valid_certname).returns(true)
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("bar")
+      @base.read(path)
+    end
+  end
+
   describe "#digest_algorithm" do
     let(:content) { stub 'content' }
     let(:base) {

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -167,7 +167,7 @@ describe Puppet::SSL::CertificateAuthority do
       Puppet::FileSystem.expects(:exist?).with(Puppet[:capass]).returns false
 
       fh = StringIO.new
-      Puppet.settings.setting(:capass).expects(:open).with('w').yields fh
+      Puppet.settings.setting(:capass).expects(:open).with('w:ASCII').yields fh
 
       @ca.stubs(:sign)
 
@@ -1067,7 +1067,7 @@ describe "CertificateAuthority.generate" do
   end
 
   def expect_to_write_the_ca_password
-    Puppet.settings.setting(:capass).expects(:open).with('w')
+    Puppet.settings.setting(:capass).expects(:open).with('w:ASCII')
   end
 
   def expect_ca_initialization

--- a/spec/unit/ssl/certificate_request_attributes_spec.rb
+++ b/spec/unit/ssl/certificate_request_attributes_spec.rb
@@ -9,6 +9,12 @@ describe Puppet::SSL::CertificateRequestAttributes do
       "custom_attributes" => {
         "1.3.6.1.4.1.34380.2.2"=>[3232235521, 3232235777], # system IPs in hex
         "1.3.6.1.4.1.34380.2.0"=>"hostname.domain.com",
+        # different UTF-8 widths
+        # 1-byte A
+        # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+        # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+        # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+        "1.2.840.113549.1.9.7"=>"utf8passwordA\u06FF\u16A0\u{2070E}"
       }
     }
   end

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -60,7 +60,7 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should be able to read requests from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my request")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("my request")
       my_req = mock 'request'
       OpenSSL::X509::Request.expects(:new).with("my request").returns(my_req)
       expect(request.read(path)).to equal(my_req)

--- a/spec/unit/ssl/certificate_spec.rb
+++ b/spec/unit/ssl/certificate_spec.rb
@@ -162,7 +162,7 @@ describe Puppet::SSL::Certificate do
 
     it "should be able to read certificates from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my certificate")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("my certificate")
       certificate = mock 'certificate'
       OpenSSL::X509::Certificate.expects(:new).with("my certificate").returns(certificate)
       expect(@certificate.read(path)).to equal(certificate)

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -5,6 +5,14 @@ require 'puppet/ssl/inventory'
 
 describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? do
   let(:cert_inventory) { File.expand_path("/inven/tory") }
+
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ܎
+
   before do
     @class = Puppet::SSL::Inventory
   end
@@ -56,7 +64,7 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
     describe "and adding a certificate" do
 
       it "should use the Settings to write to the file" do
-        Puppet.settings.setting(:cert_inventory).expects(:open).with("a")
+        Puppet.settings.setting(:cert_inventory).expects(:open).with('a:UTF-8')
 
         @inventory.add(@cert)
       end
@@ -66,13 +74,29 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
         cert.content = @cert
 
         fh = StringIO.new
-        Puppet.settings.setting(:cert_inventory).expects(:open).with("a").yields(fh)
+        Puppet.settings.setting(:cert_inventory).expects(:open).with('a:UTF-8').yields(fh)
 
         @inventory.expects(:format).with(@cert).returns "myformat"
 
         @inventory.add(@cert)
 
         expect(fh.string).to eq("myformat")
+      end
+
+      it "can use UTF-8 in the CN per RFC 5280" do
+        cert = Puppet::SSL::Certificate.new("mycert")
+        cert.content = stub 'cert',
+          :serial => 1,
+          :not_before => Time.now,
+          :not_after => Time.now,
+          :subject => "/CN=#{mixed_utf8}"
+
+        fh = StringIO.new
+        Puppet.settings.setting(:cert_inventory).expects(:open).with('a:UTF-8').yields(fh)
+
+        @inventory.add(cert)
+
+        expect(fh.string).to match(/\/CN=#{mixed_utf8}/)
       end
     end
 
@@ -118,7 +142,7 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
       end
 
       it "should return the all the serial numbers from the lines matching the provided name" do
-        File.expects(:readlines).with(cert_inventory).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
+        File.expects(:readlines).with(cert_inventory, :encoding => Encoding::UTF_8).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
 
         expect(@inventory.serials("me")).to eq([15, 2])
       end

--- a/spec/unit/ssl/key_spec.rb
+++ b/spec/unit/ssl/key_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::SSL::Key do
 
     it "should be able to read keys from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my key")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("my key")
       key = mock 'key'
       OpenSSL::PKey::RSA.expects(:new).returns(key)
       expect(@key.read(path)).to equal(key)
@@ -76,9 +76,9 @@ describe Puppet::SSL::Key do
 
       path = "/my/path"
 
-      File.stubs(:read).with(path).returns("my key")
+      Puppet::FileSystem.stubs(:read).with(path, :encoding => Encoding::ASCII).returns("my key")
       OpenSSL::PKey::RSA.expects(:new).with("my key", nil).returns(mock('key'))
-      File.expects(:read).with("/path/to/password").never
+      Puppet::FileSystem.expects(:read).with("/path/to/password", :encoding => Encoding::BINARY).never
 
       @key.read(path)
     end
@@ -88,8 +88,8 @@ describe Puppet::SSL::Key do
       @key.password_file = "/path/to/password"
 
       path = "/my/path"
-      File.expects(:read).with(path).returns("my key")
-      File.expects(:read).with("/path/to/password").returns("my password")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("my key")
+      Puppet::FileSystem.expects(:read).with("/path/to/password", :encoding => Encoding::BINARY).returns("my password")
 
       key = mock 'key'
       OpenSSL::PKey::RSA.expects(:new).with("my key", "my password").returns(key)
@@ -155,7 +155,7 @@ describe Puppet::SSL::Key do
     describe "with a password file set" do
       it "should return a nil password if the password file does not exist" do
         Puppet::FileSystem.expects(:exist?).with("/path/to/pass").returns false
-        File.expects(:read).with("/path/to/pass").never
+        Puppet::FileSystem.expects(:read).with("/path/to/pass", :encoding => Encoding::BINARY).never
 
         @instance.password_file = "/path/to/pass"
 
@@ -164,7 +164,7 @@ describe Puppet::SSL::Key do
 
       it "should return the contents of the password file as its password" do
         Puppet::FileSystem.expects(:exist?).with("/path/to/pass").returns true
-        File.expects(:read).with("/path/to/pass").returns "my password"
+        Puppet::FileSystem.expects(:read).with("/path/to/pass", :encoding => Encoding::BINARY).returns "my password"
 
         @instance.password_file = "/path/to/pass"
 


### PR DESCRIPTION
~~Builds on #5370 which must be merged first~~