### PR TITLE
(PUP-7058) Add Ruby API to #new function

### DIFF
--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -655,6 +655,14 @@ class PObjectType < PMetaType
     @i12n_type ||= create_i12n_type
   end
 
+  def create(*args)
+    implementation_class.create(*args)
+  end
+
+  def from_hash(hash)
+    implementation_class.from_hash(hash)
+  end
+
   # Creates the type that a initialization hash used for creating instances of this type must conform to.
   #
   # @return [PStructType] the initialization hash type

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -292,6 +292,10 @@ class PAnyType < TypedModelObject
     simple_name
   end
 
+  def create(*args)
+    Loaders.find_loader(nil).load(:function, 'new').call({}, self, *args)
+  end
+
   def new_function(loader)
     self.class.new_function(self, loader)
   end

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -572,6 +572,29 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'instantiation via ruby create function' do
+    around(:each) do |example|
+      Puppet.override(:loaders => Loaders.new(Puppet::Node::Environment.create(:testing, []))) do
+        example.run
+      end
+    end
+
+    it 'is supported by Integer' do
+      int = tf.integer.create('32')
+      expect(int).to eq(32)
+    end
+
+    it 'is supported by Optional[Integer]' do
+      int = tf.optional(tf.integer).create('32')
+      expect(int).to eq(32)
+    end
+
+    it 'is not supported by Any, Scalar, Collection' do
+      [tf.any, tf.scalar, tf.collection ].each do |t|
+        expect { t.create }.to raise_error(ArgumentError, /Creation of new instance of type '#{t.to_s}' is not supported/)
+      end
+    end
+  end
 end
 end
 end


### PR DESCRIPTION
This commit adds the method `create` to the `PAnyType` to make it easy to
create instances of a type from Ruby. It also adds the method `from_hash`
to the PObjectType which enables instance creation using an initialization
hash.