### PR TITLE
(PUP-7104) Fix for serialization of Sensitive with rich data.

### DIFF
--- a/lib/puppet/pops/serialization/abstract_reader.rb
+++ b/lib/puppet/pops/serialization/abstract_reader.rb
@@ -130,7 +130,7 @@ class AbstractReader
     end
 
     register_type(Extension::TYPE_REFERENCE) do |data|
-      read_payload(data) { |ep| Types::PTypeReferenceType.new(read_tpl_qname(ep)) }
+      read_payload(data) { |ep| Types::PTypeReferenceType.new(ep.read) }
     end
 
     register_type(Extension::SYMBOL) do |data|
@@ -161,8 +161,14 @@ class AbstractReader
       read_payload(data) { |ep| SemanticPuppet::VersionRange.parse(ep.read) }
     end
 
-    register_type(Extension::BINARY) do |data|
+    register_type(Extension::BASE64) do |data|
       read_payload(data) { |ep| Types::PBinaryType::Binary.from_base64_strict(ep.read) }
+    end
+
+    register_type(Extension::BINARY) do |data|
+      # The Ruby MessagePack implementation have special treatment for "ASCII-8BIT" strings. They
+      # are written as binary data.
+      read_payload(data) { |ep| Types::PBinaryType::Binary.new(ep.read) }
     end
   end
 end

--- a/lib/puppet/pops/serialization/abstract_reader.rb
+++ b/lib/puppet/pops/serialization/abstract_reader.rb
@@ -121,6 +121,10 @@ class AbstractReader
       read_payload(data) { |ep| Extension::Comment.new(ep.read) }
     end
 
+    register_type(Extension::SENSITIVE_START) do |data|
+      read_payload(data) { |ep| Extension::SensitiveStart::INSTANCE }
+    end
+
     register_type(Extension::REGEXP) do |data|
       read_payload(data) { |ep| Regexp.new(ep.read) }
     end
@@ -155,10 +159,6 @@ class AbstractReader
 
     register_type(Extension::VERSION_RANGE) do |data|
       read_payload(data) { |ep| SemanticPuppet::VersionRange.parse(ep.read) }
-    end
-
-    register_type(Extension::SENSITIVE) do |data|
-      read_payload(data) { |ep| Types::PSensitiveType::Sensitive.new(ep.read) }
     end
 
     register_type(Extension::BINARY) do |data|

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -45,6 +45,10 @@ class AbstractWriter
     @packer.flush
   end
 
+  def supports_binary?
+    false
+  end
+
   # Write a value on the underlying stream
   # @api public
   def write(value)
@@ -163,7 +167,7 @@ class AbstractWriter
     end
 
     register_type(Extension::TYPE_REFERENCE, Types::PTypeReferenceType) do |o|
-      build_payload { |ep| write_tpl_qname(ep, o.type_string) }
+      build_payload { |ep| ep.write(o.type_string) }
     end
 
     register_type(Extension::SYMBOL, Symbol) do |o|
@@ -186,8 +190,16 @@ class AbstractWriter
       build_payload { |ep| ep.write(o.to_s) }
     end
 
-    register_type(Extension::BINARY, Types::PBinaryType::Binary) do |o|
-      build_payload { |ep| ep.write(o.to_s) }
+    if supports_binary?
+      register_type(Extension::BINARY, Types::PBinaryType::Binary) do |o|
+        # The Ruby MessagePack implementation have special treatment for "ASCII-8BIT" strings. They
+        # are written as binary data.
+        build_payload { |ep| ep.write(o.binary_buffer) }
+      end
+    else
+      register_type(Extension::BASE64, Types::PBinaryType::Binary) do |o|
+        build_payload { |ep| ep.write(o.to_s) }
+      end
     end
   end
 end

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -53,7 +53,7 @@ class AbstractWriter
     when Integer
       # not tabulated, but integers larger than 64-bit cannot be allowed.
       raise SerializationError, 'Integer out of bounds' if value > MAX_INTEGER || value < MIN_INTEGER
-    when Numeric, Symbol, Types::PSensitiveType::Sensitive, Extension::NotTabulated, true, false, nil
+    when Numeric, Symbol, Extension::NotTabulated, true, false, nil
       # not tabulated
     else
       if @tabulate
@@ -152,6 +152,10 @@ class AbstractWriter
       build_payload { |ep| ep.write(o.comment) }
     end
 
+    register_type(Extension::SENSITIVE_START, Extension::SensitiveStart) do |o|
+      build_payload { |ep| }
+    end
+
     # 0x30 - 0x7f reserved for mapping of specific runtime classes
 
     register_type(Extension::REGEXP, Regexp) do |o|
