### PR TITLE
(PUP-6926) Enable lookup of rich data values

### DIFF
--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -20,7 +20,7 @@ module Lookup
   # @return [Object] The found value
   #
   def self.lookup(name, value_type, default_value, has_default, merge, lookup_invocation)
-    value_type = Types::PDataType::DEFAULT if value_type.nil?
+    value_type = DataProvider.value_type if value_type.nil?
     names = name.is_a?(Array) ? name : [name]
 
     # find first name that yields a non-nil result and wrap it in a two element array

--- a/lib/puppet/pops/lookup/data_provider.rb
+++ b/lib/puppet/pops/lookup/data_provider.rb
@@ -16,7 +16,7 @@ module DataProvider
     if @key_type.nil?
       (@key_type, @value_type) = Pcore::register_aliases(
         # The Pcore type for all keys and subkeys in a data hash.
-        'Puppet::LookupKey' => 'Variant[String,Boolean,Numeric]',
+        'Puppet::LookupKey' => 'Variant[String,Numeric]',
 
         # The Pcore type for all values and sub-values in a data hash. The
         # type is self-recursive to enforce the same constraint on values contained

--- a/lib/puppet/pops/lookup/data_provider.rb
+++ b/lib/puppet/pops/lookup/data_provider.rb
@@ -2,20 +2,38 @@ module Puppet::Pops
 module Lookup
 # @api private
 module DataProvider
-  # The Pcore type for all keys and subkeys in a data hash.
-  TYPE_DATA_KEY = Types::PVariantType.new([
-    Types::PStringType::NON_EMPTY,
-    Types::PBooleanType::DEFAULT,
-    Types::PNumericType::DEFAULT
-  ])
+  def self.key_type
+    ensure_types_initialized
+    @key_type
+  end
 
-  # The Pcore type for all values and sub-values in a data hash.
-  TYPE_DATA_VALUE = Types::PVariantType.new([
-    Types::PScalarType::DEFAULT,
-    Types::PUndefType::DEFAULT,
-    Types::PHashType::DEFAULT,
-    Types::PArrayType::DEFAULT
-  ])
+  def self.value_type
+    ensure_types_initialized
+    @value_type
+  end
+
+  def self.ensure_types_initialized
+    if @key_type.nil?
+      (@key_type, @value_type) = Pcore::register_aliases(
+        # The Pcore type for all keys and subkeys in a data hash.
+        'Puppet::LookupKey' => 'Variant[String,Boolean,Numeric]',
+
+        # The Pcore type for all values and sub-values in a data hash. The
+        # type is self-recursive to enforce the same constraint on values contained
+        # in arrays and hashes
+        'Puppet::LookupValue' => <<-PUPPET
+          Variant[
+            Scalar,
+            Undef,
+            Sensitive,
+            Type,
+            Hash[Puppet::LookupKey, Puppet::LookupValue],
+            Array[Puppet::LookupValue]
+          ]
+        PUPPET
+      )
+    end
+  end
 
   # Performs a lookup with an endless recursion check.
   #
@@ -64,7 +82,7 @@ module DataProvider
   end
 
   def validate_data_value(data_provider, value, where = '')
-    Types::TypeAsserter.assert_instance_of(nil, TYPE_DATA_VALUE, value) { "Value #{where}returned from #{data_provider.name}" }
+    Types::TypeAsserter.assert_instance_of(nil, DataProvider.value_type, value) { "Value #{where}returned from #{data_provider.name}" }
     case value
     when Hash
       value.each_pair { |k, v| validate_data_entry(data_provider, k, v) }
@@ -75,7 +93,7 @@ module DataProvider
   end
 
   def validate_data_entry(data_provider, key, value)
-    Types::TypeAsserter.assert_instance_of(nil, TYPE_DATA_KEY, key) { "Key in hash returned from #{data_provider.name}" }
+    Types::TypeAsserter.assert_instance_of(nil, DataProvider.key_type, key) { "Key in hash returned from #{data_provider.name}" }
     validate_data_value(data_provider, value, 'in hash ')
     nil
   end

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -83,6 +83,8 @@ module Pcore
     aliases.each do |name, type_string|
       add_type(Types::PTypeAliasType.new(name, Types::TypeFactory.type_reference(type_string), nil), loader, name_authority)
     end
+    parser = Types::TypeParser.singleton
+    aliases.each_key.map { |name| loader.load(:type, name.downcase).resolve(parser, loader) }
   end
 end
 end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -550,7 +550,7 @@ class PUndefType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    o.nil? || o == :undef
+    o.nil? || :undef == o
   end
 
   # @api private


### PR DESCRIPTION
This PR changes the Pcore type used to validate data found by a lookup
so that it may contain any type except Runtime. The key and value types are
registered as aliases `Puppet::LookupKey` and `Puppet::LookupValue`. The
latter alias is self-recursive in that keys and values found in hashes and
arrays must conform to their respective type, even if nested.