### PR TITLE
(maint) Use Windows line endings for batch file in integration test

### DIFF
--- a/spec/integration/util/execution_spec.rb
+++ b/spec/integration/util/execution_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::Util::Execution do
                         131, 170, 227, 131, 134].pack('c*').force_encoding(Encoding::UTF_8)
     end
     let(:temputf8filename) do
-      script_containing(utf8text, :windows => "@ECHO OFF\nECHO #{utf8text}\nEXIT 100")
+      script_containing(utf8text, :windows => "@ECHO OFF\r\nECHO #{utf8text}\r\nEXIT 100")
     end
 
     it "should execute with non-english characters in command line" do


### PR DESCRIPTION
Previously the execution_spec.rb test was using LF line endings during the UTF8
test which worked on US English systems.  However when running on a Japanese
version of Windows, this test was failing incorrectly.  This commit forces the
line endings to Windows style CRLF so that the batch file will execute correctly.