### PR TITLE
(PUP-6981) Reroute hiera_xxx functions to new lookup framework

### DIFF
--- a/lib/puppet/functions/hiera_array.rb
+++ b/lib/puppet/functions/hiera_array.rb
@@ -69,6 +69,6 @@ Puppet::Functions.create_function(:hiera_array, Hiera::PuppetFunction) do
   init_dispatch
 
   def merge_type
-    :array
+    :unique
   end
 end

--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -80,7 +80,7 @@ Puppet::Functions.create_function(:hiera_include, Hiera::PuppetFunction) do
   init_dispatch
 
   def merge_type
-    :array
+    :unique
   end
 
   def post_lookup(scope, key, value)

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -74,7 +74,7 @@ module Lookup
 
   # @api private
   def self.search_and_merge(name, lookup_invocation, merge)
-    LookupAdapter.adapt(lookup_invocation.scope.compiler).lookup(name, lookup_invocation, merge)
+    lookup_invocation.lookup_adapter.lookup(name, lookup_invocation, merge)
   end
 
   def self.assert_type(subject, type, value)

--- a/lib/puppet/pops/lookup/data_hash_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_hash_function_provider.rb
@@ -75,6 +75,33 @@ class DataHashFunctionProvider < FunctionProvider
   end
 end
 
+# @api private
+class V3DataHashFunctionProvider < DataHashFunctionProvider
+  TAG = 'v3_data_hash'.freeze
+
+  def initialize(name, parent_data_provider, function_name, options, locations)
+    @datadir = options.delete(HieraConfig::KEY_DATADIR)
+    super
+  end
+
+  def unchecked_key_lookup(key, lookup_invocation, merge)
+    extra_paths = lookup_invocation.hiera_v3_location_overrides
+    if extra_paths.nil? || extra_paths.empty?
+      super
+    else
+      # Extra paths provided. Must be resolved and placed in front of known paths
+      paths = parent_data_provider.config(lookup_invocation).resolve_paths(@datadir, extra_paths, false, lookup_invocation, ".#{@name}")
+      all_locations = paths + locations
+      root_key = key.root_key
+      lookup_invocation.with(:data_provider, self) do
+        MergeStrategy.strategy(merge).lookup(all_locations, lookup_invocation) do |location|
+          invoke_with_location(lookup_invocation, location, root_key)
+        end
+      end
+    end
+  end
+end
+
 # TODO: API 5.0, remove this class
 # @api private
 class V4DataHashFunctionProvider < DataHashFunctionProvider

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -42,6 +42,7 @@ class HieraConfig
   KEY_DATA_HASH = DataHashFunctionProvider::TAG
   KEY_LOOKUP_KEY = LookupKeyFunctionProvider::TAG
   KEY_DATA_DIG = DataDigFunctionProvider::TAG
+  KEY_V3_DATA_HASH = V3DataHashFunctionProvider::TAG
   KEY_V3_BACKEND = V3BackendFunctionProvider::TAG
   KEY_V4_DATA_HASH = V4DataHashFunctionProvider::TAG
 
@@ -52,6 +53,7 @@ class HieraConfig
     KEY_DATA_HASH => DataHashFunctionProvider,
     KEY_DATA_DIG => DataDigFunctionProvider,
     KEY_LOOKUP_KEY => LookupKeyFunctionProvider,
+    KEY_V3_DATA_HASH => V3DataHashFunctionProvider,
     KEY_V3_BACKEND => V3BackendFunctionProvider,
     KEY_V4_DATA_HASH => V4DataHashFunctionProvider
   }
@@ -232,7 +234,7 @@ class HieraConfigV3 < HieraConfig
       paths = resolve_paths(datadir, original_paths, @config_path.nil?, lookup_invocation, ".#{backend}")
       data_providers[backend] = case backend
       when 'json', 'yaml'
-        create_data_provider(backend, parent_data_provider, KEY_DATA_HASH, "#{backend}_data", EMPTY_HASH, paths)
+        create_data_provider(backend, parent_data_provider, KEY_V3_DATA_HASH, "#{backend}_data", { KEY_DATADIR => datadir }, paths)
       else
         # Custom backend. Hiera v3 must be installed and it must be made aware of the loaded config
         require 'hiera/config'
