### PR TITLE
(PUP-6961) Add risk tag to acceptance tests

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -145,6 +145,34 @@ There also may be scenarios where you want to specify the host(s) to release. E.
     HOST_NAMES=lvwwr9tdplg351u bundle exec rake ci:release_hosts
     HOST_NAMES=lvwwr9tdplg351u,ylrqjh5l6xvym4t bundle exec rake ci:release_hosts
 
+### Running tagged tests
+
+Tests runs can be segmented by tags defined in the tests themselves. These
+tags have been standardized into the following.
+
+* `risk:high`
+* `risk:medium`
+* `risk:low`
+
+For CI runs at Puppet, these are used to adjust the cadence of test execution.
+They get run in the following pattern in order to provide timely feedback.
+
+* Per commit: risk:high + untagged tests
+* Nightly:    risk:high + risk:medium + untagged tests
+* Weekly:     risk:high + risk:medium + risk:low + untagged tests
+
+Individual tests are tagged in accordance with the frequency at which the test
+should be run to balance its value and its cost. Tests without tags are
+are not filtered by the Beaker tag facility an will therefore always be run.
+
+These tags can be utilized by modifying the `local_options.rb` file with the
+`tag` option, or using the `OPTIONS` environment variable when running the
+desired Rake task as in the following example.
+
+```
+OPTIONS="--tag='risk:high,risk:medium'" TEST_TARGET='debian8-64a' SHA=#{test-commit-sha} be rake ci:test:aio
+```
+
 
 Running Tests on Vagrant Boxen
 ------------------------------

--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "the agent --disable/--enable functionality should manage the agent lockfile properly"
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 

--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "fallback to the cached catalog"
 
 step "run agents once to cache the catalog" do

--- a/acceptance/tests/agent/should_not_use_cached_catalog_with_test_flag.rb
+++ b/acceptance/tests/agent/should_not_use_cached_catalog_with_test_flag.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name '--test flag should override use_cached_catalog'
 
 with_puppet_running_on master, {} do

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "aix package provider should work correctly"
 
 confine :to, :platform => /aix/

--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "NIM package provider should work correctly"
 
 confine :to, :platform => "aix"

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "node_name_fact should be used to determine the node name for puppet agent"
 
 success_message = "node_name_fact setting was correctly used to determine the node name"

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_apply.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_apply.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "node_name_fact should be used to determine the node name for puppet apply"
 
 success_message = "node_name_fact setting was correctly used to determine the node name"

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "node_name_value should be used as the node name for puppet agent"
 
 success_message = "node_name_value setting was correctly used as the node name"

--- a/acceptance/tests/allow_arbitrary_node_name_for_apply.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_apply.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "node_name_value should be used as the node name for puppet apply"
 
 success_message = "node_name_value setting was correctly used as the node name"

--- a/acceptance/tests/allow_symlinks_as_config_directories.rb
+++ b/acceptance/tests/allow_symlinks_as_config_directories.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Should allow symlinks to directories as configuration directories"
 confine :except, :platform => 'windows'
 

--- a/acceptance/tests/apply/augeas/hosts.rb
+++ b/acceptance/tests/apply/augeas/hosts.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Augeas hosts file" do
 
 skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'

--- a/acceptance/tests/apply/augeas/puppet.rb
+++ b/acceptance/tests/apply/augeas/puppet.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Augeas puppet configuration" do
 
   skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'

--- a/acceptance/tests/apply/augeas/services.rb
+++ b/acceptance/tests/apply/augeas/services.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Augeas services file" do
 
   skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'

--- a/acceptance/tests/apply/classes/parameterized_classes.rb
+++ b/acceptance/tests/apply/classes/parameterized_classes.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "parametrized classes"
 
 ########################################################################

