### PR TITLE
(PUP-6921) Improve separation of concern between String and Enum types

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -284,7 +284,7 @@ class AccessOperator
       type = keys[0]
       unless type.is_a?(Types::PAnyType)
         if type.is_a?(String)
-          type = Types::TypeFactory.string(nil, type)
+          type = Types::TypeFactory.string(type)
         else
           fail(Issues::BAD_TYPE_SLICE_TYPE, @semantic.keys[0], {:base_type => 'Optional-Type', :actual => type.class})
         end
@@ -335,7 +335,7 @@ class AccessOperator
       type = keys[0]
       case type
       when String
-        type = Types::TypeFactory.string(nil, type)
+        type = Types::TypeFactory.string(type)
       when Types::PAnyType
         type = nil if type.class == Types::PAnyType
       else

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -311,7 +311,7 @@ class Closure < CallableSignature
 
     parameters.each do |param|
       arg_type, param_range = create_param_type(param, closure_scope)
-      key_type = type_factory.string(nil, param.name.to_s)
+      key_type = type_factory.string(param.name.to_s)
       key_type = type_factory.optional(key_type) unless param.value.nil?
       members[key_type] = arg_type
     end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -75,11 +75,20 @@ module TypeFactory
     @type_calculator.string(t)
   end
 
-  # Produces the String type, optionally with specific string values
+  # Produces the String type based on nothing, a string value that becomes an exact match constraint, or a parameterized
+  # Integer type that constraints the size.
+  #
   # @api public
   #
-  def self.string(size_type = nil, *values)
-    PStringType.new(size_type, values)
+  def self.string(size_type_or_value = nil, *deprecated_second_argument)
+    if deprecated_second_argument.empty?
+      size_type_or_value.nil? ? PStringType::DEFAULT : PStringType.new(size_type_or_value)
+    else
+      if Puppet[:strict] != :off
+        Puppet.warn_once(:deprecatation, "TypeFactory#string_multi_args", "Passing more than one argument to TypeFactory#string is deprecated")
+      end
+      deprecated_second_argument.size == 1 ? PStringType.new(deprecated_second_argument[0]) : PEnumType.new(*deprecated_second_argument)
+    end
   end
 
   # Produces the Optional type, i.e. a short hand for Variant[T, Undef]
@@ -92,7 +101,7 @@ module TypeFactory
   # @api public
   #
   def self.optional(optional_type = nil)
-    POptionalType.new(type_of(optional_type.is_a?(String) ? string(nil, optional_type) : type_of(optional_type)))
+    POptionalType.new(type_of(optional_type.is_a?(String) ? string(optional_type) : type_of(optional_type)))
   end
 
   # Produces the Enum type, optionally with specific string values
@@ -129,7 +138,7 @@ module TypeFactory
       # TODO: Should have stricter name rule
       if key_type.is_a?(String)
         raise ArgumentError, 'Struct element key cannot be an empty String' if key_type.empty?
-        key_type = string(nil, key_type)
+        key_type = string(key_type)
         # Must make key optional if the value can be Undef
         key_type = optional(key_type) if tc.assignable?(value_type, PUndefType::DEFAULT)
       else
@@ -141,12 +150,14 @@ module TypeFactory
           s = key_type
         when POptionalType
           s = key_type.optional_type
-        when PStringType, PEnumType
+        when PStringType
           s = key_type
+        when PEnumType
+          s = key_type.values.size == 1 ? PStringType.new(key_type.values[0]) : nil
         else
           raise ArgumentError, "Illegal Struct member key type. Expected NotUndef, Optional, String, or Enum. Got: #{key_type.class.name}"
         end
-        unless (s.is_a?(PStringType) || s.is_a?(PEnumType)) && s.values.size == 1 && !s.values[0].empty?
+        unless s.is_a?(PStringType) && !s.value.nil?
           raise ArgumentError, "Unable to extract a non-empty literal string from Struct member key type #{tc.string(key_type)}"
         end
       end
@@ -435,7 +446,7 @@ module TypeFactory
   # @api public
   #
   def self.not_undef(inst_type = nil)
