### PR TITLE
(PUP-6925) Use Puppet::FileSystem for file access / explicitly specify encodings

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -123,7 +123,8 @@ class WindowsDaemon < Win32::Daemon
   def log(msg, level)
     if LEVELS.index(level) >= @loglevel
       if (@LOG_TO_FILE)
-        File.open(LOG_FILE, 'a') { |f| f.puts("#{Time.now} Puppet (#{level}): #{msg}") }
+        # without this change its possible that we get Encoding errors trying to write UTF-8 messages in current codepage
+        File.open(LOG_FILE, 'a:UTF-8') { |f| f.puts("#{Time.now} Puppet (#{level}): #{msg}") }
       end
 
       case level

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -166,7 +166,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     require 'tempfile'
     # Prefer the current directory, which is more likely to be secure
     # and, in the case of interactive use, accessible to the user.
-    tmpfile = Tempfile.new('x2puppet', Dir.pwd)
+    tmpfile = Tempfile.new('x2puppet', Dir.pwd, :encoding => Encoding::UTF_8)
     begin
       # sync write, so nothing buffers before we invoke the editor.
       tmpfile.sync = true

--- a/lib/puppet/face/man.rb
+++ b/lib/puppet/face/man.rb
@@ -76,11 +76,13 @@ Puppet::Face.define(:man, '0.0.1') do
         if pager then ENV['PAGER'] = pager end
 
         args  = "--man --manual='Puppet Manual' --organization='Puppet Labs, LLC'"
-        IO.popen("#{ronn} #{args}", 'w') do |fh| fh.write text end
+        # manual pages could contain UTF-8 text
+        IO.popen("#{ronn} #{args}", 'w:UTF-8') do |fh| fh.write text end
 
         ''                      # suppress local output, neh?
       elsif pager then
-        IO.popen(pager, 'w') do |fh| fh.write text end
+        # manual pages could contain UTF-8 text
+        IO.popen(pager, 'w:UTF-8') do |fh| fh.write text end
         ''
       else
         text

--- a/lib/puppet/face/module/generate.rb
+++ b/lib/puppet/face/module/generate.rb
@@ -236,7 +236,7 @@ module Puppet::ModuleTool::Generate
         content = block[path.read, binding]
 
         target = path.parent + path.basename(".#{type}")
-        target.open('w') { |f| f.write(content) }
+        target.open('w:UTF-8') { |f| f.write(content) }
         path.unlink
       end
     end

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -3,6 +3,14 @@ require 'puppet/util/windows'
 
 class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
 
+  def open(path, mode, options, &block)
+    # PUP-6959 mode is explicitly ignored until it can be implemented
+    # Ruby on Windows uses mode for setting file attributes like read-only and
+    # archived, not for setting permissions like POSIX
+    raise TypeError.new('mode must be specified as an Integer') if mode && !mode.is_a?(Numeric)
+    ::File.open(path, options, nil, &block)
+  end
+
   def expand_path(path, dir_string = nil)
     # ensure `nil` values behave like underlying File.expand_path
     string_path = ::File.expand_path(path.nil? ? nil : path_string(path), dir_string)

--- a/lib/puppet/generate/type.rb
+++ b/lib/puppet/generate/type.rb
@@ -222,7 +222,7 @@ module Puppet
             effective_output_path = input.effective_output_path(outputdir)
             Puppet.notice "Generating '#{effective_output_path}' using '#{input.format}' format."
             FileUtils.mkdir_p(File.dirname(effective_output_path))
-            File.open(effective_output_path, 'w') do |file|
+            Puppet::FileSystem.open(effective_output_path, nil, 'w:UTF-8') do |file|
               file.write(result)
             end
           rescue Exception => e

--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -258,7 +258,8 @@ class Puppet::Graph::SimpleGraph
     graph << '}'
 
     filename = File.join(Puppet[:graphdir], "cycles.dot")
