### PR TITLE
(PUP-7122) Add wrapper for gettext:update_pot rake task

### DIFF
--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -26,4 +26,4 @@ gettext:
     - 'lib/puppet/pops/types/type_formatter.rb'
     # The semantic_puppet gem is temporarily vendored (PUP-7114), and it
     # handles its own translation.
-    - 'lib/semantic_puppet/**/*.rb'
+    - 'lib/puppet/vendor/**/*.rb'

--- a/tasks/i18n.rake
+++ b/tasks/i18n.rake
@@ -17,4 +17,9 @@ namespace :gettext do
   task :generate_po, [:language] => :load_gettext_tasks do |t, args|
     Rake::Task["gettext:po"].invoke(args[:language])
   end
+
+  desc "Update POT file if strings have changed"
+  task :update_pot => :load_gettext_tasks do
+    Rake::Task["gettext:update_pot"].invoke
+  end
 end


### PR DESCRIPTION
This adds a wrapper rake task for a new update_pot task that has been
added to the gettext-setup gem. This task will cache the old POT file,
generate a new one, diff them, and only replace the old one if actual
string changes have occurred. This can be used to reduce churn from
changing dates and SHAs.

The second commit adds the `vendor` directory to the ignore list for gettext-setup. Vendored code should handle its own internationalization.