-    inst_type = string(nil, inst_type) if inst_type.is_a?(String)
+    inst_type = string(inst_type) if inst_type.is_a?(String)
     PNotUndefType.new(inst_type)
   end
 

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -171,9 +171,8 @@ class TypeFormatter
     range = range_array_part(t.size_type)
     append_array('String', range.empty?) do
       if @debug
-        append_elements(range, true)
-        append_strings(t.values, true)
-        chomp_list
+        append_elements(range, !t.value.nil?)
+        append_string(t.value) unless t.value.nil?
       else
         append_elements(range)
       end
@@ -356,8 +355,8 @@ class TypeFormatter
   def string_PNotUndefType(t)
     contained_type = t.type
     append_array('NotUndef', contained_type.nil? || contained_type.class == PAnyType) do
-      if contained_type.is_a?(PStringType) && contained_type.values.size == 1
-        append_string(contained_type.values[0])
+      if contained_type.is_a?(PStringType) && !contained_type.value.nil?
+        append_string(contained_type.value)
       else
         append_string(contained_type)
       end
@@ -427,8 +426,8 @@ class TypeFormatter
   def string_POptionalType(t)
     optional_type = t.optional_type
     append_array('Optional', optional_type.nil?) do
-      if optional_type.is_a?(PStringType) && optional_type.values.size == 1
-        append_string(optional_type.values[0])
+      if optional_type.is_a?(PStringType) && !optional_type.value.nil?
+        append_string(optional_type.value)
       else
         append_string(optional_type)
       end

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -463,7 +463,7 @@ module Types
 
     def actual_string
       a = actual
-      a.is_a?(PStringType) && a.values.size == 1 ? "'#{a.values[0]}'" : a.simple_name
+      a.is_a?(PStringType) && !a.value.nil? ? "'#{a.value}'" : a.simple_name
     end
   end
 

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -703,18 +703,11 @@ class PEnumType < PScalarType
 
   def generalize
     # General form of an Enum is a String
-    PStringType::DEFAULT
-  end
-
-  def normalize(guard = nil)
-    # General form of an Enum is a String
-    case @values.size
-    when 0
+    if @values.empty?
       PStringType::DEFAULT
-    when 1
-      PStringType.new(@values[0])
     else
-      self
+      range = @values.map(&:size).minmax
+      PStringType.new(PIntegerType.new(range.min, range.max))
     end
   end
 
@@ -748,7 +741,7 @@ class PEnumType < PScalarType
     end
     case o
       when PStringType
-        # if the set of strings are all found in the set of enums
+        # if the contained string is found in the set of enums
         v = o.value
         !v.nil? && svalues.any? { |e| e == v }
       when PEnumType

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -701,6 +701,23 @@ class PEnumType < PScalarType
     block_given? ? r.each(&block) : r
   end
 
+  def generalize
+    # General form of an Enum is a String
+    PStringType::DEFAULT
+  end
+
+  def normalize(guard = nil)
+    # General form of an Enum is a String
+    case @values.size
+    when 0
+      PStringType::DEFAULT
+    when 1
+      PStringType.new(@values[0])
+    else
+      self
+    end
+  end
+
   def iterable?(guard = nil)
     true
   end
@@ -732,7 +749,8 @@ class PEnumType < PScalarType
     case o
       when PStringType
         # if the set of strings are all found in the set of enums
-        !o.values.empty? && o.values.all? { |s| svalues.any? { |e| e == s }}
+        v = o.value
+        !v.nil? && svalues.any? { |e| e == v }
       when PEnumType
         !o.values.empty? && o.values.all? { |s| svalues.any? {|e| e == s }}
       else
@@ -1336,27 +1354,27 @@ end
 class PStringType < PScalarType
   def self.register_ptype(loader, ir)
     create_ptype(loader, ir, 'ScalarType',
-      'size_type' => {
-        KEY_TYPE => POptionalType.new(PType.new(PIntegerType::DEFAULT)),
-        KEY_VALUE => nil
-      },
-      'values' => {
-        KEY_TYPE => PArrayType.new(PStringType::DEFAULT),
-        KEY_VALUE => EMPTY_ARRAY
-      }
-    )
+      'size_type_or_value' => {
+        KEY_TYPE => POptionalType.new(PVariantType.new([PStringType::DEFAULT, PType.new(PIntegerType::DEFAULT)])),
+      KEY_VALUE => nil
+    })
   end
 
