### PR TITLE
(PUP-7021) Use UTF-8 encoding for strings returned by Etc in Puppet::Provider::Nameservice

### DIFF
--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -55,7 +55,7 @@ class Puppet::Provider::NameService < Puppet::Provider
       Etc.send("set#{section()}ent")
       begin
         while ent = Etc.send("get#{section()}ent")
-          names << ent.name
+          names << ent.name.force_encoding(Encoding::UTF_8)
           yield ent.name if block_given?
         end
       ensure

--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -249,9 +249,9 @@ class Puppet::Provider::NameService < Puppet::Provider
     # Now iterate across all of the groups, adding each one our
     # user is a member of
     while group = Etc.getgrent
-      members = group.mem
+      members = group.mem.map { |member| member.force_encoding(Encoding::UTF_8) }
 
-      groups << group.name if members.include? user
+      groups << group.name.force_encoding(Encoding::UTF_8) if members.include? user
     end
 
     # We have to close the file, so each listing is a separate

--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -266,7 +266,11 @@ class Puppet::Provider::NameService < Puppet::Provider
     hash = {}
     self.class.resource_type.validproperties.each do |param|
       method = posixmethod(param)
-      hash[param] = info.send(posixmethod(param)) if info.respond_to? method
+      if info.respond_to?(method)
+        value = info.send(posixmethod(param))
+        value.force_encoding(Encoding::UTF_8) if value.respond_to?(:force_encoding)
+        hash[param] = value
+      end
     end
 
     hash

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 require 'puppet/provider/nameservice'
-require 'etc'
+require 'etc' # Ruby etc module is not defined on Windows
 
-describe Puppet::Provider::NameService do
+describe Puppet::Provider::NameService, :if => !Puppet.features.microsoft_windows? do
 
   before :each do
     described_class.initvars


### PR DESCRIPTION
This PR sets external encoding to UTF8 for the strings we get back from the ruby Etc module. The Etc module can return strings in system encoding, which makes its way into puppet and wreaks havoc as we try to concatenate and compare them with strings generated in puppet itself which are utf8. Rather than try to find all the different places where we concatenate, compare, or otherwise manipulate strings from this provider, just set external encoding to UTF8 at their inception.

From the commit messages:
> Use UTF-8 encoding in Puppet::Provider::NameService#listbyname
>
> The #listbyname method is used in the nameservice provider to generate the
> values for self.instances. If a name returned by the Etc module is a utf-8
> value but the system encoding is not, self.instances, and thus things like
> `puppet resource user` fail with encoding errors.
>
> This commit addresses this by setting the external encoding (not modifying byte
> values) of the returned string to UTF8. This is one of the entry points for
> these strings into the puppet system, so we prevent a cascade of downstream
> failures by setting this to utf-8 here.


> (PUP-7021) Use UTF-8 encoding in Puppet::Provider::NameService#groups
> 
> The #groups method is used by the nameservice provider (not surprisingly) in
> querying group membership. We use the Etc module to parse the group file, which
> can return strings in system encoding. Ruby considers two identical stringis
> (in bytes) with different external encodings to be unequal. Since the names in
> the groups array returned by Etc can be in system encoding, and our user is in
> utf-8 encoding, our group membership check will fail.
> 
> This commit addresses this by setting the external encoding (not modifying byte
> values) of the strings returned by Etc to UTF8. This is one of the entry points
> for these strings into the puppet system, so we prevent a cascade of downstream
> failures by setting this to utf-8 here.

> (PUP-7021) Use UTF-8 encoding in Puppet::Provider::NameService#info2hash
> 
> the #info2hash method in the nameservice provider leverages Etc module to
> gather information about a user or group. However, the strings returned by the
> module can be in system encoding, rather than UTF-8. Later, when puppet tries
> to use the information for comparison or display purposes with Puppet's UTF-8
> strings, we fail in many, many ways.
> 
> This commit addresses this by setting the external encoding (not modifying byte
> values) of the strings returned by Etc to UTF8. This is one of the entry points
> for these strings into the puppet system, so we prevent a cascade of downstream
> failures by setting this to utf-8 here.

