### PR TITLE
(PUP-868) deprecate misc cert-related faces

### DIFF
--- a/lib/puppet/face/ca.rb
+++ b/lib/puppet/face/ca.rb
@@ -254,4 +254,6 @@ Puppet::Face.define(:ca, '0.1.0') do
       end
     end
   end
+
+  deprecate
 end

--- a/lib/puppet/face/certificate_request.rb
+++ b/lib/puppet/face/certificate_request.rb
@@ -51,4 +51,6 @@ Puppet::Indirector::Face.define(:certificate_request, '0.0.1') do
 
   get_action(:save).summary "API only: submit a certificate signing request."
   get_action(:save).arguments "<x509_CSR>"
+
+  deprecate
 end

--- a/lib/puppet/face/certificate_revocation_list.rb
+++ b/lib/puppet/face/certificate_revocation_list.rb
@@ -51,4 +51,6 @@ Puppet::Indirector::Face.define(:certificate_revocation_list, '0.0.1') do
 
   deactivate_action(:search)
   deactivate_action(:save)
+
+  deprecate
 end

--- a/spec/unit/face/ca_spec.rb
+++ b/spec/unit/face/ca_spec.rb
@@ -1,0 +1,10 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/face'
+
+describe Puppet::Face[:ca, '0.1.0'] do
+  it "should be deprecated" do
+    expect(subject.deprecated?).to be_truthy
+  end
+end
+

--- a/spec/unit/face/certificate_request_spec.rb
+++ b/spec/unit/face/certificate_request_spec.rb
@@ -1,0 +1,10 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/face'
+
+describe Puppet::Face[:certificate_request, '0.0.1'] do
+  it "should be deprecated" do
+    expect(subject.deprecated?).to be_truthy
+  end
+end
+

--- a/spec/unit/face/certificate_revocation_list_spec.rb
+++ b/spec/unit/face/certificate_revocation_list_spec.rb
@@ -1,0 +1,10 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/face'
+
+describe Puppet::Face[:certificate_revocation_list, '0.0.1'] do
+  it "should be deprecated" do
+    expect(subject.deprecated?).to be_truthy
+  end
+end
+


### PR DESCRIPTION
This PR deprecates the certificate_request, certificate_revocation_list, and ca faces.

Original context from @nfagerlund on redmine #15860:

The real puppet cert mgmt command is “puppet cert.” It’s one of the classic
applications. But for some reason, there are a TON of faces related to certs
hanging around! I’m seeing:
- ca
- ~certificate~ - _note it was decided to keep certificate in PUP-868_
- certificate_request
- certificate_revocation_list
- None of these act as a replacement for puppet cert.  By using a patchwork of
  them, you might be able to get all of the functionality of puppet cert, but
  it’s not clear. This is a result of us simply exposing these indirector
  endpoints on the command line without spending any time thinking about a
  usable API for interacting with them.
- Because the find/search/save/destroy actions are generally bad fits for a
  command line API, these faces are all cluttered up with at least partially
  unusable actions.
- Because they act through the indirector, and agent and master use different
  termini for all of these endpoints, it’s not clear which faces and actions
  are meant to be used on the agent and which on the master. Additionally, some
  of these may be intended to act remotely.
- Some of these faces have actions whose behavior conflicts with an
  identically-named action on ‘puppet cert.’ Particularly, see puppet
  certificate generate vs. puppet cert generate vs.  puppet ca generate
  (?????).
- Some of these faces (particularly puppet ca) have completely undocumented
  actions. This is my “someone added an action without a description string”
  face: >:|