### PR TITLE
(PUP-3534) Deprecate caching certificate authority verify methods

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -420,6 +420,11 @@ class Puppet::SSL::CertificateAuthority
   #   of the X509 Store
   #
   # @return [OpenSSL::X509::Store]
+  #
+  # @deprecated Strictly speaking, #x509_store is marked API private, so we
+  #   don't need to publicly deprecate it. But it marked as deprecated here to
+  #   avoid the exceedingly small chance that someone comes in and uses it from
+  #   within this class before it is removed.
   def x509_store(options = {})
     if (options[:cache])
       return @x509store unless @x509store.nil?
@@ -486,7 +491,7 @@ class Puppet::SSL::CertificateAuthority
     unless cert = Puppet::SSL::Certificate.indirection.find(name)
       raise ArgumentError, "Could not find a certificate for #{name}"
     end
-    store = x509_store
+    store = create_x509_store
 
     raise CertificateVerificationError.new(store.error), store.error_string unless store.verify(cert.content)
   end

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -189,7 +189,7 @@ class Puppet::SSL::CertificateAuthority
   #
   # @return [Array<String>]
   def list(name='*')
-    list_certificates(name).collect { |c| c.name }
+    Puppet::SSL::Certificate.indirection.search(name).collect { |c| c.name }
   end
 
   # Return all the certificate objects as found by the indirector
@@ -205,7 +205,10 @@ class Puppet::SSL::CertificateAuthority
   # @param name [Array<string>] filter to cerificate names
   #
   # @return [Array<Puppet::SSL::Certificate>]
+  #
+  # @deprecated Use Puppet::SSL::CertificateAuthority#list or Puppet Server Certificate status API
   def list_certificates(name='*')
+    Puppet.deprecation_warning("Puppet::SSL::CertificateAuthority#list_certificates is deprecated. Please use Puppet::SSL::CertificateAuthority#list or the certificate status API to query certificate information. See https://docs.puppet.com/puppet/latest/http_api/http_certificate_status.html")
     Puppet::SSL::Certificate.indirection.search(name)
   end
 

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -472,7 +472,10 @@ class Puppet::SSL::CertificateAuthority
   # @param cert [Puppet::SSL::Certificate] the certificate to check validity of
   #
   # @return [Boolean] true if signed, false if unsigned or revoked
+  #
+  # @deprecated use Puppet::SSL::CertificateAuthority#verify or Puppet Server certificate status API
   def certificate_is_alive?(cert)
+    Puppet.deprecation_warning("Puppet::SSL::CertificateAuthority#certificate_is_alive? is deprecated. Please use Puppet::SSL::CertificateAuthority#verify or the certificate status API to query certificate information. See https://docs.puppet.com/puppet/latest/http_api/http_certificate_status.html")
     x509_store(:cache => true).verify(cert.content)
   end
 

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -795,6 +795,12 @@ describe Puppet::SSL::CertificateAuthority do
       expect(@ca.list_certificates).to eq([cert1, cert2])
     end
 
+    it "should print a deprecation when using #list_certificates" do
+      Puppet::SSL::Certificate.indirection.stubs(:search).with("*").returns [:foo, :bar]
+      Puppet.expects(:deprecation_warning).with(regexp_matches(/list_certificates is deprecated/))
+      @ca.list_certificates
+    end
+
     describe "and printing certificates" do
       it "should return nil if the certificate cannot be found" do
         Puppet::SSL::Certificate.indirection.expects(:find).with("myhost").returns nil

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -933,7 +933,7 @@ describe Puppet::SSL::CertificateAuthority do
           expect(@ca.certificate_is_alive?(@cert)).to be_truthy
         end
 
-        it "should used a cached instance of the x509 store" do
+        it "should use a cached instance of the x509 store" do
           OpenSSL::X509::Store.stubs(:new).returns(@store).once
 
           @cert.expects(:content).returns "mycert"
@@ -941,6 +941,11 @@ describe Puppet::SSL::CertificateAuthority do
           @store.expects(:verify).with("mycert").returns true
 
           @ca.certificate_is_alive?(@cert)
+          @ca.certificate_is_alive?(@cert)
+        end
+
+        it "should be deprecated" do
+          Puppet.expects(:deprecation_warning).with(regexp_matches(/certificate_is_alive\? is deprecated/))
           @ca.certificate_is_alive?(@cert)
         end
       end


### PR DESCRIPTION
This PR deprecates methods in `Puppet::SSL::CertificateAuthority` that were used by the PE License library (but no longer are). `#x509_store` (and its callers) in particular is problematic because it can cache the x509_store object once and never refresh it, even if it is no longer valid.

Commit outline:
> This commit deprecates Puppet::SSL::CertificateAuthority#list_certificates, as
> it is no longer used by anything. The PE License check code that originally
> used this been migrated to querying PuppetDB.

> To avoid superflous warnings emanating from use of
> Puppet::SSL::CertificateAuthority#list, that method is updated to directly do
> an indirector search instead of indirectly through #list_certificates. This is
> what it originally did, before #list_certificates was added, and is
> backwards-compatible.

> Puppet::SSL::CertificateAuthority#x509_store is a caching layer for the x509
> object that was used by the PE License code. This commit tags it as deprecated,
> as the PE License code no longer uses it, and it was questionably advisable
> back then to return a potentially stale x509 store anyway.
>
> We also update #verify to call #create_x509_store instead of #x509_store,
> skipping the cache layer and always creating a new object - the behavior before
> x509_store was introduced. This is semantically API backwards-compatible, and
> now we can remove #x509_store at a major version, as its only callers are also
> deprecated.
> 
> Note #x509_store is API private, so we don't actually do a
> Puppet.deprecation_warning. The comment tag should be enough to warn off anyone
> trying to use it before it's removed.

> Puppet::SSL::CertificateAuthority#certificate_is_alive? was introduced to
> leverage the #x509_store cached x509 object for the PE License code. It is no
> longer used, and #verify (or the Puppet Server API) should be used instead.
