### PR TITLE
Revert merge of PR#5094 - switch to semantic_puppet

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -36,5 +36,4 @@ Gem::Specification.new do |s|
   s.specification_version = 3
   s.add_runtime_dependency(%q<facter>, [">= 2.0.1", "< 4"])
   s.add_runtime_dependency(%q<hiera>, [">= 2.0", "< 4"])
-  s.add_runtime_dependency(%q<semantic_puppet>, ['>= 0.1.3', '< 2'])
 end

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ end
 gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
-gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ['>= 0.1.3', '< 2'])
 gem "rake", "10.1.1", :require => false
 # Hiera has an unbound dependency on json_pure
 # json_pure 2.0.2+ officially requires Ruby >= 2.0, but should have specified that in 2.0

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -6,9 +6,9 @@ require 'tempfile'
 require 'uri'
 require 'pathname'
 require 'json'
-require 'semantic_puppet'
+require 'semantic'
 
-class Puppet::Forge < SemanticPuppet::Dependency::Source
+class Puppet::Forge < Semantic::Dependency::Source
   require 'puppet/forge/cache'
   require 'puppet/forge/repository'
   require 'puppet/forge/errors'
@@ -83,9 +83,9 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
   # Fetches {ModuleRelease} entries for each release of the named module.
   #
   # @param input [String] the module name to look up
-  # @return [Array<SemanticPuppet::Dependency::ModuleRelease>] a list of releases for
+  # @return [Array<Semantic::Dependency::ModuleRelease>] a list of releases for
   #         the given name
-  # @see SemanticPuppet::Dependency::Source#fetch
+  # @see Semantic::Dependency::Source#fetch
   def fetch(input)
     name = input.tr('/', '-')
     uri = "/v3/releases?module=#{name}"
@@ -114,7 +114,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     @repository.make_http_request(*args)
   end
 
-  class ModuleRelease < SemanticPuppet::Dependency::ModuleRelease
+  class ModuleRelease < Semantic::Dependency::ModuleRelease
     attr_reader :install_dir, :metadata
 
     def initialize(source, data)
@@ -122,7 +122,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       @metadata = meta = data['metadata']
 
       name = meta['name'].tr('/', '-')
-      version = SemanticPuppet::Version.parse(meta['version'])
+      version = Semantic::Version.parse(meta['version'])
       release = "#{name}@#{version}"
 
       if meta['dependencies']

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -157,12 +157,12 @@ module Puppet
     end
 
     # Handles parsing of module dependency expressions into proper
-    # {SemanticPuppet::VersionRange}s, including reasonable error handling.
+    # {Semantic::VersionRange}s, including reasonable error handling.
     #
     # @param where [String] a description of the thing we're parsing the
     #        dependency expression for
     # @param dep [Hash] the dependency description to parse
-    # @return [Array(String, SemanticPuppet::VersionRange, String)] a tuple of the
+    # @return [Array(String, Semantic::VersionRange, String)] a tuple of the
     #         dependent module's name, the version range dependency, and the
     #         unparsed range expression.
     def self.parse_module_dependency(where, dep)
@@ -170,10 +170,10 @@ module Puppet
       range = dep['version_requirement'] || '>= 0.0.0'
 
       begin
-        parsed_range = SemanticPuppet::VersionRange.parse(range)
+        parsed_range = Semantic::VersionRange.parse(range)
       rescue ArgumentError => e
         Puppet.debug "Error in #{where} parsing dependency #{dep_name} (#{e.message}); using empty range."
-        parsed_range = SemanticPuppet::VersionRange::EMPTY_RANGE
+        parsed_range = Semantic::VersionRange::EMPTY_RANGE
       end
 
       [ dep_name, parsed_range, range ]

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -34,19 +34,19 @@ module Puppet::ModuleTool
           release = local_tarball_source.release
           @name = release.name
           options[:version] = release.version.to_s
-          SemanticPuppet::Dependency.add_source(local_tarball_source)
+          Semantic::Dependency.add_source(local_tarball_source)
 
           # If we're operating on a local tarball and ignoring dependencies, we
           # don't need to search any additional sources.  This will cut down on
           # unnecessary network traffic.
           unless @ignore_dependencies
-            SemanticPuppet::Dependency.add_source(installed_modules_source)
-            SemanticPuppet::Dependency.add_source(module_repository)
+            Semantic::Dependency.add_source(installed_modules_source)
+            Semantic::Dependency.add_source(module_repository)
           end
 
         else
-          SemanticPuppet::Dependency.add_source(installed_modules_source) unless forced?
-          SemanticPuppet::Dependency.add_source(module_repository)
+          Semantic::Dependency.add_source(installed_modules_source) unless forced?
+          Semantic::Dependency.add_source(module_repository)
         end
       end
 
@@ -59,7 +59,7 @@ module Puppet::ModuleTool
         begin
           if installed_module = installed_modules[name]
             unless forced?
-              if SemanticPuppet::VersionRange.parse(version).include? installed_module.version
+              if Semantic::VersionRange.parse(version).include? installed_module.version
                 results[:result] = :noop
                 results[:version] = installed_module.version
                 return results
@@ -103,7 +103,7 @@ module Puppet::ModuleTool
               # locking it to upgrades within the same major version.
               installed_range = ">=#{version} #{version.major}.x"
               graph.add_constraint('installed', mod, installed_range) do |node|
-                SemanticPuppet::VersionRange.parse(installed_range).include? node.version
+                Semantic::VersionRange.parse(installed_range).include? node.version
               end
 
               release.mod.dependencies.each do |dep|
@@ -111,7 +111,7 @@ module Puppet::ModuleTool
 
                 range = dep['version_requirement']
                 graph.add_constraint("#{mod} constraint", dep_name, range) do |node|
-                  SemanticPuppet::VersionRange.parse(range).include? node.version
+                  Semantic::VersionRange.parse(range).include? node.version
                 end
               end
             end
@@ -125,8 +125,8 @@ module Puppet::ModuleTool
 
           begin
             Puppet.info "Resolving dependencies ..."
-            releases = SemanticPuppet::Dependency.resolve(graph)
-          rescue SemanticPuppet::Dependency::UnsatisfiableGraph
+            releases = Semantic::Dependency.resolve(graph)
+          rescue Semantic::Dependency::UnsatisfiableGraph
             raise NoVersionsSatisfyError, results.merge(:requested_name => name)
           end
 
@@ -205,15 +205,15 @@ module Puppet::ModuleTool
       end
 
       def build_single_module_graph(name, version)
-        range = SemanticPuppet::VersionRange.parse(version)
-        graph = SemanticPuppet::Dependency::Graph.new(name => range)
-        releases = SemanticPuppet::Dependency.fetch_releases(name)
+        range = Semantic::VersionRange.parse(version)
+        graph = Semantic::Dependency::Graph.new(name => range)
+        releases = Semantic::Dependency.fetch_releases(name)
         releases.each { |release| release.dependencies.clear }
         graph << releases
       end
 
       def build_dependency_graph(name, version)
-        SemanticPuppet::Dependency.query(name => version)
+        Semantic::Dependency.query(name => version)
       end
 
       def build_install_graph(release, installed, graphed = [])

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -21,8 +21,8 @@ module Puppet::ModuleTool
         @ignore_changes      = forced? || options[:ignore_changes]
         @ignore_dependencies = forced? || options[:ignore_dependencies]
 
-        SemanticPuppet::Dependency.add_source(installed_modules_source)
-        SemanticPuppet::Dependency.add_source(module_repository)
+        Semantic::Dependency.add_source(installed_modules_source)
+        Semantic::Dependency.add_source(module_repository)
       end
 
       def run
@@ -48,7 +48,7 @@ module Puppet::ModuleTool
 
           installed_release = installed_modules[name]
 
-          # `priority` is an attribute of a `SemanticPuppet::Dependency::Source`,
+          # `priority` is an attribute of a `Semantic::Dependency::Source`,
           # which is delegated through `ModuleRelease` instances for the sake of
           # comparison (sorting). By default, the `InstalledModules` source has
           # a priority of 10 (making it the most preferable source, so that
@@ -66,7 +66,7 @@ module Puppet::ModuleTool
           end
 
           mod = installed_release.mod
-          results[:installed_version] = SemanticPuppet::Version.parse(mod.version)
+          results[:installed_version] = Semantic::Version.parse(mod.version)
           dir = Pathname.new(mod.modulepath)
 
           vstring = mod.version ? "v#{mod.version}" : '???'
@@ -90,7 +90,7 @@ module Puppet::ModuleTool
           if available_versions.empty?
             raise NoCandidateReleasesError, results.merge(:module_name => name, :source => module_repository.host)
           elsif results[:requested_version] != :latest
-            requested = SemanticPuppet::VersionRange.parse(results[:requested_version])
+            requested = Semantic::VersionRange.parse(results[:requested_version])
             unless available_versions.any? {|m| requested.include? m.version}
               raise NoCandidateReleasesError, results.merge(:module_name => name, :source => module_repository.host)
             end
@@ -119,7 +119,7 @@ module Puppet::ModuleTool
               # module, locking it to upgrades within the same major version.
               installed_range = ">=#{version} #{version.major}.x"
               graph.add_constraint('installed', installed_module, installed_range) do |node|
-                SemanticPuppet::VersionRange.parse(installed_range).include? node.version
+                Semantic::VersionRange.parse(installed_range).include? node.version
               end
 
               release.mod.dependencies.each do |dep|
@@ -127,7 +127,7 @@ module Puppet::ModuleTool
 
                 range = dep['version_requirement']
                 graph.add_constraint("#{installed_module} constraint", dep_name, range) do |node|
-                  SemanticPuppet::VersionRange.parse(range).include? node.version
+                  Semantic::VersionRange.parse(range).include? node.version
                 end
               end
             end
@@ -135,8 +135,8 @@ module Puppet::ModuleTool
 
           begin
             Puppet.info "Resolving dependencies ..."
-            releases = SemanticPuppet::Dependency.resolve(graph)
-          rescue SemanticPuppet::Dependency::UnsatisfiableGraph
+            releases = Semantic::Dependency.resolve(graph)
+          rescue Semantic::Dependency::UnsatisfiableGraph
             raise NoVersionsSatisfyError, results.merge(:requested_name => name)
           end
 
@@ -227,15 +227,15 @@ module Puppet::ModuleTool
       end
 
       def build_single_module_graph(name, version)
-        range = SemanticPuppet::VersionRange.parse(version)
-        graph = SemanticPuppet::Dependency::Graph.new(name => range)
-        releases = SemanticPuppet::Dependency.fetch_releases(name)
+        range = Semantic::VersionRange.parse(version)
+        graph = Semantic::Dependency::Graph.new(name => range)
+        releases = Semantic::Dependency.fetch_releases(name)
         releases.each { |release| release.dependencies.clear }
         graph << releases
       end
 
       def build_dependency_graph(name, version)
-        SemanticPuppet::Dependency.query(name => version)
+        Semantic::Dependency.query(name => version)
       end
 
       def build_install_graph(release, installed, graphed = [])

--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -4,7 +4,7 @@ require 'puppet/forge'
 require 'puppet/module_tool'
 
 module Puppet::ModuleTool
-  class InstalledModules < SemanticPuppet::Dependency::Source
+  class InstalledModules < Semantic::Dependency::Source
     attr_reader :modules, :by_name
 
     def priority
@@ -33,9 +33,9 @@ module Puppet::ModuleTool
     # Fetches {ModuleRelease} entries for each release of the named module.
     #
     # @param name [String] the module name to look up
-    # @return [Array<SemanticPuppet::Dependency::ModuleRelease>] a list of releases for
+    # @return [Array<Semantic::Dependency::ModuleRelease>] a list of releases for
     #         the given name
-    # @see SemanticPuppet::Dependency::Source#fetch
+    # @see Semantic::Dependency::Source#fetch
     def fetch(name)
       name = name.tr('/', '-')
 
@@ -51,7 +51,7 @@ module Puppet::ModuleTool
       @fetched
     end
 
-    class ModuleRelease < SemanticPuppet::Dependency::ModuleRelease
+    class ModuleRelease < Semantic::Dependency::ModuleRelease
       attr_reader :mod, :metadata
 
       def initialize(source, mod)
@@ -59,10 +59,10 @@ module Puppet::ModuleTool
         @metadata = mod.metadata
         name = mod.forge_name.tr('/', '-')
         begin
-          version = SemanticPuppet::Version.parse(mod.version)
-        rescue SemanticPuppet::Version::ValidationFailure => e
+          version = Semantic::Version.parse(mod.version)
+        rescue Semantic::Version::ValidationFailure => e
           Puppet.warning "#{mod.name} (#{mod.path}) has an invalid version number (#{mod.version}). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org)."
-          version = SemanticPuppet::Version.parse("0.0.0")
+          version = Semantic::Version.parse("0.0.0")
         end
         release = "#{name}@#{version}"
 

--- a/lib/puppet/module_tool/local_tarball.rb
+++ b/lib/puppet/module_tool/local_tarball.rb
@@ -5,7 +5,7 @@ require 'puppet/forge'
 require 'puppet/module_tool'
 
 module Puppet::ModuleTool
-  class LocalTarball < SemanticPuppet::Dependency::Source
+  class LocalTarball < Semantic::Dependency::Source
     attr_accessor :release
 
     def initialize(filename)
@@ -40,14 +40,14 @@ module Puppet::ModuleTool
       FileUtils.mv(staging_dir, module_dir)
     end
 
-    class ModuleRelease < SemanticPuppet::Dependency::ModuleRelease
+    class ModuleRelease < Semantic::Dependency::ModuleRelease
       attr_reader :mod, :install_dir, :metadata
 
       def initialize(source, mod)
         @mod = mod
         @metadata = mod.metadata
         name = mod.forge_name.tr('/', '-')
-        version = SemanticPuppet::Version.parse(mod.version)
+        version = Semantic::Version.parse(mod.version)
         release = "#{name}@#{version}"
 
         if mod.dependencies

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -213,7 +213,7 @@ module Puppet::ModuleTool
 
     # Validates that the version range can be parsed by Semantic.
     def validate_version_range(version_range)
-      SemanticPuppet::VersionRange.parse(version_range)
+      Semantic::VersionRange.parse(version_range)
     rescue ArgumentError => e
       raise ArgumentError, "Invalid 'version_range' field in metadata.json: #{e}"
     end

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -10,14 +10,14 @@ module Puppet
   #
   # @api public
   module Pops
-     EMPTY_HASH = {}.freeze
+    EMPTY_HASH = {}.freeze
     EMPTY_ARRAY = [].freeze
     EMPTY_STRING = ''.freeze
 
     DOUBLE_COLON = '::'.freeze
     USCORE = '_'.freeze
 
-    require 'semantic_puppet'
+    require 'semantic'
 
     require 'puppet/pops/patterns'
     require 'puppet/pops/utils'

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -158,7 +158,7 @@ class AccessOperator
 
   def access_PSemVerType(o, scope, keys)
     keys.flatten!
-    assert_keys(keys, o, 1, Float::INFINITY, String, SemanticPuppet::VersionRange)
+    assert_keys(keys, o, 1, Float::INFINITY, String, Semantic::VersionRange)
     Types::TypeFactory.sem_ver(*keys)
   end
 

--- a/lib/puppet/pops/evaluator/compare_operator.rb
+++ b/lib/puppet/pops/evaluator/compare_operator.rb
@@ -103,7 +103,7 @@ class CompareOperator
   end
 
   def cmp_Version(a, b)
-    raise ArgumentError.new('Versions not comparable to non Versions') unless b.is_a?(SemanticPuppet::Version)
+    raise ArgumentError.new('Versions not comparable to non Versions') unless b.is_a?(Semantic::Version)
     a <=> b
   end
 
@@ -172,7 +172,7 @@ class CompareOperator
       # Always set match data, a "not found" should not keep old match data visible
       set_match_data(matched, scope) # creates ephemeral
       return !!matched
-    when String, SemanticPuppet::Version
+    when String, Semantic::Version
       a.any? { |element| match(b, element, scope) }
     when Types::PAnyType
       a.each {|element| return true if b.instance?(element) }
@@ -206,11 +206,11 @@ class CompareOperator
 
   # Matches against semvers and strings
   def match_Version(version, left, scope)
-    if left.is_a?(SemanticPuppet::Version)
+    if left.is_a?(Semantic::Version)
       version == left
     elsif left.is_a? String
       begin
-        version == SemanticPuppet::Version.parse(left)
+        version == Semantic::Version.parse(left)
       rescue ArgumentError
         false
       end

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -570,7 +570,7 @@ class EvaluatorImpl
       return o.operator == :'=~' ? !!matched : !matched
     end
 
-    if pattern.is_a?(SemanticPuppet::VersionRange)
+    if pattern.is_a?(Semantic::VersionRange)
       # evaluate if range includes version
       matched = Types::PSemVerRangeType.include?(pattern, left)
       return o.operator == :'=~' ? matched : !matched

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -12,8 +12,8 @@ module Pcore
   KEY_PCORE_VERSION = 'pcore_version'.freeze
 
   PCORE_URI = 'http://puppet.com/2016.1/pcore'
-  PCORE_VERSION = SemanticPuppet::Version.new(1,0,0)
-  PARSABLE_PCORE_VERSIONS = SemanticPuppet::VersionRange.parse('1.x')
+  PCORE_VERSION = Semantic::Version.new(1,0,0)
+  PARSABLE_PCORE_VERSIONS = Semantic::VersionRange.parse('1.x')
 
   RUNTIME_NAME_AUTHORITY = 'http://puppet.com/2016.1/runtime'
 

--- a/lib/puppet/pops/serialization/abstract_reader.rb
+++ b/lib/puppet/pops/serialization/abstract_reader.rb
@@ -146,11 +146,11 @@ class AbstractReader
     end
 
     register_type(Extension::VERSION) do |data|
-      read_payload(data) { |ep| SemanticPuppet::Version.parse(ep.read) }
+      read_payload(data) { |ep| Semantic::Version.parse(ep.read) }
     end
 
     register_type(Extension::VERSION_RANGE) do |data|
-      read_payload(data) { |ep| SemanticPuppet::VersionRange.parse(ep.read) }
+      read_payload(data) { |ep| Semantic::VersionRange.parse(ep.read) }
     end
 
     register_type(Extension::SENSITIVE) do |data|

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -170,11 +170,11 @@ class AbstractWriter
       build_payload { |ep| nsecs = o.nsecs; ep.write(nsecs / 1000000000); ep.write(nsecs % 1000000000) }
     end
 
-    register_type(Extension::VERSION, SemanticPuppet::Version) do |o|
+    register_type(Extension::VERSION, Semantic::Version) do |o|
       build_payload { |ep| ep.write(o.to_s) }
     end
 
-    register_type(Extension::VERSION_RANGE, SemanticPuppet::VersionRange) do |o|
+    register_type(Extension::VERSION_RANGE, Semantic::VersionRange) do |o|
       build_payload { |ep| ep.write(o.to_s) }
     end
 

--- a/lib/puppet/pops/serialization/serializer.rb
+++ b/lib/puppet/pops/serialization/serializer.rb
@@ -71,7 +71,7 @@ module Serialization
     def write_tabulated_first_time(value)
       @written[value.object_id] = @written.size
       case value