@@ -180,10 +184,6 @@ class AbstractWriter
 
     register_type(Extension::VERSION_RANGE, SemanticPuppet::VersionRange) do |o|
       build_payload { |ep| ep.write(o.to_s) }
-    end
-
-    register_type(Extension::SENSITIVE, Types::PSensitiveType::Sensitive) do |o|
-      build_payload { |ep| ep.write(o.unwrap) }
     end
 
     register_type(Extension::BINARY, Types::PBinaryType::Binary) do |o|

--- a/lib/puppet/pops/serialization/abstract_writer.rb
+++ b/lib/puppet/pops/serialization/abstract_writer.rb
@@ -192,7 +192,7 @@ class AbstractWriter
 
     if supports_binary?
       register_type(Extension::BINARY, Types::PBinaryType::Binary) do |o|
-        # The Ruby MessagePack implementation have special treatment for "ASCII-8BIT" strings. They
+        # The Ruby MessagePack implementation has special treatment for "ASCII-8BIT" strings. They
         # are written as binary data.
         build_payload { |ep| ep.write(o.binary_buffer) }
       end
@@ -205,4 +205,3 @@ class AbstractWriter
 end
 end
 end
-

--- a/lib/puppet/pops/serialization/deserializer.rb
+++ b/lib/puppet/pops/serialization/deserializer.rb
@@ -56,7 +56,7 @@ module Serialization
       when Extension::ObjectStart
         type = read
         type.read(val.attribute_count - 1, self)
-      when Numeric, String, true, false, nil, Time
+      when Numeric, String, true, false, nil
         val
       else
         remember(val)

--- a/lib/puppet/pops/serialization/deserializer.rb
+++ b/lib/puppet/pops/serialization/deserializer.rb
@@ -38,6 +38,8 @@ module Serialization
         result = remember({})
         val.size.times { key = read; result[key] = read }
         result
+      when Extension::SensitiveStart
+        Types::PSensitiveType::Sensitive.new(read)
       when Extension::PcoreObjectStart
         type_name = val.type_name
         type = Types::TypeParser.singleton.parse(type_name, @loader)

--- a/lib/puppet/pops/serialization/extension.rb
+++ b/lib/puppet/pops/serialization/extension.rb
@@ -28,8 +28,8 @@ module Extension
   TIMESPAN = 0x34
   VERSION = 0x35
   VERSION_RANGE = 0x36
-  SENSITIVE = 0x37
-  BINARY = 0x38
+  BINARY = 0x37
+  BASE64 = 0x38
 
   # Marker module indicating whether or not an instance is tabulated or not
   module NotTabulated; end

--- a/lib/puppet/pops/serialization/extension.rb
+++ b/lib/puppet/pops/serialization/extension.rb
@@ -14,6 +14,7 @@ module Extension
   MAP_START = 0x11
   PCORE_OBJECT_START = 0x12
   OBJECT_START = 0x13
+  SENSITIVE_START = 0x14
 
   # 0x20 - 0x2f reserved for special extension objects
   DEFAULT = 0x20
@@ -82,6 +83,12 @@ module Extension
     def sequence_size
       @size
     end
+  end
+
+  # The class that triggers the use of the SENSITIVE_START extension. It has no payload
+  class SensitiveStart
+    include NotTabulated
+    INSTANCE = SensitiveStart.new
   end
 
   # The class that triggers the use of the PCORE_OBJECT_START extension. The payload is the name of the object type

--- a/lib/puppet/pops/serialization/object.rb
+++ b/lib/puppet/pops/serialization/object.rb
@@ -14,7 +14,7 @@ class ObjectReader
     (names, types, required_count) = type.parameter_info(impl_class)
     max = names.size
     unless value_count >= required_count && value_count <= max
-      raise Serialization::SerializationError, "Feature count mismatch for #{impl_class.name}. Expected #{min} - #{max}, actual #{value_count}"
+      raise Serialization::SerializationError, "Feature count mismatch for #{impl_class.name}. Expected #{required_count} - #{max}, actual #{value_count}"
     end
     # Deserializer must know about this instance before we read its attributes
     val = deserializer.remember(impl_class.allocate)

--- a/lib/puppet/pops/serialization/object.rb
+++ b/lib/puppet/pops/serialization/object.rb
@@ -46,9 +46,9 @@ class ObjectWriter
     (names, types, required_count) = type.parameter_info(impl_class, true)
     args = names.map { |name| value.send(name) }
 
-    # Pop optional arguments that are nil
+    # Pop optional arguments that are default
     while args.size > required_count
-      break unless args.last.nil?
+      break unless args.last == type[names[args.size-1]].value
       args.pop
     end
 

