### PR TITLE
(PUP-7061) Fix problem with unbalanced pop of debug explainer

### DIFF
--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -539,10 +539,14 @@ module Puppet::Pops::Lookup
       end
     end
 
+    def dump_on(io, indent, first_indent)
+      @current.equal?(self) ? super : @current.dump_on(io, indent, first_indent)
+    end
+
     def emit_debug_info(preamble)
       io = ''
       io << preamble << "\n"
-      @current.dump_on(io, '  ', '  ')
+      dump_on(io, '  ', '  ')
       Puppet.debug(io.chomp!)
     end
   end

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -50,11 +50,7 @@ module Puppet::Pops::Lookup
     end
 
     def emit_debug_info(preamble)
-      debug_explainer = @explainer
-      if debug_explainer.is_a?(DebugExplainer)
-        @explainer = debug_explainer.wrapped_explainer
-        debug_explainer.emit_debug_info(preamble)
-      end
+      @explainer.emit_debug_info(preamble) if @explainer.is_a?(DebugExplainer)
     end
 
     # The qualifier_type can be one of:

--- a/spec/fixtures/unit/application/environments/production/data/common.yaml
+++ b/spec/fixtures/unit/application/environments/production/data/common.yaml
@@ -16,5 +16,7 @@ f.one:
     - second value
     - third value
 
+ab: "%{hiera('a')} and %{hiera('b')}"
+
 lookup_options:
   a: first


### PR DESCRIPTION
The debug explainer that was added to an invocation and that emitted
debug info on each resolution of an interpolation, was incorrectly
removed before the interpolation call was finished. This resulted in
an attempt to do a pop on an attribute that no longer existed.

This commit ensures that the attribute is treated as read-only and
instead moves the ability to do normal explaining to the debug by having
it delegate to it's wrapped explainer.