### PR TITLE
(PUP-6777) (PUP-7031) address utf-8 related comment bugs in user providers

### DIFF
--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -1,0 +1,141 @@
+# ensure a user can be managed with UTF-8 only comments in the following scenarios:
+test_name 'PUP-6777 Manage users with UTF-8 comments' do
+  confine :except, :platform => 'windows'
+
+  user0 = "foo#{rand(99999).to_i}"
+  user1 = "bar#{rand(99999).to_i}"
+  user2 = "baz#{rand(99999).to_i}"
+  user3 = "qux#{rand(99999).to_i}"
+  user4 = "quux#{rand(99999).to_i}"
+  # osx does not handle utf-8 characters with POSIX encoding (yet)
+  posix_agents_to_test = agents.find { |a| a[:platform] !~ /osx/ } || []
+
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  mixed_utf8_0 = "A\u06FF"
+  mixed_utf8_1 = "\u16A0\u{2070E}"
+
+  teardown do
+    # remove user on all agents
+    teardown_manifest = <<-EOF
+      user { ['#{user0}','#{user1}','#{user2}','#{user3}','#{user4}']: ensure => absent }
+    EOF
+    apply_manifest_on(agents, teardown_manifest, :environment => {:LANG => "en_US.UTF-8"})
+  end
+
+  step "ensure user can be created with UTF-8 comment with UTF-8 environment" do
+    create_user = <<-EOF
+      user { '#{user0}':
+        ensure  => present,
+        comment => '#{mixed_utf8_0}',
+      }
+    EOF
+    apply_manifest_on(agents, create_user, :expect_changes => true, :environment => {:LANG => "en_US.UTF-8"})
+  end
+
+  step "ensure UTF-8 comment can be changed with UTF-8 environment" do
+    set_comment_utf8 = <<-EOF
+      user { '#{user0}':
+        comment => '#{mixed_utf8_1}',
+      }
+    EOF
+    apply_manifest_on(agents, set_comment_utf8, :expect_changes => true, :environment => {:LANG => "en_US.UTF-8"}) do |result|
+      assert_match(/changed '#{mixed_utf8_0}' to '#{mixed_utf8_1}'/, result.stdout, "failed to modify UTF-8 user comment in UTF-8 environment")
+    end
+  end
+
+  # *NIX and OSX should also work with ISO-8859-1 (at least, let's make sure we don't regress)
+  step "ensure user can be created with UTF-8 comment with ISO-8859-1 environment" do
+    create_user = <<-EOF
+      user { '#{user1}':
+        ensure  => present,
+        comment => '#{mixed_utf8_0}',
+      }
+    EOF
+    apply_manifest_on(agents, create_user, :expect_changes => true, :environment => {:LANG => "en_US.ISO8859-1"})
+  end
+
+  step "ensure UTF-8 comment can be changed with ISO-8859-1 environment" do
+    set_comment_utf8 = <<-EOF
+      user { '#{user1}':
+        comment => '#{mixed_utf8_1}',
+      }
+    EOF
+    apply_manifest_on(agents, set_comment_utf8, :expect_changes => true, :environment => {:LANG => "en_US.ISO8859-1"}) do |result|
+      assert_match(/changed '#{mixed_utf8_0}' to '#{mixed_utf8_1}'/, result.stdout, "failed to modify UTF-8 user comment in ISO-8859-1 environment")
+    end
+  end
+
+  # POSIX is known broken with UTF-8 chars on OS X and Windows, but *NIX should work
+  step "ensure user can be created with UTF-8 comment with POSIX locale" do
+    create_user = <<-EOF
+      user { '#{user2}':
+        ensure  => present,
+        comment => '#{mixed_utf8_0}',
+      }
+    EOF
+    apply_manifest_on(posix_agents_to_test, create_user, :expect_changes => true, :environment => {:LANG => "POSIX"})
+  end
+
+  step "ensure UTF-8 comment can be modifed with POSIX locale" do
+    set_comment_utf8 = <<-EOF
+      user { '#{user2}':
+        ensure  => present,
+        comment => '#{mixed_utf8_1}',
+      }
+    EOF
+    apply_manifest_on(posix_agents_to_test, set_comment_utf8, :expect_changes => true, :environment => {:LANG => "POSIX"}) do |result|
+      assert_match(/changed '#{mixed_utf8_0}' to '#{mixed_utf8_1}'/, result.stdout, "failed to modify UTF-8 user comment with POSIX environment")
+    end
+  end
+
+  step "ensure user can be created with ASCII comment with POSIX locale" do
+    create_user = <<-EOF
+      user { '#{user3}':
+        ensure => present,
+        comment => 'bar',
+      }
+    EOF
+    apply_manifest_on(posix_agents_to_test, create_user, :expect_changes => true, :environment => {:LANG => "POSIX"})
+  end
+
+
+  # this test is important because of ruby's Etc.getpwnam behavior which returns
+  # strings in current locale if compatible - make sure we can get a system
+  # value in POSIX and compare it to incoming from puppet in UTF-8
+  step "ensure ASCII comment can be modified to UTF-8 comment with POSIX locale" do
+    set_comment_utf8 = <<-EOF
+      user { '#{user3}':
+        comment => '#{mixed_utf8_0}',
+      }
+    EOF
+    apply_manifest_on(posix_agents_to_test, set_comment_utf8, :expect_changes => true, :environment => {:LANG => "POSIX"}) do |result|
+      assert_match(/changed 'bar' to '#{mixed_utf8_0}'/, result.stdout, "failed to modify user ASCII comment to UTF-8 comment with POSIX locale")
+    end
+  end
+
+  step "create second user with ASCII comment with POSIX locale" do
+    create_user = <<-EOF
+      user { '#{user4}':
+        ensure => present,
+        comment => '#{mixed_utf8_0}',
+      }
+    EOF
+    apply_manifest_on(posix_agents_to_test, create_user, :expect_changes => true, :environment => {:LANG => "POSIX"})
+  end
+
+
+  step "ensure UTF-8 comment can be modified to ASCII comment with POSIX locale" do
+    set_comment_ascii = <<-EOF
+      user { '#{user4}':
+        comment => 'bar',
+      }
+    EOF
+    apply_manifest_on(posix_agents_to_test, set_comment_ascii, :expect_changes => true, :environment => {:LANG => "POSIX"}) do |result|
+      assert_match(/changed '#{mixed_utf8_0}' to 'bar'/, result.stdout, "failed to modify user UTF-8 comment to ASCII comment with POSIX locale")
+    end
+  end
+end

