### PR TITLE
(PUP-7095) Enable portage install and uninstall options for the package provider

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -2,14 +2,19 @@ require 'puppet/provider/package'
 require 'fileutils'
 
 Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Package do
-  desc "Provides packaging support for Gentoo's portage system."
+  desc "Provides packaging support for Gentoo's portage system.
 
-  has_features :versionable, :reinstallable
+    This provider supports the `install_options` and `uninstall_options` attributes, which allows command-line
+    flags to be passed to emerge.  These options should be specified as a string (e.g. '--flag'), a hash
+    (e.g. {'--flag' => 'value'}), or an array where each element is either a string or a hash."
+
+  has_features :install_options, :purgeable, :reinstallable, :uninstall_options, :versionable, :virtual_packages
 
   {
-    :emerge => "/usr/bin/emerge",
-    :eix => "/usr/bin/eix",
-    :update_eix => "/usr/bin/eix-update",
+    :emerge => '/usr/bin/emerge',
+    :eix => '/usr/bin/eix',
+    :qatom_bin => '/usr/bin/qatom',
+    :update_eix => '/usr/bin/eix-update',
   }.each_pair do |name, path|
     has_command(name, path) do
       environment :HOME => '/'
@@ -24,15 +29,18 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     result_format = self.eix_result_format
     result_fields = self.eix_result_fields
 
+    limit = self.eix_limit
     version_format = self.eix_version_format
     slot_versions_format = self.eix_slot_versions_format
+    installed_versions_format = self.eix_installed_versions_format
+    installable_versions_format = self.eix_install_versions_format
     begin
-      eix_file = File.directory?("/var/cache/eix") ? "/var/cache/eix/portage.eix" : "/var/cache/eix"
+      eix_file = File.directory?('/var/cache/eix') ? '/var/cache/eix/portage.eix' : '/var/cache/eix'
       update_eix if !FileUtils.uptodate?(eix_file, %w{/usr/bin/eix /usr/portage/metadata/timestamp})
 
       search_output = nil
-      Puppet::Util.withenv :LASTVERSION => version_format, :LASTSLOTVERSIONS => slot_versions_format do
-        search_output = eix *(self.eix_search_arguments + ["--installed"])
+      Puppet::Util.withenv :EIX_LIMIT => limit, :LASTVERSION => version_format, :LASTSLOTVERSIONS => slot_versions_format, :INSTALLEDVERSIONS => installed_versions_format, :STABLEVERSIONS => installable_versions_format do
+        search_output = eix *(self.eix_search_arguments + ['--installed'])
       end
 
       packages = []
@@ -57,39 +65,35 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
   def install
     should = @resource.should(:ensure)
-    name = package_name
-    unless should == :present or should == :latest
-      # We must install a specific version
-      name = package_atom_with_version(should)
-    end
-    emerge name
-  end
-
-  # The common package name format.
-  def package_name
-    @resource[:category] ? "#{@resource[:category]}/#{@resource[:name]}" : @resource[:name]
-  end
-
-  def package_name_without_slot
-    package_name.sub(self.class.slot_pattern, '')
-  end
-
-  def package_slot
-    if match = package_name.match(self.class.slot_pattern)
-      match[1]
-    end
-  end
-
-  def package_atom_with_version(version)
-    if slot = package_slot
-      "=#{package_name_without_slot}-#{version}:#{package_slot}"
-    else
-      "=#{package_name}-#{version}"
-    end
+    cmd = %w{}
+    name = qatom[:category] ? "#{qatom[:category]}/#{qatom[:pn]}" : qatom[:pn]
+    name = qatom[:pfx] + name if qatom[:pfx]
+    name = name + '-' + qatom[:pv] if qatom[:pv]
+    name = name + '-' + qatom[:pr] if qatom[:pr]
+    name = name + qatom[:slot] if qatom[:slot]
+    cmd << '--update' if [:latest].include?(should)
+    cmd += install_options if @resource[:install_options]
+    cmd << name
+    emerge *cmd
   end
 
   def uninstall