-  attr_reader :size_type, :values
+  attr_reader :size_type_or_value
 
-  def initialize(size_type, values = EMPTY_ARRAY)
-    @size_type = size_type
-    @values = values.sort.freeze
+  def initialize(size_type_or_value, deprecated_multi_args = EMPTY_ARRAY)
+    unless deprecated_multi_args.empty?
+      if Puppet[:strict] != :off
+        Puppet.warn_once(:deprecatation, "PStringType#initialize_multi_args", "Passing more than one argument to PStringType#initialize is deprecated")
+      end
+      size_type_or_value = deprecated_multi_args[0]
+    end
+    @size_type_or_value = size_type_or_value
   end
 
   def accept(visitor, guard)
     super
-    @size_type.accept(visitor, guard) unless @size_type.nil?
+    @size_type_or_value.accept(visitor, guard) if @size_type_or_value.is_a?(PIntegerType)
   end
 
   def generalize
@@ -1364,7 +1382,7 @@ class PStringType < PScalarType
   end
 
   def hash
-    @size_type.hash ^ @values.hash
+    @size_type_or_value.hash
   end
 
   def iterable?(guard = nil)
@@ -1376,15 +1394,51 @@ class PStringType < PScalarType
   end
 
   def eql?(o)
-    self.class == o.class && @size_type == o.size_type && @values == o.values
+    self.class == o.class && @size_type_or_value == o.size_type_or_value
   end
 
   def instance?(o, guard = nil)
     # true if size compliant
-    if o.is_a?(String) && (@size_type.nil? || @size_type.instance?(o.size, guard))
-      @values.empty? || @values.include?(o)
+    if o.is_a?(String)
+      if @size_type_or_value.is_a?(PIntegerType)
+        @size_type_or_value.instance?(o.size, guard)
+      else
+        @size_type_or_value.nil? ? true : o == value
+      end
     else
       false
+    end
+  end
+
+  def value
+    @size_type_or_value.is_a?(PIntegerType) ? nil : @size_type_or_value
+  end
+
+  # @deprecated
+  # @api private
+  def values
+    if Puppet[:strict] != :off
+      Puppet.warn_once(:deprecatation, "PStringType#values", "Method PStringType#values is deprecated. Use #value instead")
+    end
+    @value.is_a?(String) ? [@value] : EMPTY_ARRAY
+  end
+
+  def size_type
+    @size_type_or_value.is_a?(PIntegerType) ? @size_type_or_value : nil
+  end
+
+  def size_type
+    @size_type_or_value.is_a?(PIntegerType) ? @size_type_or_value : nil
+  end
+
+  def derived_size_type
+    if @size_type_or_value.is_a?(PIntegerType)
+      @size_type_or_value
+    elsif @size_type_or_value.is_a?(String)
+      sz = @size_type_or_value.size
+      PIntegerType.new(sz, sz)
+    else
+      PCollectionType::DEFAULT_SIZE
     end
   end
 
@@ -1424,44 +1478,48 @@ class PStringType < PScalarType
 
   # @api private
   def _assignable?(o, guard)
-    if values.empty?
+    if @size_type_or_value.is_a?(PIntegerType)
       # A general string is assignable by any other string or pattern restricted string
       # if the string has a size constraint it does not match since there is no reasonable way
       # to compute the min/max length a pattern will match. For enum, it is possible to test that
       # each enumerator value is within range
       case o
-        when PStringType
-          # true if size compliant
-          (@size_type || PCollectionType::DEFAULT_SIZE).assignable?(
-            o.size_type || PCollectionType::DEFAULT_SIZE, guard)
+      when PStringType
+        @size_type_or_value.assignable?(o.derived_size_type, guard)
 
