### PR TITLE
(PUP-7017) Simplify metadata linting in generated modules.

### DIFF
--- a/lib/puppet/module_tool/skeleton/templates/generator/Gemfile
+++ b/lib/puppet/module_tool/skeleton/templates/generator/Gemfile
@@ -3,7 +3,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['>= 3.3']
 gem 'metadata-json-lint'
 gem 'puppet', puppetversion
-gem 'puppetlabs_spec_helper', '>= 1.0.0'
+gem 'puppetlabs_spec_helper', '>= 1.2.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'

--- a/lib/puppet/module_tool/skeleton/templates/generator/Rakefile
+++ b/lib/puppet/module_tool/skeleton/templates/generator/Rakefile
@@ -24,9 +24,9 @@ task :validate do
   end
 end
 
-desc 'Run metadata_lint, lint, validate, and spec tests.'
+desc 'Run lint, validate, and spec tests.'
 task :test do
-  [:metadata_lint, :lint, :validate, :spec].each do |test|
+  [:lint, :validate, :spec].each do |test|
     Rake::Task[test].invoke
   end
 end


### PR DESCRIPTION
Ensure that puppetlab_spec_helper 1.2.0 or later is used which will run
metadata-json-lint as part of the validate rake task.