### PR TITLE
(PUP-7114) Re-vendor semantic_puppet gem

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.specification_version = 3
   s.add_runtime_dependency(%q<facter>, [">= 2.0.1", "< 4"])
   s.add_runtime_dependency(%q<hiera>, [">= 2.0", "< 4"])
-  s.add_runtime_dependency(%q<semantic_puppet>, ['>= 0.1.3', '< 2'])
+  # PUP-7115 - return to a gem dependency in Puppet 5
+  # s.add_runtime_dependency(%q<semantic_puppet>, ['>= 0.1.3', '< 2'])
   s.add_runtime_dependency(%q<gettext-setup>, [">= 0.10", "< 1"])
 end

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - 'lib/puppet/pops/parser/eparser.rb'
     - 'lib/puppet/external/nagios/parser.rb'
     - 'lib/puppet/module_tool/skeleton/**/*'
+    - 'lib/semantic_puppet/dependency/module_release.rb'
 
 Lint/ConditionPosition:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,8 @@ end
 gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
-gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ['>= 0.1.3', '< 2'])
+# PUP-7115 - return to a gem dependency in Puppet 5
+# gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ['>= 0.1.3', '< 2'])
 gem "rake", "10.1.1", :require => false
 # Hiera has an unbound dependency on json_pure
 # json_pure 2.0.2+ officially requires Ruby >= 2.0, but should have specified that in 2.0

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -20,7 +20,8 @@ gem_runtime_dependencies:
   facter: ['> 2.0', '< 4']
   hiera: ['>= 2.0', '< 4']
   json_pure: '~> 1.8'
-  semantic_puppet: ['>= 0.1.3', '< 2']
+  # PUP-7115 - return to a gem dependency in Puppet 5
+  # semantic_puppet: ['>= 0.1.3', '< 2']
   gettext-setup: ['>= 0.10', '< 1']
   locale: '~> 2.1'
 gem_rdoc_options:

--- a/lib/semantic_puppet.rb
+++ b/lib/semantic_puppet.rb
@@ -1,0 +1,9 @@
+require 'gettext-setup'
+
+module SemanticPuppet
+  GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
+
+  autoload :Version, 'semantic_puppet/version'
+  autoload :VersionRange, 'semantic_puppet/version_range'
+  autoload :Dependency, 'semantic_puppet/dependency'
+end

