### PR TITLE
(PUP-6494) Support sensitive commands in Exec resource type.

### DIFF
--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -8,6 +8,7 @@ class Puppet::Provider::Exec < Puppet::Provider
     output = nil
     status = nil
     dir = nil
+    sensitive = resource.parameters[:command].sensitive
 
     checkexe(command)
 
@@ -23,7 +24,7 @@ class Puppet::Provider::Exec < Puppet::Provider
 
     dir ||= Dir.pwd
 
-    debug "Executing#{check ? " check": ""} '#{command}'"
+    debug "Executing#{check ? " check": ""} '#{sensitive ? '[redacted]' : command}'"
     begin
       # Do our chdir
       Dir.chdir(dir) do
@@ -59,7 +60,8 @@ class Puppet::Provider::Exec < Puppet::Provider
           output = Puppet::Util::Execution.execute(command, :failonfail => false, :combine => true,
                                   :uid => resource[:user], :gid => resource[:group],
                                   :override_locale => false,
-                                  :custom_environment => environment)
+                                  :custom_environment => environment,
+                                  :sensitive => sensitive)
         end
         # The shell returns 127 if the command is missing.
         if output.exitstatus == 127

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1218,6 +1218,10 @@ class Type
     resource = Puppet::Resource.new(self, title)
     resource.catalog = hash.delete(:catalog)
 
+    if sensitive = hash.delete(:sensitive_parameters)
+      resource.sensitive_parameters = sensitive
+    end
+
     hash.each do |param, value|
       resource[param] = value
     end

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -153,15 +153,18 @@ module Puppet::Util::Execution
         :squelch => false,
         :override_locale => true,
         :custom_environment => {},
+        :sensitive => false,
     }
 
     options = default_options.merge(options)
 
-    if command.is_a?(Array)
+    if options[:sensitive]
+      command_str = '[redacted]'
+    elsif command.is_a?(Array)
       command = command.flatten.map(&:to_s)
-      str = command.join(" ")
+      command_str = command.join(" ")
     elsif command.is_a?(String)
-      str = command
+      command_str = command
     end
 
     user_log_s = ''
@@ -176,9 +179,9 @@ module Puppet::Util::Execution
     end
 
     if respond_to? :debug
-      debug "Executing#{user_log_s}: '#{str}'"
+      debug "Executing#{user_log_s}: '#{command_str}'"
     else
-      Puppet.debug "Executing#{user_log_s}: '#{str}'"
+      Puppet.debug "Executing#{user_log_s}: '#{command_str}'"
     end
 
     null_file = Puppet.features.microsoft_windows? ? 'NUL' : '/dev/null'
@@ -229,7 +232,7 @@ module Puppet::Util::Execution
       end
 
       if options[:failonfail] and exit_status != 0
-        raise Puppet::ExecutionFailure, "Execution of '#{str}' returned #{exit_status}: #{output.strip}"
+        raise Puppet::ExecutionFailure, "Execution of '#{command_str}' returned #{exit_status}: #{output.strip}"
       end
     ensure
       if !options[:squelch] && stdout


### PR DESCRIPTION
This commit adds support for sensitive commands in the `Exec` resource type:
`command` parameters that are specified as `Sensitive.new(...)` are now
properly redacted when the command fails.  This supports using data from lookup
and hiera.

Example:
```puppet
exec { 'redacted':
  command => Sensitive.new('/usr/bin/false SECRET_TEXT')
}
```

Output:
```
Error: [command redacted] returned 1 instead of one of [0]
Error: /Stage[main]/Main/Exec[redacted]/returns: change from notrun to 0 failed:
[command redacted] returned 1 instead of one of [0]
```