### PR TITLE
(maint) Ensure graceful lookup fail without hocon

### DIFF
--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -803,6 +803,14 @@ describe "The lookup function" do
         it 'backend data sources are propagated to custom backend' do
           expect(lookup('datasources')).to eql(['common', 'example.com'])
         end
+
+        it 'provides a sensible error message when the hocon library is not loaded' do
+          Puppet.features.stubs(:hocon?).returns(false)
+
+          expect { lookup('a') }.to raise_error do |e|
+            expect(e.message).to match(/Lookup using Hocon data_hash function is not supported without hocon library/)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
 - Add a test demonstrating the behavior of the lookup function when
   Hocon is specified as a backend, but the hocon library is not
   present.

   This demonstrates what will happen if a newer agent is running
   on puppet-server < 2.7.0, which does not include the hocon gem