### PR TITLE
(PUP-6986) Use binary encoding when searching for pids

### DIFF
--- a/spec/fixtures/unit/provider/service/base/ps_ef.mixed_encoding
+++ b/spec/fixtures/unit/provider/service/base/ps_ef.mixed_encoding
@@ -1,0 +1,3 @@
+UID        PID  PPID  C STIME TTY          TIME CMD
+root      4113 26549  0 11:07 pts/0    00:00:00 latin-1 args m�ni interesting furry animals
+root      4056 26549  0 11:06 pts/0    00:00:00 utf-8 args including the majestik møøse

--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -91,4 +91,24 @@ describe "base service provider" do
       expect {subject.stop }.to raise_error(Puppet::Error, 'Could not stop Service[test]: failed to stop')
     end
   end
+
+  context "when hasstatus is false" do
+    subject do
+      type.new(
+         :name  => "status test",
+         :provider => :base,
+         :hasstatus => false,
+         :pattern => "majestik m\u00f8\u00f8se",
+      ).provider
+    end
+
+    it "retrieves a PID from the process table" do
+      Facter.stubs(:value).with(:operatingsystem).returns("CentOS")
+      ps_output = File.binread(my_fixture("ps_ef.mixed_encoding")).force_encoding(Encoding::UTF_8)
+
+      executor.expects(:execute).with("ps -ef").returns(ps_output)
+
+      expect(subject.status).to eq(:running)
+    end
+  end
 end


### PR DESCRIPTION
This patch updates the base service provider such that the binary
"ASCII-8BIT" string encoding is used when a process table scan is run by
service resources that have `hasstatus => false` set. This scan runs
regex matches against the output of `ps -ef` which could contain
arbitrary byte sequences depending on which services are running on the
system and how they are configured.