### PR TITLE
(DO NOT MERGE)(PUP-6481) Remove external_facts feature

### DIFF
--- a/lib/puppet/feature/external_facts.rb
+++ b/lib/puppet/feature/external_facts.rb
@@ -1,5 +1,0 @@
-require 'facter'
-
-Puppet.features.add(:external_facts) {
-  true
-}

--- a/spec/unit/configurer/plugin_handler_spec.rb
+++ b/spec/unit/configurer/plugin_handler_spec.rb
@@ -14,29 +14,23 @@ describe Puppet::Configurer::PluginHandler do
     Puppet.expects(:err).never
   end
 
-  context "when external facts are supported" do
-    before :each do
-      Puppet.features.stubs(:external_facts?).returns(true)
-    end
+  it "downloads plugins and facts" do
+    plugin_downloader = stub('plugin-downloader', :evaluate => [])
+    facts_downloader = stub('facts-downloader', :evaluate => [])
 
-    it "downloads plugins and facts" do
-      plugin_downloader = stub('plugin-downloader', :evaluate => [])
-      facts_downloader = stub('facts-downloader', :evaluate => [])
+    factory.expects(:create_plugin_downloader).returns(plugin_downloader)
+    factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
 
-      factory.expects(:create_plugin_downloader).returns(plugin_downloader)
-      factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
+    pluginhandler.download_plugins(environment)
+  end
 
-      pluginhandler.download_plugins(environment)
-    end
+  it "returns downloaded plugin and fact filenames" do
+    plugin_downloader = stub('plugin-downloader', :evaluate => %w[/a])
+    facts_downloader = stub('facts-downloader', :evaluate => %w[/b])
 
-    it "returns downloaded plugin and fact filenames" do
-      plugin_downloader = stub('plugin-downloader', :evaluate => %w[/a])
-      facts_downloader = stub('facts-downloader', :evaluate => %w[/b])
+    factory.expects(:create_plugin_downloader).returns(plugin_downloader)
+    factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
 
-      factory.expects(:create_plugin_downloader).returns(plugin_downloader)
-      factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
-
-      expect(pluginhandler.download_plugins(environment)).to match_array(%w[/a /b])
-    end
+    expect(pluginhandler.download_plugins(environment)).to match_array(%w[/a /b])
   end
 end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -51,9 +51,8 @@ describe Puppet::Node::Facts::Facter do
       @facter.find(@request)
     end
 
-    it 'should include external facts when feature is present' do
+    it 'should include external facts' do
       reset = sequence 'reset'
-      Puppet.features.stubs(:external_facts?).returns true
       Facter.expects(:reset).in_sequence(reset)
       Puppet::Node::Facts::Facter.expects(:setup_external_search_paths).in_sequence(reset)
       Puppet::Node::Facts::Facter.expects(:setup_search_paths).in_sequence(reset)


### PR DESCRIPTION
The external_facts feature is deprecated, since Puppet now relies on
a version of Facter with that support. This commit is part of the Puppet
5.0 code removal effort.

Note: this PR can't be merged until master is ready for 5.0 work.