-      when Symbol, Regexp, SemanticPuppet::Version, SemanticPuppet::VersionRange, Time::Timestamp, Time::Timespan, Types::PSensitiveType::Sensitive, Types::PBinaryType::Binary
+      when Symbol, Regexp, Semantic::Version, Semantic::VersionRange, Time::Timestamp, Time::Timespan, Types::PSensitiveType::Sensitive, Types::PBinaryType::Binary
         @writer.write(value)
       when Array
         start_array(value.size)

--- a/lib/puppet/pops/types/p_sem_ver_range_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_range_type.rb
@@ -10,21 +10,21 @@ class PSemVerRangeType < PScalarType
   end
 
   # Check if a version is included in a version range. The version can be a string or
-  # a `SemanticPuppet::SemVer`
+  # a `Semantic::SemVer`
   #
-  # @param range [SemanticPuppet::VersionRange] the range to match against
-  # @param version [SemanticPuppet::Version,String] the version to match
+  # @param range [Semantic::VersionRange] the range to match against
+  # @param version [Semantic::Version,String] the version to match
   # @return [Boolean] `true` if the range includes the given version
   #
   # @api public
   def self.include?(range, version)
     case version
-    when SemanticPuppet::Version
+    when Semantic::Version
       range.include?(version)
     when String
       begin
-        range.include?(SemanticPuppet::Version.parse(version))
-      rescue SemanticPuppet::Version::ValidationFailure
+        range.include?(Semantic::Version.parse(version))
+      rescue Semantic::Version::ValidationFailure
         false
       end
     else
@@ -32,28 +32,28 @@ class PSemVerRangeType < PScalarType
     end
   end
 
-  # Creates a {SemanticPuppet::VersionRange} from the given _version_range_ argument. If the argument is `nil` or
-  # a {SemanticPuppet::VersionRange}, it is returned. If it is a {String}, it will be parsed into a
-  # {SemanticPuppet::VersionRange}. Any other class will raise an {ArgumentError}.
+  # Creates a {Semantic::VersionRange} from the given _version_range_ argument. If the argument is `nil` or
+  # a {Semantic::VersionRange}, it is returned. If it is a {String}, it will be parsed into a
+  # {Semantic::VersionRange}. Any other class will raise an {ArgumentError}.
   #
-  # @param version_range [SemanticPuppet::VersionRange,String,nil] the version range to convert
-  # @return [SemanticPuppet::VersionRange] the converted version range
+  # @param version_range [Semantic::VersionRange,String,nil] the version range to convert
+  # @return [Semantic::VersionRange] the converted version range
   # @raise [ArgumentError] when the argument cannot be converted into a version range
   #
   def self.convert(version_range)
     case version_range
-    when nil, SemanticPuppet::VersionRange
+    when nil, Semantic::VersionRange
       version_range
     when String
-      SemanticPuppet::VersionRange.parse(version_range)
+      Semantic::VersionRange.parse(version_range)
     else
       raise ArgumentError, "Unable to convert a #{version_range.class.name} to a SemVerRange"
     end
   end
 
   # Checks if range _a_ is a sub-range of (i.e. completely covered by) range _b_
-  # @param a [SemanticPuppet::VersionRange] the first range
-  # @param b [SemanticPuppet::VersionRange] the second range
+  # @param a [Semantic::VersionRange] the first range
+  # @param b [Semantic::VersionRange] the second range
   #
   # @return [Boolean] `true` if _a_ is completely covered by _b_
   def self.covered_by?(a, b)
@@ -63,9 +63,9 @@ class PSemVerRangeType < PScalarType
   # Merge two ranges so that the result matches all versions matched by both. A merge
   # is only possible when the ranges are either adjacent or have an overlap.
   #
-  # @param a [SemanticPuppet::VersionRange] the first range
-  # @param b [SemanticPuppet::VersionRange] the second range
-  # @return [SemanticPuppet::VersionRange,nil] the result of the merge
+  # @param a [Semantic::VersionRange] the first range
+  # @param b [Semantic::VersionRange] the second range
+  # @return [Semantic::VersionRange,nil] the result of the merge
   #
   # @api public
   def self.merge(a, b)
@@ -77,13 +77,13 @@ class PSemVerRangeType < PScalarType
       elsif b.exclude_end?
         exclude_end = max == b.end && (max > a.end || a.exclude_end?)
       end
-      SemanticPuppet::VersionRange.new([a.begin, b.begin].min, max, exclude_end)
+      Semantic::VersionRange.new([a.begin, b.begin].min, max, exclude_end)
     elsif a.exclude_end? && a.end == b.begin
       # Adjacent, a before b
-      SemanticPuppet::VersionRange.new(a.begin, b.end, b.exclude_end?)
+      Semantic::VersionRange.new(a.begin, b.end, b.exclude_end?)
     elsif b.exclude_end? && b.end == a.begin
       # Adjacent, b before a
-      SemanticPuppet::VersionRange.new(b.begin, a.end, a.exclude_end?)
+      Semantic::VersionRange.new(b.begin, a.end, a.exclude_end?)
     else
       # No overlap
       nil
@@ -91,7 +91,7 @@ class PSemVerRangeType < PScalarType
   end
 
   def instance?(o, guard = nil)
-    o.is_a?(SemanticPuppet::VersionRange)
+    o.is_a?(Semantic::VersionRange)
   end
 
   def eql?(o)
@@ -115,7 +115,7 @@ class PSemVerRangeType < PScalarType
       # https://github.com/npm/node-semver#range-grammar
       #
       # The logical or || operator is not implemented since it effectively builds
-      # an array of ranges that may be disparate. The {{SemanticPuppet::VersionRange}} inherits
+      # an array of ranges that may be disparate. The {{Semantic::VersionRange}} inherits
       # from the standard ruby range. It must be possible to describe that range in terms
       # of min, max, and exclude max.
       #
@@ -144,13 +144,13 @@ class PSemVerRangeType < PScalarType
       end
 
       def from_string(str)
-        SemanticPuppet::VersionRange.parse(str)
+        Semantic::VersionRange.parse(str)
       end
 
       def from_versions(min, max = :default, exclude_max = false)
-        min = SemanticPuppet::Version::MIN if min == :default
-        max = SemanticPuppet::Version::MAX if max == :default
-        SemanticPuppet::VersionRange.new(min, max, exclude_max)
+        min = Semantic::Version::MIN if min == :default
+        max = Semantic::Version::MAX if max == :default
+        Semantic::VersionRange.new(min, max, exclude_max)
       end
 
       def from_hash(hash)

--- a/lib/puppet/pops/types/p_sem_ver_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_type.rb
@@ -1,7 +1,7 @@
 module Puppet::Pops
 module Types
 
-# A Puppet Language Type that exposes the {{SemanticPuppet::Version}} and {{SemanticPuppet::VersionRange}}.
+# A Puppet Language Type that exposes the {{Semantic::Version}} and {{Semantic::VersionRange}}.
 # The version type is parameterized with version ranges.
 #
 # @api public
@@ -18,13 +18,13 @@ class PSemVerType < PScalarType
   attr_reader :ranges
 
   def initialize(ranges)
-    ranges = ranges.map { |range| range.is_a?(SemanticPuppet::VersionRange) ? range : SemanticPuppet::VersionRange.parse(range) }
+    ranges = ranges.map { |range| range.is_a?(Semantic::VersionRange) ? range : Semantic::VersionRange.parse(range) }
     ranges = merge_ranges(ranges) if ranges.size > 1
     @ranges = ranges
   end
 
   def instance?(o, guard = nil)
-    o.is_a?(SemanticPuppet::Version) && (@ranges.empty? || @ranges.any? {|range| range.include?(o) })
+    o.is_a?(Semantic::Version) && (@ranges.empty? || @ranges.any? {|range| range.include?(o) })
   end
 
   def eql?(o)
@@ -36,19 +36,19 @@ class PSemVerType < PScalarType
   end
 
   # Creates a SemVer version from the given _version_ argument. If the argument is `nil` or
-  # a {SemanticPuppet::Version}, it is returned. If it is a {String}, it will be parsed into a
-  # {SemanticPuppet::Version}. Any other class will raise an {ArgumentError}.
+  # a {Semantic::Version}, it is returned. If it is a {String}, it will be parsed into a
+  # {Semantic::Version}. Any other class will raise an {ArgumentError}.
   #
-  # @param version [SemanticPuppet::Version,String,nil] the version to convert
-  # @return [SemanticPuppet::Version] the converted version
+  # @param version [Semantic::Version,String,nil] the version to convert
+  # @return [Semantic::Version] the converted version
   # @raise [ArgumentError] when the argument cannot be converted into a version
   #
   def self.convert(version)
     case version
-    when nil, SemanticPuppet::Version
+    when nil, Semantic::Version
       version
     when String
-      SemanticPuppet::Version.parse(version)
+      Semantic::Version.parse(version)
     else
       raise ArgumentError, "Unable to convert a #{version.class.name} to a SemVer"
     end
@@ -87,15 +87,15 @@ class PSemVerType < PScalarType
       end
 
       def from_string(str)
-        SemanticPuppet::Version.parse(str)
+        Semantic::Version.parse(str)
       end
 
       def from_args(major, minor, patch, prerelease = nil, build = nil)
-        SemanticPuppet::Version.new(major, minor, patch, prerelease, build)
+        Semantic::Version.new(major, minor, patch, prerelease, build)
       end
 
       def from_hash(hash)
-        SemanticPuppet::Version.new(hash['major'], hash['minor'], hash['patch'], hash['prerelease'], hash['build'])
+        Semantic::Version.new(hash['major'], hash['minor'], hash['patch'], hash['prerelease'], hash['build'])
       end
     end
   end

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -323,7 +323,7 @@ class PTypeSetType < PMetaType
     KEY_NAME_AUTHORITY => Pcore::RUNTIME_NAME_AUTHORITY,
     Pcore::KEY_PCORE_URI => Pcore::PCORE_URI,
     Pcore::KEY_PCORE_VERSION => Pcore::PCORE_VERSION,
-    KEY_VERSION => SemanticPuppet::Version.new(0,0,0)
+    KEY_VERSION => Semantic::Version.new(0,0,0)
   })
 
   protected

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -312,7 +312,7 @@ class TypeCalculator
         infer_set_Array(o)
       when Hash
         infer_set_Hash(o)
-      when SemanticPuppet::Version
+      when Semantic::Version
         infer_set_Version(o)
       else
         infer_set_Object(o)
@@ -755,7 +755,7 @@ class TypeCalculator
 
   # @api private
   def infer_set_Version(o)
-    PSemVerType.new([SemanticPuppet::VersionRange.new(o, o)])
+    PSemVerType.new([Semantic::VersionRange.new(o, o)])
   end
 
   def unwrap_single_variant(possible_variant)

--- a/lib/puppet/vendor/load_semantic.rb
+++ b/lib/puppet/vendor/load_semantic.rb
@@ -1,0 +1,1 @@
+$: << File.join([File.dirname(__FILE__), "semantic/lib"])

--- a/lib/puppet/vendor/require_vendored.rb
+++ b/lib/puppet/vendor/require_vendored.rb
@@ -1,6 +1,7 @@
 # This adds upfront requirements on vendored code found under lib/vendor/x
 # Add one requirement per vendored package (or a comment if it is loaded on demand).
 
+# The vendored library 'semantic' is loaded on demand.
 # The vendored library 'rgen' is loaded on demand.
 # The vendored library 'pathspec' is loaded on demand.
 # The vendored library 'deep_merge' is loaded on demand.

--- a/lib/puppet/vendor/semantic/Gemfile
+++ b/lib/puppet/vendor/semantic/Gemfile
@@ -1,0 +1,20 @@
+source "https://rubygems.org"
+
+group :development do
+  gem 'rake'
+  gem 'rubygems-tasks'
+end
+
+group :test do
+  gem 'rspec'
+end
+
+group :metrics do
+  gem 'cane',      :platform => [ :mri_19, :mri_20, :mri_21 ]
+  gem 'simplecov', :platform => [ :mri_19, :mri_20, :mri_21 ]
+end
+
+group :doc do
+  gem 'yard', '~> 0.8', :platform => [ :mri_19, :mri_20, :mri_21 ]
+  gem 'redcarpet',      :platform => [ :mri_19, :mri_20, :mri_21 ]
+end

--- a/lib/puppet/vendor/semantic/PUPPET_README.md
+++ b/lib/puppet/vendor/semantic/PUPPET_README.md
@@ -1,0 +1,6 @@
+Semantic
+========
+
+Semantic 0.0.1
+
+Copied from https://github.com/puppetlabs/semantic/tree/6d17d5283e0868cfc3d74d1e9d37b572e1739b6e

--- a/lib/puppet/vendor/semantic/Rakefile
+++ b/lib/puppet/vendor/semantic/Rakefile
@@ -1,0 +1,69 @@
+# RSpec tasks
+begin
+  require 'rspec/core/rake_task'
+
+  # Create the 'spec' task
+  RSpec::Core::RakeTask.new(:spec) do |task|
+    task.rspec_opts = '--color'
+  end
+
+  namespace :spec do
+    desc "Run the test suite and generate coverage metrics"
+    task :coverage => [ :simplecov, :spec ]
+
+    # Add test coverage to the 'spec' task.
+    task :simplecov do
+      ENV['COVERAGE'] = '1'
+    end
+  end
+
+  task :default => :spec
+rescue LoadError
+  warn "[Warning]: Could not load `rspec`."
+end
+
+# YARD tasks
+begin
+  require 'yard'
+  require 'yard/rake/yardoc_task'
+
+  YARD::Rake::YardocTask.new(:doc) do |yardoc|
+    yardoc.files = [ 'lib/**/*.rb', '-', '**/*.md' ]
+  end
+rescue LoadError
+  warn "[Warning]: Could not load `yard`."
+end
+
+# Cane tasks
+begin
+  require 'cane/rake_task'
+
+  Cane::RakeTask.new(:cane) do |cane|
+    cane.add_threshold 'coverage/.last_run.json', :>=, 100
+    cane.abc_max = 15
+  end
+
+  Rake::Task['cane'].prerequisites << Rake::Task['spec:coverage']
+  Rake::Task[:default].clear_prerequisites
+  task :default => :cane
+rescue LoadError
+  warn "[Warning]: Could not load `cane`."
+end
+
+# Gem tasks
+begin
+  require 'rubygems/tasks'
+
+  task :gem => 'gem:build'
+  task :validate => [ 'cane', 'doc', 'gem:validate' ]
+
+  namespace :gem do
+    Gem::Tasks.new(
+      :tag => { :format => 'v%s' },
+      :sign => { :checksum => true, :pgp => true },
+      :build => { :tar => true }
+    )
+  end
+rescue LoadError
+  warn "[Warning]: Could not load `rubygems/tasks`."
+end

--- a/lib/puppet/vendor/semantic/lib/semantic.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic.rb
@@ -1,0 +1,7 @@
+module Semantic
+  autoload :Version, 'semantic/version'
+  autoload :VersionRange, 'semantic/version_range'
+  autoload :Dependency, 'semantic/dependency'
+
+  VERSION = '0.0.1'
+end

--- a/lib/puppet/vendor/semantic/lib/semantic/dependency.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic/dependency.rb
@@ -1,0 +1,181 @@
+require 'semantic'
+
+module Semantic
+  module Dependency
+    extend self
+
+    autoload :Graph,         'semantic/dependency/graph'
+    autoload :GraphNode,     'semantic/dependency/graph_node'
+    autoload :ModuleRelease, 'semantic/dependency/module_release'
+    autoload :Source,        'semantic/dependency/source'
+
+    autoload :UnsatisfiableGraph, 'semantic/dependency/unsatisfiable_graph'
+
+    # @!group Sources
+
+    # @return [Array<Source>] a frozen copy of the {Source} list
+    def sources
+      (@sources ||= []).dup.freeze
+    end
+
+    # Appends a new {Source} to the current list.
+    # @param source [Source] the {Source} to add
+    # @return [void]
+    def add_source(source)
+      sources
+      @sources << source
+      nil
+    end
+
+    # Clears the current list of {Source}s.
+    # @return [void]
+    def clear_sources
+      sources
+      @sources.clear
+      nil
+    end
+
+    # @!endgroup
+
+    # Fetches a graph of modules and their dependencies from the currently
+    # configured list of {Source}s.
+    #
+    # @todo Return a specialized "Graph" object.
+    # @todo Allow for external constraints to be added to the graph.
+    # @see #sources
+    # @see #add_source
+    # @see #clear_sources
+    #
+    # @param modules [{ String => String }]
+    # @return [Graph] the root of a dependency graph
+    def query(modules)
+      constraints = Hash[modules.map { |k, v| [ k, VersionRange.parse(v) ] }]
+
+      graph = Graph.new(constraints)
+      fetch_dependencies(graph)
+      return graph
+    end
+
+    # Given a graph result from {#query}, this method will resolve the graph of
+    # dependencies, if possible, into a flat list of the best suited modules. If
+    # the dependency graph does not have a suitable resolution, this method will
+    # raise an exception to that effect.
+    #
+    # @param graph [Graph] the root of a dependency graph
+    # @return [Array<ModuleRelease>] the list of releases to act on
+    def resolve(graph)
+      catch :next do
+        return walk(graph, graph.dependencies.dup)
+      end
+      raise UnsatisfiableGraph.new(graph)
+    end
+
+    # Fetches all available releases for the given module name.
+    #
+    # @param name [String] the module name to find releases for
+    # @return [Array<ModuleRelease>] the available releases
+    def fetch_releases(name)
+      releases = {}
+
+      sources.each do |source|
+        source.fetch(name).each do |dependency|
+          releases[dependency.version] ||= dependency
+        end
+      end
+
+      return releases.values
+    end
+
+    private
+
+    # Iterates over a changing set of dependencies in search of the best
+    # solution available. Fitness is specified as meeting all the constraints
+    # placed on it, being {ModuleRelease#satisfied? satisfied}, and having the
+    # greatest version number (with stability being preferred over prereleases).
+    #
+    # @todo Traversal order is not presently guaranteed.
+    #
+    # @param graph [Graph] the root of a dependency graph
+    # @param dependencies [{ String => Array<ModuleRelease> }] the dependencies
+    # @param considering [Array<GraphNode>] the set of releases being tested
+    # @return [Array<GraphNode>] the list of releases to use, if successful
+    def walk(graph, dependencies, *considering)
+      return considering if dependencies.empty?
+
+      # Selecting a dependency from the collection...
+      name = dependencies.keys.sort.first
+      deps = dependencies.delete(name)
+
+      # ... (and stepping over it if we've seen it before) ...
+      unless (deps & considering).empty?
+        return walk(graph, dependencies, *considering)
+      end
+
+      # ... we'll iterate through the list of possible versions in order.
+      preferred_releases(deps).reverse_each do |dep|
+
+        # We should skip any releases that violate any module's constraints.
+        unless [graph, *considering].all? { |x| x.satisfies_constraints?(dep) }
+          next
+        end
+
+        # We should skip over any releases that violate graph-level constraints.
+        potential_solution = considering.dup << dep
+        unless graph.satisfies_graph? potential_solution
+          next
+        end
+
+        catch :next do
+          # After adding any new dependencies and imposing our own constraints
+          # on existing dependencies, we'll mark ourselves as "under
+          # consideration" and recurse.
+          merged = dependencies.merge(dep.dependencies) { |_,a,b| a & b }
+
+          # If all subsequent dependencies resolved well, the recursive call
+          # will return a completed dependency list. If there were problems
+          # resolving our dependencies, we'll catch `:next`, which will cause
+          # us to move to the next possibility.
+          return walk(graph, merged, *potential_solution)
+        end
+      end
+
+      # Once we've exhausted all of our possible versions, we know that our
+      # last choice was unusable, so we'll unwind the stack and make a new
+      # choice.
+      throw :next
+    end
+
+    # Given a {ModuleRelease}, this method will iterate through the current
+    # list of {Source}s to find the complete list of versions available for its
+    # dependencies.
+    #
+    # @param node [GraphNode] the node to fetch details for
+    # @return [void]
+    def fetch_dependencies(node, cache = {})
+      node.dependency_names.each do |name|
+        unless cache.key?(name)
+          cache[name] = fetch_releases(name)
+          cache[name].each { |dep| fetch_dependencies(dep, cache) }
+        end
+
+        node << cache[name]
+      end
+    end
+
+    # Given a list of potential releases, this method returns the most suitable
+    # releases for exploration. Only {ModuleRelease#satisfied? satisfied}
+    # releases are considered, and releases with stable versions are preferred.
+    #
+    # @param releases [Array<ModuleRelease>] a list of potential releases
+    # @return [Array<ModuleRelease>] releases open for consideration
+    def preferred_releases(releases)
+      satisfied = releases.select { |x| x.satisfied? }
+
+      if satisfied.any? { |x| x.version.stable? }
+        return satisfied.select { |x| x.version.stable? }
+      else
+        return satisfied
+      end
+    end
+  end
+end

