### PR TITLE
(PUP-6962) Acceptance rake split OPTIONS

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -138,9 +138,10 @@ EOS
     config_opt = "--hosts=#{config}"
   end
 
-  overriding_options = ENV['OPTIONS']
+  overriding_options = ENV['OPTIONS'].split(' ')
 
-  args = ["--options-file", options_file, config_opt, tests_opt, overriding_options].compact
+  args = ["--options-file", options_file, config_opt, tests_opt] + overriding_options
+  args = args.compact
 
   begin
     sh("beaker", *args)


### PR DESCRIPTION
This commit alters the acceptance Rakefile to split the OPTIONS
environment value into an array of strings. Prior to this commit,
the OPTIONS value was added to the beaker `args` array as a single
string. If multiple options were used in this string they were
interpreted as a single value of the first given option.

Example where previously multiple options were not parsed correctly,
```
bundle exec rake ci:test:aio OPTIONS="--tag='risk:high' --post-suite=$CHANGED_TESTS"
...
Beaker!
{
...
    "tag_includes": [
        "'risk:high' --post-suite=tests/server_list_setting.rb"
    ],
...
}
```