### PR TITLE
(PUP-7129) Use systemd service provider for Debian 9 (Strech)

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
-  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => "8"
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "9"]
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10"]
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
-  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "9"]
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10"]
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 


### PR DESCRIPTION
Currently, the 'service' provider gets confused on a Debian 9 (stretch) (updated from Debian Jessie), when trying to restart services:

> Notice: /Stage[main]/Base::Ssh/File[/etc/ssh/sshd_config]/content: content changed '{md5}6c77ef6f38ca76a455809562c7f0a9a7' to '{md5}2f0a7d2e3d7cf30c3ba9eeff6af29189'
> Info: /Stage[main]/Base::Ssh/File[/etc/ssh/sshd_config]: Scheduling refresh of Service[sshd]
> Debug: /Stage[main]/Base::Ssh/File[/etc/ssh/sshd_config]: The container Class[Base::Ssh] will propagate my refresh event
> Debug: Executing: '/usr/sbin/service sshd status'
> Debug: Executing: '/usr/sbin/service sshd status'
> Debug: Service[sshd](provider=debian): Could not find sshd in /etc/init.d
> Debug: Service[sshd](provider=debian): Could not find sshd.sh in /etc/init.d
> Error: /Stage[main]/Base::Ssh/Service[sshd]: Failed to call refresh: Could not find init script for 'sshd'
> Error: /Stage[main]/Base::Ssh/Service[sshd]: Could not find init script for 'sshd'
> Debug: Prefetching parsed resources for ssh_authorized_key
> Debug: Class[Base::Ssh]: The container Stage[main] will propagate my refresh event
> Debug: Finishing transaction 47247593282280
> Debug: Storing state
> Debug: Stored state in 0.00 seconds
> Notice: Applied catalog in 0.57 seconds

This will add Debian 9 as `defaultfor` the systemd service provider.