### PR TITLE
(PUP-7114) Vendor semantic_puppet locales

### DIFF
--- a/lib/semantic_puppet.rb
+++ b/lib/semantic_puppet.rb
@@ -8,7 +8,7 @@ end
 
 module SemanticPuppet
   if defined?(GettextSetup)
-    GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
+    GettextSetup.initialize(File.absolute_path('semantic_puppet/locales', File.dirname(__FILE__)))
   end
 
   autoload :Version, 'semantic_puppet/version'

--- a/lib/semantic_puppet/locales/config.yaml
+++ b/lib/semantic_puppet/locales/config.yaml
@@ -1,0 +1,21 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: 'semantic_puppet'
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should bea little more desctiptive than
+  # <project_name>
+  package_name: Semantic Puppet Gem
+  # The locale that the default messages in the .pot file are in
+  default_locale: en
+  # The email used for sending bug reports.
+  bugs_address: docs@puppetlabs.com
+  # The holder of the copyright.
+  copyright_holder: Puppet, Inc.
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+    - 'lib/**/*.rb'


### PR DESCRIPTION
 - Add locales content from the semantic_puppet gem that should have
   been added in 65d1d94
 - Previously in the gem, the content was laid out like:

   lib/semantic_puppet.rb
   locales/config.yaml

   Therefore the appropriate relative path to find config.yaml was:

   ../locales/config.yaml

 - However, under the puppet lib directory, the locales directory must
   be isolated since it may otherwise conflict with other gems inside
   lib, so the content is instead laid out like:

   lib/semantic_puppet.rb
   lib/semantic_puppet/locales

   Therefore the appropriate relative path to find config.yaml becomes:

   semantic_puppet/locales/config.yaml