### PR TITLE
(PUP-7086) Add benchmarks for lookup and data-binding

### DIFF
--- a/benchmarks/hiera_env_lookup/benchmarker.rb
+++ b/benchmarks/hiera_env_lookup/benchmarker.rb
@@ -1,0 +1,91 @@
+require 'fileutils'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size > 100 ? size : 100
+  end
+
+  def setup
+    require 'puppet'
+    @config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', @config])
+    envs = Puppet.lookup(:environments)
+    @node = Puppet::Node.new('testing', :environment => envs.get('benchmarking'))
+  end
+
+  def run(args=nil)
+    @compiler = Puppet::Parser::Compiler.new(@node)
+    @compiler.compile do |catalog|
+      scope = @compiler.topscope
+      scope['confdir'] = 'test'
+      @size.times do
+        100.times do |index|
+          invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
+          Puppet::Pops::Lookup.lookup("x#{index}", nil, nil, true, nil, invocation)
+        end
+      end
+      catalog
+    end
+  end
+
+  def generate
+    env_dir = File.join(@target, 'environments', 'benchmarking')
+    hiera_yaml = File.join(env_dir, 'hiera.yaml')
+    env_conf = File.join(env_dir, 'environment.conf')
+    datadir = File.join(env_dir, 'data')
+    datadir_test = File.join(datadir, 'test')
+    test_data_yaml = File.join(datadir_test, 'data.yaml')
+    common_yaml = File.join(datadir, 'common.yaml')
+
+    mkdir_p(env_dir)
+    mkdir_p(datadir)
+    mkdir_p(datadir_test)
+
+    File.open(hiera_yaml, 'w') do |f|
+      f.puts(<<-YAML)
+version: 4
+datadir: data
+hierarchy:
+  - name: Common
+    backend: yaml
+    path: common
+  - name: Configured
+    backend: yaml
+    path: "%{confdir}/data"
+      YAML
+    end
+
+    File.open(env_conf, 'w') do |f|
+      f.puts("environment_data_provider=hiera")
+    end
+
+    File.open(common_yaml, 'w') do |f|
+      100.times do |index|
+        f.puts("a#{index}: value a#{index}")
+        f.puts("b#{index}: value b#{index}")
+        f.puts("c#{index}: value c#{index}")
+        f.puts("cbm#{index}: \"%{hiera('a#{index}')}, %{hiera('b#{index}')}, %{hiera('c#{index}')}\"")
+      end
+    end
+
+    File.open(test_data_yaml, 'w') do |f|
+      100.times { |index| f.puts("x#{index}: \"%{hiera('cbm#{index}')}\"")}
+    end
+
+    templates = File.join('benchmarks', 'hiera_env_lookup')
+
+    render(File.join(templates, 'puppet.conf.erb'),
+      File.join(@target, 'puppet.conf'),
+      :location => @target)
+  end
+
+  def render(erb_file, output_file, bindings)
+    site = ERB.new(File.read(erb_file))
+    File.open(output_file, 'w') do |fh|
+      fh.write(site.result(OpenStruct.new(bindings).instance_eval { binding }))
+    end
+  end
+end

--- a/benchmarks/hiera_env_lookup/description
+++ b/benchmarks/hiera_env_lookup/description
@@ -1,0 +1,2 @@
+Benchmark scenario: Many lookups using a Hiera 5 configuration in an environment
+Benchmark target: hiera lookup.

--- a/benchmarks/hiera_env_lookup/puppet.conf.erb
+++ b/benchmarks/hiera_env_lookup/puppet.conf.erb
@@ -1,0 +1,5 @@
+confdir = <%= location %>
+vardir = <%= location %>
+codedir = <%= location %>
+environmentpath = <%= File.join(location, 'environments') %>
+environment_timeout = 0

