### PR TITLE
(PUP-6219) Remove deprecated req_bits setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1039,11 +1039,6 @@ EOT
       :desc       => "The default TTL for new certificates.
       #{AS_DURATION}"
     },
-    :req_bits => {
-      :default    => 4096,
-      :desc       => "This setting has no effect and will be removed in a future Puppet version.",
-      :deprecated => :completely,
-    },
     :keylength => {
       :default    => 4096,
       :desc       => "The bit length of keys.",

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -1434,14 +1434,6 @@ The URL that reports should be forwarded to\. This setting is only used when the
 .
 .IP "" 0
 .
-.SS "req_bits"
-The bit length of the certificates\.
-.
-.IP "\(bu" 4
-\fIDefault\fR: 4096
-.
-.IP "" 0
-.
 .SS "requestdir"
 Where host certificate requests are stored\.
 .


### PR DESCRIPTION
This commit is part of the Puppet 5.0 code removal effort.