### PR TITLE
(PUP-6982) Allow keys to be specified using patterns in lookup_options

### DIFF
--- a/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/data/common.yaml
+++ b/spec/fixtures/unit/data_providers/environments/hiera_modules/modules/two/data/common.yaml
@@ -1,4 +1,4 @@
 ---
 lookup_options:
-  roles::devco::packages:
+  two::arg:
     merge: unique


### PR DESCRIPTION
Before this commit, in order for a key to have lookup options specified,
the options had to be keyed with that same exact key. Now, such options can
also be defined for keys that matches a specific pattern. This is achieved
by treating all keys that start with a '^' as regular expression patterns.
A key that matches such a pattern is considered to have the options below
that key.

The commit also adds a check that key or pattern under `lookup_options`
in a module only can identify keys that belong to that module. Keys must
 start with "<module_name>::" and patterns must start with "^" followed
 by "<module_name>::".