--- a/benchmarks/hiera_function/benchmarker.rb
+++ b/benchmarks/hiera_function/benchmarker.rb
@@ -1,0 +1,85 @@
+require 'fileutils'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size > 100 ? size : 100
+  end
+
+  def setup
+    require 'puppet'
+    @config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', @config])
+    envs = Puppet.lookup(:environments)
+    @node = Puppet::Node.new('testing', :environment => envs.get('benchmarking'))
+  end
+
+  def run(args=nil)
+    @compiler = Puppet::Parser::Compiler.new(@node)
+    @compiler.compile do |catalog|
+      scope = @compiler.topscope
+      scope['confdir'] = 'test'
+      @size.times do
+        100.times do |index|
+          hiera_func = @compiler.loaders.puppet_system_loader.load(:function, 'hiera')
+          hiera_func.call(scope, "x#{index}")
+        end
+      end
+      catalog
+    end
+  end
+
+  def generate
+    env_dir = File.join(@target, 'environments', 'benchmarking')
+    hiera_yaml = File.join(@target, 'hiera.yaml')
+    datadir = File.join(@target, 'data')
+    datadir_test = File.join(datadir, 'test')
+    test_data_yaml = File.join(datadir_test, 'data.yaml')
+    common_yaml = File.join(datadir, 'common.yaml')
+
+    mkdir_p(env_dir)
+    mkdir_p(datadir)
+    mkdir_p(datadir_test)
+
+    File.open(hiera_yaml, 'w') do |f|
+      f.puts(<<-YAML)
+---
+:backends: yaml
+:yaml:
+   :datadir: #{datadir}
+:hierarchy:
+   - "%{confdir}/data"
+   - common
+:logger: noop
+      YAML
+    end
+
+    File.open(common_yaml, 'w') do |f|
+      100.times do |index|
+        f.puts("a#{index}: value a#{index}")
+        f.puts("b#{index}: value b#{index}")
+        f.puts("c#{index}: value c#{index}")
+        f.puts("cbm#{index}: \"%{hiera('a#{index}')}, %{hiera('b#{index}')}, %{hiera('c#{index}')}\"")
+      end
+    end
+
+    File.open(test_data_yaml, 'w') do |f|
+      100.times { |index| f.puts("x#{index}: \"%{hiera('cbm#{index}')}\"")}
+    end
+
+    templates = File.join('benchmarks', 'hiera_function')
+
+    render(File.join(templates, 'puppet.conf.erb'),
+      File.join(@target, 'puppet.conf'),
+      :location => @target)
+  end
+
+  def render(erb_file, output_file, bindings)
+    site = ERB.new(File.read(erb_file))
+    File.open(output_file, 'w') do |fh|
+      fh.write(site.result(OpenStruct.new(bindings).instance_eval { binding }))
+    end
+  end
+end

--- a/benchmarks/hiera_function/description
+++ b/benchmarks/hiera_function/description
@@ -1,0 +1,2 @@
+Benchmark scenario: Many lookups using hiera function
+Benchmark target: hiera lookup.

--- a/benchmarks/hiera_function/puppet.conf.erb
+++ b/benchmarks/hiera_function/puppet.conf.erb
@@ -1,0 +1,5 @@
+confdir = <%= location %>
+vardir = <%= location %>
+codedir = <%= location %>
+environmentpath = <%= File.join(location, 'environments') %>
+environment_timeout = 0

--- a/benchmarks/hiera_global_lookup/benchmarker.rb
+++ b/benchmarks/hiera_global_lookup/benchmarker.rb
@@ -1,0 +1,85 @@
+require 'fileutils'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size > 100 ? size : 100
+  end
+
+  def setup
+    require 'puppet'
+    @config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', @config])
+    envs = Puppet.lookup(:environments)
+    @node = Puppet::Node.new('testing', :environment => envs.get('benchmarking'))
+  end
+
+  def run(args=nil)
+    @compiler = Puppet::Parser::Compiler.new(@node)
+    @compiler.compile do |catalog|
+      scope = @compiler.topscope
+      scope['confdir'] = 'test'
+      @size.times do
+        100.times do |index|
+          invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, true)
+          Puppet::Pops::Lookup.lookup("x#{index}", nil, nil, true, nil, invocation)
+        end
+      end
+      catalog
+    end
+  end
+
+  def generate
+    env_dir = File.join(@target, 'environments', 'benchmarking')
+    hiera_yaml = File.join(@target, 'hiera.yaml')
+    datadir = File.join(@target, 'data')
+    datadir_test = File.join(datadir, 'test')
+    test_data_yaml = File.join(datadir_test, 'data.yaml')
+    common_yaml = File.join(datadir, 'common.yaml')
+
+    mkdir_p(env_dir)
+    mkdir_p(datadir)
+    mkdir_p(datadir_test)
+
+    File.open(hiera_yaml, 'w') do |f|
+      f.puts(<<-YAML)
+---
+:backends: yaml
+:yaml:
+   :datadir: #{datadir}
+:hierarchy:
+   - "%{confdir}/data"
+   - common
+:logger: noop
+      YAML
+    end
+
+    File.open(common_yaml, 'w') do |f|
+      100.times do |index|
+        f.puts("a#{index}: value a#{index}")
+        f.puts("b#{index}: value b#{index}")
+        f.puts("c#{index}: value c#{index}")
+        f.puts("cbm#{index}: \"%{hiera('a#{index}')}, %{hiera('b#{index}')}, %{hiera('c#{index}')}\"")
+      end
+    end
+
+    File.open(test_data_yaml, 'w') do |f|
+      100.times { |index| f.puts("x#{index}: \"%{hiera('cbm#{index}')}\"")}
+    end
+
+    templates = File.join('benchmarks', 'hiera_global_lookup')
+
+    render(File.join(templates, 'puppet.conf.erb'),
+      File.join(@target, 'puppet.conf'),
+      :location => @target)
+  end
+
+  def render(erb_file, output_file, bindings)
+    site = ERB.new(File.read(erb_file))
+    File.open(output_file, 'w') do |fh|
+      fh.write(site.result(OpenStruct.new(bindings).instance_eval { binding }))
+    end
+  end
+end