-    File.open(filename, "w") { |f| f.puts graph }
+    # DOT files are assumed to be UTF-8 by default - http://www.graphviz.org/doc/info/lang.html
+    File.open(filename, "w:UTF-8") { |f| f.puts graph }
     return filename
   end
 
@@ -463,7 +464,8 @@ class Puppet::Graph::SimpleGraph
     return unless Puppet[:graph]
 
     file = File.join(Puppet[:graphdir], "#{name}.dot")
-    File.open(file, "w") { |f|
+    # DOT files are assumed to be UTF-8 by default - http://www.graphviz.org/doc/info/lang.html
+    File.open(file, "w:UTF-8") { |f|
       f.puts to_dot("name" => name.to_s.capitalize)
     }
   end

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -131,11 +131,12 @@ module Puppet::ModuleTool
         # TODO: This may necessarily change the order in which the metadata.json
         # file is packaged from what was written by the user.  This is a
         # regretable, but required for now.
-        File.open(metadata_path, 'w') do |f|
+        Puppet::FileSystem.open(metadata_path, nil, 'w:UTF-8') do |f|
           f.write(metadata.to_json)
         end
 
-        File.open(File.join(build_path, 'checksums.json'), 'w') do |f|
+        # PSON.pretty_generate is a BINARY string
+        Puppet::FileSystem.open(File.join(build_path, 'checksums.json'), nil, 'wb') do |f|
           f.write(PSON.pretty_generate(Checksums.new(build_path)))
         end
       end

--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -73,7 +73,8 @@ class Puppet::Network::HTTP::WEBrick
     file = Puppet[:masterhttplog]
 
     # open the log manually to prevent file descriptor leak
-    file_io = ::File.open(file, "a+")
+    # webrick logged strings may contain UTF-8
+    file_io = ::File.open(file, "a+:UTF-8")
     file_io.sync = true
     if defined?(Fcntl::FD_CLOEXEC)
       file_io.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)

--- a/lib/puppet/provider/mcx/mcxcontent.rb
+++ b/lib/puppet/provider/mcx/mcxcontent.rb
@@ -116,7 +116,8 @@ Puppet::Type.type(:mcx).provide :mcxcontent, :parent => Puppet::Provider do
       dscl 'localhost', '-mcxdelete', ds_path
     end
 
-    tmp = Tempfile.new('puppet_mcx')
+    # val being passed in is resource[:content] which should be UTF-8
+    tmp = Tempfile.new('puppet_mcx', :encoding => Encoding::UTF_8)
     begin
       tmp << val
       tmp.flush

--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
   def self.installapp(source, name, orig_source)
     appname = File.basename(source);
     ditto "--rsrc", source, "/Applications/#{appname}"
-    File.open("/var/db/.puppet_appdmg_installed_#{name}", "w") do |t|
+    Puppet::FileSystem.open("/var/db/.puppet_appdmg_installed_#{name}", nil, "w:UTF-8") do |t|
       t.print "name: '#{name}'\n"
       t.print "source: '#{orig_source}'\n"
     end

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -62,7 +62,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
   def self.installpkg(source, name, orig_source)
     installer "-pkg", source, "-target", "/"
     # Non-zero exit status will throw an exception.
-    File.open("/var/db/.puppet_pkgdmg_installed_#{name}", "w") do |t|
+    Puppet::FileSystem.open("/var/db/.puppet_pkgdmg_installed_#{name}", nil, "w:UTF-8") do |t|
       t.print "name: '#{name}'\n"
       t.print "source: '#{orig_source}'\n"
     end

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -622,6 +622,7 @@ Puppet::Type.type(:user).provide :directoryservice do
 
   # This is a simple wrapper method for writing values to a file.
   def write_to_file(filename, value)
+    Puppet.deprecation_warning("Puppet::Type.type(:user).provider(:directoryservice).write_to_file is deprecated and will be removed in Puppet 5.")
     begin
       File.open(filename, 'w') { |f| f.write(value)}
     rescue Errno::EACCES => detail

--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -263,7 +263,10 @@ Puppet::Type.type(:zone).provide(:solaris) do
 
       unless Puppet::FileSystem.exist?(sysidcfg)
         begin
