### PR TITLE
(PUP-7059) Improve Lookup Ruby API to handle multiple instances

### DIFF
--- a/lib/hiera/puppet_function.rb
+++ b/lib/hiera/puppet_function.rb
@@ -64,7 +64,9 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
         "The function '#{self.class.name}' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html")
     end
     lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {})
-    lookup_invocation.set_hiera_v3_function_info(override, !lookup_invocation.lookup_adapter.has_environment_data_provider?(lookup_invocation))
+    adapter = lookup_invocation.lookup_adapter
+    lookup_invocation.set_global_only unless adapter.global_only? || adapter.has_environment_data_provider?(lookup_invocation)
+    lookup_invocation.set_hiera_v3_location_overrides(override) unless override.nil? || override.is_a?(Array) && override.empty?
     Puppet::Pops::Lookup.lookup(key, nil, default, has_default, merge_type, lookup_invocation, &default_block)
   end
 

--- a/lib/puppet/pops/lookup/global_data_provider.rb
+++ b/lib/puppet/pops/lookup/global_data_provider.rb
@@ -42,7 +42,7 @@ class GlobalDataProvider < ConfiguredDataProvider
   end
 
   def configuration_path(lookup_invocation)
-    Pathname.new(Puppet.settings[:hiera_config])
+    lookup_invocation.global_hiera_config_path
   end
 end
 end

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -161,6 +161,29 @@ class LookupAdapter < DataAdapter
     ep.nil? ? false : ep.config(lookup_invocation).version >= 5
   end
 
+  # @return [Pathname] the full path of the hiera.yaml config file
+  def global_hiera_config_path
+    @global_hiera_config_path ||= Pathname.new(Puppet.settings[:hiera_config])
+  end
+
+  # @param path [String] the absolute path name of the global hiera.yaml file.
+  # @return [LookupAdapter] self
+  def set_global_hiera_config_path(path)
+    @global_hiera_config_path = Pathname.new(path)
+    self
+  end
+
+  def global_only?
+    instance_variable_defined?(:@global_only) ? @global_only : false
+  end
+
+  # Instructs the lookup framework to only perform lookups in the global layer
+  # @return [LookupAdapter] self
+  def set_global_only
+    @global_only = true
+    self
+  end
+
   private
 
   PROVIDER_STACK = [:lookup_global, :lookup_in_environment, :lookup_in_module].freeze

