### PR TITLE
(PUP-6821) Fix missing file in file not found message from binary_file()

### DIFF
--- a/lib/puppet/functions/binary_file.rb
+++ b/lib/puppet/functions/binary_file.rb
@@ -10,16 +10,10 @@ Puppet::Functions.create_function(:binary_file, Puppet::Functions::InternalFunct
   end
 
   def binary_file(scope, unresolved_path)
-    path = nil
-    found = Puppet::Parser::Files.find_file(unresolved_path, scope.compiler.environment)
-    if found && Puppet::FileSystem.exist?(found)
-      path = found
+    path = Puppet::Parser::Files.find_file(unresolved_path, scope.compiler.environment)
+    unless path && Puppet::FileSystem.exist?(path)
+      raise Puppet::ParseError, "binary_file(): The given file '#{unresolved_path}' does not exist"
     end
-
-    if path
-      Puppet::Pops::Types::PBinaryType::Binary.from_binary_string(Puppet::FileSystem.binread(path))
-    else
-      raise Puppet::ParseError, "binary_file(): The given file '#{path}' does not exist"
-    end
+    Puppet::Pops::Types::PBinaryType::Binary.from_binary_string(Puppet::FileSystem.binread(path))
   end
 end

--- a/spec/unit/functions/binary_file_spec.rb
+++ b/spec/unit/functions/binary_file_spec.rb
@@ -28,7 +28,7 @@ describe 'the binary_file function' do
       with_file_content('one') do |one|
         compile_to_catalog("notify { binary_file('#{one}/nope'):}")
       end
-    end.to raise_error(/The given file '.*' does not exist/)
+    end.to raise_error(/The given file '.+\/nope' does not exist/)
   end
 
   it 'reads an existing file in a module' do


### PR DESCRIPTION
Ensure that the given file name is included in the message.