### PR TITLE
(DO NOT MERGE)(PUP-3670) Remove Facts#strip_internal method

### DIFF
--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -107,11 +107,6 @@ class Puppet::Node::Facts
     @timestamp = Time.now
   end
 
-  # @deprecated Use {#values} instead of this method.
-  def strip_internal
-    values
-  end
-
   private
 
   def sanitize_fact(fact)


### PR DESCRIPTION
This commit is part of the Puppet 5.0 code removal effort.

Note: we can't merge this until master is ready for puppet 5 changes.