### PR TITLE
(maint) SSL fixups for Ruby 2.4.0 

### DIFF
--- a/lib/puppet/ssl/certificate.rb
+++ b/lib/puppet/ssl/certificate.rb
@@ -69,7 +69,7 @@ DOC
     # is where the extensions are stored."
     @extensions_tag ||= 3
 
-    @exts_seq ||= OpenSSL::ASN1.decode(content.to_der).value[0].find do |data|
+    @exts_seq ||= OpenSSL::ASN1.decode(content.to_der).value[0].value.find do |data|
       (data.tag == @extensions_tag) && (data.tag_class == :CONTEXT_SPECIFIC)
     end.value[0]
   end

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -204,7 +204,7 @@ DOC
     end
 
     x509_attributes.map do |attr|
-      {"oid" => attr.oid, "value" => attr.value.first.value}
+      {"oid" => attr.oid, "value" => attr.value.value.first.value}
     end
   end
 

--- a/spec/unit/ssl/certificate_factory_spec.rb
+++ b/spec/unit/ssl/certificate_factory_spec.rb
@@ -32,12 +32,12 @@ describe Puppet::SSL::CertificateFactory do
 
     it "should set the certificate's subject to the CSR's subject" do
       cert = subject.build(:server, csr, issuer, serial)
-      expect(cert.subject).to eql x509_name
+      expect(cert.subject).to eq x509_name
     end
 
     it "should set the certificate's issuer to the Issuer's subject" do
       cert = subject.build(:server, csr, issuer, serial)
-      expect(cert.issuer).to eql issuer.subject
+      expect(cert.issuer).to eq issuer.subject
     end
 
     it "should set the certificate's public key to the CSR's public key" do

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -92,14 +92,13 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should set the subject to [CN, name]" do
       request.generate(key)
-      # OpenSSL::X509::Name only implements equality as `eql?`
-      expect(request.content.subject).to eql OpenSSL::X509::Name.new([['CN', key.name]])
+      expect(request.content.subject).to eq OpenSSL::X509::Name.new([['CN', key.name]])
     end
 
     it "should set the CN to the :ca_name setting when the CSR is for a CA" do
       Puppet[:ca_name] = "mycertname"
       request = described_class.new(Puppet::SSL::CA_NAME).generate(key)
-      expect(request.subject).to eql OpenSSL::X509::Name.new([['CN', Puppet[:ca_name]]])
+      expect(request.subject).to eq OpenSSL::X509::Name.new([['CN', Puppet[:ca_name]]])
     end
 
     it "should set the version to 0" do


### PR DESCRIPTION
Further validation on these changes are needed; they work but I don't fully understand what changed to necessitate these fixes.