### PR TITLE
(PUP-7089) Add ability to declare a Hiera 3 backend in a version 5 co…

### DIFF
--- a/lib/puppet/pops/lookup/lookup_key_function_provider.rb
+++ b/lib/puppet/pops/lookup/lookup_key_function_provider.rb
@@ -53,7 +53,7 @@ class LookupKeyFunctionProvider < FunctionProvider
 end
 
 class V3BackendFunctionProvider < LookupKeyFunctionProvider
-  TAG = 'v3_backend'.freeze
+  TAG = 'hiera3_backend'.freeze
 
   def lookup_key(key, lookup_invocation, location, merge)
     @backend ||= instantiate_backend(lookup_invocation)
@@ -63,16 +63,17 @@ class V3BackendFunctionProvider < LookupKeyFunctionProvider
   private
 
   def instantiate_backend(lookup_invocation)
+    backend_name = options[HieraConfig::KEY_BACKEND]
     begin
       require 'hiera/backend'
-      require "hiera/backend/#{@name.downcase}_backend"
-      backend = Hiera::Backend.const_get("#{@name.capitalize}_backend").new
+      require "hiera/backend/#{backend_name.downcase}_backend"
+      backend = Hiera::Backend.const_get("#{backend_name.capitalize}_backend").new
       return backend.method(:lookup).arity == 4 ? Hiera::Backend::Backend1xWrapper.new(backend) : backend
     rescue LoadError => e
-      lookup_invocation.report_text { "Unable to load backend '#{@name}': #{e.message}" }
+      lookup_invocation.report_text { "Unable to load backend '#{backend_name}': #{e.message}" }
       throw :no_such_key
     rescue NameError => e
-      lookup_invocation.report_text { "Unable to instantiate backend '#{@name}': #{e.message}" }
+      lookup_invocation.report_text { "Unable to instantiate backend '#{backend_name}': #{e.message}" }
       throw :no_such_key
     end
   end
@@ -84,7 +85,7 @@ class V3BackendFunctionProvider < LookupKeyFunctionProvider
   def convert_merge(merge)
     case merge
     when nil
-    when 'first'
+    when 'first', 'default'
       # Nil is OK. Defaults to Hiera :priority
       nil
     when Puppet::Pops::MergeStrategy


### PR DESCRIPTION
…nfig

This commit adds the "function type" hiera3_backend. The value of such an
entry must be the name of a Hiera 3 backend (so not a function after all).
When used, a Hiera 3 config will be created on-the-fly and assigned to
the Hiera 3 class. Lookups will then be dispatched to the backend just
as if a Hiera version 3 configuration was used.