### PR TITLE
(PUP-7099) Fix typo in LookupKeyFunctionProvider

### DIFF
--- a/lib/puppet/pops/lookup/context.rb
+++ b/lib/puppet/pops/lookup/context.rb
@@ -70,6 +70,7 @@ class Context
 
   def self.register_ptype(loader, ir)
     tf = Types::TypeFactory
+    key_type = tf.optional(tf.scalar)
     @type = Pcore::create_object_type(loader, ir, self, 'Puppet::LookupContext', 'Any',
       {
         'environment_name' => Types::PStringType::NON_EMPTY,
@@ -82,14 +83,14 @@ class Context
         'not_found' => tf.callable([0, 0], tf.undef),
         'explain' => tf.callable([0, 0, tf.callable(0,0)], tf.undef),
         'interpolate' => tf.callable(1, 1),
-        'cache' => tf.callable([tf.scalar, tf.any], tf.any),
-        'cache_all' => tf.callable([tf.hash_kv(tf.scalar, tf.any)], tf.undef),
-        'cache_has_key' => tf.callable([tf.scalar], tf.boolean),
-        'cached_value' => tf.callable([tf.scalar], tf.any),
+        'cache' => tf.callable([key_type, tf.any], tf.any),
+        'cache_all' => tf.callable([tf.hash_kv(key_type, tf.any)], tf.undef),
+        'cache_has_key' => tf.callable([key_type], tf.boolean),
+        'cached_value' => tf.callable([key_type], tf.any),
         'cached_entries' => tf.variant(
           tf.callable([0, 0, tf.callable(1,1)], tf.undef),
           tf.callable([0, 0, tf.callable(2,2)], tf.undef),
-          tf.callable([0, 0], tf.iterable(tf.tuple([tf.scalar, tf.any])))
+          tf.callable([0, 0], tf.iterable(tf.tuple([key_type, tf.any])))
         )
       }
     ).resolve(Types::TypeParser.singleton, loader)

--- a/lib/puppet/pops/lookup/lookup_key_function_provider.rb
+++ b/lib/puppet/pops/lookup/lookup_key_function_provider.rb
@@ -36,7 +36,7 @@ class LookupKeyFunctionProvider < FunctionProvider
   private
 
   def lookup_key(key, lookup_invocation, location, merge)
-    unless location.nil? || location.exists?
+    unless location.nil? || location.exist?
       lookup_invocation.report_location_not_found
       throw :no_such_key
     end


### PR DESCRIPTION
This commit fixes a typo in the `LookupKeyFunctionProvider` that prevented it from being used together with a location.

The PR also contains a maintenance commit to allow that `undef` is used as a key in the lookup context cache (using `undef` is useful when testing if the cache is initialized, see added test).
