### PR TITLE
(PUP-7083) Remove obsolete references to old DataProvider module

### DIFF
--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -11,7 +11,7 @@ Puppet::Functions.create_function(:yaml_data) do
   def yaml_data(options, context)
     begin
       data = YAML.load_file(options['path'])
-      Puppet::DataProviders::HieraConfig.symkeys_to_string(data.nil? ? {} : data)
+      Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data.nil? ? {} : data)
     rescue YAML::SyntaxError => ex
       # Psych errors includes the absolute path to the file, so no need to add that
       # to the message

--- a/lib/puppet/pops/lookup/configured_data_provider.rb
+++ b/lib/puppet/pops/lookup/configured_data_provider.rb
@@ -1,6 +1,5 @@
 require_relative 'hiera_config'
 require_relative 'data_provider'
-require 'puppet/data_providers/hiera_config'
 
 module Puppet::Pops
 module Lookup

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -1,7 +1,6 @@
 require 'puppet'
 require 'puppet/util/tagging'
 require 'puppet/parameter'
-require 'puppet/data_providers'
 
 # The simplest resource class.  Eventually it will function as the
 # base class for all resource-like behaviour.

--- a/spec/unit/pops/lookup/interpolation_spec.rb
+++ b/spec/unit/pops/lookup/interpolation_spec.rb
@@ -1,8 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet'
-require 'puppet/data_providers/hiera_config'
-require 'puppet/data_providers/hiera_interpolate'
 
 module Puppet::Pops
 describe 'Puppet::Pops::Lookup::Interpolation' do


### PR DESCRIPTION
The code base contained some references to the old Puppet::DataProvider
module (experimental 4.x lookup implementation). This commit removes
them.