### PR TITLE
(PUP-6974) Differentiate between nil and false when interpolating data

### DIFF
--- a/lib/puppet/pops/lookup/interpolation.rb
+++ b/lib/puppet/pops/lookup/interpolation.rb
@@ -58,7 +58,7 @@ module Interpolation
           # break gsub and return value immediately if this was an alias substitution. The value might be something other than a String
           return value if is_alias
         end
-        value || ''
+        value.nil? ? '' : value
       end
     end
   end

--- a/spec/unit/pops/lookup/interpolation_spec.rb
+++ b/spec/unit/pops/lookup/interpolation_spec.rb
@@ -32,6 +32,18 @@ describe 'Puppet::Pops::Lookup::Interpolation' do
     end
   end
 
+  context 'when interpolating boolean scope values' do
+    let(:scope) { { 'yes' => true, 'no' => false } }
+
+    it 'produces the string true' do
+      expect(interpolator.interpolate('should yield %{yes}', lookup_invocation, true)).to eq('should yield true')
+    end
+
+    it 'produces the string false' do
+      expect(interpolator.interpolate('should yield %{no}', lookup_invocation, true)).to eq('should yield false')
+    end
+  end
+
   context 'when there are empty interpolations %{} in data' do
 
     let(:empty_interpolation) { 'clown%{}shoe' }


### PR DESCRIPTION
 Interpolation of an `nil` should result in an empty string but `false`
 must be interpolated as the string "false". This commit ensures that this
 distinction is honored.