### PR TITLE
(PUP-871) deprecate key face

### DIFF
--- a/lib/puppet/face/key.rb
+++ b/lib/puppet/face/key.rb
@@ -12,4 +12,5 @@ Puppet::Indirector::Face.define(:key, '0.0.1') do
     subcommand directly.
   EOT
 
+  deprecate
 end

--- a/spec/unit/face/key_spec.rb
+++ b/spec/unit/face/key_spec.rb
@@ -1,0 +1,10 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/face'
+
+describe Puppet::Face[:key, '0.0.1'] do
+  it "should be deprecated" do
+    expect(subject.deprecated?).to be_truthy
+  end
+end
+


### PR DESCRIPTION
The key face is (self-described) not intended to be used - per PUP-871 it
should be removed.

From key.rb:
"it should not be necessary to use this subcommand directly"

Signed-off-by: Moses Mendoza <moses@puppet.com>