--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -17,8 +17,15 @@ end
 Puppet.features.add(:microsoft_windows) do
   begin
     # ruby
-    require 'Win32API'          # case matters in this require!
-    require 'win32ole'
+    require 'Win32API' # case matters in this require!
+
+    # Note: Setting codepage here globally ensures all strings returned via
+    # WIN32OLE (Ruby's late-bound COM support) are encoded in Encoding::UTF_8
+    #
+    # Also, this does not modify the value of WIN32OLE.locale - which defaults
+    # to 2048 (at least on US English Windows) and is not listed in the MS
+    # locales table, here: https://msdn.microsoft.com/en-us/library/ms912047(v=winembedded.10).aspx
+    require 'win32ole' ; WIN32OLE.codepage = WIN32OLE::CP_UTF8
     # gems
     require 'win32/process'
     require 'win32/dir'

--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -288,5 +288,20 @@ class Puppet::Provider::NameService < Puppet::Provider
       raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
     end
   end
+
+  # From overriding Puppet::Property#insync? Ruby Etc::getpwnam < 2.1.0 always
+  # returns a struct with binary encoded string values, and >= 2.1.0 will return
+  # binary encoded strings for values incompatible with current locale charset,
+  # or Encoding.default_external if compatible. Compare a "should" value with
+  # encoding of "current" value, to avoid unnecessary property syncs and
+  # comparison of strings with different encodings. (PUP-6777)
+  #
+  # return basic string comparison after re-encoding (same as
+  # Puppet::Property#property_matches)
+  def comments_insync?(current, should)
+    # we're only doing comparison here so don't mutate the string
+    desired = should[0].to_s.dup
+    current == desired.force_encoding(current.encoding)
+  end
 end
 

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -195,10 +195,9 @@ module Puppet::Util::Windows::ADSI
     end
 
     def [](attribute)
-      value = native_user.Get(attribute)
-      # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
-      return value.encode(Encoding::UTF_8) if value.is_a?(String)
-      value
+      # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
+      # values are returned as UTF-8
+      native_user.Get(attribute)
     end
 
     def []=(attribute, value)
@@ -248,8 +247,9 @@ module Puppet::Util::Windows::ADSI
       # https://msdn.microsoft.com/en-us/library/aa746342.aspx
       # WIN32OLE objects aren't enumerable, so no map
       groups = []
