### PR TITLE
(PUP-6981) Ensure that legacy Hiera logger is initialized

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -241,7 +241,7 @@ class HieraConfigV3 < HieraConfig
         if @config.include?(KEY_LOGGER)
           Hiera.logger = @config[KEY_LOGGER].to_s
         else
-          Hiera.logger = 'console'
+          Hiera.logger = 'puppet'
         end
         Hiera::Config.instance_variable_set(:@config, @loaded_config)
 
@@ -261,7 +261,6 @@ class HieraConfigV3 < HieraConfig
     config[KEY_VERSION] ||= 3
     config[KEY_BACKENDS] ||= 'yaml'
     config[KEY_HIERARCHY] ||= %w(nodes/%{::trusted.certname} common)
-    config[KEY_LOGGER] ||= 'console'
     config[KEY_MERGE_BEHAVIOR] ||= 'native'
     config[KEY_DEEP_MERGE_OPTIONS] ||= {}
 

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -236,8 +236,13 @@ class HieraConfigV3 < HieraConfig
       when 'json', 'yaml'
         create_data_provider(backend, parent_data_provider, KEY_V3_DATA_HASH, "#{backend}_data", { KEY_DATADIR => datadir }, paths)
       else
-        # Custom backend. Hiera v3 must be installed and it must be made aware of the loaded config
-        require 'hiera/config'
+        # Custom backend. Hiera v3 must be installed, it's logger configured, and it must be made aware of the loaded config
+        require 'hiera'
+        if @config.include?(KEY_LOGGER)
+          Hiera.logger = @config[KEY_LOGGER].to_s
+        else
+          Hiera.logger = 'console'
+        end
         Hiera::Config.instance_variable_set(:@config, @loaded_config)
 
         # Use a special lookup_key that delegates to the backend

--- a/spec/unit/functions/hiera_spec.rb
+++ b/spec/unit/functions/hiera_spec.rb
@@ -26,6 +26,10 @@ describe 'when calling' do
           'backend' => {
             'custom_backend.rb' => <<-RUBY.unindent
                     class Hiera::Backend::Custom_backend
+                      def initialize(cache = nil)
+                        Hiera.debug('Custom_backend starting')
+                      end
+      
                       def lookup(key, scope, order_override, resolution_type, context)
                         case key
                         when 'datasources'


### PR DESCRIPTION
Before this commit, the class Hiera wasn't loaded properly and its logger
was not initialized. Consequently, any custom backend that attempted to use
the logger would run into an error similar to: "Unable to instantiate
backend '<backend name>': undefined method 'debug' for nil:NilClass".

This commit adds the proper require for the class and ensures that the
logger is initialized.