### PR TITLE
(PUP-6240) Deprecate use of Puppet::SemVer

### DIFF
--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -149,12 +149,15 @@ class Puppet::Interface
 
   # @api private
   def initialize(name, version, &block)
-    unless SemVer.valid?(version)
+    unless SemanticPuppet::Version.valid?(version)
       raise ArgumentError, "Cannot create face #{name.inspect} with invalid version number '#{version}'!"
     end
 
     @name    = Puppet::Interface::FaceCollection.underscorize(name)
-    @version = SemVer.new(version)
+
+    # SemVer is deprecated but in 4.x we must use it here (the attr_reader is public api). The
+    # extra boolean argument suppresses the deprecation warning.
+    @version = SemVer.new(version, true)
 
     # The few bits of documentation we actually demand.  The default license
     # is a favour to our end users; if you happen to get that in a core face

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -320,8 +320,9 @@ class Puppet::Module
 
       if version_string
         begin
-          required_version_semver_range = SemVer[version_string]
-          actual_version_semver = SemVer.new(dep_mod.version)
+          # Suppress deprecation warnings from SemVer in 4.9. In 5.0, this will be SemanticPuppet instead
+          required_version_semver_range = SemVer[version_string, true]
+          actual_version_semver = SemVer.new(dep_mod.version, true)
         rescue ArgumentError
           error_details[:reason] = :non_semantic_version
           unmet_dependencies << error_details

--- a/spec/unit/semver_spec.rb
+++ b/spec/unit/semver_spec.rb
@@ -212,6 +212,17 @@ describe SemVer do
       expect(version.tiny).to    eq(5)
       expect(version.special).to eq('-beta6')
     end
+
+    it 'should not log a deprecation warning when strict == off' do
+      Puppet[:strict] = :off
+      SemVer.new('1.2.3')
+      expect(@logs).to be_empty
+    end
+
+    it 'should log a deprecation warning unless strict == off' do
+      SemVer.new('1.2.3')
+      expect(@logs.map(&:message)).to include(/Use of class Puppet::SemVer is deprecated. SemanticPuppet::Version or SemanticPuppet::VersionRange should be used instead/)
+    end
   end
 
   describe '#matched_by?' do

--- a/spec/unit/semver_spec.rb
+++ b/spec/unit/semver_spec.rb
@@ -220,8 +220,11 @@ describe SemVer do
     end
 
     it 'should log a deprecation warning unless strict == off' do
-      SemVer.new('1.2.3')
-      expect(@logs.map(&:message)).to include(/Use of class Puppet::SemVer is deprecated. SemanticPuppet::Version or SemanticPuppet::VersionRange should be used instead/)
+      (Puppet.settings.setting(:strict).values - [:off]).each do |setting|
+        Puppet[:strict] = setting
+        SemVer.new('1.2.3')
+        expect(@logs.map(&:message)).to include(/Use of class Puppet::SemVer is deprecated. SemanticPuppet::Version or SemanticPuppet::VersionRange should be used instead/)
+      end
     end
   end
 


### PR DESCRIPTION
This commit ensures that a deprecation warning is logged when an instance
of Puppet::SemVer is created unless `Puppet[:strict] == :off`