### PR TITLE
(PUP-6967) Reload puppetserver using HUP

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.1.0')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.5.0')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "rake", "~> 10.1"

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,17 +1,16 @@
 {
   :type => 'aio',
   :is_puppetserver => true,
+  :'use-service' => true,
   :puppetservice => 'puppetserver',
   :'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
-  :restart_when_done => false,
   :pre_suite => [
     'setup/common/pre-suite/000-delete-puppet-when-none.rb',
     'setup/aio/pre-suite/010_Install.rb',
-    'setup/aio/pre-suite/015_PackageHostsPresets.rb',
     'setup/aio/pre-suite/020_InstallCumulusModules.rb',
     'setup/aio/pre-suite/021_InstallAristaModule.rb',
     'setup/common/pre-suite/025_StopFirewall.rb',
     'setup/common/pre-suite/040_ValidateSignCert.rb',
-    'setup/aio/pre-suite/045_EnsureMasterStartedOnPassenger.rb',
+    'setup/aio/pre-suite/045_EnsureMasterStarted.rb',
   ],
 }

--- a/acceptance/setup/aio/pre-suite/015_PackageHostsPresets.rb
+++ b/acceptance/setup/aio/pre-suite/015_PackageHostsPresets.rb
@@ -1,1 +1,0 @@
-master['use-service'] = true

--- a/acceptance/setup/aio/pre-suite/045_EnsureMasterStarted.rb
+++ b/acceptance/setup/aio/pre-suite/045_EnsureMasterStarted.rb
@@ -1,0 +1,1 @@
+on(master, puppet('resource', 'service', master['puppetservice'], "ensure=running"))

--- a/acceptance/setup/aio/pre-suite/045_EnsureMasterStartedOnPassenger.rb
+++ b/acceptance/setup/aio/pre-suite/045_EnsureMasterStartedOnPassenger.rb
@@ -1,3 +1,0 @@
-if master.graceful_restarts?
-  on(master, puppet('resource', 'service', master['puppetservice'], "ensure=running"))
-end


### PR DESCRIPTION
Bump beaker to 3.5.x, which added support for reloading puppetserver
using HUP.

Beaker will fail to reload the service if it isn't already running and
it will fall back to bouncing the service using puppet's resource
service ensure=stopped and ensure=running commands. To ensure reloading
always works, we now start puppetserver in the 045_EnsureMasterStarted
pre-suite step. We don't test against passenger or webrick, so there's
no point in making the step conditional on the server type.

Prior to commit 59cce2311, Beaker's `with_puppet_running_on` method would
start puppetserver twice. Once in the beginning before the test, and
once after. Each start takes ~30 seconds per test, and that caused an
overall 1+ hour increase in test times as compared to when we tested
against passenger packages.

In commit 59cce2311, we set `restart_when_done` to true to avoid the
second start, which saved ~30 minutes. However, we have to undo that
change in order to use beaker's reload functionality.

That said, we don't regress on test times, because reloading avoids both
puppetserver starts, and puts us back on par with test times prior to
the move to puppetserver.

This commit also moves the logic for setting `use-service` from an
explicit pre-suite step to the options hash, where all of the other
options are specified. Beaker converts the symbol to a string when
processing the options, so the existing behavior is preserved.