### PR TITLE
(PUP-4283) Update Puppet Module Tool to use SemanticPuppet::Version

### DIFF
--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -138,7 +138,7 @@ class Puppet::Interface
   attr_reader :name
 
   # The version of the face
-  # @return [SemVer]
+  # @return [SemanticPuppet::Version]
   attr_reader :version
 
   # The autoloader instance for the face
@@ -149,12 +149,12 @@ class Puppet::Interface
 
   # @api private
   def initialize(name, version, &block)
-    unless SemVer.valid?(version)
+    unless SemanticPuppet::Version.valid?(version)
       raise ArgumentError, "Cannot create face #{name.inspect} with invalid version number '#{version}'!"
     end
 
     @name    = Puppet::Interface::FaceCollection.underscorize(name)
-    @version = SemVer.new(version)
+    @version = SemanticPuppet::Version.parse(version)
 
     # The few bits of documentation we actually demand.  The default license
     # is a favour to our end users; if you happen to get that in a core face

--- a/lib/puppet/interface/face_collection.rb
+++ b/lib/puppet/interface/face_collection.rb
@@ -41,8 +41,13 @@ module Puppet::Interface::FaceCollection
     return @faces[name][:current] if pattern == :current
 
     versions = @faces[name].keys - [ :current ]
-    found    = SemVer.find_matching(pattern, versions)
+    range = pattern.is_a?(SemanticPuppet::Version) ? SemanticPuppet::VersionRange.new(pattern, pattern) : SemanticPuppet::VersionRange.parse(pattern)
+    found = find_matching(range, versions)
     return @faces[name][found]
+  end
+
+  def self.find_matching(range, versions)
+    versions.select { |v| range === v }.sort.last
   end
 
   # try to load the face, and return it.

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -320,8 +320,8 @@ class Puppet::Module
 
       if version_string
         begin
-          required_version_semver_range = SemVer[version_string]
-          actual_version_semver = SemVer.new(dep_mod.version)
+          required_version_semver_range = SemanticPuppet::VersionRange.parse(version_string)
+          actual_version_semver = SemanticPuppet::Version.parse(dep_mod.version)
         rescue ArgumentError
           error_details[:reason] = :non_semantic_version
           unmet_dependencies << error_details

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -75,7 +75,7 @@ module Puppet::ModuleTool
           raise ArgumentError, "Could not parse filename to obtain the username, module name and version.  (#{@release_name})"
         end
 
-        unless SemVer.valid?(version)
+        unless SemanticPuppet::Version.valid?(version)
           raise ArgumentError, "Invalid version format: #{version} (Semantic Versions are acceptable: http://semver.org)"
         end
 

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -258,7 +258,7 @@ module Puppet::ModuleTool
           @remote = { "#{@module_name}@#{@version}" => { } }
           @versions = {
             @module_name => [
-              { :vstring => @version, :semver => SemVer.new(@version) }
+              { :vstring => @version, :semver => SemanticPuppet::Version.parse(@version) }
             ]
           }
         else

--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -57,7 +57,7 @@ module Puppet::ModuleTool
               :path    => mod.modulepath,
             }
             if @options[:version] && mod.version
-              next unless SemVer[@options[:version]].include?(SemVer.new(mod.version))
+              next unless SemanticPuppet::VersionRange.parse(@options[:version]).include?(SemanticPuppet::Version.parse(mod.version))
             end
             @installed << mod
           elsif mod_name =~ /#{@name}/

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -188,7 +188,7 @@ module Puppet::ModuleTool
 
     # Validates that the version string can be parsed as per SemVer.
     def validate_version(version)
-      return if SemVer.valid?(version)
+      return if SemanticPuppet::Version.valid?(version)
 
       err = "version string cannot be parsed as a valid Semantic Version"
       raise ArgumentError, "Invalid 'version' field in metadata.json: #{err}"

--- a/lib/puppet/module_tool/shared_behaviors.rb
+++ b/lib/puppet/module_tool/shared_behaviors.rb
@@ -36,7 +36,7 @@ module Puppet::ModuleTool::Shared
       mod_name, releases = pair
       mod_name = mod_name.gsub('/', '-')
       releases.each do |rel|
-        semver = SemVer.new(rel['version'] || '0.0.0') rescue SemVer::MIN
+        semver = SemanticPuppet::Version.parse(rel['version']) rescue SemanticPuppet::Version::MIN
         @versions[mod_name] << { :vstring => rel['version'], :semver => semver }
         @versions[mod_name].sort! { |a, b| a[:semver] <=> b[:semver] }
         @urls["#{mod_name}@#{rel['version']}"] = rel['file']
