### PR TITLE
(PUP-873) deprecate status face

### DIFF
--- a/lib/puppet/face/status.rb
+++ b/lib/puppet/face/status.rb
@@ -45,4 +45,6 @@ Puppet::Indirector::Face.define(:status, '0.0.1') do
 
     $ puppet status find --terminus rest
   EOT
+  
+  deprecate
 end

--- a/spec/unit/face/status_spec.rb
+++ b/spec/unit/face/status_spec.rb
@@ -1,0 +1,10 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/face'
+
+describe Puppet::Face[:status, '0.0.1'] do
+  it "should be deprecated" do
+    expect(subject.deprecated?).to be_truthy
+  end
+end
+


### PR DESCRIPTION
Deprecate the `puppet status` face.

Context from PUP-873/@zaphod42, suggesting this face is unusable:

  "The status face could possibly be useful, but the usability of it is so
  atrocious we are better removing it and revisiting it later."

Additional detail on the poor UX and broken-ness of this face can be found in
PUP-873.