### PR TITLE
(PUP-7038) deprecate ruby 2.0

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -4,6 +4,8 @@ if RUBY_VERSION < "1.9.3"
   raise LoadError, "Puppet #{Puppet.version} requires ruby 1.9.3 or greater."
 end
 
+Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.1.0'
+
 # see the bottom of the file for further inclusions
 # Also see the new Vendor support - towards the end
 #
@@ -140,6 +142,12 @@ module Puppet
 
   # Load all of the settings.
   require 'puppet/defaults'
+
+  # Now that settings are loaded we have the code loaded to be able to issue
+  # deprecation warnings. Warn if we're on a deprecated ruby version.
+  if RUBY_VERSION < Puppet::OLDEST_RECOMMENDED_RUBY_VERSION
+    Puppet.deprecation_warning("Support for ruby version #{RUBY_VERSION} is deprecated and will be removed in a future release. See https://docs.puppet.com/puppet/latest/system_requirements.html#ruby for a list of supported ruby versions.")
+  end
 
   # Initialize puppet's settings. This is intended only for use by external tools that are not
   #  built off of the Faces API or the Puppet::Util::Application class. It may also be used

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -39,6 +39,20 @@ describe Puppet do
     expect($LOAD_PATH).to include two
   end
 
+  context "Puppet::OLDEST_RECOMMENDED_RUBY_VERSION" do
+    it "should have an oldest recommended ruby version constant" do
+      expect(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION).not_to be_nil
+    end
+
+    it "should be a string" do
+      expect(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION).to be_a_kind_of(String)
+    end
+
+    it "should match a semver version" do
+      expect(SemVer).to be_valid(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
+    end
+  end
+
   context "newtype" do
     it "should issue a deprecation warning" do
       subject.expects(:deprecation_warning).with("Creating sometype via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.")


### PR DESCRIPTION
This commit adds a deprecation warning for users running puppet under a version
older than 2.1.0. This is accomplished by adding a new constant,
Puppet::OLDEST_RECOMMENDED_RUBY_VERSION, which we later test for in issuing a
deprecation warning.

Signed-off-by: Moses Mendoza <moses@puppet.com>