### PR TITLE
(PUP-7087) Optimize lookup type checking and caching of merge strategy

### DIFF
--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -20,7 +20,6 @@ module Lookup
   # @return [Object] The found value
   #
   def self.lookup(name, value_type, default_value, has_default, merge, lookup_invocation)
-    value_type = DataProvider.value_type if value_type.nil?
     names = name.is_a?(Array) ? name : [name]
 
     # find first name that yields a non-nil result and wrap it in a two element array
@@ -78,7 +77,7 @@ module Lookup
   end
 
   def self.assert_type(subject, type, value)
-    Types::TypeAsserter.assert_instance_of(subject, type, value)
+    type ? Types::TypeAsserter.assert_instance_of(subject, type, value) : value
   end
   private_class_method :assert_type
 


### PR DESCRIPTION
This commit optimizes the MergeStrategy so that it uses fixed instances
when no options are given (which is true in 99.9% of the cases). It also
changes how the value is validated with respect to type so that it isn't
validated unless a type is given (basic Puppet::LookupValue validation
still takes place in the provider).