@@ -240,7 +242,7 @@ class HieraConfigV3 < HieraConfig
 
         # Use a special lookup_key that delegates to the backend
         paths = nil if paths.empty?
-        create_data_provider(backend, parent_data_provider, KEY_V3_BACKEND, "hiera_v3_data", EMPTY_HASH, paths)
+        create_data_provider(backend, parent_data_provider, KEY_V3_BACKEND, "hiera_v3_data", { KEY_DATADIR => datadir }, paths)
       end
     end
     data_providers.values

--- a/lib/puppet/pops/lookup/lookup_key_function_provider.rb
+++ b/lib/puppet/pops/lookup/lookup_key_function_provider.rb
@@ -58,7 +58,7 @@ class V3BackendFunctionProvider < LookupKeyFunctionProvider
 
   def lookup_key(key, lookup_invocation, location, merge)
     @backend ||= instantiate_backend(lookup_invocation)
-    @backend.lookup(key, lookup_invocation.scope, nil, convert_merge(merge), context = {:recurse_guard => nil})
+    @backend.lookup(key, lookup_invocation.scope, lookup_invocation.hiera_v3_location_overrides, convert_merge(merge), context = {:recurse_guard => nil})
   end
 
   private

--- a/spec/fixtures/unit/functions/lookup/data/common.yaml
+++ b/spec/fixtures/unit/functions/lookup/data/common.yaml
@@ -1,0 +1,19 @@
+---
+abc::a: global_a
+abc::c:
+  - global_c
+
+abc::e:
+  k1: global_e1
+
+abc::f:
+  k1:
+    s1: global_f11
+  k2:
+    s3: global_f23
+
+bca::e:
+  k1: global_e1
+
+no_provider::e:
+  k1: global_e1

--- a/spec/unit/functions/hiera_spec.rb
+++ b/spec/unit/functions/hiera_spec.rb
@@ -1,125 +1,299 @@
 require 'spec_helper'
-require 'puppet_spec/scope'
+require 'puppet_spec/compiler'
 require 'puppet/pops'
-require 'puppet/loaders'
 
 describe 'when calling' do
-  include PuppetSpec::Scope
+  include PuppetSpec::Compiler
+  include PuppetSpec::Files
 