-    emerge "--unmerge", package_name
+    should = @resource.should(:ensure)
+    cmd = %w{--rage-clean}
+    name = qatom[:category] ? "#{qatom[:category]}/#{qatom[:pn]}" : qatom[:pn]
+    name = qatom[:pfx] + name if qatom[:pfx]
+    name = name + '-' + qatom[:pv] if qatom[:pv]
+    name = name + '-' + qatom[:pr] if qatom[:pr]
+    name = name + qatom[:slot] if qatom[:slot]
+    cmd += uninstall_options if @resource[:uninstall_options]
+    cmd << name
+    if [:purged].include?(should)
+      Puppet::Util.withenv :CONFIG_PROTECT => "-*" do
+        emerge *cmd
+      end
+    else
+      emerge *cmd
+    end
   end
 
   def reinstall
@@ -100,22 +104,84 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     self.install
   end
 
+  def qatom
+    output_format = self.qatom_output_format
+    result_format = self.qatom_result_format
+    result_fields = self.qatom_result_fields
+    @atom ||= begin
+      search_output = nil
+      package_info = {}
+      # do the search
+      search_output = qatom_bin *([@resource[:name], '--format', output_format])
+      # verify if the search found anything
+      match = result_format.match(search_output)
+      if match
+        result_fields.zip(match.captures) do |field, value|
+          # some fields can be empty or (null) (if we are not passed a category in the package name for instance)
+          if value == '(null)'
+            package_info[field] = nil
+          elsif !value or value.empty?
+            package_info[field] = nil
+          else
+            package_info[field] = value
+          end
+        end
+      end
+      @atom = package_info
+    rescue Puppet::ExecutionFailure => detail
+      raise Puppet::Error.new(detail)
+    end
+  end
+
+  def qatom_output_format
+    '"[%{CATEGORY}] [%{PN}] [%{PV}] [%[PR]] [%[SLOT]] [%[pfx]] [%[sfx]]"'
+  end
+
+  def qatom_result_format
+    /^\"\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\](.*)\"$/
+  end
+
+  def qatom_result_fields
+    [:category, :pn, :pv, :pr, :slot, :pfx, :sfx]
+  end
+
+  def self.get_sets
+    @sets ||= begin
+      @sets = emerge *(['--list-sets'])
+    end
+  end
+
   def query
+    limit = self.class.eix_limit
     result_format = self.class.eix_result_format
     result_fields = self.class.eix_result_fields
 
     version_format = self.class.eix_version_format
     slot_versions_format = self.class.eix_slot_versions_format
-    search_field = package_name_without_slot.count('/') > 0 ? "--category-name" : "--name"
-    search_value = package_name_without_slot
+    installed_versions_format = self.class.eix_installed_versions_format
+    installable_versions_format = self.class.eix_install_versions_format
+    search_field = qatom[:category] ? '--category-name' : '--name'
+    search_value = qatom[:category] ? "#{qatom[:category]}/#{qatom[:pn]}" : qatom[:pn]
 
-    begin
-      eix_file = File.directory?("/var/cache/eix") ? "/var/cache/eix/portage.eix" : "/var/cache/eix"
+    @eix_result ||= begin
+      # package sets
+      package_sets = []
+      self.class.get_sets.each_line do |package_set|
+        package_sets << package_set.to_s.strip
+      end
+
+      if @resource[:name].match(/^@/)
+         if package_sets.include?(@resource[:name][1..-1].to_s)
+           return({:name => "#{@resource[:name]}", :ensure => '9999', :version_available => nil, :installed_versions => nil, :installable_versions => "9999,"})
+        end
+      end
+
+      eix_file = File.directory?('/var/cache/eix') ? '/var/cache/eix/portage.eix' : '/var/cache/eix'
       update_eix if !FileUtils.uptodate?(eix_file, %w{/usr/bin/eix /usr/portage/metadata/timestamp})
 
       search_output = nil
-      Puppet::Util.withenv :LASTVERSION => version_format, :LASTSLOTVERSIONS => slot_versions_format do
-        search_output = eix *(self.class.eix_search_arguments + ["--exact",search_field,search_value])
+      Puppet::Util.withenv :EIX_LIMIT => limit, :LASTVERSION => version_format, :LASTSLOTVERSIONS => slot_versions_format, :INSTALLEDVERSIONS => installed_versions_format, :STABLEVERSIONS => installable_versions_format do
+        search_output = eix *(self.class.eix_search_arguments + ['--exact',search_field,search_value])
       end
 
       packages = []
