### PR TITLE
(PUP-6476) Add Hocon data_set function for Hiera version 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group(:development, :test) do
   gem 'addressable', '< 2.5.0'
   gem 'webmock', '~> 1.24'
   gem 'vcr', '~> 2.9'
+  gem "hocon", :require => false
 end
 
 group(:development) do

--- a/lib/puppet/feature/hocon.rb
+++ b/lib/puppet/feature/hocon.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:hocon, :libs => ['hocon'])

--- a/lib/puppet/functions/hocon_data.rb
+++ b/lib/puppet/functions/hocon_data.rb
@@ -1,0 +1,24 @@
+# @since 4.9.0
+#
+Puppet::Functions.create_function(:hocon_data) do
+  unless Puppet.features.hocon?
+    raise Puppet::DataBinding::LookupError, 'Lookup using Hocon data_hash function is not supported without hocon library'
+  end
+
+  require 'hocon'
+  require 'hocon/config_error'
+
+  dispatch :hocon_data do
+    param 'Struct[{path=>String[1]}]', :options
+    param 'Puppet::LookupContext', :context
+  end
+
+  def hocon_data(options, context)
+    path = options['path']
+    begin
+      Hocon.parse(Puppet::FileSystem.read(path, :encoding => 'utf-8'))
+    rescue Hocon::ConfigError => ex
+      raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
+    end
+  end
+end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -513,9 +513,12 @@ describe "The lookup function" do
           - yaml
           - json
           - custom
+          - hocon
         :yaml:
           :datadir: #{code_dir}/hieradata
         :json:
+          :datadir: #{code_dir}/hieradata
+        :hocon:
           :datadir: #{code_dir}/hieradata
         :hierarchy:
           - common
@@ -574,6 +577,10 @@ describe "The lookup function" do
                 }
               }
               JSON
+            'common.conf' =>  <<-HOCON.unindent,
+              // The 'xs' is a value used for testing
+              xs = { subkey = value xs.subkey (from global hocon) }
+              HOCON
           }
         }
       end
@@ -640,6 +647,14 @@ describe "The lookup function" do
 
       it 'backend data sources are propagated to custom backend' do
         expect(lookup('datasources')).to eql(['common', 'example.com'])
+      end
+
+      it 'delegates configured hocon backend to hocon_data function' do
+        expect(explain('xs')).to match(/Hierarchy entry "hocon"\n.*\n.*\n.*"common"\n\s*Found key: "xs"/m)
+      end
+
+      it 'can dig down into subkeys provided by hocon_data function' do
+        expect(lookup('xs.subkey')).to eql('value xs.subkey (from global hocon)')
       end
 
       context 'using relative datadir paths' do


### PR DESCRIPTION
This commit adds a 'hocon' feature to Puppet which gets enabled when the
hocon library is present. It also adds a data_set function named
`hocon_data` capable of producing a Hash from a file in hocon format. The
function can only execute if the 'hocon' feature is enabled.

The Hiera version 3 and version 4 configs are changed so that when the
'hocon' feature is enabled, the data provider will use the added function
rather than attempting to use a custom backend or a presumed data binding.