### PR TITLE
(packaging) Bump version to 4.8.3

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -7,7 +7,7 @@
 
 
 module Puppet
-  PUPPETVERSION = '4.8.2'
+  PUPPETVERSION = '4.8.3'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This commit bumps Puppet's version to 4.8.3 following the release of
4.8.2 as part of puppet-agent 1.8.3