@@ -127,10 +193,19 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
           result_fields.zip(match.captures) do |field, value|
             package[field] = value unless !value or value.empty?
           end
-          if package_slot
-            package[:version_available] = eix_get_version_for_slot(package[:slot_versions_available], package_slot)
-            package[:ensure] = eix_get_version_for_slot(package[:installed_slots], package_slot)
+          # dev-lang python [3.4.5] [3.5.2] [2.7.12:2.7,3.4.5:3.4] [2.7.12:2.7,3.4.5:3.4,3.5.2:3.5] https://www.python.org/ An interpreted, interactive, object-oriented programming language
+          # version_available is what we CAN install / update to
+          # ensure is what is currently installed
+          # This DOES NOT choose to install/upgrade or not, just provides current info
+          # prefer checking versions to slots as versions are finer grained
+          if qatom[:pv]
+            package[:version_available] = eix_get_version_for_versions(package[:installable_versions], qatom[:pv])
+            package[:ensure] = eix_get_version_for_versions(package[:installed_versions], qatom[:pv])
+          elsif qatom[:slot]
+            package[:version_available] = eix_get_version_for_slot(package[:slot_versions_available], qatom[:slot])
+            package[:ensure] = eix_get_version_for_slot(package[:installed_slots], qatom[:slot])
           end
+
           package[:ensure] = package[:ensure] ? package[:ensure] : :absent
           packages << package
         end
@@ -138,10 +213,9 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
       case packages.size
         when 0
-          not_found_value = "#{@resource[:category] ? @resource[:category] : "<unspecified category>"}/#{@resource[:name]}"
-          raise Puppet::Error.new("No package found with the specified name [#{not_found_value}]")
+          raise Puppet::Error.new("No package found with the specified name [#{@resource[:name]}]")
         when 1
-          return packages[0]
+          @eix_result = packages[0]
         else
           raise Puppet::Error.new("More than one package with the specified name [#{search_value}], please use the category parameter to disambiguate")
       end
@@ -155,39 +229,73 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
   end
 
   private
-  def eix_get_version_for_slot(versions_and_slots, slot)
-    return nil if versions_and_slots.nil?
-    versions_and_slots = versions_and_slots.split(",")
-    versions_and_slots.map! { |version_and_slot| version_and_slot.split(":") }
-    version_for_slot = versions_and_slots.find { |version_and_slot| version_and_slot.last == slot }
-    version_for_slot.first if version_for_slot
+  def eix_get_version_for_versions(versions, target)
+    # [2.7.10-r1,2.7.12,3.4.3-r1,3.4.5,3.5.2] 3.5.2
+    return nil if versions.nil?
+    versions = versions.split(',')
+    # [2.7.10-r1 2.7.12 3.4.3-r1 3.4.5 3.5.2]
+    versions.find { |version| version == target }
+    # 3.5.2
   end
 
