### PR TITLE
(PUP-6973) Make hiera configuration sensitive to scope changes

### DIFF
--- a/lib/puppet/pops/lookup/configured_data_provider.rb
+++ b/lib/puppet/pops/lookup/configured_data_provider.rb
@@ -63,7 +63,7 @@ class ConfiguredDataProvider
   private
 
   def data_providers(lookup_invocation)
-    @data_providers ||= config(lookup_invocation).create_configured_data_providers(lookup_invocation, self)
+    config(lookup_invocation).configured_data_providers(lookup_invocation, self)
   end
 end
 end

--- a/lib/puppet/pops/lookup/data_hash_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_hash_function_provider.rb
@@ -52,17 +52,7 @@ class DataHashFunctionProvider < FunctionProvider
   end
 
   def lookup_key(lookup_invocation, location, root_key)
-    value = if @verbatim
-      data_value(lookup_invocation, location, root_key)
-    else
-      if @resolved.nil?
-        @resolved = { root_key => data_value(lookup_invocation, location, root_key) }
-      else
-        @resolved[root_key] = data_value(lookup_invocation, location, root_key) unless @resolved.include?(root_key)
-      end
-      @resolved[root_key]
-    end
-    lookup_invocation.report_found(root_key, value)
+    lookup_invocation.report_found(root_key, data_value(lookup_invocation, location, root_key))
   end
 
   def data_value(lookup_invocation, location, root_key)

--- a/lib/puppet/pops/lookup/interpolation.rb
+++ b/lib/puppet/pops/lookup/interpolation.rb
@@ -94,6 +94,7 @@ module Interpolation
           catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
           value = found;
         end
+        lookup_invocation.remember_scope_lookup(key, value)
         value
       end
 

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -83,6 +83,15 @@ class Invocation
     end
   end
 
+  # This method is overridden by the special Invocation used while resolving interpolations in a
+  # Hiera configuration file (hiera.yaml) where it's used for collecting and remembering the current
+  # values that the configuration was based on
+  #
+  # @api private
+  def remember_scope_lookup(key, value)
+    # Does nothing by default
+  end
+
   # The qualifier_type can be one of:
   # :global - qualifier is the data binding terminus name
   # :data_provider - qualifier a DataProvider instance


### PR DESCRIPTION
When a hiera configuration contains values with interpolated expressions
that reference scope variables, there is a potential that such values may
change. A variable can be unset on first lookup and introduced later on, or
it may be a global variable shadowed by a local variable (or vice versa).

This commit ensures that such changes are detected and that the
configuration is reloaded.