### PR TITLE
(maint) default mode via bitwise ops in file_system_spec

### DIFF
--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -45,8 +45,8 @@ describe "Puppet::FileSystem" do
         # for local Administrators writing to their own temp folders under c:\users\USER
         # they will have (F) for themselves, and Users will not have a permission, hence 700
         (is_current_user_system? ? ['770', '2000770'] : '2000700') :
-        # default mode is applied. 100 == 'regular file'
-        '100' + (666 - File.umask.to_s(8).to_i).to_s
+        # or for *nix determine expected mode via bitwise AND complement of umask
+        (0100000 | 0666 & ~File.umask).to_s(8)
       expect([expected_perms].flatten).to include(Puppet::FileSystem.stat(file).mode.to_s(8))
 
       default_file = tmpfile('file_to_update2')


### PR DESCRIPTION
Minor correction of the determination of expected default mode for regular file
via umask in file_system_spec.rb to use bitwise operations - this will be more
familiar (and feels more correct) than previous represention.

Signed-off-by: Moses Mendoza <moses@puppet.com>