-  let(:scope) { create_test_scope_for_node('foo') }
-  let(:loaders) { Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, [])) }
-  let(:loader) { loaders.puppet_system_loader }
+  let(:global_dir) { tmpdir('global') }
+  let(:env_config) { {} }
+  let(:global_files) do
+    {
+      'hiera.yaml' => <<-YAML.unindent,
+        ---
+        :backends:
+          - yaml
+          - custom
+        :yaml:
+          :datadir: #{global_dir}/hieradata
+        :hierarchy:
+          - first
+          - second
+        YAML
+      'ruby_stuff' => {
+        'hiera' => {
+          'backend' => {
+            'custom_backend.rb' => <<-RUBY.unindent
+                    class Hiera::Backend::Custom_backend
+                      def lookup(key, scope, order_override, resolution_type, context)
+                        case key
+                        when 'datasources'
+                          Hiera::Backend.datasources(scope, order_override) { |source| source }
+                        else
+                          throw :no_such_key
+                        end
+                      end
+                    end
+              RUBY
+          }
+        }
+      },
+      'hieradata' => {
+        'first.yaml' => <<-YAML.unindent,
+                ---
+                a: first a
+                class_name: "-- %{calling_class} --"
+                class_path: "-- %{calling_class_path} --"
+                module: "-- %{calling_module} --"
+                mod_name: "-- %{module_name} --"
+                b:
+                  b1: first b1
+                  b2: first b2
+                fbb:
+                  - mod::foo
+                  - mod::bar
+                  - mod::baz
+                empty_array: []
+          YAML
+        'second.yaml' => <<-YAML.unindent,
+          ---
+          a: second a
+          b:
+            b1: second b1
+            b3: second b3
+          YAML
+        'the_override.yaml' => <<-YAML.unindent
+          ---
+          key: foo_result
+          YAML
+      },
+      'environments' => {
+        'test' => {
+          'modules' => {
+            'mod' => {
+              'manifests' => {
+                'foo.pp' => <<-PUPPET.unindent,
+                    class mod::foo {
+                      notice(hiera('class_name'))
+                      notice(hiera('class_path'))
+                      notice(hiera('module'))
+                      notice(hiera('mod_name'))
+                    }
+                  PUPPET
+                'bar.pp' => <<-PUPPET.unindent,
+                    class mod::bar {}
+                  PUPPET
+                'baz.pp' => <<-PUPPET.unindent
+                     class mod::baz {}
+                  PUPPET
+              },
+              'hiera.yaml' => <<-YAML.unindent,
+                ---
+                version: 5
+                YAML
+              'data' => {
+                 'common.yaml' => <<-YAML.unindent
+                    mod::c: mod::c (from module)
+                  YAML
+              }
+            }
+          }
+        }
+      }
+    }
+  end
+
+  let(:env_dir) { File.join(global_dir, 'environments') }
+  let(:env) { Puppet::Node::Environment.create(:test, [File.join(env_dir, 'test', 'modules')]) }
+  let(:environments) { Puppet::Environments::Directories.new(env_dir, []) }
+  let(:node) { Puppet::Node.new('test_hiera', :environment => env) }
+  let(:compiler) { Puppet::Parser::Compiler.new(node) }
+  let(:the_func) { Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'hiera') }
+
+  before(:each) do
+    Puppet.settings[:codedir] = global_dir
+    Puppet.settings[:hiera_config] = File.join(global_dir, 'hiera.yaml')
+  end
+
+  around(:each) do |example|
+    # Faking the load path to enable 'require' to load from 'ruby_stuff'. It removes the need for a static fixture
+    # for the custom backend
+    dir_contained_in(global_dir, DeepMerge.deep_merge!(global_files, { 'environments' => { 'test' => env_config } } ))
+    $LOAD_PATH.unshift(File.join(global_dir, 'ruby_stuff'))
+    begin
+      Puppet.override(:environments => environments, :current_environment => env) do
+        example.run
+      end
+    ensure
+      Hiera::Backend.send(:remove_const, :Custom_backend) if Hiera::Backend.const_defined?(:Custom_backend)
+      $LOAD_PATH.shift
+    end
+  end
+
+  def with_scope(code = 'undef')
+    result = nil
+    Puppet[:code] = 'undef'
+    compiler.topscope['environment'] = 'test'
+    compiler.compile do |catalog|
+      result = yield(compiler.topscope)
+      catalog
+    end
+    result
+  end
+
+  def func(*args, &block)
+    with_scope { |scope| the_func.call(scope, *args, &block) }
+  end
 
   context 'hiera' do
-    let(:hiera) { loader.load(:function, 'hiera') }
-
     it 'should require a key argument' do
-      expect { hiera.call(scope, []) }.to raise_error(ArgumentError)
+      expect { func([]) }.to raise_error(ArgumentError)
     end
 
     it 'should raise a useful error when nil is returned' do
-      expect { hiera.call(scope, 'badkey') }.to raise_error(Puppet::ParseError, /Could not find data item badkey/)
+      expect { func('badkey') }.to raise_error(Puppet::DataBinding::LookupError, /did not find a value for the name 'badkey'/)
     end
 
-    it 'should use the priority resolution_type' do
-      Hiera.any_instance.expects(:lookup).with { |*args| expect(args[4]).to be(:priority) }.returns('foo_result')
-      expect(hiera.call(scope, 'key')).to eql('foo_result')
+    it 'should use the "first" merge strategy' do
+      expect(func('a')).to eql('first a')
+    end
+
+    it 'should not find data in module' do
+      expect(func('mod::c', 'default mod::c')).to eql('default mod::c')
     end
 
     it 'should propagate optional override' do
       ovr = 'the_override'
