### PR TITLE
(PUP-7073) Normalize selinux category names

### DIFF
--- a/lib/puppet/type/file/selcontext.rb
+++ b/lib/puppet/type/file/selcontext.rb
@@ -29,7 +29,12 @@ module Puppet
     def retrieve
       return :absent unless @resource.stat
       context = self.get_selinux_current_context(@resource[:path])
-      parse_selinux_context(name, context)
+      is = parse_selinux_context(name, context)
+      if name == :selrange and selinux_support?
+        self.selinux_category_to_label(is)
+      else
+        is
+      end
     end
 
     def retrieve_default_context(property)
@@ -55,6 +60,18 @@ module Puppet
         true
       else
         super
+      end
+    end
+
+    def unsafe_munge(should)
+      if not selinux_support?
+        return should
+      end
+
+      if name == :selrange
+        self.selinux_category_to_label(should)
+      else
+        should
       end
     end
 

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -62,16 +62,22 @@ module Puppet::Util::SELinux
     if context.nil? or context == "unlabeled"
       return nil
     end
-    unless context =~ /^([^\s:]+):([^\s:]+):([^\s:]+)(?::([\sa-zA-Z0-9:,._-]+))?$/
+    components = /^([^\s:]+):([^\s:]+):([^\s:]+)(?::([\sa-zA-Z0-9:,._-]+))?$/.match(context)
+    unless components
       raise Puppet::Error, _("Invalid context to parse: %{context}") % { context: context }
     end
-    ret = {
-      :seluser => $1,
-      :selrole => $2,
-      :seltype => $3,
-      :selrange => $4,
-    }
-    ret[component]
+    case component
+    when :seluser
+      components[1]
+    when :selrole
+      components[2]
+    when :seltype
+      components[3]
+    when :selrange
+      components[4]
+    else
+      raise Puppet::Error, _("Invalid SELinux parameter type")
+    end
   end
 
   # This updates the actual SELinux label on the file.  You can update

--- a/spec/unit/type/file/selinux_spec.rb
+++ b/spec/unit/type/file/selinux_spec.rb
@@ -10,6 +10,8 @@ require 'spec_helper'
       @path = make_absolute("/my/file")
       @resource = Puppet::Type.type(:file).new :path => @path
       @sel = property.new :resource => @resource
+      @sel.stubs(:normalize_selinux_category).with("s0").returns("s0")
+      @sel.stubs(:normalize_selinux_category).with(nil).returns(nil)
     end
 
     it "retrieve on #{param} should return :absent if the file isn't statable" do


### PR DESCRIPTION
SELinux category names have two forms: an internal 'numeric' form, and
a human-readable name. Several SELinux commands rely on a service
called `mcstransd` to convert between them. When that service is not
functioning correctly, things will break.

Instead of using `mcstransd`, Puppet now queries the list of
translations itself and uses them to normalize all internal operations
on the numeric form.