-          File.open(sysidcfg, "w", 0600) do |f|
+          # For compatibility reasons use System encoding for this OS file
+          # the manifest string is UTF-8 so this could result in conversion errors
+          # which should propagate to users
+          Puppet::FileSystem.open(sysidcfg, 0600, "w:#{Encoding.default_external.name}") do |f|
             f.puts cfg
           end
         rescue => detail

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -538,7 +538,10 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
 
   # Store the classes in the classfile.
   def write_class_file
-    ::File.open(Puppet[:classfile], "w") do |f|
+    # classfile paths may contain UTF-8
+    # https://docs.puppet.com/puppet/latest/reference/configuration.html#classfile
+    classfile = Puppet.settings.setting(:classfile)
+    Puppet::FileSystem.open(classfile.value, classfile.mode.to_i(8), "w:UTF-8") do |f|
       f.puts classes.join("\n")
     end
   rescue => detail
@@ -547,7 +550,10 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
 
   # Store the list of resources we manage
   def write_resource_file
-    ::File.open(Puppet[:resourcefile], "w") do |f|
+    # resourcefile contains resources that may be UTF-8 names
+    # https://docs.puppet.com/puppet/latest/reference/configuration.html#resourcefile
+    resourcefile = Puppet.settings.setting(:resourcefile)
+    Puppet::FileSystem.open(resourcefile.value, resourcefile.mode.to_i(8), "w:UTF-8") do |f|
       to_print = resources.map do |resource|
         next unless resource.managed?
         if resource.name_var

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -184,9 +184,9 @@ module Puppet::Util::Execution
     null_file = Puppet.features.microsoft_windows? ? 'NUL' : '/dev/null'
 
     begin
-      stdin = File.open(options[:stdinfile] || null_file, 'r')
-      stdout = options[:squelch] ? File.open(null_file, 'w') : Puppet::FileSystem::Uniquefile.new('puppet')
-      stderr = options[:combine] ? stdout : File.open(null_file, 'w')
+      stdin = Puppet::FileSystem.open(options[:stdinfile] || null_file, nil, 'r')
+      stdout = options[:squelch] ? Puppet::FileSystem.open(null_file, nil, 'w') : Puppet::FileSystem::Uniquefile.new('puppet')
+      stderr = options[:combine] ? stdout : Puppet::FileSystem.open(null_file, nil, 'w')
 
       exec_args = [command, options, stdin, stdout, stderr]
 

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -105,7 +105,9 @@ class Puppet::Util::FileType
     # Read the file.
     def read
       if Puppet::FileSystem.exist?(@path)
-        File.read(@path)
+        # this code path is used by many callers so the original default is
+        # being explicitly preserved
+        Puppet::FileSystem.read(@path, :encoding => Encoding.default_external)
       else
         return nil
       end
@@ -118,7 +120,8 @@ class Puppet::Util::FileType
 
     # Overwrite the file.
     def write(text)
-      tf = Tempfile.new("puppet")
+      # this file is managed by the OS and should be using system encoding
+      tf = Tempfile.new("puppet", :encoding => Encoding.default_external)
       tf.print text; tf.flush
       File.chmod(@default_mode, tf.path) if @default_mode
       FileUtils.cp(tf.path, @path)
