### PR TITLE
(PUP-7054) Serialize ObjectType's along with instances of the type

### DIFF
--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -17,16 +17,16 @@ class Loaders
   attr_reader :private_environment_loader
   attr_reader :implementation_registry
 
-  def self.new(environment)
+  def self.new(environment, for_agent = false)
     obj = environment.loaders
     if obj.nil?
       obj = self.allocate
-      obj.send(:initialize, environment)
+      obj.send(:initialize, environment, for_agent)
     end
     obj
   end
 
-  def initialize(environment)
+  def initialize(environment, for_agent)
     # Protect against environment havoc
     raise ArgumentError.new("Attempt to redefine already initialized loaders for environment") unless environment.loaders.nil?
     environment.loaders = self
@@ -47,12 +47,16 @@ class Loaders
     #    concept of environment the same way as when running as a master (except when doing apply).
     #    The creation mechanisms should probably differ between the two.
     #
-    @private_environment_loader = create_environment_loader(environment)
+    @private_environment_loader = if for_agent
+      add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@puppet_system_loader, 'agent environment'))
+    else
+      create_environment_loader(environment)
+    end
 
     # 3. The implementation registry maintains mappings between Puppet types and Runtime types for
     #    the current environment
     @implementation_registry = Types::ImplementationRegistry.new(@private_environment_loader)
-    Pcore.init(@puppet_system_loader, @implementation_registry)
+    Pcore.init(@puppet_system_loader, @implementation_registry, for_agent)
 
     # 4. module loaders are set up from the create_environment_loader, they register themselves
   end
@@ -106,13 +110,28 @@ class Loaders
   # @api private
   def self.register_runtime3_type(name, origin)
     loaders = Puppet.lookup(:loaders) { nil }
-    unless loaders.nil?
-      name = name.to_s
-      caps_name = Types::TypeFormatter.singleton.capitalize_segments(name)
-      typed_name = Loader::TypedName.new(:type, name.downcase)
-      loaders.runtime3_type_loader.set_entry(typed_name, Types::PResourceType.new(caps_name), origin)
-    end
+    return nil if loaders.nil?
+
+    rt3_loader = loaders.runtime3_type_loader
+    return nil if rt3_loader.nil?
+
+    name = name.to_s
+    caps_name = Types::TypeFormatter.singleton.capitalize_segments(name)
+    typed_name = Loader::TypedName.new(:type, name.downcase)
+    rt3_loader.set_entry(typed_name, Types::PResourceType.new(caps_name), origin)
     nil
+  end
+
+  # Finds a loader to use when deserializing a catalog and then subsequenlty use user
+  # defined types found in that catalog.
+  #
+  def self.catalog_loader
+    loaders = Puppet.lookup(:loaders) { nil }
+    if loaders.nil?
+      loaders = Loaders.new(Puppet.lookup(:current_environment), true)
+      Puppet.push_context(:loaders => loaders)
+    end
+    loaders.find_loader(nil)
   end
 
   # Finds the `Loaders` instance by looking up the :loaders in the global Puppet context

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -17,25 +17,31 @@ module Pcore
 
   RUNTIME_NAME_AUTHORITY = 'http://puppet.com/2016.1/runtime'
 
-  def self.init(loader, ir)
+  def self.init(loader, ir, for_agent)
     add_alias('Pcore::URI_RX', TYPE_URI_RX, loader)
     add_type(TYPE_URI_ALIAS, loader)
     add_alias('Pcore::SimpleTypeName', TYPE_SIMPLE_TYPE_NAME, loader)
     add_alias('Pcore::TypeName', TYPE_QUALIFIED_REFERENCE, loader)
     add_alias('Pcore::QRef', TYPE_QUALIFIED_REFERENCE, loader)
+    begin
     Types::TypedModelObject.register_ptypes(loader, ir)
+    rescue Exception => e
+      puts e.message
+    end
 
     ir.register_implementation_namespace('Pcore', 'Puppet::Pops::Pcore', loader)
-    ir.register_implementation_namespace('Puppet::AST', 'Puppet::Pops::Model', loader)
-    ast_type_set = Serialization::RGen::TypeGenerator.new.generate_type_set('Puppet::AST', Puppet::Pops::Model, loader)
+    unless for_agent
+      ir.register_implementation_namespace('Puppet::AST', 'Puppet::Pops::Model', loader)
+      ast_type_set = Serialization::RGen::TypeGenerator.new.generate_type_set('Puppet::AST', Puppet::Pops::Model, loader)
 
