### PR TITLE
(PUP-6930) Make DUPLICATE_DEFAULT an error

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -619,7 +619,7 @@ module Issues
     "The key '#{key}' is declared more than once"
   end
 
-  DUPLICATE_DEFAULT = issue :DUPLICATE_DEFAULT, :container do
+  DUPLICATE_DEFAULT = hard_issue :DUPLICATE_DEFAULT, :container do
     "This #{label.label(container)} already has a 'default' entry - this is a duplicate"
   end
 

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -28,7 +28,6 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::FUTURE_RESERVED_WORD]          = :deprecation
 
     p[Issues::DUPLICATE_KEY]                 = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
-    p[Issues::DUPLICATE_DEFAULT]             = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
     p

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -88,23 +88,19 @@ describe "validating 4x" do
     end
   end
 
-  [:off, :warning, :error].each do |level|
-    context "with --strict set to #{level}" do
-      before(:each) { Puppet[:strict] = level }
+  context 'irrespective of --strict' do
+    it 'produces an error for duplicate default in a case expression' do
+      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+    end
 
-      it 'produces an error for duplicate default in a case expression' do
-        acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
-        expect(acceptor.warning_count).to eql(0)
-        expect(acceptor.error_count).to eql(1)
-        expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
-      end
-
-      it 'prouces an error for duplicate default in a selector expression' do
-        acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
-        expect(acceptor.warning_count).to eql(0)
-        expect(acceptor.error_count).to eql(1)
-        expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
-      end
+    it 'produces an error for duplicate default in a selector expression' do
+      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
     end
   end
 

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -56,20 +56,6 @@ describe "validating 4x" do
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
-
-    it 'produces a warning for duplicate default in a case expression' do
-      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
-    end
-
-    it 'produces a warning for duplicate default in a selector expression' do
-      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
-    end
   end
 
   context 'with --strict set to warning' do
@@ -79,20 +65,6 @@ describe "validating 4x" do
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
-    end
-
-    it 'produces a warning for duplicate default in a case expression' do
-      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
-    end
-
-    it 'produces a warning for duplicate default in a selector expression' do
-      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
     end
   end
 
@@ -104,20 +76,6 @@ describe "validating 4x" do
       expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
-
-    it 'produces an error for duplicate default in a case expression' do
-      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
-      expect(acceptor.warning_count).to eql(0)
-      expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
-    end
-
-    it 'produces an error for duplicate default in a selector expression' do
-      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
-      expect(acceptor.warning_count).to eql(0)
-      expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
-    end
   end
 
   context 'with --strict set to off' do
@@ -128,19 +86,25 @@ describe "validating 4x" do
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
+  end
 
-    it 'does not produce an error for duplicate default in a case expression' do
-      acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
-      expect(acceptor.warning_count).to eql(0)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
-    end
+  [:off, :warning, :error].each do |level|
+    context "with --strict set to #{level}" do
+      before(:each) { Puppet[:strict] = level }
 
-    it 'does not produce an error for duplicate default in a selector expression' do
-      acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
-      expect(acceptor.warning_count).to eql(0)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+      it 'produces an error for duplicate default in a case expression' do
+        acceptor = validate(parse('case 1 { default: {1} default : {2} }'))
+        expect(acceptor.warning_count).to eql(0)
+        expect(acceptor.error_count).to eql(1)
+        expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+      end
+
+      it 'prouces an error for duplicate default in a selector expression' do
+        acceptor = validate(parse(' 1 ? { default => 1, default => 2 }'))
+        expect(acceptor.warning_count).to eql(0)
+        expect(acceptor.error_count).to eql(1)
+        expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+      end
     end
   end
 


### PR DESCRIPTION
Before this, a DUPLICATE_KEY was under the control of the `strict`
setting. This commit changes that to be a hard error.