### PR TITLE
(PUP-7055) Add proper to_s method to class generated from pcore Object

### DIFF
--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -210,6 +210,16 @@ class RubyGenerator < TypeFormatter
     init_params.each { |a| bld << '    @' << a.name << ' = ' << a.name << "\n" if a.container.equal?(obj) }
     bld << "  end\n\n"
 
+    bld << "  def i12n_hash\n    result = "
+    bld << (obj.parent.nil? ? '{}' : 'super')
+    bld << "\n"
+    init_params.each { |a| bld << "    result['" << a.name << "'] = @" << a.name << "\n" if a.container.equal?(obj) }
+    bld << "    result\n  end\n\n"
+
+    bld << "  def to_s\n"
+    bld << "    " << namespace_relative(segments, TypeFormatter.name) << ".string(self)\n"
+    bld << "  end\n\n"
+
     # Output attr_readers
     others.each do |a|
       next unless a.container.equal?(obj)

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -42,17 +42,24 @@ class TypeFormatter
   #
   # @api public
   def indented_string(t, indent = 0, indent_width = 2)
+    @bld = ''
+    append_indented_string(t, indent, indent_width)
+    @bld
+  end
+
+  # @api private
+  def append_indented_string(t, indent = 0, indent_width = 2, skip_initial_indent = false)
+    save_indent = @indent
+    save_indent_width = @indent_width
     @indent = indent
     @indent_width = indent_width
     begin
-      @bld = ''
-      (@indent * @indent_width).times { @bld << ' ' }
+      (@indent * @indent_width).times { @bld << ' ' } unless skip_initial_indent
       append_string(t)
       @bld << "\n"
-      @bld
     ensure
-      @indent = nil
-      @indent_width = nil
+      @indent = save_indent
+      @indent_width = save_indent_width
     end
   end
 
@@ -294,6 +301,14 @@ class TypeFormatter
   def string_PCollectionType(t)
     range = range_array_part(t.size_type)
     append_array('Collection', range.empty? ) { append_elements(range) }
+  end
+
+  def string_PuppetObject(t)
+    @bld << t._ptype.name << '('
+    append_indented_string(t.i12n_hash, @indent || 0, @indent_width || 2, true)
+    @bld.chomp!
+    @bld << ')'
+    newline if @indent
   end
 
   # @api private

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -699,6 +699,17 @@ describe 'The Object Type' do
     end
   end
 
+  context 'when stringifying created instances' do
+    it 'outputs a Puppet constructor using the initializer hash' do
+      code = <<-CODE
+      type Spec::MyObject = Object[{attributes => { a => Integer }}]
+      type Spec::MySecondObject = Object[{parent => Spec::MyObject, attributes => { b => String }}]
+      notice(Spec::MySecondObject(42, 'Meaning of life'))
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(["Spec::MySecondObject({\n  'a' => 42,\n  'b' => 'Meaning of life'\n})"])
+    end
+  end
+
   context 'when used in Puppet expressions' do
     it 'two anonymous empty objects are equal' do
       code = <<-CODE


### PR DESCRIPTION
This commit adds a to_s method that will the string that corresponds to
the calling the #new function on the type with an initialization hash.