-    # Extend the Puppet::AST type set with the Locator (it's not an RGen class, but nevertheless, used in the model)
-    ast_ts_i12n = ast_type_set.i12n_hash
-    ast_ts_i12n['types'] = ast_ts_i12n['types'].merge('Locator' => Parser::Locator::Locator19.register_ptype(loader, ir))
-    add_type(Types::PTypeSetType.new(ast_ts_i12n), loader)
+      # Extend the Puppet::AST type set with the Locator (it's not an RGen class, but nevertheless, used in the model)
+      ast_ts_i12n = ast_type_set.i12n_hash
+      ast_ts_i12n['types'] = ast_ts_i12n['types'].merge('Locator' => Parser::Locator::Locator19.register_ptype(loader, ir))
+      add_type(Types::PTypeSetType.new(ast_ts_i12n), loader)
 
-    Resource.register_ptypes(loader, ir)
-    Lookup::Context.register_ptype(loader, ir);
+      Resource.register_ptypes(loader, ir)
+      Lookup::Context.register_ptype(loader, ir);
+    end
   end
 
   # Create and register a new `Object` type in the Puppet Type System and map it to an implementation class

--- a/lib/puppet/pops/serialization/abstract_reader.rb
+++ b/lib/puppet/pops/serialization/abstract_reader.rb
@@ -105,8 +105,12 @@ class AbstractReader
       read_payload(data) { |ep| Extension::MapStart.new(ep.read) }
     end
 
+    register_type(Extension::PCORE_OBJECT_START) do |data|
+      read_payload(data) { |ep| type_name = read_tpl_qname(ep); Extension::PcoreObjectStart.new(type_name, ep.read) }
+    end
+
     register_type(Extension::OBJECT_START) do |data|
-      read_payload(data) { |ep| type_name = read_tpl_qname(ep); Extension::ObjectStart.new(type_name, ep.read) }
+      read_payload(data) { |ep| Extension::ObjectStart.new(ep.read) }
     end
 
     register_type(Extension::DEFAULT) do |data|

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -134,8 +134,12 @@ class AbstractWriter
       build_payload { |ep| ep.write(o.size) }
     end
 
-    register_type(Extension::OBJECT_START, Extension::ObjectStart) do |o|
+    register_type(Extension::PCORE_OBJECT_START, Extension::PcoreObjectStart) do |o|
       build_payload { |ep| write_tpl_qname(ep, o.type_name); ep.write(o.attribute_count) }
+    end
+
+    register_type(Extension::OBJECT_START, Extension::ObjectStart) do |o|
+      build_payload { |ep| ep.write(o.attribute_count) }
     end
 
     # 0x20 - 0x2f reserved for special extension objects

--- a/lib/puppet/pops/serialization/deserializer.rb
+++ b/lib/puppet/pops/serialization/deserializer.rb
@@ -8,7 +8,7 @@ module Serialization
   class Deserializer
     # Provides access to the reader.
     # @api private
-    attr_reader :reader
+    attr_reader :reader, :loader
 
     # @param [AbstractReader] reader the reader used when reading primitive objects from a stream
     # @param [Loader::Loader] loader the loader used when resolving names of types
@@ -38,11 +38,22 @@ module Serialization
         result = remember({})
         val.size.times { key = read; result[key] = read }
         result
-      when Extension::ObjectStart
+      when Extension::PcoreObjectStart
         type_name = val.type_name
         type = Types::TypeParser.singleton.parse(type_name, @loader)
         raise SerializationError, "No implementation mapping found for Puppet Type #{type_name}" if type.is_a?(Types::PTypeReferenceType)
-        type.read(val.attribute_count, self)
+        result = type.read(val.attribute_count, self)
+        if result.is_a?(Types::PObjectType)
+          existing_type = loader.load(:type, result.name)
+
+          # Add result to the loader unless it is the exact same instance as the existing_type. The add
+          # will succeed when the existing_type is nil.
+          loader.add_entry(:type, result.name, result, nil) unless result.equal?(existing_type)
+        end
+        result
+      when Extension::ObjectStart
+        type = read
+        type.read(val.attribute_count - 1, self)
       when Numeric, String, true, false, nil, Time
         val
       else

--- a/lib/puppet/pops/serialization/extension.rb
+++ b/lib/puppet/pops/serialization/extension.rb
@@ -12,7 +12,8 @@ module Extension
   # 0x10 - 0x1F are reserved for structural extensions
   ARRAY_START = 0x10
   MAP_START = 0x11
-  OBJECT_START = 0x12
+  PCORE_OBJECT_START = 0x12
+  OBJECT_START = 0x13
 
   # 0x20 - 0x2f reserved for special extension objects
   DEFAULT = 0x20
@@ -32,7 +33,7 @@ module Extension
   # Marker module indicating whether or not an instance is tabulated or not
   module NotTabulated; end
 
-  # Marker module for objects that starts a sequence, i.e. ArrayStart, MapStart, and ObjectStart
+  # Marker module for objects that starts a sequence, i.e. ArrayStart, MapStart, and PcoreObjectStart
   module SequenceStart; end
 
   # The class that triggers the use of the DEFAULT extension. It doesn't have any payload
