### PR TITLE
(PUP-7053) shorten username in utf-8 test for aix

### DIFF
--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -16,7 +16,7 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
   user1 = "bar#{rand(99999).to_i}"
   user2 = "baz#{rand(99999).to_i}"
   user3 = "qux#{rand(99999).to_i}"
-  user4 = "quux#{rand(99999).to_i}"
+  user4 = "ris#{rand(99999).to_i}"
   osx_agents = agents.select { |a| a[:platform] =~ /osx/ } || []
   windows_agents = agents.select { |a| a[:platform] =~ /windows/ } || []
 


### PR DESCRIPTION
By default AIX usernames are 8 chars. To ensure we pass in the default
configuration, shorten the username length in test utf8_user_comment to 8
characters.

Signed-off-by: Moses Mendoza <moses@puppet.com>