### PR TITLE
(PUP-6882) Fix problem with escaped unicode escapes

### DIFF
--- a/lib/puppet/pops/parser/slurp_support.rb
+++ b/lib/puppet/pops/parser/slurp_support.rb
@@ -76,8 +76,8 @@ module SlurpSupport
     # Process unicode escapes first as they require getting 4 hex digits
     # If later a \u is found it is warned not to be a unicode escape
     if escapes.include?('u')
-      str.gsub!(/\\u(?:([\da-fA-F]{4})|\{([\da-fA-F]{1,6})\})/m) {
-        [($1 || $2).hex].pack("U")
+      str.gsub!(/((?:[^\\]|^)(?:[\\]{2})*)\\u(?:([\da-fA-F]{4})|\{([\da-fA-F]{1,6})\})/m) {
+        $1 + [($2 || $3).hex].pack("U")
       }
     end
 

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -523,6 +523,13 @@ describe 'Lexer2' do
       expect(tokens_scanned_from(code)).to match_tokens2([:STRING, "x\u{1f452}y"])
     end
 
+    it 'can escape the unicode escape' do
+      code = <<-"CODE"
+      "x\\\\u{1f452}y"
+      CODE
+      expect(tokens_scanned_from(code)).to match_tokens2([:STRING, "x\\u{1f452}y"])
+    end
+
     it 'produces byte offsets that counts each byte in a comment' do
       code = <<-"CODE"
       # \u{0400}\na


### PR DESCRIPTION
Prior to this commit, the lexer would not detect that an escaped unicode
escape such as \\uFFFF was preceded by an escape and instead treat it as
a literal `\` followed by the unicode codepoint \uFFFF. This commit alters
the regexp used so that it detects a preceding escape.