### PR TITLE
(PUP-7087) Improve lookup performance

### DIFF
--- a/lib/hiera/scope.rb
+++ b/lib/hiera/scope.rb
@@ -1,9 +1,12 @@
 class Hiera
   class Scope
-    CALLING_CLASS = "calling_class"
-    CALLING_CLASS_PATH = "calling_class_path"
-    CALLING_MODULE = "calling_module"
-    MODULE_NAME = "module_name"
+    CALLING_CLASS = 'calling_class'.freeze
+    CALLING_CLASS_PATH = 'calling_class_path'.freeze
+    CALLING_MODULE = 'calling_module'.freeze
+    MODULE_NAME = 'module_name'.freeze
+
+    CALLING_KEYS = [CALLING_CLASS, CALLING_CLASS_PATH, CALLING_MODULE].freeze
+    EMPTY_STRING = ''.freeze
 
     attr_reader :real
 
@@ -21,20 +24,15 @@ class Hiera
       else
         ans = @real.lookupvar(key)
       end
+      ans == EMPTY_STRING ? nil : ans
+    end
 
-      if ans.nil? or ans == ""
-        nil
-      else
-        ans
-      end
+    def exist?(key)
+      CALLING_KEYS.include?(key) || @real.exist?(key)
     end
 
     def include?(key)
-      if [CALLING_CLASS, CALLING_CLASS_PATH, CALLING_MODULE].include? key
-        true
-      else
-        @real.exist?(key)
-      end
+      CALLING_KEYS.include?(key) || @real.include?(key)
     end
 
     def catalog

--- a/lib/puppet/pops/lookup/function_provider.rb
+++ b/lib/puppet/pops/lookup/function_provider.rb
@@ -16,15 +16,14 @@ class FunctionProvider
     @function_name = function_name
     @options = options
     @locations = locations || [nil]
+    @contexts = {}
   end
 
   # @return [FunctionContext] the function context associated with this provider
   def function_context(lookup_invocation, location)
     scope = lookup_invocation.scope
     compiler = scope.compiler
-    adapter = DataAdapter.get(compiler) || DataAdapter.adapt(compiler)
-    key = location.nil? ? object_id : "#{object_id}:#{location}"
-    adapter[key] ||= FunctionContext.new(compiler.environment.name, module_name, function(scope))
+    @contexts[location] ||= FunctionContext.new(compiler.environment.name, module_name, function(scope))
   end
 
   def module_name

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -166,7 +166,7 @@ class HieraConfig
   end
 
   def scope_interpolations_stable?(scope)
-    @scope_interpolations.each_pair.all? { |key, value| scope[key] == value }
+    @scope_interpolations.all? { |key, value| scope[key].eql?(value) }
   end
 
   # @api private

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -85,7 +85,7 @@ class Invocation
   end
 
   def lookup_adapter
-    @adapter_class.adapt(scope.compiler)
+    @adapter ||= @adapter_class.adapt(scope.compiler)
   end
 
   # This method is overridden by the special Invocation used while resolving interpolations in a

--- a/lib/puppet/pops/lookup/sub_lookup.rb
+++ b/lib/puppet/pops/lookup/sub_lookup.rb
@@ -1,6 +1,8 @@
 module Puppet::Pops
 module Lookup
 module SubLookup
+  SPECIAL = /['"\.]/
+
   # Split key into segments. A segment may be a quoted string (both single and double quotes can
   # be used) and the segment separator is the '.' character. Whitespace will be trimmed off on
   # both sides of each segment. Whitespace within quotes are not trimmed.
@@ -15,6 +17,7 @@ module SubLookup
   #
   # @api public
   def split_key(key)
+    return [key] if key.match(SPECIAL).nil?
     segments = key.split(/(\s*"[^"]+"\s*|\s*'[^']+'\s*|[^'".]+)/)
     if segments.empty?
       # Only happens if the original key was an empty string

--- a/spec/unit/hiera/scope_spec.rb
+++ b/spec/unit/hiera/scope_spec.rb
@@ -74,14 +74,14 @@ describe Hiera::Scope do
     end
   end
 
-  describe "#include?" do
+  describe "#exist?" do
     it "should correctly report missing data" do
       real["nil_value"] = nil
       real["blank_value"] = ""
 
-      expect(scope.include?("nil_value")).to eq(true)
-      expect(scope.include?("blank_value")).to eq(true)
-      expect(scope.include?("missing_value")).to eq(false)
+      expect(scope.exist?("nil_value")).to eq(true)
+      expect(scope.exist?("blank_value")).to eq(true)
+      expect(scope.exist?("missing_value")).to eq(false)
     end
 
     it "should always return true for calling_class and calling_module" do


### PR DESCRIPTION
This commit contains a series of performance tweeks that were motivated
by findings when using a profiler. The optimizations makes the test
`benchmark:hiera_global_lookup` execute ~20% faster.

1. The special `Hiera::Scope` was improved to use frozen, predefined
   arrays when checking if a key was one of the caller keys.
2. The `Puppet::Parser::Scope` was improved to use a predefined empty
   `Hash` rather than creating a new dynamic hash on every call, and
   to only check using `#include?` when a found value was `nil`
3. The FunctionProvider has a hash of contexts instead of a DataBinding
   with a similar hash. This is OK since the provider itself is bound by
   an adapter.
4. A check for stable interpolations of the configuration was improved.
   Instead of using `#each_pair.all?` on a `Hash` it simply uses `#all?`.
5. The Invocation, which is created once for each lookup call, now caches
   it's adapter instead of calling on `#adapt` to retreive it each time
   it's used.
6. More efficient check for terminus. In particular an expensive `#to_s`
   on a `Symbol` is now avoided.
7. The logic that splits keys on dots will now first use a very simple
   regexp to determine if quotes or dots are present and return a one
   element array directly if that's not the case. This saves lots of
   evaluations of the more complex regexp that is otherwise used.
8. The interpolation logic was improved so that `#exist?` is called only
   when the found value was `nil`.

Aside from the optimizations, this commit also fixes a minor flaw in the
Hiera::Scope where `#exist?` called on the parent scope `#include?`
insted of its `#exist?` method. The fix is included here since it was
needed in order do one of the optimizations.