### PR TITLE
(PUP-869) Add face deprecation message to help summaries

### DIFF
--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -146,7 +146,9 @@ MSG
       if (is_face_app?(appname))
         begin
           face = Puppet::Face[appname, :current]
-          result << [appname, face.summary]
+          # Add deprecation message to summary if the face is deprecated
+          summary = face.deprecated? ? face.summary + _(" (Deprecated)") : face.summary
+          result << [appname, summary]
         rescue StandardError, LoadError
           result << [ "! #{appname}", _("! Subcommand unavailable due to error. Check error logs.") ]
         end

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -148,6 +148,16 @@ describe Puppet::Face[:help, '0.0.1'] do
     end
   end
 
+  context "#all_application_summaries" do
+    it "appends a deprecation warning for deprecated faces" do
+      # Stub the module face as deprecated
+      Puppet::Face[:module, :current].expects(:deprecated?).returns(true)
+      result = Puppet::Face[:help, :current].all_application_summaries.each do |appname,summary|
+        expect(summary).to match(/Deprecated/) if appname == 'module'
+      end
+    end
+  end
+
   context "#legacy_applications" do
     subject { Puppet::Face[:help, :current].legacy_applications }
 


### PR DESCRIPTION
Previously in commit 7fefceae40d5ac a deprecation message was added to the face
and the help text for a face.  However when running `puppet help` it was not
obvious which faces were deprecated or not.

This commit adds the text `(Deprecated)` to the face summary when running
`puppet help`.