### PR TITLE
(PUP-6850) Exclude commits unrelated to a PR

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ task(:commits) do
   # falls back to `master..HEAD` as a next best bet as `master` is unlikely to
   # ever be absent.
   commit_range = ENV['TRAVIS_COMMIT_RANGE'].nil? ? 'master..HEAD' : ENV['TRAVIS_COMMIT_RANGE']
-  puts "Checking commits..."
+  puts "Checking commits #{commit_range}"
   %x{git log --no-merges --pretty=%s #{commit_range}}.each_line do |commit_summary|
     # This regex tests for the currently supported commit summary tokens: maint, doc, packaging, or pup-<number>.
     # The exception tries to explain it in more full.

--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,7 @@ task(:commits) do
   # populated with the range of commits the PR contains. If not available, this
   # falls back to `master..HEAD` as a next best bet as `master` is unlikely to
   # ever be absent.
-  commit_range = ENV['TRAVIS_COMMIT_RANGE'].nil? ? 'master..HEAD' : ENV['TRAVIS_COMMIT_RANGE']
+  commit_range = ENV['TRAVIS_COMMIT_RANGE'].nil? ? 'master..HEAD' : ENV['TRAVIS_COMMIT_RANGE'].sub(/\.\.\./, '..')
   puts "Checking commits #{commit_range}"
   %x{git log --no-merges --pretty=%s #{commit_range}}.each_line do |commit_summary|
     # This regex tests for the currently supported commit summary tokens: maint, doc, packaging, or pup-<number>.


### PR DESCRIPTION
TRAVIS_COMMIT_RANGE uses triple dots, which includes commits that are in
the base branch that are not in the PR. For example, if a commit is
pushed to master with an incorrect summary, then every PR created before
that commit will include the unrelated commit, causing the PR to fail
the summary check.

As suggested in https://github.com/travis-ci/travis-ci/issues/4596#issuecomment-139811122,
replace triple dots with double dots.