-      Hiera.any_instance.expects(:lookup).with { |*args| expect(args[3]).to be(ovr) }.returns('foo_result')
-      expect(hiera.call(scope, 'key', nil, ovr)).to eql('foo_result')
+      expect(func('key', nil, ovr)).to eql('foo_result')
+    end
+
+    it 'backend data sources, including optional overrides, are propagated to custom backend' do
+      expect(func('datasources', nil, 'the_override')).to eql(['the_override', 'first', 'second'])
+    end
+
+    it 'a hiera v3 scope is used' do
+      expect(eval_and_collect_notices(<<-PUPPET, node)).to eql(['-- testing --', '-- mod::foo --', '-- mod/foo --', '-- mod --', '-- mod --'])
+      class testing () {
+         notice(hiera('class_name'))
+      }
+      include testing
+      include mod::foo
+      PUPPET
     end
 
     it 'should return default value nil when key is not found' do
-       expect(hiera.call(scope, 'foo', nil)).to be_nil
+       expect(func('foo', nil)).to be_nil
     end
 
     it "should return default value '' when key is not found" do
-      expect(hiera.call(scope, 'foo', '')).to eq('')
+      expect(func('foo', '')).to eq('')
     end
 
     it 'should use default block' do
-      #expect(hiera.call(scope, 'foo', lambda_1(scope, loader) { |k| "default for key '#{k}'" })).to eql("default for key 'foo'")
-      expect(hiera.call(scope, 'foo') { |k| "default for key '#{k}'" }).to eql("default for key 'foo'")
+      expect(func('foo') { |k| "default for key '#{k}'" }).to eql("default for key 'foo'")
     end
 
     it 'should propagate optional override when combined with default block' do
-      ovr = {}
-      Hiera::Backend::Yaml_backend.any_instance.expects(:lookup).with { |*args| expect(args[2]).to be(ovr) }.returns(nil)
-      expect(hiera.call(scope, 'foo.bar', ovr) { |k| "default for key '#{k}'" }).to eql("default for key 'foo.bar'")
+      ovr = 'the_override'
+      with_scope do |scope|
+        expect(the_func.call(scope, 'key', ovr) { |k| "default for key '#{k}'" }).to eql('foo_result')
+        expect(the_func.call(scope, 'foo.bar', ovr) { |k| "default for key '#{k}'" }).to eql("default for key 'foo.bar'")
+      end
+    end
+
+    context 'with environment with configured data provider' do
+      let(:env_config) {
+        {
+          'hiera.yaml' => <<-YAML.unindent,
+             ---
+             version: 5
+             YAML
+          'data' => {
+            'common.yaml' => <<-YAML.unindent
+              ---
+              a: a (from environment)
+              e: e (from environment)
+              YAML
+          }
+        }
+      }
+
+      it 'should find data globally' do
+        expect(func('a')).to eql('first a')
+      end
+
+      it 'should find data in the environment' do
+        expect(func('e')).to eql('e (from environment)')
+      end
+
+      it 'should find data in module' do
+        expect(func('mod::c')).to eql('mod::c (from module)')
+      end
     end
   end
 
   context 'hiera_array' do
-    # noinspection RubyResolve
-    let(:hiera_array) { loader.load(:function, 'hiera_array') }
+    let(:the_func) { Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'hiera_array') }
 
     it 'should require a key argument' do
-      expect { hiera_array.call(scope, []) }.to raise_error(ArgumentError)
+      expect { func([]) }.to raise_error(ArgumentError)
     end
 
     it 'should raise a useful error when nil is returned' do
-      expect { hiera_array.call(scope, 'badkey') }.to raise_error(Puppet::ParseError, /Could not find data item badkey/)
+      expect { func('badkey') }.to raise_error(Puppet::DataBinding::LookupError, /did not find a value for the name 'badkey'/)
     end
 
     it 'should use the array resolution_type' do
-      Hiera.any_instance.expects(:lookup).with { |*args| expect(args[4]).to be(:array) }.returns(%w[foo bar baz])
-      expect(hiera_array.call(scope, 'key', {'key' => 'foo_result'})).to eql(%w[foo bar baz])
+      expect(func('fbb', {'fbb' => 'foo_result'})).to eql(%w[mod::foo mod::bar mod::baz])
     end
 
     it 'should use default block' do
-      expect(hiera_array.call(scope, 'foo') { |k| ['key', k] }).to eql(%w[key foo])
+      expect(func('foo') { |k| ['key', k] }).to eql(%w[key foo])
     end
   end
 
   context 'hiera_hash' do
