### PR TITLE
(PUP-6844) Ignore Mercurial artifacts when downloading plugins

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1719,7 +1719,7 @@ EOT
     },
 
     :pluginsignore => {
-        :default  => ".svn CVS .git",
+        :default  => ".svn CVS .git .hg",
         :desc     => "What files to ignore when pulling down plugins.",
     }
   )

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -1285,7 +1285,7 @@ Where to retrieve external facts for pluginsync
 What files to ignore when pulling down plugins\.
 .
 .IP "\(bu" 4
-\fIDefault\fR: \.svn CVS \.git
+\fIDefault\fR: \.svn CVS \.git \.hg
 .
 .IP "" 0
 .


### PR DESCRIPTION
Just as we ignore SVN, CVS, and Git artifacts while pluginsyncing,
we should also ignore those of Mercurial. This commit adds files
with the `.hg` extension to the list of extensions in the
`pluginsignore` option.