--- a/lib/puppet/vendor/semantic/lib/semantic/dependency/graph.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic/dependency/graph.rb
@@ -1,0 +1,60 @@
+require 'semantic/dependency'
+
+module Semantic
+  module Dependency
+    class Graph
+      include GraphNode
+
+      attr_reader :modules
+
+      # Create a new instance of a dependency graph.
+      #
+      # @param modules [{String => VersionRange}] the required module
+      #        set and their version constraints
+      def initialize(modules = {})
+        @modules = modules.keys
+
+        modules.each do |name, range|
+          add_constraint('initialize', name, range.to_s) do |node|
+            range === node.version
+          end
+
+          add_dependency(name)
+        end
+      end
+
+      # Constrains graph solutions based on the given block.  Graph constraints
+      # are used to describe fundamental truths about the tooling or module
+      # system (e.g.: module names contain a namespace component which is
+      # dropped during install, so module names must be unique excluding the
+      # namespace).
+      #
+      # @example Ensuring a single source for all modules
+      #     @graph.add_constraint('installed', mod.name) do |nodes|
+      #       nodes.count { |node| node.source } == 1
+      #     end
+      #
+      # @see #considering_solution?
+      #
+      # @param source [String, Symbol] a name describing the source of the
+      #               constraint
+      # @yieldparam nodes [Array<GraphNode>] the nodes to test the constraint
+      #             against
+      # @yieldreturn [Boolean] whether the node passed the constraint
+      # @return [void]
+      def add_graph_constraint(source, &block)
+        constraints[:graph] << [ source, block ]
+      end
+
+      # Checks the proposed solution (or partial solution) against the graph's
+      # constraints.
+      #
+      # @see #add_graph_constraint
+      #
+      # @return [Boolean] true if none of the graph constraints are violated
+      def satisfies_graph?(solution)
+        constraints[:graph].all? { |_, check| check[solution] }
+      end
+    end
+  end
+end

--- a/lib/puppet/vendor/semantic/lib/semantic/dependency/graph_node.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic/dependency/graph_node.rb
@@ -1,0 +1,117 @@
+require 'semantic/dependency'
+require 'set'
+
+module Semantic
+  module Dependency
+    module GraphNode
+      include Comparable
+
+      def name
+      end
+
+      # Determines whether the modules dependencies are satisfied by the known
+      # releases.
+      #
+      # @return [Boolean] true if all dependencies are satisfied
+      def satisfied?
+        dependencies.none? { |_, v| v.empty? }
+      end
+
+      def children
+        @_children ||= {}
+      end
+
+      def populate_children(nodes)
+        if children.empty?
+          nodes = nodes.select { |node| satisfies_dependency?(node) }
+          nodes.each do |node|
+            children[node.name] = node
+            node.populate_children(nodes)
+          end
+          self.freeze
+        end
+      end
+
+      # @api internal
+      # @return [{ String => SortedSet<GraphNode> }] the satisfactory
+      #         dependency nodes
+      def dependencies
+        @_dependencies ||= Hash.new { |h, k| h[k] = SortedSet.new }
+      end
+
+      # Adds the given dependency name to the list of dependencies.
+      #
+      # @param name [String] the dependency name
+      # @return [void]
+      def add_dependency(name)
+        dependencies[name]
+      end
+
+      # @return [Array<String>] the list of dependency names
+      def dependency_names
+        dependencies.keys
+      end
+
+      def constraints
+        @_constraints ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def constraints_for(name)
+        return [] unless constraints.has_key?(name)
+
+        constraints[name].map do |constraint|
+          {
+            :source      => constraint[0],
+            :description => constraint[1],
+            :test        => constraint[2],
+          }
+        end
+      end
+
+      # Constrains the named module to suitable releases, as determined by the
+      # given block.
+      #
+      # @example Version-locking currently installed modules
+      #     installed_modules.each do |m|
+      #       @graph.add_constraint('installed', m.name, m.version) do |node|
+      #         m.version == node.version
+      #       end
+      #     end
+      #
+      # @param source [String, Symbol] a name describing the source of the
+      #               constraint
+      # @param mod [String] the name of the module
+      # @param desc [String] a description of the enforced constraint
+      # @yieldparam node [GraphNode] the node to test the constraint against
+      # @yieldreturn [Boolean] whether the node passed the constraint
+      # @return [void]
+      def add_constraint(source, mod, desc, &block)
+        constraints["#{mod}"] << [ source, desc, block ]
+      end
+
+      def satisfies_dependency?(node)
+        dependencies.key?(node.name) && satisfies_constraints?(node)
+      end
+
+      # @param release [ModuleRelease] the release to test
+      def satisfies_constraints?(release)
+        constraints_for(release.name).all? { |x| x[:test].call(release) }
+      end
+
+      def << (nodes)
+        Array(nodes).each do |node|
+          next unless dependencies.key?(node.name)
+          if satisfies_dependency?(node)
+            dependencies[node.name] << node
+          end
+        end
+
+        return self
+      end
+
+      def <=>(other)
+        name <=> other.name
+      end
+    end
+  end
+end

--- a/lib/puppet/vendor/semantic/lib/semantic/dependency/module_release.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic/dependency/module_release.rb
@@ -1,0 +1,60 @@
+require 'semantic/dependency'
+
+module Semantic
+  module Dependency
+    class ModuleRelease
+      include GraphNode
+
+      attr_reader :name, :version
+
+      # Create a new instance of a module release.
+      #
+      # @param source [Semantic::Dependency::Source]
+      # @param name [String]
+      # @param version [Semantic::Version]
+      # @param dependencies [{String => Semantic::VersionRange}]
+      def initialize(source, name, version, dependencies = {})
+        @source      = source
+        @name        = name.freeze
+        @version     = version.freeze
+
+        dependencies.each do |name, range|
+          add_constraint('initialize', name, range.to_s) do |node|
+            range === node.version
+          end
+
+          add_dependency(name)
+        end
+      end
+
+      def priority
+        @source.priority
+      end
+
+      def <=>(oth)
+        # Note that prior to ruby 2.3.0, if a <=> method threw an exception, ruby
+        # would silently rescue the exception and return nil from <=> (which causes
+        # the derived == comparison to return false). Starting in ruby 2.3.0, this
+        # behavior changed and the exception is actually thrown. Some comments at:
+        # https://bugs.ruby-lang.org/issues/7688
+        #
+        # So simply return nil here if any of the needed fields are not available,
+        # since attempting to access a missing field is one way to force an exception.
+        # This doesn't help if the  <=> use below throws an exception, but it
+        # handles the most typical cause.
+        return nil if !oth.respond_to?(:priority) ||
+                      !oth.respond_to?(:name)     ||
+                      !oth.respond_to?(:version)
+
+        our_key   = [ priority, name, version ]
+        their_key = [ oth.priority, oth.name, oth.version ]
+
+        return our_key <=> their_key
+      end
+
+      def to_s
+        "#<#{self.class} #{name}@#{version}>"
+      end
+    end
+  end
+end

--- a/lib/puppet/vendor/semantic/lib/semantic/dependency/source.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic/dependency/source.rb
@@ -1,0 +1,25 @@
+require 'semantic/dependency'
+
+module Semantic
+  module Dependency
+    class Source
+      def self.priority
+        0
+      end
+
+      def priority
+        self.class.priority
+      end
+
+      def create_release(name, version, dependencies = {})
+        version = Version.parse(version) if version.is_a? String
+        dependencies = dependencies.inject({}) do |hash, (key, value)|
+          hash[key] = VersionRange.parse(value || '>= 0.0.0')
+          hash[key] ||= VersionRange::EMPTY_RANGE
+          hash
+        end
+        ModuleRelease.new(self, name, version, dependencies)
+      end
+    end
+  end
+end

--- a/lib/puppet/vendor/semantic/lib/semantic/dependency/unsatisfiable_graph.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic/dependency/unsatisfiable_graph.rb
@@ -1,0 +1,31 @@
+require 'semantic/dependency'
+
+module Semantic
+  module Dependency
+    class UnsatisfiableGraph < StandardError
+      attr_reader :graph
+
+      def initialize(graph)
+        @graph = graph
+
+        deps = sentence_from_list(graph.modules)
+        super "Could not find satisfying releases for #{deps}"
+      end
+
+      private
+
+      def sentence_from_list(list)
+        case list.length
+        when 1
+          list.first
+        when 2
+          list.join(' and ')
+        else
+          list = list.dup
+          list.push("and #{list.pop}")
+          list.join(', ')
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet/vendor/semantic/lib/semantic/version.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic/version.rb
@@ -1,0 +1,168 @@
+require 'semantic'
+
+module Semantic
+
+  # @note Semantic::Version subclasses Numeric so that it has sane Range
+  #       semantics in Ruby 1.9+.
+  class Version < Numeric
+    include Comparable
+
+    class ValidationFailure < ArgumentError; end
+
+    class << self
+      LOOSE_REGEX = /
+        \A
+        (\d+)[.](\d+)[.](\d+) # Major . Minor . Patch
+        (?: [-](.*?))?        # Prerelease
+        (?: [+](.*?))?        # Build
+        \Z
+      /x
+
+      # Parse a Semantic Version string.
+      #
+      # @param ver [String] the version string to parse
+      # @return [Version] a comparable {Version} object
+      def parse(ver)
+        match, major, minor, patch, prerelease, build = *ver.match(LOOSE_REGEX)
+
+        if match.nil?
+          raise 'Version numbers MUST begin with three dot-separated numbers'
+        elsif [major, minor, patch].any? { |x| x =~ /^0\d+/ }
+          raise 'Version numbers MUST NOT contain leading zeroes'
+        end
+
+        prerelease = parse_prerelease(prerelease) if prerelease
+        build = parse_build_metadata(build) if build
+
+        self.new(major.to_i, minor.to_i, patch.to_i, prerelease, build)
+      end
+
+      private
+      def parse_prerelease(prerelease)
+        subject = 'Prerelease identifiers'
+        prerelease = prerelease.split('.', -1)
+
+        if prerelease.empty? or prerelease.any? { |x| x.empty? }
+          raise "#{subject} MUST NOT be empty"
+        elsif prerelease.any? { |x| x =~ /[^0-9a-zA-Z-]/ }
+          raise "#{subject} MUST use only ASCII alphanumerics and hyphens"
+        elsif prerelease.any? { |x| x =~ /^0\d+$/ }
+          raise "#{subject} MUST NOT contain leading zeroes"
+        end
+
+        return prerelease.map { |x| x =~ /^\d+$/ ? x.to_i : x }
+      end
+
+      def parse_build_metadata(build)
+        subject = 'Build identifiers'
+        build = build.split('.', -1)
+
+        if build.empty? or build.any? { |x| x.empty? }
+          raise "#{subject} MUST NOT be empty"
+        elsif build.any? { |x| x =~ /[^0-9a-zA-Z-]/ }
+          raise "#{subject} MUST use only ASCII alphanumerics and hyphens"
+        end
+
+        return build
+      end
+
+      def raise(msg)
+        super ValidationFailure, msg, caller.drop_while { |x| x !~ /\bparse\b/ }
+      end
+    end
+
+    attr_reader :major, :minor, :patch
+
+    def initialize(major, minor, patch, prerelease = nil, build = nil)
+      @major      = major
+      @minor      = minor
+      @patch      = patch
+      @prerelease = prerelease
+      @build      = build
+    end
+
+    def next(part)
+      case part
+      when :major
+        self.class.new(@major.next, 0, 0)
+      when :minor
+        self.class.new(@major, @minor.next, 0)
+      when :patch
+        self.class.new(@major, @minor, @patch.next)
+      end
+    end
+
+    def prerelease
+      @prerelease && @prerelease.join('.')
+    end
+
+    # @return [Boolean] true if this is a stable release
+    def stable?
+      @prerelease.nil?
+    end
+
+    def build
+      @build && @build.join('.')
+    end
+
+    def <=>(other)
+      return self.major <=> other.major unless self.major == other.major
+      return self.minor <=> other.minor unless self.minor == other.minor
+      return self.patch <=> other.patch unless self.patch == other.patch
+      return compare_prerelease(other)
+    end
+
+    def to_s
+      "#{major}.#{minor}.#{patch}" +
+      (@prerelease.nil? || prerelease.empty? ? '' : "-" + prerelease) +
+      (@build.nil?      || build.empty?      ? '' : "+" + build     )
+    end
+
+    def hash
+      self.to_s.hash
+    end
+
+    private
+    # This is a hack; tildes sort later than any valid identifier. The
+    # advantage is that we don't need to handle stable vs. prerelease
+    # comparisons separately.
+    @@STABLE_RELEASE = [ '~' ].freeze
+
+    def compare_prerelease(other)
+      all_mine  = @prerelease                               || @@STABLE_RELEASE
+      all_yours = other.instance_variable_get(:@prerelease) || @@STABLE_RELEASE
+
+      # Precedence is determined by comparing each dot separated identifier from
+      # left to right...
+      size = [ all_mine.size, all_yours.size ].max
+      Array.new(size).zip(all_mine, all_yours) do |_, mine, yours|
+
+        # ...until a difference is found.
+        next if mine == yours
+
+        # Numbers are compared numerically, strings are compared ASCIIbetically.
+        if mine.class == yours.class
+          return mine <=> yours
+
+        # A larger set of pre-release fields has a higher precedence.
+        elsif mine.nil?
+          return -1
+        elsif yours.nil?
+          return 1
+
+        # Numeric identifiers always have lower precedence than non-numeric.
+        elsif mine.is_a? Numeric
+          return -1
+        elsif yours.is_a? Numeric
+          return 1
+        end
+      end
+
+      return 0
+    end
+
+    def first_prerelease
+      self.class.new(@major, @minor, @patch, [])
+    end
+  end
+end

