### PR TITLE
(PUP-7015) Add multilanguage support for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,47 @@ version: 4.1.0.{build}
 clone_depth: 10
 install:
 build: off
+matrix:
+  fast_finish: true
 
+# Ruby versions under test
+platform:
+  - Ruby23-x64
+  - Ruby21-x64
+
+# Note that locales are mainly code page changes and are not the FULL set of localization
+#  changes that happen when you install French/Germam/Japanese etc. Windows
 environment:
   matrix:
-  - RUBY_VER: 23-x64
-  - RUBY_VER: 21-x64
+  - LOCALE: en-US
+  - LOCALE: ja-JP
+
+before_test:
+  # Semicolons are required below.  This renders as a single line powershell command in AppVeyor
+  - ps: >-
+      [string]$testLocale = [Environment]::GetEnvironmentVariable("LOCALE","Process");
+      $currentLocale = (Get-WinSystemLocale).Name;
+      if ($testLocale -ne '') {
+        if ($testLocale -ne $currentLocale) {
+          Write-Output "Setting Locale to $testLocale ...";
+          Set-WinSystemLocale ($testLocale);
+          Write-Output "Restarting worker in 5 seconds...";
+          Start-Sleep -Seconds 5
+          Restart-Computer -Force -Confirm:$false;
+        } else {
+          Write-Output "Locale is already set to $currentLocale";
+        };
+      } else {
+        Write-Output "LOCALE environment variable not set";
+      };
 
 test_script:
+  # The sleep is needed to allow the Appveyor tracing to start correctly after a reboot (locale change)
+  - ps: Start-Sleep -Seconds 5
   - SET
-  - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
+  - chcp
+  - ps: Get-WinSystemLocale
+  - SET PATH=C:\%PLATFORM%\bin;%PATH%
   - SET LOG_SPEC_ORDER=true
   - bundle install --jobs 4 --retry 2 --without development extra
   - type Gemfile.lock

--- a/spec/integration/test/test_helper_spec.rb
+++ b/spec/integration/test/test_helper_spec.rb
@@ -7,12 +7,16 @@ describe "Windows UTF8 environment variables", :if => Puppet.features.microsoft_
   # Do not use before and after hooks in these tests as it may have unintended consequences
 
   before(:all) {
-    @varname = 'test-helper-foo'
+    @varname = 'test_helper_spec-test_variable'
     @rune_utf8 = "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7"
 
     Puppet::Util::Windows::Process.set_environment_variable(@varname, @rune_utf8)
   }
-
+  after(:all) {
+    # Need to cleanup this environment variable otherwise it contaminates any subsequent tests
+    Puppet::Util::Windows::Process.set_environment_variable(@varname, nil)
+  }
+  
   it "#after_each_test should preserve UTF8 environment variables" do
     envhash = Puppet::Util::Windows::Process.get_environment_strings
     expect(envhash[@varname]).to eq(@rune_utf8)


### PR DESCRIPTION
Previously Appveyor PR CI tests only tested against the default US English
language.  This commit modifies the AppVeyor tests to optionally set the system
locale prior to running the test suite.  This is configured using the LOCALE
environment variable.

The ruby test matrix, which was previously set via environment variables, has
been moved to the Platform setting to create 2 axis test matrix (Platform vs
Env. Variables).  The Platform setting is presented as an additional environment
variable in Appveyor jobs which is used by the `SET PATH....` statement to set
the correct ruby path and version.

This PR also fixes two tests which were failing on a Japanese locale on Windows.