-        when PPatternType
-          # true if size constraint is at least 0 to +Infinity (which is the same as the default)
-          @size_type.nil? || @size_type.assignable?(PCollectionType::DEFAULT_SIZE, guard)
-
-        when PEnumType
-          if o.values.empty?
-            # enum represents all enums, and thus all strings, a sized constrained string can thus not
-            # be assigned any enum (unless it is max size).
-            @size_type.nil? || @size_type.assignable?(PCollectionType::DEFAULT_SIZE, guard)
-          else
-            # true if all enum values are within range
-            orange = o.values.map(&:size).minmax
-            srange = (@size_type || PCollectionType::DEFAULT_SIZE).range
-            # If o min and max are within the range of t
-            srange[0] <= orange[0] && srange[1] >= orange[1]
-          end
+      when PEnumType
+        if o.values.empty?
+          # enum represents all enums, and thus all strings, a sized constrained string can thus not
+          # be assigned any enum (unless it is max size).
+          @size_type_or_value.assignable?(PCollectionType::DEFAULT_SIZE, guard)
         else
-          # no other type matches string
-          false
+          # true if all enum values are within range
+          orange = o.values.map(&:size).minmax
+          srange = @size_type_or_value.range
+          # If o min and max are within the range of t
+          srange[0] <= orange[0] && srange[1] >= orange[1]
+        end
+
+      when PPatternType
+        # true if size constraint is at least 0 to +Infinity (which is the same as the default)
+        @size_type_or_value.assignable?(PCollectionType::DEFAULT_SIZE, guard)
+      else
+        # no other type matches string
+        false
       end
-    elsif o.is_a?(PStringType)
-      # A specific string acts as a set of strings - must have exactly the same strings
-      # In this case, size does not matter since the definition is very precise anyway
-      values == o.values
     else
-      # All others are false, since no other type describes the same set of specific strings
-      false
+      case o
+      when PStringType
+        # Must match exactly when value is a string
+        @size_type_or_value.nil? || @size_type_or_value == o.size_type_or_value
+      when PEnumType
+        @size_type_or_value.nil? ? true : o.values.size == 1 && @size_type_or_value == o.values[0]
+      when PPatternType
+        @size_type_or_value.nil?
+      else
+        # All others are false, since no other type describes the same set of specific strings
+        false
+      end
     end
   end
 end
@@ -1548,16 +1606,28 @@ class PPatternType < PScalarType
   def _assignable?(o, guard)
     return true if self == o
     case o
-    when PStringType, PEnumType
+    when PStringType
+      v = o.value
+      if v.nil?
+        # Strings cannot all match a pattern, but if there is no pattern it is ok
+        # (There should really always be a pattern, but better safe than sorry).
+        @patterns.empty?
+      else
+        # the string in String type must match one of the patterns in Pattern type,
+        # or Pattern represents all Patterns == all Strings
+        regexps = @patterns.map { |p| p.regexp }
+        regexps.empty? || regexps.any? { |re| re.match(v) }
+      end
+    when PEnumType
       if o.values.empty?
-        # Strings / Enums (unknown which ones) cannot all match a pattern, but if there is no pattern it is ok
+        # Enums (unknown which ones) cannot all match a pattern, but if there is no pattern it is ok
         # (There should really always be a pattern, but better safe than sorry).
         @patterns.empty?
       else
         # all strings in String/Enum type must match one of the patterns in Pattern type,
         # or Pattern represents all Patterns == all Strings
         regexps = @patterns.map { |p| p.regexp }
-        regexps.empty? || o.values.all? { |v| regexps.any? {|re| re.match(v) } }
+        regexps.empty? || o.values.all? { |s| regexps.any? {|re| re.match(s) } }
       end
     when PPatternType
       @patterns.empty?
@@ -1642,7 +1712,7 @@ class PStructElement < TypedModelObject
   def name
     k = key_type
     k = k.optional_type if k.is_a?(POptionalType)
-    k.values[0]
+    k.value
   end
 
   def initialize(key_type, value_type)
@@ -2719,11 +2789,11 @@ class PVariantType < PAnyType
   # @api private
   def merge_enums(array)
     if array.size > 1
