### PR TITLE
(PUP-7066) return and deprecate stack trace in http server error response

### DIFF
--- a/api/schemas/error.json
+++ b/api/schemas/error.json
@@ -13,7 +13,7 @@
             "type": "string"
         },
         "stacktrace": {
-            "description": "For 5xx responses only, a ruby stacktrace to where an error occurred.",
+            "description": "**Deprecated**. For 5xx responses only, a message containing a deprecation warning. This property will be removed in a future release of Puppet.",
             "type": "array",
             "items": { "type": "string" }
         }

--- a/api/schemas/error.json
+++ b/api/schemas/error.json
@@ -11,6 +11,11 @@
         "issue_kind": {
             "description": "A unique label to identify the error class",
             "type": "string"
+        },
+        "stacktrace": {
+            "description": "For 5xx responses only, a ruby stacktrace to where an error occurred.",
+            "type": "array",
+            "items": { "type": "string" }
         }
     },
     "required": ["message", "issue_kind"],

--- a/lib/puppet/network/http/error.rb
+++ b/lib/puppet/network/http/error.rb
@@ -63,7 +63,7 @@ module Puppet::Network::HTTP::Error
     end
 
     def to_json
-      JSON({:message => message, :issue_kind => @issue_kind})
+      JSON({:message => message, :issue_kind => @issue_kind, :stacktrace => self.backtrace})
     end
   end
 end

--- a/lib/puppet/network/http/error.rb
+++ b/lib/puppet/network/http/error.rb
@@ -59,7 +59,7 @@ module Puppet::Network::HTTP::Error
 
     def initialize(original_error, issue_kind = Issues::RUNTIME_ERROR)
       super("Server Error: " + original_error.message, CODE, issue_kind)
-      @backtrace = original_error.backtrace
+      @backtrace = ["Warning: The 'stacktrace' property is deprecated and will be removed in a future version of Puppet. For security reasons, stacktraces are not returned with Puppet HTTP Error responses."]
     end
 
     def to_json

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -68,7 +68,7 @@ module Puppet::Network::HTTP::Handler
     new_response.respond_with(e.status, "application/json", e.to_json)
   rescue StandardError => e
     http_e = Puppet::Network::HTTP::Error::HTTPServerError.new(e)
-    log_msg = [http_e.message, *http_e.backtrace].join("\n")
+    log_msg = [http_e.message, *e.backtrace].join("\n")
     Puppet.err(log_msg)
     new_response.respond_with(http_e.status, "application/json", http_e.to_json)
   ensure

--- a/spec/unit/network/http/error_spec.rb
+++ b/spec/unit/network/http/error_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Network::HTTP::Error do
   end
 
   describe Puppet::Network::HTTP::Error::HTTPServerError do
-    it "should serialize to JSON that matches the error schema" do
+    it "should serialize to JSON that matches the error schema and has the optional stacktrace property" do
       begin
         raise Exception, "a wild Exception appeared!"
       rescue Exception => e

--- a/spec/unit/network/http/error_spec.rb
+++ b/spec/unit/network/http/error_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Network::HTTP::Error do
   end
 
   describe Puppet::Network::HTTP::Error::HTTPServerError do
-    it "should serialize to JSON that matches the error schema and has the optional stacktrace property" do
+    it "should serialize to JSON that matches the error schema and has a deprecated stacktrace property" do
       begin
         raise Exception, "a wild Exception appeared!"
       rescue Exception => e
@@ -24,6 +24,7 @@ describe Puppet::Network::HTTP::Error do
       error = Puppet::Network::HTTP::Error::HTTPServerError.new(culpable)
 
       expect(error.to_json).to validate_against('api/schemas/error.json')
+      expect(error.to_json).to match(/The 'stacktrace' property is deprecated/)
     end
   end
 

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -94,10 +94,6 @@ describe Puppet::Network::HTTP::Handler do
       expect(res[:content_type_header]).to eq("application/json")
       expect(res_body["issue_kind"]).to eq(Puppet::Network::HTTP::Issues::RUNTIME_ERROR.to_s)
       expect(res_body["message"]).to eq("Server Error: the sky is falling!")
-
-      # Stactraces may contain sensitive information, returning them to API
-      # consumers is not a best practice. See
-      # https://tickets.puppetlabs.com/browse/PUP-6659
       expect(res_body["stacktrace"]).to be_nil
       expect(res[:status]).to eq(500)
     end

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -94,7 +94,8 @@ describe Puppet::Network::HTTP::Handler do
       expect(res[:content_type_header]).to eq("application/json")
       expect(res_body["issue_kind"]).to eq(Puppet::Network::HTTP::Issues::RUNTIME_ERROR.to_s)
       expect(res_body["message"]).to eq("Server Error: the sky is falling!")
-      expect(res_body["stacktrace"]).to be_nil
+      expect(res_body["stacktrace"].is_a?(Array) && !res_body["stacktrace"].empty?).to be_truthy
+      expect(res_body["stacktrace"]).to match_array(['a.rb', 'b.rb'])
       expect(res[:status]).to eq(500)
     end
 

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -95,7 +95,7 @@ describe Puppet::Network::HTTP::Handler do
       expect(res_body["issue_kind"]).to eq(Puppet::Network::HTTP::Issues::RUNTIME_ERROR.to_s)
       expect(res_body["message"]).to eq("Server Error: the sky is falling!")
       expect(res_body["stacktrace"].is_a?(Array) && !res_body["stacktrace"].empty?).to be_truthy
-      expect(res_body["stacktrace"]).to match_array(['a.rb', 'b.rb'])
+      expect(res_body["stacktrace"][0]).to match(/The 'stacktrace' property is deprecated/)
       expect(res[:status]).to eq(500)
     end
 


### PR DESCRIPTION
In 7a765b7 and 5ae2d155 we unintentionally introduced a backwards-incompatible change, removing the "stacktrace" array from the HTTP Error object schema. We also added the stack trace information to the Puppet error log. This partially reverts commits 7a765b7 and 5ae2d155, returning the stack trace as formerly constituted, except that rather than return the actual stack trace content, we return a deprecation warning. This will allow users warning in case any systems consuming this data need to change to remain compatible. However, the reverts are partial in that we retain the previous addition of the stack trace to the puppet error log to avoid surprising anyone who had already begun to rely on this behavior and because with the stack trace string content removed, retaining the content for the logs will allow users to still find this information if they need it. Eventual removal of the property is ticketed as PUP-7070.