### PR TITLE
(PUP-7030) Fix bug causing lexer hick-up on two adjacent unicode chars

### DIFF
--- a/lib/puppet/pops/parser/slurp_support.rb
+++ b/lib/puppet/pops/parser/slurp_support.rb
@@ -76,9 +76,10 @@ module SlurpSupport
     # Process unicode escapes first as they require getting 4 hex digits
     # If later a \u is found it is warned not to be a unicode escape
     if escapes.include?('u')
-      str.gsub!(/((?:[^\\]|^)(?:[\\]{2})*)\\u(?:([\da-fA-F]{4})|\{([\da-fA-F]{1,6})\})/m) {
-        $1 + [($2 || $3).hex].pack("U")
-      }
+      # gsub must be repeated to cater for adjacent escapes
+      while(str.gsub!(/((?:[^\\]|^)(?:[\\]{2})*)\\u(?:([\da-fA-F]{4})|\{([\da-fA-F]{1,6})\})/m) { $1 + [($2 || $3).hex].pack("U") })
+        # empty block. Everything happens in the gsub block
+      end
     end
 
     begin

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -513,7 +513,15 @@ describe 'Lexer2' do
       "x\\u2713y"
       CODE
       # >= Ruby 1.9.3 reports \u
-       expect(tokens_scanned_from(code)).to match_tokens2([:STRING, "x\u2713y"])
+      expect(tokens_scanned_from(code)).to match_tokens2([:STRING, "x\u2713y"])
+    end
+
+    it 'should support adjacent short form unicode characters' do
+      code = <<-CODE
+      "x\\u2713\\u2713y"
+      CODE
+      # >= Ruby 1.9.3 reports \u
+      expect(tokens_scanned_from(code)).to match_tokens2([:STRING, "x\u2713\u2713y"])
     end
 
     it 'should support unicode characters in long form' do


### PR DESCRIPTION
The lexer was only capable of recognizing the first of several adjacent
unicode characters. This commit fixes that problem.