### PR TITLE
(PUP-7088) Let Hiera v3 honor deep merge options not supported by Puppet

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -316,15 +316,9 @@ class HieraConfigV3 < HieraConfig
     when 'array'
       MergeStrategy.strategy(:unique)
     when 'deep', 'deeper'
-      merge = { 'strategy' => key == 'deep' ? 'reverse_deep' : 'deep' }
-      (@config[KEY_DEEP_MERGE_OPTIONS] || EMPTY_HASH).each_pair do |opt_key, value|
-        case opt_key
-        when 'knockout_prefix', 'merge_debug', 'merge_hash_arrays', 'sort_merge_arrays'
-          merge[opt_key] = value
-        else
-          Puppet.warning("#{@config_path}: merge_option '#{opt_key}' is not recognized. Option is ignored")
-        end
-      end
+      merge = { 'strategy' => key == 'deep' ? 'reverse_deep' : 'unconstrained_deep' }
+      dm_options = @config[KEY_DEEP_MERGE_OPTIONS]
+      merge.merge!(dm_options) if dm_options
       MergeStrategy.strategy(merge)
     end
   end

--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -42,7 +42,7 @@ module Puppet::Pops
     # @return [Array<Symbol>] List of strategy keys
     #
     def self.strategy_keys
-      strategies.keys - [:default, :reverse_deep]
+      strategies.keys - [:default, :unconstrained_deep, :reverse_deep]
     end
 
     # Adds a new merge strategy to the map of strategies known to this class
@@ -386,9 +386,24 @@ module Puppet::Pops
     MergeStrategy.add_strategy(self)
   end
 
-  # Same as {DeepMergeStrategy} but the with reverse priority of merged elements.
+  # Same as {DeepMergeStrategy} but without constraint on valid merge options
   # (needed for backward compatibility with Hiera v3)
-  class ReverseDeepMergeStrategy < MergeStrategy
+  class UnconstrainedDeepMergeStrategy < DeepMergeStrategy
+    def self.key
+      :unconstrained_deep
+    end
+
+    # @return [Types::PAnyType] the puppet type used when validating the options hash
+    def self.options_t
+      @options_t ||= Types::TypeParser.singleton.parse('Hash[String[1],Any]')
+    end
+
+    MergeStrategy.add_strategy(self)
+  end
+
+  # Same as {UnconstrainedDeepMergeStrategy} but with reverse priority of merged elements.
+  # (needed for backward compatibility with Hiera v3)
+  class ReverseDeepMergeStrategy < UnconstrainedDeepMergeStrategy
     INSTANCE = self.new(EMPTY_HASH)
 
     def self.key

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -658,6 +658,46 @@ describe "The lookup function" do
           expect(lookup('xs.subkey')).to eql('value xs.subkey (from global hocon)')
         end
 
+        context 'using deep_merge_options supported by deep_merge gem but not supported by Puppet' do
+
+          let(:hiera_yaml) do
+            <<-YAML.unindent
+              ---
+              :backends:
+                - yaml
+              :yaml:
+                :datadir: #{code_dir}/hieradata
+              :hierarchy:
+                - other
+                - common
+              :merge_behavior: deeper
+              :deep_merge_options:
+                :unpack_arrays: ','
+              YAML
+          end
+
+          let(:code_dir_files) do
+            {
+              'hiera.yaml' => hiera_yaml,
+              'hieradata' => {
+                'common.yaml' => <<-YAML.unindent,
+                  a:
+                    - x1,x2
+                  YAML
+                'other.yaml' => <<-YAML.unindent,
+                  a:
+                    - x3
+                    - x4
+                  YAML
+              }
+            }
+          end
+
+          it 'honors option :unpack_arrays: (unsupported by puppet)' do
+            expect(lookup('a')).to eql(%w(x1 x2 x3 x4))
+          end
+        end
+
         context 'using relative datadir paths' do
           let(:hiera_yaml) do
             <<-YAML.unindent


### PR DESCRIPTION
This commit adds the `UnconstrainedDeepMergeStrategy` to the list of
merge strategies supported by the lookup framework. This strategy is
used for deep merge options defined in a hiera.conf version 3 but not
otherwise accessible from Puppet.