--- a/spec/unit/pops/lookup/lookup_spec.rb
+++ b/spec/unit/pops/lookup/lookup_spec.rb
@@ -1,0 +1,197 @@
+require 'spec_helper'
+require 'puppet_spec/files'
+require 'puppet/pops'
+require 'deep_merge/core'
+
+module Puppet::Pops
+module Lookup
+describe 'The lookup API' do
+  include PuppetSpec::Files
+
+  let(:env_name) { 'spec' }
+  let(:code_dir) { Puppet[:environmentpath] }
+  let(:env_dir) { File.join(code_dir, env_name) }
+  let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(populated_env_dir, 'modules')]) }
+  let(:node) { Puppet::Node.new('test', :environment => env) }
+  let(:compiler) { Puppet::Parser::Compiler.new(node) }
+  let(:scope) { compiler.topscope }
+  let(:invocation) { Invocation.new(scope) }
+
+  let(:code_dir_content) do
+    {
+      'hiera.yaml' => <<-YAML.unindent,
+        version: 5
+        YAML
+      'data' => {
+        'common.yaml' => <<-YAML.unindent
+          a: a (from global)
+          d: d (from global)
+          mod::e: mod::e (from global)
+          YAML
+      }
+    }
+  end
+
+  let(:env_content) do
+    {
+      'hiera.yaml' => <<-YAML.unindent,
+        version: 5
+        YAML
+      'data' => {
+        'common.yaml' => <<-YAML.unindent
+          b: b (from environment)
+          d: d (from environment)
+          mod::f: mod::f (from environment)
+          YAML
+      }
+    }
+  end
+
+  let(:mod_content) do
+    {
+      'hiera.yaml' => <<-YAML.unindent,
+        version: 5
+        YAML
+      'data' => {
+        'common.yaml' => <<-YAML.unindent
+          mod::c: mod::c (from module)
+          mod::e: mod::e (from module)
+          mod::f: mod::f (from module)
+          YAML
+      }
+    }
+  end
+
+  let(:populated_env_dir) do
+    all_content = code_dir_content.merge(env_name => env_content.merge('modules' => { 'mod' => mod_content }))
+    dir_contained_in(code_dir, all_content)
+    all_content.keys.each { |key| PuppetSpec::Files.record_tmp(File.join(code_dir, key)) }
+    env_dir
+  end
+
+  before(:each) do
+    Puppet[:hiera_config] = File.join(code_dir, 'hiera.yaml')
+    Puppet.push_context(:loaders => Puppet::Pops::Loaders.new(env))
+  end
+
+  after(:each) do
+    Puppet.pop_context
+  end
+
+  context 'when doing lookup' do
+    it 'finds data in global layer' do
+      expect(Lookup.lookup('a', nil, nil, false, nil, invocation)).to eql('a (from global)')
+    end
+
+    it 'finds data in environment layer' do
+      expect(Lookup.lookup('b', nil, 'not found', true, nil, invocation)).to eql('b (from environment)')
+    end
+
+    it 'global layer wins over environment layer' do
+      expect(Lookup.lookup('d', nil, 'not found', true, nil, invocation)).to eql('d (from global)')
+    end
+
+    it 'finds data in module layer' do
+      expect(Lookup.lookup('mod::c', nil, 'not found', true, nil, invocation)).to eql('mod::c (from module)')
+    end
+
+    it 'global layer wins over module layer' do
+      expect(Lookup.lookup('mod::e', nil, 'not found', true, nil, invocation)).to eql('mod::e (from global)')
+    end
+
+    it 'environment layer wins over module layer' do
+      expect(Lookup.lookup('mod::f', nil, 'not found', true, nil, invocation)).to eql('mod::f (from environment)')
+    end
+
+    context "with 'global_only' set to true in the invocation" do
+      let(:invocation) { Invocation.new(scope).set_global_only }
+
+      it 'finds data in global layer' do
+        expect(Lookup.lookup('a', nil, nil, false, nil, invocation)).to eql('a (from global)')
+      end
+
+      it 'does not find data in environment layer' do
+        expect(Lookup.lookup('b', nil, 'not found', true, nil, invocation)).to eql('not found')
+      end
+
+      it 'does not find data in module layer' do
+        expect(Lookup.lookup('mod::c', nil, 'not found', true, nil, invocation)).to eql('not found')
+      end
+    end
+
+    context "with 'global_only' set to true in the lookup adapter" do
+      it 'finds data in global layer' do
+        invocation.lookup_adapter.set_global_only
+        expect(Lookup.lookup('a', nil, nil, false, nil, invocation)).to eql('a (from global)')
+      end
+
+      it 'does not find data in environment layer' do
+        invocation.lookup_adapter.set_global_only
+        expect(Lookup.lookup('b', nil, 'not found', true, nil, invocation)).to eql('not found')
+      end
+
+      it 'does not find data in module layer' do
+        invocation.lookup_adapter.set_global_only
+        expect(Lookup.lookup('mod::c', nil, 'not found', true, nil, invocation)).to eql('not found')
+      end
+    end
+
+    context 'with subclassed lookup adpater' do
+      let(:other_dir) { tmpdir('other') }
+      let(:other_dir_content) do
+        {
+          'hiera.yaml' => <<-YAML.unindent,
+            version: 5
+            YAML
+          'data' => {
+            'common.yaml' => <<-YAML.unindent
+              a: a (from other global)
+              d: d (from other global)
+              mod::e: mod::e (from other global)
+              YAML
+          }
+        }
+      end
+
+      let(:populated_other_dir) do
+        dir_contained_in(other_dir, other_dir_content)
+        other_dir
+      end
+
+      before(:each) do
+        eval(<<-RUBY.unindent)
+        class SpecialLookupAdapter < LookupAdapter
+           def initialize(compiler)
+             super
+             set_global_only
+             set_global_hiera_config_path(File.join('#{populated_other_dir}', 'hiera.yaml'))
+           end
+        end
+        RUBY
+      end
+
+      after(:each) do
+        Puppet::Pops::Lookup.send(:remove_const, :SpecialLookupAdapter)
+      end
+
+      let(:other_invocation) { Invocation.new(scope, EMPTY_HASH, EMPTY_HASH, nil, SpecialLookupAdapter) }
+
+      it 'finds different data in global layer' do
+        expect(Lookup.lookup('a', nil, nil, false, nil, other_invocation)).to eql('a (from other global)')
+        expect(Lookup.lookup('a', nil, nil, false, nil, invocation)).to eql('a (from global)')
+      end
+
+      it 'does not find data in environment layer' do
+        expect(Lookup.lookup('b', nil, 'not found', true, nil, other_invocation)).to eql('not found')
+        expect(Lookup.lookup('b', nil, 'not found', true, nil, invocation)).to eql('b (from environment)')
+      end
+
+      it 'does not find data in module layer' do
+        expect(Lookup.lookup('mod::c', nil, 'not found', true, nil, other_invocation)).to eql('not found')
+        expect(Lookup.lookup('mod::c', nil, 'not found', true, nil, invocation)).to eql('mod::c (from module)')
+      end
+    end
+  end
+end
+end
+end


### PR DESCRIPTION
This commit adds the ability to create a separate instances of configured
lookup layers. A new instance is created by subclassing `LookupAdapter`
and then pass that class to the `Invocation` constructor. By doing so, a
new adapter will be created and adapted to the compiler. All configured
providers are then properties of the new adapter.

The `LookupAdapter` can be configured to work in a "global layer only"
mode. The global configuration (normally determined by the Puppet setting
"hiera_config" can be overridden.