-    let(:hiera_hash) { loader.load(:function, 'hiera_hash') }
+    let(:the_func) { Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'hiera_hash') }
 
     it 'should require a key argument' do
-      expect { hiera_hash.call(scope, []) }.to raise_error(ArgumentError)
+      expect { func([]) }.to raise_error(ArgumentError)
     end
 
     it 'should raise a useful error when nil is returned' do
-      expect { hiera_hash.call(scope, 'badkey') }.to raise_error(Puppet::ParseError, /Could not find data item badkey/)
+      expect { func('badkey') }.to raise_error(Puppet::DataBinding::LookupError, /did not find a value for the name 'badkey'/)
     end
 
     it 'should use the hash resolution_type' do
-      Hiera.any_instance.expects(:lookup).with { |*args| expect(args[4]).to be(:hash) }.returns({'foo' => 'result'})
-      expect(hiera_hash.call(scope, 'key', {'key' => 'foo_result'})).to eql({'foo' => 'result'})
+      expect(func('b', {'b' => 'foo_result'})).to eql({ 'b1' => 'first b1', 'b2' => 'first b2', 'b3' => 'second b3'})
     end
 
     it 'should use default block' do
-      expect(hiera_hash.call(scope, 'foo') { |k| {'key' => k} }).to eql({'key' => 'foo'})
+      expect(func('foo') { |k| {'key' => k} }).to eql({'key' => 'foo'})
     end
   end
 
   context 'hiera_include' do
-    let(:hiera_include) { loader.load(:function, 'hiera_include') }
+    let(:the_func) { Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'hiera_include') }
 
     it 'should require a key argument' do
-      expect { hiera_include.call(scope, []) }.to raise_error(ArgumentError)
+      expect { func([]) }.to raise_error(ArgumentError)
     end
 
     it 'should raise a useful error when nil is returned' do
-      expect { hiera_include.call(scope, 'badkey') }.to raise_error(Puppet::ParseError, /Could not find data item badkey/)
+      expect { func('badkey') }.to raise_error(Puppet::DataBinding::LookupError, /did not find a value for the name 'badkey'/)
     end
 
-    it 'should use the array resolution_type' do
-      Hiera.any_instance.expects(:lookup).with { |*args| expect(args[4]).to be(:array) }.returns(%w[foo bar baz])
-      hiera_include.expects(:call_function_with_scope).with(scope, 'include', %w[foo bar baz])
-      hiera_include.call(scope, 'key', {'key' => 'foo_result'})
+    it 'should use the array resolution_type to include classes' do
+      expect(func('fbb').map { |c| c.class_name }).to eql(%w[mod::foo mod::bar mod::baz])
     end
 
     it 'should not raise an error if the resulting hiera lookup returns an empty array' do
-      Hiera.any_instance.expects(:lookup).returns []
-      expect { hiera_include.call(scope, 'key') }.to_not raise_error
+      expect { func('empty_array') }.to_not raise_error
     end
 
-    it 'should use default block' do
-      hiera_include.expects(:call_function_with_scope).with(scope,'include', %w[key foo])
-      hiera_include.call(scope, 'foo') { |k| ['key', k] }
+    it 'should use default block array to include classes' do
+      expect(func('foo') { |k| ['mod::bar', "mod::#{k}"] }.map { |c| c.class_name }).to eql(%w[mod::bar mod::foo])
     end
   end
 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -335,6 +335,7 @@ describe "The lookup function" do
             example.run
           end
         ensure
+          Hiera::Backend.send(:remove_const, :Custom_backend) if Hiera::Backend.const_defined?(:Custom_backend)
           $LOAD_PATH.shift
         end
       end


### PR DESCRIPTION
This commit changes the hiera_xxx functions so that they use the new lookup
framework instead of being hard-wired directly to the Hiera v3 code.

The functions will only use the global layer unless a hiera.yaml version 5
is present in the environment.

A special `data_hash` function dispatcher was designed to ensure that any
"override paths" that the hiera_xxx functions may provide are inserted
correctly into the hierarchy.