### PR TITLE
Pup 7046 update dnf provider

### DIFF
--- a/lib/puppet/feature/supports_dnf.rb
+++ b/lib/puppet/feature/supports_dnf.rb
@@ -1,0 +1,6 @@
+require 'puppet/util/feature'
+
+# Enable dnf feature on platforms that support it
+Puppet.features.add(:supports_dnf) do
+  File.file?('/usr/bin/dnf')
+end

--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
       end
   end
 
-  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => ['22', '23', '24', '25']
+  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => (22..30).to_a
 
   def self.update_command
     # In DNF, update is deprecated for upgrade

--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
       end
   end
 
-  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => (22..30).to_a
+  defaultfor :operatingsystem => :fedora, :feature => :supports_dnf
 
   def self.update_command
     # In DNF, update is deprecated for upgrade

--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -6,20 +6,16 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:package).provider(:dnf)
 
 context 'default' do
-  [ 19, 20, 21 ].each do |ver|
+  (19..21).each do |ver|
     it "should not be the default provider on fedora#{ver}" do
-      Facter.stubs(:value).with(:osfamily).returns(:redhat)
-      Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
-      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+      File.stubs(:file?).with('/usr/bin/dnf').returns(false)
       expect(provider_class).to_not be_default
     end
   end
 
-  [ 22, 23, 24 ].each do |ver|
+  (22..26).each do |ver|
     it "should be the default provider on fedora#{ver}" do
-      Facter.stubs(:value).with(:osfamily).returns(:redhat)
-      Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
-      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+      File.stubs(:file?).with('/usr/bin/dnf').returns(true)
       expect(provider_class).to be_default
     end
   end


### PR DESCRIPTION
The dnf provider will only work with a pre-defined list of Fedora releases.  To avoid having to update this provider every time there is a new Fedora release this patch updates the defaultfor argument to a range which will work until Fedora 31 is released.