### PR TITLE
(PUP-7128) Error when reserved options are used in Hiera config

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -525,6 +525,8 @@ class HieraConfigV5 < HieraConfig
     data_providers.values
   end
 
+  RESERVED_OPTION_KEYS = ['path', 'uri'].freeze
+
   DEFAULT_CONFIG_HASH = {
     KEY_VERSION => 5,
     KEY_DEFAULTS => {
@@ -567,6 +569,15 @@ class HieraConfigV5 < HieraConfig
       if LOCATION_KEYS.count { |key| he.include?(key) } > 1
         raise Puppet::DataBinding::LookupError,
           "#{@config_path}: Only one of #{combine_strings(LOCATION_KEYS)} can be defined in hierarchy '#{name}'"
+      end
+
+      options = he[KEY_OPTIONS]
+      unless options.nil?
+        RESERVED_OPTION_KEYS.each do |key|
+          if options.include?(key)
+            raise Puppet::DataBinding::LookupError, "#{@config_path}: Option key '#{key}' used in hierarchy '#{name}' is reserved by Puppet"
+          end
+        end
       end
     end
     config

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -278,6 +278,48 @@ describe "The lookup function" do
       end
     end
 
+    context 'that uses reserved option' do
+      let(:environment_files) do
+        {
+          env_name => {
+            'hiera.yaml' => <<-YAML.unindent,
+              ---
+              version: 5
+              hierarchy:
+                - name: "Illegal"
+                  options:
+                    #{opt_spec}
+                  data_hash: yaml_data
+              YAML
+            'data' => {
+              'foo.yaml' => "a: The value a\n"
+            }
+          }
+        }
+      end
+
+      context 'path' do
+        let(:opt_spec) { 'path: data/foo.yaml' }
+
+        it 'fails and reports the reserved option key' do
+          expect { lookup('a') }.to raise_error do |e|
+            expect(e.message).to match(/Option key 'path' used in hierarchy 'Illegal' is reserved by Puppet/)
+          end
+        end
+      end
+
+      context 'uri' do
+        let(:opt_spec) { 'uri: file:///data/foo.yaml' }
+
+        it 'fails and reports the reserved option key' do
+          expect { lookup('a') }.to raise_error do |e|
+            expect(e.message).to match(/Option key 'uri' used in hierarchy 'Illegal' is reserved by Puppet/)
+          end
+        end
+      end
+    end
+
+
     context 'with lookup_options configured using patterns' do
       let(:mod_common) {
         <<-YAML.unindent


### PR DESCRIPTION
This commit checks that options specified in a Hiera version 5 hierarchy
entry does not use the reserved keys 'path' or 'uri'.