### PR TITLE
(PUP-6777) don't run utf-8 user tests on arista

### DIFF
--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -9,6 +9,9 @@
 # Where applicable, we should be able to do this in different locales
 test_name 'PUP-6777 Manage users with UTF-8 comments' do
 
+  # PUP-7049 / ARISTA-42 - user provider bug on Arista
+  confine :except, :platform => /^eos-/
+
   user0 = "foo#{rand(99999).to_i}"
   user1 = "bar#{rand(99999).to_i}"
   user2 = "baz#{rand(99999).to_i}"


### PR DESCRIPTION
Arista EOS has known issues with the user provider (ARISTA-42, PUP-7049)
causing it to fail the tests associated with PUP-6777. Effectively,  the
`getpwnam` function on Arista will return data for a non-existent user. Ruby
`Etc` module relies on this to return info on users, and Puppet relies on Ruby
`Etc` module in the useradd provider. This commit confines this test to not run
on EOS hosts.

Signed-off-by: Moses Mendoza <moses@puppet.com>