### PR TITLE
(PUP-6958) Fix gem packaging to properly include i18n files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,3 @@ task(:commits) do
   end
 end
 
-# Add i18n tasks (gettext:pot, gettext:po*)
-spec = Gem::Specification.find_by_name 'gettext-setup'
-load "#{spec.gem_dir}/lib/tasks/gettext.rake"
-GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -9,7 +9,7 @@ version_file: 'lib/puppet/version.rb'
 # files and gem_files are space separated lists
 files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec'
 # The gem specification bits only work on Puppet >= 3.0rc, NOT 2.7.x and earlier
-gem_files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec'
+gem_files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
 gem_test_files: 'spec/**/*'
 gem_executables: 'puppet'
 gem_default_executables: 'puppet'

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -38,13 +38,12 @@ module Puppet
   require 'puppet/environments'
 
   class << self
-    # e.g. ~/code/puppet/locales
+    # e.g. ~/code/puppet/locales. Also when running as a gem.
     local_locale_path = File.absolute_path('../locales', File.dirname(__FILE__))
     # e.g. /opt/puppetlabs/puppet/share/locale
     posix_system_locale_path = File.absolute_path('../../../share/locale', File.dirname(__FILE__))
     # e.g. C:\Program Files\Puppet Labs\Puppet\puppet\share\locale
     win32_system_locale_path = File.absolute_path('../../../../../puppet/share/locale', File.dirname(__FILE__))
-    # TODO: (PUP-6958) Handle the rubygems case
 
     if File.exist?(local_locale_path)
       locale_path = local_locale_path
@@ -53,7 +52,7 @@ module Puppet
     elsif File.exist?(posix_system_locale_path)
       locale_path = posix_system_locale_path
     else
-      # We couldn't load our locale data. Possibly we're loaded as a rubygem or something?
+      # We couldn't load our locale data.
       locale_path = nil
     end
 

--- a/locales/puppet.pot
+++ b/locales/puppet.pot
@@ -1,16 +1,16 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2016 Puppet, Inc.
+# Copyright (C) 2017 Puppet, Inc.
 # This file is distributed under the same license as the Puppet automation framework package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Puppet automation framework 4.8.1-137-gad255be\n"
+"Project-Id-Version: Puppet automation framework 4.8.1-318-gb241bf3\n"
 "\n"
 "Report-Msgid-Bugs-To: https://tickets.puppetlabs.com\n"
-"POT-Creation-Date: 2016-12-12 16:37-0800\n"
-"PO-Revision-Date: 2016-12-12 16:37-0800\n"
+"POT-Creation-Date: 2017-01-12 10:24-0800\n"
+"PO-Revision-Date: 2017-01-12 10:24-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -46,9 +46,6 @@ msgstr ""
 msgid "The version of the subcommand for which to show help."
 msgstr ""
 
-#. Check our invocation, because we want varargs and can't do defaults
-#. yet.  REVISIT: when we do option defaults, and positional options, we
-#. should rewrite this to use those. --daniel 2011-04-04
 msgid "Puppet help only takes two (optional) arguments: a subcommand and an action"
 msgstr ""
 
@@ -75,14 +72,5 @@ msgstr ""
 msgid "\"Unable to load action #{actionname} from #{face}\""
 msgstr ""
 
-#. Return a list of all applications (both legacy and Face applications), along with a summary
-#. of their functionality.
-#. @return [Array] An Array of Arrays.  The outer array contains one entry per application; each
-#. element in the outer array is a pair whose first element is a String containing the application
-#. name, and whose second element is a String containing the summary for that application.
-#. Now we find the line with our summary, extract it, and return it.  This
-#. depends on the implementation coincidence of how our pages are
-#. formatted.  If we can't match the pattern we expect we return the empty
-#. string to ensure we don't blow up in the summary. --daniel 2011-04-11
 msgid "! Subcommand unavailable due to error. Check error logs."
 msgstr ""

--- a/tasks/i18n.rake
+++ b/tasks/i18n.rake
@@ -1,0 +1,20 @@
+# These tasks wrap tasks from the gettext-setup gem, used when generating
+# translation files. If you want to use a new task in the gettext-setup
+# gem, add a wrapper for it here to expose it in the Puppet repo.
+namespace :gettext do
+  task :load_gettext_tasks do
+    spec = Gem::Specification.find_by_name 'gettext-setup'
+    load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+    GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
+  end
+
+  desc "Generate a new POT file"
+  task :generate_pot => :load_gettext_tasks do
+    Rake::Task["gettext:pot"].invoke
+  end
+
+  desc "Generate a PO file for the given locale"
+  task :generate_po, [:language] => :load_gettext_tasks do |t, args|
+    Rake::Task["gettext:po"].invoke(args[:language])
+  end
+end


### PR DESCRIPTION
This PR contains two commits, one of which ensures that the `locales` directory is properly packaged with the gem, and a second which removes the build-time dependency on the `gettext-setup` gem.