### PR TITLE
(PUP-7013) Raise error when hiera.yaml version 4 is used globally

### DIFF
--- a/lib/puppet/pops/lookup/configured_data_provider.rb
+++ b/lib/puppet/pops/lookup/configured_data_provider.rb
@@ -59,7 +59,7 @@ class ConfiguredDataProvider
   #
   # @param config [HieraConfig] the configuration to check
   # @return [HieraConfig] the argument
-  # @raise [Puppet::DataBinder::LookupError] if the configuration version is unacceptable
+  # @raise [Puppet::DataBinding::LookupError] if the configuration version is unacceptable
   def assert_config_version(config)
     config
   end
@@ -68,7 +68,7 @@ class ConfiguredDataProvider
   #
   # @param lookup_invocation [Invocation] The current lookup invocation
   # @return [Pathname] Path to root of the module
-  # @raise [Puppet::DataBinder::LookupError] if the given module is can not be found
+  # @raise [Puppet::DataBinding::LookupError] if the given module is can not be found
   #
   def provider_root(lookup_invocation)
     raise NotImplementedError, "#{self.class.name} must implement method '#provider_root'"

--- a/lib/puppet/pops/lookup/environment_data_provider.rb
+++ b/lib/puppet/pops/lookup/environment_data_provider.rb
@@ -11,7 +11,7 @@ class EnvironmentDataProvider < ConfiguredDataProvider
   protected
 
   def assert_config_version(config)
-    raise Puppet::DataBinder::LookupError, "#{config.name}: cannot be used in an environment" unless config.version > 3
+    raise Puppet::DataBinding::LookupError, "#{config.name} cannot be used in an environment" unless config.version > 3
     config
   end
 

--- a/lib/puppet/pops/lookup/global_data_provider.rb
+++ b/lib/puppet/pops/lookup/global_data_provider.rb
@@ -28,6 +28,11 @@ class GlobalDataProvider < ConfiguredDataProvider
 
   protected
 
+  def assert_config_version(config)
+    raise Puppet::DataBinding::LookupError, "#{config.name} cannot be used in the global layer" if config.version == 4
+    config
+  end
+
   # Return the root of the environment
   #
   # @param lookup_invocation [Invocation] The current lookup invocation

--- a/lib/puppet/pops/lookup/module_data_provider.rb
+++ b/lib/puppet/pops/lookup/module_data_provider.rb
@@ -37,7 +37,7 @@ class ModuleDataProvider < ConfiguredDataProvider
   protected
 
   def assert_config_version(config)
-    raise Puppet::DataBinder::LookupError, "#{config.name}: cannot be used in a module" unless config.version > 3
+    raise Puppet::DataBinding::LookupError, "#{config.name} cannot be used in a module" unless config.version > 3
     config
   end
 
@@ -45,12 +45,12 @@ class ModuleDataProvider < ConfiguredDataProvider
   #
   # @param lookup_invocation [Invocation] The current lookup invocation
   # @return [Pathname] Path to root of the module
-  # @raise [Puppet::DataBinder::LookupError] if the module can not be found
+  # @raise [Puppet::DataBinding::LookupError] if the module can not be found
   #
   def provider_root(lookup_invocation)
     env = lookup_invocation.scope.environment
     mod = env.module(module_name)
-    raise Puppet::DataBinder::LookupError, "Environment '#{env.name}', cannot find module '#{module_name}'" unless mod
+    raise Puppet::DataBinding::LookupError, "Environment '#{env.name}', cannot find module '#{module_name}'" unless mod
     Pathname.new(mod.path)
   end
 end


### PR DESCRIPTION
Prior to this commit, a hiera.yaml version 4 would be allowed in global
scope. Now that is treated as an error.

This commit also adds tests to assert that it is an error to use a Hiera
version 3 in an environment or a module.