--- a/lib/puppet/vendor/semantic/lib/semantic/version_range.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic/version_range.rb
@@ -1,0 +1,424 @@
+require 'semantic'
+
+module Semantic
+  class VersionRange < Range
+    class << self
+      # Parses a version range string into a comparable {VersionRange} instance.
+      #
+      # Currently parsed version range string may take any of the following:
+      # forms:
+      #
+      # * Regular Semantic Version strings
+      #   * ex. `"1.0.0"`, `"1.2.3-pre"`
+      # * Partial Semantic Version strings
+      #   * ex. `"1.0.x"`, `"1"`, `"2.X"`
+      # * Inequalities
+      #   * ex. `"> 1.0.0"`, `"<3.2.0"`, `">=4.0.0"`
+      # * Approximate Versions
+      #   * ex. `"~1.0.0"`, `"~ 3.2.0"`, `"~4.0.0"`
+      # * Inclusive Ranges
+      #   * ex. `"1.0.0 - 1.3.9"`
+      # * Range Intersections
+      #   * ex. `">1.0.0 <=2.3.0"`
+      #
+      # @param range_str [String] the version range string to parse
+      # @return [VersionRange] a new {VersionRange} instance
+      def parse(range_str)
+        partial = '\d+(?:[.]\d+)?(?:[.][x]|[.]\d+(?:[-][0-9a-z.-]*)?)?'
+        exact   = '\d+[.]\d+[.]\d+(?:[-][0-9a-z.-]*)?'
+
+        range = range_str.gsub(/([(><=~])[ ]+/, '\1')
+        range = range.gsub(/ - /, '#').strip
+
+        return case range
+        when /\A(#{partial})\Z/i
+          parse_loose_version_expression($1)
+        when /\A([><][=]?)(#{exact})\Z/i
+          parse_inequality_expression($1, $2)
+        when /\A~(#{partial})\Z/i
+          parse_reasonably_close_expression($1)
+        when /\A(#{exact})#(#{exact})\Z/i
+          parse_inclusive_range_expression($1, $2)
+        when /[ ]+/
+          parse_intersection_expression(range)
+        else
+          raise ArgumentError
+        end
+
+      rescue ArgumentError
+        raise ArgumentError, "Unparsable version range: #{range_str.inspect}"
+      end
+
+      private
+
+      # Creates a new {VersionRange} from a range intersection expression.
+      #
+      # @param expr [String] a range intersection expression
+      # @return [VersionRange] a version range representing `expr`
+      def parse_intersection_expression(expr)
+        expr.split(/[ ]+/).map { |x| parse(x) }.inject { |a,b| a & b }
+      end
+
+      # Creates a new {VersionRange} from a "loose" description of a Semantic
+      # Version number.
+      #
+      # @see .process_loose_expr
+      #
+      # @param expr [String] a "loose" version expression
+      # @return [VersionRange] a version range representing `expr`
+      def parse_loose_version_expression(expr)
+        start, finish = process_loose_expr(expr)
+
+        if start.stable?
+          start = start.send(:first_prerelease)
+        end
+
+        if finish.stable?
+          exclude = true
+          finish = finish.send(:first_prerelease)
+        end
+
+        self.new(start, finish, exclude)
+      end
+
+      # Creates an open-ended version range from an inequality expression.
+      #
+      # @overload parse_inequality_expression('<', expr)
+      #   {include:.parse_lt_expression}
+      #
+      # @overload parse_inequality_expression('<=', expr)
+      #   {include:.parse_lte_expression}
+      #
+      # @overload parse_inequality_expression('>', expr)
+      #   {include:.parse_gt_expression}
+      #
+      # @overload parse_inequality_expression('>=', expr)
+      #   {include:.parse_gte_expression}
+      #
+      # @param comp ['<', '<=', '>', '>='] an inequality operator
+      # @param expr [String] a "loose" version expression
+      # @return [VersionRange] a range covering all versions in the inequality
+      def parse_inequality_expression(comp, expr)
+        case comp
+        when '>'
+          parse_gt_expression(expr)
+        when '>='
+          parse_gte_expression(expr)
+        when '<'
+          parse_lt_expression(expr)
+        when '<='
+          parse_lte_expression(expr)
+        end
+      end
+
+      # Returns a range covering all versions greater than the given `expr`.
+      #
+      # @param expr [String] the version to be greater than
+      # @return [VersionRange] a range covering all versions greater than the
+      #         given `expr`
+      def parse_gt_expression(expr)
+        if expr =~ /^[^+]*-/
+          start = Version.parse("#{expr}.0")
+        else
+          start = process_loose_expr(expr).last.send(:first_prerelease)
+        end
+
+        self.new(start, MAX_VERSION)
+      end
+
+      # Returns a range covering all versions greater than or equal to the given
+      # `expr`.
+      #
+      # @param expr [String] the version to be greater than or equal to
+      # @return [VersionRange] a range covering all versions greater than or
+      #         equal to the given `expr`
+      def parse_gte_expression(expr)
+        if expr =~ /^[^+]*-/
+          start = Version.parse(expr)
+        else
+          start = process_loose_expr(expr).first.send(:first_prerelease)
+        end
+
+        self.new(start, MAX_VERSION)
+      end
+
+      # Returns a range covering all versions less than the given `expr`.
+      #
+      # @param expr [String] the version to be less than
+      # @return [VersionRange] a range covering all versions less than the
+      #         given `expr`
+      def parse_lt_expression(expr)
+        if expr =~ /^[^+]*-/
+          finish = Version.parse(expr)
+        else
+          finish = process_loose_expr(expr).first.send(:first_prerelease)
+        end
+
+        self.new(MIN_VERSION, finish, true)
+      end
+
+      # Returns a range covering all versions less than or equal to the given
+      # `expr`.
+      #
+      # @param expr [String] the version to be less than or equal to
+      # @return [VersionRange] a range covering all versions less than or equal
+      #         to the given `expr`
+      def parse_lte_expression(expr)
+        if expr =~ /^[^+]*-/
+          finish = Version.parse(expr)
+          self.new(MIN_VERSION, finish)
+        else
+          finish = process_loose_expr(expr).last.send(:first_prerelease)
+          self.new(MIN_VERSION, finish, true)
+        end
+      end
+
+      # The "reasonably close" expression is used to designate ranges that have
+      # a reasonable proximity to the given "loose" version number. These take
+      # the form:
+      #
+      #     ~[Version]
+      #
+      # The general semantics of these expressions are that the given version
+      # forms a lower bound for the range, and the upper bound is either the
+      # next version number increment (at whatever precision the expression
+      # provides) or the next stable version (in the case of a prerelease
+      # version).
+      #
+      # @example "Reasonably close" major version
+      #   "~1" # => (>=1.0.0 <2.0.0)
+      # @example "Reasonably close" minor version
+      #   "~1.2" # => (>=1.2.0 <1.3.0)
+      # @example "Reasonably close" patch version
+      #   "~1.2.3" # => (1.2.3)
+      # @example "Reasonably close" prerelease version
+      #   "~1.2.3-alpha" # => (>=1.2.3-alpha <1.2.4)
+      #
+      # @param expr [String] a "loose" expression to build the range around
+      # @return [VersionRange] a "reasonably close" version range
+      def parse_reasonably_close_expression(expr)
+        parsed, succ = process_loose_expr(expr)
+
+        if parsed.stable?
+          parsed = parsed.send(:first_prerelease)
+          succ = succ.send(:first_prerelease)
+          self.new(parsed, succ, true)
+        else
+          self.new(parsed, succ.next(:patch).send(:first_prerelease), true)
+        end
+      end
+
+      # An "inclusive range" expression takes two version numbers (or partial
+      # version numbers) and creates a range that covers all versions between
+      # them. These take the form:
+      #
+      #     [Version] - [Version]
+      #
+      # @param start [String] a "loose" expresssion for the start of the range
+      # @param finish [String] a "loose" expression for the end of the range
+      # @return [VersionRange] a {VersionRange} covering `start` to `finish`
+      def parse_inclusive_range_expression(start, finish)
+        start, _ = process_loose_expr(start)
+        _, finish = process_loose_expr(finish)
+
+        start = start.send(:first_prerelease) if start.stable?
+        if finish.stable?
+          exclude = true
+          finish = finish.send(:first_prerelease)
+        end
+
+        self.new(start, finish, exclude)
+      end
+
+      # A "loose expression" is one that takes the form of all or part of a
+      # valid Semantic Version number. Particularly:
+      #
+      # * [Major].[Minor].[Patch]-[Prerelease]
+      # * [Major].[Minor].[Patch]
+      # * [Major].[Minor]
+      # * [Major]
+      #
+      # Various placeholders are also permitted in "loose expressions"
+      # (typically an 'x' or an asterisk).
+      #
+      # This method parses these expressions into a minimal and maximal version
+      # number pair.
+      #
+      # @todo Stabilize whether the second value is inclusive or exclusive
+      #
+      # @param expr [String] a string containing a "loose" version expression
+      # @return [(VersionNumber, VersionNumber)] a minimal and maximal
+      #         version pair for the given expression
+      def process_loose_expr(expr)
+        case expr
+        when /^(\d+)(?:[.][xX*])?$/
+          expr = "#{$1}.0.0"
+          arity = :major
+        when /^(\d+[.]\d+)(?:[.][xX*])?$/
+          expr = "#{$1}.0"
+          arity = :minor
+        when /^\d+[.]\d+[.]\d+$/
+          arity = :patch
+        end
+
+        version = next_version = Version.parse(expr)
+
+        if arity
+          next_version = version.next(arity)
+        end
+
+        [ version, next_version ]
+      end
+    end
+
+    # Computes the intersection of a pair of ranges. If the ranges have no
+    # useful intersection, an empty range is returned.
+    #
+    # @param other [VersionRange] the range to intersect with
+    # @return [VersionRange] the common subset
+    def intersection(other)
+      raise NOT_A_VERSION_RANGE unless other.kind_of?(VersionRange)
+
+      if self.begin < other.begin
+        return other.intersection(self)
+      end
+
+      unless include?(other.begin) || other.include?(self.begin)
+        return EMPTY_RANGE
+      end
+
+      endpoint = ends_before?(other) ? self : other
+      VersionRange.new(self.begin, endpoint.end, endpoint.exclude_end?)
+    end
+    alias :& :intersection
+
+    # Returns a string representation of this range, prefering simple common
+    # expressions for comprehension.
+    #
+    # @return [String] a range expression representing this VersionRange
+    def to_s
+      start, finish  = self.begin, self.end
+      inclusive = exclude_end? ? '' : '='
+
+      case
+      when EMPTY_RANGE == self
+        "<0.0.0"
+      when exact_version?, patch_version?
+        "#{ start }"
+      when minor_version?
+        "#{ start }".sub(/.0$/, '.x')
+      when major_version?
+        "#{ start }".sub(/.0.0$/, '.x')
+      when open_end? && start.to_s =~ /-.*[.]0$/
+        ">#{ start }".sub(/.0$/, '')
+      when open_end?
+        ">=#{ start }"
+      when open_begin?
+        "<#{ inclusive }#{ finish }"
+      else
+        ">=#{ start } <#{ inclusive }#{ finish }"
+      end
+    end
+    alias :inspect :to_s
+
+    private
+
+    # The lowest precedence Version possible
+    MIN_VERSION = Version.new(0, 0, 0, []).freeze
+
+    # The highest precedence Version possible
+    MAX_VERSION = Version.new((1.0/0.0), 0, 0).freeze
+
+    # Determines whether this {VersionRange} has an earlier endpoint than the
+    # give `other` range.
+    #
+    # @param other [VersionRange] the range to compare against
+    # @return [Boolean] true if the endpoint for this range is less than or
+    #         equal to the endpoint of the `other` range.
+    def ends_before?(other)
+      self.end < other.end || (self.end == other.end && self.exclude_end?)
+    end
+
+    # Describes whether this range has an upper limit.
+    # @return [Boolean] true if this range has no upper limit
+    def open_end?
+      self.end == MAX_VERSION
+    end
+
+    # Describes whether this range has a lower limit.
+    # @return [Boolean] true if this range has no lower limit
+    def open_begin?
+      self.begin == MIN_VERSION
+    end
+
+    # Describes whether this range follows the patterns for matching all
+    # releases with the same exact version.
+    # @return [Boolean] true if this range matches only a single exact version
+    def exact_version?
+      self.begin == self.end
+    end
+
+    # Describes whether this range follows the patterns for matching all
+    # releases with the same major version.
+    # @return [Boolean] true if this range matches only a single major version
+    def major_version?
+      start, finish = self.begin, self.end
+
+      exclude_end? &&
+      start.major.next == finish.major &&
+      same_minor? && start.minor == 0 &&
+      same_patch? && start.patch == 0 &&
+      [start.prerelease, finish.prerelease] == ['', '']
+    end
+
+    # Describes whether this range follows the patterns for matching all
+    # releases with the same minor version.
+    # @return [Boolean] true if this range matches only a single minor version
+    def minor_version?
+      start, finish = self.begin, self.end
+
+      exclude_end? &&
+      same_major? &&
+      start.minor.next == finish.minor &&
+      same_patch? && start.patch == 0 &&
+      [start.prerelease, finish.prerelease] == ['', '']
+    end
+
+    # Describes whether this range follows the patterns for matching all
+    # releases with the same patch version.
+    # @return [Boolean] true if this range matches only a single patch version
+    def patch_version?
+      start, finish = self.begin, self.end
+
+      exclude_end? &&
+      same_major? &&
+      same_minor? &&
+      start.patch.next == finish.patch &&
+      [start.prerelease, finish.prerelease] == ['', '']
+    end
+
+    # @return [Boolean] true if `begin` and `end` share the same major verion
+    def same_major?
+      self.begin.major == self.end.major
+    end
+
+    # @return [Boolean] true if `begin` and `end` share the same minor verion
+    def same_minor?
+      self.begin.minor == self.end.minor
+    end
+
+    # @return [Boolean] true if `begin` and `end` share the same patch verion
+    def same_patch?
+      self.begin.patch == self.end.patch
+    end
+
+    undef :to_a
+
+    NOT_A_VERSION_RANGE = ArgumentError.new("value must be a #{VersionRange}")
+
+    public
+
+    # A range that matches no versions
+    EMPTY_RANGE = VersionRange.parse('< 0.0.0').freeze
+  end
+end

--- a/lib/puppet/vendor/semantic/spec/spec_helper.rb
+++ b/lib/puppet/vendor/semantic/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+PROJECT_ROOT = File.join(File.dirname(__FILE__), '..')
+
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
+end
+
+RSpec.configure do |config|
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = 'random'
+
+  config.before do
+    Semantic::Dependency.instance_variable_set(:@sources, nil)
+  end
+end

--- a/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/graph_node_spec.rb
+++ b/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/graph_node_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+require 'semantic/dependency/graph_node'
+
+describe Semantic::Dependency::GraphNode do
+  let(:klass) do
+    Class.new do
+      include Semantic::Dependency::GraphNode
+
+      attr_accessor :name
+
+      def initialize(name, *satisfying)
+        @name = name
+        @satisfying = satisfying
+        @satisfying.each { |x| add_dependency(x.name) }
+      end
+
+      # @override
+      def satisfies_dependency?(node)
+        @satisfying.include?(node)
+      end
+    end
+  end
+
+  def instance(*args)
+    name = args.first.name unless args.empty?
+    klass.new(name || 'unnamed', *args)
+  end
+
+  context 'dependencies' do
+    subject { instance() }
+
+    example 'are added by #add_dependency' do
+      subject.add_dependency('foo')
+      subject.add_dependency('bar')
+      subject.add_dependency('baz')
+      expect(subject.dependency_names).to match_array %w[ foo bar baz ]
+    end
+
+    example 'are maintained in the #dependencies Hash' do
+      expect(subject.dependencies).to be_empty
+      subject.add_dependency('foo')
+      expect(subject.dependencies).to have_key 'foo'
+      expect(subject.dependencies).to respond_to :to_a
+    end
+  end
+
+  describe '#<<' do
+    let(:foo) { double('Node', :name => 'foo') }
+    let(:bar1) { double('Node', :name => 'bar', :'<=>' => 0) }
+    let(:bar2) { double('Node', :name => 'bar', :'<=>' => 0) }
+    let(:bar3) { double('Node', :name => 'bar') }
+    let(:baz) { double('Node', :name => 'baz') }
+
+    subject { instance(foo, bar1, bar2) }
+
+    it 'appends satisfying nodes to the dependencies' do
+      subject << foo << bar1 << bar2
+      expect(Array(subject.dependencies['foo'])).to match_array [ foo ]
+      expect(Array(subject.dependencies['bar'])).to match_array [ bar1, bar2 ]
+    end
+
+    it 'does not append nodes with unknown names' do
+      subject << baz
+      expect(Array(subject.dependencies['baz'])).to be_empty
+    end
+
+    it 'does not append unsatisfying nodes' do
+      subject << bar3
+      expect(Array(subject.dependencies['bar'])).to be_empty
+    end
+  end
+
+  describe '#satisfied' do
+    let(:foo) { double('Node', :name => 'foo') }
+    let(:bar) { double('Node', :name => 'bar') }
+
+    subject { instance(foo, bar) }
+
+    it 'is unsatisfied when no nodes have been appended' do
+      expect(subject).to_not be_satisfied
+    end
+
+    it 'is unsatisfied when any dependencies are missing' do
+      subject << foo
+      expect(subject).to_not be_satisfied
+    end
+
+    it 'is satisfied when all dependencies are fulfilled' do
+      subject << foo << bar
+      expect(subject).to be_satisfied
+    end
+  end
+
+  describe '#populate_children' do
+    let(:foo) { double('Node', :name => 'foo') }
+    let(:bar1) { double('Node', :name => 'bar', :'<=>' => 0) }
+    let(:bar2) { double('Node', :name => 'bar', :'<=>' => 0) }
+    let(:baz1) { double('Node', :name => 'baz', :'<=>' => 0) }
+    let(:baz2) { double('Node', :name => 'baz', :'<=>' => 0) }
+    let(:quxx) { double('Node', :name => 'quxx') }
+
+    subject do
+      graph = instance(foo, bar1, bar2, baz1, baz2)
+      graph << foo << bar1 << bar2 << baz1 << baz2
+    end
+
+    it 'saves all relevant nodes as its children' do
+      nodes = [ foo, bar2, baz1, quxx ]
+      nodes.each do |node|
+        allow(node).to receive(:populate_children)
+      end
+
+      subject.populate_children(nodes)
+
+      expected = { 'foo' => foo, 'bar' => bar2, 'baz' => baz1 }
+      expect(subject.children).to eql expected
+    end
+
+    it 'accepts a graph solution and populates it across all nodes' do
+      nodes = [ foo, bar2, baz1 ]
+      nodes.each do |node|
+        expect(node).to receive(:populate_children).with(nodes)
+      end
+
+      subject.populate_children(nodes)
+    end
+  end
+
+  describe '#<=>' do
+    it 'can be compared' do
+      a = instance(double('Node', :name => 'a'))
+      b = instance(double('Node', :name => 'b'))
+
+      expect(a).to be < b
+      expect(b).to be > a
+      expect([b, a].sort).to eql [a, b]
+      expect([a, b].sort).to eql [a, b]
+    end
+  end
+
+end

--- a/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/graph_spec.rb
+++ b/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/graph_spec.rb
@@ -1,0 +1,162 @@
+require 'spec_helper'
+require 'semantic/dependency/graph'
+
+describe Semantic::Dependency::Graph do
+  Graph         = Semantic::Dependency::Graph
+  GraphNode     = Semantic::Dependency::GraphNode
+  ModuleRelease = Semantic::Dependency::ModuleRelease
+  Version       = Semantic::Version
+  VersionRange  = Semantic::VersionRange
+
+  describe '#initialize' do
+    it 'can be called without arguments' do
+      expect { Graph.new }.to_not raise_error
+    end
+
+    it 'implements the GraphNode protocol' do
+      expect(Graph.new).to be_a GraphNode
+    end
+
+    it 'adds constraints for every key in the passed hash' do
+      graph = Graph.new('foo' => 1, 'bar' => 2, 'baz' => 3)
+      expect(graph.constraints.keys).to match_array %w[ foo bar baz ]
+    end
+
+    it 'adds the named dependencies for every key in the passed hash' do
+      graph = Graph.new('foo' => 1, 'bar' => 2, 'baz' => 3)
+      expect(graph.dependency_names).to match_array %w[ foo bar baz ]
+    end
+  end
+
+  describe '#add_constraint' do
+    let(:graph) { Graph.new }
+
+    it 'can create a new constraint on a module' do
+      expect(graph.constraints.keys).to be_empty
+
+      graph.add_constraint('test', 'module-name', 'nil') { }
+      expect(graph.constraints.keys).to match_array %w[ module-name ]
+    end
+
+    it 'permits multiple constraints against the same module name' do
+      expect(graph.constraints.keys).to be_empty
+
+      graph.add_constraint('test', 'module-name', 'nil') { }
+      graph.add_constraint('test', 'module-name', 'nil') { }
+
+      expect(graph.constraints.keys).to match_array %w[ module-name ]
+    end
+  end
+
+  describe '#satisfies_dependency?' do
+    it 'is not satisfied by modules it does not depend on' do
+      graph = Graph.new('foo' => VersionRange.parse('1.x'))
+      release = ModuleRelease.new(nil, 'bar', Version.parse('1.0.0'))
+
+      expect(graph.satisfies_dependency?(release)).to_not be true
+    end
+
+    it 'is not satisfied by modules that do not fulfill the constraint' do
+      graph = Graph.new('foo' => VersionRange.parse('1.x'))
+      release = ModuleRelease.new(nil, 'foo', Version.parse('2.3.1'))
+
+      expect(graph.satisfies_dependency?(release)).to_not be true
+    end
+
+    it 'is not satisfied by modules that do not fulfill all the constraints' do
+      graph = Graph.new('foo' => VersionRange.parse('1.x'))
+      graph.add_constraint('me', 'foo', '1.2.3') do |node|
+        node.version.to_s == '1.2.3'
+      end
+
+      release = ModuleRelease.new(nil, 'foo', Version.parse('1.2.1'))
+
+      expect(graph.satisfies_dependency?(release)).to_not be true
+    end
+
+    it 'is satisfied by modules that do fulfill all the constraints' do
+      graph = Graph.new('foo' => VersionRange.parse('1.x'))
+      graph.add_constraint('me', 'foo', '1.2.3') do |node|
+        node.version.to_s == '1.2.3'
+      end
+
+      release = ModuleRelease.new(nil, 'foo', Version.parse('1.2.3'))
+
+      expect(graph.satisfies_dependency?(release)).to be true
+    end
+  end
+
+  describe '#add_graph_constraint' do
+    let(:graph) { Graph.new }
+
+    it 'can create a new constraint on a graph' do
+      expect(graph.constraints.keys).to be_empty
+
+      graph.add_graph_constraint('test') { }
+      expect(graph.constraints.keys).to match_array [ :graph ]
+    end
+
+    it 'permits multiple graph constraints' do
+      expect(graph.constraints.keys).to be_empty
+
+      graph.add_graph_constraint('test') { }
+      graph.add_graph_constraint('test') { }
+
+      expect(graph.constraints.keys).to match_array [ :graph ]
+    end
+  end
+
+  describe '#satisfies_graph?' do
+    it 'returns false if the solution violates a graph constraint' do
+      graph = Graph.new
+      graph.add_graph_constraint('me') do |nodes|
+        nodes.none? { |node| node.name =~ /z/ }
+      end
+
+      releases = [
+        double('Node', :name => 'foo'),
+        double('Node', :name => 'bar'),
+        double('Node', :name => 'baz'),
+      ]
+
+      expect(graph.satisfies_graph?(releases)).to_not be true
+    end
+
+    it 'returns false if the solution violates any graph constraint' do
+      graph = Graph.new
+      graph.add_graph_constraint('me') do |nodes|
+        nodes.all? { |node| node.name.length < 5 }
+      end
+      graph.add_graph_constraint('me') do |nodes|
+        nodes.none? { |node| node.name =~ /z/ }
+      end
+
+      releases = [
+        double('Node', :name => 'foo'),
+        double('Node', :name => 'bar'),
+        double('Node', :name => 'bangerang'),
+      ]
+
+      expect(graph.satisfies_graph?(releases)).to_not be true
+    end
+
+    it 'returns true if the solution violates no graph constraints' do
+      graph = Graph.new
+      graph.add_graph_constraint('me') do |nodes|
+        nodes.all? { |node| node.name.length < 5 }
+      end
+      graph.add_graph_constraint('me') do |nodes|
+        nodes.none? { |node| node.name =~ /z/ }
+      end
+
+      releases = [
+        double('Node', :name => 'foo'),
+        double('Node', :name => 'bar'),
+        double('Node', :name => 'boom'),
+      ]
+
+      expect(graph.satisfies_graph?(releases)).to be true
+    end
+  end
+
+end

--- a/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/module_release_spec.rb
+++ b/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/module_release_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+require 'semantic/dependency/module_release'
+
+describe Semantic::Dependency::ModuleRelease do
+  def source
+    @source ||= Semantic::Dependency::Source.new
+  end
+
+  def make_release(name, version, deps = {})
+    source.create_release(name, version, deps)
+  end
+
+  let(:no_dependencies) do
+    make_release('module', '1.2.3')
+  end
+
+  let(:one_dependency) do
+    make_release('module', '1.2.3', 'foo' => '1.0.0')
+  end
+
+  let(:three_dependencies) do
+    dependencies = { 'foo' => '1.0.0', 'bar' => '2.0.0', 'baz' => '3.0.0' }
+    make_release('module', '1.2.3', dependencies)
+  end
+
+  describe '#dependency_names' do
+
+    it "lists the names of all the release's dependencies" do
+      expect(no_dependencies.dependency_names).to    match_array %w[]
+      expect(one_dependency.dependency_names).to     match_array %w[foo]
+      expect(three_dependencies.dependency_names).to match_array %w[foo bar baz]
+    end
+
+  end
+
+  describe '#to_s' do
+
+    let(:name) { 'foobarbaz' }
+    let(:version) { '1.2.3' }
+
+    subject { make_release(name, version).to_s }
+
+    it { should =~ /#{name}/ }
+    it { should =~ /#{version}/ }
+
+  end
+
+  describe '#<<' do
+
+    it 'marks matching dependencies as satisfied' do
+      one_dependency << make_release('foo', '1.0.0')
+      expect(one_dependency).to be_satisfied
+    end
+
+    it 'does not mark mis-matching dependency names as satisfied' do
+      one_dependency << make_release('WAT', '1.0.0')
+      expect(one_dependency).to_not be_satisfied
+    end
+
+    it 'does not mark mis-matching dependency versions as satisfied' do
+      one_dependency << make_release('foo', '0.0.1')
+      expect(one_dependency).to_not be_satisfied
+    end
+
+  end
+
+  describe '#<=>' do
+
+    it 'considers releases with greater version numbers greater' do
+      expect(make_release('foo', '1.0.0')).to be > make_release('foo', '0.1.0')
+    end
+
+    it 'considers releases with lesser version numbers lesser' do
+      expect(make_release('foo', '0.1.0')).to be < make_release('foo', '1.0.0')
+    end
+
+    it 'orders releases with different names lexographically' do
+      expect(make_release('bar', '1.0.0')).to be < make_release('foo', '1.0.0')
+    end
+
+    it 'orders releases by name first' do
+      expect(make_release('bar', '2.0.0')).to be < make_release('foo', '1.0.0')
+    end
+
+  end
+
+  describe '#satisfied?' do
+
+    it 'returns true when there are no dependencies to satisfy' do
+      expect(no_dependencies).to be_satisfied
+    end
+
+    it 'returns false when no dependencies have been satisified' do
+      expect(one_dependency).to_not be_satisfied
+    end
+
+    it 'returns false when not all dependencies have been satisified' do
+      releases = %w[ 0.9.0 1.0.0 1.0.1 ].map { |ver| make_release('foo', ver) }
+      three_dependencies << releases
+
+      expect(three_dependencies).to_not be_satisfied
+    end
+
+    it 'returns false when not all dependency versions have been satisified' do
+      releases = %w[ 0.9.0 1.0.1 ].map { |ver| make_release('foo', ver) }
+      one_dependency << releases
+
+      expect(one_dependency).to_not be_satisfied
+    end
+
+    it 'returns true when all dependencies have been satisified' do
+      releases = %w[ 0.9.0 1.0.0 1.0.1 ].map { |ver| make_release('foo', ver) }
+      one_dependency << releases
+
+      expect(one_dependency).to be_satisfied
+    end
+
+  end
+
+  describe '#satisfies_dependency?' do
+
+    it 'returns false when there are no dependencies to satisfy' do
+      release = make_release('foo', '1.0.0')
+      expect(no_dependencies.satisfies_dependency?(release)).to_not be true
+    end
+
+    it 'returns false when the release does not match the dependency name' do
+      release = make_release('bar', '1.0.0')
+      expect(one_dependency.satisfies_dependency?(release)).to_not be true
+    end
+
+    it 'returns false when the release does not match the dependency version' do
+      release = make_release('foo', '4.0.0')
+      expect(one_dependency.satisfies_dependency?(release)).to_not be true
+    end
+
+    it 'returns true when the release matches the dependency' do
+      release = make_release('foo', '1.0.0')
+      expect(one_dependency.satisfies_dependency?(release)).to be true
+    end
+
+  end
+end

--- a/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/source_spec.rb
+++ b/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/source_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+require 'semantic/dependency/source'
+
+describe Semantic::Dependency::Source do
+end

--- a/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/unsatisfiable_graph_spec.rb
+++ b/lib/puppet/vendor/semantic/spec/unit/semantic/dependency/unsatisfiable_graph_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'semantic/dependency/unsatisfiable_graph'
+
+describe Semantic::Dependency::UnsatisfiableGraph do
+
+  let(:modules) { %w[ foo bar baz ] }
+  let(:graph) { double('Graph', :modules => modules) }
+  let(:instance) { described_class.new(graph) }
+
+  subject { instance }
+
+  describe '#message' do
+    subject { instance.message }
+
+    it { should match /#{instance.send(:sentence_from_list, modules)}/ }
+  end
+
+  describe '#sentence_from_list' do
+
+    subject { instance.send(:sentence_from_list, modules) }
+
+    context 'with a list of one item' do
+      let(:modules) { %w[ foo ] }
+      it { should eql 'foo' }
+    end
+
+    context 'with a list of two items' do
+      let(:modules) { %w[ foo bar ] }
+      it { should eql 'foo and bar' }
+    end
+
+    context 'with a list of three items' do
+      let(:modules) { %w[ foo bar baz ] }
+      it { should eql 'foo, bar, and baz' }
+    end
+
+    context 'with a list of more than three items' do
+      let(:modules) { %w[ foo bar baz quux ] }
+      it { should eql 'foo, bar, baz, and quux' }
+    end
+
+  end
+
+end

--- a/lib/puppet/vendor/semantic/spec/unit/semantic/dependency_spec.rb
+++ b/lib/puppet/vendor/semantic/spec/unit/semantic/dependency_spec.rb
@@ -1,0 +1,383 @@
+require 'spec_helper'
+require 'semantic/dependency'
+
+describe Semantic::Dependency do
+  def create_release(source, name, version, deps = {})
+    Semantic::Dependency::ModuleRelease.new(
+      source,
+      name,
+      Semantic::Version.parse(version),
+      Hash[deps.map { |k, v| [k, Semantic::VersionRange.parse(v) ] }]
+    )
+  end
+
+  describe '.sources' do
+    it 'defaults to an empty list' do
+      expect(subject.sources).to be_empty
+    end
+
+    it 'is frozen' do
+      expect(subject.sources).to be_frozen
+    end
+
+    it 'can be modified by using #add_source' do
+      subject.add_source(Semantic::Dependency::Source.new)
+      expect(subject.sources).to_not be_empty
+    end
+
+    it 'can be emptied by using #clear_sources' do
+      subject.add_source(Semantic::Dependency::Source.new)
+      subject.clear_sources
+      expect(subject.sources).to be_empty
+    end
+  end
+
+  describe '.query' do
+    context 'without sources' do
+      it 'returns an unsatisfied ModuleRelease' do
+        expect(subject.query('module_name' => '1.0.0')).to_not be_satisfied
+      end
+    end
+
+    context 'with one source' do
+      let(:source) { double('Source') }
+
+      before { Semantic::Dependency.add_source(source) }
+
+      it 'queries the source for release information' do
+        source.should_receive(:fetch).with('module_name').and_return([])
+
+        Semantic::Dependency.query('module_name' => '1.0.0')
+      end
+
+      it 'queries the source for each dependency' do
+        source.should_receive(:fetch).with('module_name').and_return([
+          create_release(source, 'module_name', '1.0.0', 'bar' => '1.0.0')
+        ])
+        source.should_receive(:fetch).with('bar').and_return([])
+
+        Semantic::Dependency.query('module_name' => '1.0.0')
+      end
+
+      it 'queries the source for each dependency only once' do
+        source.should_receive(:fetch).with('module_name').and_return([
+          create_release(
+            source,
+            'module_name',
+            '1.0.0',
+            'bar' => '1.0.0', 'baz' => '0.0.2'
+          )
+        ])
+        source.should_receive(:fetch).with('bar').and_return([
+          create_release(source, 'bar', '1.0.0', 'baz' => '0.0.3')
+        ])
+        source.should_receive(:fetch).with('baz').once.and_return([])
+
+        Semantic::Dependency.query('module_name' => '1.0.0')
+      end
+
+      it 'returns a ModuleRelease with the requested dependencies' do
+        source.stub(:fetch).and_return([])
+
+        result = Semantic::Dependency.query('foo' => '1.0.0', 'bar' => '1.0.0')
+        expect(result.dependency_names).to match_array %w[ foo bar ]
+      end
+
+      it 'populates the returned ModuleRelease with related dependencies' do
+        source.stub(:fetch).and_return(
+          [ foo = create_release(source, 'foo', '1.0.0', 'bar' => '1.0.0') ],
+          [ bar = create_release(source, 'bar', '1.0.0') ]
+        )
+
+        result = Semantic::Dependency.query('foo' => '1.0.0', 'bar' => '1.0.0')
+        expect(result.dependencies['foo']).to eql SortedSet.new([ foo ])
+        expect(result.dependencies['bar']).to eql SortedSet.new([ bar ])
+      end
+
+      it 'populates all returned ModuleReleases with related dependencies' do
+        source.stub(:fetch).and_return(
+          [ foo = create_release(source, 'foo', '1.0.0', 'bar' => '1.0.0') ],
+          [ bar = create_release(source, 'bar', '1.0.0', 'baz' => '0.1.0') ],
+          [ baz = create_release(source, 'baz', '0.1.0', 'baz' => '1.0.0') ]
+        )
+
+        result = Semantic::Dependency.query('foo' => '1.0.0')
+        expect(result.dependencies['foo']).to eql SortedSet.new([ foo ])
+        expect(foo.dependencies['bar']).to eql SortedSet.new([ bar ])
+        expect(bar.dependencies['baz']).to eql SortedSet.new([ baz ])
+      end
+    end
+
+    context 'with multiple sources' do
+      let(:source1) { double('SourceOne') }
+      let(:source2) { double('SourceTwo') }
+      let(:source3) { double('SourceThree') }
+
+      before do
+        Semantic::Dependency.add_source(source1)
+        Semantic::Dependency.add_source(source2)
+        Semantic::Dependency.add_source(source3)
+      end
+
+      it 'queries each source in turn' do
+        source1.should_receive(:fetch).with('module_name').and_return([])
+        source2.should_receive(:fetch).with('module_name').and_return([])
+        source3.should_receive(:fetch).with('module_name').and_return([])
+
+        Semantic::Dependency.query('module_name' => '1.0.0')
+      end
+
+      it 'resolves all dependencies against all sources' do
+        source1.should_receive(:fetch).with('module_name').and_return([
+          create_release(source1, 'module_name', '1.0.0', 'bar' => '1.0.0')
+        ])
+        source2.should_receive(:fetch).with('module_name').and_return([])
+        source3.should_receive(:fetch).with('module_name').and_return([])
+
+        source1.should_receive(:fetch).with('bar').and_return([])
+        source2.should_receive(:fetch).with('bar').and_return([])
+        source3.should_receive(:fetch).with('bar').and_return([])
+
+        Semantic::Dependency.query('module_name' => '1.0.0')
+      end
+    end
+  end
+
+  describe '.resolve' do
+    def add_source_modules(name, versions, deps = {})
+      versions = Array(versions)
+      releases = versions.map { |ver| create_release(source, name, ver, deps) }
+      source.stub(:fetch).with(name).and_return(modules[name].concat(releases))
+    end
+
+    def subject(specs)
+      graph = Semantic::Dependency.query(specs)
+      yield graph if block_given?
+      expect(graph.dependencies).to_not be_empty
+      result = Semantic::Dependency.resolve(graph)
+      expect(graph.dependencies).to_not be_empty
+      result.map { |rel| [ rel.name, rel.version.to_s ] }
+    end
+
+    let(:modules) { Hash.new { |h,k| h[k] = [] }}
+    let(:source) { double('Source', :priority => 0) }
+
+    before { Semantic::Dependency.add_source(source) }
+
+    context 'for a module without dependencies' do
+      def foo(range)
+        subject('foo' => range).map { |x| x.last }
+      end
+
+      it 'returns the greatest release matching the version range' do
+        add_source_modules('foo', %w[ 0.9.0 1.0.0 1.1.0 2.0.0 ])
+
+        expect(foo('1.x')).to eql %w[ 1.1.0 ]
+      end
+
+      context 'when the query includes both stable and prerelease versions' do
+        it 'returns the greatest stable release matching the range' do
+          add_source_modules('foo', %w[ 0.9.0 1.0.0 1.1.0 1.2.0-pre 2.0.0 ])
+
+          expect(foo('1.x')).to eql %w[ 1.1.0 ]
+        end
+      end
+
+      context 'when the query omits all stable versions' do
+        it 'returns the greatest prerelease version matching the range' do
+          add_source_modules('foo', %w[ 1.0.0 1.1.0-a 1.1.0-b 2.0.0 ])
+
+          expect(foo('1.1.x')).to   eql %w[ 1.1.0-b ]
+          expect(foo('1.1.0-a')).to eql %w[ 1.1.0-a ]
+        end
+      end
+
+      context 'when the query omits all versions' do
+        it 'fails with an appropriate message' do
+          add_source_modules('foo', %w[ 1.0.0 1.1.0-a 1.1.0 ])
+
+          with_message = /Could not find satisfying releases/
+          expect { foo('2.x') }.to raise_exception with_message
+          expect { foo('2.x') }.to raise_exception /\bfoo\b/
+        end
+      end
+    end
+
+    context 'for a module with dependencies' do
+      def foo(range)
+        subject('foo' => range)
+      end
+
+      it 'returns the greatest releases matching the dependency range' do
+        add_source_modules('foo', '1.1.0', 'bar' => '1.x')
+        add_source_modules('bar', %w[ 0.9.0 1.0.0 1.1.0 1.2.0 2.0.0 ])
+
+        expect(foo('1.1.0')).to include %w[ foo 1.1.0 ], %w[ bar 1.2.0 ]
+      end
+
+      context 'when the dependency has both stable and prerelease versions' do
+        it 'returns the greatest stable release matching the range' do
+          add_source_modules('foo', '1.1.0', 'bar' => '1.x')
+          add_source_modules('bar', %w[ 0.9.0 1.0.0 1.1.0 1.2.0-pre 2.0.0 ])
+
+          expect(foo('1.1.0')).to include %w[ foo 1.1.0 ], %w[ bar 1.1.0 ]
+        end
+      end
+
+      context 'when the dependency has no stable versions' do
+        it 'returns the greatest prerelease version matching the range' do
+          add_source_modules('foo', '1.1.0', 'bar' => '1.1.x')
+          add_source_modules('foo', '1.1.1', 'bar' => '1.1.0-a')
+          add_source_modules('bar', %w[ 1.0.0 1.1.0-a 1.1.0-b 2.0.0 ])
+
+          expect(foo('1.1.0')).to include %w[ foo 1.1.0 ], %w[ bar 1.1.0-b ]
+          expect(foo('1.1.1')).to include %w[ foo 1.1.1 ], %w[ bar 1.1.0-a ]
+        end
+      end
+
+      context 'when the dependency cannot be satisfied' do
+        it 'fails with an appropriate message' do
+          add_source_modules('foo', %w[ 1.1.0 ], 'bar' => '1.x')
+          add_source_modules('bar', %w[ 0.0.1 0.1.0-a 0.1.0 ])
+
+          with_message = /Could not find satisfying releases/
+          expect { foo('1.1.0') }.to raise_exception with_message
+          expect { foo('1.1.0') }.to raise_exception /\bfoo\b/
+        end
+      end
+    end
+
+    context 'for a module with competing dependencies' do
+      def foo(range)
+        subject('foo' => range)
+      end
+
+      context 'that overlap' do
+        it 'returns the greatest release satisfying all dependencies' do
+          add_source_modules('foo', '1.1.0', 'bar' => '1.0.0', 'baz' => '1.0.0')
+          add_source_modules('bar', '1.0.0', 'quxx' => '1.x')
+          add_source_modules('baz', '1.0.0', 'quxx' => '1.1.x')
+          add_source_modules('quxx', %w[ 0.9.0 1.0.0 1.1.0 1.1.1 1.2.0 2.0.0 ])
+
+          expect(foo('1.1.0')).to_not include %w[ quxx 1.2.0 ]
+          expect(foo('1.1.0')).to include %w[ quxx 1.1.1 ]
+        end
+      end
+
+      context 'that do not overlap' do
+        it 'fails with an appropriate message' do
+          add_source_modules('foo','1.1.0', 'bar' => '1.0.0', 'baz' => '1.0.0')
+          add_source_modules('bar','1.0.0', 'quxx' => '1.x')
+          add_source_modules('baz','1.0.0', 'quxx' => '2.x')
+          add_source_modules('quxx', %w[ 0.9.0 1.0.0 1.1.0 1.1.1 1.2.0 2.0.0 ])
+
+          with_message = /Could not find satisfying releases/
+          expect { foo('1.1.0') }.to raise_exception with_message
+          expect { foo('1.1.0') }.to raise_exception /\bfoo\b/
+        end
+      end
+    end
+
+    context 'for a module with circular dependencies' do
+      def foo(range)
+        subject('foo' => range)
+      end
+
+      context 'that can be resolved' do
+        it 'terminates' do
+          add_source_modules('foo', '1.1.0', 'foo' => '1.x')
+
+          expect(foo('1.1.0')).to include %w[ foo 1.1.0 ]
+        end
+      end
+
+      context 'that cannot be resolved' do
+        it 'fails with an appropriate message' do
+          add_source_modules('foo', '1.1.0', 'foo' => '1.0.0')
+
+          with_message = /Could not find satisfying releases/
+          expect { foo('1.1.0') }.to raise_exception with_message
+          expect { foo('1.1.0') }.to raise_exception /\bfoo\b/
+        end
+      end
+    end
+
+    context 'for a module with dependencies' do
+      context 'that violate module constraints on the graph' do
+        def foo(range)
+          subject('foo' => range) do |graph|
+            graph.add_constraint('no downgrade', 'bar', '> 3.0.0') do |node|
+              Semantic::VersionRange.parse('> 3.0.0') === node.version
+            end
+          end
+        end
+
+        context 'that can be resolved' do
+          it 'terminates' do
+            add_source_modules('foo', '1.1.0', 'bar' => '1.x')
+            add_source_modules('foo', '1.2.0', 'bar' => '>= 2.0.0')
+            add_source_modules('bar', '1.0.0')
+            add_source_modules('bar', '2.0.0', 'baz' => '>= 1.0.0')
+            add_source_modules('bar', '3.0.0')
+            add_source_modules('bar', '3.0.1')
+            add_source_modules('baz', '1.0.0')
+
+            expect(foo('1.x')).to include %w[ foo 1.2.0 ], %w[ bar 3.0.1 ]
+          end
+        end
+
+        context 'that cannot be resolved' do
+          it 'fails with an appropriate message' do
+            add_source_modules('foo', '1.1.0', 'bar' => '1.x')
+            add_source_modules('foo', '1.2.0', 'bar' => '2.x')
+            add_source_modules('bar', '1.0.0', 'baz' => '1.x')
+            add_source_modules('bar', '2.0.0', 'baz' => '1.x')
+            add_source_modules('baz', '1.0.0')
+            add_source_modules('baz', '3.0.0')
+            add_source_modules('baz', '3.0.1')
+
+            with_message = /Could not find satisfying releases/
+            expect { foo('1.x') }.to raise_exception with_message
+            expect { foo('1.x') }.to raise_exception /\bfoo\b/
+          end
+        end
+      end
+    end
+
+    context 'that violate graph constraints' do
+      def foo(range)
+        subject('foo' => range) do |graph|
+          graph.add_graph_constraint('uniqueness') do |nodes|
+            nodes.none? { |node| node.name =~ /z/ }
+          end
+        end
+      end
+
+      context 'that can be resolved' do
+        it 'terminates' do
+          add_source_modules('foo', '1.1.0', 'bar' => '1.x')
+          add_source_modules('foo', '1.2.0', 'bar' => '2.x')
+          add_source_modules('bar', '1.0.0')
+          add_source_modules('bar', '2.0.0', 'baz' => '1.0.0')
+          add_source_modules('baz', '1.0.0')
+
+          expect(foo('1.x')).to include %w[ foo 1.1.0 ], %w[ bar 1.0.0 ]
+        end
+      end
+
+      context 'that cannot be resolved' do
+        it 'fails with an appropriate message' do
+          add_source_modules('foo', '1.1.0', 'bar' => '1.x')
+          add_source_modules('foo', '1.2.0', 'bar' => '2.x')
+          add_source_modules('bar', '1.0.0', 'baz' => '1.0.0')
+          add_source_modules('bar', '2.0.0', 'baz' => '1.0.0')
+          add_source_modules('baz', '1.0.0')
+
+          with_message = /Could not find satisfying releases/
+          expect { foo('1.1.0') }.to raise_exception with_message
+          expect { foo('1.1.0') }.to raise_exception /\bfoo\b/
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet/vendor/semantic/spec/unit/semantic/version_range_spec.rb
+++ b/lib/puppet/vendor/semantic/spec/unit/semantic/version_range_spec.rb
@@ -1,0 +1,307 @@
+require 'spec_helper'
+require 'semantic/version'
+
+describe Semantic::VersionRange do
+
+  describe '.parse' do
+    def self.test_range(range_list, str, includes, excludes)
+      Array(range_list).each do |expr|
+        example "#{expr.inspect} stringifies as #{str}" do
+          range = Semantic::VersionRange.parse(expr)
+          expect(range.to_s).to eql str
+        end
+
+        includes.each do |vstring|
+          example "#{expr.inspect} includes #{vstring}" do
+            range = Semantic::VersionRange.parse(expr)
+            expect(range).to include(Semantic::Version.parse(vstring))
+          end
+
+          example "parse(#{expr.inspect}).to_s includes #{vstring}" do
+            range = Semantic::VersionRange.parse(expr)
+            range = Semantic::VersionRange.parse(range.to_s)
+            expect(range).to include(Semantic::Version.parse(vstring))
+          end
+        end
+
+        excludes.each do |vstring|
+          example "#{expr.inspect} excludes #{vstring}" do
+            range = Semantic::VersionRange.parse(expr)
+            expect(range).to_not include(Semantic::Version.parse(vstring))
+          end
+
+          example "parse(#{expr.inspect}).to_s excludes #{vstring}" do
+            range = Semantic::VersionRange.parse(expr)
+            range = Semantic::VersionRange.parse(range.to_s)
+            expect(range).to_not include(Semantic::Version.parse(vstring))
+          end
+        end
+      end
+    end
+
+    context 'loose version expressions' do
+      expressions = {
+        [ '1.2.3-alpha' ] => {
+          :to_str   => '1.2.3-alpha',
+          :includes => [ '1.2.3-alpha'  ],
+          :excludes => [ '1.2.3-999', '1.2.3-beta' ],
+        },
+        [ '1.2.3' ] => {
+          :to_str   => '1.2.3',
+          :includes => [ '1.2.3-alpha', '1.2.3' ],
+          :excludes => [ '1.2.2', '1.2.4-alpha' ],
+        },
+        [ '1.2', '1.2.x', '1.2.X' ] => {
+          :to_str   => '1.2.x',
+          :includes => [ '1.2.0-alpha', '1.2.0', '1.2.999' ],
+          :excludes => [ '1.1.999', '1.3.0-0' ],
+        },
+        [ '1', '1.x', '1.X' ] => {
+          :to_str   => '1.x',
+          :includes => [ '1.0.0-alpha', '1.999.0' ],
+          :excludes => [ '0.999.999', '2.0.0-0' ],
+        },
+      }
+
+      expressions.each do |range, vs|
+        test_range(range, vs[:to_str], vs[:includes], vs[:excludes])
+      end
+    end
+
+    context 'open-ended expressions' do
+      expressions = {
+        [ '>1.2.3', '> 1.2.3' ] => {
+          :to_str   => '>=1.2.4',
+          :includes => [ '1.2.4-0', '999.0.0' ],
+          :excludes => [ '1.2.3' ],
+        },
+        [ '>1.2.3-alpha', '> 1.2.3-alpha' ] => {
+          :to_str   => '>1.2.3-alpha',
+          :includes => [ '1.2.3-alpha.0', '1.2.3-alpha0', '999.0.0' ],
+          :excludes => [ '1.2.3-alpha' ],
+        },
+
+        [ '>=1.2.3', '>= 1.2.3' ] => {
+          :to_str   => '>=1.2.3',
+          :includes => [ '1.2.3-0', '999.0.0' ],
+          :excludes => [ '1.2.2' ],
+        },
+        [ '>=1.2.3-alpha', '>= 1.2.3-alpha' ] => {
+          :to_str   => '>=1.2.3-alpha',
+          :includes => [ '1.2.3-alpha', '1.2.3-alpha0', '999.0.0' ],
+          :excludes => [ '1.2.3-alph' ],
+        },
+
+        [ '<1.2.3', '< 1.2.3' ] => {
+          :to_str   => '<1.2.3',
+          :includes => [ '0.0.0-0', '1.2.2' ],
+          :excludes => [ '1.2.3-0', '2.0.0' ],
+        },
+        [ '<1.2.3-alpha', '< 1.2.3-alpha' ] => {
+          :to_str   => '<1.2.3-alpha',
+          :includes => [ '0.0.0-0', '1.2.3-alph' ],
+          :excludes => [ '1.2.3-alpha', '2.0.0' ],
+        },
+
+        [ '<=1.2.3', '<= 1.2.3' ] => {
+          :to_str   => '<1.2.4',
+          :includes => [ '0.0.0-0', '1.2.3' ],
+          :excludes => [ '1.2.4-0' ],
+        },
+        [ '<=1.2.3-alpha', '<= 1.2.3-alpha' ] => {
+          :to_str   => '<=1.2.3-alpha',
+          :includes => [ '0.0.0-0', '1.2.3-alpha' ],
+          :excludes => [ '1.2.3-alpha0', '1.2.3-alpha.0', '1.2.3-alpha'.next ],
+        },
+      }
+
+      expressions.each do |range, vs|
+        test_range(range, vs[:to_str], vs[:includes], vs[:excludes])
+      end
+    end
+
+    context '"reasonably close" expressions' do
+      expressions = {
+        [ '~ 1', '~1' ] => {
+          :to_str   => '1.x',
+          :includes => [ '1.0.0-0', '1.999.999' ],
+          :excludes => [ '0.999.999', '2.0.0-0' ],
+        },
+        [ '~ 1.2', '~1.2' ] => {
+          :to_str   => '1.2.x',
+          :includes => [ '1.2.0-0', '1.2.999' ],
+          :excludes => [ '1.1.999', '1.3.0-0' ],
+        },
+        [ '~ 1.2.3', '~1.2.3' ] => {
+          :to_str   => '1.2.3',
+          :includes => [ '1.2.3-0', '1.2.3' ],
+          :excludes => [ '1.2.2', '1.2.4-0' ],
+        },
+        [ '~ 1.2.3-alpha', '~1.2.3-alpha' ] => {
+          :to_str   => '>=1.2.3-alpha <1.2.4',
+          :includes => [ '1.2.3-alpha', '1.2.3' ],
+          :excludes => [ '1.2.3-alph', '1.2.4-0' ],
+        },
+      }
+
+      expressions.each do |range, vs|
+        test_range(range, vs[:to_str], vs[:includes], vs[:excludes])
+      end
+    end
+
+    context 'inclusive range expressions' do
+      expressions = {
+        '1.2.3 - 1.3.4' => {
+          :to_str   => '>=1.2.3 <1.3.5',
+          :includes => [ '1.2.3-0', '1.3.4' ],
+          :excludes => [ '1.2.2', '1.3.5-0' ],
+        },
+        '1.2.3 - 1.3.4-alpha' => {
+          :to_str   => '>=1.2.3 <=1.3.4-alpha',
+          :includes => [ '1.2.3-0', '1.3.4-alpha' ],
+          :excludes => [ '1.2.2', '1.3.4-alpha0', '1.3.5' ],
+        },
+
+        '1.2.3-alpha - 1.3.4' => {
+          :to_str   => '>=1.2.3-alpha <1.3.5',
+          :includes => [ '1.2.3-alpha', '1.3.4' ],
+          :excludes => [ '1.2.3-alph', '1.3.5-0' ],
+        },
+        '1.2.3-alpha - 1.3.4-alpha' => {
+          :to_str   => '>=1.2.3-alpha <=1.3.4-alpha',
+          :includes => [ '1.2.3-alpha', '1.3.4-alpha' ],
+          :excludes => [ '1.2.3-alph', '1.3.4-alpha0', '1.3.5' ],
+        },
+      }
+
+      expressions.each do |range, vs|
+        test_range(range, vs[:to_str], vs[:includes], vs[:excludes])
+      end
+    end
+
+    context 'unioned expressions' do
+      expressions = {
+        [ '1.2 <1.2.5' ] => {
+          :to_str   => '>=1.2.0 <1.2.5',
+          :includes => [ '1.2.0-0', '1.2.4' ],
+          :excludes => [ '1.1.999', '1.2.5-0', '1.9.0' ],
+        },
+        [ '1 <=1.2.5' ] => {
+          :to_str   => '>=1.0.0 <1.2.6',
+          :includes => [ '1.0.0-0', '1.2.5' ],
+          :excludes => [ '0.999.999', '1.2.6-0', '1.9.0' ],
+        },
+        [ '>1.0.0 >2.0.0 >=3.0.0 <5.0.0' ] => {
+          :to_str   => '>=3.0.0 <5.0.0',
+          :includes => [ '3.0.0-0', '4.999.999' ],
+          :excludes => [ '2.999.999', '5.0.0-0' ],
+        },
+        [ '<1.0.0 >2.0.0' ] => {
+          :to_str   => '<0.0.0',
+          :includes => [  ],
+          :excludes => [ '0.0.0-0' ],
+        },
+      }
+
+      expressions.each do |range, vs|
+        test_range(range, vs[:to_str], vs[:includes], vs[:excludes])
+      end
+    end
+
+    context 'invalid expressions' do
+      example 'raise an appropriate exception' do
+        ex = [ ArgumentError, 'Unparsable version range: "invalid"' ]
+        expect { Semantic::VersionRange.parse('invalid') }.to raise_error(*ex)
+      end
+    end
+  end
+
+  describe '#intersection' do
+    def self.v(num)
+      Semantic::Version.parse("#{num}.0.0")
+    end
+
+    def self.range(x, y, ex = false)
+      Semantic::VersionRange.new(v(x), v(y), ex)
+    end
+
+    EMPTY_RANGE = Semantic::VersionRange::EMPTY_RANGE
+
+    tests = {
+      # This falls entirely before the target range
+      range(1, 4) => [ EMPTY_RANGE ],
+
+      # This falls entirely after the target range
+      range(11, 15) => [ EMPTY_RANGE ],
+
+      # This overlaps the beginning of the target range
+      range(1, 6) => [ range(5, 6) ],
+
+      # This overlaps the end of the target range
+      range(9, 15) => [ range(9, 10), range(9, 10, true) ],
+
+      # This shares the first value of the target range
+      range(1, 5) => [ range(5, 5) ],
+
+      # This shares the last value of the target range
+      range(10, 15)  => [ range(10, 10), EMPTY_RANGE ],
+
+      # This shares both values with the target range
+      range(5, 10) => [ range(5, 10), range(5, 10, true) ],
+
+      # This is a superset of the target range
+      range(4, 11) => [ range(5, 10), range(5, 10, true) ],
+
+      # This is a subset of the target range
+      range(6, 9) => [ range(6, 9) ],
+
+      # This shares the first value of the target range, but excludes it
+      range(1, 5, true)   => [ EMPTY_RANGE ],
+
+      # This overlaps the beginning of the target range, with an excluded end
+      range(1, 7, true)   => [ range(5, 7, true) ],
+
+      # This shares both values with the target range, and excludes the end
+      range(5, 10, true)  => [ range(5, 10, true) ],
+    }
+
+    inclusive = range(5, 10)
+    context "between #{inclusive} &" do
+      tests.each do |subject, result|
+        result = result.first
+
+        example subject do
+          expect(inclusive & subject).to eql(result)
+        end
+      end
+    end
+
+    exclusive = range(5, 10, true)
+    context "between #{exclusive} &" do
+      tests.each do |subject, result|
+        result = result.last
+
+        example subject do
+          expect(exclusive & subject).to eql(result)
+        end
+      end
+    end
+
+    context 'is commutative' do
+      tests.each do |subject, _|
+        example "between #{inclusive} & #{subject}" do
+          expect(inclusive & subject).to eql(subject & inclusive)
+        end
+        example "between #{exclusive} & #{subject}" do
+          expect(exclusive & subject).to eql(subject & exclusive)
+        end
+      end
+    end
+
+    it 'cannot intersect with non-VersionRanges' do
+      msg = "value must be a Semantic::VersionRange"
+      expect { inclusive.intersection(1..2) }.to raise_error(msg)
+    end
+  end
+
+end

--- a/lib/puppet/vendor/semantic/spec/unit/semantic/version_spec.rb
+++ b/lib/puppet/vendor/semantic/spec/unit/semantic/version_spec.rb
@@ -1,0 +1,608 @@
+require 'spec_helper'
+require 'semantic/version'
+
+describe Semantic::Version do
+
+  def subject(str)
+    Semantic::Version.parse(str)
+  end
+
+  describe '.parse' do
+
+    context 'Spec v2.0.0' do
+      context 'Section 2' do
+        # A normal version number MUST take the form X.Y.Z where X, Y, and Z are
+        # non-negative integers, and MUST NOT contain leading zeroes. X is the
+        # major version, Y is the minor version, and Z is the patch version.
+        # Each element MUST increase numerically.
+        # For instance: 1.9.0 -> 1.10.0 -> 1.11.0.
+
+        let(:must_begin_with_digits) do
+          'Version numbers MUST begin with three dot-separated numbers'
+        end
+
+        let(:no_leading_zeroes) do
+          'Version numbers MUST NOT contain leading zeroes'
+        end
+
+        it 'rejects versions that contain too few parts' do
+          expect { subject('1.2') }.to raise_error(must_begin_with_digits)
+        end
+
+        it 'rejects versions that contain too many parts' do
+          expect { subject('1.2.3.4') }.to raise_error(must_begin_with_digits)
+        end
+
+        it 'rejects versions that contain non-integers' do
+          expect { subject('x.2.3') }.to raise_error(must_begin_with_digits)
+          expect { subject('1.y.3') }.to raise_error(must_begin_with_digits)
+          expect { subject('1.2.z') }.to raise_error(must_begin_with_digits)
+        end
+
+        it 'rejects versions that contain negative integers' do
+          expect { subject('-1.2.3') }.to raise_error(must_begin_with_digits)
+          expect { subject('1.-2.3') }.to raise_error(must_begin_with_digits)
+          expect { subject('1.2.-3') }.to raise_error(must_begin_with_digits)
+        end
+
+        it 'rejects version numbers containing leading zeroes' do
+          expect { subject('01.2.3') }.to raise_error(no_leading_zeroes)
+          expect { subject('1.02.3') }.to raise_error(no_leading_zeroes)
+          expect { subject('1.2.03') }.to raise_error(no_leading_zeroes)
+        end
+
+        it 'permits zeroes in version number parts' do
+          expect { subject('0.2.3') }.to_not raise_error
+          expect { subject('1.0.3') }.to_not raise_error
+          expect { subject('1.2.0') }.to_not raise_error
+        end
+
+        context 'examples' do
+          example '1.9.0' do
+            version = subject('1.9.0')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 9
+            expect(version.patch).to eql 0
+          end
+
+          example '1.10.0' do
+            version = subject('1.10.0')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 10
+            expect(version.patch).to eql 0
+          end
+
+          example '1.11.0' do
+            version = subject('1.11.0')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 11
+            expect(version.patch).to eql 0
+          end
+        end
+      end
+
+      context 'Section 9' do
+        # A pre-release version MAY be denoted by appending a hyphen and a
+        # series of dot separated identifiers immediately following the patch
+        # version. Identifiers MUST comprise only ASCII alphanumerics and
+        # hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty. Numeric
+        # identifiers MUST NOT include leading zeroes. Pre-release versions
+        # have a lower precedence than the associated normal version. A
+        # pre-release version indicates that the version is unstable and
+        # might not satisfy the intended compatibility requirements as denoted
+        # by its associated normal version.
+        # Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
+
+        let(:restricted_charset) do
+          'Prerelease identifiers MUST use only ASCII alphanumerics and hyphens'
+        end
+
+        let(:must_not_be_empty) do
+          'Prerelease identifiers MUST NOT be empty'
+        end
+
+        let(:no_leading_zeroes) do
+          'Prerelease identifiers MUST NOT contain leading zeroes'
+        end
+
+        it 'rejects prerelease identifiers with non-alphanumerics' do
+          expect { subject('1.2.3-$100') }.to raise_error(restricted_charset)
+          expect { subject('1.2.3-rc.1@me') }.to raise_error(restricted_charset)
+        end
+
+        it 'rejects empty prerelease versions' do
+          expect { subject('1.2.3-') }.to raise_error(must_not_be_empty)
+        end
+
+        it 'rejects empty prerelease version identifiers' do
+          expect { subject('1.2.3-.rc1') }.to raise_error(must_not_be_empty)
+          expect { subject('1.2.3-rc1.') }.to raise_error(must_not_be_empty)
+          expect { subject('1.2.3-rc..1') }.to raise_error(must_not_be_empty)
+        end
+
+        it 'rejects numeric prerelease identifiers with leading zeroes' do
+          expect { subject('1.2.3-01') }.to raise_error(no_leading_zeroes)
+          expect { subject('1.2.3-rc.01') }.to raise_error(no_leading_zeroes)
+        end
+
+        it 'permits numeric prerelease identifiers of zero' do
+          expect { subject('1.2.3-0') }.to_not raise_error
+          expect { subject('1.2.3-rc.0') }.to_not raise_error
+        end
+
+        it 'permits non-numeric prerelease identifiers with leading zeroes' do
+          expect { subject('1.2.3-0xDEADBEEF') }.to_not raise_error
+          expect { subject('1.2.3-rc.0x10c') }.to_not raise_error
+        end
+
+        context 'examples' do
+          example '1.0.0-alpha' do
+            version = subject('1.0.0-alpha')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'alpha'
+          end
+
+          example '1.0.0-alpha.1' do
+            version = subject('1.0.0-alpha.1')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'alpha.1'
+          end
+
+          example '1.0.0-0.3.7' do
+            version = subject('1.0.0-0.3.7')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql '0.3.7'
+          end
+
+          example '1.0.0-x.7.z.92' do
+            version = subject('1.0.0-x.7.z.92')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'x.7.z.92'
+          end
+        end
+      end
+
+      context 'Section 10' do
+        # Build metadata MAY be denoted by appending a plus sign and a series
+        # of dot separated identifiers immediately following the patch or
+        # pre-release version. Identifiers MUST comprise only ASCII
+        # alphanumerics and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty.
+        # Build metadata SHOULD be ignored when determining version precedence.
+        # Thus two versions that differ only in the build metadata, have the
+        # same precedence.
+        # Examples: 1.0.0-alpha+001, 1.0.0+20130313144700,
+        # 1.0.0-beta+exp.sha.5114f85.
+
+
+        let(:restricted_charset) do
+          'Build identifiers MUST use only ASCII alphanumerics and hyphens'
+        end
+
+        let(:must_not_be_empty) do
+          'Build identifiers MUST NOT be empty'
+        end
+
+        it 'rejects build identifiers with non-alphanumerics' do
+          expect { subject('1.2.3+$100') }.to raise_error(restricted_charset)
+          expect { subject('1.2.3+rc.1@me') }.to raise_error(restricted_charset)
+        end
+
+        it 'rejects empty build metadata' do
+          expect { subject('1.2.3+') }.to raise_error(must_not_be_empty)
+        end
+
+        it 'rejects empty build identifiers' do
+          expect { subject('1.2.3+.rc1') }.to raise_error(must_not_be_empty)
+          expect { subject('1.2.3+rc1.') }.to raise_error(must_not_be_empty)
+          expect { subject('1.2.3+rc..1') }.to raise_error(must_not_be_empty)
+        end
+
+        it 'permits numeric build identifiers with leading zeroes' do
+          expect { subject('1.2.3+01') }.to_not raise_error
+          expect { subject('1.2.3+rc.01') }.to_not raise_error
+        end
+
+        it 'permits numeric build identifiers of zero' do
+          expect { subject('1.2.3+0') }.to_not raise_error
+          expect { subject('1.2.3+rc.0') }.to_not raise_error
+        end
+
+        it 'permits non-numeric build identifiers with leading zeroes' do
+          expect { subject('1.2.3+0xDEADBEEF') }.to_not raise_error
+          expect { subject('1.2.3+rc.0x10c') }.to_not raise_error
+        end
+
+        context 'examples' do
+          example '1.0.0-alpha+001' do
+            version = subject('1.0.0-alpha+001')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'alpha'
+            expect(version.build).to eql '001'
+          end
+
+          example '1.0.0+20130313144700' do
+            version = subject('1.0.0+20130313144700')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql nil
+            expect(version.build).to eql '20130313144700'
+          end
+
+          example '1.0.0-beta+exp.sha.5114f85' do
+            version = subject('1.0.0-beta+exp.sha.5114f85')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'beta'
+            expect(version.build).to eql 'exp.sha.5114f85'
+          end
+        end
+      end
+    end
+
+    context 'Spec v1.0.0' do
+      context 'Section 2' do
+        # A normal version number MUST take the form X.Y.Z where X, Y, and Z
+        # are integers. X is the major version, Y is the minor version, and Z
+        # is the patch version. Each element MUST increase numerically by
+        # increments of one.
+        # For instance: 1.9.0 -> 1.10.0 -> 1.11.0
+
+        let(:must_begin_with_digits) do
+          'Version numbers MUST begin with three dot-separated numbers'
+        end
+
+        let(:no_leading_zeroes) do
+          'Version numbers MUST NOT contain leading zeroes'
+        end
+
+        it 'rejects versions that contain too few parts' do
+          expect { subject('1.2') }.to raise_error(must_begin_with_digits)
+        end
+
+        it 'rejects versions that contain too many parts' do
+          expect { subject('1.2.3.4') }.to raise_error(must_begin_with_digits)
+        end
+
+        it 'rejects versions that contain non-integers' do
+          expect { subject('x.2.3') }.to raise_error(must_begin_with_digits)
+          expect { subject('1.y.3') }.to raise_error(must_begin_with_digits)
+          expect { subject('1.2.z') }.to raise_error(must_begin_with_digits)
+        end
+
+        it 'permits zeroes in version number parts' do
+          expect { subject('0.2.3') }.to_not raise_error
+          expect { subject('1.0.3') }.to_not raise_error
+          expect { subject('1.2.0') }.to_not raise_error
+        end
+
+        context 'examples' do
+          example '1.9.0' do
+            version = subject('1.9.0')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 9
+            expect(version.patch).to eql 0
+          end
+
+          example '1.10.0' do
+            version = subject('1.10.0')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 10
+            expect(version.patch).to eql 0
+          end
+
+          example '1.11.0' do
+            version = subject('1.11.0')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 11
+            expect(version.patch).to eql 0
+          end
+        end
+      end
+
+      context 'Section 4' do
+        # A pre-release version number MAY be denoted by appending an arbitrary
+        # string immediately following the patch version and a dash. The string
+        # MUST be comprised of only alphanumerics plus dash [0-9A-Za-z-].
+        # Pre-release versions satisfy but have a lower precedence than the
+        # associated normal version. Precedence SHOULD be determined by
+        # lexicographic ASCII sort order.
+        # For instance: 1.0.0-alpha1 < 1.0.0-beta1 < 1.0.0-beta2 < 1.0.0-rc1
+
+        let(:restricted_charset) do
+          'Prerelease identifiers MUST use only ASCII alphanumerics and hyphens'
+        end
+
+        let(:must_not_be_empty) do
+          'Prerelease identifiers MUST NOT be empty'
+        end
+
+        let(:no_leading_zeroes) do
+          'Prerelease identifiers MUST NOT contain leading zeroes'
+        end
+
+        it 'rejects prerelease identifiers with non-alphanumerics' do
+          expect { subject('1.2.3-$100') }.to raise_error(restricted_charset)
+          expect { subject('1.2.3-rc.1@me') }.to raise_error(restricted_charset)
+        end
+
+        it 'rejects empty prerelease versions' do
+          expect { subject('1.2.3-') }.to raise_error(must_not_be_empty)
+        end
+
+        pending 'permits numeric prerelease identifiers with leading zeroes' do
+          expect { subject('1.2.3-01') }.to raise_error(no_leading_zeroes)
+        end
+
+        it 'permits numeric prerelease identifiers of zero' do
+          expect { subject('1.2.3-0') }.to_not raise_error
+        end
+
+        it 'permits non-numeric prerelease identifiers with leading zeroes' do
+          expect { subject('1.2.3-0xDEADBEEF') }.to_not raise_error
+        end
+
+        context 'examples' do
+          example '1.0.0-alpha1' do
+            version = subject('1.0.0-alpha1')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'alpha1'
+          end
+
+          example '1.0.0-beta1' do
+            version = subject('1.0.0-beta1')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'beta1'
+          end
+
+          example '1.0.0-beta2' do
+            version = subject('1.0.0-beta2')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'beta2'
+          end
+
+          example '1.0.0-rc1' do
+            version = subject('1.0.0-rc1')
+            expect(version.major).to eql 1
+            expect(version.minor).to eql 0
+            expect(version.patch).to eql 0
+            expect(version.prerelease).to eql 'rc1'
+          end
+        end
+      end
+    end
+
+  end
+
+  describe '#<=>' do
+    def parse(vstring)
+      Semantic::Version.parse(vstring)
+    end
+
+    context 'Spec v2.0.0' do
+      context 'Section 11' do
+        # Precedence refers to how versions are compared to each other when
+        # ordered. Precedence MUST be calculated by separating the version into
+        # major, minor, patch and pre-release identifiers in that order (Build
+        # metadata does not figure into precedence). Precedence is determined
+        # by the first difference when comparing each of these identifiers from
+        # left to right as follows: Major, minor, and patch versions are always
+        # compared numerically.
+        # Example: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1.
+        # When major, minor, and patch are equal, a pre-release version has
+        # lower precedence than a normal version.
+        # Example: 1.0.0-alpha < 1.0.0.
+        # Precedence for two pre-release versions with the same major, minor,
+        # and patch version MUST be determined by comparing each dot separated
+        # identifier from left to right until a difference is found as follows:
+        # identifiers consisting of only digits are compared numerically and
+        # identifiers with letters or hyphens are compared lexically in ASCII
+        # sort order. Numeric identifiers always have lower precedence than
+        # non-numeric identifiers. A larger set of pre-release fields has a
+        # higher precedence than a smaller set, if all of the preceding
+        # identifiers are equal.
+        # Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta
+        # < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+
+        context 'comparisons without prereleases' do
+          subject do
+            %w[ 1.0.0 2.0.0 2.1.0 2.1.1 ].map { |v| parse(v) }.shuffle
+          end
+
+          example 'sorted order' do
+            sorted = subject.sort.map { |v| v.to_s }
+            expect(sorted).to eql(%w[ 1.0.0 2.0.0 2.1.0 2.1.1 ])
+          end
+        end
+
+        context 'comparisons against prereleases' do
+          let(:stable) { parse('1.0.0') }
+          let(:prerelease) { parse('1.0.0-alpha') }
+
+          example 'prereleases have lower precedence' do
+            expect(stable).to be > prerelease
+            expect(prerelease).to be < stable
+          end
+        end
+
+        context 'comparisions between prereleases' do
+          example 'identical prereleases are equal' do
+            expect(parse('1.0.0-rc1')).to eql parse('1.0.0-rc1')
+          end
+
+          example 'non-numeric identifiers sort ASCIIbetically' do
+            alpha, beta = parse('1.0.0-alpha'), parse('1.0.0-beta')
+            expect(alpha).to be < beta
+            expect(beta).to be > alpha
+          end
+
+          example 'numeric identifiers sort numerically' do
+            two, eleven = parse('1.0.0-2'), parse('1.0.0-11')
+            expect(two).to be < eleven
+            expect(eleven).to be > two
+          end
+
+          example 'non-numeric identifiers have a higher precendence' do
+            number, word = parse('1.0.0-1'), parse('1.0.0-one')
+            expect(number).to be < word
+            expect(word).to be > number
+          end
+
+          example 'identifiers are parsed left-to-right' do
+            a = parse('1.0.0-these.parts.are.the-same.but.not.waffles.123')
+            b = parse('1.0.0-these.parts.are.the-same.but.not.123.waffles')
+            expect(b).to be < a
+            expect(a).to be > b
+          end
+
+          example 'larger identifier sets have precendence' do
+            a = parse('1.0.0-alpha')
+            b = parse('1.0.0-alpha.1')
+            expect(a).to be < b
+            expect(b).to be > a
+          end
+
+          example 'build metadata does not figure into precendence' do
+            a = parse('1.0.0-alpha+SHA1')
+            b = parse('1.0.0-alpha+MD5')
+            expect(a).to eql b
+            expect(a.to_s).to_not eql b.to_s
+          end
+
+          example 'sorted order' do
+            list = %w[
+              1.0.0-alpha
+              1.0.0-alpha.1
+              1.0.0-alpha.beta
+              1.0.0-beta
+              1.0.0-beta.2
+              1.0.0-beta.11
+              1.0.0-rc.1
+              1.0.0
+            ].map { |v| parse(v) }.shuffle
+
+            sorted = list.sort.map { |v| v.to_s }
+            expect(sorted).to eql %w[
+              1.0.0-alpha
+              1.0.0-alpha.1
+              1.0.0-alpha.beta
+              1.0.0-beta
+              1.0.0-beta.2
+              1.0.0-beta.11
+              1.0.0-rc.1
+              1.0.0
+            ]
+          end
+        end
+      end
+    end
+
+    context 'Spec v1.0.0' do
+      context 'Section 4' do
+        # A pre-release version number MAY be denoted by appending an arbitrary
+        # string immediately following the patch version and a dash. The string
+        # MUST be comprised of only alphanumerics plus dash [0-9A-Za-z-].
+        # Pre-release versions satisfy but have a lower precedence than the
+        # associated normal version. Precedence SHOULD be determined by
+        # lexicographic ASCII sort order.
+        # For instance: 1.0.0-alpha1 < 1.0.0-beta1 < 1.0.0-beta2 < 1.0.0-rc1 <
+        # 1.0.0
+
+        example 'sorted order' do
+          list = %w[
+            1.0.0-alpha1
+            1.0.0-beta1
+            1.0.0-beta2
+            1.0.0-rc1
+            1.0.0
+          ].map { |v| parse(v) }.shuffle
+
+          sorted = list.sort.map { |v| v.to_s }
+          expect(sorted).to eql %w[
+            1.0.0-alpha1
+            1.0.0-beta1
+            1.0.0-beta2
+            1.0.0-rc1
+            1.0.0
+          ]
+        end
+      end
+    end
+
+  end
+
+  describe '#next' do
+    context 'with :major' do
+      it 'returns the next major version' do
+        expect(subject('1.0.0').next(:major)).to eql(subject('2.0.0'))
+      end
+
+      it 'does not modify the original version' do
+        v1 = subject('1.0.0')
+        v2 = v1.next(:major)
+        expect(v1).to_not eql(v2)
+      end
+
+      it 'resets the minor and patch versions to 0' do
+        expect(subject('1.1.1').next(:major)).to eql(subject('2.0.0'))
+      end
+
+      it 'removes any prerelease or build information' do
+        expect(subject('1.0.0-alpha+abc').next(:major)).to eql(subject('2.0.0'))
+      end
+    end
+
+    context 'with :minor' do
+      it 'returns the next minor version' do
+        expect(subject('1.0.0').next(:minor)).to eql(subject('1.1.0'))
+      end
+
+      it 'does not modify the original version' do
+        v1 = subject('1.0.0')
+        v2 = v1.next(:minor)
+        expect(v1).to_not eql(v2)
+      end
+
+      it 'resets the patch version to 0' do
+        expect(subject('1.1.1').next(:minor)).to eql(subject('1.2.0'))
+      end
+
+      it 'removes any prerelease or build information' do
+        expect(subject('1.1.0-alpha+abc').next(:minor)).to eql(subject('1.2.0'))
+      end
+    end
+
+    context 'with :patch' do
+      it 'returns the next patch version' do
+        expect(subject('1.1.1').next(:patch)).to eql(subject('1.1.2'))
+      end
+
+      it 'does not modify the original version' do
+        v1 = subject('1.0.0')
+        v2 = v1.next(:patch)
+        expect(v1).to_not eql(v2)
+      end
+
+      it 'removes any prerelease or build information' do
+        expect(subject('1.0.0-alpha+abc').next(:patch)).to eql(subject('1.0.1'))
+      end
+    end
+  end
+end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -414,8 +414,8 @@ class amod::bad_type {
         apply.expects(:apply_catalog).with do |catalog|
           catalog.resource(:notify, 'rx')['message'].is_a?(Regexp)
           catalog.resource(:notify, 'bin')['message'].is_a?(Puppet::Pops::Types::PBinaryType::Binary)
-          catalog.resource(:notify, 'ver')['message'].is_a?(SemanticPuppet::Version)
-          catalog.resource(:notify, 'vrange')['message'].is_a?(SemanticPuppet::VersionRange)
+          catalog.resource(:notify, 'ver')['message'].is_a?(Semantic::Version)
+          catalog.resource(:notify, 'vrange')['message'].is_a?(Semantic::VersionRange)
           catalog.resource(:notify, 'tspan')['message'].is_a?(Puppet::Pops::Time::Timespan)
           catalog.resource(:notify, 'tstamp')['message'].is_a?(Puppet::Pops::Time::Timestamp)
         end

--- a/spec/lib/puppet_spec/module_tool/shared_functions.rb
+++ b/spec/lib/puppet_spec/module_tool/shared_functions.rb
@@ -31,7 +31,7 @@ module PuppetSpec
         if options.nil?
           expect(release).to be_nil
         else
-          from = options.keys.find { |k| k.nil? || k.is_a?(SemanticPuppet::Version) }
+          from = options.keys.find { |k| k.nil? || k.is_a?(Semantic::Version) }
           to   = options.delete(from)
 
           if to or from
@@ -49,7 +49,7 @@ module PuppetSpec
       end
 
       def v(str)
-        SemanticPuppet::Version.parse(str)
+        Semantic::Version.parse(str)
       end
     end
   end

--- a/spec/lib/puppet_spec/module_tool/stub_source.rb
+++ b/spec/lib/puppet_spec/module_tool/stub_source.rb
@@ -1,6 +1,6 @@
 module PuppetSpec
   module ModuleTool
-    class StubSource < SemanticPuppet::Dependency::Source
+    class StubSource < Semantic::Dependency::Source
       def inspect; "Stub Source"; end
       def host
         "http://nowhe.re"

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1242,8 +1242,8 @@ EOS
               collect_notices("notice('success')") do |scope|
                 expect(lookup_func.call(scope, 'mod_a::sensitive')).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
                 expect(lookup_func.call(scope, 'mod_a::type')).to be_a(Puppet::Pops::Types::PObjectType)
-                expect(lookup_func.call(scope, 'mod_a::version')).to eql(SemanticPuppet::Version.parse('3.4.1'))
-                expect(lookup_func.call(scope, 'mod_a::version_range')).to eql(SemanticPuppet::VersionRange.parse('>=3.4.1'))
+                expect(lookup_func.call(scope, 'mod_a::version')).to eql(Semantic::Version.parse('3.4.1'))
+                expect(lookup_func.call(scope, 'mod_a::version_range')).to eql(Semantic::VersionRange.parse('>=3.4.1'))
                 expect(lookup_func.call(scope, 'mod_a::timestamp')).to eql(Puppet::Pops::Time::Timestamp.parse('1994-03-25T19:30:00'))
                 expect(lookup_func.call(scope, 'mod_a::timespan')).to eql(Puppet::Pops::Time::Timespan.parse('3-10:00:00'))
               end

--- a/spec/unit/module_tool/applications/installer_spec.rb
+++ b/spec/unit/module_tool/applications/installer_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::ModuleTool::Applications::Installer do
   end
 
   before do
-    SemanticPuppet::Dependency.clear_sources
+    Semantic::Dependency.clear_sources
     installer = Puppet::ModuleTool::Applications::Installer.any_instance
     installer.stubs(:module_repository).returns(remote_source)
   end

--- a/spec/unit/module_tool/applications/upgrader_spec.rb
+++ b/spec/unit/module_tool/applications/upgrader_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::ModuleTool::Applications::Upgrader do
   end
 
   before do
-    SemanticPuppet::Dependency.clear_sources
+    Semantic::Dependency.clear_sources
     installer = Puppet::ModuleTool::Applications::Upgrader.any_instance
     installer.stubs(:module_repository).returns(remote_source)
   end

--- a/spec/unit/module_tool/installed_modules_spec.rb
+++ b/spec/unit/module_tool/installed_modules_spec.rb
@@ -19,21 +19,21 @@ describe Puppet::ModuleTool::InstalledModules do
   it 'works when given a semantic version' do
     mod = PuppetSpec::Modules.create('goodsemver', @modpath, :metadata => {:version => '1.2.3'})
     installed = described_class.new(@env)
-    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(SemanticPuppet::Version.parse('1.2.3'))
+    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(Semantic::Version.parse('1.2.3'))
   end
 
   it 'defaults when not given a semantic version' do
     mod = PuppetSpec::Modules.create('badsemver', @modpath, :metadata => {:version => 'banana'})
     Puppet.expects(:warning).with(regexp_matches(/Semantic Version/))
     installed = described_class.new(@env)
-    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(SemanticPuppet::Version.parse('0.0.0'))
+    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(Semantic::Version.parse('0.0.0'))
   end
 
   it 'defaults when not given a full semantic version' do
     mod = PuppetSpec::Modules.create('badsemver', @modpath, :metadata => {:version => '1.2'})
     Puppet.expects(:warning).with(regexp_matches(/Semantic Version/))
     installed = described_class.new(@env)
-    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(SemanticPuppet::Version.parse('0.0.0'))
+    expect(installed.modules["puppetlabs-#{mod.name}"].version).to eq(Semantic::Version.parse('0.0.0'))
   end
 
   it 'still works if there is an invalid version in one of the modules' do
@@ -42,8 +42,8 @@ describe Puppet::ModuleTool::InstalledModules do
     mod3 = PuppetSpec::Modules.create('notquitesemver', @modpath, :metadata => {:version => '1.2'})
     Puppet.expects(:warning).with(regexp_matches(/Semantic Version/)).twice
     installed = described_class.new(@env)
-    expect(installed.modules["puppetlabs-#{mod1.name}"].version).to eq(SemanticPuppet::Version.parse('0.0.0'))
-    expect(installed.modules["puppetlabs-#{mod2.name}"].version).to eq(SemanticPuppet::Version.parse('1.2.3'))
-    expect(installed.modules["puppetlabs-#{mod3.name}"].version).to eq(SemanticPuppet::Version.parse('0.0.0'))
+    expect(installed.modules["puppetlabs-#{mod1.name}"].version).to eq(Semantic::Version.parse('0.0.0'))
+    expect(installed.modules["puppetlabs-#{mod2.name}"].version).to eq(Semantic::Version.parse('1.2.3'))
+    expect(installed.modules["puppetlabs-#{mod3.name}"].version).to eq(Semantic::Version.parse('0.0.0'))
   end
 end

--- a/spec/unit/module_tool_spec.rb
+++ b/spec/unit/module_tool_spec.rb
@@ -288,21 +288,21 @@ TREE
     it 'parses a dependency without a version range expression' do
       name, range, expr = subject.parse_module_dependency('source', 'name' => 'foo-bar')
       expect(name).to eql('foo-bar')
-      expect(range).to eql(SemanticPuppet::VersionRange.parse('>= 0.0.0'))
+      expect(range).to eql(Semantic::VersionRange.parse('>= 0.0.0'))
       expect(expr).to eql('>= 0.0.0')
     end
 
     it 'parses a dependency with a version range expression' do
       name, range, expr = subject.parse_module_dependency('source', 'name' => 'foo-bar', 'version_requirement' => '1.2.x')
       expect(name).to eql('foo-bar')
-      expect(range).to eql(SemanticPuppet::VersionRange.parse('1.2.x'))
+      expect(range).to eql(Semantic::VersionRange.parse('1.2.x'))
       expect(expr).to eql('1.2.x')
     end
 
     it 'does not raise an error on invalid version range expressions' do
       name, range, expr = subject.parse_module_dependency('source', 'name' => 'foo-bar', 'version_requirement' => 'nope')
       expect(name).to eql('foo-bar')
-      expect(range).to eql(SemanticPuppet::VersionRange::EMPTY_RANGE)
+      expect(range).to eql(Semantic::VersionRange::EMPTY_RANGE)
       expect(expr).to eql('nope')
     end
   end

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -26,27 +26,27 @@ describe 'when converting to 3.x' do
   end
 
   it 'does not convert a SemVer instance to string' do
-    v = SemanticPuppet::Version.parse('1.0.0')
+    v = Semantic::Version.parse('1.0.0')
     expect(converter.convert(v, {}, nil)).to equal(v)
   end
 
   it 'converts the symbol :undef to the undef value' do
-    v = SemanticPuppet::Version.parse('1.0.0')
+    v = Semantic::Version.parse('1.0.0')
     expect(converter.convert(:undef, {}, 'undef value')).to eql('undef value')
   end
 
   it 'converts the nil to the undef value' do
-    v = SemanticPuppet::Version.parse('1.0.0')
+    v = Semantic::Version.parse('1.0.0')
     expect(converter.convert(nil, {}, 'undef value')).to eql('undef value')
   end
 
   it 'does not convert a symbol nested in an array' do
-    v = SemanticPuppet::Version.parse('1.0.0')
+    v = Semantic::Version.parse('1.0.0')
     expect(converter.convert({'foo' => :undef}, {}, 'undef value')).to eql({'foo' => :undef})
   end
 
   it 'converts nil to :undef when nested in an array' do
-    v = SemanticPuppet::Version.parse('1.0.0')
+    v = Semantic::Version.parse('1.0.0')
     expect(converter.convert({'foo' => nil}, {}, 'undef value')).to eql({'foo' => :undef})
   end
 
@@ -56,12 +56,12 @@ describe 'when converting to 3.x' do
   end
 
   it 'does not convert a Version instance to string' do
-    v = SemanticPuppet::Version.parse('1.0.0')
+    v = Semantic::Version.parse('1.0.0')
     expect(converter.convert(v, {}, nil)).to equal(v)
   end
 
   it 'does not convert a VersionRange instance to string' do
-    v = SemanticPuppet::VersionRange.parse('>=1.0.0')
+    v = Semantic::VersionRange.parse('>=1.0.0')
     expect(converter.convert(v, {}, nil)).to equal(v)
   end
 
@@ -95,13 +95,13 @@ describe 'when converting to 3.x' do
     end
 
     it 'converts a Version instance to string' do
-      c = converter.convert(SemanticPuppet::Version.parse('1.0.0'), {}, nil)
+      c = converter.convert(Semantic::Version.parse('1.0.0'), {}, nil)
       expect(c).to be_a(String)
       expect(c).to eql('1.0.0')
     end
 
     it 'converts a VersionRange instance to string' do
-      c = converter.convert(SemanticPuppet::VersionRange.parse('>=1.0.0'), {}, nil)
+      c = converter.convert(Semantic::VersionRange.parse('>=1.0.0'), {}, nil)
       expect(c).to be_a(String)
       expect(c).to eql('>=1.0.0')
     end

--- a/spec/unit/pops/serialization/packer_spec.rb
+++ b/spec/unit/pops/serialization/packer_spec.rb
@@ -113,18 +113,18 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
     end
 
     it 'Version' do
-      val = SemanticPuppet::Version.parse('1.2.3-alpha2')
+      val = Semantic::Version.parse('1.2.3-alpha2')
       write(val)
       val2 = read
-      expect(val2).to be_a(SemanticPuppet::Version)
+      expect(val2).to be_a(Semantic::Version)
       expect(val2).to eql(val)
     end
 
     it 'VersionRange' do
-      val = SemanticPuppet::VersionRange.parse('>=1.2.3-alpha2 <1.2.4')
+      val = Semantic::VersionRange.parse('>=1.2.3-alpha2 <1.2.4')
       write(val)
       val2 = read
-      expect(val2).to be_a(SemanticPuppet::VersionRange)
+      expect(val2).to be_a(Semantic::VersionRange)
       expect(val2).to eql(val)
     end
 

--- a/spec/unit/pops/serialization/serialization_spec.rb
+++ b/spec/unit/pops/serialization/serialization_spec.rb
@@ -121,19 +121,19 @@ module Serialization
 
     it 'Version' do
       # It does succeed on rare occasions, so we need to repeat
-      val = SemanticPuppet::Version.parse('1.2.3-alpha2')
+      val = Semantic::Version.parse('1.2.3-alpha2')
       write(val)
       val2 = read
-      expect(val2).to be_a(SemanticPuppet::Version)
+      expect(val2).to be_a(Semantic::Version)
       expect(val2).to eql(val)
     end
 
     it 'VersionRange' do
       # It does succeed on rare occasions, so we need to repeat
-      val = SemanticPuppet::VersionRange.parse('>=1.2.3-alpha2 <1.2.4')
+      val = Semantic::VersionRange.parse('>=1.2.3-alpha2 <1.2.4')
       write(val)
       val2 = read
-      expect(val2).to be_a(SemanticPuppet::VersionRange)
+      expect(val2).to be_a(Semantic::VersionRange)
       expect(val2).to eql(val)
     end
 
@@ -232,8 +232,8 @@ module Serialization
       val = [
         Time::Timespan.from_fields(false, 3, 12, 40, 31, 123),
         Time::Timestamp.now,
-        SemanticPuppet::Version.parse('1.2.3-alpha2'),
-        SemanticPuppet::VersionRange.parse('>=1.2.3-alpha2 <1.2.4'),
+        Semantic::Version.parse('1.2.3-alpha2'),
+        Semantic::VersionRange.parse('>=1.2.3-alpha2 <1.2.4'),
         Types::PBinaryType::Binary.from_base64('w5ZzdGVuIG1lZCByw7ZzdGVuCg==')
       ]
       write(val)
@@ -246,8 +246,8 @@ module Serialization
       val = {
         'duration' => Time::Timespan.from_fields(false, 3, 12, 40, 31, 123),
         'time' => Time::Timestamp.now,
-        'version' => SemanticPuppet::Version.parse('1.2.3-alpha2'),
-        'range' => SemanticPuppet::VersionRange.parse('>=1.2.3-alpha2 <1.2.4'),
+        'version' => Semantic::Version.parse('1.2.3-alpha2'),
+        'range' => Semantic::VersionRange.parse('>=1.2.3-alpha2 <1.2.4'),
         'binary' => Types::PBinaryType::Binary.from_base64('w5ZzdGVuIG1lZCByw7ZzdGVuCg==')
       }
       write(val)

--- a/spec/unit/pops/types/p_sem_ver_type_spec.rb
+++ b/spec/unit/pops/types/p_sem_ver_type_spec.rb
@@ -20,12 +20,12 @@ describe 'Semantic Versions' do
       end
 
       it 'returns its argument when the argument is a version' do
-        v = SemanticPuppet::Version.new(1,0,0)
+        v = Semantic::Version.new(1,0,0)
         expect(PSemVerType.convert(v)).to equal(v)
       end
 
       it 'converts a valid version string argument to a version' do
-        v = SemanticPuppet::Version.new(1,0,0)
+        v = Semantic::Version.new(1,0,0)
         expect(PSemVerType.convert('1.0.0')).to eq(v)
       end
 
@@ -42,12 +42,12 @@ describe 'Semantic Versions' do
       end
 
       it 'returns its argument when the argument is a version range' do
-        vr = SemanticPuppet::VersionRange.parse('1.x')
+        vr = Semantic::VersionRange.parse('1.x')
         expect(PSemVerRangeType.convert(vr)).to equal(vr)
       end
 
       it 'converts a valid version string argument to a version range' do
-        vr = SemanticPuppet::VersionRange.parse('1.x')
+        vr = Semantic::VersionRange.parse('1.x')
         expect(PSemVerRangeType.convert('1.x')).to eq(vr)
       end
 

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -123,7 +123,7 @@ module Puppet::Pops
             version => '1.x',
             pcore_version => '1.0.0',
             OBJECT
-            expect { parse_type_set('MySet', ts) }.to raise_error(SemanticPuppet::Version::ValidationFailure)
+            expect { parse_type_set('MySet', ts) }.to raise_error(Semantic::Version::ValidationFailure)
           end
 
           it 'the pcore_version is an invalid semantic version' do
@@ -131,7 +131,7 @@ module Puppet::Pops
             version => '1.0.0',
             pcore_version => '1.x',
             OBJECT
-            expect { parse_type_set('MySet', ts) }.to raise_error(SemanticPuppet::Version::ValidationFailure)
+            expect { parse_type_set('MySet', ts) }.to raise_error(Semantic::Version::ValidationFailure)
           end
 
           it 'the pcore_version is outside of the range of that is parsable by this runtime' do

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -222,15 +222,15 @@ describe 'The type calculator' do
 
     context 'version' do
       it 'translates to PVersionType' do
-        expect(calculator.infer(SemanticPuppet::Version.new(1,0,0)).class).to eq(PSemVerType)
+        expect(calculator.infer(Semantic::Version.new(1,0,0)).class).to eq(PSemVerType)
       end
 
       it 'range translates to PVersionRangeType' do
-        expect(calculator.infer(SemanticPuppet::VersionRange.parse('1.x')).class).to eq(PSemVerRangeType)
+        expect(calculator.infer(Semantic::VersionRange.parse('1.x')).class).to eq(PSemVerRangeType)
       end
 
       it 'translates to a limited PVersionType by infer_set' do
-        v = SemanticPuppet::Version.new(1,0,0)
+        v = Semantic::Version.new(1,0,0)
         t = calculator.infer_set(v)
         expect(t.class).to eq(PSemVerType)
         expect(t.ranges.size).to eq(1)

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -82,7 +82,7 @@ describe 'The type factory' do
     end
 
     it 'sem_ver(r1, r2) returns constrained PSemVerType' do
-      expect(TypeFactory.sem_ver('1.x', '3.x').ranges).to include(SemanticPuppet::VersionRange.parse('1.x'), SemanticPuppet::VersionRange.parse('3.x'))
+      expect(TypeFactory.sem_ver('1.x', '3.x').ranges).to include(Semantic::VersionRange.parse('1.x'), Semantic::VersionRange.parse('3.x'))
     end
 
     it 'sem_ver_range() returns PSemVerRangeType' do

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -871,16 +871,16 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
         catalog = compile_to_catalog("notify {'foo': message => SemVer('1.0.0') }")
         catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
         message = catalog2.resource('notify', 'foo')['message']
-        expect(message).to be_a(SemanticPuppet::Version)
-        expect(message).to eql(SemanticPuppet::Version.parse('1.0.0'))
+        expect(message).to be_a(Semantic::Version)
+        expect(message).to eql(Semantic::Version.parse('1.0.0'))
       end
 
       it 'should read and convert ext_parameters containing VersionRange from json' do
         catalog = compile_to_catalog("notify {'foo': message => SemVerRange('>=1.0.0') }")
         catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
         message = catalog2.resource('notify', 'foo')['message']
-        expect(message).to be_a(SemanticPuppet::VersionRange)
-        expect(message).to eql(SemanticPuppet::VersionRange.parse('>=1.0.0'))
+        expect(message).to be_a(Semantic::VersionRange)
+        expect(message).to eql(Semantic::VersionRange.parse('>=1.0.0'))
       end
 
       it 'should read and convert ext_parameters containing Timespan from json' do
@@ -904,7 +904,7 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
         catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
         message = catalog2.resource('notify', 'foo')['message']
         expect(message).to be_a(Hash)
-        expect(message['version']).to eql(SemanticPuppet::Version.parse('1.0.0'))
+        expect(message['version']).to eql(Semantic::Version.parse('1.0.0'))
         expect(message['time']).to eql(Puppet::Pops::Time::Timestamp.parse('2016-09-15T08:32:16.123 UTC'))
       end
 
@@ -913,7 +913,7 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
         catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
         message = catalog2.resource('notify', 'foo')['message']
         expect(message).to be_a(Array)
-        expect(message[0]).to eql(SemanticPuppet::Version.parse('1.0.0'))
+        expect(message[0]).to eql(Semantic::Version.parse('1.0.0'))
         expect(message[1]).to eql(Puppet::Pops::Time::Timestamp.parse('2016-09-15T08:32:16.123 UTC'))
       end
     end


### PR DESCRIPTION
Revert "Merge pull request #5094 from thallgren/issue/pup-4742/switch-to-semantic_puppet-gem"

This reverts commit b60a570a2eb86a9a09af01043c1ca3f1b955e3fd, reversing
changes made to 8a9e7d49d7d00da400cfdc6d06cd54c1ca29a8aa.

This changeset failed CI, possibly due to missing puppet server
requirements/configuration