### PR TITLE
(PUP-5954) Make class merge an error

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -852,7 +852,8 @@ class Puppet::Parser::Compiler
 
   def create_settings_scope
     settings_type = Puppet::Resource::Type.new :hostclass, "settings"
-    environment.known_resource_types.add(settings_type)
+    # use replace instead of add to avoid duplication check and illegal merge (PUP-5954)
+    environment.known_resource_types.replace_settings(settings_type)
 
     settings_resource = Puppet::Parser::Resource.new("class", "settings", :scope => @topscope)
 

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -73,18 +73,13 @@ class Puppet::Resource::TypeCollection
     instance
   end
 
+  # @api private
   def handle_hostclass_merge(instance)
+    # Only main class (named '') can be merged (for purpose of merging top-scopes).
+    return instance unless instance.name == ''
     if instance.type == :hostclass && (other = @hostclasses[instance.name]) && other.type == :hostclass
-      unless instance.name == ''
-        case Puppet[:strict]
-        when :warning
-          Puppet.warning("Class '#{instance.name}' is already defined#{other.error_context}; cannot redefine at #{instance.file}:#{instance.line}") 
-        when :error
-          # returning means a merge (with throw) is not performed, that will then trigger a duplication check with error.
-          return instance
-        end
-      end
       other.merge(instance)
+      # throw is used to signal merge - avoids dupe checks and adding it to hostclasses
       throw :merged, other
     end
   end

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -89,6 +89,17 @@ class Puppet::Resource::TypeCollection
     end
   end
 
+  # Replaces the known settings with a new instance (that must be named 'settings').
+  # This is primarily needed for testing purposes. Also see PUP-5954 as it makes 
+  # it illegal to merge classes other than the '' (main) class. Prior to this change
+  # settings where always merged rather than being defined from scratch for many testing scenarios
+  # not having a complete side effect free setup for compilation.
+  # 
+  # @api private
+  def replace_settings(instance)
+    @hostclasses['settings'] = instance
+  end
+
   def hostclass(name)
     @hostclasses[munge_name(name)]
   end

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -2,6 +2,7 @@ require 'puppet/parser/type_loader'
 require 'puppet/util/file_watcher'
 require 'puppet/util/warnings'
 
+# @api private
 class Puppet::Resource::TypeCollection
   attr_reader :environment
   attr_accessor :parse_failed
@@ -49,6 +50,7 @@ class Puppet::Resource::TypeCollection
     }.inspect
   end
 
+  # @api private
   def <<(thing)
     add(thing)
     self
@@ -73,7 +75,6 @@ class Puppet::Resource::TypeCollection
     instance
   end
 
-  # @api private
   def handle_hostclass_merge(instance)
     # Only main class (named '') can be merged (for purpose of merging top-scopes).
     return instance unless instance.name == ''
@@ -90,7 +91,6 @@ class Puppet::Resource::TypeCollection
   # settings where always merged rather than being defined from scratch for many testing scenarios
   # not having a complete side effect free setup for compilation.
   # 
-  # @api private
   def replace_settings(instance)
     @hostclasses['settings'] = instance
   end

--- a/spec/unit/resource/type_collection_spec.rb
+++ b/spec/unit/resource/type_collection_spec.rb
@@ -51,14 +51,14 @@ describe Puppet::Resource::TypeCollection do
     expect(@code.hostclass("foo")).to equal(klass)
   end
 
-  it "merge together hostclasses of the same name" do
+  it "errors if an attempt is made to merge hostclasses of the same name" do
     klass1 = Puppet::Resource::Type.new(:hostclass, "foo", :doc => "first")
     klass2 = Puppet::Resource::Type.new(:hostclass, "foo", :doc => "second")
 
-    @code.add(klass1)
-    @code.add(klass2)
-
-    expect(@code.hostclass("foo").doc).to eq("firstsecond")
+    expect {
+      @code.add(klass1)
+      @code.add(klass2)
+    }.to raise_error(/.*is already defined; cannot redefine/)
   end
 
   it "should store definitions as definitions" do


### PR DESCRIPTION
Before this, if a class was defined more than once their bodies would be merged. The output of a warning or error was under the control of the --strict flag.
Now, this is always an error except for the top scope class named '' (a.k.a 'main').
