### PR TITLE
(PUP-6989) Use bundler to install dependencies for git acceptance

### DIFF
--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -1,7 +1,5 @@
 {
   :install => [
-    'facter#2.x',
-    'hiera#1.3.4',
     'puppet',
   ],
   :pre_suite => [

--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -133,7 +133,9 @@ hosts.each do |host|
   case host['platform']
   when /solaris/
     step "#{host} Install json from rubygems"
-    on host, 'gem install json_pure --no-ri --no-rdoc'
+    on host, 'gem install json_pure --no-ri --no-rdoc --version 1.8.3' # json_pure 2.0 requires ruby 2
+    on host, 'gem install bundler --no-ri --no-rdoc'
+    on host, "ln -sf /opt/csw/bin/bundle #{host['puppetbindir']}/bundle"
   when /windows/
     on host, 'cmd /c gem install bundler --no-ri --no-rdoc'
   else

--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -133,6 +133,10 @@ hosts.each do |host|
   case host['platform']
   when /solaris/
     step "#{host} Install json from rubygems"
-    on host, 'gem install json_pure'
+    on host, 'gem install json_pure --no-ri --no-rdoc'
+  when /windows/
+    on host, 'cmd /c gem install bundler --no-ri --no-rdoc'
+  else
+    on host, 'gem install bundler --no-ri --no-rdoc'
   end
 end

--- a/acceptance/setup/git/pre-suite/010_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/010_TestSetup.rb
@@ -55,9 +55,10 @@ END
 
   step "Hosts: create environments directory like AIO does" do
     hosts.each do |host|
-      on host, "mkdir -p /etc/puppetlabs/code/environments/production/manifests"
-      on host, "mkdir -p /etc/puppetlabs/code/environments/production/modules"
-      on host, "chmod -R 755 /etc/puppetlabs/code"
+      codedir = host.puppet['codedir']
+      on host, "mkdir -p #{codedir}/environments/production/manifests"
+      on host, "mkdir -p #{codedir}/environments/production/modules"
+      on host, "chmod -R 755 #{codedir}"
     end
   end
 end

--- a/acceptance/setup/git/pre-suite/010_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/010_TestSetup.rb
@@ -29,13 +29,11 @@ extend Beaker::DSL::InstallUtils
         on host, "ln -s #{source_dir} #{checkout_dir}"
         on host, "cd #{checkout_dir} && if [ -f install.rb ]; then ruby ./install.rb ; else true; fi"
       else
-        install_from_git_on host, SourcePath, repository
-      end
-
-      if index == 1
-        versions[repository[:name]] = find_git_repo_versions(host,
-                                                             SourcePath,
-                                                             repository)
+        create_remote_file(host, '/tmp/Gemfile', <<END)
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gem '#{repository[:name]}', :git => '#{repository[:path]}', :ref => '#{ENV['SHA']}'
+END
+        on host, "cd /tmp && bundle install --system --binstubs /usr/bin --standalone"
       end
     end
   end

--- a/acceptance/setup/git/pre-suite/010_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/010_TestSetup.rb
@@ -54,4 +54,12 @@ extend Beaker::DSL::InstallUtils
       end
     end
   end
+
+  step "Hosts: create environments directory like AIO does" do
+    hosts.each do |host|
+      on host, "mkdir -p /etc/puppetlabs/code/environments/production/manifests"
+      on host, "mkdir -p /etc/puppetlabs/code/environments/production/modules"
+      on host, "chmod -R 755 /etc/puppetlabs/code"
+    end
+  end
 end

--- a/acceptance/setup/git/pre-suite/010_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/010_TestSetup.rb
@@ -29,8 +29,8 @@ extend Beaker::DSL::InstallUtils
         on host, "ln -s #{source_dir} #{checkout_dir}"
         on host, "cd #{checkout_dir} && if [ -f install.rb ]; then ruby ./install.rb ; else true; fi"
       else
-        create_remote_file(host, '/tmp/Gemfile', <<END)
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+        create_remote_file(host, "#{puppet_dir}/Gemfile", <<END)
+source '#{ENV["GEM_SOURCE"] || "https://rubygems.org"}'
 gem '#{repository[:name]}', :git => '#{repository[:path]}', :ref => '#{ENV['SHA']}'
 END
         on host, "cd /tmp && bundle install --system --binstubs /usr/bin --standalone"

--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -1,4 +1,7 @@
 test_name "Environment control of static catalogs"
+
+skip_test 'requires puppetserver to test static catalogs' if @options[:type] != 'aio'
+
 require 'json'
 
 @testroot = master.tmpdir(File.basename(__FILE__, '/*'))

--- a/acceptance/tests/ensure_version_file.rb
+++ b/acceptance/tests/ensure_version_file.rb
@@ -6,7 +6,7 @@ extend Puppet::Acceptance::TempFileUtils
 
 test_name 'PA-466: Ensure version file is created on agent' do
 
-  skip_test 'requires version file which is created by AIO' if [:gem, :git].include?(@options[:type])
+  skip_test 'requires version file which is created by AIO' if @options[:type] != 'aio'
 
   step "test for existence of version file" do
     agents.each do |agent|

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -4,6 +4,7 @@ extend Puppet::Acceptance::EnvironmentUtils
 
   # user resource doesn't have a provider on arista
   skip_test if agents.any? {|agent| agent['platform'] =~ /^eos/ } # see PUP-5404, ARISTA-42
+  skip_test 'requires puppetserver to service restart' if @options[:type] != 'aio'
 
   app_type = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -68,6 +68,8 @@ MANIFEST
 
     teardown do
       restore_puppet_conf_from_backup( master, backup_file )
+      # See PUP-6995
+      on(master, "rm -f #{master.puppet('master')['yamldir']}/node/*.yaml")
     end
     #}}}
 

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -2,9 +2,10 @@ require 'puppet/acceptance/environment_utils'
 test_name 'C97760: Bignum in reduce() should not cause exception' do
   extend Puppet::Acceptance::EnvironmentUtils
 
+  skip_test "This test needs to be reworked to not rely on merge, see PUP-6994"
+
   app_type = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
-  on(master, "chmod -R 666 #{File.join(environmentpath,tmp_environment)}")
 
   step 'On master, create site.pp with bignum' do
     site_manifest = File.join(environmentpath, tmp_environment, 'manifests', 'site.pp')
@@ -17,19 +18,19 @@ node default {
       "admin_auth_keys"=>{
           "keyname1"=>{
               "key"=>"ABCDEF",
-              "options"=>["from=\"10.0.0.0/8\""]
+              "options"=>["from=\\"10.0.0.0/8\\""]
           },
           "keyname2"=>{
               "key"=>"ABCDEF",
           },
           "keyname3"=>{
               "key"=>"ABCDEF",
-              "options"=>["from=\"10.0.0.0/8\""],
+              "options"=>["from=\\"10.0.0.0/8\\""],
               "type"=>"ssh-xxx"
           },
           "keyname4"=>{
               "key"=>"ABCDEF",
-              "options"=>["from=\"10.0.0.0/8\""]
+              "options"=>["from=\\"10.0.0.0/8\\""]
           }
       },
       "admin_user"=>"ertxa",
@@ -53,6 +54,7 @@ node default {
   fail($data_reduced)
 }
 SITEPP
+    on(master, "chmod 644 #{site_manifest}")
   end
 
   with_puppet_running_on(master, {}) do

--- a/acceptance/tests/reports/finalized_on_cycle.rb
+++ b/acceptance/tests/reports/finalized_on_cycle.rb
@@ -1,6 +1,7 @@
 test_name "Reports are finalized on resource cycles"
 # PUP-4548: Skip Windows until PUP-4547 can be resolved.
 confine :except, :platform => 'windows'
+skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -3,6 +3,8 @@ extend Puppet::Acceptance::ServiceUtils
 
 test_name 'Systemd masked services are unmasked before attempting to start'
 
+skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'
+
 # This test in intended to ensure that a service which was previously marked
 # as masked and then set to enabled will first be unmasked.
 confine :to, {}, agents.select { |agent| supports_systemd?(agent) }


### PR DESCRIPTION
Previously, `git` style acceptance cloned each repo specified in `config/git/options.rb`. If the repo contained `install.rb` at the root, then acceptance would call that file to install its lib directory and binstubs into system ruby.

However, this approach doesn't work for arbitrary dependencies, and `git` acceptance was broken when we added a hard dependency on `semantic_puppet`.

This commit installs bundler into system ruby, generates a Gemfile for the `puppet` gem at the ref specified by `ENV['SHA']`. It uses bundler to install a standalone bundle into system ruby and creates binstubs, e.g. `/usr/bin/puppet`. This eliminates the duplicate dependency information, and ensures `git` acceptance works as new dependencies are added.

A few tests need to be skipped for `git` because they either rely on AIO packaging, e.g. `/opt/puppetlabs/puppet/VERSION`, rely on `static_file_content` REST endpoints only found in puppetserver, or rely on puppetserver's service scripts.

This commit works around an issue where `puppet master --compile` writes the node.yaml as root, which prevents later catalog compilations for that node to fail, see [PUP-6995](https://tickets.puppetlabs.com/browse/PUP-6995). And it skips `no_exception_in_reduce_with_bignum.rb`, which needs additional work, see [PUP-6994](https://tickets.puppetlabs.com/browse/PUP-6994).

This has only been tested using centos-7-x86_64 agents and all tests pass or are skipped. It doesn't work on Windows, in particular, as it appears our VMs no longer contain msysgit (instead relying on cygwin git, so the call to `bundle install` fails).