### PR TITLE
(PUP-1209) Allow setting empty environment vars

### DIFF
--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -41,6 +41,13 @@ class Puppet::Provider::Exec < Puppet::Provider
                 warning "Overriding environment setting '#{env_name}' with '#{value}'"
               end
               environment[env_name] = value
+            elsif setting =~ /^(\w+)=$/
+              env_name = $1
+              warning "Environment Setting #{env_name} set to `#{env_name}=`, if this is unexpected check the variable has been assigned in the string"
+              if environment.include?(env_name) || environment.include?(env_name.to_sym)
+                warning "Overriding environment setting '#{env_name}' with '#{value}'"
+              end
+              environment[env_name] = value
             else
               warning "Cannot understand environment setting #{setting.inspect}"
             end

--- a/spec/unit/provider/exec/posix_spec.rb
+++ b/spec/unit/provider/exec/posix_spec.rb
@@ -106,6 +106,17 @@ describe Puppet::Type.type(:exec).provider(:posix), :if => Puppet.features.posix
       expect { provider.run(%Q["#{command}"]) }.to raise_error(ArgumentError, "Could not find command '#{command}'")
     end
 
+    it "should allow setting environment settings to an empty value" do
+      provider.resource[:environment] = ['WHATEVER=']
+      command = make_exe
+
+      Puppet::Util::Execution.expects(:execute).with(command, instance_of(Hash)).returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
+
+      provider.run(command)
+
+      expect(@logs.map {|l| "#{l.level}: #{l.message}" }).to eq(["warning: Environment Setting WHATEVER set to `WHATEVER=`, if this is unexpected check the variable has been assigned in the string"])
+    end
+
     it "should warn if you're overriding something in environment" do
       provider.resource[:environment] = ['WHATEVER=/something/else', 'WHATEVER=/foo']
       command = make_exe


### PR DESCRIPTION
* Adds branch to logic to allow setting empty environment variable
* For example, allows setting of `HTTP_PROXY` to empty for an exec