### PR TITLE
(PUP-7004) Remove 'verbatim' data provider option

### DIFF
--- a/lib/puppet/pops/lookup/data_hash_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_hash_function_provider.rb
@@ -10,14 +10,6 @@ class DataHashFunctionProvider < FunctionProvider
 
   TAG = 'data_hash'.freeze
 
-  OPTION_KEY_VERBATIM = 'verbatim'.freeze
-  OPTION_KEY_PRUNE = 'prune'.freeze
-
-  def initialize(name, parent_data_provider, function_name, options, locations)
-    super
-    @verbatim = !(options.empty? || !options.delete(OPTION_KEY_VERBATIM))
-  end
-
   # Performs a lookup with the assumption that a recursive check has been made.
   #
   # @param key [LookupKey] The key to lookup
@@ -62,7 +54,7 @@ class DataHashFunctionProvider < FunctionProvider
       lookup_invocation.report_not_found(root_key)
       throw :no_such_key
     end
-    @verbatim ? value : interpolate(value, lookup_invocation, true)
+    interpolate(value, lookup_invocation, true)
   end
 
   def data_hash(lookup_invocation, location)

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -457,10 +457,6 @@ describe "The lookup function" do
           {
             'mod_a' => {
               'data' => {
-                'verbatim.yaml' => <<-YAML.unindent,
-                ---
-                mod_a::vbt: "verbatim %{scope_xo} --"
-                YAML
                 'common.yaml' => <<-YAML.unindent
                 ---
                 mod_a::a: value mod_a::a (from mod_a)
@@ -501,11 +497,6 @@ describe "The lookup function" do
                 - name: "Common"
                   data_hash: yaml_data
                   path: "common.yaml"
-                - name: "Verbatim"
-                  data_hash: yaml_data
-                  path: "verbatim.yaml"
-                  options:
-                    verbatim: true
             YAML
             }
           }
@@ -579,10 +570,6 @@ describe "The lookup function" do
 
         it 'interpolates a literal' do
           expect(lookup('mod_a::interpolate_literal')).to eql('-- hello --')
-        end
-
-        it 'does not interpolate when options { "verbatim" => true }' do
-          expect(lookup('mod_a::vbt')).to eql('verbatim %{scope_xo} --')
         end
 
         it 'interpolates scalar from scope' do


### PR DESCRIPTION
The 'verbatim' data provider option introduced unwanted complexity and is
therefore removed in this commit.