--- a/lib/semantic_puppet/dependency.rb
+++ b/lib/semantic_puppet/dependency.rb
@@ -1,0 +1,181 @@
+require 'semantic_puppet'
+
+module SemanticPuppet
+  module Dependency
+    extend self
+
+    autoload :Graph,         'semantic_puppet/dependency/graph'
+    autoload :GraphNode,     'semantic_puppet/dependency/graph_node'
+    autoload :ModuleRelease, 'semantic_puppet/dependency/module_release'
+    autoload :Source,        'semantic_puppet/dependency/source'
+
+    autoload :UnsatisfiableGraph, 'semantic_puppet/dependency/unsatisfiable_graph'
+
+    # @!group Sources
+
+    # @return [Array<Source>] a frozen copy of the {Source} list
+    def sources
+      (@sources ||= []).dup.freeze
+    end
+
+    # Appends a new {Source} to the current list.
+    # @param source [Source] the {Source} to add
+    # @return [void]
+    def add_source(source)
+      sources
+      @sources << source
+      nil
+    end
+
+    # Clears the current list of {Source}s.
+    # @return [void]
+    def clear_sources
+      sources
+      @sources.clear
+      nil
+    end
+
+    # @!endgroup
+
+    # Fetches a graph of modules and their dependencies from the currently
+    # configured list of {Source}s.
+    #
+    # @todo Return a specialized "Graph" object.
+    # @todo Allow for external constraints to be added to the graph.
+    # @see #sources
+    # @see #add_source
+    # @see #clear_sources
+    #
+    # @param modules [{ String => String }]
+    # @return [Graph] the root of a dependency graph
+    def query(modules)
+      constraints = Hash[modules.map { |k, v| [ k, VersionRange.parse(v) ] }]
+
+      graph = Graph.new(constraints)
+      fetch_dependencies(graph)
+      return graph
+    end
+
+    # Given a graph result from {#query}, this method will resolve the graph of
+    # dependencies, if possible, into a flat list of the best suited modules. If
+    # the dependency graph does not have a suitable resolution, this method will
+    # raise an exception to that effect.
+    #
+    # @param graph [Graph] the root of a dependency graph
+    # @return [Array<ModuleRelease>] the list of releases to act on
+    def resolve(graph)
+      catch :next do
+        return walk(graph, graph.dependencies.dup)
+      end
+      raise UnsatisfiableGraph.new(graph)
+    end
+
+    # Fetches all available releases for the given module name.
+    #
+    # @param name [String] the module name to find releases for
+    # @return [Array<ModuleRelease>] the available releases
+    def fetch_releases(name)
+      releases = {}
+
+      sources.each do |source|
+        source.fetch(name).each do |dependency|
+          releases[dependency.version] ||= dependency
+        end
+      end
+
+      return releases.values
+    end
+
+    private
+
+    # Iterates over a changing set of dependencies in search of the best
+    # solution available. Fitness is specified as meeting all the constraints
+    # placed on it, being {ModuleRelease#satisfied? satisfied}, and having the
+    # greatest version number (with stability being preferred over prereleases).
+    #
+    # @todo Traversal order is not presently guaranteed.
+    #
+    # @param graph [Graph] the root of a dependency graph
+    # @param dependencies [{ String => Array<ModuleRelease> }] the dependencies
+    # @param considering [Array<GraphNode>] the set of releases being tested
+    # @return [Array<GraphNode>] the list of releases to use, if successful
+    def walk(graph, dependencies, *considering)
+      return considering if dependencies.empty?
+
+      # Selecting a dependency from the collection...
+      name = dependencies.keys.sort.first
+      deps = dependencies.delete(name)
+
+      # ... (and stepping over it if we've seen it before) ...
+      unless (deps & considering).empty?
+        return walk(graph, dependencies, *considering)
+      end
+
+      # ... we'll iterate through the list of possible versions in order.
+      preferred_releases(deps).reverse_each do |dep|
+
+        # We should skip any releases that violate any module's constraints.
+        unless [graph, *considering].all? { |x| x.satisfies_constraints?(dep) }
+          next
+        end
+
+        # We should skip over any releases that violate graph-level constraints.
+        potential_solution = considering.dup << dep
+        unless graph.satisfies_graph? potential_solution
+          next
+        end
+
+        catch :next do
+          # After adding any new dependencies and imposing our own constraints
+          # on existing dependencies, we'll mark ourselves as "under
+          # consideration" and recurse.
+          merged = dependencies.merge(dep.dependencies) { |_,a,b| a & b }
+
+          # If all subsequent dependencies resolved well, the recursive call
+          # will return a completed dependency list. If there were problems
+          # resolving our dependencies, we'll catch `:next`, which will cause
+          # us to move to the next possibility.
+          return walk(graph, merged, *potential_solution)
+        end
+      end
+
+      # Once we've exhausted all of our possible versions, we know that our
+      # last choice was unusable, so we'll unwind the stack and make a new
+      # choice.
+      throw :next
+    end
+
+    # Given a {ModuleRelease}, this method will iterate through the current
+    # list of {Source}s to find the complete list of versions available for its
+    # dependencies.
+    #
+    # @param node [GraphNode] the node to fetch details for
+    # @return [void]
+    def fetch_dependencies(node, cache = {})
+      node.dependency_names.each do |name|
+        unless cache.key?(name)
+          cache[name] = fetch_releases(name)
+          cache[name].each { |dep| fetch_dependencies(dep, cache) }
+        end
+
+        node << cache[name]
+      end
+    end
+
+    # Given a list of potential releases, this method returns the most suitable
+    # releases for exploration. Only {ModuleRelease#satisfied? satisfied}
+    # releases are considered, and releases with stable versions are preferred.
+    #
+    # @param releases [Array<ModuleRelease>] a list of potential releases
+    # @return [Array<ModuleRelease>] releases open for consideration
+    def preferred_releases(releases)
+      satisfied = releases.select { |x| x.satisfied? }
+
+      if satisfied.any? { |x| x.version.stable? }
+        return satisfied.select { |x| x.version.stable? }
+      else
+        return satisfied
+      end
+    end
+  end
+end

--- a/lib/semantic_puppet/dependency/graph.rb
+++ b/lib/semantic_puppet/dependency/graph.rb
@@ -1,0 +1,60 @@
+require 'semantic_puppet/dependency'
+
+module SemanticPuppet
+  module Dependency
+    class Graph
+      include GraphNode
+
+      attr_reader :modules
+
+      # Create a new instance of a dependency graph.
+      #
+      # @param modules [{String => VersionRange}] the required module
+      #        set and their version constraints
+      def initialize(modules = {})
+        @modules = modules.keys
+
+        modules.each do |name, range|
+          add_constraint('initialize', name, range.to_s) do |node|
+            range === node.version
+          end
+
+          add_dependency(name)
+        end
+      end
+
+      # Constrains graph solutions based on the given block.  Graph constraints
+      # are used to describe fundamental truths about the tooling or module
+      # system (e.g.: module names contain a namespace component which is
+      # dropped during install, so module names must be unique excluding the
+      # namespace).
+      #
+      # @example Ensuring a single source for all modules
+      #     @graph.add_constraint('installed', mod.name) do |nodes|
+      #       nodes.count { |node| node.source } == 1
+      #     end
+      #
+      # @see #considering_solution?
+      #
+      # @param source [String, Symbol] a name describing the source of the
+      #               constraint
+      # @yieldparam nodes [Array<GraphNode>] the nodes to test the constraint
+      #             against
+      # @yieldreturn [Boolean] whether the node passed the constraint
+      # @return [void]
+      def add_graph_constraint(source, &block)
+        constraints[:graph] << [ source, block ]
+      end
+
+      # Checks the proposed solution (or partial solution) against the graph's
+      # constraints.
+      #
+      # @see #add_graph_constraint
+      #
+      # @return [Boolean] true if none of the graph constraints are violated
+      def satisfies_graph?(solution)
+        constraints[:graph].all? { |_, check| check[solution] }
+      end
+    end
+  end
+end

