### PR TITLE
(PUP-978) Multiple literal default in case and selector

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -619,6 +619,10 @@ module Issues
     "The key '#{key}' is declared more than once"
   end
 
+  DUPLICATE_DEFAULT = issue :DUPLICATE_DEFAULT, :container do
+    "This #{label.label(container)} already has a 'default' entry - this is a duplicate"
+  end
+
   RESERVED_PARAMETER = hard_issue :RESERVED_PARAMETER, :container, :param_name do
     "The parameter $#{param_name} redefines a built in parameter in #{label.the(container)}"
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -295,8 +295,12 @@ class Checker4_0 < Evaluator::LiteralEvaluator
 
   def check_CaseExpression(o)
     rvalue(o.test)
-    # There should only be one LiteralDefault case option value
-    # TODO: Implement this check
+    # There can only be one LiteralDefault case option value
+    defaults = o.options.values.select {|v| v.is_a?(Model::LiteralDefault) }
+    unless defaults.size <= 1
+      # Flag the second default as 'unreachable'
+      acceptor.accept(Issues::DUPLICATE_DEFAULT, defaults[1], :container => o)
+    end
   end
 
   def check_CaseOption(o)
@@ -659,6 +663,12 @@ class Checker4_0 < Evaluator::LiteralEvaluator
 
   def check_SelectorExpression(o)
     rvalue(o.left_expr)
+    # There can only be one LiteralDefault case option value
+    defaults = o.selectors.select {|v| v.matching_expr.is_a?(Model::LiteralDefault) }
+    unless defaults.size <= 1
+      # Flag the second default as 'unreachable'
+      acceptor.accept(Issues::DUPLICATE_DEFAULT, defaults[1].matching_expr, :container => o)
+    end
   end
 
   def check_SelectorEntry(o)

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -28,6 +28,7 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::FUTURE_RESERVED_WORD]          = :deprecation
 
     p[Issues::DUPLICATE_KEY]                 = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
+    p[Issues::DUPLICATE_DEFAULT]             = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
     p

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -50,7 +50,7 @@ describe "validating 4x" do
   end
 
   context 'with the default settings for --strict' do
-    it 'produces a warning for duplicate keyes in a literal hash' do
+    it 'produces a warning for duplicate keys in a literal hash' do
       acceptor = validate(parse('{ a => 1, a => 2 }'))
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
@@ -60,7 +60,7 @@ describe "validating 4x" do
 
   context 'with --strict set to warning' do
     before(:each) { Puppet[:strict] = :warning }
-    it 'produces a warning for duplicate keyes in a literal hash' do
+    it 'produces a warning for duplicate keys in a literal hash' do
       acceptor = validate(parse('{ a => 1, a => 2 }'))
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
@@ -70,7 +70,7 @@ describe "validating 4x" do
 
   context 'with --strict set to error' do
     before(:each) { Puppet[:strict] = :error }
-    it 'produces an error for duplicate keyes in a literal hash' do
+    it 'produces an error for duplicate keys in a literal hash' do
       acceptor = validate(parse('{ a => 1, a => 2 }'))
       expect(acceptor.warning_count).to eql(0)
       expect(acceptor.error_count).to eql(1)
@@ -80,7 +80,7 @@ describe "validating 4x" do
 
   context 'with --strict set to off' do
     before(:each) { Puppet[:strict] = :off }
-    it 'does not produce an error or warning for duplicate keyes in a literal hash' do
+    it 'does not produce an error or warning for duplicate keys in a literal hash' do
       acceptor = validate(parse('{ a => 1, a => 2 }'))
       expect(acceptor.warning_count).to eql(0)
       expect(acceptor.error_count).to eql(0)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -56,6 +56,20 @@ describe "validating 4x" do
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
+
+    it 'produces a warning for duplicate default in a case expression' do
+      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+    end
+
+    it 'produces a warning for duplicate default in a selector expression' do
+      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+    end
   end
 
   context 'with --strict set to warning' do
@@ -65,6 +79,20 @@ describe "validating 4x" do
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+    end
+
+    it 'produces a warning for duplicate default in a case expression' do
+      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+    end
+
+    it 'produces a warning for duplicate default in a selector expression' do
+      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
     end
   end
 
@@ -76,6 +104,20 @@ describe "validating 4x" do
       expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
+
+    it 'produces an error for duplicate default in a case expression' do
+      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+    end
+
+    it 'produces an error for duplicate default in a selector expression' do
+      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+    end
   end
 
   context 'with --strict set to off' do
@@ -85,6 +127,20 @@ describe "validating 4x" do
       expect(acceptor.warning_count).to eql(0)
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
+    end
+
+    it 'does not produce an error for duplicate default in a case expression' do
+      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+    end
+
+    it 'does not produce an error for duplicate default in a selector expression' do
+      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
     end
   end
 


### PR DESCRIPTION
This adds validation of duplicate literal default entries in case and selector expressions.