### PR TITLE
(maint) Fix windows default directories in install.rb

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -260,15 +260,19 @@ def prepare_installation
     $operatingsystem = Facter.value :operatingsystem
   end
 
-  if not InstallOptions.configdir.nil?
-    configdir = InstallOptions.configdir
-  elsif $operatingsystem == "windows"
+  if $operatingsystem == "windows"
     begin
+      # populates constants used to specify default Windows directories
       require 'win32/dir'
     rescue LoadError => e
       puts "Cannot run on Microsoft Windows without the win32-process, win32-dir & win32-service gems: #{e}"
       exit -1
     end
+  end
+
+  if not InstallOptions.configdir.nil?
+    configdir = InstallOptions.configdir
+  elsif $operatingsystem == "windows"
     configdir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "etc")
   else
     configdir = "/etc/puppetlabs/puppet"


### PR DESCRIPTION
Prior to this commit, the win32/dir gem was not being required properly
in all places that install.rb attempts to use its constants. This commit
moves the require to a higher-level location, which allows all the supplied
defaults to resolve correctly.