-      # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
-      native_user.Groups.each {|g| groups << g.Name.encode(Encoding::UTF_8)} rescue nil
+      # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
+      # values are returned as UTF-8
+      native_user.Groups.each {|g| groups << g.Name} rescue nil
       groups
     end
 
@@ -372,8 +372,9 @@ module Puppet::Util::Windows::ADSI
 
       users = []
       wql.each do |u|
-        # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
-        users << new(u.name.encode(Encoding::UTF_8))
+        # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
+        # values are returned as UTF-8
+        users << new(u.name)
       end
 
       users.each(&block)
@@ -465,8 +466,9 @@ module Puppet::Util::Windows::ADSI
     def members
       # WIN32OLE objects aren't enumerable, so no map
       members = []
-      # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
-      native_group.Members.each {|m| members << m.Name.encode(Encoding::UTF_8)}
+      # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
+      # values are returned as UTF-8
+      native_group.Members.each {|m| members << m.Name}
       members
     end
 
@@ -535,8 +537,9 @@ module Puppet::Util::Windows::ADSI
 
       groups = []
       wql.each do |g|
-        # Rubys WIN32OLE errantly converts UTF-16 values to Encoding.default_external
-        groups << new(g.name.encode(Encoding::UTF_8))
+        # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
+        # values are returned as UTF-8
+        groups << new(g.name)
       end
 
       groups.each(&block)


### PR DESCRIPTION
The nameservice provider leverages the ruby Etc::getpwnam method to return
information regarding users (subclasses include useradd and pw). In Ruby <
2.1.0, this method always returns values as strings in binary encoding. In Ruby
2.1.0 and later, this method returns strings in either the current locale
encoding (Encoding::default_external) OR binary encoding if the string returned
does not encode correctly in the current locale encoding (how they determine
this is opaque, at best, and not exposed publicly).

Prior to this commit, the :comment property of the user type would set the
external encoding of the supplied value for :comment to binary if running ruby
< 2.1.0. This effectively handles the case of incompatible encodings with ruby
< 2.1.0. However, for ruby >= 2.1.0, this will always fail in two scenarios:

- if the value of :comment contains character(s) that are not represented in
  the current locale, because ruby Etc will supply this 'is' value in binary and
  we will compare it to our 'should' value in whatever the current locale is,
  failing.

- if the current locale results in a system (is) value of :comment in a ruby
  Encoding incompatible with the formatting of the desired 'should' value from
  Puppet.

This commit instead overrides the Puppet::Property#insync? method for
Puppet::Type::User::Comment when using the nameservice provider, using
`force_encoding` to set the External encoding of the 'should' value to that of
the system 'is' value. This commit also overrides Puppet::Property#change_to_s
for Puppet::Type::User::Comment for scenarios where we are about to concatenate
strings with incompatible character encodings. In this case as well, set the
encoding of the new value to the encoding of the value returned by the system
for printing a message to the user. In both cases, we avoid manipulating the
external encoding of the underlying 'should' object, for fear of unexpected
side-effects in Puppet. One such side-effect was found in
Puppet::Util::Yaml::Dump, which will fail to write the run report if the
should value cannot actually be represented by it's assigned default external
encoding (i.e., if `valid_encoding?` would return false).

This PR also addresses PUP-7031.
Reported in PUP-7031, it was discovered that we were not appropriately
round-tripping UTF-8 values for the Description user field, using `IADs::Get`
and `IADs::Put`. Bytes for values returned by `Get` would be questions marks
('?', 63).

We are retrieving the values via the Ruby WIN32OLE COM interface. The values
are stored as BSTRs, a string data type used by COM encoded as UTF-16LE.

The Ruby WIN32OLE interface is initialized with a codepage - initially
determined by Encoding.default_internal, falling back to
Encoding.default_external. On US English Windows systems the default codepage
(and Encoding.default_external) is normally IBM 437, meaning WIN32OLE is
normally initialized with a codepage of IBM 437. Thus, in this default state,
WIN32OLE will return strings in IBM 437 encoding. The conversion from UTF-16LE
to IBM 437 is a lossy one if the string contains unicode-only characters -
hence the behavior we are seeing of values replaced by question marks.

This PR modifies takes the additional step of immediately setting the
WIN32OLE codepage to UTF-8 after we require it - specifically,
WIN32OLE::CP_UTF8 (codepage 65001). Thus, values returned are encoded by Ruby
as UTF-8.

This commit improves on f17c853 (PUP-6499) which encoded strings as UTF-8 after
they were returned, which was after the conversion from UTF16-LE to IBM437 had
already taken place.