--- a/benchmarks/hiera_global_lookup/description
+++ b/benchmarks/hiera_global_lookup/description
@@ -1,0 +1,2 @@
+Benchmark scenario: Many lookups using a global Hiera 3 configuration
+Benchmark target: hiera lookup.

--- a/benchmarks/hiera_global_lookup/puppet.conf.erb
+++ b/benchmarks/hiera_global_lookup/puppet.conf.erb
@@ -1,0 +1,5 @@
+confdir = <%= location %>
+vardir = <%= location %>
+codedir = <%= location %>
+environmentpath = <%= File.join(location, 'environments') %>
+environment_timeout = 0

--- a/benchmarks/legacy_hiera_lookup/benchmarker.rb
+++ b/benchmarks/legacy_hiera_lookup/benchmarker.rb
@@ -1,0 +1,64 @@
+require 'fileutils'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @hiera_yaml = File.join(target, 'hiera.yaml')
+    @size = size > 100 ? size : 100
+  end
+
+  def setup
+    require 'puppet'
+    require 'hiera'
+    @config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', @config])
+    Hiera.logger = 'noop'
+    @hiera = ::Hiera.new(:config => @hiera_yaml)
+  end
+
+  def run(args=nil)
+    @size.times do
+      100.times do |index|
+        @hiera.lookup("x#{index}", nil, { 'confdir' => 'test' })
+      end
+    end
+  end
+
+  def generate
+    datadir = File.join(@target, 'data')
+    datadir_test = File.join(datadir, 'test')
+    test_data_yaml = File.join(datadir_test, 'data.yaml')
+    common_yaml = File.join(datadir, 'common.yaml')
+
+    mkdir_p(datadir)
+    mkdir_p(datadir_test)
+
+    File.open(@hiera_yaml, 'w') do |f|
+      f.puts(<<-YAML)
+---
+:backends: yaml
+:yaml:
+   :datadir: #{datadir}
+:hierarchy:
+   - "%{confdir}/data"
+   - common
+:logger: noop
+      YAML
+    end
+
+    File.open(common_yaml, 'w') do |f|
+      100.times do |index|
+        f.puts("a#{index}: value a#{index}")
+        f.puts("b#{index}: value b#{index}")
+        f.puts("c#{index}: value c#{index}")
+        f.puts("cbm#{index}: \"%{hiera('a#{index}')}, %{hiera('b#{index}')}, %{hiera('c#{index}')}\"")
+      end
+    end
+
+    File.open(test_data_yaml, 'w') do |f|
+      100.times { |index| f.puts("x#{index}: \"%{hiera('cbm#{index}')}\"")}
+    end
+  end
+end

--- a/benchmarks/legacy_hiera_lookup/description
+++ b/benchmarks/legacy_hiera_lookup/description
@@ -1,0 +1,2 @@
+Benchmark scenario: Lookups that uses raw Hiera 3 (the legacy implementation)
+Benchmark target: legacy hiera lookup.


### PR DESCRIPTION
This commit adds four different benchmarks

legacy_hiera_lookup:
Performs repeated lookups using the legacy Hiera version 3 class directly

hiera_global_lookup:
Performs repeated lookups in the global layer using the lookup API

hiera_env_lookup:
Performs repeated lookups in the environment layer using the lookup API

hiera_function:
Performs repeated lookups in the global layer using the `hiera` function