### PR TITLE
(PUP-869) deprecate file face and add easier face deprecations

### DIFF
--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -245,6 +245,10 @@ class Puppet::Application::FaceBase < Puppet::Application
       end
     end
 
+    if @face.deprecated?
+      Puppet.deprecation_warning("'puppet #{@face.name}' is deprecated and will be removed in a future release")
+    end
+
     result = @face.send(@action.name, *arguments)
     puts render(result, arguments) unless result.nil?
     status = true

--- a/lib/puppet/face/file.rb
+++ b/lib/puppet/face/file.rb
@@ -44,4 +44,7 @@ Puppet::Indirector::Face.define(:file, '0.0.1') do
   deactivate_action(:destroy)
 
   set_indirection_name :file_bucket_file
+
+  # The file face is deprecated
+  deprecate
 end

--- a/lib/puppet/face/help/face.erb
+++ b/lib/puppet/face/help/face.erb
@@ -1,4 +1,7 @@
 <%# encoding: UTF-8%>
+<% if face.deprecated? -%>
+<%= "Warning: 'puppet #{face.name}' is deprecated and will be removed in a future release." %>
+<% end %>
 <% if face.synopsis -%>
 USAGE: <%= face.synopsis %>
 

--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -180,6 +180,15 @@ class Puppet::Interface
     "Puppet::Face[#{name.inspect}, #{version.inspect}]"
   end
 
+  # @return [void]
+  def deprecate
+    @deprecated = true
+  end
+
+  # @return [Boolean]
+  def deprecated?
+    @deprecated
+  end
   ########################################################################
   # Action decoration, whee!  You are not expected to care about this code,
   # which exists to support face building and construction.  I marked these

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -267,6 +267,22 @@ describe Puppet::Application::FaceBase do
       app.expects(:render).with(app.arguments.length + 1, ["myname", "myarg"])
       expect { app.main }.to exit_with(0)
     end
+
+    it "should issue a deprecation warning if the face is deprecated" do
+      # since app is shared across examples, stub to avoid affecting shared context
+      app.face.stubs(:deprecated?).returns(true)
+      app.face.expects(:foo).with(*app.arguments)
+      Puppet.expects(:deprecation_warning).with(regexp_matches(/'puppet basetest' is deprecated/))
+      expect { app.main }.to exit_with(0)
+    end
+
+    it "should not issue a deprecation warning if the face is not deprecated" do
+      Puppet.expects(:deprecation_warning).never
+      # since app is shared across examples, stub to avoid affecting shared context
+      app.face.stubs(:deprecated?).returns(false)
+      app.face.expects(:foo).with(*app.arguments)
+      expect { app.main }.to exit_with(0)
+    end
   end
 
   describe "error reporting" do

--- a/spec/unit/face/file_spec.rb
+++ b/spec/unit/face/file_spec.rb
@@ -7,4 +7,8 @@ describe Puppet::Face[:file, '0.0.1'] do
     it { is_expected.to be_action action }
     it { is_expected.to respond_to action }
   end
+
+  it "should be deprecated" do
+    expect(subject.deprecated?).to be_truthy
+  end
 end

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -141,6 +141,13 @@ describe Puppet::Face[:help, '0.0.1'] do
     end
   end
 
+  context "deprecated faces" do
+    it "prints a deprecation warning for deprecated faces" do
+      Puppet::Face[:module, :current].stubs(:deprecated?).returns(true)
+      expect(Puppet::Face[:help, :current].help(:module)).to match(/Warning: 'puppet module' is deprecated/)
+    end
+  end
+
   context "#legacy_applications" do
     subject { Puppet::Face[:help, :current].legacy_applications }
 

--- a/spec/unit/interface_spec.rb
+++ b/spec/unit/interface_spec.rb
@@ -132,6 +132,33 @@ describe Puppet::Interface do
     end
   end
 
+  context "when deprecating a face" do
+    let(:face) { subject.new(:foo, '0.0.1') }
+    describe "#deprecate" do
+      it "should respond to #deprecate" do
+        expect(subject.new(:foo, '0.0.1')).to respond_to(:deprecate)
+      end
+
+      it "should set the deprecated value to true" do
+        expect(face.deprecated?).to be_falsey
+        face.deprecate
+        expect(face.deprecated?).to be_truthy
+      end
+    end
+
+    describe "#deprecated?" do
+      it "should return a nil (falsey) value by default" do
+        expect(face.deprecated?).to be_falsey
+      end
+
+      it "should return true if the face has been deprecated" do
+        expect(face.deprecated?).to be_falsey
+        face.deprecate
+        expect(face.deprecated?).to be_truthy
+      end
+    end
+  end
+
   describe "with face-level display_global_options" do
     it "should not return any action level display_global_options" do
       face = subject.new(:with_display_global_options, '0.0.1') do


### PR DESCRIPTION
PUP-869 tracks the deprecation of the `file` face - one of many upcoming deprecations of existing faces in the puppet codebase. After initial review, issuing a simple deprecation warning in a face proved more complex than one might hope - especially in testing that face is actually deprecated when a face is actually used.  I.e., we could just put a deprecation warning in the initial face definition block, but this block is only evaluated once, at load time - a deprecation there might be fine from a ux perspective but is executed via an `instance_eval` and difficult to test. This commit adds a simple `deprecated` attribute to the Puppet::Interface class, and ensures that if a face is deprecated, we issue an appropriate deprecation warning when an action is sent to that face.

The (perhaps most appreciable) benefit of this is that it allows us to deprecate a face with a simple call to `face.deprecate` in that face's definition block.

This PR then leverages the prior commit's support for face deprecation to deprecate the file face. The file face is broken in puppet 4.x and its actions are inconsistent. It will be removed in a future release.