### PR TITLE
(PUP-6741) Correctly trigger tagged resources dependent on dynamically generated resources

### DIFF
--- a/lib/puppet/transaction/additional_resource_generator.rb
+++ b/lib/puppet/transaction/additional_resource_generator.rb
@@ -79,6 +79,13 @@ class Puppet::Transaction::AdditionalResourceGenerator
 
   def contain_generated_resources_in(resource, made)
     sentinel = Puppet::Type.type(:whit).new(:name => "completed_#{resource.title}", :catalog => resource.catalog)
+    # Tag the completed whit with all of the tags of the generating resource
+    # except the type name to allow event propogation to succeed beyond the whit
+    # "boundary" when filtering resources with tags. We include auto-generated
+    # tags such as the type name to support implicit filtering as well as
+    # explicit. Note that resource#tags returns a duplicate of the resource's
+    # tags.
+    sentinel.tag(*resource.tags)
     priority = @prioritizer.generate_priority_contained_in(resource, sentinel)
     @relationship_graph.add_vertex(sentinel, priority)
 

--- a/spec/unit/transaction/additional_resource_generator_spec.rb
+++ b/spec/unit/transaction/additional_resource_generator_spec.rb
@@ -182,6 +182,17 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
         'Generator[thing]', 'Whit[completed_thing]')
     end
 
+    it "should tag the sentinel with the tags of the resource" do
+      graph = relationships_after_eval_generating(<<-MANIFEST, 'Generator[thing]')
+        generator { thing:
+          code => 'notify { hello: }',
+          tag  => 'foo',
+        }
+      MANIFEST
+      whit = find_vertex(graph, :whit, "completed_thing")
+      expect(whit.tags).to be_superset(['thing', 'foo', 'generator'].to_set)
+    end
+
     it "should contain the generated resources in the same container as the generator" do
       catalog = compile_to_ral(<<-MANIFEST)
         class container {


### PR DESCRIPTION
When generating resources with
Puppet::Transaction::AdditionalResourceGenerator#eval_generate, we create a completed_ whit resource to "contain" the generated resource such that when its dependencies are satisifed, it effectively signals that the generating resource evaluation has completed. However, prior to this commit, the applicable tags of the parent resource were not propagated to the whit resource (they are propogated to all child resources later in Puppet::Transaction::AdditionalResourceGenerator#add_resource). Because the whit does not have any of the tags of the parent resource, if puppet is filtering resources by tags, resources in a subscribing relationship with the parent generating resources would not be refreshed, even when the generating resource issued a refresh event.

An example (as noted in PUP-6741) is an exec that subscribes to a recursive file resource, in a class tagged 'foo': puppet run with --tags foo will not evaluate the exec even if the file resource generates a refresh event.

This commit augments the tags of the whit with the applicable tags of the parent (generating) resource. Applicable here means all tags except the tag which references the name of the parent's resource type. Since all resources are automatically tagged with the name of their resource type, it seems unituitve to tag the whit with the type name of the parent resource, as it already has a "whit" tag.

Performance benchmarks were run before/after this change, as it's possible Puppet::Util::Tagging#tag could incur a small unnecessary performance penalty associated with tag validation (unnecessary because we're operating with two sets of tags that have already been validated). Puppet::Util::Tagging does not have a mechanism (probably on purpose) for augmenting an instance's tags in place without performing tag validation but a performance regression may have justified such a mechanism. However, no substantial changes were reported by the benchmarks.

Signed-off-by: Moses Mendoza <moses@puppet.com>