### PR TITLE
(PUP-6448) Indirector URIs should remain UTF-8

### DIFF
--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -392,7 +392,7 @@ module Puppet
         end
 
         # WARNING: this won't work with filesync (symlinked environments are not supported)
-        on host, "ln -sf #{tmpdir} #{File.join(environmentpath,tmp_environment)}"
+        on host, "mkdir -p #{environmentpath}; ln -sf #{tmpdir} #{File.join(environmentpath,tmp_environment)}"
         return tmp_environment
       end
       module_function :mk_tmp_environment_with_teardown

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -1,0 +1,82 @@
+require 'puppet/acceptance/environment_utils'
+extend Puppet::Acceptance::EnvironmentUtils
+
+test_name 'Ensure a file resource can have a UTF-8 source attribute, content, and path when served via a module' do
+  skip_test 'requires a master for serving module content' if master.nil?
+
+  tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))
+  agent_tmp_dirs = {}
+
+  agents.each do |agent|
+    agent_tmp_dirs[agent.hostname] = agent.tmpdir(tmp_environment)
+  end
+
+  teardown do
+    step 'remove all test files on agents' do
+      agents.each { |agent| on(agent, "rm -r #{agent_tmp_dirs[agent.hostname]}", :accept_all_exit_codes => true) }
+    end
+    # note - master teardown is registered by #mk_tmp_environment_with_teardown
+  end
+
+  step 'create unicode source file served via module on master' do
+    # 静 \u9759 0xE9 0x9D 0x99 http://www.fileformat.info/info/unicode/char/9759/index.htm
+    # 的 \u7684 0xE7 0x9A 0x84 http://www.fileformat.info/info/unicode/char/7684/index.htm
+    # ☃ \2603 0xE2 0x98 0x83 http://www.fileformat.info/info/unicode/char/2603/index.htm
+    setup_module_on_master = <<-MASTER_MANIFEST
+      File {
+        ensure => directory,
+        mode => "0755",
+      }
+
+      file {
+        '#{environmentpath}/#{tmp_environment}/modules/utf8_file_module':;
+        '#{environmentpath}/#{tmp_environment}/modules/utf8_file_module/files':;
+      }
+
+      file { '#{environmentpath}/#{tmp_environment}/modules/utf8_file_module/files/\u9759\u7684':
+        ensure => file,
+        content => "\u2603"
+      }
+    MASTER_MANIFEST
+    apply_manifest_on(master, setup_module_on_master, :expect_changes => true)
+  end
+
+  step 'create a site.pp on master containing a unicode file resource' do
+    site_pp_contents = <<-SITE_PP
+      \$test_path = \$::fqdn ? #{agent_tmp_dirs}
+      file { "\$test_path/\uff72\uff67\u30d5\u30eb":
+        ensure => present,
+        source => "puppet:///modules/utf8_file_module/\u9759\u7684",
+      }
+    SITE_PP
+
+    create_site_pp = <<-CREATE_SITE_PP
+      file { "#{environmentpath}/#{tmp_environment}/manifests/site.pp":
+        ensure => file,
+        content => @(UTF8)
+          #{site_pp_contents}
+        | UTF8
+      }
+    CREATE_SITE_PP
+    apply_manifest_on(master, create_site_pp, :expect_changes => true)
+  end
+
+  step 'ensure agent can manage unicode file resource' do
+    # イ \uff72 0xEF 0xBD 0xB2 http://www.fileformat.info/info/unicode/char/ff72/index.htm
+    # ァ \uff67 0xEF 0xBD 0xA7 http://www.fileformat.info/info/unicode/char/ff67/index.htm
+    # フ \u30d5 0xE3 0x83 0x95 http://www.fileformat.info/info/unicode/char/30d5/index.htm
+    # ル \u30eb 0xE3 0x83 0xAB http://www.fileformat.info/info/unicode/char/30eb/index.htm
+
+    with_puppet_running_on(master, {}) do
+      agents.each do |agent|
+        fqdn = agent.hostname
+        on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"), :acceptable_exit_codes => 2)
+
+        on(agent, "cat #{agent_tmp_dirs[fqdn]}/\uff72\uff67\u30d5\u30eb") do |result|
+          assert_match("\u2603", result.stdout, "managed UTF-8 file contents '#{result.stdout}' did not match expected value '\u2603'")
+        end
+      end
+    end
+  end
+end
+

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -243,6 +243,8 @@ class Puppet::Indirector::Request
   def set_uri_key(key)
     @uri = key
     begin
+      # calling URI.escape for UTF-8 characters will % escape them
+      # and the resulting string components of the URI are now ASCII
       uri = URI.parse(URI.escape(key))
     rescue => detail
       raise ArgumentError, "Could not understand URL #{key}: #{detail}", detail.backtrace
@@ -272,6 +274,8 @@ class Puppet::Indirector::Request
       @protocol = uri.scheme
     end
 
-    @key = URI.unescape(uri.path.sub(/^\//, ''))
+    # The unescaped bytes are correct but in ASCII and must be treated
+    # as UTF-8 for the sake of performing string comparisons later
+    @key = URI.unescape(uri.path.sub(/^\//, '')).force_encoding(Encoding::UTF_8)
   end
 end

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -140,6 +140,15 @@ describe Puppet::Indirector::Request do
         expect(Puppet::Indirector::Request.new(:ind, :method, "http://host/stuff with spaces", nil).key).to eq("stuff with spaces")
       end
 
+      it "should set the request key to the unescaped path from the URI, in UTF-8 encoding" do
+        path = "\u4e07"
+        uri = "http://host/#{path}"
+        request = Puppet::Indirector::Request.new(:ind, :method, uri, nil)
+
+        expect(request.key).to eq(path)
+        expect(request.key.encoding).to eq(Encoding::UTF_8)
+      end
+
       it "should set the :uri attribute to the full URI" do
         expect(Puppet::Indirector::Request.new(:ind, :method, "http:///a/path/stu ff", nil).uri).to eq('http:///a/path/stu ff')
       end


### PR DESCRIPTION
This PR supersedes #5176 

From @Iristyle / #5176

> By not preserving the original Path encoding of UTF-8 used for
incoming requests to the indirector, future string comparisons (using
Regex for instance) are invalid and will cause exceptions.

> This problem is trivially reproducible with a manifest like:

> file { "/tmp/test":
> ensure => file,
> source => 'puppet://modules/utf_8/静的',
> }

> The key of the request previously was "utf_8/\xE9\x9D\x99\xE7\x9A\x84"
> instead of the appropriate "utf_8/静的"

This PR includes the original commit from #5176 as well as an acceptance test and fix for the issue.