### PR TITLE
(PUP-7089) Fix problem with hiera5_backend and missing paths

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -210,7 +210,7 @@ class HieraConfig
     Hiera::Config.instance_variable_set(:@config, hiera3_config)
 
     # Use a special lookup_key that delegates to the backend
-    paths = nil if paths.empty?
+    paths = nil if !paths.nil? && paths.empty?
     create_data_provider(name, parent_data_provider, KEY_V3_BACKEND, 'hiera_v3_data', { KEY_DATADIR => datadir, KEY_BACKEND => backend }, paths)
   end
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -897,6 +897,23 @@ describe "The lookup function" do
           end
         end
       end
+
+      context 'with a hiera3_backend that has no paths' do
+        let(:hiera_yaml) do
+          <<-YAML.unindent
+          ---
+          version: 5
+          hierarchy:
+            - name: Custom
+              hiera3_backend: custom
+          YAML
+        end
+
+        it 'calls the backend' do
+          expect(lookup('hash_c')).to eql(
+            { 'hash_ca' => { 'cad' => 'value hash_c.hash_ca.cad (from global custom)' }})
+        end
+      end
     end
 
     context 'and a module' do


### PR DESCRIPTION
A hiera5_backend declared in such a way that no valid paths got configured
would cause a `undefined method `empty?' for nil:NilClass` problem when
the backend was configure. This commit ensures that this cannot happen.