--- a/lib/semantic_puppet/dependency/graph_node.rb
+++ b/lib/semantic_puppet/dependency/graph_node.rb
@@ -1,0 +1,117 @@
+require 'semantic_puppet/dependency'
+require 'set'
+
+module SemanticPuppet
+  module Dependency
+    module GraphNode
+      include Comparable
+
+      def name
+      end
+
+      # Determines whether the modules dependencies are satisfied by the known
+      # releases.
+      #
+      # @return [Boolean] true if all dependencies are satisfied
+      def satisfied?
+        dependencies.none? { |_, v| v.empty? }
+      end
+
+      def children
+        @_children ||= {}
+      end
+
+      def populate_children(nodes)
+        if children.empty?
+          nodes = nodes.select { |node| satisfies_dependency?(node) }
+          nodes.each do |node|
+            children[node.name] = node
+            node.populate_children(nodes)
+          end
+          self.freeze
+        end
+      end
+
+      # @api internal
+      # @return [{ String => SortedSet<GraphNode> }] the satisfactory
+      #         dependency nodes
+      def dependencies
+        @_dependencies ||= Hash.new { |h, k| h[k] = SortedSet.new }
+      end
+
+      # Adds the given dependency name to the list of dependencies.
+      #
+      # @param name [String] the dependency name
+      # @return [void]
+      def add_dependency(name)
+        dependencies[name]
+      end
+
+      # @return [Array<String>] the list of dependency names
+      def dependency_names
+        dependencies.keys
+      end
+
+      def constraints
+        @_constraints ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def constraints_for(name)
+        return [] unless constraints.has_key?(name)
+
+        constraints[name].map do |constraint|
+          {
+            :source      => constraint[0],
+            :description => constraint[1],
+            :test        => constraint[2],
+          }
+        end
+      end
+
+      # Constrains the named module to suitable releases, as determined by the
+      # given block.
+      #
+      # @example Version-locking currently installed modules
+      #     installed_modules.each do |m|
+      #       @graph.add_constraint('installed', m.name, m.version) do |node|
+      #         m.version == node.version
+      #       end
+      #     end
+      #
+      # @param source [String, Symbol] a name describing the source of the
+      #               constraint
+      # @param mod [String] the name of the module
+      # @param desc [String] a description of the enforced constraint
+      # @yieldparam node [GraphNode] the node to test the constraint against
+      # @yieldreturn [Boolean] whether the node passed the constraint
+      # @return [void]
+      def add_constraint(source, mod, desc, &block)
+        constraints["#{mod}"] << [ source, desc, block ]
+      end
+
+      def satisfies_dependency?(node)
+        dependencies.key?(node.name) && satisfies_constraints?(node)
+      end
+
+      # @param release [ModuleRelease] the release to test
+      def satisfies_constraints?(release)
+        constraints_for(release.name).all? { |x| x[:test].call(release) }
+      end
+
+      def << (nodes)
+        Array(nodes).each do |node|
+          next unless dependencies.key?(node.name)
+          if satisfies_dependency?(node)
+            dependencies[node.name] << node
+          end
+        end
+
+        return self
+      end
+
+      def <=>(other)
+        name <=> other.name
+      end
+    end
+  end
+end

--- a/lib/semantic_puppet/dependency/module_release.rb
+++ b/lib/semantic_puppet/dependency/module_release.rb
@@ -1,0 +1,58 @@
+require 'semantic_puppet/dependency'
+
+module SemanticPuppet
+  module Dependency
+    class ModuleRelease
+      include GraphNode
+
+      attr_reader :name, :version
+
+      # Create a new instance of a module release.
+      #
+      # @param source [SemanticPuppet::Dependency::Source]
+      # @param name [String]
+      # @param version [SemanticPuppet::Version]
+      # @param dependencies [{String => SemanticPuppet::VersionRange}]
+      def initialize(source, name, version, dependencies = {})
+        @source      = source
+        @name        = name.freeze
+        @version     = version.freeze
+
+        dependencies.each do |name, range|
+          add_constraint('initialize', name, range.to_s) do |node|
+            range === node.version
+          end
+
+          add_dependency(name)
+        end
+      end
+
+      def priority
+        @source.priority
+      end
+
+      def <=>(oth)
+        our_key   = [ priority, name, version ]
+        their_key = [ oth.priority, oth.name, oth.version ]
+
+        return our_key <=> their_key
+      end
+
+      def eql?(other)
+        other.is_a?(ModuleRelease) &&
+          @name.eql?(other.name) &&
+          @version.eql?(other.version) &&
+          dependencies.eql?(other.dependencies)
+      end
+      alias == eql?
+
+      def hash
+        @name.hash ^ @version.hash
+      end
+
+      def to_s
+        "#<#{self.class} #{name}@#{version}>"
+      end
+    end
+  end
+end

