### PR TITLE
(PUP-6996) Add correct permissions to auto-generated production environment

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1156,14 +1156,23 @@ Generated on #{Time.now}.
     if configured_environment == "production" && envdir && Puppet::FileSystem.exist?(envdir)
       configured_environment_path = File.join(envdir, configured_environment)
       if !Puppet::FileSystem.symlink?(configured_environment_path)
-        catalog.add_resource(
-          Puppet::Resource.new(:file,
-                               configured_environment_path,
-                               :parameters => { :ensure => 'directory',
-                                                :owner => self[:user],
-                                                :group => self[:group],
-                                                :mode => "0750" })
-        )
+        eid = Process::UID.eid
+        if eid == 0 or eid == Etc.getpwnam(self[:user]).uid
+          catalog.add_resource(
+            Puppet::Resource.new(:file,
+                                 configured_environment_path,
+                                 :parameters => { :ensure => 'directory',
+                                                  :owner => self[:user],
+                                                  :group => self[:group],
+                                                  :mode => "0750" })
+          )
+        else
+          catalog.add_resource(
+            Puppet::Resource.new(:file,
+                                 configured_environment_path,
+                                 :parameters => { :ensure => 'directory' })
+          )
+        end
       end
     end
   end

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1156,8 +1156,7 @@ Generated on #{Time.now}.
     if configured_environment == "production" && envdir && Puppet::FileSystem.exist?(envdir)
       configured_environment_path = File.join(envdir, configured_environment)
       if !Puppet::FileSystem.symlink?(configured_environment_path)
-        eid = Process::UID.eid
-        if eid == 0 or eid == Etc.getpwnam(self[:user]).uid
+        if @service_user_available and @service_group_available
           catalog.add_resource(
             Puppet::Resource.new(:file,
                                  configured_environment_path,

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1159,7 +1159,10 @@ Generated on #{Time.now}.
         catalog.add_resource(
           Puppet::Resource.new(:file,
                                configured_environment_path,
-                               :parameters => { :ensure => 'directory' })
+                               :parameters => { :ensure => 'directory',
+                                                :owner => self[:user],
+                                                :group => self[:group],
+                                                :mode => "0750" })
         )
       end
     end


### PR DESCRIPTION
When Puppet is run, it will create the production environment if it
is not already present.  If that run is done at the command line,
the resulting directory will be owned by root:root.  This is not
consistent with the ownership required by Code Manager and file
sync.

This patch corrects the permissions to be those set in the Puppet
configuration.  This prevents any possible permissions issues with
other Puppet components.