### PR TITLE
(maint) Fix two minor glitches in the TypeFormatter

### DIFF
--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -216,27 +216,18 @@ class PTypeSetType < PMetaType
   # @return [String] the name by which the type is referenced within this type set
   #
   # @api private
-  def name_for(t)
+  def name_for(t, default_name)
     key = @types.key(t)
     if key.nil?
       qname = t.name
       if @references.empty?
-        qname
+        default_name
       else
-        segments = qname.split(TypeFormatter::NAME_SEGMENT_SEPARATOR)
-        first = segments[0]
-        type_set = @references[first]
-        if type_set.nil?
-          qname
-        else
-          if segments.size == 1
-            qname
-          else
-            sub_name = type_set.name_for(t)
-            sub_name = "#{first}::#{sub_name}" unless sub_name == qname
-            sub_name
-          end
+        @references.each_pair do |ref_key, ref|
+          ref_name = ref.type_set.name_for(t, nil)
+          return "#{ref_key}::#{ref_name}" unless ref_name.nil?
         end
+        default_name
       end
     else
       key

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -169,7 +169,7 @@ class TypeFormatter
   # @api private
   def string_PStringType(t)
     range = range_array_part(t.size_type)
-    append_array('String', range.empty?) do
+    append_array('String', range.empty? && !(@debug && !t.value.nil?)) do
       if @debug
         append_elements(range, !t.value.nil?)
         append_string(t.value) unless t.value.nil?
@@ -413,7 +413,7 @@ class TypeFormatter
     if @expanded
       append_object_hash(t.i12n_hash(@type_set.nil? || !@type_set.defines_type?(t)))
     else
-      @bld << (@type_set ? @type_set.name_for(t) : t.label)
+      @bld << (@type_set ? @type_set.name_for(t, t.label) : t.label)
     end
   end
 
@@ -451,7 +451,7 @@ class TypeFormatter
       if expand && @type_set.defines_type?(t)
         append_string(t.resolved_type)
       else
-        @bld << @type_set.name_for(t)
+        @bld << @type_set.name_for(t, t.name)
       end
     end
   end

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -419,6 +419,35 @@ module Puppet::Pops
           OBJECT
         end
       end
+
+      it '#name_for method reports the name of deeply nested type correctly' do
+        tv = parse_type_set('Vehicles', <<-OBJECT)
+            version => '1.0.0',
+            pcore_version => '1.0.0',
+            types => { Car => Object[{}] }
+        OBJECT
+        tt = parse_type_set('Transports', <<-OBJECT)
+            version => '1.0.0',
+            pcore_version => '1.0.0',
+            references => {
+              Vecs => {
+                name => 'Vehicles',
+                version_range => '1.x'
+              }
+            }
+        OBJECT
+        ts = parse_type_set('TheSet', <<-OBJECT)
+            version => '1.0.0',
+            pcore_version => '1.0.0',
+            references => {
+              T => {
+                name => 'Transports',
+                version_range => '1.x'
+              }
+            }
+        OBJECT
+        expect(ts.name_for(tv['Car'], nil)).to eql('T::Vecs::Car')
+      end
     end
   end
 end

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -123,6 +123,10 @@ end
       expect(s.string(f.string('a'))).to eq('String')
     end
 
+    it "should yield 'String['a']' for PStringType with value if printed with debug_string" do
+      expect(s.debug_string(f.string('a'))).to eq("String['a']")
+    end
+
     it "should yield 'String' and from/to for PStringType" do
       expect(s.string(f.string(f.range(1,1)))).to eq('String[1, 1]')
       expect(s.string(f.string(f.range(1,2)))).to eq('String[1, 2]')


### PR DESCRIPTION
This commit fixes two minor problems in the TypeFormatter.
1. A String, when output in debug mode, didn't output a contained string
   value correctly.
2. A qualified type name resolved using a TypeSet reference would raise
   an exception due to a bogus method call in TypeSet#name_for method.