--- a/lib/semantic_puppet/dependency/source.rb
+++ b/lib/semantic_puppet/dependency/source.rb
@@ -1,0 +1,25 @@
+require 'semantic_puppet/dependency'
+
+module SemanticPuppet
+  module Dependency
+    class Source
+      def self.priority
+        0
+      end
+
+      def priority
+        self.class.priority
+      end
+
+      def create_release(name, version, dependencies = {})
+        version = Version.parse(version) if version.is_a? String
+        dependencies = dependencies.inject({}) do |hash, (key, value)|
+          hash[key] = VersionRange.parse(value || '>= 0.0.0')
+          hash[key] ||= VersionRange::EMPTY_RANGE
+          hash
+        end
+        ModuleRelease.new(self, name, version, dependencies)
+      end
+    end
+  end
+end

--- a/lib/semantic_puppet/dependency/unsatisfiable_graph.rb
+++ b/lib/semantic_puppet/dependency/unsatisfiable_graph.rb
@@ -1,0 +1,31 @@
+require 'semantic_puppet/dependency'
+
+module SemanticPuppet
+  module Dependency
+    class UnsatisfiableGraph < StandardError
+      attr_reader :graph
+
+      def initialize(graph)
+        @graph = graph
+
+        deps = sentence_from_list(graph.modules)
+        super "Could not find satisfying releases for #{deps}"
+      end
+
+      private
+
+      def sentence_from_list(list)
+        case list.length
+        when 1
+          list.first
+        when 2
+          list.join(' and ')
+        else
+          list = list.dup
+          list.push("and #{list.pop}")
+          list.join(', ')
+        end
+      end
+    end
+  end
+end

--- a/lib/semantic_puppet/gem_version.rb
+++ b/lib/semantic_puppet/gem_version.rb
@@ -1,0 +1,3 @@
+module SemanticPuppet
+  VERSION = '0.1.4'
+end