--- a/acceptance/tests/apply/classes/should_allow_param_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_override.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should allow param override"
 
 manifest = %q{

--- a/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should allow overriding a parameter to undef in inheritence"
 
 agents.each do |agent|

--- a/acceptance/tests/apply/classes/should_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_include_resources_from_class.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "resources declared in a class can be applied with include"
 manifest = %q{
 class x {

--- a/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "resources declared in classes are not applied without include"
 manifest = %q{ class x { notify { 'test': message => 'never invoked' } } }
 apply_manifest_on(agents, manifest) do

--- a/acceptance/tests/apply/hashes/should_not_reassign.rb
+++ b/acceptance/tests/apply/hashes/should_not_reassign.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "hash reassignment should fail"
 manifest = %q{
 $my_hash = {'one' => '1', 'two' => '2' }

--- a/acceptance/tests/apply/puppet_apply_graph.rb
+++ b/acceptance/tests/apply/puppet_apply_graph.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet apply should generate a graph'
 
 agents.each do |agent|

--- a/acceptance/tests/apply/puppet_apply_trace.rb
+++ b/acceptance/tests/apply/puppet_apply_trace.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet apply --trace should provide a stack trace'
 
 agents.each do |agent|

--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "concurrent catalog requests (PUP-2659)"
 
 # we're only testing the effects of loading a master with concurrent requests

--- a/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
+++ b/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#17371 file metadata specified in puppet.conf needs to be applied"
 
 # when owner/group works on windows for settings, this confine should be removed.

--- a/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
+++ b/acceptance/tests/config/puppet_manages_own_configuration_in_robust_manner.rb
@@ -3,6 +3,7 @@
 # not put the "puppet" user or group on the system. They run the puppet master,
 # which fails because of the missing user and then correct their actions. They
 # expect that after correcting their actions, puppet will work correctly.
+tag 'risk:medium'
 test_name "Puppet manages its own configuration in a robust manner"
 
 skip_test "JVM Puppet cannot change its user while running. PUP-6246" if @options[:is_puppetserver]

--- a/acceptance/tests/cycle_detection.rb
+++ b/acceptance/tests/cycle_detection.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "cycle detection and reporting"
 
 step "check we report a simple cycle"

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -1,6 +1,7 @@
 require 'puppet/acceptance/static_catalog_utils'
 extend Puppet::Acceptance::StaticCatalogUtils
 
+tag 'risk:medium'
 test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri" do
 
   skip_test 'requires puppetserver installation' if @options[:type] != 'aio'

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -1,7 +1,7 @@
 require 'puppet/acceptance/static_catalog_utils'
 extend Puppet::Acceptance::StaticCatalogUtils
 
-tag 'risk:medium'
+tag 'risk:high'
 test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri" do
 
   skip_test 'requires puppetserver installation' if @options[:type] != 'aio'

--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
   master_reportdir = create_tmpdir_for_user(master, 'reportdir')
 

--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Environment control of static catalogs"
 
 skip_test 'requires puppetserver to test static catalogs' if @options[:type] != 'aio'

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "C97172: static catalogs support utf8" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/doc/should_print_function_reference.rb
+++ b/acceptance/tests/doc/should_print_function_reference.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "verify we can print the function reference"
 on(agents, puppet_doc("-r", "function")) do
     fail_test "didn't print function reference" unless

--- a/acceptance/tests/doc/ticket_4120_cannot_generate_type_reference.rb
+++ b/acceptance/tests/doc/ticket_4120_cannot_generate_type_reference.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "verify we can print the function reference"
 confine :except, :platform => /^eos-/
 

--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -1,5 +1,6 @@
 # ensure installs and code honor new puppet-agent path spec:
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
+tag 'risk:medium'
 test_name 'PUP-4033: Ensure aio path spec is honored'
 
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/ensure_version_file.rb
+++ b/acceptance/tests/ensure_version_file.rb
@@ -4,6 +4,7 @@ extend Puppet::Acceptance::TempFileUtils
 # ensure a version file is created according to the puppet-agent path specification:
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
 
+tag 'risk:medium'
 test_name 'PA-466: Ensure version file is created on agent' do
 
   skip_test 'requires version file which is created by AIO' if @options[:type] != 'aio'

--- a/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
+++ b/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'PUP-4413 3x forbidden environment names should be allowed in 4x'
 
 step 'setup environments'

--- a/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
+++ b/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
@@ -2,6 +2,7 @@
 # time where the node retrieved facts for itself and the catalog retrieved
 # facts puppet could pluginsync with the incorrect environment. For more
 # details see PUP-3591.
+tag 'risk:medium'
 test_name "Agent should pluginsync with the environment the agent resolves to"
 
 testdir = create_tmpdir_for_user master, 'environment_resolve'

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'PUP-3755 Test an un-assigned broken environment'
 
 step 'setup environments'

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Can enumerate environments via an HTTP endpoint"
 
 confine :except, :platform => /osx/ # see PUP-4820

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C59122: ensure provider from same env as custom type' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'ensure production environment created by master if missing'
 
 testdir = create_tmpdir_for_user master, 'prod-env-created'

--- a/acceptance/tests/environment/directory_environment_with_environment_conf.rb
+++ b/acceptance/tests/environment/directory_environment_with_environment_conf.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'Use a directory environment from environmentpath with an environment.conf'
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Master should produce error if enc specifies a nonexistent environment"
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'Test behavior of directory environments when environmentpath is set to a non-existent directory'
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/environment/environment_scenario-default.rb
+++ b/acceptance/tests/environment/environment_scenario-default.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Test behavior of default environment"
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/environment/environment_scenario-default.rb
+++ b/acceptance/tests/environment/environment_scenario-default.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "Test behavior of default environment"
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/environment/environment_scenario-existing.rb
+++ b/acceptance/tests/environment/environment_scenario-existing.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Test a specific, existing directory environment configuration"
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
+++ b/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Test behavior of a directory environment when environmentpath is set in the master section"
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Test for an environment that does not exist"
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Agent should use agent environment if there is an enc that does not specify the environment"
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Agent should use agent environment if there is no enc-specified environment"
 
 testdir = create_tmpdir_for_user master, 'use_agent_env'

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Agent should use environment given by ENC"
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Agent should use environment given by ENC for fetching remote files"
 
 testdir = create_tmpdir_for_user master, 'respect_enc_test'

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Agent should use environment given by ENC for pluginsync"
 
 testdir = create_tmpdir_for_user master, 'respect_enc_test'

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Use environments from the environmentpath"
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name 'C98115 compilation should get new values in variables on each compilation' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C98115 compilation should get new values in variables on each compilation' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
+++ b/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
@@ -15,6 +15,7 @@ skip_test "Test only supported on Jetty" unless @options[:is_puppetserver]
 #  - Revocation disabled on the agent `certificate_revocation = false`
 #  - CA disabled on the master `ca = false`
 #
+tag 'risk:medium'
 test_name "Puppet agent and master work when both configured with externally issued certificates from independent intermediate CAs"
 
 step "Copy certificates and configuration files to the master..."

--- a/acceptance/tests/face/4654_facts_face.rb
+++ b/acceptance/tests/face/4654_facts_face.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Puppet facts face should resolve custom and external facts"
 
 #

--- a/acceptance/tests/face/help_test.rb
+++ b/acceptance/tests/face/help_test.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'Test `puppet help` workflow'
 
 tag 'risk:medium'

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Exercise loading a face from a module"
 
 # Because the module tool does not work on windows, we can't run this test there

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "Exercise loading a face from a module"
 
 # Because the module tool does not work on windows, we can't run this test there

--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'parser validate' do
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
+++ b/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "generate a helpful error message when hostname doesn't match server certificate"
 
 skip_test( 'Changing certnames of the master will break PE/Passenger installations' ) if master.is_using_passenger?

--- a/acceptance/tests/language/PUP-2630-server_set_facts.rb
+++ b/acceptance/tests/language/PUP-2630-server_set_facts.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'PUP-2630 ensure $server_facts is set and warning is issued if any value is overwritten by an agent'
 
 step 'ensure :trusted_server_facts is false by default'

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C98346: Binary data type' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools

--- a/acceptance/tests/language/break.rb
+++ b/acceptance/tests/language/break.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C98162 - Validate `break` terminates execution in a block of code' do
   agents.each do |agent|
 

--- a/acceptance/tests/language/class_inheritance.rb
+++ b/acceptance/tests/language/class_inheritance.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C14943: Class inheritance works correctly' do
 
   agents.each do |agent|

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "C94788: exported resources using a yaml terminus for storeconfigs" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'Puppet executes functions written in the Puppet language'
 
 teardown do

--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name 'Puppet executes functions written in the Puppet language'
 
 teardown do

--- a/acceptance/tests/language/next.rb
+++ b/acceptance/tests/language/next.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C98162 - Validate `next` immediately returns from a block of code' do
   agents.each do |agent|
 

--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C98345: ensure puppet generate assures env. isolation' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C98097 - generated pcore resource types should be loaded instead of ruby for custom types' do
   environment = 'production'
   step 'setup - install module with custom ruby resource type' do

--- a/acceptance/tests/language/resource_refs_with_nested_arrays.rb
+++ b/acceptance/tests/language/resource_refs_with_nested_arrays.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#7681: Allow using array variables in resource references"
 
 agents.each do |agent|

--- a/acceptance/tests/language/return.rb
+++ b/acceptance/tests/language/return.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C98162 - Validate `return` immediately returns from a block of code' do
   agents.each do |agent|
 

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name 'C98120, C98077: Sensitive Data is redacted on CLI, logs, reports' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'C98120, C98077: Sensitive Data is redacted on CLI, logs, reports' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools

--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Exercise a module with 4x function and 4x system function"
 
 # Purpose:

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Lookup data using the agnostic lookup function"
 # pre-docs:
 # https://puppet-on-the-edge.blogspot.com/2015/01/puppet-40-data-in-modules-and.html

--- a/acceptance/tests/modules/build/build_agent.rb
+++ b/acceptance/tests/modules/build/build_agent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module build (agent)"
 
 agents.each do |agent|

--- a/acceptance/tests/modules/build/build_basic.rb
+++ b/acceptance/tests/modules/build/build_basic.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'CODEMGMT-69 - Build a Module Using "metadata.json" Only'
 
 #Init

--- a/acceptance/tests/modules/build/build_ignore_module_file.rb
+++ b/acceptance/tests/modules/build/build_ignore_module_file.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'PUP-3981 - C63215 - Build Module Should Ignore Module File'
 
 #Init

--- a/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
+++ b/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module build should verify there are no symlinks in module"
 
 confine :except, :platform => 'windows'

--- a/acceptance/tests/modules/build/build_should_not_create_changes.rb
+++ b/acceptance/tests/modules/build/build_should_not_create_changes.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module build should not result in changed files"
 
 modauthor = 'foo'

--- a/acceptance/tests/modules/changes/invalid_module_install_path.rb
+++ b/acceptance/tests/modules/changes/invalid_module_install_path.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module changes (on an invalid module install path)'
 
 step 'Setup'

--- a/acceptance/tests/modules/changes/missing_checksums_json.rb
+++ b/acceptance/tests/modules/changes/missing_checksums_json.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module changes (on a module which is missing checksums.json)'
 
 step 'Setup'

--- a/acceptance/tests/modules/changes/missing_metadata_json.rb
+++ b/acceptance/tests/modules/changes/missing_metadata_json.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module changes (on a module which is missing metadata.json)'
 
 step 'Setup'

--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module changes (on a module with a modified file)'
 
 step 'Setup'

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module changes (on a module with a removed file)'
 
 step 'Setup'

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module changes (on an unmodified module)'
 
 step 'Setup'

--- a/acceptance/tests/modules/generate/basic_generate.rb
+++ b/acceptance/tests/modules/generate/basic_generate.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module generate (agent)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/already_installed.rb
+++ b/acceptance/tests/modules/install/already_installed.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (already installed)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (already installed elsewhere)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (already installed with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "puppet module install (agent)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (agent)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/force_ignores_dependencies.rb
+++ b/acceptance/tests/modules/install/force_ignores_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (force ignores dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/ignoring_dependencies.rb
+++ b/acceptance/tests/modules/install/ignoring_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (ignoring dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (nonexistent directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (nonexistent module)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_debug.rb
+++ b/acceptance/tests/modules/install/with_debug.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (with debug)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_dependencies.rb
+++ b/acceptance/tests/modules/install/with_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (with dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module install (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (with existing module directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+tag 'risk:medium'
 test_name "puppet module install (with modulepath)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (with necessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (with no dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (with unnecessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (with unsatisfied constraints)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module install (with version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/list/with_circular_dependencies.rb
+++ b/acceptance/tests/modules/list/with_circular_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module list (with circular dependencies)"
 
 teardown do

--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module list (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/list/with_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_installed_modules.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module list (with installed modules)"
 
 teardown do

--- a/acceptance/tests/modules/list/with_invalid_dependencies.rb
+++ b/acceptance/tests/modules/list/with_invalid_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module list (with invalid dependencies)"
 
 teardown do

--- a/acceptance/tests/modules/list/with_missing_dependencies.rb
+++ b/acceptance/tests/modules/list/with_missing_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module list (with missing dependencies)"
 
 teardown do

--- a/acceptance/tests/modules/list/with_modulepath.rb
+++ b/acceptance/tests/modules/list/with_modulepath.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module list (with modulepath)"
 
 codedir = master.puppet('master')['codedir']

--- a/acceptance/tests/modules/list/with_no_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_no_installed_modules.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module list (with no installed modules)"
 
 

--- a/acceptance/tests/modules/list/with_repeated_dependencies.rb
+++ b/acceptance/tests/modules/list/with_repeated_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module list (with repeated dependencies)"
 
 teardown do

--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module search should print a reasonable message on communication errors'
 
 step 'Setup'

--- a/acceptance/tests/modules/search/formatting.rb
+++ b/acceptance/tests/modules/search/formatting.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module search output should be well structured'
 
 step 'Setup'

--- a/acceptance/tests/modules/search/multiple_search_terms.rb
+++ b/acceptance/tests/modules/search/multiple_search_terms.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module search should handle multiple search terms sensibly'
 
 #step 'Setup'

--- a/acceptance/tests/modules/search/no_results.rb
+++ b/acceptance/tests/modules/search/no_results.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module search should print a reasonable message for no results'
 
 module_name   = "module_not_appearing_in_this_forge"

--- a/acceptance/tests/modules/search/ssl_errors.rb
+++ b/acceptance/tests/modules/search/ssl_errors.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 begin test_name 'puppet module search should print a reasonable message on ssl errors'
 
 step "Search against a website where the certificate is not signed by a public authority"

--- a/acceptance/tests/modules/uninstall/using_directory_name.rb
+++ b/acceptance/tests/modules/uninstall/using_directory_name.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module uninstall (using directory name)"
 
 teardown do

--- a/acceptance/tests/modules/uninstall/using_version_filter.rb
+++ b/acceptance/tests/modules/uninstall/using_version_filter.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module uninstall (with module installed)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/uninstall/with_active_dependency.rb
+++ b/acceptance/tests/modules/uninstall/with_active_dependency.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module uninstall (with active dependency)"
 
 step "Setup"

--- a/acceptance/tests/modules/uninstall/with_environment.rb
+++ b/acceptance/tests/modules/uninstall/with_environment.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'puppet module uninstall (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/uninstall/with_module_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_module_installed.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module uninstall (with module installed)"
 
 teardown do

--- a/acceptance/tests/modules/uninstall/with_modulepath.rb
+++ b/acceptance/tests/modules/uninstall/with_modulepath.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module uninstall (with modulepath)"
 
 codedir = master.puppet('master')['codedir']

--- a/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module uninstall (with multiple modules installed)"
 
 if master.is_pe?

--- a/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
+++ b/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (in a secondary directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (introducing new dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/not_upgradable.rb
+++ b/acceptance/tests/modules/upgrade/not_upgradable.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (not upgradable)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
+++ b/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (that was installed twice)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/to_a_specific_version.rb
+++ b/acceptance/tests/modules/upgrade/to_a_specific_version.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (to a specific version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/to_installed_version.rb
+++ b/acceptance/tests/modules/upgrade/to_installed_version.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (to installed version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (with constraints on it)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (with constraints on its dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/with_environment.rb
+++ b/acceptance/tests/modules/upgrade/with_environment.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (with environment)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/with_local_changes.rb
+++ b/acceptance/tests/modules/upgrade/with_local_changes.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (with scattered dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/modules/upgrade/with_update_available.rb
+++ b/acceptance/tests/modules/upgrade/with_update_available.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet module upgrade (with update available)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -3,7 +3,7 @@ require 'puppet/acceptance/temp_file_utils'
 require 'yaml'
 extend Puppet::Acceptance::TempFileUtils
 
-tag 'risk:medium'
+tag 'risk:high'
 test_name "ticket #16753 node data should be cached in yaml to allow it to be queried"
 
 node_name = "woy_node_#{SecureRandom.hex}"

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -3,6 +3,7 @@ require 'puppet/acceptance/temp_file_utils'
 require 'yaml'
 extend Puppet::Acceptance::TempFileUtils
 
+tag 'risk:medium'
 test_name "ticket #16753 node data should be cached in yaml to allow it to be queried"
 
 node_name = "woy_node_#{SecureRandom.hex}"

--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Puppet applies resources without dependencies in file order over the network"
 
 testdir = master.tmpdir('application_order')

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name 'Calling all functions.. test in progress!'
 
 # create single manifest calling all functions

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'Calling all functions.. test in progress!'
 
 # create single manifest calling all functions

--- a/acceptance/tests/parser_functions/hiera/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/lookup_data.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Lookup data using the hiera parser function"
 
 testdir = master.tmpdir('hiera')

--- a/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Lookup data using the hiera_array parser function"
 
 testdir = master.tmpdir('hiera')

--- a/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Lookup data using the hiera_hash parser function"
 
 testdir = master.tmpdir('hiera')

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Calling Hiera function from inside templates"
 
 @module_name = "hieratest"

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -1,4 +1,5 @@
 require 'puppet/acceptance/environment_utils'
+tag 'risk:medium'
 test_name 'C97760: Bignum in reduce() should not cause exception' do
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Puppet Lookup Command"
 # doc:
 # https://docs.puppetlabs.com/puppet/latest/reference/lookup_quick_module.html

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "pluginsync should not error when modulepath is a symlink and no modules have plugin directories"
 
 step "Create a modulepath directory which is a symlink and includes a module without facts.d or lib directories"

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Pluginsync'ed external facts should be resolvable on the agent"
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "Pluginsync'ed external facts should be resolvable on the agent"
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Pluginsync'ed custom facts should be resolvable during application runs"
 
 #

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
 
 #

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
 
 #

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "the pluginsync functionality should sync feature definitions"
 
 #

--- a/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
+++ b/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "earlier modules take precendence over later modules in the modulepath"
 
 step "Create some modules in the modulepath"

--- a/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
+++ b/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet apply should create a file and report an MD5"
 
 agents.each do |agent|

--- a/acceptance/tests/puppet_apply_basics.rb
+++ b/acceptance/tests/puppet_apply_basics.rb
@@ -2,7 +2,7 @@
 #
 # Unified into a single file because they are literally one-line tests!
 
-tag 'risk:medium'
+tag 'risk:high'
 test_name "Trivial puppet tests"
 
 step "check that puppet apply displays notices"

--- a/acceptance/tests/puppet_apply_basics.rb
+++ b/acceptance/tests/puppet_apply_basics.rb
@@ -2,6 +2,7 @@
 #
 # Unified into a single file because they are literally one-line tests!
 
+tag 'risk:medium'
 test_name "Trivial puppet tests"
 
 step "check that puppet apply displays notices"

--- a/acceptance/tests/puppet_apply_should_show_a_notice.rb
+++ b/acceptance/tests/puppet_apply_should_show_a_notice.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet apply should show a notice"
 
 agents.each do |host|

--- a/acceptance/tests/puppet_master_help_should_mention_puppet_master.rb
+++ b/acceptance/tests/puppet_master_help_should_mention_puppet_master.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet master help should mention puppet master"
 on master, puppet_master('--help') do
     fail_test "puppet master wasn't mentioned" unless stdout.include? 'puppet master'

--- a/acceptance/tests/reports/cached_catalog_status_in_report.rb
+++ b/acceptance/tests/reports/cached_catalog_status_in_report.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "PUP-5867: The report specifies whether a cached catalog was used, and if so, why" do
   master_reportdir = create_tmpdir_for_user(master, 'report_dir')
 

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 
+tag 'risk:medium'
 test_name "C98092 - a new resource should not be reported as a corrective change" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -2,6 +2,7 @@ require 'yaml'
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'risk:medium'
 test_name "C98093 - a resource changed outside of Puppet will be reported as a corrective change" do
 
   test_file_name = File.basename(__FILE__, '.*')

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -2,6 +2,7 @@ require 'yaml'
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'risk:medium'
 test_name "C98094 - a resource changed via Puppet manifest will not be reported as a corrective change" do
 
   test_file_name = File.basename(__FILE__, '.*')

--- a/acceptance/tests/reports/failover_master.rb
+++ b/acceptance/tests/reports/failover_master.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "The report specifies which master was contacted during failover" do
   master_reportdir = create_tmpdir_for_user(master, 'report_dir')
   master_port = 8140

--- a/acceptance/tests/reports/finalized_on_cycle.rb
+++ b/acceptance/tests/reports/finalized_on_cycle.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Reports are finalized on resource cycles"
 # PUP-4548: Skip Windows until PUP-4547 can be resolved.
 confine :except, :platform => 'windows'

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Report submission"
 
 if master.is_pe?

--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Cron: should allow changing parameters after creation"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500

--- a/acceptance/tests/resource/cron/should_be_idempotent.rb
+++ b/acceptance/tests/resource/cron/should_be_idempotent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Cron: check idempotency"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create cron"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500

--- a/acceptance/tests/resource/cron/should_match_existing.rb
+++ b/acceptance/tests/resource/cron/should_match_existing.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet should match existing job"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet should remove a crontab entry as expected"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500

--- a/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "(#656) leading and trailing whitespace in cron entries should should be stripped"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet should remove a crontab entry based on command matching"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500

--- a/acceptance/tests/resource/cron/should_update_existing.rb
+++ b/acceptance/tests/resource/cron/should_update_existing.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet should update existing crontab entry"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500

--- a/acceptance/tests/resource/exec/accept_multi-line_commands.rb
+++ b/acceptance/tests/resource/exec/accept_multi-line_commands.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Be able to execute multi-line commands (#9996)"
 confine :except, :platform => 'windows'
 

--- a/acceptance/tests/resource/exec/should_not_run_command_creates.rb
+++ b/acceptance/tests/resource/exec/should_not_run_command_creates.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should not run command creates"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "tests that puppet correctly runs an exec."
 # original author: Dan Bode  --daniel 2010-12-23
 

--- a/acceptance/tests/resource/exec/should_set_path.rb
+++ b/acceptance/tests/resource/exec/should_set_path.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "the path statement should work to locate commands"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Content Attribute"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "Content Attribute"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/file/should_create_directory.rb
+++ b/acceptance/tests/resource/file/should_create_directory.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create directory"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/file/should_create_empty.rb
+++ b/acceptance/tests/resource/file/should_create_empty.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create empty file for 'present'"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/file/should_create_symlink.rb
+++ b/acceptance/tests/resource/file/should_create_symlink.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create symlink"
 
 def message

--- a/acceptance/tests/resource/file/should_default_mode.rb
+++ b/acceptance/tests/resource/file/should_default_mode.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "file resource: set default modes"
 
 def regexp_mode(mode)

--- a/acceptance/tests/resource/file/should_remove_dir.rb
+++ b/acceptance/tests/resource/file/should_remove_dir.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should remove directory, but force required"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/file/should_remove_file.rb
+++ b/acceptance/tests/resource/file/should_remove_file.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should remove file"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "The source attribute"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "file resource: symbolic modes"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^solaris-10/

--- a/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
+++ b/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#7680: 'links => follow' should use the file source content"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#8740: should not enumerate root directory"
 confine :except, :platform => 'windows'
 

--- a/acceptance/tests/resource/group/should_create.rb
+++ b/acceptance/tests/resource/group/should_create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create a group"
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/group/should_destroy.rb
+++ b/acceptance/tests/resource/group/should_destroy.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should destroy a group"
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should modify gid of existing group"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/group/should_not_create_existing.rb
+++ b/acceptance/tests/resource/group/should_not_create_existing.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "group should not create existing group"
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/group/should_not_destoy_unexisting.rb
+++ b/acceptance/tests/resource/group/should_not_destoy_unexisting.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should not destroy a group that doesn't exist"
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/group/should_query.rb
+++ b/acceptance/tests/resource/group/should_query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "test that we can query and find a group that exists."
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should query all groups"
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/host/pup_2289_should_not_destroy_data_when_malformed.rb
+++ b/acceptance/tests/resource/host/pup_2289_should_not_destroy_data_when_malformed.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should not delete data when existing content is malformed"
 agents.each do |agent|
   file = agent.tmpfile('host-not-delete-data')

--- a/acceptance/tests/resource/host/should_create.rb
+++ b/acceptance/tests/resource/host/should_create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "host should create"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_create_aliases.rb
+++ b/acceptance/tests/resource/host/should_create_aliases.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "host should create aliases"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_destroy.rb
+++ b/acceptance/tests/resource/host/should_destroy.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should be able to remove a host record"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_modify_alias.rb
+++ b/acceptance/tests/resource/host/should_modify_alias.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should be able to modify a host alias"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_modify_ip.rb
+++ b/acceptance/tests/resource/host/should_modify_ip.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should be able to modify a host address"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_not_create_existing.rb
+++ b/acceptance/tests/resource/host/should_not_create_existing.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should not create host if it exists"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_query_all.rb
+++ b/acceptance/tests/resource/host/should_query_all.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should query all hosts from hosts file"
 
 content = %q{127.0.0.1 test1 test1.local

--- a/acceptance/tests/resource/host/ticket_4131_should_not_create_without_ip.rb
+++ b/acceptance/tests/resource/host/ticket_4131_should_not_create_without_ip.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#4131: should not create host without IP attribute"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/mailalias/create.rb
+++ b/acceptance/tests/resource/mailalias/create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create an email alias"
 
 confine :except, :platform => 'windows' 

--- a/acceptance/tests/resource/mailalias/destroy.rb
+++ b/acceptance/tests/resource/mailalias/destroy.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should delete an email alias"
 
 confine :except, :platform => 'windows'

--- a/acceptance/tests/resource/mailalias/modify.rb
+++ b/acceptance/tests/resource/mailalias/modify.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should modify an email alias"
 
 confine :except, :platform => 'windows'

--- a/acceptance/tests/resource/mailalias/query.rb
+++ b/acceptance/tests/resource/mailalias/query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should be able to find an exisitng email alias"
 
 confine :except, :platform => 'windows'

--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "defined should create an entry in filesystem table"
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should delete an entry in filesystem table and unmount it"
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should modify an entry in filesystem table"
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "mounted should create an entry in filesystem table and mount it"
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/mount/query.rb
+++ b/acceptance/tests/resource/mount/query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should be able to find an existing filesystem table entry"
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ticket 1073: common package name in two different providers should be allowed"
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents

--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -1,4 +1,5 @@
 # Redmine (#22529)
+tag 'risk:medium'
 test_name "Puppet returns only resource package declaration when querying an uninstalled package" do
 
   resource_declaration_regex = %r@package \{ 'not-installed-on-this-host':

--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Package:IPS basic tests"
 confine :to, :platform => 'solaris-11'
 

--- a/acceptance/tests/resource/package/ips/should_be_holdable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_holdable.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Package:IPS versionable"
 confine :to, :platform => 'solaris-11'
 

--- a/acceptance/tests/resource/package/ips/should_be_idempotent.rb
+++ b/acceptance/tests/resource/package/ips/should_be_idempotent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Package:IPS idempotency"
 confine :to, :platform => 'solaris-11'
 

--- a/acceptance/tests/resource/package/ips/should_be_updatable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_updatable.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Package:IPS test for updatable (update, latest)"
 confine :to, :platform => 'solaris-11'
 

--- a/acceptance/tests/resource/package/ips/should_be_versionable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_versionable.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Package:IPS versionable"
 confine :to, :platform => 'solaris-11'
 

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Package:IPS basic tests"
 confine :to, :platform => 'solaris-11'
 

--- a/acceptance/tests/resource/package/ips/should_query.rb
+++ b/acceptance/tests/resource/package/ips/should_query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Package:IPS query"
 confine :to, :platform => 'solaris-11'
 

--- a/acceptance/tests/resource/package/ips/should_remove.rb
+++ b/acceptance/tests/resource/package/ips/should_remove.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Package:IPS basic tests"
 confine :to, :platform => 'solaris-11'
 

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "test the yum package provider"
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "test the yum package provider"
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents

--- a/acceptance/tests/resource/scheduled_task/should_create.rb
+++ b/acceptance/tests/resource/scheduled_task/should_create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create a scheduled task"
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/scheduled_task/should_destroy.rb
+++ b/acceptance/tests/resource/scheduled_task/should_destroy.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should delete a scheduled task"
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -1,5 +1,6 @@
 require 'rexml/document'
 
+tag 'risk:medium'
 test_name "should modify a scheduled task"
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/scheduled_task/should_query.rb
+++ b/acceptance/tests/resource/scheduled_task/should_query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "test that we can query and find a scheduled task that exists."
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'AIX Service Provider Testing'
 
 confine :to, :platform =>  'aix'

--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'SysV on default Systemd Service Provider Validation' do
 
   confine :to, :platform => /el-|centos|fedora/ do |h|

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'Mac OS X launchd Provider Testing'
 
 confine :to, {:platform => /osx/}, agents

--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "Puppet and Mcollective services should be manageable with Puppet"
 
 confine :except, :platform => 'windows' # See MCO-727

--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Puppet and Mcollective services should be manageable with Puppet"
 
 confine :except, :platform => 'windows' # See MCO-727

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'SysV and Systemd Service Provider Validation'
 
 

--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "`puppet resource service` should list running services without calling dangerous init scripts"
 
 confine :except, :platform => 'windows'

--- a/acceptance/tests/resource/service/should_query_all.rb
+++ b/acceptance/tests/resource/service/should_query_all.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should query all services"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "SMF: basic tests"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
+++ b/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'Upstart Testing'
 
 # only run these on ubuntu vms

--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#4123: should list all running services on Redhat/CentOS"
 confine :to, :platform => /(el|centos|oracle|redhat|scientific)-5/
 

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#4124: should list all disabled services on Redhat/CentOS"
 confine :to, :platform => /(el|centos|oracle|redhat|scientific)-5/
 

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -1,6 +1,7 @@
 require 'puppet/acceptance/service_utils'
 extend Puppet::Acceptance::ServiceUtils
 
+tag 'risk:medium'
 test_name 'Systemd masked services are unmasked before attempting to start'
 
 skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -1,7 +1,7 @@
 require 'puppet/acceptance/service_utils'
 extend Puppet::Acceptance::ServiceUtils
 
-tag 'risk:medium'
+tag 'risk:high'
 test_name 'Systemd masked services are unmasked before attempting to start'
 
 skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'

--- a/acceptance/tests/resource/ssh_authorized_key/create.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create an entry for an SSH authorized key"
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should delete an entry for an SSH authorized key"
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/ssh_authorized_key/modify.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/modify.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should update an entry for an SSH authorized key"
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/ssh_authorized_key/query.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should be able to find an existing SSH authorized key"
 
 skip_test("This test is blocked by PUP-1605")

--- a/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
+++ b/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
@@ -1,5 +1,6 @@
 # This test is to verify multi tidy resources with same path but
 # different matches should not cause error as found in the bug PUP-6508
+tag 'risk:medium'
 test_name "PUP-6655 - C98145 tidy resources should be non-isomorphic" do
   agents. each do |agent|
     dir = agent.tmpdir('tidy-test-dir')

--- a/acceptance/tests/resource/tidy/should_remove_old_files.rb
+++ b/acceptance/tests/resource/tidy/should_remove_old_files.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Tidying files by date"
 
 agents.each do |agent|

--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should allow password, salt, and iteration attributes in OSX"
 
 confine :to, :platform => /osx/

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should create a user"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "verifies that puppet resource creates a user and assigns the correct group"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See ARISTA-37

--- a/acceptance/tests/resource/user/should_destroy.rb
+++ b/acceptance/tests/resource/user/should_destroy.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should delete a user"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_manage_shell.rb
+++ b/acceptance/tests/resource/user/should_manage_shell.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should manage user shell"
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/user/should_modify.rb
+++ b/acceptance/tests/resource/user/should_modify.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should modify a user"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "verify that we can modify the gid"
 confine :except, :platform => 'windows'
 confine :except, :platform => /aix/ # PUP-5358

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should modify a user when no longer managing home (#20726)"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should modify a user without changing home directory (pending #19542)"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "tests that user resource will not add users that already exist."
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_not_destoy_unexisting.rb
+++ b/acceptance/tests/resource/user/should_not_destoy_unexisting.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ensure that puppet does not report removing a user that does not exist"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_not_modify_disabled.rb
+++ b/acceptance/tests/resource/user/should_not_modify_disabled.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'PUP-6586 Ensure puppet does not continually reset password for disabled user' do
 
   confine :to, :platform => 'windows'

--- a/acceptance/tests/resource/user/should_query.rb
+++ b/acceptance/tests/resource/user/should_query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "test that we can query and find a user that exists."
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_query_all.rb
+++ b/acceptance/tests/resource/user/should_query_all.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "should query all users"
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/zfs/basic_tests.rb
+++ b/acceptance/tests/resource/zfs/basic_tests.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/basic_tests.rb
+++ b/acceptance/tests/resource/zfs/basic_tests.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zfs/should_be_idempotent.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zfs/should_be_idempotent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/should_create.rb
+++ b/acceptance/tests/resource/zfs/should_create.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZFS: should create"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/should_create.rb
+++ b/acceptance/tests/resource/zfs/should_create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZFS: should create"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/should_query.rb
+++ b/acceptance/tests/resource/zfs/should_query.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/should_query.rb
+++ b/acceptance/tests/resource/zfs/should_query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/should_remove.rb
+++ b/acceptance/tests/resource/zfs/should_remove.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zfs/should_remove.rb
+++ b/acceptance/tests/resource/zfs/should_remove.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zone/dataset.rb
+++ b/acceptance/tests/resource/zone/dataset.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Zone: dataset configuration"
 
 confine :to, :platform => 'solaris'

--- a/acceptance/tests/resource/zone/dataset.rb
+++ b/acceptance/tests/resource/zone/dataset.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "Zone: dataset configuration"
 
 confine :to, :platform => 'solaris'

--- a/acceptance/tests/resource/zone/set_ip.rb
+++ b/acceptance/tests/resource/zone/set_ip.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Zone:IP ip-type and ip configuration"
 confine :to, :platform => 'solaris'
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zone/set_ip.rb
+++ b/acceptance/tests/resource/zone/set_ip.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "Zone:IP ip-type and ip configuration"
 confine :to, :platform => 'solaris'
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zone/set_path.rb
+++ b/acceptance/tests/resource/zone/set_path.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Zone:Path configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zone/set_path.rb
+++ b/acceptance/tests/resource/zone/set_path.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "Zone:Path configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zone/should_be_created_and_removed.rb
+++ b/acceptance/tests/resource/zone/should_be_created_and_removed.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Zone: should be created and removed"
 
 confine :to, :platform => 'solaris'

--- a/acceptance/tests/resource/zone/should_be_created_and_removed.rb
+++ b/acceptance/tests/resource/zone/should_be_created_and_removed.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "Zone: should be created and removed"
 
 confine :to, :platform => 'solaris'

--- a/acceptance/tests/resource/zone/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zone/should_be_idempotent.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "Zone: should be idempotent"
 
 confine :to, :platform => 'solaris'

--- a/acceptance/tests/resource/zone/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zone/should_be_idempotent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Zone: should be idempotent"
 
 confine :to, :platform => 'solaris'

--- a/acceptance/tests/resource/zone/statemachine.rb
+++ b/acceptance/tests/resource/zone/statemachine.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Zone:Statemachine configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zone/statemachine.rb
+++ b/acceptance/tests/resource/zone/statemachine.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "Zone:Statemachine configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zone/stepstates.rb
+++ b/acceptance/tests/resource/zone/stepstates.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Zone:statemachine single states"
 confine :to, :platform => 'solaris'
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zone/stepstates.rb
+++ b/acceptance/tests/resource/zone/stepstates.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "Zone:statemachine single states"
 confine :to, :platform => 'solaris'
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
+++ b/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "Zone: ticket #4840 - verify that the given manifest works."
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
+++ b/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Zone: ticket #4840 - verify that the given manifest works."
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/basic_tests.rb
+++ b/acceptance/tests/resource/zpool/basic_tests.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/basic_tests.rb
+++ b/acceptance/tests/resource/zpool/basic_tests.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zpool/should_be_idempotent.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zpool/should_be_idempotent.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/should_create.rb
+++ b/acceptance/tests/resource/zpool/should_create.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/should_create.rb
+++ b/acceptance/tests/resource/zpool/should_create.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/should_query.rb
+++ b/acceptance/tests/resource/zpool/should_query.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/should_query.rb
+++ b/acceptance/tests/resource/zpool/should_query.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/should_remove.rb
+++ b/acceptance/tests/resource/zpool/should_remove.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zpool/should_remove.rb
+++ b/acceptance/tests/resource/zpool/should_remove.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:low'
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/ruby_compiler_optimization.rb
+++ b/acceptance/tests/ruby_compiler_optimization.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'ensure ruby compiler optimization is >= 2'
 
 tag 'risk:medium'

--- a/acceptance/tests/security/cve-2013-1640_facter_string.rb
+++ b/acceptance/tests/security/cve-2013-1640_facter_string.rb
@@ -1,6 +1,7 @@
 # Setting a custom fact to "string" will overwrite a local variable during
 # template compilation on the master allowing remote code execution by
 # any authenticated client.
+tag 'risk:medium'
 test_name "CVE 2013-1640 Remote Code Execution" do
   confine :except, :platform => 'windows'
   confine :except, :platform => 'cisco_nexus' # See BKR-749

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -1,5 +1,6 @@
 require 'json'
 
+tag 'risk:medium'
 test_name "CVE 2013-1652 Improper query parameter validation" do
   confine :except, :platform => 'windows'
   confine :except, :platform => /osx/ # see PUP-4820

--- a/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
+++ b/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "CVE 2013-1652 Poison node cache" do
 
   step "Determine suitability of the test" do

--- a/acceptance/tests/security/cve-2013-2275_report_acl.rb
+++ b/acceptance/tests/security/cve-2013-2275_report_acl.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "(#19531) report save access control"
 step "Verify puppet only allows saving reports from the node matching the certificate"
 

--- a/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
+++ b/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "CVE 2013-4761 Injection of bad class names causing code loading" do
   confine :except, :platform => 'windows'
 

--- a/acceptance/tests/security/cve-2013-4761_resource_type.rb
+++ b/acceptance/tests/security/cve-2013-4761_resource_type.rb
@@ -7,6 +7,7 @@ teardown do
   remove_temp_dirs
 end
 
+tag 'risk:medium'
 test_name "CVE 2013-4761 Remote code execution via REST resource_type" do
   confine :except, :platform => 'windows'
   confine :except, :platform => /osx/ # see PUP-4820

--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Priority of server_list setting over server setting" do
   master_port = 8140
 

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -5,6 +5,7 @@ extend Puppet::Acceptance::ClassifierUtils
 
 disable_pe_enterprise_mcollective_agent_classes
 
+tag 'risk:medium'
 test_name "autosign command and csr attributes behavior (#7243,#7244)" do
   confine :except, :platform => /^cisco_/ # See PUP-5827
 

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -9,6 +9,7 @@ disable_pe_enterprise_mcollective_agent_classes
 
 initialize_temp_dirs
 
+tag 'risk:medium'
 test_name "certificate extensions available as trusted data" do
   confine :except, :platform => /^cisco_/ # See PUP-5827
 

--- a/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
+++ b/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
@@ -1,6 +1,7 @@
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CAUtils
 
+tag 'risk:medium'
 test_name "Puppet cert generate behavior (#6112)" do
 
   # This acceptance test documents the behavior of `puppet cert generate` calls

--- a/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
+++ b/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
@@ -1,7 +1,7 @@
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CAUtils
 
-tag 'risk:medium'
+tag 'risk:high'
 test_name "Puppet cert generate behavior (#6112)" do
 
   # This acceptance test documents the behavior of `puppet cert generate` calls

--- a/acceptance/tests/ssl/ticket_5274_private_key_modes.rb
+++ b/acceptance/tests/ssl/ticket_5274_private_key_modes.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "PUP-5274: CA and host private keys should not be world readable"
 require 'puppet/acceptance/common_utils'
 

--- a/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
+++ b/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#4655: Allow setting the default stage for parameterized classes"
 
 agents.each do |agent|

--- a/acceptance/tests/ticket_12572_no_last_run_summary_diff.rb
+++ b/acceptance/tests/ticket_12572_no_last_run_summary_diff.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#12572: Don't print a diff for last_run_summary when show_diff is on"
 
 agents.each do |host|

--- a/acceptance/tests/ticket_13489_service_refresh.pp
+++ b/acceptance/tests/ticket_13489_service_refresh.pp
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#13489: refresh service"
 
 confine :to, :platform => 'windows'

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "the $libdir setting hook is called on startup"
 
 require 'puppet/acceptance/temp_file_utils'

--- a/acceptance/tests/ticket_15560_managehome.rb
+++ b/acceptance/tests/ticket_15560_managehome.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#15560: Manage home directories"
 
 confine :to, :platform => 'windows'

--- a/acceptance/tests/ticket_17458_puppet_command_prints_help.rb
+++ b/acceptance/tests/ticket_17458_puppet_command_prints_help.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "puppet command with an unknown external command prints help"
 
 on(agents, puppet('unknown'), :acceptable_exit_codes => [1]) do

--- a/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
+++ b/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "(PUP-2455) Service provider should start Solaris init service in its own SMF contract"
 
 skip_test unless agents.any? {|agent| agent['platform'] =~ /solaris/ }

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 
 agent_hostnames = agents.map {|a| a.to_s}

--- a/acceptance/tests/ticket_3656_requiring_multiple_resources.rb
+++ b/acceptance/tests/ticket_3656_requiring_multiple_resources.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#3656: requiring multiple resources"
 apply_manifest_on agents, %q{
     notify { 'foo': }

--- a/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
+++ b/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#3961: puppet ca should produce certs spec"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/

--- a/acceptance/tests/ticket_4059_ralsh_can_change_settings.rb
+++ b/acceptance/tests/ticket_4059_ralsh_can_change_settings.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#4059: ralsh can change settings"
 
 agents.each do |agent|

--- a/acceptance/tests/ticket_4233_resource_with_a_newline.rb
+++ b/acceptance/tests/ticket_4233_resource_with_a_newline.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#4233: resource with a newline"
 
 # 2010-07-22 Jeff McCune <jeff@puppetlabs.com>

--- a/acceptance/tests/ticket_4285_file_resource_fail_when_name_defined_instead_of_path.rb
+++ b/acceptance/tests/ticket_4285_file_resource_fail_when_name_defined_instead_of_path.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Bug #4285: ArgumentError: Cannot alias File[mytitle] to [nil]"
 
 agents.each do |host|

--- a/acceptance/tests/ticket_4289_facter_should_recognize_OEL_operatingsystemrelease.rb
+++ b/acceptance/tests/ticket_4289_facter_should_recognize_OEL_operatingsystemrelease.rb
@@ -5,6 +5,7 @@
 # NL: Facter should return OS version instead of kernel version for OEL
 # test script only applicable to OEL, provided based on ticked info, not verified.
 
+tag 'risk:medium'
 test_name "#4289: facter should recognize OEL operatingsystemrelease"
 
 # REVISIT: We don't actually have support for this yet - we need a "not

--- a/acceptance/tests/ticket_4423_cannot_declare_two_parameterized_classes.rb
+++ b/acceptance/tests/ticket_4423_cannot_declare_two_parameterized_classes.rb
@@ -6,6 +6,7 @@
 #
 # Make sure two parameterized classes are able to be declared.
 
+tag 'risk:medium'
 test_name "#4423: cannot declare two parameterized classes"
 
 class1 = %q{

--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "ticket 4622 filebucket diff test."
 confine :except, :platform => 'windows'
 skip_test 'skip test, no non-Windows agents specified' if agents.empty?

--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "ticket 4622 filebucket diff test."
 confine :except, :platform => 'windows'
 skip_test 'skip test, no non-Windows agents specified' if agents.empty?

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -3,6 +3,7 @@
 # However, if a catalog is compiled when site.pp does not exist,
 # puppetmaster does not detect when site.pp is created. This requires a restart
 #
+tag 'risk:medium'
 test_name "Ticket 5477, Puppet Master does not detect newly created site.pp file"
 
 testdir = master.tmpdir('missing_site_pp')

--- a/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
+++ b/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'Ensure hiera lookup occurs if class param is undef' do
 
   agents.each do |agent|

--- a/acceptance/tests/ticket_6418_file_recursion_and_audit.rb
+++ b/acceptance/tests/ticket_6418_file_recursion_and_audit.rb
@@ -3,6 +3,7 @@
 # AffectedVersion: 2.6.0-2.6.5
 # FixedVersion:
 
+tag 'risk:medium'
 test_name "#6418: file recursion and audit"
 
 agents.each do |agent|

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#6541: file type truncates target when filebucket cannot retrieve hash"
 
 agents.each do |agent|
@@ -13,18 +14,21 @@ agents.each do |agent|
   manifest = "file { '#{target}': content => 'some text' }"
   apply_manifest_on(agent, manifest)
 
+tag 'risk:medium'
   test_name "verify invalid hashes should not change the file"
   manifest = "file { '#{target}': content => '{md5}notahash' }"
   apply_manifest_on(agent, manifest) do
     assert_no_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
   end
 
+tag 'risk:medium'
   test_name "verify valid but unbucketed hashes should not change the file"
   manifest = "file { '#{target}': content => '{md5}13ad7345d56b566a4408ffdcd877bc78' }"
   apply_manifest_on(agent, manifest) do
     assert_no_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
   end
 
+tag 'risk:medium'
   test_name "verify that an empty file can be retrieved from the filebucket"
   manifest = "file { '#{target}': content => '{md5}d41d8cd98f00b204e9800998ecf8427e' }"
   apply_manifest_on(agent, manifest) do

--- a/acceptance/tests/ticket_6710_relationship_syntax_should_work_with_title_arrays.rb
+++ b/acceptance/tests/ticket_6710_relationship_syntax_should_work_with_title_arrays.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#6710: Relationship syntax should work with title arrays"
 
 # Jeff McCune <jeff@puppetlabs.com>

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#6857: redact password hashes when applying in noop mode"
 
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -1,4 +1,4 @@
-tag 'risk:medium'
+tag 'risk:high'
 test_name "#6857: redact password hashes when applying in noop mode"
 
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
+++ b/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "providers should be useable in the same run they become suitable"
 
 agents.each do |agent|

--- a/acceptance/tests/ticket_6928_puppet_master_parse_fails.rb
+++ b/acceptance/tests/ticket_6928_puppet_master_parse_fails.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#6928: Puppet --parseonly should return deprication message"
 
 # Create good and bad formatted manifests

--- a/acceptance/tests/ticket_7101_template_compile.rb
+++ b/acceptance/tests/ticket_7101_template_compile.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#7101: template compile"
 
 agents.each do |agent|

--- a/acceptance/tests/ticket_7139_puppet_resource_file_qualified_paths.rb
+++ b/acceptance/tests/ticket_7139_puppet_resource_file_qualified_paths.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#7139: Puppet resource file fails on path with leading '/'"
 
 agents.each do |agent|

--- a/acceptance/tests/ticket_7165_no_refresh_after_starting_service.rb
+++ b/acceptance/tests/ticket_7165_no_refresh_after_starting_service.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Bug #7165: Don't refresh service immediately after starting it"
 
 confine :except, :platform => 'windows'

--- a/acceptance/tests/ticket_7728_don't_log_whits_on_failure.rb
+++ b/acceptance/tests/ticket_7728_don't_log_whits_on_failure.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#7728: Don't log whits on resource failure"
 
 manifest = %Q{

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "#9862: puppet runs without service user or group present"
 
 # puppet doesn't try to manage ownership on windows.

--- a/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
+++ b/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Windows Exit Codes - Acceptance Tests"
 
 tag 'risk:medium'

--- a/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
+++ b/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name 'MCollective service exits on windows agent'
 
 tag 'risk:medium'

--- a/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
+++ b/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "QA-760 - Windows Files Containing '-' and '.'"
 
 tag 'risk:medium'

--- a/acceptance/tests/windows/env_windows_installdir_fact.rb
+++ b/acceptance/tests/windows/env_windows_installdir_fact.rb
@@ -1,6 +1,7 @@
 # (PA-466) The env_windows_installdir fact is set as an environment variable
 # fact via environment.bat on Windows systems. Test to ensure it is both
 # present and accurate.
+tag 'risk:medium'
 test_name 'PA-466: Ensure env_windows_installdir fact is present and correct' do
 
   confine :to, :platform => 'windows'

--- a/acceptance/tests/windows/eventlog.rb
+++ b/acceptance/tests/windows/eventlog.rb
@@ -1,3 +1,4 @@
+tag 'risk:medium'
 test_name "Write to Windows eventlog"
 
 confine :to, :platform => 'windows'


### PR DESCRIPTION
Add a beaker tag to all of the existing acceptance
tests to reflect their assessed risk level. These tags will be used
to assist with tiering the execution of the test suite in order
to provide faster test suite execution.