@@ -76,10 +76,10 @@ module Puppet::ModuleTool::Shared
       }
 
       if forced?
-        range = SemVer[@version] rescue SemVer['>= 0.0.0']
+        range = SemanticPuppet::VersionRange.parse(@version) rescue SemanticPuppet::VersionRange.parse('>= 0.0.0')
       else
         range = (@conditions[mod]).map do |r|
-          SemVer[r[:dependency]] rescue SemVer['>= 0.0.0']
+          SemanticPuppet::VersionRange.parse(r[:dependency]) rescue SemanticPuppet::VersionRange.parse('>= 0.0.0')
         end.inject(&:&)
       end
 
@@ -97,7 +97,7 @@ module Puppet::ModuleTool::Shared
       end
 
       if !(forced? || @installed[mod].empty? || source.last[:name] == :you)
-        next if range === SemVer.new(@installed[mod].first.version)
+        next if range === SemanticPuppet::Version.parse(@installed[mod].first.version)
         action = :upgrade
       elsif @installed[mod].empty?
         action = :install

--- a/spec/unit/interface/face_collection_spec.rb
+++ b/spec/unit/interface/face_collection_spec.rb
@@ -47,7 +47,7 @@ describe Puppet::Interface::FaceCollection do
 
   describe "::[]" do
     before :each do
-      subject.instance_variable_get("@faces")[:foo][SemVer.new('0.0.1')] = 10
+      subject.instance_variable_get("@faces")[:foo][SemanticPuppet::Version.parse('0.0.1')] = 10
     end
 
     it "should return the face with the given name" do
@@ -66,13 +66,13 @@ describe Puppet::Interface::FaceCollection do
     end
 
     it "should return true if the face specified is registered" do
-      subject.instance_variable_get("@faces")[:foo][SemVer.new('0.0.1')] = 10
+      subject.instance_variable_get("@faces")[:foo][SemanticPuppet::Version.parse('0.0.1')] = 10
       expect(subject["foo", '0.0.1']).to eq(10)
     end
 
     it "should attempt to require the face if it is not registered" do
       subject.expects(:require).with do |file|
-        subject.instance_variable_get("@faces")[:bar][SemVer.new('0.0.1')] = true
+        subject.instance_variable_get("@faces")[:bar][SemanticPuppet::Version.parse('0.0.1')] = true
         file == 'puppet/face/bar'
       end
       expect(subject["bar", '0.0.1']).to be_truthy
@@ -130,14 +130,14 @@ describe Puppet::Interface::FaceCollection do
         get_action_for_face(:huzzah, :obsolete, :current)
 
       expect(action).to be_an_instance_of Puppet::Interface::Action
-      expect(action.face.version).to eq(SemVer.new('1.0.0'))
+      expect(action.face.version).to eq(SemanticPuppet::Version.parse('1.0.0'))
     end
 
     it "should load the full older version of a face" do
       action = Puppet::Face::FaceCollection.
         get_action_for_face(:huzzah, :obsolete, :current)
 
-      expect(action.face.version).to eq(SemVer.new('1.0.0'))
+      expect(action.face.version).to eq(SemanticPuppet::Version.parse('1.0.0'))
       expect(action.face).to be_action :obsolete_in_core
     end
 
@@ -145,11 +145,11 @@ describe Puppet::Interface::FaceCollection do
       action = Puppet::Face::FaceCollection.
         get_action_for_face(:huzzah, :obsolete, :current)
 
-      expect(action.face.version).to eq(SemVer.new('1.0.0'))
+      expect(action.face.version).to eq(SemanticPuppet::Version.parse('1.0.0'))
       expect(action.face).to be_action :obsolete_in_core
 
       current = Puppet::Face[:huzzah, :current]
-      expect(current.version).to eq(SemVer.new('2.0.1'))
+      expect(current.version).to eq(SemanticPuppet::Version.parse('2.0.1'))
       expect(current).not_to be_action :obsolete_in_core
       expect(current).not_to be_action :obsolete
     end

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -9,7 +9,7 @@ describe Puppet do
 
   context "#version" do
     it "should be valid semver" do
-      expect(SemVer).to be_valid Puppet.version
+      expect(SemanticPuppet::Version).to be_valid Puppet.version
     end
   end
 


### PR DESCRIPTION
This commit switches the PMT from using the old Puppet::SemVer to instead
use SemanticPuppet::Version and SemanticPuppet::VersionRange.

The commit also changes one occurance in Puppet::Interface::FaceCollection