### PR TITLE
(PUP-6981) Fix issue with recursive guard detection when validating types

### DIFF
--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -862,7 +862,7 @@ class PObjectType < PMetaType
   def guarded_recursion(guard, dflt)
     if @self_recursion
       guard ||= RecursionGuard.new
-      (guard.add_this(self) & RecursionGuard::SELF_RECURSION_IN_THIS) == 0 ? yield(guard) : dflt
+      guard.with_this(self) { |state| (state & RecursionGuard::SELF_RECURSION_IN_THIS) == 0 ? yield(guard) : dflt }
     else
       yield(guard)
     end

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -439,8 +439,14 @@ class TypeFormatter
     expand = @expanded
     if expand && t.self_recursion?
       @guard ||= RecursionGuard.new
-      expand = (@guard.add_this(t) & RecursionGuard::SELF_RECURSION_IN_THIS) == 0
+      @guard.with_this(t) { |state| format_type_alias_type(t, (state & RecursionGuard::SELF_RECURSION_IN_THIS) == 0) }
+    else
+      format_type_alias_type(t, expand)
     end
+  end
+
+  # @api private
+  def format_type_alias_type(t, expand)
     if @type_set.nil?
       @bld << t.name
       if expand

--- a/spec/unit/functions/hiera_spec.rb
+++ b/spec/unit/functions/hiera_spec.rb
@@ -47,6 +47,10 @@ describe 'when calling' do
                 class_path: "-- %{calling_class_path} --"
                 module: "-- %{calling_module} --"
                 mod_name: "-- %{module_name} --"
+                database_user:
+                  name: postgres
+                  uid: 500
+                  gid: 500
                 b:
                   b1: first b1
                   b2: first b2
@@ -280,6 +284,10 @@ describe 'when calling' do
 
     it 'should use the hash resolution_type' do
       expect(func('b', {'b' => 'foo_result'})).to eql({ 'b1' => 'first b1', 'b2' => 'first b2', 'b3' => 'second b3'})
+    end
+
+    it 'should lookup and return a hash' do
+      expect(func('database_user')).to eql({ 'name' => 'postgres', 'uid' => 500, 'gid' => 500})
     end
 
     it 'should log deprecation errors' do


### PR DESCRIPTION
Lookup introduces a new recursive type `Puppet::LookupValue` which defines
all values that are legal for lookup (in essence, everything that can be
stored in a catalog). The type is recursive since hashes and arrays can
values of the same type.

The acceptance test for hiera_hash, uses a hash with two values that are
exactly the same (uid and gid are both 500). This revealed a bug in the
guard used for trapping endless recursion in recursive types where values
that are pushed didn't get popped after the branch where the recursiveness
was tested. This commit fixes that bug.