--- a/lib/puppet/pops/serialization/serializer.rb
+++ b/lib/puppet/pops/serialization/serializer.rb
@@ -37,7 +37,7 @@ module Serialization
         if index.nil?
           write_tabulated_first_time(value)
         else
-          @writer.write(Extension::Tabulation.new(index)) unless index.nil?
+          @writer.write(Extension::Tabulation.new(index))
         end
       end
     end

--- a/lib/puppet/pops/types/implementation_registry.rb
+++ b/lib/puppet/pops/types/implementation_registry.rb
@@ -59,7 +59,7 @@ module Types
         loader)
     end
 
-    # Register a bidiractional regexp mapping
+    # Register a bidirectional regexp mapping
     #
     # @param type_name_subst [Array(Regexp,String)] regexp and replacement mapping type names to runtime names
     # @param impl_name_subst [Array(Regexp,String)] regexp and replacement mapping runtime names to type names

--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -51,8 +51,8 @@ module Types
   class PTimespanType < PAbstractTimeDataType
     def self.register_ptype(loader, ir)
       create_ptype(loader, ir, 'ScalarType',
-        'from' => { KEY_TYPE => PTimespanType::DEFAULT, KEY_VALUE => :default },
-        'to' => { KEY_TYPE => PTimespanType::DEFAULT, KEY_VALUE => :default }
+        'from' => { KEY_TYPE => POptionalType.new(PTimespanType::DEFAULT), KEY_VALUE => nil },
+        'to' => { KEY_TYPE => POptionalType.new(PTimespanType::DEFAULT), KEY_VALUE => nil }
       )
     end
 

--- a/lib/puppet/pops/types/p_timestamp_type.rb
+++ b/lib/puppet/pops/types/p_timestamp_type.rb
@@ -3,8 +3,8 @@ module Types
   class PTimestampType < PAbstractTimeDataType
     def self.register_ptype(loader, ir)
       create_ptype(loader, ir, 'ScalarType',
-        'from' => { KEY_TYPE => PTimestampType::DEFAULT, KEY_VALUE => :default },
-        'to' => { KEY_TYPE => PTimestampType::DEFAULT, KEY_VALUE => :default }
+        'from' => { KEY_TYPE => POptionalType.new(PTimestampType::DEFAULT), KEY_VALUE => nil },
+        'to' => { KEY_TYPE => POptionalType.new(PTimestampType::DEFAULT), KEY_VALUE => nil }
       )
     end
 

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -822,8 +822,8 @@ end
 class PNumericType < PAbstractRangeType
   def self.register_ptype(loader, ir)
     create_ptype(loader, ir, 'ScalarType',
-      'from' => { KEY_TYPE => PNumericType::DEFAULT, KEY_VALUE => :default },
-      'to' => { KEY_TYPE => PNumericType::DEFAULT, KEY_VALUE => :default }
+      'from' => { KEY_TYPE => POptionalType.new(PNumericType::DEFAULT), KEY_VALUE => nil },
+      'to' => { KEY_TYPE => POptionalType.new(PNumericType::DEFAULT), KEY_VALUE => nil }
     )
   end
 

--- a/spec/unit/pops/serialization/packer_spec.rb
+++ b/spec/unit/pops/serialization/packer_spec.rb
@@ -87,15 +87,6 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
       expect(val2).to eql(val)
     end
 
-    it 'Sensitive' do
-      sval = 'the sensitive value'
-      val = Types::PSensitiveType::Sensitive.new(sval)
-      write(val)
-      val2 = read
-      expect(val2).to be_a(Types::PSensitiveType::Sensitive)
-      expect(val2.unwrap).to eql(sval)
-    end
-
     it 'Timespan' do
       val = Time::Timespan.from_fields(false, 3, 12, 40, 31, 123)
       write(val)
@@ -134,16 +125,6 @@ describe "the Puppet::Pops::Serialization when using #{packer_module.name}" do
       val2 = read
       expect(val2).to be_a(Types::PBinaryType::Binary)
       expect(val2).to eql(val)
-    end
-
-    it 'Sensitive with rich data' do
-      sval = Time::Timestamp.now
-      val = Types::PSensitiveType::Sensitive.new(sval)
-      write(val)
-      val2 = read
-      expect(val2).to be_a(Types::PSensitiveType::Sensitive)
-      expect(val2.unwrap).to be_a(Time::Timestamp)
-      expect(val2.unwrap).to eql(sval)
     end
   end
 


### PR DESCRIPTION
The current implementation of Sensitive serialization was broken. It assumed
that the same packer was used for both normal data and extension data and
made attempts to write rich data directly into the extension buffer. While
fine for JSON, that approach doesn't work at all for MsgPack.

This commit changes the serialzation so that a SensitiveStart marker is
written using an extension point and then the actual wrapped object is
written as a normal object.