-      parts = array.partition {|t| t.is_a?(PEnumType) || t.is_a?(PStringType) && !t.values.empty? }
+      parts = array.partition {|t| t.is_a?(PEnumType) && !t.values.empty? || t.is_a?(PStringType) && !t.value.nil? }
       enums = parts[0]
       if enums.size > 1
         others = parts[1]
-        others <<  PEnumType.new(enums.map { |enum| enum.values }.flatten.uniq)
+        others <<  PEnumType.new(enums.map { |enum| enum.is_a?(PStringType) ? enum.value : enum.values }.flatten.uniq)
         array = others
       end
     end

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -545,11 +545,11 @@ class Puppet::Resource::Type
   def create_params_struct
     arg_types = argument_types
     type_factory = Puppet::Pops::Types::TypeFactory
-    members = { type_factory.optional(type_factory.string(nil, NAME)) =>  type_factory.any }
+    members = { type_factory.optional(type_factory.string(NAME)) =>  type_factory.any }
 
     if application?
       resource_type = type_factory.type_type(type_factory.resource)
-      members[type_factory.optional(type_factory.string(nil, NODES))] = type_factory.hash_of(type_factory.variant(
+      members[type_factory.optional(type_factory.string(NODES))] = type_factory.hash_of(type_factory.variant(
           resource_type, type_factory.array_of(resource_type)), type_factory.type_type(type_factory.resource('node')))
     end
 
@@ -559,7 +559,7 @@ class Puppet::Resource::Type
     end
 
     arguments.each_pair do |name, default|
-      key_type = type_factory.string(nil, name.to_s)
+      key_type = type_factory.string(name.to_s)
       key_type = type_factory.optional(key_type) unless default.nil?
 
       arg_type = arg_types[name]

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -533,7 +533,7 @@ describe 'the new function' do
     { []            => 'Notify[Array[Unit], []]',
       [true]        => 'Notify[Array[Boolean], [true]]',
       {'a'=>true, 'b' => false}   => 'Notify[Array[Array[Scalar]], [[a, true], [b, false]]]',
-      'abc'         => 'Notify[Array[String], [a, b, c]]',
+      'abc'         => 'Notify[Array[String[1, 1]], [a, b, c]]',
       3             => 'Notify[Array[Integer], [0, 1, 2]]',
     }.each do |input, result|
       it "produces #{result} when given the value #{input.inspect} and wrap is not given" do
@@ -591,7 +591,7 @@ describe 'the new function' do
   end
 
   context 'when invoked on Tuple' do
-    { 'abc'         => 'Notify[Array[String], [a, b, c]]',
+    { 'abc'         => 'Notify[Array[String[1, 1]], [a, b, c]]',
       3             => 'Notify[Array[Integer], [0, 1, 2]]',
     }.each do |input, result|
       it "produces #{result} when given the value #{input.inspect} and wrap is not given" do
@@ -617,7 +617,7 @@ describe 'the new function' do
       {'a'=>true}   => 'Notify[Hash[String, Boolean], {a => true}]',
       [1,2,3,4]     => 'Notify[Hash[Integer, Integer], {1 => 2, 3 => 4}]',
       [[1,2],[3,4]] => 'Notify[Hash[Integer, Integer], {1 => 2, 3 => 4}]',
-      'abcd'        => 'Notify[Hash[String, String], {a => b, c => d}]',
+      'abcd'        => 'Notify[Hash[String[1, 1], String[1, 1]], {a => b, c => d}]',
       4             => 'Notify[Hash[Integer, Integer], {0 => 1, 2 => 3}]',
 
     }.each do |input, result|

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -492,13 +492,13 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
     it 'produces a NotUndef instance with String type when given a literal String' do
       type_expr = fqr('NotUndef')[literal('hey')]
       tf = Puppet::Pops::Types::TypeFactory
-      expect(evaluate(type_expr)).to be_the_type(tf.not_undef(tf.string(nil, 'hey')))
+      expect(evaluate(type_expr)).to be_the_type(tf.not_undef(tf.string('hey')))
     end
 
     it 'Produces Optional instance with String type when using a String argument' do
       type_expr = fqr('Optional')[literal('hey')]
       tf = Puppet::Pops::Types::TypeFactory
-      expect(evaluate(type_expr)).to be_the_type(tf.optional(tf.string(nil, 'hey')))
+      expect(evaluate(type_expr)).to be_the_type(tf.optional(tf.string('hey')))
     end
 
     # Type Type

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -2065,23 +2065,23 @@ describe 'The type calculator' do
     end
 
     it 'a generic inference is produced using infer_generic' do
-      expect(calculator.infer_generic(['a','b']).element_type).to eql(PStringType::DEFAULT)
+      expect(calculator.infer_generic(['a','b']).element_type).to eql(string_t(range_t(1,1)))
     end
 
     it 'a generic result is created by generalize given an instance specific result for an Array' do
       generic = calculator.infer(['a','b'])
-      expect(generic.element_type.values).to eq(['a', 'b'])
+      expect(generic.element_type.values).to eq(['a','b'])
       generic = generic.generalize
-      expect(generic.element_type).to eql(PStringType::DEFAULT)
+      expect(generic.element_type).to eql(string_t(range_t(1,1)))
     end
 
     it 'a generic result is created by generalize given an instance specific result for a Hash' do
-      generic = calculator.infer({'a' =>1,'b' => 2})
-      expect(generic.key_type.values.sort).to eq(['a', 'b'])
+      generic = calculator.infer({'a' =>1,'bcd' => 2})
+      expect(generic.key_type.values.sort).to eq(['a', 'bcd'])
       expect(generic.value_type.from).to eq(1)
       expect(generic.value_type.to).to eq(2)
       generic = generic.generalize
-      expect(generic.key_type).to eql(PStringType::DEFAULT)
+      expect(generic.key_type.size_type).to eq(range_t(1,3))
       expect(generic.value_type.from).to eq(nil)
       expect(generic.value_type.to).to eq(nil)
     end

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -119,8 +119,8 @@ end
       expect(s.string(f.string)).to eq('String')
     end
 
-    it "should yield 'String' for PStringType with multiple values" do
-      expect(s.string(f.string(nil, 'a', 'b', 'c'))).to eq('String')
+    it "should yield 'String' for PStringType with value" do
+      expect(s.string(f.string('a'))).to eq('String')
     end
 
     it "should yield 'String' and from/to for PStringType" do

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -87,7 +87,7 @@ describe 'the type mismatch describer' do
       check_port({ 34 => 'some service'})
     CODE
     expect { eval_and_collect_notices(code) }.to(raise_error(Puppet::Error,
-      /parameter 'ports' expects a PortMap = Hash\[UnprivilegedPort = Integer\[1024, 65537\], String\] value, got Hash\[Integer\[34, 34\], String\[12, 12\]\]/))
+      /parameter 'ports' expects a PortMap = Hash\[UnprivilegedPort = Integer\[1024, 65537\], String\] value, got Hash\[Integer\[34, 34\], String\]/))
   end
 
   it 'will not include the aliased type more than once when reporting a mismatch that involves an alias that is self recursive' do
@@ -98,7 +98,7 @@ describe 'the type mismatch describer' do
       check_tree({ 'x' => {'y' => {32 => 'n'}}})
     CODE
     expect { eval_and_collect_notices(code) }.to(raise_error(Puppet::Error,
-      /parameter 'tree' entry 'x' entry 'y' expects a Tree = Hash\[String, Tree\] value, got Hash\[Integer\[32, 32\], String\[1, 1\]\]/))
+      /parameter 'tree' entry 'x' entry 'y' expects a Tree = Hash\[String, Tree\] value, got Hash\[Integer\[32, 32\], String\]/))
   end
 
   it 'will use type normalization' do


### PR DESCRIPTION
Before this commit, the `PStringType` had two attributes. A `size_type` and
a `values` array. An inferred String would hence result in a String type
with two complex objects and all checkes would then take both objects into
account.

This commit simplifies the `PStringType` so that it only has one attribute.
The attribute can be either a size_type or a string value.

Since this means that a String can hold max one string value, the common
type of two different strings is now changed to instead be an Enum. I.e.
the inferred element type of the array ['a', 'b']. The logic for computing
assignability and commonality between Enum and String has been improved.