### PR TITLE
Kick should support splay and environment

### DIFF
--- a/lib/puppet/run.rb
+++ b/lib/puppet/run.rb
@@ -25,7 +25,7 @@ class Puppet::Run
       options.delete(:background)
     end
 
-    valid_options = [:tags, :ignoreschedules, :pluginsync]
+    valid_options = [:tags, :ignoreschedules, :pluginsync, :splay]
     options.each do |key, value|
       raise ArgumentError, "Run does not accept #{key}" unless valid_options.include?(key)
     end


### PR DESCRIPTION
When the Puppet agent is kicked, it should
receive an option which will allow a user
to disable splay and initiate the Puppet
run instantly.

Add support for the environment options
for the puppet kick to set which environment the
agent should use.

Yes, I know that Puppet kick is a deprecated mechanics
and is removed in the later version.