### PR TITLE
(PUP-6538) Deprecate hiera_xxx functions

### DIFF
--- a/lib/hiera/puppet_function.rb
+++ b/lib/hiera/puppet_function.rb
@@ -59,6 +59,10 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
   end
 
   def lookup(scope, key, default, has_default, override, &default_block)
+    unless Puppet[:strict] == :off
+      Puppet.warn_once(:deprecation, self.class.name,
+        "The function '#{self.class.name}' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html")
+    end
     lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {})
     lookup_invocation.set_hiera_v3_function_info(override, !lookup_invocation.lookup_adapter.has_environment_data_provider?(lookup_invocation))
     Puppet::Pops::Lookup.lookup(key, nil, default, has_default, merge_type, lookup_invocation, &default_block)

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -77,6 +77,20 @@ $users = hiera('users') | $key | { "Key \'${key}\' not found" }
 The returned value's data type depends on the types of the results. In the example
 above, Hiera matches the 'users' key and returns it as a hash.
 
+The `hiera` function is deprecated in favor of using `lookup` and will be removed in 6.0.0.
+See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+Replace the calls as follows:
+
+| from  | to |
+| ----  | ---|
+| hiera($key) | lookup($key) |
+| hiera($key, $default) | lookup($key, { 'default_value' => $default }) |
+| hiera($key, $default, $level) | override level not supported |
+
+Note that calls using the 'override level' option are not directly supported by 'lookup' and the produced
+result must be post processed to get exactly the same result, for example using simple hash/array `+` or
+with calls to stdlib's `deep_merge` function depending on kind of hiera call and setting of merge in hiera.yaml.
+
 See
 [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
 for more information about Hiera lookup functions.

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -65,6 +65,20 @@ $allusers = hiera_array('users') | $key | { "Key \'${key}\' not found" }
 `hiera_array` expects that all values returned will be strings or arrays. If any matched
 value is a hash, Puppet raises a type mismatch error.
 
+`hiera_array` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
+See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+Replace the calls as follows:
+
+| from  | to |
+| ----  | ---|
+| hiera_array($key) | lookup($key, { 'merge' => 'unique' }) |
+| hiera_array($key, $default) | lookup($key, { 'default_value' => $default, 'merge' => 'unique' }) |
+| hiera_array($key, $default, $level) | override level not supported |
+
+Note that calls using the 'override level' option are not directly supported by 'lookup' and the produced
+result must be post processed to get exactly the same result, for example using simple hash/array `+` or
+with calls to stdlib's `deep_merge` function depending on kind of hiera call and setting of merge in hiera.yaml.
+
 See
 [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
 for more information about Hiera lookup functions.

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -75,6 +75,20 @@ $allusers = hiera_hash('users') | $key | { "Key \'${key}\' not found" }
 `hiera_hash` expects that all values returned will be hashes. If any of the values
 found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 
+`hiera_hash` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
+See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+Replace the calls as follows:
+
+| from  | to |
+| ----  | ---|
+| hiera_hash($key) | lookup($key, { 'merge' => 'hash' }) |
+| hiera_hash($key, $default) | lookup($key, { 'default_value' => $default, 'merge' => 'hash' }) |
+| hiera_hash($key, $default, $level) | override level not supported |
+
+Note that calls using the 'override level' option are not directly supported by 'lookup' and the produced
+result must be post processed to get exactly the same result, for example using simple hash/array `+` or
+with calls to stdlib's `deep_merge` function depending on kind of hiera call and setting of merge in hiera.yaml.
+
 See
 [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
 for more information about Hiera lookup functions.

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -75,6 +75,20 @@ hiera_include('classes') | $key | {"Key \'${key}\' not found" }
 # "Key 'classes' not found".
 ~~~
 
+`hiera_include` is deprecated in favor of using a combination of `include`and `lookup` and will be
+removed in 6.0.0. See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+Replace the calls as follows:
+
+| from  | to |
+| ----  | ---|
+| hiera_include($key) | include(lookup($key, { 'merge' => 'unique' })) |
+| hiera_include($key, $default) | include(lookup($key, { 'default_value' => $default, 'merge' => 'unique' })) |
+| hiera_include($key, $default, $level) | override level not supported |
+
+Note that calls using the 'override level' option are not directly supported by 'lookup' and the produced
+result must be post processed to get exactly the same result, for example using simple hash/array `+` or
+with calls to stdlib's `deep_merge` function depending on kind of hiera call and setting of merge in hiera.yaml.
+
 See [the documentation](http://links.puppetlabs.com/hierainclude) for more information
 and a more detailed example of how `hiera_include` uses array merge lookups to classify
 nodes.


### PR DESCRIPTION
This commit adds a deprecation text to the documentation of the four
functions `hiera`, `hiera_array`, `hiera_hash`, and `hiera_include` that
informs the user that `lookup`should be used instead. Code is also added to
ensure that deprecation messages are logged when the functions are used.
The deprecation logging can be silenced by setting --strict setting to off.