### PR TITLE
(PUP-7116) Only use gettext functionality if gettext-setup gem is available

### DIFF
--- a/lib/semantic_puppet.rb
+++ b/lib/semantic_puppet.rb
@@ -1,7 +1,15 @@
-require 'gettext-setup'
+begin
+  require 'gettext-setup'
+rescue LoadError
+  def _(msg)
+    msg
+  end
+end
 
 module SemanticPuppet
-  GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
+  if defined?(GettextSetup)
+    GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
+  end
 
   autoload :Version, 'semantic_puppet/version'
   autoload :VersionRange, 'semantic_puppet/version_range'


### PR DESCRIPTION
We cannot guarantee that the gettext-setup gem will be present or of the
most recent version when running puppet from within puppetserver
(e.g. if the server version is < 2.7.2, the correct version of the gem
 will not be present). This commit handles the absent case by stubbing
out the `_` method used for loading translations, and the out-of-date
case by using the old API for `initialize`, which removes support for MO
translation files. If gettext-setup < 0.8 is loaded, only PO translation
files will be used.