### PR TITLE
(PUP-6576) Deprecate data_binding_terminus

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -419,7 +419,21 @@ deprecated and has been replaced by 'always_retry_plugins'."
     :data_binding_terminus => {
       :type    => :terminus,
       :default => "hiera",
-      :desc    => "Where to retrieve information about data.",
+      :desc    =>
+        "This setting has been deprecated in favor of using lookup. It will be removed in major release of puppet.
+
+         This setting controls which data binding terminus to use for global automatic data binding (across all environments).
+         Typical (deprecated) usage is to use the default value 'hiera'. After having configured lookup per environment, this
+         setting should be changed to an empty string (or nil) as that will turn off global data binding.",
+      :call_hook => :on_initialize_and_write,
+      :hook => proc do |value|
+        if Puppet[:strict] != :off
+          s_val = value.to_s # because sometimes the value is a symbol
+          unless s_val == 'hiera' || s_val == 'none' || value == '' || value.nil?
+            Puppet.deprecation_warning "Setting 'data_binding_terminus' is deprecated. Convert custom terminus to hiera 5 API."
+          end
+        end
+      end
     },
     :hiera_config => {
       :default => lambda do

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -420,11 +420,10 @@ deprecated and has been replaced by 'always_retry_plugins'."
       :type    => :terminus,
       :default => "hiera",
       :desc    =>
-        "This setting has been deprecated in favor of using lookup. It will be removed in major release of puppet.
-
-         This setting controls which data binding terminus to use for global automatic data binding (across all environments).
-         Typical (deprecated) usage is to use the default value 'hiera'. After having configured lookup per environment, this
-         setting should be changed to an empty string (or nil) as that will turn off global data binding.",
+        "This setting has been deprecated. Use of any value other than 'hiera' should instead be configured
+         in a version 5 hiera.yaml. Until this setting is removed, it controls which data binding terminus
+         to use for global automatic data binding (across all environments). By default this value is 'hiera'.
+         A value of 'none' turns off the global binding.",
       :call_hook => :on_initialize_and_write,
       :hook => proc do |value|
         if Puppet[:strict] != :off

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -63,6 +63,13 @@ class LookupAdapter < DataAdapter
 
   def lookup_global(key, lookup_invocation, merge_strategy)
     terminus = Puppet[:data_binding_terminus]
+
+    # If global lookup is disabled, immediately report as not found
+    if terminus == 'none' || terminus.nil? || terminus == ''
+      lookup_invocation.report_not_found(name)
+      throw :no_such_key
+    end
+
     lookup_invocation.with(:global, terminus) do
       catch(:no_such_key) do
         return lookup_invocation.report_found(key, Puppet::DataBinding.indirection.find(key.root_key,

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -235,6 +235,19 @@ describe "Puppet defaults" do
     it "should be set to hiera by default" do
       expect(Puppet.settings[:data_binding_terminus]).to eq(:hiera)
     end
+
+    it "to be neither 'hiera' nor 'none', a deprecation warning is logged" do
+      expect(@logs).to eql([])
+      Puppet[:data_binding_terminus] = 'magic'
+      expect(@logs[0].to_s).to match(/Setting 'data_binding_terminus' is deprecated/)
+    end
+
+    it "to not log a warning if set to 'none' or 'hiera'" do
+      expect(@logs).to eql([])
+      Puppet[:data_binding_terminus] = 'none'
+      Puppet[:data_binding_terminus] = 'hiera'
+      expect(@logs).to eql([])
+    end
   end
 
   describe "agent_catalog_run_lockfile" do

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -104,7 +104,7 @@ describe "Defaults" do
       expect(Puppet.settings[:supported_checksum_types]).to eq(['sha256', 'md5lite', 'mtime'])
     end
   end
-  
+
   describe 'server vs server_list' do
     it 'should warn when both settings are set in code' do
       Puppet.expects(:deprecation_warning).with('Attempted to set both server and server_list. Server setting will not be used.', :SERVER_DUPLICATION)


### PR DESCRIPTION
This adds a deprecation warning if a data binding terminus other than 'hiera' or 'none' are assigned.