### PR TITLE
(PUP-6112) Make trusted_server_facts always be true

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -227,9 +227,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       node.merge(facts.values) if facts
 
       # Add server facts so $server_facts[environment] exists when doing a puppet apply
-      if Puppet[:trusted_server_facts]
-        node.add_server_facts({})
-      end
+      node.add_server_facts({})
 
       # Allow users to load the classes that puppet agent creates.
       if options[:loadclasses]

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -604,14 +604,11 @@ deprecated and has been replaced by 'always_retry_plugins'."
           class, or definition other than in the site manifest.",
     },
     :trusted_server_facts => {
-      :default => false,
+      :default => true,
       :type    => :boolean,
-      :desc    => "When enabled, Puppet creates a protected top-scope variable called $server_facts.
-        This variable name can't be re-used in any local scope, and can't be overridden
-        by agent-provided facts.
-
-        The $server_facts variable is a hash, containing server-provided information
-        like the current node's environment and the version of Puppet running on the server.",
+      :deprecated => :completely,
+      :desc    => "The 'trusted_server_facts' setting is deprecated and has no effect as the
+        feature this enabled is now always on. The setting will be removed in a future version of puppet.",
     },
     :preview_outputdir => {
       :default => '$vardir/preview',

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -844,9 +844,7 @@ class Puppet::Parser::Compiler
     catalog.server_version = node.parameters["serverversion"]
     @topscope.set_trusted(node.trusted_data)
 
-    if Puppet[:trusted_server_facts]
-      @topscope.set_server_facts(node.server_facts)
-    end
+    @topscope.set_server_facts(node.server_facts)
 
     facts_hash = node.facts.nil? ? {} : node.facts.values
     @topscope.set_facts(facts_hash)

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -737,7 +737,7 @@ class Puppet::Parser::Scope
     end
 
     # Check for server_facts reserved variable name if the trusted_sever_facts setting is true
-    if Puppet[:trusted_server_facts] && name == 'server_facts' && !options[:privileged]
+    if name == 'server_facts' && !options[:privileged]
       raise Puppet::ParseError, "Attempt to assign to a reserved variable name: '#{name}'"
     end
 

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -60,13 +60,7 @@ module Runtime3Support
     # TODO: Improve the messy implementation in Scope.
     #
     if name == "server_facts"
-      if Puppet[:trusted_server_facts] || Puppet[:strict] == :error
-        fail(Issues::ILLEGAL_RESERVED_ASSIGNMENT, o, {:name => name} )
-      elsif Puppet[:strict] == :warning
-        file, line = extract_file_line(o)
-        msg = "Assignment to $server_facts is deprecated"
-        Puppet.warn_once(:deprecation, msg, msg, file, line)
-      end
+      fail(Issues::ILLEGAL_RESERVED_ASSIGNMENT, o, {:name => name} )
     end
 
     if scope.bound?(name)

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -234,9 +234,8 @@ end
     expect(@logs.map(&:to_s)).to include('it was applied')
   end
 
-  it "adds environment to the $server_facts variable if trusted_server_facts is true" do
+  it "adds environment to the $server_facts variable" do
     manifest = file_containing("manifest.pp", "notice(\"$server_facts\")")
-    Puppet[:trusted_server_facts] = true
 
     puppet = Puppet::Application[:apply]
     puppet.stubs(:command_line).returns(stub('command_line', :args => [manifest]))

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -174,70 +174,31 @@ describe Puppet::Parser::Compiler do
 
   context 'when working with $server_facts' do
     include PuppetSpec::Compiler
-    context 'and have opted in to trusted_server_facts' do
-      before :each do
-        Puppet[:trusted_server_facts] = true
-      end
 
-      it 'should make $trusted available' do
-        node = Puppet::Node.new("testing")
-        node.add_server_facts({ "server_fact" => "foo" })
+    it '$trusted is available' do
+      node = Puppet::Node.new("testing")
+      node.add_server_facts({ "server_fact" => "foo" })
 
-        catalog = compile_to_catalog(<<-MANIFEST, node)
-            notify { 'test': message => $server_facts[server_fact] }
-        MANIFEST
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+          notify { 'test': message => $server_facts[server_fact] }
+      MANIFEST
 
-        expect(catalog).to have_resource("Notify[test]").with_parameter(:message, "foo")
-      end
-
-      it 'should not allow assignment to $server_facts' do
-        node = Puppet::Node.new("testing")
-        node.add_server_facts({ "server_fact" => "foo" })
-
-        expect do
-          compile_to_catalog(<<-MANIFEST, node)
-              $server_facts = 'changed'
-              notify { 'test': message => $server_facts == 'changed' }
-          MANIFEST
-        end.to raise_error(Puppet::PreformattedError, /Attempt to assign to a reserved variable name: '\$server_facts'.*/)
-      end
+      expect(catalog).to have_resource("Notify[test]").with_parameter(:message, "foo")
     end
 
-    context 'and have not opted in to hashed_node_data' do
-      before :each do
-        Puppet[:trusted_server_facts] = false
-      end
+    it 'does not allow assignment to $server_facts' do
+      node = Puppet::Node.new("testing")
+      node.add_server_facts({ "server_fact" => "foo" })
 
-      it 'should not make $server_facts available' do
-        node = Puppet::Node.new("testing")
-        node.add_server_facts({ "server_fact" => "foo" })
-
-        catalog = compile_to_catalog(<<-MANIFEST, node)
-            notify { 'test': message => ($server_facts == undef) }
-        MANIFEST
-
-        expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
-      end
-
-      it 'should allow assignment to $server_facts' do
-        catalog = compile_to_catalog(<<-MANIFEST)
+      expect do
+        compile_to_catalog(<<-MANIFEST, node)
             $server_facts = 'changed'
             notify { 'test': message => $server_facts == 'changed' }
         MANIFEST
-
-        expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
-      end
-      it 'should warn about assignment to $server_facts' do
-        catalog = compile_to_catalog(<<-MANIFEST)
-            $server_facts = 'changed'
-            notify { 'test': message => $server_facts == 'changed' }
-        MANIFEST
-        expect(@logs).to have_matching_log(/Assignment to \$server_facts is deprecated/)
-
-        expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
-      end
+      end.to raise_error(Puppet::PreformattedError, /Attempt to assign to a reserved variable name: '\$server_facts'.*/)
     end
   end
+
   describe "the compiler when using 4.x language constructs" do
     include PuppetSpec::Compiler
 


### PR DESCRIPTION
This changes trusted_server_facts setting such that it is always as if
it was set to true. The setting itself is deprecated (rather than
removed) to not cause immediate failure, but the settings has no effect.

The default of the setting has changed to true. The acceptance test is
updated to check that it is true, and the test of the false branch is
dropped.