-  def self.slot_pattern
-    /:([\w+.\/*=-]+)$/
+  private
+  def eix_get_version_for_slot(versions_and_slots, slot)
+    # [2.7.12:2.7 3.4.5:3.4 3.5.2:3.5] 3.5
+    return nil if versions_and_slots.nil?
+    versions_and_slots = versions_and_slots.split(',')
+    # [2.7.12:2.7 3.4.5:3.4 3.5.2:3.5]
+    versions_and_slots.map! { |version_and_slot| version_and_slot.split(':') }
+    # [2.7.12: 2.7
+    #  3.4.5:  3.4
+    #  3.5.2:  3.5]
+    version_for_slot = versions_and_slots.find { |version_and_slot| version_and_slot.last == slot[1..-1] }
+    # [3.5.2:  3.5]
+    version_for_slot.first if version_for_slot
+    # 3.5.2
   end
 
   def self.eix_search_format
-    "'<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] [<installedversions:LASTSLOTVERSIONS>] [<bestslotversions:LASTSLOTVERSIONS>] <homepage> <description>\n'"
+    "'<category> <name> [<installedversions:LASTVERSION>] [<bestversion:LASTVERSION>] [<installedversions:LASTSLOTVERSIONS>] [<installedversions:INSTALLEDVERSIONS>] [<availableversions:STABLEVERSIONS>] [<bestslotversions:LASTSLOTVERSIONS>] <homepage> <description>\n'"
   end
 
   def self.eix_result_format
-    /^(\S+)\s+(\S+)\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+(\S+)\s+(.*)$/
+    /^(\S+)\s+(\S+)\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+\[(\S*)\]\s+(\S+)\s+(.*)$/
   end
 
   def self.eix_result_fields
-    [:category, :name, :ensure, :version_available, :installed_slots, :slot_versions_available, :vendor, :description]
+    # ensure:[3.4.5], version_available:[3.5.2], installed_slots:[2.7.12:2.7,3.4.5:3.4], installable_versions:[2.7.10-r1,2.7.12,3.4.3-r1,3.4.5,3.5.2] slot_versions_available:[2.7.12:2.7,3.4.5:3.4,3.5.2:3.5]
+    [:category, :name, :ensure, :version_available, :installed_slots, :installed_versions, :installable_versions, :slot_versions_available, :vendor, :description]
   end
 
   def self.eix_version_format
-    "{last}<version>{}"
+    '{last}<version>{}'
   end
 
   def self.eix_slot_versions_format
-    "{!first},{}<version>:<slot>"
+    '{!first},{}<version>:<slot>'
+  end
+
+  def self.eix_installed_versions_format
+    '{!first},{}<version>'
+  end
+
+  def self.eix_install_versions_format
+    '{!first}{!last},{}{}{isstable}<version>{}'
+  end
+
+  def self.eix_limit
+    '0'
   end
 
   def self.eix_search_arguments
-    ["--nocolor", "--pure-packages", "--format",self.eix_search_format]
+    ['--nocolor', '--pure-packages', '--format', self.eix_search_format]
+  end
+
+  def install_options
+    join_options(@resource[:install_options])
+  end
+
+  def uninstall_options
+    join_options(@resource[:uninstall_options])
   end
 end

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -9,28 +9,61 @@ describe provider do
     packagename="sl"
     @resource = stub('resource', :should => true)
     @resource.stubs(:[]).with(:name).returns(packagename)
-    @resource.stubs(:[]).with(:category).returns(nil)
+    @resource.stubs(:[]).with(:install_options).returns(['--foo', '--bar'])
+    @resource.stubs(:[]).with(:uninstall_options).returns(['--foo', { '--bar' => 'baz', '--baz' => 'foo' }])
 
     unslotted_packagename = "dev-lang/ruby"
     @unslotted_resource = stub('resource', :should => true)
+    @unslotted_resource.stubs(:should).with(:ensure).returns :latest
     @unslotted_resource.stubs(:[]).with(:name).returns(unslotted_packagename)
-    @unslotted_resource.stubs(:[]).with(:category).returns(nil)
+    @unslotted_resource.stubs(:[]).with(:install_options).returns([])
 
-    slotted_packagename = "dev-lang/ruby:1.9"
+    slotted_packagename = "dev-lang/ruby:2.1"
     @slotted_resource = stub('resource', :should => true)
     @slotted_resource.stubs(:[]).with(:name).returns(slotted_packagename)
-    @slotted_resource.stubs(:[]).with(:category).returns(nil)
+    @slotted_resource.stubs(:[]).with(:install_options).returns(['--foo', { '--bar' => 'baz', '--baz' => 'foo' }])
 
+    versioned_packagename = "dev-lang/ruby-1.9.3"
+    @versioned_resource = stub('resource', :should => true)
+    @versioned_resource.stubs(:[]).with(:name).returns(versioned_packagename)
+    @versioned_resource.stubs(:[]).with(:uninstall_options).returns([])
+
+    versioned_slotted_packagename = "=dev-lang/ruby-1.9.3:1.9"
+    @versioned_slotted_resource = stub('resource', :should => true)
+    @versioned_slotted_resource.stubs(:[]).with(:name).returns(versioned_slotted_packagename)
+    @versioned_slotted_resource.stubs(:[]).with(:uninstall_options).returns([])
+
+    set_packagename = "@system"
+    @set_resource = stub('resource', :should => true)
+    @set_resource.stubs(:[]).with(:name).returns(set_packagename)
+    @set_resource.stubs(:[]).with(:install_options).returns([])
+
+    package_sets = "system\nworld\n"
     @provider = provider.new(@resource)
+    @provider.stubs(:qatom).returns({:category=>nil, :pn=>"sl", :pv=>nil, :pr=>nil, :slot=>nil, :pfx=>nil, :sfx=>nil})
+    @provider.class.stubs(:emerge).with('--list-sets').returns(package_sets)
     @unslotted_provider = provider.new(@unslotted_resource)
+    @unslotted_provider.stubs(:qatom).returns({:category=>"dev-lang", :pn=>"ruby", :pv=>nil, :pr=>nil, :slot=>nil, :pfx=>nil, :sfx=>nil})
+    @unslotted_provider.class.stubs(:emerge).with('--list-sets').returns(package_sets)
     @slotted_provider = provider.new(@slotted_resource)
+    @slotted_provider.stubs(:qatom).returns({:category=>"dev-lang", :pn=>"ruby", :pv=>nil, :pr=>nil, :slot=>":2.1", :pfx=>nil, :sfx=>nil})
+    @slotted_provider.class.stubs(:emerge).with('--list-sets').returns(package_sets)
+    @versioned_provider = provider.new(@versioned_resource)
+    @versioned_provider.stubs(:qatom).returns({:category=>"dev-lang", :pn=>"ruby", :pv=>"1.9.3", :pr=>nil, :slot=>nil, :pfx=>nil, :sfx=>nil})
+    @versioned_provider.class.stubs(:emerge).with('--list-sets').returns(package_sets)
+    @versioned_slotted_provider = provider.new(@versioned_slotted_resource)
+    @versioned_slotted_provider.stubs(:qatom).returns({:category=>"dev-lang", :pn=>"ruby", :pv=>"1.9.3", :pr=>nil, :slot=>":1.9", :pfx=>"=", :sfx=>nil})
+    @versioned_slotted_provider.class.stubs(:emerge).with('--list-sets').returns(package_sets)
+    @set_provider = provider.new(@set_resource)
+    @set_provider.stubs(:qatom).returns({:category=>nil, :pn=>"@system", :pv=>nil, :pr=>nil, :slot=>nil, :pfx=>nil, :sfx=>nil})
+    @set_provider.class.stubs(:emerge).with('--list-sets').returns(package_sets)
 
     portage   = stub(:executable => "foo",:execute => true)
     Puppet::Provider::CommandDefiner.stubs(:define).returns(portage)
 
     @nomatch_result = ""
-    @match_result   = "app-misc sl [] [] [] [] http://www.tkl.iis.u-tokyo.ac.jp/~toyoda/index_e.html http://www.izumix.org.uk/sl/ sophisticated graphical program which corrects your miss typing\n"
-    @slot_match_result = "dev-lang ruby [2.0.0] [2.1.0] [1.8.7:1.8,1.9.2:1.9,2.0.0:2.0] [1.9.3:1.9,2.0.1:2.0,2.1.0:2.1] http://www.ruby-lang.org/ An object-oriented scripting language\n"
+    @match_result    = "app-misc sl [] [5.02] [] [] [5.02] [5.02:0] http://www.tkl.iis.u-tokyo.ac.jp/~toyoda/index_e.html https://github.com/mtoyoda/sl/ sophisticated graphical program which corrects your miss typing\n"
+    @slot_match_result = "dev-lang ruby [2.1.8] [2.1.9] [2.1.8:2.1] [2.1.8] [2.1.9,,,,,,,] [2.1.9:2.1] http://www.ruby-lang.org/ An object-oriented scripting language\n"
   end
 
   it "is versionable" do
@@ -39,6 +72,42 @@ describe provider do
 
   it "is reinstallable" do
     expect(provider).to be_reinstallable
+  end
+
+  it 'should support string install options' do
+    @provider.expects(:emerge).with('--foo', '--bar', @resource[:name])
+
+    @provider.install
+  end
+
+  it 'should support updating' do
+    @unslotted_provider.expects(:emerge).with('--update', @unslotted_resource[:name])
+
+    @unslotted_provider.install
+  end
+
+  it 'should support hash install options' do
+    @slotted_provider.expects(:emerge).with('--foo', '--bar=baz', '--baz=foo', @slotted_resource[:name])
+
+    @slotted_provider.install
+  end
+
+  it 'should support hash uninstall options' do
+    @provider.expects(:emerge).with('--rage-clean', '--foo', '--bar=baz', '--baz=foo', @resource[:name])
+
+    @provider.uninstall
+  end
+
+  it 'should support uninstall of specific version' do
+    @versioned_provider.expects(:emerge).with('--rage-clean', @versioned_resource[:name])
+
+    @versioned_provider.uninstall
+  end
+
+  it 'should support uninstall of specific version and slot' do
+    @versioned_slotted_provider.expects(:emerge).with('--rage-clean', @versioned_slotted_resource[:name])
+
+    @versioned_slotted_provider.uninstall
   end
 
   it "uses :emerge to install packages" do
@@ -58,6 +127,19 @@ describe provider do
     @provider.expects(:eix).returns(StringIO.new(@match_result))
 
     @provider.query
+  end
+
+  it "allows to emerge package sets" do
+    @set_provider.expects(:emerge).with(@set_resource[:name])
+
+    @set_provider.install
+  end
+
+  it "allows to emerge and update package sets" do
+    @set_resource.stubs(:should).with(:ensure).returns :latest
+    @set_provider.expects(:emerge).with('--update', @set_resource[:name])
+
+    @set_provider.install
   end
 
   it "eix arguments must not include --stable" do
@@ -84,23 +166,27 @@ describe provider do
   end
 
   it "can provide the package name without slot" do
-    expect(@slotted_provider.package_name_without_slot).to eq("dev-lang/ruby")
+    expect(@unslotted_provider.qatom[:slot]).to be_nil
   end
 
   it "can extract the slot from the package name" do
-    expect(@slotted_provider.package_slot).to eq("1.9")
+    expect(@slotted_provider.qatom[:slot]).to eq(':2.1')
   end
 
   it "returns nil for as the slot when no slot is specified" do
-    expect(@provider.package_slot).to be_nil
+    expect(@provider.qatom[:slot]).to be_nil
   end
 
   it "provides correct package atoms for unslotted packages" do
-    expect(@provider.package_atom_with_version("1.0")).to eq("=sl-1.0")
+    expect(@versioned_provider.qatom[:pv]).to eq('1.9.3')
   end
 
   it "provides correct package atoms for slotted packages" do
-    expect(@slotted_provider.package_atom_with_version("1.9.3")).to eq("=dev-lang/ruby-1.9.3:1.9")
+    expect(@versioned_slotted_provider.qatom[:pfx]).to eq('=')
+    expect(@versioned_slotted_provider.qatom[:category]).to eq('dev-lang')
+    expect(@versioned_slotted_provider.qatom[:pn]).to eq('ruby')
+    expect(@versioned_slotted_provider.qatom[:pv]).to eq('1.9.3')
+    expect(@versioned_slotted_provider.qatom[:slot]).to eq(':1.9')
   end
 
   it "can handle search output with slots for unslotted packages" do
@@ -108,9 +194,9 @@ describe provider do
     @unslotted_provider.expects(:eix).returns(StringIO.new(@slot_match_result))
 
     result = @unslotted_provider.query
-    expect(result[:name]).to eq("ruby")
-    expect(result[:ensure]).to eq("2.0.0")
-    expect(result[:version_available]).to eq("2.1.0")
+    expect(result[:name]).to eq('ruby')
+    expect(result[:ensure]).to eq('2.1.8')
+    expect(result[:version_available]).to eq('2.1.9')
   end
 
   it "can handle search output with slots" do
@@ -118,8 +204,8 @@ describe provider do
     @slotted_provider.expects(:eix).returns(StringIO.new(@slot_match_result))
 
     result = @slotted_provider.query
-    expect(result[:name]).to eq("ruby")
-    expect(result[:ensure]).to eq("1.9.2")
-    expect(result[:version_available]).to eq("1.9.3")
+    expect(result[:name]).to eq('ruby')
+    expect(result[:ensure]).to eq('2.1.8')
+    expect(result[:version_available]).to eq('2.1.9')
   end
 end


### PR DESCRIPTION
Allow the portage package provider to accept install and uninstall
options.  This is useful if you do not want to use the default global
EMERGE_DEFAULT_OPTS paramaters setable in make.conf.

Allow the portage package provider to purge package if requested.

Allow package sets (@world @system and the like)