### PR TITLE
(PUP-7029) dnf provider does not support Fedora 25

### DIFF
--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
       end
   end
 
-  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => ['22', '23', '24']
+  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => ['22', '23', '24', '25']
 
   def self.update_command
     # In DNF, update is deprecated for upgrade


### PR DESCRIPTION
The dnf provider must be updated to add each new Fedora release.
This is caused by the defaultfor method in puppet which only accepts
hashes as arguments.  See https://tickets.puppetlabs.com/browse/PUP-6452
for more details.