### PR TITLE
(PUP-7012) Fix issue with type mismatches being reported on wrong par…

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -721,8 +721,10 @@ module Types
         arg_count.times do |index|
           adx = index >= etypes.size ? etypes.size - 1 : index
           etype = etypes[adx]
-          descriptions = describe(etype, atypes[index], path + [ParameterPathElement.new(enames[adx])])
-          return descriptions unless descriptions.empty?
+          unless etype.assignable?(atypes[index])
+            descriptions = describe(etype, atypes[index], path + [ParameterPathElement.new(enames[adx])])
+            return descriptions unless descriptions.empty?
+          end
         end
         EMPTY_ARRAY
       else

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -130,6 +130,17 @@ describe 'the type mismatch describer' do
       /parameter 'arg' expects a match for Enum\['a', 'b'\], got Sensitive/))
   end
 
+  it "reports errors on the first failing parameter when that parameter is not the first in order" do
+    code = <<-CODE
+      type Abc = Enum['a', 'b', 'c']
+      type Cde = Enum['c', 'd', 'e']
+      function two_params(Abc $a, Cde $b) {}
+      two_params('a', 'x')
+    CODE
+    expect { eval_and_collect_notices(code) }.to(raise_error(Puppet::Error,
+      /parameter 'b' expects a match for Cde = Enum\['c', 'd', 'e'\], got 'x'/))
+  end
+
   it "will not generalize a string that doesn't match an enum in a define call" do
     code = <<-CODE
       define check_enums(Enum[a,b] $arg) {}


### PR DESCRIPTION
…ameter

Some type mismatch errors were reported on the wrong parameter. This was
caused by the lack of a test if expected type for each parameter was
assignable or not. This commit adds the missing test.