### PR TITLE
(PUP-7102) Log a warning when environment path has permission problems

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -93,7 +93,8 @@ module Puppet
 
         * `deprecations` --- disables deprecation warnings.
         * `undefined_variables` --- disables warnings about non existing variables.
-        * `undefined_resources` --- disables warnings about non existing resources.",
+        * `undefined_resources` --- disables warnings about non existing resources.
+        * `permission_deined` --- disables warnings about directories with access problems.",
       :hook      => proc do |value|
         values = munge(value)
         valid   = %w[deprecations undefined_variables undefined_resources]

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -213,9 +213,37 @@ module Puppet::Environments
     end
 
     def valid_directory?(envdir)
-      name = Puppet::FileSystem.basename_string(envdir)
-      Puppet::FileSystem.directory?(envdir) &&
-         Puppet::Node::Environment.valid_name?(name)
+      # Make an attempt to access the directory to determine if it's invalid
+      # due to permission problems or simply because it doesn't exist
+      begin
+        stat = Puppet::FileSystem.stat(envdir)
+        if stat && stat.directory?
+          if stat.readable?
+            Puppet::Node::Environment.valid_name?(Puppet::FileSystem.basename_string(envdir))
+          else
+            Puppet.warn_once(:permisson_denied, envdir, "#{envdir}: Access denied!")
+            false
+          end
+        else
+          false
+        end
+      rescue Errno::ENOENT
+        false
+      rescue Errno::EACCES
+        # Report the directory where the actual access error occurs (traverse parents)
+        prev = envdir
+        current = Puppet::FileSystem.dir_string(prev)
+        while current
+          begin
+            break if Puppet::FileSystem.stat(current).readable?
+          rescue Errno::EACCES
+          end
+          prev = current
+          current = Puppet::FileSystem.dir_string(prev)
+        end
+        Puppet.warn_once(:permisson_denied, prev, "#{prev}: Access denied!")
+        false
+      end
     end
 
     def valid_directories

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -19,6 +19,10 @@ class Puppet::FileSystem::MemoryImpl
     path.file?
   end
 
+  def readable?(path)
+    path.readable?
+  end
+
   def executable?(path)
     path.executable?
   end
@@ -59,6 +63,36 @@ class Puppet::FileSystem::MemoryImpl
     else
       return handle
     end
+  end
+
+  class MemoryStat
+    def initialize(path)
+      @path = path
+    end
+
+    def directory?
+      @path.directory?
+    end
+
+    def file?
+      @path.directory?
+    end
+
+    def executable?
+      @path.executable?
+    end
+
+    def readable?
+      true
+    end
+
+    def writable?
+      @path.executable?
+    end
+  end
+
+  def stat(path)
+    find(path.path).nil? ? nil : MemoryStat.new(path)
   end
 
   def assert_path(path)

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -69,7 +69,12 @@ module Puppet
 
         setpriority(Puppet[:priority])
 
-        find_subcommand.run
+        begin
+          find_subcommand.run
+        rescue
+          Log.force_flushqueue
+          raise
+        end
       end
 
       # @api private


### PR DESCRIPTION
Prior to this PR, a permission problem in one of the directories in
an `environmentpath` would go unnoticed. The directory would simply be
deemed invalid and excluded from the path. This would later lead to
an `EnvironmentNotFound` exception being raised with no clue as to why
the path wasn't included.

This PR ensures that the directory with permission problems is logged
as a warning (once). The warning can be silenced using a `disable_warnings`
setting that includes 'permission_denied'.