### PR TITLE
(PUP-7020) Fix bug preventing path interpolation in hiera.yaml version 3

### DIFF
--- a/lib/puppet/pops/lookup/data_hash_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_hash_function_provider.rb
@@ -82,7 +82,7 @@ class V3DataHashFunctionProvider < DataHashFunctionProvider
       super
     else
       # Extra paths provided. Must be resolved and placed in front of known paths
-      paths = parent_data_provider.config(lookup_invocation).resolve_paths(@datadir, extra_paths, false, lookup_invocation, ".#{@name}")
+      paths = parent_data_provider.config(lookup_invocation).resolve_paths(@datadir, extra_paths, lookup_invocation, false, ".#{@name}")
       all_locations = paths + locations
       root_key = key.root_key
       lookup_invocation.with(:data_provider, self) do

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -231,7 +231,7 @@ class HieraConfigV3 < HieraConfig
       original_paths = @config[KEY_HIERARCHY]
       backend_config = @config[backend] || EMPTY_HASH
       datadir = @config_root + interpolate(backend_config[KEY_DATADIR] || default_datadir, lookup_invocation, false)
-      paths = resolve_paths(datadir, original_paths, @config_path.nil?, lookup_invocation, ".#{backend}")
+      paths = resolve_paths(datadir, original_paths, lookup_invocation, @config_path.nil?, ".#{backend}")
       data_providers[backend] = case backend
       when 'json', 'yaml'
         create_data_provider(backend, parent_data_provider, KEY_V3_DATA_HASH, "#{backend}_data", { KEY_DATADIR => datadir }, paths)

--- a/lib/puppet/pops/lookup/lookup_key_function_provider.rb
+++ b/lib/puppet/pops/lookup/lookup_key_function_provider.rb
@@ -21,13 +21,8 @@ class LookupKeyFunctionProvider < FunctionProvider
           lookup_invocation.report_found(key.root_key, validate_data_value(self, value))
         else
           lookup_invocation.with(:location, location) do
-            if location.exist?
-              value = lookup_key(key.root_key, lookup_invocation, location.location, merge)
-              lookup_invocation.report_found(key.root_key, validate_data_value(self, value))
-            else
-              lookup_invocation.report_location_not_found
-              throw :no_such_key
-            end
+            value = lookup_key(key.root_key, lookup_invocation, location.location, merge)
+            lookup_invocation.report_found(key.root_key, validate_data_value(self, value))
           end
         end
       end
@@ -41,6 +36,10 @@ class LookupKeyFunctionProvider < FunctionProvider
   private
 
   def lookup_key(key, lookup_invocation, location, merge)
+    unless location.nil? || location.exists?
+      lookup_invocation.report_location_not_found
+      throw :no_such_key
+    end
     ctx = function_context(lookup_invocation, location)
     ctx.data_hash ||= {}
     catch(:no_such_key) do


### PR DESCRIPTION
This commit corrects two places where arguments was sent in the wrong order
to the hiera.yaml path resolver and adds unit tests that asserts that paths in
Hiera v3 are interpolated correctly.