### PR TITLE
(PUP-7003) Prevent lookup recursion error for same key in lookup and …

### DIFF
--- a/spec/fixtures/unit/data_providers/environments/hiera_misc/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_misc/data/common.yaml
@@ -44,3 +44,5 @@ recursive: '%{r1}'
 km_qualified: "Value from qualified interpolation OS = %{os.name}"
 
 km_multi: "cluster/%{literal('%')}{::cluster}/%{literal('%')}{role}"
+
+domain: "-- %{domain} --"

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -35,6 +35,7 @@ describe "when using a hiera data provider" do
     Puppet[:code] = code if code
     node = Puppet::Node.new("testnode", :facts => facts, :environment => environment)
     compiler = Puppet::Parser::Compiler.new(node)
+    compiler.topscope['domain'] = 'example.com'
     block_given? ? compiler.compile { |catalog| yield(compiler); catalog } : compiler.compile
   end
 
@@ -170,7 +171,12 @@ describe "when using a hiera data provider" do
   it 'traps endless interpolate recursion' do
     expect do
       compile_and_get_notifications('hiera_misc', '$r1 = "%{r2}" $r2 = "%{r1}" notify{lookup(recursive):}')
-    end.to raise_error(Puppet::DataBinding::RecursiveLookupError, /detected in \[recursive, r1, r2\]/)
+    end.to raise_error(Puppet::DataBinding::RecursiveLookupError, /detected in \[recursive, scope:r1, scope:r2\]/)
+  end
+
+  it 'does not consider use of same key in the lookup and scope namespaces as recursion' do
+    resources = compile_and_get_notifications('hiera_misc', 'notify{lookup(domain):}')
+    expect(resources).to include('-- example.com --')
   end
 
   it 'traps bad alias declarations' do


### PR DESCRIPTION
…scope

Prior to this commit, an interpolation of a key that was equal to the key
for the original lookup would cause a recursion error regardless of if the
interpolated key was for a new lookup or for a scope lookup. This commit
ensures that the two namespaces (the lookup and the scope) are kept
separate with respect to lookup recursion detection.