@@ -83,9 +84,9 @@ module Extension
     end
   end
 
-  # The class that triggers the use of the OBJECT_START extension. The payload is the name of the object type and the
-  # number of attributes in the instance.
-  class ObjectStart
+  # The class that triggers the use of the PCORE_OBJECT_START extension. The payload is the name of the object type
+  # and the number of attributes in the instance.
+  class PcoreObjectStart
     include SequenceStart
     attr_reader :type_name, :attribute_count
     def initialize(type_name, attribute_count)
@@ -98,7 +99,28 @@ module Extension
     end
 
     def eql?(o)
-      o.is_a?(ObjectStart) && o.type_name == @type_name && o.attribute_count == @attribute_count
+      o.is_a?(PcoreObjectStart) && o.type_name == @type_name && o.attribute_count == @attribute_count
+    end
+    alias == eql?
+
+    def sequence_size
+      @attribute_count
+    end
+  end
+
+  class ObjectStart
+    include SequenceStart
+    attr_reader :attribute_count
+    def initialize(attribute_count)
+      @attribute_count = attribute_count
+    end
+
+    def hash
+      attribute_count.hash
+    end
+
+    def eql?(o)
+      o.is_a?(ObjectStart) && o.attribute_count == @attribute_count
     end
     alias == eql?
 

--- a/lib/puppet/pops/serialization/object.rb
+++ b/lib/puppet/pops/serialization/object.rb
@@ -52,7 +52,15 @@ class ObjectWriter
       args.pop
     end
 
-    serializer.start_object(type.name, args.size)
+    if type.name.start_with?('Pcore::')
+      serializer.push_written(value)
+      serializer.start_object(type.name, args.size)
+    else
+      serializer.start_pcore_object(args.size + 1)
+      serializer.write(type)
+      serializer.push_written(value)
+    end
+
     args.each { |arg| serializer.write(arg) }
   end
 

--- a/lib/puppet/pops/serialization/rgen.rb
+++ b/lib/puppet/pops/serialization/rgen.rb
@@ -37,6 +37,7 @@ module RGen
     def write(type, value, serializer)
       impl_class = value.class
       features = features(impl_class)
+      serializer.push_written(value)
       serializer.start_object(type.name, features.size)
       features.each { |feature| serializer.write(value.getGeneric(feature.name)) }
     end

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -45,7 +45,7 @@ class Puppet::Resource
       raise Puppet::Error, 'Unable to deserialize non-Data type parameters unless a deserializer is provided' unless json_deserializer
       reader = json_deserializer.reader
       ext_params.each do |param, value|
-        reader.re_initialize([value])
+        reader.re_initialize(value)
         resource[param] = json_deserializer.read
       end
     end
@@ -104,7 +104,7 @@ class Puppet::Resource
         writer.clear_io
         json_serializer.write(ext_params[key])
         writer.finish
-        ext_params[key] = writer.to_a[0]
+        ext_params[key] = writer.to_a
       end
       data['ext_parameters'] = ext_params
     end

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -426,8 +426,10 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     if resources = data['resources']
       # TODO: The deserializer needs a loader in order to deserialize types defined using the puppet language.
       json_deserializer = nil
-      if Puppet[:rich_data] || result.environment_instance && result.environment_instance.rich_data?
-        json_deserializer = Puppet::Pops::Serialization::Deserializer.new(Puppet::Pops::Serialization::JSON::Reader.new([]), nil)
+      if resources.any? { |res| res.has_key?('ext_parameters') }
+        json_deserializer = Puppet::Pops::Serialization::Deserializer.new(
+            Puppet::Pops::Serialization::JSON::Reader.new([]),
+            Puppet::Pops::Loaders.catalog_loader)
       end
       result.add_resource(*resources.collect do |res|
         Puppet::Resource.from_data_hash(res, json_deserializer)

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -850,10 +850,15 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
         Puppet[:rich_data] = true
       end
 
+      after(:each) do
+        Puppet[:rich_data] = false
+      end
+
+
       let(:catalog_w_regexp)  { compile_to_catalog("notify {'foo': message => /[a-z]+/ }") }
 
       it 'should generate ext_parameters for parameter values that are not Data' do
-        expect(catalog_w_regexp.to_json).to include('"ext_parameters":{"message":[48,"[a-z]+"]}')
+        expect(catalog_w_regexp.to_json).to include('"ext_parameters":{"message":[[48,"[a-z]+"]]}')
       end
 
       it 'should validate ext_parameters against the schema' do


### PR DESCRIPTION
Ensure that when an instance of an ObjectType is serialized, that the type
itself is serialized along with it. Also ensure that when the instance and
its type is deserialized, that the type is added to the loader used during
deserialization.