### PR TITLE
(packaging) Bump puppet version to 4.9.0

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -7,7 +7,7 @@
 
 
 module Puppet
-  PUPPETVERSION = '4.8.2'
+  PUPPETVERSION = '4.9.0'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
Puppet 4.9.0 will be included in the puppet-agent 1.9.0 release.