--- a/lib/semantic_puppet/version.rb
+++ b/lib/semantic_puppet/version.rb
@@ -1,0 +1,195 @@
+require 'semantic_puppet'
+
+module SemanticPuppet
+
+  # @note SemanticPuppet::Version subclasses Numeric so that it has sane Range
+  #       semantics in Ruby 1.9+.
+  class Version < Numeric
+    include Comparable
+
+    class ValidationFailure < ArgumentError; end
+
+    class << self
+      # Parse a Semantic Version string.
+      #
+      # @param ver [String] the version string to parse
+      # @return [Version] a comparable {Version} object
+      def parse(ver)
+        match, major, minor, patch, prerelease, build = *ver.match(/\A#{REGEX_FULL}\Z/)
+
+        if match.nil?
+          raise _("Unable to parse '%{version}' as a semantic version identifier") % {version: ver}
+        end
+
+        prerelease = parse_prerelease(prerelease) if prerelease
+        # Build metadata is not yet supported in semantic_puppet, but we hope to.
+        # The following code prevents build metadata for now.
+        #build = parse_build_metadata(build) if build
+        if !build.nil?
+          raise _("'%{version}' MUST NOT include build identifiers") % {version: ver}
+        end
+
+        self.new(major.to_i, minor.to_i, patch.to_i, prerelease, build)
+      end
+
+      # Validate a Semantic Version string.
+      #
+      # @param ver [String] the version string to validate
+      # @return [bool] whether or not the string represents a valid Semantic Version
+      def valid?(ver)
+        !!(ver =~ /\A#{REGEX_FULL}\Z/)
+      end
+
+      private
+      def parse_prerelease(prerelease)
+        subject = 'Prerelease identifiers'
+        prerelease = prerelease.split('.', -1)
+
+        if prerelease.empty? or prerelease.any? { |x| x.empty? }
+          raise _("%{subject} MUST NOT be empty") % {subject: subject}
+        elsif prerelease.any? { |x| x =~ /[^0-9a-zA-Z-]/ }
+          raise _("%{subject} MUST use only ASCII alphanumerics and hyphens") % {subject: subject}
+        elsif prerelease.any? { |x| x =~ /^0\d+$/ }
+          raise _("%{subject} MUST NOT contain leading zeroes") % {subject: subject}
+        end
+
+        return prerelease.map { |x| x =~ /^\d+$/ ? x.to_i : x }
+      end
+
+      def parse_build_metadata(build)
+        subject = 'Build identifiers'
+        build = build.split('.', -1)
+
+        if build.empty? or build.any? { |x| x.empty? }
+          raise _("%{subject} MUST NOT be empty") % {subject: subject}
+        elsif build.any? { |x| x =~ /[^0-9a-zA-Z-]/ }
+          raise _("%{subject} MUST use only ASCII alphanumerics and hyphens") % {subject: subject}
+        end
+
+        return build
+      end
+
+      def raise(msg)
+        super ValidationFailure, msg, caller.drop_while { |x| x !~ /\bparse\b/ }
+      end
+    end
+
+    attr_reader :major, :minor, :patch
+
+    def initialize(major, minor, patch, prerelease = nil, build = nil)
+      @major      = major
+      @minor      = minor
+      @patch      = patch
+      @prerelease = prerelease
+      @build      = build
+    end
+
+    def next(part)
+      case part
+      when :major
+        self.class.new(@major.next, 0, 0)
+      when :minor
+        self.class.new(@major, @minor.next, 0)
+      when :patch
+        self.class.new(@major, @minor, @patch.next)
+      end
+    end
+
+    def prerelease
+      @prerelease && @prerelease.join('.')
+    end
+
+    # @return [Boolean] true if this is a stable release
+    def stable?
+      @prerelease.nil?
+    end
+
+    def build
+      @build && @build.join('.')
+    end
+
+    def <=>(other)
+      return self.major <=> other.major unless self.major == other.major
+      return self.minor <=> other.minor unless self.minor == other.minor
+      return self.patch <=> other.patch unless self.patch == other.patch
+      return compare_prerelease(other)
+    end
+
+    def eql?(other)
+      other.is_a?(Version) &&
+        @major.eql?(other.major) &&
+        @minor.eql?(other.minor) &&
+        @patch.eql?(other.patch) &&
+        @prerelease.eql?(other.instance_variable_get(:@prerelease)) &&
+        @build.eql?(other.instance_variable_get(:@build))
+    end
+    alias == eql?
+
+    def to_s
+      "#{major}.#{minor}.#{patch}" +
+      (@prerelease.nil? || prerelease.empty? ? '' : "-" + prerelease) +
+      (@build.nil?      || build.empty?      ? '' : "+" + build     )
+    end
+
+    def hash
+      self.to_s.hash
+    end
+
+    private
+    # This is a hack; tildes sort later than any valid identifier. The
+    # advantage is that we don't need to handle stable vs. prerelease
+    # comparisons separately.
+    @@STABLE_RELEASE = [ '~' ].freeze
+
+    def compare_prerelease(other)
+      all_mine  = @prerelease                               || @@STABLE_RELEASE
+      all_yours = other.instance_variable_get(:@prerelease) || @@STABLE_RELEASE
+
+      # Precedence is determined by comparing each dot separated identifier from
+      # left to right...
+      size = [ all_mine.size, all_yours.size ].max
+      Array.new(size).zip(all_mine, all_yours) do |_, mine, yours|
+
+        # ...until a difference is found.
+        next if mine == yours
+
+        # Numbers are compared numerically, strings are compared ASCIIbetically.
+        if mine.class == yours.class
+          return mine <=> yours
+
+        # A larger set of pre-release fields has a higher precedence.
+        elsif mine.nil?
+          return -1
+        elsif yours.nil?
+          return 1
+
+        # Numeric identifiers always have lower precedence than non-numeric.
+        elsif mine.is_a? Numeric
+          return -1
+        elsif yours.is_a? Numeric
+          return 1
+        end
+      end
+
+      return 0
+    end
+
+    def first_prerelease
+      self.class.new(@major, @minor, @patch, [])
+    end
+
+    public
+
+    # Version string matching regexes
+    REGEX_NUMERIC = "(0|[1-9]\\d*)[.](0|[1-9]\\d*)[.](0|[1-9]\\d*)" # Major . Minor . Patch
+    REGEX_PRE     = "(?:[-](.*?))?"            # Prerelease
+    REGEX_BUILD   = "(?:[+](.*?))?"            # Build
+    REGEX_FULL    = REGEX_NUMERIC + REGEX_PRE + REGEX_BUILD
+
+    # The lowest precedence Version possible
+    MIN = self.new(0, 0, 0, []).freeze
+
+    # The highest precedence Version possible
+    MAX = self.new((1.0/0.0), 0, 0).freeze
+  end
+end

--- a/lib/semantic_puppet/version_range.rb
+++ b/lib/semantic_puppet/version_range.rb
@@ -1,0 +1,422 @@
+require 'semantic_puppet'
+
+module SemanticPuppet
+  class VersionRange < Range
+    class << self
+      # Parses a version range string into a comparable {VersionRange} instance.
+      #
+      # Currently parsed version range string may take any of the following:
+      # forms:
+      #
+      # * Regular Semantic Version strings
+      #   * ex. `"1.0.0"`, `"1.2.3-pre"`
+      # * Partial Semantic Version strings
+      #   * ex. `"1.0.x"`, `"1"`, `"2.X"`
+      # * Inequalities
+      #   * ex. `"> 1.0.0"`, `"<3.2.0"`, `">=4.0.0"`
+      # * Approximate Versions
+      #   * ex. `"~1.0.0"`, `"~ 3.2.0"`, `"~4.0.0"`
+      # * Inclusive Ranges
+      #   * ex. `"1.0.0 - 1.3.9"`
+      # * Range Intersections
+      #   * ex. `">1.0.0 <=2.3.0"`
+      #
+      # @param range_str [String] the version range string to parse
+      # @return [VersionRange] a new {VersionRange} instance
+      def parse(range_str)
+        partial = '\d+(?:[.]\d+)?(?:[.][x]|[.]\d+(?:[-][0-9a-z.-]*)?)?'
+        exact   = '\d+[.]\d+[.]\d+(?:[-][0-9a-z.-]*)?'
+
+        range = range_str.gsub(/([(><=~])[ ]+/, '\1')
+        range = range.gsub(/ - /, '#').strip
+
+        return case range
+        when /\A(#{partial})\Z/i
+          parse_loose_version_expression($1)
+        when /\A([><][=]?)(#{exact})\Z/i
+          parse_inequality_expression($1, $2)
+        when /\A~(#{partial})\Z/i
+          parse_reasonably_close_expression($1)
+        when /\A(#{exact})#(#{exact})\Z/i
+          parse_inclusive_range_expression($1, $2)
+        when /[ ]+/
+          parse_intersection_expression(range)
+        else
+          raise ArgumentError
+        end
+
+      rescue ArgumentError
+        raise ArgumentError, _("Unparsable version range: %{range}") % {range: range_str.inspect}
+      end
+
+      private
+
+      # Creates a new {VersionRange} from a range intersection expression.
+      #
+      # @param expr [String] a range intersection expression
+      # @return [VersionRange] a version range representing `expr`
+      def parse_intersection_expression(expr)
+        expr.split(/[ ]+/).map { |x| parse(x) }.inject { |a,b| a & b }
+      end
+
+      # Creates a new {VersionRange} from a "loose" description of a Semantic
+      # Version number.
+      #
+      # @see .process_loose_expr
+      #
+      # @param expr [String] a "loose" version expression
+      # @return [VersionRange] a version range representing `expr`
+      def parse_loose_version_expression(expr)
+        start, finish = process_loose_expr(expr)
+
+        if start.stable?
+          start = start.send(:first_prerelease)
+        end
+
+        if finish.stable?
+          exclude = true
+          finish = finish.send(:first_prerelease)
+        end
+
+        self.new(start, finish, exclude)
+      end
+
+      # Creates an open-ended version range from an inequality expression.
+      #
+      # @overload parse_inequality_expression('<', expr)
+      #   {include:.parse_lt_expression}
+      #
+      # @overload parse_inequality_expression('<=', expr)
+      #   {include:.parse_lte_expression}
+      #
+      # @overload parse_inequality_expression('>', expr)
+      #   {include:.parse_gt_expression}
+      #
+      # @overload parse_inequality_expression('>=', expr)
+      #   {include:.parse_gte_expression}
+      #
+      # @param comp ['<', '<=', '>', '>='] an inequality operator
+      # @param expr [String] a "loose" version expression
+      # @return [VersionRange] a range covering all versions in the inequality
+      def parse_inequality_expression(comp, expr)
+        case comp
+        when '>'
+          parse_gt_expression(expr)
+        when '>='
+          parse_gte_expression(expr)
+        when '<'
+          parse_lt_expression(expr)
+        when '<='
+          parse_lte_expression(expr)
+        end
+      end
+
+      # Returns a range covering all versions greater than the given `expr`.
+      #
+      # @param expr [String] the version to be greater than
+      # @return [VersionRange] a range covering all versions greater than the
+      #         given `expr`
+      def parse_gt_expression(expr)
+        if expr =~ /^[^+]*-/
+          start = Version.parse("#{expr}.0")
+        else
+          start = process_loose_expr(expr).last.send(:first_prerelease)
+        end
+
+        self.new(start, SemanticPuppet::Version::MAX)
+      end
+
+      # Returns a range covering all versions greater than or equal to the given
+      # `expr`.
+      #
+      # @param expr [String] the version to be greater than or equal to
+      # @return [VersionRange] a range covering all versions greater than or
+      #         equal to the given `expr`
+      def parse_gte_expression(expr)
+        if expr =~ /^[^+]*-/
+          start = Version.parse(expr)
+        else
+          start = process_loose_expr(expr).first.send(:first_prerelease)
+        end
+
+        self.new(start, SemanticPuppet::Version::MAX)
+      end
+
+      # Returns a range covering all versions less than the given `expr`.
+      #
+      # @param expr [String] the version to be less than
+      # @return [VersionRange] a range covering all versions less than the
+      #         given `expr`
+      def parse_lt_expression(expr)
+        if expr =~ /^[^+]*-/
+          finish = Version.parse(expr)
+        else
+          finish = process_loose_expr(expr).first.send(:first_prerelease)
+        end
+
+        self.new(SemanticPuppet::Version::MIN, finish, true)
+      end
+
+      # Returns a range covering all versions less than or equal to the given
+      # `expr`.
+      #
+      # @param expr [String] the version to be less than or equal to
+      # @return [VersionRange] a range covering all versions less than or equal
+      #         to the given `expr`
+      def parse_lte_expression(expr)
+        if expr =~ /^[^+]*-/
+          finish = Version.parse(expr)
+          self.new(SemanticPuppet::Version::MIN, finish)
+        else
+          finish = process_loose_expr(expr).last.send(:first_prerelease)
+          self.new(SemanticPuppet::Version::MIN, finish, true)
+        end
+      end
+
+      # The "reasonably close" expression is used to designate ranges that have
+      # a reasonable proximity to the given "loose" version number. These take
+      # the form:
+      #
+      #     ~[Version]
+      #
+      # The general semantics of these expressions are that the given version
+      # forms a lower bound for the range, and the upper bound is either the
+      # next version number increment (at whatever precision the expression
+      # provides) or the next stable version (in the case of a prerelease
+      # version).
+      #
+      # @example "Reasonably close" major version
+      #   "~1" # => (>=1.0.0 <2.0.0)
+      # @example "Reasonably close" minor version
+      #   "~1.2" # => (>=1.2.0 <1.3.0)
+      # @example "Reasonably close" patch version
+      #   "~1.2.3" # => (>=1.2.3 <1.3.0)
+      # @example "Reasonably close" prerelease version
+      #   "~1.2.3-alpha" # => (>=1.2.3-alpha <1.2.4)
+      #
+      # @param expr [String] a "loose" expression to build the range around
+      # @return [VersionRange] a "reasonably close" version range
+      def parse_reasonably_close_expression(expr)
+        parsed, succ = process_loose_expr(expr)
+
+        if parsed.stable?
+          parsed = parsed.send(:first_prerelease)
+
+          # Handle the special case of "~1.2.3" expressions.
+          succ = succ.next(:minor) if ((parsed.major == succ.major) && (parsed.minor == succ.minor))
+
+          succ = succ.send(:first_prerelease)
+          self.new(parsed, succ, true)
+        else
+          self.new(parsed, succ.next(:patch).send(:first_prerelease), true)
+        end
+      end
+
+      # An "inclusive range" expression takes two version numbers (or partial
+      # version numbers) and creates a range that covers all versions between
+      # them. These take the form:
+      #
+      #     [Version] - [Version]
+      #
+      # @param start [String] a "loose" expresssion for the start of the range
+      # @param finish [String] a "loose" expression for the end of the range
+      # @return [VersionRange] a {VersionRange} covering `start` to `finish`
+      def parse_inclusive_range_expression(start, finish)
+        start, _ = process_loose_expr(start)
+        _, finish = process_loose_expr(finish)
+
+        start = start.send(:first_prerelease) if start.stable?
+        if finish.stable?
+          exclude = true
+          finish = finish.send(:first_prerelease)
+        end
+
+        self.new(start, finish, exclude)
+      end
+
+      # A "loose expression" is one that takes the form of all or part of a
+      # valid Semantic Version number. Particularly:
+      #
+      # * [Major].[Minor].[Patch]-[Prerelease]
+      # * [Major].[Minor].[Patch]
+      # * [Major].[Minor]
+      # * [Major]
+      #
+      # Various placeholders are also permitted in "loose expressions"
+      # (typically an 'x' or an asterisk).
+      #
+      # This method parses these expressions into a minimal and maximal version
+      # number pair.
+      #
+      # @todo Stabilize whether the second value is inclusive or exclusive
+      #
+      # @param expr [String] a string containing a "loose" version expression
+      # @return [(VersionNumber, VersionNumber)] a minimal and maximal
+      #         version pair for the given expression
+      def process_loose_expr(expr)
+        case expr
+        when /^(\d+)(?:[.][xX*])?$/
+          expr = "#{$1}.0.0"
+          arity = :major
+        when /^(\d+[.]\d+)(?:[.][xX*])?$/
+          expr = "#{$1}.0"
+          arity = :minor
+        when /^\d+[.]\d+[.]\d+$/
+          arity = :patch
+        end
+
+        version = next_version = Version.parse(expr)
+
+        if arity
+          next_version = version.next(arity)
+        end
+
+        [ version, next_version ]
+      end
+    end
+
+    # Computes the intersection of a pair of ranges. If the ranges have no
+    # useful intersection, an empty range is returned.
+    #
+    # @param other [VersionRange] the range to intersect with
+    # @return [VersionRange] the common subset
+    def intersection(other)
+      raise NOT_A_VERSION_RANGE unless other.kind_of?(VersionRange)
+
+      if self.begin < other.begin
+        return other.intersection(self)
+      end
+
+      unless include?(other.begin) || other.include?(self.begin)
+        return EMPTY_RANGE
+      end
+
+      endpoint = ends_before?(other) ? self : other
+      VersionRange.new(self.begin, endpoint.end, endpoint.exclude_end?)
+    end
+    alias :& :intersection
+
+    # Returns a string representation of this range, prefering simple common
+    # expressions for comprehension.
+    #
+    # @return [String] a range expression representing this VersionRange
+    def to_s
+      start, finish  = self.begin, self.end
+      inclusive = exclude_end? ? '' : '='
+
+      case
+      when EMPTY_RANGE == self
+        "<0.0.0"
+      when exact_version?, patch_version?
+        "#{ start }"
+      when minor_version?
+        "#{ start }".sub(/.0$/, '.x')
+      when major_version?
+        "#{ start }".sub(/.0.0$/, '.x')
+      when open_end? && start.to_s =~ /-.*[.]0$/
+        ">#{ start }".sub(/.0$/, '')
+      when open_end?
+        ">=#{ start }"
+      when open_begin?
+        "<#{ inclusive }#{ finish }"
+      else
+        ">=#{ start } <#{ inclusive }#{ finish }"
+      end
+    end
+    alias :inspect :to_s
+
+    private
+
+    # Determines whether this {VersionRange} has an earlier endpoint than the
+    # give `other` range.
+    #
+    # @param other [VersionRange] the range to compare against
+    # @return [Boolean] true if the endpoint for this range is less than or
+    #         equal to the endpoint of the `other` range.
+    def ends_before?(other)
+      self.end < other.end || (self.end == other.end && self.exclude_end?)
+    end
+
+    # Describes whether this range has an upper limit.
+    # @return [Boolean] true if this range has no upper limit
+    def open_end?
+      self.end == SemanticPuppet::Version::MAX
+    end
+
+    # Describes whether this range has a lower limit.
+    # @return [Boolean] true if this range has no lower limit
+    def open_begin?
+      self.begin == SemanticPuppet::Version::MIN
+    end
+
+    # Describes whether this range follows the patterns for matching all
+    # releases with the same exact version.
+    # @return [Boolean] true if this range matches only a single exact version
+    def exact_version?
+      self.begin == self.end
+    end
+
+    # Describes whether this range follows the patterns for matching all
+    # releases with the same major version.
+    # @return [Boolean] true if this range matches only a single major version
+    def major_version?
+      start, finish = self.begin, self.end
+
+      exclude_end? &&
+      start.major.next == finish.major &&
+      same_minor? && start.minor == 0 &&
+      same_patch? && start.patch == 0 &&
+      [start.prerelease, finish.prerelease] == ['', '']
+    end
+
+    # Describes whether this range follows the patterns for matching all
+    # releases with the same minor version.
+    # @return [Boolean] true if this range matches only a single minor version
+    def minor_version?
+      start, finish = self.begin, self.end
+
+      exclude_end? &&
+      same_major? &&
+      start.minor.next == finish.minor &&
+      same_patch? && start.patch == 0 &&
+      [start.prerelease, finish.prerelease] == ['', '']
+    end
+
+    # Describes whether this range follows the patterns for matching all
+    # releases with the same patch version.
+    # @return [Boolean] true if this range matches only a single patch version
+    def patch_version?
+      start, finish = self.begin, self.end
+
+      exclude_end? &&
+      same_major? &&
+      same_minor? &&
+      start.patch.next == finish.patch &&
+      [start.prerelease, finish.prerelease] == ['', '']
+    end
+
+    # @return [Boolean] true if `begin` and `end` share the same major verion
+    def same_major?
+      self.begin.major == self.end.major
+    end
+
+    # @return [Boolean] true if `begin` and `end` share the same minor verion
+    def same_minor?
+      self.begin.minor == self.end.minor
+    end
+
+    # @return [Boolean] true if `begin` and `end` share the same patch verion
+    def same_patch?
+      self.begin.patch == self.end.patch
+    end
+
+    undef :to_a
+
+    NOT_A_VERSION_RANGE = ArgumentError.new("value must be a #{VersionRange}")
+
+    public
+
+    # A range that matches no versions
+    EMPTY_RANGE = VersionRange.parse('< 0.0.0').freeze
+  end
+end


### PR DESCRIPTION
 - As part of PUP-4742 the dependency on semantic_puppet was moved to
   a gem.  The sequence of events leading up to its conclusion is
   rather thorny, but ultimately code landed in
   c111fb76b948d547fda7afa901802ff2e8b5a623

 - Because puppet-server was not also shipping the semantic_puppet gem
   this necessitated a strict conflict in the puppet-agent package
   on puppet-server < 2.7.2 and pe-puppet-server < 2017.0.1.3

   This has had quite a bit of fallout, including unintended upgrades
   of the puppet-server package, which is extermely undesirable in a
   production environment.

 - Until Puppet 5 is released, which will allow for more latitude of
   breaking changes and dependency requirements, it has been decided
   that semantic_puppet should be temporarily re-vendored into the
   Puppet repository.  Then there is no need to match the gem in both
   puppet-server and puppet-agent.  Instead, the code from this
   repository is loaded.

 - References to the semantic_puppet gem code have been removed from
   the Gemfile, project_data.yaml and the Puppet .gemspec.

   The code from semantic_puppet 0.1.4 has been directly copied into
   lib/semantic_puppet