@@ -197,7 +200,8 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      IO.popen("#{cmdbase()} -", "w") { |p|
+      # this file is managed by the OS and should be using system encoding
+      IO.popen("#{cmdbase()} -", "w", :encoding => Encoding.default_external) { |p|
         p.print text
       }
     end
@@ -242,7 +246,8 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      output_file = Tempfile.new("puppet_suntab")
+      # this file is managed by the OS and should be using system encoding
+      output_file = Tempfile.new("puppet_suntab", :encoding => Encoding.default_external)
       begin
         output_file.print text
         output_file.close
@@ -284,7 +289,8 @@ class Puppet::Util::FileType
     # Overwrite a specific @path's cron tab; must be passed the @path name
     # and the text with which to create the cron tab.
     def write(text)
-      output_file = Tempfile.new("puppet_aixtab")
+      # this file is managed by the OS and should be using system encoding
+      output_file = Tempfile.new("puppet_aixtab", :encoding => Encoding.default_external)
 
       begin
         output_file.print text

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -224,7 +224,8 @@ module Logging
     # find the same offender, and we'd end up logging it again.
     $logged_deprecation_warnings ||= {}
 
-    File.open(deprecations_file, "a") do |f|
+    # Deprecation messages are UTF-8 as they are produced by Ruby
+    Puppet::FileSystem.open(deprecations_file, nil, "a:UTF-8") do |f|
       if ($deprecation_warnings) then
         $deprecation_warnings.each do |offender, message|
           if (! $logged_deprecation_warnings.has_key?(offender)) then

--- a/lib/puppet/util/rdoc/generators/puppet_generator.rb
+++ b/lib/puppet/util/rdoc/generators/puppet_generator.rb
@@ -225,7 +225,7 @@ module Generators
         'style_url'  => style_url('', @options.css),
       }
 
-      File.open(filename, "w") do |f|
+      Puppet::FileSystem.open(filename, nil, "w:UTF-8") do |f|
         template.write_html_on(f, values)
       end
     end
@@ -301,7 +301,7 @@ module Generators
       values["plugins"] = res4 if res4.size>0
       values["nodes"] = res5 if res5.size>0
 
-      File.open(filename, "w") do |f|
+      Puppet::FileSystem.open(filename, nil, "w:UTF-8") do |f|
         template.write_html_on(f, values)
       end
     end

--- a/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
+++ b/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
@@ -104,7 +104,8 @@ module RDoc::PuppetParserCore
     comment = ""
     %w{README README.rdoc}.each do |rfile|
       readme = File.join(File.dirname(File.dirname(@input_file_name)), rfile)
-      comment = File.open(readme,"r") { |f| f.read } if FileTest.readable?(readme)
+      # module README should be UTF-8, not default system encoding
+      comment = File.open(readme,"r:UTF-8") { |f| f.read } if FileTest.readable?(readme)
     end
     look_for_directives_in(container, comment) unless comment.empty?
 

--- a/lib/puppet/vendor/pathspec/lib/pathspec.rb
+++ b/lib/puppet/vendor/pathspec/lib/pathspec.rb
@@ -75,7 +75,8 @@ class PathSpec
 
   # Generate specs from a filename, such as a .gitignore
   def self.from_filename(filename, type=:git)
-    self.from_lines(File.open(filename, 'r'))
+    # .gitignore is a UTF-8 file
+    self.from_lines(File.open(filename, 'r', :encoding => Encoding::UTF_8), type)
   end
 
   def self.from_lines(lines, type=:git)

--- a/spec/integration/data_binding_spec.rb
+++ b/spec/integration/data_binding_spec.rb
@@ -143,7 +143,7 @@ describe "Data binding" do
   def configure_hiera_for_one_tier(data)
     hiera_config_file = tmpfile("hiera.yaml")
 
-    File.open(hiera_config_file, 'w') do |f|
+    File.open(hiera_config_file, 'w:UTF-8') do |f|
       f.write("---
         :yaml:
           :datadir: #{dir}
@@ -154,7 +154,7 @@ describe "Data binding" do
     end
 
     data.each do | file, contents |
-      File.open(File.join(dir, "#{file}.yaml"), 'w') do |f|
+      File.open(File.join(dir, "#{file}.yaml"), 'w:UTF-8') do |f|
         f.write(YAML.dump(contents))
       end
     end
@@ -165,7 +165,7 @@ describe "Data binding" do
   def configure_hiera_for_two_tier(data)
     hiera_config_file = tmpfile("hiera.yaml")
 
-    File.open(hiera_config_file, 'w') do |f|
+    File.open(hiera_config_file, 'w:UTF-8') do |f|
       f.write("---
         :yaml:
           :datadir: #{dir}
@@ -176,7 +176,7 @@ describe "Data binding" do
     end
 
     data.each do | file, contents |
-      File.open(File.join(dir, "#{file}.yaml"), 'w') do |f|
+      File.open(File.join(dir, "#{file}.yaml"), 'w:UTF-8') do |f|
         f.write(YAML.dump(contents))
       end
     end
@@ -188,7 +188,7 @@ describe "Data binding" do
     module_dir = File.join(dir, module_name, 'manifests')
     FileUtils.mkdir_p(module_dir)
 
-    File.open(File.join(module_dir, name), 'w') do |f|
+    File.open(File.join(module_dir, name), 'w:UTF-8') do |f|
       f.write(manifest)
     end
   end

--- a/spec/integration/environments/default_manifest_spec.rb
+++ b/spec/integration/environments/default_manifest_spec.rb
@@ -18,11 +18,11 @@ describe "default manifests" do
         manifestsdir = File.join(testingdir, "manifests")
         FileUtils.mkdir_p(manifestsdir)
 
-        File.open(File.join(manifestsdir, "site.pp"), "w") do |f|
+        File.open(File.join(manifestsdir, "site.pp"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("notify { 'ManifestFromRelativeDefault': }")
         end
 
-        File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+        File.open(File.join(confdir, "puppet.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("environmentpath=#{environmentpath}")
         end
 
@@ -43,14 +43,14 @@ describe "default manifests" do
         manifestsdir = File.expand_path("manifests", confdir)
         FileUtils.mkdir_p(manifestsdir)
 
-        File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+        File.open(File.join(confdir, "puppet.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts(<<-EOF)
   environmentpath=#{environmentpath}
   default_manifest=#{manifestsdir}
           EOF
         end
 
-        File.open(File.join(manifestsdir, "site.pp"), "w") do |f|
+        File.open(File.join(manifestsdir, "site.pp"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("notify { 'ManifestFromAbsoluteDefaultManifest': }")
         end
 
@@ -61,7 +61,7 @@ describe "default manifests" do
 
       it "reads manifest from directory environment manifest when environment.conf manifest set" do
         default_manifestsdir = File.expand_path("manifests", confdir)
-        File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+        File.open(File.join(confdir, "puppet.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts(<<-EOF)
   environmentpath=#{environmentpath}
   default_manifest=#{default_manifestsdir}
@@ -71,11 +71,11 @@ describe "default manifests" do
         manifestsdir = File.join(testingdir, "special_manifests")
         FileUtils.mkdir_p(manifestsdir)
 
-        File.open(File.join(manifestsdir, "site.pp"), "w") do |f|
+        File.open(File.join(manifestsdir, "site.pp"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("notify { 'ManifestFromEnvironmentConfManifest': }")
         end
 
-        File.open(File.join(testingdir, "environment.conf"), "w") do |f|
+        File.open(File.join(testingdir, "environment.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("manifest=./special_manifests")
         end
 
@@ -89,21 +89,21 @@ describe "default manifests" do
         default_manifestsdir = File.expand_path("manifests", confdir)
         FileUtils.mkdir_p(default_manifestsdir)
 
-        File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+        File.open(File.join(confdir, "puppet.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts(<<-EOF)
   environmentpath=#{environmentpath}
   default_manifest=#{default_manifestsdir}
           EOF
         end
 
-        File.open(File.join(default_manifestsdir, "site.pp"), "w") do |f|
+        File.open(File.join(default_manifestsdir, "site.pp"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("notify { 'ManifestFromAbsoluteDefaultManifest': }")
         end
 
         implicit_manifestsdir = File.join(testingdir, "manifests")
         FileUtils.mkdir_p(implicit_manifestsdir)
 
-        File.open(File.join(implicit_manifestsdir, "site.pp"), "w") do |f|
+        File.open(File.join(implicit_manifestsdir, "site.pp"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("notify { 'ManifestFromImplicitRelativeEnvironmentManifestDirectory': }")
         end
 
@@ -125,7 +125,7 @@ describe "default manifests" do
       before(:each) do
         FileUtils.mkdir_p(manifestsdir)
 
-        File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+        File.open(File.join(confdir, "puppet.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts(<<-EOF)
   environmentpath=#{environmentpath}
   default_manifest=#{manifestsdir}
@@ -133,7 +133,7 @@ describe "default manifests" do
           EOF
         end
 
-        File.open(File.join(manifestsdir, "site.pp"), "w") do |f|
+        File.open(File.join(manifestsdir, "site.pp"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("notify { 'ManifestFromAbsoluteDefaultManifest': }")
         end
       end
@@ -145,7 +145,7 @@ describe "default manifests" do
       end
 
       it "refuses to compile if environment.conf specifies a different manifest" do
-        File.open(File.join(testingdir, "environment.conf"), "w") do |f|
+        File.open(File.join(testingdir, "environment.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("manifest=./special_manifests")
         end
 
@@ -155,7 +155,7 @@ describe "default manifests" do
       end
 
       it "reads manifest from default_manifest setting when environment.conf has manifest set if setting equals default_manifest setting" do
-        File.open(File.join(testingdir, "environment.conf"), "w") do |f|
+        File.open(File.join(testingdir, "environment.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("manifest=#{manifestsdir}")
         end
 
@@ -165,7 +165,7 @@ describe "default manifests" do
       end
 
       it "logs errors if environment.conf specifies a different manifest" do
-        File.open(File.join(testingdir, "environment.conf"), "w") do |f|
+        File.open(File.join(testingdir, "environment.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts("manifest=./special_manifests")
         end
 
@@ -177,7 +177,7 @@ describe "default manifests" do
       end
 
       it "raises an error if default_manifest is not absolute" do
-        File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+        File.open(File.join(confdir, "puppet.conf"), "w", :encoding => Encoding::UTF_8) do |f|
           f.puts(<<-EOF)
   environmentpath=#{environmentpath}
   default_manifest=./relative

--- a/spec/integration/environments/setting_hooks_spec.rb
+++ b/spec/integration/environments/setting_hooks_spec.rb
@@ -14,7 +14,7 @@ describe "setting hooks" do
     it "accesses correct directory environment settings after initializing a setting with an on_write hook" do
       expect(Puppet.settings.setting(:certname).call_hook).to eq(:on_write_only) 
 
-      File.open(File.join(confdir, "puppet.conf"), "w") do |f|
+      File.open(File.join(confdir, "puppet.conf"), "w:UTF-8") do |f|
         f.puts("environmentpath=#{environmentpath}")
         f.puts("certname=something")
       end

--- a/spec/integration/util/execution_spec.rb
+++ b/spec/integration/util/execution_spec.rb
@@ -17,6 +17,14 @@ describe Puppet::Util::Execution do
     end
   end
 
+  describe "#execute (non-Windows)", :if => !Puppet.features.microsoft_windows? do
+    it "should execute basic shell command" do
+      result = Puppet::Util::Execution.execute("ls /tmp", :failonfail => true)
+      expect(result.exitstatus).to eq(0)
+      expect(result.to_s).to_not be_nil
+    end
+  end
+
   describe "#execute (Windows)", :if => Puppet.features.microsoft_windows? do
     let(:utf8text) do
       # Japanese Lorem Ipsum snippet

--- a/spec/unit/graph/simple_graph_spec.rb
+++ b/spec/unit/graph/simple_graph_spec.rb
@@ -430,7 +430,7 @@ describe Puppet::Graph::SimpleGraph do
     end
 
     it "should write a dot file based on the passed name" do
-      File.expects(:open).with(@file, "w").yields(stub("file", :puts => nil))
+      File.expects(:open).with(@file, "w:UTF-8").yields(stub("file", :puts => nil))
       @graph.expects(:to_dot).with("name" => @name.to_s.capitalize)
       Puppet[:graph] = true
       @graph.write_graph(@name)

--- a/spec/unit/man_spec.rb
+++ b/spec/unit/man_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Face[:man, :current] do
       app = klass.new(Puppet::Util::CommandLine.new('puppet', ['man', name]))
 
       expect do
-        IO.stubs(:popen).with(pager, anything).yields($stdout)
+        IO.stubs(:popen).with(pager, 'w:UTF-8').yields($stdout)
 
         expect { app.run }.to exit_with(0)
       end.to_not have_printed(/undefined method `gsub'/)

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -730,7 +730,7 @@ describe Puppet::Module do
     it "should properly parse utf-8 contents" do
       rune_utf8 = "\u16A0\u16C7\u16BB" # ᚠᛇᚻ
       metadata_json = tmpfile('metadata.json')
-      File.open(metadata_json, 'w') do |file|
+      File.open(metadata_json, 'w:UTF-8') do |file|
         file.puts <<-EOF
   {
     "license" : "GPL2",

--- a/spec/unit/network/http/webrick_spec.rb
+++ b/spec/unit/network/http/webrick_spec.rb
@@ -136,7 +136,7 @@ describe Puppet::Network::HTTP::WEBrick do
       log = make_absolute("/master/log")
       Puppet[:masterhttplog] = log
 
-      File.expects(:open).with(log, "a+").returns @filehandle
+      File.expects(:open).with(log, "a+:UTF-8").returns @filehandle
 
       server.setup_logger
     end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -67,7 +67,8 @@ describe Puppet::Resource::Catalog, "when compiling" do
     Puppet[:classfile] = File.expand_path("/class/file")
 
     fh = mock 'filehandle'
-    File.expects(:open).with(Puppet[:classfile], "w").yields fh
+    classfile = Puppet.settings.setting(:classfile)
+    Puppet::FileSystem.expects(:open).with(classfile.value, classfile.mode.to_i(8), "w:UTF-8").yields fh
 
     fh.expects(:puts).with "foo\nbar"
 
@@ -719,7 +720,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
     end
 
     it "should only write when it is a host catalog" do
-      File.expects(:open).with(@file).never
+      Puppet::FileSystem.expects(:open).with(@file, 0640, "w:UTF-8").never
       @catalog.host_config = false
       Puppet[:graph] = true
       @catalog.write_graph(@name)

--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Util::FileType do
     describe "when the file already exists" do
       it "should return the file's contents when asked to read it" do
         Puppet::FileSystem.expects(:exist?).with(path).returns true
-        File.expects(:read).with(path).returns "my text"
+        Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding.default_external).returns "my text"
 
         expect(file.read).to eq("my text")
       end
@@ -46,7 +46,7 @@ describe Puppet::Util::FileType do
       end
 
       it "should first create a temp file and copy its contents over to the file location" do
-        Tempfile.expects(:new).with("puppet").returns tempfile
+        Tempfile.expects(:new).with("puppet", :encoding => Encoding.default_external).returns tempfile
         tempfile.expects(:print).with("my text")
         tempfile.expects(:flush)
         tempfile.expects(:close)
@@ -151,7 +151,7 @@ describe Puppet::Util::FileType do
         @tmp_cron = Tempfile.new("puppet_crontab_spec")
         @tmp_cron_path = @tmp_cron.path
         Puppet::Util.stubs(:uid).with(uid).returns 9000
-        Tempfile.expects(:new).with("puppet_#{name}").returns @tmp_cron
+        Tempfile.expects(:new).with("puppet_#{name}", :encoding => Encoding.default_external).returns @tmp_cron
       end
 
       after :each do

--- a/spec/unit/util/yaml_spec.rb
+++ b/spec/unit/util/yaml_spec.rb
@@ -60,7 +60,7 @@ describe Puppet::Util::Yaml do
   end
 
   def write_file(name, contents)
-    File.open(name, "w") do |fh|
+    File.open(name, "w:UTF-8") do |fh|
       fh.write(contents)
     end
   end


### PR DESCRIPTION
For encodings that are currently specified implicitly (through Rubys `Encoding.default_external` for instance), make sure they are specified explicitly instead.

Should be merged prior to #5384 